### PR TITLE
fix(tui): clear terminal probe artifacts on pane attach

### DIFF
--- a/scripts/tmux/genie.tmux.conf
+++ b/scripts/tmux/genie.tmux.conf
@@ -50,21 +50,19 @@ setw -g mode-style "bg=#7b2ff7,fg=#e0e0e0"
 setw -g clock-mode-colour "#7b2ff7"
 
 # ============================================================================
-# TOP BAR — pane-border: left = branding + folder | right = git, CPU, RAM, time
+# TOP BAR — pane-border: clean labels, NO shell probes
+# Shell probes (#() calls) cause garbled escape sequences when TUI/app
+# attaches to agent sessions. Observability lives in TUI/app status bar.
 # ============================================================================
 set -g pane-border-status top
 set -g pane-border-lines heavy
 set -g pane-border-format "\
 #[align=left,bg=#16213e,fg=#e0e0e0]\
- #[fg=#7b2ff7,bold]Genie#[fg=#6c6c8a,nobold] #(PATH=$HOME/.bun/bin:$HOME/.npm-global/bin:$PATH genie --version 2>/dev/null | head -1 || echo '?') \
+ #[fg=#7b2ff7,bold]Genie#[fg=#6c6c8a,nobold] \
 #[fg=#0f3460]│ \
 #[fg=#b8a9c9]#{pane_current_path}\
 #[align=right,bg=#16213e]\
-#[fg=#f5a623]#($HOME/.genie/scripts/genie-git.sh) \
-#[fg=#0f3460]│ \
-#[fg=#00d2ff]CPU #($HOME/.genie/scripts/cpu-info.sh) \
-#[fg=#0f3460]│ \
-#[fg=#00d2ff]RAM #($HOME/.genie/scripts/ram-info.sh) \
+#[fg=#e0e0e0]#{session_name}:#{window_name} \
 #[fg=#0f3460]│ \
 #[fg=#e0e0e0]%H:%M "
 

--- a/src/tui/tmux.ts
+++ b/src/tui/tmux.ts
@@ -76,9 +76,14 @@ export function attachProjectWindow(rightPane: string, targetSession: string, wi
     }
   }
   try {
-    // Attach to sessions on the genie agent server
+    // Attach to sessions on the genie agent server.
+    // Use a wrapper script that clears probe artifacts:
+    // 1. Sleep briefly so tmux finishes its terminal capability detection
+    // 2. Clear screen to hide probe escape sequences
+    // 3. Attach to the agent session
     const agentTmux = `tmux -L ${GENIE_AGENT_SOCKET}`;
-    execSync(`${TMUX} respawn-pane -k -t ${pane} "TMUX='' ${agentTmux} attach-session -t '${targetSession}'"`, {
+    const attachCmd = `sleep 0.1 && printf '\\033[2J\\033[H' && TMUX='' ${agentTmux} attach-session -t '${targetSession}'`;
+    execSync(`${TMUX} respawn-pane -k -t ${pane} "sh -c \\"${attachCmd}\\""`, {
       stdio: 'ignore',
     });
   } catch {


### PR DESCRIPTION
## Summary
- Sleep 100ms + clear screen before nested tmux attach to hide probe escape sequences
- Remove #() shell probes from genie.tmux.conf pane-border (caused garbled output)
- Observability moves to TUI status bar / genie app

## Root cause
tmux 3.5a sends terminal capability probes when respawn-pane creates a new PTY. These appear as `tmux 3.5a^[\^[[1;1R` in the pane before the attach completes.

## Test plan
- [ ] `genie serve start --daemon && genie` — right pane should show clean terminal, no garbled text