### PR TITLE
fix(cli): genie dashboard hanging - part 2

### DIFF
--- a/.genie/cli/dist/genie-cli.js
+++ b/.genie/cli/dist/genie-cli.js
@@ -1430,7 +1430,8 @@ async function startGenieServer(debug = false) {
         attempt += 1;
         mcpChild = (0, child_process_1.spawn)('node', [mcpServer], {
             stdio: 'inherit',
-            env
+            env,
+            detached: false // Keep in same process group so Ctrl+C works
         });
         const timer = setTimeout(() => {
             // After grace period, consider startup successful
@@ -1481,8 +1482,16 @@ async function startGenieServer(debug = false) {
                     console.log('');
                     console.log(genieGradient('📊 Launching dashboard...'));
                     console.log('');
-                    // Launch the engagement dashboard
-                    execGenie(['dashboard', '--live']);
+                    // Launch the engagement dashboard in background
+                    // Don't use execGenie as it exits parent when child exits
+                    const dashboardScript = path_1.default.join(__dirname, 'genie.js');
+                    const dashboardChild = (0, child_process_1.spawn)('node', [dashboardScript, 'dashboard', '--live'], {
+                        stdio: 'inherit',
+                        detached: false,
+                        env: process.env
+                    });
+                    // Don't wait for dashboard to exit - let it run independently
+                    // The parent process stays alive via stdin being open
                     // Keep stdin open so process stays alive until Ctrl+C or MCP exit
                     console.log('');
                     console.log('💡 Press ' + performanceGradient('Ctrl+C') + ' to stop Genie');


### PR DESCRIPTION
## RC72 Release - Genie Dashboard Hanging Fix (Part 2)

### Issue
After PR #344 fixed the readline issue, genie still hangs after pressing Enter. The problem was that `execGenie()` function registers an exit handler that kills the parent process when the dashboard child exits.

### Root Cause
```typescript
function execGenie(args: string[]): void {
  const child = spawn(...);
  child.on('exit', (code) => {
    process.exit(code || 0);  // <-- Kills parent!
  });
}
```

When the dashboard command was launched via `execGenie(['dashboard', '--live'])`, the parent genie process would exit as soon as the dashboard exited (or hung).

### Fix
Spawn the dashboard process directly without the exit handler:

```typescript
const dashboardChild = spawn('node', [dashboardScript, 'dashboard', '--live'], {
  stdio: 'inherit',
  detached: false,
  env: process.env
});
// No exit handler - parent stays alive independently
```

Now the parent process stays alive via stdin being open (from PR #344 fix), and the dashboard runs independently. User can stop with Ctrl+C.

### Testing
- ✅ All unit tests passing (19/19 session service, genie-cli tests)
- ✅ Pre-commit and pre-push hooks passing

### Related
- Fixes #344 (follow-up fix)
- Previous fix (PR #344): Removed `rl.close()` to keep stdin open
- This fix: Remove exit handler from dashboard spawn

fixes #344