### PR TITLE
feat(cli): add genie export/import for data portability

### DIFF
--- a/src/genie.ts
+++ b/src/genie.ts
@@ -44,7 +44,9 @@ import { registerDaemonCommands } from './term-commands/daemon.js';
 import { registerDbCommands } from './term-commands/db.js';
 import { registerAgentNamespace, registerDirNamespace } from './term-commands/dir.js';
 import { registerDispatchCommands } from './term-commands/dispatch.js';
+import { registerExportCommands } from './term-commands/export.js';
 import * as historyCmd from './term-commands/history.js';
+import { registerImportCommands } from './term-commands/import.js';
 import { type LogOptions, logCommand } from './term-commands/log.js';
 import { registerMetricsCommands } from './term-commands/metrics.js';
 import { registerSendInboxCommands } from './term-commands/msg.js';
@@ -164,6 +166,8 @@ registerNotifyCommands(program);
 registerEventsCommands(program);
 registerSessionsCommands(program);
 registerMetricsCommands(program);
+registerExportCommands(program);
+registerImportCommands(program);
 
 // ============================================================================
 // CLI audit hooks — record every command execution to audit_events

--- a/src/lib/export-format.ts
+++ b/src/lib/export-format.ts
@@ -1,0 +1,96 @@
+/**
+ * Export/Import format — schema-versioned JSON document for data portability.
+ *
+ * Every export produces an ExportDocument with version, metadata, and data keyed by table name.
+ * The version field enables forward-compatible schema evolution.
+ */
+
+export const EXPORT_VERSION = '1.0' as const;
+
+export interface ExportDocument {
+  version: typeof EXPORT_VERSION;
+  exportedAt: string;
+  exportedBy: string;
+  genieVersion: string;
+  type: 'full' | 'partial';
+  groups: string[];
+  skippedTables: string[];
+  data: Record<string, unknown[]>;
+}
+
+export type ExportGroup =
+  | 'boards'
+  | 'tasks'
+  | 'tags'
+  | 'projects'
+  | 'schedules'
+  | 'agents'
+  | 'apps'
+  | 'comms'
+  | 'config';
+
+/** Tables belonging to each export group */
+export const GROUP_TABLES: Record<ExportGroup, string[]> = {
+  boards: ['boards', 'board_templates', 'task_types'],
+  tasks: ['tasks', 'task_tags', 'task_actors', 'task_dependencies', 'task_stage_log'],
+  tags: ['tags'],
+  projects: ['projects'],
+  schedules: ['schedules'],
+  agents: ['agents', 'agent_templates', 'agent_checkpoints'],
+  apps: ['app_store', 'installed_apps', 'app_versions'],
+  comms: ['conversations', 'conversation_members', 'messages', 'mailbox', 'team_chat', 'notification_preferences'],
+  config: ['os_config', 'instances', 'warm_pool', 'golden_images'],
+};
+
+export const ALL_GROUPS: ExportGroup[] = [
+  'boards',
+  'tasks',
+  'tags',
+  'projects',
+  'schedules',
+  'agents',
+  'apps',
+  'comms',
+  'config',
+];
+
+export type ConflictMode = 'fail' | 'merge' | 'overwrite';
+
+/** Create a new empty ExportDocument shell */
+export function createExportDocument(
+  type: 'full' | 'partial',
+  groups: string[],
+  genieVersion: string,
+  actor: string,
+): ExportDocument {
+  return {
+    version: EXPORT_VERSION,
+    exportedAt: new Date().toISOString(),
+    exportedBy: actor,
+    genieVersion,
+    type,
+    groups,
+    skippedTables: [],
+    data: {},
+  };
+}
+
+/** Validate that a parsed JSON object is a valid ExportDocument */
+export function validateExportDocument(
+  obj: unknown,
+): { valid: true; doc: ExportDocument } | { valid: false; error: string } {
+  if (!obj || typeof obj !== 'object') {
+    return { valid: false, error: 'Not a valid JSON object' };
+  }
+  const doc = obj as Record<string, unknown>;
+  if (doc.version !== EXPORT_VERSION) {
+    return { valid: false, error: `Unsupported version: ${doc.version} (expected ${EXPORT_VERSION})` };
+  }
+  if (!doc.exportedAt || typeof doc.exportedAt !== 'string') {
+    return { valid: false, error: 'Missing or invalid exportedAt' };
+  }
+  if (!doc.data || typeof doc.data !== 'object') {
+    return { valid: false, error: 'Missing or invalid data' };
+  }
+  return { valid: true, doc: doc as unknown as ExportDocument };
+}

