### PR TITLE
fix: disband cleans up Claude teams settings (#760)

### DIFF
--- a/src/lib/team-manager.test.ts
+++ b/src/lib/team-manager.test.ts
@@ -284,5 +284,26 @@ describe('Team Manager', () => {
       const disbanded = await disbandTeam('nonexistent');
       expect(disbanded).toBe(false);
     });
+
+    test('cleans up Claude teams settings directory', async () => {
+      const CLAUDE_DIR = join(TEST_DIR, 'claude-config');
+      process.env.CLAUDE_CONFIG_DIR = CLAUDE_DIR;
+
+      await createTeam('feat/claude-cleanup', TEST_REPO, 'dev');
+
+      // Simulate hook injection: create ~/.claude/teams/<name>/settings.json
+      const claudeTeamDir = join(CLAUDE_DIR, 'teams', 'feat-claude-cleanup');
+      await mkdir(claudeTeamDir, { recursive: true });
+      await writeFile(join(claudeTeamDir, 'settings.json'), '{"hooks":{}}');
+      expect(existsSync(join(claudeTeamDir, 'settings.json'))).toBe(true);
+
+      await disbandTeam('feat/claude-cleanup');
+
+      // Claude team directory should be gone
+      expect(existsSync(claudeTeamDir)).toBe(false);
+
+      // Clean up
+      process.env.CLAUDE_CONFIG_DIR = undefined;
+    });
   });
 });

--- a/src/lib/team-manager.ts
+++ b/src/lib/team-manager.ts
@@ -321,13 +321,12 @@ export async function disbandTeam(teamName: string): Promise<boolean> {
   const config = await getTeam(teamName);
   if (!config) return false;
 
-  // Clean up native teams if enabled
-  if (config.nativeTeamsEnabled) {
-    try {
-      await nativeTeamsManager.deleteNativeTeam(teamName);
-    } catch {
-      // Best-effort
-    }
+  // Clean up ~/.claude/teams/<name>/ (config.json, settings.json, inboxes)
+  // Always attempt — hook injection writes settings.json regardless of nativeTeamsEnabled
+  try {
+    await nativeTeamsManager.deleteNativeTeam(teamName);
+  } catch {
+    // Best-effort
   }
 
   // Kill all running team members (scoped to this team only)
@@ -366,7 +365,7 @@ export async function disbandTeam(teamName: string): Promise<boolean> {
  * Prune stale team configs.
  *
  * Scans all team configs — if a team's worktreePath (clone directory) no longer
- * exists on disk, deletes that team's config file.
+ * exists on disk, deletes that team's config file and its ~/.claude/teams/ dir.
  */
 export async function pruneStaleWorktrees(_repoPath: string): Promise<void> {
   const dir = teamsDir();
@@ -383,6 +382,12 @@ export async function pruneStaleWorktrees(_repoPath: string): Promise<void> {
       const content = await readFile(join(dir, file), 'utf-8');
       const config: TeamConfig = JSON.parse(content);
       if (config.worktreePath && !existsSync(config.worktreePath)) {
+        // Clean up orphaned ~/.claude/teams/<name>/ (settings.json, hooks)
+        try {
+          await nativeTeamsManager.deleteNativeTeam(config.name);
+        } catch {
+          // Best-effort
+        }
         await unlink(join(dir, file));
       }
     } catch {


### PR DESCRIPTION
## Summary

- `disbandTeam()` now always deletes `~/.claude/teams/<name>/` directory (removes `nativeTeamsEnabled` guard)
- `pruneStaleWorktrees()` also cleans up orphaned Claude team dirs when pruning stale configs
- New test verifying settings.json cleanup on disband

## Root Cause

`injectTeamHooks()` writes `settings.json` with `genie hook dispatch` hooks into `~/.claude/teams/<name>/` during every `genie spawn`, regardless of `nativeTeamsEnabled`. But `disbandTeam()` only cleaned up that directory when `nativeTeamsEnabled` was true. Orphaned settings files caused ENOENT errors on every Claude Code session stop.

## Test plan
- [x] All 1166 tests pass (1 new)
- [x] New test: disband removes Claude teams settings directory
- [x] `bun run check` clean (typecheck + lint + dead-code + test)
- [x] Build succeeds

Closes #760