### PR TITLE
feat(task): add external_id and external_url for tracker linking

### DIFF
--- a/src/db/migrations/013_external_linking.sql
+++ b/src/db/migrations/013_external_linking.sql
@@ -1,0 +1,4 @@
+-- Add external linking columns to tasks table
+-- Allows linking genie tasks to GitHub Issues, Jira tickets, or any external tracker
+ALTER TABLE tasks ADD COLUMN IF NOT EXISTS external_id TEXT;
+ALTER TABLE tasks ADD COLUMN IF NOT EXISTS external_url TEXT;

--- a/src/lib/task-service.test.ts
+++ b/src/lib/task-service.test.ts
@@ -39,6 +39,7 @@ import {
   getTaskActors,
   getTaskTags,
   getType,
+  linkTask,
   listConversations,
   listProjects,
   listReleases,
@@ -1097,6 +1098,73 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
       // Cleanup
       await sql`DELETE FROM tasks WHERE repo_path = ${autoRepo}`;
       await sql`DELETE FROM projects WHERE repo_path = ${autoRepo}`;
+    });
+  });
+
+  // ============================================================================
+  // External Linking
+  // ============================================================================
+
+  describe('External Linking', () => {
+    it('should create a task with external_id and external_url', async () => {
+      const task = await createTask(
+        {
+          title: 'Linked task',
+          externalId: 'automagik-dev/genie#789',
+          externalUrl: 'https://github.com/automagik-dev/genie/issues/789',
+        },
+        REPO,
+      );
+      expect(task.externalId).toBe('automagik-dev/genie#789');
+      expect(task.externalUrl).toBe('https://github.com/automagik-dev/genie/issues/789');
+    });
+
+    it('should create a task without external fields (null by default)', async () => {
+      const task = await createTask({ title: 'No link task' }, REPO);
+      expect(task.externalId).toBeNull();
+      expect(task.externalUrl).toBeNull();
+    });
+
+    it('should link an existing task via linkTask()', async () => {
+      const task = await createTask({ title: 'To be linked' }, REPO);
+      expect(task.externalId).toBeNull();
+
+      const updated = await linkTask(task.id, 'JIRA-456', 'https://jira.example.com/JIRA-456', REPO);
+      expect(updated).not.toBeNull();
+      expect(updated!.externalId).toBe('JIRA-456');
+      expect(updated!.externalUrl).toBe('https://jira.example.com/JIRA-456');
+    });
+
+    it('should update external fields via updateTask()', async () => {
+      const task = await createTask(
+        { title: 'Update link', externalId: 'old#1', externalUrl: 'https://old.com/1' },
+        REPO,
+      );
+      const updated = await updateTask(task.id, { externalId: 'new#2', externalUrl: 'https://new.com/2' }, REPO);
+      expect(updated).not.toBeNull();
+      expect(updated!.externalId).toBe('new#2');
+      expect(updated!.externalUrl).toBe('https://new.com/2');
+    });
+
+    it('should filter tasks by externalId', async () => {
+      const extId = `filter-test-${Date.now()}`;
+      await createTask({ title: 'Filtered task', externalId: extId, externalUrl: 'https://example.com' }, REPO);
+      await createTask({ title: 'Other task' }, REPO);
+
+      const filtered = await listTasks({ repoPath: REPO, externalId: extId });
+      expect(filtered.length).toBe(1);
+      expect(filtered[0].externalId).toBe(extId);
+    });
+
+    it('should show external fields in getTask()', async () => {
+      const task = await createTask(
+        { title: 'Detail check', externalId: 'detail#99', externalUrl: 'https://detail.com/99' },
+        REPO,
+      );
+      const fetched = await getTask(task.id, REPO);
+      expect(fetched).not.toBeNull();
+      expect(fetched!.externalId).toBe('detail#99');
+      expect(fetched!.externalUrl).toBe('https://detail.com/99');
     });
   });
 });

--- a/src/lib/task-service.ts
+++ b/src/lib/task-service.ts
@@ -38,6 +38,8 @@ interface TaskInput {
   releaseId?: string;
   boardId?: string;
   columnId?: string;
+  externalId?: string;
+  externalUrl?: string;
   metadata?: Record<string, unknown>;
 }
 
