### PR TITLE
fix(types): replace explicit any with concrete types

### DIFF
--- a/src/lib/agent-registry.ts
+++ b/src/lib/agent-registry.ts
@@ -7,7 +7,7 @@
 
 import { createHash } from 'node:crypto';
 import { recordAuditEvent } from './audit.js';
-import { getConnection } from './db.js';
+import { type Sql, getConnection } from './db.js';
 import type { ProviderName } from './provider-adapters.js';
 
 export type AgentState = 'spawning' | 'working' | 'idle' | 'permission' | 'question' | 'done' | 'error' | 'suspended';
@@ -61,8 +61,53 @@ export interface WorkerTemplate {
   lastSpawnedAt: string;
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: PG row uses dynamic column names
-type PgRow = Record<string, any>;
+interface AgentRow {
+  id: string;
+  pane_id: string;
+  session: string;
+  worktree: string | null;
+  task_id: string | null;
+  task_title: string | null;
+  wish_slug: string | null;
+  group_number: number | null;
+  started_at: Date | string;
+  state: AgentState;
+  last_state_change: Date | string;
+  repo_path: string;
+  claude_session_id: string | null;
+  window_name: string | null;
+  window_id: string | null;
+  role: string | null;
+  custom_name: string | null;
+  sub_panes: string | string[] | null;
+  provider: ProviderName | null;
+  transport: TransportType | null;
+  skill: string | null;
+  team: string | null;
+  tmux_window: string | null;
+  native_agent_id: string | null;
+  native_color: string | null;
+  native_team_enabled: boolean;
+  parent_session_id: string | null;
+  suspended_at: Date | string | null;
+  auto_resume: boolean | null;
+  resume_attempts: number | null;
+  last_resume_attempt: Date | string | null;
+  max_resume_attempts: number | null;
+  pane_color: string | null;
+}
+
+interface TemplateRow {
+  id: string;
+  provider: ProviderName;
+  team: string;
+  role: string | null;
+  skill: string | null;
+  cwd: string;
+  extra_args: string | string[] | null;
+  native_team_enabled: boolean;
+  last_spawned_at: Date | string;
+}
 
 function ts(v: Date | string | null): string {
   if (!v) return new Date().toISOString();
@@ -70,7 +115,7 @@ function ts(v: Date | string | null): string {
 }
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: flat field mapping
-function rowToAgent(r: PgRow): Agent {
+function rowToAgent(r: AgentRow): Agent {
   const agent: Agent = {
     id: r.id,
     paneId: r.pane_id,
@@ -112,7 +157,7 @@ function rowToAgent(r: PgRow): Agent {
   return agent;
 }
 
-function rowToTemplate(r: PgRow): WorkerTemplate {
+function rowToTemplate(r: TemplateRow): WorkerTemplate {
   const tpl: WorkerTemplate = {
     id: r.id,
     provider: r.provider,
@@ -284,28 +329,32 @@ export async function getTeamLeadEntry(teamName: string, session?: string, repoP
 }
 
 async function findTeamLeadBySession(
-  // biome-ignore lint/suspicious/noExplicitAny: postgres.js Sql type requires generics we don't need
-  sql: any,
+  sql: Sql,
   teamName: string,
   session: string,
   repoPath?: string,
 ): Promise<Agent | null> {
   if (repoPath) {
-    const rows = await sql`SELECT * FROM agents WHERE id = ${buildProjectTeamLeadEntryId(teamName, session, repoPath)}`;
+    const rows = await sql<
+      AgentRow[]
+    >`SELECT * FROM agents WHERE id = ${buildProjectTeamLeadEntryId(teamName, session, repoPath)}`;
     if (rows.length > 0) return rowToAgent(rows[0]);
   }
-  const sessRows = await sql`SELECT * FROM agents WHERE id = ${buildSessionTeamLeadEntryId(teamName, session)}`;
+  const sessRows = await sql<
+    AgentRow[]
+  >`SELECT * FROM agents WHERE id = ${buildSessionTeamLeadEntryId(teamName, session)}`;
   if (sessRows.length > 0) {
     const a = rowToAgent(sessRows[0]);
     if (!repoPath || a.repoPath === repoPath) return a;
   }
-  const legRows = await sql`SELECT * FROM agents WHERE id = ${buildLegacyTeamLeadEntryId(teamName)}`;
+  const legRows = await sql<AgentRow[]>`SELECT * FROM agents WHERE id = ${buildLegacyTeamLeadEntryId(teamName)}`;
   if (legRows.length > 0) {
     const a = rowToAgent(legRows[0]);
     if (a.session === session && (!repoPath || a.repoPath === repoPath)) return a;
   }
-  const scanRows =
-    await sql`SELECT * FROM agents WHERE role = 'team-lead' AND team = ${teamName} AND session = ${session} ${repoPath ? sql`AND repo_path = ${repoPath}` : sql``} LIMIT 1`;
+  const scanRows = await sql<
+    AgentRow[]
+  >`SELECT * FROM agents WHERE role = 'team-lead' AND team = ${teamName} AND session = ${session} ${repoPath ? sql`AND repo_path = ${repoPath}` : sql``} LIMIT 1`;
   return scanRows.length > 0 ? rowToAgent(scanRows[0]) : null;
 }
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -12,8 +12,16 @@ import { createConnection } from 'node:net';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { MultiTenantRouter } from 'pgserve';
+import type postgres from 'postgres';
 import { runMigrations } from './db-migrations.js';
 import { needsSeed, runSeed } from './pg-seed.js';
+
+/**
+ * Re-export Sql type for callers that need to annotate sql connection parameters.
+ * getConnection() returns `any` internally due to postgres.js generic complexity,
+ * but callers can use this type for function signatures.
+ */
+export type Sql = postgres.Sql;
 
 const DEFAULT_PORT = 19642;
 const DEFAULT_HOST = '127.0.0.1';

--- a/src/lib/mailbox.ts
+++ b/src/lib/mailbox.ts
@@ -39,13 +39,22 @@ export interface MailboxMessage {
 // Internal helpers
 // ============================================================================
 
+interface MailboxRow {
+  id: string;
+  from_worker: string;
+  to_worker: string;
+  body: string;
+  created_at: Date | string;
+  read: boolean;
+  delivered_at: Date | string | null;
+}
+
 function generateMessageId(): string {
   return `msg-${uuidv4()}`;
 }
 
 /** Map a PG row to the MailboxMessage interface. */
-// biome-ignore lint/suspicious/noExplicitAny: PG row uses dynamic column names
-function rowToMessage(row: any): MailboxMessage {
+function rowToMessage(row: MailboxRow): MailboxMessage {
   return {
     id: row.id,
     from: row.from_worker,

--- a/src/lib/session-ingester.ts
+++ b/src/lib/session-ingester.ts
@@ -106,14 +106,21 @@ function discoverJsonlFiles(): Array<{ sessionId: string; jsonlPath: string; pro
  * Extract text content from a Claude message content field.
  * Content can be a string, array of blocks, or other shapes.
  */
-// biome-ignore lint/suspicious/noExplicitAny: JSONL content is dynamically typed
-function extractTextContent(content: any): string | null {
+function extractTextContent(content: unknown): string | null {
   if (typeof content === 'string') return content;
   if (Array.isArray(content)) {
     const texts: string[] = [];
     for (const block of content) {
       if (typeof block === 'string') texts.push(block);
-      else if (block?.type === 'text' && typeof block.text === 'string') texts.push(block.text);
+      else if (
+        block != null &&
+        typeof block === 'object' &&
+        'type' in block &&
+        block.type === 'text' &&
+        'text' in block &&
+        typeof block.text === 'string'
+      )
+        texts.push(block.text);
     }
     return texts.length > 0 ? texts.join('\n') : null;
   }

--- a/src/lib/task-service.ts
+++ b/src/lib/task-service.ts
@@ -9,7 +9,7 @@
 
 import { execSync } from 'node:child_process';
 import { getActor, recordAuditEvent } from './audit.js';
-import { getConnection } from './db.js';
+import { type Sql, getConnection } from './db.js';
 
 // ============================================================================
 // Types
@@ -509,8 +509,7 @@ function toDateOrNull(v?: string): Date | null {
 }
 
 /** Resolve a stage name to a column_id within a board's columns JSONB. */
-// biome-ignore lint/suspicious/noExplicitAny: postgres.js Sql type
-async function resolveColumnId(sql: any, boardId: string, stageName: string): Promise<string | null> {
+async function resolveColumnId(sql: Sql, boardId: string, stageName: string): Promise<string | null> {
   const rows = await sql`SELECT columns FROM boards WHERE id = ${boardId} LIMIT 1`;
   if (rows.length === 0) return null;
   const columns = rows[0].columns as { id: string; name: string }[];
@@ -1071,11 +1070,7 @@ export async function getDependents(idOrSeq: string, repoPath?: string): Promise
 // Conversations
 // ============================================================================
 
-async function findExistingConversation(
-  opts: FindOrCreateConversationOpts,
-  // biome-ignore lint/suspicious/noExplicitAny: postgres.js Sql type
-  sql: any,
-): Promise<ConversationRow | null> {
+async function findExistingConversation(opts: FindOrCreateConversationOpts, sql: Sql): Promise<ConversationRow | null> {
   if (opts.linkedEntity && opts.linkedEntityId) {
     const rows = await sql`
       SELECT * FROM conversations

--- a/src/lib/team-chat.ts
+++ b/src/lib/team-chat.ts
@@ -27,9 +27,15 @@ export interface ChatMessage {
 // Internal helpers
 // ============================================================================
 
+interface ChatRow {
+  id: string;
+  sender: string;
+  body: string;
+  created_at: Date | string;
+}
+
 /** Map a PG row to the ChatMessage interface. */
-// biome-ignore lint/suspicious/noExplicitAny: PG row uses dynamic column names
-function rowToMessage(row: any): ChatMessage {
+function rowToMessage(row: ChatRow): ChatMessage {
   return {
     id: row.id,
     sender: row.sender,

--- a/src/lib/team-manager.ts
+++ b/src/lib/team-manager.ts
@@ -62,8 +62,7 @@ export interface TeamConfig {
 // ============================================================================
 
 /** Parse JSONB members — handles both parsed arrays and string-encoded JSON. */
-// biome-ignore lint/suspicious/noExplicitAny: JSONB may be returned as string or parsed value
-function parseMembers(raw: any): string[] {
+function parseMembers(raw: unknown): string[] {
   if (Array.isArray(raw)) return raw;
   if (typeof raw === 'string') {
     try {
@@ -76,9 +75,23 @@ function parseMembers(raw: any): string[] {
   return [];
 }
 
+interface TeamConfigRow {
+  name: string;
+  repo: string;
+  base_branch: string;
+  worktree_path: string;
+  members: unknown;
+  status: TeamStatus;
+  created_at: Date | string;
+  leader?: string;
+  native_team_parent_session_id?: string;
+  native_teams_enabled?: boolean;
+  tmux_session_name?: string;
+  wish_slug?: string;
+}
+
 /** Map a PG row to a TeamConfig object. */
-// biome-ignore lint/suspicious/noExplicitAny: PG row is dynamically typed
-function rowToTeamConfig(row: any): TeamConfig {
+function rowToTeamConfig(row: TeamConfigRow): TeamConfig {
   const config: TeamConfig = {
     name: row.name,
     repo: row.repo,
@@ -86,7 +99,7 @@ function rowToTeamConfig(row: any): TeamConfig {
     worktreePath: row.worktree_path,
     members: parseMembers(row.members),
     status: row.status,
-    createdAt: row.created_at instanceof Date ? row.created_at.toISOString() : row.created_at,
+    createdAt: row.created_at instanceof Date ? row.created_at.toISOString() : String(row.created_at),
   };
   if (row.leader) config.leader = row.leader;
   if (row.native_team_parent_session_id) config.nativeTeamParentSessionId = row.native_team_parent_session_id;

--- a/src/lib/test-db.ts
+++ b/src/lib/test-db.ts
@@ -19,7 +19,7 @@
  */
 
 import { runMigrations } from './db-migrations.js';
-import { ensurePgserve, resetConnection } from './db.js';
+import { type Sql, ensurePgserve, resetConnection } from './db.js';
 
 /** Max age (ms) before a test schema is considered stale and eligible for cleanup. */
 const STALE_SCHEMA_AGE_MS = 10 * 60 * 1000; // 10 minutes
@@ -109,8 +109,7 @@ export async function setupTestSchema(): Promise<() => Promise<void>> {
  * Schema names encode a timestamp: test_<pid>_<timestamp>.
  * Best-effort — failures are silently ignored so tests aren't blocked.
  */
-// biome-ignore lint/suspicious/noExplicitAny: postgres.js Sql type requires generics we don't need
-async function cleanupStaleSchemas(sql: any): Promise<void> {
+async function cleanupStaleSchemas(sql: Sql): Promise<void> {
   try {
     const schemas = await sql`
       SELECT schema_name FROM information_schema.schemata

--- a/src/term-commands/import.ts
+++ b/src/term-commands/import.ts
@@ -251,7 +251,7 @@ async function runImport(filePath: string, mode: ConflictMode, groupFilter?: str
   let totalInserted = 0;
   const tableStats: Record<string, number> = {};
 
-  // biome-ignore lint/suspicious/noExplicitAny: postgres.js transaction type
+  // biome-ignore lint/suspicious/noExplicitAny: postgres.js TransactionSql loses call signatures via Omit
   await sql.begin(async (tx: any) => {
     for (const table of tablesToImport) {
       const rows = doc.data[table] as Record<string, unknown>[];

--- a/src/term-commands/metrics.ts
+++ b/src/term-commands/metrics.ts
@@ -38,6 +38,26 @@ function parseSince(since: string): string {
 }
 
 // ============================================================================
+// Row types
+// ============================================================================
+
+interface SnapshotRow {
+  active_workers: number;
+  active_teams: number;
+  tmux_sessions: number;
+  cpu_percent: number | null;
+  memory_mb: number | null;
+  created_at: string;
+}
+
+interface HeartbeatRow {
+  worker_id: string;
+  status: string;
+  context: string | Record<string, unknown>;
+  last_seen_at: string;
+}
+
+// ============================================================================
 // Command Handlers
 // ============================================================================
 
@@ -108,8 +128,7 @@ async function metricsHistoryCommand(options: { since?: string; json?: boolean }
   }
 
   const headers = ['Time', 'Workers', 'Teams', 'Tmux', 'CPU%', 'Mem MB'];
-  // biome-ignore lint/suspicious/noExplicitAny: PG row is dynamically typed
-  const data = rows.map((r: any) => [
+  const data = rows.map((r: SnapshotRow) => [
     formatTimestamp(r.created_at),
     String(r.active_workers ?? 0),
     String(r.active_teams ?? 0),
@@ -158,8 +177,7 @@ async function metricsAgentsCommand(options: { json?: boolean }): Promise<void> 
   }
 
   const headers = ['Worker', 'Status', 'Last Seen', 'Team', 'Wish'];
-  // biome-ignore lint/suspicious/noExplicitAny: PG row is dynamically typed
-  const data = rows.map((r: any) => {
+  const data = rows.map((r: HeartbeatRow) => {
     const ctx = typeof r.context === 'string' ? JSON.parse(r.context) : (r.context ?? {});
     return [
       String(r.worker_id ?? '-').slice(0, 20),

--- a/src/term-commands/schedule.ts
+++ b/src/term-commands/schedule.ts
@@ -212,7 +212,7 @@ async function scheduleCreateCommand(name: string, options: CreateOptions): Prom
       timezone: options.timezone ?? 'UTC',
     };
 
-    // biome-ignore lint/suspicious/noExplicitAny: postgres.js transaction type
+    // biome-ignore lint/suspicious/noExplicitAny: postgres.js TransactionSql loses call signatures via Omit
     await sql.begin(async (tx: any) => {
       // Insert schedule
       await tx`
@@ -344,7 +344,7 @@ async function scheduleCancelCommand(nameOrId: string, _options: CancelOptions):
 
     const schedule = schedules[0];
 
-    // biome-ignore lint/suspicious/noExplicitAny: postgres.js transaction type
+    // biome-ignore lint/suspicious/noExplicitAny: postgres.js TransactionSql loses call signatures via Omit
     await sql.begin(async (tx: any) => {
       // Pause the schedule
       await tx`UPDATE schedules SET status = 'paused', updated_at = now() WHERE id = ${schedule.id}`;
@@ -392,7 +392,7 @@ async function scheduleRetryCommand(nameOrId: string): Promise<void> {
 
     const { trigger_id, name } = results[0];
 
-    // biome-ignore lint/suspicious/noExplicitAny: postgres.js transaction type
+    // biome-ignore lint/suspicious/noExplicitAny: postgres.js TransactionSql loses call signatures via Omit
     await sql.begin(async (tx: any) => {
       // Reset trigger to pending with new due_at
       await tx`

--- a/src/term-commands/sessions.ts
+++ b/src/term-commands/sessions.ts
@@ -34,6 +34,33 @@ function formatTimestamp(ts: string): string {
 // Command Handlers
 // ============================================================================
 
+interface SessionRow {
+  id: string;
+  agent_id: string | null;
+  team: string | null;
+  role: string | null;
+  status: string;
+  total_turns: number | null;
+  started_at: string | null;
+  created_at: string;
+}
+
+interface ContentRow {
+  turn_index: number;
+  role: string;
+  content: string;
+  tool_name: string | null;
+  timestamp: string;
+}
+
+interface EventRow {
+  entity_type: string;
+  event_type: string;
+  actor: string;
+  details: Record<string, unknown>;
+  created_at: string;
+}
+
 interface ListOptions {
   active?: boolean;
   orphaned?: boolean;
@@ -49,8 +76,7 @@ async function sessionsListCommand(options: ListOptions): Promise<void> {
 
   const sql = await getConnection();
 
-  // biome-ignore lint/suspicious/noExplicitAny: PG row is dynamically typed
-  let rows: any[];
+  let rows: SessionRow[];
   if (options.active) {
     rows = await sql`SELECT * FROM sessions WHERE status = 'active' ORDER BY started_at DESC LIMIT 50`;
   } else if (options.orphaned) {
@@ -73,9 +99,8 @@ async function sessionsListCommand(options: ListOptions): Promise<void> {
   }
 
   const headers = ['ID', 'Agent', 'Team', 'Status', 'Turns', 'Started'];
-  // biome-ignore lint/suspicious/noExplicitAny: PG row is dynamically typed
-  const data = rows.map((r: any) => [
-    (r.id as string).slice(0, 12),
+  const data = rows.map((r: SessionRow) => [
+    r.id.slice(0, 12),
     r.agent_id ?? '(orphaned)',
     r.team ?? '-',
     r.status,
@@ -97,13 +122,12 @@ async function sessionsListCommand(options: ListOptions): Promise<void> {
 }
 
 /** Build a timeline by interleaving session content and audit events. */
-// biome-ignore lint/suspicious/noExplicitAny: PG rows are dynamically typed
-function buildTimeline(content: any[], events: any[]): Array<{ ts: string; type: string; text: string }> {
+function buildTimeline(content: ContentRow[], events: EventRow[]): Array<{ ts: string; type: string; text: string }> {
   const timeline: Array<{ ts: string; type: string; text: string }> = [];
   for (const c of content) {
     const prefix = c.role === 'assistant' ? '[assistant]' : c.role === 'tool_input' ? '[tool_in]' : '[tool_out]';
     const toolLabel = c.tool_name ? ` [${c.tool_name}]` : '';
-    timeline.push({ ts: c.timestamp, type: `${prefix}${toolLabel}`, text: (c.content as string).slice(0, 200) });
+    timeline.push({ ts: c.timestamp, type: `${prefix}${toolLabel}`, text: c.content.slice(0, 200) });
   }
   for (const e of events) {
     timeline.push({ ts: e.created_at, type: `[event] ${e.event_type}`, text: JSON.stringify(e.details).slice(0, 100) });
@@ -197,8 +221,7 @@ async function sessionsSearchCommand(query: string, options: { json?: boolean; l
     return;
   }
 
-  // biome-ignore lint/suspicious/noExplicitAny: PG row is dynamically typed
-  for (const r of rows as any[]) {
+  for (const r of rows) {
     console.log(`[${formatTimestamp(r.timestamp)}] ${r.agent_id ?? 'orphaned'} / ${r.session_id.slice(0, 12)}`);
     console.log(`  ${r.role}${r.tool_name ? ` [${r.tool_name}]` : ''}: ${r.headline}`);
   }


### PR DESCRIPTION
## Summary
- Replace `noExplicitAny` violations with proper types across 12 source files
- Define row interfaces (AgentRow, TemplateRow, SessionRow, ContentRow, EventRow, SnapshotRow, HeartbeatRow, MailboxRow, ChatRow, TeamConfigRow) for PG row mappers
- Use exported `Sql` type from db.ts for sql connection parameters
- Use `unknown` instead of `any` for dynamic JSONL content and JSONB values
- Remaining `tx: any` in `.begin()` callbacks documented as postgres.js TransactionSql type limitation

## Test plan
- [x] `bun run typecheck` — passes clean
- [x] `bun run lint` (biome check) — passes clean
- [x] `bun run dead-code` (knip) — passes clean
- [x] `bun test` — 1180/1180 pass