### PR TITLE
fix(hooks): add orchestration-guard to genie hook dispatch chain

### DIFF
--- a/src/hooks/handlers/orchestration-guard.ts
+++ b/src/hooks/handlers/orchestration-guard.ts
@@ -1,0 +1,57 @@
+/**
+ * Orchestration Guard Handler — PreToolUse:Bash
+ *
+ * Blocks agents from using tmux capture-pane or sleep+poll loops
+ * to monitor workers. Redirects to structured genie primitives.
+ *
+ * Priority: 2 (runs after branch-guard, before identity-inject)
+ */
+
+import type { HandlerResult, HookPayload } from '../types.js';
+
+interface BlockPattern {
+  test: RegExp;
+  reason: string;
+}
+
+const BLOCK_PATTERNS: BlockPattern[] = [
+  {
+    test: /tmux\s+capture-pane/,
+    reason:
+      'BLOCKED: tmux scraping detected. Use structured monitoring instead:\n' +
+      '  genie status <slug>        — wish progress from PG\n' +
+      '  genie agent list --json    — executor state machine\n' +
+      '  genie events timeline <id> — structured event log\n' +
+      '  genie agent send --to <a>  — PG-backed messaging\n' +
+      'Load /genie for full orchestration guidance.',
+  },
+  {
+    test: /sleep\s+\d+\s*&&\s*tmux/,
+    reason:
+      'BLOCKED: sleep+poll loop detected. Workers report via PG events — no need to poll terminals.\n' +
+      '  genie status <slug>        — check progress\n' +
+      '  genie agent send --to <a>  — communicate directly\n' +
+      'Load /genie for full orchestration guidance.',
+  },
+  {
+    test: /sleep\s+\d+\s*&&\s*.*(?:capture-pane|tmux\s+list)/,
+    reason:
+      'BLOCKED: terminal polling pattern detected. Use genie primitives:\n' +
+      '  genie status <slug>\n' +
+      '  genie events list --since 5m\n' +
+      'Load /genie for full orchestration guidance.',
+  },
+];
+
+export async function orchestrationGuard(payload: HookPayload): Promise<HandlerResult> {
+  const command = payload.tool_input?.command;
+  if (typeof command !== 'string') return undefined;
+
+  for (const { test, reason } of BLOCK_PATTERNS) {
+    if (test.test(command)) {
+      return { decision: 'deny', reason };
+    }
+  }
+
+  return undefined;
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -18,6 +18,7 @@
 import { autoSpawn } from './handlers/auto-spawn.js';
 import { branchGuard } from './handlers/branch-guard.js';
 import { identityInject } from './handlers/identity-inject.js';
+import { orchestrationGuard } from './handlers/orchestration-guard.js';
 import {
   emitAssistantResponseEvent,
   emitMessageEvent,
@@ -38,6 +39,13 @@ const handlers: Handler[] = [
     matcher: /^Bash$/,
     priority: 1,
     fn: branchGuard,
+  },
+  {
+    name: 'orchestration-guard',
+    event: 'PreToolUse',
+    matcher: /^Bash$/,
+    priority: 2,
+    fn: orchestrationGuard,
   },
   {
     name: 'identity-inject',


### PR DESCRIPTION
## Summary
The orchestration-guard from PR #880 only worked for plugin-loaded sessions, not for team-spawned agents. Root cause: two separate hook systems.

**Plugin hooks** (`hooks.json`) → loaded by Claude Code plugin system → only for sessions with the plugin active
**Team hooks** (`genie hook dispatch`) → injected into `~/.claude/teams/<team>/settings.json` → fires for ALL genie-spawned agents

This PR adds orchestration-guard as a TypeScript handler in the dispatch chain (priority 2, after branch-guard), so it fires for every team-spawned agent.

## Test plan
- [x] `genie hook dispatch` blocks `tmux capture-pane` (tested via stdin)
- [x] `genie hook dispatch` blocks `sleep && tmux` patterns (tested)
- [x] `genie hook dispatch` allows `genie status` (tested — empty output = allow)
- [x] TypeScript compiles cleanly