### PR TITLE
feat(agent-sync): auto-discover and register agents from workspace

### DIFF
--- a/src/db/migrations/015_agent_archived_state.sql
+++ b/src/db/migrations/015_agent_archived_state.sql
@@ -1,0 +1,60 @@
+-- 015_agent_archived_state.sql — Add 'archived' to agent state enum
+--
+-- Archived agents keep their statistics and history intact but don't show up
+-- in active listings. The pattern is reusable for other entities (tasks,
+-- projects, teams, boards) in future migrations.
+--
+-- Also adds 'archived' to the app_store approval_status enum so directory
+-- entries can be archived without deletion.
+
+-- ============================================================================
+-- Agents table: add 'archived' to state CHECK constraint
+-- ============================================================================
+
+-- Drop the existing CHECK constraint on state (named or inline)
+DO $$
+BEGIN
+  -- Try dropping by known constraint name patterns
+  EXECUTE (
+    SELECT string_agg('ALTER TABLE agents DROP CONSTRAINT ' || quote_ident(conname), '; ')
+    FROM pg_constraint
+    WHERE conrelid = 'agents'::regclass
+      AND contype = 'c'
+      AND pg_get_constraintdef(oid) LIKE '%state%'
+  );
+EXCEPTION WHEN OTHERS THEN
+  NULL; -- constraint may not exist or already dropped
+END $$;
+
+-- Re-add CHECK with 'archived' included
+ALTER TABLE agents ADD CONSTRAINT agents_state_check
+  CHECK (state IS NULL OR state IN (
+    'spawning', 'working', 'idle', 'permission', 'question',
+    'done', 'error', 'suspended', 'archived'
+  ));
+
+-- ============================================================================
+-- App store: add 'archived' to approval_status CHECK constraint
+-- ============================================================================
+
+DO $$
+BEGIN
+  EXECUTE (
+    SELECT string_agg('ALTER TABLE app_store DROP CONSTRAINT ' || quote_ident(conname), '; ')
+    FROM pg_constraint
+    WHERE conrelid = 'app_store'::regclass
+      AND contype = 'c'
+      AND pg_get_constraintdef(oid) LIKE '%approval_status%'
+  );
+EXCEPTION WHEN OTHERS THEN
+  NULL;
+END $$;
+
+ALTER TABLE app_store ADD CONSTRAINT app_store_approval_status_check
+  CHECK (approval_status IN ('local', 'pending', 'approved', 'rejected', 'archived'));
+
+-- ============================================================================
+-- Index: fast lookup for non-archived agents in directory listings
+-- ============================================================================
+CREATE INDEX IF NOT EXISTS idx_agents_not_archived
+  ON agents(state) WHERE state != 'archived';

--- a/src/lib/agent-directory.ts
+++ b/src/lib/agent-directory.ts
@@ -35,7 +35,7 @@ export interface DirectoryEntry {
   registeredAt: string;
 }
 
