### PR TITLE
feat: genie work <slug> auto-orchestration + bare repo safety

### DIFF
--- a/plugins/genie/agents/engineer.md
+++ b/plugins/genie/agents/engineer.md
@@ -49,6 +49,9 @@ After the implementation works:
 
 ## 6. Validate
 Run the validation command from the wish. Record output. Confirm each acceptance criterion is met.
+
+## 7. Report Completion
+After completing all deliverables and validation, call `genie done <slug>#<group>` to report completion. The slug and group are in your initial prompt. This signals the orchestrator that your work is finished so it can advance to the next wave.
 </process>
 
 <success_criteria>

--- a/plugins/genie/agents/engineer/AGENTS.md
+++ b/plugins/genie/agents/engineer/AGENTS.md
@@ -49,6 +49,9 @@ After the implementation works:
 
 ## 6. Validate
 Run the validation command from the wish. Record output. Confirm each acceptance criterion is met.
+
+## 7. Report Completion
+After completing all deliverables and validation, call `genie done <slug>#<group>` to report completion. The slug and group are in your initial prompt. This signals the orchestrator that your work is finished so it can advance to the next wave.
 </process>
 
 <success_criteria>

--- a/plugins/genie/agents/team-lead.md
+++ b/plugins/genie/agents/team-lead.md
@@ -49,31 +49,44 @@ Read the WISH.md at the path provided in your initial prompt. Parse execution gr
 **Gate:** All groups parsed, dependency DAG understood. If wish is unparseable or missing groups, report to PM and stop.
 
 ## Phase 2 — Execute Waves
-Read the **Execution Strategy** section from WISH.md. It defines waves — each wave lists groups that can run in parallel. `genie work` auto-initializes state on first call — do NOT run `genie status` before your first dispatch. Just dispatch immediately.
+Read the **Execution Strategy** section from WISH.md. It defines waves — each wave lists groups that can run in parallel.
 
-For each wave, in order:
+### Primary: Auto-orchestration (preferred)
+Run a single command that handles all wave orchestration automatically:
 
-1. **Dispatch all groups in the wave simultaneously:**
-   ```bash
-   genie work engineer <slug>#<group>   # For EACH group in the wave
-   ```
-   The auto-suffix feature (`engineer` → `engineer-1`, `engineer-2`, etc.) prevents role collisions, so all groups in a wave launch at once.
+```bash
+genie work <slug>
+```
 
-2. **After dispatching, wait for worker messages.** Workers send completion messages via SendMessage when done. Do NOT use `sleep` — it blocks incoming messages. Just proceed to the next tool call or check inbox:
-   ```bash
-   genie inbox                          # Check for worker completion messages
-   genie status <slug>                  # Check overall progress
-   genie read <team>-engineer-<group>   # Only if you need to debug a stuck worker
-   ```
+This reads the Execution Strategy, spawns all agents per wave in parallel, polls wish state for completion, advances waves, and exits 0 when all groups are done (or exits 1 on timeout). It replaces manual per-group dispatch entirely.
 
-3. **As each group completes, mark it done:**
-   ```bash
-   genie done <slug>#<group>
-   ```
+While `genie work <slug>` runs (it blocks until complete), monitor progress in parallel:
+```bash
+genie ls                              # Check running agents
+genie status <slug>                   # Check overall wish progress
+genie read <team>-engineer-<group>    # Debug a stuck worker
+```
 
-4. **When ALL groups in the current wave are done, advance to the next wave.**
+### Fallback: Manual dispatch (if auto fails)
+If `genie work <slug>` fails or is not available, dispatch groups manually per wave:
 
