### PR TITLE
fix(tui): mouse off + allow-passthrough for native terminal behavior

### DIFF
--- a/src/tui/tmux.ts
+++ b/src/tui/tmux.ts
@@ -142,7 +142,8 @@ function applyTmuxStyle(session: string): void {
       `set-option -t ${session} pane-border-style 'fg=${tmuxStyle.inactiveBorder}'`,
       `set-option -t ${session} pane-active-border-style 'fg=${tmuxStyle.activeBorder}'`,
       `set-option -t ${session} status off`,
-      `set-option -t ${session} mouse on`,
+      `set-option -t ${session} mouse off`,
+      `set-option -t ${session} allow-passthrough on`,
     ];
     for (const cmd of cmds) {
       execSync(`tmux ${cmd}`, { stdio: 'ignore' });


### PR DESCRIPTION
## Summary
- `mouse off` at TUI session level — tmux stops intercepting mouse events
- `allow-passthrough on` — OpenTUI left pane captures mouse via terminal escape sequences for click navigation
- Right pane (Claude Code) gets normal terminal behavior: select, Cmd+C, scroll

## Problem
tmux `mouse on` was intercepting ALL mouse events:
- Select auto-copied to tmux buffer (not system clipboard)
- Click in Claude Code input was glitchy (tmux treated as pane focus, not app click)
- Three layers fighting: ~/.tmux.conf, TUI code, vi copy-mode

## Test plan
- [ ] `genie tui` → left pane click navigation works (OpenTUI handles mouse)
- [ ] Right pane: select text + Cmd+C copies to system clipboard
- [ ] Right pane: scroll works normally
- [ ] Right pane: click in Claude Code input works without glitches