### PR TITLE
feat(hooks): orchestration guardrails — block tmux scraping

### DIFF
--- a/plugins/genie/hooks/hooks.json
+++ b/plugins/genie/hooks/hooks.json
@@ -35,6 +35,16 @@
         ]
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/orchestration-guard.cjs",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Write",
         "hooks": [
           {

--- a/plugins/genie/rules/genie-orchestration.md
+++ b/plugins/genie/rules/genie-orchestration.md
@@ -9,9 +9,37 @@ genie team create <name> --repo <path> --wish <slug>  # Launch autonomous team
 genie spawn <role>                                     # Spawn agent (engineer, reviewer, qa, fix)
 genie send '<msg>' --to <agent>                        # Message cross-session agent
 genie status <slug>                                    # Check wish progress
+genie events list --since 5m                           # Recent structured events
+genie events timeline <entity-id>                      # Full entity event history
+genie ls --json                                        # Agent state from PG
 ```
 
 ## Tool Restrictions
 
 NEVER use `Agent` to spawn agents — use `genie spawn` instead.
 NEVER use `TeamCreate` or `TeamDelete` — use `genie team create` / `genie team disband` instead.
+
+## Post-Dispatch Monitoring
+
+After `genie team create` or `genie spawn`, use ONLY structured primitives. A hook enforces this automatically.
+
+### DO — Structured monitoring
+| Need | Command |
+|------|---------|
+| Wish progress | `genie status <slug>` |
+| Worker state | `genie ls --json` |
+| Send instructions | `genie send '<msg>' --to <agent>` |
+| Event timeline | `genie events timeline <id>` |
+| Error patterns | `genie events errors` |
+
+### NEVER — Terminal scraping
+- `tmux capture-pane` to check worker progress (BLOCKED by hook)
+- `sleep` + poll loops to watch terminal output (BLOCKED by hook)
+- Raw terminal text parsing for workflow decisions
+
+### Post-dispatch flow
+1. **Dispatch** — `genie team create` or `genie spawn`
+2. **Trust** — workers execute autonomously, report via PG events
+3. **Check** — `genie status <slug>` for progress
+4. **Communicate** — `genie send` for instructions
+5. **Review** — when workers report done, review output

--- a/plugins/genie/scripts/orchestration-guard.cjs
+++ b/plugins/genie/scripts/orchestration-guard.cjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * orchestration-guard — PreToolUse:Bash hook that catches orchestration anti-patterns.
+ *
+ * Intercepts bash commands that bypass genie's structured monitoring primitives:
+ * - tmux capture-pane for worker monitoring (use genie status/events instead)
+ * - sleep+poll loops for terminal scraping (use genie send/events instead)
+ *
+ * Returns JSON to Claude Code hook system:
+ * - { "decision": "block", "reason": "..." } to prevent execution
+ * - Exits 0 with no output to allow
+ *
+ * Payload on stdin (PreToolUse:Bash):
+ * { "tool_name": "Bash", "tool_input": { "command": "..." }, ... }
+ */
+
+const PATTERNS = [
+  {
+    // tmux capture-pane used for monitoring worker output
+    pattern: /tmux\s+capture-pane/,
+    message: `🚫 **Orchestration guard: tmux scraping blocked**
+
+You're using \`tmux capture-pane\` to read a worker's terminal. This is screen-scraping — use genie's structured primitives instead:
+
+| Need | Command |
+|------|---------|
+| Wish progress | \`genie status <slug>\` |
+| Worker state | \`genie ls --json\` |
+| Event timeline | \`genie events timeline <entity-id>\` |
+| Send message | \`genie send '<msg>' --to <agent>\` |
+| Error patterns | \`genie events errors\` |
+
+**Why:** tmux scraping is opaque to PG, metrics, and diagnostics. Structured state persists across sessions.`
+  },
+  {
+    // sleep+tmux polling pattern (sleep followed by tmux in same command)
+    pattern: /sleep\s+\d+\s*&&\s*tmux/,
+    message: `🚫 **Orchestration guard: sleep+poll loop blocked**
+
+You're using a \`sleep && tmux\` polling loop to watch a worker. This is an anti-pattern.
+
+**Instead:** Use \`genie status <slug>\` to check progress, or \`genie send\` to communicate. Workers report back via PG events — you don't need to poll their terminals.
+
+**Post-dispatch flow:**
+1. Dispatch → \`genie team create\` or \`genie spawn\`
+2. Trust → workers execute autonomously
+3. Check → \`genie status <slug>\`
+4. Communicate → \`genie send '<msg>' --to <agent>\`
+5. Review → when done, review the output`
+  },
+  {
+    // sleep used as a polling delay for monitoring (broader catch)
+    pattern: /sleep\s+\d+\s*&&\s*.*(?:capture-pane|genie\s+ls|tmux\s+list)/,
+    message: `⚠️ **Orchestration guard: polling pattern detected**
+
+You're using \`sleep\` to poll for status. Consider using structured genie primitives instead:
+
+- \`genie status <slug>\` — wish progress from PG
+- \`genie events list --since 5m\` — recent events
+- \`genie send '<msg>' --to <agent>\` — direct communication`
+  }
+];
+
+async function main() {
+  let input = '';
+  try {
+    input = require('fs').readFileSync(0, 'utf-8').trim();
+  } catch {
+    process.exit(0);
+  }
+
+  if (!input) process.exit(0);
+
+  let payload;
+  try {
+    payload = JSON.parse(input);
+  } catch {
+    process.exit(0);
+  }
+
+  // Only intercept Bash tool calls
+  if (payload.tool_name !== 'Bash') process.exit(0);
+
+  const command = payload.tool_input?.command;
+  if (!command) process.exit(0);
+
+  // Check each pattern
+  for (const { pattern, message } of PATTERNS) {
+    if (pattern.test(command)) {
+      // Output block decision
+      console.log(JSON.stringify({
+        decision: 'block',
+        reason: message
+      }));
+      process.exit(0);
+    }
+  }
+
+  // Allow — no output means proceed
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
## Summary
- New `PreToolUse:Bash` hook (`orchestration-guard.cjs`) blocks agents from using `tmux capture-pane` or `sleep+poll` loops to monitor workers
- Redirects to structured primitives: `genie status`, `genie events`, `genie send`
- Updated `genie-orchestration.md` plugin rules with post-dispatch monitoring section
- Ships with genie plugin to all users automatically

## Why
Genie agents were defaulting to tmux terminal scraping to monitor spawned workers — invisible to PG, metrics, and diagnostics. The behavioral rules had a gap: they defined how to dispatch but not how to monitor.

## Test plan
- [x] Hook blocks `tmux capture-pane` commands
- [x] Hook blocks `sleep && tmux` polling patterns
- [x] Hook allows `genie status` and legitimate commands
- [x] hooks.json valid JSON
- [x] All 1536 tests pass