### PR TITLE
docs: add worked examples to 7 core skill files

### DIFF
--- a/skills/docs/SKILL.md
+++ b/skills/docs/SKILL.md
@@ -42,6 +42,25 @@ Audit and maintain these doc types:
 genie spawn docs
 ```
 
+## Example
+
+After shipping a new `genie work` dispatch fix, the orchestrator runs `/docs` to update documentation:
+
+```bash
+# 1. Spawn a docs subagent
+genie spawn docs
+
+# 2. Send the task
+genie send 'Audit and update docs after PR #746 (initialPrompt added to dispatch). Check: README.md, CLAUDE.md, CO-ORCHESTRATION-GUIDE.md, skills/work/SKILL.md — verify dispatch examples match current code. Fix any stale references.' --to docs
+```
+
+The docs agent:
+1. Scans all doc surfaces for references to `genie work`, dispatch, `protocolRouter.sendMessage`
+2. Finds CO-ORCHESTRATION-GUIDE.md still references the old dispatch flow
+3. Updates the guide with the new `initialPrompt` pattern
+4. Validates every file path and API reference exists in the codebase
+5. Reports: "Updated 1 file (CO-ORCHESTRATION-GUIDE.md). 3 files verified current. 0 dead references."
+
 ## Rules
 - Validate every claim against actual code — no fiction.
 - No dead references — every path, function, and API mentioned must exist in the codebase.

--- a/skills/fix/SKILL.md
+++ b/skills/fix/SKILL.md
@@ -61,6 +61,36 @@ When a PG task exists for the work being fixed, log each fix attempt as a task c
 
 **Graceful degradation:** If no PG task exists for the work being fixed, skip all `genie task` commands. Fix loop logging is an enhancement — the fix flow must never fail due to missing tasks.
 
+## Example
+
+`/review` returned FIX-FIRST with 2 gaps:
+
+```
+- [CRITICAL] workDispatchCommand missing initialPrompt — dispatch.ts:532
+- [HIGH] protocolRouter.sendMessage result not checked — dispatch.ts:541
+```
+
+The orchestrator runs `/fix`:
+
+```bash
+# Loop 1: dispatch fixer with gaps
+genie spawn fixer
+genie send 'Fix these gaps from /review on wish fix-dispatch-initial-prompt:
+- [CRITICAL] dispatch.ts:532 — add initialPrompt to handleWorkerSpawn
+- [HIGH] dispatch.ts:541 — check protocolRouter.sendMessage result, log warning on failure
+Reference: qa-runner.ts:334 shows correct pattern.' --to fixer
+
+# Wait for fixer to complete
+sleep 60 && genie read fixer
+
+# Re-review (separate subagent — never the same as fixer)
+genie spawn reviewer
+genie send 'Review wish fix-dispatch-initial-prompt. Check the fixer changes against acceptance criteria. Run bun test.' --to reviewer
+
+# Reviewer returns SHIP → done
+# If FIX-FIRST again → loop 2 (max 2 loops, then escalate)
+```
+
 ## Rules
 - Never fix and review in the same session — always separate subagents.
 - Never exceed 2 fix loops — escalate, don't spin.

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -68,6 +68,36 @@ When a learning is applied, also save it as a feedback memory:
 
 This ensures the learning persists across conversations via Claude's native memory system.
 
+## Example
+
+User corrects the agent: "Stop using `pip install` — this system only has `uv`."
+
+The agent runs `/learn`:
+
+1. **Analyze:** Agent used `pip install python-dotenv` which failed because pip isn't installed.
+2. **Root cause:** No rule in `~/.claude/rules/` about Python tooling.
+3. **Surface:** Global rules (`~/.claude/rules/python-tooling.md`) — applies to all projects.
+4. **Propose fix (plan mode):**
+   ```
+   Create ~/.claude/rules/python-tooling.md:
+   - NEVER use pip or pip3 — not installed
+   - Use uv tool install for persistent CLI tools
+   - Use uv pip install inside venvs
+   ```
+5. **User approves.** File written.
+6. **Save to memory:**
+   ```markdown
+   # ~/.claude/memory/feedback_python_tooling.md
+   ---
+   name: use-uv-not-pip
+   description: System uses uv for Python package management, pip is not installed
+   type: feedback
+   ---
+   Use uv instead of pip for all Python operations.
+   **Why:** pip is not installed on this system; uv is the only package manager.
+   **How to apply:** Any time a Python package needs installing, use uv tool install or uv pip install.
+   ```
+
 ## Rules
 - **Plan mode is mandatory** — never write without user approval via native plan mode.
 - **One learning at a time** — diagnose one surface, propose one fix.

--- a/skills/report/SKILL.md
+++ b/skills/report/SKILL.md
@@ -228,6 +228,48 @@ Priority mapping from severity:
 
 **Graceful degradation:** If PG is unavailable, skip `genie task` commands. The GitHub issue is the primary artifact — PG task tracking is an enhancement. The report must always be produced regardless of PG availability.
 
+## Example
+
+User reports: "genie work dispatches engineers but they sit idle."
+
+The report agent:
+
+```bash
+# 1. Collect symptoms (one question at a time)
+# Agent asks: "What command did you run?" → "genie team create rlmx --wish tauri-docs-agent"
+# Agent asks: "What did you see?" → "Engineers show welcome screen but empty prompt"
+
+# 2. Run /trace
+genie spawn tracer
+genie send 'Trace: genie work dispatches engineers but they start idle. Check dispatch.ts and protocol-router.ts.' --to tracer
+# Wait for diagnosis...
+
+# 3. Capture evidence
+# Screenshot of idle engineer pane showing empty ❯ prompt
+# Output of: genie status <slug> showing "in_progress" but no actual progress
+
+# 4. Create GitHub issue with all findings
+gh issue create --title "bug: genie work dispatch — engineers spawn idle without initial task prompt" --body "$(cat <<'EOF'
+## Summary
+Engineers dispatched by genie work start idle because initialPrompt is missing from handleWorkerSpawn.
+
+## Root Cause (from /trace)
+dispatch.ts:532 — handleWorkerSpawn called without initialPrompt.
+protocolRouter.sendMessage fails silently under concurrent dispatch (4/6 engineers got no message).
+
+## Evidence
+- [Screenshot: idle engineer pane]
+- genie status shows in_progress but engineers at empty prompt
+- Native inbox files: engineer-1 through engineer-4 have no dispatch message
+
+## Steps to Reproduce
+1. genie team create test --wish <any-wish-with-2+-groups>
+2. Team-lead runs genie work <slug>
+3. Check engineer panes — they show empty ❯ prompt
+EOF
+)"
+```
+
 ## Rules
 - Always run `/trace` first — it is the backbone of every report.
 - One question at a time when collecting symptoms — never batch questions.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -124,6 +124,39 @@ When a PG task exists for the reviewed work, log the verdict as a task comment:
 
 **Graceful degradation:** If no PG task exists for the reviewed work, skip all `genie task` commands. Verdict logging is an enhancement — the review flow must never fail due to missing tasks.
 
+## Example
+
+After `/work` completes wish `fix-dispatch-initial-prompt`, the orchestrator dispatches `/review`:
+
+```bash
+genie spawn reviewer
+genie send 'Review wish fix-dispatch-initial-prompt execution. Criteria:
+1. initialPrompt added to all 5 dispatch call sites
+2. protocolRouter.sendMessage kept as backup with warning logging
+3. bun test passes
+4. bun run typecheck clean
+Check: gh pr diff 746, then run validations.' --to reviewer
+```
+
+Reviewer output:
+
+```
+## Review: fix-dispatch-initial-prompt (Execution)
+
+### Checklist
+- [x] All acceptance criteria met — 5/5 call sites have initialPrompt
+- [x] Validation: bun test — 1137 pass, 0 fail
+- [x] Validation: bun run typecheck — clean
+- [x] No scope creep — only dispatch.ts and team.ts modified
+- [x] No regressions — test count unchanged
+
+### Gaps
+(none)
+
+### Verdict: SHIP
+Next: create PR targeting dev
+```
+
 ## Rules
 - Never mark PASS without evidence — verify, don't assume.
 - Never ship with CRITICAL or HIGH gaps.

--- a/skills/trace/SKILL.md
+++ b/skills/trace/SKILL.md
@@ -57,6 +57,34 @@ Include file paths and line numbers in every root cause comment so the task hist
 
 **Graceful degradation:** If no PG task exists for the investigated work, skip all `genie task` commands. Findings logging is an enhancement — the trace flow must never fail due to missing tasks.
 
+## Example
+
+An engineer reports that `genie work` dispatches engineers but they sit idle. The orchestrator runs `/trace`:
+
+```bash
+# 1. Spawn a tracer (read-only — no code changes)
+genie spawn tracer
+
+# 2. Send the symptoms
+genie send 'Trace: genie work dispatches engineers but they start idle at the prompt. No task received. genie status shows in_progress but nothing happens. Check dispatch.ts workDispatchCommand and protocol-router.ts sendMessage.' --to tracer
+
+# 3. Wait for findings
+sleep 60 && genie read tracer
+```
+
+The tracer investigates and reports back:
+
+```
+Root cause: workDispatchCommand (dispatch.ts:532) spawns without initialPrompt
+Evidence: protocolRouter.sendMessage fails silently under concurrent dispatch — 4/6 engineers got no message
+Causal chain: missing initialPrompt → agent starts with empty prompt → no task → idle forever
+Recommended correction: add initialPrompt to handleWorkerSpawn in dispatch.ts
+Affected scope: brainstormCommand, wishCommand, workDispatchCommand, reviewCommand
+Confidence: high
+```
+
+The orchestrator then hands the report to `/fix`.
+
 ## Rules
 - Never fix during trace — investigation only, always separate from correction.
 - Always reproduce before theorizing — if the failure can't be reproduced, the report must say so.

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -102,6 +102,38 @@ When PG tasks exist for the wish, use `genie task` commands to track execution:
 
 **Graceful degradation:** If no PG task exists for the wish (e.g., PG unavailable or wish was created before v4), skip all `genie task` commands and fall back to current behavior. Task integration is optional — the core flow must never break due to missing tasks.
 
+## Example: Full Dispatch Cycle
+
+Wish `fix-dispatch-initial-prompt` has 1 execution group. The orchestrator runs `/work`:
+
+```bash
+# 1. Dispatch wave (spawns engineers automatically)
+genie work fix-dispatch-initial-prompt
+# Output: 🚀 Dispatching Wave 1 — 1 group(s)
+#         ✅ Group "1" set to in_progress
+#         🔧 Dispatching work to engineer for "fix-dispatch-initial-prompt#1"
+
+# 2. Monitor (ALWAYS sleep 60 between checks)
+sleep 60 && genie status fix-dispatch-initial-prompt
+# Output: Group 1: 🔄 in_progress
+
+# 3. Check again
+sleep 60 && genie status fix-dispatch-initial-prompt
+# Output: Group 1: ✅ done — Progress: 1/1 done
+
+# 4. All groups done → local review
+genie spawn reviewer
+genie send 'Review wish fix-dispatch-initial-prompt. Run bun test and check all 5 call sites.' --to reviewer
+# Reviewer returns: SHIP
+
+# 5. Create PR
+git add -A && git commit -m "fix: pass initialPrompt to handleWorkerSpawn in all dispatch commands"
+git push origin HEAD
+gh pr create --base dev --title "fix: pass initialPrompt to dispatch" --body "Fixes #745. Wish: fix-dispatch-initial-prompt"
+```
+
+For multi-wave wishes, call `genie work <slug>` again after each wave completes — it dispatches the next wave automatically.
+
 ## Rules
 - Never execute directly — always dispatch subagents.
 - Never expand scope during execution.


### PR DESCRIPTION
## Summary

Add concrete CLI examples to 7 core skill SKILL.md files. Examples target AI agents piloting genie — real commands, real output patterns based on actual recent work (issue #745 / PR #746).

### Skills updated:
- **trace/SKILL.md** — investigation dispatch with symptom delivery and report format
- **docs/SKILL.md** — documentation audit after a code change
- **learn/SKILL.md** — behavioral correction with memory file creation
- **fix/SKILL.md** — fix-review loop with fixer + reviewer dispatch
- **review/SKILL.md** — execution review with checklist output
- **work/SKILL.md** — full dispatch cycle: spawn → monitor → review → PR
- **report/SKILL.md** — bug report with /trace, evidence, and GitHub issue creation

## Test plan
- [x] All examples use actual genie CLI commands
- [x] No code changes — documentation only
- [x] 214 lines added across 7 files

Closes #748