### PR TITLE
feat(db): add backup and restore commands

### DIFF
--- a/src/lib/db-backup.ts
+++ b/src/lib/db-backup.ts
@@ -1,13 +1,14 @@
 /**
- * Database backup & restore — pg_dump/psql wrappers for genie DB snapshots.
+ * Database backup & restore — pg_dump + node:zlib for genie DB snapshots.
  *
- * - backup(): pg_dump → gzip → .genie/snapshot.sql.gz
- * - restore(): gunzip → psql (drop + create + restore + migrate)
+ * No external dependencies beyond pg_dump (ships with pgserve).
+ * Compression uses node:zlib, restore pipes through postgres.js.
  */
 
-import { execSync } from 'node:child_process';
-import { existsSync, mkdirSync, statSync } from 'node:fs';
+import { type SpawnSyncReturns, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { gunzipSync, gzipSync } from 'node:zlib';
 import { getActivePort } from './db.js';
 import { resolveRepoPath } from './wish-state.js';
 
@@ -40,37 +41,51 @@ interface BackupResult {
 }
 
 /**
- * Run pg_dump → gzip → snapshot.sql.gz.
+ * Run pg_dump → zlib.gzip → snapshot.sql.gz.
  * Replaces the previous snapshot (single file, not accumulating).
+ * Uses spawnSync so pg_dump exit code is checked directly — no shell pipeline.
  */
 export function backup(cwd?: string): BackupResult {
   const port = getActivePort();
   const snapshotPath = getSnapshotPath(cwd);
   const genieDir = join(resolveRepoPath(cwd), '.genie');
+  const tmpPath = `${snapshotPath}.tmp`;
 
   mkdirSync(genieDir, { recursive: true });
 
-  // pg_dump piped through gzip — single atomic write
-  execSync(`pg_dump --no-owner --no-acl | gzip > "${snapshotPath}.tmp"`, {
+  // pg_dump → stdout buffer, exit code checked directly
+  const result: SpawnSyncReturns<Buffer> = spawnSync('pg_dump', ['--no-owner', '--no-acl'], {
     env: pgEnv(port),
     stdio: ['pipe', 'pipe', 'pipe'],
     timeout: 120_000,
+    maxBuffer: 1024 * 1024 * 1024, // 1GB
   });
 
-  // Atomic rename
-  execSync(`mv "${snapshotPath}.tmp" "${snapshotPath}"`, { stdio: 'ignore' });
+  if (result.status !== 0) {
+    const stderr = result.stderr?.toString().trim() || 'unknown error';
+    throw new Error(`pg_dump failed (exit ${result.status}): ${stderr}`);
+  }
+
+  // Compress with node:zlib (synchronous — data already in memory)
+  const compressed = gzipSync(result.stdout);
+
+  // Atomic write: tmp → rename
+  writeFileSync(tmpPath, compressed);
+  renameSync(tmpPath, snapshotPath);
 
   const compressedBytes = statSync(snapshotPath).size;
 
   // Get uncompressed size estimate from pg_database_size
   let uncompressedBytes = 0;
   try {
-    const out = execSync(`psql -t -A -c "SELECT pg_database_size('${DB_NAME}')"`, {
+    const sizeResult = spawnSync('psql', ['-t', '-A', '-c', `SELECT pg_database_size('${DB_NAME}')`], {
       env: pgEnv(port),
       encoding: 'utf-8',
       timeout: 10_000,
-    }).trim();
-    uncompressedBytes = Number.parseInt(out, 10) || 0;
+    });
+    if (sizeResult.status === 0) {
+      uncompressedBytes = Number.parseInt(sizeResult.stdout.trim(), 10) || 0;
+    }
   } catch {
     // Non-critical — just won't show uncompressed size
   }
@@ -80,7 +95,8 @@ export function backup(cwd?: string): BackupResult {
 
 /**
  * Restore DB from a snapshot file.
- * Drops the existing DB, creates fresh, restores, then runs migrations.
+ * Drops the existing DB, creates fresh, restores via psql stdin.
+ * Decompression uses node:zlib — no gunzip binary needed.
  */
 export function restore(snapshotFile?: string, cwd?: string): void {
   const port = getActivePort();
@@ -91,33 +107,54 @@ export function restore(snapshotFile?: string, cwd?: string): void {
   }
 
   const env = pgEnv(port);
-
-  // Drop and recreate the database
-  // Connect to 'postgres' DB to drop/create genie
   const adminEnv = { ...env, PGDATABASE: 'postgres' };
 
   // Terminate existing connections
-  execSync(
-    `psql -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${DB_NAME}' AND pid <> pg_backend_pid()"`,
-    { env: adminEnv, stdio: ['pipe', 'pipe', 'pipe'], timeout: 10_000 },
+  spawnSync(
+    'psql',
+    [
+      '-c',
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${DB_NAME}' AND pid <> pg_backend_pid()`,
+    ],
+    {
+      env: adminEnv,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 10_000,
+    },
   );
 
-  execSync(`psql -c "DROP DATABASE IF EXISTS ${DB_NAME}"`, {
+  // Drop and recreate
+  const dropResult = spawnSync('psql', ['-c', `DROP DATABASE IF EXISTS ${DB_NAME}`], {
     env: adminEnv,
     stdio: ['pipe', 'pipe', 'pipe'],
     timeout: 10_000,
   });
+  if (dropResult.status !== 0) {
+    throw new Error(`Failed to drop database: ${dropResult.stderr?.toString().trim()}`);
+  }
 
-  execSync(`psql -c "CREATE DATABASE ${DB_NAME}"`, {
+  const createResult = spawnSync('psql', ['-c', `CREATE DATABASE ${DB_NAME}`], {
     env: adminEnv,
     stdio: ['pipe', 'pipe', 'pipe'],
     timeout: 10_000,
   });
+  if (createResult.status !== 0) {
+    throw new Error(`Failed to create database: ${createResult.stderr?.toString().trim()}`);
+  }
 
-  // Restore from compressed dump
-  execSync(`gunzip -c "${filePath}" | psql`, {
+  // Decompress with node:zlib, feed to psql via stdin
+  const compressed = readFileSync(filePath);
+  const sql = gunzipSync(compressed);
+
+  const restoreResult = spawnSync('psql', [], {
     env: { ...env, PGDATABASE: DB_NAME },
+    input: sql,
     stdio: ['pipe', 'pipe', 'pipe'],
     timeout: 300_000,
+    maxBuffer: 1024 * 1024 * 1024,
   });
+
+  if (restoreResult.status !== 0) {
+    throw new Error(`psql restore failed (exit ${restoreResult.status}): ${restoreResult.stderr?.toString().trim()}`);
+  }
 }

--- a/src/lib/db-backup.ts
+++ b/src/lib/db-backup.ts
@@ -1,0 +1,123 @@
+/**
+ * Database backup & restore — pg_dump/psql wrappers for genie DB snapshots.
+ *
+ * - backup(): pg_dump → gzip → .genie/snapshot.sql.gz
+ * - restore(): gunzip → psql (drop + create + restore + migrate)
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { getActivePort } from './db.js';
+import { resolveRepoPath } from './wish-state.js';
+
+const DB_NAME = 'genie';
+const DB_USER = 'postgres';
+const DB_HOST = '127.0.0.1';
+const SNAPSHOT_FILE = 'snapshot.sql.gz';
+
+/** Resolve the snapshot path inside .genie/ at the repo root. */
+export function getSnapshotPath(cwd?: string): string {
+  const repoRoot = resolveRepoPath(cwd);
+  return join(repoRoot, '.genie', SNAPSHOT_FILE);
+}
+
+function pgEnv(port: number): Record<string, string | undefined> {
+  return {
+    ...process.env,
+    PGHOST: DB_HOST,
+    PGPORT: String(port),
+    PGUSER: DB_USER,
+    PGPASSWORD: DB_USER,
+    PGDATABASE: DB_NAME,
+  };
+}
+
+interface BackupResult {
+  path: string;
+  compressedBytes: number;
+  uncompressedBytes: number;
+}
+
+/**
+ * Run pg_dump → gzip → snapshot.sql.gz.
+ * Replaces the previous snapshot (single file, not accumulating).
+ */
+export function backup(cwd?: string): BackupResult {
+  const port = getActivePort();
+  const snapshotPath = getSnapshotPath(cwd);
+  const genieDir = join(resolveRepoPath(cwd), '.genie');
+
+  mkdirSync(genieDir, { recursive: true });
+
+  // pg_dump piped through gzip — single atomic write
+  execSync(`pg_dump --no-owner --no-acl | gzip > "${snapshotPath}.tmp"`, {
+    env: pgEnv(port),
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 120_000,
+  });
+
+  // Atomic rename
+  execSync(`mv "${snapshotPath}.tmp" "${snapshotPath}"`, { stdio: 'ignore' });
+
+  const compressedBytes = statSync(snapshotPath).size;
+
+  // Get uncompressed size estimate from pg_database_size
+  let uncompressedBytes = 0;
+  try {
+    const out = execSync(`psql -t -A -c "SELECT pg_database_size('${DB_NAME}')"`, {
+      env: pgEnv(port),
+      encoding: 'utf-8',
+      timeout: 10_000,
+    }).trim();
+    uncompressedBytes = Number.parseInt(out, 10) || 0;
+  } catch {
+    // Non-critical — just won't show uncompressed size
+  }
+
+  return { path: snapshotPath, compressedBytes, uncompressedBytes };
+}
+
+/**
+ * Restore DB from a snapshot file.
+ * Drops the existing DB, creates fresh, restores, then runs migrations.
+ */
+export function restore(snapshotFile?: string, cwd?: string): void {
+  const port = getActivePort();
+  const filePath = snapshotFile ?? getSnapshotPath(cwd);
+
+  if (!existsSync(filePath)) {
+    throw new Error(`Snapshot not found: ${filePath}`);
+  }
+
+  const env = pgEnv(port);
+
+  // Drop and recreate the database
+  // Connect to 'postgres' DB to drop/create genie
+  const adminEnv = { ...env, PGDATABASE: 'postgres' };
+
+  // Terminate existing connections
+  execSync(
+    `psql -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${DB_NAME}' AND pid <> pg_backend_pid()"`,
+    { env: adminEnv, stdio: ['pipe', 'pipe', 'pipe'], timeout: 10_000 },
+  );
+
+  execSync(`psql -c "DROP DATABASE IF EXISTS ${DB_NAME}"`, {
+    env: adminEnv,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 10_000,
+  });
+
+  execSync(`psql -c "CREATE DATABASE ${DB_NAME}"`, {
+    env: adminEnv,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 10_000,
+  });
+
+  // Restore from compressed dump
+  execSync(`gunzip -c "${filePath}" | psql`, {
+    env: { ...env, PGDATABASE: DB_NAME },
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 300_000,
+  });
+}

--- a/src/term-commands/db.ts
+++ b/src/term-commands/db.ts
@@ -7,7 +7,9 @@
  *   genie db query   — execute arbitrary SQL, print results as table
  */
 
+import { createInterface } from 'node:readline';
 import type { Command } from 'commander';
+import { backup, getSnapshotPath, restore } from '../lib/db-backup.js';
 import { getMigrationStatus, runMigrations } from '../lib/db-migrations.js';
 import { getActivePort, getConnection, getDataDir, isAvailable, shutdown } from '../lib/db.js';
 import { padRight } from '../lib/term-format.js';
@@ -160,6 +162,85 @@ async function dbQueryCommand(query: string): Promise<void> {
   }
 }
 
+/**
+ * Format bytes as human-readable string (e.g. 52.3MB).
+ */
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0B';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / 1024 ** i;
+  return `${value < 10 ? value.toFixed(1) : Math.round(value)}${units[i]}`;
+}
+
+/**
+ * `genie db backup` — pg_dump → .genie/snapshot.sql.gz
+ */
+async function dbBackupCommand(): Promise<void> {
+  const available = await isAvailable();
+  if (!available) {
+    console.error('Database is not running. Start it with: genie db status');
+    process.exit(1);
+  }
+
+  try {
+    const result = backup();
+    const compressed = formatBytes(result.compressedBytes);
+    const uncompressed = result.uncompressedBytes > 0 ? `, ${formatBytes(result.uncompressedBytes)} uncompressed` : '';
+    console.log(`✓ Backup created: ${result.path} (${compressed}${uncompressed})`);
+    await shutdown();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`Backup failed: ${message}`);
+    process.exit(1);
+  }
+}
+
+/**
+ * Prompt for confirmation on stdin. Returns true if user types y/yes.
+ */
+function confirm(prompt: string): Promise<boolean> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(prompt, (answer) => {
+      rl.close();
+      resolve(/^y(es)?$/i.test(answer.trim()));
+    });
+  });
+}
+
+/**
+ * `genie db restore [file]` — rebuild DB from snapshot.
+ */
+async function dbRestoreCommand(file: string | undefined, options: { yes?: boolean }): Promise<void> {
+  const snapshotPath = file ?? getSnapshotPath();
+
+  const available = await isAvailable();
+  if (!available) {
+    console.error('Database is not running. Start it with: genie db status');
+    process.exit(1);
+  }
+
+  if (!options.yes) {
+    const ok = await confirm('This will replace all data in the genie database. Continue? [y/N] ');
+    if (!ok) {
+      console.log('Restore cancelled.');
+      return;
+    }
+  }
+
+  try {
+    // Close our connection pool before dropping the DB
+    await shutdown();
+    restore(file);
+    console.log(`✓ Database restored from: ${snapshotPath}`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`Restore failed: ${message}`);
+    process.exit(1);
+  }
+}
+
 // ============================================================================
 // Registration
 // ============================================================================
@@ -185,4 +266,11 @@ export function registerDbCommands(program: Command): void {
         console.log(url);
       }
     });
+
+  db.command('backup').description('Dump database to .genie/snapshot.sql.gz').action(dbBackupCommand);
+
+  db.command('restore [file]')
+    .description('Restore database from snapshot (default: .genie/snapshot.sql.gz)')
+    .option('-y, --yes', 'Skip confirmation prompt')
+    .action(dbRestoreCommand);
 }


### PR DESCRIPTION
## Summary
- Adds `genie db backup` — dumps PG database to `.genie/snapshot.sql.gz` via pg_dump + gzip
- Adds `genie db restore [file]` — rebuilds DB from snapshot (drop → create → restore), with confirmation prompt (`-y` to skip)
- Core logic in `src/lib/db-backup.ts`, CLI wiring in `src/term-commands/db.ts`

Implements Wave 1 of wish `genie-db-backup`.

## Test plan
- [ ] Run `genie db backup` — verify `.genie/snapshot.sql.gz` is created with correct size output
- [ ] Run `genie db restore` — verify DB is rebuilt from snapshot, confirm prompt works
- [ ] Run `genie db restore -y` — verify prompt is skipped
- [ ] Run `genie db restore /path/to/custom.sql.gz` — verify custom file path works
- [ ] Run `bun run check` — all gates pass (typecheck, lint, dead-code, 1575 tests)