### PR TITLE
fix(log): wire PG messages into unified log + scope agent resolver (#843)

### DIFF
--- a/src/lib/unified-log.ts
+++ b/src/lib/unified-log.ts
@@ -1,9 +1,9 @@
 /**
- * Unified Log — Canonical event format and file-based aggregator.
+ * Unified Log — Canonical event format and aggregator.
  *
- * Aggregates 5 event sources (transcript, mailbox inbox, mailbox outbox,
- * team chat, registry state changes) into a single `LogEvent` stream
- * sorted by timestamp.
+ * Aggregates 6 event sources (transcript, mailbox inbox, mailbox outbox,
+ * team chat, PG messages, registry state changes) into a single `LogEvent`
+ * stream sorted by timestamp.
  *
  * Usage:
  *   const events = await readAgentLog('engineer', repoPath, { last: 50 });
@@ -20,7 +20,7 @@ import type { TranscriptEntry } from './transcript.js';
 // ============================================================================
 
 export type LogEventKind = 'user' | 'assistant' | 'message' | 'state' | 'tool_call' | 'tool_result' | 'system' | 'qa';
-export type LogEventSource = 'provider' | 'mailbox' | 'chat' | 'registry' | 'hook';
+export type LogEventSource = 'provider' | 'mailbox' | 'chat' | 'registry' | 'hook' | 'send';
 
 export interface LogEvent {
   /** ISO timestamp */
@@ -176,6 +176,44 @@ export function sortByTimestamp(events: LogEvent[]): LogEvent[] {
 }
 
 // ============================================================================
+// PG Message Source
+// ============================================================================
+
+/** Read messages from PG TaskService for a given agent. Returns [] if PG unavailable. */
+async function readPgMessages(agentName: string): Promise<LogEvent[]> {
+  try {
+    const ts = await import('./task-service.js');
+    const actor = { actorType: 'local' as const, actorId: agentName };
+    const conversations = await ts.listConversations(actor);
+
+    const events: LogEvent[] = [];
+    for (const conv of conversations) {
+      const messages = await ts.getMessages(conv.id, { limit: 100 });
+      const members = await ts.getMembers(conv.id);
+      const peerMember = members.find((m) => m.actorId !== agentName);
+
+      for (const msg of messages) {
+        const isOutgoing = msg.senderId === agentName;
+        const peer = isOutgoing ? peerMember?.actorId : msg.senderId;
+        events.push({
+          timestamp: msg.createdAt,
+          kind: 'message',
+          agent: agentName,
+          direction: isOutgoing ? 'out' : 'in',
+          peer,
+          text: msg.body,
+          data: { messageId: msg.id, conversationId: msg.conversationId, senderId: msg.senderId },
+          source: 'send',
+        });
+      }
+    }
+    return events;
+  } catch {
+    return [];
+  }
+}
+
+// ============================================================================
 // Aggregators
 // ============================================================================
 
@@ -188,15 +226,16 @@ export async function readAgentLog(agent: Agent, repoPath: string, filter?: LogF
   const team = agent.team;
 
   // Read all sources in parallel
-  const [transcriptEntries, inboxMessages, outboxMessages, chatMessages] = await Promise.all([
+  const [transcriptEntries, inboxMessages, outboxMessages, chatMessages, pgMessages] = await Promise.all([
     readTranscriptSafe(agent),
     inbox(repoPath, agentName),
     readOutbox(repoPath, agentName),
     team ? readMessages(repoPath, team) : Promise.resolve([]),
+    readPgMessages(agentName),
   ]);
 
   // Convert to LogEvents
-  const events: LogEvent[] = [];
+  const events: LogEvent[] = [...pgMessages];
 
   for (const entry of transcriptEntries) {
     const event = transcriptToLogEvent(entry, agentName, team);
@@ -241,13 +280,14 @@ export async function readTeamLog(
     agents.map(async (agent) => {
       const agentName = agent.id;
 
-      const [transcriptEntries, inboxMessages, outboxMessages] = await Promise.all([
+      const [transcriptEntries, inboxMessages, outboxMessages, pgMessages] = await Promise.all([
         readTranscriptSafe(agent),
         inbox(repoPath, agentName),
         readOutbox(repoPath, agentName),
+        readPgMessages(agentName),
       ]);
 
-      const events: LogEvent[] = [];
+      const events: LogEvent[] = [...pgMessages];
       for (const entry of transcriptEntries) {
         const event = transcriptToLogEvent(entry, agentName, teamName);
         if (event) events.push(event);

--- a/src/term-commands/log.ts
+++ b/src/term-commands/log.ts
@@ -196,7 +196,7 @@ function formatHumanOutput(events: LogEvent[], label: string): string {
 // Agent Resolution
 // ============================================================================
 
-async function findAgent(identifier: string): Promise<agentRegistry.Agent | null> {
+async function findAgent(identifier: string, teamName?: string): Promise<agentRegistry.Agent | null> {
   let agent = await agentRegistry.get(identifier);
   if (agent) return agent;
 
@@ -204,6 +204,17 @@ async function findAgent(identifier: string): Promise<agentRegistry.Agent | null
   if (agent) return agent;
 
   const all = await agentRegistry.list();
+
+  // Scope fuzzy match to team first, then fall back to global
+  const pool = teamName ? all.filter((a) => a.team === teamName) : [];
+  const teamMatch = pool.find(
+    (w) =>
+      w.id.includes(identifier) ||
+      w.taskId?.includes(identifier) ||
+      w.taskTitle?.toLowerCase().includes(identifier.toLowerCase()),
+  );
+  if (teamMatch) return teamMatch;
+
   return (
     all.find(
       (w) =>
@@ -286,8 +297,8 @@ export async function logCommand(agentName: string | undefined, options: LogOpti
     events = await readTeamLog(agents, repoPath, options.team, filter);
     label = `team:${options.team} (${agents.length} agents)`;
   } else if (agentName) {
-    // Single agent mode
-    const agent = await findAgent(agentName);
+    // Single agent mode — scope to team if specified
+    const agent = await findAgent(agentName, options.team);
     if (!agent) {
       console.error(`Agent "${agentName}" not found. Run \`genie ls\` to see agents.`);
       process.exit(1);
@@ -357,7 +368,7 @@ async function followCommand(
     console.error(`Following ${label} via ${handle.mode === 'nats' ? 'NATS' : 'file polling'} (Ctrl+C to stop)...`);
     setupShutdown(handle.stop);
   } else if (agentName) {
-    const agent = await findAgent(agentName);
+    const agent = await findAgent(agentName, options.team);
     if (!agent) {
       console.error(`Agent "${agentName}" not found. Run \`genie ls\` to see agents.`);
       process.exit(1);


### PR DESCRIPTION
## Summary

Two root causes for `log-static` and `log-filter-type` spec failures:

1. **Missing kind=message**: `genie log` only reads file-based sources (transcript, mailbox, chat). Messages sent via `genie send` (PG-backed TaskService) never appeared as `kind=message`. Fix: add `readPgMessages()` as a new source in `readAgentLog` and `readTeamLog`, with silent degradation if PG is unavailable.

2. **Agent resolver collision**: `findAgent()` uses fuzzy `.includes()` against the global registry, so `"engineer"` matches `"sofia-engineer"` before the QA team's local engineer. Fix: scope fuzzy match to `--team` first, fall back to global only if no team match.

## Changes

| File | What |
|------|------|
| `src/lib/unified-log.ts` | Add `readPgMessages()` source, wire into both aggregators, add `'send'` to `LogEventSource` |
| `src/term-commands/log.ts` | Add `teamName` param to `findAgent()`, pass `options.team` from both static and follow paths |

## Test plan

- [x] `bun run check` passes (1184 tests, 0 failures)
- [ ] `genie qa run observability/log-static` — verify `kind=message` events appear from PG
- [ ] `genie qa run observability/log-filter-type` — verify `--type message` filter returns events and correct engineer resolves

Closes #843