### PR TITLE
fix(tui): respawn-pane + dev auto-reload

### DIFF
--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -27,14 +27,21 @@ export async function launchTui(options: { dev?: boolean } = {}): Promise<void> 
   // Send the nav command to the left pane
   const bunPath = process.execPath || 'bun';
   const genieBin = process.argv[1] || 'genie';
-  const devFlag = options.dev ? ' --dev' : '';
 
   // Run the TUI nav renderer in the left pane
+  // Dev mode: bun --watch auto-restarts on source file changes
   const { execSync } = await import('node:child_process');
-  execSync(
-    `tmux send-keys -t '${leftPane}' "GENIE_TUI_PANE=left GENIE_TUI_RIGHT=${rightPane} ${bunPath} ${genieBin} tui${devFlag}" Enter`,
-    { stdio: 'ignore' },
-  );
+  if (options.dev) {
+    execSync(
+      `tmux send-keys -t '${leftPane}' "GENIE_TUI_PANE=left GENIE_TUI_RIGHT=${rightPane} bun --watch ${genieBin} tui" Enter`,
+      { stdio: 'ignore' },
+    );
+  } else {
+    execSync(
+      `tmux send-keys -t '${leftPane}' "GENIE_TUI_PANE=left GENIE_TUI_RIGHT=${rightPane} ${bunPath} ${genieBin} tui" Enter`,
+      { stdio: 'ignore' },
+    );
+  }
 
   // Attach (blocking)
   attachTuiSession();

--- a/src/tui/tmux.ts
+++ b/src/tui/tmux.ts
@@ -49,21 +49,41 @@ export function createTuiSession(): { session: string; leftPane: string; rightPa
   return { session: SESSION_NAME, leftPane, rightPane };
 }
 
+/**
+ * Resolve the right pane ID — self-healing if the pane was killed/recreated.
+ * Falls back to re-discovering from the session layout.
+ */
+function resolveRightPane(rightPane: string): string {
+  try {
+    execSync(`tmux display-message -t ${rightPane} -p ''`, { stdio: 'ignore' });
+    return rightPane;
+  } catch {
+    try {
+      const panes = execSync(`tmux list-panes -t ${SESSION_NAME}:0 -F '#{pane_id}'`, { encoding: 'utf-8' })
+        .trim()
+        .split('\n');
+      return panes[1] || panes[0];
+    } catch {
+      return rightPane;
+    }
+  }
+}
+
 /** Attach a project's tmux session in the right pane (nested) */
 export function attachProject(rightPane: string, targetSession: string): void {
-  execSync(
-    `tmux send-keys -t ${rightPane} "TMUX='' tmux attach-session -t ${targetSession} 2>/dev/null || echo 'No session: ${targetSession}'" Enter`,
-    { stdio: 'ignore' },
-  );
+  const pane = resolveRightPane(rightPane);
+  try {
+    execSync(`tmux respawn-pane -k -t ${pane} "TMUX='' tmux attach-session -t '${targetSession}'"`, {
+      stdio: 'ignore',
+    });
+  } catch {
+    // pane doesn't exist
+  }
 }
 
 /** Switch right pane to a different project session */
 export function switchRightPane(rightPane: string, targetSession: string): void {
-  execSync(`tmux send-keys -t ${rightPane} C-c`, { stdio: 'ignore' });
-  execSync(`tmux send-keys -t ${rightPane} "" Enter`, { stdio: 'ignore' });
-  setTimeout(() => {
-    attachProject(rightPane, targetSession);
-  }, 100);
+  attachProject(rightPane, targetSession);
 }
 
 /**


### PR DESCRIPTION
## Summary
- **attachProject**: use `respawn-pane -k` instead of `send-keys` — prevents command text leaking into the focused pane when pane ID is stale
- **resolveRightPane**: self-healing pane discovery — if stored pane ID is stale (session restart), re-discovers from genie-tui session layout
- **switchRightPane**: simplified to just `respawn-pane` (no more C-c + setTimeout hack)
- **--dev mode**: use `bun --watch` for auto-reload when source files change (was a no-op before)

## Test plan
- [x] Build passes
- [x] All 1422 tests pass
- [ ] Launch `genie tui --dev`, navigate between sessions — no command leaking
- [ ] Kill/recreate tmux sessions — TUI self-heals pane targeting
- [ ] Edit TUI source file — nav auto-restarts with changes