### PR TITLE
fix: resolve short agent names from genie ls (#700)

### DIFF
--- a/src/lib/target-resolver.test.ts
+++ b/src/lib/target-resolver.test.ts
@@ -1429,6 +1429,291 @@ describe('answerQuestion uses resolveTarget (verified by import)', () => {
 });
 
 // ============================================================================
+// GENIE_TEAM env var inference
+// ============================================================================
+
+describe('GENIE_TEAM env var inference', () => {
+  test('role resolves when getCurrentTeam returns GENIE_TEAM value', async () => {
+    // Simulates the case where GENIE_TEAM provides team context
+    const result = await resolveTarget('engineer', {
+      checkLiveness: false,
+      getCurrentTeam: async () => 'my-team',
+      workers: {
+        'eng-worker-abc123': {
+          id: 'eng-worker-abc123',
+          paneId: '%30',
+          session: 'my-team',
+          worktree: null,
+          startedAt: new Date().toISOString(),
+          state: 'working',
+          lastStateChange: new Date().toISOString(),
+          repoPath: '/tmp/test',
+          role: 'engineer',
+          team: 'my-team',
+        },
+      },
+    });
+
+    expect(result.paneId).toBe('%30');
+    expect(result.workerId).toBe('eng-worker-abc123');
+    expect(result.resolvedVia).toBe('worker');
+  });
+
+  test('role resolves via global fallback when no team context (GENIE_TEAM unset)', async () => {
+    const result = await resolveTarget('engineer', {
+      checkLiveness: false,
+      getCurrentTeam: async () => null,
+      workers: {
+        'eng-worker-abc123': {
+          id: 'eng-worker-abc123',
+          paneId: '%30',
+          session: 'some-team',
+          worktree: null,
+          startedAt: new Date().toISOString(),
+          state: 'working',
+          lastStateChange: new Date().toISOString(),
+          repoPath: '/tmp/test',
+          role: 'engineer',
+          team: 'some-team',
+        },
+      },
+    });
+
+    expect(result.paneId).toBe('%30');
+    expect(result.workerId).toBe('eng-worker-abc123');
+  });
+});
+
+// ============================================================================
+// Partial role matching (prefix)
+// ============================================================================
+
+describe('Partial role matching', () => {
+  const baseWorker = {
+    worktree: null as string | null,
+    startedAt: new Date().toISOString(),
+    state: 'working' as const,
+    lastStateChange: new Date().toISOString(),
+    repoPath: '/tmp/test',
+  };
+
+  test('"eng" resolves to "engineer" when unambiguous', async () => {
+    const result = await resolveTarget('eng', {
+      checkLiveness: false,
+      getCurrentTeam: async () => 'my-team',
+      workers: {
+        'eng-worker-1': {
+          ...baseWorker,
+          id: 'eng-worker-1',
+          paneId: '%30',
+          session: 'my-team',
+          role: 'engineer',
+          team: 'my-team',
+        },
+      },
+    });
+
+    expect(result.paneId).toBe('%30');
+    expect(result.workerId).toBe('eng-worker-1');
+    expect(result.resolvedVia).toBe('worker');
+  });
+
+  test('"rev" resolves to "reviewer" globally when no team context', async () => {
+    const result = await resolveTarget('rev', {
+      checkLiveness: false,
+      getCurrentTeam: async () => null,
+      workers: {
+        'rev-worker': {
+          ...baseWorker,
+          id: 'rev-worker',
+          paneId: '%40',
+          session: 'some-team',
+          role: 'reviewer',
+          team: 'some-team',
+        },
+      },
+    });
+
+    expect(result.paneId).toBe('%40');
+    expect(result.workerId).toBe('rev-worker');
+  });
+
+  test('ambiguous partial role throws with candidate list', async () => {
+    await expect(
+      resolveTarget('eng', {
+        checkLiveness: false,
+        getCurrentTeam: async () => null,
+        workers: {
+          worker1: {
+            ...baseWorker,
+            id: 'worker1',
+            paneId: '%30',
+            session: 's1',
+            role: 'engineer',
+            team: 'team-a',
+          },
+          worker2: {
+            ...baseWorker,
+            id: 'worker2',
+            paneId: '%31',
+            session: 's2',
+            role: 'engineer',
+            team: 'team-b',
+          },
+        },
+      }),
+    ).rejects.toThrow(/ambiguous/i);
+  });
+
+  test('exact role match takes priority over partial role match', async () => {
+    const result = await resolveTarget('engineer', {
+      checkLiveness: false,
+      getCurrentTeam: async () => 'my-team',
+      workers: {
+        'exact-role-worker': {
+          ...baseWorker,
+          id: 'exact-role-worker',
+          paneId: '%10',
+          session: 'my-team',
+          role: 'engineer',
+          team: 'my-team',
+        },
+        'engineer-lead-worker': {
+          ...baseWorker,
+          id: 'engineer-lead-worker',
+          paneId: '%20',
+          session: 'my-team',
+          role: 'engineer-lead',
+          team: 'my-team',
+        },
+      },
+    });
+
+    // Exact role match (resolveByRole) should win over partial (resolveByPartialRole)
+    expect(result.paneId).toBe('%10');
+    expect(result.workerId).toBe('exact-role-worker');
+  });
+
+  test('team-scoped partial role preferred over global partial role', async () => {
+    const result = await resolveTarget('eng', {
+      checkLiveness: false,
+      getCurrentTeam: async () => 'my-team',
+      workers: {
+        'team-eng': {
+          ...baseWorker,
+          id: 'team-eng',
+          paneId: '%10',
+          session: 'my-team',
+          role: 'engineer',
+          team: 'my-team',
+        },
+        'other-eng': {
+          ...baseWorker,
+          id: 'other-eng',
+          paneId: '%20',
+          session: 'other-team',
+          role: 'engineer',
+          team: 'other-team',
+        },
+      },
+    });
+
+    expect(result.paneId).toBe('%10');
+    expect(result.workerId).toBe('team-eng');
+  });
+});
+
+// ============================================================================
+// Partial customName matching (prefix)
+// ============================================================================
+
+describe('Partial customName matching', () => {
+  const baseWorker = {
+    worktree: null as string | null,
+    startedAt: new Date().toISOString(),
+    state: 'working' as const,
+    lastStateChange: new Date().toISOString(),
+    repoPath: '/tmp/test',
+  };
+
+  test('"eng" resolves to customName "engineer-4" when unambiguous', async () => {
+    const result = await resolveTarget('eng', {
+      checkLiveness: false,
+      getCurrentTeam: async () => null,
+      workers: {
+        'some-long-id': {
+          ...baseWorker,
+          id: 'some-long-id',
+          paneId: '%50',
+          session: 'my-team',
+          customName: 'engineer-4',
+          team: 'my-team',
+        },
+      },
+    });
+
+    expect(result.paneId).toBe('%50');
+    expect(result.workerId).toBe('some-long-id');
+  });
+
+  test('exact customName takes priority over partial customName', async () => {
+    const result = await resolveTarget('eng-4', {
+      checkLiveness: false,
+      getCurrentTeam: async () => 'my-team',
+      workers: {
+        'exact-custom': {
+          ...baseWorker,
+          id: 'exact-custom',
+          paneId: '%10',
+          session: 'my-team',
+          customName: 'eng-4',
+          team: 'my-team',
+        },
+        'partial-custom': {
+          ...baseWorker,
+          id: 'partial-custom',
+          paneId: '%20',
+          session: 'my-team',
+          customName: 'eng-4-extended',
+          team: 'my-team',
+        },
+      },
+    });
+
+    // Exact customName (resolveByCustomName) should win
+    expect(result.paneId).toBe('%10');
+    expect(result.workerId).toBe('exact-custom');
+  });
+
+  test('ambiguous partial customName throws with candidate list', async () => {
+    await expect(
+      resolveTarget('eng', {
+        checkLiveness: false,
+        getCurrentTeam: async () => null,
+        workers: {
+          worker1: {
+            ...baseWorker,
+            id: 'worker1',
+            paneId: '%30',
+            session: 's1',
+            customName: 'engineer-1',
+            team: 'team-a',
+          },
+          worker2: {
+            ...baseWorker,
+            id: 'worker2',
+            paneId: '%31',
+            session: 's2',
+            customName: 'engineer-2',
+            team: 'team-b',
+          },
+        },
+      }),
+    ).rejects.toThrow(/ambiguous/i);
+  });
+});
+
+// ============================================================================
 // Cleanup
 // ============================================================================
 

--- a/src/lib/target-resolver.ts
+++ b/src/lib/target-resolver.ts
@@ -5,7 +5,7 @@
  *   1. Raw pane ID (starts with %) -> passthrough
  *   2. Worker[:index] (left side is registered worker) -> registry lookup + subpane index
  *   3. Session:window (contains :, left side is tmux session) -> tmux lookup
- *   4. Bare name -> exact ID → role (team) → customName → partial ID → substring → role (global)
+ *   4. Bare name -> exact ID → role (team) → customName → partial ID → substring → role (global) → partial role → partial customName
  *
  * Returns { paneId, session, workerId?, paneIndex?, resolvedVia }
  */
@@ -331,6 +331,51 @@ function resolveByRoleGlobal(target: string, workers: Record<string, Agent>): Re
   return pickUnique(target, candidates, `${candidates.length} workers with role "${target}"`);
 }
 
