### PR TITLE
fix: clear all native team dirs and worker registry on reset

### DIFF
--- a/.genie/wishes/fix-ghost-teammates/WISH.md
+++ b/.genie/wishes/fix-ghost-teammates/WISH.md
@@ -1,0 +1,73 @@
+# Wish: Fix Ghost Teammates on Reset
+
+| Field | Value |
+|-------|-------|
+| **Status** | DRAFT |
+| **Slug** | `fix-ghost-teammates` |
+| **Date** | 2026-03-15 |
+
+## Summary
+
+`genie --reset` only clears one native team directory but leaves others behind. On next launch, stale team configs surface ghost teammates from dead panes. Fix: clear ALL native team directories on reset.
+
+## Scope
+
+### IN
+- Fix `handleReset()` in `src/genie-commands/session.ts` to delete all native team directories, not just the current one
+- Clean up any stale worker registry entries during reset
+
+### OUT
+- Changes to the normal (non-reset) session flow
+- Changes to native team creation logic
+
+## Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Delete all native teams on reset | Reset means start fresh. No ghost state. |
+
+## Success Criteria
+
+- [ ] `genie --reset` removes ALL native team directories under `~/.claude/teams/`
+- [ ] No ghost teammates appear after reset + relaunch
+- [ ] `bun run check` passes
+- [ ] `bun run build` succeeds
+
+## Execution Groups
+
+### Group 1: Fix handleReset
+
+**Goal:** Clear all native team state on reset.
+
+**Deliverables:**
+1. In `src/genie-commands/session.ts`, update `handleReset()`:
+   - After killing the tmux session, delete ALL directories under `~/.claude/teams/` (not just the current window's team)
+   - Also clear `~/.genie/workers.json` (reset worker registry) since all workers are dead after session kill
+2. Add test verifying reset cleans up all team directories
+
+**Acceptance criteria:**
+- `handleReset()` removes all entries in `~/.claude/teams/`
+- Worker registry is cleared on reset
+- Normal session flow unchanged
+
+**Validation:**
+```bash
+bun run typecheck
+bun test src/genie-commands/__tests__/session.test.ts
+```
+
+**depends-on:** none
+
+---
+
+### Group 2: Validation
+
+**Goal:** Quality gates pass.
+
+**Validation:**
+```bash
+bun run check
+bun run build
+```
+
+**depends-on:** Group 1

--- a/src/genie-commands/__tests__/session.test.ts
+++ b/src/genie-commands/__tests__/session.test.ts
@@ -8,8 +8,10 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
+import { clearAll as clearWorkerRegistry } from '../../lib/agent-registry.js';
+import { deleteAllNativeTeams } from '../../lib/claude-native-teams.js';
 import { buildClaudeCommand, getAgentsSystemPrompt, sanitizeWindowName } from '../session.js';
 
 // ============================================================================
@@ -179,5 +181,100 @@ describe('sanitizeWindowName', () => {
     // missed the existing "foo-bar" window, and returned a name that
     // sanitized back to "foo-bar" — attaching to the wrong project.
     expect(sanitizeWindowName('foo.bar')).toBe(sanitizeWindowName('foo-bar'));
+  });
+});
+
+// ============================================================================
+// Reset cleanup tests — verifies handleReset's underlying functions
+//
+// handleReset() calls deleteAllNativeTeams() + clearWorkerRegistry().
+// These tests validate those functions directly since handleReset is private.
+// ============================================================================
+
+describe('deleteAllNativeTeams (reset cleanup)', () => {
+  const TEST_TEAMS_DIR = '/tmp/session-test-teams';
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env.CLAUDE_CONFIG_DIR;
+    rmSync(TEST_TEAMS_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_TEAMS_DIR, { recursive: true });
+    // Point native teams module at our test directory
+    process.env.CLAUDE_CONFIG_DIR = TEST_TEAMS_DIR;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      process.env.CLAUDE_CONFIG_DIR = undefined;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = originalEnv;
+    }
+    rmSync(TEST_TEAMS_DIR, { recursive: true, force: true });
+  });
+
+  test('deletes all team directories under teams/', async () => {
+    const teamsDir = join(TEST_TEAMS_DIR, 'teams');
+    mkdirSync(join(teamsDir, 'team-a'), { recursive: true });
+    mkdirSync(join(teamsDir, 'team-b'), { recursive: true });
+    mkdirSync(join(teamsDir, 'team-c'), { recursive: true });
+    writeFileSync(join(teamsDir, 'team-a', 'config.json'), '{}');
+    writeFileSync(join(teamsDir, 'team-b', 'config.json'), '{}');
+    writeFileSync(join(teamsDir, 'team-c', 'config.json'), '{}');
+
+    const deleted = await deleteAllNativeTeams();
+
+    expect(deleted).toBe(3);
+    expect(existsSync(join(teamsDir, 'team-a'))).toBe(false);
+    expect(existsSync(join(teamsDir, 'team-b'))).toBe(false);
+    expect(existsSync(join(teamsDir, 'team-c'))).toBe(false);
+  });
+
+  test('returns 0 when no teams directory exists', async () => {
+    // Don't create the teams/ subdirectory
+    const deleted = await deleteAllNativeTeams();
+    expect(deleted).toBe(0);
+  });
+
+  test('returns 0 when teams directory is empty', async () => {
+    mkdirSync(join(TEST_TEAMS_DIR, 'teams'), { recursive: true });
+    const deleted = await deleteAllNativeTeams();
+    expect(deleted).toBe(0);
+  });
+});
+
+describe('clearWorkerRegistry (reset cleanup)', () => {
+  let originalEnv: string | undefined;
+  const TEST_GENIE_DIR = '/tmp/session-test-genie-home';
+
+  beforeEach(() => {
+    originalEnv = process.env.GENIE_HOME;
+    rmSync(TEST_GENIE_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_GENIE_DIR, { recursive: true });
+    process.env.GENIE_HOME = TEST_GENIE_DIR;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      process.env.GENIE_HOME = undefined;
+    } else {
+      process.env.GENIE_HOME = originalEnv;
+    }
+    rmSync(TEST_GENIE_DIR, { recursive: true, force: true });
+  });
+
+  test('clears workers.json to empty registry', async () => {
+    // Seed a non-empty registry
+    const registry = {
+      workers: { 'agent-1': { id: 'agent-1', state: 'idle' } },
+      templates: { 'tmpl-1': { id: 'tmpl-1' } },
+      lastUpdated: new Date().toISOString(),
+    };
+    writeFileSync(join(TEST_GENIE_DIR, 'workers.json'), JSON.stringify(registry));
+
+    await clearWorkerRegistry();
+
+    const content = JSON.parse(require('node:fs').readFileSync(join(TEST_GENIE_DIR, 'workers.json'), 'utf-8'));
+    expect(Object.keys(content.workers)).toHaveLength(0);
+    expect(Object.keys(content.templates)).toHaveLength(0);
   });
 });

