### PR TITLE
feat: auto-download tmux at install time

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:plugin": "node scripts/build.js",
     "sync": "node scripts/sync.js",
     "build-and-sync": "npm run build:plugin && npm run sync",
+    "postinstall": "node scripts/postinstall-tmux.js",
     "prepack": "bun run build",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",

--- a/scripts/postinstall-tmux.js
+++ b/scripts/postinstall-tmux.js
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * postinstall-tmux.js — Download tmux static binary if not on PATH.
+ *
+ * Runs during `bun add -g @automagik/genie` and from smart-install.js.
+ * Downloads from the official tmux-builds repository:
+ *   https://github.com/tmux/tmux-builds
+ *
+ * Standalone — no imports outside node builtins.
+ */
+
+import { execSync, spawnSync } from 'node:child_process';
+import { chmodSync, copyFileSync, existsSync, mkdirSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
+import { arch, homedir, platform, tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const TMUX_VERSION = '3.6a';
+const GENIE_HOME = process.env.GENIE_HOME || join(homedir(), '.genie');
+const BIN_DIR = join(GENIE_HOME, 'bin');
+const TMUX_PATH = join(BIN_DIR, 'tmux');
+
+function getPlatformAsset() {
+  const os = platform();
+  const cpu = arch();
+  const map = {
+    'linux-x64': `tmux-${TMUX_VERSION}-linux-x86_64.tar.gz`,
+    'linux-arm64': `tmux-${TMUX_VERSION}-linux-arm64.tar.gz`,
+    'darwin-arm64': `tmux-${TMUX_VERSION}-macos-arm64.tar.gz`,
+    'darwin-x64': `tmux-${TMUX_VERSION}-macos-x86_64.tar.gz`,
+  };
+  return map[`${os}-${cpu}`] || null;
+}
+
+function isTmuxOnPath() {
+  try {
+    const r = spawnSync('tmux', ['-V'], { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+    return r.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+function isTmuxCached() {
+  if (!existsSync(TMUX_PATH)) return false;
+  try {
+    const r = spawnSync(TMUX_PATH, ['-V'], { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+    return r.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+async function downloadTmux() {
+  const asset = getPlatformAsset();
+  if (!asset) {
+    const key = `${platform()}-${arch()}`;
+    console.error(`[genie] tmux: no prebuilt binary for ${key}. Install tmux manually.`);
+    return false;
+  }
+
+  const url =
+    process.env.GENIE_TMUX_URL || `https://github.com/tmux/tmux-builds/releases/download/v${TMUX_VERSION}/${asset}`;
+
+  const tempDir = join(tmpdir(), `genie-tmux-${Date.now()}`);
+
+  console.error(`[genie] tmux not found — downloading ${asset}...`);
+
+  try {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+    const buffer = Buffer.from(await res.arrayBuffer());
+    const sizeMB = (buffer.byteLength / 1024 / 1024).toFixed(1);
+    console.error(`[genie] Downloaded ${sizeMB} MB`);
+
+    mkdirSync(tempDir, { recursive: true });
+    const tarball = join(tempDir, asset);
+    writeFileSync(tarball, buffer);
+
+    execSync(`tar -xzf '${tarball}' -C '${tempDir}'`, { stdio: 'ignore' });
+
+    const extracted = join(tempDir, 'tmux');
+    if (!existsSync(extracted)) throw new Error('Tarball did not contain tmux binary');
+
+    mkdirSync(BIN_DIR, { recursive: true });
+    copyFileSync(extracted, TMUX_PATH);
+    chmodSync(TMUX_PATH, 0o755);
+
+    // Verify
+    const r = spawnSync(TMUX_PATH, ['-V'], { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+    if (r.status !== 0) throw new Error('Downloaded binary not executable on this system');
+
+    console.error(`[genie] ${r.stdout.trim()} installed to ${TMUX_PATH}`);
+    return true;
+  } catch (err) {
+    try {
+      if (existsSync(TMUX_PATH)) unlinkSync(TMUX_PATH);
+    } catch {}
+    console.error(`[genie] tmux download failed: ${err.message}`);
+    console.error('[genie] Install manually:');
+    if (platform() === 'darwin') console.error('  brew install tmux');
+    else console.error('  sudo apt install tmux');
+    return false;
+  } finally {
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {}
+  }
+}
+
+// Main
+if (!isTmuxOnPath() && !isTmuxCached()) {
+  downloadTmux().catch(() => {});
+}

--- a/scripts/postinstall-tmux.js
+++ b/scripts/postinstall-tmux.js
@@ -2,14 +2,14 @@
 /**
  * postinstall-tmux.js — Download tmux static binary if not on PATH.
  *
- * Runs during `bun add -g @automagik/genie` and from smart-install.js.
+ * Runs during `bun add -g @automagik/genie` and callable from smart-install.js.
  * Downloads from the official tmux-builds repository:
  *   https://github.com/tmux/tmux-builds
  *
  * Standalone — no imports outside node builtins.
  */
 
-import { execSync, spawnSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { chmodSync, copyFileSync, existsSync, mkdirSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
 import { arch, homedir, platform, tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -77,7 +77,9 @@ async function downloadTmux() {
     const tarball = join(tempDir, asset);
     writeFileSync(tarball, buffer);
 
-    execSync(`tar -xzf '${tarball}' -C '${tempDir}'`, { stdio: 'ignore' });
+    // Use spawnSync with args array to avoid shell injection with special path chars
+    const tarResult = spawnSync('tar', ['-xzf', tarball, '-C', tempDir], { stdio: 'ignore' });
+    if (tarResult.status !== 0) throw new Error('Failed to extract tmux tarball');
 
     const extracted = join(tempDir, 'tmux');
     if (!existsSync(extracted)) throw new Error('Tarball did not contain tmux binary');
@@ -108,7 +110,14 @@ async function downloadTmux() {
   }
 }
 
-// Main
-if (!isTmuxOnPath() && !isTmuxCached()) {
-  downloadTmux().catch(() => {});
+/**
+ * Ensure tmux is available — download if missing.
+ * Exported for use by smart-install.js and other callers.
+ */
+export async function ensureTmux() {
+  if (isTmuxOnPath() || isTmuxCached()) return true;
+  return downloadTmux();
 }
+
+// Run directly when invoked as a script (postinstall or CLI)
+await ensureTmux();

--- a/scripts/smart-install.js
+++ b/scripts/smart-install.js
@@ -325,25 +325,34 @@ try {
     installBun();
   }
 
-  // 2. Check tmux - REQUIRED, but can't auto-install
+  // 2. Check tmux — auto-download static binary if missing
   if (!isTmuxInstalled()) {
-    console.error('');
-    console.error('ERROR: tmux is required but not installed.');
-    console.error('');
-    console.error('Please install tmux manually:');
-    if (process.platform === 'darwin') {
-      console.error('  brew install tmux');
-    } else if (process.platform === 'linux') {
-      console.error('  sudo apt install tmux    # Debian/Ubuntu');
-      console.error('  sudo dnf install tmux    # Fedora/RHEL');
-      console.error('  sudo pacman -S tmux      # Arch');
-    } else if (IS_WINDOWS) {
-      console.error('  WSL is required for tmux on Windows');
-      console.error('  Inside WSL: sudo apt install tmux');
+    const tmuxCached = join(GENIE_DIR, 'bin', 'tmux');
+    if (existsSync(tmuxCached)) {
+      console.error(`tmux found at ${tmuxCached}`);
+    } else {
+      console.error('tmux not found — downloading static binary...');
+      try {
+        // Import and run the shared tmux downloader
+        await import('./postinstall-tmux.js');
+      } catch (e) {
+        console.error(`tmux auto-download failed: ${e.message}`);
+        console.error('Please install tmux manually:');
+        if (process.platform === 'darwin') {
+          console.error('  brew install tmux');
+        } else if (process.platform === 'linux') {
+          console.error('  sudo apt install tmux    # Debian/Ubuntu');
+          console.error('  sudo dnf install tmux    # Fedora/RHEL');
+          console.error('  sudo pacman -S tmux      # Arch');
+        } else if (IS_WINDOWS) {
+          console.error('  WSL is required for tmux on Windows');
+          console.error('  Inside WSL: sudo apt install tmux');
+        }
+        console.error('');
+        console.error('Then restart Claude Code.');
+        process.exit(2);
+      }
     }
-    console.error('');
-    console.error('Then restart Claude Code.');
-    process.exit(2); // Exit code 2 = blocking error for Claude to process
   }
 
   // 3. Check/install beads

--- a/scripts/smart-install.js
+++ b/scripts/smart-install.js
@@ -131,6 +131,69 @@ function getTmuxVersion() {
 }
 
 /**
+ * Download static tmux binary from official tmux-builds.
+ * Inlined here because the plugin build only copies smart-install.js.
+ */
+async function downloadTmuxBinary() {
+  const TMUX_VERSION = '3.6a';
+  const os = process.platform;
+  const cpu = process.arch;
+  const assetMap = {
+    'linux-x64': `tmux-${TMUX_VERSION}-linux-x86_64.tar.gz`,
+    'linux-arm64': `tmux-${TMUX_VERSION}-linux-arm64.tar.gz`,
+    'darwin-arm64': `tmux-${TMUX_VERSION}-macos-arm64.tar.gz`,
+    'darwin-x64': `tmux-${TMUX_VERSION}-macos-x86_64.tar.gz`,
+  };
+  const asset = assetMap[`${os}-${cpu}`];
+  if (!asset) {
+    console.error(`tmux: no prebuilt binary for ${os}-${cpu}.`);
+    return false;
+  }
+
+  const url = `https://github.com/tmux/tmux-builds/releases/download/v${TMUX_VERSION}/${asset}`;
+  const { tmpdir } = await import('node:os');
+  const { copyFileSync, chmodSync, rmSync, writeFileSync } = await import('node:fs');
+  const tempDir = join(tmpdir(), `genie-tmux-${Date.now()}`);
+  const dest = join(GENIE_DIR, 'bin', 'tmux');
+
+  console.error(`Downloading tmux ${TMUX_VERSION} (${asset})...`);
+  try {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const buffer = Buffer.from(await res.arrayBuffer());
+    console.error(`Downloaded ${(buffer.byteLength / 1024 / 1024).toFixed(1)} MB`);
+
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(join(tempDir, asset), buffer);
+    const tarResult = spawnSync('tar', ['-xzf', join(tempDir, asset), '-C', tempDir], { stdio: 'ignore' });
+    if (tarResult.status !== 0) throw new Error('tar extraction failed');
+
+    const extracted = join(tempDir, 'tmux');
+    if (!existsSync(extracted)) throw new Error('tarball did not contain tmux binary');
+
+    mkdirSync(join(GENIE_DIR, 'bin'), { recursive: true });
+    copyFileSync(extracted, dest);
+    chmodSync(dest, 0o755);
+
+    const verify = spawnSync(dest, ['-V'], { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+    if (verify.status !== 0) throw new Error('binary not executable');
+
+    console.error(`${verify.stdout.trim()} installed to ${dest}`);
+    return true;
+  } catch (e) {
+    try {
+      if (existsSync(dest)) (await import('node:fs')).unlinkSync(dest);
+    } catch {}
+    console.error(`tmux download failed: ${e.message}`);
+    return false;
+  } finally {
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {}
+  }
+}
+
+/**
  * Check if beads (bd) is installed
  */
 function getBeadsPath() {
@@ -331,12 +394,8 @@ try {
     if (existsSync(tmuxCached)) {
       console.error(`tmux found at ${tmuxCached}`);
     } else {
-      console.error('tmux not found — downloading static binary...');
-      try {
-        // Import and run the shared tmux downloader
-        await import('./postinstall-tmux.js');
-      } catch (e) {
-        console.error(`tmux auto-download failed: ${e.message}`);
+      const ok = await downloadTmuxBinary();
+      if (!ok) {
         console.error('Please install tmux manually:');
         if (process.platform === 'darwin') {
           console.error('  brew install tmux');

--- a/src/lib/ensure-tmux.ts
+++ b/src/lib/ensure-tmux.ts
@@ -16,7 +16,7 @@
  */
 
 import { execSync } from 'node:child_process';
-import { chmodSync, existsSync, mkdirSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
+import { chmodSync, copyFileSync, existsSync, mkdirSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
 import { arch, homedir, platform, tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -149,10 +149,8 @@ async function downloadTmux(): Promise<string> {
       throw new Error('Tarball did not contain a tmux binary');
     }
 
-    // 4. Move to cache
+    // 4. Move to cache (copy, not rename — may cross filesystem boundaries with /tmp)
     mkdirSync(genieBinDir(), { recursive: true });
-    // Copy instead of rename (may cross filesystem boundaries with /tmp)
-    const { copyFileSync } = require('node:fs');
     copyFileSync(extractedBin, dest);
     chmodSync(dest, 0o755);
 


### PR DESCRIPTION
## Summary
- Adds `scripts/postinstall-tmux.js` — downloads tmux during `bun add -g @automagik/genie`
- Updates `smart-install.js` — replaces "can't auto-install" error with actual download
- Adds `postinstall` hook to `package.json`

Follows up on #939 which added runtime auto-download. This adds install-time download so tmux is ready before the user ever runs `genie`.

## Three layers of tmux provisioning

| Path | When | Script |
|------|------|--------|
| `bun add -g` | npm postinstall | `scripts/postinstall-tmux.js` |
| Claude Code plugin | plugin init | `smart-install.js` |
| `genie serve` | runtime fallback | `ensureTmux()` |

All download from official [`tmux/tmux-builds`](https://github.com/tmux/tmux-builds) to `~/.genie/bin/tmux`.

## Test plan
- [x] `postinstall-tmux.js` tested standalone — downloads and verifies binary
- [ ] `bun add -g @automagik/genie` on clean machine
- [ ] `smart-install.js` plugin path without tmux installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)