### PR TITLE
fix: session capture — discovery path, pgserve cleanup, backfill status

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -44,6 +44,11 @@ function selfHealPostgres(dataDir: string): void {
       stdio: 'ignore',
       timeout: 5000,
     });
+    // Also kill stale pgserve router/wrapper processes on the same data dir
+    execSync(`pkill -9 -f "pgserve.*${dataDir.replace(/\//g, '\\/')}" 2>/dev/null || true`, {
+      stdio: 'ignore',
+      timeout: 5000,
+    });
   } catch {
     // Best effort
   }

--- a/src/lib/session-backfill.ts
+++ b/src/lib/session-backfill.ts
@@ -30,7 +30,7 @@ interface BackfillProgress {
   totalBytes: number;
   processedBytes: number;
   errors: number;
-  status: 'pending' | 'running' | 'paused' | 'complete';
+  status: 'pending' | 'running' | 'paused' | 'complete' | 'failed';
 }
 
 async function updateSyncState(sql: SqlClient, progress: BackfillProgress): Promise<void> {
@@ -61,6 +61,7 @@ export async function startBackfill(sql: SqlClient): Promise<void> {
   try {
     const existing = await sql`SELECT status FROM session_sync WHERE id = 'backfill'`;
     if (existing.length > 0 && existing[0].status === 'complete') return;
+    // 'failed' status = retry on next start (reset to running)
   } catch {
     // table may not exist yet
   }
@@ -160,15 +161,20 @@ export async function startBackfill(sql: SqlClient): Promise<void> {
       await sleep(SLEEP_BETWEEN_FILES_MS);
     }
 
-    if (running) {
-      progress.status = 'complete';
-      console.log(
-        `[backfill] complete: ${progress.processedFiles}/${progress.totalFiles} files, ${progress.errors} errors`,
-      );
-    } else {
+    if (!running) {
       progress.status = 'paused';
       console.log(
         `[backfill] paused: ${progress.processedFiles}/${progress.totalFiles} files (will resume on next daemon start)`,
+      );
+    } else if (progress.errors > 0 && progress.errors >= progress.totalFiles) {
+      progress.status = 'failed';
+      console.error(
+        `[backfill] failed: ${progress.errors}/${progress.totalFiles} files errored — will retry on next daemon start`,
+      );
+    } else {
+      progress.status = 'complete';
+      console.log(
+        `[backfill] complete: ${progress.processedFiles}/${progress.totalFiles} files, ${progress.errors} errors`,
       );
     }
     await updateSyncState(sql, progress);

--- a/src/lib/session-capture.ts
+++ b/src/lib/session-capture.ts
@@ -171,38 +171,34 @@ export async function discoverAllJsonlFiles(): Promise<DiscoveredFile[]> {
   for (const project of projects) {
     const projectPath = join(claudeDir, project);
 
-    // Main sessions: <project>/sessions/<id>.jsonl
-    const sessionsDir = join(projectPath, 'sessions');
-    try {
-      const files = await readdir(sessionsDir);
-      for (const file of files) {
-        if (!file.endsWith('.jsonl')) continue;
-        const sessionId = basename(file, '.jsonl');
-        const filePath = join(sessionsDir, file);
-        try {
-          const st = await stat(filePath);
-          results.push({
-            sessionId,
-            jsonlPath: filePath,
-            projectPath,
-            parentSessionId: null,
-            isSubagent: false,
-            mtime: Math.floor(st.mtimeMs),
-            fileSize: st.size,
-          });
-        } catch {
-          // File may have been deleted between readdir and stat
-        }
-      }
-    } catch {
-      // sessions dir may not exist
-    }
-
+    // Claude Code stores JSONL files directly in project dirs: <project>/<session-id>.jsonl
     // Subagent sessions: <project>/<session-id>/subagents/<sub-id>.jsonl
     try {
       const entries = await readdir(projectPath, { withFileTypes: true });
       for (const entry of entries) {
-        if (!entry.isDirectory() || entry.name === 'sessions') continue;
+        // Main sessions: direct .jsonl files in project dir
+        if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+          const sessionId = basename(entry.name, '.jsonl');
+          const filePath = join(projectPath, entry.name);
+          try {
+            const st = await stat(filePath);
+            results.push({
+              sessionId,
+              jsonlPath: filePath,
+              projectPath,
+              parentSessionId: null,
+              isSubagent: false,
+              mtime: Math.floor(st.mtimeMs),
+              fileSize: st.size,
+            });
+          } catch {
+            // File may have been deleted between readdir and stat
+          }
+          continue;
+        }
+
+        // Subagent sessions: <session-id>/subagents/<sub-id>.jsonl
+        if (!entry.isDirectory()) continue;
         const subagentsDir = join(projectPath, entry.name, 'subagents');
         try {
           const subFiles = await readdir(subagentsDir);


### PR DESCRIPTION
## Summary

Three bugs found during QA that caused 100% backfill failure and pgserve port conflicts:

1. **JSONL discovery path wrong** — looked in `<project>/sessions/*.jsonl` but Claude Code stores files at `<project>/*.jsonl` directly. Caused all 1,723 files to error during backfill.

2. **selfHealPostgres missed pgserve router** — only killed `postgres` processes, not the `bun`/`node` pgserve router process. Stale router held port 19642, blocking daemon from starting pgserve. Agents worked around it calling it "known flaky issue."

3. **Backfill marked `complete` at 100% error rate** — now marks `failed` and retries on next daemon start instead of permanently skipping.

## Test plan
- [x] `bun run typecheck` — PASS
- [x] `bun run dead-code` — PASS
- [ ] Backfill: restart daemon → verify files discovered and ingested
- [ ] pgserve: kill pgserve process → verify daemon self-heals