### PR TITLE
fix: restore SessionService alias and persist task completion status

### DIFF
--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -185,6 +185,14 @@ export async function runRun(
       }
     });
 
+    // Persist final task status to local store
+    const updatedStore = sessionService.load();
+    if (updatedStore.sessions[attemptId]) {
+      updatedStore.sessions[attemptId].status = result.status;
+      updatedStore.sessions[attemptId].lastUsed = new Date().toISOString();
+      await sessionService.save(updatedStore);
+    }
+
     if (raw) {
       console.log(result.output);
     } else {
@@ -218,6 +226,14 @@ export async function runRun(
 
     process.exitCode = result.status === 'completed' ? 0 : 1;
   } catch (error) {
+    // Update status to error on monitoring failure
+    const errorStore = sessionService.load();
+    if (errorStore.sessions[attemptId]) {
+      errorStore.sessions[attemptId].status = 'error';
+      errorStore.sessions[attemptId].lastUsed = new Date().toISOString();
+      await sessionService.save(errorStore);
+    }
+
     console.error('');
     console.error('❌ Monitoring failed:', error);
     console.error('');


### PR DESCRIPTION
- Add SessionService as backward compatibility alias for TaskService
- Add SessionServiceOptions type alias for TaskServiceOptions
- Persist task completion status to local store after monitoring
- Update lastUsed timestamp when task completes or fails

This fixes P1 (SessionService export removal breaking backward compatibility) and P2 (task status stuck as 'running' after completion).

## 🔗 Linked Issue/Wish (Optional but Recommended)

<!-- Link to issue using GitHub keywords below (one per line): -->
<!-- - Closes #123 -->
<!-- - Fixes #456 -->
<!-- - Resolves #789 -->

<!-- Or reference wish implementation: -->
<!-- Implements: .genie/wishes/my-feature.md -->

**Linked Issues:**
<!-- - Closes #number or N/A -->

**Wish Path:**
<!-- .genie/wishes/file.md or N/A -->

---

## 📝 Summary

<!-- Brief description of what this PR does -->

---

## 🔧 Changes Implemented

<!-- Bulleted list or sections of changes -->

1. **Component 1**
   - Change A
   - Change B

2. **Component 2**
   - Change C

---

## ✅ Testing

<!-- What testing was done? -->

- [ ] Tests added/updated
- [ ] All tests passing locally
- [ ] Manual testing completed

<!-- Add testing details if needed -->

---

## 💥 Breaking Changes

<!-- Does this introduce breaking changes? -->

- [ ] Yes (describe migration path below)
- [x] No

<!-- If yes, describe migration path: -->

---

## 📸 Screenshots/Evidence (Optional)

<!-- Add screenshots, logs, or other evidence -->

<details>
<summary>Before/After</summary>

<!-- Images or code snippets here -->

</details>

---

## 📚 Additional Context (Optional)

<!-- Any other relevant information -->

---

<!--
🤖 Automation Notes:
- If issue linked: PR inherits labels (type:*, priority:*, area:*) from issue
- If wish path provided: PR marked for archival on merge
- No issue link required for quick fixes, typos, or external contributions
-->