-IMPORTANT: Never use `sleep` to wait for workers. Messages arrive via SendMessage — sleeping blocks them. Dispatch all groups in the wave, then check inbox repeatedly until all report completion.
+```bash
+genie work engineer <slug>#<group>    # For EACH group in the wave
+```
+
+The auto-suffix feature (`engineer` → `engineer-1`, `engineer-2`, etc.) prevents role collisions. After dispatching, wait for worker messages via inbox — do NOT use `sleep`:
+```bash
+genie inbox                           # Check for worker completion messages
+genie status <slug>                   # Check overall progress
+```
+
+As each group completes, mark it done: `genie done <slug>#<group>`. Advance to the next wave when all groups in the current wave are done.
+
+### Escape hatch: Custom agents
+For non-standard work not covered by execution groups, spawn agents directly:
+```bash
+genie spawn <role> --team <name>
+```
 
 **Gate:** All groups show `done` in `genie status`. If any group is stuck after 2 fix attempts, mark team blocked and stop.
 
@@ -157,7 +170,8 @@ When running in a loop, execute this checklist each iteration. Exit early if not
 
 <commands_reference>
 ```
-genie work <agent> <slug>#<group>     — dispatch group work (auto-spawns agent)
+genie work <slug>                     — auto-orchestrate full wish (preferred)
+genie work <agent> <slug>#<group>     — dispatch single group manually (fallback)
 genie done <slug>#<group>             — mark group complete
 genie status <slug>                   — check wish progress
 genie spawn <role> --team <name>      — spawn a worker in your team

--- a/plugins/genie/agents/team-lead/AGENTS.md
+++ b/plugins/genie/agents/team-lead/AGENTS.md
@@ -49,31 +49,44 @@ Read the WISH.md at the path provided in your initial prompt. Parse execution gr
 **Gate:** All groups parsed, dependency DAG understood. If wish is unparseable or missing groups, report to PM and stop.
 
 ## Phase 2 — Execute Waves
-Read the **Execution Strategy** section from WISH.md. It defines waves — each wave lists groups that can run in parallel. `genie work` auto-initializes state on first call — do NOT run `genie status` before your first dispatch. Just dispatch immediately.
+Read the **Execution Strategy** section from WISH.md. It defines waves — each wave lists groups that can run in parallel.
 
-For each wave, in order:
+### Primary: Auto-orchestration (preferred)
+Run a single command that handles all wave orchestration automatically:
 
-1. **Dispatch all groups in the wave simultaneously:**
-   ```bash
-   genie work engineer <slug>#<group>   # For EACH group in the wave
-   ```
-   The auto-suffix feature (`engineer` → `engineer-1`, `engineer-2`, etc.) prevents role collisions, so all groups in a wave launch at once.
+```bash
+genie work <slug>
+```
 
-2. **After dispatching, wait for worker messages.** Workers send completion messages via SendMessage when done. Do NOT use `sleep` — it blocks incoming messages. Just proceed to the next tool call or check inbox:
-   ```bash
-   genie inbox                          # Check for worker completion messages
-   genie status <slug>                  # Check overall progress
-   genie read <team>-engineer-<group>   # Only if you need to debug a stuck worker
-   ```
+This reads the Execution Strategy, spawns all agents per wave in parallel, polls wish state for completion, advances waves, and exits 0 when all groups are done (or exits 1 on timeout). It replaces manual per-group dispatch entirely.
 
-3. **As each group completes, mark it done:**
-   ```bash
-   genie done <slug>#<group>
-   ```
+While `genie work <slug>` runs (it blocks until complete), monitor progress in parallel:
+```bash
+genie ls                              # Check running agents
+genie status <slug>                   # Check overall wish progress
+genie read <team>-engineer-<group>    # Debug a stuck worker
+```
 
-4. **When ALL groups in the current wave are done, advance to the next wave.**
+### Fallback: Manual dispatch (if auto fails)
+If `genie work <slug>` fails or is not available, dispatch groups manually per wave:
 
-IMPORTANT: Never use `sleep` to wait for workers. Messages arrive via SendMessage — sleeping blocks them. Dispatch all groups in the wave, then check inbox repeatedly until all report completion.
+```bash
+genie work engineer <slug>#<group>    # For EACH group in the wave
+```
+
+The auto-suffix feature (`engineer` → `engineer-1`, `engineer-2`, etc.) prevents role collisions. After dispatching, wait for worker messages via inbox — do NOT use `sleep`:
+```bash
+genie inbox                           # Check for worker completion messages
+genie status <slug>                   # Check overall progress
+```
+
+As each group completes, mark it done: `genie done <slug>#<group>`. Advance to the next wave when all groups in the current wave are done.
+
+### Escape hatch: Custom agents
+For non-standard work not covered by execution groups, spawn agents directly:
+```bash
+genie spawn <role> --team <name>
+```
 
 **Gate:** All groups show `done` in `genie status`. If any group is stuck after 2 fix attempts, mark team blocked and stop.
 
