### PR TITLE
fix: bridge genie send to CC native inbox + auto-clean dead workers

### DIFF
--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -743,17 +743,22 @@ function prependEnvVars(command: string, env?: Record<string, string>): string {
 
 /**
  * Reject spawn if a live worker with the same role already exists in the team.
- * Dead/suspended workers (pane gone) are ignored — only live panes block.
+ * Dead/suspended workers (pane gone) are auto-cleaned from registry — only live panes block.
  */
 async function rejectDuplicateRole(team: string, role: string): Promise<void> {
   const existing = await registry.list();
   for (const w of existing) {
-    if (w.role === role && w.team === team && (await isPaneAlive(w.paneId))) {
-      console.error(
-        `Error: Worker with role "${role}" already exists in team "${team}" (state: ${w.state}, pane: ${w.paneId})\n` +
-          `Use a different --role name for a second worker, e.g.: --role ${role}-2`,
-      );
-      process.exit(1);
+    if (w.role === role && w.team === team) {
+      const alive = await isPaneAlive(w.paneId);
+      if (alive) {
+        console.error(
+          `Error: Worker with role "${role}" already exists in team "${team}" (state: ${w.state}, pane: ${w.paneId})\n` +
+            `Use a different --role name for a second worker, e.g.: --role ${role}-2`,
+        );
+        process.exit(1);
+      }
+      // Dead worker with same role — clean up stale registry entry so spawn can proceed
+      await registry.unregister(w.id);
     }
   }
 }

--- a/src/term-commands/msg.ts
+++ b/src/term-commands/msg.ts
@@ -399,6 +399,32 @@ export function registerSendInboxCommands(program: Command): void {
         await ts.addMember(conv.id, recipientActor);
 
         const msg = await ts.sendMessage(conv.id, senderActor, body);
+
+        // Bridge to CC native inbox so Claude Code agents receive in real-time
+        try {
+          const nativeTeams = await import('../lib/claude-native-teams.js');
+          const teamName = await nativeTeams.discoverTeamName().catch(() => null);
+          if (teamName) {
+            const config = await nativeTeams.loadConfig(teamName).catch(() => null);
+            const memberExists = config?.members?.some(
+              (m: { name?: string; agentId?: string }) =>
+                m.name === options.to || m.agentId === `${options.to}@${teamName}`,
+            );
+            if (memberExists) {
+              await nativeTeams.writeNativeInbox(teamName, options.to, {
+                from,
+                text: body,
+                summary: body.length > 50 ? `${body.substring(0, 50)}...` : body,
+                timestamp: new Date().toISOString(),
+                color: 'blue',
+                read: false,
+              });
+            }
+          }
+        } catch {
+          // Native inbox delivery is best-effort — PG message already persisted
+        }
+
         console.log(`Message sent to "${options.to}".`);
         console.log(`  ID: ${msg.id}`);
         console.log(`  Conversation: ${conv.id}`);


### PR DESCRIPTION
## Summary
Two surgical fixes for genie team orchestration:

### 1. Message bridge (#713)
`genie send` now delivers to CC native inbox after PG write. Uses existing `writeNativeInbox` from `claude-native-teams.ts`. Best-effort — PG is primary, native inbox is bonus.

### 2. Auto-clean dead workers (#708 partial)
`rejectDuplicateRole` now auto-cleans stale registry entries for dead workers (pane gone) instead of blocking spawn with "already exists" error.

Fixes #713, partial fix for #708