### PR TITLE
fix: default run command to foreground (interactive) mode

### DIFF
--- a/src/cli/lib/config.ts
+++ b/src/cli/lib/config.ts
@@ -16,7 +16,7 @@ const BASE_CONFIG: GenieConfig = {
   defaults: {
     executor: 'OPENCODE',
     executorVariant: 'DEFAULT',
-    background: true
+    background: false
   },
   paths: {
     baseDir: undefined,
@@ -96,7 +96,7 @@ export function loadConfig(): GenieConfig {
   config.defaults = config.defaults || {};
   if (!config.defaults.executor) config.defaults.executor = 'OPENCODE';
   if (!config.defaults.executorVariant) config.defaults.executorVariant = 'DEFAULT';
-  config.defaults.background = config.defaults.background ?? true;
+  config.defaults.background = config.defaults.background ?? false;
 
   config.forge = config.forge || { executors: {} };
   config.forge.executors = config.forge.executors || {};
@@ -135,7 +135,14 @@ export function prepareDirectories(paths: Required<ConfigPaths>): void {
 }
 
 export function applyDefaults(options: CLIOptions, defaults?: GenieConfig['defaults']): void {
-  if (options.background === undefined) {
-    options.background = defaults?.background ?? true;
+  // Only apply config defaults if user hasn't explicitly set --background or --no-background
+  // The run command defaults to foreground (interactive) mode, so we don't force background: true
+  // Users can still pass --background to enable headless mode
+  if (!options.backgroundExplicit && defaults?.background !== undefined) {
+    // Respect explicit config override, but don't force background: true by default
+    // This allows the run command to default to foreground (interactive) mode
+    options.background = defaults.background;
   }
+  // Note: if backgroundExplicit is false and defaults.background is undefined,
+  // options.background stays as initialized (false), enabling foreground mode
 }


### PR DESCRIPTION
- Change BASE_CONFIG.defaults.background from true to false
- Add --no-background flag support for explicit foreground mode
- Update applyDefaults to respect explicit user preferences

This fixes P1 issue where run command was unreachable in interactive mode because config forced background: true by default. Now genie run defaults to foreground (browser+monitoring) mode, and users can opt into headless mode with --background flag.

## 🔗 Linked Issue/Wish (Optional but Recommended)

<!-- Link to issue using GitHub keywords below (one per line): -->
<!-- - Closes #123 -->
<!-- - Fixes #456 -->
<!-- - Resolves #789 -->

<!-- Or reference wish implementation: -->
<!-- Implements: .genie/wishes/my-feature.md -->

**Linked Issues:**
<!-- - Closes #number or N/A -->

**Wish Path:**
<!-- .genie/wishes/file.md or N/A -->

---

## 📝 Summary

<!-- Brief description of what this PR does -->

---

## 🔧 Changes Implemented

<!-- Bulleted list or sections of changes -->

1. **Component 1**
   - Change A
   - Change B

2. **Component 2**
   - Change C

---

## ✅ Testing

<!-- What testing was done? -->

- [ ] Tests added/updated
- [ ] All tests passing locally
- [ ] Manual testing completed

<!-- Add testing details if needed -->

---

## 💥 Breaking Changes

<!-- Does this introduce breaking changes? -->

- [ ] Yes (describe migration path below)
- [x] No

<!-- If yes, describe migration path: -->

---

## 📸 Screenshots/Evidence (Optional)

<!-- Add screenshots, logs, or other evidence -->

<details>
<summary>Before/After</summary>

<!-- Images or code snippets here -->

</details>

---

## 📚 Additional Context (Optional)

<!-- Any other relevant information -->

---

<!--
🤖 Automation Notes:
- If issue linked: PR inherits labels (type:*, priority:*, area:*) from issue
- If wish path provided: PR marked for archival on merge
- No issue link required for quick fixes, typos, or external contributions
-->
