### PR TITLE
feat: archive lifecycle — soft-delete for projects, boards, tasks, teams

### DIFF
--- a/src/db/migrations/015_archive_lifecycle.sql
+++ b/src/db/migrations/015_archive_lifecycle.sql
@@ -1,0 +1,37 @@
+-- 015: Archive Lifecycle — soft-delete for tasks, projects, boards, teams.
+-- Adds 'archived' status + archived_at timestamp to all four entities.
+-- Idempotent: safe to re-run.
+
+-- Tasks: extend status CHECK to include 'archived'
+ALTER TABLE tasks DROP CONSTRAINT IF EXISTS tasks_status_check;
+ALTER TABLE tasks ADD CONSTRAINT tasks_status_check
+  CHECK (status IN ('blocked', 'ready', 'in_progress', 'done', 'failed', 'cancelled', 'archived'));
+ALTER TABLE tasks ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ;
+
+-- Projects: add status + archived_at
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS status TEXT DEFAULT 'active';
+ALTER TABLE projects DROP CONSTRAINT IF EXISTS projects_status_check;
+ALTER TABLE projects ADD CONSTRAINT projects_status_check
+  CHECK (status IN ('active', 'archived'));
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ;
+UPDATE projects SET status = 'active' WHERE status IS NULL;
+
+-- Boards: add status + archived_at
+ALTER TABLE boards ADD COLUMN IF NOT EXISTS status TEXT DEFAULT 'active';
+ALTER TABLE boards DROP CONSTRAINT IF EXISTS boards_status_check;
+ALTER TABLE boards ADD CONSTRAINT boards_status_check
+  CHECK (status IN ('active', 'archived'));
+ALTER TABLE boards ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ;
+UPDATE boards SET status = 'active' WHERE status IS NULL;
+
+-- Teams: extend status CHECK to include 'archived'
+ALTER TABLE teams DROP CONSTRAINT IF EXISTS teams_status_check;
+ALTER TABLE teams ADD CONSTRAINT teams_status_check
+  CHECK (status IN ('in_progress', 'done', 'blocked', 'archived'));
+ALTER TABLE teams ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ;
+
+-- Partial indexes for fast active queries
+CREATE INDEX IF NOT EXISTS idx_tasks_archived ON tasks(status) WHERE status = 'archived';
+CREATE INDEX IF NOT EXISTS idx_projects_archived ON projects(status) WHERE status = 'archived';
+CREATE INDEX IF NOT EXISTS idx_boards_archived ON boards(status) WHERE status = 'archived';
+CREATE INDEX IF NOT EXISTS idx_teams_archived ON teams(status) WHERE status = 'archived';

