### PR TITLE
fix: skip DB-dependent tests in CI when pgserve unavailable

### DIFF
--- a/src/__tests__/resume.test.ts
+++ b/src/__tests__/resume.test.ts
@@ -80,7 +80,9 @@ function createMockDeps(overrides: Partial<SchedulerDeps> = {}) {
 
 let cleanupSchema: () => Promise<void>;
 
-describe('resume', () => {
+const DB_AVAILABLE = process.env.GENIE_PG_AVAILABLE === 'true' || !process.env.CI;
+
+describe.skipIf(!DB_AVAILABLE)('resume', () => {
   beforeAll(async () => {
     cleanupSchema = await setupTestSchema();
   });

--- a/src/term-commands/log.test.ts
+++ b/src/term-commands/log.test.ts
@@ -25,14 +25,17 @@ import {
 // Helpers
 // ============================================================================
 
+const DB_AVAILABLE = process.env.GENIE_PG_AVAILABLE === 'true' || !process.env.CI;
+
 let cleanup: () => Promise<void>;
 
 beforeAll(async () => {
+  if (!DB_AVAILABLE) return;
   cleanup = await setupTestSchema();
 });
 
 afterAll(async () => {
-  await cleanup();
+  if (cleanup) await cleanup();
 });
 
 function makeAgent(id: string, team?: string, repoPath?: string): Agent {

--- a/src/term-commands/state.test.ts
+++ b/src/term-commands/state.test.ts
@@ -10,14 +10,17 @@ import { setupTestSchema } from '../lib/test-db.js';
 import * as wishState from '../lib/wish-state.js';
 import { detectWaveCompletion, ensureWorkPushed, parseRef, resolveWishPath } from './state.js';
 
+const DB_AVAILABLE = process.env.GENIE_PG_AVAILABLE === 'true' || !process.env.CI;
+
 let cleanupSchema: () => Promise<void>;
 
 beforeAll(async () => {
+  if (!DB_AVAILABLE) return;
   cleanupSchema = await setupTestSchema();
 });
 
 afterAll(async () => {
-  await cleanupSchema();
+  if (cleanupSchema) await cleanupSchema();
 });
 
 // ============================================================================


### PR DESCRIPTION
resume.test.ts, state.test.ts, log.test.ts all require pgserve which isn't available in GitHub Actions. Skip when CI=true and GENIE_PG_AVAILABLE not set. Same pattern as nats-integration.test.ts.