### PR TITLE
fix(cli): fix remaining 'lamp' reference in version mismatch error

### DIFF
--- a/.genie/cli/dist/genie-cli.js
+++ b/.genie/cli/dist/genie-cli.js
@@ -263,7 +263,7 @@ if (shouldCheckVersion) {
                 console.log(successGradient('   🧞 ✨ NEW VERSION READY! ✨ 🧞   '));
                 console.log(successGradient('━'.repeat(60)));
                 console.log('');
-                console.log(`You bumped to ${successGradient(localVersion)} but your global lamp is still ${performanceGradient(runningVersion)}`);
+                console.log(`You bumped to ${successGradient(localVersion)} but your global Genie is still ${performanceGradient(runningVersion)}`);
                 console.log('');
                 console.log('Install your new build globally:');
                 console.log('  ' + performanceGradient('pnpm install -g .'));

--- a/.genie/cli/src/genie-cli.ts
+++ b/.genie/cli/src/genie-cli.ts
@@ -296,7 +296,7 @@ if (shouldCheckVersion) {
         console.log(successGradient('   🧞 ✨ NEW VERSION READY! ✨ 🧞   '));
         console.log(successGradient('━'.repeat(60)));
         console.log('');
-        console.log(`You bumped to ${successGradient(localVersion)} but your global lamp is still ${performanceGradient(runningVersion)}`);
+        console.log(`You bumped to ${successGradient(localVersion)} but your global Genie is still ${performanceGradient(runningVersion)}`);
         console.log('');
         console.log('Install your new build globally:');
         console.log('  ' + performanceGradient('pnpm install -g .'));


### PR DESCRIPTION
## Summary

Fixes #274 - Completes the "lamp" → "Genie" terminology cleanup.

## Change

Line 299 in `genie-cli.ts`:
```diff
- console.log(`You bumped to ${successGradient(localVersion)} but your global lamp is still ${performanceGradient(runningVersion)}`);
+ console.log(`You bumped to ${successGradient(localVersion)} but your global Genie is still ${performanceGradient(runningVersion)}`);
```

## Context

PR #273 fixed "lamp" in `update.ts` but missed this instance in the master version detection logic in `genie-cli.ts`.

## Testing

- ✅ Version mismatch error now shows "global Genie" instead of "global lamp"
- ✅ All tests pass