### PR TITLE
v2.4.1-rc.1 - Fix accidental stable release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "automagik-genie",
-  "version": "2.4.0-rc.37",
+  "version": "2.4.1-rc.1",
   "description": "Self-evolving AI agent orchestration framework with Model Context Protocol support",
   "main": ".genie/cli/dist/genie.js",
   "bin": {


### PR DESCRIPTION
## Summary

This RC fixes the accidental publication of 2.4.0 stable release.

## What Happened

The auto-publish workflow bumped from 2.4.0-rc.37 → 2.4.0 stable instead of creating a proper RC release. This happened because:
- The workflow detected the commit as a stable release (not RC)
- Published to @latest tag instead of @next

## This Release

**Version:** 2.4.1-rc.1
**Tag:** @next (RC releases only)

**Changes:**
- Version bump to 2.4.1-rc.1
- Fixed pnpm version constraints in workflows
- All changes from previous RC37 work

## Notes

- 2.4.0 stable is now live on npm (will remain as @latest)
- 2.4.1-rc.1 will publish to @next tag
- Future stable release will be 2.4.1 (after RC testing)

**Ready for merge and release** ✅