### PR TITLE
fix(cli): prevent genie from auto-exiting after dashboard launch

### DIFF
--- a/.genie/cli/dist/genie-cli.js
+++ b/.genie/cli/dist/genie-cli.js
@@ -1475,12 +1475,17 @@ async function startGenieServer(debug = false) {
                     };
                     console.log('');
                     await createQuestion(genieGradient('Press Enter to open dashboard...'));
-                    rl.close();
+                    // Don't close readline - keep it open to prevent process exit
+                    // The stdin being open keeps Node's event loop alive
+                    // rl.close(); // REMOVED - was causing premature exit
                     console.log('');
                     console.log(genieGradient('📊 Launching dashboard...'));
                     console.log('');
                     // Launch the engagement dashboard
                     execGenie(['dashboard', '--live']);
+                    // Keep stdin open so process stays alive until Ctrl+C or MCP exit
+                    console.log('');
+                    console.log('💡 Press ' + performanceGradient('Ctrl+C') + ' to stop Genie');
                 })();
             }
         }, 1000);

--- a/.genie/cli/src/genie-cli.ts
+++ b/.genie/cli/src/genie-cli.ts
@@ -1618,7 +1618,9 @@ async function startGenieServer(debug = false): Promise<void> {
           console.log('');
           await createQuestion(genieGradient('Press Enter to open dashboard...'));
 
-          rl.close();
+          // Don't close readline - keep it open to prevent process exit
+          // The stdin being open keeps Node's event loop alive
+          // rl.close(); // REMOVED - was causing premature exit
 
           console.log('');
           console.log(genieGradient('📊 Launching dashboard...'));
@@ -1626,6 +1628,10 @@ async function startGenieServer(debug = false): Promise<void> {
 
           // Launch the engagement dashboard
           execGenie(['dashboard', '--live']);
+
+          // Keep stdin open so process stays alive until Ctrl+C or MCP exit
+          console.log('');
+          console.log('💡 Press ' + performanceGradient('Ctrl+C') + ' to stop Genie');
         })();
       }
     }, 1000);


### PR DESCRIPTION
## Problem
After showing "Press Enter to open dashboard...", genie closes readline and exits immediately instead of staying alive.

## Root Cause
`rl.close()` closed stdin, causing Node's event loop to exit even though MCP child process was still running.

## Solution
- Removed `rl.close()` call to keep stdin open
- Added reminder message "Press Ctrl+C to stop Genie"  
- Stdin being open keeps Node event loop alive
- MCP exit handler still works properly on Ctrl+C

## Testing
- ✅ All tests pass
- ✅ Ready for manual testing: `genie` should now stay alive after dashboard launch

fixes #340