### PR TITLE
fix: stable release fixes — cron, timezone, lease-timeout, notifications

### DIFF
--- a/src/lib/cron.test.ts
+++ b/src/lib/cron.test.ts
@@ -76,4 +76,38 @@ describe('computeNextCronDue', () => {
   test('rejects invalid cron expression', () => {
     expect(() => computeNextCronDue('bad')).toThrow('Invalid cron expression');
   });
+
+  test('rejects step=0 in cron field (Fixes #678)', () => {
+    expect(() => computeNextCronDue('*/0 * * * *')).toThrow('step value cannot be 0');
+    expect(() => computeNextCronDue('1-10/0 * * * *')).toThrow('step value cannot be 0');
+  });
+
+  test('timezone-aware cron computes correct UTC time (Fixes #679)', () => {
+    // 2026-03-20 12:00 UTC. In America/New_York (EDT, UTC-4), that's 08:00.
+    // Cron "0 9 * * *" = 9 AM New York = 13:00 UTC
+    const base = new Date('2026-03-20T12:00:00Z');
+    const next = computeNextCronDue('0 9 * * *', { after: base, timezone: 'America/New_York' });
+
+    // 9 AM ET on March 20 (EDT) = 13:00 UTC
+    expect(next.getUTCHours()).toBe(13);
+    expect(next.getUTCMinutes()).toBe(0);
+  });
+
+  test('timezone-aware cron with different timezone', () => {
+    // 2026-03-20 12:00 UTC. In Asia/Tokyo (JST, UTC+9), that's 21:00.
+    // Cron "0 6 * * *" = 6 AM Tokyo = 21:00 UTC (previous day)
+    // Since we're at 21:00 JST, next 6 AM JST is tomorrow = 2026-03-20 21:00 UTC
+    const base = new Date('2026-03-20T12:00:00Z');
+    const next = computeNextCronDue('0 6 * * *', { after: base, timezone: 'Asia/Tokyo' });
+
+    // 6 AM JST = 21:00 UTC (previous day)
+    expect(next.getUTCHours()).toBe(21);
+    expect(next.getUTCMinutes()).toBe(0);
+  });
+
+  test('backward compat: Date arg still works', () => {
+    const base = new Date('2026-03-20T12:00:00Z');
+    const next = computeNextCronDue('0 0 * * *', base);
+    expect(next.getUTCHours()).toBe(0);
+  });
 });