-export type DirectoryScope = 'project' | 'global' | 'built-in';
+export type DirectoryScope = 'project' | 'global' | 'built-in' | 'archived';
 
 export interface ScopedDirectoryEntry extends DirectoryEntry {
   scope: DirectoryScope;

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -5,6 +5,12 @@
  * For each found agent, reads the git remote to derive repo_path, then registers or
  * updates the entry in the app_store.
  *
+ * Handles lifecycle:
+ *   - New agent dir → register in app_store + agents table
+ *   - Existing agent with stale data → update
+ *   - Archived agent reappearing → reactivate with full backfill
+ *   - Missing agent dir → archive (never delete — preserves history)
+ *
  * Used by:
  *   - `genie serve` (startup sync + file watcher)
  *   - `genie init` (post-scan registration)
@@ -14,7 +20,13 @@
 import { execSync } from 'node:child_process';
 import { existsSync, watch as fsWatch, readdirSync, realpathSync } from 'node:fs';
 import { join } from 'node:path';
-import { getItemFromStore, regenerateAgentCache, registerItemInStore, updateItemInStore } from './agent-cache.js';
+import {
+  getItemFromStore,
+  listItemsFromStore,
+  regenerateAgentCache,
+  registerItemInStore,
+  updateItemInStore,
+} from './agent-cache.js';
 
 // ============================================================================
 // Types
@@ -24,6 +36,8 @@ interface SyncResult {
   registered: string[];
   updated: string[];
   unchanged: string[];
+  archived: string[];
+  reactivated: string[];
   errors: Array<{ name: string; error: string }>;
 }
 
@@ -38,10 +52,7 @@ interface AgentInfo {
 // Git helpers
 // ============================================================================
 
-/**
- * Read the git remote origin URL for a directory.
- * Returns null if the directory is not a git repo or has no remote.
- */
+/** Read the git remote origin URL for a directory. */
 function getGitRemoteUrl(dir: string): string | null {
   try {
     const url = execSync(`git -C "${dir}" config --get remote.origin.url`, {
@@ -54,23 +65,14 @@ function getGitRemoteUrl(dir: string): string | null {
   }
 }
 
-/**
- * Extract org/repo from a git remote URL.
- * Handles HTTPS (github.com/org/repo.git) and SSH (git@github.com:org/repo.git) formats.
- */
+/** Extract org/repo from a git remote URL (HTTPS or SSH). */
 function extractOrgRepo(remoteUrl: string): string | null {
-  // SSH: git@github.com:org/repo.git
   const sshMatch = remoteUrl.match(/[^/:]+\/[^/]+?(?:\.git)?$/);
-  if (sshMatch) {
-    return sshMatch[0].replace(/\.git$/, '');
-  }
+  if (sshMatch) return sshMatch[0].replace(/\.git$/, '');
   return null;
 }
 
-/**
- * Resolve the product repo path for an agent.
- * If {agentDir}/repos is a symlink, resolve it and detect its git remote.
- */
+/** Resolve the product repo path from {agentDir}/repos symlink. */
 function getRepoPathForAgent(agentDir: string): string | null {
   const reposLink = join(agentDir, 'repos');
   try {
@@ -98,8 +100,7 @@ function discoverAgents(workspaceRoot: string): AgentInfo[] {
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
       const agentDir = join(agentsDir, entry.name);
-      const marker = join(agentDir, 'AGENTS.md');
-      if (!existsSync(marker)) continue;
+      if (!existsSync(join(agentDir, 'AGENTS.md'))) continue;
 
       agents.push({
         name: entry.name,
@@ -117,8 +118,7 @@ function discoverAgents(workspaceRoot: string): AgentInfo[] {
 /** Discover a single agent by name. */
 function discoverSingleAgent(workspaceRoot: string, agentName: string): AgentInfo | null {
   const agentDir = join(workspaceRoot, 'agents', agentName);
-  const marker = join(agentDir, 'AGENTS.md');
-  if (!existsSync(marker)) return null;
+  if (!existsSync(join(agentDir, 'AGENTS.md'))) return null;
 
   return {
     name: agentName,
@@ -129,6 +129,98 @@ function discoverSingleAgent(workspaceRoot: string, agentName: string): AgentInf
 }
 
 // ============================================================================
+// Archive / Reactivation helpers
+// ============================================================================
+
+/** Archive an agent in both agents table and app_store. Never deletes rows. */
+async function archiveAgent(name: string): Promise<boolean> {
+  let archived = false;
+  try {
+    const { getConnection } = await import('./db.js');
+    const sql = await getConnection();
+    // Archive in agents table (set state='archived')
+    const result = await sql`
+      UPDATE agents SET state = 'archived', updated_at = now()
+      WHERE (custom_name = ${name} OR role = ${name})
+        AND (state IS NULL OR state != 'archived')
+    `;
+    if (result.count > 0) archived = true;
+  } catch {
+    // DB may not be available
+  }
+
+  // Archive in app_store (set approval_status='archived')
+  try {
+    const existing = await getItemFromStore(name).catch(() => null);
+    if (existing && existing.approval_status !== 'archived') {
+      await updateItemInStore(name, {
+        manifest: {
+          ...(existing.manifest as Record<string, unknown>),
+          archived: true,
+          archivedAt: new Date().toISOString(),
+        },
+      });
+      archived = true;
+    }
+  } catch {
+    // Best-effort
+  }
+
+  return archived;
+}
+
+/** Reactivate an archived agent with full backfill. */
+async function reactivateAgent(agent: AgentInfo): Promise<void> {
+  const orgRepo = agent.repoUrl ? extractOrgRepo(agent.repoUrl) : null;
+  const repoPath = orgRepo ?? agent.repoUrl ?? agent.dir;
+
+  // Update app_store entry — clear archived flag, refresh paths
+  const existing = await getItemFromStore(agent.name).catch(() => null);
+  if (existing) {
+    const manifest = { ...(existing.manifest as Record<string, unknown>) };
+    manifest.archived = undefined;
+    manifest.archivedAt = undefined;
+    manifest.repo = repoPath;
+    manifest.productRepo = agent.productRepo;
+    manifest.source = 'auto-sync';
+    await updateItemInStore(agent.name, {
+      installPath: agent.dir,
+      gitUrl: agent.repoUrl ?? undefined,
+      manifest,
+    });
+  }
+
+  // Reactivate in agents table
+  try {
+    const { getConnection } = await import('./db.js');
+    const sql = await getConnection();
+    await sql`
+      UPDATE agents SET state = 'idle', repo_path = ${repoPath}, updated_at = now()
+      WHERE (custom_name = ${agent.name} OR role = ${agent.name})
+        AND state = 'archived'
+    `;
+  } catch {
+    // DB may not be available
+  }
+
+  // Trigger session backfill for conversation history recovery
+  await triggerSessionBackfill(agent).catch(() => {});
+}
+
+/** Trigger session backfill for a reactivated agent. */
+async function triggerSessionBackfill(_agent: AgentInfo): Promise<void> {
+  try {
+    const { getConnection, isAvailable } = await import('./db.js');
+    if (!(await isAvailable())) return;
+    const sql = await getConnection();
+    const { startBackfill } = await import('./session-backfill.js');
+    await startBackfill(sql);
+  } catch {
+    // Best-effort — backfill may not be ready
+  }
+}
+
+// ============================================================================
 // Sync
 // ============================================================================
 
@@ -136,13 +228,15 @@ function discoverSingleAgent(workspaceRoot: string, agentName: string): AgentInf
  * Sync all agents from {workspaceRoot}/agents/ into the directory.
  * - New agents → registered
  * - Existing agents with stale repo_path → updated
- * - Existing agents with correct data → unchanged
+ * - Archived agents reappearing → reactivated with backfill
+ * - Agents in store whose dirs are gone → archived
  *
  * Idempotent — safe to run repeatedly.
  */
 export async function syncAgentDirectory(workspaceRoot: string): Promise<SyncResult> {
-  const result: SyncResult = { registered: [], updated: [], unchanged: [], errors: [] };
+  const result: SyncResult = { registered: [], updated: [], unchanged: [], archived: [], reactivated: [], errors: [] };
   const agents = discoverAgents(workspaceRoot);
+  const discoveredNames = new Set(agents.map((a) => a.name));
 
   for (const agent of agents) {
     try {
@@ -155,32 +249,59 @@ export async function syncAgentDirectory(workspaceRoot: string): Promise<SyncRes
     }
   }
 
-  // Regenerate cache after all mutations
-  if (result.registered.length > 0 || result.updated.length > 0) {
+  // Archive agents in store whose dirs no longer exist
+  await archiveMissingAgents(workspaceRoot, discoveredNames, result);
+
+  // Regenerate cache after mutations
+  const hasMutations =
+    result.registered.length + result.updated.length + result.archived.length + result.reactivated.length;
+  if (hasMutations > 0) {
     await regenerateAgentCache().catch(() => {});
   }
 
   return result;
 }
 
-/**
- * Sync a single agent by name from the workspace.
- * Used by the file watcher for targeted registration.
- */
-async function syncSingleAgentByName(
+/** Archive app_store agents whose directories no longer exist on disk. */
+async function archiveMissingAgents(
   workspaceRoot: string,
-  agentName: string,
-): Promise<'registered' | 'updated' | 'unchanged' | 'not-found'> {
+  discoveredNames: Set<string>,
+  result: SyncResult,
+): Promise<void> {
+  try {
+    const storeItems = await listItemsFromStore('agent');
+    const agentsDir = join(workspaceRoot, 'agents');
+
+    for (const item of storeItems) {
+      if (discoveredNames.has(item.name)) continue;
+      const manifest = (item.manifest ?? {}) as Record<string, unknown>;
+      if (manifest.archived) continue; // already archived
+      if (manifest.source !== 'auto-sync') continue; // only archive auto-synced agents
+
+      // Verify the agent was from this workspace
+      if (item.install_path && !item.install_path.startsWith(agentsDir)) continue;
+
+      const archived = await archiveAgent(item.name);
+      if (archived) result.archived.push(item.name);
+    }
+  } catch {
+    // Best-effort — don't block sync on archive failures
+  }
+}
+
+/** Sync a single agent by name from the workspace (used by file watcher). */
+async function syncSingleAgentByName(workspaceRoot: string, agentName: string): Promise<string> {
   const agent = discoverSingleAgent(workspaceRoot, agentName);
   if (!agent) return 'not-found';
 
-  const result: SyncResult = { registered: [], updated: [], unchanged: [], errors: [] };
+  const result: SyncResult = { registered: [], updated: [], unchanged: [], archived: [], reactivated: [], errors: [] };
   await syncSingleAgent(agent, result);
 
-  if (result.registered.length > 0 || result.updated.length > 0) {
+  if (result.registered.length > 0 || result.updated.length > 0 || result.reactivated.length > 0) {
     await regenerateAgentCache().catch(() => {});
   }
 
+  if (result.reactivated.length > 0) return 'reactivated';
   if (result.registered.length > 0) return 'registered';
   if (result.updated.length > 0) return 'updated';
   return 'unchanged';
@@ -194,42 +315,36 @@ async function syncSingleAgent(agent: AgentInfo, result: SyncResult): Promise<vo
   const existing = await getItemFromStore(agent.name).catch(() => null);
 
   if (!existing) {
-    // Register new agent
     await registerItemInStore({
       name: agent.name,
       itemType: 'agent',
       installPath: agent.dir,
       gitUrl: agent.repoUrl ?? undefined,
-      manifest: {
-        promptMode: 'append',
-        repo: repoPath,
-        productRepo: agent.productRepo,
-        source: 'auto-sync',
-      },
+      manifest: { promptMode: 'append', repo: repoPath, productRepo: agent.productRepo, source: 'auto-sync' },
     });
     result.registered.push(agent.name);
     return;
   }
 
-  // Check if update needed
+  // Check if this is a reactivation (was archived)
   const manifest = (existing.manifest ?? {}) as Record<string, unknown>;
-  const currentRepo = manifest.repo as string | undefined;
-  const currentInstallPath = existing.install_path;
+  if (manifest.archived) {
+    await reactivateAgent(agent);
+    result.reactivated.push(agent.name);
+    return;
+  }
+
+  // Check if update needed
   const needsUpdate =
-    currentRepo !== repoPath ||
-    currentInstallPath !== agent.dir ||
+    (manifest.repo as string) !== repoPath ||
+    existing.install_path !== agent.dir ||
     (agent.productRepo && manifest.productRepo !== agent.productRepo);
 
   if (needsUpdate) {
     await updateItemInStore(agent.name, {
       installPath: agent.dir,
       gitUrl: agent.repoUrl ?? undefined,
-      manifest: {
-        ...manifest,
-        repo: repoPath,
-        productRepo: agent.productRepo,
-        source: 'auto-sync',
-      },
+      manifest: { ...manifest, repo: repoPath, productRepo: agent.productRepo, source: 'auto-sync' },
     });
     result.updated.push(agent.name);
   } else {
@@ -245,19 +360,18 @@ interface AgentWatcher {
   close: () => void;
 }
 
-/** Process a single watched agent change — register, update, or remove. */
+/** Process a single watched agent change — register, update, archive, or reactivate. */
 async function processWatchedAgent(workspaceRoot: string, agentsDir: string, name: string): Promise<string | null> {
   const agentDir = join(agentsDir, name);
   if (existsSync(agentDir) && existsSync(join(agentDir, 'AGENTS.md'))) {
     const action = await syncSingleAgentByName(workspaceRoot, name);
-    return action === 'registered' || action === 'updated' ? action : null;
+    return action !== 'unchanged' && action !== 'not-found' ? action : null;
   }
   if (!existsSync(agentDir)) {
-    const { removeItemFromStore } = await import('./agent-cache.js');
-    const removed = await removeItemFromStore(name).catch(() => false);
-    if (removed) {
+    const archived = await archiveAgent(name);
+    if (archived) {
       await regenerateAgentCache().catch(() => {});
-      return 'removed';
+      return 'archived';
     }
   }
   return null;
@@ -268,7 +382,8 @@ async function processWatchedAgent(workspaceRoot: string, agentsDir: string, nam
  * Debounces changes with a 2s window.
  *
  * - New directory with AGENTS.md → auto-register
- * - Removed directory → mark inactive (remove from store)
+ * - Archived agent reappearing → reactivate with backfill
+ * - Removed directory → archive (never delete)
  */
 export function watchAgentDirectory(
   workspaceRoot: string,

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -1,0 +1,313 @@
+/**
+ * Agent Sync — Auto-discover and register agents from workspace agents/ directory.
+ *
+ * Scans {workspace}/agents/ for directories containing AGENTS.md (the discovery marker).
+ * For each found agent, reads the git remote to derive repo_path, then registers or
+ * updates the entry in the app_store.
+ *
+ * Used by:
+ *   - `genie serve` (startup sync + file watcher)
+ *   - `genie init` (post-scan registration)
+ *   - `genie dir sync` (manual trigger)
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync, watch as fsWatch, readdirSync, realpathSync } from 'node:fs';
+import { join } from 'node:path';
+import { getItemFromStore, regenerateAgentCache, registerItemInStore, updateItemInStore } from './agent-cache.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface SyncResult {
+  registered: string[];
+  updated: string[];
+  unchanged: string[];
+  errors: Array<{ name: string; error: string }>;
+}
+
+interface AgentInfo {
+  name: string;
+  dir: string;
+  repoUrl: string | null;
+  productRepo: string | null;
+}
+
+// ============================================================================
+// Git helpers
+// ============================================================================
+
+/**
+ * Read the git remote origin URL for a directory.
+ * Returns null if the directory is not a git repo or has no remote.
+ */
+function getGitRemoteUrl(dir: string): string | null {
+  try {
+    const url = execSync(`git -C "${dir}" config --get remote.origin.url`, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    return url || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract org/repo from a git remote URL.
+ * Handles HTTPS (github.com/org/repo.git) and SSH (git@github.com:org/repo.git) formats.
+ */
+function extractOrgRepo(remoteUrl: string): string | null {
+  // SSH: git@github.com:org/repo.git
+  const sshMatch = remoteUrl.match(/[^/:]+\/[^/]+?(?:\.git)?$/);
+  if (sshMatch) {
+    return sshMatch[0].replace(/\.git$/, '');
+  }
+  return null;
+}
+
+/**
+ * Resolve the product repo path for an agent.
+ * If {agentDir}/repos is a symlink, resolve it and detect its git remote.
+ */
+function getRepoPathForAgent(agentDir: string): string | null {
+  const reposLink = join(agentDir, 'repos');
+  try {
+    if (!existsSync(reposLink)) return null;
+    const target = realpathSync(reposLink);
+    if (!existsSync(target)) return null;
+    return target;
+  } catch {
+    return null;
+  }
+}
+
+// ============================================================================
+// Discovery
+// ============================================================================
+
+/** Discover all agents in {workspaceRoot}/agents/ that have AGENTS.md. */
+function discoverAgents(workspaceRoot: string): AgentInfo[] {
+  const agentsDir = join(workspaceRoot, 'agents');
+  if (!existsSync(agentsDir)) return [];
+
+  const agents: AgentInfo[] = [];
+  try {
+    const entries = readdirSync(agentsDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const agentDir = join(agentsDir, entry.name);
+      const marker = join(agentDir, 'AGENTS.md');
+      if (!existsSync(marker)) continue;
+
+      agents.push({
+        name: entry.name,
+        dir: agentDir,
+        repoUrl: getGitRemoteUrl(agentDir),
+        productRepo: getRepoPathForAgent(agentDir),
+      });
+    }
+  } catch {
+    // agents/ dir may not be readable
+  }
+  return agents;
+}
+
+/** Discover a single agent by name. */
+function discoverSingleAgent(workspaceRoot: string, agentName: string): AgentInfo | null {
+  const agentDir = join(workspaceRoot, 'agents', agentName);
+  const marker = join(agentDir, 'AGENTS.md');
+  if (!existsSync(marker)) return null;
+
+  return {
+    name: agentName,
+    dir: agentDir,
+    repoUrl: getGitRemoteUrl(agentDir),
+    productRepo: getRepoPathForAgent(agentDir),
+  };
+}
+
+// ============================================================================
+// Sync
+// ============================================================================
+
+/**
+ * Sync all agents from {workspaceRoot}/agents/ into the directory.
+ * - New agents → registered
+ * - Existing agents with stale repo_path → updated
+ * - Existing agents with correct data → unchanged
+ *
+ * Idempotent — safe to run repeatedly.
+ */
+export async function syncAgentDirectory(workspaceRoot: string): Promise<SyncResult> {
+  const result: SyncResult = { registered: [], updated: [], unchanged: [], errors: [] };
+  const agents = discoverAgents(workspaceRoot);
+
+  for (const agent of agents) {
+    try {
+      await syncSingleAgent(agent, result);
+    } catch (err) {
+      result.errors.push({
+        name: agent.name,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  // Regenerate cache after all mutations
+  if (result.registered.length > 0 || result.updated.length > 0) {
+    await regenerateAgentCache().catch(() => {});
+  }
+
+  return result;
+}
+
+/**
+ * Sync a single agent by name from the workspace.
+ * Used by the file watcher for targeted registration.
+ */
+async function syncSingleAgentByName(
+  workspaceRoot: string,
+  agentName: string,
+): Promise<'registered' | 'updated' | 'unchanged' | 'not-found'> {
+  const agent = discoverSingleAgent(workspaceRoot, agentName);
+  if (!agent) return 'not-found';
+
+  const result: SyncResult = { registered: [], updated: [], unchanged: [], errors: [] };
+  await syncSingleAgent(agent, result);
+
+  if (result.registered.length > 0 || result.updated.length > 0) {
+    await regenerateAgentCache().catch(() => {});
+  }
+
+  if (result.registered.length > 0) return 'registered';
+  if (result.updated.length > 0) return 'updated';
+  return 'unchanged';
+}
+
+/** Core sync logic for a single agent. */
+async function syncSingleAgent(agent: AgentInfo, result: SyncResult): Promise<void> {
+  const orgRepo = agent.repoUrl ? extractOrgRepo(agent.repoUrl) : null;
+  const repoPath = orgRepo ?? agent.repoUrl ?? agent.dir;
+
+  const existing = await getItemFromStore(agent.name).catch(() => null);
+
+  if (!existing) {
+    // Register new agent
+    await registerItemInStore({
+      name: agent.name,
+      itemType: 'agent',
+      installPath: agent.dir,
+      gitUrl: agent.repoUrl ?? undefined,
+      manifest: {
+        promptMode: 'append',
+        repo: repoPath,
+        productRepo: agent.productRepo,
+        source: 'auto-sync',
+      },
+    });
+    result.registered.push(agent.name);
+    return;
+  }
+
+  // Check if update needed
+  const manifest = (existing.manifest ?? {}) as Record<string, unknown>;
+  const currentRepo = manifest.repo as string | undefined;
+  const currentInstallPath = existing.install_path;
+  const needsUpdate =
+    currentRepo !== repoPath ||
+    currentInstallPath !== agent.dir ||
+    (agent.productRepo && manifest.productRepo !== agent.productRepo);
+
+  if (needsUpdate) {
+    await updateItemInStore(agent.name, {
+      installPath: agent.dir,
+      gitUrl: agent.repoUrl ?? undefined,
+      manifest: {
+        ...manifest,
+        repo: repoPath,
+        productRepo: agent.productRepo,
+        source: 'auto-sync',
+      },
+    });
+    result.updated.push(agent.name);
+  } else {
+    result.unchanged.push(agent.name);
+  }
+}
+
+// ============================================================================
+// Watcher (used by serve.ts)
+// ============================================================================
+
+interface AgentWatcher {
+  close: () => void;
+}
+
+/** Process a single watched agent change — register, update, or remove. */
+async function processWatchedAgent(workspaceRoot: string, agentsDir: string, name: string): Promise<string | null> {
+  const agentDir = join(agentsDir, name);
+  if (existsSync(agentDir) && existsSync(join(agentDir, 'AGENTS.md'))) {
+    const action = await syncSingleAgentByName(workspaceRoot, name);
+    return action === 'registered' || action === 'updated' ? action : null;
+  }
+  if (!existsSync(agentDir)) {
+    const { removeItemFromStore } = await import('./agent-cache.js');
+    const removed = await removeItemFromStore(name).catch(() => false);
+    if (removed) {
+      await regenerateAgentCache().catch(() => {});
+      return 'removed';
+    }
+  }
+  return null;
+}
+
+/**
+ * Watch {workspaceRoot}/agents/ for new/removed agent directories.
+ * Debounces changes with a 2s window.
+ *
+ * - New directory with AGENTS.md → auto-register
+ * - Removed directory → mark inactive (remove from store)
+ */
+export function watchAgentDirectory(
+  workspaceRoot: string,
+  options?: { onSync?: (name: string, action: string) => void },
+): AgentWatcher | null {
+  const agentsDir = join(workspaceRoot, 'agents');
+  if (!existsSync(agentsDir)) return null;
+
+  let debounceTimer: Timer | null = null;
+  const pendingChanges = new Set<string>();
+
+  const processChanges = async () => {
+    const names = [...pendingChanges];
+    pendingChanges.clear();
+
+    for (const name of names) {
+      try {
+        const action = await processWatchedAgent(workspaceRoot, agentsDir, name);
+        if (action) options?.onSync?.(name, action);
+      } catch {
+        // Best-effort — don't crash the watcher
+      }
+    }
+  };
+
+  const watcher = fsWatch(agentsDir, { persistent: false }, (_event, filename) => {
+    if (!filename) return;
+    const name = filename.split('/')[0];
+    if (!name || name.startsWith('.')) return;
+
+    pendingChanges.add(name);
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(processChanges, 2000);
+  });
+
+  return {
+    close: () => {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      watcher.close();
+    },
+  };
+}

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -262,6 +262,20 @@ export async function syncAgentDirectory(workspaceRoot: string): Promise<SyncRes
   return result;
 }
 
+/** Print sync result summary to console. Shared by dir sync and agent dir sync. */
+export function printSyncResult(result: SyncResult): void {
+  if (result.registered.length > 0) console.log(`  Registered: ${result.registered.join(', ')}`);
+  if (result.updated.length > 0) console.log(`  Updated: ${result.updated.join(', ')}`);
+  if (result.reactivated.length > 0) console.log(`  Reactivated: ${result.reactivated.join(', ')}`);
+  if (result.archived.length > 0) console.log(`  Archived: ${result.archived.join(', ')}`);
+  if (result.unchanged.length > 0) console.log(`  Unchanged: ${result.unchanged.join(', ')}`);
+  for (const err of result.errors) {
+    console.error(`  Error (${err.name}): ${err.error}`);
+  }
+  const total = result.registered.length + result.updated.length + result.unchanged.length + result.reactivated.length;
+  console.log(`\nSync complete: ${total} active agent(s), ${result.archived.length} archived.`);
+}
+
 /** Archive app_store agents whose directories no longer exist on disk. */
 async function archiveMissingAgents(
   workspaceRoot: string,

--- a/src/term-commands/agent/directory.ts
+++ b/src/term-commands/agent/directory.ts
@@ -6,7 +6,7 @@
 import type { Command } from 'commander';
 import { type StoreRow, listItemsFromStore, migrateAgentDirectory } from '../../lib/agent-cache.js';
 import * as directory from '../../lib/agent-directory.js';
-import { syncAgentDirectory } from '../../lib/agent-sync.js';
+import { printSyncResult, syncAgentDirectory } from '../../lib/agent-sync.js';
 import { ALL_BUILTINS } from '../../lib/builtin-agents.js';
 import { contractPath } from '../../lib/genie-config.js';
 
@@ -163,7 +163,13 @@ export function registerAgentDirectory(parent: Command): void {
     .action(async (name: string | undefined, options: { json?: boolean; builtins?: boolean; all?: boolean }) => {
       try {
         if (name === 'sync') {
-          await handleSync();
+          // 'sync' is a subcommand — but if an agent named 'sync' exists, show it instead
+          const resolved = await directory.resolve('sync');
+          if (resolved && !resolved.builtin) {
+            await showEntry('sync', options.json);
+          } else {
+            await handleSync();
+          }
         } else if (name) {
           await showEntry(name, options.json);
         } else {
@@ -187,16 +193,5 @@ async function handleSync(): Promise<void> {
 
   console.log(`Syncing agents from ${ws.root}/agents/...`);
   const result = await syncAgentDirectory(ws.root);
-
-  if (result.registered.length > 0) console.log(`  Registered: ${result.registered.join(', ')}`);
-  if (result.updated.length > 0) console.log(`  Updated: ${result.updated.join(', ')}`);
-  if (result.reactivated.length > 0) console.log(`  Reactivated: ${result.reactivated.join(', ')}`);
-  if (result.archived.length > 0) console.log(`  Archived: ${result.archived.join(', ')}`);
-  if (result.unchanged.length > 0) console.log(`  Unchanged: ${result.unchanged.join(', ')}`);
-  for (const err of result.errors) {
-    console.error(`  Error (${err.name}): ${err.error}`);
-  }
-
-  const total = result.registered.length + result.updated.length + result.unchanged.length + result.reactivated.length;
-  console.log(`\nSync complete: ${total} active agent(s), ${result.archived.length} archived.`);
+  printSyncResult(result);
 }

--- a/src/term-commands/agent/directory.ts
+++ b/src/term-commands/agent/directory.ts
@@ -90,25 +90,31 @@ function normalizeRoles(roles?: string[]): string[] | undefined {
     .filter(Boolean);
 }
 
-async function listEntries(json?: boolean, includeBuiltins?: boolean): Promise<void> {
+async function listEntries(json?: boolean, includeBuiltins?: boolean, includeArchived?: boolean): Promise<void> {
   await migrateAgentDirectory().catch(() => {});
 
   let entries: directory.ScopedDirectoryEntry[];
   try {
     const storeItems = await listItemsFromStore('agent');
-    entries = storeItems.map((item: StoreRow) => {
-      const manifest = (item.manifest ?? {}) as Record<string, unknown>;
-      return {
-        name: item.name,
-        dir: (item.install_path as string) ?? '',
-        repo: (manifest.repo as string) ?? '',
-        promptMode: ((manifest.promptMode as string) ?? 'append') as directory.PromptMode,
-        model: manifest.model as string | undefined,
-        roles: normalizeRoles(manifest.roles as string[] | undefined),
-        registeredAt: item.installed_at as string,
-        scope: 'global' as directory.DirectoryScope,
-      };
-    });
+    entries = storeItems
+      .filter((item: StoreRow) => {
+        if (includeArchived) return true;
+        const manifest = (item.manifest ?? {}) as Record<string, unknown>;
+        return !manifest.archived;
+      })
+      .map((item: StoreRow) => {
+        const manifest = (item.manifest ?? {}) as Record<string, unknown>;
+        return {
+          name: item.name,
+          dir: (item.install_path as string) ?? '',
+          repo: (manifest.repo as string) ?? '',
+          promptMode: ((manifest.promptMode as string) ?? 'append') as directory.PromptMode,
+          model: manifest.model as string | undefined,
+          roles: normalizeRoles(manifest.roles as string[] | undefined),
+          registeredAt: item.installed_at as string,
+          scope: (manifest.archived ? 'archived' : 'global') as directory.DirectoryScope,
+        };
+      });
   } catch {
     entries = await directory.ls();
   }
@@ -153,14 +159,15 @@ export function registerAgentDirectory(parent: Command): void {
     .description('List all agents or show single entry details from directory')
     .option('--json', 'Output as JSON')
     .option('--builtins', 'Include built-in roles and council members')
-    .action(async (name: string | undefined, options: { json?: boolean; builtins?: boolean }) => {
+    .option('--all', 'Include archived agents')
+    .action(async (name: string | undefined, options: { json?: boolean; builtins?: boolean; all?: boolean }) => {
       try {
         if (name === 'sync') {
           await handleSync();
         } else if (name) {
           await showEntry(name, options.json);
         } else {
-          await listEntries(options.json, options.builtins);
+          await listEntries(options.json, options.builtins, options.all);
         }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -181,21 +188,15 @@ async function handleSync(): Promise<void> {
   console.log(`Syncing agents from ${ws.root}/agents/...`);
   const result = await syncAgentDirectory(ws.root);
 
-  if (result.registered.length > 0) {
-    console.log(`  Registered: ${result.registered.join(', ')}`);
-  }
-  if (result.updated.length > 0) {
-    console.log(`  Updated: ${result.updated.join(', ')}`);
-  }
-  if (result.unchanged.length > 0) {
-    console.log(`  Unchanged: ${result.unchanged.join(', ')}`);
-  }
-  if (result.errors.length > 0) {
-    for (const err of result.errors) {
-      console.error(`  Error (${err.name}): ${err.error}`);
-    }
+  if (result.registered.length > 0) console.log(`  Registered: ${result.registered.join(', ')}`);
+  if (result.updated.length > 0) console.log(`  Updated: ${result.updated.join(', ')}`);
+  if (result.reactivated.length > 0) console.log(`  Reactivated: ${result.reactivated.join(', ')}`);
+  if (result.archived.length > 0) console.log(`  Archived: ${result.archived.join(', ')}`);
+  if (result.unchanged.length > 0) console.log(`  Unchanged: ${result.unchanged.join(', ')}`);
+  for (const err of result.errors) {
+    console.error(`  Error (${err.name}): ${err.error}`);
   }
 
-  const total = result.registered.length + result.updated.length + result.unchanged.length;
-  console.log(`\nSync complete: ${total} agent(s) found.`);
+  const total = result.registered.length + result.updated.length + result.unchanged.length + result.reactivated.length;
+  console.log(`\nSync complete: ${total} active agent(s), ${result.archived.length} archived.`);
 }

--- a/src/term-commands/agent/directory.ts
+++ b/src/term-commands/agent/directory.ts
@@ -6,6 +6,7 @@
 import type { Command } from 'commander';
 import { type StoreRow, listItemsFromStore, migrateAgentDirectory } from '../../lib/agent-cache.js';
 import * as directory from '../../lib/agent-directory.js';
+import { syncAgentDirectory } from '../../lib/agent-sync.js';
 import { ALL_BUILTINS } from '../../lib/builtin-agents.js';
 import { contractPath } from '../../lib/genie-config.js';
 
@@ -154,7 +155,9 @@ export function registerAgentDirectory(parent: Command): void {
     .option('--builtins', 'Include built-in roles and council members')
     .action(async (name: string | undefined, options: { json?: boolean; builtins?: boolean }) => {
       try {
-        if (name) {
+        if (name === 'sync') {
+          await handleSync();
+        } else if (name) {
           await showEntry(name, options.json);
         } else {
           await listEntries(options.json, options.builtins);
@@ -165,4 +168,34 @@ export function registerAgentDirectory(parent: Command): void {
         process.exit(1);
       }
     });
+}
+
+async function handleSync(): Promise<void> {
+  const { findWorkspace } = await import('../../lib/workspace.js');
+  const ws = findWorkspace();
+  if (!ws) {
+    console.error('Not in a genie workspace. Run `genie init` first.');
+    process.exit(1);
+  }
+
+  console.log(`Syncing agents from ${ws.root}/agents/...`);
+  const result = await syncAgentDirectory(ws.root);
+
+  if (result.registered.length > 0) {
+    console.log(`  Registered: ${result.registered.join(', ')}`);
+  }
+  if (result.updated.length > 0) {
+    console.log(`  Updated: ${result.updated.join(', ')}`);
+  }
+  if (result.unchanged.length > 0) {
+    console.log(`  Unchanged: ${result.unchanged.join(', ')}`);
+  }
+  if (result.errors.length > 0) {
+    for (const err of result.errors) {
+      console.error(`  Error (${err.name}): ${err.error}`);
+    }
+  }
+
+  const total = result.registered.length + result.updated.length + result.unchanged.length;
+  console.log(`\nSync complete: ${total} agent(s) found.`);
 }

--- a/src/term-commands/dir.ts
+++ b/src/term-commands/dir.ts
@@ -29,6 +29,7 @@ import {
   updateItemInStore,
 } from '../lib/agent-cache.js';
 import * as directory from '../lib/agent-directory.js';
+import { syncAgentDirectory } from '../lib/agent-sync.js';
 import { getActor, recordAuditEvent } from '../lib/audit.js';
 import { ALL_BUILTINS } from '../lib/builtin-agents.js';
 import { contractPath } from '../lib/genie-config.js';
@@ -125,6 +126,20 @@ export function registerDirNamespace(program: Command): void {
         process.exit(1);
       }
     });
+
+  // dir sync
+  dir
+    .command('sync')
+    .description('Sync agents from workspace agents/ directory')
+    .action(async () => {
+      try {
+        await handleDirSync();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`Error: ${message}`);
+        process.exit(1);
+      }
+    });
 }
 
 interface DirAddOptions {
@@ -209,6 +224,28 @@ async function handleEdit(name: string, options: EditOptions): Promise<void> {
   const scope = options.global ? 'global' : 'project';
   console.log(`Agent "${name}" updated (${scope}).`);
   printEntry(entry);
+}
+
+async function handleDirSync(): Promise<void> {
+  const { findWorkspace } = await import('../lib/workspace.js');
+  const ws = findWorkspace();
+  if (!ws) {
+    console.error('Not in a genie workspace. Run `genie init` first.');
+    process.exit(1);
+  }
+
+  console.log(`Syncing agents from ${ws.root}/agents/...`);
+  const result = await syncAgentDirectory(ws.root);
+
+  if (result.registered.length > 0) console.log(`  Registered: ${result.registered.join(', ')}`);
+  if (result.updated.length > 0) console.log(`  Updated: ${result.updated.join(', ')}`);
+  if (result.unchanged.length > 0) console.log(`  Unchanged: ${result.unchanged.join(', ')}`);
+  for (const err of result.errors) {
+    console.error(`  Error (${err.name}): ${err.error}`);
+  }
+
+  const total = result.registered.length + result.updated.length + result.unchanged.length;
+  console.log(`\nSync complete: ${total} agent(s) found.`);
 }
 
 // ============================================================================

--- a/src/term-commands/dir.ts
+++ b/src/term-commands/dir.ts
@@ -91,14 +91,13 @@ export function registerDirNamespace(program: Command): void {
     .description('List all agents or show single entry details')
     .option('--json', 'Output as JSON')
     .option('--builtins', 'Include built-in roles and council members')
-    .action(async (name: string | undefined, options: { json?: boolean; builtins?: boolean }) => {
+    .option('--all', 'Include archived agents')
+    .action(async (name: string | undefined, options: { json?: boolean; builtins?: boolean; all?: boolean }) => {
       try {
         if (name) {
-          // Show single entry
           await showEntry(name, options.json);
         } else {
-          // List all
-          await listEntries(options.json, options.builtins);
+          await listEntries(options.json, options.builtins, options.all);
         }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -239,13 +238,15 @@ async function handleDirSync(): Promise<void> {
 
   if (result.registered.length > 0) console.log(`  Registered: ${result.registered.join(', ')}`);
   if (result.updated.length > 0) console.log(`  Updated: ${result.updated.join(', ')}`);
+  if (result.reactivated.length > 0) console.log(`  Reactivated: ${result.reactivated.join(', ')}`);
+  if (result.archived.length > 0) console.log(`  Archived: ${result.archived.join(', ')}`);
   if (result.unchanged.length > 0) console.log(`  Unchanged: ${result.unchanged.join(', ')}`);
   for (const err of result.errors) {
     console.error(`  Error (${err.name}): ${err.error}`);
   }
 
-  const total = result.registered.length + result.updated.length + result.unchanged.length;
-  console.log(`\nSync complete: ${total} agent(s) found.`);
+  const total = result.registered.length + result.updated.length + result.unchanged.length + result.reactivated.length;
+  console.log(`\nSync complete: ${total} active agent(s), ${result.archived.length} archived.`);
 }
 
 // ============================================================================
@@ -290,7 +291,7 @@ async function showEntry(name: string, json?: boolean): Promise<void> {
   console.log('');
 }
 
-async function listEntries(json?: boolean, includeBuiltins?: boolean): Promise<void> {
+async function listEntries(json?: boolean, includeBuiltins?: boolean, includeArchived?: boolean): Promise<void> {
   // One-time migration from legacy JSON → DB (idempotent, best-effort)
   await migrateAgentDirectory().catch(() => {});
 
@@ -298,19 +299,25 @@ async function listEntries(json?: boolean, includeBuiltins?: boolean): Promise<v
   let entries: directory.ScopedDirectoryEntry[];
   try {
     const storeItems = await listItemsFromStore('agent');
-    entries = storeItems.map((item: StoreRow) => {
-      const manifest = (item.manifest ?? {}) as Record<string, unknown>;
-      return {
-        name: item.name,
-        dir: (item.install_path as string) ?? '',
-        repo: (manifest.repo as string) ?? '',
-        promptMode: ((manifest.promptMode as string) ?? 'append') as directory.PromptMode,
-        model: manifest.model as string | undefined,
-        roles: normalizeRoles(manifest.roles as string[] | undefined),
-        registeredAt: item.installed_at as string,
-        scope: 'global' as directory.DirectoryScope,
-      };
-    });
+    entries = storeItems
+      .filter((item: StoreRow) => {
+        if (includeArchived) return true;
+        const manifest = (item.manifest ?? {}) as Record<string, unknown>;
+        return !manifest.archived;
+      })
+      .map((item: StoreRow) => {
+        const manifest = (item.manifest ?? {}) as Record<string, unknown>;
+        return {
+          name: item.name,
+          dir: (item.install_path as string) ?? '',
+          repo: (manifest.repo as string) ?? '',
+          promptMode: ((manifest.promptMode as string) ?? 'append') as directory.PromptMode,
+          model: manifest.model as string | undefined,
+          roles: normalizeRoles(manifest.roles as string[] | undefined),
+          registeredAt: item.installed_at as string,
+          scope: (manifest.archived ? 'archived' : 'global') as directory.DirectoryScope,
+        };
+      });
   } catch {
     // Fallback to legacy
     entries = await directory.ls();

--- a/src/term-commands/dir.ts
+++ b/src/term-commands/dir.ts
@@ -29,7 +29,7 @@ import {
   updateItemInStore,
 } from '../lib/agent-cache.js';
 import * as directory from '../lib/agent-directory.js';
-import { syncAgentDirectory } from '../lib/agent-sync.js';
+import { printSyncResult, syncAgentDirectory } from '../lib/agent-sync.js';
 import { getActor, recordAuditEvent } from '../lib/audit.js';
 import { ALL_BUILTINS } from '../lib/builtin-agents.js';
 import { contractPath } from '../lib/genie-config.js';
@@ -235,18 +235,7 @@ async function handleDirSync(): Promise<void> {
 
   console.log(`Syncing agents from ${ws.root}/agents/...`);
   const result = await syncAgentDirectory(ws.root);
-
-  if (result.registered.length > 0) console.log(`  Registered: ${result.registered.join(', ')}`);
-  if (result.updated.length > 0) console.log(`  Updated: ${result.updated.join(', ')}`);
-  if (result.reactivated.length > 0) console.log(`  Reactivated: ${result.reactivated.join(', ')}`);
-  if (result.archived.length > 0) console.log(`  Archived: ${result.archived.join(', ')}`);
-  if (result.unchanged.length > 0) console.log(`  Unchanged: ${result.unchanged.join(', ')}`);
-  for (const err of result.errors) {
-    console.error(`  Error (${err.name}): ${err.error}`);
-  }
-
-  const total = result.registered.length + result.updated.length + result.unchanged.length + result.reactivated.length;
-  console.log(`\nSync complete: ${total} active agent(s), ${result.archived.length} archived.`);
+  printSyncResult(result);
 }
 
 // ============================================================================

--- a/src/term-commands/init.ts
+++ b/src/term-commands/init.ts
@@ -53,10 +53,22 @@ async function initWorkspace(): Promise<void> {
   console.log(`Workspace created: ${cwd}`);
   if (pgUrl) console.log(`  pgUrl: ${pgUrl}`);
 
-  // Scan for existing agents
+  // Scan for existing agents and auto-register them
   const agents = scanAgents(cwd);
   if (agents.length > 0) {
     console.log(`  Found ${agents.length} agent(s): ${agents.join(', ')}`);
+    try {
+      const { syncAgentDirectory } = await import('../lib/agent-sync.js');
+      const result = await syncAgentDirectory(cwd);
+      if (result.registered.length > 0) {
+        console.log(`  Registered: ${result.registered.join(', ')}`);
+      }
+      if (result.updated.length > 0) {
+        console.log(`  Updated: ${result.updated.join(', ')}`);
+      }
+    } catch {
+      // Sync is best-effort during init — DB may not be ready
+    }
   }
 }
 

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -346,9 +346,40 @@ function discoverAgents(): string[] {
 
 interface DaemonHandles {
   schedulerHandle: { stop: () => void; done: Promise<void> } | null;
+  agentWatcher: { close: () => void } | null;
 }
 
-const handles: DaemonHandles = { schedulerHandle: null };
+const handles: DaemonHandles = { schedulerHandle: null, agentWatcher: null };
+
+/** Sync agent directory from workspace and start file watcher. */
+async function startAgentSync(): Promise<{ close: () => void } | null> {
+  try {
+    const { findWorkspace } = require('../lib/workspace.js') as typeof import('../lib/workspace.js');
+    const ws = findWorkspace();
+    if (!ws) return null;
+
+    const { syncAgentDirectory, watchAgentDirectory } = await import('../lib/agent-sync.js');
+    const syncResult = await syncAgentDirectory(ws.root);
+    const synced = syncResult.registered.length + syncResult.updated.length;
+    if (synced > 0) {
+      console.log(`  Agent sync: ${syncResult.registered.length} registered, ${syncResult.updated.length} updated`);
+    }
+
+    const watcher = watchAgentDirectory(ws.root, {
+      onSync: (name, action) => {
+        console.log(`  [agent-watcher] ${name}: ${action}`);
+      },
+    });
+    if (watcher) {
+      console.log('  Agent watcher started (watching agents/ directory)');
+    }
+    return watcher;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`  Agent sync failed: ${msg}`);
+    return null;
+  }
+}
 
 /** Start all services in foreground mode */
 async function startForeground(): Promise<void> {
@@ -382,6 +413,9 @@ async function startForeground(): Promise<void> {
   const sessions = listAgentSessions();
   console.log(`  Agent sessions: ${sessions.length > 0 ? sessions.join(', ') : '(none)'}`);
 
+  // 2b. Sync agent directory + start watcher
+  handles.agentWatcher = await startAgentSync();
+
   // 3. Start TUI tmux server with split layout
   console.log(`  Starting tmux -L ${TUI_SOCKET} server...`);
   const { leftPane, rightPane } = startTuiTmuxServer();
@@ -414,6 +448,7 @@ async function startForeground(): Promise<void> {
   // Signal handlers for graceful shutdown
   const shutdown = () => {
     console.log('\nShutting down genie serve...');
+    handles.agentWatcher?.close();
     handles.schedulerHandle?.stop();
     killTmuxServer(TUI_SOCKET, tuiTmuxConf());
     killTmuxServer(GENIE_SOCKET, genieTmuxConf());


### PR DESCRIPTION
## Summary

- Add `src/lib/agent-sync.ts` with `syncAgentDirectory()` that scans `{workspace}/agents/` for directories containing `AGENTS.md`, reads git remotes, and registers/updates entries in app_store
- Add `genie dir sync` command as manual trigger for the sync logic
- Integrate sync into `genie init` to auto-register agents after workspace creation
- Add `fs.watch` on `agents/` directory in `genie serve` with 2s debounce for auto-registration of new agents and removal detection

## Test plan

- [x] `bun run check` passes (typecheck + lint + dead-code + 1575 tests)
- [ ] `genie dir sync` in workspace registers all agents from `agents/`
- [ ] `genie serve` auto-registers agents on startup and watches for new ones
- [ ] `genie init` auto-registers found agents (not just prints)
- [ ] Creating `agents/test-agent/AGENTS.md` auto-registers within 5s
- [ ] Stale repo_path entries are fixed on sync