### PR TITLE
fix(msg): emit NATS events from genie send/broadcast (#842)

### DIFF
--- a/.genie/qa/messaging/mailbox-delivery.md
+++ b/.genie/qa/messaging/mailbox-delivery.md
@@ -9,4 +9,4 @@
 
 ## Expect
 - [ ] follow stream contains event kind=message peer=reviewer
-- [ ] follow stream contains event source=mailbox text~=review PR
+- [ ] follow stream contains event source=send text~=review PR

--- a/src/term-commands/msg.ts
+++ b/src/term-commands/msg.ts
@@ -435,6 +435,23 @@ async function handleSend(body: string, options: { to: string; from?: string }):
 
   const msg = await ts.sendMessage(conv.id, senderActor, body);
 
+  // Emit NATS event for real-time observability (fire-and-forget)
+  try {
+    const { publish } = await import('../lib/nats-client.js');
+    await publish(`genie.msg.${options.to}`, {
+      timestamp: new Date().toISOString(),
+      kind: 'message',
+      agent: from,
+      direction: 'out',
+      peer: options.to,
+      text: body,
+      data: { messageId: msg.id, conversationId: conv.id, from, to: options.to },
+      source: 'send',
+    });
+  } catch {
+    // NATS unavailable — silent degradation
+  }
+
   // Best-effort native inbox bridge
   await bridgeToNativeInbox(from, options.to, body).catch((err) => {
     const reason = err instanceof Error ? err.message : String(err);
@@ -495,6 +512,24 @@ export function registerSendInboxCommands(program: Command): void {
         await ts.addMember(conv.id, senderActor);
 
         const msg = await ts.sendMessage(conv.id, senderActor, body);
+
+        // Emit NATS event for real-time observability (fire-and-forget)
+        try {
+          const { publish } = await import('../lib/nats-client.js');
+          await publish('genie.msg.broadcast', {
+            timestamp: new Date().toISOString(),
+            kind: 'message',
+            agent: from,
+            direction: 'out',
+            peer: teamName,
+            text: body,
+            data: { messageId: msg.id, conversationId: conv.id, from, team: teamName },
+            source: 'send',
+          });
+        } catch {
+          // NATS unavailable — silent degradation
+        }
+
         console.log(`Broadcast sent to team "${teamName}".`);
         console.log(`  Message ID: ${msg.id}`);
         console.log(`  Conversation: ${conv.id}`);


### PR DESCRIPTION
## Summary

- **Root cause**: `genie send` routes through PG-backed `TaskService.sendMessage()` which only does a SQL INSERT — no NATS publish. The `mailbox-delivery` QA spec expects `kind=message` NATS events that never fire.
- **Fix**: Add NATS publish in `handleSend` and `broadcast` handlers after PG message is saved (fire-and-forget, silent degradation — matches mailbox.ts pattern)
- **Spec update**: `source=mailbox` → `source=send` in mailbox-delivery spec to match the new event source

## Changes

| File | What |
|------|------|
| `src/term-commands/msg.ts` | Add NATS publish after `ts.sendMessage()` in both `handleSend` and broadcast |
| `.genie/qa/messaging/mailbox-delivery.md` | Update spec: `source=mailbox` → `source=send` |

## Test plan

- [x] `bun run check` passes (1184 tests, 0 failures)
- [ ] `genie qa run messaging/mailbox-delivery` — verify `kind=message peer=reviewer` and `source=send` events appear

Closes #842