### PR TITLE
fix(cli): fix version detection and messaging in update command

### DIFF
--- a/.genie/cli/dist/commands/update.js
+++ b/.genie/cli/dist/commands/update.js
@@ -58,7 +58,13 @@ async function runUpdate(parsed, _config, _paths) {
             try {
                 const { stdout } = await execAsync(`${packageManager} list -g automagik-genie --depth=0 --json`);
                 const globalData = JSON.parse(stdout);
-                globalVersion = globalData.dependencies?.['automagik-genie']?.version || '';
+                // pnpm returns an array, npm returns an object
+                if (Array.isArray(globalData)) {
+                    globalVersion = globalData[0]?.dependencies?.['automagik-genie']?.version || '';
+                }
+                else {
+                    globalVersion = globalData.dependencies?.['automagik-genie']?.version || '';
+                }
             }
             catch {
                 globalVersion = '';
@@ -69,7 +75,7 @@ async function runUpdate(parsed, _config, _paths) {
                 console.log(successGradient('   🧞 ✨ MASTER GENIE - ALREADY UP TO DATE ✨ 🧞   '));
                 console.log(successGradient('━'.repeat(60)));
                 console.log('');
-                console.log('Your lamp already matches your local version: ' + successGradient(currentVersion));
+                console.log('Your global Genie already matches your local version: ' + successGradient(currentVersion));
                 console.log('');
                 console.log('✨ Nothing to update!');
                 console.log('');
@@ -80,7 +86,7 @@ async function runUpdate(parsed, _config, _paths) {
             console.log(successGradient('   🧞 ✨ MASTER GENIE UPDATE ✨ 🧞   '));
             console.log(successGradient('━'.repeat(60)));
             console.log('');
-            console.log(`Updating lamp: ${performanceGradient(globalVersion || '(not installed)')} → ${successGradient(currentVersion)}`);
+            console.log(`Updating global Genie: ${performanceGradient(globalVersion || '(not installed)')} → ${successGradient(currentVersion)}`);
             console.log('');
             console.log(`Installing your local build globally (using ${packageManager})...`);
             console.log('');
@@ -89,7 +95,7 @@ async function runUpdate(parsed, _config, _paths) {
                 console.log('');
                 console.log(successGradient('✅ Successfully installed local build globally!'));
                 console.log('');
-                console.log('Your lamp now matches your local version: ' + successGradient(currentVersion));
+                console.log('Your global Genie now matches your local version: ' + successGradient(currentVersion));
                 console.log('');
                 return;
             }

--- a/.genie/cli/src/commands/update.ts
+++ b/.genie/cli/src/commands/update.ts
@@ -66,7 +66,12 @@ export async function runUpdate(
       try {
         const { stdout } = await execAsync(`${packageManager} list -g automagik-genie --depth=0 --json`);
         const globalData = JSON.parse(stdout);
-        globalVersion = globalData.dependencies?.['automagik-genie']?.version || '';
+        // pnpm returns an array, npm returns an object
+        if (Array.isArray(globalData)) {
+          globalVersion = globalData[0]?.dependencies?.['automagik-genie']?.version || '';
+        } else {
+          globalVersion = globalData.dependencies?.['automagik-genie']?.version || '';
+        }
       } catch {
         globalVersion = '';
       }
@@ -77,7 +82,7 @@ export async function runUpdate(
         console.log(successGradient('   🧞 ✨ MASTER GENIE - ALREADY UP TO DATE ✨ 🧞   '));
         console.log(successGradient('━'.repeat(60)));
         console.log('');
-        console.log('Your lamp already matches your local version: ' + successGradient(currentVersion));
+        console.log('Your global Genie already matches your local version: ' + successGradient(currentVersion));
         console.log('');
         console.log('✨ Nothing to update!');
         console.log('');
@@ -89,7 +94,7 @@ export async function runUpdate(
       console.log(successGradient('   🧞 ✨ MASTER GENIE UPDATE ✨ 🧞   '));
       console.log(successGradient('━'.repeat(60)));
       console.log('');
-      console.log(`Updating lamp: ${performanceGradient(globalVersion || '(not installed)')} → ${successGradient(currentVersion)}`);
+      console.log(`Updating global Genie: ${performanceGradient(globalVersion || '(not installed)')} → ${successGradient(currentVersion)}`);
       console.log('');
       console.log(`Installing your local build globally (using ${packageManager})...`);
       console.log('');
@@ -99,7 +104,7 @@ export async function runUpdate(
         console.log('');
         console.log(successGradient('✅ Successfully installed local build globally!'));
         console.log('');
-        console.log('Your lamp now matches your local version: ' + successGradient(currentVersion));
+        console.log('Your global Genie now matches your local version: ' + successGradient(currentVersion));
         console.log('');
         return;
       } catch (error: any) {


### PR DESCRIPTION
## Summary

Fixes #272 - `genie update` command had two bugs:
- Version detection failed with pnpm (showed "(not installed)")
- Hardcoded "lamp" text instead of "global Genie"

## Changes

1. **Fixed pnpm version detection** (lines 68-74)
   - pnpm returns JSON array, npm returns object
   - Added check for both formats

2. **Fixed text** (3 occurrences)
   - "lamp" → "global Genie"

## Test Results

**Before:**
```
Updating lamp: (not installed) → 2.5.1-rc.6
```

**After:**
```
Your global Genie already matches your local version: 2.5.1-rc.6
✨ Nothing to update!
```

## Testing
- ✅ All tests pass (genie-cli + session-service)
- ✅ Pre-commit hooks pass
- ✅ Version detection works correctly with pnpm
- ✅ Messaging is clear and accurate