+/** Resolve by partial role prefix (e.g., "eng" matches "engineer"). Team-scoped first, then global. */
+function resolveByPartialRole(
+  target: string,
+  workers: Record<string, Agent>,
+  currentTeam: string | null,
+): ResolvedTarget | null {
+  const matches = ([, w]: [string, Agent]) => w.role !== undefined && w.role !== target && w.role.startsWith(target);
+
+  if (currentTeam) {
+    const teamCandidates = Object.entries(workers).filter((e) => matches(e) && e[1].team === currentTeam);
+    const teamHit = pickUnique(
+      target,
+      teamCandidates,
+      `${teamCandidates.length} workers with role starting with "${target}" in team "${currentTeam}"`,
+    );
+    if (teamHit) return teamHit;
+  }
+
+  const allCandidates = Object.entries(workers).filter(matches);
+  return pickUnique(target, allCandidates, `${allCandidates.length} workers with role starting with "${target}"`);
+}
+
+/** Resolve by partial customName prefix (e.g., "eng" matches "engineer-4"). Team-scoped first, then global. */
+function resolveByPartialCustomName(
+  target: string,
+  workers: Record<string, Agent>,
+  currentTeam: string | null,
+): ResolvedTarget | null {
+  const matches = ([, w]: [string, Agent]) =>
+    w.customName !== undefined && w.customName !== target && w.customName.startsWith(target);
+
+  if (currentTeam) {
+    const teamCandidates = Object.entries(workers).filter((e) => matches(e) && e[1].team === currentTeam);
+    const teamHit = pickUnique(
+      target,
+      teamCandidates,
+      `${teamCandidates.length} workers with customName starting with "${target}" in team "${currentTeam}"`,
+    );
+    if (teamHit) return teamHit;
+  }
+
+  const allCandidates = Object.entries(workers).filter(matches);
+  return pickUnique(target, allCandidates, `${allCandidates.length} workers with customName starting with "${target}"`);
+}
+
 // ============================================================================
 // Extracted sub-resolvers (keeps resolveTarget under complexity limit)
 // ============================================================================
