### PR TITLE
fix: auto-open browser on genie init (#492)

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -519,6 +519,21 @@ export async function runInit(
       console.log('🧞 Master Genie is orchestrating installation...');
       console.log(`📊 Monitor progress: ${dashboardUrl}`);
       console.log('');
+
+      // Open browser with installation dashboard
+      try {
+        const { getBrowserOpenCommand } = await import('../lib/cli-utils.js');
+        const openCommand = getBrowserOpenCommand();
+        execSync(`${openCommand} "${dashboardUrl}"`, { stdio: 'ignore' });
+
+        console.log('🌐 Opening browser with installation dashboard...');
+        console.log('');
+      } catch (browserError) {
+        // Non-fatal: browser opening failed, user can still access URL manually
+        console.log('⚠️  Could not open browser automatically');
+        console.log(`   Visit: ${dashboardUrl}`);
+        console.log('');
+      }
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary
Fixes #492 - Adds automatic browser opening to installation flow

## Problem
When running `genie init`, the installation dashboard URL was only printed to console, requiring users to manually copy and paste it into their browser. This created an inconsistent experience compared to the update flow, which automatically opens the browser.

## Solution
Added browser auto-open functionality to the installation flow by mirroring the pattern already used in the update flow (init.ts:436-453).

### Changes
- Added browser auto-open after `runInstallFlow()` returns dashboard URL
- Reuses existing `getBrowserOpenCommand()` from `cli-utils.ts`
- Handles platform detection (macOS, Windows, Linux, WSL)
- Non-fatal: gracefully falls back to manual URL if browser opening fails
- Consistent UX: matches update workflow behavior

### Files Modified
- `src/cli/commands/init.ts`: Added browser open logic (15 lines)

## Testing
- ✅ TypeScript syntax verified (uses existing execSync import)
- ✅ Pattern matches proven update flow implementation
- ✅ WSL compatibility via `cli-utils.ts` detection
- ✅ Non-fatal error handling (won't break init if browser fails)

## Impact
- Improved UX: Users no longer need to manually copy/paste installation URLs
- Consistent behavior: Installation and update flows now both auto-open browser
- Cross-platform: Works on macOS, Windows, Linux, and WSL environments