### PR TITLE
fix(team): resolve tmux session from repo owner, not caller

### DIFF
--- a/src/lib/agent-directory.ts
+++ b/src/lib/agent-directory.ts
@@ -168,6 +168,30 @@ export async function resolve(name: string): Promise<ResolvedAgent | null> {
 }
 
 /**
+ * Find the tmux session name for the agent that owns a given repo path.
+ * Queries PG agents table for an active agent whose repo_path matches.
+ * Returns null if no match or PG is unavailable.
+ */
+export async function findSessionByRepo(repoPath: string): Promise<string | null> {
+  try {
+    const { getConnection } = await import('./db.js');
+    const sql = await getConnection();
+    const rows = await sql`
+      SELECT session FROM agents
+      WHERE repo_path = ${repoPath}
+        AND session IS NOT NULL
+        AND session != ''
+        AND state IN ('working', 'idle', 'permission', 'question')
+      ORDER BY started_at DESC
+      LIMIT 1
+    `;
+    return rows.length > 0 ? (rows[0].session as string) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * List agents from all scopes with scope labels.
  * Returns PG-derived entries + built-in entries.
  */

--- a/src/term-commands/team.ts
+++ b/src/term-commands/team.ts
@@ -250,11 +250,12 @@ async function spawnLeaderWithWish(
   sessionOverride?: string,
 ): Promise<void> {
   const { handleWorkerSpawn } = await import('./agents.js');
-  const { getCurrentSessionName } = await import('../lib/tmux.js');
+  const { findSessionByRepo } = await import('../lib/agent-directory.js');
   const resolvedRepo = resolve(repoPath);
 
   // Resolve tmux session BEFORE spawning — prevents parallel creates from each creating a new session
-  const tmuxSession = sessionOverride ?? (await getCurrentSessionName(config.name)) ?? config.name;
+  // Resolution: 1) explicit --session, 2) repo owner agent's session, 3) team name as new session
+  const tmuxSession = sessionOverride ?? (await findSessionByRepo(resolvedRepo)) ?? config.name;
   config.tmuxSessionName = tmuxSession;
   await teamManager.updateTeamConfig(config.name, config);
 


### PR DESCRIPTION
## Summary

- `spawnLeaderWithWish()` used `getCurrentSessionName()` which returned the **caller's** tmux session via `$TMUX` env. When vegapunk (in sofia's session) created a team for the genie repo, the team window landed in sofia's session instead of genie's.
- Added `findSessionByRepo()` to `agent-directory.ts` — queries PG agents table for an active agent whose `repo_path` matches the target repo, returns its tmux session name.
- Updated session resolution chain: `--session` flag → repo owner lookup → team name as new session.

## Test plan

- [ ] `genie team create foo --repo /path/to/genie` spawns window in genie's session, not caller's
- [ ] `genie team create --session explicit` still uses the explicit override
- [ ] Teams for repos without a directory agent get their own session (fallback)
- [ ] `bun run check` passes (1575 tests, typecheck, lint, dead-code)