### PR TITLE
chore: remove 71 unnecessary exports, tighten knip config

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -4,5 +4,5 @@
   "project": ["src/**/*.ts"],
   "ignoreBinaries": ["tmux", "which"],
   "ignoreDependencies": ["nats"],
-  "ignoreExportsUsedInFile": true
+  "ignoreExportsUsedInFile": false
 }

--- a/src/genie-commands/session.ts
+++ b/src/genie-commands/session.ts
@@ -46,7 +46,7 @@ export function getAgentsFilePath(): string | null {
   return null;
 }
 
-export interface SessionOptions {
+interface SessionOptions {
   reset?: boolean;
   name?: string;
   dir?: string;

--- a/src/lib/agent-cache.ts
+++ b/src/lib/agent-cache.ts
@@ -28,7 +28,7 @@ const CACHE_BACKUP = 'agent-directory.json.bak';
 // ============================================================================
 
 /** Denormalised cache entry written to agent-directory.json. */
-export interface CacheEntry {
+interface CacheEntry {
   name: string;
   dir: string;
   repo?: string;
@@ -60,7 +60,7 @@ export interface StoreRow {
 }
 
 /** Insert payload for registerItemInStore. */
-export interface StoreInsert {
+interface StoreInsert {
   name: string;
   itemType: string;
   version?: string;

--- a/src/lib/agent-directory.ts
+++ b/src/lib/agent-directory.ts
@@ -41,12 +41,12 @@ export interface ScopedDirectoryEntry extends DirectoryEntry {
   scope: DirectoryScope;
 }
 
-export interface ScopeOptions {
+interface ScopeOptions {
   global?: boolean;
 }
 
 /** Resolved agent — either a user directory entry or a built-in. */
-export interface ResolvedAgent {
+interface ResolvedAgent {
   /** The agent entry (user or synthetic built-in). */
   entry: DirectoryEntry;
   /** Whether this came from the built-in registry. */

--- a/src/lib/board-service.ts
+++ b/src/lib/board-service.ts
@@ -462,7 +462,7 @@ export async function importBoard(json: BoardExport, projectId: string): Promise
 // Reconciliation
 // ============================================================================
 
-export interface ReconcileResult {
+interface ReconcileResult {
   fixed: number;
   orphaned: number;
   details: { taskId: string; stage: string; oldColumnId: string | null; newColumnId: string | null }[];

--- a/src/lib/claude-logs.ts
+++ b/src/lib/claude-logs.ts
@@ -316,7 +316,7 @@ export function parseLogEntry(line: string): ClaudeLogEntry | null {
  * @param logPath - Path to the .jsonl log file
  * @returns Array of parsed log entries
  */
-export async function readLogFile(logPath: string): Promise<ClaudeLogEntry[]> {
+async function readLogFile(logPath: string): Promise<ClaudeLogEntry[]> {
   const entries: ClaudeLogEntry[] = [];
 
   try {
@@ -385,7 +385,7 @@ async function findLogsForWorkspace(
  * @param claudeDir - Optional custom Claude directory
  * @returns Log file path and session info, or null if not found
  */
-export async function getLogsForPane(
+async function getLogsForPane(
   paneWorkdir: string,
   claudeDir?: string,
 ): Promise<{ logPath: string; session: ClaudeSession; projectDir: string } | null> {

--- a/src/lib/codex-logs.ts
+++ b/src/lib/codex-logs.ts
@@ -305,4 +305,4 @@ export const codexTranscriptProvider: TranscriptProvider = {
 };
 
 // Exported for testing
-export { parseCodexLine, discoverViaSqlite, discoverViaScan, extractCodexContent };
+export { parseCodexLine, extractCodexContent };

--- a/src/lib/cron.ts
+++ b/src/lib/cron.ts
@@ -82,7 +82,7 @@ function parseCronField(field: string, min: number, max: number): number[] {
  *   - If both DOM and DOW are restricted (not *), the day matches if EITHER matches (union).
  *   - Otherwise, both must match (intersection — wildcards always match).
  */
-export interface CronOptions {
+interface CronOptions {
   /** Compute next occurrence after this time. Defaults to now. */
   after?: Date;
   /** IANA timezone (e.g. 'America/New_York'). When set, cron fields are matched against wall-clock time in this timezone. */

--- a/src/lib/db-migrations.ts
+++ b/src/lib/db-migrations.ts
@@ -20,12 +20,12 @@ type Sql = postgres.Sql;
 // Types
 // ---------------------------------------------------------------------------
 
-export interface MigrationRecord {
+interface MigrationRecord {
   name: string;
   applied_at: string | null; // ISO timestamp if applied, null if pending
 }
 
-export interface MigrationStatus {
+interface MigrationStatus {
   applied: MigrationRecord[];
   pending: MigrationRecord[];
 }

--- a/src/lib/import-order.ts
+++ b/src/lib/import-order.ts
@@ -9,7 +9,7 @@
  */
 
 /** Tables at each FK dependency level (0 = no FK deps, higher = more deps) */
-export const IMPORT_LEVELS: string[][] = [
+const IMPORT_LEVELS: string[][] = [
   // Level 0: No FK dependencies
   [
     'schedules',
@@ -54,7 +54,7 @@ export const SELF_REFERENTIAL_COLUMNS: Record<string, string> = {
 /**
  * Get the import level for a table. Returns -1 if not in the graph.
  */
-export function getTableLevel(table: string): number {
+function getTableLevel(table: string): number {
   for (let i = 0; i < IMPORT_LEVELS.length; i++) {
     if (IMPORT_LEVELS[i].includes(table)) return i;
   }

--- a/src/lib/inbox-watcher.ts
+++ b/src/lib/inbox-watcher.ts
@@ -35,7 +35,7 @@ const defaultDeps: InboxWatcherDeps = {
 // ============================================================================
 
 /** Default inbox poll interval in milliseconds (30 seconds). */
-export const INBOX_POLL_INTERVAL_MS = 30_000;
+const INBOX_POLL_INTERVAL_MS = 30_000;
 
 /** Maximum consecutive spawn failures before skipping a team. */
 const MAX_SPAWN_FAILURES = 3;

--- a/src/lib/manifest.ts
+++ b/src/lib/manifest.ts
@@ -18,7 +18,7 @@ import * as yaml from 'js-yaml';
 
 export type ItemType = 'agent' | 'skill' | 'app' | 'board' | 'workflow' | 'stack' | 'template' | 'hook';
 
-export const ITEM_TYPES: ItemType[] = ['agent', 'skill', 'app', 'board', 'workflow', 'stack', 'template', 'hook'];
+const ITEM_TYPES: ItemType[] = ['agent', 'skill', 'app', 'board', 'workflow', 'stack', 'template', 'hook'];
 
 export interface StageConfig {
   name: string;
@@ -56,7 +56,7 @@ export interface GenieManifest {
   license?: string;
 }
 
-export interface ValidationResult {
+interface ValidationResult {
   valid: boolean;
   errors: string[];
   warnings: string[];
@@ -72,7 +72,7 @@ export interface ValidationResult {
  * Validates that required fields (name, type, version) are present and that
  * the type value is a recognized ItemType. Throws on invalid input.
  */
-export function parseManifest(yamlContent: string): GenieManifest {
+function parseManifest(yamlContent: string): GenieManifest {
   const raw = yaml.load(yamlContent);
   if (!raw || typeof raw !== 'object') {
     throw new Error('Manifest YAML is empty or not an object');

--- a/src/lib/nats-client.ts
+++ b/src/lib/nats-client.ts
@@ -12,9 +12,9 @@
 // Types
 // ============================================================================
 
-export type NatsMessageCallback = (subject: string, data: unknown) => void;
+type NatsMessageCallback = (subject: string, data: unknown) => void;
 
-export interface NatsSubscription {
+interface NatsSubscription {
   unsubscribe: () => void;
 }
 

--- a/src/lib/omni-registration.ts
+++ b/src/lib/omni-registration.ts
@@ -15,7 +15,7 @@ import { loadGenieConfig } from './genie-config.js';
 // Types
 // ============================================================================
 
-export interface OmniAgentRegistration {
+interface OmniAgentRegistration {
   name: string;
   provider: 'claude' | 'agno' | 'openai' | 'gemini' | 'custom' | 'omni-internal';
   model?: string;
@@ -24,7 +24,7 @@ export interface OmniAgentRegistration {
   metadata?: Record<string, unknown>;
 }
 
-export interface OmniAgentResponse {
+interface OmniAgentResponse {
   id: string;
   name: string;
   provider: string;

--- a/src/lib/orchestrator/state-detector.ts
+++ b/src/lib/orchestrator/state-detector.ts
@@ -19,17 +19,9 @@ import {
   workingPatterns,
 } from './patterns.js';
 
-export type ClaudeStateType =
-  | 'idle'
-  | 'working'
-  | 'permission'
-  | 'question'
-  | 'error'
-  | 'complete'
-  | 'tool_use'
-  | 'unknown';
+type ClaudeStateType = 'idle' | 'working' | 'permission' | 'question' | 'error' | 'complete' | 'tool_use' | 'unknown';
 
-export interface ClaudeState {
+interface ClaudeState {
   type: ClaudeStateType;
   detail?: string;
   options?: string[];

--- a/src/lib/pg-seed.ts
+++ b/src/lib/pg-seed.ts
@@ -432,7 +432,7 @@ export async function runSeed(sql: Sql, repoPath?: string): Promise<SeedResult> 
   return result;
 }
 
-export interface SeedResult {
+interface SeedResult {
   agents: number;
   templates: number;
   teams: number;

--- a/src/lib/qa-parser.ts
+++ b/src/lib/qa-parser.ts
@@ -20,7 +20,7 @@ import { readFile } from 'node:fs/promises';
 // Types
 // ============================================================================
 
-export type SetupStepKind = 'spawn' | 'follow';
+type SetupStepKind = 'spawn' | 'follow';
 
 export interface SetupStep {
   kind: SetupStepKind;
@@ -30,7 +30,7 @@ export interface SetupStep {
   options: Record<string, string>;
 }
 
-export type ActionStepKind = 'send' | 'wait' | 'run';
+type ActionStepKind = 'send' | 'wait' | 'run';
 
 export interface ActionStep {
   kind: ActionStepKind;
@@ -94,7 +94,7 @@ function detectSection(line: string): Section | null {
 }
 
 /** Parse QA spec content directly (for testing). */
-export function parseQaSpecContent(content: string, filePath = '<inline>'): QaSpec {
+function parseQaSpecContent(content: string, filePath = '<inline>'): QaSpec {
   const lines = content.split('\n');
 
   let name = '';

--- a/src/lib/qa-state.ts
+++ b/src/lib/qa-state.ts
@@ -25,7 +25,7 @@ export interface StoredResult {
   error?: string;
 }
 
-export interface QaResults {
+interface QaResults {
   [specKey: string]: StoredResult;
 }
 

--- a/src/lib/routing-header.ts
+++ b/src/lib/routing-header.ts
@@ -14,7 +14,7 @@ import { createHash } from 'node:crypto';
 // Types
 // ============================================================================
 
-export interface RoutingHeader {
+interface RoutingHeader {
   channel: string; // telegram, whatsapp-baileys, discord, slack
   instance: string; // source instance ID
   chat: string; // chat/conversation ID

--- a/src/lib/scheduler-daemon.ts
+++ b/src/lib/scheduler-daemon.ts
@@ -673,7 +673,7 @@ const DEFAULT_MAX_RESUME_ATTEMPTS = 3;
  *   - 'exhausted' — retry budget depleted, agent marked permanently failed
  *   - 'skipped' — ineligible (autoResume off, cooldown, cap, no session, etc.)
  */
-export type ResumeResult = 'resumed' | 'exhausted' | 'skipped';
+type ResumeResult = 'resumed' | 'exhausted' | 'skipped';
 
 /**
  * Attempt to auto-resume a dead agent.
@@ -1158,7 +1158,7 @@ function startInboxWatcherIfEnabled(deps: SchedulerDeps): NodeJS.Timeout | null 
 // Daemon loop
 // ============================================================================
 
-export interface DaemonHandle {
+interface DaemonHandle {
   /** Stop the daemon gracefully. */
   stop: () => void;
   /** Promise that resolves when the daemon exits. */

--- a/src/lib/spawn-command.ts
+++ b/src/lib/spawn-command.ts
@@ -103,7 +103,7 @@ export const DEFAULT_SPAWN_TIMEOUT_MS = 30_000;
 export const READINESS_POLL_INTERVAL_MS = 2_000;
 
 /** Result of a readiness check. */
-export interface ReadinessResult {
+interface ReadinessResult {
   ready: boolean;
   elapsedMs: number;
 }

--- a/src/lib/table-detect.ts
+++ b/src/lib/table-detect.ts
@@ -12,7 +12,7 @@ type Sql = postgres.Sql;
 /**
  * Get all user tables in the current schema (excludes system tables and migration tracker).
  */
-export async function getAvailableTables(sql: Sql): Promise<string[]> {
+async function getAvailableTables(sql: Sql): Promise<string[]> {
   const rows = await sql<{ table_name: string }[]>`
     SELECT table_name
     FROM information_schema.tables

--- a/src/lib/task-service.ts
+++ b/src/lib/task-service.ts
@@ -20,7 +20,7 @@ export interface Actor {
   actorId: string;
 }
 
-export interface TaskInput {
+interface TaskInput {
   title: string;
   description?: string;
   acceptanceCriteria?: string;
@@ -102,7 +102,7 @@ export interface TaskFilters {
   offset?: number;
 }
 
-export interface TaskActorRow {
+interface TaskActorRow {
   taskId: string;
   actorType: string;
   actorId: string;
@@ -111,7 +111,7 @@ export interface TaskActorRow {
   createdAt: string;
 }
 
-export interface DependencyRow {
+interface DependencyRow {
   taskId: string;
   dependsOnId: string;
   depType: string;
@@ -132,7 +132,7 @@ export interface ConversationRow {
   updatedAt: string;
 }
 
-export interface ConversationMemberRow {
+interface ConversationMemberRow {
   conversationId: string;
   actorType: string;
   actorId: string;
@@ -140,7 +140,7 @@ export interface ConversationMemberRow {
   joinedAt: string;
 }
 
-export interface MessageRow {
+interface MessageRow {
   id: number;
   conversationId: string;
   replyToId: number | null;
@@ -152,7 +152,7 @@ export interface MessageRow {
   updatedAt: string;
 }
 
-export interface TagRow {
+interface TagRow {
   id: string;
   name: string;
   color: string;
@@ -183,7 +183,7 @@ export interface NotificationPrefRow {
   updatedAt: string;
 }
 
-export interface StageLogRow {
+interface StageLogRow {
   id: number;
   taskId: string;
   fromStage: string | null;
@@ -195,7 +195,7 @@ export interface StageLogRow {
   createdAt: string;
 }
 
-export interface FindOrCreateConversationOpts {
+interface FindOrCreateConversationOpts {
   type?: 'dm' | 'group';
   name?: string;
   linkedEntity?: string;
@@ -205,7 +205,7 @@ export interface FindOrCreateConversationOpts {
   createdBy?: Actor;
 }
 
-export interface MessageListOpts {
+interface MessageListOpts {
   limit?: number;
   offset?: number;
   since?: string;
@@ -388,7 +388,7 @@ function mapProject(row: Record<string, unknown>): ProjectRow {
 // ============================================================================
 
 /** Resolve repo root via `git rev-parse --show-toplevel`, fallback to cwd. */
-export function getRepoPath(): string {
+function getRepoPath(): string {
   try {
     return execSync('git rev-parse --show-toplevel', {
       encoding: 'utf-8',

--- a/src/lib/team-manager.ts
+++ b/src/lib/team-manager.ts
@@ -426,7 +426,7 @@ export async function disbandTeam(teamName: string): Promise<boolean> {
  * Scans all team configs in PG — if a team's worktreePath (clone directory) no longer
  * exists on disk, deletes that team's row and its ~/.claude/teams/ dir.
  */
-export async function pruneStaleWorktrees(_repoPath: string): Promise<void> {
+async function pruneStaleWorktrees(_repoPath: string): Promise<void> {
   const sql = await getConnection();
   const rows = await sql`SELECT name, worktree_path FROM teams`;
 

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -74,7 +74,7 @@ export async function getCurrentSessionName(hint?: string): Promise<string | nul
 /**
  * List all tmux sessions
  */
-export async function listSessions(): Promise<TmuxSession[]> {
+async function listSessions(): Promise<TmuxSession[]> {
   try {
     const format = '#{session_id}:#{session_name}:#{?session_attached,1,0}:#{session_windows}';
     const output = await executeTmux(`list-sessions -F '${format}'`);
@@ -234,7 +234,7 @@ export async function createSession(name: string): Promise<TmuxSession | null> {
 /**
  * Create a new window in a session
  */
-export async function createWindow(sessionId: string, name: string, workingDir?: string): Promise<TmuxWindow | null> {
+async function createWindow(sessionId: string, name: string, workingDir?: string): Promise<TmuxWindow | null> {
   const cdFlag = workingDir ? ` -c '${workingDir.replace(/'/g, "'\\''")}'` : '';
   // Use -d (don't switch focus) and -P -F to capture the window ID and index directly.
   // Avoids relying on findWindowByName which can fail if automatic-rename fires.
@@ -273,7 +273,7 @@ export async function findWindowByName(sessionId: string, name: string): Promise
  * @param session - The tmux session name
  * @param masterName - The expected name of the master/team-lead window
  */
-export async function ensureMasterWindow(session: string, masterName: string): Promise<void> {
+async function ensureMasterWindow(session: string, masterName: string): Promise<void> {
   try {
     const windows = await listWindows(session);
     if (windows.length < 2) return; // Nothing to swap with a single window

--- a/src/lib/unified-log.ts
+++ b/src/lib/unified-log.ts
@@ -273,10 +273,10 @@ export async function readTeamLog(
 // ============================================================================
 
 /** Callback for new events in follow mode. */
-export type LogEventCallback = (event: LogEvent) => void;
+type LogEventCallback = (event: LogEvent) => void;
 
 /** Handle returned by follow functions to stop streaming. */
-export interface FollowHandle {
+interface FollowHandle {
   stop: () => Promise<void>;
   /** 'nats' if streaming via NATS, 'poll' if file polling fallback */
   mode: 'nats' | 'poll';

--- a/src/lib/wish-state.ts
+++ b/src/lib/wish-state.ts
@@ -20,24 +20,24 @@ import { getConnection } from './db.js';
 // Schemas
 // ============================================================================
 
-export const GroupStatusSchema = z.enum(['blocked', 'ready', 'in_progress', 'done']);
+const GroupStatusSchema = z.enum(['blocked', 'ready', 'in_progress', 'done']);
 
-export const GroupStateSchema = z.object({
+const GroupStateSchema = z.object({
   status: GroupStatusSchema,
   assignee: z.string().optional(),
   dependsOn: z.array(z.string()).default([]),
   startedAt: z.string().optional(),
   completedAt: z.string().optional(),
 });
-export type GroupState = z.infer<typeof GroupStateSchema>;
+type GroupState = z.infer<typeof GroupStateSchema>;
 
-export const WishStateSchema = z.object({
+const WishStateSchema = z.object({
   wish: z.string(),
   groups: z.record(z.string(), GroupStateSchema),
   createdAt: z.string(),
   updatedAt: z.string(),
 });
-export type WishState = z.infer<typeof WishStateSchema>;
+type WishState = z.infer<typeof WishStateSchema>;
 
 // ============================================================================
 // Group definition (input to createState)

--- a/src/term-commands/dispatch.ts
+++ b/src/term-commands/dispatch.ts
@@ -188,12 +188,12 @@ export function parseWishGroups(content: string): GroupDefinition[] {
 // Execution Strategy Parser
 // ============================================================================
 
-export interface WaveGroup {
+interface WaveGroup {
   group: string;
   agent: string;
 }
 
-export interface Wave {
+interface Wave {
   name: string;
   groups: WaveGroup[];
 }
@@ -326,7 +326,7 @@ export function detectWorkMode(
  * the terminal immediately. Wave advancement is handled by `genie done`
  * notifying the team-lead.
  */
-export async function autoOrchestrateCommand(slug: string): Promise<void> {
+async function autoOrchestrateCommand(slug: string): Promise<void> {
   const wishPath = join(process.cwd(), '.genie', 'wishes', slug, 'WISH.md');
 
   if (!existsSync(wishPath)) {
@@ -384,7 +384,7 @@ export async function autoOrchestrateCommand(slug: string): Promise<void> {
 /**
  * `genie brainstorm <agent> <slug>` — Read DRAFT.md, spawn agent with content.
  */
-export async function brainstormCommand(agentName: string, slug: string): Promise<void> {
+async function brainstormCommand(agentName: string, slug: string): Promise<void> {
   const draftPath = join(process.cwd(), '.genie', 'brainstorms', slug, 'DRAFT.md');
 
   if (!existsSync(draftPath)) {
@@ -426,7 +426,7 @@ export async function brainstormCommand(agentName: string, slug: string): Promis
 /**
  * `genie wish <agent> <slug>` — Read DESIGN.md, spawn agent with content.
  */
-export async function wishCommand(agentName: string, slug: string): Promise<void> {
+async function wishCommand(agentName: string, slug: string): Promise<void> {
   const designPath = join(process.cwd(), '.genie', 'brainstorms', slug, 'DESIGN.md');
 
   if (!existsSync(designPath)) {
@@ -474,7 +474,7 @@ export async function wishCommand(agentName: string, slug: string): Promise<void
  * 5. Build context with wish-level info + group section
  * 6. Spawn agent
  */
-export async function workDispatchCommand(agentName: string, ref: string): Promise<void> {
+async function workDispatchCommand(agentName: string, ref: string): Promise<void> {
   const { slug, group } = parseRef(ref);
   const wishPath = join(process.cwd(), '.genie', 'wishes', slug, 'WISH.md');
 
@@ -548,7 +548,7 @@ export async function workDispatchCommand(agentName: string, ref: string): Promi
 /**
  * `genie review <agent> <slug>#<group>` — Spawn with group + git diff context.
  */
-export async function reviewCommand(agentName: string, ref: string): Promise<void> {
+async function reviewCommand(agentName: string, ref: string): Promise<void> {
   const { slug, group } = parseRef(ref);
   const wishPath = join(process.cwd(), '.genie', 'wishes', slug, 'WISH.md');
 

--- a/src/term-commands/schedule.ts
+++ b/src/term-commands/schedule.ts
@@ -12,7 +12,7 @@
 import type { Command } from 'commander';
 import { computeNextCronDue, parseDuration } from '../lib/cron.js';
 import { getConnection, shutdown } from '../lib/db.js';
-export { computeNextCronDue, parseDuration };
+export { parseDuration };
 
 // ============================================================================
 // Types

--- a/src/term-commands/state.ts
+++ b/src/term-commands/state.ts
@@ -210,7 +210,7 @@ async function autoCleanupTeam(): Promise<void> {
 /**
  * Kill the calling agent's tmux pane. If not in tmux, exit the process.
  */
-export function autoKillPane(): void {
+function autoKillPane(): void {
   const paneId = process.env.TMUX_PANE;
   if (paneId) {
     // Small delay to ensure all output is flushed before killing the pane
@@ -265,7 +265,7 @@ async function notifyWaveCompletion(
  * `genie done <slug>#<group>` — complete a group, push work, notify team-lead
  * on wave completion, and auto-kill the calling agent's tmux pane.
  */
-export async function doneCommand(ref: string): Promise<void> {
+async function doneCommand(ref: string): Promise<void> {
   try {
     const { slug, group } = parseRef(ref);
     const result = await wishState.completeGroup(slug, group);
@@ -317,7 +317,7 @@ export async function doneCommand(ref: string): Promise<void> {
 /**
  * `genie status <slug>` — pretty-print all groups with state/assignee/timestamps.
  */
-export async function statusCommand(slug: string): Promise<void> {
+async function statusCommand(slug: string): Promise<void> {
   try {
     let state = await wishState.getState(slug);
     if (!state) {

--- a/src/types/genie-config.ts
+++ b/src/types/genie-config.ts
@@ -46,7 +46,7 @@ const CodexConfigSchema = z.object({
 // Worker profile configuration
 // Defines how to launch a Claude worker
 // Uses preprocess to migrate legacy "claudio" launcher values to "claude"
-export const WorkerProfileSchema = z
+const WorkerProfileSchema = z
   .object({
     /** Which binary to invoke */
     launcher: z.preprocess((val) => (val === 'claudio' ? 'claude' : val), z.literal('claude')),
@@ -56,7 +56,7 @@ export const WorkerProfileSchema = z
   .passthrough();
 
 // OTel observability configuration
-export const OtelConfigSchema = z.object({
+const OtelConfigSchema = z.object({
   /** Whether OTel telemetry injection is enabled for spawned agents. Default: true. */
   enabled: z.boolean().default(true),
   /** Port for the OTLP HTTP/JSON receiver. Default: pgserve port + 1 (19643). */
@@ -66,7 +66,7 @@ export const OtelConfigSchema = z.object({
 });
 
 // Omni integration configuration
-export const OmniConfigSchema = z.object({
+const OmniConfigSchema = z.object({
   apiUrl: z.string(),
   apiKey: z.string().optional(),
   defaultInstanceId: z.string().optional(),
@@ -74,7 +74,7 @@ export const OmniConfigSchema = z.object({
 
 // Council preset configuration
 // Defines a pair of profiles for dual-model deliberation
-export const CouncilPresetSchema = z.object({
+const CouncilPresetSchema = z.object({
   /** Worker profile name for left pane */
   left: z.string(),
   /** Worker profile name for right pane */


### PR DESCRIPTION
## Summary

- De-exported 71 symbols (30 functions/constants + 27 types + 14 more found after tightening knip) across 31 files that were exported but never imported from outside their defining file
- Changed `ignoreExportsUsedInFile` from `true` to `false` in `knip.json` so future unnecessary exports are caught by the dead-code gate

## Details

**Scope:** Only removed `export` keywords — no logic changes, no deletions, no renames. Every de-exported symbol is still defined and used within its own file.

**Files affected:** 31 files across `src/lib/`, `src/term-commands/`, `src/types/`, `src/genie-commands/`

**Gate results:**
- typecheck: clean
- lint: clean (only pre-existing warnings)
- knip: 0 unused exports (was 71 before cleanup)
- tests: 1288 pass, 0 fail (first run); team.test.ts has pre-existing PG-dependent flaky failures on dev

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes (only pre-existing warnings)
- [x] `bun run dead-code` passes (0 unused exports)
- [x] `bun test` — 1288 pass, 0 fail
- [x] `bun run build` succeeds