### PR TITLE
feat(tui): quit confirmation popup + swap Ctrl+Q/Ctrl+D

### DIFF
--- a/src/lib/wish-resolve.test.ts
+++ b/src/lib/wish-resolve.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdir, realpath, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { parseWishRef, resolveWish } from './wish-resolve.js';
 
@@ -91,7 +91,7 @@ describe('resolveWish', () => {
 
   test('bare slug found in cwd resolves correctly', async () => {
     // Temporarily change cwd to a dir with a wish
-    const repoDir = join(FAKE_REPOS, 'myrepo');
+    const repoDir = await realpath(join(FAKE_REPOS, 'myrepo'));
     const originalCwd = process.cwd();
     process.chdir(repoDir);
 

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -144,8 +144,8 @@ function setupTuiKeybindings(): void {
     `bind-key -T root C-t send-keys -t ${TUI_SESSION}:0.1 C-b c`,
     // Ctrl+D: detach from TUI (leave running)
     'bind-key -T root C-d detach-client',
-    // Ctrl+Q: pass through to TUI pane for quit confirmation popup
-    `bind-key -T root C-q send-keys -t ${TUI_SESSION}:0.0 C-q`,
+    // Ctrl+Q: focus nav pane + pass through for quit confirmation popup
+    `bind-key -T root C-q select-pane -t ${TUI_SESSION}:0.0 \\; send-keys -t ${TUI_SESSION}:0.0 C-q`,
   ];
   for (const cmd of bindings) {
     try {

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -142,8 +142,10 @@ function setupTuiKeybindings(): void {
     `bind-key -T root C-b if-shell "[ $(tmux display-message -p '#\\{pane_width\\}' -t ${TUI_SESSION}:0.0) -gt 5 ]" "resize-pane -t ${TUI_SESSION}:0.0 -x 0" "resize-pane -t ${TUI_SESSION}:0.0 -x ${NAV_WIDTH}"`,
     // Ctrl+T: new window in agent session (sends C-b c to the nested tmux in right pane)
     `bind-key -T root C-t send-keys -t ${TUI_SESSION}:0.1 C-b c`,
-    // Ctrl+Q: detach from TUI
-    'bind-key -T root C-q detach-client',
+    // Ctrl+D: detach from TUI (leave running)
+    'bind-key -T root C-d detach-client',
+    // Ctrl+Q: pass through to TUI pane for quit confirmation popup
+    `bind-key -T root C-q send-keys -t ${TUI_SESSION}:0.0 C-q`,
   ];
   for (const cmd of bindings) {
     try {

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -1,8 +1,12 @@
 /** @jsxImportSource @opentui/react */
 /** Root App component — Sessions nav + tmux right pane management */
 
-import { useCallback } from 'react';
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { useKeyboard } from '@opentui/react';
+import { useCallback, useState } from 'react';
 import { Nav } from './components/Nav.js';
+import { QuitDialog } from './components/QuitDialog.js';
 import { attachProjectWindow } from './tmux.js';
 
 interface AppProps {
@@ -14,8 +18,32 @@ interface AppProps {
 }
 
 export function App({ rightPane, workspaceRoot, initialAgent }: AppProps) {
-  // Quit is handled by tmux key table (Ctrl+Q → kill-session), not by OpenTUI.
-  // This ensures BOTH panes die together regardless of which pane has focus.
+  const [showQuit, setShowQuit] = useState(false);
+
+  // Ctrl+Q: show quit confirmation, double Ctrl+Q: quit immediately
+  useKeyboard((key) => {
+    if (key.ctrl && key.name === 'q') {
+      if (showQuit) {
+        handleQuit();
+      } else {
+        setShowQuit(true);
+      }
+    }
+  });
+
+  const handleQuit = useCallback(() => {
+    // Kill genie serve via its PID file
+    try {
+      const genieHome = process.env.GENIE_HOME ?? `${process.env.HOME}/.genie`;
+      const pid = readFileSync(`${genieHome}/serve.pid`, 'utf-8').trim();
+      process.kill(Number.parseInt(pid, 10), 'SIGTERM');
+    } catch {
+      // Fallback: kill the TUI tmux server directly
+      try {
+        execSync('tmux -L genie-tui kill-server', { stdio: 'ignore' });
+      } catch {}
+    }
+  }, []);
 
   const handleTmuxSessionSelect = useCallback(
     (sessionName: string, windowIndex?: number) => {
@@ -26,6 +54,9 @@ export function App({ rightPane, workspaceRoot, initialAgent }: AppProps) {
   );
 
   return (
-    <Nav onTmuxSessionSelect={handleTmuxSessionSelect} workspaceRoot={workspaceRoot} initialAgent={initialAgent} />
+    <box width="100%" height="100%">
+      <Nav onTmuxSessionSelect={handleTmuxSessionSelect} workspaceRoot={workspaceRoot} initialAgent={initialAgent} />
+      {showQuit ? <QuitDialog onConfirm={handleQuit} onCancel={() => setShowQuit(false)} /> : null}
+    </box>
   );
 }

--- a/src/tui/components/QuitDialog.tsx
+++ b/src/tui/components/QuitDialog.tsx
@@ -1,0 +1,56 @@
+/** @jsxImportSource @opentui/react */
+/** Quit confirmation popup — shown on Ctrl+Q */
+
+import { useKeyboard } from '@opentui/react';
+import { palette } from '../theme.js';
+
+interface QuitDialogProps {
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function QuitDialog({ onConfirm, onCancel }: QuitDialogProps) {
+  useKeyboard((key) => {
+    if (key.name === 'enter' || key.name === 'return' || key.name === 'y') {
+      onConfirm();
+    } else if (key.name === 'escape' || key.name === 'n') {
+      onCancel();
+    }
+  });
+
+  return (
+    <box
+      position="absolute"
+      width="100%"
+      height="100%"
+      justifyContent="center"
+      alignItems="center"
+      backgroundColor="#0a0a0a"
+    >
+      <box
+        border
+        borderColor={palette.violet}
+        backgroundColor="#111111"
+        paddingX={3}
+        paddingY={1}
+        flexDirection="column"
+        alignItems="center"
+        gap={1}
+      >
+        <text>
+          <span fg={palette.purple}>Quit genie?</span>
+        </text>
+        <text>
+          <span fg={palette.text}>Enter</span>
+          <span fg={palette.textDim}> to quit </span>
+          <span fg={palette.textMuted}> | </span>
+          <span fg={palette.text}> Esc</span>
+          <span fg={palette.textDim}> to cancel</span>
+        </text>
+        <text>
+          <span fg={palette.textMuted}>Hint: Ctrl+D to detach (keep running)</span>
+        </text>
+      </box>
+    </box>
+  );
+}


### PR DESCRIPTION
## Summary
- **Ctrl+D** now detaches from TUI (standard convention, keeps genie running)
- **Ctrl+Q** shows a quit confirmation popup before killing genie serve
- **Double Ctrl+Q** quits immediately without confirmation
- Fix macOS `/tmp` vs `/private/tmp` symlink issue in wish-resolve test

## Test plan
- [ ] `genie serve` → Ctrl+D detaches, genie keeps running
- [ ] `genie serve` → Ctrl+Q shows popup with Enter/Esc/hint
- [ ] Popup → Enter or Y quits genie serve
- [ ] Popup → Esc or N cancels
- [ ] Popup → second Ctrl+Q quits immediately
- [ ] `bun run check` passes (1611/1611)