### PR TITLE
fix: release workflow — use github.token and handle first release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Check if release already exists
         id: exists
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           TAG="v${{ steps.pkg.outputs.version }}"
 
@@ -44,7 +44,7 @@ jobs:
         id: prev
         if: steps.exists.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           TAG="v${{ steps.pkg.outputs.version }}"
           PREV=$(gh release list --limit 50 --json tagName -q '.[].tagName' | grep -v "^${TAG}$" | head -1)
@@ -54,21 +54,24 @@ jobs:
       - name: Generate changelog
         uses: orhun/git-cliff-action@v4
         id: cliff
-        if: steps.exists.outputs.skip != 'true'
+        if: steps.exists.outputs.skip != 'true' && steps.prev.outputs.tag != ''
         with:
           config: cliff.toml
-          args: ${{ steps.prev.outputs.tag && format('{0}..HEAD', steps.prev.outputs.tag) || 'HEAD~20..HEAD' }}
+          args: ${{ format('{0}..HEAD', steps.prev.outputs.tag) }}
         env:
           GITHUB_REPO: ${{ github.repository }}
 
       - name: Create release
         if: steps.exists.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          RELEASE_NOTES: ${{ steps.cliff.outputs.content }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           TAG="v${{ steps.pkg.outputs.version }}"
-          printf '%s' "$RELEASE_NOTES" > /tmp/release-notes.md
+          NOTES="${{ steps.cliff.outputs.content }}"
+          if [ -z "$NOTES" ]; then
+            NOTES="Initial release of genie v3 CLI."
+          fi
+          printf '%s' "$NOTES" > /tmp/release-notes.md
           gh release create "${TAG}" \
             --target "${{ github.sha }}" \
             --title "${TAG}" \


### PR DESCRIPTION
## Summary

Fixes the release workflow that's been failing on every push to main since v3 promotion.

**Root causes:**
1. `secrets.RELEASE_PLEASE_TOKEN` was never set — `gh` CLI exits with code 4 (auth error)
2. No previous release tag exists, so git-cliff traverses the entire v2 merge history, generating a changelog too large for shell arguments

**Fixes:**
- Use `github.token` (built-in, already has `contents: write` permission) instead of a custom secret
- Skip git-cliff entirely when no previous release tag exists
- Fall back to "Initial release of genie v3 CLI." as release notes
- Write notes to a temp file (`--notes-file`) to avoid argument length limits

## Test plan

- [ ] After merge: release workflow triggers and creates GitHub release `v3.260302.2`
- [ ] npm publish step runs successfully
- [ ] `npm info @automagik/genie` shows the published version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow automation to enhance authentication handling and release notes generation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->