### PR TITLE
fix: crash-resilient registry with atomic writes and backup recovery

### DIFF
--- a/src/lib/agent-registry.test.ts
+++ b/src/lib/agent-registry.test.ts
@@ -402,6 +402,67 @@ describe('findByWindow', () => {
 });
 
 // ============================================================================
+// Crash Resilience — atomic writes and backup recovery (#774)
+// ============================================================================
+
+describe('crash resilience', () => {
+  beforeEach(cleanTestDir);
+
+  test('saveRegistry creates .bak file of previous state', async () => {
+    const worker = makeAgent();
+    const registry = {
+      workers: { [worker.id]: worker },
+      lastUpdated: new Date().toISOString(),
+    };
+    writeFileSync(TEST_REGISTRY_PATH, JSON.stringify(registry, null, 2));
+
+    // Trigger a save (addSubPane modifies and saves)
+    await addSubPane('bd-42', '%22', TEST_REGISTRY_PATH);
+
+    // Backup should contain the previous state (without subPanes)
+    const backup = JSON.parse(readFileSync(`${TEST_REGISTRY_PATH}.bak`, 'utf-8'));
+    expect(backup.workers['bd-42'].subPanes).toBeUndefined();
+
+    // Primary should have the new state
+    const primary = JSON.parse(readFileSync(TEST_REGISTRY_PATH, 'utf-8'));
+    expect(primary.workers['bd-42'].subPanes).toEqual(['%22']);
+  });
+
+  test('loadRegistry falls back to .bak when primary is corrupt', async () => {
+    const worker = makeAgent({ subPanes: ['%22'] });
+    const goodState = {
+      workers: { [worker.id]: worker },
+      templates: {},
+      lastUpdated: new Date().toISOString(),
+    };
+
+    // Write corrupt primary, valid backup
+    writeFileSync(TEST_REGISTRY_PATH, '{ truncated JSON...');
+    writeFileSync(`${TEST_REGISTRY_PATH}.bak`, JSON.stringify(goodState, null, 2));
+
+    // loadRegistry should recover from backup
+    const pane = await getPane('bd-42', 0, TEST_REGISTRY_PATH);
+    expect(pane).toBe('%17');
+  });
+
+  test('loadRegistry returns empty registry when both primary and backup are corrupt', async () => {
+    writeFileSync(TEST_REGISTRY_PATH, '{ truncated...');
+    writeFileSync(`${TEST_REGISTRY_PATH}.bak`, 'also corrupt');
+
+    // Should not throw — returns empty registry
+    const pane = await getPane('bd-42', 0, TEST_REGISTRY_PATH);
+    expect(pane).toBeNull();
+  });
+
+  test('loadRegistry rejects files without workers object', async () => {
+    writeFileSync(TEST_REGISTRY_PATH, JSON.stringify({ foo: 'bar' }));
+
+    const pane = await getPane('bd-42', 0, TEST_REGISTRY_PATH);
+    expect(pane).toBeNull();
+  });
+});
+
+// ============================================================================
 // Cleanup
 // ============================================================================
 

