### PR TITLE
fix: set GENIE_TEAM env var on agent spawn

### DIFF
--- a/src/lib/provider-adapters.ts
+++ b/src/lib/provider-adapters.ts
@@ -216,9 +216,12 @@ export function buildClaudeCommand(params: SpawnParams): LaunchCommand {
   const parts: string[] = ['claude', '--dangerously-skip-permissions'];
   const env: Record<string, string> = {};
 
-  // Always set GENIE_AGENT_NAME, even for non-native spawns
+  // Always set GENIE_AGENT_NAME and GENIE_TEAM, even for non-native spawns
   if (params.role) {
     env.GENIE_AGENT_NAME = params.role;
+  }
+  if (params.team) {
+    env.GENIE_TEAM = params.team;
   }
 
   if (params.nativeTeam?.enabled) {


### PR DESCRIPTION
Agents spawned by genie had no GENIE_TEAM set. When they called genie work/dispatch, it fell back to 'genie' (the default) instead of their actual team. Workers spawned into wrong windows.