### PR TITLE
fix: disband resets wish state to prevent stale dispatch (#761)

### DIFF
--- a/src/lib/team-manager.ts
+++ b/src/lib/team-manager.ts
@@ -52,6 +52,8 @@ export interface TeamConfig {
   nativeTeamsEnabled?: boolean;
   /** Tmux session name used by this team — single source of truth for all workers. */
   tmuxSessionName?: string;
+  /** Wish slug this team is working on (set via --wish). */
+  wishSlug?: string;
 }
 
 // ============================================================================
@@ -335,6 +337,19 @@ export async function disbandTeam(teamName: string): Promise<boolean> {
       await killWorkersByName(member, teamName);
     } catch {
       // Best-effort — continue with other members
+    }
+  }
+
+  // Reset in-progress wish groups so re-dispatch works cleanly
+  if (config.wishSlug) {
+    try {
+      const wishState = await import('./wish-state.js');
+      const resetCount = await wishState.resetInProgressGroups(config.wishSlug, config.repo);
+      if (resetCount > 0) {
+        console.log(`   Reset ${resetCount} in-progress group(s) for wish "${config.wishSlug}"`);
+      }
+    } catch {
+      // Best-effort — DB may be unavailable
     }
   }
 

--- a/src/lib/wish-state.test.ts
+++ b/src/lib/wish-state.test.ts
@@ -22,6 +22,7 @@ import {
   getState,
   isWishComplete,
   resetGroup,
+  resetInProgressGroups,
   resolveRepoPath,
   startGroup,
 } from './wish-state.js';
@@ -607,6 +608,53 @@ describe('isWishComplete', () => {
     await startGroup('test-wish', '1', 'agent-a', cwd);
 
     expect(await isWishComplete('test-wish', cwd)).toBe(false);
+  });
+});
+
+// ============================================================================
+// resetInProgressGroups
+// ============================================================================
+
+describe('resetInProgressGroups', () => {
+  test('returns 0 for nonexistent wish', async () => {
+    expect(await resetInProgressGroups('nonexistent', cwd)).toBe(0);
+  });
+
+  test('resets all in_progress groups to ready', async () => {
+    const groups: GroupDefinition[] = [{ name: 'a' }, { name: 'b' }, { name: 'c' }];
+    await createState('reset-all', groups, cwd);
+    await startGroup('reset-all', 'a', 'agent-1', cwd);
+    await startGroup('reset-all', 'b', 'agent-2', cwd);
+
+    const count = await resetInProgressGroups('reset-all', cwd);
+    expect(count).toBe(2);
+
+    const state = await getState('reset-all', cwd);
+    expect(state?.groups.a.status).toBe('ready');
+    expect(state?.groups.a.assignee).toBeUndefined();
+    expect(state?.groups.b.status).toBe('ready');
+    expect(state?.groups.b.assignee).toBeUndefined();
+    expect(state?.groups.c.status).toBe('ready'); // was already ready
+  });
+
+  test('does not touch done groups', async () => {
+    await createState('reset-done', sampleGroups, cwd);
+    await startGroup('reset-done', '1', 'a', cwd);
+    await completeGroup('reset-done', '1', cwd);
+    await startGroup('reset-done', '2', 'b', cwd);
+
+    const count = await resetInProgressGroups('reset-done', cwd);
+    expect(count).toBe(1); // only group 2
+
+    const state = await getState('reset-done', cwd);
+    expect(state?.groups['1'].status).toBe('done');
+    expect(state?.groups['2'].status).toBe('ready');
+  });
+
+  test('returns 0 when no groups are in_progress', async () => {
+    await createState('reset-none', [{ name: '1' }], cwd);
+    const count = await resetInProgressGroups('reset-none', cwd);
+    expect(count).toBe(0);
   });
 });
 

--- a/src/lib/wish-state.ts
+++ b/src/lib/wish-state.ts
@@ -573,3 +573,41 @@ export async function isWishComplete(slug: string, cwd?: string): Promise<boolea
   const groups = Object.values(state.groups);
   return groups.length > 0 && groups.every((g) => g.status === 'done');
 }
+
+/**
+ * Reset all in_progress groups back to ready for a wish.
+ * Used during team disband to prevent stale state from blocking re-dispatch.
+ * Returns the number of groups that were reset.
+ */
+export async function resetInProgressGroups(slug: string, cwd?: string): Promise<number> {
+  const sql = await getConnection();
+  const repoPath = resolveRepoPath(cwd);
+
+  const parent = await findParent(sql, slug, repoPath);
+  if (!parent) return 0;
+
+  const now = new Date();
+
+  // Find all in_progress children
+  const inProgress = await sql`
+    SELECT id FROM tasks
+    WHERE parent_id = ${parent.id as string} AND status = 'in_progress'
+  `;
+
+  if (inProgress.length === 0) return 0;
+
+  const ids = inProgress.map((r: Record<string, unknown>) => r.id as string);
+
+  // Reset to ready, clear started_at
+  await sql`
+    UPDATE tasks SET status = 'ready', started_at = NULL, updated_at = ${now}
+    WHERE id = ANY(${ids})
+  `;
+
+  // Remove assignees
+  await sql`
+    DELETE FROM task_actors WHERE task_id = ANY(${ids}) AND role = 'assignee'
+  `;
+
+  return ids.length;
+}

--- a/src/term-commands/team.ts
+++ b/src/term-commands/team.ts
@@ -198,9 +198,17 @@ async function handleTeamCreate(
 
   const config = await teamManager.createTeam(name, options.repo, options.branch);
 
-  // Store tmux session name in team config (prevents session explosion on parallel creates)
+  // Store wish slug and tmux session in team config
+  let needsUpdate = false;
+  if (options.wish) {
+    config.wishSlug = options.wish;
+    needsUpdate = true;
+  }
   if (options.session) {
     config.tmuxSessionName = options.session;
+    needsUpdate = true;
+  }
+  if (needsUpdate) {
     await teamManager.updateTeamConfig(name, config);
   }
 


### PR DESCRIPTION
## Summary

- Adds `wishSlug` field to `TeamConfig` — set when team is created with `--wish`
- `disbandTeam()` now resets all in-progress groups for the team's wish back to `ready`
- Adds `resetInProgressGroups()` to `wish-state.ts` for bulk reset (uses SQL `ANY()` for efficiency)
- 4 new tests covering all edge cases

## Root Cause

`genie team disband` killed agents and cleaned worktree files but left wish groups as `in_progress` in PG. When a new team was created for the same wish, `genie work` found the stale state and skipped dispatch entirely.

## Test plan
- [x] All 1170 tests pass (4 new)
- [x] New tests: reset returns 0 for nonexistent wish, resets in_progress, preserves done, returns 0 when nothing to reset
- [x] `bun run check` clean
- [x] Build succeeds

Closes #761