### PR TITLE
fix(cli): add --limit/--offset to task list and sessions list (#835, #836)

### DIFF
--- a/src/term-commands/sessions.ts
+++ b/src/term-commands/sessions.ts
@@ -48,6 +48,7 @@ interface ListOptions {
   active?: boolean;
   orphaned?: boolean;
   agent?: string;
+  limit?: string;
   json?: boolean;
 }
 
@@ -58,17 +59,18 @@ async function sessionsListCommand(options: ListOptions): Promise<void> {
   }
 
   const sql = await getConnection();
+  const limit = Number(options.limit) || 50;
 
   let rows: SessionRow[];
   if (options.active) {
-    rows = await sql`SELECT * FROM sessions WHERE status = 'active' ORDER BY started_at DESC LIMIT 50`;
+    rows = await sql`SELECT * FROM sessions WHERE status = 'active' ORDER BY started_at DESC LIMIT ${limit}`;
   } else if (options.orphaned) {
-    rows = await sql`SELECT * FROM sessions WHERE status = 'orphaned' ORDER BY started_at DESC LIMIT 50`;
+    rows = await sql`SELECT * FROM sessions WHERE status = 'orphaned' ORDER BY started_at DESC LIMIT ${limit}`;
   } else if (options.agent) {
     rows =
-      await sql`SELECT * FROM sessions WHERE agent_id = ${options.agent} OR agent_id LIKE ${`%${options.agent}%`} ORDER BY started_at DESC LIMIT 50`;
+      await sql`SELECT * FROM sessions WHERE agent_id = ${options.agent} OR agent_id LIKE ${`%${options.agent}%`} ORDER BY started_at DESC LIMIT ${limit}`;
   } else {
-    rows = await sql`SELECT * FROM sessions ORDER BY started_at DESC LIMIT 50`;
+    rows = await sql`SELECT * FROM sessions ORDER BY started_at DESC LIMIT ${limit}`;
   }
 
   if (options.json) {
@@ -244,6 +246,7 @@ export function registerSessionsCommands(program: Command): void {
     .option('--active', 'Show only active sessions')
     .option('--orphaned', 'Show only orphaned sessions')
     .option('--agent <name>', 'Filter by agent')
+    .option('--limit <n>', 'Max number of sessions to return (default: 50)')
     .option('--json', 'Output as JSON')
     .action(async (options: ListOptions) => {
       await sessionsListCommand(options);

--- a/src/term-commands/task.ts
+++ b/src/term-commands/task.ts
@@ -421,6 +421,8 @@ export function registerTaskCommands(program: Command): void {
     .option('--by-column', 'Group tasks by board column (kanban view)')
     .option('--include-done', 'Include done tasks in kanban view (hidden by default)')
     .option('--all', 'Show tasks from ALL projects')
+    .option('--limit <n>', 'Max number of tasks to return', '100')
+    .option('--offset <n>', 'Skip first N tasks (for pagination)', '0')
     .option('--json', 'Output as JSON')
     .action(
       async (options: {
@@ -436,6 +438,8 @@ export function registerTaskCommands(program: Command): void {
         byColumn?: boolean;
         includeDone?: boolean;
         all?: boolean;
+        limit?: string;
+        offset?: string;
         json?: boolean;
       }) => {
         try {
@@ -450,6 +454,8 @@ export function registerTaskCommands(program: Command): void {
             projectName: options.project,
             boardName: options.board,
             allProjects: options.all,
+            limit: Number(options.limit) || 100,
+            offset: Number(options.offset) || 0,
             ...(options.all ? { limit: 10000 } : {}),
           };
 


### PR DESCRIPTION
## Summary

- `genie task list` now accepts `--limit <n>` (default 100) and `--offset <n>` (default 0) for pagination
- `genie sessions list` now accepts `--limit <n>` (default 50), replacing the hard-coded LIMIT 50

Both issues were flagged during daily-sync power session (#800, items P1-5).

## Test plan

- [x] `bun run check` passes (1184 tests, 0 failures)
- [ ] `genie task list --limit 3` returns 3 tasks
- [ ] `genie sessions list --limit 3` returns 3 sessions

Closes #835
Closes #836