### PR TITLE
fix(build): mark pgserve and bun as external in bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "prepare": "test \"$CI\" = true || husky",
     "version": "bun run scripts/version.ts",
-    "build": "bun build src/genie.ts --outdir dist --target bun --minify-syntax --minify-whitespace && chmod +x dist/*.js",
+    "build": "bun build src/genie.ts --outdir dist --target bun --minify-syntax --minify-whitespace --external bun --external pgserve && chmod +x dist/*.js",
     "build:plugin": "node scripts/build.js",
     "sync": "node scripts/sync.js",
     "build-and-sync": "npm run build:plugin && npm run sync",


### PR DESCRIPTION
## Summary
- The Bun bundler was transforming `await import('bun')` inside pgserve's source into `awaitPromise.resolve(globalThis.Bun)` — a broken expression that crashes at runtime
- Every pgserve startup attempt failed with "awaitPromise is not defined", exhausting all 11 fallback ports (19642-19652)
- Fix: add `--external bun --external pgserve` to the build command so dynamic imports are preserved at runtime

## Root cause
`bun build --target bun` bundles `node_modules/pgserve` inline, but its `await import('bun')` pattern (used for `Bun.SQL`) gets mangled by the minifier into invalid code.

## Test plan
- [x] `bun run build` succeeds
- [x] `grep -c "awaitPromise" dist/genie.js` returns 0
- [x] `genie status` starts pgserve on port 19642 successfully
- [ ] `genie task list` completes without port exhaustion

Fixes #702