### PR TITLE
fix: make genie status actionable when no state found

### DIFF
--- a/plugins/genie/agents/team-lead/AGENTS.md
+++ b/plugins/genie/agents/team-lead/AGENTS.md
@@ -68,4 +68,5 @@ Never rely on messages alone to determine completion. Always check `genie status
 - NEVER push to main or master.
 - NEVER use the Agent tool.
 - NEVER run `genie status`, `genie ls`, or `genie inbox` before Phase 2.
+- If you ran `genie status` and got "No state found", this means work has NOT been dispatched. Go to Phase 2 immediately and run `genie work <slug>`. Do NOT poll or wait.
 </constraints>

--- a/plugins/genie/agents/team-lead/HEARTBEAT.md
+++ b/plugins/genie/agents/team-lead/HEARTBEAT.md
@@ -16,6 +16,9 @@ genie status <slug>
 ```
 Which groups are done? Which are in progress? Which are blocked?
 
+If `genie status` returns "No state found", work was never dispatched.
+Run `genie work <slug>` to initialize and dispatch — do NOT poll.
+
 ### 3. Check Workers
 ```bash
 genie ls

--- a/src/term-commands/state.ts
+++ b/src/term-commands/state.ts
@@ -238,7 +238,8 @@ export async function statusCommand(slug: string): Promise<void> {
     const state = await wishState.getState(slug);
     if (!state) {
       console.error(`❌ No state found for wish "${slug}"`);
-      console.error('   Initialize with: genie work <slug>');
+      console.error('   This means work has not been dispatched yet.');
+      console.error(`   Run: genie work ${slug}`);
       process.exit(1);
     }
 


### PR DESCRIPTION
## Summary
- `genie status` now prints actionable guidance ("Run: genie work <slug>") when no state exists, instead of a generic error
- Team-lead AGENTS.md adds explicit recovery path: if "No state found", dispatch work immediately instead of polling
- Team-lead HEARTBEAT.md handles "no state" = dispatch work, not poll

## Wish
`fix-team-lead-polling` — Fixes #710

## Test plan
- [x] `bun test` passes (1070/1070)
- [x] No behavioral changes beyond improved error messaging