### PR TITLE
fix(target-resolver): add substring matching for short display names

### DIFF
--- a/src/lib/target-resolver.test.ts
+++ b/src/lib/target-resolver.test.ts
@@ -1025,6 +1025,162 @@ describe('Partial ID suffix resolution', () => {
 });
 
 // ============================================================================
+// Substring resolution (fixes #700: short display names from genie ls)
+// ============================================================================
+
+describe('Substring resolution', () => {
+  test('resolves "engineer-4" when ID is "sofia-t1re-engineer-4-ec331228"', async () => {
+    const result = await resolveTarget('engineer-4', {
+      checkLiveness: false,
+      getCurrentTeam: async () => null,
+      workers: {
+        'sofia-t1re-engineer-4-ec331228': {
+          id: 'sofia-t1re-engineer-4-ec331228',
+          paneId: '%40',
+          session: 'my-team',
+          worktree: null,
+          startedAt: new Date().toISOString(),
+          state: 'working',
+          lastStateChange: new Date().toISOString(),
+          repoPath: '/tmp/test',
+          role: 'engineer',
+          team: 'my-team',
+        },
+      },
+    });
+
+    expect(result.paneId).toBe('%40');
+    expect(result.workerId).toBe('sofia-t1re-engineer-4-ec331228');
+    expect(result.resolvedVia).toBe('worker');
+  });
+
+  test('prefers same-team match on ambiguous substring', async () => {
+    const result = await resolveTarget('engineer-4', {
+      checkLiveness: false,
+      getCurrentTeam: async () => 'my-team',
+      workers: {
+        'teamA-engineer-4-abc123': {
+          id: 'teamA-engineer-4-abc123',
+          paneId: '%40',
+          session: 'other-team',
+          worktree: null,
+          startedAt: new Date().toISOString(),
+          state: 'working',
+          lastStateChange: new Date().toISOString(),
+          repoPath: '/tmp/test',
+          team: 'other-team',
+        },
+        'teamB-engineer-4-def456': {
+          id: 'teamB-engineer-4-def456',
+          paneId: '%41',
+          session: 'my-team',
+          worktree: null,
+          startedAt: new Date().toISOString(),
+          state: 'working',
+          lastStateChange: new Date().toISOString(),
+          repoPath: '/tmp/test',
+          team: 'my-team',
+        },
+      },
+    });
+
+    expect(result.paneId).toBe('%41');
+    expect(result.workerId).toBe('teamB-engineer-4-def456');
+  });
+
+  test('throws on ambiguous substring without team disambiguation', async () => {
+    await expect(
+      resolveTarget('engineer-4', {
+        checkLiveness: false,
+        getCurrentTeam: async () => null,
+        workers: {
+          'teamA-engineer-4-abc123': {
+            id: 'teamA-engineer-4-abc123',
+            paneId: '%40',
+            session: 's1',
+            worktree: null,
+            startedAt: new Date().toISOString(),
+            state: 'working',
+            lastStateChange: new Date().toISOString(),
+            repoPath: '/tmp/test',
+            team: 'team-a',
+          },
+          'teamB-engineer-4-def456': {
+            id: 'teamB-engineer-4-def456',
+            paneId: '%41',
+            session: 's2',
+            worktree: null,
+            startedAt: new Date().toISOString(),
+            state: 'working',
+            lastStateChange: new Date().toISOString(),
+            repoPath: '/tmp/test',
+            team: 'team-b',
+          },
+        },
+      }),
+    ).rejects.toThrow(/ambiguous/i);
+  });
+
+  test('suffix match (endsWith) takes priority over substring match', async () => {
+    const result = await resolveTarget('engineer-4', {
+      checkLiveness: false,
+      getCurrentTeam: async () => null,
+      workers: {
+        'team-engineer-4': {
+          id: 'team-engineer-4',
+          paneId: '%10',
+          session: 'genie',
+          worktree: null,
+          startedAt: new Date().toISOString(),
+          state: 'working',
+          lastStateChange: new Date().toISOString(),
+          repoPath: '/tmp/test',
+          team: 'my-team',
+        },
+        'sofia-t1re-engineer-4-ec331228': {
+          id: 'sofia-t1re-engineer-4-ec331228',
+          paneId: '%20',
+          session: 'genie',
+          worktree: null,
+          startedAt: new Date().toISOString(),
+          state: 'working',
+          lastStateChange: new Date().toISOString(),
+          repoPath: '/tmp/test',
+          team: 'my-team',
+        },
+      },
+    });
+
+    // endsWith match wins (resolveByPartialId runs before resolveBySubstring)
+    expect(result.paneId).toBe('%10');
+    expect(result.workerId).toBe('team-engineer-4');
+  });
+
+  test('does not match when target is the exact ID', async () => {
+    // exact ID match should resolve first, substring should not interfere
+    const result = await resolveTarget('worker-1', {
+      checkLiveness: false,
+      getCurrentTeam: async () => null,
+      workers: {
+        'worker-1': {
+          id: 'worker-1',
+          paneId: '%50',
+          session: 'genie',
+          worktree: null,
+          startedAt: new Date().toISOString(),
+          state: 'working',
+          lastStateChange: new Date().toISOString(),
+          repoPath: '/tmp/test',
+        },
+      },
+    });
+
+    expect(result.paneId).toBe('%50');
+    expect(result.workerId).toBe('worker-1');
+  });
+});
+
+// ============================================================================
 // Global role resolution (fallback)
 // ============================================================================
 
