### PR TITLE
fix(tui): enable mouse + focus left nav pane by default

### DIFF
--- a/scripts/tmux/tui-tmux.conf
+++ b/scripts/tmux/tui-tmux.conf
@@ -18,8 +18,8 @@ set -g set-clipboard on
 set -g allow-passthrough on
 set -ga terminal-overrides ",*:Ms=\\E]52;c;%p2%s\\7"
 
-# Mouse off (apps handle their own via passthrough)
-set -g mouse off
+# Mouse on — needed for clicking between left nav and right terminal panes
+set -g mouse on
 setw -g mode-keys vi
 
 # Vi copy mode

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -231,6 +231,11 @@ function startTuiTmuxServer(): { leftPane: string; rightPane: string } {
   applyTuiStyle();
   setupTuiKeybindings();
 
+  // Focus left pane (nav) so keyboard input goes to OpenTUI by default
+  try {
+    execSync(tuiTmux(`select-pane -t ${panes[0]}`), { stdio: 'ignore' });
+  } catch {}
+
   return { leftPane: panes[0], rightPane: panes[1] || panes[0] };
 }
 


### PR DESCRIPTION
Mouse was off, clicking left nav didn't work. Left pane wasn't focused so j/k went to terminal.