### PR TITLE
fix(update): delete bun lockfile before install

### DIFF
--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -146,7 +146,11 @@ async function detectInstallationType(): Promise<InstallationType> {
 
 async function updateViaBun(channel: string): Promise<void> {
   // Delete global lockfile — it pins old versions even with --force --no-cache
-  try { require("node:fs").unlinkSync(join(homedir(), ".bun", "install", "global", "bun.lock")); } catch { /* may not exist */ }
+  try {
+    require('node:fs').unlinkSync(join(homedir(), '.bun', 'install', 'global', 'bun.lock'));
+  } catch {
+    /* may not exist */
+  }
 
   log(`Updating via bun (channel: ${channel})...`);
   const result = await runCommand('bun', ['add', '-g', '--force', '--no-cache', `@automagik/genie@${channel}`]);


### PR DESCRIPTION
bun's global lockfile pins old versions even with --force --no-cache. Delete it before installing.