### PR TITLE
fix(cli): add takeover prompt for MCP port conflicts

### DIFF
--- a/.genie/cli/dist/genie-cli.js
+++ b/.genie/cli/dist/genie-cli.js
@@ -1271,16 +1271,44 @@ async function startGenieServer(debug = false) {
     const mcpPortConflict = await checkPortConflict(mcpPort);
     if (mcpPortConflict) {
         console.log('');
-        console.error(`❌ Port ${mcpPort} is already in use by another process`);
-        console.error(`   PID: ${mcpPortConflict.pid}`);
-        console.error(`   Command: ${mcpPortConflict.command}`);
-        console.error('');
-        console.error('Please kill that process or use a different port:');
-        console.error(`   kill ${mcpPortConflict.pid}`);
-        console.error(`   # or use a different port:`);
-        console.error(`   MCP_PORT=8886 genie`);
-        console.error('');
-        process.exit(1);
+        console.log(performanceGradient('⚠️  Another Genie instance is already running'));
+        console.log('');
+        console.log(`   Port: ${mcpPort}`);
+        console.log(`   PID: ${mcpPortConflict.pid}`);
+        console.log(`   Command: ${mcpPortConflict.command}`);
+        console.log('');
+        // Create readline for takeover prompt
+        const takeoverRl = require('readline').createInterface({
+            input: process.stdin,
+            output: process.stdout
+        });
+        const answer = await new Promise((resolve) => {
+            takeoverRl.question(performanceGradient('? Take over and shutdown the other instance? [y/N]: '), resolve);
+        });
+        takeoverRl.close();
+        if (answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes') {
+            console.log('');
+            console.log(performanceGradient('🔄 Taking over from previous instance...'));
+            // Kill the old MCP server process
+            try {
+                process.kill(parseInt(mcpPortConflict.pid), 'SIGTERM');
+                // Wait a bit for graceful shutdown
+                await new Promise(resolve => setTimeout(resolve, 3000));
+                console.log(successGradient('✅ Previous instance stopped'));
+            }
+            catch (err) {
+                console.error(`⚠️  Could not stop previous instance: ${err.message}`);
+                console.error(`   You may need to kill it manually: kill ${mcpPortConflict.pid}`);
+                process.exit(1);
+            }
+        }
+        else {
+            console.log('');
+            console.log('❌ Cancelled. To use a different port:');
+            console.log(`   MCP_PORT=8886 genie`);
+            console.log('');
+            process.exit(0);
+        }
     }
     // Phase 3: Start MCP server with SSE transport
     console.log('');


### PR DESCRIPTION
## RC76 Release - Takeover Prompt for Port Conflicts

### Issue
The MCP port conflict detection was showing an error and exiting immediately, which was confusing for users. The user requested the same behavior as Forge: **prompt to take over the process**.

### Changes

**Implemented takeover prompt** matching Forge's UX:

```
⚠️  Another Genie instance is already running

   Port: 8885
   PID: 12345
   Command: node .../server.js

? Take over and shutdown the other instance? [y/N]:
```

**If user chooses yes:**
```
🔄 Taking over from previous instance...
✅ Previous instance stopped
[continues with startup]
```

**If user chooses no:**
```
❌ Cancelled. To use a different port:
   MCP_PORT=8886 genie
```

### Benefits
- **User control**: Let users decide whether to take over or use different port
- **Clear communication**: Shows what's running and gives options
- **Matches Forge UX**: Consistent experience across genie components
- **Graceful shutdown**: Sends SIGTERM and waits for clean exit

### Related
- Fixes #344 (final fix #4)
- Previous fixes: PR #344 (readline), PR #346 (dashboard), PR #348 (port detection)

fixes #344