@@ -157,7 +170,8 @@ When running in a loop, execute this checklist each iteration. Exit early if not
 
 <commands_reference>
 ```
-genie work <agent> <slug>#<group>     — dispatch group work (auto-spawns agent)
+genie work <slug>                     — auto-orchestrate full wish (preferred)
+genie work <agent> <slug>#<group>     — dispatch single group manually (fallback)
 genie done <slug>#<group>             — mark group complete
 genie status <slug>                   — check wish progress
 genie spawn <role> --team <name>      — spawn a worker in your team

--- a/src/term-commands/dispatch.test.ts
+++ b/src/term-commands/dispatch.test.ts
@@ -18,7 +18,15 @@ import { join } from 'node:path';
 import * as wishState from '../lib/wish-state.js';
 import { parseRef } from './state.js';
 
-import { buildContextPrompt, extractGroup, extractWishContext, parseWishGroups, writeContextFile } from './dispatch.js';
+import {
+  buildContextPrompt,
+  detectWorkMode,
+  extractGroup,
+  extractWishContext,
+  parseExecutionStrategy,
+  parseWishGroups,
+  writeContextFile,
+} from './dispatch.js';
 
 // ============================================================================
 // Sample WISH.md content for testing
@@ -541,5 +549,179 @@ describe('parseWishGroups()', () => {
   it('should handle depends-on: none', () => {
     const groups = parseWishGroups(SAMPLE_WISH);
     expect(groups[0].dependsOn).toEqual([]);
+  });
+});
+
+// ============================================================================
+// parseExecutionStrategy — wave parsing
+// ============================================================================
+
+const WISH_WITH_STRATEGY = `# Wish: Auto-Orchestrate
+
+## Summary
+
+Auto-orchestrate wish execution.
+
+## Execution Groups
+
+### Group 1: Parse Strategy
+
+**depends-on:** none
+
+---
+
+### Group 2: Orchestrator
+
+**depends-on:** Group 1
+
+---
+
+### Group 3: Engineer done
+
+**depends-on:** none
+
+---
+
+### Group 4: Team-lead prompt
+
+**depends-on:** Group 2
+
+---
+
+### Group 5: Validate
+
+**depends-on:** Group 1, Group 2, Group 3, Group 4
+
+---
+
+## Execution Strategy
+
+### Wave 1 (parallel)
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 1 | engineer | Parse Execution Strategy |
+| 3 | engineer | Engineer reports completion |
+
+### Wave 2 (after Wave 1)
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 2 | engineer | Auto-orchestration loop |
+
+### Wave 3 (after Wave 2)
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 4 | engineer | Team-lead prompt update |
+
+### Wave 4 (after Wave 3)
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 5 | reviewer | Full validation |
+
+---
+
+## Assumptions / Risks
+`;
+
+describe('parseExecutionStrategy()', () => {
+  it('should parse waves from Execution Strategy section', () => {
+    const waves = parseExecutionStrategy(WISH_WITH_STRATEGY);
+    expect(waves.length).toBe(4);
+  });
+
+  it('should parse wave names', () => {
+    const waves = parseExecutionStrategy(WISH_WITH_STRATEGY);
+    expect(waves[0].name).toBe('Wave 1 (parallel)');
+    expect(waves[1].name).toBe('Wave 2 (after Wave 1)');
+    expect(waves[2].name).toBe('Wave 3 (after Wave 2)');
+    expect(waves[3].name).toBe('Wave 4 (after Wave 3)');
+  });
+
+  it('should parse groups in Wave 1', () => {
+    const waves = parseExecutionStrategy(WISH_WITH_STRATEGY);
+    expect(waves[0].groups.length).toBe(2);
+    expect(waves[0].groups[0]).toEqual({ group: '1', agent: 'engineer' });
+    expect(waves[0].groups[1]).toEqual({ group: '3', agent: 'engineer' });
+  });
+
+  it('should parse single-group waves', () => {
+    const waves = parseExecutionStrategy(WISH_WITH_STRATEGY);
+    expect(waves[1].groups.length).toBe(1);
+    expect(waves[1].groups[0]).toEqual({ group: '2', agent: 'engineer' });
+  });
+
+  it('should parse reviewer agent', () => {
+    const waves = parseExecutionStrategy(WISH_WITH_STRATEGY);
+    expect(waves[3].groups[0]).toEqual({ group: '5', agent: 'reviewer' });
+  });
+
+  it('should fall back to single wave when no Execution Strategy section', () => {
+    const waves = parseExecutionStrategy(SAMPLE_WISH);
+    expect(waves.length).toBe(1);
+    expect(waves[0].name).toContain('fallback');
+    expect(waves[0].groups.length).toBe(3);
+    expect(waves[0].groups[0]).toEqual({ group: '1', agent: 'engineer' });
+    expect(waves[0].groups[1]).toEqual({ group: '2', agent: 'engineer' });
+    expect(waves[0].groups[2]).toEqual({ group: '3', agent: 'engineer' });
+  });
+
+  it('should return empty array for content with no groups', () => {
+    const waves = parseExecutionStrategy('# Just a title\n\nNo groups here.');
+    expect(waves).toEqual([]);
+  });
+
+  it('should fall back when Execution Strategy section has no wave headings', () => {
+    const content = `## Execution Groups
+
+### Group 1: Only group
+
+**depends-on:** none
+
+## Execution Strategy
+
+No waves defined here, just text.
+`;
+    const waves = parseExecutionStrategy(content);
+    expect(waves.length).toBe(1);
+    expect(waves[0].name).toContain('fallback');
+    expect(waves[0].groups[0]).toEqual({ group: '1', agent: 'engineer' });
+  });
+});
+
+// ============================================================================
+// detectWorkMode — auto vs manual mode detection
+// ============================================================================
+
+describe('detectWorkMode()', () => {
+  it('should detect auto mode from single slug (no #)', () => {
+    const result = detectWorkMode('my-wish');
+    expect(result).toEqual({ mode: 'auto', slug: 'my-wish' });
+  });
+
+  it('should detect manual mode — new style: ref#group then agent', () => {
+    const result = detectWorkMode('my-wish#2', 'engineer');
+    expect(result).toEqual({ mode: 'manual', ref: 'my-wish#2', agent: 'engineer' });
+  });
+
+  it('should detect manual mode — old style: agent then ref#group (backwards compatible)', () => {
+    const result = detectWorkMode('engineer', 'my-wish#2');
+    expect(result).toEqual({ mode: 'manual', ref: 'my-wish#2', agent: 'engineer' });
+  });
+
+  it('should throw when single arg contains # (no agent for manual dispatch)', () => {
+    expect(() => detectWorkMode('my-wish#2')).toThrow('requires an agent');
+  });
+
+  it('should throw when neither arg contains #', () => {
+    expect(() => detectWorkMode('something', 'other')).toThrow('must contain "#"');
+  });
+
+  it('should handle complex slug with # in new style', () => {
+    const result = detectWorkMode('auto-orchestrate#5', 'reviewer');
+    expect(result).toEqual({ mode: 'manual', ref: 'auto-orchestrate#5', agent: 'reviewer' });
+  });
+
+  it('should handle complex slug with # in old style', () => {
+    const result = detectWorkMode('reviewer', 'auto-orchestrate#5');
+    expect(result).toEqual({ mode: 'manual', ref: 'auto-orchestrate#5', agent: 'reviewer' });
   });
 });

--- a/src/term-commands/dispatch.ts
+++ b/src/term-commands/dispatch.ts
@@ -178,6 +178,229 @@ export function parseWishGroups(content: string): GroupDefinition[] {
 }
 
 // ============================================================================
+// Execution Strategy Parser
+// ============================================================================
+
+export interface WaveGroup {
+  group: string;
+  agent: string;
+}
+
+export interface Wave {
+  name: string;
+  groups: WaveGroup[];
+}
+
+/**
+ * Parse the Execution Strategy section from WISH.md content.
+ *
+ * Looks for `## Execution Strategy` section, then parses `### Wave N` headings
+ * with their markdown tables (Group | Agent | Description).
+ *
+ * Falls back to a single wave with all groups assigned to `engineer` if no
+ * Execution Strategy section is found.
+ */
+export function parseExecutionStrategy(content: string): Wave[] {
+  // Find the Execution Strategy section
+  const strategyMatch = content.match(/^## Execution Strategy\s*$/m);
+  if (!strategyMatch || strategyMatch.index === undefined) {
+    return buildFallbackWaves(content);
+  }
+
+  const strategyStart = strategyMatch.index + strategyMatch[0].length;
+
+  // Find the end of the Execution Strategy section (next ## heading or end of content)
+  const nextSectionMatch = content.slice(strategyStart).match(/^## /m);
+  const strategyEnd = nextSectionMatch?.index !== undefined ? strategyStart + nextSectionMatch.index : content.length;
+
+  const strategyContent = content.slice(strategyStart, strategyEnd);
+
+  // Parse each ### Wave heading and its table
+  const waves: Wave[] = [];
+  const wavePattern = /^### (Wave \d+[^\n]*)/gm;
+  let waveMatch: RegExpExecArray | null = wavePattern.exec(strategyContent);
+
+  while (waveMatch !== null) {
+    const waveName = waveMatch[1].trim();
+    const waveStart = waveMatch.index + waveMatch[0].length;
+
+    // Find the end of this wave section (next ### heading or end of strategy)
+    const restAfterWave = strategyContent.slice(waveStart);
+    const nextWaveIdx = restAfterWave.search(/^### /m);
+    const waveEnd = nextWaveIdx !== -1 ? waveStart + nextWaveIdx : strategyContent.length;
+
+    const waveContent = strategyContent.slice(waveStart, waveEnd);
+
+    // Parse markdown table rows (skip header row and separator)
+    const waveGroups: WaveGroup[] = [];
+    const tableRowPattern = /^\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|\s*[^|]*\s*\|$/gm;
+    let rowMatch: RegExpExecArray | null = tableRowPattern.exec(waveContent);
+
+    while (rowMatch !== null) {
+      const groupVal = rowMatch[1].trim();
+      const agentVal = rowMatch[2].trim();
+
+      // Skip header row and separator row
+      if (groupVal !== 'Group' && !groupVal.startsWith('-')) {
+        waveGroups.push({ group: groupVal, agent: agentVal });
+      }
+
+      rowMatch = tableRowPattern.exec(waveContent);
+    }
+
+    if (waveGroups.length > 0) {
+      waves.push({ name: waveName, groups: waveGroups });
+    }
+
+    waveMatch = wavePattern.exec(strategyContent);
+  }
+
+  // If strategy section exists but had no parseable waves, fall back
+  if (waves.length === 0) {
+    return buildFallbackWaves(content);
+  }
+
+  return waves;
+}
+
+/**
+ * Build fallback waves — all groups in a single wave with `engineer` as default agent.
+ */
+function buildFallbackWaves(content: string): Wave[] {
+  const groups = parseWishGroups(content);
+  if (groups.length === 0) return [];
+
+  return [
+    {
+      name: 'Wave 1 (sequential fallback)',
+      groups: groups.map((g) => ({ group: g.name, agent: 'engineer' })),
+    },
+  ];
+}
+
+// ============================================================================
+// Auto-Orchestration
+// ============================================================================
+
+/** Poll interval for checking wave completion (30 seconds). */
+export const ORCHESTRATE_POLL_MS = 30_000;
+
+/** Maximum time to wait for a wave to complete (30 minutes). */
+export const ORCHESTRATE_TIMEOUT_MS = 30 * 60 * 1000;
+
+/**
+ * Detect whether `genie work` should run in auto or manual mode.
+ *
+ * - 1 arg, no `#` → auto mode (slug only)
+ * - 2 args, first has `#` → manual mode, new style: `work <slug#group> <agent>`
+ * - 2 args, second has `#` → manual mode, old style: `work <agent> <slug#group>`
+ */
+export function detectWorkMode(
+  ref: string,
+  agent?: string,
+): { mode: 'auto'; slug: string } | { mode: 'manual'; ref: string; agent: string } {
+  if (!agent) {
+    if (ref.includes('#')) {
+      throw new Error('Manual dispatch requires an agent: genie work <slug>#<group> <agent>');
+    }
+    return { mode: 'auto', slug: ref };
+  }
+
+  if (ref.includes('#')) {
+    return { mode: 'manual', ref, agent };
+  }
+  if (agent.includes('#')) {
+    // Backwards compatible: genie work <agent> <slug>#<group>
+    return { mode: 'manual', ref: agent, agent: ref };
+  }
+
+  throw new Error('Invalid: ref must contain "#" — use "genie work <slug>" or "genie work <agent> <slug>#<group>"');
+}
+
+/**
+ * `genie work <slug>` — Auto-orchestrate full wish execution.
+ *
+ * Reads the Execution Strategy, spawns all agents per wave in parallel,
+ * monitors completion via state polling, advances waves, and exits when done.
+ */
+export async function autoOrchestrateCommand(slug: string): Promise<void> {
+  const wishPath = join(process.cwd(), '.genie', 'wishes', slug, 'WISH.md');
+
+  if (!existsSync(wishPath)) {
+    console.error(`❌ Wish not found: ${wishPath}`);
+    console.error(`   Create it first: genie wish <agent> ${slug}`);
+    process.exit(1);
+  }
+
+  const content = await readFile(wishPath, 'utf-8');
+  const groups = parseWishGroups(content);
+  const waves = parseExecutionStrategy(content);
+
+  if (waves.length === 0) {
+    console.error('❌ No execution groups found in wish');
+    process.exit(1);
+  }
+
+  // Auto-initialize wish state
+  let state = await wishState.getState(slug);
+  if (!state) {
+    state = await wishState.createState(slug, groups);
+    console.log(`📝 Initialized state for wish "${slug}" (${groups.length} groups)`);
+  }
+
+  console.log(`🚀 Auto-orchestrating wish "${slug}" — ${waves.length} waves, ${groups.length} groups`);
+
+  for (const wave of waves) {
+    console.log(`\n⏳ ${wave.name} — dispatching ${wave.groups.length} group(s)`);
+
+    // Dispatch all groups in this wave concurrently.
+    // workDispatchCommand spawns a tmux pane and returns immediately,
+    // so Promise.all resolves once all panes are created.
+    await Promise.all(
+      wave.groups.map(({ group, agent }) => {
+        const ref = `${slug}#${group}`;
+        return workDispatchCommand(agent, ref);
+      }),
+    );
+
+    // Poll state until all groups in wave are done
+    const waveStart = Date.now();
+    const waveGroupNames = wave.groups.map((g) => g.group);
+
+    while (true) {
+      const currentState = await wishState.getState(slug);
+      if (!currentState) {
+        console.error('❌ State file disappeared during orchestration');
+        process.exit(1);
+      }
+
+      const allDone = waveGroupNames.every((g) => currentState.groups[g]?.status === 'done');
+      if (allDone) {
+        console.log(`✅ ${wave.name} complete`);
+        break;
+      }
+
+      // Check timeout
+      if (Date.now() - waveStart > ORCHESTRATE_TIMEOUT_MS) {
+        const pending = waveGroupNames
+          .filter((g) => currentState.groups[g]?.status !== 'done')
+          .map((g) => `${g} (${currentState.groups[g]?.status ?? 'unknown'})`)
+          .join(', ');
+        console.error(`❌ ${wave.name} timed out after 30min — pending: ${pending}`);
+        process.exit(1);
+      }
+
+      // Log status and wait
+      const statuses = waveGroupNames.map((g) => `${g}:${currentState.groups[g]?.status ?? '?'}`).join(' ');
+      console.log(`   ⏳ ${statuses}`);
+      await new Promise((resolve) => setTimeout(resolve, ORCHESTRATE_POLL_MS));
+    }
+  }
+
+  console.log(`\n🎉 All waves complete — wish "${slug}" fully executed`);
+}
+
+// ============================================================================
 // Dispatch Commands
 // ============================================================================
 
@@ -320,7 +543,7 @@ export async function workDispatchCommand(agentName: string, ref: string): Promi
     team: process.env.GENIE_TEAM ?? 'genie',
     role: `${agentName}-${group}`,
     extraArgs: ['--append-system-prompt-file', contextFile],
-    initialPrompt: `Execute Group ${group} of wish "${slug}". Your full context is in the system prompt. Read the wish at ${wishPath} if needed. Implement all deliverables, run validation, and report completion.`,
+    initialPrompt: `Execute Group ${group} of wish "${slug}". Your full context is in the system prompt. Read the wish at ${wishPath} if needed. Implement all deliverables, run validation, and report completion. When done, run: genie done ${slug}#${group}`,
   });
 }
 
