### PR TITLE
fix: session hook respects updateChannel, release skip-ci fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   release:
     name: Create Release
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    if: "!startsWith(github.event.head_commit.message, '[skip ci]')"
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     steps:

--- a/plugins/genie/scripts/smart-install.js
+++ b/plugins/genie/scripts/smart-install.js
@@ -230,11 +230,30 @@ function getPluginVersion() {
 }
 
 /**
+ * Read updateChannel from ~/.genie/config.json.
+ * Returns 'latest' or 'next'.
+ */
+function getUpdateChannel() {
+  try {
+    const configPath = join(GENIE_DIR, 'config.json');
+    if (existsSync(configPath)) {
+      const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+      return config.updateChannel || 'latest';
+    }
+  } catch {
+    // Ignore
+  }
+  return 'latest';
+}
+
+/**
  * Check if genie CLI needs install or upgrade via bun global
  */
 function genieCliNeedsInstall() {
   const installed = getGenieVersion();
   if (!installed) return true;
+  // Never overwrite dev builds — dev users update manually via genie update --next
+  if (getUpdateChannel() === 'next') return false;
   const pluginVersion = getPluginVersion();
   if (!pluginVersion) return false;
   return installed !== pluginVersion;
@@ -309,7 +328,7 @@ function createDefaultConfig() {
       version: 2,
       promptMode: 'append',
       session: { name: 'genie', defaultWindow: 'shell', autoCreate: true },
-      terminal: { execTimeout: 120000, readLines: 100, worktreeBase: '.worktrees' },
+      terminal: { execTimeout: 120000, readLines: 100 },
       logging: { tmuxDebug: false, verbose: false },
       shell: { preference: 'auto' },
       shortcuts: { tmuxInstalled: false, shellInstalled: false },


### PR DESCRIPTION
## Summary

- **smart-install.js**: reads `updateChannel` from `~/.genie/config.json`. When `next`, skips CLI reinstall — stops the downgrade cycle that overwrites dev builds on every SessionStart
- **release.yml**: `startsWith` instead of `contains` for `[skip ci]` — squash merge bodies with `[skip ci]` in sub-commits no longer skip the release workflow
- **createDefaultConfig()**: removed hardcoded `worktreeBase: '.worktrees'`

## Test plan

- [x] 736/736 tests pass
- [x] typecheck + lint clean
- [ ] Verify: with `updateChannel: "next"`, new CC session doesn't downgrade genie
- [ ] Verify: merge to main triggers release workflow