@@ -80,6 +82,8 @@ export interface TaskRow {
   traceId: string | null;
   boardId: string | null;
   columnId: string | null;
+  externalId: string | null;
+  externalUrl: string | null;
   metadata: Record<string, unknown>;
   createdAt: string;
   updatedAt: string;
@@ -98,6 +102,7 @@ export interface TaskFilters {
   boardId?: string;
   boardName?: string;
   dueBefore?: string;
+  externalId?: string;
   limit?: number;
   offset?: number;
 }
@@ -256,6 +261,8 @@ function mapTask(row: Record<string, unknown>): TaskRow {
     traceId: str(row.trace_id),
     boardId: str(row.board_id),
     columnId: str(row.column_id),
+    externalId: str(row.external_id),
+    externalUrl: str(row.external_url),
     metadata: (row.metadata as Record<string, unknown>) ?? {},
     createdAt: strOrDefault(row.created_at, ''),
     updatedAt: strOrDefault(row.updated_at, ''),
@@ -534,6 +541,8 @@ function buildTaskVals(input: TaskInput) {
     release: input.releaseId ?? null,
     boardId: input.boardId ?? null,
     columnId: (input.columnId as string | null) ?? null,
+    externalId: input.externalId ?? null,
+    externalUrl: input.externalUrl ?? null,
   };
 }
 
@@ -556,7 +565,8 @@ export async function createTask(input: TaskInput, repoPath?: string, projectId?
       type_id, stage, status, priority,
       parent_id, wish_file, group_name,
       start_date, due_date, estimated_effort,
-      blocked_reason, release_id, board_id, column_id, metadata
+      blocked_reason, release_id, board_id, column_id,
+      external_id, external_url, metadata
     ) VALUES (
       ${repo},
       ${projId},
@@ -577,6 +587,8 @@ export async function createTask(input: TaskInput, repoPath?: string, projectId?
       ${vals.release},
       ${vals.boardId},
       ${vals.columnId},
+      ${vals.externalId},
+      ${vals.externalUrl},
       ${sql.json(input.metadata ?? {})}
     )
     RETURNING *
@@ -642,6 +654,10 @@ function buildFieldConditions(filters: TaskFilters, conditions: string[], values
     conditions.push(`board_id IN (SELECT id FROM boards WHERE name = $${paramIdx++})`);
     values.push(filters.boardName);
   }
+  if (filters.externalId) {
+    conditions.push(`external_id = $${paramIdx++}`);
+    values.push(filters.externalId);
+  }
   if (filters.dueBefore) {
     conditions.push(`due_date <= $${paramIdx++}`);
     values.push(new Date(filters.dueBefore));
@@ -697,6 +713,8 @@ export async function updateTask(
     estimatedEffort: ['estimated_effort', updates.estimatedEffort],
     blockedReason: ['blocked_reason', updates.blockedReason],
     releaseId: ['release_id', updates.releaseId],
+    externalId: ['external_id', updates.externalId],
+    externalUrl: ['external_url', updates.externalUrl],
   };
 
   for (const [key, [col, val]] of Object.entries(fieldMap)) {
@@ -731,6 +749,15 @@ export async function updateTask(
   }
 
   return mapTask(rows[0]);
+}
+
+export async function linkTask(
+  idOrSeq: string,
+  externalId: string,
+  externalUrl: string,
+  repoPath?: string,
+): Promise<TaskRow | null> {
+  return updateTask(idOrSeq, { externalId, externalUrl }, repoPath);
 }
 
 export async function moveTask(

--- a/src/term-commands/task.ts
+++ b/src/term-commands/task.ts
@@ -15,6 +15,7 @@
  *   genie task checkout <id|#seq>           — Claim task for execution
  *   genie task release <id|#seq>            — Release task claim
  *   genie task unlock <id|#seq>             — Force-release stale checkout
+ *   genie task link <id|#seq> [options]     — Link task to external tracker
  *   genie task dep <id|#seq> [options]      — Manage dependencies
  */
 
@@ -117,27 +118,32 @@ function getProjectName(repoPath: string): string {
   return parts[parts.length - 1] || repoPath;
 }
 
+function formatTaskRow(t: taskServiceTypes.TaskRow, showProject: boolean, hasExternal: boolean): string {
+  const seq = showProject ? `${getProjectName(t.repoPath)}#${t.seq}` : `#${t.seq}`;
+  const title = truncate(t.title, 38);
+  const color = PRIORITY_COLORS[t.priority] ?? '';
+  const due = formatDate(t.dueDate);
+  const proj = showProject ? `${padRight(getProjectName(t.repoPath), 16)} ` : '';
+  const ext = hasExternal ? `${padRight(truncate(t.externalId ?? '', 25), 27)} ` : '';
+  return `  ${padRight(seq, showProject ? 22 : 6)} ${proj}${padRight(title, 40)} ${ext}${padRight(t.stage, 12)} ${padRight(t.status, 12)} ${color}${padRight(t.priority, 10)}${RESET} ${padRight(due, 12)}`;
+}
+
 function printTaskList(tasks: taskServiceTypes.TaskRow[], showProject = false): void {
   if (tasks.length === 0) {
     console.log('No tasks found.');
     return;
   }
 
+  const hasExternal = tasks.some((t) => t.externalId);
+  const extCol = hasExternal ? `${padRight('EXTERNAL', 27)} ` : '';
   const projCol = showProject ? `${padRight('PROJECT', 16)} ` : '';
-  const header = `  ${padRight('#', 6)} ${projCol}${padRight('TITLE', 40)} ${padRight('STAGE', 12)} ${padRight('STATUS', 12)} ${padRight('PRIORITY', 10)} ${padRight('DUE', 12)}`;
-  const lineLen = showProject ? 108 : 92;
+  const header = `  ${padRight('#', 6)} ${projCol}${padRight('TITLE', 40)} ${extCol}${padRight('STAGE', 12)} ${padRight('STATUS', 12)} ${padRight('PRIORITY', 10)} ${padRight('DUE', 12)}`;
+  const lineLen = (showProject ? 108 : 92) + (hasExternal ? 28 : 0);
   console.log(header);
   console.log(`  ${'─'.repeat(lineLen)}`);
 
   for (const t of tasks) {
-    const seq = showProject ? `${getProjectName(t.repoPath)}#${t.seq}` : `#${t.seq}`;
-    const title = truncate(t.title, 38);
-    const color = PRIORITY_COLORS[t.priority] ?? '';
-    const due = formatDate(t.dueDate);
-    const proj = showProject ? `${padRight(getProjectName(t.repoPath), 16)} ` : '';
-    console.log(
-      `  ${padRight(seq, showProject ? 22 : 6)} ${proj}${padRight(title, 40)} ${padRight(t.stage, 12)} ${padRight(t.status, 12)} ${color}${padRight(t.priority, 10)}${RESET} ${padRight(due, 12)}`,
-    );
+    console.log(formatTaskRow(t, showProject, hasExternal));
   }
 
   console.log(`\n  ${tasks.length} task${tasks.length === 1 ? '' : 's'}`);
@@ -163,6 +169,8 @@ function printTaskFields(task: taskServiceTypes.TaskRow): void {
     ['Parent', task.parentId],
     ['Release', task.releaseId],
     ['Wish', task.wishFile],
+    ['External', task.externalId],
+    ['Ext URL', task.externalUrl],
   ];
   for (const [label, value] of optionalFields) {
     if (value) console.log(`  ${padRight(`${label}:`, 12)} ${value}`);
@@ -301,6 +309,23 @@ interface CreateOptions {
   comment?: string;
   project?: string;
   board?: string;
+  gh?: string;
+  externalId?: string;
+  externalUrl?: string;
+}
+
+/** Parse --gh owner/repo#N into { externalId, externalUrl }. */
+function parseGhRef(gh: string): { externalId: string; externalUrl: string } {
+  const match = gh.match(/^([^#]+)#(\d+)$/);
+  if (!match) {
+    console.error(`Error: Invalid --gh format. Expected owner/repo#N, got: ${gh}`);
+    process.exit(1);
+  }
+  const [, ownerRepo, num] = match;
+  return {
+    externalId: `${ownerRepo}#${num}`,
+    externalUrl: `https://github.com/${ownerRepo}/issues/${num}`,
+  };
 }
 
 async function handleTaskCreate(title: string, options: CreateOptions): Promise<void> {
@@ -332,6 +357,15 @@ async function handleTaskCreate(title: string, options: CreateOptions): Promise<
 
   const boardId = await resolveBoardOption(options.board);
 
+  // Resolve external linking: --gh takes priority over --external-id/--external-url
+  let externalId: string | undefined = options.externalId;
+  let externalUrl: string | undefined = options.externalUrl;
+  if (options.gh) {
+    const parsed = parseGhRef(options.gh);
+    externalId = parsed.externalId;
+    externalUrl = parsed.externalUrl;
+  }
+
   const task = await ts.createTask(
     {
       title,
@@ -343,6 +377,8 @@ async function handleTaskCreate(title: string, options: CreateOptions): Promise<
       description: options.description,
       estimatedEffort: options.effort,
       boardId,
+      externalId,
+      externalUrl,
     },
     repoPath,
     projectId,
@@ -396,6 +432,9 @@ export function registerTaskCommands(program: Command): void {
     .option('--comment <msg>', 'Initial comment on the task')
     .option('--project <name>', 'Create task in a specific project (overrides CWD)')
     .option('--board <name>', 'Board name to assign task to')
+    .option('--gh <owner/repo#N>', 'Link to GitHub issue (sets external_id + external_url)')
+    .option('--external-id <id>', 'External tracker ID (e.g., JIRA-123)')
+    .option('--external-url <url>', 'External tracker URL')
     .action(async (title: string, options: CreateOptions) => {
       try {
         await handleTaskCreate(title, options);
@@ -418,6 +457,7 @@ export function registerTaskCommands(program: Command): void {
     .option('--mine', 'Show only tasks assigned to me')
     .option('--project <name>', 'Show tasks for a specific project')
     .option('--board <name>', 'Filter by board name')
+    .option('--gh <owner/repo#N>', 'Filter by GitHub issue link')
     .option('--by-column', 'Group tasks by board column (kanban view)')
     .option('--include-done', 'Include done tasks in kanban view (hidden by default)')
     .option('--all', 'Show tasks from ALL projects')
@@ -435,6 +475,7 @@ export function registerTaskCommands(program: Command): void {
         mine?: boolean;
         project?: string;
         board?: string;
+        gh?: string;
         byColumn?: boolean;
         includeDone?: boolean;
         all?: boolean;
@@ -453,6 +494,7 @@ export function registerTaskCommands(program: Command): void {
             dueBefore: options.dueBefore,
             projectName: options.project,
             boardName: options.board,
+            externalId: options.gh ? parseGhRef(options.gh).externalId : undefined,
             allProjects: options.all,
             limit: Number(options.limit) || 100,
             offset: Number(options.offset) || 0,
@@ -512,6 +554,44 @@ export function registerTaskCommands(program: Command): void {
         }
 
         await printTaskDetail(t);
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    });
+
+  // ── task link ──
+  task
+    .command('link <id>')
+    .description('Link task to an external tracker (GitHub, Jira, etc.)')
+    .option('--gh <owner/repo#N>', 'Link to GitHub issue')
+    .option('--external-id <id>', 'External tracker ID')
+    .option('--external-url <url>', 'External tracker URL')
+    .action(async (id: string, options: { gh?: string; externalId?: string; externalUrl?: string }) => {
+      try {
+        const ts = await getTaskService();
+        let externalId: string;
+        let externalUrl: string;
+
+        if (options.gh) {
+          const parsed = parseGhRef(options.gh);
+          externalId = parsed.externalId;
+          externalUrl = parsed.externalUrl;
+        } else if (options.externalId && options.externalUrl) {
+          externalId = options.externalId;
+          externalUrl = options.externalUrl;
+        } else {
+          console.error('Error: Provide --gh or both --external-id and --external-url.');
+          process.exit(1);
+        }
+
+        const t = await ts.linkTask(id, externalId, externalUrl);
+        if (!t) {
+          console.error(`Error: Task not found: ${id}`);
+          process.exit(1);
+        }
+        console.log(`Linked task #${t.seq} to ${externalId}`);
+        if (t.externalUrl) console.log(`  URL: ${t.externalUrl}`);
       } catch (error) {
         console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);


### PR DESCRIPTION
## Summary

- Add `external_id` and `external_url` columns to the tasks table via migration 013
- Support `--gh owner/repo#N` on `task create`, `task link`, and `task list` for GitHub Issue linking
- Support `--external-id` and `--external-url` for generic tracker linking (Jira, Linear, etc.)
- New `genie task link <id>` subcommand to link existing tasks
- Show external_id column in `task list` when present (truncated to 25 chars)
- Show external fields in `task show` detail view
- 6 new tests covering create, link, update, filter, and detail display

Closes #796

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes (only pre-existing warnings)
- [x] `bun test` — all 1428 tests pass (87 in task-service, including 6 new external linking tests)
- [x] `bun run build` succeeds