### PR TITLE
fix(tmux): restore click-to-switch and double-click session picker

### DIFF
--- a/scripts/tmux/genie.tmux.conf
+++ b/scripts/tmux/genie.tmux.conf
@@ -56,7 +56,7 @@ set -g pane-border-status top
 set -g pane-border-lines heavy
 set -g pane-border-format "\
 #[align=left,bg=#16213e,fg=#e0e0e0]\
- #[fg=#7b2ff7,bold]Genie#[fg=#6c6c8a,nobold] #(genie --version 2>/dev/null | head -1 || echo '?') \
+ #[fg=#7b2ff7,bold]Genie#[fg=#6c6c8a,nobold] #(PATH=$HOME/.bun/bin:$HOME/.npm-global/bin:$PATH genie --version 2>/dev/null | head -1 || echo '?') \
 #[fg=#0f3460]│ \
 #[fg=#b8a9c9]#{pane_current_path}\
 #[align=right,bg=#16213e]\
@@ -115,11 +115,16 @@ bind -n M-Right next-window
 bind s choose-tree -s
 bind w choose-tree -w
 
-# Single-click on status bar: handled natively by tmux 3.3+
-# range=window targets trigger select-window, range=session targets trigger
-# switch-client. Custom MouseDown1Status bindings would override the native
-# range dispatch and break session clicking on status line 1.
+# Single-click on status bar: select clicked window
+bind -n MouseDown1Status select-window -t =
+bind -n MouseDown1StatusDefault select-window -t =
 
-# Double-click on pane opens interactive session/window picker
+# Single-click on right side of status bar: open session picker
+bind -n MouseDown1StatusRight choose-tree -s
+
+# Double-click anywhere on status bar or pane: open session/window picker
 bind -n DoubleClick1Pane choose-tree -s
 bind -n DoubleClick1Status choose-tree -s
+bind -n DoubleClick1StatusDefault choose-tree -s
+bind -n DoubleClick1StatusLeft choose-tree -s
+bind -n DoubleClick1StatusRight choose-tree -s

--- a/src/__tests__/tmux-config.test.ts
+++ b/src/__tests__/tmux-config.test.ts
@@ -1,8 +1,8 @@
 /**
  * Regression tests for genie.tmux.conf
  *
- * Ensures status-bar click handling relies on tmux 3.3+ native range=
- * dispatch and is not overridden by custom MouseDown1Status bindings.
+ * Ensures status-bar click handling works for both windows (single-click)
+ * and sessions (double-click on any status area).
  * See: https://github.com/automagik-dev/genie/issues/784
  */
 
@@ -22,17 +22,29 @@ function activeLines(pattern: RegExp): string[] {
 }
 
 describe('tmux config — status bar click handling', () => {
-  test('must NOT bind MouseDown1Status (breaks native range=session dispatch)', () => {
-    const hits = activeLines(/MouseDown1Status\b/);
-    expect(hits).toEqual([]);
+  test('MouseDown1Status binds select-window for window clicking', () => {
+    const hits = activeLines(/bind\s+-n\s+MouseDown1Status\s+select-window/);
+    expect(hits.length).toBe(1);
+  });
+
+  test('MouseDown1StatusDefault binds select-window for gap clicking', () => {
+    const hits = activeLines(/bind\s+-n\s+MouseDown1StatusDefault\s+select-window/);
+    expect(hits.length).toBe(1);
+  });
+
+  test('MouseDown1StatusRight opens session picker', () => {
+    const hits = activeLines(/bind\s+-n\s+MouseDown1StatusRight\s+choose-tree/);
+    expect(hits.length).toBe(1);
   });
 
   test('status-format[0] uses range=window for window tabs', () => {
-    expect(conf).toContain('range=window|');
+    const hits = activeLines(/range=window\|/);
+    expect(hits.length).toBeGreaterThanOrEqual(1);
   });
 
   test('status-format[1] uses range=session for agent sessions', () => {
-    expect(conf).toContain('range=session|');
+    const hits = activeLines(/range=session\|/);
+    expect(hits.length).toBeGreaterThanOrEqual(1);
   });
 
   test('mouse is enabled globally', () => {
@@ -40,13 +52,15 @@ describe('tmux config — status bar click handling', () => {
     expect(hits.length).toBeGreaterThanOrEqual(1);
   });
 
-  test('DoubleClick1Pane binding still exists', () => {
+  test('DoubleClick1Pane binding exists', () => {
     const hits = activeLines(/DoubleClick1Pane/);
     expect(hits.length).toBe(1);
   });
 
-  test('DoubleClick1Status binding still exists', () => {
-    const hits = activeLines(/DoubleClick1Status/);
-    expect(hits.length).toBe(1);
+  test('double-click opens session picker on all status areas', () => {
+    expect(activeLines(/DoubleClick1Status\b/).length).toBe(1);
+    expect(activeLines(/DoubleClick1StatusDefault/).length).toBe(1);
+    expect(activeLines(/DoubleClick1StatusLeft/).length).toBe(1);
+    expect(activeLines(/DoubleClick1StatusRight/).length).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- Restores `MouseDown1Status select-window` for single-click window switching
- Adds double-click session picker on **all** status areas (Status, StatusDefault, StatusLeft, StatusRight) so double-clicking anywhere on the status bar opens the session picker
- Fixes `genie --version` not showing in top pane-border by adding `bun`/`npm` to PATH for tmux shell commands

## What was broken
PR #785 removed all `MouseDown1Status` bindings, which broke window clicking. The session picker also only worked via `DoubleClick1Status` and `DoubleClick1Pane`, missing clicks on non-range areas of the status bar.

## Test plan
- [x] Single-click on window tab switches window
- [x] Double-click on agents bar (status line 1) opens session picker
- [x] Double-click on windows bar opens session picker
- [x] Double-click on pane content opens session picker
- [x] Genie version shows in top border bar
- [x] `bun test src/__tests__/tmux-config.test.ts` passes