@@ -1117,7 +1273,7 @@ describe('Global role resolution', () => {
 // Resolution priority with new steps
 // ============================================================================
 
-describe('Resolution priority: exact ID > role (team) > customName > partial ID > role (global)', () => {
+describe('Resolution priority: exact ID > role (team) > customName > partial ID > substring > role (global)', () => {
   const baseWorker = {
     worktree: null as string | null,
     startedAt: new Date().toISOString(),
@@ -1201,6 +1357,58 @@ describe('Resolution priority: exact ID > role (team) > customName > partial ID 
 
     expect(result.paneId).toBe('%10');
     expect(result.workerId).toBe('custom-name-worker');
+  });
+
+  test('partial ID suffix wins over substring match', async () => {
+    const result = await resolveTarget('engineer-4', {
+      checkLiveness: false,
+      getCurrentTeam: async () => 'my-team',
+      workers: {
+        'team-engineer-4': {
+          ...baseWorker,
+          id: 'team-engineer-4',
+          paneId: '%10',
+          session: 'my-team',
+        },
+        'sofia-t1re-engineer-4-ec331228': {
+          ...baseWorker,
+          id: 'sofia-t1re-engineer-4-ec331228',
+          paneId: '%20',
+          session: 'my-team',
+        },
+      },
+    });
+
+    // endsWith match (resolveByPartialId) runs first
+    expect(result.paneId).toBe('%10');
+    expect(result.workerId).toBe('team-engineer-4');
+  });
+
+  test('substring wins over global role', async () => {
+    const result = await resolveTarget('engineer-4', {
+      checkLiveness: false,
+      getCurrentTeam: async () => null,
+      workers: {
+        'sofia-t1re-engineer-4-ec331228': {
+          ...baseWorker,
+          id: 'sofia-t1re-engineer-4-ec331228',
+          paneId: '%10',
+          session: 'my-team',
+          role: 'other-role',
+        },
+        'global-role-worker': {
+          ...baseWorker,
+          id: 'global-role-worker',
+          paneId: '%20',
+          session: 'my-team',
+          role: 'engineer-4',
+        },
+      },
+    });
+
+    // substring match runs before global role
+    expect(result.paneId).toBe('%10');
+    expect(result.workerId).toBe('sofia-t1re-engineer-4-ec331228');
   });
 });
 

--- a/src/lib/target-resolver.ts
+++ b/src/lib/target-resolver.ts
@@ -5,7 +5,7 @@
  *   1. Raw pane ID (starts with %) -> passthrough
  *   2. Worker[:index] (left side is registered worker) -> registry lookup + subpane index
  *   3. Session:window (contains :, left side is tmux session) -> tmux lookup
- *   4. Bare name -> exact ID → role (team) → customName → partial ID → role (global)
+ *   4. Bare name -> exact ID → role (team) → customName → partial ID → substring → role (global)
  *
  * Returns { paneId, session, workerId?, paneIndex?, resolvedVia }
  */
@@ -295,6 +295,36 @@ function resolveByPartialId(
   );
 }
 
+/** Resolve a target by substring match on worker ID. Prefers same-team on ambiguity. */
+function resolveBySubstring(
+  target: string,
+  workers: Record<string, Agent>,
+  currentTeam: string | null,
+): ResolvedTarget | null {
+  // Only match IDs that contain the target but don't end with it (endsWith is handled by resolveByPartialId)
+  const candidates = Object.entries(workers).filter(
+    ([id]) => id !== target && !id.endsWith(target) && id.includes(target),
+  );
+  if (candidates.length === 0) return null;
+  if (candidates.length === 1) {
+    const [id, w] = candidates[0];
+    return { paneId: w.paneId, session: w.session, workerId: id, resolvedVia: 'worker' };
+  }
+
+  if (currentTeam) {
+    const teamCandidates = candidates.filter(([, w]) => w.team === currentTeam);
+    if (teamCandidates.length === 1) {
+      const [id, w] = teamCandidates[0];
+      return { paneId: w.paneId, session: w.session, workerId: id, resolvedVia: 'worker' };
+    }
+  }
+
+  const ids = candidates.map(([id]) => id).join(', ');
+  throw new Error(
+    `Ambiguous target "${target}" — matches ${candidates.length} workers: ${ids}\nUse the full ID instead.`,
+  );
+}
+
 /** Resolve a target by role name across all teams (global fallback). */
 function resolveByRoleGlobal(target: string, workers: Record<string, Agent>): ResolvedTarget | null {
   const candidates = Object.entries(workers).filter(([, w]) => w.role === target);
@@ -351,7 +381,7 @@ async function resolveColonTarget(
   return { paneId: sessionWindowResult.paneId, session: sessionWindowResult.session, resolvedVia: 'session:window' };
 }
 
-/** Resolve a bare name: exact ID → role (team) → customName → partial ID → role (global). */
+/** Resolve a bare name: exact ID → role (team) → customName → partial ID → substring → role (global). */
 async function resolveBareName(
   target: string,
   workers: Record<string, Agent>,
@@ -383,6 +413,7 @@ async function resolveBareName(
     resolveByRole(target, workers, currentTeam) ??
     resolveByCustomName(target, workers, currentTeam) ??
     resolveByPartialId(target, workers, currentTeam) ??
+    resolveBySubstring(target, workers, currentTeam) ??
     resolveByRoleGlobal(target, workers);
 
   if (fuzzyMatch) {
@@ -428,7 +459,7 @@ export async function resolveTarget(target: string, options: ResolveOptions = {}
     return resolveColonTarget(target, workers, { checkLiveness, isPaneLive, cleanupDeadPane, tmuxLookup });
   }
 
-  // Level 3: Bare name — exact ID → role (team) → customName → partial ID → role (global)
+  // Level 3: Bare name — exact ID → role (team) → customName → partial ID → substring → role (global)
   return resolveBareName(target, workers, {
     checkLiveness,
     isPaneLive,


### PR DESCRIPTION
## Summary
- Fixes #700: `genie read` fails with short display names from `genie ls`
- Worker IDs have format `sofia-t1re-engineer-4-ec331228`. When `genie ls` shows `engineer-4` and user runs `genie read engineer-4`, `resolveByPartialId` fails because `id.endsWith("engineer-4")` is false (the ID ends with `-ec331228`)
- Added `resolveBySubstring()` that uses `id.includes(target)` in the resolution chain after `resolveByPartialId` and before `resolveByRoleGlobal`, using the same team-scoped disambiguation pattern

## Resolution chain (updated)
```
exact ID → role (team) → customName → partial ID (endsWith) → substring (includes) → role (global)
```

## Test plan
- [x] Added 6 new tests for substring resolution: unique match, team disambiguation, ambiguity error, suffix-takes-priority, exact-ID-precedence, and global-role fallback
- [x] Added 2 priority tests verifying partial ID > substring > global role ordering
- [x] All 58 target-resolver tests pass
- [x] Full test suite: 1090 tests pass, 0 failures
- [x] TypeScript typecheck passes
- [x] Biome lint passes (only pre-existing msg.ts warning)