### PR TITLE
fix: unset GIT_DIR in husky hooks to prevent test pollution

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,5 @@
+# Prevent GIT_DIR/GIT_WORK_TREE from leaking into child processes (see pre-push)
+unset GIT_DIR
+unset GIT_WORK_TREE
+
 bunx commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,7 @@
+# Prevent GIT_DIR/GIT_WORK_TREE from leaking into child processes (see pre-push)
+unset GIT_DIR
+unset GIT_WORK_TREE
+
 # Check if CI is red on current branch — block commits on broken branches
 branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 if [ -n "$branch" ] && [ "${SKIP_CI_CHECK:-}" != "1" ] && command -v gh >/dev/null 2>&1; then

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,12 @@
 set -e
 
+# Prevent GIT_DIR/GIT_WORK_TREE from leaking into child processes.
+# Git sets these in hook environments, but bun test spawns git commands
+# that must discover their own repos. Without this, test setupTestRepo()
+# commits land on the REAL repo branch, causing catastrophic data loss.
+unset GIT_DIR
+unset GIT_WORK_TREE
+
 remote="$1"
 while read local_ref local_oid remote_ref remote_oid; do
   if echo "$remote_ref" | grep -qE 'refs/heads/(main|master)$'; then


### PR DESCRIPTION
## Summary
- Git sets `GIT_DIR` in hook environments, which leaks into `bun test` child processes
- Test `setupTestRepo()` uses `git -C /tmp/...` but `GIT_DIR` takes precedence over `-C`
- This causes test commits to land on the **real repo branch**, wiping all tracked files with test fixtures
- Unsets `GIT_DIR` and `GIT_WORK_TREE` at the top of all three husky hooks (pre-push, pre-commit, commit-msg)

## Root cause
When `git push` runs from a worktree, the pre-push hook inherits `GIT_DIR=<repo>/.git/worktrees/<branch>`. The hook runs `bun run check` → `bun test`. Tests call `git -C /tmp/test-repo commit -m "Initial commit"` but `GIT_DIR` overrides `-C`, committing to the real repo instead.

## Evidence
- Destructive "Initial commit" on dev: author `Test <test@test.com>`, content `# Test Repo` — test fixture data
- Repo config contaminated: `user.email=test@test.com`, `core.bare=true`
- Timing: destructive commit appears 6s after push start (test execution time)

## Test plan
- [ ] `git push` from a worktree no longer creates "Initial commit" on the real branch
- [ ] `bun run check` passes from both main repo and worktree contexts
- [ ] Repo config stays clean after push from worktree