### PR TITLE
fix(tmux): restore session clicking on status line 1

### DIFF
--- a/scripts/tmux/genie.tmux.conf
+++ b/scripts/tmux/genie.tmux.conf
@@ -115,9 +115,10 @@ bind -n M-Right next-window
 bind s choose-tree -s
 bind w choose-tree -w
 
-# Single-click on status bar: switch to clicked window/session via range= targets
-bind -n MouseDown1Status select-window -t =
-bind -n MouseDown1StatusDefault select-window -t =
+# Single-click on status bar: handled natively by tmux 3.3+
+# range=window targets trigger select-window, range=session targets trigger
+# switch-client. Custom MouseDown1Status bindings would override the native
+# range dispatch and break session clicking on status line 1.
 
 # Double-click on pane opens interactive session/window picker
 bind -n DoubleClick1Pane choose-tree -s

--- a/src/__tests__/tmux-config.test.ts
+++ b/src/__tests__/tmux-config.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Regression tests for genie.tmux.conf
+ *
+ * Ensures status-bar click handling relies on tmux 3.3+ native range=
+ * dispatch and is not overridden by custom MouseDown1Status bindings.
+ * See: https://github.com/automagik-dev/genie/issues/784
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const CONF_PATH = resolve(import.meta.dirname, '../../scripts/tmux/genie.tmux.conf');
+const conf = readFileSync(CONF_PATH, 'utf-8');
+
+/** Return non-comment, non-empty lines that match a pattern. */
+function activeLines(pattern: RegExp): string[] {
+  return conf
+    .split('\n')
+    .filter((l) => !l.trimStart().startsWith('#') && l.trim() !== '')
+    .filter((l) => pattern.test(l));
+}
+
+describe('tmux config — status bar click handling', () => {
+  test('must NOT bind MouseDown1Status (breaks native range=session dispatch)', () => {
+    const hits = activeLines(/MouseDown1Status\b/);
+    expect(hits).toEqual([]);
+  });
+
+  test('status-format[0] uses range=window for window tabs', () => {
+    expect(conf).toContain('range=window|');
+  });
+
+  test('status-format[1] uses range=session for agent sessions', () => {
+    expect(conf).toContain('range=session|');
+  });
+
+  test('mouse is enabled globally', () => {
+    const hits = activeLines(/set\s+-g\s+mouse\s+on/);
+    expect(hits.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('DoubleClick1Pane binding still exists', () => {
+    const hits = activeLines(/DoubleClick1Pane/);
+    expect(hits.length).toBe(1);
+  });
+
+  test('DoubleClick1Status binding still exists', () => {
+    const hits = activeLines(/DoubleClick1Status/);
+    expect(hits.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Remove custom `MouseDown1Status` and `MouseDown1StatusDefault` bindings that overrode tmux's native `range=` click dispatch
- Session names on status line 1 now correctly trigger `switch-client` instead of `select-window`
- Window tab clicking on status line 0 still works via native `range=window` handling

## Root Cause

The `bind -n MouseDown1Status select-window -t =` intercepted ALL status-bar clicks and forced `select-window`, which is correct for `range=window|idx` targets on line 0, but wrong for `range=session|name` targets on line 1 (which need `switch-client`). Removing both bindings lets tmux 3.3+ native range dispatch handle both click types correctly.

## Test Plan

- [x] Regression test added: `src/__tests__/tmux-config.test.ts` (6 assertions)
- [x] Verifies no `MouseDown1Status` bindings exist in active config lines
- [x] Verifies `range=window` and `range=session` targets are present
- [x] Verifies mouse is enabled and DoubleClick bindings preserved
- [x] All 1225 existing tests pass (1 pre-existing failure in `wish-state.test.ts` unrelated)

Fixes #784