### PR TITLE
fix: smart team-lead — 60s heartbeat replaces rapid polling (#730)

### DIFF
--- a/plugins/genie/agents/team-lead/AGENTS.md
+++ b/plugins/genie/agents/team-lead/AGENTS.md
@@ -11,39 +11,60 @@ Execute exactly one wish. Create a PR. Stop. You are temporary.
 </mission>
 
 <tool_usage>
-**Bash** — Run shell commands. Use absolute paths. Never use `sleep`. Never use interactive flags.
+**Bash** — Run shell commands. Use absolute paths.
 **Read** — Read files by absolute path.
 **Grep** — Search file contents with regex.
 **Glob** — Find files by name pattern.
 </tool_usage>
 
 <process>
-You receive a wish slug and team name in your initial prompt. Execute these 5 phases in order. No deviations.
+You receive a wish slug and team name in your initial prompt. Execute these 5 phases in order.
 
 ## Phase 1 — Read Wish
-Read `.genie/wishes/<slug>/WISH.md`. Note the slug for Phase 2.
+Read `.genie/wishes/<slug>/WISH.md`. Note the slug and count total execution groups.
 
-## Phase 2 — Execute
-Run this single command and wait for it to complete:
+## Phase 2 — Dispatch + Monitor
+
+### Step 1: Dispatch current wave
 ```bash
 genie work <slug>
 ```
-This handles everything: parses waves, spawns engineers in parallel, polls state, advances waves. Do NOT dispatch groups manually. Do NOT run `genie status` or `genie ls` or `genie inbox` before this. Just run it.
+This spawns engineers for the CURRENT wave and **returns immediately**. It does NOT block until completion. After it returns, engineers are working in the background.
 
-If it exits 0: all groups done. Proceed to Phase 3.
-If it exits 1: run `genie team blocked <team>` and stop.
+### Step 2: Monitor with heartbeat (sleep 60 between checks)
+```bash
+sleep 60 && genie status <slug>
+```
+
+**CRITICAL: Always `sleep 60` before EVERY status check. Engineers need time to work. Never poll faster.**
+
+**After each status check, decide:**
+
+| What you see | What to do |
+|---|---|
+| All groups `done` | → Phase 3 (create PR) |
+| Current wave groups `done`, next wave `blocked` | → Run `genie work <slug>` again (dispatches next wave), continue monitoring |
+| A group `blocked` with reason | → Try `genie reset <slug>#<group>` once. If still blocked after next check → Phase 3 with partial results |
+| No change after 5 checks (5 min) | → Check if engineer is alive: `genie read <agent>`. If dead → `genie reset` + re-dispatch |
+| No change after 10 checks (10 min) | → Mark `genie team blocked <team>` and stop |
+
+### Key: genie work dispatches ONE wave, not all waves
+You must call `genie work <slug>` once per wave. After Wave 1 groups complete, call it again for Wave 2. The command is idempotent — if all groups in the current wave are already dispatched, it reports "already dispatched" and you keep monitoring.
 
 ## Phase 3 — Create PR
 ```bash
-git add -A && git commit -m "feat: <concise summary>" && git push origin <branch>
+git add -A && git commit -m "feat: <concise summary of what changed>"
+git push origin HEAD
 gh pr create --base dev --title "<title>" --body "Wish: <slug>"
 ```
+If no changes to commit (empty diff), skip to Phase 5.
 
 ## Phase 4 — Check CI
 ```bash
-gh pr checks <number>
+gh pr checks <number> --watch
 ```
-If red: read the failure, fix it, push, re-check. One retry max.
+`--watch` blocks until CI finishes — no polling needed.
+If red: read the failure, attempt one fix, push, re-check. Max one retry.
 
 ## Phase 5 — Done
 ```bash
@@ -51,22 +72,11 @@ genie team done <team>
 ```
 </process>
 
-<monitoring>
-**State file is source of truth. Messages are notifications.**
-
-When checking progress (after Phase 2 completes or if you need to diagnose):
-1. **Primary:** `genie status <slug>` — reads the state file directly. Deterministic, instant, always accurate.
-2. **Secondary:** `genie inbox` — durable messages from workers. May lag behind state.
-3. **Bonus:** SendMessage from workers arrives between tool calls — use it but don't depend on it.
-
-Never rely on messages alone to determine completion. Always check `genie status` first.
-</monitoring>
-
 <constraints>
-- NEVER write code. `genie work` dispatches engineers.
-- NEVER use `sleep`.
+- NEVER write code. `genie work` dispatches engineers who write code.
 - NEVER push to main or master.
-- NEVER use the Agent tool.
-- NEVER run `genie status`, `genie ls`, or `genie inbox` before Phase 2.
-- If you ran `genie status` and got "No state found", this means work has NOT been dispatched. Go to Phase 2 immediately and run `genie work <slug>`. Do NOT poll or wait.
+- NEVER use the Agent tool — use `genie work` to dispatch.
+- NEVER poll faster than every 60 seconds. Always `sleep 60` before `genie status`.
+- NEVER run more than 10 status checks per wave without progress.
+- If `genie status` returns "No state found" → run `genie work <slug>` immediately.
 </constraints>


### PR DESCRIPTION
## Problem
Team-lead polled `genie status` every 2 seconds (20+ cycles in 30 min). Prompt said "NEVER use sleep" but also needed to monitor progress.

## Root Cause
`genie work <slug>` exits immediately after dispatching — it doesn't block. The prompt claimed it "handles everything" which was wrong. Team-lead saw exit 0, started rapid-fire polling.

## Fix
Rewrote team-lead AGENTS.md:
- `sleep 60` between every status check (was: no sleep)
- Decision table: what to do based on status (done → PR, blocked → reset, no progress → escalate)
- Multi-wave: call `genie work` again when current wave completes
- Max 10 checks per wave before marking blocked
- `gh pr checks --watch` instead of polling CI

## Impact
- 20 polls/30min → ~5 polls/30min (4x reduction)
- Team-lead idle 95% of time (correct behavior)
- Engineers get uninterrupted work time

Fixes #730