### PR TITLE
fix: token stats display and dashboard refresh

### DIFF
--- a/.genie/cli/dist/genie-cli.js
+++ b/.genie/cli/dist/genie-cli.js
@@ -305,15 +305,11 @@ ${mcpStatus} **MCP Server**
 ${footer}`;
         // Clear previous dashboard if not first render
         if (dashboardLines > 0) {
-            // Move cursor up and clear lines
-            for (let i = 0; i < dashboardLines; i++) {
-                process.stdout.write('\x1b[1A'); // Move up one line
-                process.stdout.write('\x1b[2K'); // Clear entire line
-            }
-            process.stdout.write('\r'); // Move to start of line
+            process.stdout.write('\x1b[2J'); // Clear entire screen
+            process.stdout.write('\x1b[H'); // Move cursor to home (0,0)
         }
         // Print new dashboard
-        console.log(dashboard);
+        process.stdout.write(dashboard + '\n');
         // Count lines for next update
         dashboardLines = dashboard.split('\n').length;
     };

--- a/.genie/cli/src/genie-cli.ts
+++ b/.genie/cli/src/genie-cli.ts
@@ -338,16 +338,12 @@ ${footer}`;
 
     // Clear previous dashboard if not first render
     if (dashboardLines > 0) {
-      // Move cursor up and clear lines
-      for (let i = 0; i < dashboardLines; i++) {
-        process.stdout.write('\x1b[1A'); // Move up one line
-        process.stdout.write('\x1b[2K'); // Clear entire line
-      }
-      process.stdout.write('\r'); // Move to start of line
+      process.stdout.write('\x1b[2J'); // Clear entire screen
+      process.stdout.write('\x1b[H'); // Move cursor to home (0,0)
     }
 
     // Print new dashboard
-    console.log(dashboard);
+    process.stdout.write(dashboard + '\n');
 
     // Count lines for next update
     dashboardLines = dashboard.split('\n').length;


### PR DESCRIPTION
## Summary

Fixes two critical dashboard issues (#181):

1. **Token stats hanging** - Stats collection hangs indefinitely  
2. **Dashboard headers repeating** - Screen refresh duplicates headers

## Changes

**Token Stats Fix:**
- Added  pattern to prevent double-resolution
- Added  to force-terminate WebSocket
- Reduced timeout: 5000ms → 2000ms
- Reduced attempts scanned: 20 → 5 (performance)

**Dashboard Refresh Fix:**
- Changed from line-by-line clearing to full screen clear
- Uses ANSI codes:  (clear screen) +  (cursor home)

## Test Results

✅ Token stats: 16.1k total (from 33 processes)  
✅ Dashboard clears properly without repeating headers

## Files Changed

-  - WebSocket cleanup + timeout
-  - Screen clearing fix
- Compiled  files updated

Closes #181