### PR TITLE
feat(cli/paths): Add comprehensive JSDoc and unit test coverage

### DIFF
--- a/.genie/cli/src/lib/paths.ts
+++ b/.genie/cli/src/lib/paths.ts
@@ -1,8 +1,16 @@
 import fs from 'fs';
 import path from 'path';
 
-// Find workspace root by searching upward for .genie/ directory
-// This locates the USER'S project root (where they run genie)
+/**
+ * Walks upward from the current working directory to locate the user's workspace root that contains a `.genie` folder.
+ * Returns the current working directory when no `.genie` directory is found.
+ * @returns {string} Absolute path to the detected workspace root or the current working directory as a fallback.
+ * @example
+ * ```ts
+ * const root = findWorkspaceRoot();
+ * console.log(root);
+ * ```
+ */
 export function findWorkspaceRoot(): string {
   let dir = process.cwd();
   while (dir !== path.dirname(dir)) {
@@ -15,9 +23,16 @@ export function findWorkspaceRoot(): string {
   return process.cwd();
 }
 
-// Get Genie framework package root (where automagik-genie package.json lives)
-// This is DIFFERENT from workspace root!
-// Works in both dev mode and npm mode (npx automagik-genie)
+/**
+ * Resolves the root directory of the installed Genie framework package relative to the compiled distribution files.
+ * Supports both development and globally installed scenarios.
+ * @returns {string} Absolute path to the automagik-genie package root directory.
+ * @example
+ * ```ts
+ * const packageRoot = getPackageRoot();
+ * console.log(packageRoot);
+ * ```
+ */
 export function getPackageRoot(): string {
   // __dirname = .genie/cli/dist/lib/
   // ../../../../ = workspace root (dev) or package root (npm)
@@ -26,21 +41,61 @@ export function getPackageRoot(): string {
 
 export type TemplateType = 'code' | 'create';
 
+/**
+ * Builds the absolute path to the framework-provided `.genie` template directory for the requested template type.
+ * @param {TemplateType} [template='code'] Template variant to reference, typically `code` or `create`.
+ * @returns {string} Absolute path to the template's `.genie` directory within the package root.
+ * @example
+ * ```ts
+ * const genieTemplate = getTemplateGeniePath('create');
+ * console.log(genieTemplate);
+ * ```
+ */
 export function getTemplateGeniePath(template: TemplateType = 'code'): string {
   // Copy from framework's .genie/code/ or .genie/create/ directory
   return path.join(getPackageRoot(), '.genie', template);
 }
 
+/**
+ * Retrieves the path to the framework's `.claude` directory when a Claude template is requested.
+ * Currently returns the root `.claude` directory irrespective of the supplied template type.
+ * @param {TemplateType} [_template='code'] Template identifier (unused, reserved for future flexibility).
+ * @returns {string} Absolute path to the package-level `.claude` resources.
+ * @example
+ * ```ts
+ * const claudeTemplate = getTemplateClaudePath();
+ * console.log(claudeTemplate);
+ * ```
+ */
 export function getTemplateClaudePath(_template: TemplateType = 'code'): string {
   // .claude/ not used - Claude Code wraps core agents directly
   return path.join(getPackageRoot(), '.claude');
 }
 
+/**
+ * Determines the root directory that should be used as the source when copying framework root files into a workspace.
+ * @param {TemplateType} [_template='code'] Template identifier (unused, included for API symmetry).
+ * @returns {string} Absolute path to the package root for framework root file replication.
+ * @example
+ * ```ts
+ * const rootTemplatePath = getTemplateRootPath();
+ * console.log(rootTemplatePath);
+ * ```
+ */
 export function getTemplateRootPath(_template: TemplateType = 'code'): string {
   // Root files (AGENTS.md, CLAUDE.md) copied from framework root
   return getPackageRoot();
 }
 
+/**
+ * Provides the set of relative paths within the workspace that must never be overwritten by template synchronization.
+ * @returns {Set<string>} A set containing relative directory names that are protected from template operations.
+ * @example
+ * ```ts
+ * const blacklist = getTemplateRelativeBlacklist();
+ * console.log(blacklist.has('wishes'));
+ * ```
+ */
 export function getTemplateRelativeBlacklist(): Set<string> {
   // Protect user work - these directories should NEVER be overwritten
   return new Set([
@@ -53,34 +108,114 @@ export function getTemplateRelativeBlacklist(): Set<string> {
   ]);
 }
 
+/**
+ * Resolves the absolute path to the workspace's `.genie` directory using the provided working directory.
+ * @param {string} [cwd=process.cwd()] Working directory from which the `.genie` directory should be resolved.
+ * @returns {string} Absolute path to the `.genie` directory within the target workspace.
+ * @example
+ * ```ts
+ * const targetGenie = resolveTargetGeniePath('/tmp/project');
+ * console.log(targetGenie);
+ * ```
+ */
 export function resolveTargetGeniePath(cwd: string = process.cwd()): string {
   return path.resolve(cwd, '.genie');
 }
 
+/**
+ * Builds the absolute path to the workspace state directory inside `.genie` based on the provided working directory.
+ * @param {string} [cwd=process.cwd()] Working directory of the target workspace.
+ * @returns {string} Absolute path to the `.genie/state` directory.
+ * @example
+ * ```ts
+ * const stateDir = resolveTargetStatePath('/tmp/project');
+ * console.log(stateDir);
+ * ```
+ */
 export function resolveTargetStatePath(cwd: string = process.cwd()): string {
   return path.join(resolveTargetGeniePath(cwd), 'state');
 }
 
+/**
+ * Generates the absolute path to the root backups directory inside a workspace's `.genie` folder.
+ * @param {string} [cwd=process.cwd()] Working directory used to resolve the target workspace.
+ * @returns {string} Absolute path to `.genie/backups` for the workspace.
+ * @example
+ * ```ts
+ * const backupsDir = resolveBackupsRoot('/tmp/project');
+ * console.log(backupsDir);
+ * ```
+ */
 export function resolveBackupsRoot(cwd: string = process.cwd()): string {
   return path.join(resolveTargetGeniePath(cwd), 'backups');
 }
 
+/**
+ * Resolves the path to the `provider.json` file that stores workspace provider metadata.
+ * @param {string} [cwd=process.cwd()] Working directory indicating the workspace base.
+ * @returns {string} Absolute path to `.genie/state/provider.json`.
+ * @example
+ * ```ts
+ * const providerPath = resolveWorkspaceProviderPath('/tmp/project');
+ * console.log(providerPath);
+ * ```
+ */
 export function resolveWorkspaceProviderPath(cwd: string = process.cwd()): string {
   return path.join(resolveTargetStatePath(cwd), 'provider.json');
 }
 
+/**
+ * Resolves the path to the `version.json` file that tracks the workspace's framework version information.
+ * @param {string} [cwd=process.cwd()] Working directory indicating the workspace base.
+ * @returns {string} Absolute path to `.genie/state/version.json`.
+ * @example
+ * ```ts
+ * const versionPath = resolveWorkspaceVersionPath('/tmp/project');
+ * console.log(versionPath);
+ * ```
+ */
 export function resolveWorkspaceVersionPath(cwd: string = process.cwd()): string {
   return path.join(resolveTargetStatePath(cwd), 'version.json');
 }
 
+/**
+ * Computes the absolute path to the `.genie/package.json` file within the workspace.
+ * @param {string} [cwd=process.cwd()] Working directory indicating the workspace base.
+ * @returns {string} Absolute path to the framework-managed `package.json` file.
+ * @example
+ * ```ts
+ * const packageJsonPath = resolveWorkspacePackageJson('/tmp/project');
+ * console.log(packageJsonPath);
+ * ```
+ */
 export function resolveWorkspacePackageJson(cwd: string = process.cwd()): string {
   return path.join(resolveTargetGeniePath(cwd), 'package.json');
 }
 
+/**
+ * Resolves the path to the `provider-status.json` file inside the workspace state directory.
+ * @param {string} [cwd=process.cwd()] Working directory indicating the workspace base.
+ * @returns {string} Absolute path to `.genie/state/provider-status.json`.
+ * @example
+ * ```ts
+ * const statusPath = resolveProviderStatusPath('/tmp/project');
+ * console.log(statusPath);
+ * ```
+ */
 export function resolveProviderStatusPath(cwd: string = process.cwd()): string {
   return path.join(resolveTargetStatePath(cwd), 'provider-status.json');
 }
 
+/**
+ * Builds the absolute path to the temporary backups directory used during workspace synchronization operations.
+ * @param {string} [cwd=process.cwd()] Working directory indicating the workspace base.
+ * @returns {string} Absolute path to the `.genie-backups-temp` directory alongside the workspace root.
+ * @example
+ * ```ts
+ * const tempBackups = resolveTempBackupsRoot('/tmp/project');
+ * console.log(tempBackups);
+ * ```
+ */
 export function resolveTempBackupsRoot(cwd: string = process.cwd()): string {
   return path.join(cwd, '.genie-backups-temp');
 }

--- a/tests/paths.test.js
+++ b/tests/paths.test.js
@@ -1,0 +1,416 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const {
+  findWorkspaceRoot,
+  getPackageRoot,
+  getTemplateGeniePath,
+  getTemplateClaudePath,
+  getTemplateRootPath,
+  getTemplateRelativeBlacklist,
+  resolveTargetGeniePath,
+  resolveTargetStatePath,
+  resolveBackupsRoot,
+  resolveWorkspaceProviderPath,
+  resolveWorkspaceVersionPath,
+  resolveWorkspacePackageJson,
+  resolveProviderStatusPath,
+  resolveTempBackupsRoot
+} = require('../.genie/cli/dist/lib/paths.js');
+
+const ORIGINAL_CWD = process.cwd();
+
+function makeTempDir(prefix = 'paths-test-') {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanupTempDir(dir) {
+  if (dir && fs.existsSync(dir)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// Test: findWorkspaceRoot returns directory containing .genie
+(function testFindWorkspaceRootInCurrentDirectory() {
+  const tempDir = makeTempDir();
+  const genieDir = path.join(tempDir, '.genie');
+  fs.mkdirSync(genieDir);
+  const previousCwd = process.cwd();
+  process.chdir(tempDir);
+  try {
+    const result = findWorkspaceRoot();
+    assert.strictEqual(result, tempDir, 'should return directory containing .genie');
+  } finally {
+    process.chdir(previousCwd);
+    cleanupTempDir(tempDir);
+  }
+})();
+
+// Test: findWorkspaceRoot ascends to parent directories
+(function testFindWorkspaceRootInAncestor() {
+  const tempDir = makeTempDir();
+  const nestedDir = path.join(tempDir, 'a', 'b', 'c');
+  fs.mkdirSync(path.join(tempDir, '.genie'));
+  fs.mkdirSync(nestedDir, { recursive: true });
+  const previousCwd = process.cwd();
+  process.chdir(nestedDir);
+  try {
+    const result = findWorkspaceRoot();
+    assert.strictEqual(result, tempDir, 'should locate .genie in ancestor directory');
+  } finally {
+    process.chdir(previousCwd);
+    cleanupTempDir(tempDir);
+  }
+})();
+
+// Test: findWorkspaceRoot falls back to current directory
+(function testFindWorkspaceRootFallback() {
+  const tempDir = makeTempDir();
+  const previousCwd = process.cwd();
+  process.chdir(tempDir);
+  try {
+    const result = findWorkspaceRoot();
+    assert.strictEqual(result, tempDir, 'should fall back to cwd when .genie is missing');
+  } finally {
+    process.chdir(previousCwd);
+    cleanupTempDir(tempDir);
+  }
+})();
+
+// Test: getPackageRoot returns absolute path
+(function testGetPackageRootIsAbsolute() {
+  const packageRoot = getPackageRoot();
+  assert.ok(path.isAbsolute(packageRoot), 'package root should be absolute');
+})();
+
+// Test: getPackageRoot points to repository root
+(function testGetPackageRootContainsPackageJson() {
+  const packageRoot = getPackageRoot();
+  assert.ok(fs.existsSync(path.join(packageRoot, 'package.json')), 'package root should contain package.json');
+})();
+
+// Test: getPackageRoot is stable across calls
+(function testGetPackageRootStable() {
+  const first = getPackageRoot();
+  const second = getPackageRoot();
+  assert.strictEqual(first, second, 'multiple calls should return same root');
+})();
+
+// Test: getTemplateGeniePath defaults to code template
+(function testGetTemplateGeniePathDefault() {
+  const expected = path.join(getPackageRoot(), '.genie', 'code');
+  const result = getTemplateGeniePath();
+  assert.strictEqual(result, expected, 'default template should point to .genie/code');
+})();
+
+// Test: getTemplateGeniePath returns create template
+(function testGetTemplateGeniePathCreate() {
+  const expected = path.join(getPackageRoot(), '.genie', 'create');
+  const result = getTemplateGeniePath('create');
+  assert.strictEqual(result, expected, 'create template should point to .genie/create');
+})();
+
+// Test: getTemplateGeniePath stays inside package root
+(function testGetTemplateGeniePathWithinRoot() {
+  const result = getTemplateGeniePath('code');
+  const relative = path.relative(getPackageRoot(), result);
+  assert.ok(!relative.startsWith('..'), 'template path should stay within package root');
+})();
+
+// Test: getTemplateClaudePath points to .claude directory
+(function testGetTemplateClaudePathLocation() {
+  const expected = path.join(getPackageRoot(), '.claude');
+  const result = getTemplateClaudePath();
+  assert.strictEqual(result, expected, 'should resolve to .claude directory');
+})();
+
+// Test: getTemplateClaudePath returns absolute path
+(function testGetTemplateClaudePathAbsolute() {
+  const result = getTemplateClaudePath();
+  assert.ok(path.isAbsolute(result), 'Claude template path should be absolute');
+})();
+
+// Test: getTemplateClaudePath ignores template argument
+(function testGetTemplateClaudePathIgnoresTemplate() {
+  const defaultPath = getTemplateClaudePath();
+  const createPath = getTemplateClaudePath('create');
+  assert.strictEqual(defaultPath, createPath, 'template argument should not change Claude path');
+})();
+
+// Test: getTemplateRootPath matches package root
+(function testGetTemplateRootPathMatchesRoot() {
+  const packageRoot = getPackageRoot();
+  const result = getTemplateRootPath();
+  assert.strictEqual(result, packageRoot, 'root template path should equal package root');
+})();
+
+// Test: getTemplateRootPath returns absolute path
+(function testGetTemplateRootPathAbsolute() {
+  const result = getTemplateRootPath();
+  assert.ok(path.isAbsolute(result), 'root template path should be absolute');
+})();
+
+// Test: getTemplateRootPath ignores template argument
+(function testGetTemplateRootPathIgnoresTemplate() {
+  const defaultPath = getTemplateRootPath();
+  const createPath = getTemplateRootPath('create');
+  assert.strictEqual(defaultPath, createPath, 'template argument should not change root path');
+})();
+
+// Test: getTemplateRelativeBlacklist contains protected folders
+(function testGetTemplateRelativeBlacklistContents() {
+  const blacklist = getTemplateRelativeBlacklist();
+  assert.ok(blacklist.has('wishes'), 'blacklist should protect wishes directory');
+  assert.ok(blacklist.has('reports'), 'blacklist should protect reports directory');
+})();
+
+// Test: getTemplateRelativeBlacklist returns new set each call
+(function testGetTemplateRelativeBlacklistFreshInstances() {
+  const first = getTemplateRelativeBlacklist();
+  first.add('temp');
+  const second = getTemplateRelativeBlacklist();
+  assert.ok(!second.has('temp'), 'each call should return a fresh set instance');
+})();
+
+// Test: getTemplateRelativeBlacklist includes cli directory
+(function testGetTemplateRelativeBlacklistIncludesCli() {
+  const blacklist = getTemplateRelativeBlacklist();
+  assert.ok(blacklist.has('cli'), 'blacklist should include cli directory');
+})();
+
+// Test: resolveTargetGeniePath uses current working directory by default
+(function testResolveTargetGeniePathDefaultCwd() {
+  const tempDir = makeTempDir();
+  const previousCwd = process.cwd();
+  process.chdir(tempDir);
+  try {
+    const expected = path.join(tempDir, '.genie');
+    const result = resolveTargetGeniePath();
+    assert.strictEqual(result, expected, 'should base path on current working directory');
+  } finally {
+    process.chdir(previousCwd);
+    cleanupTempDir(tempDir);
+  }
+})();
+
+// Test: resolveTargetGeniePath handles absolute inputs
+(function testResolveTargetGeniePathAbsolute() {
+  const absPath = path.join(os.tmpdir(), 'paths-test-absolute');
+  const result = resolveTargetGeniePath(absPath);
+  assert.strictEqual(result, path.join(absPath, '.genie'), 'should append .genie to absolute path');
+})();
+
+// Test: resolveTargetGeniePath resolves relative inputs
+(function testResolveTargetGeniePathRelative() {
+  const relative = path.join('tmp', 'paths-relative');
+  const expected = path.resolve(relative, '.genie');
+  const result = resolveTargetGeniePath(relative);
+  assert.strictEqual(result, expected, 'should resolve relative input to absolute path');
+})();
+
+// Test: resolveTargetStatePath appends state directory
+(function testResolveTargetStatePathStructure() {
+  const base = path.join('tmp', 'state-structure');
+  const result = resolveTargetStatePath(base);
+  const expected = path.join(resolveTargetGeniePath(base), 'state');
+  assert.strictEqual(result, expected, 'should append state directory to genie path');
+})();
+
+// Test: resolveTargetStatePath uses current directory when omitted
+(function testResolveTargetStatePathDefaultCwd() {
+  const tempDir = makeTempDir();
+  const previousCwd = process.cwd();
+  process.chdir(tempDir);
+  try {
+    const result = resolveTargetStatePath();
+    assert.strictEqual(result, path.join(tempDir, '.genie', 'state'), 'should use cwd when no argument provided');
+  } finally {
+    process.chdir(previousCwd);
+    cleanupTempDir(tempDir);
+  }
+})();
+
+// Test: resolveTargetStatePath resolves relative paths
+(function testResolveTargetStatePathRelative() {
+  const relative = path.join('tmp', 'state-relative');
+  const result = resolveTargetStatePath(relative);
+  const expected = path.resolve(relative, '.genie', 'state');
+  assert.strictEqual(result, expected, 'should resolve relative path to absolute state directory');
+})();
+
+// Test: resolveBackupsRoot appends backups directory
+(function testResolveBackupsRootStructure() {
+  const cwd = path.join('tmp', 'backups-structure');
+  const result = resolveBackupsRoot(cwd);
+  const expected = path.join(resolveTargetGeniePath(cwd), 'backups');
+  assert.strictEqual(result, expected, 'should append backups directory to genie path');
+})();
+
+// Test: resolveBackupsRoot uses current directory when omitted
+(function testResolveBackupsRootDefaultCwd() {
+  const tempDir = makeTempDir();
+  const previousCwd = process.cwd();
+  process.chdir(tempDir);
+  try {
+    const result = resolveBackupsRoot();
+    assert.strictEqual(result, path.join(tempDir, '.genie', 'backups'), 'should use cwd for default backups path');
+  } finally {
+    process.chdir(previousCwd);
+    cleanupTempDir(tempDir);
+  }
+})();
+
+// Test: resolveBackupsRoot resolves relative paths
+(function testResolveBackupsRootRelative() {
+  const relative = path.join('tmp', 'backups-relative');
+  const result = resolveBackupsRoot(relative);
+  const expected = path.resolve(relative, '.genie', 'backups');
+  assert.strictEqual(result, expected, 'should resolve relative path to backups directory');
+})();
+
+// Test: resolveWorkspaceProviderPath ends with provider.json
+(function testResolveWorkspaceProviderPathFileName() {
+  const result = resolveWorkspaceProviderPath('/tmp/provider-file');
+  assert.strictEqual(path.basename(result), 'provider.json', 'should point to provider.json file');
+})();
+
+// Test: resolveWorkspaceProviderPath default cwd behavior
+(function testResolveWorkspaceProviderPathDefaultCwd() {
+  const tempDir = makeTempDir();
+  const previousCwd = process.cwd();
+  process.chdir(tempDir);
+  try {
+    const result = resolveWorkspaceProviderPath();
+    assert.strictEqual(result, path.join(tempDir, '.genie', 'state', 'provider.json'), 'should resolve using cwd when no argument');
+  } finally {
+    process.chdir(previousCwd);
+    cleanupTempDir(tempDir);
+  }
+})();
+
+// Test: resolveWorkspaceProviderPath resolves relative paths
+(function testResolveWorkspaceProviderPathRelative() {
+  const relative = path.join('tmp', 'provider-relative');
+  const result = resolveWorkspaceProviderPath(relative);
+  const expected = path.resolve(relative, '.genie', 'state', 'provider.json');
+  assert.strictEqual(result, expected, 'should resolve relative provider path to absolute location');
+})();
+
+// Test: resolveWorkspaceVersionPath ends with version.json
+(function testResolveWorkspaceVersionPathFileName() {
+  const result = resolveWorkspaceVersionPath('/tmp/version-file');
+  assert.strictEqual(path.basename(result), 'version.json', 'should point to version.json file');
+})();
+
+// Test: resolveWorkspaceVersionPath default cwd behavior
+(function testResolveWorkspaceVersionPathDefaultCwd() {
+  const tempDir = makeTempDir();
+  const previousCwd = process.cwd();
+  process.chdir(tempDir);
+  try {
+    const result = resolveWorkspaceVersionPath();
+    assert.strictEqual(result, path.join(tempDir, '.genie', 'state', 'version.json'), 'should use cwd for version path when omitted');
+  } finally {
+    process.chdir(previousCwd);
+    cleanupTempDir(tempDir);
+  }
+})();
+
+// Test: resolveWorkspaceVersionPath resolves relative paths
+(function testResolveWorkspaceVersionPathRelative() {
+  const relative = path.join('tmp', 'version-relative');
+  const result = resolveWorkspaceVersionPath(relative);
+  const expected = path.resolve(relative, '.genie', 'state', 'version.json');
+  assert.strictEqual(result, expected, 'should resolve relative version path to absolute location');
+})();
+
+// Test: resolveWorkspacePackageJson points to package.json
+(function testResolveWorkspacePackageJsonFileName() {
+  const result = resolveWorkspacePackageJson('/tmp/package-file');
+  assert.strictEqual(path.basename(result), 'package.json', 'should point to package.json file within .genie');
+})();
+
+// Test: resolveWorkspacePackageJson default cwd behavior
+(function testResolveWorkspacePackageJsonDefaultCwd() {
+  const tempDir = makeTempDir();
+  const previousCwd = process.cwd();
+  process.chdir(tempDir);
+  try {
+    const result = resolveWorkspacePackageJson();
+    assert.strictEqual(result, path.join(tempDir, '.genie', 'package.json'), 'should use cwd when no argument provided');
+  } finally {
+    process.chdir(previousCwd);
+    cleanupTempDir(tempDir);
+  }
+})();
+
+// Test: resolveWorkspacePackageJson resolves relative paths
+(function testResolveWorkspacePackageJsonRelative() {
+  const relative = path.join('tmp', 'package-relative');
+  const result = resolveWorkspacePackageJson(relative);
+  const expected = path.resolve(relative, '.genie', 'package.json');
+  assert.strictEqual(result, expected, 'should resolve relative package path to absolute location');
+})();
+
+// Test: resolveProviderStatusPath ends with provider-status.json
+(function testResolveProviderStatusPathFileName() {
+  const result = resolveProviderStatusPath('/tmp/status-file');
+  assert.strictEqual(path.basename(result), 'provider-status.json', 'should point to provider-status.json file');
+})();
+
+// Test: resolveProviderStatusPath default cwd behavior
+(function testResolveProviderStatusPathDefaultCwd() {
+  const tempDir = makeTempDir();
+  const previousCwd = process.cwd();
+  process.chdir(tempDir);
+  try {
+    const result = resolveProviderStatusPath();
+    assert.strictEqual(result, path.join(tempDir, '.genie', 'state', 'provider-status.json'), 'should use cwd when no argument provided');
+  } finally {
+    process.chdir(previousCwd);
+    cleanupTempDir(tempDir);
+  }
+})();
+
+// Test: resolveProviderStatusPath resolves relative paths
+(function testResolveProviderStatusPathRelative() {
+  const relative = path.join('tmp', 'status-relative');
+  const result = resolveProviderStatusPath(relative);
+  const expected = path.resolve(relative, '.genie', 'state', 'provider-status.json');
+  assert.strictEqual(result, expected, 'should resolve relative status path to absolute location');
+})();
+
+// Test: resolveTempBackupsRoot appends temporary backups directory
+(function testResolveTempBackupsRootStructure() {
+  const cwd = path.join('tmp', 'temp-backups-structure');
+  const result = resolveTempBackupsRoot(cwd);
+  const expected = path.join(cwd, '.genie-backups-temp');
+  assert.strictEqual(result, expected, 'should append .genie-backups-temp to provided cwd');
+})();
+
+// Test: resolveTempBackupsRoot default cwd behavior
+(function testResolveTempBackupsRootDefaultCwd() {
+  const tempDir = makeTempDir();
+  const previousCwd = process.cwd();
+  process.chdir(tempDir);
+  try {
+    const result = resolveTempBackupsRoot();
+    assert.strictEqual(result, path.join(tempDir, '.genie-backups-temp'), 'should base temporary backups path on cwd');
+  } finally {
+    process.chdir(previousCwd);
+    cleanupTempDir(tempDir);
+  }
+})();
+
+// Test: resolveTempBackupsRoot resolves relative inputs
+(function testResolveTempBackupsRootRelative() {
+  const relative = path.join('tmp', 'temp-backups-relative');
+  const result = resolveTempBackupsRoot(relative);
+  const expected = path.join(relative, '.genie-backups-temp');
+  assert.strictEqual(result, expected, 'should append .genie-backups-temp preserving relative resolution semantics');
+  assert.ok(!path.isAbsolute(result), 'relative cwd should yield relative backups path');
+})();
+
+process.chdir(ORIGINAL_CWD);
+console.log('✅ paths tests passed');


### PR DESCRIPTION
<html>
<body>
<h2>Overview</h2>
<p>This PR adds comprehensive documentation and test coverage for the core path utility functions in <code inline="">.genie/cli/src/lib/paths.ts</code>, fully addressing issue <strong>#207</strong>.</p>
<hr>
<h2>Changes Made</h2>
<h3>Documentation Enhancements</h3>
<ul>
<li>
<p>Added <strong>complete JSDoc</strong> coverage for all <strong>14 exported path utility functions</strong></p>
</li>
<li>
<p>Includes:</p>
<ul>
<li>
<p>Clear behavioral descriptions</p>
</li>
<li>
<p>Detailed <code inline="">@param</code> annotations</p>
</li>
<li>
<p>Accurate <code inline="">@returns</code> type information</p>
</li>
<li>
<p>Practical <code inline="">@example</code> usage snippets</p>
</li>
</ul>
</li>
</ul>
<h3>Test Coverage Improvements</h3>
<ul>
<li>
<p>Introduced a brand-new test suite: <code inline="">tests/paths.test.js</code></p>
</li>
<li>
<p><strong>42</strong> total test cases covering:</p>
<ul>
<li>
<p>Absolute vs. relative path handling</p>
</li>
<li>
<p>CWD fallbacks</p>
</li>
<li>
<p>Filesystem traversal scenarios</p>
</li>
<li>
<p>Template type variations</p>
</li>
<li>
<p>Protected directory validation logic</p>
</li>
<li>
<p>Resolution semantics across platforms</p>
</li>
</ul>
</li>
<li>
<p>Test structure follows existing conventions (<code inline="">require('assert')</code>, IIFE structure) as seen in <code inline="">tests/utils.test.js</code></p>
</li>
</ul>
<hr>
<h2>Testing</h2>
<pre><code class="language-bash">node tests/paths.test.js
# ✅ paths tests passed
</code></pre>
<h4>Summary</h4>

Category | Status
-- | --
Functions documented | 14 / 14 ✅
Test cases implemented | 42 ✅
Edge cases covered | ✅
Pattern compliance | ✅ Matches existing test style
Breaking changes | ❌ None


<hr>
<h2>Technical Notes</h2>
<ul>
<li>
<p>Temporary directories used in tests with full cleanup</p>
</li>
<li>
<p>Original working directory restored after each scenario</p>
</li>
<li>
<p>Explicit validation of relative path semantics</p>
</li>
<li>
<p>Cross-platform path behavior considered</p>
</li>
<li>
<p>Comprehensive testing of template type functionality</p>
</li>
</ul>
<hr>
<h2>Related</h2>
<ul>
<li>
<p>Closes: <strong>#207</strong></p>
</li>
<li>
<p>Initiative: <strong>namastexlabs/automagik-roadmap#74</strong></p>
</li>
<li>
<p>Type: Documentation + Test Coverage Enhancement</p>
</li>
</ul>
<hr>
<h2>Checklist</h2>
<ul class="contains-task-list">
<li class="task-list-item">
<p><input type="checkbox" checked="" disabled=""> All functions documented with JSDoc (<code inline="">@param</code>, <code inline="">@returns</code>, <code inline="">@example</code>)</p>
</li>
<li class="task-list-item">
<p><input type="checkbox" checked="" disabled=""> Full test suite added</p>
</li>
<li class="task-list-item">
<p><input type="checkbox" checked="" disabled=""> Edge cases thoroughly validated</p>
</li>
<li class="task-list-item">
<p><input type="checkbox" checked="" disabled=""> Tests pass locally</p>
</li>
<li class="task-list-item">
<p><input type="checkbox" checked="" disabled=""> No breaking changes</p>
</li>
<li class="task-list-item">
<p><input type="checkbox" checked="" disabled=""> Documentation considered clear and helpful</p>
</li>
</ul>
<hr>
</body>
</html>