### PR TITLE
fix: builtin agent folder scanner — resolve package root via process.argv[1] (#576)

### DIFF
--- a/src/lib/builtin-agents.ts
+++ b/src/lib/builtin-agents.ts
@@ -9,7 +9,7 @@
  * Resolution: user directory entries override built-ins of the same name.
  */
 
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, realpathSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import * as yaml from 'js-yaml';
 import type { PromptMode } from './agent-directory.js';
@@ -44,12 +44,17 @@ export interface BuiltinAgent {
  * Works from both `src/lib/` (dev) and `dist/` (compiled).
  */
 function resolvePackageRoot(): string {
-  const base = import.meta.dir ?? __dirname;
+  // In compiled dist, import.meta.dir returns CWD, not the module's dir.
+  // Use the actual script path (process.argv[1]) to find the package root.
+  const scriptPath = realpathSync(process.argv[1] || '');
   const candidates = [
-    // From src/lib/ → ../../
-    resolve(dirname(base), '..', '..'),
-    // From dist/ → ../
-    resolve(dirname(base), '..'),
+    // From dist/genie.js → ../
+    resolve(dirname(scriptPath), '..'),
+    // From src/lib/builtin-agents.ts → ../../
+    resolve(dirname(scriptPath), '..', '..'),
+    // Fallback: import.meta.dir-based (works in dev with bun run)
+    resolve(dirname(import.meta.dir ?? __dirname), '..', '..'),
+    resolve(dirname(import.meta.dir ?? __dirname), '..'),
   ];
   for (const candidate of candidates) {
     if (existsSync(join(candidate, 'plugins', 'genie', 'agents'))) {


### PR DESCRIPTION
## Summary

Fixes #576 — `genie dir ls --builtins` returned empty list because `import.meta.dir` returns CWD in compiled bundles, not the module's directory.

## Fix

Use `realpathSync(process.argv[1])` to resolve the actual script path, then navigate to the package root. Falls back to `import.meta.dir` for dev mode.

## Test plan
- [x] `bun run typecheck` passes
- [x] 18 builtin-agents tests pass
- [ ] After install: `genie dir ls --builtins` shows all agents