### PR TITLE
fix: auto-cleanup team on wish completion (idle spam #768)

### DIFF
--- a/src/lib/wish-state.test.ts
+++ b/src/lib/wish-state.test.ts
@@ -20,6 +20,7 @@ import {
   getGroupState,
   getOrCreateState,
   getState,
+  isWishComplete,
   resetGroup,
   resolveRepoPath,
   startGroup,
@@ -563,6 +564,49 @@ describe('findAnyGroupByAssignee', () => {
 
     const result = await findAnyGroupByAssignee('nobody', cwd);
     expect(result).toBeNull();
+  });
+});
+
+// ============================================================================
+// isWishComplete
+// ============================================================================
+
+describe('isWishComplete', () => {
+  test('returns false when no state exists', async () => {
+    expect(await isWishComplete('nonexistent', cwd)).toBe(false);
+  });
+
+  test('returns false when some groups are not done', async () => {
+    await createState('test-wish', sampleGroups, cwd);
+    await startGroup('test-wish', '1', 'agent-a', cwd);
+    await completeGroup('test-wish', '1', cwd);
+
+    expect(await isWishComplete('test-wish', cwd)).toBe(false);
+  });
+
+  test('returns true when all groups are done', async () => {
+    await createState('test-wish', sampleGroups, cwd);
+
+    await startGroup('test-wish', '1', 'a', cwd);
+    await completeGroup('test-wish', '1', cwd);
+
+    await startGroup('test-wish', '2', 'b', cwd);
+    await completeGroup('test-wish', '2', cwd);
+
+    await startGroup('test-wish', '3', 'c', cwd);
+    await completeGroup('test-wish', '3', cwd);
+
+    await startGroup('test-wish', '4', 'd', cwd);
+    await completeGroup('test-wish', '4', cwd);
+
+    expect(await isWishComplete('test-wish', cwd)).toBe(true);
+  });
+
+  test('returns false when groups are in_progress', async () => {
+    await createState('test-wish', [{ name: '1' }], cwd);
+    await startGroup('test-wish', '1', 'agent-a', cwd);
+
+    expect(await isWishComplete('test-wish', cwd)).toBe(false);
   });
 });
 

--- a/src/lib/wish-state.ts
+++ b/src/lib/wish-state.ts
@@ -562,3 +562,14 @@ export async function getGroupState(slug: string, groupName: string, cwd?: strin
   if (!state) return null;
   return state.groups[groupName] ?? null;
 }
+
+/**
+ * Check if all groups in a wish are done.
+ * Returns true only when every group has status === 'done'.
+ */
+export async function isWishComplete(slug: string, cwd?: string): Promise<boolean> {
+  const state = await getState(slug, cwd);
+  if (!state) return false;
+  const groups = Object.values(state.groups);
+  return groups.length > 0 && groups.every((g) => g.status === 'done');
+}

--- a/src/term-commands/state.ts
+++ b/src/term-commands/state.ts
@@ -173,6 +173,37 @@ export async function ensureWorkPushed(slug: string, group: string): Promise<voi
 }
 
 // ============================================================================
+// Team Auto-Cleanup
+// ============================================================================
+
+/**
+ * Auto-cleanup team when wish is fully complete.
+ * Looks up the active team (via GENIE_TEAM env) and marks it done + kills members.
+ * Best-effort — if team lookup fails, cleanup is skipped (manual `genie team done` still works).
+ */
+async function autoCleanupTeam(): Promise<void> {
+  const teamName = process.env.GENIE_TEAM;
+  if (!teamName) return;
+
+  try {
+    const teamManager = await import('../lib/team-manager.js');
+    const config = await teamManager.getTeam(teamName);
+    if (!config) return;
+
+    // Only clean up if the team is still active
+    if (config.status === 'done') return;
+
+    console.log(`   🧹 Auto-cleaning team "${teamName}"...`);
+    await teamManager.setTeamStatus(teamName, 'done');
+    await teamManager.killTeamMembers(teamName);
+    console.log(`   ✅ Team "${teamName}" marked done, members killed.`);
+  } catch {
+    // Best-effort — manual cleanup via `genie team done` still works
+    console.log(`   ⚠️ Auto-cleanup skipped — run \`genie team done ${teamName}\` manually.`);
+  }
+}
+
+// ============================================================================
 // Pane Auto-Kill
 // ============================================================================
 
