### PR TITLE
fix(team): resolve leader from project's leader_agent, not wish slug

### DIFF
--- a/src/lib/task-service.ts
+++ b/src/lib/task-service.ts
@@ -48,6 +48,8 @@ export interface ProjectRow {
   name: string;
   repoPath: string | null;
   description: string | null;
+  leaderAgent: string | null;
+  tmuxSession: string | null;
   status: string;
   archivedAt: string | null;
   createdAt: string;
@@ -391,6 +393,8 @@ function mapProject(row: Record<string, unknown>): ProjectRow {
     name: row.name as string,
     repoPath: str(row.repo_path),
     description: str(row.description),
+    leaderAgent: str(row.leader_agent),
+    tmuxSession: str(row.tmux_session),
     status: strOrDefault(row.status, 'active'),
     archivedAt: str(row.archived_at),
     createdAt: String(row.created_at),

--- a/src/term-commands/team.ts
+++ b/src/term-commands/team.ts
@@ -336,8 +336,11 @@ async function spawnLeaderWithWish(
   config.tmuxSessionName = tmuxSession;
   await teamManager.updateTeamConfig(config.name, config);
 
-  // Set leader name = wish slug, spawner = caller identity
-  config.leader = slug;
+  // Resolve leader from project's leader_agent, spawner = caller identity
+  const { getProjectByRepoPath } = await import('../lib/task-service.js');
+  const project = await getProjectByRepoPath(resolvedRepo);
+  const leaderAgent = project?.leaderAgent || slug;
+  config.leader = leaderAgent;
   config.spawner = process.env.GENIE_AGENT_NAME || 'cli';
   await teamManager.updateTeamConfig(config.name, config);
 
@@ -355,21 +358,21 @@ async function spawnLeaderWithWish(
   await copyFile(sourceWishPath, destWishPath);
   console.log(`  Wish: copied ${slug}/WISH.md into worktree`);
 
-  // Hire the standard team: leader + engineer + reviewer + qa + fix
-  const leaderName = config.leader || 'team-lead';
-  const standardTeam = [leaderName, 'engineer', 'reviewer', 'qa', 'fix'];
+  // Hire the standard team: leader (by agent name) + engineer + reviewer + qa + fix
+  const standardTeam = [leaderAgent, 'engineer', 'reviewer', 'qa', 'fix'];
   for (const role of standardTeam) {
     await teamManager.hireAgent(config.name, role);
   }
   console.log(`  Team: hired ${standardTeam.join(', ')}`);
 
-  // Spawn leader — AGENTS.md comes from the built-in resolver, prompt delivered as initialPrompt
-  const members = standardTeam.filter((r) => r !== leaderName).join(', ');
+  // Spawn leader — resolve agent definition from leaderAgent, use slug as role identity
+  const members = standardTeam.filter((r) => r !== leaderAgent).join(', ');
   const spawner = config.spawner || 'cli';
   const kickoffPrompt = `Your team is "${config.name}". Repo: ${config.repo}. Branch: ${config.name}. Worktree: ${config.worktreePath}. Wish slug: ${slug}. Your team members are: ${members} (already hired — genie work will spawn them automatically). Report completion to: ${spawner} (via genie send --to ${spawner}). Read the wish at .genie/wishes/${slug}/WISH.md and execute the full lifecycle autonomously.`;
-  await handleWorkerSpawn(leaderName, {
+  await handleWorkerSpawn(leaderAgent, {
     provider: 'claude',
     team: config.name,
+    role: slug,
     cwd: config.worktreePath,
     session: tmuxSession,
     initialPrompt: kickoffPrompt,
@@ -377,11 +380,11 @@ async function spawnLeaderWithWish(
 
   // Deliver kickoff prompt via mailbox as backup (durable, queued to disk)
   const protocolRouter = await import('../lib/protocol-router.js');
-  const result = await protocolRouter.sendMessage(config.worktreePath, 'cli', leaderName, kickoffPrompt);
+  const result = await protocolRouter.sendMessage(config.worktreePath, 'cli', leaderAgent, kickoffPrompt);
   if (!result.delivered) {
-    console.warn(`⚠ Backup delivery to ${leaderName} failed: ${result.reason ?? 'unknown'}`);
+    console.warn(`⚠ Backup delivery to ${leaderAgent} failed: ${result.reason ?? 'unknown'}`);
   }
-  console.log('  Leader: spawned and working');
+  console.log(`  Leader: ${leaderAgent} spawned as ${slug}`);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- `genie work genie/council-rework` was failing: "Agent 'council-rework' not found"
- Root cause: `setupWish()` set `config.leader = slug` (wish slug) and tried to spawn it as an agent, but wish slugs aren't registered agents
- Fix: query project by repo path → get `leader_agent` → spawn that registered agent with wish slug as role identity
- Also exposes `leaderAgent` and `tmuxSession` on `ProjectRow` (columns existed in DB since migration 011, weren't mapped in TypeScript)

## Resolution chain (now working)

```
genie work genie/council-rework
  → resolveWish("genie/council-rework") → repo = /workspace/repos/genie
  → getProjectByRepoPath(repo) → project.leaderAgent = "genie"
  → handleWorkerSpawn("genie", { role: "council-rework", ... })
  → resolves "genie" agent definition ✅
  → spawns with identity "council-rework" ✅
```

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (pre-existing warnings only)
- [x] `bun test` — 1611 pass, 0 fail
- [x] No `team-lead` references in team.ts