### PR TITLE
fix(dispatch): add initialPrompt to all dispatch commands

### DIFF
--- a/src/term-commands/dispatch.ts
+++ b/src/term-commands/dispatch.ts
@@ -210,6 +210,7 @@ export async function brainstormCommand(agentName: string, slug: string): Promis
     provider: 'claude',
     team: process.env.GENIE_TEAM ?? 'genie',
     extraArgs: ['--append-system-prompt-file', contextFile],
+    initialPrompt: `Brainstorm "${slug}". Your context is in the system prompt. Explore the idea, ask clarifying questions, and build toward a design.`,
   });
 }
 
@@ -241,6 +242,7 @@ export async function wishCommand(agentName: string, slug: string): Promise<void
     provider: 'claude',
     team: process.env.GENIE_TEAM ?? 'genie',
     extraArgs: ['--append-system-prompt-file', contextFile],
+    initialPrompt: `Create a wish from the design for "${slug}". Your context is in the system prompt. Write the WISH.md with execution groups, acceptance criteria, and validation commands.`,
   });
 }
 
@@ -316,6 +318,7 @@ export async function workDispatchCommand(agentName: string, ref: string): Promi
     provider: 'claude',
     team: process.env.GENIE_TEAM ?? 'genie',
     extraArgs: ['--append-system-prompt-file', contextFile],
+    initialPrompt: `Execute Group ${group} of wish "${slug}". Your full context is in the system prompt. Read the wish at ${wishPath} if needed. Implement all deliverables, run validation, and report completion.`,
   });
 }
 
@@ -370,6 +373,7 @@ export async function reviewCommand(agentName: string, ref: string): Promise<voi
     provider: 'claude',
     team: process.env.GENIE_TEAM ?? 'genie',
     extraArgs: ['--append-system-prompt-file', contextFile],
+    initialPrompt: `Review "${ref}". Your context and diff are in the system prompt. Evaluate against acceptance criteria and return SHIP, FIX-FIRST, or BLOCKED with severity-tagged findings.`,
   });
 }
 


### PR DESCRIPTION
## Summary

All four dispatch commands (`genie work`, `genie brainstorm`, `genie wish`, `genie review`) spawned agents with context in the system prompt but **no initial user message**. Claude Code needs a user turn to start working, so agents sat idle at the `>` prompt forever.

Added `initialPrompt` to all `handleWorkerSpawn` calls — agents now start executing immediately on spawn.

## What was broken

```
genie work engineer slug#1
→ Engineer spawns
→ Gets system prompt with wish context
→ Sits at blank > prompt
→ Does nothing until someone manually sends "Start"
```

## What's fixed

```
genie work engineer slug#1
→ Engineer spawns
→ Gets system prompt + initial message: "Execute Group 1 of wish..."
→ Starts working immediately
```

## Test plan

- [x] typecheck + lint clean
- [ ] `genie work engineer <slug>#<group>` — engineer starts immediately
- [ ] `genie brainstorm <agent> <slug>` — agent starts brainstorming
- [ ] `genie wish <agent> <slug>` — agent starts writing wish
- [ ] `genie review <agent> <ref>` — reviewer starts reviewing