### PR TITLE
feat(registry): unified item registry with git-backed install

### DIFF
--- a/src/db/migrations/009_app_store.sql
+++ b/src/db/migrations/009_app_store.sql
@@ -1,0 +1,65 @@
+-- 009_app_store.sql — Item registry: app_store, installed_apps, app_versions
+-- Unified item registry for agents, skills, apps, boards, workflows, stacks, templates, hooks.
+
+-- ============================================================================
+-- Table: app_store — Central item registry (source of truth)
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS app_store (
+  id TEXT PRIMARY KEY DEFAULT 'item-' || substr(gen_random_uuid()::text, 1, 8),
+  name TEXT UNIQUE NOT NULL,
+  item_type TEXT NOT NULL
+    CHECK (item_type IN ('agent', 'skill', 'app', 'board', 'workflow', 'stack', 'template', 'hook')),
+  version TEXT NOT NULL DEFAULT '0.0.0',
+  description TEXT,
+  author_name TEXT,
+  author_url TEXT,
+  git_url TEXT,
+  install_path TEXT,
+  manifest JSONB NOT NULL DEFAULT '{}',
+  approval_status TEXT NOT NULL DEFAULT 'local'
+    CHECK (approval_status IN ('local', 'pending', 'approved', 'rejected')),
+  tags TEXT[] DEFAULT '{}',
+  category TEXT,
+  license TEXT,
+  dependencies TEXT[] DEFAULT '{}',
+  installed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_app_store_type ON app_store(item_type);
+CREATE INDEX IF NOT EXISTS idx_app_store_status ON app_store(approval_status);
+CREATE INDEX IF NOT EXISTS idx_app_store_name ON app_store(name);
+
+-- ============================================================================
+-- Table: installed_apps — Runtime install state (tracks what's active)
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS installed_apps (
+  id TEXT PRIMARY KEY DEFAULT 'inst-' || substr(gen_random_uuid()::text, 1, 8),
+  app_store_id TEXT NOT NULL REFERENCES app_store(id) ON DELETE CASCADE,
+  install_path TEXT NOT NULL,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  config JSONB DEFAULT '{}',
+  installed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(app_store_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_installed_apps_store ON installed_apps(app_store_id);
+CREATE INDEX IF NOT EXISTS idx_installed_apps_active ON installed_apps(is_active) WHERE is_active = true;
+
+-- ============================================================================
+-- Table: app_versions — Version history for published items
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS app_versions (
+  id TEXT PRIMARY KEY DEFAULT 'ver-' || substr(gen_random_uuid()::text, 1, 8),
+  app_store_id TEXT NOT NULL REFERENCES app_store(id) ON DELETE CASCADE,
+  version TEXT NOT NULL,
+  git_tag TEXT,
+  git_sha TEXT,
+  manifest JSONB NOT NULL DEFAULT '{}',
+  changelog TEXT,
+  published_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(app_store_id, version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_app_versions_store ON app_versions(app_store_id);

--- a/src/genie.ts
+++ b/src/genie.ts
@@ -47,12 +47,16 @@ import { registerDispatchCommands } from './term-commands/dispatch.js';
 import { registerExportCommands } from './term-commands/export.js';
 import * as historyCmd from './term-commands/history.js';
 import { registerImportCommands } from './term-commands/import.js';
+import { registerInstallCommand } from './term-commands/install.js';
+import { registerItemUninstallCommand } from './term-commands/item-uninstall.js';
+import { registerItemUpdateCommand } from './term-commands/item-update.js';
 import { type LogOptions, logCommand } from './term-commands/log.js';
 import { registerMetricsCommands } from './term-commands/metrics.js';
 import { registerSendInboxCommands } from './term-commands/msg.js';
 import { registerNotifyCommands } from './term-commands/notify.js';
 import * as orchestrateCmd from './term-commands/orchestrate.js';
 import { registerProjectCommands } from './term-commands/project.js';
+import { registerPublishCommand } from './term-commands/publish.js';
 import { type QaOptions, qaCommand, qaHistoryCommand, qaStatusCommand } from './term-commands/qa.js';
 import * as readCmd from './term-commands/read.js';
 import { registerReleaseCommands } from './term-commands/release.js';
@@ -168,6 +172,13 @@ registerSessionsCommands(program);
 registerMetricsCommands(program);
 registerExportCommands(program);
 registerImportCommands(program);
+
+// Item registry commands — install, publish (top-level), item uninstall/update (namespaced)
+registerInstallCommand(program);
+registerPublishCommand(program);
+const itemCmd = program.command('item').description('Item registry management');
+registerItemUninstallCommand(itemCmd);
+registerItemUpdateCommand(itemCmd);
 
 // ============================================================================
 // CLI audit hooks — record every command execution to audit_events

--- a/src/lib/agent-cache.ts
+++ b/src/lib/agent-cache.ts
@@ -1,0 +1,282 @@
+/**
+ * Agent Cache — Maintains agent-directory.json as a cache of app_store agents.
+ *
+ * Also provides generic CRUD helpers for the `app_store` table (register,
+ * remove, update, get, list). The cache file is a denormalised snapshot
+ * written to GENIE_HOME so that non-PG consumers (hooks, shell scripts)
+ * can read agent metadata without a database connection.
+ *
+ * Best-effort: DB failures never block the CLI.
+ */
+
+import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { getActor, recordAuditEvent } from './audit.js';
+import { getConnection, isAvailable } from './db.js';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const GENIE_HOME = process.env.GENIE_HOME ?? join(homedir(), '.genie');
+const CACHE_FILE = 'agent-directory.json';
+const CACHE_BACKUP = 'agent-directory.json.bak';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Denormalised cache entry written to agent-directory.json. */
+export interface CacheEntry {
+  name: string;
+  dir: string;
+  repo?: string;
+  promptMode: string;
+  model?: string;
+  roles?: string[];
+  registeredAt: string;
+}
+
+/** Row shape returned by SELECT * FROM app_store. */
+export interface StoreRow {
+  id: string;
+  name: string;
+  item_type: string;
+  version: string;
+  description: string | null;
+  author_name: string | null;
+  author_url: string | null;
+  git_url: string | null;
+  install_path: string | null;
+  manifest: Record<string, unknown>;
+  approval_status: string;
+  tags: string[];
+  category: string | null;
+  license: string | null;
+  dependencies: string[];
+  installed_at: string;
+  updated_at: string;
+}
+
+/** Insert payload for registerItemInStore. */
+export interface StoreInsert {
+  name: string;
+  itemType: string;
+  version?: string;
+  description?: string;
+  authorName?: string;
+  authorUrl?: string;
+  gitUrl?: string;
+  installPath?: string;
+  manifest?: Record<string, unknown>;
+  tags?: string[];
+  category?: string;
+  license?: string;
+  dependencies?: string[];
+}
+
+// ============================================================================
+// Cache regeneration
+// ============================================================================
+
+/**
+ * Rebuild agent-directory.json from all `item_type = 'agent'` rows in app_store.
+ *
+ * Silently returns if the database is unavailable — the stale cache (if any)
+ * remains on disk until the next successful regeneration.
+ */
+export async function regenerateAgentCache(): Promise<void> {
+  try {
+    if (!(await isAvailable())) return;
+
+    const sql = await getConnection();
+    const rows = await sql`
+      SELECT name, install_path, manifest, installed_at
+      FROM app_store
+      WHERE item_type = 'agent'
+      ORDER BY name
+    `;
+
+    const entries: CacheEntry[] = rows.map((r: Record<string, unknown>) => {
+      const manifest = (r.manifest ?? {}) as Record<string, unknown>;
+      const entry: CacheEntry = {
+        name: r.name as string,
+        dir: (r.install_path as string) ?? '',
+        promptMode: (manifest.promptMode as string) ?? 'append',
+        registeredAt: r.installed_at ? new Date(r.installed_at as string).toISOString() : new Date().toISOString(),
+      };
+      if (manifest.repo) entry.repo = manifest.repo as string;
+      if (manifest.model) entry.model = manifest.model as string;
+      if (Array.isArray(manifest.roles) && manifest.roles.length > 0) {
+        entry.roles = manifest.roles as string[];
+      }
+      return entry;
+    });
+
+    writeFileSync(join(GENIE_HOME, CACHE_FILE), JSON.stringify(entries, null, 2));
+  } catch {
+    // Best effort — never block the CLI on cache regeneration failure
+  }
+}
+
+// ============================================================================
+// One-time migration from JSON → PG
+// ============================================================================
+
+/**
+ * Migrate the legacy agent-directory.json into the app_store table.
+ *
+ * Idempotent: skips if the backup file already exists (meaning migration
+ * already ran) or if the source file is missing (nothing to migrate).
+ * Uses ON CONFLICT (name) DO NOTHING so partially-completed runs are safe.
+ */
+export async function migrateAgentDirectory(): Promise<void> {
+  const sourcePath = join(GENIE_HOME, CACHE_FILE);
+  const backupPath = join(GENIE_HOME, CACHE_BACKUP);
+
+  // Already migrated or nothing to migrate
+  if (existsSync(backupPath) || !existsSync(sourcePath)) return;
+
+  try {
+    const raw = readFileSync(sourcePath, 'utf-8');
+    const entries: CacheEntry[] = JSON.parse(raw);
+    if (!Array.isArray(entries) || entries.length === 0) return;
+
+    const sql = await getConnection();
+
+    for (const entry of entries) {
+      const manifest: Record<string, unknown> = {};
+      if (entry.promptMode) manifest.promptMode = entry.promptMode;
+      if (entry.model) manifest.model = entry.model;
+      if (entry.roles) manifest.roles = entry.roles;
+      if (entry.repo) manifest.repo = entry.repo;
+
+      await sql`
+        INSERT INTO app_store (name, item_type, version, install_path, manifest)
+        VALUES (${entry.name}, 'agent', '0.0.0', ${entry.dir ?? null}, ${sql.json(manifest)})
+        ON CONFLICT (name) DO NOTHING
+      `;
+    }
+
+    renameSync(sourcePath, backupPath);
+
+    await recordAuditEvent('item', 'migration', 'agent_directory_migrated', getActor(), {
+      count: entries.length,
+    });
+  } catch {
+    // Best effort — migration can be retried on the next run
+  }
+}
+
+// ============================================================================
+// CRUD helpers for app_store
+// ============================================================================
+
+/**
+ * Insert a new item into the app_store. Returns the generated id.
+ *
+ * Throws if an item with the same name already exists — callers should
+ * check beforehand or use `--force` to remove + re-insert.
+ */
+export async function registerItemInStore(item: StoreInsert): Promise<string> {
+  const sql = await getConnection();
+
+  const rows = await sql`
+    INSERT INTO app_store (
+      name, item_type, version, description,
+      author_name, author_url, git_url, install_path,
+      manifest, tags, category, license, dependencies
+    ) VALUES (
+      ${item.name},
+      ${item.itemType},
+      ${item.version ?? '0.0.0'},
+      ${item.description ?? null},
+      ${item.authorName ?? null},
+      ${item.authorUrl ?? null},
+      ${item.gitUrl ?? null},
+      ${item.installPath ?? null},
+      ${sql.json(item.manifest ?? {})},
+      ${item.tags ?? []},
+      ${item.category ?? null},
+      ${item.license ?? null},
+      ${item.dependencies ?? []}
+    )
+    RETURNING id
+  `;
+
+  if (rows.length === 0) {
+    throw new Error(`Failed to insert item "${item.name}" — no id returned.`);
+  }
+
+  return rows[0].id as string;
+}
+
+/**
+ * Delete an item from the app_store by name.
+ *
+ * @returns true if an item was deleted, false if no matching item was found.
+ */
+export async function removeItemFromStore(name: string): Promise<boolean> {
+  const sql = await getConnection();
+  const result = await sql`DELETE FROM app_store WHERE name = ${name}`;
+  return result.count > 0;
+}
+
+/**
+ * Update an existing item in the app_store by name.
+ * Only provided fields are updated; updated_at is always set to now().
+ *
+ * @returns true if the item was updated, false if no matching item was found.
+ */
+export async function updateItemInStore(name: string, updates: Partial<StoreInsert>): Promise<boolean> {
+  const sql = await getConnection();
+
+  const s: Record<string, unknown> = {};
+  if (updates.name !== undefined) s.name = updates.name;
+  if (updates.itemType !== undefined) s.item_type = updates.itemType;
+  if (updates.version !== undefined) s.version = updates.version;
+  if (updates.description !== undefined) s.description = updates.description;
+  if (updates.authorName !== undefined) s.author_name = updates.authorName;
+  if (updates.authorUrl !== undefined) s.author_url = updates.authorUrl;
+  if (updates.gitUrl !== undefined) s.git_url = updates.gitUrl;
+  if (updates.installPath !== undefined) s.install_path = updates.installPath;
+  if (updates.manifest !== undefined) s.manifest = sql.json(updates.manifest);
+  if (updates.tags !== undefined) s.tags = updates.tags;
+  if (updates.category !== undefined) s.category = updates.category;
+  if (updates.license !== undefined) s.license = updates.license;
+  if (updates.dependencies !== undefined) s.dependencies = updates.dependencies;
+
+  if (Object.keys(s).length === 0) return false;
+
+  s.updated_at = sql`now()`;
+  const result = await sql`UPDATE app_store SET ${sql(s)} WHERE name = ${name}`;
+  return result.count > 0;
+}
+
+/**
+ * Fetch a single item from the app_store by name.
+ *
+ * @returns the row or null if not found.
+ */
+export async function getItemFromStore(name: string): Promise<StoreRow | null> {
+  const sql = await getConnection();
+  const rows = await sql`SELECT * FROM app_store WHERE name = ${name}`;
+  return rows.length > 0 ? (rows[0] as unknown as StoreRow) : null;
+}
+
+/**
+ * List items from the app_store, optionally filtered by item_type.
+ *
+ * @param itemType - When provided, only rows matching this type are returned.
+ * @returns rows ordered by name.
+ */
+export async function listItemsFromStore(itemType?: string): Promise<StoreRow[]> {
+  const sql = await getConnection();
+
+  const rows = itemType
+    ? await sql`SELECT * FROM app_store WHERE item_type = ${itemType} ORDER BY name`
+    : await sql`SELECT * FROM app_store ORDER BY name`;
+
+  return rows as unknown as StoreRow[];
+}

--- a/src/lib/manifest.ts
+++ b/src/lib/manifest.ts
@@ -1,0 +1,342 @@
+/**
+ * Manifest — Genie item manifest parsing, validation, and detection.
+ *
+ * Every registry item (agent, skill, app, board, workflow, stack, template, hook)
+ * is described by a `genie.yaml` manifest. This module handles:
+ * - Parsing YAML manifests into typed GenieManifest objects
+ * - Validating manifests against type-specific rules
+ * - Auto-detecting manifests from directory conventions (AGENTS.md, skill.md, etc.)
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import * as yaml from 'js-yaml';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type ItemType = 'agent' | 'skill' | 'app' | 'board' | 'workflow' | 'stack' | 'template' | 'hook';
+
+export const ITEM_TYPES: ItemType[] = ['agent', 'skill', 'app', 'board', 'workflow', 'stack', 'template', 'hook'];
+
+export interface StageConfig {
+  name: string;
+  label?: string;
+  gate: 'human' | 'agent' | 'human+agent';
+  action?: string;
+  auto_advance?: boolean;
+  roles?: string[];
+  color?: string;
+}
+
+export interface StackItem {
+  name: string;
+  type: ItemType;
+  source?: string;
+  inline?: boolean;
+  config?: Record<string, unknown>;
+}
+
+export interface GenieManifest {
+  name: string;
+  version: string;
+  type: ItemType;
+  description?: string;
+  author?: { name: string; url?: string };
+  agent?: { model?: string; promptMode?: string; roles?: string[]; entrypoint: string };
+  skill?: { triggers?: string[]; entrypoint: string };
+  app?: { runtime?: string; natsPrefix?: string; icon?: string; entrypoint: string };
+  board?: { stages: StageConfig[] };
+  workflow?: { cron: string; timezone?: string; command: string; run_spec?: Record<string, unknown> };
+  stack?: { items: StackItem[] };
+  dependencies?: string[];
+  tags?: string[];
+  category?: string;
+  license?: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+// ============================================================================
+// Parsing
+// ============================================================================
+
+/**
+ * Parse a YAML string into a typed GenieManifest.
+ *
+ * Validates that required fields (name, type, version) are present and that
+ * the type value is a recognized ItemType. Throws on invalid input.
+ */
+export function parseManifest(yamlContent: string): GenieManifest {
+  const raw = yaml.load(yamlContent);
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('Manifest YAML is empty or not an object');
+  }
+
+  const obj = raw as Record<string, unknown>;
+
+  if (!obj.name || typeof obj.name !== 'string') {
+    throw new Error('Manifest is missing required field: name');
+  }
+  if (!obj.type || typeof obj.type !== 'string') {
+    throw new Error('Manifest is missing required field: type');
+  }
+  if (!obj.version || typeof obj.version !== 'string') {
+    throw new Error('Manifest is missing required field: version');
+  }
+
+  if (!ITEM_TYPES.includes(obj.type as ItemType)) {
+    throw new Error(`Invalid item type "${obj.type}". Must be one of: ${ITEM_TYPES.join(', ')}`);
+  }
+
+  return obj as unknown as GenieManifest;
+}
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+const VALID_GATES = new Set(['human', 'agent', 'human+agent']);
+
+/**
+ * Validate a manifest against type-specific rules.
+ *
+ * Checks required fields, type-specific sections, entrypoint file existence,
+ * board stage structure, cron format, and stack item completeness.
+ * Returns a ValidationResult with errors (blockers) and warnings (advisory).
+ */
+export function validateManifest(manifest: GenieManifest, itemDir: string): ValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  // Required top-level fields
+  if (!manifest.name) errors.push('Missing required field: name');
+  if (!manifest.type) errors.push('Missing required field: type');
+  if (!manifest.version) errors.push('Missing required field: version');
+
+  if (manifest.type && !ITEM_TYPES.includes(manifest.type)) {
+    errors.push(`Invalid item type "${manifest.type}". Must be one of: ${ITEM_TYPES.join(', ')}`);
+  }
+
+  // Type-specific validation
+  const { type } = manifest;
+
+  // Warn if the type-specific section is missing
+  if (type && !manifest[type as keyof GenieManifest]) {
+    warnings.push(`Manifest type is "${type}" but no "${type}" section is defined`);
+  }
+
+  // Agent validation
+  if (manifest.agent) {
+    validateEntrypoint(manifest.agent.entrypoint, itemDir, 'agent', errors);
+  }
+
+  // Skill validation
+  if (manifest.skill) {
+    validateEntrypoint(manifest.skill.entrypoint, itemDir, 'skill', errors);
+  }
+
+  // App validation
+  if (manifest.app) {
+    validateEntrypoint(manifest.app.entrypoint, itemDir, 'app', errors);
+  }
+
+  // Board validation
+  if (manifest.board) {
+    validateStages(manifest.board.stages, errors);
+  }
+
+  // Workflow validation
+  if (manifest.workflow) {
+    validateCron(manifest.workflow.cron, errors);
+  }
+
+  // Stack validation
+  if (manifest.stack) {
+    validateStackItems(manifest.stack.items, errors);
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+/** Check that an entrypoint file exists on disk. */
+function validateEntrypoint(entrypoint: string | undefined, itemDir: string, section: string, errors: string[]): void {
+  if (!entrypoint) {
+    errors.push(`${section} section is missing required field: entrypoint`);
+    return;
+  }
+  const fullPath = join(itemDir, entrypoint);
+  if (!existsSync(fullPath)) {
+    errors.push(`${section} entrypoint not found: ${entrypoint} (expected at ${fullPath})`);
+  }
+}
+
+/** Validate board stage definitions. */
+function validateStages(stages: StageConfig[] | undefined, errors: string[]): void {
+  if (!stages || !Array.isArray(stages)) {
+    errors.push('board section is missing required field: stages');
+    return;
+  }
+  for (let i = 0; i < stages.length; i++) {
+    const stage = stages[i];
+    if (!stage.name) {
+      errors.push(`board.stages[${i}] is missing required field: name`);
+    }
+    if (!stage.gate) {
+      errors.push(`board.stages[${i}] is missing required field: gate`);
+    } else if (!VALID_GATES.has(stage.gate)) {
+      errors.push(`board.stages[${i}].gate "${stage.gate}" is invalid. Must be one of: human, agent, human+agent`);
+    }
+  }
+}
+
+/**
+ * Validate a cron expression has 5 or 6 space-separated fields.
+ * This is a basic format check, not full cron syntax validation.
+ */
+function validateCron(cron: string | undefined, errors: string[]): void {
+  if (!cron) {
+    errors.push('workflow section is missing required field: cron');
+    return;
+  }
+  const fields = cron.trim().split(/\s+/);
+  if (fields.length < 5 || fields.length > 6) {
+    errors.push(`workflow.cron "${cron}" is invalid: expected 5 or 6 space-separated fields, got ${fields.length}`);
+  }
+}
+
+/** Validate stack item definitions. */
+function validateStackItems(items: StackItem[] | undefined, errors: string[]): void {
+  if (!items || !Array.isArray(items)) {
+    errors.push('stack section is missing required field: items');
+    return;
+  }
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    if (!item.type) {
+      errors.push(`stack.items[${i}] is missing required field: type`);
+    }
+    if (!item.source && !item.inline) {
+      errors.push(`stack.items[${i}] must have either "source" or "inline: true"`);
+    }
+  }
+}
+
+// ============================================================================
+// Detection
+// ============================================================================
+
+/**
+ * Detect a manifest from a directory using a fallback chain.
+ *
+ * Detection order:
+ * 1. `genie.yaml` — explicit manifest file
+ * 2. `AGENTS.md` — infer agent manifest from YAML frontmatter
+ * 3. `manifest.ts` — infer app manifest
+ * 4. `skill.md` — infer skill manifest
+ * 5. None found — return error
+ */
+export async function detectManifest(
+  dir: string,
+): Promise<{ manifest: GenieManifest; source: string } | { error: string }> {
+  // 1. Explicit genie.yaml
+  const yamlPath = join(dir, 'genie.yaml');
+  if (existsSync(yamlPath)) {
+    try {
+      const content = readFileSync(yamlPath, 'utf-8');
+      const manifest = parseManifest(content);
+      return { manifest, source: 'genie.yaml' };
+    } catch (err) {
+      return { error: `Failed to parse genie.yaml: ${(err as Error).message}` };
+    }
+  }
+
+  const dirName = basename(dir);
+
+  // 2. AGENTS.md — infer agent manifest from frontmatter
+  const agentsPath = join(dir, 'AGENTS.md');
+  if (existsSync(agentsPath)) {
+    const manifest = inferAgentManifest(agentsPath, dirName);
+    return { manifest, source: 'AGENTS.md' };
+  }
+
+  // 3. manifest.ts — infer app manifest
+  const manifestTsPath = join(dir, 'manifest.ts');
+  if (existsSync(manifestTsPath)) {
+    const manifest: GenieManifest = {
+      name: dirName,
+      type: 'app',
+      version: '0.0.0',
+    };
+    return { manifest, source: 'manifest.ts' };
+  }
+
+  // 4. skill.md — infer skill manifest
+  const skillPath = join(dir, 'skill.md');
+  if (existsSync(skillPath)) {
+    const manifest: GenieManifest = {
+      name: dirName,
+      type: 'skill',
+      version: '0.0.0',
+    };
+    return { manifest, source: 'skill.md' };
+  }
+
+  // 5. Nothing found
+  return {
+    error:
+      'No manifest found. Create a genie.yaml or use a recognized file pattern (AGENTS.md, manifest.ts, skill.md).',
+  };
+}
+
+/**
+ * Extract YAML frontmatter from a markdown file.
+ *
+ * Looks for content between `---` markers at the top of the file.
+ * Returns the parsed object or null if no frontmatter is found.
+ */
+function extractFrontmatter(filePath: string): Record<string, unknown> | null {
+  const content = readFileSync(filePath, 'utf-8');
+  const match = content.match(/^---\s*\n([\s\S]*?)\n---/);
+  if (!match) return null;
+
+  try {
+    const parsed = yaml.load(match[1]);
+    if (parsed && typeof parsed === 'object') {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Frontmatter is not valid YAML — ignore
+  }
+  return null;
+}
+
+/** Build an agent manifest from AGENTS.md frontmatter. */
+function inferAgentManifest(agentsPath: string, dirName: string): GenieManifest {
+  const frontmatter = extractFrontmatter(agentsPath);
+
+  const name = (frontmatter?.name as string) || dirName;
+  const model = frontmatter?.model as string | undefined;
+  const roles = Array.isArray(frontmatter?.roles) ? (frontmatter.roles as string[]) : undefined;
+
+  const manifest: GenieManifest = {
+    name,
+    type: 'agent',
+    version: '0.0.0',
+  };
+
+  if (model || roles) {
+    manifest.agent = {
+      entrypoint: 'AGENTS.md',
+      ...(model && { model }),
+      ...(roles && { roles }),
+    };
+  }
+
+  return manifest;
+}

--- a/src/term-commands/dir.ts
+++ b/src/term-commands/dir.ts
@@ -11,11 +11,25 @@
  *
  * Commands:
  *   genie agent register <name>  — Register agent locally + auto-register in Omni
+ *
+ * Storage: Primary source is `app_store` table (item_type='agent').
+ * Legacy `agents` table kept for backward compat with spawn.
+ * JSON cache (~/.genie/agent-directory.json) regenerated after every mutation.
  */
 
 import { resolve as resolvePath } from 'node:path';
 import type { Command } from 'commander';
+import {
+  type StoreRow,
+  listItemsFromStore,
+  migrateAgentDirectory,
+  regenerateAgentCache,
+  registerItemInStore,
+  removeItemFromStore,
+  updateItemInStore,
+} from '../lib/agent-cache.js';
 import * as directory from '../lib/agent-directory.js';
+import { getActor, recordAuditEvent } from '../lib/audit.js';
 import { ALL_BUILTINS } from '../lib/builtin-agents.js';
 import { contractPath } from '../lib/genie-config.js';
 import { findOmniAgent, registerAgentInOmni, resolveOmniApiUrl } from '../lib/omni-registration.js';
@@ -47,10 +61,11 @@ export function registerDirNamespace(program: Command): void {
       ) => {
         try {
           const promptMode = validatePromptMode(options.promptMode);
+          const resolvedDir = resolvePath(options.dir);
           const entry = await directory.add(
             {
               name,
-              dir: resolvePath(options.dir),
+              dir: resolvedDir,
               repo: options.repo ? resolvePath(options.repo) : undefined,
               promptMode,
               model: options.model,
@@ -58,6 +73,23 @@ export function registerDirNamespace(program: Command): void {
             },
             { global: options.global },
           );
+
+          // Also register in app_store (primary source of truth)
+          try {
+            await registerItemInStore({
+              name,
+              itemType: 'agent',
+              installPath: resolvedDir,
+              manifest: { promptMode, model: options.model, roles: options.roles, repo: options.repo },
+            });
+          } catch {
+            // Best-effort — legacy agents table is still the spawn path
+          }
+          await regenerateAgentCache();
+          recordAuditEvent('item', name, 'item_registered', getActor(), { type: 'agent', source: 'dir_add' }).catch(
+            () => {},
+          );
+
           const scope = options.global ? 'global' : 'project';
           console.log(`Agent "${entry.name}" registered (${scope}).`);
           console.log(`  Dir: ${contractPath(entry.dir)}`);
@@ -81,6 +113,11 @@ export function registerDirNamespace(program: Command): void {
     .action(async (name: string, options: { global?: boolean }) => {
       try {
         const removed = await directory.rm(name, { global: options.global });
+        // Also remove from app_store
+        await removeItemFromStore(name).catch(() => {});
+        await regenerateAgentCache();
+        recordAuditEvent('item', name, 'item_removed', getActor(), { type: 'agent', source: 'dir_rm' }).catch(() => {});
+
         if (removed) {
           const scope = options.global ? 'global' : 'project';
           console.log(`Agent "${name}" removed from ${scope} directory.`);
@@ -161,6 +198,19 @@ async function handleEdit(name: string, options: EditOptions): Promise<void> {
   }
 
   const entry = await directory.edit(name, updates, { global: options.global });
+
+  // Also update app_store
+  try {
+    await updateItemInStore(name, {
+      installPath: updates.dir,
+      manifest: { promptMode: updates.promptMode, model: updates.model, roles: updates.roles, repo: updates.repo },
+    });
+  } catch {
+    // Best-effort
+  }
+  await regenerateAgentCache();
+  recordAuditEvent('item', name, 'item_updated', getActor(), { type: 'agent', source: 'dir_edit' }).catch(() => {});
+
   const scope = options.global ? 'global' : 'project';
   console.log(`Agent "${name}" updated (${scope}).`);
   printEntry(entry);
@@ -209,7 +259,30 @@ async function showEntry(name: string, json?: boolean): Promise<void> {
 }
 
 async function listEntries(json?: boolean, includeBuiltins?: boolean): Promise<void> {
-  const entries = await directory.ls();
+  // One-time migration from legacy JSON → DB (idempotent, best-effort)
+  await migrateAgentDirectory().catch(() => {});
+
+  // Try app_store first (primary), fall back to legacy agents table
+  let entries: directory.ScopedDirectoryEntry[];
+  try {
+    const storeItems = await listItemsFromStore('agent');
+    entries = storeItems.map((item: StoreRow) => {
+      const manifest = (item.manifest ?? {}) as Record<string, unknown>;
+      return {
+        name: item.name,
+        dir: (item.install_path as string) ?? '',
+        repo: (manifest.repo as string) ?? '',
+        promptMode: ((manifest.promptMode as string) ?? 'append') as directory.PromptMode,
+        model: manifest.model as string | undefined,
+        roles: manifest.roles as string[] | undefined,
+        registeredAt: item.installed_at as string,
+        scope: 'global' as directory.DirectoryScope,
+      };
+    });
+  } catch {
+    // Fallback to legacy
+    entries = await directory.ls();
+  }
 
   if (json) {
     listEntriesJson(entries, includeBuiltins);

--- a/src/term-commands/install.ts
+++ b/src/term-commands/install.ts
@@ -1,0 +1,370 @@
+/**
+ * Install Command — `genie install <git-url>[@version]`
+ *
+ * Clones a git repository, detects/validates the manifest, registers in
+ * app_store, and performs type-specific setup (cache regen, board creation, etc.).
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, join } from 'node:path';
+import type { Command } from 'commander';
+import {
+  getItemFromStore,
+  regenerateAgentCache,
+  registerItemInStore,
+  removeItemFromStore,
+} from '../lib/agent-cache.js';
+import { getActor, recordAuditEvent } from '../lib/audit.js';
+import { getConnection, isAvailable } from '../lib/db.js';
+import { type GenieManifest, type StageConfig, detectManifest, validateManifest } from '../lib/manifest.js';
+
+const GENIE_HOME = process.env.GENIE_HOME ?? join(homedir(), '.genie');
+const ITEMS_DIR = join(GENIE_HOME, 'items');
+
+// ============================================================================
+// URL parsing
+// ============================================================================
+
+interface ParsedUrl {
+  url: string;
+  version?: string;
+  name: string;
+}
+
+/**
+ * Parse a git install target like `github.com/user/repo@v1.2.0`
+ * into its components.
+ */
+function parseInstallTarget(target: string): ParsedUrl {
+  let url = target;
+  let version: string | undefined;
+
+  // Extract @version suffix
+  const atIdx = url.lastIndexOf('@');
+  if (atIdx > 0 && !url.slice(atIdx).includes('/')) {
+    version = url.slice(atIdx + 1);
+    url = url.slice(0, atIdx);
+  }
+
+  // Normalise bare github.com/user/repo → https://github.com/user/repo.git
+  if (!url.startsWith('http') && !url.startsWith('git@') && !url.startsWith('ssh://')) {
+    url = `https://${url}`;
+  }
+  if (url.startsWith('https://') && !url.endsWith('.git')) {
+    url = `${url}.git`;
+  }
+
+  // Derive name from repo URL
+  const name = basename(url, '.git');
+
+  return { url, version, name };
+}
+
+// ============================================================================
+// Git operations
+// ============================================================================
+
+function cloneRepo(url: string, dest: string, options: { shallow?: boolean; version?: string }): void {
+  const args = ['git', 'clone'];
+  if (options.shallow !== false) args.push('--depth', '1');
+  if (options.version) args.push('--branch', options.version);
+  args.push(url, dest);
+
+  execSync(args.join(' '), { stdio: 'pipe', timeout: 120_000 });
+}
+
+function cleanupDir(dir: string): void {
+  if (existsSync(dir)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ============================================================================
+// Type-specific registration
+// ============================================================================
+
+async function registerByType(manifest: GenieManifest, installPath: string): Promise<void> {
+  switch (manifest.type) {
+    case 'agent':
+      await regenerateAgentCache();
+      break;
+    case 'board':
+      await registerBoard(manifest);
+      break;
+    case 'workflow':
+      await registerWorkflow(manifest);
+      break;
+    case 'stack':
+      await installStack(manifest, installPath);
+      break;
+    // skill, app, template, hook — no extra registration needed beyond app_store
+  }
+}
+
+async function registerBoard(manifest: GenieManifest): Promise<void> {
+  if (!manifest.board?.stages) return;
+  if (!(await isAvailable())) return;
+
+  const sql = await getConnection();
+  const stages = manifest.board.stages.map((s, i) => ({
+    id: crypto.randomUUID(),
+    name: s.name,
+    label: s.label ?? s.name,
+    gate: s.gate,
+    action: s.action ?? null,
+    auto_advance: s.auto_advance ?? false,
+    roles: s.roles ?? ['*'],
+    color: s.color ?? '#94a3b8',
+    parallel: false,
+    on_fail: null,
+    position: i,
+    transitions: [],
+  }));
+
+  await sql`
+    INSERT INTO task_types (id, name, description, stages, is_builtin)
+    VALUES (
+      ${manifest.name},
+      ${manifest.name},
+      ${manifest.description ?? null},
+      ${sql.json(stages)},
+      false
+    )
+    ON CONFLICT (id) DO UPDATE SET
+      stages = EXCLUDED.stages,
+      description = EXCLUDED.description,
+      updated_at = now()
+  `;
+}
+
+async function registerWorkflow(manifest: GenieManifest): Promise<void> {
+  if (!manifest.workflow) return;
+  if (!(await isAvailable())) return;
+
+  const sql = await getConnection();
+  const wf = manifest.workflow;
+
+  await sql`
+    INSERT INTO schedules (id, name, cron_expression, timezone, command, run_spec, status)
+    VALUES (
+      ${`sched-${manifest.name}`},
+      ${manifest.name},
+      ${wf.cron},
+      ${wf.timezone ?? 'UTC'},
+      ${wf.command},
+      ${sql.json(wf.run_spec ?? {})},
+      'active'
+    )
+    ON CONFLICT (id) DO UPDATE SET
+      cron_expression = EXCLUDED.cron_expression,
+      timezone = EXCLUDED.timezone,
+      command = EXCLUDED.command,
+      run_spec = EXCLUDED.run_spec,
+      updated_at = now()
+  `;
+}
+
+async function handleInlineStackItem(
+  item: import('../lib/manifest.js').StackItem,
+  version: string,
+  tx: Awaited<ReturnType<typeof getConnection>>,
+): Promise<void> {
+  if (item.type === 'board' && item.config) {
+    await registerBoard({
+      name: item.name,
+      type: 'board',
+      version,
+      board: { stages: (item.config.stages ?? []) as StageConfig[] },
+    });
+  } else if (item.type === 'workflow' && item.config) {
+    await registerWorkflow({
+      name: item.name,
+      type: 'workflow',
+      version,
+      workflow: item.config as unknown as NonNullable<GenieManifest['workflow']>,
+    });
+  }
+  await tx`
+    INSERT INTO app_store (name, item_type, version, manifest)
+    VALUES (${item.name}, ${item.type}, ${version}, ${tx.json(item.config ?? {})})
+    ON CONFLICT (name) DO NOTHING
+  `;
+}
+
+async function handleExternalStackItem(
+  item: import('../lib/manifest.js').StackItem,
+  tx: Awaited<ReturnType<typeof getConnection>>,
+): Promise<string> {
+  const parsed = parseInstallTarget(item.source!);
+  const itemDir = join(ITEMS_DIR, parsed.name);
+  mkdirSync(ITEMS_DIR, { recursive: true });
+  cloneRepo(parsed.url, itemDir, { version: parsed.version });
+
+  const detection = await detectManifest(itemDir);
+  if ('error' in detection) {
+    throw new Error(`Stack item "${item.name}" (${item.source}): ${detection.error}`);
+  }
+  const validation = validateManifest(detection.manifest, itemDir);
+  if (!validation.valid) {
+    throw new Error(`Stack item "${item.name}" validation failed: ${validation.errors.join(', ')}`);
+  }
+
+  await tx`
+    INSERT INTO app_store (name, item_type, version, git_url, install_path, manifest)
+    VALUES (
+      ${detection.manifest.name}, ${detection.manifest.type}, ${detection.manifest.version},
+      ${item.source}, ${itemDir}, ${tx.json(detection.manifest)}
+    )
+    ON CONFLICT (name) DO NOTHING
+  `;
+  await registerByType(detection.manifest, itemDir);
+  return parsed.name;
+}
+
+async function installStack(manifest: GenieManifest, _installPath: string): Promise<void> {
+  if (!manifest.stack?.items) return;
+  if (!(await isAvailable())) return;
+
+  const sql = await getConnection();
+  const installed: string[] = [];
+
+  try {
+    await sql.begin(async (tx: typeof sql) => {
+      for (const item of manifest.stack!.items) {
+        if (item.inline) {
+          await handleInlineStackItem(item, manifest.version, tx);
+          installed.push(item.name);
+        } else if (item.source) {
+          const name = await handleExternalStackItem(item, tx);
+          installed.push(name);
+        }
+      }
+    });
+  } catch (err) {
+    // Rollback: clean up cloned dirs
+    for (const name of installed) {
+      cleanupDir(join(ITEMS_DIR, name));
+      await removeItemFromStore(name).catch(() => {});
+    }
+    throw err;
+  }
+}
+
+// ============================================================================
+// Install command
+// ============================================================================
+
+interface InstallOptions {
+  force?: boolean;
+  full?: boolean;
+}
+
+async function handleInstall(target: string, options: InstallOptions): Promise<void> {
+  const parsed = parseInstallTarget(target);
+  const installDir = join(ITEMS_DIR, parsed.name);
+
+  // Check for name conflict
+  const existing = await getItemFromStore(parsed.name).catch(() => null);
+  if (existing && !options.force) {
+    console.error(`Item "${parsed.name}" is already installed. Use --force to override.`);
+    process.exit(1);
+  }
+  if (existing && options.force) {
+    await removeItemFromStore(parsed.name).catch(() => {});
+    cleanupDir(installDir);
+  }
+
+  // Clone
+  mkdirSync(ITEMS_DIR, { recursive: true });
+  console.log(`Cloning ${parsed.url}${parsed.version ? ` @ ${parsed.version}` : ''}...`);
+  try {
+    cloneRepo(parsed.url, installDir, { shallow: !options.full, version: parsed.version });
+  } catch (err) {
+    cleanupDir(installDir);
+    console.error(`Clone failed: ${(err as Error).message}`);
+    process.exit(1);
+  }
+
+  // Detect manifest
+  const detection = await detectManifest(installDir);
+  if ('error' in detection) {
+    cleanupDir(installDir);
+    console.error(`Manifest detection failed: ${detection.error}`);
+    process.exit(1);
+  }
+
+  const { manifest, source } = detection;
+  console.log(`Detected ${manifest.type} manifest from ${source}`);
+
+  // Validate
+  const validation = validateManifest(manifest, installDir);
+  for (const w of validation.warnings) {
+    console.log(`  Warning: ${w}`);
+  }
+  if (!validation.valid) {
+    cleanupDir(installDir);
+    console.error(`Validation failed:\n${validation.errors.map((e) => `  - ${e}`).join('\n')}`);
+    process.exit(1);
+  }
+
+  // Register in app_store
+  try {
+    await registerItemInStore({
+      name: manifest.name,
+      itemType: manifest.type,
+      version: manifest.version,
+      description: manifest.description,
+      authorName: manifest.author?.name,
+      authorUrl: manifest.author?.url,
+      gitUrl: parsed.url,
+      installPath: installDir,
+      manifest: manifest as unknown as Record<string, unknown>,
+      tags: manifest.tags,
+      category: manifest.category,
+      license: manifest.license,
+      dependencies: manifest.dependencies,
+    });
+  } catch (err) {
+    cleanupDir(installDir);
+    console.error(`Registration failed: ${(err as Error).message}`);
+    process.exit(1);
+  }
+
+  // Type-specific registration
+  await registerByType(manifest, installDir);
+
+  // Audit
+  recordAuditEvent('item', manifest.name, 'item_installed', getActor(), {
+    type: manifest.type,
+    version: manifest.version,
+    source: parsed.url,
+    manifestSource: source,
+  }).catch(() => {});
+
+  console.log(`\nInstalled ${manifest.type} "${manifest.name}" v${manifest.version}`);
+  console.log(`  Source: ${parsed.url}`);
+  console.log(`  Path: ${installDir}`);
+}
+
+// ============================================================================
+// Command registration
+// ============================================================================
+
+export function registerInstallCommand(program: Command): void {
+  program
+    .command('install <target>')
+    .description('Install a genie item from a git URL (e.g. github.com/user/repo[@version])')
+    .option('--force', 'Override existing item with same name')
+    .option('--full', 'Full git clone instead of shallow')
+    .action(async (target: string, options: InstallOptions) => {
+      try {
+        await handleInstall(target, options);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`Error: ${message}`);
+        process.exit(1);
+      }
+    });
+}

--- a/src/term-commands/item-uninstall.ts
+++ b/src/term-commands/item-uninstall.ts
@@ -1,0 +1,118 @@
+/**
+ * Uninstall Command — `genie uninstall <name>`
+ *
+ * Removes a previously installed item: deregisters from app_store,
+ * performs type-specific cleanup, and removes the cloned directory.
+ */
+
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { Command } from 'commander';
+import { getItemFromStore, regenerateAgentCache, removeItemFromStore } from '../lib/agent-cache.js';
+import { getActor, recordAuditEvent } from '../lib/audit.js';
+import { getConnection, isAvailable } from '../lib/db.js';
+
+const GENIE_HOME = process.env.GENIE_HOME ?? join(homedir(), '.genie');
+const ITEMS_DIR = join(GENIE_HOME, 'items');
+
+// ============================================================================
+// Type-specific deregistration
+// ============================================================================
+
+async function deregisterByType(itemType: string, name: string): Promise<void> {
+  if (!(await isAvailable())) return;
+  const sql = await getConnection();
+
+  switch (itemType) {
+    case 'agent':
+      // Remove from legacy agents table too
+      await sql`DELETE FROM agents WHERE id = ${`dir:${name}`}`.catch(() => {});
+      await regenerateAgentCache();
+      break;
+    case 'board':
+      await sql`DELETE FROM task_types WHERE id = ${name}`.catch(() => {});
+      break;
+    case 'workflow':
+      await sql`DELETE FROM schedules WHERE id = ${`sched-${name}`}`.catch(() => {});
+      break;
+    case 'app':
+      await sql`DELETE FROM installed_apps WHERE app_store_id IN (
+        SELECT id FROM app_store WHERE name = ${name}
+      )`.catch(() => {});
+      break;
+    case 'stack': {
+      // Try to read manifest and uninstall sub-items
+      const manifestPath = join(ITEMS_DIR, name, 'genie.yaml');
+      if (existsSync(manifestPath)) {
+        try {
+          const yaml = await import('js-yaml');
+          const raw = yaml.load(readFileSync(manifestPath, 'utf-8')) as Record<string, unknown>;
+          const stack = raw.stack as { items?: Array<{ name: string; type: string }> } | undefined;
+          if (stack?.items) {
+            for (const item of stack.items) {
+              await deregisterByType(item.type, item.name);
+              await removeItemFromStore(item.name).catch(() => {});
+            }
+          }
+        } catch {
+          // Best effort
+        }
+      }
+      break;
+    }
+  }
+}
+
+// ============================================================================
+// Uninstall handler
+// ============================================================================
+
+async function handleUninstall(name: string): Promise<void> {
+  const existing = await getItemFromStore(name).catch(() => null);
+  if (!existing) {
+    console.error(`Item "${name}" is not installed.`);
+    process.exit(1);
+  }
+
+  const itemType = existing.item_type;
+
+  // Type-specific deregistration
+  await deregisterByType(itemType, name);
+
+  // Remove from app_store
+  await removeItemFromStore(name);
+
+  // Remove cloned directory
+  const installDir = join(ITEMS_DIR, name);
+  if (existsSync(installDir)) {
+    rmSync(installDir, { recursive: true, force: true });
+  }
+
+  // Audit
+  recordAuditEvent('item', name, 'item_uninstalled', getActor(), {
+    type: itemType,
+    version: existing.version,
+  }).catch(() => {});
+
+  console.log(`Uninstalled ${itemType} "${name}".`);
+}
+
+// ============================================================================
+// Command registration
+// ============================================================================
+
+export function registerItemUninstallCommand(parent: Command): void {
+  parent
+    .command('uninstall <name>')
+    .description('Remove an installed genie item')
+    .action(async (name: string) => {
+      try {
+        await handleUninstall(name);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`Error: ${message}`);
+        process.exit(1);
+      }
+    });
+}

--- a/src/term-commands/item-update.ts
+++ b/src/term-commands/item-update.ts
@@ -1,0 +1,205 @@
+/**
+ * Update Command — `genie update <name>` or `genie update --all`
+ *
+ * Pulls the latest version (or a specific tag) of an installed item,
+ * re-validates its manifest, and updates the app_store entry.
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { Command } from 'commander';
+import { getItemFromStore, listItemsFromStore, regenerateAgentCache, updateItemInStore } from '../lib/agent-cache.js';
+import { getActor, recordAuditEvent } from '../lib/audit.js';
+import { getConnection, isAvailable } from '../lib/db.js';
+import { type GenieManifest, detectManifest, validateManifest } from '../lib/manifest.js';
+
+const GENIE_HOME = process.env.GENIE_HOME ?? join(homedir(), '.genie');
+const ITEMS_DIR = join(GENIE_HOME, 'items');
+
+// ============================================================================
+// Type-specific re-registration
+// ============================================================================
+
+async function reregisterByType(manifest: GenieManifest): Promise<void> {
+  if (!(await isAvailable())) return;
+  const sql = await getConnection();
+
+  switch (manifest.type) {
+    case 'agent':
+      await regenerateAgentCache();
+      break;
+    case 'board':
+      if (manifest.board?.stages) {
+        const stages = manifest.board.stages.map((s, i) => ({
+          id: crypto.randomUUID(),
+          name: s.name,
+          label: s.label ?? s.name,
+          gate: s.gate,
+          action: s.action ?? null,
+          auto_advance: s.auto_advance ?? false,
+          roles: s.roles ?? ['*'],
+          color: s.color ?? '#94a3b8',
+          parallel: false,
+          on_fail: null,
+          position: i,
+          transitions: [],
+        }));
+        await sql`
+          UPDATE task_types SET stages = ${sql.json(stages)}, updated_at = now()
+          WHERE id = ${manifest.name}
+        `.catch(() => {});
+      }
+      break;
+    case 'workflow':
+      if (manifest.workflow) {
+        await sql`
+          UPDATE schedules SET
+            cron_expression = ${manifest.workflow.cron},
+            timezone = ${manifest.workflow.timezone ?? 'UTC'},
+            command = ${manifest.workflow.command},
+            run_spec = ${sql.json(manifest.workflow.run_spec ?? {})},
+            updated_at = now()
+          WHERE id = ${`sched-${manifest.name}`}
+        `.catch(() => {});
+      }
+      break;
+  }
+}
+
+// ============================================================================
+// Update handler
+// ============================================================================
+
+interface UpdateOptions {
+  all?: boolean;
+}
+
+async function handleUpdateSingle(name: string, version?: string): Promise<boolean> {
+  const existing = await getItemFromStore(name).catch(() => null);
+  if (!existing) {
+    console.error(`Item "${name}" is not installed.`);
+    return false;
+  }
+
+  const installDir = existing.install_path ?? join(ITEMS_DIR, name);
+  if (!existsSync(installDir)) {
+    console.error(`Install directory not found: ${installDir}`);
+    return false;
+  }
+
+  // Pull latest or checkout specific version
+  try {
+    if (version) {
+      execSync(`git fetch --tags && git checkout ${version}`, {
+        cwd: installDir,
+        stdio: 'pipe',
+        timeout: 60_000,
+      });
+    } else {
+      execSync('git pull --ff-only', {
+        cwd: installDir,
+        stdio: 'pipe',
+        timeout: 60_000,
+      });
+    }
+  } catch (err) {
+    console.error(`Git update failed for "${name}": ${(err as Error).message}`);
+    return false;
+  }
+
+  // Re-detect and validate manifest
+  const detection = await detectManifest(installDir);
+  if ('error' in detection) {
+    console.error(`Manifest detection failed after update: ${detection.error}`);
+    return false;
+  }
+
+  const { manifest } = detection;
+  const validation = validateManifest(manifest, installDir);
+  for (const w of validation.warnings) {
+    console.log(`  Warning: ${w}`);
+  }
+  if (!validation.valid) {
+    console.error(`Validation failed after update:\n${validation.errors.map((e) => `  - ${e}`).join('\n')}`);
+    return false;
+  }
+
+  // Update app_store
+  await updateItemInStore(name, {
+    version: manifest.version,
+    description: manifest.description,
+    manifest: manifest as unknown as Record<string, unknown>,
+  });
+
+  // Type-specific re-registration
+  await reregisterByType(manifest);
+
+  // Audit
+  recordAuditEvent('item', name, 'item_updated', getActor(), {
+    type: manifest.type,
+    version: manifest.version,
+    previousVersion: existing.version,
+  }).catch(() => {});
+
+  console.log(`Updated ${manifest.type} "${name}" → v${manifest.version}`);
+  return true;
+}
+
+async function handleUpdate(nameOrVersion: string | undefined, options: UpdateOptions): Promise<void> {
+  if (options.all) {
+    const items = await listItemsFromStore();
+    const gitItems = items.filter((i) => i.git_url);
+    if (gitItems.length === 0) {
+      console.log('No git-installed items to update.');
+      return;
+    }
+
+    console.log(`Updating ${gitItems.length} item(s)...`);
+    let updated = 0;
+    for (const item of gitItems) {
+      const ok = await handleUpdateSingle(item.name);
+      if (ok) updated++;
+    }
+    console.log(`\n${updated}/${gitItems.length} items updated successfully.`);
+    return;
+  }
+
+  if (!nameOrVersion) {
+    console.error('Usage: genie update <name>[@version] or genie update --all');
+    process.exit(1);
+  }
+
+  // Parse name@version
+  let name = nameOrVersion;
+  let version: string | undefined;
+  const atIdx = name.lastIndexOf('@');
+  if (atIdx > 0) {
+    version = name.slice(atIdx + 1);
+    name = name.slice(0, atIdx);
+  }
+
+  const ok = await handleUpdateSingle(name, version);
+  if (!ok) process.exit(1);
+}
+
+// ============================================================================
+// Command registration
+// ============================================================================
+
+export function registerItemUpdateCommand(parent: Command): void {
+  parent
+    .command('update [name]')
+    .description('Update an installed item to the latest version or a specific tag')
+    .option('--all', 'Update all git-installed items')
+    .action(async (name: string | undefined, options: UpdateOptions) => {
+      try {
+        await handleUpdate(name, options);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`Error: ${message}`);
+        process.exit(1);
+      }
+    });
+}

--- a/src/term-commands/publish.ts
+++ b/src/term-commands/publish.ts
@@ -1,0 +1,187 @@
+/**
+ * Publish Command — `genie publish`
+ *
+ * Publishes the current directory as a genie item. Must be run from a
+ * directory containing a genie.yaml. Requires a pushed git tag matching
+ * the manifest version.
+ */
+
+import { execSync } from 'node:child_process';
+import type { Command } from 'commander';
+import { getItemFromStore, registerItemInStore, updateItemInStore } from '../lib/agent-cache.js';
+import { getActor, recordAuditEvent } from '../lib/audit.js';
+import { getConnection, isAvailable } from '../lib/db.js';
+import { detectManifest, validateManifest } from '../lib/manifest.js';
+
+// ============================================================================
+// Git tag verification
+// ============================================================================
+
+function getGitRemoteTags(cwd: string): string[] {
+  try {
+    const output = execSync('git tag --list --merged HEAD', {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return output.trim().split('\n').filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function isTagPushed(tag: string, cwd: string): boolean {
+  try {
+    execSync(`git ls-remote --tags origin refs/tags/${tag}`, {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getGitSha(cwd: string): string | null {
+  try {
+    return execSync('git rev-parse HEAD', { cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+  } catch {
+    return null;
+  }
+}
+
+// ============================================================================
+// Publish handler
+// ============================================================================
+
+async function handlePublish(): Promise<void> {
+  const cwd = process.cwd();
+
+  // Detect and validate manifest
+  const detection = await detectManifest(cwd);
+  if ('error' in detection) {
+    console.error(`Cannot publish: ${detection.error}`);
+    process.exit(1);
+  }
+
+  const { manifest, source } = detection;
+  const validation = validateManifest(manifest, cwd);
+  for (const w of validation.warnings) {
+    console.log(`  Warning: ${w}`);
+  }
+  if (!validation.valid) {
+    console.error(`Validation failed:\n${validation.errors.map((e) => `  - ${e}`).join('\n')}`);
+    process.exit(1);
+  }
+
+  // Check for git tag matching version
+  const expectedTag = `v${manifest.version}`;
+  const tags = getGitRemoteTags(cwd);
+  const hasTag = tags.includes(expectedTag) || tags.includes(manifest.version);
+  if (!hasTag) {
+    console.error(`No git tag "${expectedTag}" found. Create and push a tag first:`);
+    console.error(`  git tag ${expectedTag} && git push origin ${expectedTag}`);
+    process.exit(1);
+  }
+
+  // Verify tag is pushed to remote
+  const tagToPush = tags.includes(expectedTag) ? expectedTag : manifest.version;
+  if (!isTagPushed(tagToPush, cwd)) {
+    console.error(`Tag "${tagToPush}" exists locally but is not pushed to remote.`);
+    console.error(`  git push origin ${tagToPush}`);
+    process.exit(1);
+  }
+
+  const gitSha = getGitSha(cwd);
+
+  // UPSERT into app_store
+  const existing = await getItemFromStore(manifest.name).catch(() => null);
+  if (existing) {
+    await updateItemInStore(manifest.name, {
+      version: manifest.version,
+      description: manifest.description,
+      manifest: manifest as unknown as Record<string, unknown>,
+    });
+
+    // Update approval status
+    if (await isAvailable()) {
+      const sql = await getConnection();
+      await sql`
+        UPDATE app_store
+        SET approval_status = 'pending', updated_at = now()
+        WHERE name = ${manifest.name}
+      `;
+    }
+  } else {
+    await registerItemInStore({
+      name: manifest.name,
+      itemType: manifest.type,
+      version: manifest.version,
+      description: manifest.description,
+      authorName: manifest.author?.name,
+      authorUrl: manifest.author?.url,
+      installPath: cwd,
+      manifest: manifest as unknown as Record<string, unknown>,
+      tags: manifest.tags,
+      category: manifest.category,
+      license: manifest.license,
+      dependencies: manifest.dependencies,
+    });
+  }
+
+  // Record version in app_versions
+  if (await isAvailable()) {
+    const sql = await getConnection();
+    const storeItem = await getItemFromStore(manifest.name);
+    if (storeItem) {
+      await sql`
+        INSERT INTO app_versions (app_store_id, version, git_tag, git_sha, manifest)
+        VALUES (
+          ${storeItem.id},
+          ${manifest.version},
+          ${tagToPush},
+          ${gitSha},
+          ${sql.json(manifest as unknown as Record<string, unknown>)}
+        )
+        ON CONFLICT (app_store_id, version) DO UPDATE SET
+          git_sha = EXCLUDED.git_sha,
+          manifest = EXCLUDED.manifest,
+          published_at = now()
+      `;
+    }
+  }
+
+  // Audit
+  recordAuditEvent('item', manifest.name, 'item_published', getActor(), {
+    type: manifest.type,
+    version: manifest.version,
+    tag: tagToPush,
+    sha: gitSha,
+    manifestSource: source,
+  }).catch(() => {});
+
+  console.log(`\nPublished ${manifest.type} "${manifest.name}" v${manifest.version}`);
+  console.log(`  Tag: ${tagToPush}`);
+  if (gitSha) console.log(`  SHA: ${gitSha.slice(0, 8)}`);
+  console.log('  Status: pending approval');
+}
+
+// ============================================================================
+// Command registration
+// ============================================================================
+
+export function registerPublishCommand(program: Command): void {
+  program
+    .command('publish')
+    .description('Publish the current directory as a genie item (requires pushed git tag)')
+    .action(async () => {
+      try {
+        await handlePublish();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`Error: ${message}`);
+        process.exit(1);
+      }
+    });
+}


### PR DESCRIPTION
## Summary

- Adds `genie install <git-url>[@version]` — clone, validate manifest, register in DB with type-specific handlers
- Adds `genie item uninstall <name>` / `genie item update <name>` — clean removal and git-pull updates
- Adds `genie publish` — publishes items requiring a pushed git tag, records versions in `app_versions`
- Introduces `genie.yaml` manifest format supporting 8 item types: agent, skill, app, board, workflow, stack, template, hook
- Migrates `genie dir` to use `app_store` as primary store (backward compat with legacy `agents` table preserved)
- Board install → `task_types`, workflow install → `schedules`, stack install is transactional
- Fallback manifest detection chain: `genie.yaml` → `AGENTS.md` → `manifest.ts` → `skill.md`
- One-time idempotent migration from `agent-directory.json` to DB on first `genie dir ls`

### Files Created
- `src/db/migrations/009_app_store.sql` — app_store, installed_apps, app_versions tables
- `src/lib/manifest.ts` — manifest parser, validator, type definitions, fallback detection
- `src/lib/agent-cache.ts` — agent cache regeneration, app_store CRUD helpers, JSON→DB migration
- `src/term-commands/install.ts` — `genie install` command
- `src/term-commands/item-uninstall.ts` — `genie item uninstall` command
- `src/term-commands/item-update.ts` — `genie item update` command
- `src/term-commands/publish.ts` — `genie publish` command

### Files Modified
- `src/genie.ts` — registers new commands
- `src/term-commands/dir.ts` — writes to app_store on add/rm/edit, reads from app_store on ls

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` — 0 errors (4 pre-existing warnings)
- [x] `bun run build` — dist/genie.js bundled successfully (1.27MB)
- [x] `bun test` — 1282 pass, 6 fail (pre-existing OTel port conflicts)
- [ ] `genie dir ls` queries app_store with fallback to legacy table
- [ ] `genie dir add` writes to both app_store and legacy agents table
- [ ] `genie install github.com/user/repo` clones, validates, registers
- [ ] `genie item uninstall <name>` removes clone + DB entries
- [ ] `genie publish` requires pushed git tag, records version