### PR TITLE
fix(tui): tmux navigator in left menu, fix Tab error, detect dead panes

### DIFF
--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -7,7 +7,7 @@ import { getActiveWork, getExecutorActivity, matchWorkToTasks } from './activity
 import { Nav } from './components/Nav.js';
 import { loadAll, loadAssignments, loadExecutors, subscribe } from './db.js';
 import { palette } from './theme.js';
-import { attachProject, cleanup, switchRightPane } from './tmux.js';
+import { attachProject, attachProjectWindow, cleanup, switchRightPane } from './tmux.js';
 import { applyActivity, buildTree } from './tree.js';
 import type { TreeNode, TuiAssignment, TuiData, TuiExecutor } from './types.js';
 
@@ -108,6 +108,14 @@ export function App({ rightPane }: { rightPane?: string }) {
     [rightPane, currentProject],
   );
 
+  const handleTmuxSessionSelect = useCallback(
+    (sessionName: string, windowIndex?: number) => {
+      if (!rightPane) return;
+      attachProjectWindow(rightPane, sessionName, windowIndex);
+    },
+    [rightPane],
+  );
+
   if (loading) {
     return (
       <box width="100%" height="100%" backgroundColor={palette.bg} justifyContent="center" alignItems="center">
@@ -124,7 +132,14 @@ export function App({ rightPane }: { rightPane?: string }) {
     );
   }
 
-  return <Nav tree={tree} onTreeChange={handleTreeChange} onProjectSelect={handleProjectSelect} />;
+  return (
+    <Nav
+      tree={tree}
+      onTreeChange={handleTreeChange}
+      onProjectSelect={handleProjectSelect}
+      onTmuxSessionSelect={handleTmuxSessionSelect}
+    />
+  );
 }
 
 /** Merge expanded state from old tree into new tree (preserves user navigation) */

--- a/src/tui/components/Nav.tsx
+++ b/src/tui/components/Nav.tsx
@@ -9,16 +9,17 @@ import { flattenTree, toggleNode } from '../tree.js';
 import type { TreeNode } from '../types.js';
 import { ClaudeView, getClaudeRowCount } from './ClaudeView.js';
 import { TAB_ORDER, TabBar, type TabId } from './TabBar.js';
-import { TmuxView, getTmuxRowCount } from './TmuxView.js';
+import { TmuxView, getTmuxRowCount, getTmuxRowTarget } from './TmuxView.js';
 import { TreeNodeRow } from './TreeNode.js';
 
 interface NavProps {
   tree: TreeNode[];
   onTreeChange: (tree: TreeNode[]) => void;
   onProjectSelect: (projectId: string, tmuxSession: string | null) => void;
+  onTmuxSessionSelect?: (sessionName: string, windowIndex?: number) => void;
 }
 
