### PR TITLE
fix(team): kill all members on team done/blocked

### DIFF
--- a/src/lib/team-manager.ts
+++ b/src/lib/team-manager.ts
@@ -426,6 +426,20 @@ export async function listMembers(teamName: string): Promise<string[] | null> {
   return config.members;
 }
 
+/** Kill all running workers for a team's members. Best-effort — continues on failure. */
+export async function killTeamMembers(teamName: string): Promise<void> {
+  const config = await getTeam(teamName);
+  if (!config) return;
+
+  for (const member of config.members) {
+    try {
+      await killWorkersByName(member);
+    } catch {
+      // Best-effort — continue with other members
+    }
+  }
+}
+
 /** Set team lifecycle status. */
 export async function setTeamStatus(teamName: string, status: TeamStatus): Promise<void> {
   const filePath = teamFilePath(teamName);

--- a/src/term-commands/team.ts
+++ b/src/term-commands/team.ts
@@ -157,11 +157,12 @@ export function registerTeamNamespace(program: Command): void {
   // team done
   team
     .command('done <name>')
-    .description('Mark a team as done')
+    .description('Mark a team as done and kill all members')
     .action(async (name: string) => {
       try {
         await teamManager.setTeamStatus(name, 'done');
-        console.log(`Team "${name}" marked as done.`);
+        await teamManager.killTeamMembers(name);
+        console.log(`Team "${name}" marked as done. All members killed.`);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         console.error(`Error: ${message}`);
@@ -172,11 +173,12 @@ export function registerTeamNamespace(program: Command): void {
   // team blocked
   team
     .command('blocked <name>')
-    .description('Mark a team as blocked')
+    .description('Mark a team as blocked and kill all members')
     .action(async (name: string) => {
       try {
         await teamManager.setTeamStatus(name, 'blocked');
-        console.log(`Team "${name}" marked as blocked.`);
+        await teamManager.killTeamMembers(name);
+        console.log(`Team "${name}" marked as blocked. All members killed.`);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         console.error(`Error: ${message}`);


### PR DESCRIPTION
## Summary

- `genie team done <name>` and `genie team blocked <name>` now kill all team member processes after setting status
- Reuses `killWorkersByName()` from `disbandTeam()` — same mechanism, without deleting worktree/config
- Fixes infinite idle loop where team-lead keeps running after lifecycle is complete

## Changes

- **`src/lib/team-manager.ts`**: Added `killTeamMembers()` — iterates team members and kills each via `killWorkersByName()`
- **`src/term-commands/team.ts`**: `done` and `blocked` handlers now call `killTeamMembers()` after `setTeamStatus()`

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test` — 736 tests pass
- [x] `bun run build` — builds successfully
- [ ] Manual: `genie team done <name>` sets status to `done` AND kills all agent processes
- [ ] Manual: `genie team blocked <name>` sets status to `blocked` AND kills all agent processes
- [ ] Verify team config file still exists after done/blocked (not deleted)