### PR TITLE
fix(tui): restore working TUI + targeted fixes

### DIFF
--- a/scripts/tmux/tui-tmux.conf
+++ b/scripts/tmux/tui-tmux.conf
@@ -33,3 +33,8 @@ set -g pane-border-status off
 # Pane borders (visual only, no #() shell commands)
 set -g pane-border-style "fg=#0f3460"
 set -g pane-active-border-style "fg=#7b2ff7"
+
+# Unbind prefix key — all keystrokes go directly to the active pane
+# TUI keybindings are set in the root table by serve.ts
+set -g prefix None
+unbind C-b

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -88,9 +88,15 @@ function genieTmux(subcmd: string): string {
   return `tmux -L ${GENIE_SOCKET} -f ${genieTmuxConf()} ${subcmd}`;
 }
 
-/** Plain tmux command (default server — used for TUI session) */
+/** TUI tmux config — minimal, no shell probes, no prefix key interference */
+function tuiTmuxConf(): string {
+  const candidates = [join(genieHome(), 'tui-tmux.conf')];
+  return candidates.find((p) => existsSync(p)) ?? '/dev/null';
+}
+
+/** TUI tmux command — uses -L genie-tui socket + minimal TUI config */
 function tuiTmux(subcmd: string): string {
-  return `tmux ${subcmd}`;
+  return `tmux -L genie-tui -f ${tuiTmuxConf()} ${subcmd}`;
 }
 
 /** Check if a tmux server is running on a socket */
@@ -104,7 +110,6 @@ function isGenieTmuxRunning(): boolean {
 }
 
 const NAV_WIDTH = 30;
