### PR TITLE
chore: gitignore Rust target/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 # Build output
 dist/
 build/
+target/
 *.js.map
 *.tsbuildinfo
 


### PR DESCRIPTION
Tauri build creates target/ with compiled Rust artifacts. Should be gitignored like node_modules.