### PR TITLE
fix: GitHub Actions permissions for automated RC publishing

### DIFF
--- a/.github/workflows/publish-rc-on-merge.yml
+++ b/.github/workflows/publish-rc-on-merge.yml
@@ -11,6 +11,9 @@ jobs:
     # Only run if PR was merged (not just closed) and came from dev branch
     if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'dev'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## 🔧 Final Fix for Automated RC Publishing

This completes the automation workflow by adding the necessary permissions for GitHub Actions to push commits back to the repository.

### What Was Fixed

**Permission Error:**
```
remote: Permission to namastexlabs/automagik-genie.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/namastexlabs/automagik-genie/': The requested URL returned error: 403
```

**Solution:**
Added explicit permissions to the workflow job:
```yaml
permissions:
  contents: write
  pull-requests: read
```

### Previous Successes

From the last run (18695855276):
- ✅ Setup pnpm (fixed version conflict)
- ✅ Run tests
- ✅ Bump RC version
- ✅ **Published v2.4.2-rc.22 to npm @next tag**
- ❌ Push version bump to main (fixed by this PR)

### Complete Automation Flow

When this PR is merged, the workflow will:
1. ✅ Run all tests
2. ✅ Bump RC version
3. ✅ Publish to npm @next
4. ✅ **Push version bump back to main** (now with permissions)
5. ✅ Create GitHub prerelease

Fixes #161