### PR TITLE
fix(ci): prevent set -e from aborting coverage capture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Test with coverage
         run: |
-          COVERAGE_OUTPUT=$(bun test --coverage 2>&1)
+          COVERAGE_OUTPUT=$(bun test --coverage 2>&1) || true
           echo "$COVERAGE_OUTPUT"
           LINE_COV=$(echo "$COVERAGE_OUTPUT" | grep "All files" | awk -F'|' '{print $2}' | tr -d ' ')
           echo "Line coverage: ${LINE_COV}%"


### PR DESCRIPTION
## Summary
- `bash -e` kills the CI script when `bun test --coverage` exits non-zero, before output is printed or the coverage threshold check runs
- Adding `|| true` lets the script capture output regardless of exit code, then the existing threshold logic handles pass/fail

One-line fix: `COVERAGE_OUTPUT=$(bun test --coverage 2>&1) || true`

## Context
This was caught on PR #644 (rolling promotion) — the quality gate crashed silently with no test output.

## Test plan
- [ ] CI quality gate prints coverage output even when bun exits non-zero