### PR TITLE
fix: Forge executor detection broken (#344)

### DIFF
--- a/.genie/mcp/src/lib/server-helpers.ts
+++ b/.genie/mcp/src/lib/server-helpers.ts
@@ -86,12 +86,12 @@ export function loadForgeExecutor(): { createForgeExecutor: () => any } | null {
   // Prefer compiled dist (works in published package)
   try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    return require('../../cli/dist/lib/forge-executor');
+    return require('../../../cli/dist/lib/forge-executor');
   } catch (_distErr) {
     // Fallback to TypeScript sources for local dev (within repo)
     try {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      return require('../../cli/src/lib/forge-executor');
+      return require('../../../cli/src/lib/forge-executor');
     } catch (_srcErr) {
       return null;
     }


### PR DESCRIPTION
## Problem

MCP server shows **"⚠️  Skipping agent profile sync - Forge executor unavailable"** even when Forge is running on port 8887.

## Root Cause

`loadForgeExecutor()` in `.genie/mcp/src/lib/server-helpers.ts` used **incorrect relative path**:

```typescript
// BEFORE (BROKEN)
return require('../../cli/dist/lib/forge-executor');  // ❌

// Resolved to: .genie/mcp/cli/dist/lib/forge-executor.js (WRONG - inside mcp/)
```

**Path calculation:**
- From: `.genie/mcp/src/lib/server-helpers.ts`
- To: `.genie/cli/dist/lib/forge-executor.js`
- Needs: 3 levels up (`lib → src → mcp → .genie`), not 2

## Solution

```typescript
// AFTER (FIXED)
return require('../../../cli/dist/lib/forge-executor');  // ✅

// Resolves to: .genie/cli/dist/lib/forge-executor.js (CORRECT - sibling to mcp/)
```

## Impact

- ✅ **Forge detection now works** (agent profile sync succeeds)
- ✅ **No more false "Forge executor unavailable" warnings**
- ✅ **MCP tools can access Forge API correctly**
- ✅ **Agent profiles sync automatically on startup**

## Testing

**Before (RC93):**
```bash
node -e "const {loadForgeExecutor} = require('./.genie/mcp/dist/lib/server-helpers.js'); console.log(loadForgeExecutor() ? '✅' : '❌');"
# Output: ❌ (Failed)
```

**After (RC94):**
```bash
node -e "const {loadForgeExecutor} = require('./.genie/mcp/dist/lib/server-helpers.js'); console.log(loadForgeExecutor() ? '✅' : '❌');"
# Output: ✅ (Loaded)
```

**User experience:**
```bash
# Before: Broken Forge detection
genie
# ⚠️  Skipping agent profile sync - Forge executor unavailable

# After: Working Forge detection  
genie
# ✅ Agent profiles synced! ✓ (43 agents, 2.1s)
```

## Related

- Fixes #344 (genie auto-exit + OAuth + Forge detection issues)
- Complements PR #375 (OAuth config loading fix)

## Files Changed

- `.genie/mcp/src/lib/server-helpers.ts` - Fixed `loadForgeExecutor()` path (`../../cli` → `../../../cli`)

---

**Note:** Other files in `.genie/mcp/src/` were already using correct `../../../cli` paths. Only `server-helpers.ts` had this bug.