### PR TITLE
feat: scaffold AGENTS.md on first run when missing

### DIFF
--- a/src/genie-commands/__tests__/session.test.ts
+++ b/src/genie-commands/__tests__/session.test.ts
@@ -8,8 +8,9 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
+import { AGENTS_TEMPLATE, HEARTBEAT_TEMPLATE, SOUL_TEMPLATE, scaffoldAgentFiles } from '../../templates/index.js';
 import { buildClaudeCommand, getAgentsFilePath, sanitizeWindowName } from '../session.js';
 
 // ============================================================================
@@ -192,5 +193,73 @@ describe('sanitizeWindowName', () => {
     // missed the existing "foo-bar" window, and returned a name that
     // sanitized back to "foo-bar" — attaching to the wrong project.
     expect(sanitizeWindowName('foo.bar')).toBe(sanitizeWindowName('foo-bar'));
+  });
+});
+
+// ============================================================================
+// scaffoldAgentFiles tests — first-run scaffold creates SOUL/HEARTBEAT/AGENTS
+// ============================================================================
+
+describe('scaffoldAgentFiles', () => {
+  const TEST_DIR = `${realpathSync('/tmp')}/session-test-scaffold`;
+
+  beforeEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  test('creates SOUL.md, HEARTBEAT.md, and AGENTS.md', () => {
+    scaffoldAgentFiles(TEST_DIR);
+    expect(existsSync(join(TEST_DIR, 'SOUL.md'))).toBe(true);
+    expect(existsSync(join(TEST_DIR, 'HEARTBEAT.md'))).toBe(true);
+    expect(existsSync(join(TEST_DIR, 'AGENTS.md'))).toBe(true);
+  });
+
+  test('created files contain valid markdown with placeholder content', () => {
+    scaffoldAgentFiles(TEST_DIR);
+
+    const soul = readFileSync(join(TEST_DIR, 'SOUL.md'), 'utf-8');
+    expect(soul).toContain('# Soul');
+    expect(soul.length).toBeGreaterThan(0);
+
+    const heartbeat = readFileSync(join(TEST_DIR, 'HEARTBEAT.md'), 'utf-8');
+    expect(heartbeat).toContain('# Heartbeat');
+    expect(heartbeat).toContain('## Checklist');
+
+    const agents = readFileSync(join(TEST_DIR, 'AGENTS.md'), 'utf-8');
+    expect(agents).toContain('name: my-agent');
+    expect(agents).toContain('@HEARTBEAT.md');
+    expect(agents).toContain('<mission>');
+  });
+
+  test('file contents match exported template constants', () => {
+    scaffoldAgentFiles(TEST_DIR);
+    expect(readFileSync(join(TEST_DIR, 'SOUL.md'), 'utf-8')).toBe(SOUL_TEMPLATE);
+    expect(readFileSync(join(TEST_DIR, 'HEARTBEAT.md'), 'utf-8')).toBe(HEARTBEAT_TEMPLATE);
+    expect(readFileSync(join(TEST_DIR, 'AGENTS.md'), 'utf-8')).toBe(AGENTS_TEMPLATE);
+  });
+
+  test('AGENTS.md has valid YAML frontmatter', () => {
+    scaffoldAgentFiles(TEST_DIR);
+    const agents = readFileSync(join(TEST_DIR, 'AGENTS.md'), 'utf-8');
+    // Verify frontmatter delimiters
+    expect(agents.startsWith('---\n')).toBe(true);
+    expect(agents.indexOf('---', 4)).toBeGreaterThan(4);
+  });
+
+  test('getAgentsFilePath finds scaffolded AGENTS.md', () => {
+    const originalCwd = process.cwd();
+    try {
+      scaffoldAgentFiles(TEST_DIR);
+      process.chdir(TEST_DIR);
+      const result = getAgentsFilePath();
+      expect(result).toBe(join(TEST_DIR, 'AGENTS.md'));
+    } finally {
+      process.chdir(originalCwd);
+    }
   });
 });

