### PR TITLE
fix(cli): add missing reset redirect, update header comment

### DIFF
--- a/src/genie.ts
+++ b/src/genie.ts
@@ -3,14 +3,14 @@
 /**
  * genie — Single entrypoint CLI.
  *
- * Top-level commands:
- *   spawn, kill, stop, ls, history, read, answer, work
- *
  * Namespaces:
- *   team, dir, send/inbox, state, hook
+ *   agent  — spawn, kill, stop, resume, list, show, log, send, answer, register, directory, inbox, brief
+ *   task   — create, list, status, done, reset, board, project, releases, type
+ *   team   — create, hire, fire, list, disband
+ *   exec   — list, show, terminate (debug)
  *
- * Utilities:
- *   setup, doctor, update, uninstall, shortcuts
+ * Top-level:
+ *   setup, doctor, update, uninstall, shortcuts, qa, tui, run
  *
  * Session:
  *   genie --session <name>  — Start or resume a named leader session
@@ -344,6 +344,10 @@ program
   .description('(moved) → genie task status')
   .action(errorRedirect('status', 'task status'));
 program.command('done [args...]').description('(moved) → genie task done').action(errorRedirect('done', 'task done'));
+program
+  .command('reset [args...]')
+  .description('(moved) → genie task reset')
+  .action(errorRedirect('reset', 'task reset'));
 program.command('send [args...]').description('(moved) → genie agent send').action(errorRedirect('send', 'agent send'));
 program
   .command('broadcast [args...]')


### PR DESCRIPTION
## Summary
- Add error redirect for `genie reset` → `genie task reset` (the only old top-level command missing a redirect after the Wave 1-3 namespace migration)
- Update file header comment to reflect the current 4-namespace CLI structure (agent, task, team, exec)
- Verify all other redirects and namespace registrations (exec, agent brief) are already wired correctly

## Test plan
- [x] `bun run check` passes (typecheck + lint + dead-code + 1536 tests)
- [ ] Run `genie reset` and verify error redirect message appears