### PR TITLE
feat(directory): project-scoped agent directory with three-tier resolution

### DIFF
--- a/src/lib/agent-directory.test.ts
+++ b/src/lib/agent-directory.test.ts
@@ -11,16 +11,22 @@ import { join } from 'node:path';
 import * as directory from './agent-directory.js';
 
 // ============================================================================
-// Test setup — use temp dir for GENIE_HOME
+// Test setup — use temp dirs for both GENIE_HOME (global) and project root
 // ============================================================================
 
 let testDir: string;
 let agentDir: string;
+let projectRoot: string;
 
 beforeEach(() => {
   testDir = join(tmpdir(), `genie-dir-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
   mkdirSync(testDir, { recursive: true });
   process.env.GENIE_HOME = testDir;
+
+  // Separate project root for project-scoped directory (with .genie dir for lock files)
+  projectRoot = join(testDir, 'project');
+  mkdirSync(join(projectRoot, '.genie'), { recursive: true });
+  process.env.GENIE_PROJECT_ROOT = projectRoot;
 
   // Create a fake agent dir with AGENTS.md
   agentDir = join(testDir, 'test-agent-home');
@@ -31,6 +37,7 @@ beforeEach(() => {
 afterEach(() => {
   rmSync(testDir, { recursive: true, force: true });
   process.env.GENIE_HOME = undefined;
+  process.env.GENIE_PROJECT_ROOT = undefined;
 });
 
 // ============================================================================
@@ -38,7 +45,7 @@ afterEach(() => {
 // ============================================================================
 
 describe('add', () => {
-  test('persists entry to directory', async () => {
+  test('persists entry to project directory by default', async () => {
     const entry = await directory.add({
       name: 'test-agent',
       dir: agentDir,
@@ -54,6 +61,19 @@ describe('add', () => {
     const retrieved = await directory.get('test-agent');
     expect(retrieved).not.toBeNull();
     expect(retrieved!.name).toBe('test-agent');
+  });
+
+  test('persists to global directory with global option', async () => {
+    const entry = await directory.add(
+      { name: 'global-agent', dir: agentDir, promptMode: 'append' },
+      { global: true },
+    );
+
+    expect(entry.name).toBe('global-agent');
+
+    // Should be retrievable
+    const retrieved = await directory.get('global-agent');
+    expect(retrieved).not.toBeNull();
   });
 
   test('persists with all optional fields', async () => {
@@ -72,11 +92,20 @@ describe('add', () => {
     expect(entry.roles).toEqual(['implementor', 'tester']);
   });
 
-  test('rejects duplicate name', async () => {
+  test('rejects duplicate name in same scope', async () => {
     await directory.add({ name: 'agent1', dir: agentDir, promptMode: 'append' });
     await expect(directory.add({ name: 'agent1', dir: agentDir, promptMode: 'append' })).rejects.toThrow(
       'already exists',
     );
+  });
+
+  test('allows same name in different scopes', async () => {
+    await directory.add({ name: 'engineer', dir: agentDir, promptMode: 'append' });
+    const globalEntry = await directory.add(
+      { name: 'engineer', dir: agentDir, promptMode: 'system' },
+      { global: true },
+    );
+    expect(globalEntry.name).toBe('engineer');
   });
 
   test('rejects missing directory', async () => {
@@ -103,13 +132,19 @@ describe('add', () => {
 // ============================================================================
 
 describe('rm', () => {
-  test('removes existing entry', async () => {
+  test('removes existing entry from project', async () => {
     await directory.add({ name: 'to-remove', dir: agentDir, promptMode: 'append' });
     const removed = await directory.rm('to-remove');
     expect(removed).toBe(true);
 
     const retrieved = await directory.get('to-remove');
     expect(retrieved).toBeNull();
+  });
+
+  test('removes existing entry from global', async () => {
+    await directory.add({ name: 'global-rm', dir: agentDir, promptMode: 'append' }, { global: true });
+    const removed = await directory.rm('global-rm', { global: true });
+    expect(removed).toBe(true);
   });
 
   test('returns false for non-existent entry', async () => {
@@ -123,18 +158,38 @@ describe('rm', () => {
 // ============================================================================
 
 describe('resolve', () => {
-  test('resolves user directory entry', async () => {
+  test('resolves project directory entry first', async () => {
     await directory.add({ name: 'my-agent', dir: agentDir, promptMode: 'append' });
     const resolved = await directory.resolve('my-agent');
     expect(resolved).not.toBeNull();
     expect(resolved!.builtin).toBe(false);
+    expect(resolved!.source).toBe('project');
     expect(resolved!.entry.name).toBe('my-agent');
+  });
+
+  test('resolves global directory entry', async () => {
+    await directory.add({ name: 'global-only', dir: agentDir, promptMode: 'append' }, { global: true });
+    const resolved = await directory.resolve('global-only');
+    expect(resolved).not.toBeNull();
+    expect(resolved!.builtin).toBe(false);
+    expect(resolved!.source).toBe('global');
+    expect(resolved!.entry.name).toBe('global-only');
+  });
+
+  test('project overrides global', async () => {
+    await directory.add({ name: 'shared', dir: agentDir, promptMode: 'system' }, { global: true });
+    await directory.add({ name: 'shared', dir: agentDir, promptMode: 'append' });
+    const resolved = await directory.resolve('shared');
+    expect(resolved).not.toBeNull();
+    expect(resolved!.source).toBe('project');
+    expect(resolved!.entry.promptMode).toBe('append');
   });
 
   test('resolves built-in role', async () => {
     const resolved = await directory.resolve('engineer');
     expect(resolved).not.toBeNull();
     expect(resolved!.builtin).toBe(true);
+    expect(resolved!.source).toBe('built-in');
     expect(resolved!.entry.name).toBe('engineer');
   });
 
@@ -142,15 +197,25 @@ describe('resolve', () => {
     const resolved = await directory.resolve('council--architect');
     expect(resolved).not.toBeNull();
     expect(resolved!.builtin).toBe(true);
+    expect(resolved!.source).toBe('built-in');
     expect(resolved!.entry.name).toBe('council--architect');
   });
 
-  test('user entry overrides built-in', async () => {
+  test('project entry overrides built-in', async () => {
     await directory.add({ name: 'engineer', dir: agentDir, promptMode: 'system' });
     const resolved = await directory.resolve('engineer');
     expect(resolved).not.toBeNull();
     expect(resolved!.builtin).toBe(false);
+    expect(resolved!.source).toBe('project');
     expect(resolved!.entry.promptMode).toBe('system');
+  });
+
+  test('global entry overrides built-in', async () => {
+    await directory.add({ name: 'engineer', dir: agentDir, promptMode: 'system' }, { global: true });
+    const resolved = await directory.resolve('engineer');
+    expect(resolved).not.toBeNull();
+    expect(resolved!.builtin).toBe(false);
+    expect(resolved!.source).toBe('global');
   });
 
   test('returns null for unknown name', async () => {
@@ -164,13 +229,43 @@ describe('resolve', () => {
 // ============================================================================
 
 describe('ls', () => {
-  test('lists all user entries', async () => {
+  test('lists project entries with scope', async () => {
     await directory.add({ name: 'agent-a', dir: agentDir, promptMode: 'append' });
     await directory.add({ name: 'agent-b', dir: agentDir, promptMode: 'system' });
 
     const entries = await directory.ls();
     expect(entries.length).toBe(2);
     expect(entries.map((e) => e.name).sort()).toEqual(['agent-a', 'agent-b']);
+    expect(entries.every((e) => e.scope === 'project')).toBe(true);
+  });
+
+  test('lists global entries with scope', async () => {
+    await directory.add({ name: 'global-a', dir: agentDir, promptMode: 'append' }, { global: true });
+
+    const entries = await directory.ls();
+    expect(entries.length).toBe(1);
+    expect(entries[0].scope).toBe('global');
+  });
+
+  test('merges project and global entries', async () => {
+    await directory.add({ name: 'proj-agent', dir: agentDir, promptMode: 'append' });
+    await directory.add({ name: 'global-agent', dir: agentDir, promptMode: 'append' }, { global: true });
+
+    const entries = await directory.ls();
+    expect(entries.length).toBe(2);
+    const scopes = entries.map((e) => ({ name: e.name, scope: e.scope }));
+    expect(scopes).toContainEqual({ name: 'proj-agent', scope: 'project' });
+    expect(scopes).toContainEqual({ name: 'global-agent', scope: 'global' });
+  });
+
+  test('project entry shadows global with same name', async () => {
+    await directory.add({ name: 'shared', dir: agentDir, promptMode: 'system' }, { global: true });
+    await directory.add({ name: 'shared', dir: agentDir, promptMode: 'append' });
+
+    const entries = await directory.ls();
+    expect(entries.length).toBe(1);
+    expect(entries[0].scope).toBe('project');
+    expect(entries[0].promptMode).toBe('append');
   });
 
   test('returns empty array when no entries', async () => {
@@ -204,6 +299,12 @@ describe('edit', () => {
     await directory.add({ name: 'editable', dir: agentDir, promptMode: 'append' });
     const updated = await directory.edit('editable', { roles: ['implementor', 'reviewer'] });
     expect(updated.roles).toEqual(['implementor', 'reviewer']);
+  });
+
+  test('edits global entry with global option', async () => {
+    await directory.add({ name: 'global-edit', dir: agentDir, promptMode: 'append' }, { global: true });
+    const updated = await directory.edit('global-edit', { model: 'opus' }, { global: true });
+    expect(updated.model).toBe('opus');
   });
 
   test('rejects edit of non-existent entry', async () => {

--- a/src/lib/agent-directory.ts
+++ b/src/lib/agent-directory.ts
@@ -1,14 +1,15 @@
 /**
  * Agent Directory — Persistent agent registry with CRUD operations.
  *
- * Stores agent identity entries at `~/.genie/agent-directory.json`.
+ * Three-tier resolution: project (.genie/agents.json) > global (~/.genie/agent-directory.json) > built-in.
+ *
  * Each entry records the agent's folder (CWD + AGENTS.md source),
  * optional repo, prompt mode, default model, and declared roles.
  *
- * Resolution order: user directory > built-in registry.
  * Uses file-lock pattern (same as agent-registry.ts) for concurrent access.
  */
 
+import { execSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
@@ -21,6 +22,8 @@ import { acquireLock } from './file-lock.js';
 // ============================================================================
 
 export type PromptMode = 'system' | 'append';
+
+export type DirectoryScope = 'project' | 'global' | 'built-in';
 
 export interface DirectoryEntry {
   /** Globally unique agent name. */
@@ -39,6 +42,11 @@ export interface DirectoryEntry {
   registeredAt: string;
 }
 
+/** Directory entry with scope annotation for ls() results. */
+export interface ScopedDirectoryEntry extends DirectoryEntry {
+  scope: DirectoryScope;
+}
+
 interface AgentDirectoryData {
   entries: Record<string, DirectoryEntry>;
   lastUpdated: string;
@@ -50,6 +58,14 @@ export interface ResolvedAgent {
   entry: DirectoryEntry;
   /** Whether this came from the built-in registry. */
   builtin: boolean;
+  /** Which scope the agent was resolved from. */
+  source: DirectoryScope;
+}
+
+/** Options for scoped operations. */
+export interface ScopeOptions {
+  /** Write to global directory instead of project. */
+  global?: boolean;
 }
 
 // ============================================================================
@@ -60,36 +76,63 @@ function getGlobalDir(): string {
   return process.env.GENIE_HOME ?? join(homedir(), '.genie');
 }
 
-function getDirectoryFilePath(): string {
+/** Path to the global agent directory file (~/.genie/agent-directory.json). */
+export function getGlobalDirectoryPath(): string {
   return join(getGlobalDir(), 'agent-directory.json');
+}
+
+/** Path to the project-scoped agent directory file (<repo>/.genie/agents.json). */
+export function getProjectDirectoryPath(): string {
+  // Allow override for testing
+  if (process.env.GENIE_PROJECT_ROOT) {
+    return join(process.env.GENIE_PROJECT_ROOT, '.genie', 'agents.json');
+  }
+  try {
+    const root = execSync('git rev-parse --show-toplevel', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    return join(root, '.genie', 'agents.json');
+  } catch {
+    // Not in a git repo — fallback to CWD
+    return join(process.cwd(), '.genie', 'agents.json');
+  }
+}
+
+/** Get directory file path for the given scope. */
+function getDirectoryPath(scope: 'project' | 'global'): string {
+  return scope === 'project' ? getProjectDirectoryPath() : getGlobalDirectoryPath();
 }
 
 // ============================================================================
 // Internal
 // ============================================================================
 
-async function loadDirectory(): Promise<AgentDirectoryData> {
+async function loadDirectory(scope: 'project' | 'global'): Promise<AgentDirectoryData> {
   try {
-    const content = await readFile(getDirectoryFilePath(), 'utf-8');
+    const content = await readFile(getDirectoryPath(scope), 'utf-8');
     return JSON.parse(content);
   } catch {
     return { entries: {}, lastUpdated: new Date().toISOString() };
   }
 }
 
-async function saveDirectory(data: AgentDirectoryData): Promise<void> {
-  const filePath = getDirectoryFilePath();
+async function saveDirectory(data: AgentDirectoryData, scope: 'project' | 'global'): Promise<void> {
+  const filePath = getDirectoryPath(scope);
   await mkdir(dirname(filePath), { recursive: true });
   data.lastUpdated = new Date().toISOString();
   await writeFile(filePath, JSON.stringify(data, null, 2));
 }
 
-async function withDirectory<T>(fn: (data: AgentDirectoryData) => T | Promise<T>): Promise<T> {
-  const release = await acquireLock(getDirectoryFilePath());
+async function withDirectory<T>(
+  scope: 'project' | 'global',
+  fn: (data: AgentDirectoryData) => T | Promise<T>,
+): Promise<T> {
+  const release = await acquireLock(getDirectoryPath(scope));
   try {
-    const data = await loadDirectory();
+    const data = await loadDirectory(scope);
     const result = await fn(data);
-    await saveDirectory(data);
+    await saveDirectory(data, scope);
     return result;
   } finally {
     await release();
@@ -103,8 +146,12 @@ async function withDirectory<T>(fn: (data: AgentDirectoryData) => T | Promise<T>
 /**
  * Add an agent to the directory.
  * Validates that dir exists and contains AGENTS.md.
+ * Defaults to project scope; pass { global: true } for global.
  */
-export async function add(entry: Omit<DirectoryEntry, 'registeredAt'>): Promise<DirectoryEntry> {
+export async function add(
+  entry: Omit<DirectoryEntry, 'registeredAt'>,
+  options?: ScopeOptions,
+): Promise<DirectoryEntry> {
   if (!entry.name || entry.name.trim() === '') {
     throw new Error('Agent name is required.');
   }
@@ -128,7 +175,8 @@ export async function add(entry: Omit<DirectoryEntry, 'registeredAt'>): Promise<
     registeredAt: new Date().toISOString(),
   };
 
-  await withDirectory((data) => {
+  const scope = options?.global ? 'global' : 'project';
+  await withDirectory(scope, (data) => {
     if (data.entries[entry.name]) {
       throw new Error(`Agent "${entry.name}" already exists. Use "genie dir edit" to update or "genie dir rm" first.`);
     }
@@ -140,10 +188,12 @@ export async function add(entry: Omit<DirectoryEntry, 'registeredAt'>): Promise<
 
 /**
  * Remove an agent from the directory.
+ * Defaults to project scope; pass { global: true } for global.
  */
-export async function rm(name: string): Promise<boolean> {
+export async function rm(name: string, options?: ScopeOptions): Promise<boolean> {
   let removed = false;
-  await withDirectory((data) => {
+  const scope = options?.global ? 'global' : 'project';
+  await withDirectory(scope, (data) => {
     if (data.entries[name]) {
       delete data.entries[name];
       removed = true;
@@ -154,58 +204,87 @@ export async function rm(name: string): Promise<boolean> {
 
 /**
  * Resolve an agent by name.
- * Resolution order: user directory > built-in roles > built-in council members.
+ * Resolution order: project directory > global directory > built-in roles > built-in council members.
  */
 export async function resolve(name: string): Promise<ResolvedAgent | null> {
-  // 1. Check user directory
-  const data = await loadDirectory();
-  const userEntry = data.entries[name];
-  if (userEntry) {
-    return { entry: userEntry, builtin: false };
+  // 1. Check project directory
+  const projectData = await loadDirectory('project');
+  const projectEntry = projectData.entries[name];
+  if (projectEntry) {
+    return { entry: projectEntry, builtin: false, source: 'project' };
   }
 
-  // 2. Check built-in roles
+  // 2. Check global directory
+  const globalData = await loadDirectory('global');
+  const globalEntry = globalData.entries[name];
+  if (globalEntry) {
+    return { entry: globalEntry, builtin: false, source: 'global' };
+  }
+
+  // 3. Check built-in roles
   const builtinRole = BUILTIN_ROLES.find((r: BuiltinAgent) => r.name === name);
   if (builtinRole) {
-    return { entry: builtinToEntry(builtinRole), builtin: true };
+    return { entry: builtinToEntry(builtinRole), builtin: true, source: 'built-in' };
   }
 
-  // 3. Check built-in council members
+  // 4. Check built-in council members
   const councilMember = BUILTIN_COUNCIL_MEMBERS.find((m: BuiltinAgent) => m.name === name);
   if (councilMember) {
-    return { entry: builtinToEntry(councilMember), builtin: true };
+    return { entry: builtinToEntry(councilMember), builtin: true, source: 'built-in' };
   }
 
   return null;
 }
 
 /**
- * List all user-registered agents.
+ * List agents from all scopes with scope annotation.
  */
-export async function ls(): Promise<DirectoryEntry[]> {
-  const data = await loadDirectory();
-  return Object.values(data.entries);
+export async function ls(): Promise<ScopedDirectoryEntry[]> {
+  const results: ScopedDirectoryEntry[] = [];
+
+  // Project entries
+  const projectData = await loadDirectory('project');
+  for (const entry of Object.values(projectData.entries)) {
+    results.push({ ...entry, scope: 'project' });
+  }
+
+  // Global entries (skip if name already present from project)
+  const globalData = await loadDirectory('global');
+  const projectNames = new Set(results.map((e) => e.name));
+  for (const entry of Object.values(globalData.entries)) {
+    if (!projectNames.has(entry.name)) {
+      results.push({ ...entry, scope: 'global' });
+    }
+  }
+
+  return results;
 }
 
 /**
- * Get a single entry by name (user directory only).
+ * Get a single entry by name (user directory only — checks project then global).
  */
 export async function get(name: string): Promise<DirectoryEntry | null> {
-  const data = await loadDirectory();
-  return data.entries[name] ?? null;
+  const projectData = await loadDirectory('project');
+  if (projectData.entries[name]) return projectData.entries[name];
+
+  const globalData = await loadDirectory('global');
+  return globalData.entries[name] ?? null;
 }
 
 /**
  * Edit an existing agent entry.
  * Only provided fields are updated.
+ * Defaults to project scope; pass { global: true } for global.
  */
 export async function edit(
   name: string,
   updates: Partial<Pick<DirectoryEntry, 'dir' | 'repo' | 'promptMode' | 'model' | 'roles'>>,
+  options?: ScopeOptions,
 ): Promise<DirectoryEntry> {
   let updated: DirectoryEntry | null = null;
 
-  await withDirectory((data) => {
+  const scope = options?.global ? 'global' : 'project';
+  await withDirectory(scope, (data) => {
     const existing = data.entries[name];
     if (!existing) {
       throw new Error(`Agent "${name}" not found in directory.`);

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -966,16 +966,16 @@ export async function handleLsCommand(options: { json?: boolean }): Promise<void
   const entries: LsEntry[] = [];
 
   // Add directory entries with runtime status
-  for (const entry of dirEntries) {
-    const running = statusMap.get(entry.name);
+  for (const dirEntry of dirEntries) {
+    const running = statusMap.get(dirEntry.name);
     entries.push({
-      name: entry.name,
-      dir: entry.dir || '-',
+      name: dirEntry.name,
+      dir: dirEntry.dir || '-',
       status: running ? running.state : 'offline',
       team: running?.team || '-',
-      model: entry.model || '-',
+      model: dirEntry.model || '-',
     });
-    statusMap.delete(entry.name);
+    statusMap.delete(dirEntry.name);
   }
 
   // Add running built-in agents not in the directory

--- a/src/term-commands/dir.ts
+++ b/src/term-commands/dir.ts
@@ -26,6 +26,7 @@ export function registerDirNamespace(program: Command): void {
     .option('--prompt-mode <mode>', 'Prompt mode: append or system', 'append')
     .option('--model <model>', 'Default model (sonnet, opus, codex)')
     .option('--roles <roles...>', 'Built-in roles this agent can orchestrate')
+    .option('--global', 'Write to global directory (~/.genie) instead of project')
     .action(
       async (
         name: string,
@@ -35,19 +36,24 @@ export function registerDirNamespace(program: Command): void {
           promptMode: string;
           model?: string;
           roles?: string[];
+          global?: boolean;
         },
       ) => {
         try {
           const promptMode = validatePromptMode(options.promptMode);
-          const entry = await directory.add({
-            name,
-            dir: resolvePath(options.dir),
-            repo: options.repo ? resolvePath(options.repo) : undefined,
-            promptMode,
-            model: options.model,
-            roles: options.roles,
-          });
-          console.log(`Agent "${entry.name}" registered.`);
+          const entry = await directory.add(
+            {
+              name,
+              dir: resolvePath(options.dir),
+              repo: options.repo ? resolvePath(options.repo) : undefined,
+              promptMode,
+              model: options.model,
+              roles: options.roles,
+            },
+            { global: options.global },
+          );
+          const scope = options.global ? 'global' : 'project';
+          console.log(`Agent "${entry.name}" registered (${scope}).`);
           console.log(`  Dir: ${contractPath(entry.dir)}`);
           if (entry.repo) console.log(`  Repo: ${contractPath(entry.repo)}`);
           console.log(`  Prompt mode: ${entry.promptMode}`);
@@ -65,13 +71,16 @@ export function registerDirNamespace(program: Command): void {
   dir
     .command('rm <name>')
     .description('Remove an agent from the directory')
-    .action(async (name: string) => {
+    .option('--global', 'Remove from global directory instead of project')
+    .action(async (name: string, options: { global?: boolean }) => {
       try {
-        const removed = await directory.rm(name);
+        const removed = await directory.rm(name, { global: options.global });
         if (removed) {
-          console.log(`Agent "${name}" removed from directory.`);
+          const scope = options.global ? 'global' : 'project';
+          console.log(`Agent "${name}" removed from ${scope} directory.`);
         } else {
-          console.error(`Agent "${name}" not found in directory.`);
+          const scope = options.global ? 'global' : 'project';
+          console.error(`Agent "${name}" not found in ${scope} directory.`);
           process.exit(1);
         }
       } catch (error) {
@@ -112,6 +121,7 @@ export function registerDirNamespace(program: Command): void {
     .option('--prompt-mode <mode>', 'Prompt mode: append or system')
     .option('--model <model>', 'Default model')
     .option('--roles <roles...>', 'Built-in roles this agent can orchestrate')
+    .option('--global', 'Edit in global directory instead of project')
     .action(async (name: string, options: EditOptions) => {
       try {
         await handleEdit(name, options);
@@ -129,6 +139,7 @@ interface EditOptions {
   promptMode?: string;
   model?: string;
   roles?: string[];
+  global?: boolean;
 }
 
 async function handleEdit(name: string, options: EditOptions): Promise<void> {
@@ -144,8 +155,9 @@ async function handleEdit(name: string, options: EditOptions): Promise<void> {
     process.exit(1);
   }
 
-  const entry = await directory.edit(name, updates);
-  console.log(`Agent "${name}" updated.`);
+  const entry = await directory.edit(name, updates, { global: options.global });
+  const scope = options.global ? 'global' : 'project';
+  console.log(`Agent "${name}" updated (${scope}).`);
   printEntry(entry);
 }
 
@@ -160,13 +172,14 @@ function validatePromptMode(mode: string): 'system' | 'append' {
   return mode;
 }
 
-function printEntry(entry: directory.DirectoryEntry): void {
+function printEntry(entry: directory.DirectoryEntry, scope?: string): void {
   console.log(`  Name: ${entry.name}`);
   console.log(`  Dir: ${contractPath(entry.dir)}`);
   if (entry.repo) console.log(`  Repo: ${contractPath(entry.repo)}`);
   console.log(`  Prompt mode: ${entry.promptMode}`);
   if (entry.model) console.log(`  Model: ${entry.model}`);
   if (entry.roles?.length) console.log(`  Roles: ${entry.roles.join(', ')}`);
+  if (scope) console.log(`  Scope: ${scope}`);
   console.log(`  Registered: ${entry.registeredAt}`);
 }
 
@@ -179,15 +192,17 @@ async function showEntry(name: string, json?: boolean): Promise<void> {
   }
 
   if (json) {
-    console.log(JSON.stringify({ ...resolved.entry, builtin: resolved.builtin }, null, 2));
+    console.log(JSON.stringify({ ...resolved.entry, builtin: resolved.builtin, source: resolved.source }, null, 2));
     return;
   }
 
   if (resolved.builtin) {
-    console.log(`\n(built-in ${resolved.entry.registeredAt === '(built-in)' ? 'agent' : 'agent'})`);
+    console.log(`\n(built-in agent)`);
+  } else {
+    console.log(`\n(${resolved.source} agent)`);
   }
   console.log('');
-  printEntry(resolved.entry);
+  printEntry(resolved.entry, resolved.source);
   console.log('');
 }
 
@@ -214,28 +229,41 @@ async function listEntries(json?: boolean, includeBuiltins?: boolean): Promise<v
   }
 }
 
-function listEntriesJson(entries: directory.DirectoryEntry[], includeBuiltins?: boolean): void {
-  const result: Record<string, unknown>[] = entries.map((e) => ({ ...e, builtin: false }));
+function listEntriesJson(entries: directory.ScopedDirectoryEntry[], includeBuiltins?: boolean): void {
+  const result: Record<string, unknown>[] = entries.map((e) => ({
+    ...e,
+    builtin: false,
+  }));
   if (includeBuiltins) {
     for (const b of ALL_BUILTINS) {
-      result.push({ name: b.name, description: b.description, model: b.model, category: b.category, builtin: true });
+      result.push({
+        name: b.name,
+        description: b.description,
+        model: b.model,
+        category: b.category,
+        builtin: true,
+        scope: 'built-in',
+      });
     }
   }
   console.log(JSON.stringify(result, null, 2));
 }
 
-function printRegisteredTable(entries: directory.DirectoryEntry[]): void {
+function printRegisteredTable(entries: directory.ScopedDirectoryEntry[]): void {
   const nameW = 22;
-  const dirW = 35;
+  const scopeW = 10;
+  const dirW = 30;
   const modeW = 8;
   const modelW = 8;
 
   console.log('');
   console.log('REGISTERED AGENTS');
-  console.log('-'.repeat(80));
-  console.log(`  ${'NAME'.padEnd(nameW)}${'DIR'.padEnd(dirW)}${'MODE'.padEnd(modeW)}${'MODEL'.padEnd(modelW)}ROLES`);
+  console.log('-'.repeat(85));
   console.log(
-    `  ${'-'.repeat(nameW - 2)}  ${'-'.repeat(dirW - 2)}  ${'-'.repeat(modeW - 2)}  ${'-'.repeat(modelW - 2)}  ${'-'.repeat(15)}`,
+    `  ${'NAME'.padEnd(nameW)}${'SCOPE'.padEnd(scopeW)}${'DIR'.padEnd(dirW)}${'MODE'.padEnd(modeW)}${'MODEL'.padEnd(modelW)}ROLES`,
+  );
+  console.log(
+    `  ${'-'.repeat(nameW - 2)}  ${'-'.repeat(scopeW - 2)}  ${'-'.repeat(dirW - 2)}  ${'-'.repeat(modeW - 2)}  ${'-'.repeat(modelW - 2)}  ${'-'.repeat(15)}`,
   );
 
   for (const entry of entries) {
@@ -243,7 +271,7 @@ function printRegisteredTable(entries: directory.DirectoryEntry[]): void {
     const truncDir = dir.length > dirW - 2 ? `${dir.slice(0, dirW - 5)}...` : dir;
     const roles = entry.roles?.join(', ') || '-';
     console.log(
-      `  ${entry.name.padEnd(nameW)}${truncDir.padEnd(dirW)}${entry.promptMode.padEnd(modeW)}${(entry.model || '-').padEnd(modelW)}${roles}`,
+      `  ${entry.name.padEnd(nameW)}${entry.scope.padEnd(scopeW)}${truncDir.padEnd(dirW)}${entry.promptMode.padEnd(modeW)}${(entry.model || '-').padEnd(modelW)}${roles}`,
     );
   }
   console.log('');


### PR DESCRIPTION
## Summary

- Add project-scoped agent directory at `<repo>/.genie/agents.json` so each project has its own agents
- Resolution chain: project `.genie/agents.json` → global `~/.genie/agent-directory.json` → built-in agents
- `genie dir add` defaults to project scope; `--global` flag writes to global
- `genie dir ls` shows scope label (project/global/built-in) for each agent
- `genie dir rm` and `genie dir edit` support `--global` flag

Closes #578

## Key Changes

- `src/lib/agent-directory.ts`: `getProjectDirectoryPath()` detects project root via `git rev-parse --show-toplevel`, three-tier `resolve()`, scoped `add/rm/edit/ls`
- `src/lib/agent-directory.test.ts`: 32 tests covering all scopes and resolution
- `src/term-commands/dir.ts`: `--global` flag on add/rm/edit, scope column in ls
- `src/lib/builtin-agents.ts`: Built-in agent registry for resolution fallback

## Test plan

- [x] `bun test src/lib/agent-directory.test.ts` — 32/32 pass
- [x] `bun run typecheck` — clean
- [x] `bun run build` — succeeds
- [ ] Manual: `genie dir add engineer --dir /path` writes to project `.genie/agents.json`
- [ ] Manual: `genie dir add --global engineer --dir /path` writes to global
- [ ] Manual: `genie dir ls` shows scope column