### PR TITLE
fix: final polish — board reconcile, kanban filter, export flag, otel port, msg refactor

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,9 +1,8 @@
 {
   "$schema": "https://unpkg.com/knip@5.85.0/schema.json",
-  "entry": ["src/genie.ts", "src/hooks/dispatch-command.ts"],
+  "entry": ["src/hooks/dispatch-command.ts"],
   "project": ["src/**/*.ts"],
-  "ignoreBinaries": ["tmux", "which", "husky", "biome", "tsc"],
-  "ignoreDependencies": ["nats", "@biomejs/biome", "@commitlint/cli", "esbuild", "husky"],
-  "ignore": ["src/lib/team-auto-spawn.ts", "src/lib/inbox-watcher.ts"],
+  "ignoreBinaries": ["tmux", "which"],
+  "ignoreDependencies": ["nats"],
   "ignoreExportsUsedInFile": true
 }

--- a/src/lib/board-service.ts
+++ b/src/lib/board-service.ts
@@ -457,3 +457,69 @@ export async function importBoard(json: BoardExport, projectId: string): Promise
     columns: json.columns,
   });
 }
+
+// ============================================================================
+// Reconciliation
+// ============================================================================
+
+export interface ReconcileResult {
+  fixed: number;
+  orphaned: number;
+  details: { taskId: string; stage: string; oldColumnId: string | null; newColumnId: string | null }[];
+}
+
+/**
+ * Reconcile orphaned column_ids on a board.
+ * For each task whose column_id doesn't match any board column,
+ * resolve by matching task.stage → board column name.
+ */
+export async function reconcileBoard(nameOrId: string): Promise<ReconcileResult> {
+  const sql = await getConnection();
+  const board = await getBoard(nameOrId);
+  if (!board) throw new Error(`Board not found: ${nameOrId}`);
+
+  const columnByName = new Map(board.columns.map((c) => [c.name, c]));
+  const columnIds = new Set(board.columns.map((c) => c.id));
+
+  // Find tasks on this board with orphaned or missing column_ids
+  const tasks = await sql`
+    SELECT id, stage, column_id FROM tasks
+    WHERE board_id = ${board.id}
+  `;
+
+  const result: ReconcileResult = { fixed: 0, orphaned: 0, details: [] };
+
+  for (const task of tasks) {
+    const currentColId = task.column_id as string | null;
+    if (currentColId && columnIds.has(currentColId)) continue;
+
+    const matchedCol = columnByName.get(task.stage as string);
+    if (matchedCol) {
+      await sql`UPDATE tasks SET column_id = ${matchedCol.id} WHERE id = ${task.id}`;
+      result.fixed++;
+      result.details.push({
+        taskId: task.id as string,
+        stage: task.stage as string,
+        oldColumnId: currentColId,
+        newColumnId: matchedCol.id,
+      });
+    } else {
+      result.orphaned++;
+      result.details.push({
+        taskId: task.id as string,
+        stage: task.stage as string,
+        oldColumnId: currentColId,
+        newColumnId: null,
+      });
+    }
+  }
+
+  if (result.fixed > 0) {
+    recordAuditEvent('board', board.id, 'board_reconciled', getActor(), {
+      fixed: result.fixed,
+      orphaned: result.orphaned,
+    }).catch(() => {});
+  }
+
+  return result;
+}

