### PR TITLE
fix(tmux): restore dual status bar with clickable tabs and agent enrichment

### DIFF
--- a/scripts/tmux/genie-projects.sh
+++ b/scripts/tmux/genie-projects.sh
@@ -40,22 +40,24 @@ else
   has_tmux=false
 fi
 
+max_visible=8
 output=""
 declare -A seen_sessions=()
+declare -a all_sessions=()
+active_output=""
 
 if [[ "$has_tmux" == "true" ]]; then
-  # Merge tmux sessions with agent counts
+  # Collect all sessions with their rendered output
   while IFS=$'\t' read -r session_name window_count; do
     [[ -z "$session_name" ]] && continue
     seen_sessions["$session_name"]=1
+    all_sessions+=("$session_name")
 
     # Use agent count from workers.json; fall back to window count
     task_count="${agent_counts[$session_name]:-$window_count}"
 
     if [[ "$session_name" == "$active_session" ]]; then
-      output+="#[bg=#7b2ff7,fg=#e0e0e0,bold] ${session_name} (${task_count}) ● #[bg=#1a1a2e,fg=#7b2ff7] "
-    else
-      output+="#[fg=#b8a9c9,bg=#1a1a2e] ${session_name} (${task_count}) "
+      active_output="#[bg=#7b2ff7,fg=#e0e0e0,bold] ${session_name} (${task_count}) ● #[bg=#1a1a2e,fg=#7b2ff7] "
     fi
   done < <(tmux list-sessions -F "#{session_name}	#{session_windows}" 2>/dev/null)
 fi
@@ -63,8 +65,69 @@ fi
 # Also include sessions from workers.json not yet seen (no tmux session or testing mode)
 for sess in "${!agent_counts[@]}"; do
   [[ -n "${seen_sessions[$sess]:-}" ]] && continue
-  count="${agent_counts[$sess]}"
-  output+="#[fg=#b8a9c9,bg=#1a1a2e] ${sess} (${count}) "
+  all_sessions+=("$sess")
 done