-const KEY_TABLE = 'genie-tui';
 
 /** Theme colors for TUI tmux styling */
 const TUI_STYLE = {
@@ -117,7 +122,7 @@ function applyTuiStyle(): void {
   const cmds = [
     `set-option -t ${TUI_SESSION} pane-border-style 'fg=${TUI_STYLE.inactiveBorder}'`,
     `set-option -t ${TUI_SESSION} pane-active-border-style 'fg=${TUI_STYLE.activeBorder}'`,
-    `set-option -t ${TUI_SESSION} mouse off`,
+    `set-option -t ${TUI_SESSION} mouse on`,
     `set-option -t ${TUI_SESSION} status off`,
     `set-option -t ${TUI_SESSION} pane-border-status off`,
   ];
@@ -128,18 +133,17 @@ function applyTuiStyle(): void {
   }
 }
 
-/** Set up keybindings in a dedicated key table for TUI */
+/** Set up keybindings in root table so they work immediately */
 function setupTuiKeybindings(): void {
   const bindings = [
     // Tab: toggle focus between left nav (pane 0) and right terminal (pane 1)
-    `bind-key -T ${KEY_TABLE} Tab if-shell "[ '#{pane_index}' = '0' ]" "select-pane -t ${TUI_SESSION}:0.1" "select-pane -t ${TUI_SESSION}:0.0" \\; switch-client -T ${KEY_TABLE}`,
+    `bind-key -T root Tab if-shell "[ '#{pane_index}' = '0' ]" "select-pane -t ${TUI_SESSION}:0.1" "select-pane -t ${TUI_SESSION}:0.0"`,
     // Ctrl+B: toggle sidebar width (collapse/expand)
-    `bind-key -T ${KEY_TABLE} C-b if-shell "[ $(tmux display-message -p '#\\{pane_width\\}' -t ${TUI_SESSION}:0.0) -gt 5 ]" "resize-pane -t ${TUI_SESSION}:0.0 -x 0" "resize-pane -t ${TUI_SESSION}:0.0 -x ${NAV_WIDTH}" \\; switch-client -T ${KEY_TABLE}`,
-    // Ctrl+Q: detach from TUI (don't kill — serve owns the session)
-    `bind-key -T ${KEY_TABLE} C-q detach-client`,
-    `bind-key -T ${KEY_TABLE} 'C-\\\\' detach-client`,
-    // Activate key table on session attach
-    `set-hook -t ${TUI_SESSION} client-session-changed "switch-client -T ${KEY_TABLE}"`,
+    `bind-key -T root C-b if-shell "[ $(tmux display-message -p '#\\{pane_width\\}' -t ${TUI_SESSION}:0.0) -gt 5 ]" "resize-pane -t ${TUI_SESSION}:0.0 -x 0" "resize-pane -t ${TUI_SESSION}:0.0 -x ${NAV_WIDTH}"`,
+    // Ctrl+T: new window in agent session (sends C-b c to the nested tmux in right pane)
+    `bind-key -T root C-t send-keys -t ${TUI_SESSION}:0.1 C-b c`,
+    // Ctrl+Q: detach from TUI
+    'bind-key -T root C-q detach-client',
   ];
   for (const cmd of bindings) {
     try {
@@ -169,7 +173,7 @@ function startTuiTmuxServer(): { leftPane: string; rightPane: string } {
   const cols = 120;
   const rows = 40;
 
-  execSync(tuiTmux(`new-session -d -s ${TUI_SESSION} -x ${cols} -y ${rows} -e GENIE_TUI_PANE=left`), {
+  execSync(tuiTmux(`new-session -d -s ${TUI_SESSION} -x ${cols} -y ${rows}`), {
     stdio: 'ignore',
   });
   execSync(tuiTmux(`split-window -h -t ${TUI_SESSION}:0 -l ${cols - NAV_WIDTH - 1}`), { stdio: 'ignore' });
@@ -210,10 +214,10 @@ function sendTuiLaunchScript(leftPane: string, rightPane: string, workspaceRoot?
   } catch {}
 }
 
-/** Kill the TUI session on the default tmux server */
+/** Kill the TUI tmux server */
 function killTuiSession(): void {
   try {
-    execSync(`tmux kill-session -t ${TUI_SESSION} 2>/dev/null`, { stdio: 'ignore' });
+    execSync(tuiTmux('kill-server'), { stdio: 'ignore' });
   } catch {
     // not running
   }
@@ -269,10 +273,10 @@ export async function autoStartServe(): Promise<void> {
   }
 }
 
-/** Check if the genie-tui session exists on the default tmux server */
+/** Check if the genie-tui session exists on the TUI socket */
 export function isTuiSessionReady(): boolean {
   try {
-    execSync(`tmux has-session -t ${TUI_SESSION} 2>/dev/null`, { stdio: 'ignore' });
+    execSync(tuiTmux(`has-session -t ${TUI_SESSION}`), { stdio: 'ignore' });
     return true;
   } catch {
     return false;
@@ -539,7 +543,7 @@ function printTmuxStatus(): void {
   }
 
   const tuiReady = isTuiSessionReady();
-  console.log(`  TUI session: ${tuiReady ? 'running' : 'stopped'}`);
+  console.log(`  tmux -L genie-tui: ${tuiReady ? 'running' : 'stopped'}`);
 }
 
 /** Print scheduler and inbox status */

--- a/src/tui/components/Nav.tsx
+++ b/src/tui/components/Nav.tsx
@@ -24,7 +24,7 @@ export function Nav({ onTmuxSessionSelect, workspaceRoot, initialAgent }: NavPro
   const [sessionTree, setSessionTree] = useState<TreeNode[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const lastTarget = useRef<string | null>(null);
-  const genieHome = useRef(process.env.GENIE_HOME ?? `${process.env.HOME}/.genie`);
+  const initialSelectDone = useRef(false);
 
   // Refresh diagnostics every 2s
   useEffect(() => {
@@ -76,34 +76,15 @@ export function Nav({ onTmuxSessionSelect, workspaceRoot, initialAgent }: NavPro
     }
   }, [flatNodes.length, selectedIndex]);
 
-  // File-based initial agent: thin client writes ~/.genie/tui-initial-agent before attaching.
-  // Check on each diagnostics refresh (2s) so re-attach from a different agent dir works.
-  const [pendingAgent, setPendingAgent] = useState<string | undefined>(initialAgent);
-
+  // Initial agent pre-selection (once)
   useEffect(() => {
-    if (!diagnostics) return;
-    try {
-      const fs = require('node:fs') as typeof import('node:fs');
-      const agentFile = `${genieHome.current}/tui-initial-agent`;
-      if (fs.existsSync(agentFile)) {
-        const agent = fs.readFileSync(agentFile, 'utf-8').trim();
-        fs.unlinkSync(agentFile);
-        if (agent) setPendingAgent(agent);
-      }
-    } catch {
-      // best-effort
-    }
-  }, [diagnostics]);
-
-  // Apply pending agent selection (from prop or file)
-  useEffect(() => {
-    if (!pendingAgent || flatNodes.length === 0) return;
-    const idx = flatNodes.findIndex((n) => n.node.id === `agent:${pendingAgent}`);
+    if (!initialAgent || initialSelectDone.current || flatNodes.length === 0) return;
+    const idx = flatNodes.findIndex((n) => n.node.id === `agent:${initialAgent}`);
     if (idx >= 0) {
       setSelectedIndex(idx);
-      setPendingAgent(undefined);
+      initialSelectDone.current = true;
     }
-  }, [pendingAgent, flatNodes]);
+  }, [initialAgent, flatNodes]);
 
   // Auto-switch right pane when cursor moves to a new target
   useEffect(() => {
@@ -162,11 +143,12 @@ export function Nav({ onTmuxSessionSelect, workspaceRoot, initialAgent }: NavPro
     const node = flatNodes[selectedIndex]?.node;
     if (!node) return;
 
-    // Agent node: spawn if not running, then attach
     if (node.type === 'agent') {
-      if (node.wsAgentState !== 'running') {
+      // No session → spawn the agent (creates session + window 0 with Claude)
+      if (node.wsAgentState === 'stopped') {
         spawnAgent(node.label);
       }
+      // Attach right pane to the agent's session (existing or just-spawned)
       const target = getSessionTarget(node);
       if (target) onTmuxSessionSelect(target.sessionName, target.windowIndex);
       return;
@@ -255,26 +237,19 @@ export function Nav({ onTmuxSessionSelect, workspaceRoot, initialAgent }: NavPro
   );
 }
 
-/** Spawn a stopped agent by launching `genie spawn <name>` in its workspace directory */
+/** Spawn a stopped agent by launching `genie spawn <name>` from its workspace directory */
 function spawnAgent(name: string): void {
   try {
     const { spawn } = require('node:child_process') as typeof import('node:child_process');
     const { join, resolve } = require('node:path') as typeof import('node:path');
     const { existsSync } = require('node:fs') as typeof import('node:fs');
-
-    // Resolve agent CWD from workspace path
     const wsRoot = process.env.GENIE_TUI_WORKSPACE;
     let cwd: string | undefined;
     if (wsRoot) {
       const agentDir = resolve(join(wsRoot, 'agents', name));
       if (existsSync(agentDir)) cwd = agentDir;
     }
-
-    spawn('genie', ['spawn', name], {
-      detached: true,
-      stdio: 'ignore',
-      cwd,
-    }).unref();
+    spawn('genie', ['spawn', name, '--session', name], { detached: true, stdio: 'ignore', cwd }).unref();
   } catch {
     // best-effort spawn
   }

--- a/src/tui/tmux.ts
+++ b/src/tui/tmux.ts
@@ -1,28 +1,30 @@
 /**
  * TUI tmux runtime helpers — attach, navigate, pane management.
  *
- * TUI session lives on the DEFAULT tmux server (no -L flag).
- * Agent sessions live on the genie server (-L genie).
- * This module bridges the two for the right-pane attach.
+ * Session creation is handled by `genie serve` (see serve.ts).
+ * This module only provides runtime operations for the TUI client.
  */
 
 import { execSync, spawnSync } from 'node:child_process';
 
 const SESSION_NAME = 'genie-tui';
-/** Genie's agent tmux socket — where all agents/teams/sessions live. */
+const TMUX_SOCKET = 'genie-tui';
 const GENIE_AGENT_SOCKET = 'genie';
+const TUI_TMUX_CONF = (() => {
+  const { existsSync } = require('node:fs') as typeof import('node:fs');
+  const home = process.env.GENIE_HOME ?? `${process.env.HOME}/.genie`;
+  const tuiConf = `${home}/tui-tmux.conf`;
+  return existsSync(tuiConf) ? tuiConf : '/dev/null';
+})();
+const TMUX = `tmux -L ${TMUX_SOCKET} -f ${TUI_TMUX_CONF}`;
 
-/**
- * Resolve the right pane ID — self-healing if the pane was killed/recreated.
- * Falls back to re-discovering from the session layout.
- */
 function resolveRightPane(rightPane: string): string {
   try {
-    execSync(`tmux display-message -t ${rightPane} -p ''`, { stdio: 'ignore' });
+    execSync(`${TMUX} display-message -t ${rightPane} -p ''`, { stdio: 'ignore' });
     return rightPane;
   } catch {
     try {
-      const panes = execSync(`tmux list-panes -t ${SESSION_NAME}:0 -F '#{pane_id}'`, { encoding: 'utf-8' })
+      const panes = execSync(`${TMUX} list-panes -t ${SESSION_NAME}:0 -F '#{pane_id}'`, { encoding: 'utf-8' })
         .trim()
         .split('\n');
       return panes[1] || panes[0];
@@ -32,49 +34,45 @@ function resolveRightPane(rightPane: string): string {
   }
 }
 
-/** Ensure a tmux session exists on the agent server, creating it if needed */
-function ensureAgentSession(sessionName: string): void {
-  const agentTmux = `tmux -L ${GENIE_AGENT_SOCKET}`;
-  try {
-    execSync(`${agentTmux} has-session -t '${sessionName}' 2>/dev/null`, { stdio: 'ignore' });
-  } catch {
-    try {
-      execSync(`${agentTmux} new-session -d -s '${sessionName}'`, { stdio: 'ignore' });
-    } catch {
-      // race: another process created it
-    }
-  }
-}
-
-/** Switch right pane to a specific session window on the genie agent server */
+/** Switch right pane to a specific agent session. NEVER kills the pane. */
 export function attachProjectWindow(rightPane: string, targetSession: string, windowIndex?: number): void {
-  // Guard: never attach the TUI session to itself (causes infinite loop)
   if (targetSession === SESSION_NAME) return;
   const pane = resolveRightPane(rightPane);
-  ensureAgentSession(targetSession);
+  const agentTmux = `tmux -L ${GENIE_AGENT_SOCKET}`;
+
+  // Ensure agent session exists
+  try {
+    execSync(`${agentTmux} has-session -t '${targetSession}' 2>/dev/null`, { stdio: 'ignore' });
+  } catch {
+    return; // No session — don't create empty ones, don't kill the pane
+  }
+
   if (windowIndex !== undefined) {
     try {
-      const agentTmux = `tmux -L ${GENIE_AGENT_SOCKET}`;
       execSync(`${agentTmux} select-window -t '${targetSession}:${windowIndex}'`, { stdio: 'ignore' });
-    } catch {
-      // window may not exist
-    }
+    } catch {}
   }
+
+  // Hide green status bar
   try {
-    // Respawn right pane with a while-true loop so it survives agent exit.
-    // When the inner attach ends (agent exits or detach), the loop re-attaches.
-    // If the session is destroyed, attach fails quickly and retries after sleep.
-    // Selecting a different agent calls respawn-pane -k again, killing this loop.
-    const attachCmd = `tmux -L ${GENIE_AGENT_SOCKET} attach-session -t '${targetSession}'`;
-    execSync(`tmux respawn-pane -k -t ${pane} "TMUX='' while true; do ${attachCmd} 2>/dev/null; sleep 0.5; done"`, {
-      stdio: 'ignore',
-    });
-  } catch {
-    // pane doesn't exist or command failed
-  }
+    execSync(`${agentTmux} set-option -t '${targetSession}' status off 2>/dev/null`, { stdio: 'ignore' });
+  } catch {}
+
+  // respawn-pane with a loop wrapper — the pane process is bash running a loop,
+  // so if the attach ends (agent exit, detach), the loop retries and the pane survives.
+  try {
+    const cmd = `while true; do TMUX='' ${agentTmux} attach-session -t '${targetSession}' 2>/dev/null; sleep 0.3; done`;
+    execSync(`${TMUX} respawn-pane -k -t ${pane} "bash -c '${cmd}'"`, { stdio: 'ignore' });
+  } catch {}
+
+  // Restore focus to left pane
+  try {
+    execSync(`${TMUX} select-pane -t ${SESSION_NAME}:0.0`, { stdio: 'ignore' });
+  } catch {}
 }
 
-/** Attach to the TUI session on default tmux server (blocking call) */
 export function attachTuiSession(): void {
-  spawnSync('tmux', ['attach-session', '-t', SESSION_NAME], { stdio: 'inherit' });
+  spawnSync('tmux', ['-L', TMUX_SOCKET, '-f', TUI_TMUX_CONF, 'attach-session', '-t', SESSION_NAME], {
+    stdio: 'inherit',
+  });
 }


### PR DESCRIPTION
Restores tmux.ts and Nav.tsx from 9a55ac32 (last working state).
Adds: spawn CWD from workspace, --session flag, tui-tmux.conf with
no prefix key, root table keybindings, no empty agent sessions.