### PR TITLE
fix(cli): resolve 5 daily-driver DX bugs from #800

### DIFF
--- a/src/lib/agent-directory.ts
+++ b/src/lib/agent-directory.ts
@@ -175,15 +175,26 @@ export async function ls(): Promise<ScopedDirectoryEntry[]> {
   const result: ScopedDirectoryEntry[] = [];
   const seen = new Set<string>();
 
-  // PG agents — distinct roles from running/registered agents
+  // PG agents — distinct roles with directory metadata
   try {
     const { getConnection } = await import('./db.js');
     const sql = await getConnection();
-    const rows = await sql`SELECT DISTINCT role, team FROM agents WHERE role IS NOT NULL ORDER BY role`;
+    const rows = await sql`
+      SELECT DISTINCT ON (role) role, team, repo_path, provider, worktree
+      FROM agents
+      WHERE role IS NOT NULL
+      ORDER BY role, started_at DESC
+    `;
     for (const row of rows) {
       const name = row.role as string;
       if (!seen.has(name)) {
-        result.push({ ...roleToEntry(name, row.team as string), scope: 'global' });
+        const entry = roleToEntry(name, row.team as string);
+        const repoPath = row.repo_path as string;
+        if (repoPath) {
+          entry.dir = repoPath;
+          entry.repo = repoPath;
+        }
+        result.push({ ...entry, scope: 'global' });
         seen.add(name);
       }
     }

--- a/src/lib/board-service.ts
+++ b/src/lib/board-service.ts
@@ -195,19 +195,25 @@ export async function getBoard(nameOrId: string, projectId?: string): Promise<Bo
   const byId = await sql`SELECT * FROM boards WHERE id = ${nameOrId} LIMIT 1`;
   if (byId.length > 0) return mapBoard(byId[0]);
 
-  // Try by name within project scope
+  // Try by name within project scope (ILIKE for case-insensitive match)
   if (projectId) {
     const byName = await sql`
-      SELECT * FROM boards WHERE name = ${nameOrId} AND project_id = ${projectId} LIMIT 1
+      SELECT * FROM boards WHERE name ILIKE ${nameOrId} AND project_id = ${projectId} LIMIT 1
     `;
     if (byName.length > 0) return mapBoard(byName[0]);
   }
 
   // Try by name with null project (global boards)
   const byName = await sql`
-    SELECT * FROM boards WHERE name = ${nameOrId} AND project_id IS NULL LIMIT 1
+    SELECT * FROM boards WHERE name ILIKE ${nameOrId} AND project_id IS NULL LIMIT 1
   `;
   if (byName.length > 0) return mapBoard(byName[0]);
+
+  // Try by name across all projects (ILIKE fallback)
+  const anyName = await sql`
+    SELECT * FROM boards WHERE name ILIKE ${nameOrId} LIMIT 1
+  `;
+  if (anyName.length > 0) return mapBoard(anyName[0]);
 
   return null;
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -21,7 +21,6 @@ const MAX_PORT_RETRIES = 3;
 const GENIE_HOME = process.env.GENIE_HOME ?? join(homedir(), '.genie');
 const DATA_DIR = join(GENIE_HOME, 'data', 'pgserve');
 const LOCKFILE_PATH = join(GENIE_HOME, 'pgserve.port');
-const MIGRATION_MARKER = join(GENIE_HOME, 'pgserve.migrated');
 const DB_NAME = 'genie';
 
 /** Sanitize connection URLs for logging — never expose credentials */
@@ -292,29 +291,8 @@ function registerExitHandler(): void {
   });
 }
 