--- a/src/lib/board-service.ts
+++ b/src/lib/board-service.ts
@@ -45,6 +45,8 @@ export interface BoardRow {
   name: string;
   projectId: string | null;
   description: string | null;
+  status: string;
+  archivedAt: string | null;
   columns: BoardColumn[];
   config: Record<string, unknown>;
   createdAt: string;
@@ -101,6 +103,8 @@ function mapBoard(row: Record<string, unknown>): BoardRow {
     name: row.name as string,
     projectId: str(row.project_id),
     description: str(row.description),
+    status: strOrDefault(row.status, 'active'),
+    archivedAt: str(row.archived_at),
     columns: parseJsonb<BoardColumn[]>(row.columns, []),
     config: parseJsonb<Record<string, unknown>>(row.config, {}),
     createdAt: strOrDefault(row.created_at, ''),
@@ -218,17 +222,28 @@ export async function getBoard(nameOrId: string, projectId?: string): Promise<Bo
   return null;
 }
 
-export async function listBoards(projectId?: string): Promise<BoardRow[]> {
+export async function listBoards(projectId?: string, includeArchived = false): Promise<BoardRow[]> {
   const sql = await getConnection();
 
   if (projectId) {
+    if (includeArchived) {
+      const rows = await sql`
+        SELECT * FROM boards WHERE project_id = ${projectId} ORDER BY name
+      `;
+      return rows.map(mapBoard);
+    }
     const rows = await sql`
-      SELECT * FROM boards WHERE project_id = ${projectId} ORDER BY name
+      SELECT * FROM boards WHERE project_id = ${projectId}
+        AND (status IS NULL OR status = 'active') ORDER BY name
     `;
     return rows.map(mapBoard);
   }
 
-  const rows = await sql`SELECT * FROM boards ORDER BY name`;
+  if (includeArchived) {
+    const rows = await sql`SELECT * FROM boards ORDER BY name`;
+    return rows.map(mapBoard);
+  }
+  const rows = await sql`SELECT * FROM boards WHERE status IS NULL OR status = 'active' ORDER BY name`;
   return rows.map(mapBoard);
 }
 

--- a/src/lib/task-service.ts
+++ b/src/lib/task-service.ts
@@ -48,6 +48,8 @@ export interface ProjectRow {
   name: string;
   repoPath: string | null;
   description: string | null;
+  status: string;
+  archivedAt: string | null;
   createdAt: string;
 }
 
@@ -84,6 +86,7 @@ export interface TaskRow {
   columnId: string | null;
   externalId: string | null;
   externalUrl: string | null;
+  archivedAt: string | null;
   metadata: Record<string, unknown>;
   createdAt: string;
   updatedAt: string;
@@ -103,6 +106,7 @@ export interface TaskFilters {
   boardName?: string;
   dueBefore?: string;
   externalId?: string;
+  includeArchived?: boolean;
   limit?: number;
   offset?: number;
 }
@@ -263,6 +267,7 @@ function mapTask(row: Record<string, unknown>): TaskRow {
     columnId: str(row.column_id),
     externalId: str(row.external_id),
     externalUrl: str(row.external_url),
+    archivedAt: str(row.archived_at),
     metadata: (row.metadata as Record<string, unknown>) ?? {},
     createdAt: strOrDefault(row.created_at, ''),
     updatedAt: strOrDefault(row.updated_at, ''),
@@ -386,6 +391,8 @@ function mapProject(row: Record<string, unknown>): ProjectRow {
     name: row.name as string,
     repoPath: str(row.repo_path),
     description: str(row.description),
+    status: strOrDefault(row.status, 'active'),
+    archivedAt: str(row.archived_at),
     createdAt: String(row.created_at),
   };
 }
@@ -630,7 +637,13 @@ function buildScopeConditions(filters: TaskFilters, conditions: string[], values
 }
 
 /** Build field-level filter conditions. */
-function buildFieldConditions(filters: TaskFilters, conditions: string[], values: unknown[], startIdx: number): number {
+function buildFieldConditions(
+  filters: TaskFilters,
+  conditions: string[],
+  values: unknown[],
+  startIdx: number,
+  colPrefix = '',
+): number {
   let paramIdx = startIdx;
   const simple: [string, string | undefined][] = [
     ['stage', filters.stage],
@@ -641,9 +654,13 @@ function buildFieldConditions(filters: TaskFilters, conditions: string[], values
   ];
   for (const [col, val] of simple) {
     if (val) {
-      conditions.push(`${col} = $${paramIdx++}`);
+      conditions.push(`${colPrefix}${col} = $${paramIdx++}`);
       values.push(val);
     }
+  }
+  // Exclude archived by default unless explicitly filtered or includeArchived
+  if (!filters.status && !filters.includeArchived) {
+    conditions.push(`${colPrefix}status != 'archived'`);
   }
   if (filters.parentId !== undefined) {
     if (filters.parentId === null) {
@@ -1607,6 +1624,137 @@ export async function markDone(idOrSeq: string, actor?: Actor, comment?: string,
 }
 
 // ============================================================================
+// Archive / Unarchive
+// ============================================================================
+
+/** Archive a task — sets status='archived', archived_at=now(). */
+export async function archiveTask(idOrSeq: string, actor?: Actor, repoPath?: string): Promise<TaskRow> {
+  const sql = await getConnection();
+  const repo = repoPath ?? getRepoPath();
+  const id = await resolveTaskId(idOrSeq, repo);
+  if (!id) throw new Error(`Task not found: ${idOrSeq}`);
+
+  const rows = await sql`
+    UPDATE tasks
+    SET status = 'archived', archived_at = now(), updated_at = now()
+    WHERE id = ${id}
+    RETURNING *
+  `;
+  if (rows.length === 0) throw new Error(`Task not found: ${idOrSeq}`);
+
+  recordAuditEvent('task', id, 'archived', actor?.actorId ?? getActor(), {}).catch(() => {});
+  return mapTask(rows[0]);
+}
+
+/** Unarchive a task — restores previous status from stage_log or defaults to 'ready'. */
+export async function unarchiveTask(idOrSeq: string, actor?: Actor, repoPath?: string): Promise<TaskRow> {
+  const sql = await getConnection();
+  const repo = repoPath ?? getRepoPath();
+  const id = await resolveTaskId(idOrSeq, repo);
+  if (!id) throw new Error(`Task not found: ${idOrSeq}`);
+
+  // Infer previous status: if ended_at is set it was done, otherwise default to 'ready'.
+  // Never restore to 'blocked' — use 'ready' instead.
+  const task = await sql`SELECT * FROM tasks WHERE id = ${id} LIMIT 1`;
+  if (task.length === 0) throw new Error(`Task not found: ${idOrSeq}`);
+
+  let restoredStatus = 'ready';
+  if (task[0].ended_at) {
+    restoredStatus = 'done';
+  }
+
+  const rows = await sql`
+    UPDATE tasks
+    SET status = ${restoredStatus}, archived_at = NULL, updated_at = now()
+    WHERE id = ${id}
+    RETURNING *
+  `;
+  if (rows.length === 0) throw new Error(`Task not found: ${idOrSeq}`);
+
+  recordAuditEvent('task', id, 'unarchived', actor?.actorId ?? getActor(), { restoredStatus }).catch(() => {});
+  return mapTask(rows[0]);
+}
+
+/** Archive a project and cascade to its boards and unfinished tasks. */
+export async function archiveProject(name: string): Promise<void> {
+  const sql = await getConnection();
+  const project = await getProjectByName(name);
+  if (!project) throw new Error(`Project not found: ${name}`);
+
+  // Archive the project
+  await sql`
+    UPDATE projects SET status = 'archived', archived_at = now()
+    WHERE id = ${project.id}
+  `;
+
+  // Cascade: archive boards for this project
+  await sql`
+    UPDATE boards SET status = 'archived', archived_at = now(), updated_at = now()
+    WHERE project_id = ${project.id} AND (status IS NULL OR status = 'active')
+  `;
+
+  // Cascade: archive unfinished tasks (not done, cancelled, or already archived)
+  await sql`
+    UPDATE tasks SET status = 'archived', archived_at = now(), updated_at = now()
+    WHERE project_id = ${project.id}
+      AND status NOT IN ('done', 'cancelled', 'archived')
+  `;
+
+  recordAuditEvent('project', project.id, 'archived', getActor(), { name }).catch(() => {});
+}
+
+/** Unarchive a project — restores project and its boards (tasks stay as-is). */
+export async function unarchiveProject(name: string): Promise<void> {
+  const sql = await getConnection();
+  const project = await getProjectByName(name);
+  if (!project) throw new Error(`Project not found: ${name}`);
+
+  // Restore the project
+  await sql`
+    UPDATE projects SET status = 'active', archived_at = NULL
+    WHERE id = ${project.id}
+  `;
+
+  // Restore boards for this project
+  await sql`
+    UPDATE boards SET status = 'active', archived_at = NULL, updated_at = now()
+    WHERE project_id = ${project.id} AND status = 'archived'
+  `;
+
+  recordAuditEvent('project', project.id, 'unarchived', getActor(), { name }).catch(() => {});
+}
+
+/** Archive a board and its unfinished tasks. */
+export async function archiveBoard(boardId: string): Promise<void> {
+  const sql = await getConnection();
+
+  await sql`
+    UPDATE boards SET status = 'archived', archived_at = now(), updated_at = now()
+    WHERE id = ${boardId}
+  `;
+
+  // Cascade: archive unfinished tasks on this board
+  await sql`
+    UPDATE tasks SET status = 'archived', archived_at = now(), updated_at = now()
+    WHERE board_id = ${boardId}
+      AND status NOT IN ('done', 'cancelled', 'archived')
+  `;
+
+  recordAuditEvent('board', boardId, 'archived', getActor(), {}).catch(() => {});
+}
+
+/** List projects, optionally including archived ones. */
+export async function listProjectsFiltered(includeArchived = false): Promise<ProjectRow[]> {
+  const sql = await getConnection();
+  if (includeArchived) {
+    const rows = await sql`SELECT * FROM projects ORDER BY name`;
+    return rows.map(mapProject);
+  }
+  const rows = await sql`SELECT * FROM projects WHERE status IS NULL OR status = 'active' ORDER BY name`;
+  return rows.map(mapProject);
+}
+
+// ============================================================================
 // Delete Notification Preference
 // ============================================================================
 
@@ -1656,6 +1804,8 @@ export async function listTasksForActor(actor: Actor, filters: TaskFilters = {})
   if (filters.status) {
     conditions.push(`t.status = $${paramIdx++}`);
     values.push(filters.status);
+  } else if (!filters.includeArchived) {
+    conditions.push(`t.status != 'archived'`);
   }
   if (filters.priority) {
     conditions.push(`t.priority = $${paramIdx++}`);

--- a/src/lib/team-manager.ts
+++ b/src/lib/team-manager.ts
@@ -29,7 +29,7 @@ import * as tmux from './tmux.js';
 // ============================================================================
 
 /** Team lifecycle status. */
-export type TeamStatus = 'in_progress' | 'done' | 'blocked';
+export type TeamStatus = 'in_progress' | 'done' | 'blocked' | 'archived';
 
 /** Persisted team configuration. */
 export interface TeamConfig {
@@ -57,6 +57,8 @@ export interface TeamConfig {
   tmuxSessionName?: string;
   /** Wish slug this team is working on (set via --wish). */
   wishSlug?: string;
+  /** ISO timestamp when the team was archived (null if not archived). */
+  archivedAt?: string;
 }
 
 // ============================================================================
@@ -90,6 +92,7 @@ interface TeamConfigRow {
   native_teams_enabled?: boolean;
   tmux_session_name?: string;
   wish_slug?: string;
+  archived_at?: Date | string | null;
 }
 
 /** Map a PG row to a TeamConfig object. */
@@ -108,6 +111,9 @@ function rowToTeamConfig(row: TeamConfigRow): TeamConfig {
   if (row.native_teams_enabled) config.nativeTeamsEnabled = row.native_teams_enabled;
   if (row.tmux_session_name) config.tmuxSessionName = row.tmux_session_name;
   if (row.wish_slug) config.wishSlug = row.wish_slug;
+  if (row.archived_at) {
+    config.archivedAt = row.archived_at instanceof Date ? row.archived_at.toISOString() : String(row.archived_at);
+  }
   return config;
 }
 
@@ -430,8 +436,60 @@ async function cleanupTeamTmuxSession(tmuxSessionName: string, teamName: string)
 }
 
 /**
- * Disband a team: remove shared clone and delete team config from PG.
+ * Archive a team: set status='archived', kill members, clean up tmux.
+ * Preserves all data (members, wish_slug, metadata).
+ */
+export async function archiveTeam(teamName: string): Promise<boolean> {
+  const config = await getTeam(teamName);
+  if (!config) return false;
+
+  // Kill all running team members (scoped to this team only)
+  for (const member of config.members) {
+    try {
+      await killWorkersByName(member, teamName);
+    } catch {
+      // Best-effort — continue with other members
+    }
+  }
+
+  await cleanupTeamTmuxSession(config.tmuxSessionName ?? teamName, teamName);
+
+  const sql = await getConnection();
+  const result = await sql`
+    UPDATE teams SET status = 'archived', archived_at = now(), updated_at = now()
+    WHERE name = ${teamName}
+  `;
+  if (result.count === 0) return false;
+
+  recordAuditEvent('team', teamName, 'archived', getActor(), { repo: config.repo }).catch(() => {});
+  return true;
+}
+
+/**
+ * Unarchive a team: restore status to 'done' or 'in_progress'.
+ */
+export async function unarchiveTeam(teamName: string): Promise<boolean> {
+  const config = await getTeam(teamName);
+  if (!config) return false;
+
+  const restoredStatus = 'done';
+  const sql = await getConnection();
+  const result = await sql`
+    UPDATE teams SET status = ${restoredStatus}, archived_at = NULL, updated_at = now()
+    WHERE name = ${teamName}
+  `;
+  if (result.count === 0) return false;
+
+  recordAuditEvent('team', teamName, 'unarchived', getActor(), { repo: config.repo, restoredStatus }).catch(() => {});
+  return true;
+}
+
+/**
+ * Disband a team: archives instead of deleting (data-preserving).
+ * Kills members, cleans up native team config, resets wish groups, removes worktree.
  * Returns true if the team was found and disbanded.
+ *
+ * @deprecated Use `archiveTeam` directly. Disband now archives to preserve data.
  */
 export async function disbandTeam(teamName: string): Promise<boolean> {
   const config = await getTeam(teamName);
@@ -459,9 +517,12 @@ export async function disbandTeam(teamName: string): Promise<boolean> {
 
   await cleanupTeamTmuxSession(config.tmuxSessionName ?? teamName, teamName);
 
-  // Delete team config from PG
+  // Archive instead of delete — preserves all historical data
   const sql = await getConnection();
-  const result = await sql`DELETE FROM teams WHERE name = ${teamName}`;
+  const result = await sql`
+    UPDATE teams SET status = 'archived', archived_at = now(), updated_at = now()
+    WHERE name = ${teamName}
+  `;
   if (result.count === 0) return false;
 
   recordAuditEvent('team', teamName, 'disbanded', getActor(), { repo: config.repo }).catch(() => {});
@@ -526,11 +587,15 @@ export async function getTeam(name: string): Promise<TeamConfig | null> {
   }
 }
 
-/** List all teams globally. */
-export async function listTeams(): Promise<TeamConfig[]> {
+/** List all teams globally, optionally including archived. */
+export async function listTeams(includeArchived = false): Promise<TeamConfig[]> {
   try {
     const sql = await getConnection();
-    const rows = await sql`SELECT * FROM teams ORDER BY created_at DESC`;
+    if (includeArchived) {
+      const rows = await sql`SELECT * FROM teams ORDER BY created_at DESC`;
+      return rows.map(rowToTeamConfig);
+    }
+    const rows = await sql`SELECT * FROM teams WHERE status != 'archived' ORDER BY created_at DESC`;
     return rows.map(rowToTeamConfig);
   } catch {
     return [];

--- a/src/term-commands/board.ts
+++ b/src/term-commands/board.ts
@@ -164,7 +164,7 @@ async function handleBoardCreate(
   console.log(`Created board "${board.name}" (${board.id}) with ${board.columns.length} columns`);
 }
 
-async function handleBoardList(options: { project?: string; json?: boolean }): Promise<void> {
+async function handleBoardList(options: { project?: string; all?: boolean; json?: boolean }): Promise<void> {
   const bs = await getBoardService();
   const ts = await getTaskService();
 
@@ -173,7 +173,7 @@ async function handleBoardList(options: { project?: string; json?: boolean }): P
     projectId = await resolveProjectId(options.project);
   }
 
-  const boards = await bs.listBoards(projectId);
+  const boards = await bs.listBoards(projectId, options.all);
 
   if (options.json) {
     console.log(JSON.stringify(boards, null, 2));
@@ -577,8 +577,9 @@ export function registerBoardCommands(program: Command): void {
     .command('list')
     .description('List all boards')
     .option('--project <project>', 'Filter by project')
+    .option('--all', 'Include archived boards')
     .option('--json', 'Output as JSON')
-    .action(async (options: { project?: string; json?: boolean }) => {
+    .action(async (options: { project?: string; all?: boolean; json?: boolean }) => {
       try {
         await handleBoardList(options);
       } catch (error) {
@@ -706,6 +707,23 @@ export function registerBoardCommands(program: Command): void {
     .action(async (nameParts: string[], options: { project?: string; json?: boolean }) => {
       try {
         await handleBoardReconcile(nameParts.join(' '), options);
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    });
+
+  // ── board archive ──
+  board
+    .command('archive <name...>')
+    .description('Archive a board and its unfinished tasks')
+    .option('--project <project>', 'Disambiguate by project')
+    .action(async (nameParts: string[], options: { project?: string }) => {
+      try {
+        const ts = await getTaskService();
+        const board = await resolveBoard(nameParts.join(' '), options.project);
+        await ts.archiveBoard(board.id);
+        console.log(`Archived board "${board.name}" and its unfinished tasks.`);
       } catch (error) {
         console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);

--- a/src/term-commands/project.ts
+++ b/src/term-commands/project.ts
@@ -77,11 +77,12 @@ export function registerProjectCommands(program: Command): void {
   project
     .command('list')
     .description('List all projects')
+    .option('--all', 'Include archived projects')
     .option('--json', 'Output as JSON')
-    .action(async (options: { json?: boolean }) => {
+    .action(async (options: { all?: boolean; json?: boolean }) => {
       try {
         const ts = await getTaskService();
-        const projects = await ts.listProjects();
+        const projects = await ts.listProjectsFiltered(options.all);
 
         if (options.json) {
           console.log(JSON.stringify(projects, null, 2));
@@ -145,6 +146,36 @@ export function registerProjectCommands(program: Command): void {
 
         const tasks = await ts.listTasks({ projectName: name, allProjects: true });
         printProjectDetail(p, tasks);
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    });
+
+  // ── project archive ──
+  project
+    .command('archive <name>')
+    .description('Archive a project (cascades to boards and unfinished tasks)')
+    .action(async (name: string) => {
+      try {
+        const ts = await getTaskService();
+        await ts.archiveProject(name);
+        console.log(`Archived project "${name}" and cascaded to boards + unfinished tasks.`);
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    });
+
+  // ── project unarchive ──
+  project
+    .command('unarchive <name>')
+    .description('Restore an archived project and its boards (tasks stay as-is)')
+    .action(async (name: string) => {
+      try {
+        const ts = await getTaskService();
+        await ts.unarchiveProject(name);
+        console.log(`Unarchived project "${name}" and restored boards.`);
       } catch (error) {
         console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);

--- a/src/term-commands/task.ts
+++ b/src/term-commands/task.ts
@@ -128,11 +128,12 @@ function getProjectName(repoPath: string): string {
 function formatTaskRow(t: taskServiceTypes.TaskRow, showProject: boolean, hasExternal: boolean): string {
   const seq = showProject ? `${getProjectName(t.repoPath)}#${t.seq}` : `#${t.seq}`;
   const title = truncate(t.title, 38);
-  const color = PRIORITY_COLORS[t.priority] ?? '';
+  const color = t.status === 'archived' ? '\x1b[90m' : (PRIORITY_COLORS[t.priority] ?? '');
   const due = formatDate(t.dueDate);
   const proj = showProject ? `${padRight(getProjectName(t.repoPath), 16)} ` : '';
   const ext = hasExternal ? `${padRight(truncate(t.externalId ?? '', 25), 27)} ` : '';
-  return `  ${padRight(seq, showProject ? 22 : 6)} ${proj}${padRight(title, 40)} ${ext}${padRight(t.stage, 12)} ${padRight(t.status, 12)} ${color}${padRight(t.priority, 10)}${RESET} ${padRight(due, 12)}`;
+  const statusLabel = t.status === 'archived' ? '\x1b[90m[archived]\x1b[0m' : t.status;
+  return `  ${padRight(seq, showProject ? 22 : 6)} ${proj}${padRight(title, 40)} ${ext}${padRight(t.stage, 12)} ${padRight(statusLabel, 12)} ${color}${padRight(t.priority, 10)}${RESET} ${padRight(due, 12)}`;
 }
 
 function printTaskList(tasks: taskServiceTypes.TaskRow[], showProject = false): void {
@@ -486,6 +487,7 @@ export function registerTaskCommands(program: Command): void {
       boardName: options.board,
       externalId: options.gh ? parseGhRef(options.gh).externalId : undefined,
       allProjects: options.all,
+      includeArchived: options.all,
       limit: Number(options.limit) || 100,
       offset: Number(options.offset) || 0,
       ...(options.all ? { limit: 10000 } : {}),
@@ -815,6 +817,38 @@ export function registerTaskCommands(program: Command): void {
     .action(async (options: { since?: string; dryRun?: boolean; repo?: string }) => {
       try {
         await handleCloseMerged(options);
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    });
+
+  // ── task archive ──
+  task
+    .command('archive <id>')
+    .description('Archive a task (soft-delete — preserves all data)')
+    .action(async (id: string) => {
+      try {
+        const ts = await getTaskService();
+        const actor = currentActor();
+        const t = await ts.archiveTask(id, actor);
+        console.log(`Archived task #${t.seq}: ${t.title}`);
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    });
+
+  // ── task unarchive ──
+  task
+    .command('unarchive <id>')
+    .description('Restore an archived task to its previous status')
+    .action(async (id: string) => {
+      try {
+        const ts = await getTaskService();
+        const actor = currentActor();
+        const t = await ts.unarchiveTask(id, actor);
+        console.log(`Unarchived task #${t.seq}: ${t.title} (status: ${t.status})`);
       } catch (error) {
         console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);

--- a/src/term-commands/task/status.ts
+++ b/src/term-commands/task/status.ts
@@ -15,6 +15,7 @@ const STATUS_ICONS: Record<string, string> = {
   ready: '🟢',
   in_progress: '🔄',
   done: '✅',
+  archived: '📦',
 };
 
 async function loadExecutorInfo() {

--- a/src/term-commands/team.ts
+++ b/src/term-commands/team.ts
@@ -106,13 +106,14 @@ export function registerTeamNamespace(program: Command): void {
     .command('ls [name]')
     .alias('list')
     .description('List teams or members of a team')
+    .option('--all', 'Include archived teams')
     .option('--json', 'Output as JSON')
-    .action(async (name: string | undefined, options: { json?: boolean }) => {
+    .action(async (name: string | undefined, options: { all?: boolean; json?: boolean }) => {
       try {
         if (name) {
           await printMembers(name, options.json);
         } else {
-          await printTeams(options.json);
+          await printTeams(options.json, options.all);
         }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -121,15 +122,56 @@ export function registerTeamNamespace(program: Command): void {
       }
     });
 
-  // team disband
+  // team archive
+  team
+    .command('archive <name>')
+    .description('Archive a team (preserves all data, kills members)')
+    .action(async (name: string) => {
+      try {
+        const archived = await teamManager.archiveTeam(name);
+        if (archived) {
+          console.log(`Team "${name}" archived.`);
+        } else {
+          console.error(`Team "${name}" not found.`);
+          process.exit(1);
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`Error: ${message}`);
+        process.exit(1);
+      }
+    });
+
+  // team unarchive
+  team
+    .command('unarchive <name>')
+    .description('Restore an archived team')
+    .action(async (name: string) => {
+      try {
+        const restored = await teamManager.unarchiveTeam(name);
+        if (restored) {
+          console.log(`Team "${name}" unarchived.`);
+        } else {
+          console.error(`Team "${name}" not found.`);
+          process.exit(1);
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`Error: ${message}`);
+        process.exit(1);
+      }
+    });
+
+  // team disband (now archives instead of deleting)
   team
     .command('disband <name>')
-    .description('Disband a team: kill members, remove worktree, delete config')
+    .description('Disband a team (archives — preserves data). Use `genie team archive` directly.')
     .action(async (name: string) => {
       try {
         const disbanded = await teamManager.disbandTeam(name);
         if (disbanded) {
-          console.log(`Team "${name}" disbanded.`);
+          console.log('Note: disband now archives the team. Use `genie team archive` directly.');
+          console.log(`Team "${name}" disbanded (archived).`);
         } else {
           console.error(`Team "${name}" not found.`);
           process.exit(1);
@@ -343,8 +385,8 @@ async function printMembers(name: string, json?: boolean): Promise<void> {
 }
 
 /** Print all teams. */
-async function printTeams(json?: boolean): Promise<void> {
-  const teams = await teamManager.listTeams();
+async function printTeams(json?: boolean, includeArchived?: boolean): Promise<void> {
+  const teams = await teamManager.listTeams(includeArchived);
 
   if (json) {
     console.log(JSON.stringify(teams, null, 2));
@@ -368,7 +410,9 @@ async function printTeams(json?: boolean): Promise<void> {
 /** Print a single team summary line. */
 function printTeamSummary(t: TeamConfig): void {
   const status = t.status ?? 'in_progress';
-  console.log(`  ${t.name}  [${status}]`);
+  const dimmed = status === 'archived' ? '\x1b[90m' : '';
+  const reset = status === 'archived' ? '\x1b[0m' : '';
+  console.log(`  ${dimmed}${t.name}  [${status}]${reset}`);
   console.log(`    Repo: ${t.repo}`);
   console.log(`    Branch: ${t.name} (from ${t.baseBranch})`);
   console.log(`    Worktree: ${t.worktreePath}`);


### PR DESCRIPTION
## Summary

- **Schema migration 015**: Adds `archived` status + `archived_at` timestamp to tasks, projects, boards, and teams tables. Partial indexes for fast active queries.
- **Task archive/unarchive**: `genie task archive <id>` sets status=archived; `genie task unarchive <id>` restores previous status. `genie task list` hides archived by default; `--all` shows them dimmed.
- **Project + board cascade**: `genie project archive <name>` cascades to boards + unfinished tasks (done tasks stay done). `genie project unarchive <name>` restores project + boards. `genie board archive <name>` cascades to unfinished tasks.
- **Team archive**: `genie team archive <name>` preserves all data (members, wish_slug, metadata). `genie team disband` now archives instead of deleting rows (data-preserving, with deprecation notice).
- **List filtering**: All list commands (`task list`, `project list`, `board list`, `team list`) hide archived by default. `--all` flag reveals them with visual dimming/tagging.

## Files changed

| File | Change |
|------|--------|
| `src/db/migrations/015_archive_lifecycle.sql` | New migration: archived status + indexes |
| `src/lib/task-service.ts` | archive/unarchive functions, list filtering, project/board archive cascade |
| `src/lib/board-service.ts` | BoardRow status fields, filtered listBoards |
| `src/lib/team-manager.ts` | archiveTeam/unarchiveTeam, disbandTeam→archive, filtered listTeams |
| `src/term-commands/task.ts` | archive/unarchive subcommands, --all includes archived |
| `src/term-commands/project.ts` | archive/unarchive commands, --all flag on list |
| `src/term-commands/board.ts` | archive command, --all flag on list |
| `src/term-commands/team.ts` | archive/unarchive commands, --all on list, disband deprecation |
| `src/term-commands/task/status.ts` | archived status icon |

## Test plan

- [x] `bun run check` passes (typecheck + lint + dead-code + 1575 tests)
- [x] `bun run build` succeeds
- [ ] Run migration on dev DB and verify idempotency
- [ ] `genie task archive <id>` + `genie task unarchive <id>` round-trip
- [ ] `genie project archive <name>` cascades correctly
- [ ] `genie team archive <name>` preserves all data
- [ ] `genie team disband` shows deprecation notice and archives
- [ ] All list commands hide archived by default, show with `--all`