### PR TITLE
fix(tui): restore default tmux server, fix agent CWD, add pane survival

### DIFF
--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -5,7 +5,7 @@
  *   - pgserve (database)
  *   - tmux -L genie server (agent sessions)
  *   - Agent sessions from workspace manifest
- *   - tmux -L genie-tui server (TUI display)
+ *   - TUI session on default tmux server
  *   - Scheduler, event-router, inbox-watcher
  *   - PID file at .genie/serve.pid
  *
@@ -39,10 +39,7 @@ function genieTmuxConf(): string {
   return candidates.find((p) => existsSync(p)) ?? '/dev/null';
 }
 
-function tuiTmuxConf(): string {
-  const candidates = [join(genieHome(), 'tui-tmux.conf')];
-  return candidates.find((p) => existsSync(p)) ?? '/dev/null';
-}
+// TUI uses default tmux server (no separate socket or config)
 
 // ============================================================================
 // PID helpers
@@ -85,25 +82,21 @@ function isProcessAlive(pid: number): boolean {
 // ============================================================================
 
 const GENIE_SOCKET = 'genie';
-const TUI_SOCKET = 'genie-tui';
 const TUI_SESSION = 'genie-tui';
 
-function tmuxCmd(socket: string, conf: string, subcmd: string): string {
-  return `tmux -L ${socket} -f ${conf} ${subcmd}`;
-}
-
 function genieTmux(subcmd: string): string {
-  return tmuxCmd(GENIE_SOCKET, genieTmuxConf(), subcmd);
+  return `tmux -L ${GENIE_SOCKET} -f ${genieTmuxConf()} ${subcmd}`;
 }
 
+/** Plain tmux command (default server — used for TUI session) */
 function tuiTmux(subcmd: string): string {
-  return tmuxCmd(TUI_SOCKET, tuiTmuxConf(), subcmd);
+  return `tmux ${subcmd}`;
 }
 
 /** Check if a tmux server is running on a socket */
-function isTmuxServerRunning(socket: string, conf: string): boolean {
+function isGenieTmuxRunning(): boolean {
   try {
-    execSync(tmuxCmd(socket, conf, 'list-sessions'), { stdio: 'ignore' });
+    execSync(genieTmux('list-sessions'), { stdio: 'ignore' });
     return true;
   } catch {
     return false;
@@ -141,7 +134,7 @@ function setupTuiKeybindings(): void {
     // Tab: toggle focus between left nav (pane 0) and right terminal (pane 1)
     `bind-key -T ${KEY_TABLE} Tab if-shell "[ '#{pane_index}' = '0' ]" "select-pane -t ${TUI_SESSION}:0.1" "select-pane -t ${TUI_SESSION}:0.0" \\; switch-client -T ${KEY_TABLE}`,
     // Ctrl+B: toggle sidebar width (collapse/expand)
-    `bind-key -T ${KEY_TABLE} C-b if-shell "[ $(tmux -L ${TUI_SOCKET} display-message -p '#\\{pane_width\\}' -t ${TUI_SESSION}:0.0) -gt 5 ]" "resize-pane -t ${TUI_SESSION}:0.0 -x 0" "resize-pane -t ${TUI_SESSION}:0.0 -x ${NAV_WIDTH}" \\; switch-client -T ${KEY_TABLE}`,
+    `bind-key -T ${KEY_TABLE} C-b if-shell "[ $(tmux display-message -p '#\\{pane_width\\}' -t ${TUI_SESSION}:0.0) -gt 5 ]" "resize-pane -t ${TUI_SESSION}:0.0 -x 0" "resize-pane -t ${TUI_SESSION}:0.0 -x ${NAV_WIDTH}" \\; switch-client -T ${KEY_TABLE}`,
     // Ctrl+Q: detach from TUI (don't kill — serve owns the session)
     `bind-key -T ${KEY_TABLE} C-q detach-client`,
     `bind-key -T ${KEY_TABLE} 'C-\\\\' detach-client`,
@@ -217,10 +210,10 @@ function sendTuiLaunchScript(leftPane: string, rightPane: string, workspaceRoot?
   } catch {}
 }
 
-/** Kill a tmux server by socket */
-function killTmuxServer(socket: string, conf: string): void {
+/** Kill the TUI session on the default tmux server */
+function killTuiSession(): void {
   try {
-    execSync(tmuxCmd(socket, conf, 'kill-server'), { stdio: 'ignore' });
+    execSync(`tmux kill-session -t ${TUI_SESSION} 2>/dev/null`, { stdio: 'ignore' });
   } catch {
     // not running
   }
@@ -248,7 +241,7 @@ export function isServeRunning(): boolean {
 
 /**
  * Auto-start genie serve in daemon mode and wait until ready.
- * Ready = PID file exists + PID alive + genie-tui session exists on -L genie-tui.
+ * Ready = PID file exists + PID alive + genie-tui session exists on default server.
  */
 export async function autoStartServe(): Promise<void> {
   if (isServeRunning()) return;
@@ -276,10 +269,10 @@ export async function autoStartServe(): Promise<void> {
   }
 }
 
-/** Check if the genie-tui session exists on the TUI socket */
+/** Check if the genie-tui session exists on the default tmux server */
 export function isTuiSessionReady(): boolean {
   try {
-    execSync(tmuxCmd(TUI_SOCKET, tuiTmuxConf(), `has-session -t ${TUI_SESSION}`), { stdio: 'ignore' });
+    execSync(`tmux has-session -t ${TUI_SESSION} 2>/dev/null`, { stdio: 'ignore' });
     return true;
   } catch {
     return false;
@@ -378,8 +371,8 @@ async function startForeground(): Promise<void> {
   // 2b. Sync agent directory + start watcher
   handles.agentWatcher = await startAgentSync();
 
-  // 3. Start TUI tmux server with split layout
-  console.log(`  Starting tmux -L ${TUI_SOCKET} server...`);
+  // 3. Start TUI session on default tmux server
+  console.log('  Setting up TUI session...');
   const { leftPane, rightPane } = startTuiTmuxServer();
 
   // 4. Send launch script to left pane (discovers workspace from serve cwd)
@@ -412,9 +405,9 @@ async function startForeground(): Promise<void> {
     console.log('\nShutting down genie serve...');
     handles.agentWatcher?.close();
     handles.schedulerHandle?.stop();
-    killTmuxServer(TUI_SOCKET, tuiTmuxConf());
+    killTuiSession();
     // NEVER kill the agent tmux server — agent sessions are eternal and must
-    // survive serve restarts. Only the TUI display server is owned by serve.
+    // survive serve restarts. Only the TUI session is owned by serve.
     removeServePid();
     console.log('genie serve stopped.');
   };
@@ -485,8 +478,8 @@ async function stopServe(): Promise<void> {
   if (!isProcessAlive(pid)) {
     console.log(`Stale PID file (PID ${pid} not running). Cleaning up.`);
     removeServePid();
-    // Only kill TUI server — agent server is independent
-    killTmuxServer(TUI_SOCKET, tuiTmuxConf());
+    // Only kill TUI session — agent server is independent
+    killTuiSession();
     return;
   }
 
@@ -518,8 +511,8 @@ async function stopServe(): Promise<void> {
     }
   }
 
-  // Only kill TUI display server — agent tmux server is eternal
-  killTmuxServer(TUI_SOCKET, tuiTmuxConf());
+  // Only kill TUI session — agent tmux server is eternal
+  killTuiSession();
 
   removeServePid();
   console.log('genie serve stopped.');
@@ -538,15 +531,15 @@ async function printPgserveStatus(): Promise<void> {
 
 /** Print tmux server statuses */
 function printTmuxStatus(): void {
-  const agentRunning = isTmuxServerRunning(GENIE_SOCKET, genieTmuxConf());
+  const agentRunning = isGenieTmuxRunning();
   const sessions = agentRunning ? listAgentSessions() : [];
   console.log(`  tmux -L ${GENIE_SOCKET}: ${agentRunning ? `running (${sessions.length} sessions)` : 'stopped'}`);
   if (sessions.length > 0) {
     console.log(`              ${sessions.join(', ')}`);
   }
 
-  const tuiRunning = isTmuxServerRunning(TUI_SOCKET, tuiTmuxConf());
-  console.log(`  tmux -L ${TUI_SOCKET}: ${tuiRunning ? 'running' : 'stopped'}`);
+  const tuiReady = isTuiSessionReady();
+  console.log(`  TUI session: ${tuiReady ? 'running' : 'stopped'}`);
 }
 
 /** Print scheduler and inbox status */

--- a/src/tui/components/Nav.tsx
+++ b/src/tui/components/Nav.tsx
@@ -255,13 +255,25 @@ export function Nav({ onTmuxSessionSelect, workspaceRoot, initialAgent }: NavPro
   );
 }
 
-/** Spawn a stopped agent by launching `genie spawn <name>` in background */
+/** Spawn a stopped agent by launching `genie spawn <name>` in its workspace directory */
 function spawnAgent(name: string): void {
   try {
     const { spawn } = require('node:child_process') as typeof import('node:child_process');
+    const { join, resolve } = require('node:path') as typeof import('node:path');
+    const { existsSync } = require('node:fs') as typeof import('node:fs');
+
+    // Resolve agent CWD from workspace path
+    const wsRoot = process.env.GENIE_TUI_WORKSPACE;
+    let cwd: string | undefined;
+    if (wsRoot) {
+      const agentDir = resolve(join(wsRoot, 'agents', name));
+      if (existsSync(agentDir)) cwd = agentDir;
+    }
+
     spawn('genie', ['spawn', name], {
       detached: true,
       stdio: 'ignore',
+      cwd,
     }).unref();
   } catch {
     // best-effort spawn

--- a/src/tui/tmux.ts
+++ b/src/tui/tmux.ts
@@ -1,31 +1,16 @@
 /**
  * TUI tmux runtime helpers — attach, navigate, pane management.
  *
- * Session creation is handled by `genie serve` (see serve.ts).
- * This module only provides runtime operations for the TUI client.
+ * TUI session lives on the DEFAULT tmux server (no -L flag).
+ * Agent sessions live on the genie server (-L genie).
+ * This module bridges the two for the right-pane attach.
  */
 
 import { execSync, spawnSync } from 'node:child_process';
 
 const SESSION_NAME = 'genie-tui';
-/** TUI's own tmux socket — isolates the nav+split from everything else */
-const TMUX_SOCKET = 'genie-tui';
 /** Genie's agent tmux socket — where all agents/teams/sessions live. */
 const GENIE_AGENT_SOCKET = 'genie';
-/**
- * TUI tmux config — minimal config WITHOUT shell probes.
- * The full genie.tmux.conf has #() shell commands in pane-border-format that
- * cause garbled escape sequences when the TUI attaches to agent sessions.
- * Falls back to /dev/null if tui config not found.
- */
-const TUI_TMUX_CONF = (() => {
-  const { existsSync } = require('node:fs') as typeof import('node:fs');
-  const home = process.env.GENIE_HOME ?? `${process.env.HOME}/.genie`;
-  const tuiConf = `${home}/tui-tmux.conf`;
-  return existsSync(tuiConf) ? tuiConf : '/dev/null';
-})();
-/** Prefix for all TUI tmux commands — TUI socket + TUI config (no shell probes) */
-const TMUX = `tmux -L ${TMUX_SOCKET} -f ${TUI_TMUX_CONF}`;
 
 /**
  * Resolve the right pane ID — self-healing if the pane was killed/recreated.
@@ -33,11 +18,11 @@ const TMUX = `tmux -L ${TMUX_SOCKET} -f ${TUI_TMUX_CONF}`;
  */
 function resolveRightPane(rightPane: string): string {
   try {
-    execSync(`${TMUX} display-message -t ${rightPane} -p ''`, { stdio: 'ignore' });
+    execSync(`tmux display-message -t ${rightPane} -p ''`, { stdio: 'ignore' });
     return rightPane;
   } catch {
     try {
-      const panes = execSync(`${TMUX} list-panes -t ${SESSION_NAME}:0 -F '#{pane_id}'`, { encoding: 'utf-8' })
+      const panes = execSync(`tmux list-panes -t ${SESSION_NAME}:0 -F '#{pane_id}'`, { encoding: 'utf-8' })
         .trim()
         .split('\n');
       return panes[1] || panes[0];
@@ -76,35 +61,20 @@ export function attachProjectWindow(rightPane: string, targetSession: string, wi
     }
   }
   try {
-    // Write a tiny attach script that:
-    // 1. Starts the nested tmux attach in background
-    // 2. Sleeps to let tmux finish terminal probes
-    // 3. Sends clear-screen escape to hide probe artifacts
-    // This avoids the garbled "tmux 3.5a^[\^[[1;1R" output.
-    const { writeFileSync } = require('node:fs') as typeof import('node:fs');
-    const { join } = require('node:path') as typeof import('node:path');
-    const home = process.env.GENIE_HOME ?? `${process.env.HOME}/.genie`;
-    const script = join(home, 'tui-attach.sh');
-    writeFileSync(
-      script,
-      [
-        '#!/bin/sh',
-        'clear',
-        `tmux -L ${GENIE_AGENT_SOCKET} set-option -t '${targetSession}' status off 2>/dev/null`,
-        `exec tmux -L ${GENIE_AGENT_SOCKET} attach-session -t '${targetSession}'`,
-        '',
-      ].join('\n'),
-      { mode: 0o755 },
-    );
-    execSync(`${TMUX} respawn-pane -k -t ${pane} "TMUX='' ${script}"`, { stdio: 'ignore' });
+    // Respawn right pane with a while-true loop so it survives agent exit.
+    // When the inner attach ends (agent exits or detach), the loop re-attaches.
+    // If the session is destroyed, attach fails quickly and retries after sleep.
+    // Selecting a different agent calls respawn-pane -k again, killing this loop.
+    const attachCmd = `tmux -L ${GENIE_AGENT_SOCKET} attach-session -t '${targetSession}'`;
+    execSync(`tmux respawn-pane -k -t ${pane} "TMUX='' while true; do ${attachCmd} 2>/dev/null; sleep 0.5; done"`, {
+      stdio: 'ignore',
+    });
   } catch {
     // pane doesn't exist or command failed
   }
 }
 
-/** Attach to the TUI session (blocking call) */
+/** Attach to the TUI session on default tmux server (blocking call) */
 export function attachTuiSession(): void {
-  spawnSync('tmux', ['-L', TMUX_SOCKET, '-f', TUI_TMUX_CONF, 'attach-session', '-t', SESSION_NAME], {
-    stdio: 'inherit',
-  });
+  spawnSync('tmux', ['attach-session', '-t', SESSION_NAME], { stdio: 'inherit' });
 }


### PR DESCRIPTION
## Summary

- **tmux.ts**: Restore TUI to use default tmux server (remove `-L genie-tui` socket). Agent sessions stay on `-L genie` server. Add `while true` loop in `respawn-pane` so right pane survives agent exit.
- **serve.ts**: Remove `TUI_SOCKET`, `tuiTmuxConf()`, and `killTmuxServer()`. TUI session lives on default server — kill only the session on shutdown, not a separate server.
- **Nav.tsx**: Resolve agent CWD from `GENIE_TUI_WORKSPACE/agents/{name}` and pass to `child_process.spawn` so agents start in the correct directory.

Fixes the broken TUI introduced by the `-L genie-tui` socket separation (garbled terminal probes, config mismatch, wrong CWD, dying right pane).

## Test plan
- [x] `bun run check` passes (typecheck + lint + dead-code + 1575 tests)
- [ ] `genie` launches TUI with left nav + right terminal pane
- [ ] j/k navigates agents in left nav
- [ ] Enter on agent spawns in correct directory, shows in right pane
- [ ] Right pane survives agent exit (while-true loop re-attaches)
- [ ] Tab toggles focus between panes
- [ ] Ctrl+Q exits TUI
- [ ] No garbled escape sequences