### PR TITLE
fix: auto-publish @next on dev merge, fix rolling PR history sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,34 @@ jobs:
 
       - name: Test
         run: bun test || bun test
+
+  publish-next:
+    name: Publish @next
+    needs: [quality-gate]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.10"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+
+      - name: Publish to npm @next
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+          HUSKY: "0"
+        run: |
+          if [ -z "$NPM_TOKEN" ]; then
+            echo "NPM_TOKEN not set — skipping @next publish"
+            exit 0
+          fi
+          bun publish --tag next --access public

--- a/.github/workflows/rolling-pr.yml
+++ b/.github/workflows/rolling-pr.yml
@@ -39,9 +39,12 @@ jobs:
 
           **Process:**
           - This PR is automatically created and kept open
-          - Agent monitors CI status and fixes issues
           - Human reviews and merges when ready
           - Label `ready-to-merge` added when all checks pass
+
+          > **IMPORTANT: Merge with "Create a merge commit" — NEVER squash.**
+          > Squash merging breaks history sync between dev and main,
+          > causing the next rolling PR to show all commits again.
 
           > Human approval required for merge to production.
           BODY


### PR DESCRIPTION
## Summary

- **ci.yml**: new `publish-next` job — auto-publishes to npm `@next` on every dev push (after quality gate passes). No more manual publishes.
- **rolling-pr.yml**: updated PR body to explicitly warn "NEVER squash" — squash merging dev→main breaks history sync, causing every subsequent rolling PR to show the full diff again (the 6k lines bug).

## How it works now

| Event | What happens |
|-------|-------------|
| PR merged to dev | CI runs → quality gate passes → `@next` auto-published to npm |
| Rolling PR merged to main (merge commit) | Release workflow fires → GitHub release + npm `latest` publish |

## What was broken

1. No `@next` publish on dev — had to publish manually every time
2. Rolling PR squash-merged → main/dev diverged → next rolling PR showed all commits again as "new" (+6k lines)
3. Rolling PR body didn't warn about merge method

## Test plan

- [x] 736/736 tests pass
- [x] YAML syntax valid
- [ ] Merge this to dev → verify `@next` publish fires
- [ ] Close stale #602, let rolling-pr workflow create fresh one
- [ ] Merge fresh rolling PR with merge commit → verify release fires