### PR TITLE
fix(session): v4 stability — executor lifecycle + tmux race conditions

### DIFF
--- a/src/genie-commands/session.ts
+++ b/src/genie-commands/session.ts
@@ -124,7 +124,6 @@ async function registerSessionInRegistry(sessionName: string, windowName: string
 
     // Executor model: create agent identity + executor for leader session
     const agentIdentity = await registry.findOrCreateAgent(leaderName, sanitized, leaderName);
-    await executorRegistry.terminateActiveExecutor(agentIdentity.id);
 
     let pid: number | null = null;
     try {
@@ -135,7 +134,8 @@ async function registerSessionInRegistry(sessionName: string, windowName: string
       /* best-effort */
     }
 
-    const executor = await executorRegistry.createExecutor(agentIdentity.id, 'claude', 'tmux', {
+    // Atomic: create executor + set as current in a single transaction
+    await executorRegistry.createAndLinkExecutor(agentIdentity.id, 'claude', 'tmux', {
       pid,
       tmuxSession: sessionName,
       tmuxPaneId: paneId,
@@ -143,7 +143,6 @@ async function registerSessionInRegistry(sessionName: string, windowName: string
       state: 'spawning',
       repoPath: workspaceDir,
     });
-    await registry.setCurrentExecutor(agentIdentity.id, executor.id);
   } catch {
     // Best-effort — don't block session startup if registration fails
   }
@@ -227,6 +226,16 @@ async function createSession(
   await tmux.executeTmux(`send-keys -t ${shellQuote(target)} ${shellQuote(cmd)} Enter`);
   console.log(`Started Claude Code as ${agentName} in ${workspaceDir}`);
 
+  // Guard: terminate old executor before spawning new one (prevents duplicates)
+  try {
+    const sanitized = sanitizeTeamName(windowName);
+    const leaderName = await resolveSessionLeaderName(windowName);
+    const agentIdentity = await registry.findOrCreateAgent(leaderName, sanitized, leaderName);
+    await executorRegistry.terminateActiveExecutor(agentIdentity.id);
+  } catch {
+    // Best-effort — don't block session creation if guard fails
+  }
+
   // Register interactive session so spawned agents can find the team-lead
   await registerSessionInRegistry(sessionName, windowName, workspaceDir);
 }
@@ -285,6 +294,16 @@ async function focusTeamWindow(
     await launchWithContinueFallback(target, windowName, systemPromptFile);
     console.log(`Started Claude Code as ${basename(workingDir)}@${sanitizeTeamName(windowName)} in ${workingDir}`);
 
+    // Guard: terminate old executor before registering new one
+    try {
+      const sanitized = sanitizeTeamName(windowName);
+      const leaderName = await resolveSessionLeaderName(windowName);
+      const agentIdentity = await registry.findOrCreateAgent(leaderName, sanitized, leaderName);
+      await executorRegistry.terminateActiveExecutor(agentIdentity.id);
+    } catch {
+      // Best-effort guard
+    }
+
     // Register interactive session so spawned agents can find the team-lead
     await registerSessionInRegistry(sessionName, windowName, workingDir);
   } else {
@@ -302,6 +321,16 @@ async function focusTeamWindow(
       await tmux.executeTmux(`send-keys -t ${shellQuote(target)} ${shellQuote(cdCmd)} Enter`);
 
       await launchWithContinueFallback(target, windowName, systemPromptFile);
+
+      // Guard: terminate old executor before registering new one
+      try {
+        const sanitized = sanitizeTeamName(windowName);
+        const leaderName = await resolveSessionLeaderName(windowName);
+        const agentIdentity = await registry.findOrCreateAgent(leaderName, sanitized, leaderName);
+        await executorRegistry.terminateActiveExecutor(agentIdentity.id);
+      } catch {
+        // Best-effort guard
+      }
 
       await registerSessionInRegistry(sessionName, windowName, workingDir);
     }

--- a/src/lib/executor-registry.test.ts
+++ b/src/lib/executor-registry.test.ts
@@ -11,6 +11,7 @@ import { completeAssignment, createAssignment, getActiveAssignment } from './ass
 import { getConnection } from './db.js';
 import {
   type CreateExecutorOpts,
+  createAndLinkExecutor,
   createExecutor,
   findExecutorByPane,
   findExecutorBySession,
@@ -834,6 +835,133 @@ describe.skipIf(!DB_AVAILABLE)('executor-registry', () => {
       expect(names).toContain('idx_executors_agent_id');
       expect(names).toContain('idx_executors_state');
       expect(names).toContain('idx_executors_provider');
+    });
+  });
+
+  // ==========================================================================
+  // Atomic Create + Link (createAndLinkExecutor)
+  // ==========================================================================
+
+  describe('createAndLinkExecutor', () => {
+    test('creates executor and sets current_executor_id atomically', async () => {
+      const agentId = await seedAgent();
+      const exec = await createAndLinkExecutor(agentId, 'claude', 'tmux', {
+        pid: 7001,
+        tmuxSession: 'genie',
+        tmuxPaneId: '%50',
+      });
+
+      expect(exec.id).toBeTruthy();
+      expect(exec.agentId).toBe(agentId);
+      expect(exec.pid).toBe(7001);
+      expect(exec.state).toBe('spawning');
+
+      // FK should be set in the same transaction
+      const agent = await getAgent(agentId);
+      expect(agent!.currentExecutorId).toBe(exec.id);
+    });
+
+    test('linked executor is returned by getCurrentExecutor', async () => {
+      const agentId = await seedAgent();
+      const exec = await createAndLinkExecutor(agentId, 'claude', 'tmux');
+
+      const current = await getCurrentExecutor(agentId);
+      expect(current).not.toBeNull();
+      expect(current!.id).toBe(exec.id);
+    });
+
+    test('replaces previous FK when called again', async () => {
+      const agentId = await seedAgent();
+      const e1 = await createAndLinkExecutor(agentId, 'claude', 'tmux', { pid: 8001 });
+      const e2 = await createAndLinkExecutor(agentId, 'claude', 'tmux', { pid: 8002 });
+
+      // FK now points to e2
+      const agent = await getAgent(agentId);
+      expect(agent!.currentExecutorId).toBe(e2.id);
+
+      // Both executors exist in history
+      const history = await listExecutors(agentId);
+      expect(history.length).toBe(2);
+      expect(history.map((e) => e.id)).toContain(e1.id);
+      expect(history.map((e) => e.id)).toContain(e2.id);
+    });
+
+    test('accepts all CreateExecutorOpts', async () => {
+      const agentId = await seedAgent();
+      const exec = await createAndLinkExecutor(agentId, 'claude', 'tmux', {
+        id: 'linked-exec-id',
+        pid: 9001,
+        tmuxSession: 'genie',
+        tmuxPaneId: '%99',
+        tmuxWindow: 'test-window',
+        state: 'running',
+        metadata: { key: 'value' },
+        repoPath: '/tmp/repo',
+      });
+
+      expect(exec.id).toBe('linked-exec-id');
+      expect(exec.state).toBe('running');
+      expect(exec.metadata).toEqual({ key: 'value' });
+    });
+
+    test('no orphaned executor if agent does not exist', async () => {
+      // Inserting an executor for a non-existent agent should fail the FK constraint
+      // and the transaction should roll back both the INSERT and UPDATE
+      try {
+        await createAndLinkExecutor('nonexistent-agent', 'claude', 'tmux');
+        expect(true).toBe(false); // Should not reach
+      } catch {
+        // Expected — FK violation
+      }
+
+      // No executor should have been created
+      const all = await listExecutors();
+      expect(all.length).toBe(0);
+    });
+  });
+
+  // ==========================================================================
+  // Atomic terminateActiveExecutor (WHERE current_executor_id = $id)
+  // ==========================================================================
+
+  describe('terminateActiveExecutor atomicity', () => {
+    test('only nulls FK if still pointing to the same executor', async () => {
+      const agentId = await seedAgent();
+      const e1 = await createAndLinkExecutor(agentId, 'claude', 'tmux', { state: 'working' });
+
+      // Simulate a concurrent spawn: e2 takes over the FK before terminate runs
+      const e2 = await createAndLinkExecutor(agentId, 'claude', 'tmux', { state: 'spawning' });
+
+      // Now terminate e1 — the FK should NOT be nulled since it points to e2
+      const sql = await getConnection();
+      await terminateExecutor(e1.id);
+      await sql`UPDATE agents SET current_executor_id = NULL WHERE id = ${agentId} AND current_executor_id = ${e1.id}`;
+
+      // FK should still point to e2
+      const agent = await getAgent(agentId);
+      expect(agent!.currentExecutorId).toBe(e2.id);
+    });
+
+    test('concurrent terminate + spawn does not orphan new executor', async () => {
+      const agentId = await seedAgent();
+
+      // Simulate rapid terminate + respawn cycles
+      for (let i = 0; i < 5; i++) {
+        await terminateActiveExecutor(agentId);
+        await createAndLinkExecutor(agentId, 'claude', 'tmux', { pid: 2000 + i });
+      }
+
+      const all = await listExecutors(agentId);
+      expect(all.length).toBe(5);
+
+      // Only the last one should be non-terminated (previous 4 terminated by guard)
+      const active = all.filter((e) => e.state !== 'terminated');
+      expect(active.length).toBe(1);
+      expect(active[0].pid).toBe(2004);
+
+      // FK points to the last executor
+      const agent = await getAgent(agentId);
+      expect(agent!.currentExecutorId).toBe(active[0].id);
     });
   });
 });

--- a/src/lib/executor-registry.ts
+++ b/src/lib/executor-registry.ts
@@ -77,6 +77,44 @@ export async function createExecutor(
   return rowToExecutor(rows[0]);
 }
 
+/**
+ * Atomically create an executor and set it as the agent's current executor.
+ * Both operations happen in a single SQL transaction to prevent orphaned records.
+ */
+export async function createAndLinkExecutor(
+  agentId: string,
+  provider: ProviderName,
+  transport: TransportType,
+  opts: CreateExecutorOpts = {},
+): Promise<Executor> {
+  const sql = await getConnection();
+  const id = opts.id ?? randomUUID();
+  const now = new Date().toISOString();
+
+  return sql.begin(async (tx: any) => {
+    const rows = await tx<ExecutorRow[]>`
+      INSERT INTO executors (
+        id, agent_id, provider, transport, pid,
+        tmux_session, tmux_pane_id, tmux_window, tmux_window_id,
+        claude_session_id, state, metadata, worktree, repo_path, pane_color,
+        started_at
+      ) VALUES (
+        ${id}, ${agentId}, ${provider}, ${transport}, ${opts.pid ?? null},
+        ${opts.tmuxSession ?? null}, ${opts.tmuxPaneId ?? null},
+        ${opts.tmuxWindow ?? null}, ${opts.tmuxWindowId ?? null},
+        ${opts.claudeSessionId ?? null}, ${opts.state ?? 'spawning'},
+        ${tx.json(opts.metadata ?? {})}, ${opts.worktree ?? null},
+        ${opts.repoPath ?? null}, ${opts.paneColor ?? null},
+        ${now}
+      ) RETURNING *
+    `;
+
+    await tx`UPDATE agents SET current_executor_id = ${id} WHERE id = ${agentId}`;
+
+    return rowToExecutor(rows[0]);
+  });
+}
+
 /** Get an executor by ID. */
 export async function getExecutor(id: string): Promise<Executor | null> {
   const sql = await getConnection();
@@ -138,8 +176,8 @@ export async function terminateActiveExecutor(agentId: string): Promise<void> {
   // Terminate the executor
   await terminateExecutor(executorId);
 
-  // Null the FK
-  await sql`UPDATE agents SET current_executor_id = NULL WHERE id = ${agentId}`;
+  // Atomic null — only if still pointing to the same executor (prevents race with concurrent spawns)
+  await sql`UPDATE agents SET current_executor_id = NULL WHERE id = ${agentId} AND current_executor_id = ${executorId}`;
 }
 
 /** List executors, optionally filtered by agent ID. */

--- a/src/lib/team-auto-spawn.ts
+++ b/src/lib/team-auto-spawn.ts
@@ -57,14 +57,17 @@ async function ensureSession(teamName: string): Promise<string> {
     if (existing) return teamConfig.tmuxSessionName;
   }
 
-  // Fallback: create/find session named after the team
+  // Fallback: atomically create session named after the team.
+  // Uses new-session directly and catches "duplicate session" to eliminate TOCTOU race.
   const sessionName = sanitizeTeamName(teamName);
-  const existing = await tmux.findSessionByName(sessionName);
-  if (existing) return sessionName;
-
-  const session = await tmux.createSession(sessionName);
-  if (!session) {
-    throw new Error(`Failed to create tmux session "${sessionName}"`);
+  try {
+    await tmux.createSession(sessionName);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    // "duplicate session" means another process created it first — that's fine
+    if (!message.includes('duplicate session')) {
+      throw error;
+    }
   }
   return sessionName;
 }

--- a/src/lib/tmux-alive.test.ts
+++ b/src/lib/tmux-alive.test.ts
@@ -8,7 +8,7 @@ mock.module('./tmux-wrapper.js', () => ({
   genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
 }));
 
-const { isPaneAlive } = await import('./tmux.js');
+const { isPaneAlive, TmuxUnreachableError } = await import('./tmux.js');
 
 describe('isPaneAlive', () => {
   beforeEach(() => {
@@ -32,8 +32,23 @@ describe('isPaneAlive', () => {
     expect(await isPaneAlive('%2')).toBe(false);
   });
 
-  test('returns false when the tmux server is unavailable', async () => {
+  test('returns false when pane is not found (tmux reachable)', async () => {
+    mockExecuteTmux.mockRejectedValueOnce(new Error("can't find pane %99"));
+    expect(await isPaneAlive('%99')).toBe(false);
+  });
+
+  test('throws TmuxUnreachableError when tmux server is down', async () => {
     mockExecuteTmux.mockRejectedValueOnce(new Error('no server running'));
-    expect(await isPaneAlive('%2')).toBe(false);
+    await expect(isPaneAlive('%2')).rejects.toBeInstanceOf(TmuxUnreachableError);
+  });
+
+  test('throws TmuxUnreachableError on server exited', async () => {
+    mockExecuteTmux.mockRejectedValueOnce(new Error('server exited unexpectedly'));
+    await expect(isPaneAlive('%2')).rejects.toBeInstanceOf(TmuxUnreachableError);
+  });
+
+  test('throws TmuxUnreachableError on connection error', async () => {
+    mockExecuteTmux.mockRejectedValueOnce(new Error('error connecting to /tmp/tmux-1000/default'));
+    await expect(isPaneAlive('%2')).rejects.toBeInstanceOf(TmuxUnreachableError);
   });
 });

--- a/src/lib/tmux.test.ts
+++ b/src/lib/tmux.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for tmux.ts — session creation atomicity and retry logic.
+ *
+ * Run with: bun test src/lib/tmux.test.ts
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const mockExecuteTmux = mock(async (_cmd: string) => '');
+
+mock.module('./tmux-wrapper.js', () => ({
+  executeTmux: mockExecuteTmux,
+  genieTmuxPrefix: () => ['-L', 'genie'],
+  genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
+}));
+
+// Must import after mock.module
+const { ensureTeamWindow, TmuxUnreachableError } = await import('./tmux.js');
+
+/** Standard mock responses for common tmux commands */
+function defaultTmuxResponse(cmd: string, overrides?: Record<string, string | (() => string)>): string {
+  for (const [key, val] of Object.entries(overrides ?? {})) {
+    if (cmd.includes(key)) return typeof val === 'function' ? val() : val;
+  }
+  if (cmd.includes('list-windows')) return '@1:my-team:0:1';
+  if (cmd.includes('list-panes')) return '%0:pane-title:1';
+  if (cmd.includes('set-window-option') || cmd.includes('set-hook')) return '';
+  return '';
+}
+
+describe('ensureTeamWindow', () => {
+  beforeEach(() => {
+    mockExecuteTmux.mockReset();
+  });
+
+  test('creates session atomically — handles duplicate session gracefully', async () => {
+    let newSessionCalls = 0;
+    mockExecuteTmux.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('new-session')) {
+        newSessionCalls++;
+        throw new Error('duplicate session: test-session');
+      }
+      return defaultTmuxResponse(cmd);
+    });
+
+    const result = await ensureTeamWindow('test-session', 'my-team');
+    expect(newSessionCalls).toBe(1);
+    expect(result.created).toBe(false);
+    expect(result.windowName).toBe('my-team');
+  });
+
+  test('retries on tmux server unreachable with backoff', async () => {
+    let attempts = 0;
+    mockExecuteTmux.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('new-session')) {
+        attempts++;
+        if (attempts <= 2) throw new Error('no server running on /tmp/tmux-1000/default');
+        return '';
+      }
+      return defaultTmuxResponse(cmd);
+    });
+
+    const result = await ensureTeamWindow('test-session', 'my-team');
+    expect(attempts).toBe(3);
+    expect(result.created).toBe(false);
+  });
+
+  test('gives up after max retries on persistent tmux server failure', async () => {
+    mockExecuteTmux.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('new-session')) throw new Error('no server running on /tmp/tmux-1000/default');
+      return '';
+    });
+
+    await expect(ensureTeamWindow('test-session', 'my-team')).rejects.toThrow('no server running');
+  });
+
+  test('does not retry on non-server errors', async () => {
+    let attempts = 0;
+    mockExecuteTmux.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('new-session')) {
+        attempts++;
+        throw new Error('some other tmux error');
+      }
+      return '';
+    });
+
+    await expect(ensureTeamWindow('test-session', 'my-team')).rejects.toThrow('some other tmux error');
+    expect(attempts).toBe(1);
+  });
+
+  test('creates new window when none exists', async () => {
+    mockExecuteTmux.mockImplementation(async (cmd: string) =>
+      defaultTmuxResponse(cmd, {
+        'new-session': '',
+        'list-windows': '',
+        'new-window': '@2:1',
+        'list-panes': '%1:pane-title:1',
+      }),
+    );
+
+    const result = await ensureTeamWindow('test-session', 'new-team');
+    expect(result.created).toBe(true);
+    expect(result.windowName).toBe('new-team');
+  });
+
+  test('concurrent calls: both succeed when one gets duplicate session', async () => {
+    let sessionCreated = false;
+    mockExecuteTmux.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('new-session')) {
+        if (sessionCreated) throw new Error('duplicate session: test-session');
+        sessionCreated = true;
+        return '';
+      }
+      return defaultTmuxResponse(cmd, { 'list-windows': '@1:team-a:0:1' });
+    });
+
+    const [result1, result2] = await Promise.allSettled([
+      ensureTeamWindow('test-session', 'team-a'),
+      ensureTeamWindow('test-session', 'team-a'),
+    ]);
+
+    expect(result1.status).toBe('fulfilled');
+    expect(result2.status).toBe('fulfilled');
+  });
+});
+
+describe('TmuxUnreachableError', () => {
+  test('is an instance of Error', () => {
+    const err = new TmuxUnreachableError('no server running');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(TmuxUnreachableError);
+    expect(err.name).toBe('TmuxUnreachableError');
+    expect(err.message).toBe('no server running');
+  });
+});

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -296,20 +296,73 @@ async function ensureMasterWindow(session: string, masterName: string): Promise<
 }
 
 /**
+ * Atomically ensure a tmux session exists.
+ * Uses `new-session` directly and catches "duplicate session" errors,
+ * eliminating the TOCTOU race of find-then-create.
+ */
+async function ensureSessionExists(name: string): Promise<void> {
+  try {
+    await executeTmux(`new-session -d -s "${name}" -e LC_ALL=C.UTF-8 -e LANG=C.UTF-8`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    // "duplicate session" means another process created it first — that's fine
+    if (message.includes('duplicate session')) return;
+    throw error;
+  }
+}
+
+/**
  * Ensure a tmux window exists for a team within a session.
  * Idempotent: if the window already exists, returns its first pane.
  * If not, creates the window and returns pane 0.
+ *
+ * Retries with backoff on "no server running" errors (tmux server crash recovery).
  */
 export async function ensureTeamWindow(
   session: string,
   teamName: string,
   workingDir?: string,
 ): Promise<{ windowId: string; windowName: string; paneId: string; created: boolean }> {
-  // Auto-create session if it doesn't exist (enables --session with new session names)
-  const sessionExists = await findSessionByName(session);
-  if (!sessionExists) {
-    await createSession(session);
+  const maxRetries = 3;
+  const baseDelayMs = 250;
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      return await ensureTeamWindowOnce(session, teamName, workingDir);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (
+        message.includes('no server running') ||
+        message.includes('server exited') ||
+        message.includes('error connecting')
+      ) {
+        if (attempt < maxRetries - 1) {
+          const delay = baseDelayMs * 2 ** attempt;
+          console.warn(
+            `[genie-tmux] tmux server unreachable (attempt ${attempt + 1}/${maxRetries}), retrying in ${delay}ms...`,
+          );
+          await new Promise((resolve) => setTimeout(resolve, delay));
+          continue;
+        }
+      }
+      throw error;
+    }
   }
+
+  // Unreachable, but TypeScript doesn't know that
+  throw new Error(`Failed to ensure team window after ${maxRetries} attempts`);
+}
+
+/**
+ * Single-attempt implementation of ensureTeamWindow (called by the retry wrapper).
+ */
+async function ensureTeamWindowOnce(
+  session: string,
+  teamName: string,
+  workingDir?: string,
+): Promise<{ windowId: string; windowName: string; paneId: string; created: boolean }> {
+  // Atomic session creation — eliminates TOCTOU race
+  await ensureSessionExists(session);
 
   const existing = await findWindowByName(session, teamName);
   if (existing) {
@@ -475,8 +528,21 @@ export async function resolveRepoSession(repoPath: string): Promise<string> {
 }
 
 /**
+ * Error thrown when the tmux server is unreachable (crashed, not started, etc.).
+ * Callers can catch this to distinguish "tmux is down" from "pane is dead".
+ */
+export class TmuxUnreachableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TmuxUnreachableError';
+  }
+}
+
+/**
  * Check if a tmux pane is still alive.
  * Returns false for invalid pane IDs ('inline', empty, non-%N format).
+ * Returns false when the pane is dead but tmux is reachable.
+ * Throws TmuxUnreachableError when the tmux server itself is unreachable.
  */
 export async function isPaneAlive(paneId: string): Promise<boolean> {
   if (!paneId || paneId === 'inline') return false;
@@ -484,7 +550,16 @@ export async function isPaneAlive(paneId: string): Promise<boolean> {
   try {
     const paneDead = (await executeTmux(`display-message -t '${paneId}' -p '#{pane_dead}'`)).trim();
     return paneDead !== '1';
-  } catch {
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (
+      message.includes('no server running') ||
+      message.includes('server exited') ||
+      message.includes('error connecting')
+    ) {
+      throw new TmuxUnreachableError(message);
+    }
+    // Pane not found, session not found, etc. — pane is dead but tmux is reachable
     return false;
   }
 }


### PR DESCRIPTION
## Summary
- Remove unconditional `terminateActiveExecutor()` from session attach — agents no longer killed on reconnect
- Atomic session creation via tmux error handling (eliminates TOCTOU race)
- Executor creation + FK linking wrapped in SQL transaction
- Atomic `UPDATE WHERE current_executor_id = $1` prevents orphaned records
- Tmux retry with backoff for server crash recovery
- `isPaneAlive()` now distinguishes dead-pane vs dead-tmux

## Wish
`v4-session-executor` — 4 P0 + 6 P1 fixes

## Test plan
- [ ] Attaching to running agent does NOT kill it
- [ ] Concurrent session creation doesn't duplicate
- [ ] `bun test src/genie-commands/__tests__/session.test.ts`
- [ ] `bun test src/lib/executor-registry.test.ts`
- [ ] `bun test src/lib/tmux.test.ts`