### PR TITLE
fix(tmux): dual bar layout — tabs top, sessions bottom

### DIFF
--- a/scripts/tmux/genie-update-check.sh
+++ b/scripts/tmux/genie-update-check.sh
@@ -29,7 +29,7 @@ get_current_version() {
 check_latest_version() {
   # Try npm registry
   local latest
-  latest=$(npm view automagik-genie version 2>/dev/null) || true
+  latest=$(npm view @automagik/genie version 2>/dev/null) || true
   echo "${latest:-}"
 }
 
@@ -78,15 +78,18 @@ main() {
     return 0
   fi
 
-  # Compare versions
-  if [[ "$current_version" == "$latest_version" ]]; then
-    echo "v${current_version}" > "$CACHE_FILE"
-    echo "v${current_version}"
-  else
-    local result="v${current_version} (${latest_version} available)"
-    echo "$result" > "$CACHE_FILE"
-    echo "$result"
+  # Compare versions — only show update if npm is newer
+  local result="v${current_version}"
+  if [[ "$current_version" != "$latest_version" ]]; then
+    # Sort versions; if current comes first, npm is newer
+    local older
+    older=$(printf '%s\n%s\n' "$current_version" "$latest_version" | sort -V | head -1)
+    if [[ "$older" == "$current_version" ]]; then
+      result="v${current_version} ⬆ ${latest_version}"
+    fi
   fi
+  echo "$result" > "$CACHE_FILE"
+  echo "$result"
 }
 
 main

--- a/scripts/tmux/genie.tmux.conf
+++ b/scripts/tmux/genie.tmux.conf
@@ -2,6 +2,11 @@
 # Genie TUI — tmux configuration
 # Dark theme with purple/cyan/gold palette
 # Native tmux, zero plugins
+#
+# Layout:
+#   Top (pane-border):  system info — git, CPU, RAM, clock
+#   Bottom line 0:      clickable window tabs
+#   Bottom line 1:      clickable session list + 🧞 Genie version
 # ============================================================================
 
 # --- Terminal & basics ---
@@ -30,10 +35,11 @@ setw -g mode-keys vi
 # Text:        #e0e0e0 (primary text)
 # Dim:         #6c6c8a (dim text)
 
-# --- Pane borders ---
+# --- Pane borders — top info bar ---
 set -g pane-border-style "fg=#0f3460"
 set -g pane-active-border-style "fg=#7b2ff7"
-set -g pane-border-status off
+set -g pane-border-status top
+set -g pane-border-format "#[bg=#1a1a2e,fg=#e0e0e0]#[align=right]#[fg=#6c6c8a]#($HOME/.genie/scripts/genie-git.sh) #[fg=#0f3460]| #[fg=#00d2ff]CPU #($HOME/.genie/scripts/cpu-info.sh) #[fg=#0f3460]| #[fg=#00d2ff]RAM #($HOME/.genie/scripts/ram-info.sh) #[fg=#0f3460]| #[fg=#e0e0e0]%H:%M "
 
 # --- Message styling ---
 set -g message-style "bg=#16213e,fg=#00d2ff"
@@ -46,28 +52,35 @@ setw -g mode-style "bg=#7b2ff7,fg=#e0e0e0"
 setw -g clock-mode-colour "#7b2ff7"
 
 # ============================================================================
-# STATUS BAR — Single bar at bottom with clickable tabs + info
+# STATUS BAR — Dual bar at bottom (tmux 3.2+)
+#   Line 0 (top):    clickable window tabs (native tmux rendering)
+#   Line 1 (bottom): clickable session list + Genie version
 # ============================================================================
 set -g status on
 set -g status-interval 5
 set -g status-position bottom
-set -g status-justify left
+set -g status 2
 set -g status-style "bg=#1a1a2e,fg=#e0e0e0"
+set -g status-justify left
 
-# Left: branding
-set -g status-left-length 40
-set -g status-left "#[bg=#7b2ff7,fg=#e0e0e0,bold] 🧞 #(genie --version 2>/dev/null | head -1 || echo Genie) #[bg=#1a1a2e,fg=#7b2ff7]"
+# Clear status-left/right — dual bar uses status-format[] directly
+set -g status-left ""
+set -g status-left-length 0
+set -g status-right ""
+set -g status-right-length 0
 
-# Right: system info
-set -g status-right-length 100
-set -g status-right "#[fg=#6c6c8a]#($HOME/.genie/scripts/genie-git.sh) #[fg=#0f3460]| #[fg=#00d2ff]CPU #($HOME/.genie/scripts/cpu-info.sh) #[fg=#0f3460]| #[fg=#00d2ff]RAM #($HOME/.genie/scripts/ram-info.sh) #[fg=#0f3460]| #[fg=#e0e0e0]%H:%M "
+# --- Line 0: clickable window tabs (native tmux window rendering) ---
+set -g status-format[0] "#[align=left range=left #{E:status-left-style}]#[push-default]#{T;=/#{status-left-length}:status-left}#[pop-default]#[norange default]#[list=on align=#{status-justify}]#[list=left-marker]<#[list=right-marker]>#[list=on]#{W:#[range=window|#{window_index} #{E:window-status-style}#{?#{&&:#{window_last_flag},#{!=:#{E:window-status-last-style},default}}, #{E:window-status-last-style},}#{?#{&&:#{window_bell_flag},#{!=:#{E:window-status-bell-style},default}}, #{E:window-status-bell-style},#{?#{&&:#{||:#{window_activity_flag},#{window_silence_flag}},#{!=:#{E:window-status-activity-style},default}}, #{E:window-status-activity-style},}}]#[push-default]#{T:window-status-format}#[pop-default]#[norange default]#{?window_end_flag,,#{window-status-separator}},#[range=window|#{window_index} list=focus #{?#{!=:#{E:window-status-current-style},default},#{E:window-status-current-style},#{E:window-status-style}}#{?#{&&:#{window_last_flag},#{!=:#{E:window-status-last-style},default}}, #{E:window-status-last-style},}#{?#{&&:#{window_bell_flag},#{!=:#{E:window-status-bell-style},default}}, #{E:window-status-bell-style},#{?#{&&:#{||:#{window_activity_flag},#{window_silence_flag}},#{!=:#{E:window-status-activity-style},default}}, #{E:window-status-activity-style},}}]#[push-default]#{T:window-status-current-format}#[pop-default]#[norange list=on default]#{?window_end_flag,,#{window-status-separator}}}#[nolist align=right range=right #{E:status-right-style}]#[push-default]#{T;=/#{status-right-length}:status-right}#[pop-default]#[norange default]"
+
+# --- Line 1: clickable session list + Genie branding (right) ---
+set -g status-format[1] "#[align=left,bg=#16213e] #{S:#[range=session|#{session_name}]#{?#{==:#{session_name},#{client_session}},#[bg=#7b2ff7 fg=#e0e0e0 bold] #{session_name} #[bg=#16213e fg=#7b2ff7 nobold],#[fg=#b8a9c9 bg=#16213e] #{session_name} }#[norange default]}#[align=right,bg=#16213e]#[bg=#7b2ff7,fg=#e0e0e0,bold] 🧞 #($HOME/.genie/scripts/genie-update-check.sh) #[bg=#16213e,fg=#7b2ff7] "
 
 # ============================================================================
-# WINDOW (TAB) STYLING — clickable tabs
+# WINDOW (TAB) STYLING — used by line 0
 # ============================================================================
 set -g window-status-separator ""
-set -g window-status-format "#[fg=#b8a9c9,bg=#1a1a2e] #I:#W "
-set -g window-status-current-format "#[fg=#1a1a2e,bg=#7b2ff7]#[fg=#e0e0e0,bg=#7b2ff7,bold] #I:#W #[fg=#7b2ff7,bg=#1a1a2e]"
+set -g window-status-format "#[fg=#b8a9c9,bg=#16213e] #I:#W "
+set -g window-status-current-format "#[fg=#16213e,bg=#7b2ff7]#[fg=#e0e0e0,bg=#7b2ff7,bold] #I:#W #[fg=#7b2ff7,bg=#16213e]"
 
 # Activity
 setw -g monitor-activity on


### PR DESCRIPTION
## Summary
- **Top bar** (pane-border): system info — git branch, CPU, RAM, clock
- **Bottom line 0**: native clickable window tabs
- **Bottom line 1**: clickable session list + 🧞 Genie version (right-aligned)
- Fix `genie-update-check.sh` to query `@automagik/genie` (not the old unscoped package)
- Only show update notice when npm has a newer version (no false positives for dev builds)

## Test plan
- [ ] Verify two bars at bottom: tabs on top line, sessions on bottom line
- [ ] Click window tabs to switch windows
- [ ] Click sessions to switch sessions
- [ ] Double-click status bar opens session tree picker
- [ ] Top pane-border shows CPU/RAM/git/clock
- [ ] Version check shows clean version when local is ahead of npm