### PR TITLE
fix: recover dead TUI session when serve is still running

### DIFF
--- a/src/genie.ts
+++ b/src/genie.ts
@@ -486,12 +486,17 @@ if (args.length === 0) {
     process.exit(1);
   }
 
-  const { isServeRunning, autoStartServe } = await import('./term-commands/serve.js');
+  const { isServeRunning, autoStartServe, isTuiSessionReady, ensureTuiSession } = await import(
+    './term-commands/serve.js'
+  );
 
   // Auto-start serve if not running
   if (!isServeRunning()) {
     console.log('Starting genie serve...');
     await autoStartServe();
+  } else if (!isTuiSessionReady()) {
+    // Serve is alive but TUI tmux session died — recreate it
+    ensureTuiSession(ws.root);
   }
 
   // Set env vars for TUI (workspace root + agent) before attach

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -315,13 +315,23 @@ export async function autoStartServe(): Promise<void> {
 }
 
 /** Check if the genie-tui session exists on the TUI socket */
-function isTuiSessionReady(): boolean {
+export function isTuiSessionReady(): boolean {
   try {
     execSync(tmuxCmd(TUI_SOCKET, tuiTmuxConf(), `has-session -t ${TUI_SESSION}`), { stdio: 'ignore' });
     return true;
   } catch {
     return false;
   }
+}
+
+/**
+ * Ensure the TUI tmux session exists and is ready for attachment.
+ * If the TUI server died while serve is still running, recreate it.
+ */
+export function ensureTuiSession(workspaceRoot?: string): void {
+  if (isTuiSessionReady()) return;
+  const { leftPane, rightPane } = startTuiTmuxServer();
+  sendTuiLaunchScript(leftPane, rightPane, workspaceRoot);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- When `genie serve` is running but the `genie-tui` tmux session dies, `genie` (no args) would fail with "no sessions" and exit
- Root cause: `genie.ts` only checked if serve PID was alive, not if the TUI tmux session existed
- Fix: after confirming serve is running, also check `isTuiSessionReady()` — if TUI is dead, call `ensureTuiSession()` to recreate it before attaching

## Changes

- `src/term-commands/serve.ts`: export `isTuiSessionReady()`, add new `ensureTuiSession()` that recreates the TUI tmux server + launches the nav script
- `src/genie.ts`: add `else if (!isTuiSessionReady())` branch to recover dead TUI when serve is alive

## Test plan

- [x] Typecheck passes (`tsc --noEmit`)
- [x] Lint passes (`biome check`)
- [x] All 1575 tests pass
- [x] Manual QA: kill `tmux -L genie-tui` server → run `genie` → TUI session recreated automatically
- [x] Manual QA: repeated kill+recover cycle works reliably
- [x] `genie serve status` shows `tmux -L genie-tui: running` after recovery