### PR TITLE
fix: Complete auto-publish automation with permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Final fix for fully automatic RC publishing + GitHub releases.

## Changes
1. **Token tracking via WebSocket** (#176) ✅
2. **Auto-publish RC on PR merge** (Amendment #6) ✅
3. **Auto-create GitHub releases** (user request) ✅  
4. **Handle existing tags gracefully** ✅
5. **Add GitHub Actions permissions** (this PR) ✅

## Workflow Permissions
Added to publish.yml:
- `contents: write` - Push commits and tags
- `packages: write` - Create releases

## Complete Automation Flow
```
dev → PR → main 
  ↓
GitHub Actions:
  1. Auto-bump RC (rc.N++)
  2. Commit + tag
  3. Push to main
  4. Publish to npm @next
  5. Create GitHub pre-release with notes
```

## Testing
Merging this PR should:
- ✅ Bump to rc.30
- ✅ Publish to npm
- ✅ Create GitHub release with install instructions

## Related
Fixes #176
