### PR TITLE
fix: release workflow — use notes-file and cap initial changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
         if: steps.exists.outputs.skip != 'true'
         with:
           config: cliff.toml
-          args: ${{ steps.prev.outputs.tag && format('{0}..HEAD', steps.prev.outputs.tag) || '' }}
+          args: ${{ steps.prev.outputs.tag && format('{0}..HEAD', steps.prev.outputs.tag) || 'HEAD~20..HEAD' }}
         env:
           GITHUB_REPO: ${{ github.repository }}
 
@@ -68,10 +68,11 @@ jobs:
           RELEASE_NOTES: ${{ steps.cliff.outputs.content }}
         run: |
           TAG="v${{ steps.pkg.outputs.version }}"
+          printf '%s' "$RELEASE_NOTES" > /tmp/release-notes.md
           gh release create "${TAG}" \
             --target "${{ github.sha }}" \
             --title "${TAG}" \
-            --notes "$RELEASE_NOTES"
+            --notes-file /tmp/release-notes.md
 
       - name: Setup Bun
         if: steps.exists.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

Fixes the release workflow failure on v3 promotion merge (run #22799429132).

- **`--notes-file` instead of `--notes`**: Write release notes to a temp file before passing to `gh release create`. The v3 promotion merge brought full v2 history, making the changelog too large for a shell argument ("Argument list too long").
- **Cap initial changelog**: When no previous release tag exists, limit git-cliff to `HEAD~20..HEAD` instead of traversing the entire history.

## Test plan

- [ ] After merge: release workflow triggers and completes successfully
- [ ] GitHub release is created with a reasonable changelog
- [ ] npm publish step runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release workflow for better changelog generation and release notes handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->