### PR TITLE
fix(tui): send-keys targets TUI socket, not agent server

### DIFF
--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -45,13 +45,13 @@ export async function launchTui(options: TuiLaunchOptions = {}): Promise<void> {
   // Run the TUI nav renderer in the left pane
   // Uses GENIE_TUI_PANE=left to trigger renderer mode (not a subcommand)
   const { execSync } = await import('node:child_process');
-  const { genieTmuxCmd } = await import('../lib/tmux-wrapper.js');
+  const { tuiTmuxCmd } = await import('./tmux.js');
   if (options.dev) {
-    execSync(genieTmuxCmd(`send-keys -t '${leftPane}' "${envPrefix} bun --watch ${genieBin}" Enter`), {
+    execSync(tuiTmuxCmd(`send-keys -t '${leftPane}' "${envPrefix} bun --watch ${genieBin}" Enter`), {
       stdio: 'ignore',
     });
   } else {
-    execSync(genieTmuxCmd(`send-keys -t '${leftPane}' "${envPrefix} ${bunPath} ${genieBin}" Enter`), {
+    execSync(tuiTmuxCmd(`send-keys -t '${leftPane}' "${envPrefix} ${bunPath} ${genieBin}" Enter`), {
       stdio: 'ignore',
     });
   }

--- a/src/tui/tmux.ts
+++ b/src/tui/tmux.ts
@@ -25,6 +25,11 @@ const GENIE_TMUX_CONF = (() => {
 /** Prefix for all tmux commands — dedicated socket + genie config (ignores user's global tmux) */
 const TMUX = `tmux -L ${TMUX_SOCKET} -f ${GENIE_TMUX_CONF}`;
 
+/** Build a TUI-scoped tmux command (targets genie-tui server, NOT agent server) */
+export function tuiTmuxCmd(subcommand: string): string {
+  return `${TMUX} ${subcommand}`;
+}
+
 /** Check if tmux is available */
 export function hasTmux(): boolean {
   try {


### PR DESCRIPTION
send-keys was using genieTmuxCmd (-L genie = agent server) but the left pane lives on -L genie-tui. Changed to tuiTmuxCmd.