### PR TITLE
fix(tui): rename Claude tab to Executors, fix Tab key toggle

### DIFF
--- a/src/tui/components/ClaudeView.tsx
+++ b/src/tui/components/ClaudeView.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @opentui/react */
-/** Executor list — renders executor metadata from DB with gap detection */
+/** Executor list — renders executor metadata from DB grouped by provider, with gap detection */
 
 import { useMemo } from 'react';
 import type { DiagnosticGaps } from '../diagnostics.js';
@@ -96,7 +96,34 @@ function flattenExecutors(
   gaps: DiagnosticGaps,
 ): FlatClaudeRow[] {
   const deadIds = new Set(gaps.deadPidExecutors.map((e) => e.id));
-  const rows: FlatClaudeRow[] = executors.flatMap((exec) => executorToRows(exec, assignments, deadIds.has(exec.id)));
+
+  // Group executors by provider
+  const byProvider = new Map<string, TuiExecutor[]>();
+  for (const exec of executors) {
+    const key = exec.provider;
+    if (!byProvider.has(key)) byProvider.set(key, []);
+    byProvider.get(key)?.push(exec);
+  }
+
+  const rows: FlatClaudeRow[] = [];
+
+  for (const [provider, group] of byProvider) {
+    // Provider header
+    rows.push({
+      id: `provider:${provider}`,
+      depth: 0,
+      label: `\u2500\u2500 ${provider} (${group.length}) \u2500\u2500`,
+      color: palette.cyan,
+      detail: '',
+      detailColor: palette.textMuted,
+      isOrphan: false,
+    });
+    for (const exec of group) {
+      for (const row of executorToRows(exec, assignments, deadIds.has(exec.id))) {
+        rows.push({ ...row, depth: row.depth + 1 });
+      }
+    }
+  }
 
   if (gaps.orphanPanes.length > 0) {
     rows.push({
@@ -182,7 +209,9 @@ export function getClaudeRowCount(
   assignments: TuiAssignment[],
   gaps: DiagnosticGaps,
 ): number {
-  let count = 0;
+  // Count provider group headers
+  const providers = new Set(executors.map((e) => e.provider));
+  let count = providers.size;
   for (const exec of executors) {
     count += 2; // executor + meta line
     if (assignments.some((a) => a.executorId === exec.id)) count++; // assignment line

--- a/src/tui/components/Nav.tsx
+++ b/src/tui/components/Nav.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @opentui/react */
-/** Navigation panel with 3 tabs: Projects | tmux | Claude — arrow keys navigate, left/right switch tabs */
+/** Navigation panel with 3 tabs: Projects | tmux | Executors — arrow keys navigate, left/right switch tabs */
 
 import { useKeyboard } from '@opentui/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';

--- a/src/tui/components/TabBar.tsx
+++ b/src/tui/components/TabBar.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @opentui/react */
-/** Horizontal tab bar: Projects | tmux | Claude — left/right to switch */
+/** Horizontal tab bar: Projects | tmux | Executors — left/right to switch */
 
 import { palette } from '../theme.js';
 
@@ -10,7 +10,7 @@ export const TAB_ORDER: TabId[] = ['projects', 'tmux', 'claude'];
 const TAB_LABELS: Record<TabId, string> = {
   projects: 'Projects',
   tmux: 'tmux',
-  claude: 'Claude',
+  claude: 'Executors',
 };
 
 interface TabBarProps {

--- a/src/tui/tmux.ts
+++ b/src/tui/tmux.ts
@@ -128,7 +128,7 @@ export function attachProjectWindow(rightPane: string, targetSession: string, wi
 function setupKeybindings(session: string): void {
   try {
     // Define bindings in the genie-tui key table (session-scoped, not global)
-    execSync(`tmux bind-key -T ${KEY_TABLE} Tab select-pane -t :.+ \\; switch-client -T ${KEY_TABLE}`, {
+    execSync(`tmux bind-key -T ${KEY_TABLE} Tab select-pane -t ${session}:0.1 \\; switch-client -T ${KEY_TABLE}`, {
       stdio: 'ignore',
     });
 


### PR DESCRIPTION
## Summary
- **Tab key fix**: Use deterministic `select-pane -t session:0.1` instead of relative `:0.+` which could cycle through unexpected panes
- **Rename tab**: Third nav tab renamed from "Claude" to "Executors" (TabBar + Nav comments)
- **Group by provider**: Executor list now groups entries by provider (claude, codex, etc.) with section headers showing provider name and count

## Test plan
- [x] `bun run check` passes (typecheck + lint + dead-code + 1536 tests)
- [ ] Verify Tab key toggles to pane 1 in the TUI tmux session
- [ ] Verify third tab displays "Executors" label
- [ ] Verify executors are grouped under provider headers