### PR TITLE
feat(resume): wire injectResumeContext into manual resume path

### DIFF
--- a/src/lib/protocol-router-spawn.ts
+++ b/src/lib/protocol-router-spawn.ts
@@ -225,6 +225,19 @@ async function getRecentGitLog(repoPath: string, count = 3): Promise<string> {
 }
 
 /**
+ * Get uncommitted changes (staged + unstaged) as a short summary.
+ * Best-effort — returns empty string on failure.
+ */
+async function getGitStatus(repoPath: string): Promise<string> {
+  try {
+    const { stdout } = await execAsync(`git -C '${repoPath}' status --short 2>/dev/null`);
+    return stdout.trim();
+  } catch {
+    return '';
+  }
+}
+
+/**
  * Build and deliver resume context to a respawned agent.
  *
  * Queries PG for any in_progress group assigned to this worker's
@@ -234,7 +247,7 @@ async function getRecentGitLog(repoPath: string, count = 3): Promise<string> {
  * Delivered via mailbox as the FIRST message before any task prompt,
  * so the agent has immediate context even without conversation history.
  */
-async function injectResumeContext(
+export async function injectResumeContext(
   repoPath: string,
   workerId: string,
   agentName: string,
@@ -260,6 +273,7 @@ async function injectResumeContext(
     }
 
     const gitLog = await getRecentGitLog(repoPath);
+    const gitStatus = await getGitStatus(repoPath);
 
     const resumePrompt = [
       `RESUME CONTEXT: You were working on wish "${slug}", group "${groupName}".`,
@@ -269,6 +283,8 @@ async function injectResumeContext(
       groupSection ? `Group section:\n${groupSection}` : '',
       '',
       gitLog ? `Last git log:\n${gitLog}` : '',
+      '',
+      gitStatus ? `Uncommitted changes:\n${gitStatus}` : '',
       '',
       'Pick up where you left off. Read the wish file for full context.',
     ]

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -15,6 +15,7 @@ import { resolveBuiltinAgentPath } from '../lib/builtin-agents.js';
 import * as nativeTeams from '../lib/claude-native-teams.js';
 import { OTEL_RELAY_PORT, ensureCodexOtelConfig } from '../lib/codex-config.js';
 import { buildLayoutCommand, resolveLayoutMode } from '../lib/mosaic-layout.js';
+import { injectResumeContext } from '../lib/protocol-router-spawn.js';
 import {
   type ClaudeTeamColor,
   type ProviderName,
@@ -1228,18 +1229,13 @@ export async function buildResumeContext(agent: registry.Agent): Promise<string 
   return undefined;
 }
 
-/**
- * Resume a single agent by rebuilding spawn params with --resume <sessionId>.
- * Resets resumeAttempts to 0 (manual resume = fresh retry budget).
- */
-async function resumeAgent(agent: registry.Agent): Promise<void> {
-  const template = (await registry.listTemplates()).find((t) => t.id === (agent.role ?? agent.id));
-
-  await registry.update(agent.id, { resumeAttempts: 0 });
-
+/** Build full spawn params for resume, including initial prompt and native team config. */
+async function buildFullResumeParams(
+  agent: registry.Agent,
+  template: registry.WorkerTemplate | undefined,
+): Promise<SpawnParams> {
   const params = buildResumeParams(agent, template);
 
-  // Inject resume context so the agent knows where it left off
   const resumeContext = await buildResumeContext(agent);
   if (resumeContext) {
     params.initialPrompt = resumeContext;
@@ -1253,6 +1249,20 @@ async function resumeAgent(agent: registry.Agent): Promise<void> {
     });
     if (nativeResult.nativeTeam) params.nativeTeam = nativeResult.nativeTeam;
   }
+
+  return params;
+}
+
+/**
+ * Resume a single agent by rebuilding spawn params with --resume <sessionId>.
+ * Resets resumeAttempts to 0 (manual resume = fresh retry budget).
+ */
+async function resumeAgent(agent: registry.Agent): Promise<void> {
+  const template = (await registry.listTemplates()).find((t) => t.id === (agent.role ?? agent.id));
+
+  await registry.update(agent.id, { resumeAttempts: 0 });
+
+  const params = await buildFullResumeParams(agent, template);
 
   const validated = validateSpawnParams(params);
   const launch = buildLaunchCommand(validated);
@@ -1307,6 +1317,9 @@ async function resumeAgent(agent: registry.Agent): Promise<void> {
   });
 
   await notifySpawnJoin(ctx, paneId);
+
+  // Inject resume context so the agent knows what wish/group it was working on
+  await injectResumeContext(ctx.cwd ?? agent.repoPath ?? process.cwd(), agent.id, agent.role ?? agent.id, params.team);
 
   if (ctx.spawnColor && paneId !== 'inline') {
     await tmux.applyPaneColor(paneId, ctx.spawnColor, teamWindow?.windowId);


### PR DESCRIPTION
## Summary

- Calls `injectResumeContext()` in `resumeAgent()` after pane creation, so manual `genie resume` delivers the same structured context as auto-resume
- Adds `getGitStatus()` helper to include uncommitted changes (`git status --short`) in the resume context prompt
- Extracts `buildFullResumeParams()` to keep `resumeAgent()` clean

## Wish

`resilient-resume` — Closes #741, #744

## Test plan

- [ ] `bun test` passes (1143 tests ✅)
- [ ] Kill an engineer pane mid-work, run `genie resume <name>`, verify it gets context message with wish/group info and uncommitted changes
- [ ] Verify auto-resume path still works unchanged