### PR TITLE
refactor(history): reduce cognitive complexity of formatTranscriptEntryForDisplay

### DIFF
--- a/src/term-commands/history.ts
+++ b/src/term-commands/history.ts
@@ -310,41 +310,34 @@ function getEventIcon(type: CompressedEvent['type']): string {
   }
 }
 
+function formatToolDetail(toolCall: NonNullable<TranscriptEntry['toolCall']>): string {
+  const input = toolCall.input as Record<string, unknown>;
+  if (toolCall.name === 'Bash' || toolCall.name === 'shell') {
+    return `  ${toolCall.name}: ${input.command ?? ''}`;
+  }
+  if (['Read', 'Edit', 'Write'].includes(toolCall.name)) {
+    return `  ${toolCall.name}: ${input.file_path ?? ''}`;
+  }
+  return `  ${toolCall.name}`;
+}
+
 function formatTranscriptEntryForDisplay(entry: TranscriptEntry): string[] {
   const time = formatTime(entry.timestamp);
 
-  if (entry.role === 'user') {
-    return [`\n[${time}] USER:`, entry.text];
+  switch (entry.role) {
+    case 'user':
+      return [`\n[${time}] USER:`, entry.text];
+    case 'tool_call':
+      return entry.toolCall ? [`\n[${time}] TOOL:`, formatToolDetail(entry.toolCall)] : [];
+    case 'assistant':
+      return [`\n[${time}] ASSISTANT:`, truncate(entry.text, 500)];
+    case 'tool_result':
+      return [`\n[${time}] RESULT:`, `  ${truncate(entry.text, 500)}`];
+    case 'system':
+      return [`\n[${time}] SYSTEM:`, entry.text];
+    default:
+      return [];
   }
-
-  if (entry.role === 'tool_call' && entry.toolCall) {
-    const input = entry.toolCall.input as Record<string, unknown>;
-    let detail: string;
-    if (entry.toolCall.name === 'Bash' || entry.toolCall.name === 'shell') {
-      detail = `  ${entry.toolCall.name}: ${input.command ?? ''}`;
-    } else if (['Read', 'Edit', 'Write'].includes(entry.toolCall.name)) {
-      detail = `  ${entry.toolCall.name}: ${input.file_path ?? ''}`;
-    } else {
-      detail = `  ${entry.toolCall.name}`;
-    }
-    return [`\n[${time}] TOOL:`, detail];
-  }
-
-  if (entry.role === 'assistant') {
-    const text = entry.text.slice(0, 500) + (entry.text.length > 500 ? '...' : '');
-    return [`\n[${time}] ASSISTANT:`, text];
-  }
-
-  if (entry.role === 'tool_result') {
-    const text = entry.text.slice(0, 500) + (entry.text.length > 500 ? '...' : '');
-    return [`\n[${time}] RESULT:`, `  ${text}`];
-  }
-
-  if (entry.role === 'system') {
-    return [`\n[${time}] SYSTEM:`, entry.text];
-  }
-
-  return [];
 }
 
 function formatFullConversation(entries: TranscriptEntry[]): string {


### PR DESCRIPTION
## Summary
- Extract `formatToolDetail()` helper from `formatTranscriptEntryForDisplay()`
- Convert if-chain to switch statement
- Reuse existing `truncate()` instead of duplicating
- Reduces biome cognitive complexity from 18 to under 15

## Test plan
- [x] `bun run check` passes (1065 tests, 0 warnings)
- [x] `bun biome check src/term-commands/history.ts` — zero warnings