### PR TITLE
fix(spawn): pass CWD to tmux split-window via -c flag

### DIFF
--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -502,7 +502,8 @@ async function launchTmuxSpawn(ctx: SpawnCtx): Promise<void> {
 
   let paneId: string;
   try {
-    const splitCmd = `tmux split-window -d ${splitTarget} -P -F '#{pane_id}' ${ctx.fullCommand}`;
+    const cwdFlag = ctx.cwd ? `-c '${ctx.cwd}'` : '';
+    const splitCmd = `tmux split-window -d ${splitTarget} ${cwdFlag} -P -F '#{pane_id}' ${ctx.fullCommand}`;
     paneId = execSync(splitCmd, { encoding: 'utf-8' }).trim();
   } catch (err) {
     console.error(`Failed to create tmux pane: ${err instanceof Error ? err.message : 'unknown error'}`);


### PR DESCRIPTION
## Summary

One-line fix: add `-c '${ctx.cwd}'` to `tmux split-window` command so spawned agents start in the team's worktree directory instead of inheriting the parent pane's CWD.

## Root Cause

`launchTmuxSpawn()` line 505 ran `tmux split-window` without a `-c` flag, so the new pane inherited the leader's `process.cwd()`. The worktree CWD override from PR #560 (`ctx.cwd = teamConfig.worktreePath`) was set correctly but never passed to tmux.

Closes #562

## Test plan

```bash
# From any CWD (e.g., PM agent dir)
genie team create qa-test --repo /path/to/repo --branch dev
genie spawn tester --team qa-test
# Tester pane should show /path/to/repo/.worktrees/qa-test/
```