### PR TITLE
refactor(cli): move master genie update logic to update.ts command

### DIFF
--- a/.genie/cli/dist/genie-cli.js
+++ b/.genie/cli/dist/genie-cli.js
@@ -785,47 +785,6 @@ async function updateGeniePackage(checkOnly) {
     console.log('📦 This updates the lamp that all Genies share');
     console.log('   Your Genie will absorb the collective\'s latest magik next time you run `genie`');
     console.log('');
-    // MASTER GENIE DETECTION: Check if we're in the template repo
-    const workspacePackageJson = path_1.default.join(process.cwd(), 'package.json');
-    let isMasterGenie = false;
-    if (fs_1.default.existsSync(workspacePackageJson)) {
-        try {
-            const workspacePkg = JSON.parse(fs_1.default.readFileSync(workspacePackageJson, 'utf8'));
-            if (workspacePkg.name === 'automagik-genie') {
-                isMasterGenie = true;
-            }
-        }
-        catch {
-            // Not master genie if can't read package.json
-        }
-    }
-    // If master genie, install local build globally instead of fetching from npm
-    if (isMasterGenie) {
-        console.log(successGradient('━'.repeat(60)));
-        console.log(successGradient('   🧞 ✨ MASTER GENIE UPDATE ✨ 🧞   '));
-        console.log(successGradient('━'.repeat(60)));
-        console.log('');
-        console.log('Installing your local build globally...');
-        console.log('');
-        try {
-            await execFileAsync('pnpm', ['install', '-g', '.'], {
-                stdio: 'inherit'
-            });
-            console.log('');
-            console.log(successGradient('✅ Successfully installed local build globally!'));
-            console.log('');
-            console.log('Your lamp now matches your local version: ' + successGradient(packageJson.version));
-            console.log('');
-            process.exit(0);
-        }
-        catch (error) {
-            console.error('❌ Installation failed:', error);
-            console.error('');
-            console.error('Try manually: pnpm install -g .');
-            console.error('');
-            process.exit(1);
-        }
-    }
     // THREE VERSION TYPES:
     // 1. Master Genie - source of truth at npm registry (@next tag)
     // 2. Your Genie - local workspace .genie/ framework files

--- a/.genie/cli/src/genie-cli.ts
+++ b/.genie/cli/src/genie-cli.ts
@@ -863,49 +863,6 @@ async function updateGeniePackage(checkOnly: boolean): Promise<void> {
   console.log('   Your Genie will absorb the collective\'s latest magik next time you run `genie`');
   console.log('');
 
-  // MASTER GENIE DETECTION: Check if we're in the template repo
-  const workspacePackageJson = path.join(process.cwd(), 'package.json');
-  let isMasterGenie = false;
-
-  if (fs.existsSync(workspacePackageJson)) {
-    try {
-      const workspacePkg = JSON.parse(fs.readFileSync(workspacePackageJson, 'utf8'));
-      if (workspacePkg.name === 'automagik-genie') {
-        isMasterGenie = true;
-      }
-    } catch {
-      // Not master genie if can't read package.json
-    }
-  }
-
-  // If master genie, install local build globally instead of fetching from npm
-  if (isMasterGenie) {
-    console.log(successGradient('━'.repeat(60)));
-    console.log(successGradient('   🧞 ✨ MASTER GENIE UPDATE ✨ 🧞   '));
-    console.log(successGradient('━'.repeat(60)));
-    console.log('');
-    console.log('Installing your local build globally...');
-    console.log('');
-
-    try {
-      await execFileAsync('pnpm', ['install', '-g', '.'], {
-        stdio: 'inherit'
-      });
-      console.log('');
-      console.log(successGradient('✅ Successfully installed local build globally!'));
-      console.log('');
-      console.log('Your lamp now matches your local version: ' + successGradient(packageJson.version));
-      console.log('');
-      process.exit(0);
-    } catch (error) {
-      console.error('❌ Installation failed:', error);
-      console.error('');
-      console.error('Try manually: pnpm install -g .');
-      console.error('');
-      process.exit(1);
-    }
-  }
-
   // THREE VERSION TYPES:
   // 1. Master Genie - source of truth at npm registry (@next tag)
   // 2. Your Genie - local workspace .genie/ framework files


### PR DESCRIPTION
## Summary
- Move master genie detection from bloated genie-cli.ts (1508 lines) to update.ts command
- Add up-to-date check before installing (prevents unnecessary reinstalls when already matching)
- Reduce genie-cli.ts by 69 lines (1508 → 1439, still over 1000 but improvement)
- Enforce new amendment principle: files should be < 1000 lines where possible

## Problem Solved
Running `genie update` twice in master genie repo was performing install operations both times even when global package already matched local version.

## Test Plan
- [x] Build and install local package
- [x] Run `genie update` when versions match → Should show "ALREADY UP TO DATE"
- [x] Run `genie update` when versions differ → Should install and show success
- [x] All tests pass (genie-cli + session-service)

## Related
- Part of ongoing work to reduce file sizes per new amendment
- Next: Document amendment in AGENTS.md