### PR TITLE
fix(hooks): add matcher to team hook injection, make guard informational

### DIFF
--- a/plugins/genie/scripts/orchestration-guard.cjs
+++ b/plugins/genie/scripts/orchestration-guard.cjs
@@ -2,64 +2,35 @@
 "use strict";
 
 /**
- * orchestration-guard — PreToolUse:Bash hook that catches orchestration anti-patterns.
+ * orchestration-guard — PreToolUse:Bash informational nudge.
  *
- * Intercepts bash commands that bypass genie's structured monitoring primitives:
- * - tmux capture-pane for worker monitoring (use genie status/events instead)
- * - sleep+poll loops for terminal scraping (use genie send/events instead)
+ * When agents use tmux capture-pane or sleep+poll loops, suggests
+ * structured genie primitives instead. Does NOT block — people may
+ * legitimately use tmux directly.
  *
- * Returns JSON to Claude Code hook system:
- * - { "decision": "block", "reason": "..." } to prevent execution
- * - Exits 0 with no output to allow
- *
- * Payload on stdin (PreToolUse:Bash):
- * { "tool_name": "Bash", "tool_input": { "command": "..." }, ... }
+ * Outputs suggestion to stderr (agent sees it), exits 0 (allows).
  */
 
 const PATTERNS = [
   {
-    // tmux capture-pane used for monitoring worker output
     pattern: /tmux\s+capture-pane/,
-    message: `🚫 **Orchestration guard: tmux scraping blocked**
-
-You're using \`tmux capture-pane\` to read a worker's terminal. This is screen-scraping — use genie's structured primitives instead:
-
-| Need | Command |
-|------|---------|
-| Wish progress | \`genie status <slug>\` |
-| Worker state | \`genie ls --json\` |
-| Event timeline | \`genie events timeline <entity-id>\` |
-| Send message | \`genie send '<msg>' --to <agent>\` |
-| Error patterns | \`genie events errors\` |
-
-**Why:** tmux scraping is opaque to PG, metrics, and diagnostics. Structured state persists across sessions.`
+    message: `If you're checking genie agent progress, use structured monitoring instead:
+  genie task status <slug>   — wish progress from PG
+  genie agent list --json    — executor state machine
+  genie events timeline <id> — structured event log
+  genie agent send --to <a>  — PG-backed messaging`
   },
   {
-    // sleep+tmux polling pattern (sleep followed by tmux in same command)
     pattern: /sleep\s+\d+\s*&&\s*tmux/,
-    message: `🚫 **Orchestration guard: sleep+poll loop blocked**
-
-You're using a \`sleep && tmux\` polling loop to watch a worker. This is an anti-pattern.
-
-**Instead:** Use \`genie status <slug>\` to check progress, or \`genie send\` to communicate. Workers report back via PG events — you don't need to poll their terminals.
-
-**Post-dispatch flow:**
-1. Dispatch → \`genie team create\` or \`genie spawn\`
-2. Trust → workers execute autonomously
-3. Check → \`genie status <slug>\`
-4. Communicate → \`genie send '<msg>' --to <agent>\`
-5. Review → when done, review the output`
+    message: `Workers report via PG events — polling terminals is not needed.
+  genie task status <slug>   — check progress
+  genie agent send --to <a>  — communicate directly`
   },
   {
-    // sleep used as a polling delay for monitoring (broader catch)
-    pattern: /sleep\s+\d+\s*&&\s*.*(?:capture-pane|genie\s+ls|tmux\s+list)/,
-    message: `⚠️ **Orchestration guard: polling pattern detected**
-
-You're using \`sleep\` to poll for status. Consider using structured genie primitives instead:
-
-- \`genie status <slug>\` — wish progress from PG
-- \`genie events list --since 5m\` — recent events
-- \`genie send '<msg>' --to <agent>\` — direct communication`
+    pattern: /sleep\s+\d+\s*&&\s*.*(?:capture-pane|tmux\s+list)/,
+    message: `Consider using genie primitives instead of terminal polling:
+  genie task status <slug>
+  genie events list --since 5m`
   }
 ];
 
@@ -80,25 +51,19 @@ async function main() {
     process.exit(0);
   }
 
-  // Only intercept Bash tool calls
   if (payload.tool_name !== 'Bash') process.exit(0);
 
   const command = payload.tool_input?.command;
   if (!command) process.exit(0);
 
-  // Check each pattern
   for (const { pattern, message } of PATTERNS) {
     if (pattern.test(command)) {
-      // Output block decision
-      console.log(JSON.stringify({
-        decision: 'block',
-        reason: message
-      }));
+      // Informational — log to stderr, exit 0 to allow
+      console.error(`[orchestration-guard] ${message}`);
       process.exit(0);
     }
   }
 
