### PR TITLE
fix(tmux): rebuild TUI with 3-bar layout and clickable sessions

### DIFF
--- a/scripts/tmux/genie.tmux.conf
+++ b/scripts/tmux/genie.tmux.conf
@@ -1,7 +1,12 @@
 # ============================================================================
 # Genie TUI — tmux configuration
 # Dark theme with purple/cyan/gold palette
-# Native tmux, zero plugins
+# Native tmux 3.3+, zero plugins
+#
+# Layout:
+#   TOP:     pane-border — left: version + folder | right: git, CPU, RAM, time
+#   BOTTOM:  status line 0 — window tabs for current session (clickable)
+#            status line 1 — agent sessions list (clickable to switch)
 # ============================================================================
 
 # --- Terminal & basics ---
@@ -45,45 +50,44 @@ setw -g mode-style "bg=#7b2ff7,fg=#e0e0e0"
 setw -g clock-mode-colour "#7b2ff7"
 
 # ============================================================================
-# STATUS BAR — Top: info + clickable window tabs | Bottom: session switcher
+# TOP BAR — pane-border: left = branding + folder | right = git, CPU, RAM, time
+# ============================================================================
+set -g pane-border-status top
+set -g pane-border-lines heavy
+set -g pane-border-format "\
+#[align=left,bg=#16213e,fg=#e0e0e0]\
+ #[fg=#7b2ff7,bold]Genie#[fg=#6c6c8a,nobold] #(genie --version 2>/dev/null | head -1 || echo '?') \
+#[fg=#0f3460]│ \
+#[fg=#b8a9c9]#{pane_current_path}\
+#[align=right,bg=#16213e]\
+#[fg=#f5a623]#($HOME/.genie/scripts/genie-git.sh) \
+#[fg=#0f3460]│ \
+#[fg=#00d2ff]CPU #($HOME/.genie/scripts/cpu-info.sh) \
+#[fg=#0f3460]│ \
+#[fg=#00d2ff]RAM #($HOME/.genie/scripts/ram-info.sh) \
+#[fg=#0f3460]│ \
+#[fg=#e0e0e0]%H:%M "
+
+# ============================================================================
+# BOTTOM BARS — dual status lines (status 2)
+#   Line 0 (top):    windows in current session (clickable tabs)
+#   Line 1 (bottom): agents = tmux sessions (clickable to switch)
 # ============================================================================
 set -g status on
+set -g status 2
 set -g status-interval 5
-set -g status-position top
-set -g status-justify left
+set -g status-position bottom
 set -g status-style "bg=#1a1a2e,fg=#e0e0e0"
 
-# --- Top bar (native line 0): branding + clickable window tabs + system info ---
-set -g status-left-length 40
-set -g status-left "#[bg=#7b2ff7,fg=#e0e0e0,bold] #(genie --version 2>/dev/null | head -1 || echo 'Genie') #[bg=#1a1a2e,fg=#7b2ff7]"
+# --- Line 0 (very bottom): Window tabs for current session ---
+set -g status-format[0] "#[align=left,bg=#1a1a2e,fg=#e0e0e0] #{W:#[range=window|#{window_index}]#{?#{window_active},#[bg=#7b2ff7#,fg=#e0e0e0#,bold] #{window_index}:#{window_name} #[bg=#1a1a2e#,fg=#7b2ff7#,nobold],#[bg=#1a1a2e#,fg=#b8a9c9] #{window_index}:#{window_name} }#[norange default]}#[align=right,bg=#1a1a2e,fg=#6c6c8a]#{session_name} "
 
