### PR TITLE
fix: strip parenthetical comments from depends-on parser

### DIFF
--- a/src/term-commands/dispatch.test.ts
+++ b/src/term-commands/dispatch.test.ts
@@ -550,6 +550,15 @@ describe('parseWishGroups()', () => {
     const groups = parseWishGroups(SAMPLE_WISH);
     expect(groups[0].dependsOn).toEqual([]);
   });
+
+  it('should strip parenthetical comments from depends-on values', () => {
+    const content =
+      '### Group 1: First\n**depends-on:** none (this is the start)\n\n### Group 2: Second\n**depends-on:** 1 (must be done first)\n\n### Group 3: Third\n**depends-on:** Group 1 (setup), Group 2 (core work)';
+    const groups = parseWishGroups(content);
+    expect(groups[0].dependsOn).toEqual([]);
+    expect(groups[1].dependsOn).toEqual(['1']);
+    expect(groups[2].dependsOn).toEqual(['1', '2']);
+  });
 });
 
 // ============================================================================

--- a/src/term-commands/dispatch.ts
+++ b/src/term-commands/dispatch.ts
@@ -162,10 +162,17 @@ export function parseWishGroups(content: string): GroupDefinition[] {
     let dependsOn: string[] = [];
     if (depsMatch) {
       const depsStr = depsMatch[1].trim();
-      if (depsStr.toLowerCase() !== 'none') {
+      const depsNormalized = depsStr.replace(/\s*\([^)]*\)/g, '').trim();
+      if (depsNormalized.toLowerCase() !== 'none') {
         dependsOn = depsStr
           .split(',')
-          .map((d) => d.trim().replace(/^group\s*/i, ''))
+          .map((d) =>
+            d
+              .trim()
+              .replace(/^group\s*/i, '')
+              .replace(/\s*\(.*\)\s*$/, '')
+              .trim(),
+          )
           .filter(Boolean);
       }
     }


### PR DESCRIPTION
## Summary

- Fixes `parseWishGroups()` in `dispatch.ts` to strip parenthetical comments like `(must be done first)` from `depends-on` values
- `depends-on: 1 (comment)` now correctly parses as dependency on `"1"` instead of `"1 (comment)"`
- `depends-on: none (comment)` now correctly parses as no dependencies

## Wish
`fix-depends-parser`

## Test plan
- [x] Added test covering parenthetical comments on numbered deps, none deps, and Group-prefixed deps
- [x] All 752 tests pass
- [x] Typecheck passes
- [x] Lint passes (pre-existing warning only)