### PR TITLE
feat(app): Tauri v2 frontend scaffold + build fixes

### DIFF
--- a/packages/genie-app/src-tauri/tauri.conf.json
+++ b/packages/genie-app/src-tauri/tauri.conf.json
@@ -4,8 +4,8 @@
   "version": "0.1.0",
   "identifier": "dev.automagik.genie",
   "build": {
-    "beforeDevCommand": "cd .. && npx vite --port 1420",
-    "beforeBuildCommand": "cd .. && npx vite build",
+    "beforeDevCommand": "bun run dev",
+    "beforeBuildCommand": "bun run build",
     "frontendDist": "../dist",
     "devUrl": "http://localhost:1420"
   },


### PR DESCRIPTION
## Summary
- Remove duplicate `tauri.conf.json` at package root (caused Cargo.toml not found)
- Add missing `src-tauri/build.rs` + generated icon set
- Add Vite frontend scaffold: `index.html`, `src/main.tsx`, `src/App.tsx` with sidebar nav
- Fix `beforeDevCommand`/`beforeBuildCommand` — runs from project root, no `cd ..`
- New deps: react-dom, vite, @vitejs/plugin-react
- Fix app.ts cognitive complexity warning

## Test plan
- [x] `make tauri-dev` on Mac — Vite starts on :1420, Rust compiling (verified via SSH)
- [ ] Tauri window opens with app shell
- [ ] `make tauri` builds desktop binary