### PR TITLE
chore: sync dev → main for v2.5.1-rc.1

### DIFF
--- a/.genie/scripts/commit-advisory.cjs
+++ b/.genie/scripts/commit-advisory.cjs
@@ -377,11 +377,17 @@ class CommitAdvisory {
    * Get branch validation tier
    *
    * HIERARCHICAL VALIDATION STRATEGY:
-   * - Feature branches: Relaxed (warnings only, fast iteration)
+   * - Worktree branches (forge/*): Relaxed (warnings only, fast iteration in isolated worktrees)
+   * - Feature branches (feat/*, bug/*, fix/*): Relaxed (warnings only, work in progress)
    * - Dev branch: Stricter (require issues for feat/fix)
    * - Main branch: Extreme (require everything + version bump)
    */
   getBranchTier(branch) {
+    // Forge worktrees: isolated environment, relaxed validation
+    if (branch.startsWith('forge/')) {
+      return 'feature'; // Relaxed (warnings only)
+    }
+    // Manual feature branches: work in progress
     if (branch.startsWith('feat/') || branch.startsWith('bug/') || branch.startsWith('fix/')) {
       return 'feature'; // Relaxed (warnings only)
     }


### PR DESCRIPTION
## Summary
- fix(qa): use forge/ prefix for worktree branch detection

## Changes
Updated `getBranchTier()` in commit-advisory.cjs to prioritize forge/ prefix detection, aligning with pre-push hook logic.

## QA
Ready for QA testing after RC publishes.

## Release
This PR triggers auto RC bump on merge (via GitHub Actions).

Co-authored-by: Automagik Genie 🧞 <genie@namastex.ai>