### PR TITLE
fix(install): Filter Windows PATH in WSL to prevent permission denied errors

### DIFF
--- a/get-genie.sh
+++ b/get-genie.sh
@@ -80,9 +80,19 @@ install_package() {
     esac
 }
 
-# Check if a command exists
+# Check if a command exists (with WSL path filtering)
 command_exists() {
-    command -v "$1" &> /dev/null
+    local cmd="$1"
+    local cmd_path=$(command -v "$cmd" 2>/dev/null)
+
+    # In WSL, ignore Windows paths (mounted under /mnt/)
+    # Windows binaries cannot be executed from Linux context
+    if [[ -n "$cmd_path" ]] && [[ "$cmd_path" == /mnt/* ]]; then
+        return 1  # Treat as not found
+    fi
+
+    # Verify the command is actually executable
+    [ -n "$cmd_path" ] && [ -x "$cmd_path" ]
 }
 
 # Add line to shell profile if not already present


### PR DESCRIPTION
## Summary
Fixes #409 - WSL bug where installation script detects Windows binaries and fails with permission denied errors.

## Problem
- WSL inherits Windows PATH environment
- Installation script finds Windows binaries (e.g., `/mnt/c/nvm4w/nodejs/pnpm`)
- Attempts to execute Windows binaries from Linux → Permission denied
- Installation completely blocked for WSL users

## Root Cause
- `command_exists()` function uses `command -v` without path filtering
- No WSL detection or Windows path exclusion
- Windows executables cannot run from Linux context

## Solution
Enhanced `command_exists()` function in `get-genie.sh`:
- Filters `/mnt/*` paths (Windows mounts in WSL)
- Verifies executables are actually accessible with `-x` test
- Forces installation of Linux-native binaries via corepack/npm

## Testing
✅ Linux-native binaries still detected correctly
✅ Windows binaries at `/mnt/*` paths filtered out
✅ Installation proceeds with Linux-native versions
✅ No permission denied errors

## Impact
- Unblocks WSL users completely
- No behavior change for native Linux/macOS
- Maintains backward compatibility

## Files Changed
- `get-genie.sh` - Enhanced `command_exists()` with WSL path filtering

## Test Plan
1. WSL users: Run installation script
2. Verify Linux-native pnpm/node installed
3. Confirm no permission errors
4. Verify installation completes successfully