### PR TITLE
feat: workspace detection, genie init, and stateful TUI agent tree

### DIFF
--- a/src/genie.ts
+++ b/src/genie.ts
@@ -51,6 +51,7 @@ import { registerDispatchCommands } from './term-commands/dispatch.js';
 import { registerExportCommands } from './term-commands/export.js';
 import * as historyCmd from './term-commands/history.js';
 import { registerImportCommands } from './term-commands/import.js';
+import { registerInitCommands } from './term-commands/init.js';
 import { registerInstallCommand } from './term-commands/install.js';
 import { registerItemUninstallCommand } from './term-commands/item-uninstall.js';
 import { registerItemUpdateCommand } from './term-commands/item-update.js';
@@ -162,6 +163,15 @@ shortcuts
   .action(shortcutsInstallCommand);
 shortcuts.command('uninstall').description('Remove shortcuts from config files').action(shortcutsUninstallCommand);
 
+// genie serve — alias for `genie daemon start --foreground`
+program
+  .command('serve')
+  .description('Start genie daemon (foreground)')
+  .action(async () => {
+    // Re-invoke as `genie daemon start --foreground`
+    await program.parseAsync(['node', 'genie', 'daemon', 'start', '--foreground']);
+  });
+
 // ============================================================================
 // Orchestration namespaces
 // ============================================================================
@@ -174,6 +184,7 @@ shortcuts.command('uninstall').description('Remove shortcuts from config files')
 
 registerAppCommand(program);
 
+registerInitCommands(program);
 registerTeamNamespace(program);
 registerDirNamespace(program);
 registerAgentNamespace(program);
@@ -470,10 +481,18 @@ if (process.env.GENIE_TUI_PANE === 'left') {
   process.exit(0);
 }
 
