### PR TITLE
fix(build): drop minify-identifiers — fixes pgserve Bun.sql import

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "prepare": "test \"$CI\" = true || husky",
     "version": "bun run scripts/version.ts",
-    "build": "bun build src/genie.ts --outdir dist --target bun --minify && chmod +x dist/*.js",
+    "build": "bun build src/genie.ts --outdir dist --target bun --minify-syntax --minify-whitespace && chmod +x dist/*.js",
     "build:plugin": "node scripts/build.js",
     "sync": "node scripts/sync.js",
     "build-and-sync": "npm run build:plugin && npm run sync",


### PR DESCRIPTION
## Summary
- Bun bundler mangles `await import('bun')` into `awaitPromise.resolve(globalThis.Bun)` with `--minify` (includes `--minify-identifiers`)
- This breaks pgserve startup completely — `genie db migrate` fails, nothing works
- Fix: use `--minify-syntax --minify-whitespace` only (0.82MB vs 0.60MB — acceptable tradeoff)

## QA verified
- `genie db migrate` — works
- `genie task create/list/show/move/assign/tag` — all working
- Inline comments, stage history, short IDs — all working
- 1027 tests pass