### PR TITLE
fix(tui): Sessions as default tab, remove Projects tab

### DIFF
--- a/src/tui/components/Nav.tsx
+++ b/src/tui/components/Nav.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @opentui/react */
-/** Navigation panel with 3 tabs: Projects | tmux | Executors — arrow keys navigate, left/right switch tabs */
+/** Navigation panel with 2 tabs: Sessions | Executors — arrow keys navigate, left/right switch tabs */
 
 import { useKeyboard } from '@opentui/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -20,7 +20,7 @@ interface NavProps {
 }
 
 export function Nav({ tree, onTreeChange, onProjectSelect, onTmuxSessionSelect }: NavProps) {
-  const [activeTab, setActiveTab] = useState<TabId>('projects');
+  const [activeTab, setActiveTab] = useState<TabId>('tmux');
   const [tabBarFocused, setTabBarFocused] = useState(false);
   const [diagnostics, setDiagnostics] = useState<DiagnosticSnapshot | null>(null);
 

--- a/src/tui/components/TabBar.tsx
+++ b/src/tui/components/TabBar.tsx
@@ -1,15 +1,15 @@
 /** @jsxImportSource @opentui/react */
-/** Horizontal tab bar: Projects | tmux | Executors — left/right to switch */
+/** Horizontal tab bar: Sessions | Executors — left/right to switch */
 
 import { palette } from '../theme.js';
 
 export type TabId = 'projects' | 'tmux' | 'claude';
 
-export const TAB_ORDER: TabId[] = ['projects', 'tmux', 'claude'];
+export const TAB_ORDER: TabId[] = ['tmux', 'claude'];
 
 const TAB_LABELS: Record<TabId, string> = {
   projects: 'Projects',
-  tmux: 'tmux',
+  tmux: 'Sessions',
   claude: 'Executors',
 };
 


### PR DESCRIPTION
Rename tmux→Sessions, make it default. Remove Projects tab. Executors stays as tab 2. Pre-existing lint complexity warning in Nav.tsx (not from this change).