### PR TITLE
fix: release workflow — shell injection and tag ancestry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,14 @@ jobs:
         run: |
           TAG="v${{ steps.pkg.outputs.version }}"
           PREV=$(gh release list --limit 50 --json tagName -q '.[].tagName' | grep -v "^${TAG}$" | head -1)
-          echo "tag=${PREV:-}" >> "$GITHUB_OUTPUT"
-          echo "Previous release tag: ${PREV:-none}"
+          # Verify the tag is reachable from HEAD (same history line)
+          if [ -n "$PREV" ] && git merge-base --is-ancestor "$PREV" HEAD 2>/dev/null; then
+            echo "tag=${PREV}" >> "$GITHUB_OUTPUT"
+            echo "Previous release tag: ${PREV}"
+          else
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            echo "Previous release tag not reachable from HEAD — treating as initial release"
+          fi
 
       - name: Generate changelog
         uses: orhun/git-cliff-action@v4
@@ -65,13 +71,13 @@ jobs:
         if: steps.exists.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_NOTES: ${{ steps.cliff.outputs.content }}
         run: |
           TAG="v${{ steps.pkg.outputs.version }}"
-          NOTES="${{ steps.cliff.outputs.content }}"
-          if [ -z "$NOTES" ]; then
-            NOTES="Initial release of genie v3 CLI."
+          if [ -z "$RELEASE_NOTES" ]; then
+            RELEASE_NOTES="Initial release of genie v3 CLI."
           fi
-          printf '%s' "$NOTES" > /tmp/release-notes.md
+          printf '%s' "$RELEASE_NOTES" > /tmp/release-notes.md
           gh release create "${TAG}" \
             --target "${{ github.sha }}" \
             --title "${TAG}" \


### PR DESCRIPTION
## Summary

Fixes remaining release workflow failures after v3 promotion.

**Bug 1: Shell injection from changelog backticks**
- `NOTES="${{ steps.cliff.outputs.content }}"` injected backtick-wrapped commit hashes directly into bash, causing them to be interpreted as command substitutions
- Fix: pass changelog via `RELEASE_NOTES` env var (set by the runner, not shell-interpreted)

**Bug 2: Cross-history changelog**  
- Previous release tag `v2.5.28-rc.4` exists but is on the v2 history (unrelated to v3)
- git-cliff generating `v2.5.28-rc.4..HEAD` traverses the merge boundary into all v2 commits
- Fix: verify the tag is reachable from HEAD via `git merge-base --is-ancestor` before using it

## Test plan

- [ ] After merge: release workflow creates GitHub release with "Initial release of genie v3 CLI."
- [ ] npm publish completes
- [ ] Future releases with proper v3 tags generate normal changelogs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation and validation process to ensure accurate release note generation and proper handling of initial releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->