### PR TITLE
fix: Auto-publish RC when PR merges to main (Amendment #6)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Publish to NPM
 
 on:
+  push:
+    branches:
+      - main
   release:
     types: [published]
   workflow_dispatch:
@@ -18,6 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -28,12 +32,27 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
+      - name: Auto-bump RC version on push to main
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          pnpm install
+          pnpm run bump:rc
+          git push origin main --follow-tags
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Determine tag ref
         id: tagref
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             RAW=${{ github.event.inputs.tag }}
             VERSION=${RAW#v}
+            REF=refs/tags/v$VERSION
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            # Get version from package.json after bump
+            VERSION=$(node -p "require('./package.json').version")
             REF=refs/tags/v$VERSION
           else
             REF="$GITHUB_REF"


### PR DESCRIPTION
## Summary
Implements automatic RC publishing when PRs merge to main, per Amendment #6.

## Problem
- Amendment #6 states: "NEVER manually publish RCs. GitHub Actions does it automatically when PRs merge to main"
- Current workflow only triggered on manual release events
- Required manual 
> automagik-genie@2.4.2-rc.28 bump:rc /home/namastex/workspace/automagik-genie
> node scripts/bump.js rc-increment

[34m🔍 Running pre-flight checks...[0m
[31m❌ Working directory not clean. Commit or stash changes first.[0m
 ELIFECYCLE  Command failed with exit code 1. after each PR merge

## Solution
Updated :
1. Added  trigger
2. Auto-bump RC version using  script on push to main
3. Push new version tag automatically
4. Publish to npm @next tag

## Workflow (THE ONLY ALLOWED RC METHOD)
```
dev → PR → main → auto-bump rc.N → auto-publish @next
```

## Testing
Will be validated when this PR merges - should auto-publish rc.29

## Related
Fixes #176 (token tracking) + implements Amendment #6 automation
