### PR TITLE
fix: pass initialPrompt to handleWorkerSpawn in all dispatch commands

### DIFF
--- a/src/term-commands/dispatch.ts
+++ b/src/term-commands/dispatch.ts
@@ -408,20 +408,20 @@ export async function brainstormCommand(agentName: string, slug: string): Promis
   console.log(`📝 Dispatching brainstorm to ${agentName} for "${slug}"`);
   console.log(`   Draft: ${draftPath}`);
 
+  const brainstormPrompt = `Brainstorm "${slug}". Your context is in the system prompt. Explore the idea, ask clarifying questions, and build toward a design.`;
   await handleWorkerSpawn(agentName, {
     provider: 'claude',
     team: process.env.GENIE_TEAM ?? 'genie',
     extraArgs: ['--append-system-prompt-file', contextFile],
+    initialPrompt: brainstormPrompt,
   });
 
-  // Deliver work prompt via mailbox (durable, queued to disk)
+  // Deliver work prompt via mailbox as backup (durable, queued to disk)
   const repoPath = process.cwd();
-  await protocolRouter.sendMessage(
-    repoPath,
-    'cli',
-    agentName,
-    `Brainstorm "${slug}". Your context is in the system prompt. Explore the idea, ask clarifying questions, and build toward a design.`,
-  );
+  const result = await protocolRouter.sendMessage(repoPath, 'cli', agentName, brainstormPrompt);
+  if (!result.delivered) {
+    console.warn(`⚠ Backup delivery to ${agentName} failed: ${result.reason ?? 'unknown'}`);
+  }
 }
 
 /**
@@ -448,20 +448,20 @@ export async function wishCommand(agentName: string, slug: string): Promise<void
   console.log(`📝 Dispatching wish to ${agentName} for "${slug}"`);
   console.log(`   Design: ${designPath}`);
 
+  const wishPrompt = `Create a wish from the design for "${slug}". Your context is in the system prompt. Write the WISH.md with execution groups, acceptance criteria, and validation commands.`;
   await handleWorkerSpawn(agentName, {
     provider: 'claude',
     team: process.env.GENIE_TEAM ?? 'genie',
     extraArgs: ['--append-system-prompt-file', contextFile],
+    initialPrompt: wishPrompt,
   });
 
-  // Deliver work prompt via mailbox (durable, queued to disk)
+  // Deliver work prompt via mailbox as backup (durable, queued to disk)
   const repoPath = process.cwd();
-  await protocolRouter.sendMessage(
-    repoPath,
-    'cli',
-    agentName,
-    `Create a wish from the design for "${slug}". Your context is in the system prompt. Write the WISH.md with execution groups, acceptance criteria, and validation commands.`,
-  );
+  const result = await protocolRouter.sendMessage(repoPath, 'cli', agentName, wishPrompt);
+  if (!result.delivered) {
+    console.warn(`⚠ Backup delivery to ${agentName} failed: ${result.reason ?? 'unknown'}`);
+  }
 }
 
 /**
@@ -529,21 +529,21 @@ export async function workDispatchCommand(agentName: string, ref: string): Promi
   console.log(`   Group: ${group}`);
 
   const effectiveRole = `${agentName}-${group}`;
+  const workPrompt = `Execute Group ${group} of wish "${slug}". Your full context is in the system prompt. Read the wish at ${wishPath} if needed. Implement all deliverables, run validation, and report completion.\n\nWhen done:\n1. Run: genie done ${slug}#${group}\n2. Run: genie send 'Group ${group} complete. <summary>' --to team-lead`;
   await handleWorkerSpawn(agentName, {
     provider: 'claude',
     team: process.env.GENIE_TEAM ?? 'genie',
     role: effectiveRole,
     extraArgs: ['--append-system-prompt-file', contextFile],
+    initialPrompt: workPrompt,
   });
 
-  // Deliver work prompt via mailbox (durable, queued to disk)
+  // Deliver work prompt via mailbox as backup (durable, queued to disk)
   const repoPath = process.cwd();
-  await protocolRouter.sendMessage(
-    repoPath,
-    'cli',
-    effectiveRole,
-    `Execute Group ${group} of wish "${slug}". Your full context is in the system prompt. Read the wish at ${wishPath} if needed. Implement all deliverables, run validation, and report completion.\n\nWhen done:\n1. Run: genie done ${slug}#${group}\n2. Run: genie send 'Group ${group} complete. <summary>' --to team-lead`,
-  );
+  const result = await protocolRouter.sendMessage(repoPath, 'cli', effectiveRole, workPrompt);
+  if (!result.delivered) {
+    console.warn(`⚠ Backup delivery to ${effectiveRole} failed: ${result.reason ?? 'unknown'}`);
+  }
 }
 
 /**
@@ -593,20 +593,20 @@ export async function reviewCommand(agentName: string, ref: string): Promise<voi
   console.log(`   Group: ${group}`);
   if (diff) console.log(`   Diff: ${diff.split('\n').length} lines`);
 
+  const reviewPrompt = `Review "${ref}". Your context and diff are in the system prompt. Evaluate against acceptance criteria and return SHIP, FIX-FIRST, or BLOCKED with severity-tagged findings.\n\nWhen done, report your verdict:\nRun: genie send '<SHIP|FIX-FIRST|BLOCKED> — <summary>' --to team-lead`;
   await handleWorkerSpawn(agentName, {
     provider: 'claude',
     team: process.env.GENIE_TEAM ?? 'genie',
     extraArgs: ['--append-system-prompt-file', contextFile],
+    initialPrompt: reviewPrompt,
   });
 
-  // Deliver work prompt via mailbox (durable, queued to disk)
+  // Deliver work prompt via mailbox as backup (durable, queued to disk)
   const repoPath = process.cwd();
-  await protocolRouter.sendMessage(
-    repoPath,
-    'cli',
-    agentName,
-    `Review "${ref}". Your context and diff are in the system prompt. Evaluate against acceptance criteria and return SHIP, FIX-FIRST, or BLOCKED with severity-tagged findings.\n\nWhen done, report your verdict:\nRun: genie send '<SHIP|FIX-FIRST|BLOCKED> — <summary>' --to team-lead`,
-  );
+  const result = await protocolRouter.sendMessage(repoPath, 'cli', agentName, reviewPrompt);
+  if (!result.delivered) {
+    console.warn(`⚠ Backup delivery to ${agentName} failed: ${result.reason ?? 'unknown'}`);
+  }
 }
 
 // ============================================================================

--- a/src/term-commands/team.ts
+++ b/src/term-commands/team.ts
@@ -255,19 +255,23 @@ async function spawnLeaderWithWish(
   }
   console.log(`  Team: hired ${standardTeam.join(', ')}`);
 
-  // Spawn leader — AGENTS.md comes from the built-in resolver, prompt delivered via mailbox
+  // Spawn leader — AGENTS.md comes from the built-in resolver, prompt delivered as initialPrompt
+  const members = standardTeam.filter((r) => r !== 'team-lead').join(', ');
+  const kickoffPrompt = `Your team is "${config.name}". Repo: ${config.repo}. Branch: ${config.name}. Worktree: ${config.worktreePath}. Wish slug: ${slug}. Your team members are: ${members} (already hired — genie work will spawn them automatically). Read the wish at .genie/wishes/${slug}/WISH.md and execute the full lifecycle autonomously.`;
   await handleWorkerSpawn('team-lead', {
     provider: 'claude',
     team: config.name,
     cwd: config.worktreePath,
     session: tmuxSession,
+    initialPrompt: kickoffPrompt,
   });
 
-  // Deliver kickoff prompt via mailbox (durable, queued to disk)
-  const members = standardTeam.filter((r) => r !== 'team-lead').join(', ');
-  const kickoffPrompt = `Your team is "${config.name}". Repo: ${config.repo}. Branch: ${config.name}. Worktree: ${config.worktreePath}. Wish slug: ${slug}. Your team members are: ${members} (already hired — genie work will spawn them automatically). Read the wish at .genie/wishes/${slug}/WISH.md and execute the full lifecycle autonomously.`;
+  // Deliver kickoff prompt via mailbox as backup (durable, queued to disk)
   const protocolRouter = await import('../lib/protocol-router.js');
-  await protocolRouter.sendMessage(config.worktreePath, 'cli', 'team-lead', kickoffPrompt);
+  const result = await protocolRouter.sendMessage(config.worktreePath, 'cli', 'team-lead', kickoffPrompt);
+  if (!result.delivered) {
+    console.warn(`⚠ Backup delivery to team-lead failed: ${result.reason ?? 'unknown'}`);
+  }
   console.log('  Leader: spawned and working');
 }
 


### PR DESCRIPTION
## Summary

Fixes #745 — Engineers spawned by `genie work` were starting idle because the task prompt was sent via `protocolRouter.sendMessage` after spawn, which fails silently under concurrent dispatch.

- Pass `initialPrompt` to `handleWorkerSpawn` in all 5 dispatch call sites (`workDispatchCommand`, `brainstormCommand`, `wishCommand`, `reviewCommand`, `spawnLeaderWithWish`)
- Keep existing `protocolRouter.sendMessage` calls as backup with warning logging on delivery failure
- Follows the same pattern already used successfully in `qa-runner.ts:334`

## Test plan

- [x] All 1137 existing tests pass (`bun test`)
- [x] Typecheck passes (`bun run typecheck`)
- [x] Lint passes (`bun run lint`)

Wish: fix-dispatch-initial-prompt