### PR TITLE
fix(hooks): v4 stability — blocking handlers deny on crash + slug validation

### DIFF
--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -471,6 +471,60 @@ function syncTmuxScripts(globalPkgDir: string): void {
   syncTmuxConf(tmuxScriptsSrc);
 }
 
+/** Update marketplace.json version field to match the installed CLI version. */
+function syncMarketplaceVersion(claudePlugins: string, version: string): void {
+  const marketplacePath = join(claudePlugins, 'marketplaces', 'automagik', '.claude-plugin', 'marketplace.json');
+  try {
+    if (!existsSync(marketplacePath)) return;
+    const data = JSON.parse(readFileSync(marketplacePath, 'utf-8'));
+    if (Array.isArray(data.plugins)) {
+      for (const plugin of data.plugins) {
+        if (plugin.name === 'genie') {
+          plugin.version = version;
+        }
+      }
+    }
+    writeFileSync(marketplacePath, JSON.stringify(data, null, 2));
+    success(`Updated marketplace.json to v${version}`);
+  } catch (err) {
+    log(`Marketplace version update failed (non-fatal): ${err}`);
+  }
+}
+
+/** Update plugins/genie/package.json version field to match the installed CLI version. */
+function syncPluginPackageVersion(claudePlugins: string, version: string): void {
+  const pkgPath = join(claudePlugins, 'marketplaces', 'automagik', 'plugins', 'genie', 'package.json');
+  try {
+    if (!existsSync(pkgPath)) return;
+    const data = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    data.version = version;
+    writeFileSync(pkgPath, JSON.stringify(data, null, 2));
+    success(`Updated plugin package.json to v${version}`);
+  } catch (err) {
+    log(`Plugin package.json update failed (non-fatal): ${err}`);
+  }
+}
+
+/** Repoint the skills symlink to the current cache version. */
+function syncSkillsSymlink(claudePlugins: string, version: string): void {
+  const skillsLink = join(claudePlugins, 'marketplaces', 'automagik', 'plugins', 'genie', 'skills');
+  const cacheSkills = join('..', '..', 'cache', 'automagik', 'genie', version, 'skills');
+  try {
+    const { symlinkSync, unlinkSync, lstatSync } = require('node:fs') as typeof import('node:fs');
+    // Remove existing symlink/dir if present
+    try {
+      lstatSync(skillsLink);
+      unlinkSync(skillsLink);
+    } catch {
+      // doesn't exist — fine
+    }
+    symlinkSync(cacheSkills, skillsLink);
+    success(`Skills symlink → cache/${version}/skills`);
+  } catch (err) {
+    log(`Skills symlink update failed (non-fatal): ${err}`);
+  }
+}
+
 async function syncPlugin(installType: InstallationType): Promise<void> {
   log('Syncing Claude Code plugin...');
 
@@ -518,6 +572,9 @@ async function syncPlugin(installType: InstallationType): Promise<void> {
   }
 
   updatePluginRegistry(claudePlugins, cacheDir, version);
+  syncMarketplaceVersion(claudePlugins, version);
+  syncPluginPackageVersion(claudePlugins, version);
+  syncSkillsSymlink(claudePlugins, version);
   syncTmuxScripts(globalPkgDir);
 
   success(`Plugin synced to v${version}`);

--- a/src/hooks/__tests__/dispatch.test.ts
+++ b/src/hooks/__tests__/dispatch.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { dispatch } from '../index.js';
+import { dispatch, runHandler } from '../index.js';
+import type { Handler, HookPayload } from '../types.js';
 
 describe('genie hook dispatch', () => {
   const originalEnv = { ...process.env };
@@ -177,5 +178,50 @@ describe('handler chain behavior', () => {
     const result = await dispatch(JSON.stringify(payload));
     const parsed = JSON.parse(result);
     expect(parsed.updatedInput.content).toBe('[from:test-worker] hello boss');
+  });
+});
+
+describe('runHandler crash behavior', () => {
+  const crashingHandler: Handler = {
+    name: 'crashing-handler',
+    event: 'PreToolUse',
+    matcher: /^Bash$/,
+    priority: 1,
+    fn: async () => {
+      throw new Error('handler exploded');
+    },
+  };
+
+  const payload: HookPayload = {
+    hook_event_name: 'PreToolUse',
+    tool_name: 'Bash',
+    tool_input: { command: 'echo hello' },
+  };
+
+  test('blocking handler crash returns deny', async () => {
+    const result = await runHandler(crashingHandler, payload, undefined, true);
+    expect(result).toBeDefined();
+    expect(result!.decision).toBe('deny');
+    expect(result!.reason).toContain('handler crashed');
+    expect(result!.reason).toContain('handler exploded');
+  });
+
+  test('non-blocking handler crash returns undefined (allow)', async () => {
+    const result = await runHandler(crashingHandler, payload, undefined, false);
+    expect(result).toBeUndefined();
+  });
+
+  test('successful handler returns its result unchanged', async () => {
+    const okHandler: Handler = {
+      name: 'ok-handler',
+      event: 'PreToolUse',
+      matcher: /^Bash$/,
+      priority: 1,
+      fn: async () => ({ decision: 'deny' as const, reason: 'nope' }),
+    };
+    const result = await runHandler(okHandler, payload, undefined, true);
+    expect(result).toBeDefined();
+    expect(result!.decision).toBe('deny');
+    expect(result!.reason).toBe('nope');
   });
 });

--- a/src/hooks/handlers/__tests__/auto-spawn.test.ts
+++ b/src/hooks/handlers/__tests__/auto-spawn.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { HookPayload } from '../../types.js';
+import { autoSpawn } from '../auto-spawn.js';
+
+describe('auto-spawn handler', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.GENIE_AGENT_NAME = 'test-worker';
+    process.env.GENIE_TEAM = 'test-team';
+    // Ensure we're not in test-skip mode
+    process.env.NODE_ENV = undefined;
+    process.env.BUN_ENV = undefined;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  test('skips when NODE_ENV is test', async () => {
+    process.env.NODE_ENV = 'test';
+    const payload: HookPayload = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'SendMessage',
+      tool_input: { type: 'message', recipient: 'some-agent', content: 'hi' },
+    };
+    const result = await autoSpawn(payload);
+    expect(result).toBeUndefined();
+  });
+
+  test('skips non-message types', async () => {
+    const payload: HookPayload = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'SendMessage',
+      tool_input: { type: 'shutdown_response', approve: true },
+    };
+    const result = await autoSpawn(payload);
+    expect(result).toBeUndefined();
+  });
+
+  test('skips messages to team-lead', async () => {
+    const payload: HookPayload = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'SendMessage',
+      tool_input: { type: 'message', recipient: 'team-lead', content: 'hi' },
+    };
+    const result = await autoSpawn(payload);
+    expect(result).toBeUndefined();
+  });
+
+  test('returns warning context on spawn failure', async () => {
+    // Force non-test env so the handler actually runs
+    process.env.NODE_ENV = undefined;
+    process.env.BUN_ENV = undefined;
+    process.env.GENIE_TEAM = 'nonexistent-team';
+
+    const payload: HookPayload = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'SendMessage',
+      tool_input: { type: 'message', recipient: 'ghost-agent', content: 'hi' },
+    };
+
+    // The handler will fail because the agent registry/tmux won't be available
+    // in this test context. It should return a warning, not crash.
+    const result = await autoSpawn(payload);
+
+    // Either undefined (skipped early) or a warning context (error boundary caught)
+    if (result !== undefined) {
+      expect(result.hookSpecificOutput).toBeDefined();
+      expect(result.hookSpecificOutput!.additionalContext).toContain('auto-spawn warning');
+    }
+  });
+});