-// Default command: genie (no args) → launch TUI. genie --reset → reset session.
+// Default command: genie (no args) → launch TUI with workspace detection.
 if (args.length === 0) {
+  const { findWorkspace } = await import('./lib/workspace.js');
+  const ws = findWorkspace();
+
+  if (!ws) {
+    console.error('Not in a genie workspace. Run `genie init` to create one.');
+    process.exit(1);
+  }
+
   const { launchTui } = await import('./tui/index.js');
-  await launchTui();
+  await launchTui({ workspaceRoot: ws.root, initialAgent: ws.agent });
   process.exit(0);
 }
 if (args.every((a) => a === '--reset')) {

--- a/src/lib/workspace.test.ts
+++ b/src/lib/workspace.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { findWorkspace, getWorkspaceConfig, scanAgents } from './workspace.js';
+
+let testDir: string;
+
+beforeEach(() => {
+  testDir = join(tmpdir(), `genie-workspace-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(testDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+function makeWorkspace(root: string, config: Record<string, unknown> = { name: 'test-ws' }) {
+  mkdirSync(join(root, '.genie'), { recursive: true });
+  writeFileSync(join(root, '.genie', 'workspace.json'), JSON.stringify(config));
+}
+
+function makeAgent(root: string, name: string) {
+  const agentDir = join(root, 'agents', name);
+  mkdirSync(agentDir, { recursive: true });
+  writeFileSync(join(agentDir, 'AGENTS.md'), `---\nname: ${name}\n---\n`);
+}
+
+describe('findWorkspace', () => {
+  test('finds workspace from root directory', () => {
+    makeWorkspace(testDir);
+    const result = findWorkspace(testDir);
+    expect(result).not.toBeNull();
+    expect(result!.root).toBe(testDir);
+    expect(result!.agent).toBeUndefined();
+  });
+
+  test('finds workspace from deeply nested path', () => {
+    makeWorkspace(testDir);
+    const deep = join(testDir, 'some', 'deep', 'path');
+    mkdirSync(deep, { recursive: true });
+    const result = findWorkspace(deep);
+    expect(result).not.toBeNull();
+    expect(result!.root).toBe(testDir);
+  });
+
+  test('detects agent name when inside agents/<name>/', () => {
+    makeWorkspace(testDir);
+    makeAgent(testDir, 'sofia');
+    const agentDir = join(testDir, 'agents', 'sofia');
+    const result = findWorkspace(agentDir);
+    expect(result).not.toBeNull();
+    expect(result!.root).toBe(testDir);
+    expect(result!.agent).toBe('sofia');
+  });
+
+  test('detects agent from nested path inside agent directory', () => {
+    makeWorkspace(testDir);
+    makeAgent(testDir, 'genie');
+    const nested = join(testDir, 'agents', 'genie', 'repos', 'project');
+    mkdirSync(nested, { recursive: true });
+    const result = findWorkspace(nested);
+    expect(result).not.toBeNull();
+    expect(result!.agent).toBe('genie');
+  });
+
+  test('returns null outside any workspace', () => {
+    const result = findWorkspace(testDir);
+    expect(result).toBeNull();
+  });
+
+  test('no agent detected when in agents/ but no AGENTS.md', () => {
+    makeWorkspace(testDir);
+    const orphanDir = join(testDir, 'agents', 'orphan');
+    mkdirSync(orphanDir, { recursive: true });
+    const result = findWorkspace(orphanDir);
+    expect(result).not.toBeNull();
+    expect(result!.agent).toBeUndefined();
+  });
+
+  test('no agent detected when at workspace root', () => {
+    makeWorkspace(testDir);
+    makeAgent(testDir, 'atlas');
+    const result = findWorkspace(testDir);
+    expect(result!.agent).toBeUndefined();
+  });
+});
+
+describe('getWorkspaceConfig', () => {
+  test('reads workspace.json', () => {
+    makeWorkspace(testDir, { name: 'my-ws', pgUrl: 'postgres://localhost:5432/genie' });
+    const config = getWorkspaceConfig(testDir);
+    expect(config.name).toBe('my-ws');
+    expect(config.pgUrl).toBe('postgres://localhost:5432/genie');
+  });
+});
+
+describe('scanAgents', () => {
+  test('lists agents with AGENTS.md', () => {
+    makeWorkspace(testDir);
+    makeAgent(testDir, 'sofia');
+    makeAgent(testDir, 'genie');
+    makeAgent(testDir, 'atlas');
+    // orphan dir without AGENTS.md
+    mkdirSync(join(testDir, 'agents', 'orphan'), { recursive: true });
+
+    const agents = scanAgents(testDir);
+    expect(agents).toEqual(['atlas', 'genie', 'sofia']);
+  });
+
+  test('returns empty array when no agents directory', () => {
+    makeWorkspace(testDir);
+    const agents = scanAgents(testDir);
+    expect(agents).toEqual([]);
+  });
+});

--- a/src/lib/workspace.ts
+++ b/src/lib/workspace.ts
@@ -1,0 +1,101 @@
+/**
+ * Workspace detection — walk-up algorithm for .genie/workspace.json.
+ *
+ * A "workspace" is a directory containing `.genie/workspace.json`.
+ * If the cwd passes through `agents/<name>/`, the agent name is extracted.
+ */
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve, sep } from 'node:path';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface WorkspaceConfig {
+  name: string;
+  pgUrl?: string;
+  daemonPid?: number;
+  tmuxSocket?: string;
+}
+
+interface WorkspaceInfo {
+  /** Absolute path to the workspace root (parent of .genie/) */
+  root: string;
+  /** Agent name if cwd is inside agents/<name>/ */
+  agent?: string;
+}
+
+// ─── Walk-up Detection ────────────────────────────────────────────────────────
+
+const WORKSPACE_MARKER = '.genie/workspace.json';
+
+/**
+ * Walk up from `cwd` looking for `.genie/workspace.json`.
+ * Returns workspace root + optional agent name, or null if not in a workspace.
+ */
+export function findWorkspace(cwd?: string): WorkspaceInfo | null {
+  const startDir = resolve(cwd ?? process.cwd());
+  let current = startDir;
+
+  while (true) {
+    const candidate = join(current, WORKSPACE_MARKER);
+    if (existsSync(candidate)) {
+      const agent = detectAgent(startDir, current);
+      return { root: current, agent: agent ?? undefined };
+    }
+    const parent = dirname(current);
+    if (parent === current) break; // reached filesystem root
+    current = parent;
+  }
+
+  return null;
+}
+
+/**
+ * Detect agent name from path.
+ * If startDir passes through `<root>/agents/<name>/`, extract `<name>`.
+ */
+function detectAgent(startDir: string, workspaceRoot: string): string | null {
+  const agentsDir = join(workspaceRoot, 'agents');
+  // startDir must be inside or equal to agentsDir
+  const relative = startDir.slice(agentsDir.length);
+  if (!startDir.startsWith(agentsDir) || (relative.length > 0 && relative[0] !== sep)) {
+    return null;
+  }
+
+  // relative is like /sofia/repos/... or /sofia
+  const parts = relative.split(sep).filter(Boolean);
+  if (parts.length === 0) return null;
+
+  const agentName = parts[0];
+  // Verify this agent has an AGENTS.md
+  const agentsMd = join(agentsDir, agentName, 'AGENTS.md');
+  if (existsSync(agentsMd)) return agentName;
+
+  return null;
+}
+
+// ─── Config Reading ───────────────────────────────────────────────────────────
+
+/** Read and parse workspace.json from a workspace root. */
+export function getWorkspaceConfig(root: string): WorkspaceConfig {
+  const configPath = join(root, WORKSPACE_MARKER);
+  const raw = readFileSync(configPath, 'utf-8');
+  return JSON.parse(raw) as WorkspaceConfig;
+}
+
+// ─── Agent Scanning ───────────────────────────────────────────────────────────
+
+/** List all agent names found under {root}/agents/{name}/AGENTS.md */
+export function scanAgents(root: string): string[] {
+  const agentsDir = join(root, 'agents');
+  if (!existsSync(agentsDir)) return [];
+
+  try {
+    return readdirSync(agentsDir, { withFileTypes: true })
+      .filter((d) => d.isDirectory() && existsSync(join(agentsDir, d.name, 'AGENTS.md')))
+      .map((d) => d.name)
+      .sort();
+  } catch {
+    return [];
+  }
+}

--- a/src/term-commands/init.ts
+++ b/src/term-commands/init.ts
@@ -1,0 +1,123 @@
+/**
+ * genie init — workspace creation + agent scaffolding.
+ *
+ * Commands:
+ *   genie init              — Create .genie/workspace.json at cwd
+ *   genie init agent <name> — Scaffold an agent directory
+ */
+
+import { existsSync, mkdirSync, symlinkSync, writeFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import type { Command } from 'commander';
+import { type WorkspaceConfig, findWorkspace, scanAgents } from '../lib/workspace.js';
+import { scaffoldAgentFiles } from '../templates/index.js';
+
+/** Auto-detect pgUrl from environment or running pgserve. */
+function detectPgUrl(): string | undefined {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  if (process.env.PG_URL) return process.env.PG_URL;
+  try {
+    const { execSync } = require('node:child_process') as typeof import('node:child_process');
+    const out = execSync('pgrep -af pgserve 2>/dev/null', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+    const match = out.match(/postgres(?:ql)?:\/\/[^\s]+/);
+    if (match) return match[0];
+  } catch {
+    // pgserve not running
+  }
+  return undefined;
+}
+
+/** genie init — create workspace */
+async function initWorkspace(): Promise<void> {
+  const cwd = process.cwd();
+
+  // Check if already inside a workspace
+  const existing = findWorkspace(cwd);
+  if (existing) {
+    console.log(`Already inside workspace: ${existing.root}`);
+    return;
+  }
+
+  // Create .genie/ and workspace.json
+  const genieDir = join(cwd, '.genie');
+  mkdirSync(genieDir, { recursive: true });
+
+  const pgUrl = detectPgUrl();
+  const config: WorkspaceConfig = {
+    name: basename(cwd),
+    pgUrl,
+    tmuxSocket: 'genie',
+  };
+
+  writeFileSync(join(genieDir, 'workspace.json'), `${JSON.stringify(config, null, 2)}\n`);
+  console.log(`Workspace created: ${cwd}`);
+  if (pgUrl) console.log(`  pgUrl: ${pgUrl}`);
+
+  // Scan for existing agents
+  const agents = scanAgents(cwd);
+  if (agents.length > 0) {
+    console.log(`  Found ${agents.length} agent(s): ${agents.join(', ')}`);
+  }
+}
+
+/** genie init agent <name> — scaffold agent directory */
+async function initAgent(name: string): Promise<void> {
+  const cwd = process.cwd();
+  const ws = findWorkspace(cwd);
+  if (!ws) {
+    console.error('Error: Not in a genie workspace. Run `genie init` first.');
+    process.exit(1);
+  }
+
+  const agentDir = join(ws.root, 'agents', name);
+  if (existsSync(agentDir)) {
+    console.error(`Error: Agent directory already exists: ${agentDir}`);
+    process.exit(1);
+  }
+
+  // Create agent directory structure
+  mkdirSync(agentDir, { recursive: true });
+  mkdirSync(join(agentDir, 'brain', 'memory'), { recursive: true });
+  mkdirSync(join(agentDir, '.claude'), { recursive: true });
+
+  // Scaffold AGENTS.md, SOUL.md, HEARTBEAT.md
+  scaffoldAgentFiles(agentDir);
+
+  // Write .claude/settings.local.json
+  writeFileSync(join(agentDir, '.claude', 'settings.local.json'), `${JSON.stringify({ agentName: name }, null, 2)}\n`);
+
+  // Create repos symlink (pointing to workspace root's repos if it exists)
+  const reposTarget = join(ws.root, 'repos');
+  if (existsSync(reposTarget)) {
+    try {
+      symlinkSync(reposTarget, join(agentDir, 'repos'));
+    } catch {
+      // symlink may fail on some filesystems
+    }
+  }
+
+  console.log(`Agent scaffolded: agents/${name}/`);
+  console.log('  AGENTS.md, SOUL.md, HEARTBEAT.md');
+  console.log('  brain/memory/');
+  console.log('  .claude/settings.local.json');
+  if (existsSync(join(agentDir, 'repos'))) {
+    console.log('  repos -> ../repos (symlink)');
+  }
+}
+
+/** Register init commands on the program */
+export function registerInitCommands(program: Command): void {
+  const init = program
+    .command('init')
+    .description('Initialize a genie workspace')
+    .action(async () => {
+      await initWorkspace();
+    });
+
+  init
+    .command('agent <name>')
+    .description('Scaffold a new agent in the workspace')
+    .action(async (name: string) => {
+      await initAgent(name);
+    });
+}

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -5,7 +5,15 @@ import { useCallback } from 'react';
 import { Nav } from './components/Nav.js';
 import { attachProjectWindow } from './tmux.js';
 
-export function App({ rightPane }: { rightPane?: string }) {
+interface AppProps {
+  rightPane?: string;
+  /** Workspace root path — enables workspace mode */
+  workspaceRoot?: string;
+  /** Pre-select this agent on initial render */
+  initialAgent?: string;
+}
+
+export function App({ rightPane, workspaceRoot, initialAgent }: AppProps) {
   // Quit is handled by tmux key table (Ctrl+Q → kill-session), not by OpenTUI.
   // This ensures BOTH panes die together regardless of which pane has focus.
 
@@ -17,5 +25,7 @@ export function App({ rightPane }: { rightPane?: string }) {
     [rightPane],
   );
 
-  return <Nav onTmuxSessionSelect={handleTmuxSessionSelect} />;
+  return (
+    <Nav onTmuxSessionSelect={handleTmuxSessionSelect} workspaceRoot={workspaceRoot} initialAgent={initialAgent} />
+  );
 }

--- a/src/tui/components/Nav.tsx
+++ b/src/tui/components/Nav.tsx
@@ -3,8 +3,9 @@
 
 import { useKeyboard } from '@opentui/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { scanAgents } from '../../lib/workspace.js';
 import { type DiagnosticSnapshot, collectDiagnostics } from '../diagnostics.js';
-import { buildSessionTree, getSessionTarget } from '../session-tree.js';
+import { buildSessionTree, buildWorkspaceTree, getSessionTarget } from '../session-tree.js';
 import { palette } from '../theme.js';
 import { flattenTree, toggleNode } from '../tree.js';
 import type { TreeNode } from '../types.js';
@@ -12,13 +13,18 @@ import { TreeNodeRow } from './TreeNode.js';
 
 interface NavProps {
   onTmuxSessionSelect: (sessionName: string, windowIndex?: number) => void;
+  /** Workspace root path — enables workspace mode (merged agent tree) */
+  workspaceRoot?: string;
+  /** Pre-select this agent on initial render */
+  initialAgent?: string;
 }
 
-export function Nav({ onTmuxSessionSelect }: NavProps) {
+export function Nav({ onTmuxSessionSelect, workspaceRoot, initialAgent }: NavProps) {
   const [diagnostics, setDiagnostics] = useState<DiagnosticSnapshot | null>(null);
   const [sessionTree, setSessionTree] = useState<TreeNode[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const lastTarget = useRef<string | null>(null);
+  const initialSelectDone = useRef(false);
 
   // Refresh diagnostics every 2s
   useEffect(() => {
@@ -45,9 +51,21 @@ export function Nav({ onTmuxSessionSelect }: NavProps) {
   // Build session tree from diagnostics, preserving expanded state
   useEffect(() => {
     if (!diagnostics) return;
-    const newTree = buildSessionTree(diagnostics);
+
+    let newTree: TreeNode[];
+    if (workspaceRoot) {
+      const agentNames = scanAgents(workspaceRoot);
+      newTree = buildWorkspaceTree({
+        agentNames,
+        sessions: diagnostics.sessions,
+        executors: diagnostics.executors,
+      });
+    } else {
+      newTree = buildSessionTree(diagnostics);
+    }
+
     setSessionTree((prev) => mergeExpandedState(prev, newTree));
-  }, [diagnostics]);
+  }, [diagnostics, workspaceRoot]);
 
   const flatNodes = useMemo(() => flattenTree(sessionTree), [sessionTree]);
 
@@ -58,6 +76,16 @@ export function Nav({ onTmuxSessionSelect }: NavProps) {
     }
   }, [flatNodes.length, selectedIndex]);
 
+  // Initial agent pre-selection (once)
+  useEffect(() => {
+    if (!initialAgent || initialSelectDone.current || flatNodes.length === 0) return;
+    const idx = flatNodes.findIndex((n) => n.node.id === `agent:${initialAgent}`);
+    if (idx >= 0) {
+      setSelectedIndex(idx);
+      initialSelectDone.current = true;
+    }
+  }, [initialAgent, flatNodes]);
+
   // Auto-switch right pane when cursor moves to a new target
   useEffect(() => {
     const current = flatNodes[selectedIndex]?.node;
@@ -67,6 +95,9 @@ export function Nav({ onTmuxSessionSelect }: NavProps) {
     const key = `${target.sessionName}:${target.windowIndex ?? ''}`;
     if (key === lastTarget.current) return;
     lastTarget.current = key;
+
+    // Only auto-attach for running agents (or session/window/pane nodes)
+    if (current.type === 'agent' && current.wsAgentState !== 'running') return;
     onTmuxSessionSelect(target.sessionName, target.windowIndex);
   }, [selectedIndex, flatNodes, onTmuxSessionSelect]);
 
@@ -111,6 +142,13 @@ export function Nav({ onTmuxSessionSelect }: NavProps) {
   const handleEnter = useCallback(() => {
     const node = flatNodes[selectedIndex]?.node;
     if (!node) return;
+
+    // Stopped agent: spawn it
+    if (node.type === 'agent' && node.wsAgentState === 'stopped') {
+      spawnAgent(node.label);
+      return;
+    }
+
     if (node.children.length > 0) handleToggle(node.id);
     const target = getSessionTarget(node);
     if (target) onTmuxSessionSelect(target.sessionName, target.windowIndex);
@@ -127,24 +165,27 @@ export function Nav({ onTmuxSessionSelect }: NavProps) {
   });
 
   // Summary counts
-  const sessionCount = diagnostics?.sessions.length ?? 0;
-  const totalPanes =
-    diagnostics?.sessions.reduce((sum, s) => sum + s.windows.reduce((ws, w) => ws + w.panes.length, 0), 0) ?? 0;
-  const deadPanes = diagnostics?.gaps.deadPaneCount ?? 0;
+  const agentCount = workspaceRoot
+    ? sessionTree.filter((n) => n.type === 'agent').length
+    : (diagnostics?.sessions.length ?? 0);
+  const runningCount = workspaceRoot
+    ? sessionTree.filter((n) => n.wsAgentState === 'running').length
+    : (diagnostics?.sessions.reduce((sum, s) => sum + s.windows.reduce((ws, w) => ws + w.panes.length, 0), 0) ?? 0);
+
+  const headerLabel = workspaceRoot ? 'Agents' : 'Sessions';
 
   return (
     <box flexDirection="column" width="100%" height="100%" backgroundColor={palette.bg}>
       {/* Header */}
       <box height={1} paddingX={1} backgroundColor={palette.bgLight}>
         <text>
-          <span fg={palette.purple}>Sessions</span>
+          <span fg={palette.purple}>{headerLabel}</span>
           {diagnostics ? (
             <span fg={palette.textDim}>
               {' '}
-              {sessionCount}s {totalPanes}p
+              {workspaceRoot ? `${runningCount}/${agentCount}` : `${agentCount}s ${runningCount}p`}
             </span>
           ) : null}
-          {deadPanes > 0 ? <span fg={palette.error}> {deadPanes}\u2620</span> : null}
         </text>
       </box>
 
@@ -183,12 +224,25 @@ export function Nav({ onTmuxSessionSelect }: NavProps) {
       <box height={1} paddingX={1} backgroundColor={palette.bgLight}>
         <text>
           <span fg={palette.textMuted}>
-            {'\u2191\u2193'}:nav {'\u2190\u2192'}:expand Enter:attach
+            {'\u2191\u2193'}:nav {'\u2190\u2192'}:expand Enter:{workspaceRoot ? 'spawn/attach' : 'attach'}
           </span>
         </text>
       </box>
     </box>
   );
+}
+
+/** Spawn a stopped agent by launching `genie spawn <name>` in background */
+function spawnAgent(name: string): void {
+  try {
+    const { spawn } = require('node:child_process') as typeof import('node:child_process');
+    spawn('genie', ['spawn', name], {
+      detached: true,
+      stdio: 'ignore',
+    }).unref();
+  } catch {
+    // best-effort spawn
+  }
 }
 
 /** Merge expanded state from old tree into new tree (preserves user navigation) */

--- a/src/tui/components/TreeNode.tsx
+++ b/src/tui/components/TreeNode.tsx
@@ -19,7 +19,7 @@ export const TreeNodeRow = memo(function TreeNodeRow({ node, selected, onSelect,
 
   const icon = getNodeIcon(node);
   const color = getNodeColor(node);
-  const activeIndicator = node.activePanes > 0 ? ` ${icons.agent}${node.activePanes}` : '';
+  const suffix = getNodeSuffix(node);
 
   return (
     <box
@@ -38,7 +38,7 @@ export const TreeNodeRow = memo(function TreeNodeRow({ node, selected, onSelect,
         </span>
         <span fg={color}>{icon} </span>
         <span fg={selected ? '#ffffff' : palette.text}>{node.label}</span>
-        {activeIndicator ? <span fg={palette.cyan}>{activeIndicator}</span> : null}
+        {suffix ? <span fg={palette.textDim}>{suffix}</span> : null}
         {node.agentState ? <span fg={getStateColor(node.agentState)}> {node.agentState}</span> : null}
       </text>
     </box>
@@ -46,6 +46,11 @@ export const TreeNodeRow = memo(function TreeNodeRow({ node, selected, onSelect,
 });
 
 function getNodeIcon(node: TreeNodeType): string {
+  // Workspace agent nodes
+  if (node.type === 'agent') {
+    return getAgentIcon(node);
+  }
+
   switch (node.type) {
     case 'session':
       return node.data.attached ? '\u25b6' : '\u25b8'; // ▶ attached, ▸ detached
@@ -58,17 +63,36 @@ function getNodeIcon(node: TreeNodeType): string {
   }
 }
 
+function getAgentIcon(node: TreeNodeType): string {
+  switch (node.wsAgentState) {
+    case 'running':
+      return '\u25cf'; // ●
+    case 'stopped':
+      return '\u25cb'; // ○
+    case 'error':
+      return '\u2298'; // ⊘
+    case 'spawning':
+      return '\u231b'; // ⏳
+    default:
+      return '\u25cb'; // ○
+  }
+}
+
 function getPaneIcon(node: TreeNodeType): string {
   if (node.data.isDead) return '\u2718'; // ✘
   if (node.agentState === 'working') return '\u25cf'; // ●
   if (node.agentState === 'idle') return '\u25cb'; // ○
   if (node.agentState === 'permission') return '\u26a0'; // ⚠
   if (node.agentState === 'error') return '\u2718'; // ✘
-  if (node.data.command === 'claude') return '\u25c6'; // ◆
+  if (node.data.command === 'claude') return '\u25c6'; // ���
   return '\u25cb'; // ○
 }
 
 function getNodeColor(node: TreeNodeType): string {
+  if (node.type === 'agent') {
+    return getAgentColor(node);
+  }
+
   switch (node.type) {
     case 'session':
       return node.data.attached ? palette.emerald : palette.textDim;
@@ -81,6 +105,21 @@ function getNodeColor(node: TreeNodeType): string {
   }
 }
 
+function getAgentColor(node: TreeNodeType): string {
+  switch (node.wsAgentState) {
+    case 'running':
+      return palette.emerald;
+    case 'stopped':
+      return palette.textDim;
+    case 'error':
+      return palette.error;
+    case 'spawning':
+      return palette.warning;
+    default:
+      return palette.textDim;
+  }
+}
+
 function getPaneColor(node: TreeNodeType): string {
   if (node.data.isDead) return palette.error;
   if (node.agentState === 'working') return palette.cyan;
@@ -89,6 +128,20 @@ function getPaneColor(node: TreeNodeType): string {
   if (node.agentState === 'idle') return palette.textDim;
   if (node.data.command === 'claude') return palette.cyan;
   return palette.textDim;
+}
+
+function getNodeSuffix(node: TreeNodeType): string {
+  if (node.type === 'agent') {
+    const wc = node.data.windowCount as number;
+    if (wc > 1) return ` (${wc} windows)`;
+    if (wc === 1) return ' (1 window)';
+    return '';
+  }
+  if (node.type === 'session' || node.type === 'pane') {
+    const count = node.activePanes;
+    if (count > 0) return ` ${icons.agent}${count}`;
+  }
+  return '';
 }
 
 function getStateColor(state: string): string {

--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -8,7 +8,15 @@
 
 import { attachTuiSession, cleanup, createTuiSession, hasTmux, isInsideTuiSession } from './tmux.js';
 
-export async function launchTui(options: { dev?: boolean } = {}): Promise<void> {
+interface TuiLaunchOptions {
+  dev?: boolean;
+  /** Workspace root path — enables workspace mode */
+  workspaceRoot?: string;
+  /** Pre-select this agent on initial render */
+  initialAgent?: string;
+}
+
+export async function launchTui(options: TuiLaunchOptions = {}): Promise<void> {
   // If already inside the TUI pane, render OpenTUI directly
   if (isInsideTuiSession()) {
     const { renderNav } = await import('./render.js');
@@ -28,24 +36,24 @@ export async function launchTui(options: { dev?: boolean } = {}): Promise<void> 
   const bunPath = process.execPath || 'bun';
   const genieBin = process.argv[1] || 'genie';
 
+  // Build env vars for workspace mode
+  const envVars = ['GENIE_TUI_PANE=left', `GENIE_TUI_RIGHT=${rightPane}`];
+  if (options.workspaceRoot) envVars.push(`GENIE_TUI_WORKSPACE=${options.workspaceRoot}`);
+  if (options.initialAgent) envVars.push(`GENIE_TUI_AGENT=${options.initialAgent}`);
+  const envPrefix = envVars.join(' ');
+
   // Run the TUI nav renderer in the left pane
   // Uses GENIE_TUI_PANE=left to trigger renderer mode (not a subcommand)
   const { execSync } = await import('node:child_process');
   const { genieTmuxCmd } = await import('../lib/tmux-wrapper.js');
   if (options.dev) {
-    execSync(
-      genieTmuxCmd(
-        `send-keys -t '${leftPane}' "GENIE_TUI_PANE=left GENIE_TUI_RIGHT=${rightPane} bun --watch ${genieBin}" Enter`,
-      ),
-      { stdio: 'ignore' },
-    );
+    execSync(genieTmuxCmd(`send-keys -t '${leftPane}' "${envPrefix} bun --watch ${genieBin}" Enter`), {
+      stdio: 'ignore',
+    });
   } else {
-    execSync(
-      genieTmuxCmd(
-        `send-keys -t '${leftPane}' "GENIE_TUI_PANE=left GENIE_TUI_RIGHT=${rightPane} ${bunPath} ${genieBin}" Enter`,
-      ),
-      { stdio: 'ignore' },
-    );
+    execSync(genieTmuxCmd(`send-keys -t '${leftPane}' "${envPrefix} ${bunPath} ${genieBin}" Enter`), {
+      stdio: 'ignore',
+    });
   }
 
   // Attach (blocking)

--- a/src/tui/render.tsx
+++ b/src/tui/render.tsx
@@ -7,6 +7,8 @@ import { App } from './app.js';
 
 export async function renderNav(): Promise<void> {
   const rightPane = process.env.GENIE_TUI_RIGHT || undefined;
+  const workspaceRoot = process.env.GENIE_TUI_WORKSPACE || undefined;
+  const initialAgent = process.env.GENIE_TUI_AGENT || undefined;
 
   // OpenTUI handles SIGTERM/SIGHUP/SIGINT cleanup automatically
   const renderer = await createCliRenderer({
@@ -14,5 +16,5 @@ export async function renderNav(): Promise<void> {
     useMouse: true,
   });
 
-  createRoot(renderer).render(<App rightPane={rightPane} />);
+  createRoot(renderer).render(<App rightPane={rightPane} workspaceRoot={workspaceRoot} initialAgent={initialAgent} />);
 }

--- a/src/tui/session-tree.ts
+++ b/src/tui/session-tree.ts
@@ -1,15 +1,22 @@
 /**
  * Build TreeNode[] from tmux sessions + executor state from PG.
  * Powers the Sessions view with the same tree pattern as TreeNodeRow.
+ *
+ * In workspace mode, merges three data sources:
+ *   1. Filesystem: agents/AGENTS.md → all agents that COULD run
+ *   2. tmux: `tmux -L genie ls` → agents that ARE running + their windows
+ *   3. Executors table: state (working/idle/permission/error)
  */
 
 import type { DiagnosticSnapshot, TmuxPane, TmuxSession, TmuxWindow } from './diagnostics.js';
-import type { TreeNode, TuiExecutor } from './types.js';
+import type { AgentState, TreeNode, TuiExecutor } from './types.js';
 
-/** Build a TreeNode tree from tmux sessions, enriched with executor state. */
 /** The TUI's own session name — filtered from the tree to prevent self-attach loops */
 const TUI_SESSION = 'genie-tui';
 
+// ─── Legacy Mode (no workspace) ──────────────────────────────────────────────
+
+/** Build a TreeNode tree from tmux sessions, enriched with executor state. */
 export function buildSessionTree(snapshot: DiagnosticSnapshot): TreeNode[] {
   const executorByPaneId = new Map<string, TuiExecutor>();
   for (const exec of snapshot.executors) {
@@ -22,6 +29,122 @@ export function buildSessionTree(snapshot: DiagnosticSnapshot): TreeNode[] {
     .filter((s) => s.name !== TUI_SESSION)
     .map((session) => sessionToNode(session, executorByPaneId));
 }
+
+// ─── Workspace Mode (merged data sources) ────────────────────────────────────
+
+interface WorkspaceTreeInput {
+  /** Agent names from filesystem (agents/AGENTS.md) */
+  agentNames: string[];
+  /** Tmux sessions from `tmux -L genie ls` */
+  sessions: TmuxSession[];
+  /** Executors from PG */
+  executors: TuiExecutor[];
+}
+
+/** Build workspace-aware tree: all agents from filesystem, enriched with tmux + executor state. */
+export function buildWorkspaceTree(input: WorkspaceTreeInput): TreeNode[] {
+  const { agentNames, sessions, executors } = input;
+
+  // Index tmux sessions by name
+  const sessionByName = new Map<string, TmuxSession>();
+  for (const s of sessions) {
+    if (s.name !== TUI_SESSION) sessionByName.set(s.name, s);
+  }
+
+  // Index executors by pane ID
+  const executorByPaneId = new Map<string, TuiExecutor>();
+  for (const exec of executors) {
+    if (exec.tmuxPaneId) executorByPaneId.set(exec.tmuxPaneId, exec);
+  }
+
+  // Index executors by agent name (for state derivation)
+  const executorsByAgent = new Map<string, TuiExecutor[]>();
+  for (const exec of executors) {
+    const name = exec.agentName ?? exec.metadata?.agentName;
+    if (typeof name === 'string') {
+      const list = executorsByAgent.get(name) ?? [];
+      list.push(exec);
+      executorsByAgent.set(name, list);
+    }
+  }
+
+  const nodes: TreeNode[] = [];
+
+  // Build agent nodes from filesystem, enriched with tmux + executor
+  for (const name of agentNames) {
+    const session = sessionByName.get(name);
+    const agentExecutors = executorsByAgent.get(name) ?? [];
+    const wsState = deriveWsAgentState(session, agentExecutors);
+
+    const children: TreeNode[] = [];
+    if (session) {
+      // Add non-home windows as children (window 0 IS the agent row)
+      for (const win of session.windows) {
+        if (win.index === 0) continue;
+        children.push(windowToNode(session.name, win, executorByPaneId));
+      }
+    }
+
+    const windowCount = session ? session.windows.length : 0;
+
+    nodes.push({
+      id: `agent:${name}`,
+      type: 'agent',
+      label: name,
+      depth: 0,
+      expanded: children.length > 0,
+      children,
+      data: { sessionName: name, windowCount },
+      activePanes: session
+        ? session.windows.reduce(
+            (sum, w) => sum + w.panes.filter((p) => p.command === 'claude' || p.title.includes('claude')).length,
+            0,
+          )
+        : 0,
+      agentState: agentExecutors.length > 0 ? deriveExecutorState(agentExecutors) : undefined,
+      wsAgentState: wsState,
+    });
+  }
+
+  // Add orphan sessions (tmux sessions with no matching agent in filesystem)
+  const agentNameSet = new Set(agentNames);
+  for (const [name, session] of sessionByName) {
+    if (!agentNameSet.has(name)) {
+      nodes.push(sessionToNode(session, executorByPaneId));
+    }
+  }
+
+  return nodes;
+}
+
+/** Derive workspace-level agent state from tmux session + executors */
+function deriveWsAgentState(session: TmuxSession | undefined, agentExecutors: TuiExecutor[]): AgentState {
+  if (!session) return 'stopped';
+
+  // Check executor states
+  for (const exec of agentExecutors) {
+    if (exec.state === 'error' || exec.state === 'terminated') return 'error';
+    if (exec.state === 'spawning') return 'spawning';
+  }
+
+  return 'running';
+}
+
+/** Derive pane-level executor state from multiple executors */
+function deriveExecutorState(execs: TuiExecutor[]): TreeNode['agentState'] {
+  for (const e of execs) {
+    if (e.state === 'working') return 'working';
+  }
+  for (const e of execs) {
+    if (e.state === 'permission') return 'permission';
+  }
+  for (const e of execs) {
+    if (e.state === 'error' || e.state === 'terminated') return 'error';
+  }
+  return 'idle';
+}
+
+// ─── Shared Node Builders ────────────────────────────────────────────────────
 
 function sessionToNode(session: TmuxSession, executorMap: Map<string, TuiExecutor>): TreeNode {
   const claudePanes = session.windows.reduce(
@@ -39,6 +162,7 @@ function sessionToNode(session: TmuxSession, executorMap: Map<string, TuiExecuto
     data: { attached: session.attached, windowCount: session.windowCount },
     activePanes: claudePanes,
     agentState: undefined,
+    wsAgentState: undefined,
   };
 }
 
@@ -57,6 +181,7 @@ function windowToNode(sessionName: string, window: TmuxWindow, executorMap: Map<
     data: { active: window.active, paneCount: window.paneCount },
     activePanes,
     agentState: undefined,
+    wsAgentState: undefined,
   };
 }
 
@@ -87,6 +212,7 @@ function paneToNode(
     },
     activePanes: 0,
     agentState: derivePaneState(pane, executor),
+    wsAgentState: undefined,
   };
 }
 
@@ -110,6 +236,10 @@ function derivePaneState(pane: TmuxPane, executor: TuiExecutor | undefined): Tre
 
 /** Resolve tmux target for a tree node (for right pane attach). */
 export function getSessionTarget(node: TreeNode): { sessionName: string; windowIndex?: number } | null {
+  if (node.type === 'agent') {
+    const sessionName = node.data.sessionName as string;
+    return { sessionName };
+  }
   if (node.type === 'session') {
     return { sessionName: node.label };
   }

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -3,7 +3,9 @@
 import type { ExecutorState, TransportType } from '../lib/executor-types.js';
 import type { ProviderName } from '../lib/provider-adapters.js';
 
-export type TreeNodeType = 'session' | 'window' | 'pane';
+export type TreeNodeType = 'session' | 'window' | 'pane' | 'agent';
+
+export type AgentState = 'running' | 'stopped' | 'error' | 'spawning';
 
 export interface TreeNode {
   id: string;
@@ -17,6 +19,8 @@ export interface TreeNode {
   activePanes: number;
   /** Agent state if applicable */
   agentState?: 'idle' | 'working' | 'permission' | 'error';
+  /** Workspace agent lifecycle state */
+  wsAgentState?: AgentState;
 }
 
 export interface FlatNode {


### PR DESCRIPTION
## Summary

- **Workspace detection**: `findWorkspace(cwd)` walk-up algorithm finds `.genie/workspace.json`, detects agent name when inside `agents/<name>/`
- **`genie init`**: creates workspace.json, auto-detects pgUrl, scans existing agents. `genie init agent <name>` scaffolds full agent directory
- **Stateful TUI**: merges 3 data sources (filesystem agents, tmux sessions, executor state). Shows ● running, ○ stopped, ⊘ error, ⏳ spawning. Hover auto-attaches running agents, Enter spawns stopped agents
- **Entry point wiring**: `genie` (no args) requires workspace context, pre-selects agent from cwd. `genie serve` alias for daemon start

## Files

### New
- `src/lib/workspace.ts` — findWorkspace(), getWorkspaceConfig(), scanAgents()
- `src/lib/workspace.test.ts` — 10 unit tests
- `src/term-commands/init.ts` — genie init + genie init agent commands

### Modified
- `src/genie.ts` — workspace detection before TUI, serve alias, init registration
- `src/tui/session-tree.ts` — buildWorkspaceTree() merging filesystem + tmux + executors
- `src/tui/types.ts` — AgentState type, wsAgentState field
- `src/tui/app.tsx` — accepts workspaceRoot + initialAgent props
- `src/tui/index.ts` — passes workspace env vars to TUI pane
- `src/tui/render.tsx` — reads workspace env vars
- `src/tui/components/Nav.tsx` — workspace mode, hover=attach, Enter=spawn
- `src/tui/components/TreeNode.tsx` — agent state indicators (● ○ ⊘ ⏳)

## Test plan
- [x] `bun run check` passes (typecheck + lint + dead-code + 1546 tests)
- [ ] `genie init` creates workspace.json in a new directory
- [ ] `genie init agent atlas` scaffolds agents/atlas/ with all files
- [ ] `genie` from workspace root opens TUI with agent list
- [ ] `genie` from agents/sofia/ opens TUI with sofia pre-selected
- [ ] Running agents show ● and auto-attach on hover
- [ ] Stopped agents show ○ and spawn on Enter
- [ ] `genie serve` starts daemon in foreground