### PR TITLE
fix: add body length validation for GitHub releases (#387)

### DIFF
--- a/scripts/release.cjs
+++ b/scripts/release.cjs
@@ -159,7 +159,14 @@ Co-authored-by: Automagik Genie 🧞 <genie@namastex.ai>`;
   log('blue', '🏷️', 'Creating GitHub release...');
   try {
     const changelogSection = extractChangelogSection(stableVersion);
-    const releaseBody = changelogSection || generateStableReleaseNotes(stableVersion);
+    let releaseBody = changelogSection || generateStableReleaseNotes(stableVersion);
+
+    // GitHub has an effective limit of ~125k characters for release body
+    const MAX_GITHUB_BODY = 120000; // Leave buffer below GitHub's limit
+    if (releaseBody.length > MAX_GITHUB_BODY) {
+      log('yellow', '⚠️', `Release body too long (${releaseBody.length} chars), truncating to ${MAX_GITHUB_BODY}...`);
+      releaseBody = releaseBody.substring(0, MAX_GITHUB_BODY) + '\n\n---\n\n*Changelog truncated due to length. See full CHANGELOG.md for details.*';
+    }
 
     exec(`gh release create v${stableVersion} --title "v${stableVersion}" --notes "${releaseBody}" --latest`, true);
     log('green', '✅', 'GitHub release created with changelog content');


### PR DESCRIPTION
## Summary
Prevents GitHub release creation failures when changelog exceeds ~125k character limit.

## Changes
- Added `MAX_GITHUB_BODY` constant (120k with safety buffer)
- Added length validation before creating GitHub release
- Truncates release body with helpful message if too long
- Includes reference to full CHANGELOG.md for complete details

## Testing
- ✅ All tests pass (19/19)
- ✅ Pre-commit validations pass
- ✅ No breaking changes

## Related
- Fixes #387
- Cherry-picked from `forge/9a81-code-fix-default` branch

Co-authored-by: Automagik Genie 🧞 <genie@namastex.ai>