### PR TITLE
fix(db): SQL injection + retention + pool recovery

### DIFF
--- a/src/db/migrations/019_retention.sql
+++ b/src/db/migrations/019_retention.sql
@@ -1,0 +1,15 @@
+-- 019_retention.sql — Activate retention policies for unbounded tables
+-- These DELETEs run once as a migration to clean existing data,
+-- and are also executed on every process startup via getConnection().
+
+-- Heartbeats: 7-day retention
+DELETE FROM heartbeats WHERE created_at < now() - interval '7 days';
+
+-- Machine snapshots: 30-day retention
+DELETE FROM machine_snapshots WHERE created_at < now() - interval '30 days';
+
+-- Audit events (otel-prefixed): 30-day retention
+DELETE FROM audit_events WHERE entity_type LIKE 'otel_%' AND created_at < now() - interval '30 days';
+
+-- Runtime events: 14-day retention
+DELETE FROM genie_runtime_events WHERE created_at < now() - interval '14 days';

--- a/src/lib/db-backup.ts
+++ b/src/lib/db-backup.ts
@@ -78,7 +78,7 @@ export function backup(cwd?: string): BackupResult {
   // Get uncompressed size estimate from pg_database_size
   let uncompressedBytes = 0;
   try {
-    const sizeResult = spawnSync('psql', ['-t', '-A', '-c', `SELECT pg_database_size('${DB_NAME}')`], {
+    const sizeResult = spawnSync('psql', ['-t', '-A', '-c', 'SELECT pg_database_size(current_database())'], {
       env: pgEnv(port),
       encoding: 'utf-8',
       timeout: 10_000,
@@ -109,12 +109,14 @@ export function restore(snapshotFile?: string, cwd?: string): void {
   const env = pgEnv(port);
   const adminEnv = { ...env, PGDATABASE: 'postgres' };
 
-  // Terminate existing connections
+  // Terminate existing connections (use psql variable to avoid string interpolation)
   spawnSync(
     'psql',
     [
+      '-v',
+      `target_db=${DB_NAME}`,
       '-c',
-      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${DB_NAME}' AND pid <> pg_backend_pid()`,
+      "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = :'target_db' AND pid <> pg_backend_pid()",
     ],
     {
       env: adminEnv,
@@ -123,8 +125,8 @@ export function restore(snapshotFile?: string, cwd?: string): void {
     },
   );
 
-  // Drop and recreate
-  const dropResult = spawnSync('psql', ['-c', `DROP DATABASE IF EXISTS ${DB_NAME}`], {
+  // Drop and recreate (use psql variable to avoid string interpolation)
+  const dropResult = spawnSync('psql', ['-v', `target_db=${DB_NAME}`, '-c', 'DROP DATABASE IF EXISTS :"target_db"'], {
     env: adminEnv,
     stdio: ['pipe', 'pipe', 'pipe'],
     timeout: 10_000,
@@ -133,7 +135,7 @@ export function restore(snapshotFile?: string, cwd?: string): void {
     throw new Error(`Failed to drop database: ${dropResult.stderr?.toString().trim()}`);
   }
 
-  const createResult = spawnSync('psql', ['-c', `CREATE DATABASE ${DB_NAME}`], {
+  const createResult = spawnSync('psql', ['-v', `target_db=${DB_NAME}`, '-c', 'CREATE DATABASE :"target_db"'], {
     env: adminEnv,
     stdio: ['pipe', 'pipe', 'pipe'],
     timeout: 10_000,

--- a/src/lib/db-migrations.ts
+++ b/src/lib/db-migrations.ts
@@ -55,13 +55,14 @@ function getPackageRootMigrationsDir(): string {
 
 /**
  * Load all .sql migration files sorted by name.
- * Searches multiple candidate directories to handle dev, bundled, and global-install layouts.
+ * Searches two deterministic directories derived from import.meta.dir:
+ *   1. dev layout: src/lib/../db/migrations
+ *   2. bundled layout: dist/../src/db/migrations
  */
 async function loadMigrationFiles(): Promise<MigrationFile[]> {
   const candidates = [
     getMigrationsDir(), // dev: src/lib/../db/migrations
     getPackageRootMigrationsDir(), // bundled: dist/../src/db/migrations
-    join(process.cwd(), 'src', 'db', 'migrations'), // legacy fallback
   ];
 
   for (const dir of candidates) {

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -338,3 +338,79 @@ describe('daemon-owned pgserve', () => {
     expect(source.includes('selfHealPostgres')).toBe(true);
   });
 });
+
+describe('retention cleanup', () => {
+  test('retention DELETEs are present in getConnection()', () => {
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    // All 4 retention policies present
+    expect(source).toContain("DELETE FROM heartbeats WHERE created_at < now() - interval '7 days'");
+    expect(source).toContain("DELETE FROM machine_snapshots WHERE created_at < now() - interval '30 days'");
+    expect(source).toContain("DELETE FROM audit_events WHERE entity_type LIKE 'otel_%' AND created_at < now() - interval '30 days'");
+    expect(source).toContain("DELETE FROM genie_runtime_events WHERE created_at < now() - interval '14 days'");
+  });
+
+  test('retention is guarded by retentionRan flag', () => {
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    expect(source).toContain('let retentionRan = false');
+    expect(source).toContain('!retentionRan');
+    expect(source).toContain('retentionRan = true');
+  });
+
+  test('retention failure is non-fatal — logs warning, does not throw', () => {
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    expect(source).toContain('retention cleanup warning');
+    // retentionRan set to true even on failure to prevent retries
+    const catchBlock = source.slice(
+      source.indexOf('catch (retErr)'),
+      source.indexOf('catch (retErr)') + 300,
+    );
+    expect(catchBlock).toContain('retentionRan = true');
+  });
+
+  test('retention migration file exists with all 4 tables', () => {
+    const migration = readFileSync(join(__dirname, '..', 'db', 'migrations', '019_retention.sql'), 'utf-8');
+    expect(migration).toContain('DELETE FROM heartbeats');
+    expect(migration).toContain('DELETE FROM machine_snapshots');
+    expect(migration).toContain('DELETE FROM audit_events');
+    expect(migration).toContain('DELETE FROM genie_runtime_events');
+  });
+});
+
+describe('pool error recovery', () => {
+  test('migration failure resets both sqlClient and activePort', () => {
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    // Find the migration/seed catch block
+    const catchIdx = source.indexOf('Migration/seed failure');
+    expect(catchIdx).toBeGreaterThan(-1);
+    const catchBlock = source.slice(catchIdx, catchIdx + 300);
+    // Both must be null'd to force full reconnect
+    expect(catchBlock).toContain('sqlClient = null');
+    expect(catchBlock).toContain('activePort = null');
+  });
+
+  test('health-check failure in cached client resets both sqlClient and activePort', () => {
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    // Find the cached client health check catch block
+    const healthCheckIdx = source.indexOf('Connection is broken');
+    expect(healthCheckIdx).toBeGreaterThan(-1);
+    const block = source.slice(healthCheckIdx, healthCheckIdx + 200);
+    expect(block).toContain('sqlClient = null');
+    expect(block).toContain('activePort = null');
+  });
+});
+
+describe('migration directory resolution', () => {
+  test('does not use process.cwd() for migration lookup', () => {
+    const source = readFileSync(join(__dirname, 'db-migrations.ts'), 'utf-8');
+    // The legacy cwd fallback was removed for deterministic resolution
+    expect(source).not.toContain('process.cwd()');
+  });
+
+  test('uses only import.meta.dir-based paths', () => {
+    const source = readFileSync(join(__dirname, 'db-migrations.ts'), 'utf-8');
+    expect(source).toContain('import.meta.dir');
+    // Two deterministic candidates: dev and bundled
+    expect(source).toContain('getMigrationsDir()');
+    expect(source).toContain('getPackageRootMigrationsDir()');
+  });
+});

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -345,7 +345,9 @@ describe('retention cleanup', () => {
     // All 4 retention policies present
     expect(source).toContain("DELETE FROM heartbeats WHERE created_at < now() - interval '7 days'");
     expect(source).toContain("DELETE FROM machine_snapshots WHERE created_at < now() - interval '30 days'");
-    expect(source).toContain("DELETE FROM audit_events WHERE entity_type LIKE 'otel_%' AND created_at < now() - interval '30 days'");
+    expect(source).toContain(
+      "DELETE FROM audit_events WHERE entity_type LIKE 'otel_%' AND created_at < now() - interval '30 days'",
+    );
     expect(source).toContain("DELETE FROM genie_runtime_events WHERE created_at < now() - interval '14 days'");
   });
 
@@ -360,10 +362,7 @@ describe('retention cleanup', () => {
     const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
     expect(source).toContain('retention cleanup warning');
     // retentionRan set to true even on failure to prevent retries
-    const catchBlock = source.slice(
-      source.indexOf('catch (retErr)'),
-      source.indexOf('catch (retErr)') + 300,
-    );
+    const catchBlock = source.slice(source.indexOf('catch (retErr)'), source.indexOf('catch (retErr)') + 300);
     expect(catchBlock).toContain('retentionRan = true');
   });
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -170,6 +170,8 @@ let ensurePromise: Promise<number> | null = null;
 /** Whether this process spawned pgserve (and thus owns the lockfile) */
 let ownsLockfile = false;
 let exitHandlerRegistered = false;
+/** Whether retention cleanup has already run in this process */
+let retentionRan = false;
 
 /**
  * Ensure pgserve is running. Starts it if not already listening.
@@ -428,14 +430,34 @@ export async function getConnection() {
     if (!testSchema && needsSeed()) {
       await runSeed(sqlClient);
     }
+
+    // Run retention cleanup once per process — prune old rows from unbounded tables.
+    // Runs AFTER migrations succeed. Failure is non-fatal: log and continue.
+    if (!testSchema && !retentionRan) {
+      try {
+        await sqlClient.unsafe(`
+          DELETE FROM heartbeats WHERE created_at < now() - interval '7 days';
+          DELETE FROM machine_snapshots WHERE created_at < now() - interval '30 days';
+          DELETE FROM audit_events WHERE entity_type LIKE 'otel_%' AND created_at < now() - interval '30 days';
+          DELETE FROM genie_runtime_events WHERE created_at < now() - interval '14 days';
+        `);
+        retentionRan = true;
+      } catch (retErr) {
+        // Non-fatal — log warning and continue, never block startup
+        retentionRan = true; // Don't retry on next call
+        const msg = retErr instanceof Error ? retErr.message : String(retErr);
+        process.stderr.write(`[genie] retention cleanup warning: ${msg}\n`);
+      }
+    }
   } catch (err) {
-    // Migration/seed failure — reset client so next call retries
+    // Migration/seed failure — reset client AND port so next call fully reconnects
     try {
       await sqlClient.end({ timeout: 2 });
     } catch {
       /* ignore */
     }
     sqlClient = null;
+    activePort = null;
     throw err;
   }
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -173,6 +173,24 @@ let exitHandlerRegistered = false;
 /** Whether retention cleanup has already run in this process */
 let retentionRan = false;
 
+/** Prune old rows from unbounded tables. Runs once per process, non-fatal. */
+async function runRetention(sql: any): Promise<void> {
+  try {
+    await sql.unsafe(`
+      DELETE FROM heartbeats WHERE created_at < now() - interval '7 days';
+      DELETE FROM machine_snapshots WHERE created_at < now() - interval '30 days';
+      DELETE FROM audit_events WHERE entity_type LIKE 'otel_%' AND created_at < now() - interval '30 days';
+      DELETE FROM genie_runtime_events WHERE created_at < now() - interval '14 days';
+    `);
+    retentionRan = true;
+  } catch (retErr) {
+    // Non-fatal — log warning and continue, never block startup
+    retentionRan = true; // Don't retry on next call
+    const msg = retErr instanceof Error ? retErr.message : String(retErr);
+    process.stderr.write(`[genie] retention cleanup warning: ${msg}\n`);
+  }
+}
+
 /**
  * Ensure pgserve is running. Starts it if not already listening.
  * Idempotent — safe to call multiple times.
@@ -431,23 +449,9 @@ export async function getConnection() {
       await runSeed(sqlClient);
     }
 
-    // Run retention cleanup once per process — prune old rows from unbounded tables.
-    // Runs AFTER migrations succeed. Failure is non-fatal: log and continue.
+    // Run retention cleanup once per process (non-fatal).
     if (!testSchema && !retentionRan) {
-      try {
-        await sqlClient.unsafe(`
-          DELETE FROM heartbeats WHERE created_at < now() - interval '7 days';
-          DELETE FROM machine_snapshots WHERE created_at < now() - interval '30 days';
-          DELETE FROM audit_events WHERE entity_type LIKE 'otel_%' AND created_at < now() - interval '30 days';
-          DELETE FROM genie_runtime_events WHERE created_at < now() - interval '14 days';
-        `);
-        retentionRan = true;
-      } catch (retErr) {
-        // Non-fatal — log warning and continue, never block startup
-        retentionRan = true; // Don't retry on next call
-        const msg = retErr instanceof Error ? retErr.message : String(retErr);
-        process.stderr.write(`[genie] retention cleanup warning: ${msg}\n`);
-      }
+      await runRetention(sqlClient);
     }
   } catch (err) {
     // Migration/seed failure — reset client AND port so next call fully reconnects

--- a/src/term-commands/import.test.ts
+++ b/src/term-commands/import.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Tests for import command — table name validation against schema whitelist.
+ *
+ * Verifies that SQL injection via malicious table names in export JSON is blocked.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { GROUP_TABLES } from '../lib/export-format.js';
+import { assertValidTable } from './import.js';
+
+describe('assertValidTable', () => {
+  test('accepts all tables from GROUP_TABLES', () => {
+    const allTables = Object.values(GROUP_TABLES).flat();
+    for (const table of allTables) {
+      expect(() => assertValidTable(table)).not.toThrow();
+    }
+  });
+
+  test('rejects SQL injection attempt with DROP TABLE', () => {
+    expect(() => assertValidTable('users; DROP TABLE users --')).toThrow('not in the schema whitelist');
+  });
+
+  test('rejects SQL injection attempt with UNION SELECT', () => {
+    expect(() => assertValidTable("' UNION SELECT * FROM pg_shadow --")).toThrow('not in the schema whitelist');
+  });
+
+  test('rejects unknown table name', () => {
+    expect(() => assertValidTable('nonexistent_table')).toThrow('not in the schema whitelist');
+  });
+
+  test('rejects empty string', () => {
+    expect(() => assertValidTable('')).toThrow('not in the schema whitelist');
+  });
+
+  test('rejects table name with semicolon', () => {
+    expect(() => assertValidTable('tasks; DELETE FROM tasks')).toThrow('not in the schema whitelist');
+  });
+
+  test('error message includes the invalid table name', () => {
+    expect(() => assertValidTable('evil_table')).toThrow('Invalid table name: "evil_table"');
+  });
+});

--- a/src/term-commands/import.ts
+++ b/src/term-commands/import.ts
@@ -17,8 +17,18 @@ import { readFileSync } from 'node:fs';
 import type { Command } from 'commander';
 import type postgres from 'postgres';
 import type { ConflictMode } from '../lib/export-format.js';
-import { validateExportDocument } from '../lib/export-format.js';
+import { GROUP_TABLES, validateExportDocument } from '../lib/export-format.js';
 import { SELF_REFERENTIAL_COLUMNS, getPrimaryKey, sortByImportOrder } from '../lib/import-order.js';
+
+/** Canonical set of tables that can appear in an export/import document. */
+const VALID_TABLES = new Set(Object.values(GROUP_TABLES).flat());
+
+/** Throws if the table name is not in the export schema whitelist. */
+export function assertValidTable(name: string): void {
+  if (!VALID_TABLES.has(name)) {
+    throw new Error(`Invalid table name: "${name}" is not in the schema whitelist`);
+  }
+}
 
 type Sql = postgres.Sql;
 
@@ -51,6 +61,7 @@ async function detectConflicts(
   rows: Record<string, unknown>[],
 ): Promise<Record<string, unknown>[]> {
   if (rows.length === 0) return [];
+  assertValidTable(table);
   const pk = getPrimaryKey(table);
 
   if (pk.length === 1) {
@@ -122,6 +133,7 @@ async function insertOneRow(
   prepared: PreparedRow,
   mode: ConflictMode,
 ): Promise<void> {
+  assertValidTable(table);
   const { quotedCols, placeholders, values } = prepared;
   const pk = getPrimaryKey(table);
 
@@ -142,6 +154,7 @@ async function insertOneRow(
 }
 
 async function updateSelfRefs(tx: Sql, table: string, updates: { pk: unknown; value: unknown }[]): Promise<void> {
+  assertValidTable(table);
   const selfRefCol = SELF_REFERENTIAL_COLUMNS[table];
   const pk = getPrimaryKey(table);
   if (pk.length !== 1) return;


### PR DESCRIPTION
## Summary
- **P0 SQL injection fix** in `import.ts`: whitelist table names against `GROUP_TABLES` via `assertValidTable()` before every `sql.unsafe()` call
- **P0 SQL injection fix** in `db-backup.ts`: replace `'${DB_NAME}'` string interpolation with `current_database()` and psql `-v` variables
- **P1 Retention policies**: add `019_retention.sql` migration + startup cleanup for `heartbeats` (7d), `machine_snapshots` (30d), `audit_events` otel_ (30d), `genie_runtime_events` (14d)
- **P1 Pool error recovery**: set both `sqlClient = null` AND `activePort = null` on migration/seed failure to force full reconnect
- **P1 Migration directory**: remove `process.cwd()` legacy fallback, use only deterministic `import.meta.dir`-based paths

## Test plan
- [x] `bun test src/term-commands/import.test.ts` — 7 injection tests pass
- [x] `bun test src/lib/db.test.ts` — 22 tests pass (retention, pool recovery, migrations)
- [x] `grep -c "'${DB_NAME}'" src/lib/db-backup.ts` → 0
- [x] Full suite: 1651 pass, 0 fail