### PR TITLE
fix(tui): stop creating empty sessions, spawn on Enter

### DIFF
--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -110,39 +110,6 @@ function isTmuxServerRunning(socket: string, conf: string): boolean {
   }
 }
 
-/** Start the genie agent tmux server and create sessions for all agents */
-function startAgentTmuxServer(agents: string[]): void {
-  const conf = genieTmuxConf();
-
-  // Start server with a bootstrap session (tmux needs at least one)
-  if (!isTmuxServerRunning(GENIE_SOCKET, conf)) {
-    execSync(genieTmux('new-session -d -s _bootstrap'), { stdio: 'ignore' });
-  }
-
-  // Create a session per agent
-  for (const agent of agents) {
-    try {
-      execSync(genieTmux(`has-session -t '${agent}'`), { stdio: 'ignore' });
-    } catch {
-      // Session doesn't exist — create it
-      try {
-        execSync(genieTmux(`new-session -d -s '${agent}'`), { stdio: 'ignore' });
-      } catch {
-        // race or naming conflict
-      }
-    }
-  }
-
-  // Kill the bootstrap session if we have real agent sessions
-  if (agents.length > 0) {
-    try {
-      execSync(genieTmux('kill-session -t _bootstrap'), { stdio: 'ignore' });
-    } catch {
-      // already gone or was the only session
-    }
-  }
-}
-
 const NAV_WIDTH = 30;
 const KEY_TABLE = 'genie-tui';
 
@@ -343,18 +310,6 @@ export function ensureTuiSession(workspaceRoot?: string): void {
 // Workspace agent scanning
 // ============================================================================
 
-/** Scan for agents from workspace.json and filesystem */
-function discoverAgents(): string[] {
-  try {
-    const { findWorkspace, scanAgents } = require('../lib/workspace.js') as typeof import('../lib/workspace.js');
-    const ws = findWorkspace();
-    if (!ws) return [];
-    return scanAgents(ws.root);
-  } catch {
-    return [];
-  }
-}
-
 // ============================================================================
 // Service management
 // ============================================================================
@@ -421,12 +376,14 @@ async function startForeground(): Promise<void> {
     console.error(`  pgserve failed: ${msg}`);
   }
 
-  // 2. Start genie agent tmux server + agent sessions
-  const agents = discoverAgents();
-  console.log(`  Starting tmux -L ${GENIE_SOCKET} server...`);
-  startAgentTmuxServer(agents);
+  // 2. Report agent tmux server state (don't create empty sessions —
+  // sessions are created on-demand by `genie spawn`).
   const sessions = listAgentSessions();
-  console.log(`  Agent sessions: ${sessions.length > 0 ? sessions.join(', ') : '(none)'}`);
+  if (sessions.length > 0) {
+    console.log(`  Agent server (-L ${GENIE_SOCKET}): ${sessions.length} sessions`);
+  } else {
+    console.log(`  Agent server (-L ${GENIE_SOCKET}): no sessions yet (created on first spawn)`);
+  }
 
   // 2b. Sync agent directory + start watcher
   handles.agentWatcher = await startAgentSync();

--- a/src/tui/components/Nav.tsx
+++ b/src/tui/components/Nav.tsx
@@ -162,10 +162,11 @@ export function Nav({ onTmuxSessionSelect, workspaceRoot, initialAgent }: NavPro
     const node = flatNodes[selectedIndex]?.node;
     if (!node) return;
 
-    // Stopped agent: spawn it and attach to the session
-    if (node.type === 'agent' && node.wsAgentState === 'stopped') {
-      spawnAgent(node.label);
-      // Attach immediately — ensureAgentSession in tmux.ts creates the session if needed
+    // Agent node: spawn if not running, then attach
+    if (node.type === 'agent') {
+      if (node.wsAgentState !== 'running') {
+        spawnAgent(node.label);
+      }
       const target = getSessionTarget(node);
       if (target) onTmuxSessionSelect(target.sessionName, target.windowIndex);
       return;


### PR DESCRIPTION
## Summary
- Remove `startAgentTmuxServer()` from serve — no more empty bash sessions
- Sessions created on-demand by `genie spawn`
- TUI Enter handler spawns agent if not running, then attaches

## Test plan
- [ ] `genie serve start` does NOT create agent sessions
- [ ] Press Enter on agent in TUI → Claude spawns + right pane attaches