### PR TITLE
feat(tui): Genie tmux TUI with custom dark theme

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -725,20 +725,60 @@ install_tmux_if_needed() {
 
 configure_tmux_defaults() {
     local tmux_conf="$HOME/.tmux.conf"
+    local scripts_dir="$GENIE_HOME/scripts"
+    local tmux_scripts_src=""
 
-    if [[ -f "$tmux_conf" ]] && grep -q "base-index" "$tmux_conf"; then
-        info "tmux base-index already configured"
+    # Find tmux scripts source directory
+    if [[ -n "$PKG_DIR" && -d "$PKG_DIR/scripts/tmux" ]]; then
+        tmux_scripts_src="$PKG_DIR/scripts/tmux"
+    fi
+
+    if [[ -z "$tmux_scripts_src" ]]; then
+        warn "tmux scripts not found in package — skipping TUI setup"
         return 0
     fi
 
-    cat >> "$tmux_conf" <<'TMUX_EOF'
+    # --- Copy scripts to ~/.genie/scripts/ ---
+    log "Installing tmux scripts to $scripts_dir..."
+    mkdir -p "$scripts_dir"
 
-# Genie defaults (required for agent orchestration)
-set -g base-index 0
-setw -g pane-base-index 0
-TMUX_EOF
+    local script_count=0
+    for script in "$tmux_scripts_src"/*.sh; do
+        [[ -f "$script" ]] || continue
+        cp "$script" "$scripts_dir/"
+        chmod +x "$scripts_dir/$(basename "$script")"
+        script_count=$((script_count + 1))
+    done
+    success "Installed $script_count tmux scripts to $scripts_dir"
 
-    success "tmux defaults written to $tmux_conf"
+    # --- Write full tmux config ---
+    local tmux_conf_src="$tmux_scripts_src/genie.tmux.conf"
+    if [[ ! -f "$tmux_conf_src" ]]; then
+        warn "genie.tmux.conf template not found — skipping config"
+        return 0
+    fi
+
+    info "Genie will configure tmux. Your existing config will be backed up."
+
+    # Backup existing config if it exists and differs
+    if [[ -f "$tmux_conf" ]]; then
+        if ! diff -q "$tmux_conf" "$tmux_conf_src" &>/dev/null; then
+            cp "$tmux_conf" "${tmux_conf}.bak"
+            success "Backed up existing config to ${tmux_conf}.bak"
+        else
+            info "tmux config already matches Genie template"
+            return 0
+        fi
+    fi
+
+    cp "$tmux_conf_src" "$tmux_conf"
+    success "Genie tmux config written to $tmux_conf"
+
+    # Reload tmux if running
+    if tmux list-sessions &>/dev/null; then
+        tmux source-file "$tmux_conf" 2>/dev/null || true
+        log "tmux config reloaded"
+    fi
 }
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/plugins/genie/scripts/smart-install.js
+++ b/plugins/genie/scripts/smart-install.js
@@ -350,31 +350,85 @@ function createDefaultConfig() {
 }
 
 /**
- * Ensure tmux base-index defaults are set in ~/.tmux.conf
- * Only runs when version changes (or file missing).
- * @param {string|null} oldVersion - marker version captured before installDeps ran
+ * Copy tmux scripts from npm package to ~/.genie/scripts/ and configure tmux.
+ * On first run (no ~/.tmux.conf or no "Genie TUI" marker): write full config with backup.
+ * On subsequent runs: only refresh scripts, don't touch ~/.tmux.conf.
  */
-function ensureTmuxDefaults(oldVersion) {
-  let pluginVersion = null;
-  try {
-    const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf-8'));
-    pluginVersion = pkg.version || null;
-  } catch {
-    // Ignore
+function configureTmux() {
+  const scriptsDir = join(GENIE_DIR, 'scripts');
+  const tmuxScriptsSrc = join(ROOT, '..', '..', 'scripts', 'tmux');
+
+  // Fallback: try global package dir structure (npm package root)
+  const altSrc = join(ROOT, 'scripts', 'tmux');
+  const srcDir = existsSync(tmuxScriptsSrc) ? tmuxScriptsSrc : existsSync(altSrc) ? altSrc : null;
+
+  if (!srcDir) {
+    console.error('tmux scripts not found in package — skipping TUI setup');
+    return;
   }
 
-  if (oldVersion === pluginVersion) return;
+  // --- Copy scripts to ~/.genie/scripts/ ---
+  if (!existsSync(scriptsDir)) {
+    mkdirSync(scriptsDir, { recursive: true });
+  }
 
+  const { readdirSync, chmodSync } = require('node:fs');
+  let scriptCount = 0;
+  for (const entry of readdirSync(srcDir)) {
+    if (entry.endsWith('.sh')) {
+      const srcFile = join(srcDir, entry);
+      const destFile = join(scriptsDir, entry);
+      const content = readFileSync(srcFile);
+      writeFileSync(destFile, content);
+      chmodSync(destFile, 0o755);
+      scriptCount++;
+    }
+  }
+
+  if (scriptCount > 0) {
+    console.error(`Installed ${scriptCount} tmux scripts to ${scriptsDir}`);
+  }
+
+  // --- Write tmux config on first run only ---
   const tmuxConf = join(homedir(), '.tmux.conf');
-  let contents = '';
-  if (existsSync(tmuxConf)) {
-    contents = readFileSync(tmuxConf, 'utf-8');
+  const tmuxConfSrc = join(srcDir, 'genie.tmux.conf');
+
+  if (!existsSync(tmuxConfSrc)) {
+    console.error('genie.tmux.conf template not found — skipping config');
+    return;
   }
 
-  if (!contents.includes('base-index 0')) {
-    const append = '\n# Genie defaults\nset -g base-index 0\nsetw -g pane-base-index 0\n';
-    writeFileSync(tmuxConf, contents + append, 'utf-8');
-    console.error('Added tmux base-index defaults to ~/.tmux.conf');
+  // Check if this is a first run (no config or no Genie marker)
+  let isFirstRun = true;
+  if (existsSync(tmuxConf)) {
+    const existing = readFileSync(tmuxConf, 'utf-8');
+    if (existing.includes('Genie TUI')) {
+      isFirstRun = false;
+    }
+  }
+
+  if (isFirstRun) {
+    console.error('Genie will configure tmux. Your existing config will be backed up.');
+
+    // Backup existing config
+    if (existsSync(tmuxConf)) {
+      const { copyFileSync } = require('node:fs');
+      copyFileSync(tmuxConf, `${tmuxConf}.bak`);
+      console.error(`Backed up existing config to ${tmuxConf}.bak`);
+    }
+
+    // Write full config
+    const template = readFileSync(tmuxConfSrc, 'utf-8');
+    writeFileSync(tmuxConf, template, 'utf-8');
+    console.error(`Genie tmux config written to ${tmuxConf}`);
+
+    // Reload tmux if running
+    try {
+      const { spawnSync: spSync } = require('node:child_process');
+      spSync('tmux', ['source-file', tmuxConf], { stdio: 'ignore' });
+    } catch {
+      // tmux not running — that's fine
+    }
   }
 }
 
@@ -464,11 +518,11 @@ try {
     console.error(`Warning: Could not create default config: ${e.message}`);
   }
 
-  // 3c. Ensure tmux base-index defaults (idempotent — checks version marker)
+  // 3c. Configure tmux TUI (scripts + config on first run)
   try {
-    ensureTmuxDefaults(oldVersion);
+    configureTmux();
   } catch (e) {
-    console.error(`Warning: Could not update ~/.tmux.conf: ${e.message}`);
+    console.error(`Warning: Could not configure tmux TUI: ${e.message}`);
   }
 
   // 4. Install or upgrade genie CLI via bun global (non-fatal)

--- a/scripts/tmux/cpu-info.sh
+++ b/scripts/tmux/cpu-info.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Genie TUI — CPU usage for tmux status bar
+# Linux: reads /proc/stat (instant). macOS: falls back to ps.
+# Self-contained — no external dependencies
+
+set -euo pipefail
+
+CACHE_DIR="${HOME}/.genie/cache"
+CACHE_FILE="${CACHE_DIR}/cpu_stat_prev"
+
+# Inline helper: get tmux option with default
+get_tmux_option() {
+  local option="$1"
+  local default_value="${2:-}"
+  local value
+  value=$(tmux show-option -gqv "$option" 2>/dev/null) || true
+  if [[ -n "$value" ]]; then
+    echo "$value"
+  else
+    echo "$default_value"
+  fi
+}
+
+cpu_linux() {
+  # Read current /proc/stat
+  local line
+  line=$(head -1 /proc/stat)
+  # cpu  user nice system idle iowait irq softirq steal
+  local -a fields
+  read -ra fields <<< "$line"
+
+  local user="${fields[1]}"
+  local nice="${fields[2]}"
+  local system="${fields[3]}"
+  local idle="${fields[4]}"
+  local iowait="${fields[5]:-0}"
+  local irq="${fields[6]:-0}"
+  local softirq="${fields[7]:-0}"
+  local steal="${fields[8]:-0}"
+
+  local total=$((user + nice + system + idle + iowait + irq + softirq + steal))
+  local busy=$((total - idle - iowait))
+
+  # Read previous sample from cache
+  mkdir -p "$CACHE_DIR"
+  if [[ -f "$CACHE_FILE" ]]; then
+    local prev_busy prev_total
+    read -r prev_busy prev_total < "$CACHE_FILE" 2>/dev/null || true
+
+    if [[ -n "${prev_busy:-}" && -n "${prev_total:-}" ]]; then
+      local diff_busy=$((busy - prev_busy))
+      local diff_total=$((total - prev_total))
+
+      if [[ "$diff_total" -gt 0 ]]; then
+        local cpu_pct=$((diff_busy * 100 / diff_total))
+        echo "$busy $total" > "$CACHE_FILE"
+        echo "${cpu_pct}%"
+        return 0
+      fi
+    fi
+  fi
+
+  # First run — store baseline, show current snapshot
+  echo "$busy $total" > "$CACHE_FILE"
+  if [[ "$total" -gt 0 ]]; then
+    local cpu_pct=$((busy * 100 / total))
+    echo "${cpu_pct}%"
+  else
+    echo "0%"
+  fi
+}
+
+cpu_macos() {
+  local cpu_pct
+  cpu_pct=$(ps -A -o %cpu | awk '{sum += $1} END {printf "%.0f", sum / NR}')
+  echo "${cpu_pct}%"
+}
+
+main() {
+  case "$(uname -s)" in
+    Linux)  cpu_linux ;;
+    Darwin) cpu_macos ;;
+    *)      echo "?%" ;;
+  esac
+}
+
+main

--- a/scripts/tmux/genie-git.sh
+++ b/scripts/tmux/genie-git.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Genie TUI — git status for tmux status bar
+# Shows: branch, staged, modified, ahead/behind
+# Self-contained — no external dependencies
+
+set -euo pipefail
+
+# Inline helper: get tmux option with default
+get_tmux_option() {
+  local option="$1"
+  local default_value="${2:-}"
+  local value
+  value=$(tmux show-option -gqv "$option" 2>/dev/null) || true
+  if [[ -n "$value" ]]; then
+    echo "$value"
+  else
+    echo "$default_value"
+  fi
+}
+
+# Find the git repo for the active pane's working directory
+get_pane_path() {
+  local pane_path
+  pane_path=$(tmux display-message -p -F "#{pane_current_path}" 2>/dev/null) || true
+  echo "${pane_path:-$PWD}"
+}
+
+main() {
+  local pane_path
+  pane_path=$(get_pane_path)
+
+  # Check if we're in a git repo
+  if ! git -C "$pane_path" rev-parse --is-inside-work-tree &>/dev/null; then
+    echo ""
+    return 0
+  fi
+
+  # Branch name
+  local branch
+  branch=$(git -C "$pane_path" symbolic-ref --short HEAD 2>/dev/null) || \
+    branch=$(git -C "$pane_path" rev-parse --short HEAD 2>/dev/null) || \
+    branch="?"
+
+  local status_parts=()
+  status_parts+=("$branch")
+
+  # Staged count
+  local staged
+  staged=$(git -C "$pane_path" diff --cached --numstat 2>/dev/null | wc -l | tr -d ' ')
+  if [[ "$staged" -gt 0 ]]; then
+    status_parts+=("+${staged}")
+  fi
+
+  # Modified (unstaged) count
+  local modified
+  modified=$(git -C "$pane_path" diff --numstat 2>/dev/null | wc -l | tr -d ' ')
+  if [[ "$modified" -gt 0 ]]; then
+    status_parts+=("!${modified}")
+  fi
+
+  # Untracked count
+  local untracked
+  untracked=$(git -C "$pane_path" ls-files --others --exclude-standard 2>/dev/null | wc -l | tr -d ' ')
+  if [[ "$untracked" -gt 0 ]]; then
+    status_parts+=("?${untracked}")
+  fi
+
+  # Ahead/behind
+  local upstream
+  upstream=$(git -C "$pane_path" rev-parse --abbrev-ref '@{upstream}' 2>/dev/null) || true
+  if [[ -n "$upstream" ]]; then
+    local ahead behind
+    ahead=$(git -C "$pane_path" rev-list --count '@{upstream}..HEAD' 2>/dev/null) || ahead=0
+    behind=$(git -C "$pane_path" rev-list --count 'HEAD..@{upstream}' 2>/dev/null) || behind=0
+    if [[ "$ahead" -gt 0 ]]; then
+      status_parts+=("^${ahead}")
+    fi
+    if [[ "$behind" -gt 0 ]]; then
+      status_parts+=("v${behind}")
+    fi
+  fi
+
+  # Join with spaces
+  local IFS=' '
+  echo "${status_parts[*]}"
+}
+
+main

--- a/scripts/tmux/genie-update-check.sh
+++ b/scripts/tmux/genie-update-check.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Genie TUI — version check with 30-minute cache
+# Compares installed version against npm registry
+# Self-contained — no external dependencies
+
+set -euo pipefail
+
+CACHE_DIR="${HOME}/.genie/cache"
+CACHE_FILE="${CACHE_DIR}/update_check"
+CACHE_TTL=1800  # 30 minutes in seconds
+
+# Inline helper: get tmux option with default
+get_tmux_option() {
+  local option="$1"
+  local default_value="${2:-}"
+  local value
+  value=$(tmux show-option -gqv "$option" 2>/dev/null) || true
+  if [[ -n "$value" ]]; then
+    echo "$value"
+  else
+    echo "$default_value"
+  fi
+}
+
+get_current_version() {
+  genie --version 2>/dev/null | head -1 | sed 's/[^0-9.]//g' || echo ""
+}
+
+check_latest_version() {
+  # Try npm registry
+  local latest
+  latest=$(npm view automagik-genie version 2>/dev/null) || true
+  echo "${latest:-}"
+}
+
+is_cache_valid() {
+  if [[ ! -f "$CACHE_FILE" ]]; then
+    return 1
+  fi
+
+  local now file_age cache_age
+  now=$(date +%s)
+  file_age=$(stat -c %Y "$CACHE_FILE" 2>/dev/null || stat -f %m "$CACHE_FILE" 2>/dev/null || echo 0)
+  cache_age=$((now - file_age))
+
+  [[ "$cache_age" -lt "$CACHE_TTL" ]]
+}
+
+main() {
+  mkdir -p "$CACHE_DIR"
+
+  local current_version
+  current_version=$(get_current_version)
+
+  if [[ -z "$current_version" ]]; then
+    echo ""
+    return 0
+  fi
+
+  # Check cache
+  if is_cache_valid; then
+    local cached_result
+    cached_result=$(cat "$CACHE_FILE" 2>/dev/null) || true
+    if [[ -n "$cached_result" ]]; then
+      echo "$cached_result"
+      return 0
+    fi
+  fi
+
+  # Fetch latest version (run in background-safe way)
+  local latest_version
+  latest_version=$(check_latest_version)
+
+  if [[ -z "$latest_version" ]]; then
+    # Can't reach registry — show current version, cache empty result
+    echo "v${current_version}" > "$CACHE_FILE"
+    echo "v${current_version}"
+    return 0
+  fi
+
+  # Compare versions
+  if [[ "$current_version" == "$latest_version" ]]; then
+    echo "v${current_version}" > "$CACHE_FILE"
+    echo "v${current_version}"
+  else
+    local result="v${current_version} (${latest_version} available)"
+    echo "$result" > "$CACHE_FILE"
+    echo "$result"
+  fi
+}
+
+main

--- a/scripts/tmux/genie.tmux.conf
+++ b/scripts/tmux/genie.tmux.conf
@@ -1,0 +1,98 @@
+# ============================================================================
+# Genie TUI — tmux configuration
+# Dark theme with purple/cyan/gold palette
+# Native tmux, zero plugins
+# ============================================================================
+
+# --- Terminal & basics ---
+set -g default-terminal "tmux-256color"
+set -ga terminal-overrides ",*256col*:Tc"
+set -g base-index 0
+setw -g pane-base-index 0
+set -g renumber-windows on
+set -g history-limit 50000
+set -g escape-time 0
+set -g focus-events on
+set -g set-clipboard on
+
+# --- Mouse & vi mode ---
+set -g mouse on
+setw -g mode-keys vi
+
+# --- Genie dark theme palette ---
+# Background:  #1a1a2e (deep navy)
+# Surface:     #16213e (panel bg)
+# Border:      #0f3460 (subtle blue)
+# Active:      #7b2ff7 (purple — active tab, accents)
+# Inactive:    #b8a9c9 (lavender — inactive tab text)
+# Cyan:        #00d2ff (info accents)
+# Gold:        #f5a623 (warnings, updates)
+# Text:        #e0e0e0 (primary text)
+# Dim:         #6c6c8a (dim text)
+
+# --- Pane borders ---
+set -g pane-border-style "fg=#0f3460"
+set -g pane-active-border-style "fg=#7b2ff7"
+
+# --- Message styling ---
+set -g message-style "bg=#16213e,fg=#00d2ff"
+set -g message-command-style "bg=#16213e,fg=#f5a623"
+
+# --- Mode (copy mode) styling ---
+setw -g mode-style "bg=#7b2ff7,fg=#e0e0e0"
+
+# --- Clock ---
+setw -g clock-mode-colour "#7b2ff7"
+
+# ============================================================================
+# STATUS BAR
+# ============================================================================
+set -g status on
+set -g status-interval 5
+set -g status-position top
+set -g status-justify left
+set -g status-style "bg=#1a1a2e,fg=#e0e0e0"
+
+# --- Left: Genie branding + version ---
+set -g status-left-length 60
+set -g status-left "#[bg=#7b2ff7,fg=#e0e0e0,bold] #(genie --version 2>/dev/null | head -1 || echo 'Genie') #[bg=#1a1a2e,fg=#7b2ff7]"
+
+# --- Right: git | CPU | RAM | clock ---
+set -g status-right-length 120
+set -g status-right "#[fg=#6c6c8a]#($HOME/.genie/scripts/genie-git.sh) #[fg=#0f3460]| #[fg=#00d2ff]CPU #($HOME/.genie/scripts/cpu-info.sh) #[fg=#0f3460]| #[fg=#00d2ff]RAM #($HOME/.genie/scripts/ram-info.sh) #[fg=#0f3460]| #[fg=#e0e0e0]%H:%M "
+
+# ============================================================================
+# WINDOW (TAB) STYLING — clickable tabs
+# ============================================================================
+
+# Tab separator
+set -g window-status-separator ""
+
+# Inactive tabs: lavender text on dark bg
+set -g window-status-format "#[fg=#b8a9c9,bg=#1a1a2e] #I:#W "
+
+# Active tab: purple bg, white text, bold
+set -g window-status-current-format "#[fg=#1a1a2e,bg=#7b2ff7]#[fg=#e0e0e0,bg=#7b2ff7,bold] #I:#W #[fg=#7b2ff7,bg=#1a1a2e]"
+
+# Activity monitoring
+setw -g monitor-activity on
+set -g visual-activity off
+set -g window-status-activity-style "fg=#f5a623,bg=#1a1a2e"
+
+# ============================================================================
+# SECOND STATUS LINE — bottom tab bar (tmux 3.2+)
+# ============================================================================
+# Uncomment the following for a dual status bar (requires tmux 3.2+):
+# set -g status 2
+# set -g status-format[1] "#[align=centre,fg=#6c6c8a,bg=#16213e] #($HOME/.genie/scripts/genie-update-check.sh) "
+
+# ============================================================================
+# KEYBINDINGS (standard — no changes from defaults beyond vi mode)
+# ============================================================================
+
+# Reload config
+bind r source-file ~/.tmux.conf \; display-message "Config reloaded"
+
+# Vi copy mode bindings
+bind -T copy-mode-vi v send-keys -X begin-selection
+bind -T copy-mode-vi y send-keys -X copy-selection-and-cancel

--- a/scripts/tmux/ram-info.sh
+++ b/scripts/tmux/ram-info.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Genie TUI — RAM usage for tmux status bar
+# Supports Linux + macOS
+# Self-contained — no external dependencies
+
+set -euo pipefail
+
+# Inline helper: get tmux option with default
+get_tmux_option() {
+  local option="$1"
+  local default_value="${2:-}"
+  local value
+  value=$(tmux show-option -gqv "$option" 2>/dev/null) || true
+  if [[ -n "$value" ]]; then
+    echo "$value"
+  else
+    echo "$default_value"
+  fi
+}
+
+ram_linux() {
+  # Parse /proc/meminfo
+  local total_kb available_kb
+  total_kb=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)
+  available_kb=$(awk '/^MemAvailable:/ {print $2}' /proc/meminfo)
+
+  if [[ -z "$total_kb" || "$total_kb" -eq 0 ]]; then
+    echo "?G"
+    return 0
+  fi
+
+  local used_kb=$((total_kb - available_kb))
+  local total_gb used_gb pct
+
+  # Integer math: multiply by 10 for one decimal place
+  used_gb=$(( (used_kb * 10) / 1048576 ))
+  total_gb=$(( (total_kb * 10) / 1048576 ))
+  pct=$((used_kb * 100 / total_kb))
+
+  # Format with one decimal: e.g. 82 -> 8.2
+  local used_int=$((used_gb / 10))
+  local used_dec=$((used_gb % 10))
+  local total_int=$((total_gb / 10))
+  local total_dec=$((total_gb % 10))
+
+  echo "${used_int}.${used_dec}/${total_int}.${total_dec}G ${pct}%"
+}
+
+ram_macos() {
+  # Use vm_stat for memory info
+  local page_size
+  page_size=$(sysctl -n hw.pagesize 2>/dev/null || echo 4096)
+
+  local total_bytes
+  total_bytes=$(sysctl -n hw.memsize 2>/dev/null) || {
+    echo "?G"
+    return 0
+  }
+
+  # Get pages from vm_stat
+  local active inactive wired compressed
+  local vmstat
+  vmstat=$(vm_stat 2>/dev/null) || {
+    echo "?G"
+    return 0
+  }
+
+  active=$(echo "$vmstat" | awk '/Pages active:/ {gsub(/\./,"",$3); print $3}')
+  inactive=$(echo "$vmstat" | awk '/Pages inactive:/ {gsub(/\./,"",$3); print $3}')
+  wired=$(echo "$vmstat" | awk '/Pages wired down:/ {gsub(/\./,"",$4); print $4}')
+  compressed=$(echo "$vmstat" | awk '/Pages occupied by compressor:/ {gsub(/\./,"",$5); print $5}')
+
+  local used_pages=$(( ${active:-0} + ${wired:-0} + ${compressed:-0} ))
+  local used_bytes=$((used_pages * page_size))
+
+  local total_gb used_gb pct
+  used_gb=$(( (used_bytes / 1073741824 * 10 + used_bytes % 1073741824 * 10 / 1073741824) ))
+  total_gb=$(( (total_bytes / 1073741824 * 10 + total_bytes % 1073741824 * 10 / 1073741824) ))
+
+  if [[ "$total_bytes" -gt 0 ]]; then
+    pct=$((used_bytes * 100 / total_bytes))
+  else
+    pct=0
+  fi
+
+  local used_int=$((used_gb / 10))
+  local used_dec=$((used_gb % 10))
+  local total_int=$((total_gb / 10))
+  local total_dec=$((total_gb % 10))
+
+  echo "${used_int}.${used_dec}/${total_int}.${total_dec}G ${pct}%"
+}
+
+main() {
+  case "$(uname -s)" in
+    Linux)  ram_linux ;;
+    Darwin) ram_macos ;;
+    *)      echo "?G" ;;
+  esac
+}
+
+main

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -1,5 +1,14 @@
 import { spawn } from 'node:child_process';
