### PR TITLE
fix: quote fullCommand in tmux split-window to prevent prompt splitting

### DIFF
--- a/src/lib/protocol-router-spawn.ts
+++ b/src/lib/protocol-router-spawn.ts
@@ -98,7 +98,9 @@ async function spawnPaneInSession(
   }
 
   const splitTarget = teamWindow ? `-t '${teamWindow.windowId}'` : '';
-  const { stdout } = await execAsync(`tmux split-window -d ${splitTarget} -P -F '#{pane_id}' ${fullCommand}`);
+  // Wrap fullCommand in shell quotes so it survives the outer-shell → tmux → inner-shell pipeline.
+  const escapedCmd = fullCommand.replace(/'/g, "'\\''");
+  const { stdout } = await execAsync(`tmux split-window -d ${splitTarget} -P -F '#{pane_id}' '${escapedCmd}'`);
   const paneId = stdout.trim();
 
   let layoutTarget = `${session}:${teamWindow?.windowName ?? ''}`;

--- a/src/lib/provider-adapters.test.ts
+++ b/src/lib/provider-adapters.test.ts
@@ -240,6 +240,32 @@ describe('buildClaudeCommand', () => {
     expect(result.env).toBeDefined();
     expect(result.env!.GENIE_WORKER).toBe('1');
   });
+
+  it('initialPrompt with quotes and newlines survives tmux split-window re-quoting (#776)', () => {
+    const prompt =
+      'Execute Group 1 of wish "db-cleanup".\n\nWhen done:\n1. Run: genie done db-cleanup#1\n2. Run: genie send \'Group 1 complete.\' --to team-lead';
+    const result = buildClaudeCommand({
+      provider: 'claude',
+      team: 'work',
+      role: 'engineer-1',
+      initialPrompt: prompt,
+    });
+
+    // The command contains the prompt as a shell-escaped positional arg
+    expect(result.command).toContain('claude');
+    expect(result.command).toContain('engineer-1');
+
+    // Simulate the tmux split-window re-quoting fix:
+    // fullCommand is re-wrapped in single quotes for the outer shell → tmux → inner shell pipeline.
+    const fullCommand = result.command;
+    const reQuoted = fullCommand.replace(/'/g, "'\\''");
+
+    // The re-quoted command round-trips through sh -c back to the original fullCommand.
+    // This proves the outer shell → tmux → inner shell pipeline preserves the command.
+    const { execSync } = require('node:child_process');
+    const roundTripped = execSync(`printf '%s' '${reQuoted}'`, { encoding: 'utf-8' });
+    expect(roundTripped).toBe(fullCommand);
+  });
 });
 
 // ============================================================================

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -633,7 +633,11 @@ function createTmuxPane(ctx: SpawnCtx, teamWindow: TeamWindowInfo | null): strin
 
   const splitTarget = teamWindow ? `-t '${teamWindow.windowId}'` : '';
   const cwdFlag = ctx.cwd ? `-c '${ctx.cwd}'` : '';
-  const splitCmd = `tmux split-window -d ${splitTarget} ${cwdFlag} -P -F '#{pane_id}' ${ctx.fullCommand}`;
+  // Wrap fullCommand in shell quotes so it survives the outer-shell → tmux → inner-shell pipeline.
+  // Without this, single quotes from escapeShellArg (e.g. around the initialPrompt) are consumed
+  // by the outer shell, and tmux's inner shell sees unquoted args — splitting multi-word prompts.
+  const escapedCmd = ctx.fullCommand.replace(/'/g, "'\\''");
+  const splitCmd = `tmux split-window -d ${splitTarget} ${cwdFlag} -P -F '#{pane_id}' '${escapedCmd}'`;
   return execSync(splitCmd, { encoding: 'utf-8' }).trim();
 }
 


### PR DESCRIPTION
## Summary

Fixes #776 — `genie work` fails to spawn engineer tmux sessions.

- **Root cause:** `createTmuxPane`'s `split-window` path embedded `fullCommand` directly in the tmux command string without re-quoting. Single quotes from `escapeShellArg` (protecting multi-word `initialPrompt` args) were consumed by the outer shell (`execSync → sh -c`), so tmux's inner shell saw unquoted arguments — splitting prompts like `'Execute Group 1 of wish "db-cleanup"'` into many positional args. Claude Code received a garbled command and crashed immediately, making the pane vanish.

- **Fix:** Re-wrap `fullCommand` in shell quotes (same `'\''` escape pattern already used in the `send-keys` path) so the command survives the outer-shell → tmux → inner-shell pipeline. Applied to both `createTmuxPane` in `agents.ts` and `spawnPaneInSession` in `protocol-router-spawn.ts`.

- **Regression test:** Verifies the re-quoting round-trips an `initialPrompt` with newlines and embedded single quotes through `sh -c` back to the original command.

## Changed files

| File | Change |
|------|--------|
| `src/term-commands/agents.ts` | Re-quote `fullCommand` in `split-window` path |
| `src/lib/protocol-router-spawn.ts` | Same fix for the protocol-router spawn path |
| `src/lib/provider-adapters.test.ts` | Regression test for tmux quoting round-trip |

## Test plan

- [x] `bun test src/lib/provider-adapters.test.ts` — 36/36 pass (includes new regression test)
- [x] `bun test src/term-commands/dispatch.test.ts` — 54/54 pass
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (1 pre-existing warning)
- [ ] Manual: `genie work <slug>` with multi-group wish — verify engineer panes are created

Closes #776