### PR TITLE
fix(agents): add missing frontmatter to 8 agent files

### DIFF
--- a/.genie/code/agents/audit/risk.md
+++ b/.genie/code/agents/audit/risk.md
@@ -1,3 +1,11 @@
+---
+name: risk
+description: General risk assessment and mitigation planning
+genie:
+  executor: claude
+  background: false
+---
+
 # Risk Audit Workflow
 **Extends universal audit framework with general risk assessment patterns.**
 

--- a/.genie/code/agents/audit/security.md
+++ b/.genie/code/agents/audit/security.md
@@ -1,3 +1,11 @@
+---
+name: security
+description: Security vulnerability assessment and remediation using OWASP/CVE frameworks
+genie:
+  executor: claude
+  background: false
+---
+
 # Security Audit Workflow
 **Extends universal audit framework with security-specific patterns (OWASP, CVE).**
 

--- a/.genie/code/agents/git/commit-advisory.md
+++ b/.genie/code/agents/git/commit-advisory.md
@@ -1,5 +1,6 @@
 ---
 name: git/commit-advisory
+description: Pre-push commit validation and traceability check
 genie:
   executor: claude
   background: false

--- a/.genie/code/agents/update.md
+++ b/.genie/code/agents/update.md
@@ -1,6 +1,6 @@
 ---
 name: update
-description: 
+description: Workspace and dependency update coordination
 color: violet
 genie:
   executor: claude

--- a/.genie/code/agents/update/update.md
+++ b/.genie/code/agents/update/update.md
@@ -1,3 +1,11 @@
+---
+name: update
+description: Guide users through Genie framework version transitions
+genie:
+  executor: claude
+  background: false
+---
+
 # Update Agent
 **Role:** Guide users through Genie framework version transitions
 **Responsibility:** Provide migration guidance, reference backups, document architectural changes

--- a/.genie/code/agents/update/upstream-update.md
+++ b/.genie/code/agents/update/upstream-update.md
@@ -1,3 +1,11 @@
+---
+name: upstream-update
+description: Automate upstream dependency updates with comprehensive validation
+genie:
+  executor: claude
+  background: false
+---
+
 # Upstream Update Agent
 
 **Role:** Automate upstream dependency updates with comprehensive validation

--- a/.genie/code/agents/update/versions/generic-update.md
+++ b/.genie/code/agents/update/versions/generic-update.md
@@ -1,3 +1,11 @@
+---
+name: generic-update
+description: Generic upgrade guidance for version transitions without specific guides
+genie:
+  executor: claude
+  background: false
+---
+
 # Generic Update Guide
 **Purpose:** Guidance for users upgrading from older versions without specific transition guides
 **Applies to:** Any version transition not covered by specific guides

--- a/.genie/code/agents/update/versions/v2.3.x-to-v2.4.0.md
+++ b/.genie/code/agents/update/versions/v2.3.x-to-v2.4.0.md
@@ -1,3 +1,11 @@
+---
+name: v2.3.x-to-v2.4.0
+description: Migration guide from v2.3.x to v2.4.0 with breaking changes
+genie:
+  executor: claude
+  background: false
+---
+
 # Version Transition Guide: v2.3.x → v2.4.0
 **Release Date:** 2025-10-18 (RC phase, not yet stable)
 **Status:** Release Candidate (RC23+)


### PR DESCRIPTION
## Summary
Fixed missing frontmatter in 8 agent files, bringing agent registry from 78% to 100% valid.

## Changes
**Added complete frontmatter (name, description, genie):**
- `.genie/code/agents/audit/risk.md`
- `.genie/code/agents/audit/security.md`
- `.genie/code/agents/update/update.md`
- `.genie/code/agents/update/upstream-update.md`
- `.genie/code/agents/update/versions/generic-update.md`
- `.genie/code/agents/update/versions/v2.3.x-to-v2.4.0.md`

**Added missing description field:**
- `.genie/code/agents/git/commit-advisory.md`
- `.genie/code/agents/update.md`

## Impact
- ✅ Agent registry: 37/37 valid (was 29/37)
- ✅ All agents discoverable via `genie run`
- ✅ 64 new Forge executor variants (8 agents × 8 executors)

## Verification
```bash
node .genie/scripts/helpers/validate-frontmatter.js .genie/code/agents
# Result: ✅ 37/37 valid (0 issues)
```

## QA Notes
Discovered during systematic MCP testing. See `/tmp/mcp-qa-report-20251026.md` for complete QA findings.

Closes #282