### PR TITLE
fix(ci): version workflow triggers on dev with v4 prefix

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -4,14 +4,13 @@ on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
-    branches: [main]
+    branches: [main, dev]
   workflow_dispatch:
 
 permissions:
   contents: write
 
 concurrency:
-  # This workflow always writes to `dev`, regardless of the trigger ref.
   group: version-dev
   cancel-in-progress: false
 
@@ -24,10 +23,14 @@ jobs:
       (github.event_name == 'workflow_dispatch') ||
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event == 'push' &&
-       github.event.workflow_run.head_branch == 'main' &&
-       startsWith(github.event.workflow_run.head_commit.message, 'Merge pull request') &&
-       contains(github.event.workflow_run.head_commit.message, '/dev') &&
-       !contains(github.event.workflow_run.head_commit.message, '[skip ci]'))
+       !contains(github.event.workflow_run.head_commit.message, '[skip ci]') &&
+       (
+         (github.event.workflow_run.head_branch == 'main' &&
+          startsWith(github.event.workflow_run.head_commit.message, 'Merge pull request') &&
+          contains(github.event.workflow_run.head_commit.message, '/dev'))
+         ||
+         (github.event.workflow_run.head_branch == 'dev')
+       ))
 
     steps:
       - uses: actions/checkout@v4
@@ -52,9 +55,9 @@ jobs:
         id: version
         run: |
           TODAY=$(date -u +%y%m%d)
-          EXISTING=$(git tag --list "v3.${TODAY}.*" | wc -l)
+          EXISTING=$(git tag --list "v4.${TODAY}.*" | wc -l)
           BUILD_NUMBER=$((EXISTING + 1))
-          VERSION="3.${TODAY}.${BUILD_NUMBER}"
+          VERSION="4.${TODAY}.${BUILD_NUMBER}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "build_number=${BUILD_NUMBER}" >> "$GITHUB_OUTPUT"
           echo "Derived version: ${VERSION}"


### PR DESCRIPTION
## Summary

- Add `dev` to `workflow_run` branches so CI completions on dev trigger auto-versioning
- Fix hardcoded `v3` → `v4` prefix in the Derive version step
- Dev pushes trigger without requiring "Merge pull request" in commit message
- All versioning still targets `dev` branch and publishes to npm as `@next`

**Why this must target main:** GitHub evaluates `workflow_run` triggers using the workflow file from the default branch. The fix on `dev` has no effect until `main` has it too.

## Test plan

- [x] Only changes `.github/workflows/version.yml` — no code changes
- [ ] After merge, push to dev → CI passes → Version workflow triggers → `v4.YYMMDD.N` tag created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build workflow now triggers on both main and dev branches with enhanced skip-ci support
  * Release versioning updated from v3 to v4 format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->