### PR TITLE
docs: update skills and agent docs for transcript system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,9 @@ bun test src/lib/wish-state.test.ts  # Single file
 ```
 src/genie.ts              CLI entry point (commander)
 src/lib/                  Core modules (state, registry, locking, messaging, providers)
+src/lib/transcript.ts     Provider-agnostic transcript abstraction (Claude + Codex)
+src/lib/codex-logs.ts     Codex JSONL parsing + SQLite discovery
+src/lib/claude-logs.ts    Claude log parsing + transcript adapter
 src/term-commands/        CLI command handlers (agents, team, dispatch, msg, state, dir)
 src/hooks/                Git hook system (branch-guard, auto-spawn, identity-inject)
 src/genie-commands/       Setup/utility commands (setup, doctor, update, session)

--- a/plugins/genie/agents/pm.md
+++ b/plugins/genie/agents/pm.md
@@ -49,6 +49,7 @@ Monitor team-leads. They work autonomously — intervene only on blocks:
 ```bash
 genie status <slug>       # Check wish progress
 genie read <team-lead>    # Read team-lead output
+genie history <agent> --ndjson | jq '.text'  # Structured session review
 genie ls                  # List active agents
 ```
 
@@ -115,6 +116,7 @@ For cross-session agents, use `genie send '<text>' --to <agent>` via Bash.
 genie team create <name> --repo <path> --wish <slug>  — create team for wish
 genie status <slug>                                   — check wish progress
 genie read <agent>                                    — read agent output
+genie history <agent> --ndjson | jq '.text'           — structured session review
 genie send '<msg>' --to <agent>                       — message cross-session agent
 genie team done|blocked|disband <name>                — lifecycle management
 genie team ls [<name>]                                — list teams or members

--- a/plugins/genie/agents/pm/AGENTS.md
+++ b/plugins/genie/agents/pm/AGENTS.md
@@ -49,6 +49,7 @@ Monitor team-leads. They work autonomously — intervene only on blocks:
 ```bash
 genie status <slug>       # Check wish progress
 genie read <team-lead>    # Read team-lead output
+genie history <agent> --ndjson | jq '.text'  # Structured session review
 genie ls                  # List active agents
 ```
 
@@ -115,6 +116,7 @@ For cross-session agents, use `genie send '<text>' --to <agent>` via Bash.
 genie team create <name> --repo <path> --wish <slug>  — create team for wish
 genie status <slug>                                   — check wish progress
 genie read <agent>                                    — read agent output
+genie history <agent> --ndjson | jq '.text'           — structured session review
 genie send '<msg>' --to <agent>                       — message cross-session agent
 genie team done|blocked|disband <name>                — lifecycle management
 genie team ls [<name>]                                — list teams or members

--- a/plugins/genie/agents/team-lead/HEARTBEAT.md
+++ b/plugins/genie/agents/team-lead/HEARTBEAT.md
@@ -20,6 +20,7 @@ Which groups are done? Which are in progress? Which are blocked?
 ```bash
 genie ls
 genie read <worker> --follow
+genie history <worker> --last 10           # Quick catch-up
 ```
 For each active worker: is it alive? Is it stuck? Is it waiting for approval?
 If stuck for >5 minutes with no output, kill and re-dispatch.

--- a/skills/genie/SKILL.md
+++ b/skills/genie/SKILL.md
@@ -76,7 +76,10 @@ genie team ls                    # List all teams
 genie team ls my-feature         # Show team members and status
 genie status my-feature-slug     # Show wish group progress
 genie read team-lead             # Tail team-lead output
-genie history team-lead          # Compressed session timeline
+genie history team-lead                    # Compressed session timeline
+genie history team-lead --last 20          # Last 20 transcript entries
+genie history team-lead --type assistant   # Only assistant messages
+genie history team-lead --ndjson | jq '.text'  # Pipe to jq
 ```
 
 ### Team Lifecycle


### PR DESCRIPTION
## Summary

Updates documentation across 5 files to reflect the provider-agnostic transcript system introduced in PR #669.

**Wish:** `.genie/wishes/transcript-docs/WISH.md`

### Changes
- **`skills/genie/SKILL.md`** — Added `--last`, `--type`, `--ndjson` examples to monitoring section
- **`CLAUDE.md`** — Added `transcript.ts`, `codex-logs.ts`, `claude-logs.ts` to architecture tree
- **`plugins/genie/agents/pm.md`** — Added `genie history --ndjson | jq` to both monitoring command sections
- **`plugins/genie/agents/pm/AGENTS.md`** — Mirror of pm.md updates
- **`plugins/genie/agents/team-lead/HEARTBEAT.md`** — Added `genie history --last 10` for quick catch-up

### Test plan
- [x] All 5 files contain new transcript references (grep validated)
- [x] No existing content removed — additions only
- [x] Full test suite passes (786 tests, 0 failures)
- [x] typecheck, lint, dead-code all green