### PR TITLE
fix(cli): remove hardcoded column truncation in genie dir ls

### DIFF
--- a/src/term-commands/dir.ts
+++ b/src/term-commands/dir.ts
@@ -269,7 +269,7 @@ async function listEntries(json?: boolean, includeBuiltins?: boolean): Promise<v
         repo: (manifest.repo as string) ?? '',
         promptMode: ((manifest.promptMode as string) ?? 'append') as directory.PromptMode,
         model: manifest.model as string | undefined,
-        roles: manifest.roles as string[] | undefined,
+        roles: normalizeRoles(manifest.roles as string[] | undefined),
         registeredAt: item.installed_at as string,
         scope: 'global' as directory.DirectoryScope,
       };
@@ -338,7 +338,7 @@ function printRegisteredTable(entries: directory.ScopedDirectoryEntry[]): void {
   const roleValues: string[] = [];
   for (const entry of entries) {
     repoValues.push(entry.repo ? contractPath(entry.repo) : contractPath(entry.dir));
-    roleValues.push(normalizeRoles(entry.roles)?.join(', ') || '-');
+    roleValues.push(entry.roles?.join(', ') || '-');
   }
 
   // Size REPO column to fit longest value, capped to leave room for ROLES


### PR DESCRIPTION
## Summary
- **REPO column** now sizes dynamically based on actual content width and terminal width, instead of truncating at 28 chars with ellipsis — no more data loss in table output
- **Roles normalization**: `--roles` flag now splits comma-separated values into individual array items (e.g. `"engineer,reviewer,qa"` → `["engineer", "reviewer", "qa"]`), applied on write (dir add, dir edit, agent register) and on display for legacy data

## Test plan
- [ ] Run `genie dir ls` with agents that have long repo paths — verify full paths are displayed
- [ ] Run `genie dir add test --dir /tmp --roles engineer,reviewer,qa` and verify roles stored as separate array items via `genie dir ls test --json`
- [ ] Verify table renders correctly at different terminal widths (narrow, wide)

Closes #807