### PR TITLE
fix: team-lead uses genie work directly + wish template QA section

### DIFF
--- a/plugins/genie/agents/team-lead.md
+++ b/plugins/genie/agents/team-lead.md
@@ -38,12 +38,11 @@ You autonomously execute a wish lifecycle from start to finish. Your team member
 Read the WISH.md at the path given in your initial prompt. Parse execution groups, their dependencies, and acceptance criteria.
 
 ### 2. Execute Groups (respecting dependencies)
-For each group whose dependencies are satisfied, spawn an engineer and dispatch the group:
+For each group whose dependencies are satisfied, dispatch it. `genie work` auto-initializes state and spawns the engineer — one command does everything:
 ```bash
-genie spawn engineer --team <your-team-name>
 genie work engineer <slug>#<group>
 ```
-Monitor with `genie read engineer`. When the engineer signals completion, verify output.
+This checks dependencies, sets the group to in_progress, and spawns the engineer with the group context. Monitor with `genie read <team>-engineer`.
 
 Mark completed groups:
 ```bash
@@ -58,13 +57,13 @@ genie status <slug>
 Run groups in parallel when dependencies allow. Wait for all dependencies before starting a group.
 
 ### 3. Review
-After all groups complete, spawn a reviewer:
+After all groups complete, run the wish validation commands, then dispatch a review:
 ```bash
-genie spawn reviewer --team <your-team-name>
+genie work reviewer <slug>#review
 ```
-If review returns FIX-FIRST, spawn a fixer:
+If review returns FIX-FIRST:
 ```bash
-genie spawn fix --team <your-team-name>
+genie work fix <slug>#fix
 ```
 Re-review after fix. Max 2 rounds.
 
@@ -93,7 +92,7 @@ Check autoMergeDev config. If true, merge. If false, leave PR open for human rev
 
 ### 7. QA (if merged)
 ```bash
-genie spawn qa --team <your-team-name>
+genie work qa <slug>#qa
 ```
 Monitor qa. If failures, dispatch fix and re-test (max 2 rounds).
 

--- a/plugins/genie/agents/team-lead/AGENTS.md
+++ b/plugins/genie/agents/team-lead/AGENTS.md
@@ -38,12 +38,11 @@ You autonomously execute a wish lifecycle from start to finish. Your team member
 Read the WISH.md at the path given in your initial prompt. Parse execution groups, their dependencies, and acceptance criteria.
 
 ### 2. Execute Groups (respecting dependencies)
-For each group whose dependencies are satisfied, spawn an engineer and dispatch the group:
+For each group whose dependencies are satisfied, dispatch it. `genie work` auto-initializes state and spawns the engineer — one command does everything:
 ```bash
-genie spawn engineer --team <your-team-name>
 genie work engineer <slug>#<group>
 ```
-Monitor with `genie read engineer`. When the engineer signals completion, verify output.
+This checks dependencies, sets the group to in_progress, and spawns the engineer with the group context. Monitor with `genie read <team>-engineer`.
 
 Mark completed groups:
 ```bash
@@ -58,13 +57,13 @@ genie status <slug>
 Run groups in parallel when dependencies allow. Wait for all dependencies before starting a group.
 
 ### 3. Review
-After all groups complete, spawn a reviewer:
+After all groups complete, run the wish validation commands, then dispatch a review:
 ```bash
-genie spawn reviewer --team <your-team-name>
+genie work reviewer <slug>#review
 ```
-If review returns FIX-FIRST, spawn a fixer:
+If review returns FIX-FIRST:
 ```bash
-genie spawn fix --team <your-team-name>
+genie work fix <slug>#fix
 ```
 Re-review after fix. Max 2 rounds.
 
@@ -93,7 +92,7 @@ Check autoMergeDev config. If true, merge. If false, leave PR open for human rev
 
 ### 7. QA (if merged)
 ```bash
-genie spawn qa --team <your-team-name>
+genie work qa <slug>#qa
 ```
 Monitor qa. If failures, dispatch fix and re-test (max 2 rounds).
 

--- a/plugins/genie/references/wish-template.md
+++ b/plugins/genie/references/wish-template.md
@@ -79,9 +79,19 @@
 
 ---
 
+## QA Criteria
+
+_What must be verified on dev after merge. The QA agent tests each criterion._
+
+- [ ] <functional criterion — user-facing behavior works>
+- [ ] <integration criterion — system works end-to-end>
+- [ ] <regression criterion — existing behavior not broken>
+
+---
+
 ## Review Results
 
-_Populated by `/review` after make execution completes._
+_Populated by `/review` after execution completes._
 
 ---
 


### PR DESCRIPTION
Two fixes: (1) team-lead AGENTS.md uses genie work (auto-inits state + spawns), no separate genie spawn. (2) Wish template includes QA Criteria section.