@@ -193,6 +224,36 @@ export function autoKillPane(): void {
     }, 1000);
   } else {
     process.exit(0);
+  }
+}
+
+// ============================================================================
+// Wave + Wish Completion Notifications
+// ============================================================================
+
+/**
+ * Notify team-lead of wave or wish completion via protocol-router.
+ * Best-effort — failures are logged but do not block the done flow.
+ */
+async function notifyWaveCompletion(
+  waveResult: { waveName: string; waveGroups: string[] },
+  wishComplete: boolean,
+): Promise<void> {
+  console.log(`   🌊 ${waveResult.waveName} complete! All groups done: ${waveResult.waveGroups.join(', ')}`);
+  try {
+    const protocolRouter = await import('../lib/protocol-router.js');
+    const repoPath = process.cwd();
+    const message = wishComplete
+      ? `WISH COMPLETE — all groups done: [${waveResult.waveGroups.join(', ')}]. Run \`genie team done\` to clean up.`
+      : `${waveResult.waveName} complete. All groups done: [${waveResult.waveGroups.join(', ')}]. Run /review or advance to next wave.`;
+    const result = await protocolRouter.sendMessage(repoPath, 'cli', 'team-lead', message);
+    if (result && typeof result === 'object' && 'delivered' in result && !result.delivered) {
+      console.warn('   ⚠️ Wave-complete notification may not have been delivered.');
+    } else {
+      console.log('   Notified team-lead of wave completion.');
+    }
+  } catch {
+    console.warn('   ⚠️ Could not notify team-lead (messaging unavailable).');
   }
 }
 
@@ -229,23 +290,19 @@ export async function doneCommand(ref: string): Promise<void> {
     // Push enforcement: commit dirty tree + push unpushed commits
     await ensureWorkPushed(slug, group);
 
+    // Wish-level completion check — are ALL groups done?
+    const wishComplete = await wishState.isWishComplete(slug);
+
     // Wave completion detection + team-lead notification
     const waveResult = await detectWaveCompletion(slug, group);
     if (waveResult) {
-      console.log(`   🌊 ${waveResult.waveName} complete! All groups done: ${waveResult.waveGroups.join(', ')}`);
-      try {
-        const protocolRouter = await import('../lib/protocol-router.js');
-        const repoPath = process.cwd();
-        const message = `${waveResult.waveName} complete. All groups done: [${waveResult.waveGroups.join(', ')}]. Run /review or advance to next wave.`;
-        const result = await protocolRouter.sendMessage(repoPath, 'cli', 'team-lead', message);
-        if (result && typeof result === 'object' && 'delivered' in result && !result.delivered) {
-          console.warn('   ⚠️ Wave-complete notification may not have been delivered.');
-        } else {
-          console.log('   Notified team-lead of wave completion.');
-        }
-      } catch {
-        console.warn('   ⚠️ Could not notify team-lead (messaging unavailable).');
-      }
+      await notifyWaveCompletion(waveResult, wishComplete);
+    }
+
+    // If entire wish is complete, auto-trigger team cleanup
+    if (wishComplete) {
+      console.log('   🎉 Wish fully complete — all groups done.');
+      await autoCleanupTeam();
     }
 
     // Auto-kill the calling agent's tmux pane


### PR DESCRIPTION
## Summary

- Adds `isWishComplete()` to `wish-state.ts` — returns true when every group in a wish has status `done`
- Adds `autoCleanupTeam()` to the `genie done` flow — when the last group completes, automatically marks the team as done and kills all members
- Extracts `notifyWaveCompletion()` helper to keep cognitive complexity within lint bounds
- Updates wave-complete notification to say "WISH COMPLETE" when all groups are done (not just the current wave)
- 4 new tests for `isWishComplete` covering all edge cases

## Root Cause

After all wish groups completed, idle agents were never shut down. Claude Code's native team system sent `idle_notification` every ~3 seconds indefinitely. No wish-level completion detection existed — only wave-level.

## Test plan
- [x] All 1165 existing tests pass
- [x] 4 new `isWishComplete` tests pass (nonexistent wish, partial, full, in-progress)
- [x] `bun run check` passes (typecheck + lint + dead-code + test)
- [x] Build succeeds

Closes #768