### PR TITLE
fix: copy skills dir to plugin cache on sync

### DIFF
--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -395,6 +395,12 @@ async function syncPlugin(installType: InstallationType): Promise<void> {
       rmSync(cacheDir, { recursive: true, force: true });
     }
     copyDirSync(pluginSrc, cacheDir);
+
+    // Skills live at <pkg>/skills/ (symlink in plugins/genie/ doesn't survive npm)
+    const skillsSrc = join(globalPkgDir, 'skills');
+    if (existsSync(skillsSrc) && !existsSync(join(cacheDir, 'skills'))) {
+      copyDirSync(skillsSrc, join(cacheDir, 'skills'));
+    }
   } catch (err) {
     error(`Failed to copy plugin: ${err}`);
     return;


### PR DESCRIPTION
## Summary

Skills symlink at `plugins/genie/skills -> ../../skills` doesn't survive npm packaging. `syncPlugin()` now copies `skills/` from the package root to the cache dir so CC can find `/genie` and all other skills.

+6 lines in `update.ts`. Symlink preserved for dev.

## Test plan

- [x] 736/736 tests pass
- [ ] `genie update` → `/genie` skill available in new CC session