### PR TITLE
fix: native inbox delivery — team discovery + name mapping (#727)

### DIFF
--- a/src/lib/claude-native-teams.test.ts
+++ b/src/lib/claude-native-teams.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Claude Native Teams — Unit Tests
+ *
+ * Covers:
+ *   - resolveNativeMemberName mapping strategies
+ *   - writeNativeInbox file format
+ *   - loadConfig handling of missing/invalid configs
+ *
+ * Run with: bun test src/lib/claude-native-teams.test.ts
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  type NativeInboxMessage,
+  loadConfig,
+  resolveNativeMemberName,
+  sanitizeTeamName,
+  writeNativeInbox,
+} from './claude-native-teams.js';
+
+// ---------------------------------------------------------------------------
+// Helpers: isolated Claude config directory per test
+// ---------------------------------------------------------------------------
+
+let tempDir: string;
+let savedClaudeConfigDir: string | undefined;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'native-teams-test-'));
+  savedClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  process.env.CLAUDE_CONFIG_DIR = tempDir;
+});
+
+afterEach(async () => {
+  if (savedClaudeConfigDir === undefined) {
+    process.env.CLAUDE_CONFIG_DIR = undefined;
+  } else {
+    process.env.CLAUDE_CONFIG_DIR = savedClaudeConfigDir;
+  }
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+/** Create a native team config on disk for testing. */
+async function createTestTeamConfig(
+  teamName: string,
+  members: { agentId: string; name: string; isActive?: boolean }[],
+): Promise<void> {
+  const sanitized = sanitizeTeamName(teamName);
+  const teamDir = join(tempDir, 'teams', sanitized);
+  const inboxDir = join(teamDir, 'inboxes');
+  await mkdir(inboxDir, { recursive: true });
+
+  const config = {
+    name: sanitized,
+    description: `Test team: ${teamName}`,
+    createdAt: Date.now(),
+    leadAgentId: `team-lead@${sanitized}`,
+    leadSessionId: 'test-session-id',
+    members: members.map((m) => ({
+      agentId: m.agentId,
+      name: m.name,
+      agentType: 'general-purpose',
+      joinedAt: Date.now(),
+      backendType: 'tmux',
+      color: 'blue',
+      planModeRequired: false,
+      isActive: m.isActive ?? true,
+    })),
+  };
+
+  await writeFile(join(teamDir, 'config.json'), JSON.stringify(config, null, 2));
+}
+
+// ---------------------------------------------------------------------------
+// resolveNativeMemberName tests
+// ---------------------------------------------------------------------------
+
+describe('resolveNativeMemberName', () => {
+  test('exact match on member name', async () => {
+    await createTestTeamConfig('my-team', [
+      { agentId: 'engineer@my-team', name: 'engineer' },
+      { agentId: 'reviewer@my-team', name: 'reviewer' },
+    ]);
+
+    const result = await resolveNativeMemberName('my-team', 'engineer');
+    expect(result).toBe('engineer');
+  });
+
+  test('match on agentId', async () => {
+    await createTestTeamConfig('my-team', [{ agentId: 'engineer@my-team', name: 'engineer' }]);
+
+    // Even when passed a name that doesn't match directly,
+    // should match via agentId if sanitized version matches
+    const result = await resolveNativeMemberName('my-team', 'engineer');
+    expect(result).toBe('engineer');
+  });
+
+  test('strips team prefix from worker ID', async () => {
+    await createTestTeamConfig('bugfix-4', [{ agentId: 'engineer@bugfix-4', name: 'engineer' }]);
+
+    const result = await resolveNativeMemberName('bugfix-4', 'bugfix-4-engineer');
+    expect(result).toBe('engineer');
+  });
+
+  test('returns null for non-existent member', async () => {
+    await createTestTeamConfig('my-team', [{ agentId: 'engineer@my-team', name: 'engineer' }]);
+
+    const result = await resolveNativeMemberName('my-team', 'nonexistent');
+    expect(result).toBeNull();
+  });
+
+  test('returns null when team config does not exist', async () => {
+    const result = await resolveNativeMemberName('no-such-team', 'engineer');
+    expect(result).toBeNull();
+  });
+
+  test('returns null for team with no members', async () => {
+    await createTestTeamConfig('empty-team', []);
+
+    const result = await resolveNativeMemberName('empty-team', 'engineer');
+    expect(result).toBeNull();
+  });
+
+  test('prefers active members over inactive', async () => {
+    await createTestTeamConfig('my-team', [{ agentId: 'engineer@my-team', name: 'engineer', isActive: false }]);
+
+    // Falls through active match strategies, finds inactive fallback
+    const result = await resolveNativeMemberName('my-team', 'engineer');
+    expect(result).toBe('engineer');
+  });
+
+  test('handles team-lead as recipient', async () => {
+    await createTestTeamConfig('my-team', [
+      { agentId: 'team-lead@my-team', name: 'team-lead' },
+      { agentId: 'engineer@my-team', name: 'engineer' },
+    ]);
+
+    const result = await resolveNativeMemberName('my-team', 'team-lead');
+    expect(result).toBe('team-lead');
+  });
+
+  test('sanitizes worker ID before matching', async () => {
+    await createTestTeamConfig('my-team', [{ agentId: 'my-agent@my-team', name: 'my-agent' }]);
+
+    // Input with special chars gets sanitized to match
+    const result = await resolveNativeMemberName('my-team', 'my agent');
+    expect(result).toBe('my-agent');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writeNativeInbox format tests
+// ---------------------------------------------------------------------------
+
+describe('writeNativeInbox', () => {
+  test('writes correct JSON array format', async () => {
+    await createTestTeamConfig('my-team', [{ agentId: 'engineer@my-team', name: 'engineer' }]);
+
+    // Create the inbox file first (simulates registerNativeMember)
+    const sanitized = sanitizeTeamName('my-team');
+    const inboxFile = join(tempDir, 'teams', sanitized, 'inboxes', 'engineer.json');
+    await writeFile(inboxFile, '[]');
+
+    const msg: NativeInboxMessage = {
+      from: 'team-lead',
+      text: 'Hello engineer, please start working on the task.',
+      summary: 'Hello engineer, please start working on the ta...',
+      timestamp: '2026-03-24T10:00:00.000Z',
+      color: 'blue',
+      read: false,
+    };
+
+    await writeNativeInbox('my-team', 'engineer', msg);
+
+    const content = JSON.parse(await readFile(inboxFile, 'utf-8'));
+    expect(Array.isArray(content)).toBe(true);
+    expect(content).toHaveLength(1);
+    expect(content[0].from).toBe('team-lead');
+    expect(content[0].text).toBe('Hello engineer, please start working on the task.');
+    expect(content[0].summary).toBe('Hello engineer, please start working on the ta...');
+    expect(content[0].timestamp).toBe('2026-03-24T10:00:00.000Z');
+    expect(content[0].color).toBe('blue');
+    expect(content[0].read).toBe(false);
+  });
+
+  test('appends to existing inbox messages', async () => {
+    await createTestTeamConfig('my-team', [{ agentId: 'engineer@my-team', name: 'engineer' }]);
+
+    const sanitized = sanitizeTeamName('my-team');
+    const inboxFile = join(tempDir, 'teams', sanitized, 'inboxes', 'engineer.json');
+
+    // Pre-populate with an existing message
+    const existingMsg = [
+      {
+        from: 'reviewer',
+        text: 'First message',
+        summary: 'First message',
+        timestamp: '2026-03-24T09:00:00.000Z',
+        color: 'green',
+        read: true,
+      },
+    ];
+    await writeFile(inboxFile, JSON.stringify(existingMsg));
+
+    const newMsg: NativeInboxMessage = {
+      from: 'team-lead',
+      text: 'Second message',
+      summary: 'Second message',
+      timestamp: '2026-03-24T10:00:00.000Z',
+      color: 'blue',
+      read: false,
+    };
+
+    await writeNativeInbox('my-team', 'engineer', newMsg);
+
+    const content = JSON.parse(await readFile(inboxFile, 'utf-8'));
+    expect(content).toHaveLength(2);
+    expect(content[0].from).toBe('reviewer');
+    expect(content[1].from).toBe('team-lead');
+  });
+
+  test('creates inbox file if it does not exist', async () => {
+    await createTestTeamConfig('my-team', [{ agentId: 'engineer@my-team', name: 'engineer' }]);
+
+    const msg: NativeInboxMessage = {
+      from: 'team-lead',
+      text: 'Hello',
+      summary: 'Hello',
+      timestamp: '2026-03-24T10:00:00.000Z',
+      color: 'blue',
+      read: false,
+    };
+
+    await writeNativeInbox('my-team', 'engineer', msg);
+
+    const sanitized = sanitizeTeamName('my-team');
+    const inboxFile = join(tempDir, 'teams', sanitized, 'inboxes', 'engineer.json');
+    const content = JSON.parse(await readFile(inboxFile, 'utf-8'));
+    expect(content).toHaveLength(1);
+    expect(content[0].text).toBe('Hello');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadConfig tests
+// ---------------------------------------------------------------------------
+
+describe('loadConfig', () => {
+  test('returns null for non-existent team', async () => {
+    const config = await loadConfig('no-such-team');
+    expect(config).toBeNull();
+  });
+
+  test('loads valid team config', async () => {
+    await createTestTeamConfig('test-team', [{ agentId: 'engineer@test-team', name: 'engineer' }]);
+
+    const config = await loadConfig('test-team');
+    expect(config).not.toBeNull();
+    expect(config!.name).toBe('test-team');
+    expect(config!.members).toHaveLength(1);
+    expect(config!.members[0].name).toBe('engineer');
+  });
+
+  test('handles corrupted config gracefully', async () => {
+    const sanitized = sanitizeTeamName('bad-team');
+    const teamDir = join(tempDir, 'teams', sanitized);
+    await mkdir(teamDir, { recursive: true });
+    await writeFile(join(teamDir, 'config.json'), 'not valid json');
+
+    const config = await loadConfig('bad-team');
+    expect(config).toBeNull();
+  });
+});

--- a/src/lib/claude-native-teams.ts
+++ b/src/lib/claude-native-teams.ts
@@ -288,6 +288,46 @@ export async function writeNativeInbox(
 }
 
 /**
+ * Resolve a genie worker ID to the native team member name.
+ *
+ * Matching strategy:
+ *   1. Exact match on member.name
+ *   2. Match on agentId prefix (workerId@team)
+ *   3. Strip team prefix from workerId and match (e.g., "bugfix-4-engineer" → "engineer")
+ *
+ * Returns the native member name if found, null otherwise.
+ */
+export async function resolveNativeMemberName(teamName: string, genieWorkerId: string): Promise<string | null> {
+  const config = await loadConfig(teamName);
+  if (!config || config.members.length === 0) return null;
+
+  const sanitizedId = sanitizeTeamName(genieWorkerId);
+  const sanitizedTeam = sanitizeTeamName(teamName);
+
+  // 1. Exact match on name
+  const exactMatch = config.members.find((m) => m.name === sanitizedId && m.isActive);
+  if (exactMatch) return exactMatch.name;
+
+  // 2. Match on agentId
+  const agentIdMatch = config.members.find((m) => m.agentId === `${sanitizedId}@${sanitizedTeam}` && m.isActive);
+  if (agentIdMatch) return agentIdMatch.name;
+
+  // 3. Strip team prefix and match (e.g., "bugfix-4-engineer" → "engineer")
+  const teamPrefix = `${sanitizedTeam}-`;
+  if (sanitizedId.startsWith(teamPrefix)) {
+    const stripped = sanitizedId.slice(teamPrefix.length);
+    const prefixMatch = config.members.find((m) => m.name === stripped && m.isActive);
+    if (prefixMatch) return prefixMatch.name;
+  }
+
+  // 4. Fallback: try inactive members (recently unregistered)
+  const inactiveMatch = config.members.find((m) => m.name === sanitizedId);
+  if (inactiveMatch) return inactiveMatch.name;
+
+  return null;
+}
+
+/**
  * Assign the next unused color from the palette for a team.
  */
 export async function assignColor(teamName: string): Promise<ClaudeTeamColor> {

--- a/src/term-commands/msg.ts
+++ b/src/term-commands/msg.ts
@@ -413,40 +413,50 @@ export function registerSendInboxCommands(program: Command): void {
             read: false,
           };
 
-          // Try current team first (fast path)
-          const currentTeam = await nativeTeams.discoverTeamName().catch(() => null);
+          // Team discovery chain: GENIE_TEAM env → discoverTeamName() → worker registry
+          let currentTeam = await nativeTeams.discoverTeamName().catch(() => null);
+
+          if (!currentTeam) {
+            // Fallback: check worker registry for sender's team
+            const registryMod = await getRegistry();
+            const workers = await registryMod.list();
+            const senderWorker = workers.find((w) => w.role === from || w.id === from || w.customName === from);
+            if (senderWorker?.team) {
+              currentTeam = senderWorker.team;
+            }
+          }
+
           let delivered = false;
 
+          // Try current team first (fast path) — resolve genie worker ID to native member name
           if (currentTeam) {
-            const config = await nativeTeams.loadConfig(currentTeam).catch(() => null);
-            const memberExists = config?.members?.some(
-              (m: { name?: string; agentId?: string }) =>
-                m.name === options.to || m.agentId === `${options.to}@${currentTeam}`,
-            );
-            if (memberExists) {
-              await nativeTeams.writeNativeInbox(currentTeam, options.to, nativeMsg);
+            const nativeName = await nativeTeams.resolveNativeMemberName(currentTeam, options.to);
+            if (nativeName) {
+              await nativeTeams.writeNativeInbox(currentTeam, nativeName, nativeMsg);
               delivered = true;
             }
           }
 
-          // If not in current team, search all teams
+          // If not in current team, search all native teams
           if (!delivered) {
             const allTeams = await nativeTeams.listTeams().catch(() => [] as string[]);
             for (const team of allTeams) {
               if (team === currentTeam) continue; // already checked
-              const config = await nativeTeams.loadConfig(team).catch(() => null);
-              const memberExists = config?.members?.some(
-                (m: { name?: string; agentId?: string }) =>
-                  m.name === options.to || m.agentId === `${options.to}@${team}`,
-              );
-              if (memberExists) {
-                await nativeTeams.writeNativeInbox(team, options.to, nativeMsg);
+              const nativeName = await nativeTeams.resolveNativeMemberName(team, options.to);
+              if (nativeName) {
+                await nativeTeams.writeNativeInbox(team, nativeName, nativeMsg);
+                delivered = true;
                 break;
               }
             }
           }
-        } catch {
-          // Native inbox delivery is best-effort — PG message already persisted
+
+          if (!delivered) {
+            console.warn(`[genie send] Native inbox bridge: could not find native team member for "${options.to}"`);
+          }
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          console.warn(`[genie send] Native inbox bridge failed: ${reason}`);
         }
 
         console.log(`Message sent to "${options.to}".`);


### PR DESCRIPTION
## Summary
Fixed `genie send` to reliably deliver to Claude Code native team inbox.
- Team name discovery: GENIE_TEAM env → discoverTeamName() → registry
- Worker ID → native member name mapping
- Bridge failures logged with reason

## Test plan
- [x] `bun run check` passes (1108 tests)
- [ ] `genie send` delivers to native inbox
- [ ] Bridge failures produce warnings

Fixes #727