### PR TITLE
chore: promote dev to main — auto-orchestration, tmux TUI, safety fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "3.260317.8",
+      "version": "3.260317.9",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "genie",
   "name": "Genie",
   "description": "Skills, agents, and hooks for the Genie CLI terminal orchestration toolkit",
-  "version": "3.260317.8",
+  "version": "3.260317.9",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/genie",
-  "version": "3.260317.8",
+  "version": "3.260317.9",
   "description": "Collaborative terminal toolkit for human + AI workflows",
   "type": "module",
   "bin": {

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "3.260317.8",
+  "version": "3.260317.9",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "3.260317.8",
+  "version": "3.260317.9",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "type": "module",


### PR DESCRIPTION
## Changes since last release

| PR | What |
|----|------|
| #628 | feat: parallel execution — auto-suffix roles, wave dispatch |
| #632 | feat: tmux TUI with custom dark theme |
| #635 | feat: genie work <slug> auto-orchestration + bare repo safety |
| Various | team-lead no-sleep fix, worktreeBase migration, config cleanup |

### Highlights
- `genie work <slug>` auto-orchestrates full wish — reads waves, spawns parallel agents, polls state
- Genie TUI — custom dark theme, clickable tabs, top info bar (version/git/CPU/RAM)
- `core.bare=false` safety after worktree removal (prevents repo corruption)
- Engineer reports completion via `genie done`

> **Merge with "Create a merge commit" — NEVER squash.**