### PR TITLE
fix(hooks): update auto-spawn to use top-level genie spawn command

### DIFF
--- a/src/hooks/handlers/auto-spawn.ts
+++ b/src/hooks/handlers/auto-spawn.ts
@@ -3,7 +3,7 @@
  *
  * When an agent sends a message to a recipient that doesn't have a live
  * tmux pane, this handler attempts to respawn them from their saved
- * template (created during the original `genie agent spawn`).
+ * template (created during the original `genie spawn`).
  *
  * Resolution order (directory-aware):
  *   1. Check worker registry for live pane → skip if alive
@@ -78,9 +78,9 @@ export async function autoSpawn(payload: HookPayload): Promise<HandlerResult> {
       return;
     }
 
-    // Respawn via genie agent spawn (non-blocking fork)
+    // Respawn via genie spawn (non-blocking fork)
     const { spawnSync } = require('node:child_process') as typeof import('node:child_process');
-    const args = ['agent', 'spawn', '--provider', template.provider, '--team', template.team];
+    const args = ['spawn', '--provider', template.provider, '--team', template.team];
     if (template.role) args.push('--role', template.role);
     if (template.skill) args.push('--skill', template.skill);
     if (template.cwd) args.push('--cwd', template.cwd);

--- a/src/hooks/handlers/identity-inject.ts
+++ b/src/hooks/handlers/identity-inject.ts
@@ -17,7 +17,7 @@ export async function identityInject(payload: HookPayload): Promise<HandlerResul
   const msgType = input.type as string | undefined;
   if (msgType !== 'message' && msgType !== 'broadcast') return;
 
-  // Resolve agent name from env (set by genie agent spawn via GENIE_AGENT_NAME)
+  // Resolve agent name from env (set by genie spawn via GENIE_AGENT_NAME)
   const agentName = process.env.GENIE_AGENT_NAME;
   if (!agentName) return;
 

--- a/src/hooks/inject.ts
+++ b/src/hooks/inject.ts
@@ -1,7 +1,7 @@
 /**
  * Hook Injection — writes CC hook config into team settings.json
  *
- * Called during `genie agent spawn` to ensure every spawned agent
+ * Called during `genie spawn` to ensure every spawned agent
  * routes its hook events through `genie hook dispatch`.
  */
 
@@ -109,7 +109,7 @@ async function injectIntoFile(settingsPath: string): Promise<boolean> {
 
 /**
  * Inject hook dispatch config into a team's settings.json.
- * Called automatically during `genie agent spawn`.
+ * Called automatically during `genie spawn`.
  */
 export async function injectTeamHooks(teamName: string): Promise<boolean> {
   const path = teamSettingsPath(teamName);


### PR DESCRIPTION
## Summary

- Auto-spawn hook was invoking `genie agent spawn` which no longer exists (agent namespace removed in v2 redesign)
- Updated to use top-level `genie spawn` command
- Found by Codex review on PR #536

## Changes

- `src/hooks/handlers/auto-spawn.ts`: Remove `'agent'` from spawn args array
- Update related comments

## Test Plan

- [ ] `bun run typecheck` passes
- [ ] `grep -rn '"agent", "spawn"' src/` returns nothing