### PR TITLE
Release: RC.85 with MCP fixes + release workflow hotfix

### DIFF
--- a/scripts/bump.cjs
+++ b/scripts/bump.cjs
@@ -220,6 +220,9 @@ function main() {
   if (!NO_PUSH) {
     log('blue', '📤', 'Pushing to remote...');
 
+    // Fetch remote to update refs for --force-with-lease
+    exec('git fetch origin main', true);
+
     // Pull first to handle any remote changes (e.g., auto-sync workflow)
     try {
       exec('git pull --rebase --no-verify origin main', true);


### PR DESCRIPTION
## Summary

This release includes MCP reliability improvements, build validation, and critical hotfixes for the release workflow.

## Changes

### MCP Reliability Fixes

1. **MCP Build Validation** (f37dec0c)
   - Added pre-commit hook to validate MCP dist files are in sync with source
   - Prevents accidental deletion of compiled files (like authorize.html)
   - Validates TypeScript compilation is up-to-date

2. **Restored authorize.html** (3f86fb8a)
   - Restored .genie/mcp/dist/lib/views/authorize.html that was accidentally removed
   - OAuth2.1 authorization flow now complete

### Release Workflow Hotfixes

3. **Fixed --force-with-lease stale ref error** (b7805454)
   - Added `git fetch origin main` before force-with-lease
   - Prevents race condition when auto-sync workflow updates main
   - Fixes "stale info" error that blocked RC.85 release

4. **Fixed detached HEAD in CI** (152727c5)
   - Added `git checkout main` before bump in workflow
   - PR merge leaves CI in detached HEAD state
   - Fixes "You are not currently on a branch" error in RC.85/RC.86

## Root Causes

1. **Stale ref error:** `git pull --rebase` doesn't update local tracking ref for `--force-with-lease`
2. **Detached HEAD:** PR merge to main checks out merge commit, not the branch

## Testing

- ✅ All tests passing (19/19)
- ✅ Pre-commit validation working
- ✅ MCP build validation tested and functional

## Related

- Fixes root cause of MCP dist file loss during refactoring
- Fixes release workflow failures in RC.85 and RC.86 CI runs
- Adds build integrity checks to prevent future regressions