### PR TITLE
fix(ci): bump bun 1.3.11 + fix test timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.11"
 
       - name: Cache bun packages
         uses: actions/cache@v4
@@ -79,7 +79,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.11"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/src/lib/db-backup.test.ts
+++ b/src/lib/db-backup.test.ts
@@ -50,12 +50,12 @@ describe('restore error handling', () => {
     const tmpFile = join(tmpdir(), `genie-bad-snapshot-${Date.now()}.sql.gz`);
     writeFileSync(tmpFile, 'not gzip data');
     try {
-      // Should fail at decompression or psql — either way it throws
+      // restore calls getActivePort() which needs pgserve — will throw if not running
       expect(() => restore(tmpFile)).toThrow();
     } finally {
       rmSync(tmpFile, { force: true });
     }
-  });
+  }, 15000);
 });
 
 // ============================================================================
@@ -80,14 +80,14 @@ describe('backup error handling', () => {
     expect(existsSync(genieDir)).toBe(false);
 
     const { backup } = await import('./db-backup.js');
-    // backup will fail (no pg_dump or no DB) but should create the directory first
+    // backup calls pg_dump which needs pgserve — will fail but should create dir first
     try {
       backup(tmpDir);
     } catch {
       // Expected — pg_dump will fail without a running DB on this port
     }
     expect(existsSync(genieDir)).toBe(true);
-  });
+  }, 15000);
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Bump bun from 1.3.10 to 1.3.11 in CI — fixes `loadGenieConfigSync` export resolution failure (54 test failures)
- Increase db-backup test timeouts from 5s to 15s — restore/backup trigger pgserve startup which exceeds default timeout

## Test plan
- [x] 1636 pass, 0 fail locally
- [ ] CI should pass with bun 1.3.11