### PR TITLE
revert: back to NODE_AUTH_TOKEN + MASTER→GENIE refactor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  id-token: write  # Required for npm provenance
 
 jobs:
   release:
@@ -86,6 +85,7 @@ jobs:
         id: bump_rc
         env:
           GENIE_SKIP_ADVISORY_SMOKE: "1"
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Checkout main branch (ensure we're not in detached HEAD)
@@ -120,6 +120,7 @@ jobs:
         if: steps.detect.outputs.action == 'tag-push'
         id: tag_push
         env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ github.ref }}"
@@ -141,6 +142,7 @@ jobs:
         id: manual
         env:
           GENIE_SKIP_ADVISORY_SMOKE: "1"
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ACTION="${{ github.event.inputs.action }}"

--- a/scripts/unified-release.cjs
+++ b/scripts/unified-release.cjs
@@ -106,8 +106,7 @@ async function main() {
   if (opts['publish']) {
     log('blue', '📦', 'Publishing to npm...');
     const tag = version.includes('-rc.') ? 'next' : 'latest';
-    // Use --provenance for npm trusted publishers (OIDC auth)
-    exec(`npm publish --tag ${tag} --access public --provenance`, false);
+    exec(`npm publish --tag ${tag} --access public`, false);
     log('green', '✅', `Published to @${tag}`);
   }
 


### PR DESCRIPTION
## Summary
Complete MASTER→GENIE refactor + revert to token-based npm auth

## Changes
1. ✅ MASTER neuron → GENIE neuron (complete refactor)
2. ✅ Fixed repository URL in package.json
3. ✅ Reverted to NODE_AUTH_TOKEN (Trusted Publishers not working with org)
4. ✅ NPM_TOKEN secret updated in GitHub

## Ready to Release
- All tests pass
- NPM_TOKEN configured
- Workflow will publish rc.7 automatically

## Test Plan
- [x] MASTER→GENIE refactor complete  
- [x] Token authentication restored
- [x] NPM_TOKEN secret updated
- [ ] Release workflow publishes successfully