--- a/src/lib/cron.ts
+++ b/src/lib/cron.ts
@@ -42,6 +42,7 @@ export function parseDuration(input: string): number {
 
 /** Expand a range (start-end) or wildcard (*) with an optional step into a list of values. */
 function expandRange(range: string, step: number, min: number, max: number): number[] {
+  if (step === 0) throw new Error('Cron step value cannot be 0');
   if (range === '*') {
     const out: number[] = [];
     for (let i = min; i <= max; i += step) out.push(i);
@@ -81,64 +82,125 @@ function parseCronField(field: string, min: number, max: number): number[] {
  *   - If both DOM and DOW are restricted (not *), the day matches if EITHER matches (union).
  *   - Otherwise, both must match (intersection — wildcards always match).
  */
-export function computeNextCronDue(cronExpr: string, after?: Date): Date {
+export interface CronOptions {
+  /** Compute next occurrence after this time. Defaults to now. */
+  after?: Date;
+  /** IANA timezone (e.g. 'America/New_York'). When set, cron fields are matched against wall-clock time in this timezone. */
+  timezone?: string;
+}
+
+/** Get the wall-clock components of a UTC Date in a given timezone. */
+function getTimeParts(
+  date: Date,
+  tz?: string,
+): { month: number; dom: number; dow: number; hour: number; minute: number } {
+  if (!tz) {
+    return {
+      month: date.getMonth() + 1,
+      dom: date.getDate(),
+      dow: date.getDay(),
+      hour: date.getHours(),
+      minute: date.getMinutes(),
+    };
+  }
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    weekday: 'short',
+    hour12: false,
+  });
+  const parts = fmt.formatToParts(date);
+  const get = (type: Intl.DateTimeFormatPartTypes) => Number(parts.find((p) => p.type === type)?.value ?? 0);
+  const dayMap: Record<string, number> = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+  const weekday = parts.find((p) => p.type === 'weekday')?.value ?? 'Sun';
+  return {
+    month: get('month'),
+    dom: get('day'),
+    dow: dayMap[weekday] ?? 0,
+    hour: get('hour') === 24 ? 0 : get('hour'),
+    minute: get('minute'),
+  };
+}
+
+function parseOpts(afterOrOpts?: Date | CronOptions): { after?: Date; timezone?: string } {
+  if (afterOrOpts instanceof Date) return { after: afterOrOpts };
+  if (afterOrOpts) return { after: afterOrOpts.after, timezone: afterOrOpts.timezone };
+  return {};
+}
+
+/** Advance candidate to the start of the next day in the given timezone. */
+function advanceToNextDay(candidate: Date, tz?: string): void {
+  candidate.setTime(candidate.getTime() + 24 * 60 * 60 * 1000);
+  const tp = getTimeParts(candidate, tz);
+  candidate.setTime(candidate.getTime() - tp.hour * 3_600_000 - tp.minute * 60_000);
+}
+
+interface ParsedCron {
+  minutes: number[];
+  hours: number[];
+  doms: number[];
+  months: number[];
+  dows: number[];
+  domRestricted: boolean;
+  dowRestricted: boolean;
+}
+
+function parseCronExpr(cronExpr: string): ParsedCron {
   const parts = cronExpr.trim().split(/\s+/);
   if (parts.length < 5) throw new Error(`Invalid cron expression: "${cronExpr}"`);
-
   const [minField, hourField, domField, monthField, dowField] = parts;
+  return {
+    minutes: parseCronField(minField, 0, 59),
+    hours: parseCronField(hourField, 0, 23),
+    doms: parseCronField(domField, 1, 31),
+    months: parseCronField(monthField, 1, 12),
+    dows: parseCronField(dowField, 0, 6),
+    domRestricted: domField !== '*',
+    dowRestricted: dowField !== '*',
+  };
+}
 
-  const minutes = parseCronField(minField, 0, 59);
-  const hours = parseCronField(hourField, 0, 23);
-  const doms = parseCronField(domField, 1, 31);
-  const months = parseCronField(monthField, 1, 12);
-  const dows = parseCronField(dowField, 0, 6);
-
-  const domRestricted = domField !== '*';
-  const dowRestricted = dowField !== '*';
+export function computeNextCronDue(cronExpr: string, afterOrOpts?: Date | CronOptions): Date {
+  const { after, timezone } = parseOpts(afterOrOpts);
+  const cron = parseCronExpr(cronExpr);
 
   const base = after ?? new Date();
   const candidate = new Date(base.getTime());
   candidate.setSeconds(0, 0);
-  candidate.setMinutes(candidate.getMinutes() + 1);
+  candidate.setTime(candidate.getTime() + 60_000);
 
   const limit = new Date(candidate.getTime() + 366 * 24 * 60 * 60 * 1000);
 
   while (candidate <= limit) {
-    const month = candidate.getMonth() + 1;
-    const dom = candidate.getDate();
-    const dow = candidate.getDay();
-    const hour = candidate.getHours();
-    const minute = candidate.getMinutes();
+    const tp = getTimeParts(candidate, timezone);
 
-    if (!months.includes(month)) {
-      candidate.setMonth(candidate.getMonth() + 1, 1);
-      candidate.setHours(0, 0, 0, 0);
+    if (!cron.months.includes(tp.month)) {
+      advanceToNextDay(candidate, timezone);
       continue;
     }
 
-    let dayMatch: boolean;
-    if (domRestricted && dowRestricted) {
-      dayMatch = doms.includes(dom) || dows.includes(dow);
-    } else {
-      dayMatch = doms.includes(dom) && dows.includes(dow);
-    }
+    const dayMatch =
+      cron.domRestricted && cron.dowRestricted
+        ? cron.doms.includes(tp.dom) || cron.dows.includes(tp.dow)
+        : cron.doms.includes(tp.dom) && cron.dows.includes(tp.dow);
 
     if (!dayMatch) {
-      candidate.setDate(candidate.getDate() + 1);
-      candidate.setHours(0, 0, 0, 0);
+      advanceToNextDay(candidate, timezone);
       continue;
     }
 
-    if (!hours.includes(hour)) {
-      candidate.setHours(candidate.getHours() + 1, 0, 0, 0);
+    if (!cron.hours.includes(tp.hour)) {
+      candidate.setTime(candidate.getTime() + 3_600_000 - tp.minute * 60_000);
       continue;
     }
 
-    if (minutes.includes(minute)) {
-      return candidate;
-    }
+    if (cron.minutes.includes(tp.minute)) return candidate;
 
-    candidate.setMinutes(candidate.getMinutes() + 1);
+    candidate.setTime(candidate.getTime() + 60_000);
   }
 
   throw new Error(`No next cron occurrence found for "${cronExpr}" within 366 days`);

--- a/src/term-commands/schedule.ts
+++ b/src/term-commands/schedule.ts
@@ -108,7 +108,7 @@ function computeFirstDueAt(options: CreateOptions): { dueAt: Date; cronExpr: str
   if (options.every) {
     if (isCronExpression(options.every)) {
       // Store cron expression directly
-      const dueAt = computeNextCronDue(options.every);
+      const dueAt = computeNextCronDue(options.every, { timezone: options.timezone });
       return { dueAt, cronExpr: options.every, scheduleType: 'cron' };
     }
     // Parse as interval duration
@@ -205,19 +205,19 @@ async function scheduleCreateCommand(name: string, options: CreateOptions): Prom
 
     const scheduleId = generateId();
     const triggerId = generateId();
+    const runSpec = options.leaseTimeout ? { lease_timeout_ms: parseDuration(options.leaseTimeout) } : {};
     const metadata = {
       type: scheduleType,
       original_spec: options.at ?? options.every ?? options.after,
       timezone: options.timezone ?? 'UTC',
-      ...(options.leaseTimeout ? { lease_timeout_ms: parseDuration(options.leaseTimeout) } : {}),
     };
 
     // biome-ignore lint/suspicious/noExplicitAny: postgres.js transaction type
     await sql.begin(async (tx: any) => {
       // Insert schedule
       await tx`
-        INSERT INTO schedules (id, name, cron_expression, timezone, command, metadata, status)
-        VALUES (${scheduleId}, ${name}, ${cronExpr}, ${options.timezone ?? 'UTC'}, ${options.command}, ${JSON.stringify(metadata)}, 'active')
+        INSERT INTO schedules (id, name, cron_expression, timezone, command, run_spec, metadata, status)
+        VALUES (${scheduleId}, ${name}, ${cronExpr}, ${options.timezone ?? 'UTC'}, ${options.command}, ${JSON.stringify(runSpec)}, ${JSON.stringify(metadata)}, 'active')
       `;
 
       // Insert first trigger

--- a/src/term-commands/state.ts
+++ b/src/term-commands/state.ts
@@ -210,10 +210,14 @@ export async function doneCommand(ref: string): Promise<void> {
         const protocolRouter = await import('../lib/protocol-router.js');
         const repoPath = process.cwd();
         const message = `${waveResult.waveName} complete. All groups done: [${waveResult.waveGroups.join(', ')}]. Run /review or advance to next wave.`;
-        await protocolRouter.sendMessage(repoPath, 'cli', 'team-lead', message);
-        console.log('   Notified team-lead of wave completion.');
+        const result = await protocolRouter.sendMessage(repoPath, 'cli', 'team-lead', message);
+        if (result && typeof result === 'object' && 'delivered' in result && !result.delivered) {
+          console.warn('   ⚠️ Wave-complete notification may not have been delivered.');
+        } else {
+          console.log('   Notified team-lead of wave completion.');
+        }
       } catch {
-        console.log('   ⚠️ Could not notify team-lead (messaging unavailable).');
+        console.warn('   ⚠️ Could not notify team-lead (messaging unavailable).');
       }
     }
 


### PR DESCRIPTION
## Summary

Fixes all 4 remaining open bugs before stable release promotion to main.

- **Fixes #678** (P1): Reject `step=0` in cron field parser — prevents infinite loop on `*/0` input
- **Fixes #679** (P2): Apply `--timezone` to cron due computation — uses `Intl.DateTimeFormat` for wall-clock matching
- **Fixes #680** (P2): Store `--lease-timeout` in `run_spec` JSONB column — scheduler daemon now reads it via `resolveRunSpec()`
- **Fixes #682** (P2): Check `sendMessage` delivery result in wave-complete notification — logs warning on failure

Note: #681 was closed as not-a-bug (`computeNextCronDue` already correctly iterates from `now+1min`).

## Changes

### cron.ts
- Added `expandRange` step=0 guard (throws immediately)
- Added `CronOptions` interface with `timezone?: string` field
- `computeNextCronDue()` now accepts `Date | CronOptions` (backward compatible)
- Added `getTimeParts()` — uses `Intl.DateTimeFormat` to get wall-clock components in any timezone
- Extracted `parseCronExpr()`, `advanceToNextDay()`, `parseOpts()` helpers to stay under complexity limit

### schedule.ts
- Passes `{ timezone: options.timezone }` to `computeNextCronDue()` in cron path
- Builds `runSpec` object with `lease_timeout_ms` and writes it to `run_spec` column in INSERT

### state.ts
- Checks `sendMessage` return value for `delivered: false`
- Logs warning instead of silent drop

## Test plan

- [x] `bun run check` passes (932 tests, 0 failures)
- [x] `*/0` cron input throws "step value cannot be 0"
- [x] Timezone-aware cron computes correct UTC time (tested with America/New_York and Asia/Tokyo)
- [x] Backward compat: Date arg still works as before
- [x] All existing cron/schedule/state tests pass