### PR TITLE
fix: stop registering non-native agents as SendMessage recipients

### DIFF
--- a/src/lib/protocol-router-spawn.ts
+++ b/src/lib/protocol-router-spawn.ts
@@ -166,21 +166,26 @@ export async function spawnWorkerFromTemplate(
   };
 
   await registry.register(workerEntry);
-  await nativeTeams.registerNativeMember(team, {
-    agentName,
-    agentType: template.role ?? 'general-purpose',
-    color: spawnColor ?? 'blue',
-    tmuxPaneId: paneId,
-    cwd: repoPath,
-  });
-  await nativeTeams.writeNativeInbox(team, 'team-lead', {
-    from: agentName,
-    text: `Worker ${agentName} (${template.provider}) auto-spawned${resumeSessionId ? ' with --resume' : ''}. Ready for tasks.`,
-    summary: `${agentName} auto-spawned`,
-    timestamp: now,
-    color: spawnColor ?? 'blue',
-    read: false,
-  });
+
+  // Only register native-team-enabled agents (Claude) as SendMessage recipients.
+  // Non-native agents (Codex) can't read the Claude Code inbox (#777).
+  if (isClaude) {
+    await nativeTeams.registerNativeMember(team, {
+      agentName,
+      agentType: template.role ?? 'general-purpose',
+      color: spawnColor ?? 'blue',
+      tmuxPaneId: paneId,
+      cwd: repoPath,
+    });
+    await nativeTeams.writeNativeInbox(team, 'team-lead', {
+      from: agentName,
+      text: `Worker ${agentName} (${template.provider}) auto-spawned${resumeSessionId ? ' with --resume' : ''}. Ready for tasks.`,
+      summary: `${agentName} auto-spawned`,
+      timestamp: now,
+      color: spawnColor ?? 'blue',
+      read: false,
+    });
+  }
 
   if (spawnColor) {
     await applyPaneColor(paneId, spawnColor, teamWindow?.windowId);

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -481,20 +481,26 @@ async function registerSpawnWorker(
 
 async function notifySpawnJoin(ctx: SpawnCtx, paneId: string): Promise<void> {
   const nt = ctx.validated.nativeTeam;
+
+  // Only register native-team-enabled agents (Claude) as SendMessage recipients.
+  // Non-native agents (Codex) can't read the Claude Code inbox, so registering them
+  // causes SendMessage to silently succeed but never deliver (#777).
+  if (!nt?.enabled) return;
+
   await nativeTeams.registerNativeMember(ctx.validated.team, {
     agentName: ctx.agentName,
-    agentType: nt?.agentType ?? ctx.validated.role ?? 'general-purpose',
-    color: nt?.color ?? ctx.spawnColor ?? 'blue',
+    agentType: nt.agentType ?? ctx.validated.role ?? 'general-purpose',
+    color: nt.color ?? ctx.spawnColor ?? 'blue',
     tmuxPaneId: paneId,
     cwd: ctx.cwd,
-    planModeRequired: nt?.planModeRequired,
+    planModeRequired: nt.planModeRequired,
   });
   await nativeTeams.writeNativeInbox(ctx.validated.team, 'team-lead', {
     from: ctx.agentName,
     text: `Worker ${ctx.agentName} (${ctx.validated.provider}) joined team ${ctx.validated.team}. cwd: ${ctx.cwd}. Ready for tasks.`,
     summary: `${ctx.agentName} (${ctx.validated.provider}) joined`,
     timestamp: new Date().toISOString(),
-    color: nt?.color ?? ctx.spawnColor ?? 'blue',
+    color: nt.color ?? ctx.spawnColor ?? 'blue',
     read: false,
   });
 }


### PR DESCRIPTION
## Summary

Fixes #777 — SendMessage silently fails for Codex (non-Claude) agents.

**Root cause:** `notifySpawnJoin()` registered ALL agents — including Codex — as native team members in Claude Code's `config.json`. This made them valid `SendMessage` targets. But Codex CLI has no inbox polling mechanism, so messages accumulated in `~/.claude/teams/<team>/inboxes/<agent>.json` with `read: false` forever.

**Fix:** Guard `registerNativeMember` and `writeNativeInbox` calls:
- `agents.ts`: skip entirely when `nt.enabled` is false (early return)
- `protocol-router-spawn.ts`: wrap in `if (isClaude)` check

Only Claude agents that can actually read the native inbox are now registered. Non-native agents should use `genie send` (protocol-router) for messaging instead.

## Changed files

| File | Change |
|------|--------|
| `src/term-commands/agents.ts` | Guard `notifySpawnJoin` with `nt.enabled` check |
| `src/lib/protocol-router-spawn.ts` | Guard registration with `isClaude` check |

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (1 pre-existing warning)
- [ ] Manual: spawn Codex agent, verify it does NOT appear in native team config
- [ ] Manual: spawn Claude agent, verify it DOES appear and SendMessage works

Closes #777