### PR TITLE
fix(tui): guard against self-attach loop when clicking genie-tui session

### DIFF
--- a/src/tui/tmux.ts
+++ b/src/tui/tmux.ts
@@ -84,6 +84,8 @@ function ensureSession(sessionName: string): void {
 
 /** Switch right pane to a specific session window */
 export function attachProjectWindow(rightPane: string, targetSession: string, windowIndex?: number): void {
+  // Guard: never attach the TUI session to itself (causes infinite loop)
+  if (targetSession === SESSION_NAME) return;
   const pane = resolveRightPane(rightPane);
   ensureSession(targetSession);
   if (windowIndex !== undefined) {


### PR DESCRIPTION
One-liner: skip attachProjectWindow if targetSession === SESSION_NAME. Prevents infinite respawn loop when user clicks the genie-tui session in the Sessions tree.