### PR TITLE
fix(lint): remove non-null assertions in install.ts

### DIFF
--- a/src/term-commands/install.ts
+++ b/src/term-commands/install.ts
@@ -197,7 +197,10 @@ async function handleExternalStackItem(
   item: import('../lib/manifest.js').StackItem,
   tx: Awaited<ReturnType<typeof getConnection>>,
 ): Promise<string> {
-  const parsed = parseInstallTarget(item.source!);
+  if (!item.source) {
+    throw new Error(`Stack item "${item.name}" has no source URL`);
+  }
+  const parsed = parseInstallTarget(item.source);
   const itemDir = join(ITEMS_DIR, parsed.name);
   mkdirSync(ITEMS_DIR, { recursive: true });
   cloneRepo(parsed.url, itemDir, { version: parsed.version });
@@ -227,12 +230,13 @@ async function installStack(manifest: GenieManifest, _installPath: string): Prom
   if (!manifest.stack?.items) return;
   if (!(await isAvailable())) return;
 
+  const stackItems = manifest.stack.items;
   const sql = await getConnection();
   const installed: string[] = [];
 
   try {
     await sql.begin(async (tx: typeof sql) => {
-      for (const item of manifest.stack!.items) {
+      for (const item of stackItems) {
         if (item.inline) {
           await handleInlineStackItem(item, manifest.version, tx);
           installed.push(item.name);


### PR DESCRIPTION
## Summary
- Replace `item.source!` with a proper null guard + descriptive error in `handleExternalStackItem`
- Extract `manifest.stack.items` into a local variable after the early-return guard in `installStack`, eliminating the non-null assertion

Eliminates both `noNonNullAssertion` warnings in `src/`. Remaining warnings in `src/` are 1 complexity issue (separate sweeper scope).

## Test plan
- [x] `bun run typecheck` — passes
- [x] `bun run build` — passes  
- [x] `biome check src/` — 0 noNonNullAssertion warnings remaining
- [x] `bun test` — 1288 pass, 0 fail