-import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { chmod, copyFile, mkdir, unlink } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
@@ -360,6 +369,34 @@ function updatePluginRegistry(claudePlugins: string, cacheDir: string, version: 
   }
 }
 
+/** Copy tmux scripts from the global package to ~/.genie/scripts/ */
+function syncTmuxScripts(globalPkgDir: string): void {
+  const tmuxScriptsSrc = join(globalPkgDir, 'scripts', 'tmux');
+  if (!existsSync(tmuxScriptsSrc)) return;
+
+  const scriptsDir = join(GENIE_HOME, 'scripts');
+  mkdirSync(scriptsDir, { recursive: true });
+
+  let scriptCount = 0;
+  for (const entry of readdirSync(tmuxScriptsSrc)) {
+    if (entry.endsWith('.sh')) {
+      const src = join(tmuxScriptsSrc, entry);
+      const dest = join(scriptsDir, entry);
+      copyFileSync(src, dest);
+      try {
+        chmodSync(dest, 0o755);
+      } catch {
+        // chmod may fail on some filesystems — non-fatal
+      }
+      scriptCount++;
+    }
+  }
+
+  if (scriptCount > 0) {
+    success(`Refreshed ${scriptCount} tmux scripts at ${scriptsDir}`);
+  }
+}
+
 async function syncPlugin(installType: InstallationType): Promise<void> {
   log('Syncing Claude Code plugin...');
 
@@ -407,6 +444,7 @@ async function syncPlugin(installType: InstallationType): Promise<void> {
   }
 
   updatePluginRegistry(claudePlugins, cacheDir, version);
+  syncTmuxScripts(globalPkgDir);
 
   success(`Plugin synced to v${version}`);
 }


### PR DESCRIPTION
## Summary
- Bundle self-contained tmux scripts (git status, CPU, RAM, version check) at scripts/tmux/
- Complete .tmux.conf with Genie dark theme (purple/cyan/gold palette), clickable tabs, top info bar
- All 3 install paths deploy TUI: install.sh, smart-install.js (bun install -g), genie update
- Removed Dracula plugin dependency — all helpers inlined
- Scripts use $HOME/.genie/scripts/ paths, no hardcoded home dirs
- CPU uses /proc/stat on Linux (instant), ps fallback on macOS

## Wish
tmux-tui

## Test plan
- [ ] Fresh install.sh sets up full TUI with theme, top bar, clickable tabs
- [ ] bun install -g + new session → TUI deployed via smart-install hook
- [ ] genie update refreshes scripts at ~/.genie/scripts/
- [ ] No Dracula plugin referenced anywhere
- [ ] Scripts work on Linux and macOS
- [ ] bun run check passes