### PR TITLE
fix(spawn): reduce agent spawn delay by skipping hooks for workers (#712)

### DIFF
--- a/plugins/genie/scripts/first-run-check.cjs
+++ b/plugins/genie/scripts/first-run-check.cjs
@@ -13,6 +13,11 @@
 const fs = require("node:fs");
 const path = require("node:path");
 
+// Workers don't need onboarding prompts — skip to reduce spawn latency (#712)
+if (process.env.GENIE_WORKER === '1') {
+  process.exit(0);
+}
+
 // Use CLAUDE_CWD if available (set by Claude Code), otherwise process.cwd()
 const cwd = process.env.CLAUDE_CWD || process.cwd();
 const agentsMd = path.join(cwd, "AGENTS.md");

--- a/plugins/genie/scripts/session-context.cjs
+++ b/plugins/genie/scripts/session-context.cjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-"use strict";var c=require("fs"),a=require("path"),p=require("util"),u={};try{u=(0,p.parseArgs)({args:process.argv.slice(2),options:{help:{type:"boolean",short:"h"}},strict:!1}).values}catch{let e=process.argv.slice(2);for(let t of e)(t==="--help"||t==="-h")&&(u.help=!0)}u.help&&(console.log(`
+"use strict";if(process.env.GENIE_WORKER==='1'){process.exit(0)}var c=require("fs"),a=require("path"),p=require("util"),u={};try{u=(0,p.parseArgs)({args:process.argv.slice(2),options:{help:{type:"boolean",short:"h"}},strict:!1}).values}catch{let e=process.argv.slice(2);for(let t of e)(t==="--help"||t==="-h")&&(u.help=!0)}u.help&&(console.log(`
 session-context - Load active wish context on session start
 
 Usage:

--- a/plugins/genie/scripts/smart-install.js
+++ b/plugins/genie/scripts/smart-install.js
@@ -436,6 +436,11 @@ function installGenieCli() {
 
 // Main execution
 try {
+  // Workers inherit parent's deps — skip all checks to reduce spawn latency (#712)
+  if (process.env.GENIE_WORKER === '1') {
+    process.exit(0);
+  }
+
   // Quick check: if everything is already installed, exit silently
   if (isBunInstalled() && isTmuxInstalled() && !needsInstall() && !genieCliNeedsInstall()) {
     process.exit(0);

--- a/src/genie-commands/__tests__/session.test.ts
+++ b/src/genie-commands/__tests__/session.test.ts
@@ -44,6 +44,11 @@ describe('buildClaudeCommand', () => {
     expect(cmd).toContain('--dangerously-skip-permissions');
   });
 
+  test('sets GENIE_WORKER=1 to skip SessionStart hooks on spawn (#712)', () => {
+    const cmd = buildClaudeCommand('genie');
+    expect(cmd).toContain('GENIE_WORKER=1');
+  });
+
   test('includes --agent-id with team-lead@team pattern', () => {
     const cmd = buildClaudeCommand('my-team');
     expect(cmd).toContain(`--agent-id 'team-lead@my-team'`);

--- a/src/lib/provider-adapters.test.ts
+++ b/src/lib/provider-adapters.test.ts
@@ -228,6 +228,18 @@ describe('buildClaudeCommand', () => {
     expect(content).toContain('User agent instructions');
     expect(content).toContain('Built-in prompt');
   });
+
+  it('sets GENIE_WORKER=1 in env for spawn latency optimization (#712)', () => {
+    const result = buildClaudeCommand({ provider: 'claude', team: 'work', role: 'implementor' });
+    expect(result.env).toBeDefined();
+    expect(result.env!.GENIE_WORKER).toBe('1');
+  });
+
+  it('sets GENIE_WORKER=1 even without role or nativeTeam', () => {
+    const result = buildClaudeCommand({ provider: 'claude', team: 'work' });
+    expect(result.env).toBeDefined();
+    expect(result.env!.GENIE_WORKER).toBe('1');
+  });
 });
 
 // ============================================================================

--- a/src/lib/provider-adapters.ts
+++ b/src/lib/provider-adapters.ts
@@ -256,6 +256,10 @@ export function buildClaudeCommand(params: SpawnParams): LaunchCommand {
   const parts: string[] = ['claude', '--dangerously-skip-permissions'];
   const env: Record<string, string> = {};
 
+  // Mark as worker so SessionStart hooks (smart-install, first-run-check,
+  // session-context) fast-exit — workers inherit parent's deps and config.
+  env.GENIE_WORKER = '1';
+
   if (params.role) env.GENIE_AGENT_NAME = params.role;
   if (params.team) env.GENIE_TEAM = params.team;
 

--- a/src/lib/team-lead-command.ts
+++ b/src/lib/team-lead-command.ts
@@ -45,6 +45,7 @@ export function buildTeamLeadCommand(teamName: string, options?: BuildTeamLeadCo
   const qTeam = shellQuote(sanitized);
   const folderName = basename(process.cwd());
   const parts = [
+    'GENIE_WORKER=1',
     'CLAUDECODE=1',
     'CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1',
     `GENIE_TEAM=${qTeam}`,


### PR DESCRIPTION
## Summary
- Add `GENIE_WORKER=1` env var to all spawned workers (via `provider-adapters.ts` and `team-lead-command.ts`)
- All 3 SessionStart hooks (`smart-install.js`, `first-run-check.cjs`, `session-context.cjs`) now fast-exit when `GENIE_WORKER=1` is set
- Workers inherit the parent session's deps and config, so these checks are redundant and add up to ~75s of latency

## Test plan
- [x] `bun test src/lib/provider-adapters.test.ts` — 35 pass (2 new tests for GENIE_WORKER)
- [x] `bun test src/genie-commands/__tests__/session.test.ts` — 26 pass (1 new test)
- [x] `bun test src/lib/spawn-command.test.ts` — 13 pass
- [x] `bun test src/lib/team-auto-spawn.test.ts` — 5 pass
- [x] `bun run check` — 1083 tests pass, typecheck + lint + dead-code clean

Closes #712