### PR TITLE
fix: increase timeout for team create --wish tests

### DIFF
--- a/src/term-commands/team.test.ts
+++ b/src/term-commands/team.test.ts
@@ -193,7 +193,7 @@ describe('genie team CLI', () => {
     // Verify wish was copied to repo
     const repoWishPath = join(TEST_REPO, '.genie', 'wishes', wishSlug, 'WISH.md');
     expect(existsSync(repoWishPath)).toBe(true);
-  });
+  }, 15_000);
 
   test('team create --wish uses existing wish in repo without copying', async () => {
     // Create a wish directly in the repo
@@ -214,5 +214,5 @@ describe('genie team CLI', () => {
 
     // Wish should still be there
     expect(existsSync(join(wishDir, 'WISH.md'))).toBe(true);
-  });
+  }, 15_000);
 });


### PR DESCRIPTION
## Summary

Fixes #778 — team create --wish tests timeout in CI.

The wish auto-copy tests call `genie team create --wish` which triggers `spawnLeaderWithWish()`. Without tmux in test environments, the spawn hangs until the default 5s `bun:test` timeout kills the test.

Increased timeout to 15s for both tests so the spawn has time to fail gracefully (the existing try/catch handles the failure).

## Test plan

- [x] `bun test src/term-commands/team.test.ts` — 14/14 pass (0 timeout failures)

Closes #778