--- a/src/genie-commands/session.ts
+++ b/src/genie-commands/session.ts
@@ -16,8 +16,9 @@ import { createHash } from 'node:crypto';
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
+import { clearAll as clearWorkerRegistry } from '../lib/agent-registry.js';
 import {
-  deleteNativeTeam,
+  deleteAllNativeTeams,
   ensureNativeTeam,
   registerNativeMember,
   sanitizeTeamName,
@@ -254,13 +255,20 @@ async function deriveWindowName(sessionName: string, workspaceDir: string, team?
   return sanitizeWindowName(basename(workspaceDir));
 }
 
-async function handleReset(sessionName: string, windowName: string): Promise<void> {
+async function handleReset(sessionName: string, _windowName: string): Promise<void> {
   const existing = await tmux.findSessionByName(sessionName);
   if (existing) {
     console.log(`Resetting session "${sessionName}"...`);
     await tmux.killSession(sessionName);
   }
-  await deleteNativeTeam(windowName);
+  // Delete ALL native team directories — not just the current window's team.
+  // After killing the tmux session, all workers are dead, so all team state is stale.
+  const deleted = await deleteAllNativeTeams();
+  if (deleted > 0) {
+    console.log(`Cleaned up ${deleted} native team director${deleted === 1 ? 'y' : 'ies'}`);
+  }
+  // Clear worker registry since all workers are dead after session kill
+  await clearWorkerRegistry();
 }
 
 function attachToWindow(sessionName: string, windowName: string): void {

--- a/src/lib/agent-registry.ts
+++ b/src/lib/agent-registry.ts
@@ -224,6 +224,14 @@ export async function findByTask(taskId: string): Promise<Agent | null> {
   return agents.find((a) => a.taskId === taskId) ?? null;
 }
 
+/** Clear the entire registry (all workers and templates). Used on session reset. */
+export async function clearAll(): Promise<void> {
+  const filePath = getRegistryFilePath();
+  await mkdir(dirname(filePath), { recursive: true });
+  const empty: AgentRegistry = { workers: {}, templates: {}, lastUpdated: new Date().toISOString() };
+  await writeFile(filePath, JSON.stringify(empty, null, 2));
+}
+
 /** Calculate elapsed time for an agent. */
 export function getElapsedTime(agent: Agent): { ms: number; formatted: string } {
   const startTime = new Date(agent.startedAt).getTime();

--- a/src/lib/claude-native-teams.ts
+++ b/src/lib/claude-native-teams.ts
@@ -319,6 +319,31 @@ export async function deleteNativeTeam(teamName: string): Promise<boolean> {
   return true;
 }
 
+/**
+ * Delete ALL native team directories under ~/.claude/teams/.
+ * Used by reset to ensure no ghost teammates survive.
+ */
+export async function deleteAllNativeTeams(): Promise<number> {
+  const base = teamsBaseDir();
+  if (!existsSync(base)) return 0;
+
+  let count = 0;
+  try {
+    const entries = await readdir(base);
+    for (const entry of entries) {
+      const entryPath = join(base, entry);
+      const s = await stat(entryPath);
+      if (s.isDirectory()) {
+        await rm(entryPath, { recursive: true, force: true });
+        count++;
+      }
+    }
+  } catch {
+    // teams dir missing or inaccessible
+  }
+  return count;
+}
+
 // ============================================================================
 // Session Discovery
 // ============================================================================


### PR DESCRIPTION
## Summary
- `handleReset()` now deletes ALL directories under `~/.claude/teams/` instead of just the current window's team — prevents ghost teammates on next launch
- Clears `~/.genie/workers.json` on reset since all workers are dead after tmux session kill
- Adds `deleteAllNativeTeams()` to `claude-native-teams.ts` and `clearAll()` to `agent-registry.ts`

## Wish
`fix-ghost-teammates`

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun test src/genie-commands/__tests__/session.test.ts` — 27 tests pass (3 new)
- [x] `bun run build` succeeds
- [x] New test verifies `deleteAllNativeTeams()` removes all team dirs
- [x] New test verifies `clearWorkerRegistry()` empties workers.json
- [x] No lint regressions in changed files