### PR TITLE
feat: spawn into current session without --team

### DIFF
--- a/plugins/genie/rules/genie-orchestration.md
+++ b/plugins/genie/rules/genie-orchestration.md
@@ -1,16 +1,32 @@
-# Genie CLI — Use genie CLI, not native tools
+# Genie CLI — Agent Orchestration Rules
 
-NEVER use `Agent`, `SendMessage`, `TeamCreate`, or `TeamDelete` tools. Use genie CLI instead.
+## Communication: SendMessage vs genie send
+
+**Same-session teammates** (spawned with `genie spawn <role>` into your window):
+- Use `SendMessage` — Claude Code's native IPC handles it bidirectionally
+- These teammates appear as panes in your tmux window
+- SendMessage works because you share the same native team
+
+**Cross-session agents** (in different tmux windows or teams):
+- Use `genie send '<text>' --to <agent>` — routes via genie's messaging layer
+- These agents run in separate windows or were created with `genie team create`
+
+## CLI Commands
 
 ```bash
 genie spawn <role>          # Spawn agent (engineer, reviewer, qa, fix, refactor)
 genie kill <name>           # Force kill agent
 genie stop <name>           # Graceful stop
 genie ls                    # List agents
-genie send '<text>' --to <agent>  # Message agent
+genie send '<text>' --to <agent>  # Message agent (cross-session)
 genie broadcast '<text>'    # Broadcast to all
 genie team create|hire|fire|ls|disband|done|blocked  # Team management
 genie work <agent> <ref>    # Dispatch work
 genie done <ref>            # Mark done
 genie status <slug>         # Check status
 ```
+
+## Tool Restrictions
+
+NEVER use `Agent` to spawn agents — use `genie spawn` instead.
+NEVER use `TeamCreate` or `TeamDelete` — use `genie team create` / `genie team disband` instead.