--- a/src/genie-commands/session.ts
+++ b/src/genie-commands/session.ts
@@ -15,6 +15,7 @@ import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import { basename, join } from 'node:path';
+import { confirm } from '@inquirer/prompts';
 import * as registry from '../lib/agent-registry.js';
 import {
   deleteNativeTeam,
@@ -24,6 +25,7 @@ import {
 } from '../lib/claude-native-teams.js';
 import { buildTeamLeadCommand, sessionExists, shellQuote } from '../lib/team-lead-command.js';
 import * as tmux from '../lib/tmux.js';
+import { scaffoldAgentFiles } from '../templates/index.js';
 
 /**
  * Generate a short 4-char hash of a path for disambiguation.
@@ -321,9 +323,21 @@ export async function sessionCommand(options: SessionOptions = {}): Promise<void
     if (options.reset) await handleReset(sessionName, windowName);
 
     const session = await tmux.findSessionByName(sessionName);
-    const systemPromptFile = getAgentsFilePath();
+    let systemPromptFile = getAgentsFilePath();
     if (!systemPromptFile) {
-      console.warn('Info: No AGENTS.md found in current directory. Team-lead will use orchestration rules only.');
+      const shouldScaffold = await confirm({
+        message: 'No agent found in this directory. Scaffold one?',
+        default: true,
+      });
+
+      if (shouldScaffold) {
+        scaffoldAgentFiles(workspaceDir);
+        systemPromptFile = join(workspaceDir, 'AGENTS.md');
+        console.log('Created SOUL.md, HEARTBEAT.md, and AGENTS.md');
+      } else {
+        console.error('AGENTS.md required. Run `genie` again to scaffold.');
+        process.exit(1);
+      }
     }
 
     if (!session) {

--- a/src/templates/AGENTS.md
+++ b/src/templates/AGENTS.md
@@ -1,0 +1,22 @@
+---
+name: my-agent
+description: "Describe what this agent does."
+model: inherit
+color: blue
+promptMode: system
+---
+
+@HEARTBEAT.md
+
+<mission>
+Define your agent's mission here. What is their primary goal? What do they own?
+</mission>
+
+<principles>
+- **Clarity over ambiguity.** Be specific about expectations and outcomes.
+- **Quality over speed.** Do it right the first time.
+</principles>
+
+<constraints>
+- List any hard constraints or rules this agent must follow.
+</constraints>

--- a/src/templates/HEARTBEAT.md
+++ b/src/templates/HEARTBEAT.md
@@ -1,0 +1,17 @@
+# Heartbeat
+
+Run this checklist on every iteration. Exit early if nothing actionable.
+
+## Checklist
+
+### 1. Check Assignments
+Review your task queue. What's assigned to you? Prioritize by urgency and impact.
+
+### 2. Do Work
+Execute on your current tasks. Focus on the highest-priority item first.
+
+### 3. Report Progress
+Update status on completed or blocked items. Keep it factual.
+
+### 4. Exit If Nothing Actionable
+If all work is done and no new tasks exist — exit. Don't create busywork.

--- a/src/templates/SOUL.md
+++ b/src/templates/SOUL.md
@@ -1,0 +1,5 @@
+# Soul
+
+You are an AI assistant. Define your role, personality, and approach here.
+
+Replace this with your agent's identity — who they are, how they communicate, and what they care about.

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -1,0 +1,68 @@
+/**
+ * Scaffold templates — embedded as string constants for single-file bundle compatibility.
+ *
+ * Source .md files in this directory are the human-editable originals.
+ * Keep these constants in sync with the .md files.
+ */
+
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export const SOUL_TEMPLATE = `# Soul
+
+You are an AI assistant. Define your role, personality, and approach here.
+
+Replace this with your agent's identity — who they are, how they communicate, and what they care about.
+`;
+
+export const HEARTBEAT_TEMPLATE = `# Heartbeat
+
+Run this checklist on every iteration. Exit early if nothing actionable.
+
+## Checklist
+
+### 1. Check Assignments
+Review your task queue. What's assigned to you? Prioritize by urgency and impact.
+
+### 2. Do Work
+Execute on your current tasks. Focus on the highest-priority item first.
+
+### 3. Report Progress
+Update status on completed or blocked items. Keep it factual.
+
+### 4. Exit If Nothing Actionable
+If all work is done and no new tasks exist — exit. Don't create busywork.
+`;
+
+export const AGENTS_TEMPLATE = `---
+name: my-agent
+description: "Describe what this agent does."
+model: inherit
+color: blue
+promptMode: system
+---
+
+@HEARTBEAT.md
+
+<mission>
+Define your agent's mission here. What is their primary goal? What do they own?
+</mission>
+
+<principles>
+- **Clarity over ambiguity.** Be specific about expectations and outcomes.
+- **Quality over speed.** Do it right the first time.
+</principles>
+
+<constraints>
+- List any hard constraints or rules this agent must follow.
+</constraints>
+`;
+
+/**
+ * Write scaffold templates (SOUL.md, HEARTBEAT.md, AGENTS.md) into the target directory.
+ */
+export function scaffoldAgentFiles(targetDir: string): void {
+  writeFileSync(join(targetDir, 'SOUL.md'), SOUL_TEMPLATE);
+  writeFileSync(join(targetDir, 'HEARTBEAT.md'), HEARTBEAT_TEMPLATE);
+  writeFileSync(join(targetDir, 'AGENTS.md'), AGENTS_TEMPLATE);
+}


### PR DESCRIPTION
## Summary
- Detect missing AGENTS.md when running `genie` in a bare folder and prompt user to scaffold
- On confirm: creates SOUL.md, HEARTBEAT.md, AGENTS.md from embedded PM templates
- On decline: exits with code 1 and clear error message

Closes #717

## Changes
- **New** `src/templates/` — SOUL.md, HEARTBEAT.md, AGENTS.md templates + index.ts scaffold function
- **Modified** `src/genie-commands/session.ts` — scaffold detection before session launch
- **New** tests in `src/genie-commands/__tests__/session.test.ts` for scaffold behavior

## Test plan
- [x] `bun run check` passes (typecheck + lint + dead-code + 1088 tests)
- [ ] Manual: run `genie` in folder without AGENTS.md → prompt appears
- [ ] Manual: choose Y → 3 files created
- [ ] Manual: choose N → exit 1 with clear message