### PR TITLE
fix: genie immediate exit + CLI refactoring (RC.80 → main)

### DIFF
--- a/.genie/cli/src/lib/server-manager.ts
+++ b/.genie/cli/src/lib/server-manager.ts
@@ -200,11 +200,11 @@ export async function startGenieServer(debug = false): Promise<void> {
       env
     });
 
-    const timer = setTimeout(() => {
+    const timer = setTimeout(async () => {
       // After grace period, consider startup successful
       if (!monitoringStarted && mcpChild) {
         monitoringStarted = true;
-        showStartupSuccess(startTime, timings, baseUrl);
+        await showStartupSuccess(startTime, timings, baseUrl);
       }
     }, 1000);
 
@@ -747,11 +747,11 @@ function displayGoodbyeReport(
 /**
  * Show startup success message and launch dashboard
  */
-function showStartupSuccess(
+async function showStartupSuccess(
   startTime: number,
   timings: Record<string, number>,
   baseUrl: string
-): void {
+): Promise<void> {
   // Calculate total startup time
   const totalTime = Date.now() - startTime;
   timings.total = totalTime;
@@ -779,37 +779,43 @@ function showStartupSuccess(
   console.log('   • Use ' + performanceGradient('Ctrl+C') + ' here to shutdown Genie gracefully');
   console.log('');
 
-  // Dashboard prompt
-  (async () => {
-    const readline = require('readline');
-    const rl = readline.createInterface({
-      input: process.stdin,
-      output: process.stdout
+  // Dashboard prompt - MUST await to keep process alive
+  const readline = require('readline');
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+  });
+
+  const createQuestion = (query: string): Promise<string> => {
+    return new Promise(resolve => {
+      rl.question(query, resolve);
     });
+  };
 
-    const createQuestion = (query: string): Promise<string> => {
-      return new Promise(resolve => {
-        rl.question(query, resolve);
-      });
-    };
+  console.log('');
+  await createQuestion(genieGradient('Press Enter to open dashboard...'));
 
-    console.log('');
-    await createQuestion(genieGradient('Press Enter to open dashboard...'));
+  console.log('');
+  console.log(genieGradient('📊 Launching dashboard...'));
+  console.log('');
 
-    console.log('');
-    console.log(genieGradient('📊 Launching dashboard...'));
-    console.log('');
+  // Launch the engagement dashboard in background
+  const dashboardScript = path.join(__dirname, '../genie.js');
+  const dashboardChild = spawn('node', [dashboardScript, 'dashboard', '--live'], {
+    stdio: 'inherit',
+    detached: false,
+    env: process.env
+  });
 
-    // Launch the engagement dashboard in background
-    const dashboardScript = path.join(__dirname, '../genie.js');
-    const dashboardChild = spawn('node', [dashboardScript, 'dashboard', '--live'], {
-      stdio: 'inherit',
-      detached: false,
-      env: process.env
+  // Wait for dashboard to exit (keeps process alive)
+  await new Promise<void>((resolve) => {
+    dashboardChild.on('exit', () => {
+      console.log('');
+      console.log('📊 Dashboard closed');
+      resolve();
     });
+  });
 
-    // Keep stdin open so process stays alive until Ctrl+C or MCP exit
-    console.log('');
-    console.log('💡 Press ' + performanceGradient('Ctrl+C') + ' to stop Genie');
-  })();
+  console.log('');
+  console.log('💡 Press ' + performanceGradient('Ctrl+C') + ' to stop Genie');
 }


### PR DESCRIPTION
## Summary
- **Critical Fix:** Genie CLI exits immediately after startup (issue #356)
- **File Size Fix:** CLI refactored from 1780 lines → 515 lines (71% reduction, resolves #297)
- **Documentation:** Context file updates (STATE.md, USERCONTEXT.md, CLAUDE.md optimization)
- **Automation:** Auto-sync workflow improvements (PR #353)

## Changes

### 🐛 Critical Bug Fix (Issue #356)
**Problem:** `genie` command exits immediately after starting, sends SIGTERM to MCP server before user can interact

**Root Cause:** `showStartupSuccess()` in server-manager.ts was void function with fire-and-forget async IIFE - function returned immediately, process exited

**Fix:**
- Made `showStartupSuccess` properly async (returns `Promise<void>`)
- Removed IIFE wrapper, directly await operations
- Added promise to wait for dashboard child process exit
- Updated caller to await function

**Files Modified:**
- `.genie/cli/src/lib/server-manager.ts:326` - Made function async and properly await lifecycle
- `.genie/cli/dist/lib/server-manager.js` - Compiled output

### 📦 CLI Refactoring (Issue #297)
**Problem:** `genie-cli.ts` was 1780 lines (78% over Amendment #10's 1000 line hard limit)

**Solution:** Extracted monolithic file into focused modules
- `router.ts` - Smart routing logic (version detection, upgrade checks)
- `server-manager.ts` - Forge + MCP server startup
- `mcp-stdio.ts` - MCP stdio transport handler
- `cli-utils.ts` - Helper functions (port checks, formatting)

**Result:**
- Before: 1780 lines (78% violation)
- After: 515 lines (71% reduction, 35% under target)
- Zero regressions (all 19 tests passing)

**Files Changed:**
- `.genie/cli/src/genie-cli.ts` - Reduced from 1780 → 515 lines
- `.genie/cli/src/lib/*.ts` - New modules (router, server-manager, mcp-stdio, cli-utils)
- `.genie/cli/dist/**` - Compiled outputs

### 📝 Documentation Updates
**Context Files:**
- `.genie/STATE.md` - Updated with RC70-RC80 history, auto-sync status
- `.genie/USERCONTEXT.md` - Updated with recent patterns and bug fixes
- `CLAUDE.md` - Optimized from 2,029 tokens → 5 tokens (99.75% reduction)

**Code Documentation:**
- `.genie/code/AGENTS.md` - Added Amendment #Code-13 (file size refactoring tactics)
- `AGENTS.md` - Removed Amendment #12 (consolidated into CLAUDE.md optimization)
- `.genie/wishes/refactor-genie-cli-split.md` - Complete refactoring blueprint (288 lines)

### 🔄 Workflow Improvements
**Auto-sync Workflow (PR #353):**
- Fixed workflow_run trigger (removed branches filter, added head_branch condition)
- Still experiencing GitHub Actions cache issues (manual sync used for RC.80)

**Files Modified:**
- `.github/workflows/sync-dev-after-release.yml` - Trigger fix

## Testing
- ✅ All 19 session service tests passing
- ✅ CLI smoke tests passing
- ✅ TypeScript compilation successful
- ✅ Pre-commit hooks passed (secrets, worktree, user files, cross-refs, tokens)
- ✅ Pre-push hooks passed (tests, commit advisory)

## Test Plan
- [ ] Install RC.80: `npm install -g automagik-genie@next`
- [ ] Run `genie --debug` - should stay alive and show dashboard prompt
- [ ] Press Enter - dashboard should open
- [ ] Close dashboard - process should exit cleanly
- [ ] Run `genie init` - should detect version, route correctly
- [ ] Run `genie update` - should upgrade framework files

## Related Issues
- Fixes #356 - Genie exits immediately after startup
- Fixes #297 - genie-cli.ts file size violation (1780 lines)
- Related to #352 - Auto-sync workflow improvements (PR #353)

## Version
RC.80 → main (will trigger RC.81 release)