-  // Allow — no output means proceed
   process.exit(0);
 }
 

--- a/src/hooks/handlers/orchestration-guard.ts
+++ b/src/hooks/handlers/orchestration-guard.ts
@@ -1,45 +1,43 @@
 /**
  * Orchestration Guard Handler — PreToolUse:Bash
  *
- * Blocks agents from using tmux capture-pane or sleep+poll loops
- * to monitor workers. Redirects to structured genie primitives.
+ * Informational nudge when agents use tmux capture-pane or sleep+poll
+ * loops to monitor workers. Suggests structured genie primitives but
+ * does NOT block — people may legitimately use tmux directly.
  *
  * Priority: 2 (runs after branch-guard, before identity-inject)
  */
 
 import type { HandlerResult, HookPayload } from '../types.js';
 
-interface BlockPattern {
+interface NudgePattern {
   test: RegExp;
-  reason: string;
+  message: string;
 }
 
-const BLOCK_PATTERNS: BlockPattern[] = [
+const NUDGE_PATTERNS: NudgePattern[] = [
   {
     test: /tmux\s+capture-pane/,
-    reason:
-      'BLOCKED: tmux scraping detected. Use structured monitoring instead:\n' +
-      '  genie status <slug>        — wish progress from PG\n' +
+    message:
+      "If you're checking genie agent progress, use structured monitoring instead:\n" +
+      '  genie task status <slug>   — wish progress from PG\n' +
       '  genie agent list --json    — executor state machine\n' +
       '  genie events timeline <id> — structured event log\n' +
-      '  genie agent send --to <a>  — PG-backed messaging\n' +
-      'Load /genie for full orchestration guidance.',
+      '  genie agent send --to <a>  — PG-backed messaging',
   },
   {
     test: /sleep\s+\d+\s*&&\s*tmux/,
-    reason:
-      'BLOCKED: sleep+poll loop detected. Workers report via PG events — no need to poll terminals.\n' +
-      '  genie status <slug>        — check progress\n' +
-      '  genie agent send --to <a>  — communicate directly\n' +
-      'Load /genie for full orchestration guidance.',
+    message:
+      'Workers report via PG events — polling terminals is not needed.\n' +
+      '  genie task status <slug>   — check progress\n' +
+      '  genie agent send --to <a>  — communicate directly',
   },
   {
     test: /sleep\s+\d+\s*&&\s*.*(?:capture-pane|tmux\s+list)/,
-    reason:
-      'BLOCKED: terminal polling pattern detected. Use genie primitives:\n' +
-      '  genie status <slug>\n' +
-      '  genie events list --since 5m\n' +
-      'Load /genie for full orchestration guidance.',
+    message:
+      'Consider using genie primitives instead of terminal polling:\n' +
+      '  genie task status <slug>\n' +
+      '  genie events list --since 5m',
   },
 ];
 
@@ -47,9 +45,12 @@ export async function orchestrationGuard(payload: HookPayload): Promise<HandlerR
   const command = payload.tool_input?.command;
   if (typeof command !== 'string') return undefined;
 
-  for (const { test, reason } of BLOCK_PATTERNS) {
+  for (const { test, message } of NUDGE_PATTERNS) {
     if (test.test(command)) {
-      return { decision: 'deny', reason };
+      // Informational only — log to stderr so the agent sees the suggestion,
+      // but return undefined to allow the command to proceed.
+      console.error(`[orchestration-guard] ${message}`);
+      return undefined;
     }
   }
 

--- a/src/hooks/inject.ts
+++ b/src/hooks/inject.ts
@@ -59,6 +59,7 @@ function buildHooksConfig(): HooksConfig {
   for (const event of DISPATCHED_EVENTS) {
     hooks[event] = [
       {
+        matcher: '*',
         hooks: [
           {
             type: 'command',


### PR DESCRIPTION
## Summary
Two fixes:

1. **Missing matcher in team hook injection** — `inject.ts` created hook entries without `matcher: '*'`. Claude Code needs this to know which tools to fire hooks for. Without it, NO PreToolUse hooks fired for team-spawned agents — not branch-guard, not orchestration-guard, nothing. This was the root cause of hooks not working.

2. **Orchestration guard is now informational** — changed from `deny` (blocking) to a stderr nudge that allows the command through. People may legitimately use tmux directly. The hook suggests genie primitives but doesn't force them.

## Test plan
- [x] inject.ts now includes `matcher: '*'` in all hook entries
- [x] orchestration-guard logs to stderr and returns undefined (allows)
- [x] Plugin script matches (informational, not blocking)
- [x] TypeScript compiles cleanly
- [x] inject.test.ts passes (6/6)
- [ ] Live test: spawn agent, verify hooks fire (needs merge + publish + update)