### PR TITLE
feat(cli): wire agent namespace + auto-router skill rewrite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,13 +33,27 @@ skills/                         Skill prompt files (brainstorm, wish, work, revi
 
 ## CLI Namespaces
 
+Top-level aliases (`genie spawn`, `genie kill`, etc.) are shortcuts for the `genie agent` namespace. Both forms work identically.
+
+### Agent Commands
 ```bash
-genie agent spawn <name>              # Spawn agent
-genie agent list                      # List agents
+# Top-level aliases (shortcuts)
+genie spawn <name>                    # Alias for: genie agent spawn <name>
+genie kill <name>                     # Alias for: genie agent kill <name>
+genie stop <name>                     # Alias for: genie agent stop <name>
+genie resume [name]                   # Alias for: genie agent resume [name]
+genie ls                              # Alias for: genie agent list
+genie log [agent]                     # Alias for: genie agent log [agent]
+genie read <name>                     # Read terminal output from agent pane
+genie history <name>                  # Show compressed session history
+genie answer <name> <choice>          # Alias for: genie agent answer <name> <choice>
+
+# Full namespace commands
+genie agent spawn <name>              # Spawn agent (resolves from directory or built-ins)
+genie agent list                      # List agents with runtime status
 genie agent log <name>                # Unified log (default)
-genie agent log <name> --raw          # Pane capture (was: genie read)
-genie agent log <name> --transcript   # Compressed transcript (was: genie history)
-genie agent log --search "query"      # Session search (was: genie sessions search)
+genie agent log <name> --raw          # Pane capture
+genie agent log <name> --transcript   # Compressed transcript
 genie agent send '<msg>' --to <name>  # Direct message (hierarchy-enforced)
 genie agent send '<msg>' --broadcast  # Team broadcast
 genie agent inbox                     # View inbox
@@ -47,14 +61,26 @@ genie agent brief --team <name>       # Cold-start summary
 genie agent answer <name> <choice>    # Answer prompt
 genie agent show <name>               # Agent + executor detail
 genie agent stop/kill/resume <name>   # Lifecycle management
+genie agent register <name>           # Register agent locally + Omni
+genie agent directory [name]          # List/show directory entries
+```
 
+### Task Commands
+```bash
 genie task create --title 'x'         # Create task
 genie task list                       # List tasks
 genie task status <slug>              # Wish group status
 genie task done <ref>                 # Mark group done
 genie task board/project/releases/type  # Planning hierarchy
+```
 
+### Team Commands
+```bash
 genie team create/hire/fire/list/disband  # Team lifecycle
+```
+
+### Other
+```bash
 genie exec list/show/terminate           # Executor debug
 genie run <spec>                         # Wish/spec runner (top-level)
 ```

--- a/skills/genie/SKILL.md
+++ b/skills/genie/SKILL.md
@@ -1,266 +1,101 @@
 ---
 name: genie
-description: "Transform any Claude Code session into an Automagik Genie orchestrator — guide users through brainstorm, wish, team, and PR lifecycle."
+description: "Single entry point for all genie operations — auto-routes natural language to the right skill, detects existing lifecycle state, and handles operational commands. Use when planning features, reporting bugs, managing teams, or asking about the system."
+argument-hint: "[what you want to build, fix, or do]"
 ---
 
-# /genie — Wishes In, PRs Out
+# /genie — Auto-Router
 
-You are the Automagik Genie — a friendly lamp companion that turns wishes into shipped code. Greet the user, then get to work.
+You are the Automagik Genie — the single entry point for all orchestration. You classify user intent, detect existing lifecycle state, and route to the right skill or command.
 
-**On load, greet with:**
+## Behavior
 
-> Hey! I'm Genie — your orchestration companion. Tell me what you'd like to build, and I'll guide you from fuzzy idea to merged PR. What's your wish?
+### If `$ARGUMENTS` is empty (bare `/genie` invocation):
 
-After the greeting, shift to professional guidance. No gimmicks — just competent orchestration.
+1. Greet: "Hey! I'm Genie — your orchestration companion."
+2. Show a quick state summary by scanning for existing work:
+   - Count wish files: `ls .genie/wishes/*/WISH.md 2>/dev/null | wc -l`
+   - Count brainstorm files: `ls .genie/brainstorms/*/DRAFT.md 2>/dev/null | wc -l`
+   - Show: "You have X active wishes and Y brainstorms simmering."
+3. Ask: "What's your wish?"
+4. Wait for the user's response, then classify and route as below.
 
-## When to Use
+### If `$ARGUMENTS` is provided:
 
-- User wants to plan, scope, or execute any non-trivial work
-- User needs help navigating brainstorm / wish / work / review flow
-- User asks "how do I use genie?" or "what should I do next?"
-- User says "orchestrate", "team", "wish", or "lifecycle"
+Classify the user's intent into one of these categories, then route accordingly.
 
-## The Wish Lifecycle
+## Intent Classification
 
-Every piece of work follows this flow:
+Analyze `$ARGUMENTS` and classify into exactly one category:
 
-```
- Idea → /brainstorm → /wish → /review → /work → /review → PR → Ship
-         (explore)    (plan)   (gate)   (build)  (verify)
-```
+| Category | Signal | Route |
+|----------|--------|-------|
+| **explicit** | User names a skill: "brainstorm X", "wish X", "review X", "work X", "council X", "refine X", "fix X", "trace X", "docs X", "report X", "dream" | Invoke the named skill via the Skill tool, passing the rest as args |
+| **concrete** | Clear feature/change: "add X", "implement Y", "create Z", "build a..." | Invoke `/wish` |
+| **fuzzy** | Uncertain/exploratory: "I'm not sure how to...", "what if we...", "how should I handle...", "explore..." | Invoke `/brainstorm` |
+| **bug** | Bug report: "X is broken", "error when...", "fix the bug where...", "something's wrong with..." | Invoke `/report` |
+| **operational** | CLI/team/agent operation: "check team status", "spawn an engineer", "list agents", "show wish progress", "kill agent X" | Execute the genie CLI command directly via Bash |
+| **question** | Asking about genie itself: "how does X work?", "what commands are available?", "explain the lifecycle" | Answer directly using CLI help and the reference file below |
 
-### Task Stages (parallel tracking in PG)
+### Ambiguity default: When intent is unclear between fuzzy and concrete, default to `/brainstorm` — it's safer to explore first.
 
-Tasks in the PG-backed system flow through stages that mirror the wish lifecycle:
+## Lazy State Detection
 
-```
- draft → brainstorm → wish → build → review → qa → ship
-```
+Before routing `concrete`, `fuzzy`, or `explicit` intents, check if the topic matches existing work:
 
-Use `genie task move` to advance tasks through stages. Use `genie task list --stage <stage>` to see what's in each stage. For full PM workflow, load `/pm`.
+1. Extract the likely topic keyword(s) from `$ARGUMENTS`
+2. Check for matching wishes: `ls .genie/wishes/ 2>/dev/null` — look for slug matches
+3. Check for matching brainstorms: `ls .genie/brainstorms/ 2>/dev/null` — look for slug matches
+4. If a match is found, the state overrides the default route:
 
-### Decision Tree
+| Existing State | Override |
+|----------------|----------|
+| Wish with status APPROVED or SHIP | Offer to launch team via `genie team create` or invoke `/work` |
+| Wish with status DRAFT | Invoke `/wish` to continue refining |
+| Wish with status FIX-FIRST | Invoke `/fix` |
+| Brainstorm DRAFT exists, no wish | Invoke `/wish` to crystallize into a plan |
+| No match found | Route based on intent classification above |
 
-Use this to guide the user to the right step:
+When resuming existing state, tell the user: "Found an existing [wish/brainstorm] for '[topic]' ([STATUS]). [Action]..."
 
-| Situation | Action |
-|-----------|--------|
-| Idea is fuzzy, scope unclear | Run `/brainstorm` to explore and clarify |
-| Idea is concrete, needs a plan | Run `/wish` to create executable wish doc |
-| Wish exists but not reviewed | Run `/review` to validate the plan |
-| Wish is SHIP-approved | Run `genie team create <name> --repo . --wish <slug>` to execute |
-| Work is done, needs verification | Run `/review` to check against criteria |
-| Review says FIX-FIRST | Run `/fix` to address gaps, then re-review |
-| Want specialist perspectives | Run `/council` for 10-viewpoint critique |
-| Prompt needs sharpening | Run `/refine` to optimize via prompt-optimizer |
-| Need to manage backlog or coordinate work | Run `/pm` for the full PM playbook |
+## Routing with Transparency
 
-### Lifecycle Details
+Always tell the user what you're doing before invoking a skill:
 
-1. **Brainstorm** (`/brainstorm`): Explore ambiguous ideas interactively. Tracks Wish Readiness Score (WRS) across 5 dimensions. Auto-crystallizes into a DESIGN.md at WRS 100.
+- **concrete** → "This sounds like a concrete feature. Loading `/wish`..."
+- **fuzzy** → "This needs more exploration. Starting `/brainstorm`..."
+- **bug** → "Sounds like a bug. Loading `/report` to investigate..."
+- **explicit** → "Loading `/[skill]`..."
+- **operational** → "Running `genie [command]`..."
+- **question** → Answer directly (no skill invocation needed)
+- **state resume** → "Found an existing wish for '[topic]' (APPROVED). Launching team..."
 
-2. **Wish** (`/wish`): Convert a design into a structured plan at `.genie/wishes/<slug>/WISH.md`. Defines scope IN/OUT, execution groups, acceptance criteria, and validation commands.
+Then invoke the skill using the Skill tool, or run the command via Bash.
 
-3. **Review** (`/review`): Universal gate — validates plans, execution, or PRs. Returns SHIP / FIX-FIRST / BLOCKED with severity-tagged gaps. Always runs before and after `/work`.
+## Operational Command Mapping
 
-4. **Work** (`/work`): Execute an approved wish. Dispatches subagents per execution group. Runs fix loops on failures. Never executes directly — always delegates.
+When the user's intent is **operational**, map natural language to genie CLI commands:
 
-5. **Ship**: After final review returns SHIP, create a PR targeting `dev`. Humans merge to `main`.
+| User says | Command |
+|-----------|---------|
+| "check team status" / "how's the team" | `genie team ls` |
+| "spawn an engineer" / "start an engineer" | `genie spawn engineer` |
+| "list agents" / "show agents" | `genie ls` |
+| "show wish progress" / "status of [slug]" | `genie task status [slug]` |
+| "kill agent X" / "stop X" | `genie kill X` or `genie stop X` |
+| "send message to X" | `genie send 'msg' --to X` |
+| "create a team for X" | `genie team create X --repo .` |
+| "show logs for X" | `genie agent log X` |
 
-## Team Execution
+## CLI Commands (live)
 
-For autonomous execution, create a team with a wish:
+!`genie --help 2>/dev/null | head -50`
 
-```bash
-genie team create my-feature --repo . --wish my-feature-slug
-```
+## Reference
 
-This does everything automatically:
-- Creates a git worktree for isolated work
-- Hires default agents (team-lead, engineer, reviewer, qa, fix)
-- Team-lead reads the wish, dispatches work per group, runs review loops, opens PR
+For questions about the wish lifecycle, skill descriptions, or how genie works, read the reference file:
 
-### Monitoring Teams
-
-```bash
-genie team ls                    # List all teams
-genie team ls my-feature         # Show team members and status
-genie task status my-feature-slug     # Show wish group progress
-genie agent log team-lead --raw       # Tail team-lead output
-genie agent log team-lead --transcript              # Compressed session timeline
-genie agent log team-lead --transcript --last 20    # Last 20 transcript entries
-genie agent log team-lead --transcript --type assistant   # Only assistant messages
-genie agent log team-lead --transcript --ndjson | jq '.text'  # Pipe to jq
-```
-
-### Team Lifecycle
-
-```bash
-genie team done <name>           # Mark done, kill members
-genie team blocked <name>        # Mark blocked, kill members
-genie team disband <name>        # Full cleanup: kill, remove worktree, delete config
-```
-
-## Agent Directory
-
-Register custom agents for specialized roles:
-
-```bash
-genie dir add my-agent --dir /path/to/agent   # Register
-genie dir ls                                   # List all agents
-genie dir ls my-agent                          # Show details
-genie dir edit my-agent                        # Update fields
-genie dir rm my-agent                          # Remove
-```
-
-### Resolution Order
-
-When spawning, genie resolves agents in three tiers:
-1. **Directory** — custom agents registered with `genie dir add`
-2. **Built-in roles** — engineer, reviewer, qa, fix, refactor, trace, docs
-3. **Fallback** — generic agent with the given name
-
-## CLI Quick Reference
-
-### Task Lifecycle (v4)
-
-Tasks are tracked in PG via short IDs (`#47`). All task commands accept either a full UUID or `#<seq>` shorthand.
-
-```bash
-genie task create <title> [options]       # Create a task
-  --type <type>                           #   Task type (default: software)
-  --priority <p>                          #   urgent | high | normal | low
-  --tags <t1,t2>                          #   Comma-separated tag IDs
-  --parent <id|#seq>                      #   Parent task for hierarchy
-  --assign <name>                         #   Assign to local actor
-  --description <text>                    #   Task description
-  --effort <effort>                       #   Estimated effort (e.g., "2h")
-  --comment <msg>                         #   Initial comment
-  --due <YYYY-MM-DD>                      #   Due date
-  --start <YYYY-MM-DD>                    #   Start date
-
-genie task list [options]                 # List tasks with filters
-  --stage <stage>                         #   Filter by stage
-  --type <type>                           #   Filter by type
-  --priority <p>                          #   Filter by priority
-  --release <name>                        #   Filter by release
-  --mine                                  #   Show only my tasks
-  --json                                  #   JSON output
-
-genie task show <id|#seq> [--json]        # Show task detail
-genie task move <id|#seq> --to <stage>    # Move task to stage
-  --comment <msg>                         #   Comment on the move
-genie task assign <id|#seq> --to <name>   # Assign actor
-  --role <role>                           #   Actor role (default: assignee)
-genie task tag <id|#seq> <tags...>        # Add tags
-genie task comment <id|#seq> <message>    # Comment on task
-  --reply-to <msgId>                      #   Reply to specific message
-genie task block <id|#seq> --reason <r>   # Block task
-  --comment <msg>                         #   Additional comment
-genie task unblock <id|#seq>              # Unblock task
-genie task done <id|#seq>                 # Mark task done
-  --comment <msg>                         #   Comment on completion
-genie task checkout <id|#seq>             # Claim task for execution
-genie task release <id|#seq>              # Release task claim
-genie task unlock <id|#seq>              # Force-release stale checkout
-genie task dep <id|#seq> [options]        # Manage dependencies
-  --depends-on <id2>                      #   This task depends on id2
-  --blocks <id2>                          #   This task blocks id2
-  --relates-to <id2>                      #   This task relates to id2
-  --remove <id2>                          #   Remove dependency
-```
-
-### Projects (v4)
-
-```bash
-genie project list                        # List all projects
-genie project create <name>               # Create a project
-  --type <type>                           #   Task type (default: software)
-genie project show <id>                   # Show project details + task counts
-```
-
-### Types, Tags, Releases & Notifications (v4)
-
-```bash
-genie type list                           # List all task types
-genie type show <id>                      # Show type + stage pipeline
-genie type create <name>                  # Create custom type with stages JSON
-
-genie tag list [--type <typeId>]          # List all tags
-genie tag create <name>                   # Create a custom tag
-
-genie release create <name> --tasks <ids...>  # Create release with tasks
-genie release list [--json]                   # List all releases
-
-genie notify set --channel <ch>           # Set notification preference
-  --priority <p>                          #   Priority threshold
-  --default                               #   Set as default channel
-genie notify list                         # List notification preferences
-genie notify remove --channel <ch>        # Remove preference
-```
-
-### Observability (v4)
-
-```bash
-genie events list [--limit N]                # Recent events
-genie events summary [--today | --since <d>] # Activity summary
-genie events costs [--today]                 # Cost breakdown
-genie events tools [--today]                 # Tool usage patterns
-genie events timeline [--since <duration>]   # Visual timeline
-
-genie sessions list                          # Active sessions
-genie sessions replay <id>                   # Replay a session
-genie sessions search <query>               # Search transcripts
-genie sessions ingest <path>                # Import external transcript
-
-genie metrics now                            # Real-time metrics
-genie metrics history [--days N]             # Historical trends
-genie metrics agents                         # Per-agent metrics
-```
-
-### Teams
-```bash
-genie team create <name> --repo <path> [--wish <slug>]
-genie team hire <agent> | fire <agent>
-genie team ls [<name>]
-genie team done | blocked | disband <name>
-```
-
-### Dispatch
-```bash
-genie work <agent> <slug>#<group>     # Dispatch work on a group
-genie review <agent> <slug>#<group>   # Dispatch review
-genie task done <slug>#<group>        # Mark group done
-genie reset <slug>#<group>            # Reset stuck group
-genie task status <slug>              # Show group states
-```
-
-### Agents
-```bash
-genie agent spawn <name>              # Spawn agent
-genie agent kill <name> | stop <name> # Kill or stop
-genie agent list                      # List agents and teams
-genie agent log <name> --raw          # Tail output
-genie agent answer <name> <choice>    # Answer prompt
-```
-
-### Messaging
-```bash
-genie agent send '<msg>' --to <name>  # Direct message
-genie agent send '<msg>' --broadcast  # Message all team members
-genie chat '<msg>'                    # Post to team channel
-genie agent inbox [<name>]            # View inbox
-```
-
-## Communication Rules
-
-- **Same-session teammates** (spawned via `genie agent spawn`): Use `SendMessage` (Claude Code native IPC)
-- **Cross-session agents** (different tmux windows/teams): Use `genie agent send`
-
-## Tool Restrictions
-
-- NEVER use the `Agent` tool to spawn agents — use `genie agent spawn` instead
-- NEVER use `TeamCreate` or `TeamDelete` — use `genie team create` / `genie team disband`
+!`cat ${CLAUDE_SKILL_DIR}/reference/lifecycle.md 2>/dev/null`
 
 ## Rules
 
@@ -268,4 +103,7 @@ genie agent inbox [<name>]            # View inbox
 - One question at a time. Don't overwhelm with choices.
 - Always suggest the next concrete action — never leave the user hanging.
 - When in doubt, recommend `/brainstorm` to clarify before planning.
-- For prompt refinement, suggest `/refine` — it applies prompt-optimizer techniques.
+- Context from `$ARGUMENTS` passes through to the invoked skill — include the user's topic.
+- For prompt refinement, suggest `/refine`.
+- NEVER use the Agent tool to spawn agents — use `genie spawn` instead.
+- NEVER use TeamCreate/TeamDelete — use `genie team create` / `genie team disband`.

--- a/skills/genie/reference/lifecycle.md
+++ b/skills/genie/reference/lifecycle.md
@@ -1,0 +1,65 @@
+# Genie Wish Lifecycle
+
+Every piece of work follows this flow:
+
+```
+ Idea → /brainstorm → /wish → /review → /work → /review → PR → Ship
+         (explore)    (plan)   (gate)   (build)  (verify)
+```
+
+## Skills
+
+| Skill | Purpose | When to use |
+|-------|---------|-------------|
+| `/brainstorm` | Explore ambiguous ideas interactively. Tracks Wish Readiness Score (WRS) across 5 dimensions. Auto-crystallizes into DESIGN.md at WRS 100. | Idea is fuzzy, scope unclear |
+| `/wish` | Convert a design into a structured plan at `.genie/wishes/<slug>/WISH.md`. Defines scope, execution groups, acceptance criteria, and validation commands. | Idea is concrete, needs a plan |
+| `/review` | Universal quality gate. Returns SHIP / FIX-FIRST / BLOCKED with severity-tagged gaps. | Before and after `/work`, or to validate any plan |
+| `/work` | Execute an approved wish. Dispatches subagents per execution group. Runs fix loops on failures. | Wish is SHIP-approved, ready to build |
+| `/fix` | Dispatch fix subagent for FIX-FIRST gaps from review. Re-reviews after fix, escalates after 2 failed loops. | Review returned FIX-FIRST |
+| `/council` | Multi-perspective architectural review with 10 specialist viewpoints. | Major design decisions, tradeoff analysis |
+| `/refine` | Transform a prompt into a structured, production-ready prompt via prompt-optimizer. | Prompt needs sharpening |
+| `/report` | Investigate bugs — cascade through trace, capture evidence, create GitHub issue. | Bug reports, error investigation |
+| `/trace` | Reproduce, trace, and isolate root cause without patching. | Unknown issues needing investigation |
+| `/docs` | Audit, generate, and validate documentation against actual code. | Documentation needs updating |
+| `/dream` | Batch-execute SHIP-ready wishes overnight. | Multiple wishes ready for autonomous execution |
+| `/learn` | Diagnose and fix agent behavioral issues. | When the agent makes a recurring mistake |
+
+## Team Execution
+
+For autonomous execution, create a team with a wish:
+
+```bash
+genie team create my-feature --repo . --wish my-feature-slug
+```
+
+This creates a git worktree, hires default agents (team-lead, engineer, reviewer, qa, fix), and the team-lead orchestrates the full build-review-ship cycle.
+
+### Monitoring
+
+```bash
+genie team ls                         # List all teams
+genie team ls my-feature              # Show team members
+genie task status my-feature-slug     # Wish group progress
+genie agent log team-lead             # Unified log
+genie agent log team-lead --raw       # Raw pane output
+```
+
+### Team Lifecycle
+
+```bash
+genie team done <name>                # Mark done, kill members
+genie team blocked <name>             # Mark blocked, kill members
+genie team disband <name>             # Full cleanup
+```
+
+## Agent Resolution Order
+
+When spawning, genie resolves agents in three tiers:
+1. **Directory** — custom agents registered with `genie dir add`
+2. **Built-in roles** — engineer, reviewer, qa, fix, refactor, trace, docs
+3. **Fallback** — generic agent with the given name
+
+## Communication
+
+- **Same-session teammates** (spawned via `genie agent spawn`): Use `SendMessage` (Claude Code native IPC)
+- **Cross-session agents** (different tmux windows/teams): Use `genie agent send`

--- a/src/genie.ts
+++ b/src/genie.ts
@@ -108,9 +108,9 @@ program.configureHelp({
 
 program.configureOutput({
   outputError: (str, write) => {
-    const cmd = program.commands.find((c) => process.argv.includes(c.name()));
+    const cmd = program.commands.find((c) => process.argv.slice(2, 6).includes(c.name()));
     const prefix = cmd ? `genie ${cmd.name()}` : 'genie';
-    write(`\x1b[31mError (${prefix}): ${str}\x1b[0m`);
+    write(`\x1b[31mError (${prefix}): ${str}\x1b[0m\n`);
   },
 });
 

--- a/src/genie.ts
+++ b/src/genie.ts
@@ -32,6 +32,7 @@ import { registerHookNamespace } from './hooks/dispatch-command.js';
 import { getActor, recordAuditEvent } from './lib/audit.js';
 import { shutdown as shutdownDb } from './lib/db.js';
 import { stopOtelReceiver } from './lib/otel-receiver.js';
+import { registerAgentCommands } from './term-commands/agent/index.js';
 import {
   type SpawnOptions,
   handleLsCommand,
@@ -46,7 +47,7 @@ import { registerBoardCommands } from './term-commands/board.js';
 import { registerBriefCommands } from './term-commands/brief.js';
 import { registerDaemonCommands } from './term-commands/daemon.js';
 import { registerDbCommands } from './term-commands/db.js';
-import { registerAgentNamespace, registerDirNamespace } from './term-commands/dir.js';
+import { registerDirNamespace } from './term-commands/dir.js';
 import { registerDispatchCommands } from './term-commands/dispatch.js';
 import { registerExportCommands } from './term-commands/export.js';
 import * as historyCmd from './term-commands/history.js';
@@ -99,6 +100,19 @@ try {
 const program = new Command();
 
 program.name('genie').description('Genie CLI - AI-assisted development').version(VERSION);
+
+program.configureHelp({
+  sortSubcommands: true,
+  showGlobalOptions: true,
+});
+
+program.configureOutput({
+  outputError: (str, write) => {
+    const cmd = program.commands.find((c) => process.argv.includes(c.name()));
+    const prefix = cmd ? `genie ${cmd.name()}` : 'genie';
+    write(`\x1b[31mError (${prefix}): ${str}\x1b[0m`);
+  },
+});
 
 // ============================================================================
 // Named session — genie --session <name>
@@ -182,7 +196,7 @@ registerAppCommand(program);
 registerInitCommands(program);
 registerTeamNamespace(program);
 registerDirNamespace(program);
-registerAgentNamespace(program);
+registerAgentCommands(program);
 registerSendInboxCommands(program);
 registerStateCommands(program);
 registerDispatchCommands(program);
@@ -249,7 +263,7 @@ program.hook('postAction', (_thisCommand, actionCommand) => {
 });
 
 // ============================================================================
-// Top-level agent commands (promoted from genie agent namespace)
+// Top-level aliases — shortcuts for genie agent <command>
 // ============================================================================
 
 // genie spawn <name>
@@ -268,6 +282,15 @@ program
   .option('--cwd <path>', 'Working directory for the agent (overrides directory entry)')
   .option('--session <session>', 'Tmux session name to spawn into')
   .option('--no-auto-resume', 'Disable auto-resume on pane death')
+  .addHelpText(
+    'after',
+    `
+Examples:
+  genie spawn engineer                          # Spawn built-in engineer role
+  genie spawn researcher --model sonnet         # Spawn with model override
+  genie spawn my-agent --team my-feature        # Spawn into a specific team
+  genie spawn council--questioner --provider codex  # Use Codex provider`,
+  )
   .action(async (name: string, options: SpawnOptions) => {
     try {
       await handleWorkerSpawn(name, options);

--- a/src/term-commands/agent/index.ts
+++ b/src/term-commands/agent/index.ts
@@ -37,4 +37,11 @@ export function registerAgentCommands(program: Command): void {
   registerAgentBrief(agent);
   registerAgentLog(agent);
   registerAgentSend(agent);
+
+  agent.on('command:*', (operands: string[]) => {
+    const cmd = operands[0];
+    const available = agent.commands.map((c) => c.name()).join(', ');
+    console.error(`Unknown agent command '${cmd}'. Available: ${available}`);
+    process.exitCode = 1;
+  });
 }

--- a/src/term-commands/agent/index.ts
+++ b/src/term-commands/agent/index.ts
@@ -41,7 +41,6 @@ export function registerAgentCommands(program: Command): void {
   agent.on('command:*', (operands: string[]) => {
     const cmd = operands[0];
     const available = agent.commands.map((c) => c.name()).join(', ');
-    console.error(`Unknown agent command '${cmd}'. Available: ${available}`);
-    process.exitCode = 1;
+    agent.error(`Unknown agent command '${cmd}'. Available: ${available}`);
   });
 }

--- a/src/term-commands/dir.ts
+++ b/src/term-commands/dir.ts
@@ -33,7 +33,6 @@ import { printSyncResult, syncAgentDirectory } from '../lib/agent-sync.js';
 import { getActor, recordAuditEvent } from '../lib/audit.js';
 import { ALL_BUILTINS } from '../lib/builtin-agents.js';
 import { contractPath } from '../lib/genie-config.js';
-import { findOmniAgent, registerAgentInOmni, resolveOmniApiUrl } from '../lib/omni-registration.js';
 
 export function registerDirNamespace(program: Command): void {
   const dir = program.command('dir').description('Agent directory management');
@@ -419,95 +418,4 @@ function printBuiltinsTable(): void {
     );
   }
   console.log('');
-}
-
-// ============================================================================
-// Agent namespace — genie agent register
-// ============================================================================
-
-interface RegisterOptions {
-  dir: string;
-  repo?: string;
-  promptMode: string;
-  model?: string;
-  roles?: string[];
-  global?: boolean;
-  skipOmni?: boolean;
-}
-
-async function handleOmniRegistration(
-  name: string,
-  options: { model?: string; roles?: string[]; global?: boolean },
-): Promise<void> {
-  const omniUrl = await resolveOmniApiUrl();
-  if (!omniUrl) return;
-
-  console.log(`\nRegistering in Omni (${omniUrl})...`);
-
-  const existingId = await findOmniAgent(name);
-  if (existingId) {
-    console.log(`  Agent already exists in Omni: ${existingId}`);
-    await directory.edit(name, { omniAgentId: existingId }, { global: options.global });
-    console.log('  Linked existing Omni agent to directory entry.');
-    return;
-  }
-
-  const omniAgentId = await registerAgentInOmni(name, {
-    model: options.model,
-    roles: options.roles,
-  });
-  if (omniAgentId) {
-    await directory.edit(name, { omniAgentId }, { global: options.global });
-    console.log(`  Omni agent created: ${omniAgentId}`);
-    console.log('  Session isolation: per-person + per-channel');
-  }
-}
-
-async function handleAgentRegister(name: string, options: RegisterOptions): Promise<void> {
-  const promptMode = validatePromptMode(options.promptMode);
-
-  const roles = normalizeRoles(options.roles);
-  const entry = await directory.add(
-    {
-      name,
-      dir: resolvePath(options.dir),
-      repo: options.repo ? resolvePath(options.repo) : undefined,
-      promptMode,
-      model: options.model,
-      roles,
-    },
-    { global: options.global },
-  );
-
-  const scope = options.global ? 'global' : 'project';
-  console.log(`Agent "${entry.name}" registered (${scope}).`);
-  printEntry(entry);
-
-  if (!options.skipOmni) {
-    await handleOmniRegistration(name, { ...options, roles });
-  }
-}
-
-export function registerAgentNamespace(program: Command): void {
-  const agent = program.command('agent').description('Agent lifecycle management');
-
-  agent
-    .command('register <name>')
-    .description('Register an agent locally and auto-register in Omni when configured')
-    .requiredOption('--dir <path>', 'Agent folder (CWD + AGENTS.md)')
-    .option('--repo <path>', 'Default git repo (overridden by team)')
-    .option('--prompt-mode <mode>', 'Prompt mode: append or system', 'append')
-    .option('--model <model>', 'Default model (sonnet, opus, codex)')
-    .option('--roles <roles...>', 'Built-in roles this agent can orchestrate')
-    .option('--global', 'Write to global directory instead of project')
-    .option('--skip-omni', 'Skip Omni auto-registration')
-    .action(async (name: string, options: RegisterOptions) => {
-      try {
-        await handleAgentRegister(name, options);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        console.error(`Error: ${message}`);
-        process.exit(1);
-      }
-    });
 }

--- a/src/term-commands/msg.ts
+++ b/src/term-commands/msg.ts
@@ -526,6 +526,14 @@ export function registerSendInboxCommands(program: Command): void {
     .option('--to <agent>', 'Recipient agent name (default: team-lead)', 'team-lead')
     .option('--from <sender>', 'Sender ID (auto-detected from context)')
     .option('--team <name>', 'Explicit team context for sender/recipient resolution')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  genie send 'start task #3' --to engineer         # Message a specific agent
+  genie send 'status update' --to team-lead         # Report to team lead
+  genie send 'deploy ready' --team my-feature       # Message within team context`,
+    )
     .action(async (body: string, options: { to: string; from?: string; team?: string }) => {
       try {
         await handleSend(body, options);

--- a/src/term-commands/team.ts
+++ b/src/term-commands/team.ts
@@ -29,6 +29,14 @@ export function registerTeamNamespace(program: Command): void {
     .option('--tmux-session <name>', 'Tmux session to place team window in (default: derived from repo path)')
     .option('--session <name>', 'Alias for --tmux-session (deprecated)')
     .option('--no-spawn', 'Create team and copy wish without spawning the leader (useful for testing)')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  genie team create my-feature --repo .                          # Create team in current repo
+  genie team create my-feature --repo . --wish my-feature-slug   # Create team with a wish
+  genie team create hotfix --repo . --branch main                # Create from main branch`,
+    )
     .action(
       async (
         name: string,


### PR DESCRIPTION
## Summary

- **Fix CLI namespace**: Wire `registerAgentCommands` from `agent/index.ts` into `genie.ts` so `genie agent spawn/list/log/send/...` all work (13 subcommands). Remove duplicate `registerAgentNamespace` from `dir.ts`. Keep top-level aliases as shortcuts.
- **CLI help improvements**: Add `configureHelp()` (sorted subcommands), `configureOutput()` (contextual errors), and `addHelpText()` examples on spawn, team create, and send. Unknown agent subcommand handler.
- **Rewrite `/genie` SKILL.md**: Transform from passive guide into always-on auto-router with intent classifier (6 categories), lazy state detection, routing with transparency messages, `$ARGUMENTS` support, and live CLI reference via `` !`genie --help` ``.
- **Update CLAUDE.md**: Document both top-level aliases and `genie agent` namespace paths with alias relationship note.

Net result: -117 lines (removed duplicate code in dir.ts, condensed verbose static docs in SKILL.md).

## Test plan

- [x] `bun run check` passes (typecheck + lint + dead-code + 1583 tests)
- [x] `genie agent --help` shows all 13 subcommands
- [x] `genie spawn --help` still works (top-level alias preserved)
- [x] `genie spawn --help` shows examples
- [x] `genie team create --help` shows examples
- [x] `genie --help` shows sorted commands
- [x] SKILL.md contains intent classifier, lazy state, $ARGUMENTS, argument-hint
- [x] No `disable-model-invocation` in SKILL.md (always-on)
- [x] `reference/lifecycle.md` exists
- [x] CLAUDE.md documents both paths with alias note