### PR TITLE
feat: auto-create tmux session for --session flag

### DIFF
--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -268,6 +268,12 @@ export async function ensureTeamWindow(
   teamName: string,
   workingDir?: string,
 ): Promise<{ windowId: string; windowName: string; paneId: string; created: boolean }> {
+  // Auto-create session if it doesn't exist (enables --session with new session names)
+  const sessionExists = await findSessionByName(session);
+  if (!sessionExists) {
+    await createSession(session);
+  }
+
   const existing = await findWindowByName(session, teamName);
   if (existing) {
     // Ensure automatic-rename is off so the team name sticks


### PR DESCRIPTION
## Summary

Fixes #684 — Unblocks omni#239.

When `genie spawn --session claudia-whatsapp` targets a session that doesn't exist, `ensureTeamWindow()` now auto-creates it before creating the window. 4 lines added.

## Change

```typescript
// src/lib/tmux.ts — ensureTeamWindow()
const sessionExists = await findSessionByName(session);
if (!sessionExists) {
  await createSession(session);
}
```

## Result

```
genie spawn claudia --session claudia-whatsapp --team claudia-chat123
```

Creates:
```
tmux session: claudia-whatsapp
  └── window: claudia-chat123
```

Second spawn adds another window to the same session. Existing behavior unchanged when session already exists.

## Test plan

- [x] `bun run check` passes (932 tests, 0 failures)
- [x] No regressions — `findSessionByName` + `createSession` are existing tested functions
- [ ] E2E: `genie spawn agent --session new-name --team test` creates session (requires tmux)

## Unblocks

- **omni#239**: Omni can now pass `--session` from `schemaConfig.sessionName` to group chat agents into dedicated per-provider sessions