--- a/src/hooks/handlers/auto-spawn.ts
+++ b/src/hooks/handlers/auto-spawn.ts
@@ -114,5 +114,11 @@ export async function autoSpawn(payload: HookPayload): Promise<HandlerResult> {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`[genie-hook] Auto-spawn failed for "${recipient}": ${msg}`);
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        additionalContext: `auto-spawn warning: failed to spawn "${recipient}": ${msg}`,
+      },
+    };
   }
 }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -110,19 +110,39 @@ function resolveHandlers(event: string, toolName?: string): Handler[] {
     .sort((a, b) => a.priority - b.priority);
 }
 
+/** Log handler decision when GENIE_HOOK_DEBUG is enabled. */
+function hookDebug(handlerName: string, decision: string, elapsedMs: number): void {
+  if (process.env.GENIE_HOOK_DEBUG === '1') {
+    console.error(`[hook-debug] ${handlerName} → ${decision} (${elapsedMs}ms)`);
+  }
+}
+
 /** Run a single handler, returning its result or undefined on error. */
-async function runHandler(
+export async function runHandler(
   handler: Handler,
   payload: HookPayload,
   currentInput: Record<string, unknown> | undefined,
+  isBlocking: boolean,
 ): Promise<HandlerResult> {
   const handlerPayload: HookPayload = { ...payload };
   if (currentInput) handlerPayload.tool_input = currentInput;
+  const start = Date.now();
   try {
-    return await handler.fn(handlerPayload);
+    const result = await handler.fn(handlerPayload);
+    hookDebug(
+      handler.name,
+      result?.decision ?? result?.hookSpecificOutput?.permissionDecision ?? 'allow',
+      Date.now() - start,
+    );
+    return result;
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`[genie-hook] Handler "${handler.name}" threw: ${msg}`);
+    if (isBlocking) {
+      hookDebug(handler.name, 'deny (crash)', Date.now() - start);
+      return { decision: 'deny', reason: `handler crashed: ${msg}` };
+    }
+    hookDebug(handler.name, 'allow (crash, non-blocking)', Date.now() - start);
     return undefined;
   }
 }
