### PR TITLE
fix(hooks): emit kind=message for native CC SendMessage (#840)

### DIFF
--- a/src/hooks/__tests__/dispatch.test.ts
+++ b/src/hooks/__tests__/dispatch.test.ts
@@ -80,6 +80,25 @@ describe('genie hook dispatch', () => {
     expect(result).toBe('');
   });
 
+  test('identity-inject works with native CC SendMessage (no type, message field)', async () => {
+    const payload = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'SendMessage',
+      tool_input: {
+        to: 'team-lead',
+        message: 'hello from native CC',
+      },
+    };
+
+    const result = await dispatch(JSON.stringify(payload));
+    const parsed = JSON.parse(result);
+
+    expect(parsed.updatedInput).toBeDefined();
+    expect(parsed.updatedInput.message).toBe('[from:test-worker] hello from native CC');
+    // Should not create a content field
+    expect(parsed.updatedInput.content).toBeUndefined();
+  });
+
   test('identity-inject skips non-message types', async () => {
     const payload = {
       hook_event_name: 'PreToolUse',

--- a/src/hooks/handlers/identity-inject.ts
+++ b/src/hooks/handlers/identity-inject.ts
@@ -14,14 +14,17 @@ export async function identityInject(payload: HookPayload): Promise<HandlerResul
   if (!input) return;
 
   // Only inject on outgoing messages (not shutdown_response, etc.)
+  // Native CC SendMessage has no type field — treat as message by default.
   const msgType = input.type as string | undefined;
-  if (msgType !== 'message' && msgType !== 'broadcast') return;
+  if (msgType && msgType !== 'message' && msgType !== 'broadcast') return;
 
   // Resolve agent name from env (set by genie spawn via GENIE_AGENT_NAME)
   const agentName = process.env.GENIE_AGENT_NAME;
   if (!agentName) return;
 
-  const content = input.content as string | undefined;
+  // Support both genie-internal (content) and native CC (message) field names
+  const contentField = input.content !== undefined ? 'content' : 'message';
+  const content = input[contentField] as string | undefined;
   if (!content) return;
 
   // Don't double-inject if already tagged
@@ -30,7 +33,7 @@ export async function identityInject(payload: HookPayload): Promise<HandlerResul
   return {
     updatedInput: {
       ...input,
-      content: `[from:${agentName}] ${content}`,
+      [contentField]: `[from:${agentName}] ${content}`,
     },
   };
 }

--- a/src/hooks/handlers/nats-emit.ts
+++ b/src/hooks/handlers/nats-emit.ts
@@ -49,11 +49,14 @@ export async function natsEmit(payload: HookPayload): Promise<HandlerResult> {
   const input = payload.tool_input;
   if (!input) return;
 
+  // Filter out non-message SendMessage types (e.g., shutdown_response).
+  // Native CC SendMessage has no type field — treat as message by default.
   const msgType = input.type as string | undefined;
-  if (msgType !== 'message' && msgType !== 'broadcast') return;
+  if (msgType && msgType !== 'message' && msgType !== 'broadcast') return;
 
   const to = input.to as string | undefined;
-  const content = input.content as string | undefined;
+  // Support both genie-internal (content) and native CC (message) field names
+  const content = (input.content ?? input.message) as string | undefined;
   if (!to || !content) return;
 
   const subject = msgType === 'broadcast' ? 'genie.msg.broadcast' : `genie.msg.${to}`;


### PR DESCRIPTION
## Summary

- **Root cause**: `natsEmit` and `identityInject` handlers required `type='message'|'broadcast'` in SendMessage `tool_input`, but Claude Code's native SendMessage has no `type` field and uses `message` instead of `content`. This caused PostToolUse to silently skip emitting `kind=message` events.
- **Fix**: Relax type check (absent type → treat as message; only reject explicit non-message types like `shutdown_response`). Support both `content` (genie-internal) and `message` (native CC) field names in both handlers.
- **Test**: Added test for native CC SendMessage format (no type, `message` field).

## Affected Specs (from #840)

| Spec | Was | Now |
|------|-----|-----|
| `lifecycle/agent-lifecycle` | `kind=message` missing | PostToolUse emits it |
| `messaging/round-trip-response` | `kind=message` missing | PostToolUse emits it |
| `observability/log-follow-events` | `kind=message` missing | PostToolUse emits it |
| `messaging/multi-agent-comm` | relaxed workaround | proper `kind=message` events |

## Test plan

- [x] `bun run check` passes (1184 tests, 0 failures)
- [x] Hook dispatch tests pass (11 tests including new native CC format test)
- [ ] `genie qa run lifecycle/agent-lifecycle` — verify `kind=message` events appear
- [ ] `genie qa run messaging/round-trip-response` — verify `kind=message` events appear

Closes #840