--- a/src/lib/otel-receiver.test.ts
+++ b/src/lib/otel-receiver.test.ts
@@ -1,9 +1,19 @@
-import { afterEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { getOtelPort, isOtelReceiverRunning, startOtelReceiver, stopOtelReceiver } from './otel-receiver.js';
 
 describe('otel-receiver', () => {
+  let origPort: string | undefined;
+
+  beforeEach(() => {
+    origPort = process.env.GENIE_OTEL_PORT;
+    // Use a random high port to avoid conflicts with running pgserve
+    process.env.GENIE_OTEL_PORT = String(49152 + Math.floor(Math.random() * 16383));
+  });
+
   afterEach(() => {
     stopOtelReceiver();
+    if (origPort !== undefined) process.env.GENIE_OTEL_PORT = origPort;
+    else process.env.GENIE_OTEL_PORT = undefined;
   });
 
   test('getOtelPort returns pgserve port + 1 by default', () => {
@@ -13,14 +23,8 @@ describe('otel-receiver', () => {
   });
 
   test('getOtelPort respects GENIE_OTEL_PORT env', () => {
-    const orig = process.env.GENIE_OTEL_PORT;
     process.env.GENIE_OTEL_PORT = '12345';
-    try {
-      expect(getOtelPort()).toBe(12345);
-    } finally {
-      if (orig) process.env.GENIE_OTEL_PORT = orig;
-      else process.env.GENIE_OTEL_PORT = undefined;
-    }
+    expect(getOtelPort()).toBe(12345);
   });
 
   test('startOtelReceiver starts and is idempotent', async () => {

--- a/src/term-commands/board.ts
+++ b/src/term-commands/board.ts
@@ -387,6 +387,29 @@ async function handleBoardExport(name: string, options: { project?: string; outp
   }
 }
 
+async function handleBoardReconcile(name: string, options: { project?: string; json?: boolean }): Promise<void> {
+  const { reconcileBoard } = await import('../lib/board-service.js');
+  const board = await resolveBoard(name, options.project);
+  const result = await reconcileBoard(board.id);
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  if (result.fixed === 0 && result.orphaned === 0) {
+    console.log(`Board "${board.name}": all tasks have valid column_ids.`);
+    return;
+  }
+
+  console.log(`Board "${board.name}" reconciliation:`);
+  console.log(`  Fixed: ${result.fixed} task${result.fixed === 1 ? '' : 's'}`);
+  if (result.orphaned > 0) {
+    const count = result.orphaned;
+    console.log(`  Still orphaned: ${count} task${count === 1 ? '' : 's'} (stage doesn't match any column)`);
+  }
+}
+
 async function handleBoardImport(options: { json: string; project: string }): Promise<void> {
   const bs = await getBoardService();
 
@@ -681,9 +704,25 @@ export function registerBoardCommands(program: Command): void {
     .description('Export board as JSON')
     .option('--project <project>', 'Disambiguate by project')
     .option('--output <file>', 'Write to file instead of stdout')
-    .action(async (nameParts: string[], options: { project?: string; output?: string }) => {
+    .option('--json', 'Output as JSON (default, accepted for consistency)')
+    .action(async (nameParts: string[], options: { project?: string; output?: string; json?: boolean }) => {
       try {
         await handleBoardExport(nameParts.join(' '), options);
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    });
+
+  // ── board reconcile ──
+  board
+    .command('reconcile <name...>')
+    .description('Fix orphaned column_ids by matching task stage to board columns')
+    .option('--project <project>', 'Disambiguate by project')
+    .option('--json', 'Output as JSON')
+    .action(async (nameParts: string[], options: { project?: string; json?: boolean }) => {
+      try {
+        await handleBoardReconcile(nameParts.join(' '), options);
       } catch (error) {
         console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);

--- a/src/term-commands/msg.ts
+++ b/src/term-commands/msg.ts
@@ -361,6 +361,104 @@ async function handleChatRead(
 }
 
 // ============================================================================
+// Native Inbox Bridge
+// ============================================================================
+
+/** Discover the current team name from env, native discovery, or worker registry. */
+async function discoverCurrentTeam(
+  nativeTeams: typeof import('../lib/claude-native-teams.js'),
+  from: string,
+): Promise<string | null> {
+  const discovered = await nativeTeams.discoverTeamName().catch(() => null);
+  if (discovered) return discovered;
+
+  const registryMod = await getRegistry();
+  const workers = await registryMod.list();
+  const senderWorker = workers.find((w) => w.role === from || w.id === from || w.customName === from);
+  return senderWorker?.team ?? null;
+}
+
+/** Try delivering a native inbox message to a specific team. */
+async function deliverToTeam(
+  nativeTeams: typeof import('../lib/claude-native-teams.js'),
+  team: string,
+  recipient: string,
+  msg: { from: string; text: string; summary: string; timestamp: string; color: 'blue'; read: false },
+): Promise<boolean> {
+  const nativeName = await nativeTeams.resolveNativeMemberName(team, recipient);
+  if (!nativeName) return false;
+  await nativeTeams.writeNativeInbox(team, nativeName, msg);
+  return true;
+}
+
+/** Bridge a message to the Claude Code native inbox for real-time delivery. */
+async function bridgeToNativeInbox(from: string, recipient: string, body: string): Promise<void> {
+  const nativeTeams = await import('../lib/claude-native-teams.js');
+  const nativeMsg = {
+    from,
+    text: body,
+    summary: body.length > 50 ? `${body.substring(0, 50)}...` : body,
+    timestamp: new Date().toISOString(),
+    color: 'blue' as const,
+    read: false as const,
+  };
+
+  const currentTeam = await discoverCurrentTeam(nativeTeams, from);
+
+  // Try current team first (fast path)
+  if (currentTeam && (await deliverToTeam(nativeTeams, currentTeam, recipient, nativeMsg))) return;
+
+  // Search all native teams
+  const allTeams = await nativeTeams.listTeams().catch(() => [] as string[]);
+  for (const team of allTeams) {
+    if (team === currentTeam) continue;
+    if (await deliverToTeam(nativeTeams, team, recipient, nativeMsg)) return;
+  }
+
+  console.warn(`[genie send] Native inbox bridge: could not find native team member for "${recipient}"`);
+}
+
+// ============================================================================
+// Send Handler
+// ============================================================================
+
+async function handleSend(body: string, options: { to: string; from?: string }): Promise<void> {
+  const ts = await getTaskService();
+  const repoPath = process.cwd();
+  const from = options.from ?? (await detectSenderIdentity());
+
+  const scopeError = await checkSendScope(repoPath, from, options.to);
+  if (scopeError) {
+    console.error(`Error: ${scopeError}`);
+    process.exit(1);
+  }
+
+  const senderActor = localActor(from);
+  const recipientActor = localActor(options.to);
+
+  const conv = await ts.findOrCreateConversation({
+    type: 'dm',
+    members: [senderActor, recipientActor],
+    createdBy: senderActor,
+  });
+
+  await ts.addMember(conv.id, senderActor);
+  await ts.addMember(conv.id, recipientActor);
+
+  const msg = await ts.sendMessage(conv.id, senderActor, body);
+
+  // Best-effort native inbox bridge
+  await bridgeToNativeInbox(from, options.to, body).catch((err) => {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.warn(`[genie send] Native inbox bridge failed: ${reason}`);
+  });
+
+  console.log(`Message sent to "${options.to}".`);
+  console.log(`  ID: ${msg.id}`);
+  console.log(`  Conversation: ${conv.id}`);
+}
+
+// ============================================================================
 // Command Registration
 // ============================================================================
 
@@ -373,95 +471,7 @@ export function registerSendInboxCommands(program: Command): void {
     .option('--from <sender>', 'Sender ID (auto-detected from context)')
     .action(async (body: string, options: { to: string; from?: string }) => {
       try {
-        const ts = await getTaskService();
-        const repoPath = process.cwd();
-        const from = options.from ?? (await detectSenderIdentity());
-
-        // Scope check
-        const scopeError = await checkSendScope(repoPath, from, options.to);
-        if (scopeError) {
-          console.error(`Error: ${scopeError}`);
-          process.exit(1);
-        }
-
-        const senderActor = localActor(from);
-        const recipientActor = localActor(options.to);
-
-        // Find or create DM conversation
-        const conv = await ts.findOrCreateConversation({
-          type: 'dm',
-          members: [senderActor, recipientActor],
-          createdBy: senderActor,
-        });
-
-        // Ensure both are members
-        await ts.addMember(conv.id, senderActor);
-        await ts.addMember(conv.id, recipientActor);
-
-        const msg = await ts.sendMessage(conv.id, senderActor, body);
-
-        // Bridge to CC native inbox so Claude Code agents receive in real-time
-        // Search ALL teams for the recipient, not just the current team
-        try {
-          const nativeTeams = await import('../lib/claude-native-teams.js');
-          const nativeMsg = {
-            from,
-            text: body,
-            summary: body.length > 50 ? `${body.substring(0, 50)}...` : body,
-            timestamp: new Date().toISOString(),
-            color: 'blue' as const,
-            read: false,
-          };
-
-          // Team discovery chain: GENIE_TEAM env → discoverTeamName() → worker registry
-          let currentTeam = await nativeTeams.discoverTeamName().catch(() => null);
-
-          if (!currentTeam) {
-            // Fallback: check worker registry for sender's team
-            const registryMod = await getRegistry();
-            const workers = await registryMod.list();
-            const senderWorker = workers.find((w) => w.role === from || w.id === from || w.customName === from);
-            if (senderWorker?.team) {
-              currentTeam = senderWorker.team;
-            }
-          }
-
-          let delivered = false;
-
-          // Try current team first (fast path) — resolve genie worker ID to native member name
-          if (currentTeam) {
-            const nativeName = await nativeTeams.resolveNativeMemberName(currentTeam, options.to);
-            if (nativeName) {
-              await nativeTeams.writeNativeInbox(currentTeam, nativeName, nativeMsg);
-              delivered = true;
-            }
-          }
-
-          // If not in current team, search all native teams
-          if (!delivered) {
-            const allTeams = await nativeTeams.listTeams().catch(() => [] as string[]);
-            for (const team of allTeams) {
-              if (team === currentTeam) continue; // already checked
-              const nativeName = await nativeTeams.resolveNativeMemberName(team, options.to);
-              if (nativeName) {
-                await nativeTeams.writeNativeInbox(team, nativeName, nativeMsg);
-                delivered = true;
-                break;
-              }
-            }
-          }
-
-          if (!delivered) {
-            console.warn(`[genie send] Native inbox bridge: could not find native team member for "${options.to}"`);
-          }
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          console.warn(`[genie send] Native inbox bridge failed: ${reason}`);
-        }
-
-        console.log(`Message sent to "${options.to}".`);
-        console.log(`  ID: ${msg.id}`);
-        console.log(`  Conversation: ${conv.id}`);
+        await handleSend(body, options);
       } catch (error) {
         console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);

--- a/src/term-commands/task.ts
+++ b/src/term-commands/task.ts
@@ -448,6 +448,7 @@ export function registerTaskCommands(program: Command): void {
     .option('--project <name>', 'Show tasks for a specific project')
     .option('--board <name>', 'Filter by board name')
     .option('--by-column', 'Group tasks by board column (kanban view)')
+    .option('--include-done', 'Include done tasks in kanban view (hidden by default)')
     .option('--all', 'Show tasks from ALL projects')
     .option('--json', 'Output as JSON')
     .action(
@@ -462,6 +463,7 @@ export function registerTaskCommands(program: Command): void {
         project?: string;
         board?: string;
         byColumn?: boolean;
+        includeDone?: boolean;
         all?: boolean;
         json?: boolean;
       }) => {
@@ -490,6 +492,10 @@ export function registerTaskCommands(program: Command): void {
             if (!options.board) {
               console.error('Error: --by-column requires --board');
               process.exit(1);
+            }
+            // Hide done tasks by default in kanban view
+            if (!options.includeDone) {
+              tasks = tasks.filter((t) => t.status !== 'done');
             }
             await printByColumn(tasks, options.board);
             return;


### PR DESCRIPTION
## Summary

- **Board reconcile command** (`genie board reconcile <name>`) — fixes orphaned `column_id` by matching `task.stage` → board column name
- **Kanban done filter** — `--by-column` hides `status=done` tasks by default; `--include-done` shows all
- **Export `--json` flag** — `genie board export <name> --json` no longer errors on unknown option
- **OTel test port fix** — tests use random high port to avoid conflicts with running pgserve
- **msg.ts refactor** — extracted native inbox bridge helpers, complexity 40 → <15
- **knip config cleanup** — removed stale ignores and redundant entry pattern (0 hints now)

## Test plan

- [x] `bun run check` exits 0 (typecheck + lint + dead-code + test)
- [x] 1288 tests pass, 0 failures
- [x] `git push` succeeds with all hooks passing
- [x] knip reports zero unused exports and zero configuration hints