+
+total=${#all_sessions[@]}
+
+if [[ "$total" -le "$max_visible" ]]; then
+  # No overflow — render all sessions
+  for session_name in "${all_sessions[@]}"; do
+    task_count="${agent_counts[$session_name]:-0}"
+    # Prefer window count from tmux if available
+    if [[ "$has_tmux" == "true" ]]; then
+      wcount=$(tmux list-windows -t "$session_name" -F "x" 2>/dev/null | wc -l) || wcount=0
+      task_count="${agent_counts[$session_name]:-$wcount}"
+    fi
+
+    if [[ "$session_name" == "$active_session" ]]; then
+      output+="#[bg=#7b2ff7,fg=#e0e0e0,bold] ${session_name} (${task_count}) ● #[bg=#1a1a2e,fg=#7b2ff7] "
+    else
+      output+="#[fg=#b8a9c9,bg=#1a1a2e] ${session_name} (${task_count}) "
+    fi
+  done
+else
+  # Overflow — show up to max_visible with active session always included
+  shown=0
+  active_shown=false
+
+  for session_name in "${all_sessions[@]}"; do
+    if [[ "$shown" -ge "$((max_visible - 1))" && "$active_shown" == "false" && "$session_name" != "$active_session" ]]; then
+      # Reserve last slot for active session
+      continue
+    fi
+    if [[ "$shown" -ge "$max_visible" ]]; then
+      break
+    fi
+
+    task_count="${agent_counts[$session_name]:-0}"
+    if [[ "$has_tmux" == "true" ]]; then
+      wcount=$(tmux list-windows -t "$session_name" -F "x" 2>/dev/null | wc -l) || wcount=0
+      task_count="${agent_counts[$session_name]:-$wcount}"
+    fi
+
+    if [[ "$session_name" == "$active_session" ]]; then
+      output+="#[bg=#7b2ff7,fg=#e0e0e0,bold] ${session_name} (${task_count}) ● #[bg=#1a1a2e,fg=#7b2ff7] "
+      active_shown=true
+    else
+      output+="#[fg=#b8a9c9,bg=#1a1a2e] ${session_name} (${task_count}) "
+    fi
+    ((shown++)) || true
+  done
+
+  # If active session wasn't shown yet, append it
+  if [[ "$active_shown" == "false" && -n "$active_session" ]]; then
+    task_count="${agent_counts[$active_session]:-0}"
+    if [[ "$has_tmux" == "true" ]]; then
+      wcount=$(tmux list-windows -t "$active_session" -F "x" 2>/dev/null | wc -l) || wcount=0
+      task_count="${agent_counts[$active_session]:-$wcount}"
+    fi
+    output+="#[bg=#7b2ff7,fg=#e0e0e0,bold] ${active_session} (${task_count}) ● #[bg=#1a1a2e,fg=#7b2ff7] "
+  fi
+
+  # Append overflow indicator
+  remaining=$((total - max_visible))
+  output+="#[fg=#6c6c8a,bg=#1a1a2e] +${remaining} more "
+fi
 
 echo -n "$output"

--- a/scripts/tmux/genie-window-label.sh
+++ b/scripts/tmux/genie-window-label.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Genie TUI — per-window agent enrichment label
+# Called from window-status-format via #() for each window tab.
+# Must be fast (< 50ms) — single jq query, early exit on missing data.
+#
+# Usage: genie-window-label.sh <session_name> <window_name>
+# Output: " ×count emoji" (e.g., " ×3 🔨") or empty string
+#
+# Env: GENIE_WORKERS — override path to workers.json (for testing)
+
+session="${1:-}"
+window="${2:-}"
+
+# Early exit if no args
+if [ -z "$session" ] || [ -z "$window" ]; then
+  exit 0
+fi
+
+workers_file="${GENIE_WORKERS:-${HOME}/.genie/workers.json}"
+
+# Early exit if no workers file
+if [ ! -f "$workers_file" ]; then
+  exit 0
+fi
+
+# Single jq pass: filter by session + window, count + worst state emoji
+result=$(jq -r --arg sess "$session" --arg win "$window" '
+  def state_priority:
+    {"error": 7, "permission": 6, "working": 5, "spawning": 4, "idle": 3, "done": 2, "suspended": 1};
+  def state_emoji:
+    {"spawning": "⏳", "working": "🔨", "idle": "⏸", "done": "✓", "error": "✗", "permission": "❓", "suspended": "💤"};
+
+  .workers // {} | to_entries
+  | map(select(.value.session == $sess and (.value.windowName // .value.team // "unknown") == $win))
+  | if length == 0 then ""
+    else
+      length as $count
+      | map(.value.state // "idle")
+      | map(. as $s | state_priority[$s] // 0)
+      | max as $max_pri
+      | (state_priority | to_entries | map(select(.value == $max_pri)) | .[0].key // "idle") as $worst
+      | " ×\($count) \(state_emoji[$worst] // "")"
+    end
+' "$workers_file" 2>/dev/null) || exit 0
+
+# Only print if non-empty
+if [ -n "$result" ]; then
+  printf '%s' "$result"
+fi

--- a/scripts/tmux/genie.tmux.conf
+++ b/scripts/tmux/genie.tmux.conf
@@ -61,8 +61,9 @@ set -g status 2
 # --- Top bar (status-format[0]): branding + project tabs + system info ---
 set -g status-format[0] "#[align=left,bg=#1a1a2e]#[bg=#7b2ff7,fg=#e0e0e0,bold] #(genie --version 2>/dev/null | head -1 || echo 'Genie') #[bg=#1a1a2e,fg=#7b2ff7] #($HOME/.genie/scripts/genie-projects.sh)#[align=right]#[fg=#6c6c8a]#($HOME/.genie/scripts/genie-git.sh) #[fg=#0f3460]| #[fg=#00d2ff]CPU #($HOME/.genie/scripts/cpu-info.sh) #[fg=#0f3460]| #[fg=#00d2ff]RAM #($HOME/.genie/scripts/ram-info.sh) #[fg=#0f3460]| #[fg=#e0e0e0]%H:%M "
 
-# --- Bottom bar (status-format[1]): task window tabs for active session ---
-set -g status-format[1] "#[align=left,bg=#16213e] #($HOME/.genie/scripts/genie-tasks.sh #{session_name}) "
+# --- Bottom bar (status-format[1]): native clickable window tabs ---
+# #{W} expands window-status-format / window-status-current-format with mouse support
+set -g status-format[1] "#[align=left,bg=#16213e] #{W} "
 
 # --- Legacy single-line fallback values (used when dual status is unavailable) ---
 set -g status-left-length 60
@@ -78,11 +79,11 @@ set -g status-right "#[fg=#6c6c8a]#($HOME/.genie/scripts/genie-git.sh) #[fg=#0f3
 # Tab separator
 set -g window-status-separator ""
 
-# Inactive tabs: lavender text on dark bg
-set -g window-status-format "#[fg=#b8a9c9,bg=#1a1a2e] #I:#W "
+# Inactive tabs: lavender text on surface bg (matches bottom bar line bg)
+set -g window-status-format "#[fg=#b8a9c9,bg=#16213e] #I:#W#($HOME/.genie/scripts/genie-window-label.sh #{session_name} #{window_name}) "
 
-# Active tab: purple bg, white text, bold
-set -g window-status-current-format "#[fg=#1a1a2e,bg=#7b2ff7]#[fg=#e0e0e0,bg=#7b2ff7,bold] #I:#W #[fg=#7b2ff7,bg=#1a1a2e]"
+# Active tab: purple bg, white text, bold with agent enrichment
+set -g window-status-current-format "#[fg=#16213e,bg=#7b2ff7]#[fg=#e0e0e0,bg=#7b2ff7,bold] #I:#W#($HOME/.genie/scripts/genie-window-label.sh #{session_name} #{window_name}) #[fg=#7b2ff7,bg=#16213e]"
 
 # Activity monitoring
 setw -g monitor-activity on
@@ -94,7 +95,7 @@ set -g window-status-activity-style "fg=#f5a623,bg=#1a1a2e"
 # ============================================================================
 # tmux < 3.2 gets single bar. tmux >= 3.2 keeps dual bar (status-format[0..1]).
 # Check major/minor explicitly; tmux 3.0/3.1 report status-format support as unavailable.
-if-shell 'tmux -V | sed -nE "s/^tmux ([0-9]+)\\.([0-9]+).*/\\1 \\2/" | awk "{exit !($1 > 3 || ($1 == 3 && $2 >= 2))}"' \
+if-shell '[ "$(tmux -V | tr -dc "0-9." | awk -F. "{v=\$1*100+\$2; print v}")" -ge 302 ]' \
   'set -g status 2' \
   'set -g status on'
 


### PR DESCRIPTION
## Summary

Fixes two bugs from PR #646 (tmux-split-tabbar) that made the dual status bar completely non-functional:

- **Fixed awk `$1`/`$2` shell expansion bug** in the version guard (`genie.tmux.conf:97`) — the dual bar now correctly activates on tmux >= 3.2 and falls back to single bar on older versions
- **Made bottom bar window tabs clickable** — replaced `#()` shell script with `#{W}` token in `status-format[1]`, which uses native tmux window-status-format templates with mouse support
- **Added agent enrichment to window tabs** — `window-status-format` and `window-status-current-format` now show `×count emoji` (e.g., `×3 🔨`) per window via new `genie-window-label.sh` script
- **Added overflow handling** for projects bar — truncates at 8 sessions with `+N more` indicator, active session always visible

## Files Changed

| File | Change |
|------|--------|
| `scripts/tmux/genie.tmux.conf` | Fix version guard awk escaping, use `#{W}` in status-format[1], enrich window-status-format |
| `scripts/tmux/genie-window-label.sh` | **NEW** — per-window agent count + state emoji (<50ms, jq-based) |
| `scripts/tmux/genie-projects.sh` | Add overflow handling for >8 sessions |

## Test plan

- [ ] Verify dual bar (2 lines) activates on tmux >= 3.2
- [ ] Verify single bar fallback on tmux < 3.2
- [ ] Click window tabs in bottom bar — should switch windows
- [ ] Verify agent count/emoji display per window
- [ ] Run `tmux source ~/.tmux.conf` — no errors
- [ ] Test with >8 sessions — overflow shows `+N more`

Wish: fix-tmux-dual-statusbar