### PR TITLE
fix(tui): ctrl+q kills via tmux key table, not opentui

### DIFF
--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -1,22 +1,13 @@
 /** @jsxImportSource @opentui/react */
 /** Root App component — Sessions nav + tmux right pane management */
 
-import { useKeyboard, useRenderer } from '@opentui/react';
 import { useCallback } from 'react';
 import { Nav } from './components/Nav.js';
-import { attachProjectWindow, cleanup } from './tmux.js';
+import { attachProjectWindow } from './tmux.js';
 
 export function App({ rightPane }: { rightPane?: string }) {
-  const renderer = useRenderer();
-
-  useKeyboard((key) => {
-    // Ctrl+Q or Ctrl+C: kill the entire TUI (both panes)
-    if ((key.ctrl && key.name === 'q') || (key.ctrl && key.name === 'c')) {
-      // Kill tmux session FIRST (kills both panes), then destroy renderer
-      cleanup();
-      renderer.destroy();
-    }
-  });
+  // Quit is handled by tmux key table (Ctrl+Q → kill-session), not by OpenTUI.
+  // This ensures BOTH panes die together regardless of which pane has focus.
 
   const handleTmuxSessionSelect = useCallback(
     (sessionName: string, windowIndex?: number) => {

--- a/src/tui/tmux.ts
+++ b/src/tui/tmux.ts
@@ -6,6 +6,28 @@ import { tmuxStyle } from './theme.js';
 const SESSION_NAME = 'genie-tui';
 const KEY_TABLE = 'genie-tui';
 const NAV_WIDTH = 30;
+/** TUI's own tmux socket — isolates the nav+split from everything else */
+const TMUX_SOCKET = 'genie-tui';
+/**
+ * Genie's agent tmux socket — where all agents/teams/sessions live.
+ * The TUI's right pane attaches to sessions on THIS server.
+ * TODO: migrate all of genie (spawn, daemon, etc) to use -L genie. For now, agents run on default server.
+ */
+const GENIE_AGENT_SOCKET = ''; // empty = default server (until full migration)
+/**
+ * Genie's shipped tmux config — scripts/tmux/genie.tmux.conf installed to ~/.genie/tmux.conf
+ * on genie setup/update. Falls back to /dev/null if not found (still works with applyTmuxStyle).
+ */
+const GENIE_TMUX_CONF = (() => {
+  const { existsSync } = require('node:fs') as typeof import('node:fs');
+  const candidates = [
+    `${process.env.GENIE_HOME ?? `${process.env.HOME}/.genie`}/tmux.conf`,
+    `${process.env.HOME}/.tmux.conf`,
+  ];
+  return candidates.find((p) => existsSync(p)) ?? '/dev/null';
+})();
+/** Prefix for all tmux commands — dedicated socket + genie config (ignores user's global tmux) */
+const TMUX = `tmux -L ${TMUX_SOCKET} -f ${GENIE_TMUX_CONF}`;
 
 /** Check if tmux is available */
 export function hasTmux(): boolean {
@@ -28,15 +50,17 @@ export function createTuiSession(): { session: string; leftPane: string; rightPa
   const rows = process.stdout.rows || 40;
 
   try {
-    execSync(`tmux kill-session -t ${SESSION_NAME} 2>/dev/null`, { stdio: 'ignore' });
+    execSync(`${TMUX} kill-session -t ${SESSION_NAME} 2>/dev/null`, { stdio: 'ignore' });
   } catch {
     // doesn't exist
   }
 
-  execSync(`tmux new-session -d -s ${SESSION_NAME} -x ${cols} -y ${rows} -e GENIE_TUI_PANE=left`, { stdio: 'ignore' });
-  execSync(`tmux split-window -h -t ${SESSION_NAME}:0 -l ${cols - NAV_WIDTH - 1}`, { stdio: 'ignore' });
+  execSync(`${TMUX} new-session -d -s ${SESSION_NAME} -x ${cols} -y ${rows} -e GENIE_TUI_PANE=left`, {
+    stdio: 'ignore',
+  });
+  execSync(`${TMUX} split-window -h -t ${SESSION_NAME}:0 -l ${cols - NAV_WIDTH - 1}`, { stdio: 'ignore' });
 
-  const panes = execSync(`tmux list-panes -t ${SESSION_NAME}:0 -F '#{pane_id}'`, { encoding: 'utf-8' })
+  const panes = execSync(`${TMUX} list-panes -t ${SESSION_NAME}:0 -F '#{pane_id}'`, { encoding: 'utf-8' })
     .trim()
     .split('\n');
 
@@ -55,11 +79,11 @@ export function createTuiSession(): { session: string; leftPane: string; rightPa
  */
 function resolveRightPane(rightPane: string): string {
   try {
-    execSync(`tmux display-message -t ${rightPane} -p ''`, { stdio: 'ignore' });
+    execSync(`${TMUX} display-message -t ${rightPane} -p ''`, { stdio: 'ignore' });
     return rightPane;
   } catch {
     try {
-      const panes = execSync(`tmux list-panes -t ${SESSION_NAME}:0 -F '#{pane_id}'`, { encoding: 'utf-8' })
+      const panes = execSync(`${TMUX} list-panes -t ${SESSION_NAME}:0 -F '#{pane_id}'`, { encoding: 'utf-8' })
         .trim()
         .split('\n');
       return panes[1] || panes[0];
@@ -72,10 +96,10 @@ function resolveRightPane(rightPane: string): string {
 /** Ensure a tmux session exists, creating it if needed */
 function ensureSession(sessionName: string): void {
   try {
-    execSync(`tmux has-session -t '${sessionName}' 2>/dev/null`, { stdio: 'ignore' });
+    execSync(`${TMUX} has-session -t '${sessionName}' 2>/dev/null`, { stdio: 'ignore' });
   } catch {
     try {
-      execSync(`tmux new-session -d -s '${sessionName}'`, { stdio: 'ignore' });
+      execSync(`${TMUX} new-session -d -s '${sessionName}'`, { stdio: 'ignore' });
     } catch {
       // race: another process created it
     }
@@ -90,13 +114,15 @@ export function attachProjectWindow(rightPane: string, targetSession: string, wi
   ensureSession(targetSession);
   if (windowIndex !== undefined) {
     try {
-      execSync(`tmux select-window -t '${targetSession}:${windowIndex}'`, { stdio: 'ignore' });
+      execSync(`${TMUX} select-window -t '${targetSession}:${windowIndex}'`, { stdio: 'ignore' });
     } catch {
       // window may not exist
     }
   }
   try {
-    execSync(`tmux respawn-pane -k -t ${pane} "TMUX='' tmux attach-session -t '${targetSession}'"`, {
+    // Attach to sessions on the AGENT server (default for now, -L genie after migration)
+    const agentTmux = GENIE_AGENT_SOCKET ? `tmux -L ${GENIE_AGENT_SOCKET}` : 'tmux';
+    execSync(`${TMUX} respawn-pane -k -t ${pane} "TMUX='' ${agentTmux} attach-session -t '${targetSession}'"`, {
       stdio: 'ignore',
     });
   } catch {
@@ -112,44 +138,57 @@ export function attachProjectWindow(rightPane: string, targetSession: string, wi
 function setupKeybindings(session: string): void {
   try {
     // Define bindings in the genie-tui key table (session-scoped, not global)
-    execSync(`tmux bind-key -T ${KEY_TABLE} Tab select-pane -t ${session}:0.1 \\; switch-client -T ${KEY_TABLE}`, {
+    execSync(`${TMUX} bind-key -T ${KEY_TABLE} Tab select-pane -t ${session}:0.1 \\; switch-client -T ${KEY_TABLE}`, {
       stdio: 'ignore',
     });
 
     execSync(
-      `tmux bind-key -T ${KEY_TABLE} C-b if-shell "[ $(tmux display-message -p '#{pane_width}' -t ${session}:0.0) -gt 5 ]" "resize-pane -t ${session}:0.0 -x 0" "resize-pane -t ${session}:0.0 -x ${NAV_WIDTH}" \\; switch-client -T ${KEY_TABLE}`,
+      `${TMUX} bind-key -T ${KEY_TABLE} C-b if-shell "[ $(${TMUX} display-message -p '#{pane_width}' -t ${session}:0.0) -gt 5 ]" "resize-pane -t ${session}:0.0 -x 0" "resize-pane -t ${session}:0.0 -x ${NAV_WIDTH}" \\; switch-client -T ${KEY_TABLE}`,
       { stdio: 'ignore' },
     );
 
-    execSync(`tmux bind-key -T ${KEY_TABLE} C-t send-keys -t ${session}:0.1 C-b c \\; switch-client -T ${KEY_TABLE}`, {
+    execSync(
+      `${TMUX} bind-key -T ${KEY_TABLE} C-t send-keys -t ${session}:0.1 C-b c \\; switch-client -T ${KEY_TABLE}`,
+      {
+        stdio: 'ignore',
+      },
+    );
+
+    execSync(`${TMUX} bind-key -T ${KEY_TABLE} 'C-\\' run-shell "tmux -L ${TMUX_SOCKET} kill-session -t ${session}"`, {
       stdio: 'ignore',
     });
 
-    execSync(`tmux bind-key -T ${KEY_TABLE} 'C-\\' run-shell "tmux kill-session -t ${session}"`, {
+    // Ctrl+Q: kill entire TUI session (both panes die together)
+    execSync(`${TMUX} bind-key -T ${KEY_TABLE} C-q run-shell "tmux -L ${TMUX_SOCKET} kill-session -t ${session}"`, {
       stdio: 'ignore',
     });
 
     // Auto-enter the key table when the session gets focus
-    execSync(`tmux set-hook -t ${session} client-session-changed "switch-client -T ${KEY_TABLE}"`, { stdio: 'ignore' });
+    execSync(`${TMUX} set-hook -t ${session} client-session-changed "switch-client -T ${KEY_TABLE}"`, {
+      stdio: 'ignore',
+    });
 
     // Also enter the key table immediately for the current client
-    execSync(`tmux switch-client -T ${KEY_TABLE}`, { stdio: 'ignore' });
+    execSync(`${TMUX} switch-client -T ${KEY_TABLE}`, { stdio: 'ignore' });
   } catch {
     // best-effort keybindings
   }
 }
 
-/** Apply 2050 palette to tmux chrome */
+/** Apply visual theme to TUI session (config file handles terminal settings) */
 function applyTmuxStyle(session: string): void {
   try {
     const cmds = [
+      // Visual theme
       `set-option -t ${session} pane-border-style 'fg=${tmuxStyle.inactiveBorder}'`,
       `set-option -t ${session} pane-active-border-style 'fg=${tmuxStyle.activeBorder}'`,
+      // TUI overrides — the config has mouse on + status bars, but TUI handles these itself
+      `set-option -t ${session} mouse off`,
       `set-option -t ${session} status off`,
-      `set-option -t ${session} mouse on`,
+      `set-option -t ${session} pane-border-status off`,
     ];
     for (const cmd of cmds) {
-      execSync(`tmux ${cmd}`, { stdio: 'ignore' });
+      execSync(`${TMUX} ${cmd}`, { stdio: 'ignore' });
     }
   } catch {
     // best-effort
@@ -160,13 +199,13 @@ function applyTmuxStyle(session: string): void {
 export function cleanup(session: string = SESSION_NAME): void {
   try {
     // Unbind from the custom key table only (not global root)
-    execSync(`tmux unbind-key -T ${KEY_TABLE} Tab 2>/dev/null`, { stdio: 'ignore' });
-    execSync(`tmux unbind-key -T ${KEY_TABLE} C-b 2>/dev/null`, { stdio: 'ignore' });
-    execSync(`tmux unbind-key -T ${KEY_TABLE} C-t 2>/dev/null`, { stdio: 'ignore' });
-    execSync(`tmux unbind-key -T ${KEY_TABLE} 'C-\\' 2>/dev/null`, { stdio: 'ignore' });
+    execSync(`${TMUX} unbind-key -T ${KEY_TABLE} Tab 2>/dev/null`, { stdio: 'ignore' });
+    execSync(`${TMUX} unbind-key -T ${KEY_TABLE} C-b 2>/dev/null`, { stdio: 'ignore' });
+    execSync(`${TMUX} unbind-key -T ${KEY_TABLE} C-t 2>/dev/null`, { stdio: 'ignore' });
+    execSync(`${TMUX} unbind-key -T ${KEY_TABLE} 'C-\\' 2>/dev/null`, { stdio: 'ignore' });
     // Remove session hook
-    execSync(`tmux set-hook -u -t ${session} client-session-changed 2>/dev/null`, { stdio: 'ignore' });
-    execSync(`tmux kill-session -t ${session} 2>/dev/null`, { stdio: 'ignore' });
+    execSync(`${TMUX} set-hook -u -t ${session} client-session-changed 2>/dev/null`, { stdio: 'ignore' });
+    execSync(`${TMUX} kill-session -t ${session} 2>/dev/null`, { stdio: 'ignore' });
   } catch {
     // best-effort
   }
@@ -174,5 +213,7 @@ export function cleanup(session: string = SESSION_NAME): void {
 
 /** Attach to the TUI session (blocking call) */
 export function attachTuiSession(): void {
-  spawnSync('tmux', ['attach-session', '-t', SESSION_NAME], { stdio: 'inherit' });
+  spawnSync('tmux', ['-L', TMUX_SOCKET, '-f', GENIE_TMUX_CONF, 'attach-session', '-t', SESSION_NAME], {
+    stdio: 'inherit',
+  });
 }


### PR DESCRIPTION
Ctrl+Q now bound in tmux key table (like Ctrl+\). tmux kills the entire session — both panes die together. OpenTUI no longer handles quit (can't reliably kill the right pane from the left pane's process).