### PR TITLE
fix(cli): prevent GENIE_TUI_PANE env leak to child processes

### DIFF
--- a/src/genie.ts
+++ b/src/genie.ts
@@ -469,14 +469,16 @@ program
 
 const args = process.argv.slice(2);
 
-// If GENIE_TUI_PANE=left AND no args, we're the TUI renderer inside the left tmux pane.
-// Must check args.length — otherwise `genie work`, `genie spawn`, etc. launched from
-// within TUI panes would render the TUI instead of running the command.
+// TUI renderer mode: only when GENIE_TUI_PANE=left AND no subcommand given.
+// Any subcommand (work, spawn, team, etc.) runs normally regardless of env.
+// Clear the env var after checking so child processes never inherit it.
 if (process.env.GENIE_TUI_PANE === 'left' && args.length === 0) {
+  process.env.GENIE_TUI_PANE = undefined;
   const { launchTui } = await import('./tui/index.js');
   await launchTui();
   process.exit(0);
 }
+process.env.GENIE_TUI_PANE = undefined;
 
 // Default command: genie (no args) → thin TUI client (attach to serve).
 if (args.length === 0) {

--- a/src/genie.ts
+++ b/src/genie.ts
@@ -469,8 +469,10 @@ program
 
 const args = process.argv.slice(2);
 
-// If GENIE_TUI_PANE=left, we're the TUI renderer inside the left tmux pane — render directly
-if (process.env.GENIE_TUI_PANE === 'left') {
+// If GENIE_TUI_PANE=left AND no args, we're the TUI renderer inside the left tmux pane.
+// Must check args.length — otherwise `genie work`, `genie spawn`, etc. launched from
+// within TUI panes would render the TUI instead of running the command.
+if (process.env.GENIE_TUI_PANE === 'left' && args.length === 0) {
   const { launchTui } = await import('./tui/index.js');
   await launchTui();
   process.exit(0);


### PR DESCRIPTION
Agents spawned from TUI panes inherited GENIE_TUI_PANE=left, causing
`genie work`, `genie spawn` etc. to launch the TUI renderer instead
of running the command. Fix: only bare `genie` (no args) enters TUI
mode, and clear the env var so children never inherit it.