@@ -399,10 +622,20 @@ export function registerDispatchCommands(program: Command): void {
     });
 
   program
-    .command('work <agent> <ref>')
-    .description('Dispatch work on a wish group (format: <slug>#<group>)')
-    .action(async (agent: string, ref: string) => {
-      await workDispatchCommand(agent, ref);
+    .command('work <ref> [agent]')
+    .description('Auto-orchestrate a wish, or dispatch work on a specific group')
+    .action(async (ref: string, agent?: string) => {
+      try {
+        const work = detectWorkMode(ref, agent);
+        if (work.mode === 'auto') {
+          await autoOrchestrateCommand(work.slug);
+        } else {
+          await workDispatchCommand(work.agent, work.ref);
+        }
+      } catch (error) {
+        console.error(`❌ ${error instanceof Error ? error.message : error}`);
+        process.exit(1);
+      }
     });
 
   program


### PR DESCRIPTION
## Summary

- **`genie work <slug>`** — auto-orchestrates full wish execution. Reads Execution Strategy waves, spawns all agents per wave in parallel, polls state for completion, advances waves. Team-lead reduced to: read wish → `genie work <slug>` → create PR → done.
- **Engineer completion reporting** — engineer prompt updated to call `genie done <slug>#<group>` on completion
- **Team-lead prompt** — uses `genie work <slug>` as primary, manual dispatch as fallback
- **core.bare safety** — forces `core.bare=false` after worktree removal (fixes #634)

## Test plan

- [x] typecheck clean
- [x] lint clean  
- [x] 751 tests pass
- [ ] `genie work <slug>` orchestrates waves in parallel
- [ ] Manual `genie work engineer slug#1` still works