@@ -381,7 +426,7 @@ async function resolveColonTarget(
   return { paneId: sessionWindowResult.paneId, session: sessionWindowResult.session, resolvedVia: 'session:window' };
 }
 
-/** Resolve a bare name: exact ID → role (team) → customName → partial ID → substring → role (global). */
+/** Resolve a bare name: exact ID → role (team) → customName → partial ID → substring → role (global) → partial role → partial customName. */
 async function resolveBareName(
   target: string,
   workers: Record<string, Agent>,
@@ -414,7 +459,9 @@ async function resolveBareName(
     resolveByCustomName(target, workers, currentTeam) ??
     resolveByPartialId(target, workers, currentTeam) ??
     resolveBySubstring(target, workers, currentTeam) ??
-    resolveByRoleGlobal(target, workers);
+    resolveByRoleGlobal(target, workers) ??
+    resolveByPartialRole(target, workers, currentTeam) ??
+    resolveByPartialCustomName(target, workers, currentTeam);
 
   if (fuzzyMatch) {
     const rid = fuzzyMatch.workerId ?? target;
@@ -459,7 +506,7 @@ export async function resolveTarget(target: string, options: ResolveOptions = {}
     return resolveColonTarget(target, workers, { checkLiveness, isPaneLive, cleanupDeadPane, tmuxLookup });
   }
 
-  // Level 3: Bare name — exact ID → role (team) → customName → partial ID → substring → role (global)
+  // Level 3: Bare name — exact ID → role (team) → customName → partial ID → substring → role (global) → partial role → partial customName
   return resolveBareName(target, workers, {
     checkLiveness,
     isPaneLive,


### PR DESCRIPTION
## Summary
Fixed `resolveTarget()` to match short display names shown by `genie ls` via partial role/customName matching.

## Test plan
- [x] `bun run check` passes (1103 tests, 0 failures)
- [ ] `genie read engineer` resolves when one engineer in team
- [ ] `genie answer <customName>` resolves

Fixes #700