--- a/src/genie-commands/session.ts
+++ b/src/genie-commands/session.ts
@@ -16,6 +16,7 @@ import { createHash } from 'node:crypto';
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
+import * as registry from '../lib/agent-registry.js';
 import {
   deleteNativeTeam,
   ensureNativeTeam,
@@ -127,6 +128,39 @@ export function buildClaudeCommand(teamName: string, systemPromptFile?: string, 
 }
 
 /**
+ * Register the interactive genie session in `~/.genie/workers.json`.
+ *
+ * This allows spawned agents to resolve the team-lead for messaging
+ * via the agent registry (e.g., for SendMessage bidirectional comms).
+ */
+async function registerSessionInRegistry(sessionName: string, windowName: string, workspaceDir: string): Promise<void> {
+  try {
+    const target = `${sessionName}:${windowName}`;
+    const paneId = (await tmux.executeTmux(`display -t ${shellQuote(target)} -p '#{pane_id}'`)).trim();
+    const now = new Date().toISOString();
+    const sanitized = sanitizeTeamName(windowName);
+    await registry.register({
+      id: `${sanitized}-team-lead`,
+      paneId,
+      session: sessionName,
+      team: windowName,
+      role: 'team-lead',
+      worktree: null,
+      startedAt: now,
+      state: 'working',
+      lastStateChange: now,
+      repoPath: workspaceDir,
+      provider: 'claude',
+      transport: 'tmux',
+      nativeTeamEnabled: true,
+      nativeAgentId: `team-lead@${sanitized}`,
+    });
+  } catch {
+    // Best-effort — don't block session startup if registration fails
+  }
+}
+
+/**
  * Resolve the window name for the current working directory.
  *
  * Logic:
@@ -206,6 +240,9 @@ async function createSession(
   const cmd = buildClaudeCommand(windowName, systemPromptFile || undefined, resumeSessionId || undefined);
   await tmux.executeTmux(`send-keys -t ${shellQuote(target)} ${shellQuote(cmd)} Enter`);
   console.log(`Started Claude Code as ${agentName}@${sanitizeTeamName(windowName)} in ${workspaceDir}`);
+
+  // Register interactive session so spawned agents can find the team-lead
+  await registerSessionInRegistry(sessionName, windowName, workspaceDir);
 }
 
 /** Focus (or create) a team window within an existing session. */
@@ -235,6 +272,9 @@ async function focusTeamWindow(
     const cmd = buildClaudeCommand(windowName, systemPromptFile || undefined, resumeSessionId || undefined);
     await tmux.executeTmux(`send-keys -t ${shellQuote(target)} ${shellQuote(cmd)} Enter`);
     console.log(`Started Claude Code as ${agentName}@${sanitizeTeamName(windowName)} in ${workingDir}`);
+
+    // Register interactive session so spawned agents can find the team-lead
+    await registerSessionInRegistry(sessionName, windowName, workingDir);
   }
   await tmux.executeTmux(`select-window -t ${shellQuote(`${sessionName}:${windowName}`)}`);
   console.log(`Focused team window "${windowName}"`);

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -393,6 +393,8 @@ interface SpawnCtx {
   extraArgs?: string[];
   /** Working directory for the worker (defaults to process.cwd()). */
   cwd: string;
+  /** When true, spawn into the current tmux window instead of resolving/creating a team window. */
+  spawnIntoCurrentWindow: boolean;
 }
 
 async function registerSpawnWorker(
@@ -497,7 +499,9 @@ async function resolveSpawnTeamWindow(team: string | undefined, cwd: string): Pr
 async function launchTmuxSpawn(ctx: SpawnCtx): Promise<void> {
   const { execSync } = require('node:child_process');
 
-  const teamWindow = await resolveSpawnTeamWindow(ctx.validated.team, ctx.cwd);
+  // When spawning into the current session (no explicit --team), skip team window
+  // resolution and split the current window directly.
+  const teamWindow = ctx.spawnIntoCurrentWindow ? null : await resolveSpawnTeamWindow(ctx.validated.team, ctx.cwd);
   const splitTarget = teamWindow ? `-t '${teamWindow.windowId}'` : '';
 
   let paneId: string;
@@ -754,7 +758,8 @@ export async function handleWorkerSpawn(name: string, options: SpawnOptions): Pr
   // 1. Resolve agent from directory or built-ins
   let agent = await resolveAgentForSpawn(name, options);
 
-  // 2. Resolve team
+  // 2. Resolve team (track whether it was explicitly provided via --team)
+  const teamWasExplicit = Boolean(options.team);
   const team = options.team || (await nativeTeams.discoverTeamName());
   if (!team) {
     console.error('Error: --team is required (or set GENIE_TEAM, or run inside a genie session)');
@@ -805,6 +810,7 @@ export async function handleWorkerSpawn(name: string, options: SpawnOptions): Pr
     transport: insideTmux ? 'tmux' : 'inline',
     extraArgs: options.extraArgs,
     cwd: agent.repoPath,
+    spawnIntoCurrentWindow: !teamWasExplicit && insideTmux,
   };
 
   if (insideTmux) {


### PR DESCRIPTION
## Summary

- `genie spawn <role>` without `--team` now spawns the agent into the current tmux window instead of creating/resolving a team window. Team is auto-detected from `GENIE_TEAM` env var.
- Interactive genie sessions are registered in `~/.genie/workers.json` so spawned agents can find the team-lead for bidirectional `SendMessage` communication.
- Orchestration rules updated: `SendMessage` for same-session teammates, `genie send` for cross-session agents.

## Test plan

- [ ] `genie spawn engineer` (no --team) from a genie session spawns engineer in same window
- [ ] Spawned engineer can SendMessage to the session leader
- [ ] Session leader can SendMessage to the spawned engineer
- [ ] `genie spawn engineer --team other-team` still works (spawns into other team's window)
- [ ] Interactive session appears in `~/.genie/workers.json`
- [ ] `bun run typecheck` passes
- [ ] `bun run build` succeeds