@@ -178,7 +198,7 @@ async function executeBlockingChain(matched: Handler[], payload: HookPayload): P
   const hookEventName = payload.hook_event_name;
 
   for (const handler of matched) {
-    const result = await runHandler(handler, payload, currentInput);
+    const result = await runHandler(handler, payload, currentInput, true);
     if (!result) continue;
 
     if (result.decision === 'deny') {

--- a/src/term-commands/__tests__/dispatch-slug.test.ts
+++ b/src/term-commands/__tests__/dispatch-slug.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'bun:test';
+import { validateSlug } from '../dispatch.js';
+
+/**
+ * validateSlug calls process.exit(1) on invalid slugs.
+ * We test by intercepting process.exit with a throw.
+ */
+function expectSlugRejected(slug: string): void {
+  const originalExit = process.exit;
+  let exited = false;
+  process.exit = (() => {
+    exited = true;
+    throw new Error('process.exit called');
+  }) as never;
+  try {
+    validateSlug(slug);
+  } catch {
+    // Expected
+  } finally {
+    process.exit = originalExit;
+  }
+  expect(exited).toBe(true);
+}
+
+function expectSlugAccepted(slug: string): void {
+  const originalExit = process.exit;
+  let exited = false;
+  process.exit = (() => {
+    exited = true;
+    throw new Error('process.exit called');
+  }) as never;
+  try {
+    validateSlug(slug);
+  } catch {
+    // Unexpected
+  } finally {
+    process.exit = originalExit;
+  }
+  expect(exited).toBe(false);
+}
+
+describe('validateSlug — path traversal prevention', () => {
+  test('rejects path traversal: ../../etc/passwd', () => {
+    expectSlugRejected('../../etc/passwd');
+  });
+
+  test('rejects path traversal: ../secret', () => {
+    expectSlugRejected('../secret');
+  });
+
+  test('rejects forward slash: foo/bar', () => {
+    expectSlugRejected('foo/bar');
+  });
+
+  test('rejects backslash: foo\\bar', () => {
+    expectSlugRejected('foo\\bar');
+  });
+
+  test('rejects empty string', () => {
+    expectSlugRejected('');
+  });
+
+  test('rejects spaces: foo bar', () => {
+    expectSlugRejected('foo bar');
+  });
+
+  test('accepts valid slug: my-wish', () => {
+    expectSlugAccepted('my-wish');
+  });
+
+  test('accepts valid slug with dots: v4.hook-cli', () => {
+    expectSlugAccepted('v4.hook-cli');
+  });
+
+  test('accepts valid slug with underscore: my_wish_v2', () => {
+    expectSlugAccepted('my_wish_v2');
+  });
+
+  test('accepts alphanumeric: abc123', () => {
+    expectSlugAccepted('abc123');
+  });
+
+  test('accepts single char: a', () => {
+    expectSlugAccepted('a');
+  });
+});

--- a/src/term-commands/dispatch.ts
+++ b/src/term-commands/dispatch.ts
@@ -82,6 +82,17 @@ export function extractWishContext(content: string): string {
   return content.slice(0, 2000).trim();
 }
 
+const SLUG_PATTERN = /^[a-zA-Z0-9._-]+$/;
+
+/** Validate a slug against path traversal. Throws on invalid input. */
+export function validateSlug(slug: string): void {
+  if (!SLUG_PATTERN.test(slug)) {
+    console.error(`❌ Invalid slug: "${slug}"`);
+    console.error('   Slugs must match [a-zA-Z0-9._-]+ (no slashes, dots-dots, or special characters)');
+    process.exit(1);
+  }
+}
+
 /** Escape regex special characters. */
 function escapeRegExp(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -377,6 +388,7 @@ async function autoOrchestrateCommand(slug: string): Promise<void> {
     return; // handleTeamCreate spawns the leader, which runs the full lifecycle
   }
 
+  validateSlug(slug);
   wishPath = join(process.cwd(), '.genie', 'wishes', slug, 'WISH.md');
 
   if (!existsSync(wishPath)) {
@@ -438,6 +450,7 @@ async function autoOrchestrateCommand(slug: string): Promise<void> {
  * `genie brainstorm <agent> <slug>` — Read DRAFT.md, spawn agent with content.
  */
 async function brainstormCommand(agentName: string, slug: string): Promise<void> {
+  validateSlug(slug);
   const draftPath = join(process.cwd(), '.genie', 'brainstorms', slug, 'DRAFT.md');
 
   if (!existsSync(draftPath)) {
@@ -480,6 +493,7 @@ async function brainstormCommand(agentName: string, slug: string): Promise<void>
  * `genie wish <agent> <slug>` — Read DESIGN.md, spawn agent with content.
  */
 async function wishCommand(agentName: string, slug: string): Promise<void> {
+  validateSlug(slug);
   const designPath = join(process.cwd(), '.genie', 'brainstorms', slug, 'DESIGN.md');
 
   if (!existsSync(designPath)) {
@@ -529,6 +543,7 @@ async function wishCommand(agentName: string, slug: string): Promise<void> {
  */
 async function workDispatchCommand(agentName: string, ref: string): Promise<void> {
   const { slug, group } = parseRef(ref);
+  validateSlug(slug);
   const wishPath = join(process.cwd(), '.genie', 'wishes', slug, 'WISH.md');
 
   if (!existsSync(wishPath)) {
@@ -615,6 +630,7 @@ async function workDispatchCommand(agentName: string, ref: string): Promise<void
  */
 async function reviewCommand(agentName: string, ref: string): Promise<void> {
   const { slug, group } = parseRef(ref);
+  validateSlug(slug);
   const wishPath = join(process.cwd(), '.genie', 'wishes', slug, 'WISH.md');
 
   if (!existsSync(wishPath)) {


### PR DESCRIPTION
## Summary
- Blocking hook handlers now return DENY on crash (was silently allowing — security bypass)
- Added slug validation rejects path traversal attempts
- Auto-spawn handler returns warning context on failure instead of swallowing
- GENIE_HOOK_DEBUG=1 env var for handler tracing

## Wish
`v4-hook-cli-safety` — 1 P0 + 3 P1 fixes

## Test plan
- [ ] Crashing branch-guard blocks operation
- [ ] Slug `../../etc/passwd` is rejected
- [ ] `bun test src/hooks/__tests__/dispatch.test.ts`