### PR TITLE
feat: dedicated genie tmux server (-L genie)

### DIFF
--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -185,7 +185,7 @@ async function checkTmux(): Promise<CheckResult[]> {
 
   // Check if tmux server is running
   try {
-    const serverResult = await $`tmux list-sessions 2>/dev/null`.quiet();
+    const serverResult = await $`tmux -L genie list-sessions 2>/dev/null`.quiet();
     if (serverResult.exitCode === 0) {
       results.push({
         name: 'Server running',
@@ -214,7 +214,7 @@ async function checkTmux(): Promise<CheckResult[]> {
   const sessionName = config.session.name;
 
   try {
-    const sessionResult = await $`tmux has-session -t ${sessionName} 2>/dev/null`.quiet();
+    const sessionResult = await $`tmux -L genie has-session -t ${sessionName} 2>/dev/null`.quiet();
     if (sessionResult.exitCode === 0) {
       results.push({
         name: `Session '${sessionName}' exists`,

--- a/src/genie-commands/session.ts
+++ b/src/genie-commands/session.ts
@@ -334,7 +334,8 @@ function attachToWindow(sessionName: string, windowName: string): void {
   console.log('Attaching...');
   const target = `${sessionName}:${windowName}`;
   const cmd = process.env.TMUX ? 'switch-client' : 'attach';
-  spawnSync('tmux', [cmd, '-t', target], { stdio: 'inherit' });
+  const { genieTmuxPrefix } = require('../lib/tmux-wrapper.js');
+  spawnSync('tmux', [...genieTmuxPrefix(), cmd, '-t', target], { stdio: 'inherit' });
 }
 
 export async function sessionCommand(options: SessionOptions = {}): Promise<void> {

--- a/src/genie-commands/setup.ts
+++ b/src/genie-commands/setup.ts
@@ -422,6 +422,34 @@ export async function setupCommand(options: SetupOptions = {}): Promise<void> {
   // Save and show summary
   await showSummaryAndSave(config);
 
+  // Install genie tmux config
+  installGenieTmuxConf();
+
   // Print next steps
   printNextSteps();
+}
+
+/** Copy shipped genie.tmux.conf to ~/.genie/tmux.conf if it doesn't exist yet. */
+function installGenieTmuxConf(): void {
+  const { existsSync, copyFileSync, mkdirSync } = require('node:fs') as typeof import('node:fs');
+  const { resolve } = require('node:path') as typeof import('node:path');
+  const genieHome = process.env.GENIE_HOME ?? join(homedir(), '.genie');
+  const dest = join(genieHome, 'tmux.conf');
+  if (existsSync(dest)) return; // already installed
+
+  // Resolve shipped config relative to package root
+  const candidates = [
+    resolve(__dirname, '..', '..', 'scripts', 'tmux', 'genie.tmux.conf'),
+    resolve(__dirname, '..', 'scripts', 'tmux', 'genie.tmux.conf'),
+  ];
+  const src = candidates.find((p) => existsSync(p));
+  if (!src) return;
+
+  try {
+    mkdirSync(genieHome, { recursive: true });
+    copyFileSync(src, dest);
+    console.log(`\x1b[32m\u2713\x1b[0m Installed genie tmux config to ${dest}`);
+  } catch {
+    // non-fatal
+  }
 }

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -405,26 +405,22 @@ function updatePluginRegistry(claudePlugins: string, cacheDir: string, version: 
   }
 }
 
-const GENIE_TMUX_HEADER = '# Genie TUI — tmux configuration';
-
-/** If ~/.tmux.conf was installed by genie, overwrite it and reload tmux. */
+/** Install genie.tmux.conf to ~/.genie/tmux.conf and reload the genie tmux server. */
 function syncTmuxConf(tmuxScriptsSrc: string): void {
   const tmuxConfSrc = join(tmuxScriptsSrc, 'genie.tmux.conf');
-  const tmuxConfDest = join(homedir(), '.tmux.conf');
-  if (!existsSync(tmuxConfSrc) || !existsSync(tmuxConfDest)) return;
+  const tmuxConfDest = join(GENIE_HOME, 'tmux.conf');
+  if (!existsSync(tmuxConfSrc)) return;
 
   try {
-    const existing = readFileSync(tmuxConfDest, 'utf-8');
-    if (!existing.includes(GENIE_TMUX_HEADER)) return;
-
+    mkdirSync(GENIE_HOME, { recursive: true });
     copyFileSync(tmuxConfSrc, tmuxConfDest);
-    success('Updated ~/.tmux.conf (genie-managed)');
+    success(`Installed tmux config to ${tmuxConfDest}`);
 
     try {
-      execSync('tmux source-file ~/.tmux.conf', { stdio: 'ignore' });
-      success('Reloaded tmux configuration');
+      execSync(`tmux -L genie source-file '${tmuxConfDest}'`, { stdio: 'ignore' });
+      success('Reloaded genie tmux server configuration');
     } catch {
-      // tmux not running or reload failed — non-fatal
+      // genie tmux server not running or reload failed — non-fatal
     }
   } catch {
     // Read/write failed — non-fatal

--- a/src/lib/protocol-router-spawn.ts
+++ b/src/lib/protocol-router-spawn.ts
@@ -26,6 +26,7 @@ import {
 } from './provider-adapters.js';
 import { getProvider } from './providers/registry.js';
 import * as teamManager from './team-manager.js';
+import { genieTmuxCmd } from './tmux-wrapper.js';
 import { applyPaneColor, ensureTeamWindow, getCurrentSessionName, listWindows } from './tmux.js';
 import * as wishState from './wish-state.js';
 
@@ -118,7 +119,7 @@ async function createExecutorForAutoSpawn(
   // Capture PID from tmux pane
   let pid: number | null = null;
   try {
-    const { stdout: pidOut } = await execAsync(`tmux display -t '${paneId}' -p '#{pane_pid}'`);
+    const { stdout: pidOut } = await execAsync(genieTmuxCmd(`display -t '${paneId}' -p '#{pane_pid}'`));
     const parsed = Number.parseInt(pidOut.trim(), 10);
     if (parsed > 0) pid = parsed;
   } catch {
@@ -157,7 +158,7 @@ async function spawnPaneInSession(
   const splitTarget = teamWindow ? `-t '${teamWindow.windowId}'` : '';
   // Wrap fullCommand in shell quotes so it survives the outer-shell → tmux → inner-shell pipeline.
   const escapedCmd = fullCommand.replace(/'/g, "'\\''");
-  const { stdout } = await execAsync(`tmux split-window -d ${splitTarget} -P -F '#{pane_id}' '${escapedCmd}'`);
+  const { stdout } = await execAsync(genieTmuxCmd(`split-window -d ${splitTarget} -P -F '#{pane_id}' '${escapedCmd}'`));
   const paneId = stdout.trim();
 
   let layoutTarget = `${session}:${teamWindow?.windowName ?? ''}`;
@@ -166,7 +167,7 @@ async function spawnPaneInSession(
     layoutTarget = wins[0] ? wins[0].id : `${session}:`;
   }
   try {
-    await execAsync(`tmux ${buildLayoutCommand(layoutTarget, resolveLayoutMode())}`);
+    await execAsync(genieTmuxCmd(buildLayoutCommand(layoutTarget, resolveLayoutMode())));
   } catch {
     /* best-effort */
   }

--- a/src/lib/scheduler-daemon.ts
+++ b/src/lib/scheduler-daemon.ts
@@ -208,7 +208,8 @@ async function defaultPublishEvent(subject: string, data: unknown, repoPath: str
 async function defaultCountTmuxSessions(): Promise<number> {
   try {
     const { execSync } = await import('node:child_process');
-    const output = execSync('tmux list-sessions 2>/dev/null', { encoding: 'utf-8' });
+    const { genieTmuxCmd } = await import('./tmux-wrapper.js');
+    const output = execSync(`${genieTmuxCmd('list-sessions')} 2>/dev/null`, { encoding: 'utf-8' });
     return output.trim().split('\n').filter(Boolean).length;
   } catch {
     return 0;

--- a/src/lib/team-manager.ts
+++ b/src/lib/team-manager.ts
@@ -190,7 +190,8 @@ async function killWorkersByName(agentName: string, teamName?: string): Promise<
     try {
       if (w.paneId && w.paneId !== 'inline') {
         const { execSync } = require('node:child_process');
-        execSync(`tmux kill-pane -t ${w.paneId}`, { stdio: 'ignore' });
+        const { genieTmuxCmd } = require('./tmux-wrapper.js');
+        execSync(genieTmuxCmd(`kill-pane -t ${w.paneId}`), { stdio: 'ignore' });
       }
     } catch {
       // Pane may already be gone

--- a/src/lib/tmux-wrapper.ts
+++ b/src/lib/tmux-wrapper.ts
@@ -6,6 +6,33 @@ import { promisify } from 'node:util';
 
 const exec = promisify(execCallback);
 
+/** Dedicated tmux socket name for all genie agent operations. */
+const GENIE_TMUX_SOCKET = process.env.GENIE_TMUX_SOCKET || 'genie';
+
+/**
+ * Resolve the genie tmux config path.
+ * Priority: ~/.genie/tmux.conf → shipped scripts/tmux/genie.tmux.conf → /dev/null
+ */
+function resolveGenieTmuxConf(): string {
+  const home = homedir();
+  const genieHome = process.env.GENIE_HOME ?? join(home, '.genie');
+  const candidates = [join(genieHome, 'tmux.conf'), join(__dirname, '..', '..', 'scripts', 'tmux', 'genie.tmux.conf')];
+  return candidates.find((p) => existsSync(p)) ?? '/dev/null';
+}
+
+/**
+ * Build the tmux prefix args for the genie server: `-L <socket> -f <config>`.
+ * Used by both the async wrapper and bare execSync calls that can't go through executeTmux().
+ */
+export function genieTmuxPrefix(): string[] {
+  return ['-L', GENIE_TMUX_SOCKET, '-f', resolveGenieTmuxConf()];
+}
+
+/** Build a tmux command string prefixed with `-L genie -f <config>`. */
+export function genieTmuxCmd(subcommand: string): string {
+  return `tmux ${genieTmuxPrefix().join(' ')} ${subcommand}`;
+}
+
 /**
  * Get the directory for tmux debug logs
  */
@@ -55,6 +82,9 @@ export async function executeTmux(args: string | string[]): Promise<string> {
     finalArgs = ['-v', ...finalArgs];
     options.cwd = getLogDir();
   }
+
+  // Prepend genie server flags: -L genie -f <config>
+  finalArgs = [...genieTmuxPrefix(), ...finalArgs];
 
   const command = `tmux ${finalArgs.join(' ')}`;
   const { stdout } = await exec(command, options);

--- a/src/term-commands/agents.test.ts
+++ b/src/term-commands/agents.test.ts
@@ -142,7 +142,8 @@ describe('buildInitialSplitWindowCommand', () => {
       "claude --append-system-prompt-file '/tmp/prompt file.md' 'Execute the QA spec'",
     );
 
-    expect(command).toContain('tmux split-window -d');
+    expect(command).toContain('tmux -L genie');
+    expect(command).toContain('split-window -d');
     expect(command).toContain("-t '@42'");
     expect(command).toContain("-c '/tmp/genie qa/test'\\''s'");
     expect(command).toContain("-P -F '#{pane_id}'");

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -30,6 +30,7 @@ import {
 import { getProvider } from '../lib/providers/registry.js';
 import { waitForAgentReady } from '../lib/spawn-command.js';
 import * as teamManager from '../lib/team-manager.js';
+import { genieTmuxCmd } from '../lib/tmux-wrapper.js';
 import * as tmux from '../lib/tmux.js';
 import { isPaneAlive } from '../lib/tmux.js';
 
@@ -229,7 +230,7 @@ function relayAll() {
 
     let output;
     try {
-      output = execSync(\`tmux capture-pane -p -t '\${paneId}' -S -80\`, { encoding: 'utf-8' }).trim();
+      output = execSync(\`tmux -L genie capture-pane -p -t '\${paneId}' -S -80\`, { encoding: 'utf-8' }).trim();
     } catch {
       // Pane gone — final relay if we had previous content
       const lastContent = lastHashes.get(workerId + ':content');
@@ -328,7 +329,7 @@ setInterval(async () => {
     try {
       const paneId = readFileSync(join(RELAY_DIR, file), 'utf-8').trim();
       if (!/^%\\d+$/.test(paneId)) throw new Error('invalid pane id');
-      execSync(\`tmux display -t '\${paneId}' -p '#{pane_id}'\`, { stdio: 'ignore' });
+      execSync(\`tmux -L genie display -t '\${paneId}' -p '#{pane_id}'\`, { stdio: 'ignore' });
     } catch {
       const workerId = file.replace(/-pane$/, '');
       // Read meta before cleanup (for liveness reset)
@@ -415,7 +416,7 @@ async function capturePanePid(paneId: string): Promise<number | null> {
   if (paneId === 'inline') return null;
   try {
     const { execSync } = require('node:child_process');
-    const output = execSync(`tmux display -t '${paneId}' -p '#{pane_pid}'`, { encoding: 'utf-8' }).trim();
+    const output = execSync(genieTmuxCmd(`display -t '${paneId}' -p '#{pane_pid}'`), { encoding: 'utf-8' }).trim();
     const pid = Number.parseInt(output, 10);
     return pid > 0 ? pid : null;
   } catch {
@@ -655,7 +656,9 @@ function writeTmuxLaunchScript(workerId: string, fullCommand: string): string {
  */
 export function buildInitialSplitWindowCommand(windowId: string, cwd: string | undefined, fullCommand: string): string {
   const cwdFlag = cwd ? ` -c ${shellQuote(cwd)}` : '';
-  return `tmux split-window -d -t ${shellQuote(windowId)}${cwdFlag} -P -F '#{pane_id}' ${shellQuote(fullCommand)}`;
+  return genieTmuxCmd(
+    `split-window -d -t ${shellQuote(windowId)}${cwdFlag} -P -F '#{pane_id}' ${shellQuote(fullCommand)}`,
+  );
 }
 
 /**
@@ -705,7 +708,7 @@ async function autoConfirmTrustPrompt(paneId: string): Promise<void> {
 
     let content: string;
     try {
-      content = execSync(`tmux capture-pane -t '${paneId}' -p`, { encoding: 'utf-8' });
+      content = execSync(genieTmuxCmd(`capture-pane -t '${paneId}' -p`), { encoding: 'utf-8' });
     } catch {
       return; // Pane gone — nothing to do
     }
@@ -713,7 +716,7 @@ async function autoConfirmTrustPrompt(paneId: string): Promise<void> {
     // Trust prompt detected — send Enter to confirm "Yes, I trust this folder"
     if (content.includes('trust this folder') || content.includes('Quick safety check')) {
       try {
-        execSync(`tmux send-keys -t '${paneId}' Enter`, { encoding: 'utf-8' });
+        execSync(genieTmuxCmd(`send-keys -t '${paneId}' Enter`), { encoding: 'utf-8' });
       } catch {
         // Best effort
       }
@@ -741,16 +744,18 @@ function createTmuxPane(ctx: SpawnCtx, teamWindow: TeamWindowInfo | null): strin
     ? shellQuote(writeTmuxLaunchScript(ctx.workerId, ctx.fullCommand))
     : shellQuote(ctx.fullCommand);
 
+  const tmuxPrefix = genieTmuxCmd('');
+
   if (teamWindow?.created) {
     const cwdFlag = ctx.cwd ? ` -c ${shellQuote(ctx.cwd)}` : '';
     const paneId = execSync(
-      `tmux split-window -d -t ${shellQuote(teamWindow.windowId)}${cwdFlag} -P -F '#{pane_id}' ${tmuxCommand}`,
+      `${tmuxPrefix}split-window -d -t ${shellQuote(teamWindow.windowId)}${cwdFlag} -P -F '#{pane_id}' ${tmuxCommand}`,
       {
         encoding: 'utf-8',
       },
     ).trim();
     try {
-      execSync(`tmux kill-pane -t '${teamWindow.paneId}'`, { stdio: 'ignore' });
+      execSync(genieTmuxCmd(`kill-pane -t '${teamWindow.paneId}'`), { stdio: 'ignore' });
     } catch {
       /* best-effort */
     }
@@ -760,14 +765,14 @@ function createTmuxPane(ctx: SpawnCtx, teamWindow: TeamWindowInfo | null): strin
   const splitTarget = teamWindow ? `-t '${teamWindow.windowId}'` : '';
   const cwdFlag = ctx.cwd ? `-c '${ctx.cwd}'` : '';
   if (useLaunchScript) {
-    const splitCmd = `tmux split-window -d ${splitTarget} ${cwdFlag} -P -F '#{pane_id}' ${tmuxCommand}`;
+    const splitCmd = `${tmuxPrefix}split-window -d ${splitTarget} ${cwdFlag} -P -F '#{pane_id}' ${tmuxCommand}`;
     return execSync(splitCmd, { encoding: 'utf-8' }).trim();
   }
   // Wrap fullCommand in shell quotes so it survives the outer-shell → tmux → inner-shell pipeline.
   // Without this, single quotes from escapeShellArg (e.g. around the initialPrompt) are consumed
   // by the outer shell, and tmux's inner shell sees unquoted args — splitting multi-word prompts.
   const escapedCmd = ctx.fullCommand.replace(/'/g, "'\\''");
-  const splitCmd = `tmux split-window -d ${splitTarget} ${cwdFlag} -P -F '#{pane_id}' '${escapedCmd}'`;
+  const splitCmd = `${tmuxPrefix}split-window -d ${splitTarget} ${cwdFlag} -P -F '#{pane_id}' '${escapedCmd}'`;
   return execSync(splitCmd, { encoding: 'utf-8' }).trim();
 }
 
@@ -781,7 +786,7 @@ async function applySpawnLayout(ctx: SpawnCtx, teamWindow: TeamWindowInfo | null
     layoutTarget = wins[0] ? wins[0].id : `${session}:`;
   }
   try {
-    execSync(`tmux ${buildLayoutCommand(layoutTarget, ctx.layoutMode)}`, { stdio: 'ignore' });
+    execSync(genieTmuxCmd(buildLayoutCommand(layoutTarget, ctx.layoutMode)), { stdio: 'ignore' });
   } catch {
     /* best-effort */
   }
@@ -1198,10 +1203,10 @@ async function cleanupWorkerNativeTeam(w: registry.Agent): Promise<void> {
 function killWorkerPane(w: registry.Agent): void {
   try {
     const { execSync } = require('node:child_process');
-    const currentPane = execSync("tmux display-message -p '#{pane_id}'", { encoding: 'utf-8' }).trim();
+    const currentPane = execSync(genieTmuxCmd("display-message -p '#{pane_id}'"), { encoding: 'utf-8' }).trim();
     const validPaneId = w.paneId && /^(%\d+|inline)$/.test(w.paneId);
     if (validPaneId && w.paneId !== currentPane) {
-      execSync(`tmux kill-pane -t ${w.paneId}`, { stdio: 'ignore' });
+      execSync(genieTmuxCmd(`kill-pane -t ${w.paneId}`), { stdio: 'ignore' });
     } else if (w.paneId === currentPane) {
       console.log('  (skipped pane kill — would kill current session)');
     }

--- a/src/term-commands/state.ts
+++ b/src/term-commands/state.ts
@@ -218,7 +218,8 @@ function autoKillPane(): void {
     // Small delay to ensure all output is flushed before killing the pane
     setTimeout(() => {
       try {
-        execSync(`tmux kill-pane -t '${paneId}'`, { encoding: 'utf-8' });
+        const { genieTmuxCmd } = require('../lib/tmux-wrapper.js');
+        execSync(genieTmuxCmd(`kill-pane -t '${paneId}'`), { encoding: 'utf-8' });
       } catch {
         // Pane already dead or not in tmux
         process.exit(0);

--- a/src/tui/diagnostics.ts
+++ b/src/tui/diagnostics.ts
@@ -128,10 +128,10 @@ function parsePaneLine(parts: string[]): {
   };
 }
 
-/** Collect all tmux sessions, windows, and panes into a typed tree. */
+/** Collect all tmux sessions, windows, and panes into a typed tree (genie server). */
 function getTmuxInventory(): TmuxSession[] {
   const paneOutput = execQuiet(
-    "tmux list-panes -a -F '#{session_name}|#{window_index}|#{window_name}|#{window_active}|#{window_panes}|#{pane_index}|#{pane_id}|#{pane_pid}|#{pane_current_command}|#{pane_title}|#{pane_width}x#{pane_height}|#{session_attached}|#{session_windows}|#{session_created}|#{pane_dead}'",
+    "tmux -L genie list-panes -a -F '#{session_name}|#{window_index}|#{window_name}|#{window_active}|#{window_panes}|#{pane_index}|#{pane_id}|#{pane_pid}|#{pane_current_command}|#{pane_title}|#{pane_width}x#{pane_height}|#{session_attached}|#{session_windows}|#{session_created}|#{pane_dead}'",
   );
 
   if (!paneOutput) return [];

--- a/src/tui/tmux.ts
+++ b/src/tui/tmux.ts
@@ -8,12 +8,8 @@ const KEY_TABLE = 'genie-tui';
 const NAV_WIDTH = 30;
 /** TUI's own tmux socket — isolates the nav+split from everything else */
 const TMUX_SOCKET = 'genie-tui';
-/**
- * Genie's agent tmux socket — where all agents/teams/sessions live.
- * The TUI's right pane attaches to sessions on THIS server.
- * TODO: migrate all of genie (spawn, daemon, etc) to use -L genie. For now, agents run on default server.
- */
-const GENIE_AGENT_SOCKET = ''; // empty = default server (until full migration)
+/** Genie's agent tmux socket — where all agents/teams/sessions live. */
+const GENIE_AGENT_SOCKET = 'genie';
 /**
  * Genie's shipped tmux config — scripts/tmux/genie.tmux.conf installed to ~/.genie/tmux.conf
  * on genie setup/update. Falls back to /dev/null if not found (still works with applyTmuxStyle).
@@ -120,8 +116,8 @@ export function attachProjectWindow(rightPane: string, targetSession: string, wi
     }
   }
   try {
-    // Attach to sessions on the AGENT server (default for now, -L genie after migration)
-    const agentTmux = GENIE_AGENT_SOCKET ? `tmux -L ${GENIE_AGENT_SOCKET}` : 'tmux';
+    // Attach to sessions on the genie agent server
+    const agentTmux = `tmux -L ${GENIE_AGENT_SOCKET}`;
     execSync(`${TMUX} respawn-pane -k -t ${pane} "TMUX='' ${agentTmux} attach-session -t '${targetSession}'"`, {
       stdio: 'ignore',
     });


### PR DESCRIPTION
## Summary
- Move ALL genie tmux operations to a dedicated server (`-L genie -f ~/.genie/tmux.conf`)
- Users keep their own tmux for personal use; `tmux ls` shows only their sessions
- `tmux -L genie ls` shows all genie agent sessions
- Config installed to `~/.genie/tmux.conf` by `genie setup` / `genie update`

## Changes
- **tmux-wrapper.ts**: inject `-L genie -f <config>` into `executeTmux()`, export `genieTmuxCmd()`/`genieTmuxPrefix()` helpers
- **agents.ts**: prefix all bare tmux calls (spawn, capture-pane, kill-pane, layout)
- **protocol-router-spawn.ts**: route auto-spawn tmux through genie server
- **scheduler-daemon.ts**: query genie server for session count
- **team-manager.ts, state.ts, session.ts**: prefix kill/attach calls
- **diagnostics.ts**: query genie server for tmux inventory
- **tui/tmux.ts**: set `GENIE_AGENT_SOCKET='genie'` (right pane attaches to genie server)
- **update.ts**: install `genie.tmux.conf` to `~/.genie/tmux.conf` (not `~/.tmux.conf`)
- **setup.ts**: install genie tmux config on first setup
- **doctor.ts**: check genie server instead of default

## Test plan
- [x] `bun run check` passes (typecheck + lint + dead-code + 1536 tests)
- [ ] `genie agent spawn eng` creates session on genie server (`tmux -L genie ls`)
- [ ] `tmux ls` shows NO genie sessions (only user's own)
- [ ] `genie tui` right pane attaches to genie server sessions
- [ ] `genie agent list` reads from genie server
- [ ] Daemon heartbeat monitors genie server