### PR TITLE
feat: auto-kickoff leader on wish spawn + orchestration rules audit

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -657,8 +657,6 @@ inject_orchestration_prompt() {
     mkdir -p "$rules_dir"
 
     cat > "$rules_file" <<'ORCHESTRATION_EOF'
-<!-- SOURCE OF TRUTH: This content is injected into ~/.claude/rules/genie-orchestration.md
-     by install.sh and smart-install.js. Edits here must be copied to both scripts. -->
 <GENIE_CLI>
 # Genie CLI — MANDATORY Agent Orchestration
 
@@ -679,8 +677,8 @@ If you catch yourself about to use Agent, SendMessage, TeamCreate, or TeamDelete
 ```bash
 genie spawn <role>                         # Spawn agent (implementor, tests, review, fix, refactor)
 genie kill <name>                          # Force kill agent
-genie stop <name>                          # Graceful stop
-genie ls                                   # List all agents
+genie stop <name>                          # Graceful stop (preserves session for resume)
+genie ls                                   # List all agents with status
 genie history <name>                       # Session history
 genie read <name> --follow                 # Tail terminal output
 genie answer <name> <choice>               # Answer prompt (1-9 or text:...)
@@ -698,11 +696,23 @@ genie inbox [agent]                        # View message inbox
 ### Teams
 
 ```bash
-genie team create <name> --repo <path>     # Create a team
+genie team create <name> --repo <path>     # Create team with git worktree
+genie team create <name> --repo <path> --wish <slug>  # Create team + auto-spawn task leader
 genie team hire <agent>                    # Add agent to team
 genie team fire <agent>                    # Remove agent from team
 genie team ls [name]                       # List teams or team members
 genie team disband <name>                  # Disband and clean up team
+genie team done <name>                     # Mark team as done
+genie team blocked <name>                  # Mark team as blocked
+```
+
+### Agent Directory
+
+```bash
+genie dir add <name> --dir <path>          # Register agent directory
+genie dir rm <name>                        # Remove agent from directory
+genie dir ls [name]                        # List agents or agent details
+genie dir edit <name>                      # Edit agent config
 ```
 
 ### Dispatch (Skill-Bound Work)
@@ -720,6 +730,14 @@ genie review <agent> <ref>                 # Dispatch review
 genie done <ref>                           # Mark group/task done
 genie status <slug>                        # Check wish/group status
 genie reset <ref>                          # Reset stuck group
+```
+
+### System
+
+```bash
+genie update                               # Update to latest stable version
+genie update --next                        # Switch to dev builds (npm @next tag)
+genie update --stable                      # Switch to stable releases (npm @latest tag)
 ```
 
 ## 3. Skill Flow — Auto-Invocation Chain
@@ -745,7 +763,17 @@ Skills trigger the next step automatically where possible:
   Decisions stuck after 2+ exchanges ──▸ suggest /council
 ```
 
-## 4. Team Lifecycle
+## 4. Task Leader Workflow
+
+For autonomous wish execution, use `--wish` to spawn a task leader that works without manual intervention:
+
+```bash
+genie team create <name> --repo <path> --wish <slug>
+```
+
+This creates the team, copies the wish into the worktree, hires a leader, and auto-sends a kickoff prompt so the leader begins immediately — no manual `genie send` needed.
+
+## 5. Team Lifecycle
 
 ```
 create team ──▸ hire agents ──▸ dispatch work ──▸ review ──▸ PR to dev ──▸ QA ──▸ disband
@@ -758,9 +786,16 @@ create team ──▸ hire agents ──▸ dispatch work ──▸ review ─�
 5. Workers signal completion via `genie send`; leader runs `/review`
 6. Create PR targeting `dev`. CI must be green before merge.
 7. QA loop on dev: test against wish criteria → `/fix` → retest
-8. `genie team disband <name>` — clean up when done
+8. If `autoMergeDev` config is true, leader merges PR to dev automatically. Otherwise, leave PR open for human review.
+9. `genie team disband <name>` — clean up when done
 
-## 5. Rules
+## 6. Configuration
+
+Key config options in `~/.genie/config.json`:
+
+- **`autoMergeDev`** (boolean, default: false) — When true, task leaders can auto-merge PRs to `dev` after CI passes. When false (default), PRs are left open for human review.
+
+## 7. Rules
 
 - **No native tools.** All agent/team/messaging operations go through `genie` CLI.
 - **Role separation.** Leader orchestrates; workers implement. Workers never spawn other agents.

--- a/plugins/genie/scripts/smart-install.js
+++ b/plugins/genie/scripts/smart-install.js
@@ -260,8 +260,8 @@ If you catch yourself about to use Agent, SendMessage, TeamCreate, or TeamDelete
 \`\`\`bash
 genie spawn <role>                         # Spawn agent (implementor, tests, review, fix, refactor)
 genie kill <name>                          # Force kill agent
-genie stop <name>                          # Graceful stop
-genie ls                                   # List all agents
+genie stop <name>                          # Graceful stop (preserves session for resume)
+genie ls                                   # List all agents with status
 genie history <name>                       # Session history
 genie read <name> --follow                 # Tail terminal output
 genie answer <name> <choice>               # Answer prompt (1-9 or text:...)
@@ -279,11 +279,23 @@ genie inbox [agent]                        # View message inbox
 ### Teams
 
 \`\`\`bash
-genie team create <name> --repo <path>     # Create a team
+genie team create <name> --repo <path>     # Create team with git worktree
+genie team create <name> --repo <path> --wish <slug>  # Create team + auto-spawn task leader
 genie team hire <agent>                    # Add agent to team
 genie team fire <agent>                    # Remove agent from team
 genie team ls [name]                       # List teams or team members
 genie team disband <name>                  # Disband and clean up team
+genie team done <name>                     # Mark team as done
+genie team blocked <name>                  # Mark team as blocked
+\`\`\`
+
+### Agent Directory
+
+\`\`\`bash
+genie dir add <name> --dir <path>          # Register agent directory
+genie dir rm <name>                        # Remove agent from directory
+genie dir ls [name]                        # List agents or agent details
+genie dir edit <name>                      # Edit agent config
 \`\`\`
 
 ### Dispatch (Skill-Bound Work)
@@ -301,6 +313,14 @@ genie review <agent> <ref>                 # Dispatch review
 genie done <ref>                           # Mark group/task done
 genie status <slug>                        # Check wish/group status
 genie reset <ref>                          # Reset stuck group
+\`\`\`
+
+### System
+
+\`\`\`bash
+genie update                               # Update to latest stable version
+genie update --next                        # Switch to dev builds (npm @next tag)
+genie update --stable                      # Switch to stable releases (npm @latest tag)
 \`\`\`
 
 ## 3. Skill Flow — Auto-Invocation Chain
@@ -326,7 +346,17 @@ Skills trigger the next step automatically where possible:
   Decisions stuck after 2+ exchanges ──▸ suggest /council
 \`\`\`
 
-## 4. Team Lifecycle
+## 4. Task Leader Workflow
+
+For autonomous wish execution, use \`--wish\` to spawn a task leader that works without manual intervention:
+
+\`\`\`bash
+genie team create <name> --repo <path> --wish <slug>
+\`\`\`
+
+This creates the team, copies the wish into the worktree, hires a leader, and auto-sends a kickoff prompt so the leader begins immediately — no manual \`genie send\` needed.
+
+## 5. Team Lifecycle
 
 \`\`\`
 create team ──▸ hire agents ──▸ dispatch work ──▸ review ──▸ PR to dev ──▸ QA ──▸ disband
@@ -339,9 +369,16 @@ create team ──▸ hire agents ──▸ dispatch work ──▸ review ─�
 5. Workers signal completion via \`genie send\`; leader runs \`/review\`
 6. Create PR targeting \`dev\`. CI must be green before merge.
 7. QA loop on dev: test against wish criteria → \`/fix\` → retest
-8. \`genie team disband <name>\` — clean up when done
+8. If \`autoMergeDev\` config is true, leader merges PR to dev automatically. Otherwise, leave PR open for human review.
+9. \`genie team disband <name>\` — clean up when done
 
-## 5. Rules
+## 6. Configuration
+
+Key config options in \`~/.genie/config.json\`:
+
+- **\`autoMergeDev\`** (boolean, default: false) — When true, task leaders can auto-merge PRs to \`dev\` after CI passes. When false (default), PRs are left open for human review.
+
+## 7. Rules
 
 - **No native tools.** All agent/team/messaging operations go through \`genie\` CLI.
 - **Role separation.** Leader orchestrates; workers implement. Workers never spawn other agents.

--- a/src/lib/provider-adapters.ts
+++ b/src/lib/provider-adapters.ts
@@ -74,6 +74,8 @@ export interface SpawnParams {
   promptMode?: 'system' | 'append';
   /** Model override (e.g., 'sonnet', 'opus'). Emits --model flag. */
   model?: string;
+  /** Initial prompt to send as the first user message (Claude Code positional [prompt] arg). */
+  initialPrompt?: string;
 }
 
 /** Result of a successful launch-command build. */
@@ -118,6 +120,7 @@ const spawnParamsSchema = z.object({
   systemPrompt: z.string().optional(),
   promptMode: z.enum(['system', 'append']).optional(),
   model: z.string().optional(),
+  initialPrompt: z.string().optional(),
 });
 
 /**
@@ -267,6 +270,11 @@ export function buildClaudeCommand(params: SpawnParams): LaunchCommand {
 
   if (params.extraArgs) {
     for (const arg of params.extraArgs) parts.push(escapeShellArg(arg));
+  }
+
+  // Positional [prompt] arg must be last — becomes the first user message
+  if (params.initialPrompt) {
+    parts.push(escapeShellArg(params.initialPrompt));
   }
 
   return {

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -653,6 +653,8 @@ export interface SpawnOptions {
   permissionMode?: string;
   extraArgs?: string[];
   cwd?: string;
+  /** Initial prompt to send as the first user message (Claude Code positional [prompt] arg). */
+  initialPrompt?: string;
 }
 
 /** Resolve agent from directory, returning entry + derived CWD/identity/model/systemPrompt. */
@@ -708,6 +710,7 @@ async function buildSpawnParams(
     systemPromptFile: agent.identityPath ?? undefined,
     systemPrompt: agent.systemPrompt,
     promptMode: agent.entry.promptMode,
+    initialPrompt: options.initialPrompt,
   };
 
   const { parentSessionId, spawnColor, nativeTeam } = await resolveNativeTeam(team, agent.repoPath, {

--- a/src/term-commands/team.ts
+++ b/src/term-commands/team.ts
@@ -231,12 +231,14 @@ async function spawnLeaderWithWish(config: TeamConfig, slug: string, repoPath: s
   ].join('\n');
   const contextFile = await writeContextFile(contextContent);
 
-  // Spawn leader in the worktree
+  // Spawn leader in the worktree with auto-kickoff prompt
+  const kickoffPrompt = `Begin. Read the wish at .genie/wishes/${slug}/WISH.md and execute the full lifecycle autonomously. Your team is ${config.name}.`;
   await handleWorkerSpawn('leader', {
     provider: 'claude',
     team: config.name,
     cwd: config.worktreePath,
     extraArgs: ['--append-system-prompt-file', contextFile],
+    initialPrompt: kickoffPrompt,
   });
   console.log('  Leader: spawned and working');
 }


### PR DESCRIPTION
## Summary

Two fixes:
1. **Auto-kickoff:** Leader spawned via `genie team create --wish` now starts working immediately — initial prompt passed as Claude Code positional arg, no manual `genie send` needed
2. **Orchestration rules audit:** Updated `smart-install.js` and `install.sh` orchestration prompt with current CLI commands, task leader workflow, skill chain, `autoMergeDev` config

## Changes

### Group 1: Auto-kickoff
- Added `initialPrompt` to `SpawnParams` in `provider-adapters.ts`
- `buildClaudeCommand()` appends it as positional `[prompt]` arg
- `spawnLeaderWithWish()` passes kick-off prompt through spawn options
- No delay, no race — prompt is part of the launch command

### Group 2: Orchestration rules
- Updated `ORCHESTRATION_PROMPT` in `smart-install.js` with:
  - Current CLI commands (spawn, kill, stop, ls, team done/blocked, etc.)
  - Task leader workflow (`genie team create --wish`)
  - Skill chain (brainstorm → review → wish → work → PR → QA)
  - `autoMergeDev` config documentation
- Updated matching content in `install.sh`

## Test plan
- [x] `bun run typecheck` passes
- [x] Tests pass
- [ ] E2E: `genie team create --wish <slug>` → leader starts working immediately