### PR TITLE
fix: respect --session flag when team is auto-discovered

### DIFF
--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -967,7 +967,7 @@ export async function handleWorkerSpawn(name: string, options: SpawnOptions): Pr
     transport: insideTmux ? 'tmux' : 'inline',
     extraArgs: options.extraArgs,
     cwd: agent.repoPath,
-    spawnIntoCurrentWindow: !teamWasExplicit && insideTmux,
+    spawnIntoCurrentWindow: !teamWasExplicit && insideTmux && !options.session,
     sessionOverride: options.session,
     autoResume: options.autoResume,
   };


### PR DESCRIPTION
## Summary

- When `--session` was passed without explicit `--team`, the spawn path set `spawnIntoCurrentWindow=true`, bypassing `resolveSpawnTeamWindow` entirely — silently ignoring the session override and spawning into the current session instead
- Adding `!options.session` to the condition ensures the spawn flow reaches `ensureTeamWindow` (which has auto-create logic) whenever `--session` is specified

## Root Cause

In `handleWorkerSpawn` (agents.ts:970):
```diff
-spawnIntoCurrentWindow: !teamWasExplicit && insideTmux,
+spawnIntoCurrentWindow: !teamWasExplicit && insideTmux && !options.session,
```

When `spawnIntoCurrentWindow` was `true`, `launchTmuxSpawn` skipped `resolveSpawnTeamWindow` (line 656-658), so `sessionOverride` was never passed to `ensureTeamWindow`. The auto-create session code (lines 306-310) existed but was unreachable through this path.

## Test plan

- [ ] `genie spawn engineer --session foo` creates session `foo` if it doesn't exist
- [ ] `genie spawn engineer --session foo` reuses session `foo` if it already exists
- [ ] `genie spawn engineer` (no `--session`) still spawns in current session as before

Fixes #691
Wish: session-auto-create