### PR TITLE
fix: session capture v2 — PR review fixes

### DIFF
--- a/src/lib/scheduler-daemon.ts
+++ b/src/lib/scheduler-daemon.ts
@@ -1362,7 +1362,29 @@ export function startDaemon(
       const captureSql = await deps.getConnection();
       const { startFilewatch } = await import('./session-filewatch.js');
       const { startBackfill } = await import('./session-backfill.js');
-      await startFilewatch(captureSql);
+      const filewatchOk = await startFilewatch(captureSql);
+      if (!filewatchOk) {
+        // Filewatch failed (path missing, recursive unsupported, too many watchers)
+        // Fall back to polling ingest every 60s as degraded mode
+        const { ingestFileFull, discoverAllJsonlFiles, buildWorkerMap } = await import('./session-capture.js');
+        deps.log({ timestamp: deps.now().toISOString(), level: 'warn', event: 'filewatch_failed_fallback_polling' });
+        setInterval(async () => {
+          if (!running) return;
+          try {
+            const files = await discoverAllJsonlFiles();
+            const workerMap = await buildWorkerMap(captureSql);
+            for (const f of files) {
+              await ingestFileFull(captureSql, f.sessionId, f.jsonlPath, f.projectPath, 0, {
+                parentSessionId: f.parentSessionId,
+                isSubagent: f.isSubagent,
+                workerMap,
+              });
+            }
+          } catch {
+            /* best-effort fallback */
+          }
+        }, config.heartbeatIntervalMs);
+      }
       // Backfill runs in background — non-blocking, auto-skips if already complete
       startBackfill(captureSql).catch((err) => {
         const message = err instanceof Error ? err.message : String(err);

--- a/src/lib/session-backfill.ts
+++ b/src/lib/session-backfill.ts
@@ -160,11 +160,18 @@ export async function startBackfill(sql: SqlClient): Promise<void> {
       await sleep(SLEEP_BETWEEN_FILES_MS);
     }
 
-    progress.status = 'complete';
+    if (running) {
+      progress.status = 'complete';
+      console.log(
+        `[backfill] complete: ${progress.processedFiles}/${progress.totalFiles} files, ${progress.errors} errors`,
+      );
+    } else {
+      progress.status = 'paused';
+      console.log(
+        `[backfill] paused: ${progress.processedFiles}/${progress.totalFiles} files (will resume on next daemon start)`,
+      );
+    }
     await updateSyncState(sql, progress);
-    console.log(
-      `[backfill] complete: ${progress.processedFiles}/${progress.totalFiles} files, ${progress.errors} errors`,
-    );
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(`[backfill] fatal error: ${message}`);

--- a/src/lib/session-capture.ts
+++ b/src/lib/session-capture.ts
@@ -593,8 +593,19 @@ export async function ingestFile(
       // Chunk may end mid-line — scan backward for last \n
       const lastNewline = raw.lastIndexOf('\n');
       if (lastNewline === -1) {
-        // Entire chunk is one partial line — can't parse, advance to try with more data next time
-        return { newOffset: effectiveOffset, contentRowsInserted: 0, toolEventsInserted: 0 };
+        // Entire chunk is one partial line (>64KB single JSONL line)
+        // Skip this line by scanning forward to find the next newline
+        const skipBuf = Buffer.alloc(Math.min(bytesAvailable, chunkSize * 4));
+        const { bytesRead: skipRead } = await fh.read(skipBuf, 0, skipBuf.length, effectiveOffset);
+        const skipStr = skipBuf.subarray(0, skipRead).toString('utf-8');
+        const nlPos = skipStr.indexOf('\n');
+        if (nlPos === -1) {
+          // Entire remaining file is one line — skip to EOF
+          return { newOffset: fileSize, contentRowsInserted: 0, toolEventsInserted: 0 };
+        }
+        // Skip past the oversized line, return so next call starts after it
+        const skipOffset = effectiveOffset + Buffer.byteLength(skipStr.slice(0, nlPos + 1), 'utf-8');
+        return { newOffset: skipOffset, contentRowsInserted: 0, toolEventsInserted: 0 };
       }
       safeEnd = lastNewline + 1;
     }


### PR DESCRIPTION
## Summary

Follow-up fixes for session capture v2 after Codex PR review:

- **Backfill pause state** — don't mark `complete` on early stop (daemon shutdown); mark `paused` so it resumes on next start
- **Oversized JSONL lines** — lines >64KB no longer cause infinite loop; scans forward to next `\n` and skips
- **Filewatch fallback** — if `fs.watch` fails (path missing, recursive unsupported), falls back to 60s polling so live sessions are still captured

## Test plan
- [x] `bun run typecheck` — PASS
- [x] `bun run lint` — PASS (warnings only, complexity)
- [x] `bun run dead-code` — PASS