### PR TITLE
fix(reset): clean up all team dirs on --reset, not just current window

### DIFF
--- a/src/genie-commands/session.ts
+++ b/src/genie-commands/session.ts
@@ -258,9 +258,9 @@ async function handleReset(sessionName: string, windowName: string): Promise<voi
   const existing = await tmux.findSessionByName(sessionName);
   if (existing) {
     // Collect all window names BEFORE killing the session
-    const windows = await tmux.listWindows(sessionName);
+    const windows = await tmux.listWindows(existing.id);
     console.log(`Resetting session "${sessionName}"...`);
-    await tmux.killSession(sessionName);
+    await tmux.killSession(existing.id);
     // Delete native team dirs for ALL windows in the session
     await Promise.all(windows.map((w) => deleteNativeTeam(w.name)));
   } else {


### PR DESCRIPTION
Fixes #545

## Problem

`genie --reset` kills the entire tmux session but only deletes one native team directory — the current `windowName`. Any other windows in the session leave their configs behind in `~/.claude/teams/`. On the next `genie` launch, these stale directories are reused, causing ghost teammates from already-terminated panes.

## Fix

Call `listWindows()` **before** `killSession()` to capture all window names, then delete each window's team directory.

```typescript
async function handleReset(sessionName: string, windowName: string): Promise<void> {
  const existing = await tmux.findSessionByName(sessionName);
  if (existing) {
    // Collect all window names BEFORE killing the session
    const windows = await tmux.listWindows(sessionName);
    console.log(`Resetting session "${sessionName}"...`);
    await tmux.killSession(sessionName);
    // Delete native team dirs for ALL windows in the session
    await Promise.all(windows.map((w) => deleteNativeTeam(w.name)));
  } else {
    // Session not running — still clean up the current window's team dir
    await deleteNativeTeam(windowName);
  }
}
```

`listWindows` is already used elsewhere in `session.ts` and handles the `no server running` / `session not found` error cases internally, so no extra guard is needed.

The `else` branch preserves the existing behavior for when `--reset` is called with no active session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session reset so that when a session exists, all associated window directories are collected and removed, ensuring complete cleanup across multiple windows.
  * When no session exists, only the current window's directory is cleaned up (previous unconditional deletion was removed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->