--- a/src/lib/import-order.ts
+++ b/src/lib/import-order.ts
@@ -1,0 +1,91 @@
+/**
+ * Import ordering — FK dependency graph for safe transactional inserts.
+ *
+ * Tables are grouped into dependency levels. Each level can be inserted
+ * in any order, but all tables in level N must be inserted before level N+1.
+ *
+ * Self-referential tables (tasks.parent_id, messages.reply_to_id) are handled
+ * by inserting with NULLed self-refs first, then updating after all rows exist.
+ */
+
+/** Tables at each FK dependency level (0 = no FK deps, higher = more deps) */
+export const IMPORT_LEVELS: string[][] = [
+  // Level 0: No FK dependencies
+  [
+    'schedules',
+    'sessions',
+    'projects',
+    'agent_templates',
+    'agent_checkpoints',
+    'tags',
+    'task_types',
+    'notification_preferences',
+    // Optional (KhalOS)
+    'app_store',
+    'os_config',
+    'golden_images',
+    'warm_pool',
+    'instances',
+  ],
+  // Level 1: Depend on Level 0
+  [
+    'triggers',
+    'boards',
+    'board_templates',
+    'agents',
+    'conversations',
+    // Optional (KhalOS)
+    'installed_apps',
+    'app_versions',
+  ],
+  // Level 2: Depend on Level 1
+  ['tasks', 'runs', 'messages', 'conversation_members', 'mailbox', 'team_chat'],
+  // Level 3: Depend on Level 2
+  ['task_tags', 'task_actors', 'task_dependencies', 'task_stage_log', 'heartbeats', 'machine_snapshots'],
+];
+
+/** Tables with self-referential FKs that need two-pass insert */
+export const SELF_REFERENTIAL_COLUMNS: Record<string, string> = {
+  tasks: 'parent_id',
+  messages: 'reply_to_id',
+  conversations: 'parent_message_id',
+};
+
+/**
+ * Get the import level for a table. Returns -1 if not in the graph.
+ */
+export function getTableLevel(table: string): number {
+  for (let i = 0; i < IMPORT_LEVELS.length; i++) {
+    if (IMPORT_LEVELS[i].includes(table)) return i;
+  }
+  return -1;
+}
+
+/**
+ * Sort tables by their import level (ascending).
+ * Unknown tables are appended at the end.
+ */
+export function sortByImportOrder(tables: string[]): string[] {
+  return [...tables].sort((a, b) => {
+    const la = getTableLevel(a);
+    const lb = getTableLevel(b);
+    const effectiveA = la === -1 ? 999 : la;
+    const effectiveB = lb === -1 ? 999 : lb;
+    return effectiveA - effectiveB;
+  });
+}
+
+/**
+ * Get the primary key column(s) for known tables.
+ * Most tables use 'id', but some have composite keys.
+ */
+export function getPrimaryKey(table: string): string[] {
+  const compositeKeys: Record<string, string[]> = {
+    task_tags: ['task_id', 'tag_id'],
+    task_actors: ['task_id', 'actor_type', 'actor_id', 'role'],
+    task_dependencies: ['task_id', 'depends_on_id'],
+    conversation_members: ['conversation_id', 'actor_type', 'actor_id'],
+    notification_preferences: ['actor_type', 'actor_id', 'channel'],
+  };
+  return compositeKeys[table] ?? ['id'];
+}

--- a/src/lib/table-detect.ts
+++ b/src/lib/table-detect.ts
@@ -1,0 +1,46 @@
+/**
+ * Table detection — check which tables exist in the connected database.
+ *
+ * Used by export/import to gracefully skip tables that don't exist
+ * (e.g., KhalOS-specific tables on a pure genie install).
+ */
+
+import type postgres from 'postgres';
+
+type Sql = postgres.Sql;
+
+/**
+ * Get all user tables in the current schema (excludes system tables and migration tracker).
+ */
+export async function getAvailableTables(sql: Sql): Promise<string[]> {
+  const rows = await sql<{ table_name: string }[]>`
+    SELECT table_name
+    FROM information_schema.tables
+    WHERE table_schema = current_schema()
+      AND table_type = 'BASE TABLE'
+      AND table_name NOT LIKE '_genie_%'
+    ORDER BY table_name
+  `;
+  return rows.map((r) => r.table_name);
+}
+
+/**
+ * Filter a list of requested tables to only those that exist.
+ * Returns { available, skipped } so callers can log what was skipped.
+ */
+export async function filterAvailableTables(
+  sql: Sql,
+  requested: string[],
+): Promise<{ available: string[]; skipped: string[] }> {
+  const existing = new Set(await getAvailableTables(sql));
+  const available: string[] = [];
+  const skipped: string[] = [];
+  for (const table of requested) {
+    if (existing.has(table)) {
+      available.push(table);
+    } else {
+      skipped.push(table);
+    }
+  }
+  return { available, skipped };
+}

