### PR TITLE
fix: auto-download tmux binary when not installed

### DIFF
--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -10,6 +10,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { $ } from 'bun';
 import { contractClaudePath, getClaudeSettingsPath } from '../lib/claude-settings.js';
+import { tmuxBin } from '../lib/ensure-tmux.js';
 import { genieConfigExists, getGenieConfigPath, isSetupComplete, loadGenieConfig } from '../lib/genie-config.js';
 import { checkCommand } from '../lib/system-detect.js';
 
@@ -185,7 +186,7 @@ async function checkTmux(): Promise<CheckResult[]> {
 
   // Check if tmux server is running
   try {
-    const serverResult = await $`tmux -L genie list-sessions 2>/dev/null`.quiet();
+    const serverResult = await $`${tmuxBin()} -L genie list-sessions 2>/dev/null`.quiet();
     if (serverResult.exitCode === 0) {
       results.push({
         name: 'Server running',
@@ -214,7 +215,7 @@ async function checkTmux(): Promise<CheckResult[]> {
   const sessionName = config.session.name;
 
   try {
-    const sessionResult = await $`tmux -L genie has-session -t ${sessionName} 2>/dev/null`.quiet();
+    const sessionResult = await $`${tmuxBin()} -L genie has-session -t ${sessionName} 2>/dev/null`.quiet();
     if (sessionResult.exitCode === 0) {
       results.push({
         name: `Session '${sessionName}' exists`,

--- a/src/genie-commands/session.ts
+++ b/src/genie-commands/session.ts
@@ -347,7 +347,8 @@ function attachToWindow(sessionName: string, windowName: string): void {
   const target = `${sessionName}:${windowName}`;
   const cmd = process.env.TMUX ? 'switch-client' : 'attach';
   const { genieTmuxPrefix } = require('../lib/tmux-wrapper.js');
-  spawnSync('tmux', [...genieTmuxPrefix(), cmd, '-t', target], { stdio: 'inherit' });
+  const { tmuxBin } = require('../lib/ensure-tmux.js');
+  spawnSync(tmuxBin(), [...genieTmuxPrefix(), cmd, '-t', target], { stdio: 'inherit' });
 }
 
 export async function sessionCommand(options: SessionOptions = {}): Promise<void> {

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -417,7 +417,8 @@ function syncTmuxConf(tmuxScriptsSrc: string): void {
       copyFileSync(tmuxConfSrc, tmuxConfDest);
       success(`Installed tmux config to ${tmuxConfDest}`);
       try {
-        execSync(`tmux -L genie source-file '${tmuxConfDest}'`, { stdio: 'ignore' });
+        const { tmuxBin } = require('../lib/ensure-tmux.js');
+        execSync(`${tmuxBin()} -L genie source-file '${tmuxConfDest}'`, { stdio: 'ignore' });
         success('Reloaded genie tmux server configuration');
       } catch {
         // genie tmux server not running or reload failed — non-fatal

--- a/src/lib/ensure-tmux.ts
+++ b/src/lib/ensure-tmux.ts
@@ -1,0 +1,181 @@
+/**
+ * Ensure tmux is available — auto-provision from official builds if missing.
+ *
+ * Downloads prebuilt static binaries from the official tmux-builds repository
+ * (https://github.com/tmux/tmux-builds) — same approach pgserve uses for
+ * PostgreSQL binaries from @embedded-postgres.
+ *
+ * Supported platforms: linux-x64, linux-arm64, macos-arm64, macos-x64.
+ *
+ * Resolution order:
+ *   1. System PATH (`which tmux`)
+ *   2. Cached binary at `~/.genie/bin/tmux`
+ *   3. Download from tmux/tmux-builds → extract → cache
+ *
+ * All tmux invocations should use `tmuxBin()` instead of bare `'tmux'`.
+ */
+
+import { execSync } from 'node:child_process';
+import { chmodSync, existsSync, mkdirSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
+import { arch, homedir, platform, tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/** Pinned tmux version — bump when tmux-builds publishes a new release. */
+const TMUX_VERSION = '3.6a';
+
+/**
+ * Map Node os identifiers to the tmux-builds asset naming convention.
+ * Asset format: tmux-{version}-{platform}-{arch}.tar.gz
+ */
+function getPlatformAsset(): string {
+  const os = platform();
+  const cpu = arch();
+
+  const key = `${os}-${cpu}`;
+  const map: Record<string, string> = {
+    'linux-x64': `tmux-${TMUX_VERSION}-linux-x86_64.tar.gz`,
+    'linux-arm64': `tmux-${TMUX_VERSION}-linux-arm64.tar.gz`,
+    'darwin-arm64': `tmux-${TMUX_VERSION}-macos-arm64.tar.gz`,
+    'darwin-x64': `tmux-${TMUX_VERSION}-macos-x86_64.tar.gz`,
+  };
+
+  const asset = map[key];
+  if (!asset) {
+    throw new Error(
+      `Unsupported platform: ${key}\ntmux auto-download supports: linux-x64, linux-arm64, macos-arm64, macos-x64.\nInstall tmux manually: https://github.com/tmux/tmux/wiki/Installing`,
+    );
+  }
+  return asset;
+}
+
+function genieHome(): string {
+  return process.env.GENIE_HOME ?? join(homedir(), '.genie');
+}
+
+function genieBinDir(): string {
+  return join(genieHome(), 'bin');
+}
+
+function cachedTmuxPath(): string {
+  return join(genieBinDir(), 'tmux');
+}
+
+// Cached result — resolved once per process
+let _resolved: string | null = null;
+
+/**
+ * Return the tmux binary path. Cached after first resolution.
+ * Prefers system tmux, falls back to ~/.genie/bin/tmux.
+ * Returns bare 'tmux' if neither exists yet (caller should run ensureTmux() first).
+ */
+export function tmuxBin(): string {
+  if (_resolved) return _resolved;
+
+  // 1. System PATH
+  try {
+    const p = execSync('which tmux', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
+    if (p) {
+      _resolved = p;
+      return p;
+    }
+  } catch {}
+
+  // 2. Cached binary from previous download
+  const cached = cachedTmuxPath();
+  if (existsSync(cached)) {
+    _resolved = cached;
+    return cached;
+  }
+
+  // Not yet available
+  return 'tmux';
+}
+
+/**
+ * Ensure tmux is available, downloading a static binary if needed.
+ * Call once at startup (e.g., top of `genie serve`).
+ * Returns the resolved binary path.
+ */
+export async function ensureTmux(): Promise<string> {
+  const bin = tmuxBin();
+  if (bin !== 'tmux') return bin;
+
+  return downloadTmux();
+}
+
+/**
+ * Download tmux from the official tmux-builds GitHub releases.
+ *
+ * Pattern follows pgserve's postgres.js:
+ *   1. Resolve platform asset name
+ *   2. Download tarball to temp dir
+ *   3. Extract with `tar`
+ *   4. Move binary to ~/.genie/bin/tmux
+ *   5. Verify with `tmux -V`
+ *   6. Clean up temp
+ */
+async function downloadTmux(): Promise<string> {
+  const asset = getPlatformAsset();
+  const url =
+    process.env.GENIE_TMUX_URL ?? `https://github.com/tmux/tmux-builds/releases/download/v${TMUX_VERSION}/${asset}`;
+
+  const dest = cachedTmuxPath();
+  const tempDir = join(tmpdir(), `genie-tmux-download-${Date.now()}`);
+
+  console.log('  tmux not found — downloading static binary...');
+  console.log(`  ${url}`);
+
+  try {
+    // 1. Download tarball
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} ${response.statusText}`);
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    const sizeMB = (buffer.byteLength / 1024 / 1024).toFixed(1);
+    console.log(`  Downloaded ${sizeMB} MB`);
+
+    // 2. Write tarball to temp
+    mkdirSync(tempDir, { recursive: true });
+    const tarballPath = join(tempDir, asset);
+    writeFileSync(tarballPath, buffer);
+
+    // 3. Extract — tarball contains a single 'tmux' binary at root
+    execSync(`tar -xzf '${tarballPath}' -C '${tempDir}'`, { stdio: 'ignore' });
+
+    const extractedBin = join(tempDir, 'tmux');
+    if (!existsSync(extractedBin)) {
+      throw new Error('Tarball did not contain a tmux binary');
+    }
+
+    // 4. Move to cache
+    mkdirSync(genieBinDir(), { recursive: true });
+    // Copy instead of rename (may cross filesystem boundaries with /tmp)
+    const { copyFileSync } = require('node:fs');
+    copyFileSync(extractedBin, dest);
+    chmodSync(dest, 0o755);
+
+    // 5. Verify
+    const version = execSync(`'${dest}' -V`, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
+    _resolved = dest;
+    console.log(`  ${version} installed to ${dest}`);
+
+    return dest;
+  } catch (err) {
+    // Clean up partial download
+    try {
+      if (existsSync(dest)) unlinkSync(dest);
+    } catch {}
+
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Failed to download tmux: ${msg}\nInstall manually:\n  Linux: sudo apt install tmux\n  macOS: brew install tmux`,
+    );
+  } finally {
+    // Always clean up temp dir
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {}
+  }
+}

--- a/src/lib/tmux-wrapper.ts
+++ b/src/lib/tmux-wrapper.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
+import { tmuxBin } from './ensure-tmux.js';
 
 const exec = promisify(execCallback);
 
@@ -30,7 +31,7 @@ export function genieTmuxPrefix(): string[] {
 
 /** Build a tmux command string prefixed with `-L genie -f <config>`. */
 export function genieTmuxCmd(subcommand: string): string {
-  return `tmux ${genieTmuxPrefix().join(' ')} ${subcommand}`;
+  return `${tmuxBin()} ${genieTmuxPrefix().join(' ')} ${subcommand}`;
 }
 
 /**
@@ -86,7 +87,7 @@ export async function executeTmux(args: string | string[]): Promise<string> {
   // Prepend genie server flags: -L genie -f <config>
   finalArgs = [...genieTmuxPrefix(), ...finalArgs];
 
-  const command = `tmux ${finalArgs.join(' ')}`;
+  const command = `${tmuxBin()} ${finalArgs.join(' ')}`;
   const { stdout } = await exec(command, options);
   return stdout.trim();
 }

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -1,4 +1,5 @@
 import { basename } from 'node:path';
+import { tmuxBin } from './ensure-tmux.js';
 import { shellQuote } from './team-lead-command.js';
 import { executeTmux as wrapperExecuteTmux } from './tmux-wrapper.js';
 
@@ -374,14 +375,15 @@ function ensurePaneColorScript(): void {
   if (existsSync(PANE_COLOR_SCRIPT)) return;
 
   mkdirSync(dirname(PANE_COLOR_SCRIPT), { recursive: true });
+  const bin = tmuxBin();
   writeFileSync(
     PANE_COLOR_SCRIPT,
     `#!/bin/bash
 # Genie tmux pane color router — reads @genie_color pane option
 PANE_ID="$1"
-COLOR=$(tmux display-message -p -t "$PANE_ID" '#{@genie_color}' 2>/dev/null)
+COLOR=$(${bin} display-message -p -t "$PANE_ID" '#{@genie_color}' 2>/dev/null)
 [ -z "$COLOR" ] && COLOR="default"
-tmux set-option -w pane-active-border-style "fg=$COLOR"
+${bin} set-option -w pane-active-border-style "fg=$COLOR"
 `,
   );
   chmodSync(PANE_COLOR_SCRIPT, 0o755);

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -15,6 +15,7 @@ import { getActor, recordAuditEvent } from '../lib/audit.js';
 import { resolveBuiltinAgentPath } from '../lib/builtin-agents.js';
 import * as nativeTeams from '../lib/claude-native-teams.js';
 import { OTEL_RELAY_PORT, ensureCodexOtelConfig } from '../lib/codex-config.js';
+import { tmuxBin } from '../lib/ensure-tmux.js';
 import * as executorRegistry from '../lib/executor-registry.js';
 import type { TransportType as ExecutorTransport } from '../lib/executor-types.js';
 import { buildLayoutCommand, resolveLayoutMode } from '../lib/mosaic-layout.js';
@@ -115,6 +116,7 @@ import { readFileSync, writeFileSync, mkdirSync, readdirSync, unlinkSync, statSy
 import { createHash } from 'crypto';
 import { join } from 'path';
 
+const TMUX_BIN = '${tmuxBin().replace(/\\/g, '\\\\').replace(/'/g, "\\'")}';
 const RELAY_DIR = '${escapedRelayDir}';
 const INBOX_DIR = '${escapedInboxDir}';
 const INBOX = join(INBOX_DIR, '${leaderInboxName}.json');
@@ -244,7 +246,7 @@ function relayAll() {
 
     let output;
     try {
-      output = execSync(\`tmux -L genie capture-pane -p -t '\${paneId}' -S -80\`, { encoding: 'utf-8' }).trim();
+      output = execSync(\`\${TMUX_BIN} -L genie capture-pane -p -t '\${paneId}' -S -80\`, { encoding: 'utf-8' }).trim();
     } catch {
       // Pane gone — final relay if we had previous content
       const lastContent = lastHashes.get(workerId + ':content');
@@ -343,7 +345,7 @@ setInterval(async () => {
     try {
       const paneId = readFileSync(join(RELAY_DIR, file), 'utf-8').trim();
       if (!/^%\\d+$/.test(paneId)) throw new Error('invalid pane id');
-      execSync(\`tmux -L genie display -t '\${paneId}' -p '#{pane_id}'\`, { stdio: 'ignore' });
+      execSync(\`\${TMUX_BIN} -L genie display -t '\${paneId}' -p '#{pane_id}'\`, { stdio: 'ignore' });
     } catch {
       const workerId = file.replace(/-pane$/, '');
       // Read meta before cleanup (for liveness reset)

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -21,6 +21,7 @@ import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from '
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { Command } from 'commander';
+import { ensureTmux, tmuxBin } from '../lib/ensure-tmux.js';
 
 // ============================================================================
 // Paths
@@ -85,7 +86,7 @@ const GENIE_SOCKET = 'genie';
 const TUI_SESSION = 'genie-tui';
 
 function genieTmux(subcmd: string): string {
-  return `tmux -L ${GENIE_SOCKET} -f ${genieTmuxConf()} ${subcmd}`;
+  return `${tmuxBin()} -L ${GENIE_SOCKET} -f ${genieTmuxConf()} ${subcmd}`;
 }
 
 /** TUI tmux config — minimal, no shell probes, no prefix key interference */
@@ -96,7 +97,7 @@ function tuiTmuxConf(): string {
 
 /** TUI tmux command — uses -L genie-tui socket + minimal TUI config */
 function tuiTmux(subcmd: string): string {
-  return `tmux -L genie-tui -f ${tuiTmuxConf()} ${subcmd}`;
+  return `${tmuxBin()} -L genie-tui -f ${tuiTmuxConf()} ${subcmd}`;
 }
 
 /** Check if a tmux server is running on a socket */
@@ -351,6 +352,9 @@ async function startForeground(): Promise<void> {
   writeServePid(process.pid);
 
   console.log(`genie serve starting (PID ${process.pid})`);
+
+  // Ensure tmux is available (downloads static binary if missing)
+  await ensureTmux();
 
   // 1. Start pgserve
   console.log('  Starting pgserve...');

--- a/src/tui/diagnostics.ts
+++ b/src/tui/diagnostics.ts
@@ -8,6 +8,7 @@
  */
 
 import { execSync } from 'node:child_process';
+import { tmuxBin } from '../lib/ensure-tmux.js';
 import type { TuiAssignment, TuiExecutor } from './types.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -131,7 +132,7 @@ function parsePaneLine(parts: string[]): {
 /** Collect all tmux sessions, windows, and panes into a typed tree (genie server). */
 function getTmuxInventory(): TmuxSession[] {
   const paneOutput = execQuiet(
-    "tmux -L genie list-panes -a -F '#{session_name}|#{window_index}|#{window_name}|#{window_active}|#{window_panes}|#{pane_index}|#{pane_id}|#{pane_pid}|#{pane_current_command}|#{pane_title}|#{pane_width}x#{pane_height}|#{session_attached}|#{session_windows}|#{session_created}|#{pane_dead}'",
+    `${tmuxBin()} -L genie list-panes -a -F '#{session_name}|#{window_index}|#{window_name}|#{window_active}|#{window_panes}|#{pane_index}|#{pane_id}|#{pane_pid}|#{pane_current_command}|#{pane_title}|#{pane_width}x#{pane_height}|#{session_attached}|#{session_windows}|#{session_created}|#{pane_dead}'`,
   );
 
   if (!paneOutput) return [];

--- a/src/tui/tmux.ts
+++ b/src/tui/tmux.ts
@@ -6,6 +6,7 @@
  */
 
 import { execSync, spawnSync } from 'node:child_process';
+import { tmuxBin } from '../lib/ensure-tmux.js';
 
 const SESSION_NAME = 'genie-tui';
 const TMUX_SOCKET = 'genie-tui';
@@ -16,7 +17,7 @@ const TUI_TMUX_CONF = (() => {
   const tuiConf = `${home}/tui-tmux.conf`;
   return existsSync(tuiConf) ? tuiConf : '/dev/null';
 })();
-const TMUX = `tmux -L ${TMUX_SOCKET} -f ${TUI_TMUX_CONF}`;
+const TMUX = `${tmuxBin()} -L ${TMUX_SOCKET} -f ${TUI_TMUX_CONF}`;
 
 function resolveRightPane(rightPane: string): string {
   try {
@@ -38,7 +39,7 @@ function resolveRightPane(rightPane: string): string {
 export function attachProjectWindow(rightPane: string, targetSession: string, windowIndex?: number): void {
   if (targetSession === SESSION_NAME) return;
   const pane = resolveRightPane(rightPane);
-  const agentTmux = `tmux -L ${GENIE_AGENT_SOCKET}`;
+  const agentTmux = `${tmuxBin()} -L ${GENIE_AGENT_SOCKET}`;
 
   // Ensure agent session exists
   try {
@@ -72,7 +73,7 @@ export function attachProjectWindow(rightPane: string, targetSession: string, wi
 }
 
 export function attachTuiSession(): void {
-  spawnSync('tmux', ['-L', TMUX_SOCKET, '-f', TUI_TMUX_CONF, 'attach-session', '-t', SESSION_NAME], {
+  spawnSync(tmuxBin(), ['-L', TMUX_SOCKET, '-f', TUI_TMUX_CONF, 'attach-session', '-t', SESSION_NAME], {
     stdio: 'inherit',
   });
 }


### PR DESCRIPTION
## Summary
- Adds `src/lib/ensure-tmux.ts` — auto-downloads the official static tmux binary from [`tmux/tmux-builds`](https://github.com/tmux/tmux-builds) when tmux is not on PATH (same pattern pgserve uses for PostgreSQL binaries)
- Replaces all hardcoded `'tmux'` binary references across the codebase with `tmuxBin()` which resolves system tmux > cached `~/.genie/bin/tmux`
- Calls `ensureTmux()` at the top of `genie serve` startup to provision before any tmux operations
- **Supported platforms**: linux-x64, linux-arm64, macos-arm64, macos-x64 (all from official tmux-builds releases)

## Problem
Running `genie` or `genie serve` without tmux installed crashes with a cryptic stack trace (`/bin/sh: 1: tmux: not found`, exit code 127). tmux is a hard dependency with no fallback and no clear error message.

## Solution
Downloads a statically-linked tmux binary from the official `tmux/tmux-builds` GitHub releases (v3.6a) on first use, caches it at `~/.genie/bin/tmux`. System tmux is always preferred when available. Override download URL via `GENIE_TMUX_URL` env var.

### Files changed
| File | Change |
|------|--------|
| `src/lib/ensure-tmux.ts` | **New** — `tmuxBin()` resolver + `ensureTmux()` downloader |
| `src/lib/tmux-wrapper.ts` | Use `tmuxBin()` in `genieTmuxCmd()` and `executeTmux()` |
| `src/term-commands/serve.ts` | `ensureTmux()` preflight + `tmuxBin()` in helpers |
| `src/tui/tmux.ts` | `tmuxBin()` in TMUX constant, agent socket, `attachTuiSession()` |
| `src/lib/tmux.ts` | Embed resolved path in generated pane-color shell script |
| `src/term-commands/agents.ts` | Embed `TMUX_BIN` in generated OTel relay `.mjs` script |
| `src/genie-commands/doctor.ts` | `tmuxBin()` in diagnostic shell commands |
| `src/genie-commands/session.ts` | `tmuxBin()` in `attachToWindow()` spawnSync |
| `src/genie-commands/update.ts` | `tmuxBin()` in config reload |
| `src/tui/diagnostics.ts` | `tmuxBin()` in tmux inventory collection |

## Test plan
- [ ] `genie serve` on a machine **without** tmux — should auto-download and start
- [ ] `genie serve` on a machine **with** tmux — should use system tmux (no download)
- [ ] Verify on linux-x64 and macos-arm64
- [ ] `bun run typecheck` and `bun run lint` pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)