### PR TITLE
fix(tasks): pass projectId when --project flag used

### DIFF
--- a/src/term-commands/task.ts
+++ b/src/term-commands/task.ts
@@ -239,16 +239,17 @@ async function handleTaskCreate(title: string, options: CreateOptions): Promise<
   const ts = await getTaskService();
   const actor = currentActor();
 
-  // Resolve project → repoPath override
+  // Resolve project → repoPath + projectId override
   let repoPath: string | undefined;
+  let projectId: string | undefined;
   if (options.project) {
-    const project = await ts.getProjectByName(options.project);
-    if (project) {
-      repoPath = project.repoPath ?? undefined;
-    } else {
+    let project = await ts.getProjectByName(options.project);
+    if (!project) {
       // Auto-create virtual project if --project used with unknown name
-      await ts.createProject({ name: options.project });
+      project = await ts.createProject({ name: options.project });
     }
+    projectId = project.id;
+    repoPath = project.repoPath ?? undefined;
   }
 
   // Resolve parent
@@ -273,6 +274,7 @@ async function handleTaskCreate(title: string, options: CreateOptions): Promise<
       estimatedEffort: options.effort,
     },
     repoPath,
+    projectId,
   );
 
   // Assign creator


### PR DESCRIPTION
Task create with `--project` now actually assigns the task to that project.

**Bug:** `--project` resolved the project name but never passed its `id` to `createTask`. Tasks went to CWD's auto-ensured project instead.

**Fix:** Capture `projectId` from resolved/created project, pass as third arg to `createTask`.

Fixes #725