--- a/src/lib/agent-registry.ts
+++ b/src/lib/agent-registry.ts
@@ -7,7 +7,8 @@
  */
 
 import { createHash } from 'node:crypto';
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { copyFile, mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { acquireLock } from './file-lock.js';
@@ -153,22 +154,71 @@ function getRegistryFilePath(): string {
 // ============================================================================
 
 async function loadRegistry(registryPath?: string): Promise<AgentRegistry> {
+  const filePath = registryPath ?? getRegistryFilePath();
+  const backupPath = `${filePath}.bak`;
+
+  // Try primary file first
+  const primary = await tryParseRegistryFile(filePath);
+  if (primary) return primary;
+
+  // Primary corrupt or missing — try backup
+  if (existsSync(backupPath)) {
+    const backup = await tryParseRegistryFile(backupPath);
+    if (backup) {
+      // Restore backup to primary (best-effort)
+      try {
+        await copyFile(backupPath, filePath);
+      } catch {
+        /* best-effort */
+      }
+      return backup;
+    }
+  }
+
+  return { workers: {}, templates: {}, lastUpdated: new Date().toISOString() };
+}
+
+/** Try to read and parse a registry JSON file. Returns null on any failure. */
+async function tryParseRegistryFile(filePath: string): Promise<AgentRegistry | null> {
   try {
-    const filePath = registryPath ?? getRegistryFilePath();
     const content = await readFile(filePath, 'utf-8');
     const data = JSON.parse(content);
+    if (!data.workers || typeof data.workers !== 'object') return null;
     if (!data.templates) data.templates = {};
     return data;
   } catch {
-    return { workers: {}, templates: {}, lastUpdated: new Date().toISOString() };
+    return null;
   }
 }
 
+/**
+ * Atomic save: write to temp file then rename.
+ * Also keeps a `.bak` of the previous good state.
+ */
 async function saveRegistry(registry: AgentRegistry, registryPath?: string): Promise<void> {
   const filePath = registryPath ?? getRegistryFilePath();
-  await mkdir(dirname(filePath), { recursive: true });
+  const dir = dirname(filePath);
+  await mkdir(dir, { recursive: true });
   registry.lastUpdated = new Date().toISOString();
-  await writeFile(filePath, JSON.stringify(registry, null, 2));
+
+  const tmpPath = `${filePath}.tmp.${process.pid}`;
+  const backupPath = `${filePath}.bak`;
+  const content = JSON.stringify(registry, null, 2);
+
+  // Write to temp file
+  await writeFile(tmpPath, content);
+
+  // Rotate current → backup (best-effort, don't fail if primary doesn't exist yet)
+  if (existsSync(filePath)) {
+    try {
+      await copyFile(filePath, backupPath);
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  // Atomic rename temp → primary (POSIX rename is atomic on same filesystem)
+  await rename(tmpPath, filePath);
 }
 
 // ============================================================================

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -1105,11 +1105,19 @@ export async function handleWorkerStop(name: string): Promise<void> {
   }
 }
 
-/** Check if an agent is eligible for resume (suspended/error, has session, pane dead). */
+/**
+ * Check if an agent is eligible for resume.
+ * Includes agents in working/idle/spawning states whose panes have died (crash recovery).
+ */
 async function isResumeEligible(w: registry.Agent): Promise<boolean> {
-  return (
-    (w.state === 'suspended' || w.state === 'error') && Boolean(w.claudeSessionId) && !(await isPaneAlive(w.paneId))
-  );
+  if (!w.claudeSessionId) return false;
+  if (w.state === 'done') return false;
+  const paneAlive = await isPaneAlive(w.paneId);
+  // Suspended/error agents with dead panes are always eligible
+  if ((w.state === 'suspended' || w.state === 'error') && !paneAlive) return true;
+  // Working/idle/spawning agents whose panes died (crash) are also eligible
+  if (!paneAlive && (w.state === 'working' || w.state === 'idle' || w.state === 'spawning')) return true;
+  return false;
 }
 
 /** Resume all eligible agents (--all mode). */


### PR DESCRIPTION
## Summary

Addresses short-term crash resilience fixes from #774.

### 1. Atomic writes for `workers.json`
`saveRegistry` now writes to a temp file (`workers.json.tmp.<pid>`) then renames to the target path. POSIX `rename()` is atomic on the same filesystem, so a crash mid-write can no longer leave a truncated/corrupt primary file.

### 2. Backup recovery on load
Each save rotates the previous good state to `workers.json.bak`. On load, if the primary file is corrupt (truncated JSON, missing `workers` key), `loadRegistry` automatically falls back to the backup file. Also restores the backup to primary for subsequent reads.

### 3. Broader resume eligibility
`isResumeEligible` now includes agents in `working`/`idle`/`spawning` states whose panes have died — not just `suspended`/`error`. After a host crash, agents stuck in "working" state with dead tmux panes can now be recovered via `genie resume --all`.

## Changed files

| File | Change |
|------|--------|
| `src/lib/agent-registry.ts` | Atomic write + backup recovery in save/load |
| `src/term-commands/agents.ts` | Broader `isResumeEligible` for crash recovery |
| `src/lib/agent-registry.test.ts` | 4 new crash resilience regression tests |

## Test plan

- [x] `bun test src/lib/agent-registry.test.ts` — 26/26 pass (4 new)
- [x] `bun test src/__tests__/resume.test.ts` — 10/10 pass
- [x] `bun test src/lib/scheduler-daemon.test.ts` — 54/54 pass
- [x] `bun run typecheck` — clean

Partially addresses #774 (short-term fixes only — medium/long-term PG migration is separate work).