### PR TITLE
fix: workflow_run trigger not firing for auto-sync

### DIFF
--- a/.github/workflows/sync-dev-after-release.yml
+++ b/.github/workflows/sync-dev-after-release.yml
@@ -5,8 +5,6 @@ on:
     workflows: ["🚀 Unified Release"]
     types:
       - completed
-    branches:
-      - main
 
 permissions:
   contents: write
@@ -16,8 +14,8 @@ jobs:
   sync-dev:
     name: Sync dev with main
     runs-on: ubuntu-latest
-    # Only run if the release workflow succeeded
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Only run if the release workflow succeeded AND ran on main branch
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
 
     steps:
       - name: 📥 Checkout


### PR DESCRIPTION
## Summary

Fixes the auto-sync workflow that wasn't triggering after releases.

**Root Cause:** The `workflow_run` trigger with `branches` filter doesn't work as expected. According to GitHub's documentation, the `branches` filter in `workflow_run` doesn't filter the branch where the triggering workflow ran - it filters branches for the workflow_run workflow itself (which doesn't make sense in this context).

## Changes

- **Removed** `branches: [main]` filter from `workflow_run` trigger
- **Added** condition to check `github.event.workflow_run.head_branch == 'main'`
- This ensures sync only runs when the release workflow runs on the main branch

## How It Works Now

1. PR merged to main
2. Release workflow runs on main (version bump + changelog + npm publish)
3. **Workflow_run trigger fires** (no branch filter blocking it)
4. Sync workflow checks: `conclusion == 'success' && head_branch == 'main'`
5. If true → merges main → dev automatically
6. Dev stays in sync with version bumps

## Test Plan

Will be tested on the next RC release:
- [ ] Merge this PR to main
- [ ] Next PR merge should trigger release workflow
- [ ] Release workflow completes successfully
- [ ] Auto-sync workflow should trigger and merge main → dev
- [ ] Verify dev has the version bump commit

## Related

- Fixes #352
- Related to PR #350 (original auto-sync implementation)
- Part of Amendment #9 (unified version tracking)