### PR TITLE
fix(tui): ctrl+q to quit, kill session before renderer

### DIFF
--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -10,9 +10,11 @@ export function App({ rightPane }: { rightPane?: string }) {
   const renderer = useRenderer();
 
   useKeyboard((key) => {
-    if (key.name === 'q' || (key.ctrl && key.name === 'c')) {
-      renderer.destroy();
+    // Ctrl+Q or Ctrl+C: kill the entire TUI (both panes)
+    if ((key.ctrl && key.name === 'q') || (key.ctrl && key.name === 'c')) {
+      // Kill tmux session FIRST (kills both panes), then destroy renderer
       cleanup();
+      renderer.destroy();
     }
   });
 


### PR DESCRIPTION
Bare 'q' no longer quits — only Ctrl+Q and Ctrl+C. Kill tmux session first so both panes die together.