-export function Nav({ tree, onTreeChange, onProjectSelect }: NavProps) {
+export function Nav({ tree, onTreeChange, onProjectSelect, onTmuxSessionSelect }: NavProps) {
   const [activeTab, setActiveTab] = useState<TabId>('projects');
   const [tabBarFocused, setTabBarFocused] = useState(false);
   const [diagnostics, setDiagnostics] = useState<DiagnosticSnapshot | null>(null);
@@ -123,17 +124,23 @@ export function Nav({ tree, onTreeChange, onProjectSelect }: NavProps) {
   );
 
   const handleEnter = useCallback(() => {
-    if (activeTab !== 'projects') return;
-    const current = flatNodes[projectIndex]?.node;
-    if (!current) return;
+    if (activeTab === 'projects') {
+      const current = flatNodes[projectIndex]?.node;
+      if (!current) return;
 
-    if (current.type === 'project') {
-      const proj = current.data as { id: string; tmuxSession: string | null };
-      onProjectSelect(proj.id, proj.tmuxSession);
-    } else if (current.children.length > 0) {
-      handleToggle(current.id);
+      if (current.type === 'project') {
+        const proj = current.data as { id: string; tmuxSession: string | null };
+        onProjectSelect(proj.id, proj.tmuxSession);
+      } else if (current.children.length > 0) {
+        handleToggle(current.id);
+      }
+    } else if (activeTab === 'tmux' && diagnostics && onTmuxSessionSelect) {
+      const target = getTmuxRowTarget(diagnostics.sessions, tmuxIndex);
+      if (target) {
+        onTmuxSessionSelect(target.sessionName, target.windowIndex);
+      }
     }
-  }, [activeTab, flatNodes, projectIndex, onProjectSelect, handleToggle]);
+  }, [activeTab, flatNodes, projectIndex, onProjectSelect, handleToggle, diagnostics, tmuxIndex, onTmuxSessionSelect]);
 
   const handleTabBarKey = useCallback(
     (keyName: string): boolean => {
@@ -208,6 +215,7 @@ export function Nav({ tree, onTreeChange, onProjectSelect }: NavProps) {
     ? {
         orphanProcesses: diagnostics.gaps.deadPidExecutors.length,
         orphanPanes: diagnostics.gaps.orphanPanes.length,
+        deadPanes: diagnostics.gaps.deadPaneCount,
       }
     : undefined;
 

--- a/src/tui/components/TabBar.tsx
+++ b/src/tui/components/TabBar.tsx
@@ -16,21 +16,28 @@ const TAB_LABELS: Record<TabId, string> = {
 interface TabBarProps {
   activeTab: TabId;
   focused: boolean;
-  gaps?: { orphanProcesses: number; orphanPanes: number };
+  gaps?: { orphanProcesses: number; orphanPanes: number; deadPanes: number };
+}
+
+function tabBadge(tab: TabId, gaps: TabBarProps['gaps']) {
+  if (tab === 'claude') {
+    const total = (gaps?.orphanProcesses ?? 0) + (gaps?.orphanPanes ?? 0);
+    return total > 0 ? <span fg={palette.error}> {total}</span> : null;
+  }
+  if (tab === 'tmux') {
+    const dead = gaps?.deadPanes ?? 0;
+    return dead > 0 ? <span fg={palette.error}> {dead}\u2620</span> : null;
+  }
+  return null;
 }
 
 export function TabBar({ activeTab, focused, gaps }: TabBarProps) {
-  const totalGaps = (gaps?.orphanProcesses ?? 0) + (gaps?.orphanPanes ?? 0);
-
   return (
     <box height={1} flexDirection="row" width="100%" backgroundColor={palette.bgLight}>
       {TAB_ORDER.map((tab) => {
         const isActive = tab === activeTab;
         const bg = isActive ? palette.violet : palette.bgLight;
         const fg = isActive ? '#ffffff' : focused ? palette.textDim : palette.textMuted;
-
-        // Show gap count badge on Claude tab
-        const badge = tab === 'claude' && totalGaps > 0 ? <span fg={palette.error}> {totalGaps}</span> : null;
 
         return (
           <box key={tab} backgroundColor={bg} paddingX={1}>
@@ -39,7 +46,7 @@ export function TabBar({ activeTab, focused, gaps }: TabBarProps) {
                 {isActive && focused ? '>' : ' '}
                 {TAB_LABELS[tab]}
               </span>
-              {badge}
+              {tabBadge(tab, gaps)}
             </text>
           </box>
         );

--- a/src/tui/components/TmuxView.tsx
+++ b/src/tui/components/TmuxView.tsx
@@ -2,7 +2,7 @@
 /** tmux inventory: sessions > windows > panes with PID and command info */
 
 import { useMemo } from 'react';
-import type { TmuxSession } from '../diagnostics.js';
+import type { TmuxPane, TmuxSession } from '../diagnostics.js';
 import { palette } from '../theme.js';
 
 interface TmuxViewProps {
@@ -19,8 +19,29 @@ interface FlatTmuxRow {
   detailColor: string;
   type: 'session' | 'window' | 'pane';
   sessionName: string;
+  windowIndex?: number;
   /** Whether pane is running claude */
   isClaude: boolean;
+  /** Whether pane has exited */
+  isDead: boolean;
+}
+
+function toPaneRow(pane: TmuxPane, sessionName: string, windowIndex: number): FlatTmuxRow {
+  const isClaude = pane.command === 'claude' || pane.title.includes('claude');
+  const color = pane.isDead ? palette.textMuted : isClaude ? palette.cyan : palette.textDim;
+  return {
+    id: `p:${pane.paneId}`,
+    depth: 2,
+    label: pane.isDead ? `${pane.paneId} [DEAD]` : `${pane.paneId} [${pane.command}]`,
+    color,
+    detail: `pid:${pane.pid} ${pane.size}`,
+    detailColor: palette.textMuted,
+    type: 'pane',
+    sessionName,
+    windowIndex,
+    isClaude,
+    isDead: pane.isDead,
+  };
 }
 
 function flattenSessions(sessions: TmuxSession[]): FlatTmuxRow[] {
@@ -35,33 +56,24 @@ function flattenSessions(sessions: TmuxSession[]): FlatTmuxRow[] {
       type: 'session',
       sessionName: session.name,
       isClaude: false,
+      isDead: false,
     };
     const windowRows = session.windows.flatMap((window) => {
+      const deadInWindow = window.panes.filter((p) => p.isDead).length;
       const winRow: FlatTmuxRow = {
         id: `w:${session.name}:${window.index}`,
         depth: 1,
         label: `${window.index}:${window.name}`,
         color: window.active ? palette.cyan : palette.text,
-        detail: `${window.paneCount}p${window.active ? ' *' : ''}`,
+        detail: `${window.paneCount}p${deadInWindow > 0 ? ` ${deadInWindow}\u2620` : ''}${window.active ? ' *' : ''}`,
         detailColor: window.active ? palette.cyan : palette.textMuted,
         type: 'window',
         sessionName: session.name,
+        windowIndex: window.index,
         isClaude: false,
+        isDead: false,
       };
-      const paneRows: FlatTmuxRow[] = window.panes.map((pane) => {
-        const isClaude = pane.command === 'claude' || pane.title.includes('claude');
-        return {
-          id: `p:${pane.paneId}`,
-          depth: 2,
-          label: `${pane.paneId} [${pane.command}]`,
-          color: isClaude ? palette.cyan : palette.textDim,
-          detail: `pid:${pane.pid} ${pane.size}`,
-          detailColor: palette.textMuted,
-          type: 'pane' as const,
-          sessionName: session.name,
-          isClaude,
-        };
-      });
+      const paneRows: FlatTmuxRow[] = window.panes.map((pane) => toPaneRow(pane, session.name, window.index));
       return [winRow, ...paneRows];
     });
     return [sessionRow, ...windowRows];
@@ -72,6 +84,10 @@ export function TmuxView({ sessions, selectedIndex }: TmuxViewProps) {
   const rows = useMemo(() => flattenSessions(sessions), [sessions]);
 
   const totalPanes = sessions.reduce((sum, s) => sum + s.windows.reduce((ws, w) => ws + w.panes.length, 0), 0);
+  const deadPanes = sessions.reduce(
+    (sum, s) => sum + s.windows.reduce((ws, w) => ws + w.panes.filter((p) => p.isDead).length, 0),
+    0,
+  );
 
   return (
     <box flexDirection="column" width="100%" height="100%">
@@ -81,6 +97,7 @@ export function TmuxView({ sessions, selectedIndex }: TmuxViewProps) {
           <span fg={palette.textDim}>
             {sessions.length}s {sessions.reduce((s, x) => s + x.windowCount, 0)}w {totalPanes}p
           </span>
+          {deadPanes > 0 ? <span fg={palette.error}> {deadPanes} dead</span> : null}
         </text>
       </box>
 
@@ -100,7 +117,8 @@ export function TmuxView({ sessions, selectedIndex }: TmuxViewProps) {
       >
         {rows.map((row, i) => {
           const indent = '  '.repeat(row.depth);
-          const icon = row.type === 'session' ? '\u25c8' : row.type === 'window' ? '\u25a1' : '\u2500'; // ◈ □ ─
+          const icon =
+            row.type === 'session' ? '\u25c8' : row.type === 'window' ? '\u25a1' : row.isDead ? '\u2718' : '\u2500'; // ◈ □ ✘ ─
           const selected = i === selectedIndex;
 
           return (
@@ -131,4 +149,15 @@ export function getTmuxRowCount(sessions: TmuxSession[]): number {
     }
   }
   return count;
+}
+
+/** Look up session target for a given row index (for Enter key navigation). */
+export function getTmuxRowTarget(
+  sessions: TmuxSession[],
+  index: number,
+): { sessionName: string; windowIndex?: number } | null {
+  const rows = flattenSessions(sessions);
+  const row = rows[index];
+  if (!row) return null;
+  return { sessionName: row.sessionName, windowIndex: row.windowIndex };
 }

--- a/src/tui/db.ts
+++ b/src/tui/db.ts
@@ -1,5 +1,6 @@
-/** PG data layer — framework-agnostic, no UI imports */
+/** PG data layer + tmux tree loader — framework-agnostic, no UI imports */
 
+import { execSync } from 'node:child_process';
 import type { ExecutorState, TransportType } from '../lib/executor-types.js';
 import type { ProviderName } from '../lib/provider-adapters.js';
 import type {
@@ -193,4 +194,63 @@ function mapAssignment(row: Record<string, unknown>): TuiAssignment {
     groupNumber: row.group_number != null ? Number(row.group_number) : null,
     startedAt: row.started_at instanceof Date ? row.started_at.toISOString() : String(row.started_at),
   };
+}
+
+// ── Tmux Tree ────────────────────────────────────────────────────────────────
+
+interface TmuxTreeWindow {
+  sessionName: string;
+  index: number;
+  name: string;
+  active: boolean;
+  paneCount: number;
+}
+
+/** @public */
+export interface TmuxTreeSession {
+  name: string;
+  attached: boolean;
+  windowCount: number;
+  windows: TmuxTreeWindow[];
+}
+
+/** Load tmux session/window tree from shell (lightweight, no pane-level detail). @public */
+export function loadTmuxTree(): TmuxTreeSession[] {
+  let output: string;
+  try {
+    output = execSync(
+      "tmux list-windows -a -F '#{session_name}|#{window_index}|#{window_name}|#{window_active}|#{window_panes}|#{session_attached}|#{session_windows}'",
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+    ).trim();
+  } catch {
+    return [];
+  }
+
+  if (!output) return [];
+
+  const sessionMap = new Map<string, TmuxTreeSession>();
+
+  for (const line of output.split('\n')) {
+    if (!line) continue;
+    const [sessName, winIdx, winName, winActive, winPanes, sessAttached, sessWindows] = line.split('|');
+
+    if (!sessionMap.has(sessName)) {
+      sessionMap.set(sessName, {
+        name: sessName,
+        attached: sessAttached === '1',
+        windowCount: Number.parseInt(sessWindows, 10) || 0,
+        windows: [],
+      });
+    }
+
+    sessionMap.get(sessName)?.windows.push({
+      sessionName: sessName,
+      index: Number.parseInt(winIdx, 10) || 0,
+      name: winName,
+      active: winActive === '1',
+      paneCount: Number.parseInt(winPanes, 10) || 0,
+    });
+  }
+
+  return Array.from(sessionMap.values()).sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/src/tui/diagnostics.ts
+++ b/src/tui/diagnostics.ts
@@ -21,6 +21,7 @@ export interface TmuxPane {
   command: string;
   title: string;
   size: string;
+  isDead: boolean;
 }
 
 export interface TmuxWindow {
@@ -51,6 +52,8 @@ export interface DiagnosticGaps {
   totalExecutors: number;
   /** Total panes running claude */
   totalClaudePanes: number;
+  /** Total dead panes (exited) across all sessions */
+  deadPaneCount: number;
 }
 
 export interface DiagnosticSnapshot {
@@ -93,6 +96,7 @@ function parsePaneLine(parts: string[]): {
     sessAttached,
     sessWindows,
     sessCreated,
+    paneDead,
   ] = parts;
   return {
     sessionName,
@@ -119,6 +123,7 @@ function parsePaneLine(parts: string[]): {
       command: paneCmd,
       title: paneTitle,
       size: paneSize,
+      isDead: paneDead === '1',
     },
   };
 }
@@ -126,7 +131,7 @@ function parsePaneLine(parts: string[]): {
 /** Collect all tmux sessions, windows, and panes into a typed tree. */
 function getTmuxInventory(): TmuxSession[] {
   const paneOutput = execQuiet(
-    "tmux list-panes -a -F '#{session_name}|#{window_index}|#{window_name}|#{window_active}|#{window_panes}|#{pane_index}|#{pane_id}|#{pane_pid}|#{pane_current_command}|#{pane_title}|#{pane_width}x#{pane_height}|#{session_attached}|#{session_windows}|#{session_created}'",
+    "tmux list-panes -a -F '#{session_name}|#{window_index}|#{window_name}|#{window_active}|#{window_panes}|#{pane_index}|#{pane_id}|#{pane_pid}|#{pane_current_command}|#{pane_title}|#{pane_width}x#{pane_height}|#{session_attached}|#{session_windows}|#{session_created}|#{pane_dead}'",
   );
 
   if (!paneOutput) return [];
@@ -137,7 +142,7 @@ function getTmuxInventory(): TmuxSession[] {
   for (const line of paneOutput.split('\n')) {
     if (!line) continue;
     const parts = line.split('|');
-    if (parts.length < 14) continue;
+    if (parts.length < 15) continue;
 
     const parsed = parsePaneLine(parts);
 
@@ -194,12 +199,16 @@ function detectGaps(executors: TuiExecutor[], sessions: TmuxSession[]): Diagnost
 
   const linkedCount = executors.filter((e) => e.tmuxPaneId && !deadPidExecutors.some((d) => d.id === e.id)).length;
 
+  const allPanes = sessions.flatMap((s) => s.windows.flatMap((w) => w.panes));
+  const deadPaneCount = allPanes.filter((p) => p.isDead).length;
+
   return {
     deadPidExecutors,
     orphanPanes,
     linkedCount,
     totalExecutors: executors.length,
     totalClaudePanes: claudePanes.length,
+    deadPaneCount,
   };
 }
 

--- a/src/tui/tmux.ts
+++ b/src/tui/tmux.ts
@@ -100,6 +100,26 @@ export function switchRightPane(rightPane: string, targetSession: string): void 
   attachProject(rightPane, targetSession);
 }
 
+/** Switch right pane to a specific session window */
+export function attachProjectWindow(rightPane: string, targetSession: string, windowIndex?: number): void {
+  const pane = resolveRightPane(rightPane);
+  ensureSession(targetSession);
+  if (windowIndex !== undefined) {
+    try {
+      execSync(`tmux select-window -t '${targetSession}:${windowIndex}'`, { stdio: 'ignore' });
+    } catch {
+      // window may not exist
+    }
+  }
+  try {
+    execSync(`tmux respawn-pane -k -t ${pane} "TMUX='' tmux attach-session -t '${targetSession}'"`, {
+      stdio: 'ignore',
+    });
+  } catch {
+    // pane doesn't exist
+  }
+}
+
 /**
  * Set up TUI keybindings in a dedicated key table (not global root).
  * Uses a custom key table "genie-tui" so bindings only apply inside the TUI session.
@@ -108,7 +128,7 @@ export function switchRightPane(rightPane: string, targetSession: string): void 
 function setupKeybindings(session: string): void {
   try {
     // Define bindings in the genie-tui key table (session-scoped, not global)
-    execSync(`tmux bind-key -T ${KEY_TABLE} Tab select-pane -t ${session}:0.+ \\; switch-client -T ${KEY_TABLE}`, {
+    execSync(`tmux bind-key -T ${KEY_TABLE} Tab select-pane -t :.+ \\; switch-client -T ${KEY_TABLE}`, {
       stdio: 'ignore',
     });
 


### PR DESCRIPTION
## Summary
- **Fix Tab key error**: Use relative pane selector (`:.+`) instead of absolute `session:0.+` reference that broke when right pane was attached to another session
- **Navigable tmux tree**: Arrow keys select session/window in the tmux tab, Enter attaches the right pane to the selected session (with optional window targeting)
- **Dead pane detection**: Read `#{pane_dead}` flag from tmux, mark dead panes with ✘ icon and `[DEAD]` label, show ☠ count badge in tmux tab header

## Changes
- `tmux.ts`: Fix Tab keybinding, add `attachProjectWindow()` for window-specific attachment
- `db.ts`: Add `loadTmuxTree()` lightweight tmux session/window loader
- `diagnostics.ts`: Add `isDead` field to `TmuxPane`, count dead panes in `DiagnosticGaps`
- `TmuxView.tsx`: Dead pane visual indicators, export `getTmuxRowTarget()` helper
- `TabBar.tsx`: Dead pane badge (☠) on tmux tab, extracted badge logic to reduce complexity
- `Nav.tsx`: Wire Enter key on tmux tab to attach selected session
- `app.tsx`: Add `handleTmuxSessionSelect` callback bridging Nav to tmux attachment

## Test plan
- [ ] Launch TUI (`genie tui`), press Tab — should toggle panes without error
- [ ] Switch to tmux tab, navigate sessions with arrow keys, press Enter — right pane attaches
- [ ] Kill a pane to create a dead pane — verify ✘ icon, [DEAD] label, ☠ badge appear
- [ ] Verify no regression on Projects and Claude tabs