### PR TITLE
chore: release RC71 - genie auto-exit fix

### DIFF
--- a/.genie/cli/dist/genie-cli.js
+++ b/.genie/cli/dist/genie-cli.js
@@ -1475,12 +1475,17 @@ async function startGenieServer(debug = false) {
                     };
                     console.log('');
                     await createQuestion(genieGradient('Press Enter to open dashboard...'));
-                    rl.close();
+                    // Don't close readline - keep it open to prevent process exit
+                    // The stdin being open keeps Node's event loop alive
+                    // rl.close(); // REMOVED - was causing premature exit
                     console.log('');
                     console.log(genieGradient('📊 Launching dashboard...'));
                     console.log('');
                     // Launch the engagement dashboard
                     execGenie(['dashboard', '--live']);
+                    // Keep stdin open so process stays alive until Ctrl+C or MCP exit
+                    console.log('');
+                    console.log('💡 Press ' + performanceGradient('Ctrl+C') + ' to stop Genie');
                 })();
             }
         }, 1000);

--- a/.genie/cli/src/genie-cli.ts
+++ b/.genie/cli/src/genie-cli.ts
@@ -1618,7 +1618,9 @@ async function startGenieServer(debug = false): Promise<void> {
           console.log('');
           await createQuestion(genieGradient('Press Enter to open dashboard...'));
 
-          rl.close();
+          // Don't close readline - keep it open to prevent process exit
+          // The stdin being open keeps Node's event loop alive
+          // rl.close(); // REMOVED - was causing premature exit
 
           console.log('');
           console.log(genieGradient('📊 Launching dashboard...'));
@@ -1626,6 +1628,10 @@ async function startGenieServer(debug = false): Promise<void> {
 
           // Launch the engagement dashboard
           execGenie(['dashboard', '--live']);
+
+          // Keep stdin open so process stays alive until Ctrl+C or MCP exit
+          console.log('');
+          console.log('💡 Press ' + performanceGradient('Ctrl+C') + ' to stop Genie');
         })();
       }
     }, 1000);


### PR DESCRIPTION
## RC71 Release - Genie Auto-Exit Fix

### Changes
- **Fix:** Prevent genie command from auto-exiting after dashboard launch (#344)
  - Removed `rl.close()` that was causing premature process exit
  - Keeps stdin open to maintain Node event loop
  - Added user message about Ctrl+C to stop

### Testing
- ✅ All unit tests passing (19/19 session service, genie-cli tests)
- ✅ Pre-commit and pre-push hooks passing
- ✅ GitHub Actions checks passing

### Commits
- fix(cli): prevent genie from auto-exiting after dashboard launch

### Version
- 2.5.5-rc.71 (will be bumped by release workflow)