### PR TITLE
fix(lint): remove noNonNullAssertion violations in install.ts

### DIFF
--- a/src/term-commands/install.ts
+++ b/src/term-commands/install.ts
@@ -197,7 +197,8 @@ async function handleExternalStackItem(
   item: import('../lib/manifest.js').StackItem,
   tx: Awaited<ReturnType<typeof getConnection>>,
 ): Promise<string> {
-  const parsed = parseInstallTarget(item.source!);
+  if (!item.source) throw new Error(`Stack item "${item.name}" is missing source`);
+  const parsed = parseInstallTarget(item.source);
   const itemDir = join(ITEMS_DIR, parsed.name);
   mkdirSync(ITEMS_DIR, { recursive: true });
   cloneRepo(parsed.url, itemDir, { version: parsed.version });
@@ -224,7 +225,8 @@ async function handleExternalStackItem(
 }
 
 async function installStack(manifest: GenieManifest, _installPath: string): Promise<void> {
-  if (!manifest.stack?.items) return;
+  const stackItems = manifest.stack?.items;
+  if (!stackItems) return;
   if (!(await isAvailable())) return;
 
   const sql = await getConnection();
@@ -232,7 +234,7 @@ async function installStack(manifest: GenieManifest, _installPath: string): Prom
 
   try {
     await sql.begin(async (tx: typeof sql) => {
-      for (const item of manifest.stack!.items) {
+      for (const item of stackItems) {
         if (item.inline) {
           await handleInlineStackItem(item, manifest.version, tx);
           installed.push(item.name);


### PR DESCRIPTION
## Summary
- Replace `item.source!` non-null assertion with explicit null check + early throw in `handleExternalStackItem`
- Extract `manifest.stack?.items` into `stackItems` local variable to eliminate `manifest.stack!.items` non-null assertion in `installStack`

Fixes 2 `noNonNullAssertion` biome warnings in `src/term-commands/install.ts`.

## Test plan
- [x] `bun run lint` — 0 errors (1 pre-existing complexity warning in dir.ts)
- [x] `bun run typecheck` — clean
- [x] `bun test` — 1180+ pass, 0 fail (excluding pre-existing NATS/infra flakes)
- [x] `bun run build` — succeeds (1.27 MB bundle)