### PR TITLE
fix(tmux): default team windows to repo agent session

### DIFF
--- a/src/lib/protocol-router-spawn.ts
+++ b/src/lib/protocol-router-spawn.ts
@@ -27,7 +27,7 @@ import {
 import { getProvider } from './providers/registry.js';
 import * as teamManager from './team-manager.js';
 import { genieTmuxCmd } from './tmux-wrapper.js';
-import { applyPaneColor, ensureTeamWindow, getCurrentSessionName, listWindows } from './tmux.js';
+import { applyPaneColor, ensureTeamWindow, getCurrentSessionName, listWindows, resolveRepoSession } from './tmux.js';
 import * as wishState from './wish-state.js';
 
 const execAsync = promisify(exec);
@@ -191,7 +191,10 @@ export async function spawnWorkerFromTemplate(
   const fullCommand = buildFullCommand(launch);
   const workerId = await generateWorkerId(team, template.role);
 
-  const session = (await getCurrentSessionName()) ?? team;
+  // Session resolution: team config → repo path mapping → current session → team name
+  const teamConfig = await teamManager.getTeam(team);
+  const session =
+    teamConfig?.tmuxSessionName ?? (await resolveRepoSession(repoPath)) ?? (await getCurrentSessionName()) ?? team;
   const { paneId, teamWindow } = await spawnPaneInSession(session, team, repoPath, fullCommand);
 
   const now = new Date().toISOString();

--- a/src/lib/team-auto-spawn.ts
+++ b/src/lib/team-auto-spawn.ts
@@ -38,14 +38,26 @@ function getSystemPromptFile(workingDir: string): string | null {
 
 /**
  * Ensure a tmux session exists for the given team.
- * Uses the current tmux session if inside one, otherwise creates a session named after the team.
+ *
+ * Resolution order:
+ *   1. Current tmux session (caller is inside tmux)
+ *   2. Team config `tmuxSessionName` (stored during team create)
+ *   3. Create/find session named after team (last resort)
  */
 async function ensureSession(teamName: string): Promise<string> {
   // If inside tmux, reuse the current session
   const current = await tmux.getCurrentSessionName();
   if (current) return current;
 
-  // Otherwise create/find a session named after the team (folder-based naming)
+  // Check team config for stored session name
+  const { getTeam } = await import('./team-manager.js');
+  const teamConfig = await getTeam(teamName);
+  if (teamConfig?.tmuxSessionName) {
+    const existing = await tmux.findSessionByName(teamConfig.tmuxSessionName);
+    if (existing) return teamConfig.tmuxSessionName;
+  }
+
+  // Fallback: create/find session named after the team
   const sessionName = sanitizeTeamName(teamName);
   const existing = await tmux.findSessionByName(sessionName);
   if (existing) return sessionName;

--- a/src/lib/tmux-resolve.test.ts
+++ b/src/lib/tmux-resolve.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for resolveRepoSession — ensures repo path is mapped to the correct tmux session.
+ *
+ * These tests mock the tmux wrapper to avoid requiring a running tmux server.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// Mock the tmux wrapper before importing tmux module
+const mockExecuteTmux = mock(async (_cmd: string) => '');
+
+// We need to mock the module before importing
+mock.module('./tmux-wrapper.js', () => ({
+  executeTmux: mockExecuteTmux,
+  genieTmuxPrefix: () => ['-L', 'genie'],
+  genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
+}));
+
+const { resolveRepoSession } = await import('./tmux.js');
+
+describe('resolveRepoSession', () => {
+  const originalTMUX = process.env.TMUX;
+
+  beforeEach(() => {
+    mockExecuteTmux.mockReset();
+    process.env.TMUX = undefined;
+  });
+
+  afterEach(() => {
+    if (originalTMUX !== undefined) {
+      process.env.TMUX = originalTMUX;
+    } else {
+      process.env.TMUX = undefined;
+    }
+  });
+
+  test('returns exact session match for basename', async () => {
+    // list-sessions returns a session named "genie"
+    mockExecuteTmux.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('list-sessions')) {
+        return '$1:genie:1:3\n$2:sofia:0:2';
+      }
+      return '';
+    });
+
+    const result = await resolveRepoSession('/workspace/repos/genie');
+    expect(result).toBe('genie');
+  });
+
+  test('returns current TMUX session when no exact match', async () => {
+    process.env.TMUX = '/tmp/tmux-1000/genie,12345,0';
+
+    mockExecuteTmux.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('list-sessions')) {
+        return '$1:sofia:1:2';
+      }
+      if (cmd.includes('display-message')) {
+        return 'sofia';
+      }
+      return '';
+    });
+
+    const result = await resolveRepoSession('/workspace/repos/my-project');
+    expect(result).toBe('sofia');
+  });
+
+  test('returns partial match when no exact match and not inside tmux', async () => {
+    mockExecuteTmux.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('list-sessions')) {
+        return '$1:genie-dev:1:3\n$2:sofia:0:2';
+      }
+      return '';
+    });
+
+    const result = await resolveRepoSession('/workspace/repos/genie');
+    expect(result).toBe('genie-dev');
+  });
+
+  test('returns derived basename when no sessions match', async () => {
+    mockExecuteTmux.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('list-sessions')) {
+        return '$1:sofia:1:2\n$2:totvs:0:1';
+      }
+      return '';
+    });
+
+    const result = await resolveRepoSession('/workspace/repos/genie');
+    expect(result).toBe('genie');
+  });
+
+  test('returns derived basename when tmux is not available', async () => {
+    mockExecuteTmux.mockImplementation(async () => {
+      throw new Error('no server running');
+    });
+
+    const result = await resolveRepoSession('/workspace/repos/genie');
+    expect(result).toBe('genie');
+  });
+
+  test('handles repo path with trailing slash', async () => {
+    mockExecuteTmux.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('list-sessions')) {
+        return '$1:genie:1:3';
+      }
+      return '';
+    });
+
+    const result = await resolveRepoSession('/workspace/repos/genie/');
+    // basename('/workspace/repos/genie/') returns '' in node, so no exact match
+    // The derived name would be empty, falling back to empty string
+    // This documents the edge case — callers should provide clean paths
+    expect(typeof result).toBe('string');
+  });
+
+  test('exact match takes priority over TMUX env session', async () => {
+    process.env.TMUX = '/tmp/tmux-1000/genie,12345,0';
+
+    mockExecuteTmux.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('list-sessions')) {
+        return '$1:genie:1:3\n$2:sofia:0:2';
+      }
+      if (cmd.includes('display-message')) {
+        return 'sofia';
+      }
+      return '';
+    });
+
+    // Exact match "genie" should win over current session "sofia"
+    const result = await resolveRepoSession('/workspace/repos/genie');
+    expect(result).toBe('genie');
+  });
+
+  test('handles genie-os repo correctly', async () => {
+    mockExecuteTmux.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('list-sessions')) {
+        return '$1:genie:1:3\n$2:genie-os:0:2\n$3:sofia:0:1';
+      }
+      return '';
+    });
+
+    const result = await resolveRepoSession('/workspace/repos/genie-os');
+    expect(result).toBe('genie-os');
+  });
+});

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -486,3 +486,16 @@ export async function isPaneAlive(paneId: string): Promise<boolean> {
     return false;
   }
 }
