### PR TITLE
fix: Auto-publish RC + GitHub releases when PR merges to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,12 +34,29 @@ jobs:
 
       - name: Auto-bump RC version on push to main
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        id: bump
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           pnpm install
-          pnpm run bump:rc
-          git push origin main --follow-tags
+
+          # Capture old version before bump
+          OLD_VERSION=$(node -p "require('./package.json').version")
+
+          # Run bump (will fail if tag exists, that's OK)
+          pnpm run bump:rc || echo "Bump failed (tag may exist)"
+
+          # Check if version changed
+          NEW_VERSION=$(node -p "require('./package.json').version")
+
+          if [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
+            echo "bumped=true" >> $GITHUB_OUTPUT
+            echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+            git push origin main --follow-tags
+          else
+            echo "bumped=false" >> $GITHUB_OUTPUT
+            echo "No version bump needed (tag already exists)"
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -171,6 +188,62 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GENIE_SKIP_IDENTITY_SMOKE: '1'
+
+      - name: Create GitHub Release
+        if: steps.npm_version.outputs.exists == '0'
+        run: |
+          VERSION="${{ steps.tagref.outputs.version }}"
+
+          # Determine if this is an RC release
+          if [[ "$VERSION" == *"-rc."* ]]; then
+            PRERELEASE_FLAG="--prerelease"
+            RELEASE_TYPE="Release Candidate"
+            INSTALL_CMD="npm install automagik-genie@next"
+          else
+            PRERELEASE_FLAG=""
+            RELEASE_TYPE="Stable Release"
+            INSTALL_CMD="npm install automagik-genie"
+          fi
+
+          # Extract changelog for this version
+          CHANGELOG_SECTION=$(awk "/^## \[${VERSION}\]/,/^## \[/{print}" CHANGELOG.md | sed '$d')
+
+          # Create release notes
+          cat > /tmp/release-notes.md <<EOF
+          # ${RELEASE_TYPE}: v${VERSION}
+
+          ${CHANGELOG_SECTION}
+
+          ## Installation
+
+          \`\`\`bash
+          ${INSTALL_CMD}
+          \`\`\`
+
+          ## Usage
+
+          For RC releases, use the \`@next\` tag to get the latest release candidate.
+          These are pre-release versions for testing new features before stable release.
+
+          \`\`\`bash
+          # Install latest RC
+          npm install automagik-genie@next
+
+          # Or install specific version
+          npm install automagik-genie@${VERSION}
+          \`\`\`
+
+          ---
+          📦 [View on NPM](https://www.npmjs.com/package/automagik-genie/v/${VERSION})
+          EOF
+
+          # Create GitHub release
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --notes-file /tmp/release-notes.md \
+            ${PRERELEASE_FLAG}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Success notification
         run: |


### PR DESCRIPTION
## Summary
Implements fully automatic RC publishing with GitHub releases per Amendment #6 + user request.

## Changes

### 1. Auto-Publish RC (Amendment #6)
- ✅ Trigger on push to main
- ✅ Auto-bump RC version
- ✅ Handle existing tags gracefully
- ✅ Push tags automatically
- ✅ Publish to npm @next

### 2. Auto-Create GitHub Releases
- ✅ Create release after successful npm publish
- ✅ Mark RC releases as pre-release
- ✅ Extract changelog for release notes
- ✅ Include installation instructions
- ✅ Show @next tag usage for RCs
- ✅ Link to NPM package

## Workflow (THE ONLY ALLOWED RC METHOD)
```
dev → PR → main → auto-bump rc.N → auto-publish @next → create GitHub release
```

## Release Notes Format
Release notes automatically include:
- Release type (RC or Stable)
- Changelog excerpt
- Installation command: `npm install automagik-genie@next`
- Usage instructions for @next tag
- NPM package link

## Testing
Will be validated when this PR merges - should:
1. Bump to rc.30
2. Publish to npm @next
3. Create GitHub pre-release with full notes

## Related
Fixes #176 + implements Amendment #6 + addresses user requirement for GitHub releases
