### PR TITLE
Fix: Guard executor arrays in talk.ts before normalizing

### DIFF
--- a/src/cli/commands/talk.ts
+++ b/src/cli/commands/talk.ts
@@ -21,6 +21,20 @@ import fs from 'fs';
 const genieGradient = gradient(['#0066ff', '#9933ff', '#ff00ff']);
 const successGradient = gradient(['#00ff88', '#00ccff', '#0099ff']);
 
+function firstNonEmptyString(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      if (typeof item === 'string' && item.trim().length > 0) {
+        return item;
+      }
+    }
+  }
+  return undefined;
+}
+
 export async function runTalk(
   parsed: ParsedCommand,
   config: GenieConfig,
@@ -39,12 +53,13 @@ export async function runTalk(
   const agentGenie = agentSpec.meta?.genie || {};
 
   // Resolve executor configuration
+  const executorFromAgent = firstNonEmptyString(agentGenie.executor);
   const executorKey = normalizeExecutorKeyOrDefault(
-    agentGenie.executor || config.defaults?.executor
+    executorFromAgent || config.defaults?.executor
   );
+  const variantFromAgent = firstNonEmptyString(agentGenie.executorVariant || agentGenie.variant);
   const executorVariant = (
-    agentGenie.executorVariant ||
-    agentGenie.variant ||
+    variantFromAgent ||
     config.defaults?.executorVariant ||
     'DEFAULT'
   ).trim().toUpperCase();


### PR DESCRIPTION
## 🔗 Linked Issue/Wish

**Linked Issues:**
- Addresses Codex P1 review issue (executor array handling)

**Wish Path:**
N/A

---

## 📝 Summary

Fixes a TypeError in `genie talk` command when agents declare `executor` or `variant` as arrays in their frontmatter (e.g., `analyze.md` declares `executor: [CLAUDE_CODE, CODEX, OPENCODE]`). The command was passing these arrays directly to `normalizeExecutorKeyOrDefault()`, which calls `.trim()` on the input, causing a crash.

---

## 🔧 Changes Implemented

1. **Added `firstNonEmptyString()` helper function**
   - Coerces `unknown | string | string[]` to the first non-empty string
   - Returns `undefined` if no valid string found
   - Handles both string and array inputs safely

2. **Updated executor resolution in `talk.ts`**
   - Extract executor from agent frontmatter using helper before normalizing
   - Extract variant from agent frontmatter using helper before `.trim().toUpperCase()`
   - Preserves precedence: CLI flags > agent frontmatter > config defaults

**Note:** The `run.ts` handler already had proper type guards (`typeof agentGenie.executor === 'string'`), but `talk.ts` was missing them.

---

## ✅ Testing

- [x] Build passes (TypeScript compilation successful)
- [ ] Tests added/updated (no new tests added - existing behavior preserved)
- [ ] Manual testing completed (not tested with actual array executor agents)

**Testing recommendation:** Manually test with `genie talk analyze "test prompt"` to verify the fix works with agents that declare executor as an array.

---

## 💥 Breaking Changes

- [x] No

---

## 🔍 Review Focus Areas

1. **Helper function correctness**: Does `firstNonEmptyString()` handle all expected input types correctly? Are there edge cases we're missing?
2. **Completeness**: Are there other commands or MCP tools that might have similar issues with agent frontmatter arrays?
3. **Precedence preservation**: Verify that the precedence logic (CLI flags > agent frontmatter > config defaults) is still correct after the changes.
4. **P2 issue**: The Codex review also mentioned a P2 issue about task URL construction in `task-monitor.ts`, but this file doesn't exist in the current codebase. All current URL construction uses the correct pattern (`/projects/{projectId}/tasks/{taskId}/attempts/{attemptId}`). Should we investigate further or is this truly outdated?

---

## 📚 Additional Context

**Codex Review Context:**
- P1 (Critical): Executor arrays not guarded - **FIXED in this PR**
- P2 (Medium): Task monitor prints unusable task URL - **Appears outdated** (file doesn't exist, all current URLs are correct)

**Investigation findings:**
- Only `talk.ts` had the executor array issue; `run.ts` already had proper guards
- No agents currently declare `variant` as an array (only `executor`)
- All current Forge URL construction follows the correct pattern

---

<!--
🤖 Devin Session: https://app.devin.ai/sessions/baeeb455e96a49e3a7bd5a7ac8e460df
👤 Requested by: Felipe Rosa (felipe@namastex.ai) / @namastex888
-->