### PR TITLE
Dev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,14 +190,27 @@ jobs:
 
       - name: 🔄 Sync dev branch
         run: |
-          # Fetch latest main
-          git fetch origin main
+          # Fetch all branches
+          git fetch origin dev main
 
-          # Reset dev to match main exactly (fast-forward, no merge commits)
-          git checkout -B dev origin/main
+          # Checkout dev
+          git checkout dev
 
-          # Force push to sync dev with main
-          git push --force origin dev
+          # Merge main into dev (fast-forward if possible)
+          # This preserves dev's commit history while bringing in any changes from main
+          if git merge-base --is-ancestor origin/main dev; then
+            echo "✅ Dev already contains all commits from main"
+            exit 0
+          else
+            git merge origin/main --no-edit || {
+              echo "❌ Merge conflict detected"
+              echo "This should not happen - main should always be mergeable into dev"
+              exit 1
+            }
+          fi
+
+          # Push synced dev
+          git push origin dev
 
       - name: ✅ Report Success
         if: success()


### PR DESCRIPTION
## 🔗 Linked Issue/Wish

Fixes #372 (self-referencing - this PR fixes the issue it describes)

---

## 📝 Summary

Fixed the auto-sync workflow causing dev to diverge from main with duplicate commits (same content, different commit SHAs).

---

## 🔧 Changes Implemented

**1. Root Cause Analysis**

The `sync-dev` job was using force-reset strategy:
```bash
git checkout -B dev origin/main  # Discard dev history
git push --force origin dev
```

**Why this caused problems:**
- Main has merge commits (from PR merges)
- Dev has individual commits (from development)
- Force-reset discarded dev's commits and recreated them
- Result: Same content, different commit SHAs = "dev ahead by 13 commits"

**2. The Fix (Commit f8dafb59)**

Changed to proper merge strategy:
```bash
git checkout dev
if git merge-base --is-ancestor origin/main dev; then
  echo "✅ Already synced"
  exit 0
else
  git merge origin/main --no-edit
fi
git push origin dev  # No force
```

**Benefits:**
- ✅ Preserves both dev and main histories
- ✅ Fast-forward when possible
- ✅ Clean merge when needed
- ✅ No force push
- ✅ No duplicate commits

---

## ✅ Testing

- [x] Verified `git merge-base --is-ancestor` logic locally
- [x] Confirmed dev currently contains all main commits
- [x] All tests passing (19/19 session service, CLI tests)
- [x] Pre-commit hooks passed

**Test Case:**
- Before: dev ahead by 13 commits with duplicate content
- After: Next sync will fast-forward cleanly

---

## 💥 Breaking Changes

- [x] No

---

## 📚 Additional Context

This fixes the auto-sync workflow introduced recently. The original implementation assumed dev should mirror main exactly, but that's incorrect for our workflow:
- PRs merge to main (creating merge commits)
- Dev contains individual commits from those PRs
- Main's merge commits would duplicate dev's history with force-reset

New implementation respects both histories and only syncs when truly needed.