### PR TITLE
fix: MCP version displays as 0.0.0 instead of actual package version

### DIFF
--- a/.genie/mcp/src/lib/server-helpers.ts
+++ b/.genie/mcp/src/lib/server-helpers.ts
@@ -219,7 +219,8 @@ export async function listSessions(): Promise<Array<{ id: string; name: string; 
 // Helper: Get Genie version from package.json
 export function getGenieVersion(): string {
   try {
-    const packageJsonPath = path.join(__dirname, '..', '..', '..', 'package.json');
+    // From .genie/mcp/dist/lib/server-helpers.js → root package.json (4 levels up)
+    const packageJsonPath = path.join(__dirname, '../../../..', 'package.json');
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
     return packageJson.version || '0.0.0';
   } catch (error) {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,6 @@ If you're reading this in YOUR project (not the template repo):
 
 ## Session Context (Auto-Loaded)
 @.genie/STATE.md
-@.genie/USERCONTEXT.md
 
 ## Primary References
 See `.genie/` directory for comprehensive documentation:


### PR DESCRIPTION
## Summary
Fixes issue #400 where MCP server displayed version as "0.0.0" instead of the actual package version.

## Problem
- MCP server at `.genie/mcp/dist/lib/server-helpers.js` displayed `v0.0.0` in all tool outputs
- Root cause: Incorrect path calculation in `getGenieVersion()` function
- Path went up 3 levels instead of 4 to reach root `package.json`

## Changes
**1. Fixed version path calculation (.genie/mcp/src/lib/server-helpers.ts:223)**
- Changed: `path.join(__dirname, '..', '..', '..', 'package.json')`
- To: `path.join(__dirname, '../../../..', 'package.json')`
- Now correctly resolves from `.genie/mcp/dist/lib/` to root (4 levels up)

**2. Fixed AGENTS.md cross-reference (AGENTS.md:51)**
- Removed `@.genie/USERCONTEXT.md` from auto-loaded session context
- Per Amendment #5: USERCONTEXT.md is gitignored per-user file
- Template exists at `.genie/USERCONTEXT.template.md`

## Verification
- ✅ MCP built successfully: `pnpm run build:mcp`
- ✅ Version retrieval test passed: Returns `2.5.9-rc.2`
- ✅ All tests pass: 19/19 (genie-cli + session-service)
- ✅ Version header displays correctly: `Genie MCP v2.5.9-rc.2`
- ✅ Pre-commit validations passed (cross-references, secrets, tests)
- ✅ Pre-push hooks passed (all tests, commit advisory)

## Testing Evidence
```bash
$ node -e "const helpers = require('./.genie/mcp/dist/lib/server-helpers.js'); console.log('Version:', helpers.getGenieVersion());"
Version: 2.5.9-rc.2

$ pnpm run test:all
✅ All tests passed: 19/19
```

## Impact
- Fixes user-facing bug where MCP version appeared as 0.0.0
- Enables proper version tracking in MCP tool outputs
- Resolves cross-reference validation error in pre-commit hooks

Fixes #400