### PR TITLE
Fix: Allow multiple stdio MCP instances + HTTP takeover prompt

### DIFF
--- a/.genie/mcp/src/server.ts
+++ b/.genie/mcp/src/server.ts
@@ -831,16 +831,14 @@ if (debugMode) {
     }
   }
 
-  // Check if another server is already running for this workspace
-  const serverStatus = isServerAlreadyRunning(WORKSPACE_ROOT);
-  if (serverStatus.running) {
-    console.error(`⚠️  MCP server already running (PID ${serverStatus.pid})`);
-    console.error('   Kill the existing server first or check for stale PID file');
-    process.exit(1);
-  }
+  // NOTE: PID file conflict check moved to server-manager.ts (with takeover prompt)
+  // This allows user-friendly takeover instead of immediate exit
 
-  // Write PID file for this instance
-  writePidFile(WORKSPACE_ROOT);
+  // Write PID file ONLY for HTTP/SSE transport (singleton per port)
+  // Stdio transport allows multiple instances (no PID file needed)
+  if (TRANSPORT === 'httpStream' || TRANSPORT === 'http') {
+    writePidFile(WORKSPACE_ROOT);
+  }
 })();
 
 // Forge sync (always show, one line)


### PR DESCRIPTION
## Summary
- Allow multiple stdio MCP instances to run simultaneously
- Add takeover prompt for HTTP/SSE transport conflicts
- Fix MCP startup loop with stale PID (Issue #344)

## Problem
1. **Single PID file prevented multiple MCP instances**
   - Stdio transport (Claude Desktop) failed when HTTP server running
   - Error: "MCP server already running (PID XXX)"
   - Users couldn't run `genie mcp` alongside `genie`

2. **No takeover prompt for HTTP conflicts**
   - Immediate exit with error (not user-friendly)
   - No way to gracefully take over port

## Solution
### Transport-Specific PID Handling
- **Stdio transport:** No PID file (multiple instances allowed)
- **HTTP/SSE transport:** PID file + takeover prompt (singleton per port)

### Takeover Prompt (HTTP only)
- Matches Forge pattern from PR #349
- Detects live process vs stale PID file
- Offers graceful takeover (SIGTERM → SIGKILL)
- Clean exit on decline

## Changes
1. **server.ts:** Conditional PID file writing (HTTP only)
2. **server-manager.ts:** Added `handleMCPPIDConflict()` with takeover
3. **cli-utils.ts:** Added `isProcessAlive()` + `killProcess()` helpers

## Testing
✅ Stdio MCP starts with existing HTTP server (no PID conflict)
✅ HTTP server gets takeover prompt on conflict
✅ Multiple stdio instances can run simultaneously
✅ All tests pass (19/19)

## Architecture
```
HTTP/SSE Transport (singleton):
  - Port conflict check → Takeover prompt
  - PID file enforcement → Takeover prompt
  - User-friendly takeover flow

Stdio Transport (multiple):
  - No port conflicts (uses stdin/stdout)
  - No PID file enforcement
  - Multiple instances allowed
```

Closes #344