### PR TITLE
chore: consolidate 31 duplicated formatting helpers into term-format module

### DIFF
--- a/src/lib/term-format.ts
+++ b/src/lib/term-format.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared formatting utilities for CLI table output.
+ *
+ * Consolidates padRight, truncate, formatDate, formatRelativeTimestamp,
+ * formatTimestamp, and formatTime — previously duplicated across 14+ files.
+ */
+
+/** Pad a string to a minimum width with trailing spaces. */
+export function padRight(str: string, len: number): string {
+  return str.length >= len ? str : str + ' '.repeat(len - str.length);
+}
+
+/** Truncate a string with a trailing Unicode ellipsis (…). */
+export function truncate(str: string, len: number): string {
+  return str.length <= len ? str : `${str.slice(0, len - 1)}…`;
+}
+
+/** Format an ISO date as "Mon DD" (short locale date). Returns '-' for null/undefined. */
+export function formatDate(iso: string | null | undefined): string {
+  if (!iso) return '-';
+  const d = new Date(iso);
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+/** Format a timestamp as a relative string ("3m ago") or absolute ISO if >24h. */
+export function formatRelativeTimestamp(ts: string): string {
+  const d = new Date(ts);
+  const now = Date.now();
+  const diffMs = now - d.getTime();
+  if (diffMs < 60_000) return `${Math.floor(diffMs / 1000)}s ago`;
+  if (diffMs < 3_600_000) return `${Math.floor(diffMs / 60_000)}m ago`;
+  if (diffMs < 86_400_000) return `${Math.floor(diffMs / 3_600_000)}h ago`;
+  return d.toISOString().replace('T', ' ').slice(0, 19);
+}
+
+/** Format an ISO/Date timestamp as a locale string ("Mon DD, HH:MM" or with seconds). */
+export function formatTimestamp(
+  iso: string | null | undefined | Date,
+  opts?: { fallback?: string; seconds?: boolean },
+): string {
+  if (!iso) return opts?.fallback ?? '-';
+  const d = iso instanceof Date ? iso : new Date(iso);
+  const fmt: Intl.DateTimeFormatOptions = {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  };
+  if (opts?.seconds) fmt.second = '2-digit';
+  return d.toLocaleString('en-US', fmt);
+}
+
+/** Format an ISO timestamp as "HH:MM" or "HH:MM:SS". Returns fallback on error. */
+export function formatTime(iso: string, opts?: { seconds?: boolean; fallback?: string }): string {
+  try {
+    const date = new Date(iso);
+    const fmt: Intl.DateTimeFormatOptions = {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    };
+    if (opts?.seconds) fmt.second = '2-digit';
+    return date.toLocaleTimeString('en-US', fmt);
+  } catch {
+    return opts?.fallback ?? '??:??';
+  }
+}

--- a/src/term-commands/audit-events.ts
+++ b/src/term-commands/audit-events.ts
@@ -21,25 +21,7 @@ import {
   queryTimeline,
   queryToolUsage,
 } from '../lib/audit.js';
-
-// ============================================================================
-// Helpers
-// ============================================================================
-
-function padRight(str: string, len: number): string {
-  return str.length >= len ? str : str + ' '.repeat(len - str.length);
-}
-
-function formatTimestamp(ts: string): string {
-  const d = new Date(ts);
-  const now = Date.now();
-  const diffMs = now - d.getTime();
-
-  if (diffMs < 60_000) return `${Math.floor(diffMs / 1000)}s ago`;
-  if (diffMs < 3_600_000) return `${Math.floor(diffMs / 60_000)}m ago`;
-  if (diffMs < 86_400_000) return `${Math.floor(diffMs / 3_600_000)}h ago`;
-  return d.toISOString().replace('T', ' ').slice(0, 19);
-}
+import { formatRelativeTimestamp as formatTimestamp, padRight } from '../lib/term-format.js';
 
 function printEventsTable(rows: AuditEventRow[]): void {
   if (rows.length === 0) {

--- a/src/term-commands/board.ts
+++ b/src/term-commands/board.ts
@@ -26,6 +26,7 @@ import type { Command } from 'commander';
 import type * as boardServiceTypes from '../lib/board-service.js';
 import type * as taskServiceTypes from '../lib/task-service.js';
 import type * as templateServiceTypes from '../lib/template-service.js';
+import { formatDate, padRight, truncate } from '../lib/term-format.js';
 
 // ============================================================================
 // Lazy Loaders
@@ -47,24 +48,6 @@ let _templateService: typeof templateServiceTypes | undefined;
 async function getTemplateService(): Promise<typeof templateServiceTypes> {
   if (!_templateService) _templateService = await import('../lib/template-service.js');
   return _templateService;
-}
-
-// ============================================================================
-// Helpers
-// ============================================================================
-
-function padRight(str: string, len: number): string {
-  return str.length >= len ? str : str + ' '.repeat(len - str.length);
-}
-
-function truncate(str: string, len: number): string {
-  return str.length <= len ? str : `${str.slice(0, len - 1)}…`;
-}
-
-function formatDate(iso: string | null): string {
-  if (!iso) return '-';
-  const d = new Date(iso);
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 }
 
 async function resolveProjectId(name: string): Promise<string> {

--- a/src/term-commands/db.ts
+++ b/src/term-commands/db.ts
@@ -10,14 +10,7 @@
 import type { Command } from 'commander';
 import { getMigrationStatus, runMigrations } from '../lib/db-migrations.js';
 import { getActivePort, getConnection, getDataDir, isAvailable, shutdown } from '../lib/db.js';
-
-// ============================================================================
-// Helpers
-// ============================================================================
-
-function padRight(str: string, len: number): string {
-  return str.length >= len ? str : str + ' '.repeat(len - str.length);
-}
+import { padRight } from '../lib/term-format.js';
 
 /**
  * Print query results as an aligned table.

--- a/src/term-commands/history.ts
+++ b/src/term-commands/history.ts
@@ -16,6 +16,7 @@
  */
 
 import * as workerRegistry from '../lib/agent-registry.js';
+import { formatTime } from '../lib/term-format.js';
 import type { TranscriptEntry, TranscriptFilter, TranscriptRole } from '../lib/transcript.js';
 
 // ============================================================================
@@ -70,15 +71,6 @@ interface SessionStats {
 // ============================================================================
 // Event Extraction (from TranscriptEntry)
 // ============================================================================
-
-function formatTime(timestamp: string): string {
-  try {
-    const date = new Date(timestamp);
-    return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false });
-  } catch {
-    return '??:??';
-  }
-}
 
 function truncate(str: string, maxLen: number): string {
   if (str.length <= maxLen) return str;

--- a/src/term-commands/log.ts
+++ b/src/term-commands/log.ts
@@ -12,6 +12,7 @@
  */
 
 import * as agentRegistry from '../lib/agent-registry.js';
+import { formatTime as _fmtTime } from '../lib/term-format.js';
 import {
   type LogEvent,
   type LogEventKind,
@@ -41,19 +42,6 @@ export interface LogOptions {
   json?: boolean;
   /** Follow mode — real-time streaming (placeholder for Group 5) */
   follow?: boolean;
-}
-
-// ============================================================================
-// Display Formatting
-// ============================================================================
-
-function formatTime(timestamp: string): string {
-  try {
-    const date = new Date(timestamp);
-    return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false });
-  } catch {
-    return '??:??:??';
-  }
 }
 
 function kindIcon(kind: LogEventKind): string {
@@ -141,7 +129,7 @@ function summarizeToolCall(event: LogEvent): string {
 }
 
 function formatEventBlock(event: LogEvent): string {
-  const time = formatTime(event.timestamp);
+  const time = _fmtTime(event.timestamp, { seconds: true, fallback: '??:??:??' });
   const icon = kindIcon(event.kind);
   const color = kindColor(event.kind);
 

--- a/src/term-commands/metrics.ts
+++ b/src/term-commands/metrics.ts
@@ -9,24 +9,7 @@
 
 import type { Command } from 'commander';
 import { getConnection, isAvailable } from '../lib/db.js';
-
-// ============================================================================
-// Helpers
-// ============================================================================
-
-function padRight(str: string, len: number): string {
-  return str.length >= len ? str : str + ' '.repeat(len - str.length);
-}
-
-function formatTimestamp(ts: string): string {
-  const d = new Date(ts);
-  const now = Date.now();
-  const diffMs = now - d.getTime();
-  if (diffMs < 60_000) return `${Math.floor(diffMs / 1000)}s ago`;
-  if (diffMs < 3_600_000) return `${Math.floor(diffMs / 60_000)}m ago`;
-  if (diffMs < 86_400_000) return `${Math.floor(diffMs / 3_600_000)}h ago`;
-  return d.toISOString().replace('T', ' ').slice(0, 19);
-}
+import { formatRelativeTimestamp as formatTimestamp, padRight } from '../lib/term-format.js';
 
 function parseSince(since: string): string {
   const match = since.match(/^(\d+)([smhd])$/);

--- a/src/term-commands/msg.ts
+++ b/src/term-commands/msg.ts
@@ -20,6 +20,7 @@ import type { Command } from 'commander';
 import type * as registryTypes from '../lib/agent-registry.js';
 import type * as taskServiceTypes from '../lib/task-service.js';
 import type * as teamManagerTypes from '../lib/team-manager.js';
+import { formatTime, padRight, truncate } from '../lib/term-format.js';
 
 // ============================================================================
 // Lazy Loaders
@@ -168,22 +169,6 @@ async function findAgentTeam(_repoPath: string, agentName: string): Promise<team
 
 function localActor(name: string): taskServiceTypes.Actor {
   return { actorType: 'local', actorId: name };
-}
-
-// ============================================================================
-// Display Helpers
-// ============================================================================
-
-function padRight(str: string, len: number): string {
-  return str.length >= len ? str : str + ' '.repeat(len - str.length);
-}
-
-function truncate(str: string, len: number): string {
-  return str.length <= len ? str : `${str.slice(0, len - 1)}…`;
-}
-
-function formatTime(iso: string): string {
-  return new Date(iso).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false });
 }
 
 /** Resolve team name from explicit option, agent lookup, or env var. Exits on failure. */

--- a/src/term-commands/notify.ts
+++ b/src/term-commands/notify.ts
@@ -9,15 +9,12 @@
 
 import type { Command } from 'commander';
 import type * as taskServiceTypes from '../lib/task-service.js';
+import { padRight } from '../lib/term-format.js';
 
 let _taskService: typeof taskServiceTypes | undefined;
 async function getTaskService(): Promise<typeof taskServiceTypes> {
   if (!_taskService) _taskService = await import('../lib/task-service.js');
   return _taskService;
-}
-
-function padRight(str: string, len: number): string {
-  return str.length >= len ? str : str + ' '.repeat(len - str.length);
 }
 
 function currentActor(): taskServiceTypes.Actor {

--- a/src/term-commands/project.ts
+++ b/src/term-commands/project.ts
@@ -10,25 +10,12 @@
 
 import type { Command } from 'commander';
 import type * as taskServiceTypes from '../lib/task-service.js';
+import { formatDate, padRight, truncate } from '../lib/term-format.js';
 
 let _taskService: typeof taskServiceTypes | undefined;
 async function getTaskService(): Promise<typeof taskServiceTypes> {
   if (!_taskService) _taskService = await import('../lib/task-service.js');
   return _taskService;
-}
-
-function padRight(str: string, len: number): string {
-  return str.length >= len ? str : str + ' '.repeat(len - str.length);
-}
-
-function truncate(str: string, len: number): string {
-  return str.length <= len ? str : `${str.slice(0, len - 1)}…`;
-}
-
-function formatDate(iso: string | null): string {
-  if (!iso) return '-';
-  const d = new Date(iso);
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 }
 
 async function printProjectList(ts: typeof taskServiceTypes, projects: taskServiceTypes.ProjectRow[]): Promise<void> {

--- a/src/term-commands/release.ts
+++ b/src/term-commands/release.ts
@@ -8,15 +8,12 @@
 
 import type { Command } from 'commander';
 import type * as taskServiceTypes from '../lib/task-service.js';
+import { padRight } from '../lib/term-format.js';
 
 let _taskService: typeof taskServiceTypes | undefined;
 async function getTaskService(): Promise<typeof taskServiceTypes> {
   if (!_taskService) _taskService = await import('../lib/task-service.js');
   return _taskService;
-}
-
-function padRight(str: string, len: number): string {
-  return str.length >= len ? str : str + ' '.repeat(len - str.length);
 }
 
 export function registerReleaseCommands(program: Command): void {

--- a/src/term-commands/schedule.ts
+++ b/src/term-commands/schedule.ts
@@ -12,7 +12,12 @@
 import type { Command } from 'commander';
 import { computeNextCronDue, parseDuration } from '../lib/cron.js';
 import { getConnection, shutdown } from '../lib/db.js';
+import { formatTimestamp as _fmtTs, padRight } from '../lib/term-format.js';
 export { parseDuration };
+
+function formatTimestamp(iso: string | null | Date): string {
+  return _fmtTs(iso, { seconds: true });
+}
 
 // ============================================================================
 // Types
@@ -126,23 +131,6 @@ function computeFirstDueAt(options: CreateOptions): { dueAt: Date; cronExpr: str
 
 function generateId(): string {
   return crypto.randomUUID();
-}
-
-function padRight(str: string, len: number): string {
-  return str.length >= len ? str : str + ' '.repeat(len - str.length);
-}
-
-function formatTimestamp(iso: string | null | Date): string {
-  if (!iso) return '-';
-  const d = iso instanceof Date ? iso : new Date(iso);
-  return d.toLocaleString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-    hour12: false,
-  });
 }
 
 function formatDuration(ms: number | null): string {

--- a/src/term-commands/sessions.ts
+++ b/src/term-commands/sessions.ts
@@ -11,24 +11,7 @@
 import type { Command } from 'commander';
 import { getConnection, isAvailable } from '../lib/db.js';
 import { ingestSessions } from '../lib/session-ingester.js';
-
-// ============================================================================
-// Helpers
-// ============================================================================
-
-function padRight(str: string, len: number): string {
-  return str.length >= len ? str : str + ' '.repeat(len - str.length);
-}
-
-function formatTimestamp(ts: string): string {
-  const d = new Date(ts);
-  const now = Date.now();
-  const diffMs = now - d.getTime();
-  if (diffMs < 60_000) return `${Math.floor(diffMs / 1000)}s ago`;
-  if (diffMs < 3_600_000) return `${Math.floor(diffMs / 60_000)}m ago`;
-  if (diffMs < 86_400_000) return `${Math.floor(diffMs / 3_600_000)}h ago`;
-  return d.toISOString().replace('T', ' ').slice(0, 19);
-}
+import { formatRelativeTimestamp as formatTimestamp, padRight } from '../lib/term-format.js';
 
 // ============================================================================
 // Command Handlers

--- a/src/term-commands/state.ts
+++ b/src/term-commands/state.ts
@@ -13,6 +13,7 @@ import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import type { Command } from 'commander';
+import { formatTimestamp, padRight } from '../lib/term-format.js';
 import * as wishState from '../lib/wish-state.js';
 import { parseExecutionStrategy, parseWishGroups } from './dispatch.js';
 
@@ -75,22 +76,6 @@ const STATUS_ICONS: Record<string, string> = {
   in_progress: '🔄',
   done: '✅',
 };
-
-function formatTimestamp(iso?: string): string {
-  if (!iso) return '';
-  const d = new Date(iso);
-  return d.toLocaleString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  });
-}
-
-function padRight(str: string, len: number): string {
-  return str.length >= len ? str : str + ' '.repeat(len - str.length);
-}
 
 // ============================================================================
 // Wave Detection

--- a/src/term-commands/tag.ts
+++ b/src/term-commands/tag.ts
@@ -8,15 +8,12 @@
 
 import type { Command } from 'commander';
 import type * as taskServiceTypes from '../lib/task-service.js';
+import { padRight } from '../lib/term-format.js';
 
 let _taskService: typeof taskServiceTypes | undefined;
 async function getTaskService(): Promise<typeof taskServiceTypes> {
   if (!_taskService) _taskService = await import('../lib/task-service.js');
   return _taskService;
-}
-
-function padRight(str: string, len: number): string {
-  return str.length >= len ? str : str + ' '.repeat(len - str.length);
 }
 
 export function registerTagCommands(program: Command): void {

--- a/src/term-commands/task.ts
+++ b/src/term-commands/task.ts
@@ -20,6 +20,7 @@
 
 import type { Command } from 'commander';
 import type * as taskServiceTypes from '../lib/task-service.js';
+import { formatDate, formatTimestamp, padRight, truncate } from '../lib/term-format.js';
 
 // ============================================================================
 // Lazy Loaders
@@ -35,36 +36,6 @@ let _boardService: typeof import('../lib/board-service.js') | undefined;
 async function getBoardService() {
   if (!_boardService) _boardService = await import('../lib/board-service.js');
   return _boardService;
-}
-
-// ============================================================================
-// Helpers
-// ============================================================================
-
-function padRight(str: string, len: number): string {
-  return str.length >= len ? str : str + ' '.repeat(len - str.length);
-}
-
-function truncate(str: string, len: number): string {
-  return str.length <= len ? str : `${str.slice(0, len - 1)}…`;
-}
-
-function formatDate(iso: string | null): string {
-  if (!iso) return '-';
-  const d = new Date(iso);
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-}
-
-function formatTimestamp(iso: string | null): string {
-  if (!iso) return '-';
-  const d = new Date(iso);
-  return d.toLocaleString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  });
 }
 
 /** Build an Actor from a local name string. */

--- a/src/term-commands/type.ts
+++ b/src/term-commands/type.ts
@@ -9,15 +9,12 @@
 
 import type { Command } from 'commander';
 import type * as taskServiceTypes from '../lib/task-service.js';
+import { padRight } from '../lib/term-format.js';
 
 let _taskService: typeof taskServiceTypes | undefined;
 async function getTaskService(): Promise<typeof taskServiceTypes> {
   if (!_taskService) _taskService = await import('../lib/task-service.js');
   return _taskService;
-}
-
-function padRight(str: string, len: number): string {
-  return str.length >= len ? str : str + ' '.repeat(len - str.length);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Extract `padRight` (14 copies), `truncate` (4), `formatDate` (3), `formatTimestamp` (6), and `formatTime` (3) into a shared `src/lib/term-format.ts` module
- Replace 213 lines of duplicated code across 16 CLI command files with single-line imports
- Net reduction: ~125 lines of duplicated code removed

## Context
Previous surgeon-questioner sessions (PR #814) removed 71 unnecessary exports and 4 dead modules. This session targets the next sweep layer: **duplicated private helper functions** that knip can't detect because they're file-local, not exported.

## Files changed
- **New:** `src/lib/term-format.ts` — shared formatting utilities (padRight, truncate, formatDate, formatRelativeTimestamp, formatTimestamp, formatTime)
- **Modified (16):** All `src/term-commands/*.ts` files that previously had local copies of these functions

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (188 files, no errors)
- [x] `bun run dead-code` — clean (knip passes)
- [x] `bun test` — 1180 pass, 0 fail
- [x] `bun run build` — bundle success (1.27 MB)