-set -g status-right-length 100
-set -g status-right "#[fg=#6c6c8a]#($HOME/.genie/scripts/genie-git.sh) #[fg=#0f3460]| #[fg=#00d2ff]CPU #($HOME/.genie/scripts/cpu-info.sh) #[fg=#0f3460]| #[fg=#00d2ff]RAM #($HOME/.genie/scripts/ram-info.sh) #[fg=#0f3460]| #[fg=#e0e0e0]%H:%M "
-
-# ============================================================================
-# WINDOW (TAB) STYLING — clickable tabs in top bar
-# ============================================================================
-
-# Tab separator
-set -g window-status-separator ""
-
-# Inactive tabs: lavender text on dark bg
-set -g window-status-format "#[fg=#b8a9c9,bg=#1a1a2e] #I:#W "
-
-# Active tab: purple bg, white text, bold
-set -g window-status-current-format "#[fg=#1a1a2e,bg=#7b2ff7]#[fg=#e0e0e0,bg=#7b2ff7,bold] #I:#W #[fg=#7b2ff7,bg=#1a1a2e]"
+# --- Line 1 (above, closer to content): Agent sessions ---
+set -g status-format[1] "#[align=left,bg=#16213e,fg=#b8a9c9] #[fg=#6c6c8a]Agents: #{S:#[range=session|#{session_name}]#{?#{==:#{session_name},#{client_session}},#[bg=#7b2ff7#,fg=#e0e0e0#,bold] #{session_name} #[bg=#16213e#,nobold],#[bg=#16213e#,fg=#b8a9c9] #{session_name} }#[norange default]}"
 
 # Activity monitoring
 setw -g monitor-activity on
 set -g visual-activity off
-set -g window-status-activity-style "fg=#f5a623,bg=#1a1a2e"
-
-# ============================================================================
-# BOTTOM BAR — Session list via pane borders
-# ============================================================================
-set -g pane-border-status bottom
-set -g pane-border-format "#[align=left,bg=#16213e,fg=#b8a9c9] Agents: #($HOME/.genie/scripts/genie-sessions.sh #{session_name})"
-set -g pane-border-lines heavy
 
 # ============================================================================
 # KEYBINDINGS
@@ -92,19 +96,29 @@ set -g pane-border-lines heavy
 # Reload config
 bind r source-file ~/.tmux.conf \; display-message "Config reloaded"
 
-# Ctrl+T — new tab in current session, using session start directory
-# Uses #{session_path} (the directory where the session was created)
-# Falls back to #{pane_current_path} if session_path is empty
+# Ctrl+T — new tab in current session
 bind -n C-t new-window -c "#{?session_path,#{session_path},#{pane_current_path}}"
 
 # Vi copy mode bindings
 bind -T copy-mode-vi v send-keys -X begin-selection
 bind -T copy-mode-vi y send-keys -X copy-selection-and-cancel
 
-# Session switching — Ctrl+( / Ctrl+) cycle through sessions
-bind -n C-) switch-client -n
-bind -n C-( switch-client -p
+# Session switching — Alt+[ / Alt+] cycle sessions (works in all terminals)
+bind -n M-] switch-client -n
+bind -n M-[ switch-client -p
 
-# Double-click anywhere opens interactive session/window picker
+# Window switching — Alt+left / Alt+right cycle windows
+bind -n M-Left previous-window
+bind -n M-Right next-window
+
+# Interactive picker — prefix+s for sessions, prefix+w for windows
+bind s choose-tree -s
+bind w choose-tree -w
+
+# Single-click on status bar: switch to clicked window/session via range= targets
+bind -n MouseDown1Status select-window -t =
+bind -n MouseDown1StatusDefault select-window -t =
+
+# Double-click on pane opens interactive session/window picker
 bind -n DoubleClick1Pane choose-tree -s
-bind -n DoubleClick1StatusDefault choose-tree -s
+bind -n DoubleClick1Status choose-tree -s


### PR DESCRIPTION
## Summary

Hotfix for the tmux TUI that broke in the v3.260322.1 release. Rebuilds the layout as a proper 3-bar design:

- **Top bar** (pane-border): version + folder (left) | git, CPU, RAM, time (right)
- **Bottom bar 1** (status-format[1]): agent sessions via `#{S:}` with `range=session`
- **Bottom bar 0** (status-format[0]): window tabs via `#{W:}` with `range=window` — clickable

## Fixes
- Clickable window switching on bottom bar (via `range=window` + `MouseDown1Status`)
- Proper left/right alignment on top info bar
- Replaced broken `Ctrl+(/)` keybindings with `Alt+[/]` (works in all terminals)
- Uses `status 2` for dual bottom bars (tmux 3.3+)

## Test plan
- [ ] Top bar shows version + folder on left, git/CPU/RAM/time on right
- [ ] Bottom bars: windows on bottom, agents above
- [ ] Click on window tab switches to that window
- [ ] `Alt+[` / `Alt+]` cycles sessions
- [ ] Double-click opens tree picker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Reorganized tmux status bar layout with repositioned information display
  * Updated keyboard shortcuts for session and window navigation
  * Modified mouse interaction patterns for session and window selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->