### PR TITLE
fix(db): reconcile agents schema — missing columns break spawn

### DIFF
--- a/src/db/migrations/006_fix_agents_schema.sql
+++ b/src/db/migrations/006_fix_agents_schema.sql
@@ -1,0 +1,73 @@
+-- 006_fix_agents_schema.sql — Reconcile agents/agent_templates schema
+-- Fixes: tables created by seed with old schema before 005_pg_state migration.
+-- The seed used text[] for sub_panes/extra_args and missed tmux_window, pane_color, updated_at.
+-- This migration ensures the schema matches 005_pg_state regardless of creation order.
+
+-- ============================================================================
+-- agents table — add missing columns, fix column types
+-- ============================================================================
+
+-- Columns that may not exist if table was created by pre-005 seed
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS tmux_window TEXT;
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS pane_color TEXT;
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT now();
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT now();
+
+-- sub_panes: seed created as text[], code expects jsonb
+-- Safe migration: convert existing text[] data to jsonb, set correct default
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'agents' AND column_name = 'sub_panes' AND data_type = 'ARRAY'
+  ) THEN
+    ALTER TABLE agents ALTER COLUMN sub_panes DROP DEFAULT;
+    ALTER TABLE agents ALTER COLUMN sub_panes TYPE jsonb
+      USING COALESCE(array_to_json(sub_panes)::jsonb, '[]'::jsonb);
+    ALTER TABLE agents ALTER COLUMN sub_panes SET DEFAULT '[]'::jsonb;
+  END IF;
+END $$;
+
+-- ============================================================================
+-- agent_templates table — fix column types
+-- ============================================================================
+
+-- extra_args: seed created as text[], code expects jsonb
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'agent_templates' AND column_name = 'extra_args' AND data_type = 'ARRAY'
+  ) THEN
+    ALTER TABLE agent_templates ALTER COLUMN extra_args DROP DEFAULT;
+    ALTER TABLE agent_templates ALTER COLUMN extra_args TYPE jsonb
+      USING COALESCE(array_to_json(extra_args)::jsonb, '[]'::jsonb);
+    ALTER TABLE agent_templates ALTER COLUMN extra_args SET DEFAULT '[]'::jsonb;
+  END IF;
+END $$;
+
+-- Add missing timestamp columns to agent_templates
+ALTER TABLE agent_templates ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT now();
+ALTER TABLE agent_templates ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT now();
+
+-- ============================================================================
+-- Ensure update triggers exist (idempotent CREATE OR REPLACE)
+-- ============================================================================
+CREATE OR REPLACE FUNCTION update_agents_timestamp()
+RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Drop and re-create triggers (idempotent)
+DROP TRIGGER IF EXISTS trg_agents_updated_at ON agents;
+CREATE TRIGGER trg_agents_updated_at
+  BEFORE UPDATE ON agents
+  FOR EACH ROW EXECUTE FUNCTION update_agents_timestamp();
+
+DROP TRIGGER IF EXISTS trg_agent_templates_updated_at ON agent_templates;
+CREATE TRIGGER trg_agent_templates_updated_at
+  BEFORE UPDATE ON agent_templates
+  FOR EACH ROW EXECUTE FUNCTION update_agents_timestamp();


### PR DESCRIPTION
## Summary
- Adds migration `006_fix_agents_schema.sql` to reconcile the `agents` and `agent_templates` tables when they were created by the seed with the old schema before migration 005 ran
- Fixes `genie spawn` failures: `column "tmux_window" does not exist`, `column "pane_color" does not exist`, `column "updated_at" does not exist`, `sub_panes text[] vs jsonb` type mismatch

## Root Cause
The seed (`pg-seed.ts`) creates tables via `INSERT INTO agents` which auto-creates the table with the old schema (from `workers.json`). Migration 005 then tries `CREATE TABLE agents` which silently fails since the table exists. Result: schema is stuck on the old version.

## What the migration does
- `ALTER TABLE ADD COLUMN IF NOT EXISTS` for `tmux_window`, `pane_color`, `updated_at`, `created_at`
- Converts `sub_panes` from `text[]` to `jsonb` (with data preservation)
- Converts `extra_args` from `text[]` to `jsonb` (with data preservation)
- Re-creates update triggers (idempotent)

## Test plan
- [x] `bun run typecheck` — pass
- [x] `bun run lint` — pass (1 pre-existing warning)
- [x] `bun test` — 1246 pass, 0 fail

Fixes #790