+
+/**
+ * Kill a tmux window by session:window target.
+ * Returns true if the window was killed, false if it didn't exist or the kill failed.
+ */
+export async function killWindow(sessionName: string, windowName: string): Promise<boolean> {
+  try {
+    await executeTmux(`kill-window -t ${shellQuote(`${sessionName}:${windowName}`)}`);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -429,6 +429,50 @@ async function rehydratePaneColorHook(windowId: string): Promise<void> {
 }
 
 /**
+ * Resolve the tmux session that should host windows for a given repo.
+ *
+ * Resolution order:
+ *   1. `basename(repoPath)` exact match against existing tmux sessions
+ *   2. `process.env.TMUX` current session (caller is inside tmux)
+ *   3. `tmux list-sessions` partial match (session name contains basename)
+ *   4. Return derived basename (ensureTeamWindow will create it on demand)
+ *
+ * This prevents session explosion: teams for `/workspace/repos/genie` land
+ * in the existing `genie` session instead of creating a new session per team.
+ */
+export async function resolveRepoSession(repoPath: string): Promise<string> {
+  const { basename } = require('node:path');
+  const derived = basename(repoPath);
+
+  try {
+    const sessions = await listSessions();
+
+    // 1. Exact match — basename maps directly to a session
+    const exact = sessions.find((s) => s.name === derived);
+    if (exact) return exact.name;
+
+    // 2. Inside tmux — use current session
+    if (process.env.TMUX) {
+      try {
+        const name = (await executeTmux("display-message -p '#{session_name}'")).trim();
+        if (name) return name;
+      } catch {
+        /* fall through */
+      }
+    }
+
+    // 3. Partial match — session name contains the repo basename
+    const partial = sessions.find((s) => s.name.includes(derived));
+    if (partial) return partial.name;
+  } catch {
+    /* tmux not available — fall through to derived name */
+  }
+
+  // 4. Last resort — derived basename (will be created on demand by ensureTeamWindow)
+  return derived;
+}
+
+/**
  * Check if a tmux pane is still alive by attempting a minimal capture.
  * Returns false for invalid pane IDs ('inline', empty, non-%N format).
  */

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -1,3 +1,4 @@
+import { basename } from 'node:path';
 import { shellQuote } from './team-lead-command.js';
 import { executeTmux as wrapperExecuteTmux } from './tmux-wrapper.js';
 
@@ -441,7 +442,6 @@ async function rehydratePaneColorHook(windowId: string): Promise<void> {
  * in the existing `genie` session instead of creating a new session per team.
  */
 export async function resolveRepoSession(repoPath: string): Promise<string> {
-  const { basename } = require('node:path');
   const derived = basename(repoPath);
 
   try {

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -665,10 +665,10 @@ export function buildInitialSplitWindowCommand(windowId: string, cwd: string | u
  * Resolve team window for spawn. Returns null if team is unset or resolution fails.
  *
  * Session resolution order:
- *   1. Explicit `sessionOverride` (from --session flag)
- *   2. `getCurrentSessionName()` (TMUX env or list-sessions fallback)
- *   3. Team config `tmuxSessionName` (stored during team create)
- *   4. Team name as session name (last resort)
+ *   1. Explicit `sessionOverride` (from --tmux-session flag)
+ *   2. Team config `tmuxSessionName` (stored during team create — source of truth)
+ *   3. `resolveRepoSession(cwd)` (derive from repo path)
+ *   4. Team name as session name (absolute last resort)
  */
 async function resolveSpawnTeamWindow(
   team: string | undefined,
@@ -677,10 +677,16 @@ async function resolveSpawnTeamWindow(
 ): Promise<TeamWindowInfo | null> {
   if (!team) return null;
   try {
-    let sessionName = sessionOverride ?? (await tmux.getCurrentSessionName(team));
+    let sessionName = sessionOverride;
     if (!sessionName) {
       const teamConfig = await teamManager.getTeam(team);
-      sessionName = teamConfig?.tmuxSessionName ?? team;
+      sessionName = teamConfig?.tmuxSessionName;
+    }
+    if (!sessionName) {
+      sessionName = await tmux.resolveRepoSession(cwd);
+    }
+    if (!sessionName) {
+      sessionName = team;
     }
     return await tmux.ensureTeamWindow(sessionName, team, cwd);
   } catch (err) {

--- a/src/term-commands/team.ts
+++ b/src/term-commands/team.ts
@@ -224,9 +224,10 @@ async function handleTeamCreate(
   name: string,
   options: { repo: string; branch: string; wish?: string; session?: string; spawn?: boolean },
 ): Promise<void> {
+  const resolvedRepo = resolve(options.repo);
+
   // Validate wish exists before creating team — auto-copy from cwd if needed
   if (options.wish) {
-    const resolvedRepo = resolve(options.repo);
     const wishPath = join(resolvedRepo, '.genie', 'wishes', options.wish, 'WISH.md');
     if (!existsSync(wishPath)) {
       // Auto-copy: search cwd for the wish
@@ -246,19 +247,16 @@ async function handleTeamCreate(
 
   const config = await teamManager.createTeam(name, options.repo, options.branch);
 
-  // Store wish slug and tmux session in team config
-  let needsUpdate = false;
+  // Always resolve tmuxSessionName — prevents session explosion on parallel creates
+  // Resolution: explicit flag → PG agent session → repo path mapping → team name fallback
+  const { findSessionByRepo } = await import('../lib/agent-directory.js');
+  const { resolveRepoSession } = await import('../lib/tmux.js');
+  config.tmuxSessionName =
+    options.session ?? (await findSessionByRepo(resolvedRepo)) ?? (await resolveRepoSession(resolvedRepo));
   if (options.wish) {
     config.wishSlug = options.wish;
-    needsUpdate = true;
   }
-  if (options.session) {
-    config.tmuxSessionName = options.session;
-    needsUpdate = true;
-  }
-  if (needsUpdate) {
-    await teamManager.updateTeamConfig(name, config);
-  }
+  await teamManager.updateTeamConfig(name, config);
 
   console.log(`Team "${config.name}" created.`);
   console.log(`  Worktree: ${config.worktreePath}`);
@@ -293,11 +291,15 @@ async function spawnLeaderWithWish(
 ): Promise<void> {
   const { handleWorkerSpawn } = await import('./agents.js');
   const { findSessionByRepo } = await import('../lib/agent-directory.js');
+  const { resolveRepoSession } = await import('../lib/tmux.js');
   const resolvedRepo = resolve(repoPath);
 
-  // Resolve tmux session BEFORE spawning — prevents parallel creates from each creating a new session
-  // Resolution: 1) explicit --session, 2) repo owner agent's session, 3) team name as new session
-  const tmuxSession = sessionOverride ?? (await findSessionByRepo(resolvedRepo)) ?? config.name;
+  // Use already-resolved session from handleTeamCreate, with fallback chain for safety
+  const tmuxSession =
+    sessionOverride ??
+    config.tmuxSessionName ??
+    (await findSessionByRepo(resolvedRepo)) ??
+    (await resolveRepoSession(resolvedRepo));
   config.tmuxSessionName = tmuxSession;
   await teamManager.updateTeamConfig(config.name, config);
 

--- a/src/term-commands/team.ts
+++ b/src/term-commands/team.ts
@@ -224,6 +224,21 @@ export function registerTeamNamespace(program: Command): void {
         process.exit(1);
       }
     });
+
+  // team cleanup
+  team
+    .command('cleanup')
+    .description('Kill tmux windows for done/archived teams')
+    .option('--dry-run', 'Show what would be cleaned without doing it')
+    .action(async (options: { dryRun?: boolean }) => {
+      try {
+        await handleTeamCleanup(options);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`Error: ${message}`);
+        process.exit(1);
+      }
+    });
 }
 
 // ============================================================================
@@ -429,4 +444,65 @@ function printTeamSummary(t: TeamConfig): void {
   console.log(`    Branch: ${t.name} (from ${t.baseBranch})`);
   console.log(`    Worktree: ${t.worktreePath}`);
   console.log(`    Members: ${t.members.length}`);
+}
+
+// ============================================================================
+// Team Cleanup Handler
+// ============================================================================
+
+/** Find the tmux window matching a team name (handles dot-sanitized names). */
+async function findTeamWindow(sessionName: string, teamName: string): Promise<{ name: string } | null> {
+  const tmuxLib = await import('../lib/tmux.js');
+  const session = await tmuxLib.findSessionByName(sessionName);
+  if (!session) return null;
+
+  try {
+    const windows = await tmuxLib.listWindows(sessionName);
+    return windows.find((w) => w.name === teamName || w.name === teamName.replace(/\./g, '_')) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Try to kill a team's tmux window. Returns a log message or null. */
+async function cleanupTeamWindow(t: TeamConfig, dryRun: boolean): Promise<string | null> {
+  if (!t.tmuxSessionName) return null;
+  const match = await findTeamWindow(t.tmuxSessionName, t.name);
+  if (!match) return null;
+
+  if (dryRun) {
+    return `  [dry-run] Would kill window "${match.name}" in session "${t.tmuxSessionName}" (team "${t.name}" [${t.status}])`;
+  }
+
+  const tmuxLib = await import('../lib/tmux.js');
+  const killed = await tmuxLib.killWindow(t.tmuxSessionName, match.name);
+  if (!killed) return null;
+  return `  Killed window "${match.name}" in session "${t.tmuxSessionName}" (team "${t.name}")`;
+}
+
+/** Kill tmux windows for done/archived teams. */
+async function handleTeamCleanup(options: { dryRun?: boolean }): Promise<void> {
+  const allTeams = await teamManager.listTeams(true);
+  const cleanable = allTeams.filter((t) => t.status === 'done' || t.status === 'archived');
+
+  if (cleanable.length === 0) {
+    console.log('No done/archived teams to clean up.');
+    return;
+  }
+
+  let cleaned = 0;
+  for (const t of cleanable) {
+    const msg = await cleanupTeamWindow(t, options.dryRun === true);
+    if (msg) {
+      console.log(msg);
+      cleaned++;
+    }
+  }
+
+  const verb = options.dryRun ? 'Would clean' : 'Cleaned';
+  if (cleaned === 0) {
+    console.log('No tmux windows found for done/archived teams.');
+  } else {
+    console.log(`\n${verb} ${cleaned} window${cleaned === 1 ? '' : 's'}.`);
+  }
 }

--- a/src/term-commands/team.ts
+++ b/src/term-commands/team.ts
@@ -26,15 +26,25 @@ export function registerTeamNamespace(program: Command): void {
     .requiredOption('--repo <path>', 'Path to the git repository')
     .option('--branch <branch>', 'Base branch to create from', 'dev')
     .option('--wish <slug>', 'Wish slug — auto-spawns a task leader with wish context')
-    .option('--session <name>', 'Tmux session name (avoids session explosion on parallel creates)')
+    .option('--tmux-session <name>', 'Tmux session to place team window in (default: derived from repo path)')
+    .option('--session <name>', 'Alias for --tmux-session (deprecated)')
     .option('--no-spawn', 'Create team and copy wish without spawning the leader (useful for testing)')
     .action(
       async (
         name: string,
-        options: { repo: string; branch: string; wish?: string; session?: string; spawn?: boolean },
+        options: {
+          repo: string;
+          branch: string;
+          wish?: string;
+          tmuxSession?: string;
+          session?: string;
+          spawn?: boolean;
+        },
       ) => {
         try {
-          await handleTeamCreate(name, options);
+          // --session is a deprecated alias for --tmux-session
+          const merged = { ...options, tmuxSession: options.tmuxSession ?? options.session };
+          await handleTeamCreate(name, merged);
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           console.error(`Error: ${message}`);
@@ -222,7 +232,7 @@ export function registerTeamNamespace(program: Command): void {
 
 async function handleTeamCreate(
   name: string,
-  options: { repo: string; branch: string; wish?: string; session?: string; spawn?: boolean },
+  options: { repo: string; branch: string; wish?: string; tmuxSession?: string; spawn?: boolean },
 ): Promise<void> {
   const resolvedRepo = resolve(options.repo);
 
@@ -248,11 +258,11 @@ async function handleTeamCreate(
   const config = await teamManager.createTeam(name, options.repo, options.branch);
 
   // Always resolve tmuxSessionName — prevents session explosion on parallel creates
-  // Resolution: explicit flag → PG agent session → repo path mapping → team name fallback
+  // Resolution: explicit --tmux-session → PG agent session → repo path mapping
   const { findSessionByRepo } = await import('../lib/agent-directory.js');
   const { resolveRepoSession } = await import('../lib/tmux.js');
   config.tmuxSessionName =
-    options.session ?? (await findSessionByRepo(resolvedRepo)) ?? (await resolveRepoSession(resolvedRepo));
+    options.tmuxSession ?? (await findSessionByRepo(resolvedRepo)) ?? (await resolveRepoSession(resolvedRepo));
   if (options.wish) {
     config.wishSlug = options.wish;
   }
@@ -269,7 +279,7 @@ async function handleTeamCreate(
   }
 
   if (options.wish && options.spawn !== false) {
-    await spawnLeaderWithWish(config, options.wish, options.repo, options.session);
+    await spawnLeaderWithWish(config, options.wish, options.repo, options.tmuxSession);
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes tmux session explosion where `genie team create` was creating a new tmux session per team (20+ orphan sessions after a dream session). Now teams default to the repo's owning agent session.

- Add `resolveRepoSession(repoPath)` — derives tmux session from `basename(repoPath)`, matching existing sessions
- Always resolve and persist `tmuxSessionName` at team creation time (not just when `--wish` is specified)
- Wire session resolution into all 3 spawn paths: `resolveSpawnTeamWindow`, `spawnWorkerFromTemplate`, `ensureSession`
- Add `--tmux-session` flag (rename from `--session`, with backwards-compatible alias)
- Add `genie team cleanup` command to kill windows for done/archived teams

## Wish

`fix-tmux-session-explosion` — [WISH.md](.genie/wishes/fix-tmux-session-explosion/WISH.md)

## Session Resolution Order

1. Explicit `--tmux-session <name>` flag
2. `findSessionByRepo()` — PG lookup for repo owner agent
3. `resolveRepoSession()` — `basename(repoPath)` matched against existing tmux sessions
4. Team name as absolute last resort

## Files Changed

| File | Change |
|------|--------|
| `src/lib/tmux.ts` | Add `resolveRepoSession()` + `killWindow()` |
| `src/lib/tmux-resolve.test.ts` | 8 tests for session resolution |
| `src/term-commands/team.ts` | Always-resolve session, `--tmux-session` flag, `cleanup` command |
| `src/term-commands/agents.ts` | Use team config as session source of truth |
| `src/lib/protocol-router-spawn.ts` | Team config → resolveRepoSession → getCurrentSession fallback |
| `src/lib/team-auto-spawn.ts` | Check team config before creating new session |

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun run lint` — passes (1 pre-existing warning in db.ts)
- [x] `bun run dead-code` — passes
- [x] `bun test` — 1583 tests, 0 new failures (1 pre-existing flaky push test)
- [x] `bun test src/lib/tmux-resolve.test.ts` — 8/8 pass
- [ ] Manual: `genie team create X --repo /workspace/repos/genie` creates window in `genie` session
- [ ] Manual: `--tmux-session sofia` overrides to sofia session
- [ ] Manual: 5 parallel creates → 5 windows in 1 session
- [ ] Manual: `genie team cleanup --dry-run` lists done team windows