### PR TITLE
fix: release workflow — disable husky in CI publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,7 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+          HUSKY: "0"
         run: |
           if [ -z "$NPM_TOKEN" ]; then
             echo "ERROR: NPM_TOKEN secret is not set. Cannot publish to npm." >&2


### PR DESCRIPTION
## Summary

Fixes npm publish failure in release workflow. `bun publish` triggers the `prepare` script which runs `husky`, but husky is not installed in CI.

- Set `HUSKY=0` env var to skip husky during publish
- Deleted the failed `v3.260302.2` release so the workflow can retry

## Test plan

- [ ] After merge: full release pipeline completes (release + npm publish)
- [ ] `npm info @automagik/genie` shows v3.260302.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration for improved publishing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->