-/**
- * Check if migrations have already been applied (marker file).
- * The marker stores the version so we re-run on upgrades.
- */
-function migrationsDone(): boolean {
-  try {
-    const marker = readFileSync(MIGRATION_MARKER, 'utf-8').trim();
-    // Re-run migrations if the genie version changed
-    const currentVersion = process.env.npm_package_version ?? '';
-    return marker === currentVersion || (currentVersion === '' && marker.length > 0);
-  } catch {
-    return false;
-  }
-}
-
-function markMigrationsDone(): void {
-  try {
-    const version = process.env.npm_package_version ?? Date.now().toString();
-    writeFileSync(MIGRATION_MARKER, version, 'utf-8');
-  } catch {
-    // Best effort
-  }
-}
+// Migration marker file is legacy — kept for backward compat but no longer used for skip logic.
+// The migration runner (db-migrations.ts) checks _genie_migrations table directly.
 
 /**
  * Get a postgres.js connection. Lazy singleton — calls ensurePgserve() on first use.
@@ -342,11 +320,8 @@ export async function getConnection() {
     ...(testSchema ? { connection: { search_path: `${testSchema}, public` } } : {}),
   });
 
-  // Only run migrations if not yet applied for this version
-  if (!migrationsDone()) {
-    await runMigrations(sqlClient);
-    markMigrationsDone();
-  }
+  // Always call runMigrations — it's idempotent (checks _genie_migrations table)
+  await runMigrations(sqlClient);
 
   // Run idempotent JSON → PG seed if source files exist
   if (!testSchema && needsSeed()) {

--- a/src/lib/task-service.ts
+++ b/src/lib/task-service.ts
@@ -403,10 +403,25 @@ export function getRepoPath(): string {
 // ID Resolution
 // ============================================================================
 
-/** Resolve `#47` (seq) or `task-abc123` (PK) to internal ID. */
+/** Resolve `#47` (seq), `project#seq`, or `task-abc123` (PK) to internal ID. */
 export async function resolveTaskId(idOrSeq: string, repoPath?: string): Promise<string | null> {
   const sql = await getConnection();
   const repo = repoPath ?? getRepoPath();
+
+  // project#seq format — e.g. "genie#1", "wk-resilience#17"
+  const projectSeqMatch = idOrSeq.match(/^([^#]+)#(\d+)$/);
+  if (projectSeqMatch && !idOrSeq.startsWith('#')) {
+    const [, projectName, seqStr] = projectSeqMatch;
+    const seq = Number.parseInt(seqStr, 10);
+    if (Number.isNaN(seq)) return null;
+    const rows = await sql`
+      SELECT t.id FROM tasks t
+      JOIN projects p ON t.project_id = p.id
+      WHERE p.name = ${projectName} AND t.seq = ${seq}
+      LIMIT 1
+    `;
+    return rows.length > 0 ? (rows[0].id as string) : null;
+  }
 
   if (idOrSeq.startsWith('#')) {
     const seq = Number.parseInt(idOrSeq.slice(1), 10);

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -868,7 +868,7 @@ async function resolveAgentForSpawn(
 
   return {
     entry,
-    repoPath: options.cwd ?? (entry.dir || undefined) ?? process.cwd(),
+    repoPath: options.cwd ?? (entry.repo || undefined) ?? (entry.dir || undefined) ?? process.cwd(),
     identityPath,
     model: options.model ?? entry.model,
   };

--- a/src/term-commands/board.ts
+++ b/src/term-commands/board.ts
@@ -583,13 +583,13 @@ export function registerBoardCommands(program: Command): void {
 
   // ── board show ──
   board
-    .command('show <name>')
+    .command('show <name...>')
     .description('Show board detail')
     .option('--project <project>', 'Disambiguate by project')
     .option('--json', 'Output as JSON')
-    .action(async (name: string, options: { project?: string; json?: boolean }) => {
+    .action(async (nameParts: string[], options: { project?: string; json?: boolean }) => {
       try {
-        await handleBoardShow(name, options);
+        await handleBoardShow(nameParts.join(' '), options);
       } catch (error) {
         console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
@@ -598,7 +598,7 @@ export function registerBoardCommands(program: Command): void {
 
   // ── board edit ──
   board
-    .command('edit <name>')
+    .command('edit <name...>')
     .description('Edit board or column properties')
     .option('--project <project>', 'Disambiguate by project')
     .option('--column <col>', 'Column name to edit')
@@ -610,7 +610,7 @@ export function registerBoardCommands(program: Command): void {
     .option('--description <text>', 'Update description')
     .action(
       async (
-        editName: string,
+        nameParts: string[],
         options: {
           project?: string;
           column?: string;
@@ -623,7 +623,7 @@ export function registerBoardCommands(program: Command): void {
         },
       ) => {
         try {
-          await handleBoardEdit(editName, options);
+          await handleBoardEdit(nameParts.join(' '), options);
         } catch (error) {
           console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
           process.exit(1);
@@ -633,13 +633,13 @@ export function registerBoardCommands(program: Command): void {
 
   // ── board delete ──
   board
-    .command('delete <name>')
+    .command('delete <name...>')
     .description('Delete a board')
     .option('--project <project>', 'Disambiguate by project')
     .option('--force', 'Skip confirmation')
-    .action(async (name: string, options: { project?: string; force?: boolean }) => {
+    .action(async (nameParts: string[], options: { project?: string; force?: boolean }) => {
       try {
-        await handleBoardDelete(name, options);
+        await handleBoardDelete(nameParts.join(' '), options);
       } catch (error) {
         console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
@@ -648,13 +648,13 @@ export function registerBoardCommands(program: Command): void {
 
   // ── board columns ──
   board
-    .command('columns <name>')
+    .command('columns <name...>')
     .description('Show board column pipeline')
     .option('--project <project>', 'Disambiguate by project')
     .option('--json', 'Output as JSON')
-    .action(async (name: string, options: { project?: string; json?: boolean }) => {
+    .action(async (nameParts: string[], options: { project?: string; json?: boolean }) => {
       try {
-        await handleBoardColumns(name, options);
+        await handleBoardColumns(nameParts.join(' '), options);
       } catch (error) {
         console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
@@ -663,12 +663,12 @@ export function registerBoardCommands(program: Command): void {
 
   // ── board use ──
   board
-    .command('use <name>')
+    .command('use <name...>')
     .description('Set active board for current repo')
     .option('--project <project>', 'Disambiguate by project')
-    .action(async (name: string, options: { project?: string }) => {
+    .action(async (nameParts: string[], options: { project?: string }) => {
       try {
-        await handleBoardUse(name, options);
+        await handleBoardUse(nameParts.join(' '), options);
       } catch (error) {
         console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);
@@ -677,13 +677,13 @@ export function registerBoardCommands(program: Command): void {
 
   // ── board export ──
   board
-    .command('export <name>')
+    .command('export <name...>')
     .description('Export board as JSON')
     .option('--project <project>', 'Disambiguate by project')
     .option('--output <file>', 'Write to file instead of stdout')
-    .action(async (name: string, options: { project?: string; output?: string }) => {
+    .action(async (nameParts: string[], options: { project?: string; output?: string }) => {
       try {
-        await handleBoardExport(name, options);
+        await handleBoardExport(nameParts.join(' '), options);
       } catch (error) {
         console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);

--- a/src/term-commands/dir.ts
+++ b/src/term-commands/dir.ts
@@ -254,26 +254,26 @@ function listEntriesJson(entries: directory.ScopedDirectoryEntry[], includeBuilt
 function printRegisteredTable(entries: directory.ScopedDirectoryEntry[]): void {
   const nameW = 22;
   const scopeW = 10;
-  const dirW = 30;
-  const modeW = 8;
+  const repoW = 30;
   const modelW = 8;
+  const rolesW = 20;
 
   console.log('');
   console.log('REGISTERED AGENTS');
-  console.log('-'.repeat(85));
+  console.log('-'.repeat(90));
   console.log(
-    `  ${'NAME'.padEnd(nameW)}${'SCOPE'.padEnd(scopeW)}${'DIR'.padEnd(dirW)}${'MODE'.padEnd(modeW)}${'MODEL'.padEnd(modelW)}ROLES`,
+    `  ${'NAME'.padEnd(nameW)}${'SCOPE'.padEnd(scopeW)}${'REPO'.padEnd(repoW)}${'MODEL'.padEnd(modelW)}ROLES`,
   );
   console.log(
-    `  ${'-'.repeat(nameW - 2)}  ${'-'.repeat(scopeW - 2)}  ${'-'.repeat(dirW - 2)}  ${'-'.repeat(modeW - 2)}  ${'-'.repeat(modelW - 2)}  ${'-'.repeat(15)}`,
+    `  ${'-'.repeat(nameW - 2)}  ${'-'.repeat(scopeW - 2)}  ${'-'.repeat(repoW - 2)}  ${'-'.repeat(modelW - 2)}  ${'-'.repeat(rolesW)}`,
   );
 
   for (const entry of entries) {
-    const dir = contractPath(entry.dir);
-    const truncDir = dir.length > dirW - 2 ? `${dir.slice(0, dirW - 5)}...` : dir;
+    const repo = entry.repo ? contractPath(entry.repo) : contractPath(entry.dir);
+    const truncRepo = repo.length > repoW - 2 ? `${repo.slice(0, repoW - 5)}...` : repo;
     const roles = entry.roles?.join(', ') || '-';
     console.log(
-      `  ${entry.name.padEnd(nameW)}${entry.scope.padEnd(scopeW)}${truncDir.padEnd(dirW)}${entry.promptMode.padEnd(modeW)}${(entry.model || '-').padEnd(modelW)}${roles}`,
+      `  ${entry.name.padEnd(nameW)}${entry.scope.padEnd(scopeW)}${truncRepo.padEnd(repoW)}${(entry.model || '-').padEnd(modelW)}${roles}`,
     );
   }
   console.log('');


### PR DESCRIPTION
## Summary

Fixes the 5 highest-friction DX bugs blocking daily genie operations (#800):

- **Task ID aliasing (#795):** `resolveTaskId()` now accepts `project#seq` format (e.g. `genie#1`, `wk-resilience#17`) via JOIN on projects table
- **Board name spaces (#799):** Board CLI commands accept multi-word names via variadic args, `getBoard()` uses ILIKE for case-insensitive matching
- **Dir registry CWD:** `genie spawn` now prefers `entry.repo` over `entry.dir` in CWD fallback chain
- **Dir ls display:** `genie dir ls` populates repo column from PG `agents.repo_path`
- **Migration marker:** Removed stale file-based version marker, always calls idempotent `runMigrations()` which checks `_genie_migrations` table

## Files changed

| File | Change |
|------|--------|
| `src/lib/task-service.ts` | `resolveTaskId()` parses `project#seq` format |
| `src/lib/board-service.ts` | `getBoard()` uses ILIKE with cross-project fallback |
| `src/term-commands/board.ts` | Board commands use `<name...>` variadic args |
| `src/term-commands/agents.ts` | Spawn CWD: `entry.repo` before `entry.dir` |
| `src/lib/agent-directory.ts` | `ls()` reads `repo_path` from PG |
| `src/term-commands/dir.ts` | Table shows REPO column from PG data |
| `src/lib/db.ts` | Remove file marker, always run idempotent migrations |

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (pre-existing msg.ts warning only)
- [x] `bun test` — 1288 pass, 0 fail
- [x] `bun run build` — succeeds
- [ ] `genie task done genie#1` resolves project#seq to UUID
- [ ] `genie board show "Dev Pipeline"` works with spaces
- [ ] `genie dir ls` shows populated repo column
- [ ] `genie db migrate` idempotent on already-migrated DB

Closes #795, #799