--- a/src/term-commands/export.ts
+++ b/src/term-commands/export.ts
@@ -1,0 +1,397 @@
+/**
+ * Export commands — dump genie data as schema-versioned JSON.
+ *
+ * Commands:
+ *   genie export all                — Full backup (all present tables)
+ *   genie export boards [name]      — Boards, templates, task_types
+ *   genie export tasks [--project]  — Tasks with deps/actors/stage_log
+ *   genie export tags               — Tags
+ *   genie export projects           — Projects
+ *   genie export schedules [name]   — Schedules with run_spec
+ *   genie export agents             — Agents, templates, checkpoints
+ *   genie export apps               — App store (KhalOS, graceful skip)
+ *   genie export comms              — Conversations, messages, mailbox
+ *   genie export config             — OS config (KhalOS, graceful skip)
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import type { Command } from 'commander';
+import type postgres from 'postgres';
+import {
+  ALL_GROUPS,
+  type ExportDocument,
+  type ExportGroup,
+  GROUP_TABLES,
+  createExportDocument,
+} from '../lib/export-format.js';
+
+type Sql = postgres.Sql;
+
+// ============================================================================
+// Lazy loaders
+// ============================================================================
+
+async function getSql(): Promise<Sql> {
+  const { getConnection } = await import('../lib/db.js');
+  return getConnection();
+}
+
+async function getVersion(): Promise<string> {
+  const { VERSION } = await import('../lib/version.js');
+  return VERSION;
+}
+
+async function getActorName(): Promise<string> {
+  const { getActor } = await import('../lib/audit.js');
+  return getActor();
+}
+
+async function detectTables(sql: Sql, tables: string[]): Promise<{ available: string[]; skipped: string[] }> {
+  const { filterAvailableTables } = await import('../lib/table-detect.js');
+  return filterAvailableTables(sql, tables);
+}
+
+// ============================================================================
+// Output helper
+// ============================================================================
+
+interface ExportOptions {
+  output?: string;
+  pretty?: boolean;
+}
+
+function outputDocument(doc: ExportDocument, options: ExportOptions): void {
+  const json = options.pretty ? JSON.stringify(doc, null, 2) : JSON.stringify(doc);
+  if (options.output) {
+    const dir = dirname(options.output);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    writeFileSync(options.output, `${json}\n`);
+    const tables = Object.keys(doc.data);
+    const rows = Object.values(doc.data).reduce((sum, arr) => sum + (arr as unknown[]).length, 0);
+    console.log(`Exported ${tables.length} tables (${rows} rows) to ${options.output}`);
+    if (doc.skippedTables.length > 0) {
+      console.log(`Skipped tables (not found): ${doc.skippedTables.join(', ')}`);
+    }
+  } else {
+    console.log(json);
+  }
+}
+
+function autoOutputName(): string {
+  const d = new Date();
+  const date = `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, '0')}${String(d.getDate()).padStart(2, '0')}`;
+  return `genie-backup-${date}.json`;
+}
+
+// ============================================================================
+// Export group handlers
+// ============================================================================
+
+async function exportGroup(
+  sql: Sql,
+  group: ExportGroup,
+  filter?: { column: string; value: string },
+): Promise<{ data: Record<string, unknown[]>; skipped: string[] }> {
+  const tables = GROUP_TABLES[group];
+  const { available, skipped } = await detectTables(sql, tables);
+  const data: Record<string, unknown[]> = {};
+
+  for (const table of available) {
+    if (filter) {
+      data[table] = [...(await sql.unsafe(`SELECT * FROM ${table} WHERE ${filter.column} = $1`, [filter.value]))];
+    } else {
+      data[table] = [...(await sql.unsafe(`SELECT * FROM ${table}`))];
+    }
+  }
+
+  return { data, skipped };
+}
+
+async function exportBoards(sql: Sql, name?: string): Promise<{ data: Record<string, unknown[]>; skipped: string[] }> {
+  const tables = GROUP_TABLES.boards;
+  const { available, skipped } = await detectTables(sql, tables);
+  const data: Record<string, unknown[]> = {};
+
+  for (const table of available) {
+    if (name && table === 'boards') {
+      data[table] = [...(await sql`SELECT * FROM boards WHERE name = ${name}`)];
+    } else if (table === 'task_types') {
+      data[table] = [...(await sql`SELECT * FROM task_types WHERE is_builtin = false`)];
+    } else {
+      data[table] = [...(await sql.unsafe(`SELECT * FROM ${table}`))];
+    }
+  }
+
+  return { data, skipped };
+}
+
+/** Task-related tables that can be filtered by project via JOIN */
+const TASK_JOIN_ALIASES: Record<string, string> = {
+  task_tags: 'tt',
+  task_actors: 'ta',
+  task_dependencies: 'td',
+  task_stage_log: 'tsl',
+};
+
+async function resolveProjectId(sql: Sql, projectName: string): Promise<string> {
+  const projects = await sql<{ id: string }[]>`SELECT id FROM projects WHERE name = ${projectName}`;
+  if (projects.length === 0) throw new Error(`Project not found: ${projectName}`);
+  return projects[0].id;
+}
+
+function stripEphemeralFields(rows: Record<string, unknown>[]): Record<string, unknown>[] {
+  return rows.map((r) => {
+    const { checkout_run_id, execution_locked_at, session_id, pane_id, ...rest } = r;
+    return rest;
+  });
+}
+
+async function exportTaskTable(sql: Sql, table: string, projectId: string | null): Promise<unknown[]> {
+  const alias = TASK_JOIN_ALIASES[table];
+  if (table === 'tasks') {
+    const rows = projectId
+      ? [...(await sql.unsafe('SELECT * FROM tasks WHERE project_id = $1', [projectId]))]
+      : [...(await sql`SELECT * FROM tasks`)];
+    return stripEphemeralFields(rows as Record<string, unknown>[]);
+  }
+  if (alias && projectId) {
+    return [
+      ...(await sql.unsafe(
+        `SELECT ${alias}.* FROM ${table} ${alias} JOIN tasks t ON ${alias}.task_id = t.id WHERE t.project_id = $1`,
+        [projectId],
+      )),
+    ];
+  }
+  return [...(await sql.unsafe(`SELECT * FROM ${table}`))];
+}
+
+async function exportTasks(
+  sql: Sql,
+  projectName?: string,
+): Promise<{ data: Record<string, unknown[]>; skipped: string[] }> {
+  const tables = GROUP_TABLES.tasks;
+  const { available, skipped } = await detectTables(sql, tables);
+  const data: Record<string, unknown[]> = {};
+  const projectId = projectName ? await resolveProjectId(sql, projectName) : null;
+
+  for (const table of available) {
+    data[table] = await exportTaskTable(sql, table, projectId);
+  }
+
+  return { data, skipped };
+}
+
+async function exportSchedules(
+  sql: Sql,
+  name?: string,
+): Promise<{ data: Record<string, unknown[]>; skipped: string[] }> {
+  const { available, skipped } = await detectTables(sql, ['schedules']);
+  const data: Record<string, unknown[]> = {};
+
+  if (available.includes('schedules')) {
+    if (name) {
+      data.schedules = [...(await sql`SELECT * FROM schedules WHERE name = ${name}`)];
+    } else {
+      data.schedules = [...(await sql`SELECT * FROM schedules`)];
+    }
+  }
+
+  return { data, skipped };
+}
+
+async function exportTags(sql: Sql): Promise<{ data: Record<string, unknown[]>; skipped: string[] }> {
+  const { available, skipped } = await detectTables(sql, ['tags']);
+  const data: Record<string, unknown[]> = {};
+
+  if (available.includes('tags')) {
+    data.tags = [...(await sql`SELECT * FROM tags WHERE name NOT LIKE 'test-%'`)];
+  }
+
+  return { data, skipped };
+}
+
+async function exportAll(sql: Sql): Promise<{ data: Record<string, unknown[]>; skipped: string[] }> {
+  const allSkipped: string[] = [];
+  const allData: Record<string, unknown[]> = {};
+
+  // Export each group
+  for (const group of ALL_GROUPS) {
+    let result: { data: Record<string, unknown[]>; skipped: string[] };
+
+    switch (group) {
+      case 'boards':
+        result = await exportBoards(sql);
+        break;
+      case 'tasks':
+        result = await exportTasks(sql);
+        break;
+      case 'tags':
+        result = await exportTags(sql);
+        break;
+      case 'schedules':
+        result = await exportSchedules(sql);
+        break;
+      default:
+        result = await exportGroup(sql, group);
+        break;
+    }
+
+    Object.assign(allData, result.data);
+    allSkipped.push(...result.skipped);
+  }
+
+  return { data: allData, skipped: allSkipped };
+}
+
+// ============================================================================
+// Shared action wrapper
+// ============================================================================
+
+async function runExport(
+  groups: string[],
+  type: 'full' | 'partial',
+  exportFn: (sql: Sql) => Promise<{ data: Record<string, unknown[]>; skipped: string[] }>,
+  options: ExportOptions,
+): Promise<void> {
+  const sql = await getSql();
+  const [version, actor] = await Promise.all([getVersion(), getActorName()]);
+  const doc = createExportDocument(type, groups, version, actor);
+
+  const { data, skipped } = await exportFn(sql);
+  doc.data = data;
+  doc.skippedTables = skipped;
+
+  outputDocument(doc, options);
+}
+
+// ============================================================================
+// Registration
+// ============================================================================
+
+export function registerExportCommands(program: Command): void {
+  const exp = program.command('export').description('Export genie data as JSON');
+
+  const sharedOpts = (cmd: ReturnType<Command['command']>) =>
+    cmd.option('--output <file>', 'Write to file instead of stdout').option('--pretty', 'Pretty-print JSON');
+
+  // genie export all
+  sharedOpts(exp.command('all').description('Full backup (all present tables)')).action(
+    async (options: ExportOptions) => {
+      try {
+        if (!options.output) options.output = autoOutputName();
+        await runExport([...ALL_GROUPS], 'full', (sql) => exportAll(sql), options);
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+  // genie export boards [name]
+  sharedOpts(exp.command('boards [name]').description('Export boards, templates, and task types')).action(
+    async (name: string | undefined, options: ExportOptions) => {
+      try {
+        await runExport(['boards'], 'partial', (sql) => exportBoards(sql, name), options);
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+  // genie export tasks
+  sharedOpts(
+    exp
+      .command('tasks')
+      .description('Export tasks with deps, actors, and stage log')
+      .option('--project <name>', 'Filter by project name'),
+  ).action(async (options: ExportOptions & { project?: string }) => {
+    try {
+      await runExport(['tasks'], 'partial', (sql) => exportTasks(sql, options.project), options);
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+  // genie export tags
+  sharedOpts(exp.command('tags').description('Export tags')).action(async (options: ExportOptions) => {
+    try {
+      await runExport(['tags'], 'partial', (sql) => exportTags(sql), options);
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+  // genie export projects
+  sharedOpts(exp.command('projects').description('Export projects')).action(async (options: ExportOptions) => {
+    try {
+      await runExport(['projects'], 'partial', (sql) => exportGroup(sql, 'projects'), options);
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+  // genie export schedules [name]
+  sharedOpts(exp.command('schedules [name]').description('Export schedules with run_spec')).action(
+    async (name: string | undefined, options: ExportOptions) => {
+      try {
+        await runExport(['schedules'], 'partial', (sql) => exportSchedules(sql, name), options);
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+  // genie export agents
+  sharedOpts(exp.command('agents').description('Export agents, templates, and checkpoints')).action(
+    async (options: ExportOptions) => {
+      try {
+        await runExport(['agents'], 'partial', (sql) => exportGroup(sql, 'agents'), options);
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+  // genie export apps
+  sharedOpts(exp.command('apps').description('Export app store (graceful skip if missing)')).action(
+    async (options: ExportOptions) => {
+      try {
+        await runExport(['apps'], 'partial', (sql) => exportGroup(sql, 'apps'), options);
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+  // genie export comms
+  sharedOpts(exp.command('comms').description('Export conversations, messages, mailbox')).action(
+    async (options: ExportOptions) => {
+      try {
+        await runExport(['comms'], 'partial', (sql) => exportGroup(sql, 'comms'), options);
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+
+  // genie export config
+  sharedOpts(exp.command('config').description('Export OS config (graceful skip if missing)')).action(
+    async (options: ExportOptions) => {
+      try {
+        await runExport(['config'], 'partial', (sql) => exportGroup(sql, 'config'), options);
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    },
+  );
+}

--- a/src/term-commands/import.ts
+++ b/src/term-commands/import.ts
@@ -1,0 +1,315 @@
+/**
+ * Import command — restore genie data from a schema-versioned JSON export.
+ *
+ * Commands:
+ *   genie import <file> [--fail|--merge|--overwrite] [--groups <list>]
+ *
+ * Features:
+ *   - Schema version validation
+ *   - Conflict detection with 3 resolution modes
+ *   - FK-ordered transactional insert (4 dependency levels)
+ *   - Self-referential table handling (tasks.parent_id, messages.reply_to_id)
+ *   - Audit logging on success
+ *   - Selective import via --groups filter
+ */
+
+import { readFileSync } from 'node:fs';
+import type { Command } from 'commander';
+import type postgres from 'postgres';
+import type { ConflictMode } from '../lib/export-format.js';
+import { validateExportDocument } from '../lib/export-format.js';
+import { SELF_REFERENTIAL_COLUMNS, getPrimaryKey, sortByImportOrder } from '../lib/import-order.js';
+
+type Sql = postgres.Sql;
+
+// ============================================================================
+// Lazy loaders
+// ============================================================================
+
+async function getSql(): Promise<Sql> {
+  const { getConnection } = await import('../lib/db.js');
+  return getConnection();
+}
+
+async function getActorName(): Promise<string> {
+  const { getActor } = await import('../lib/audit.js');
+  return getActor();
+}
+
+async function detectTables(sql: Sql, tables: string[]): Promise<{ available: string[]; skipped: string[] }> {
+  const { filterAvailableTables } = await import('../lib/table-detect.js');
+  return filterAvailableTables(sql, tables);
+}
+
+// ============================================================================
+// Conflict detection
+// ============================================================================
+
+async function detectConflicts(
+  sql: Sql,
+  table: string,
+  rows: Record<string, unknown>[],
+): Promise<Record<string, unknown>[]> {
+  if (rows.length === 0) return [];
+  const pk = getPrimaryKey(table);
+
+  if (pk.length === 1) {
+    const key = pk[0];
+    const ids = rows.map((r) => r[key]);
+    const existing = await sql.unsafe(`SELECT ${key} FROM ${table} WHERE ${key} = ANY($1)`, [ids] as never[]);
+    const existingSet = new Set((existing as Record<string, unknown>[]).map((r) => String(r[key])));
+    return rows.filter((r) => existingSet.has(String(r[key])));
+  }
+
+  // Composite key — check each row individually
+  const conflicts: Record<string, unknown>[] = [];
+  for (const row of rows) {
+    const conditions = pk.map((col, i) => `${col} = $${i + 1}`).join(' AND ');
+    const values = pk.map((col) => row[col]) as never[];
+    const existing = await sql.unsafe(`SELECT 1 FROM ${table} WHERE ${conditions} LIMIT 1`, values);
+    if ((existing as unknown[]).length > 0) conflicts.push(row);
+  }
+  return conflicts;
+}
+
+// ============================================================================
+// Insert helpers
+// ============================================================================
+
+interface PreparedRow {
+  columns: string[];
+  values: unknown[];
+  quotedCols: string;
+  placeholders: string;
+}
+
+function prepareRow(
+  row: Record<string, unknown>,
+  table: string,
+  selfRefUpdates: { pk: unknown; value: unknown }[],
+): PreparedRow {
+  const selfRefCol = SELF_REFERENTIAL_COLUMNS[table];
+  const entries = Object.entries(row);
+  const columns = entries.map(([k]) => k);
+  const values = entries.map(([, v]) => v);
+
+  // Null out self-referential column for first pass
+  if (selfRefCol && row[selfRefCol] != null) {
+    const idx = columns.indexOf(selfRefCol);
+    if (idx !== -1) {
+      const originalSelfRef = values[idx];
+      values[idx] = null;
+      const pk = getPrimaryKey(table);
+      selfRefUpdates.push({
+        pk: pk.length === 1 ? row[pk[0]] : pk.map((k) => row[k]),
+        value: originalSelfRef,
+      });
+    }
+  }
+
+  return {
+    columns,
+    values,
+    quotedCols: columns.map((c) => `"${c}"`).join(', '),
+    placeholders: values.map((_, i) => `$${i + 1}`).join(', '),
+  };
+}
+
+async function insertOneRow(
+  tx: Sql,
+  table: string,
+  row: Record<string, unknown>,
+  prepared: PreparedRow,
+  mode: ConflictMode,
+): Promise<void> {
+  const { quotedCols, placeholders, values } = prepared;
+  const pk = getPrimaryKey(table);
+
+  if (mode === 'overwrite') {
+    const pkCondition = pk.map((col, i) => `"${col}" = $${values.length + i + 1}`).join(' AND ');
+    const pkValues = pk.map((col) => row[col]) as never[];
+    await tx.unsafe(`DELETE FROM ${table} WHERE ${pkCondition}`, pkValues);
+    await tx.unsafe(`INSERT INTO ${table} (${quotedCols}) VALUES (${placeholders})`, values as never[]);
+  } else if (mode === 'merge') {
+    const onConflict = pk.map((c) => `"${c}"`).join(', ');
+    await tx.unsafe(
+      `INSERT INTO ${table} (${quotedCols}) VALUES (${placeholders}) ON CONFLICT (${onConflict}) DO NOTHING`,
+      values as never[],
+    );
+  } else {
+    await tx.unsafe(`INSERT INTO ${table} (${quotedCols}) VALUES (${placeholders})`, values as never[]);
+  }
+}
+
+async function updateSelfRefs(tx: Sql, table: string, updates: { pk: unknown; value: unknown }[]): Promise<void> {
+  const selfRefCol = SELF_REFERENTIAL_COLUMNS[table];
+  const pk = getPrimaryKey(table);
+  if (pk.length !== 1) return;
+  for (const { pk: pkVal, value } of updates) {
+    await tx.unsafe(`UPDATE ${table} SET "${selfRefCol}" = $1 WHERE "${pk[0]}" = $2`, [value, pkVal] as never[]);
+  }
+}
+
+async function insertRows(
+  tx: Sql,
+  table: string,
+  rows: Record<string, unknown>[],
+  mode: ConflictMode,
+): Promise<number> {
+  if (rows.length === 0) return 0;
+
+  const selfRefUpdates: { pk: unknown; value: unknown }[] = [];
+
+  for (const row of rows) {
+    const prepared = prepareRow(row, table, selfRefUpdates);
+    await insertOneRow(tx, table, row, prepared, mode);
+  }
+
+  if (selfRefUpdates.length > 0) {
+    await updateSelfRefs(tx, table, selfRefUpdates);
+  }
+
+  return rows.length;
+}
+
+// ============================================================================
+// Main import logic
+// ============================================================================
+
+function parseExportFile(filePath: string) {
+  const raw = readFileSync(filePath, 'utf-8');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`Invalid JSON in ${filePath}`);
+  }
+  const validation = validateExportDocument(parsed);
+  if (!validation.valid) {
+    throw new Error(`Invalid export document: ${validation.error}`);
+  }
+  return validation.doc;
+}
+
+async function filterTablesByGroup(allTables: string[], groupFilter?: string[]): Promise<string[]> {
+  if (!groupFilter || groupFilter.length === 0) return allTables;
+  const { GROUP_TABLES } = await import('../lib/export-format.js');
+  const allowedTables = new Set<string>();
+  for (const group of groupFilter) {
+    const tables = GROUP_TABLES[group as keyof typeof GROUP_TABLES];
+    if (tables) {
+      for (const t of tables) allowedTables.add(t);
+    } else {
+      console.warn(`Warning: Unknown group "${group}", skipping`);
+    }
+  }
+  return allTables.filter((t) => allowedTables.has(t));
+}
+
+async function checkConflicts(sql: Sql, tables: string[], data: Record<string, unknown[]>): Promise<void> {
+  for (const table of tables) {
+    const rows = data[table] as Record<string, unknown>[];
+    if (!rows || rows.length === 0) continue;
+    const conflicts = await detectConflicts(sql, table, rows);
+    if (conflicts.length > 0) {
+      const pk = getPrimaryKey(table);
+      const ids = conflicts
+        .slice(0, 5)
+        .map((r) => pk.map((k) => r[k]).join(','))
+        .join('; ');
+      throw new Error(
+        `Conflict in table "${table}": ${conflicts.length} existing row(s) (e.g., ${ids}). Use --merge or --overwrite to resolve.`,
+      );
+    }
+  }
+}
+
+async function runImport(filePath: string, mode: ConflictMode, groupFilter?: string[]): Promise<void> {
+  const doc = parseExportFile(filePath);
+
+  let tablesToImport = await filterTablesByGroup(Object.keys(doc.data), groupFilter);
+  if (tablesToImport.length === 0) {
+    console.log('No tables to import.');
+    return;
+  }
+
+  tablesToImport = sortByImportOrder(tablesToImport);
+
+  const sql = await getSql();
+  const { available } = await detectTables(sql, tablesToImport);
+  const skippedTables = tablesToImport.filter((t) => !available.includes(t));
+  tablesToImport = available;
+
+  if (skippedTables.length > 0) {
+    console.log(`Skipping tables not in database: ${skippedTables.join(', ')}`);
+  }
+
+  if (mode === 'fail') {
+    await checkConflicts(sql, tablesToImport, doc.data);
+  }
+
+  let totalInserted = 0;
+  const tableStats: Record<string, number> = {};
+
+  // biome-ignore lint/suspicious/noExplicitAny: postgres.js transaction type
+  await sql.begin(async (tx: any) => {
+    for (const table of tablesToImport) {
+      const rows = doc.data[table] as Record<string, unknown>[];
+      if (!rows || rows.length === 0) continue;
+      const count = await insertRows(tx as unknown as Sql, table, rows, mode);
+      tableStats[table] = count;
+      totalInserted += count;
+    }
+  });
+
+  const actor = await getActorName();
+  const { recordAuditEvent } = await import('../lib/audit.js');
+  await recordAuditEvent('import', filePath, 'import_complete', actor, {
+    mode,
+    tables: tableStats,
+    totalRows: totalInserted,
+    skippedTables,
+    sourceVersion: doc.version,
+    sourceDate: doc.exportedAt,
+  });
+
+  // Report
+  console.log(`Import complete: ${totalInserted} rows across ${Object.keys(tableStats).length} tables`);
+  for (const [table, count] of Object.entries(tableStats)) {
+    if (count > 0) console.log(`  ${table}: ${count} rows`);
+  }
+  if (skippedTables.length > 0) {
+    console.log(`Skipped (not in DB): ${skippedTables.join(', ')}`);
+  }
+}
+
+// ============================================================================
+// Registration
+// ============================================================================
+
+export function registerImportCommands(program: Command): void {
+  program
+    .command('import <file>')
+    .description('Import genie data from JSON export')
+    .option('--fail', 'Abort on any conflict (default)')
+    .option('--merge', 'Skip existing rows, import new ones')
+    .option('--overwrite', 'Replace existing rows with imported data')
+    .option('--groups <list>', 'Comma-separated groups to import (e.g., boards,tags)')
+    .action(
+      async (file: string, options: { fail?: boolean; merge?: boolean; overwrite?: boolean; groups?: string }) => {
+        try {
+          // Determine conflict mode
+          let mode: ConflictMode = 'fail';
+          if (options.overwrite) mode = 'overwrite';
+          else if (options.merge) mode = 'merge';
+
+          const groupFilter = options.groups?.split(',').map((g) => g.trim());
+
+          await runImport(file, mode, groupFilter);
+        } catch (error) {
+          console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+          process.exit(1);
+        }
+      },
+    );
+}


### PR DESCRIPTION
## Summary

- Add `genie export` command with 9 export groups + `export all`
- Add `genie import` command with `--fail`/`--merge`/`--overwrite` modes
- Schema-versioned JSON format (v1.0) for forward compatibility
- FK-ordered transactional imports across 4 dependency levels
- Self-referential table handling (two-pass insert)
- Graceful skip for missing tables (KhalOS-specific)
- Audit logging of all import operations

## New Files

- `src/lib/export-format.ts` — ExportDocument types + validation
- `src/lib/table-detect.ts` — table existence detection
- `src/lib/import-order.ts` — FK dependency graph
- `src/term-commands/export.ts` — export command group
- `src/term-commands/import.ts` — import command

## Test plan

- [ ] `genie export all --pretty --output backup.json` valid JSON
- [ ] `genie export boards/tags/projects/schedules` work
- [ ] `genie export tasks --project <name>` filters correctly
- [ ] `genie export apps/config` gracefully skip missing tables
- [ ] `genie import backup.json --fail` aborts on conflicts
- [ ] `genie import backup.json --merge` skips existing rows
- [ ] `genie import backup.json --overwrite` replaces existing
- [ ] `genie import backup.json --groups boards,tags` works
- [ ] Round-trip: export -> import -> re-export matches