### PR TITLE
fix(plugin): remove invalid manifest fields that block installation

### DIFF
--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -7,9 +7,5 @@
   },
   "repository": "https://github.com/automagik-dev/genie",
   "license": "MIT",
-  "keywords": ["workflow", "orchestration", "collaboration", "claude-code", "tmux", "agents"],
-  "skills": "./skills",
-  "hooks": "./hooks/hooks.json",
-  "agents": "./agents",
-  "settings": "./settings.json"
+  "keywords": ["workflow", "orchestration", "collaboration", "claude-code", "tmux", "agents"]
 }


### PR DESCRIPTION
## Summary
- Removes `agents`, `skills`, `hooks`, and `settings` string-path declarations from `plugin.json`
- These fields are auto-discovered by Claude Code from the plugin root — declaring them as strings fails manifest validation
- Fixes: `agents: Invalid input, settings: Invalid input: expected record, received string`

## Test plan
- [ ] Run `/plugin` → install genie → should succeed without validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin configuration by removing exported paths for skills, hooks, agents, and settings components. This streamlines the plugin manifest structure without affecting existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->