### PR TITLE
fix: remove invalid string-path fields from plugin manifest

### DIFF
--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -7,9 +7,5 @@
   },
   "repository": "https://github.com/automagik-dev/genie",
   "license": "MIT",
-  "keywords": ["workflow", "orchestration", "collaboration", "claude-code", "tmux", "agents"],
-  "skills": "./skills",
-  "hooks": "./hooks/hooks.json",
-  "agents": "./agents",
-  "settings": "./settings.json"
+  "keywords": ["workflow", "orchestration", "collaboration", "claude-code", "tmux", "agents"]
 }


### PR DESCRIPTION
## Summary

- Remove `agents`, `settings`, `skills`, and `hooks` string-path fields from `plugin.json` that caused validation errors (`agents: Invalid input, settings: Invalid input: expected record, received string`)
- These resources are auto-discovered by convention from the plugin root and should not be declared in the manifest

## Test plan

- [ ] Run `claude --plugin-dir ./plugins/genie` and verify no validation errors
- [ ] Check `/help` to confirm skills are listed under `automagik-genie:` namespace
- [ ] Check `/agents` to verify agents are discovered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined plugin configuration by removing unused extension point declarations, resulting in a simplified plugin manifest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->