### PR TITLE
fix(spawn): v4 stability — spawn watchdog + dynamic leader identity

### DIFF
--- a/src/genie-commands/session.ts
+++ b/src/genie-commands/session.ts
@@ -88,8 +88,13 @@ async function ensureNativeTeamForLeader(teamName: string, cwd: string): Promise
  * Build the claude launch command with native team flags.
  * Delegates to the shared buildTeamLeadCommand (single source of truth).
  */
-export function buildClaudeCommand(teamName: string, systemPromptFile?: string, continueName?: string): string {
-  return buildTeamLeadCommand(teamName, { systemPromptFile, continueName });
+export function buildClaudeCommand(
+  teamName: string,
+  systemPromptFile?: string,
+  continueName?: string,
+  leaderName?: string,
+): string {
+  return buildTeamLeadCommand(teamName, { systemPromptFile, continueName, leaderName });
 }
 
 /**
@@ -192,6 +197,7 @@ async function createSession(
   windowName: string,
   workspaceDir: string,
   systemPromptFile: string | null,
+  leaderName?: string,
 ): Promise<void> {
   await ensureNativeTeamForLeader(windowName, workspaceDir);
   console.log(`Native team "${windowName}" ready at ~/.claude/teams/${sanitizeTeamName(windowName)}/`);
@@ -224,7 +230,7 @@ async function createSession(
 
   const agentName = basename(workspaceDir);
   // First run — no session to continue, just start fresh with --name
-  const cmd = buildClaudeCommand(windowName, systemPromptFile || undefined, undefined);
+  const cmd = buildClaudeCommand(windowName, systemPromptFile || undefined, undefined, leaderName);
   await tmux.executeTmux(`send-keys -t ${shellQuote(target)} ${shellQuote(cmd)} Enter`);
   console.log(`Started Claude Code as ${agentName} in ${workspaceDir}`);
 
@@ -243,10 +249,16 @@ async function launchWithContinueFallback(
   target: string,
   windowName: string,
   systemPromptFile: string | null,
+  leaderName?: string,
 ): Promise<void> {
   const continueName = sanitizeTeamName(windowName);
   const hasPriorSession = sessionExists(continueName);
-  const cmd = buildClaudeCommand(windowName, systemPromptFile || undefined, hasPriorSession ? continueName : undefined);
+  const cmd = buildClaudeCommand(
+    windowName,
+    systemPromptFile || undefined,
+    hasPriorSession ? continueName : undefined,
+    leaderName,
+  );
 
   await tmux.executeTmux(`send-keys -t ${shellQuote(target)} ${shellQuote(cmd)} Enter`);
 
@@ -257,7 +269,7 @@ async function launchWithContinueFallback(
 
     if (['bash', 'zsh', 'sh', 'fish'].includes(afterCmd)) {
       console.log('Resume failed unexpectedly, starting fresh session...');
-      const freshCmd = buildClaudeCommand(windowName, systemPromptFile || undefined, undefined);
+      const freshCmd = buildClaudeCommand(windowName, systemPromptFile || undefined, undefined, leaderName);
       await tmux.executeTmux(`send-keys -t ${shellQuote(target)} ${shellQuote(freshCmd)} Enter`);
     }
   }
@@ -269,6 +281,7 @@ async function focusTeamWindow(
   windowName: string,
   workingDir: string,
   systemPromptFile: string | null,
+  leaderName?: string,
 ): Promise<void> {
   const teamWindow = await tmux.ensureTeamWindow(sessionName, windowName, workingDir);
   if (teamWindow.created) {
@@ -283,7 +296,7 @@ async function focusTeamWindow(
     const cdCmd = `cd ${shellQuote(workingDir)}`;
     await tmux.executeTmux(`send-keys -t ${shellQuote(target)} ${shellQuote(cdCmd)} Enter`);
 
-    await launchWithContinueFallback(target, windowName, systemPromptFile);
+    await launchWithContinueFallback(target, windowName, systemPromptFile, leaderName);
     console.log(`Started Claude Code as ${basename(workingDir)}@${sanitizeTeamName(windowName)} in ${workingDir}`);
 
     // Register interactive session so spawned agents can find the team-lead
@@ -302,7 +315,7 @@ async function focusTeamWindow(
       const cdCmd = `cd ${shellQuote(workingDir)}`;
       await tmux.executeTmux(`send-keys -t ${shellQuote(target)} ${shellQuote(cdCmd)} Enter`);
 
-      await launchWithContinueFallback(target, windowName, systemPromptFile);
+      await launchWithContinueFallback(target, windowName, systemPromptFile, leaderName);
 
       await registerSessionInRegistry(sessionName, windowName, workingDir);
     }
@@ -352,15 +365,48 @@ function attachToWindow(sessionName: string, windowName: string): void {
   spawnSync(tmuxBin(), [...genieTmuxPrefix(), cmd, '-t', target], { stdio: 'inherit' });
 }
 
+/** Reconcile stale leadAgentId entries in native team configs. */
+async function reconcileLeaderConfigs(): Promise<void> {
+  try {
+    const { readdirSync, readFileSync, writeFileSync } = await import('node:fs');
+    const { join } = await import('node:path');
+    const { resolveLeaderName } = await import('../lib/team-manager.js');
+    const teamsDir = join(process.env.HOME ?? '/root', '.claude', 'teams');
+    const teams = readdirSync(teamsDir);
+    for (const team of teams) {
+      try {
+        const configPath = join(teamsDir, team, 'config.json');
+        const raw = readFileSync(configPath, 'utf-8');
+        const config = JSON.parse(raw);
+        if (config.leadAgentId?.startsWith('team-lead@')) {
+          const actualLeader = await resolveLeaderName(team);
+          const sanitized = sanitizeTeamName(team);
+          config.leadAgentId = `${sanitizeTeamName(actualLeader)}@${sanitized}`;
+          writeFileSync(configPath, JSON.stringify(config, null, 2));
+          console.log(`[reconcile] Updated leadAgentId for team "${team}": ${config.leadAgentId}`);
+        }
+      } catch {
+        /* skip individual team errors */
+      }
+    }
+  } catch {
+    /* teams dir doesn't exist yet or DB unavailable — best-effort */
+  }
+}
+
 export async function sessionCommand(options: SessionOptions = {}): Promise<void> {
   // One-shot startup reconciliation: reset agents stuck in 'spawning' with no pane for >60s
   await reconcileStaleSpawns();
+
+  // Reconcile stale 'team-lead@' leadAgentId entries in native team configs
+  await reconcileLeaderConfigs();
 
   const workspaceDir = options.dir ?? process.cwd();
   const sessionName = options.name ?? sanitizeWindowName(basename(workspaceDir));
 
   try {
     const windowName = await deriveWindowName(sessionName, workspaceDir, options.team);
+    const leaderName = await resolveSessionLeaderName(windowName);
 
     if (options.reset) await handleReset(sessionName, windowName);
 
@@ -383,7 +429,7 @@ export async function sessionCommand(options: SessionOptions = {}): Promise<void
     }
 
     if (!session) {
-      await createSession(sessionName, windowName, workspaceDir, systemPromptFile);
+      await createSession(sessionName, windowName, workspaceDir, systemPromptFile, leaderName);
       attachToWindow(sessionName, windowName);
     } else if (process.env.TMUX) {
       // Already inside tmux — launch Claude Code in the CURRENT pane
@@ -392,13 +438,13 @@ export async function sessionCommand(options: SessionOptions = {}): Promise<void
       await tmux.executeTmux(`rename-window ${shellQuote(currentWindowName)}`);
       await ensureNativeTeamForLeader(currentWindowName, workspaceDir);
       // Fresh session — random suffix means no prior conversation to continue
-      const cmd = buildClaudeCommand(currentWindowName, systemPromptFile || undefined, undefined);
+      const cmd = buildClaudeCommand(currentWindowName, systemPromptFile || undefined, undefined, leaderName);
       const { execSync: execSyncCmd } = require('node:child_process');
       execSyncCmd(cmd, { stdio: 'inherit', cwd: workspaceDir });
     } else {
       // Outside tmux — attach to existing session
       console.log(`Session "${sessionName}" already exists`);
-      await focusTeamWindow(sessionName, windowName, workspaceDir, systemPromptFile);
+      await focusTeamWindow(sessionName, windowName, workspaceDir, systemPromptFile, leaderName);
       attachToWindow(sessionName, windowName);
     }
   } catch (error) {

--- a/src/genie-commands/session.ts
+++ b/src/genie-commands/session.ts
@@ -17,6 +17,7 @@ import { existsSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import { confirm } from '@inquirer/prompts';
 import * as registry from '../lib/agent-registry.js';
+import { reconcileStaleSpawns } from '../lib/agent-registry.js';
 import {
   deleteNativeTeam,
   ensureNativeTeam,
@@ -67,7 +68,7 @@ async function resolveSessionLeaderName(teamName: string): Promise<string> {
     const { resolveLeaderName } = await import('../lib/team-manager.js');
     return await resolveLeaderName(teamName);
   } catch {
-    return 'team-lead'; // Fallback for legacy teams or when DB is unavailable
+    return teamName; // Fallback when DB is unavailable — never return 'team-lead'
   }
 }
 
@@ -352,6 +353,9 @@ function attachToWindow(sessionName: string, windowName: string): void {
 }
 
 export async function sessionCommand(options: SessionOptions = {}): Promise<void> {
+  // One-shot startup reconciliation: reset agents stuck in 'spawning' with no pane for >60s
+  await reconcileStaleSpawns();
+
   const workspaceDir = options.dir ?? process.cwd();
   const sessionName = options.name ?? sanitizeWindowName(basename(workspaceDir));
 

--- a/src/hooks/handlers/auto-spawn.ts
+++ b/src/hooks/handlers/auto-spawn.ts
@@ -68,12 +68,12 @@ export async function autoSpawn(payload: HookPayload): Promise<HandlerResult> {
   if (!input || input.type !== 'message') return;
 
   const recipient = input.recipient as string | undefined;
-  if (!recipient || recipient === 'team-lead') return;
+  if (!recipient) return;
 
   const teamName = process.env.GENIE_TEAM ?? payload.team_name;
   if (!teamName) return;
 
-  // Skip auto-spawn for the team's actual leader (not just 'team-lead' alias)
+  // Skip auto-spawn for the team's leader (resolved dynamically, never hardcoded)
   if (await isRecipientLeader(recipient, teamName)) return;
 
   try {

--- a/src/lib/agent-registry.test.ts
+++ b/src/lib/agent-registry.test.ts
@@ -17,6 +17,7 @@ import {
   list,
   listAgents,
   listTemplates,
+  reconcileStaleSpawns,
   register,
   removeSubPane,
   saveTemplate,
@@ -251,6 +252,62 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
     });
     test('null', async () => {
       expect(await getTeamLeadEntry('no-such-team')).toBeNull();
+    });
+  });
+
+  describe('reconcileStaleSpawns', () => {
+    test('resets stuck spawning agents with no pane', async () => {
+      // Agent stuck: spawning, no pane, started >2s ago
+      const oldStart = new Date(Date.now() - 5_000).toISOString();
+      await register(makeAgent({ id: 'stuck-1', paneId: '', state: 'spawning', startedAt: oldStart }));
+      await register(makeAgent({ id: 'stuck-2', paneId: '', state: 'spawning', startedAt: oldStart }));
+
+      // Use 2s threshold for test speed (production uses 60s)
+      const reset = await reconcileStaleSpawns(2);
+      expect(reset.sort()).toEqual(['stuck-1', 'stuck-2']);
+
+      const a1 = await get('stuck-1');
+      expect(a1!.state).toBe('error');
+      const a2 = await get('stuck-2');
+      expect(a2!.state).toBe('error');
+    });
+
+    test('does not touch spawning agents with a pane', async () => {
+      const oldStart = new Date(Date.now() - 5_000).toISOString();
+      await register(makeAgent({ id: 'has-pane', paneId: '%42', state: 'spawning', startedAt: oldStart }));
+
+      const reset = await reconcileStaleSpawns(2);
+      expect(reset).toEqual([]);
+
+      const a = await get('has-pane');
+      expect(a!.state).toBe('spawning');
+    });
+
+    test('does not touch recently spawning agents', async () => {
+      // Just now — should not be reset even with 2s threshold
+      await register(makeAgent({ id: 'recent', paneId: '', state: 'spawning' }));
+
+      const reset = await reconcileStaleSpawns(2);
+      expect(reset).toEqual([]);
+
+      const a = await get('recent');
+      expect(a!.state).toBe('spawning');
+    });
+
+    test('does not touch non-spawning agents', async () => {
+      const oldStart = new Date(Date.now() - 5_000).toISOString();
+      await register(makeAgent({ id: 'working-agent', paneId: '', state: 'working', startedAt: oldStart }));
+
+      const reset = await reconcileStaleSpawns(2);
+      expect(reset).toEqual([]);
+
+      const a = await get('working-agent');
+      expect(a!.state).toBe('working');
+    });
+
+    test('returns empty array when nothing to reconcile', async () => {
+      const reset = await reconcileStaleSpawns(2);
+      expect(reset).toEqual([]);
     });
   });
 

--- a/src/lib/agent-registry.ts
+++ b/src/lib/agent-registry.ts
@@ -260,7 +260,7 @@ export async function reconcileStaleSpawns(thresholdSeconds = 60): Promise<strin
         reason: 'stale_spawn',
       }).catch(() => {});
     }
-    return rows.map((r) => r.id);
+    return rows.map((r: { id: string }) => r.id);
   } catch {
     return []; // Best-effort — don't block startup if DB is unavailable
   }

--- a/src/lib/agent-registry.ts
+++ b/src/lib/agent-registry.ts
@@ -235,6 +235,37 @@ export async function list(): Promise<Agent[]> {
   return rows.map(rowToAgent);
 }
 
+/**
+ * Reconcile stale spawns: reset agents stuck in 'spawning' state
+ * with no pane_id for longer than the threshold back to 'error'.
+ * Returns the IDs of agents that were reset.
+ *
+ * @param thresholdSeconds - How long an agent must be stuck before reset (default: 60)
+ */
+export async function reconcileStaleSpawns(thresholdSeconds = 60): Promise<string[]> {
+  try {
+    const sql = await getConnection();
+    const rows = await sql<{ id: string }[]>`
+      UPDATE agents
+      SET state = 'error', last_state_change = now()
+      WHERE state = 'spawning'
+        AND (pane_id IS NULL OR pane_id = '')
+        AND started_at < now() - interval '1 second' * ${thresholdSeconds}
+      RETURNING id
+    `;
+    for (const row of rows) {
+      console.error(`[reconcile] Reset stuck agent ${row.id} from spawning → error`);
+      recordAuditEvent('worker', row.id, 'state_changed', 'reconciler', {
+        state: 'error',
+        reason: 'stale_spawn',
+      }).catch(() => {});
+    }
+    return rows.map((r) => r.id);
+  } catch {
+    return []; // Best-effort — don't block startup if DB is unavailable
+  }
+}
+
 export async function filterBySession(sessionName: string): Promise<Agent[]> {
   const sql = await getConnection();
   const rows = await sql`SELECT * FROM agents WHERE session = ${sessionName}`;
@@ -340,14 +371,14 @@ export async function removeSubPane(workerId: string, paneId: string, _registryP
   await sql`UPDATE agents SET sub_panes = ${sql.json(filtered)} WHERE id = ${workerId}`;
 }
 
-/** Resolve the dynamic leader name for a team (null if only 'team-lead' applies). */
+/** Resolve the dynamic leader name for a team. Never returns 'team-lead'. */
 async function resolveDynamicLeaderName(teamName: string): Promise<string | null> {
   try {
-    const { getTeam } = await import('./team-manager.js');
-    const config = await getTeam(teamName);
-    return config?.leader && config.leader !== 'team-lead' ? config.leader : null;
+    const { resolveLeaderName } = await import('./team-manager.js');
+    const name = await resolveLeaderName(teamName);
+    return name !== teamName ? name : null;
   } catch {
-    return null; // Fallback to team-lead only
+    return null;
   }
 }
 

--- a/src/lib/claude-native-teams.ts
+++ b/src/lib/claude-native-teams.ts
@@ -196,7 +196,7 @@ export async function ensureNativeTeam(
   if (existing) return existing;
 
   const sanitized = sanitizeTeamName(teamName);
-  const resolvedLeader = sanitizeTeamName(leaderName ?? 'team-lead');
+  const resolvedLeader = sanitizeTeamName(leaderName ?? teamName);
   const config: NativeTeamConfig = {
     name: sanitized,
     description,
@@ -390,10 +390,10 @@ export async function deleteNativeTeam(teamName: string): Promise<boolean> {
 // ============================================================================
 
 /** Extract the leader inbox name from a native team config's leadAgentId. */
-function extractLeaderInboxName(config: NativeTeamConfig | null): string {
-  if (!config?.leadAgentId) return 'team-lead';
+function extractLeaderInboxName(config: NativeTeamConfig | null, teamName?: string): string {
+  if (!config?.leadAgentId) return teamName ?? 'unknown';
   const atIdx = config.leadAgentId.indexOf('@');
-  return atIdx > 0 ? config.leadAgentId.slice(0, atIdx) : 'team-lead';
+  return atIdx > 0 ? config.leadAgentId.slice(0, atIdx) : (teamName ?? 'unknown');
 }
 
 /** Scan a single team directory for unread leader inbox messages. */
@@ -414,7 +414,7 @@ async function scanTeamInbox(
     // Config missing or malformed
   }
 
-  const leaderInboxName = extractLeaderInboxName(config);
+  const leaderInboxName = extractLeaderInboxName(config, name);
   const inboxFile = join(base, name, 'inboxes', `${leaderInboxName}.json`);
 
   let messages: NativeInboxMessage[];
@@ -569,8 +569,8 @@ async function readSessionMetadata(filePath: string): Promise<SessionMetadata> {
  */
 function rootScore(metadata: { teamName?: string; agentName?: string }): number {
   if (!metadata.teamName && !metadata.agentName) return 2;
-  // Score leader sessions higher — matches both legacy "team-lead" and dynamic leader names
-  if (metadata.agentName === 'team-lead' || (metadata.teamName && !metadata.agentName)) return 1;
+  // Score leader sessions higher — matches sessions without an explicit agentName (leader sessions)
+  if (metadata.teamName && !metadata.agentName) return 1;
   return 0;
 }
 
@@ -694,7 +694,7 @@ export async function registerAsTeamLead(
     );
   }
 
-  const resolvedLeaderName = opts?.leaderName ?? 'team-lead';
+  const resolvedLeaderName = opts?.leaderName ?? teamName;
 
   // Create or load the native team, using the real CC session ID
   const config = await ensureNativeTeam(teamName, `Genie team: ${teamName}`, sessionId, resolvedLeaderName);

--- a/src/lib/protocol-router-spawn.ts
+++ b/src/lib/protocol-router-spawn.ts
@@ -246,13 +246,12 @@ export async function spawnWorkerFromTemplate(
       cwd: repoPath,
     });
     // Resolve the actual leader name for inbox notification
-    let leaderInboxTarget = 'team-lead';
+    let leaderInboxTarget: string;
     try {
-      const { getTeam } = await import('./team-manager.js');
-      const teamConfig = await getTeam(team);
-      if (teamConfig?.leader) leaderInboxTarget = teamConfig.leader;
+      const { resolveLeaderName } = await import('./team-manager.js');
+      leaderInboxTarget = await resolveLeaderName(team);
     } catch {
-      // Fallback to 'team-lead' for legacy teams
+      leaderInboxTarget = team; // Fallback to team name, never 'team-lead'
     }
     await nativeTeams.writeNativeInbox(team, leaderInboxTarget, {
       from: agentName,

--- a/src/lib/team-auto-spawn.ts
+++ b/src/lib/team-auto-spawn.ts
@@ -137,7 +137,7 @@ export async function ensureTeamLead(teamName: string, workingDir: string): Prom
     const target = `${session}:${windowName}`;
     const cdCmd = `cd ${shellQuote(workingDir)}`;
     await tmux.executeTmux(`send-keys -t ${shellQuote(target)} ${shellQuote(cdCmd)} Enter`);
-    const cmd = buildTeamLeadCommand(teamName, { systemPromptFile: systemPromptFile ?? undefined });
+    const cmd = buildTeamLeadCommand(teamName, { systemPromptFile: systemPromptFile ?? undefined, leaderName });
     await tmux.executeTmux(`send-keys -t ${shellQuote(target)} ${shellQuote(cmd)} Enter`);
   }
 

--- a/src/lib/team-auto-spawn.ts
+++ b/src/lib/team-auto-spawn.ts
@@ -111,10 +111,9 @@ export async function ensureTeamLead(teamName: string, workingDir: string): Prom
     return { created: false, session: currentSession, window: sanitizeWindowName(teamName) };
   }
 
-  // Resolve the actual leader name from team config (falls back to 'team-lead' for legacy)
-  const { getTeam } = await import('./team-manager.js');
-  const teamConfig = await getTeam(teamName);
-  const leaderName = teamConfig?.leader || 'team-lead';
+  // Resolve the actual leader name from team config (never returns 'team-lead')
+  const { resolveLeaderName } = await import('./team-manager.js');
+  const leaderName = await resolveLeaderName(teamName);
 
   // Create native team structure
   await ensureNativeTeam(teamName, `Genie team: ${teamName}`, 'pending', leaderName);

--- a/src/lib/team-lead-command.ts
+++ b/src/lib/team-lead-command.ts
@@ -28,6 +28,8 @@ interface BuildTeamLeadCommandOptions {
   sessionId?: string;
   /** Override promptMode instead of reading from config (useful for testing) */
   promptMode?: 'append' | 'system';
+  /** Actual leader name — used for --agent-id and --agent-name instead of 'team-lead'. Falls back to teamName. */
+  leaderName?: string;
 }
 
 /**
@@ -44,6 +46,8 @@ export function buildTeamLeadCommand(teamName: string, options?: BuildTeamLeadCo
   const sanitized = sanitizeTeamName(teamName);
   const qTeam = shellQuote(sanitized);
   const folderName = basename(process.cwd());
+  const resolvedLeader = options?.leaderName ?? teamName;
+  const sanitizedLeader = sanitizeTeamName(resolvedLeader);
   const parts = [
     'GENIE_WORKER=1',
     'CLAUDECODE=1',
@@ -51,8 +55,8 @@ export function buildTeamLeadCommand(teamName: string, options?: BuildTeamLeadCo
     `GENIE_TEAM=${qTeam}`,
     `GENIE_AGENT_NAME=${shellQuote(folderName)}`,
     'claude',
-    `--agent-id ${shellQuote(`team-lead@${sanitized}`)}`,
-    '--agent-name team-lead',
+    `--agent-id ${shellQuote(`${sanitizedLeader}@${sanitized}`)}`,
+    `--agent-name ${shellQuote(sanitizedLeader)}`,
     `--team-name ${qTeam}`,
     '--agent-type team-lead',
     '--dangerously-skip-permissions',

--- a/src/lib/team-manager.test.ts
+++ b/src/lib/team-manager.test.ts
@@ -297,15 +297,25 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
         expect(name).toBe('my-wish-slug');
       });
 
-      test('resolveLeaderName falls back to team-lead for legacy teams', async () => {
+      test('resolveLeaderName falls back to teamName for legacy teams (never returns team-lead)', async () => {
         await createTeam('feat/legacy-leader', TEST_REPO, 'dev');
-        // No leader set — legacy team
+        // No leader set — legacy team, should return teamName not 'team-lead'
         const name = await resolveLeaderName('feat/legacy-leader');
-        expect(name).toBe('team-lead');
+        expect(name).toBe('feat/legacy-leader');
       });
 
-      test('resolveLeaderName throws for nonexistent team', async () => {
-        expect(resolveLeaderName('nonexistent-team')).rejects.toThrow('not found');
+      test('resolveLeaderName returns teamName for nonexistent team (never throws)', async () => {
+        const name = await resolveLeaderName('nonexistent-team');
+        expect(name).toBe('nonexistent-team');
+      });
+
+      test('resolveLeaderName skips leader if it equals team-lead', async () => {
+        const config = await createTeam('feat/skip-team-lead', TEST_REPO, 'dev');
+        config.leader = 'team-lead';
+        await updateTeamConfig(config.name, config);
+        const name = await resolveLeaderName('feat/skip-team-lead');
+        // Should return teamName, not 'team-lead'
+        expect(name).toBe('feat/skip-team-lead');
       });
 
       test('spawner persisted in PG teams table', async () => {

--- a/src/lib/team-manager.ts
+++ b/src/lib/team-manager.ts
@@ -629,15 +629,18 @@ export async function killTeamMembers(teamName: string): Promise<void> {
 }
 
 /**
- * Resolve the leader name for a team.
- * Returns config.leader for teams that have it set, falls back to "team-lead" for legacy teams.
+ * Resolve the actual leader name for a team. Never returns 'team-lead'.
+ * Resolution order: team config DB → teamName as fallback.
+ * If DB is unreachable or team doesn't exist, returns teamName (never 'team-lead').
  */
 export async function resolveLeaderName(teamName: string): Promise<string> {
-  const config = await getTeam(teamName);
-  if (!config) {
-    throw new Error(`Team "${teamName}" not found.`);
+  try {
+    const config = await getTeam(teamName);
+    if (config?.leader && config.leader !== 'team-lead') return config.leader;
+  } catch {
+    // DB unreachable — fall through to teamName
   }
-  return config.leader || 'team-lead';
+  return teamName;
 }
 
 /** Set team lifecycle status. */

--- a/src/term-commands/agent/register.ts
+++ b/src/term-commands/agent/register.ts
@@ -12,6 +12,7 @@ import type { Command } from 'commander';
 import * as directory from '../../lib/agent-directory.js';
 import { contractPath } from '../../lib/genie-config.js';
 import { findOmniAgent, registerAgentInOmni, resolveOmniApiUrl } from '../../lib/omni-registration.js';
+import { validateRepoPath } from '../dir.js';
 
 interface RegisterOptions {
   dir: string;
@@ -78,6 +79,7 @@ async function handleOmniRegistration(
 
 async function handleAgentRegister(name: string, options: RegisterOptions): Promise<void> {
   const promptMode = validatePromptMode(options.promptMode);
+  if (options.repo) validateRepoPath(options.repo);
   const roles = normalizeRoles(options.roles);
   const entry = await directory.add(
     {

--- a/src/term-commands/agent/send.ts
+++ b/src/term-commands/agent/send.ts
@@ -19,7 +19,7 @@ export function registerAgentSend(parent: Command): void {
   parent
     .command('send <body>')
     .description('Send a direct message to an agent (hierarchy-enforced)')
-    .option('--to <agent>', 'Recipient agent name (default: team-lead)', 'team-lead')
+    .option('--to <agent>', 'Recipient agent name (default: team leader)', 'team-lead')
     .option('--from <sender>', 'Sender ID (auto-detected from context)')
     .option('--team <name>', 'Explicit team context for sender/recipient resolution')
     .option('--broadcast', 'Send to all direct reports')
@@ -44,13 +44,12 @@ export function registerAgentSend(parent: Command): void {
 // Hierarchy ACL
 // ============================================================================
 
-/** Check if an agent name matches the team's leader (by alias or actual name). */
+/** Check if an agent name matches the team's leader (by resolved name). */
 async function isTeamLeader(agentName: string, teamName: string): Promise<boolean> {
-  if (agentName === 'team-lead') return true;
   try {
-    const teamMgr = await import('../../lib/team-manager.js');
-    const config = await teamMgr.getTeam(teamName);
-    return agentName === config?.leader;
+    const { resolveLeaderName } = await import('../../lib/team-manager.js');
+    const leaderName = await resolveLeaderName(teamName);
+    return agentName === leaderName;
   } catch {
     return false;
   }

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -41,15 +41,10 @@ import { isPaneAlive } from '../lib/tmux.js';
 
 /**
  * Resolve the leader name for a team from team config.
- * Falls back to 'team-lead' for legacy teams without a leader set.
+ * Never returns 'team-lead' — uses resolveLeaderName() which falls back to teamName.
  */
 async function resolveTeamLeaderName(teamNameOrDefault: string): Promise<string> {
-  try {
-    const config = await teamManager.getTeam(teamNameOrDefault);
-    return config?.leader || 'team-lead';
-  } catch {
-    return 'team-lead';
-  }
+  return teamManager.resolveLeaderName(teamNameOrDefault);
 }
 
 /** Check if a process is alive by PID file. */

--- a/src/term-commands/dir.test.ts
+++ b/src/term-commands/dir.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test';
+import { validateRepoPath } from './dir.js';
+
+describe('validateRepoPath', () => {
+  test('accepts absolute paths', () => {
+    expect(() => validateRepoPath('/home/user/project')).not.toThrow();
+    expect(() => validateRepoPath('/tmp/repo')).not.toThrow();
+  });
+
+  test('accepts home-relative paths', () => {
+    expect(() => validateRepoPath('~/projects/app')).not.toThrow();
+    expect(() => validateRepoPath('~/repo')).not.toThrow();
+  });
+
+  test('accepts dot-relative paths', () => {
+    expect(() => validateRepoPath('./local-repo')).not.toThrow();
+    expect(() => validateRepoPath('../sibling-repo')).not.toThrow();
+  });
+
+  test('rejects bare words', () => {
+    expect(() => validateRepoPath('genie')).toThrow(/Invalid --repo value/);
+    expect(() => validateRepoPath('my-project')).toThrow(/Invalid --repo value/);
+  });
+
+  test('rejects URLs', () => {
+    expect(() => validateRepoPath('https://github.com/org/repo')).toThrow(/Invalid --repo value/);
+  });
+
+  test('rejects git SSH URLs', () => {
+    expect(() => validateRepoPath('git@github.com:org/repo.git')).toThrow(/Invalid --repo value/);
+  });
+});

--- a/src/term-commands/dir.ts
+++ b/src/term-commands/dir.ts
@@ -138,6 +138,7 @@ interface DirAddOptions {
 async function handleDirAdd(name: string, options: DirAddOptions): Promise<void> {
   const promptMode = validatePromptMode(options.promptMode);
   const resolvedDir = resolvePath(options.dir);
+  if (options.repo) validateRepoPath(options.repo);
   const entry = await directory.add(
     {
       name,
@@ -204,6 +205,18 @@ async function handleDirSync(): Promise<void> {
 // ============================================================================
 // Helpers
 // ============================================================================
+
+/**
+ * Validate that a REPO value looks like a real path.
+ * Accepts: absolute paths (/...), home-relative (~/...), dot-relative (./..., ../...).
+ * Rejects: bare words like 'genie' that are likely agent names, not paths.
+ */
+export function validateRepoPath(repo: string): void {
+  if (repo.startsWith('/') || repo.startsWith('~/') || repo.startsWith('./') || repo.startsWith('../')) return;
+  throw new Error(
+    `Invalid --repo value "${repo}". Must be a path (absolute "/...", home-relative "~/...", or dot-relative "./..." / "../..."). Got a bare word instead.`,
+  );
+}
 
 function validatePromptMode(mode: string): 'system' | 'append' {
   if (mode !== 'system' && mode !== 'append') {

--- a/src/term-commands/dispatch.ts
+++ b/src/term-commands/dispatch.ts
@@ -299,18 +299,17 @@ function buildFallbackWaves(content: string): Wave[] {
 /**
  * Resolve the leader name for --to in dispatch prompts.
  * Uses GENIE_TEAM to look up the team config's leader field.
- * Falls back to 'team-lead' for legacy teams.
+ * Never returns 'team-lead' — falls back to teamName.
  */
 async function resolveLeaderTarget(): Promise<string> {
   const teamName = process.env.GENIE_TEAM;
   if (!teamName) return 'team-lead';
 
   try {
-    const teamManager = await import('../lib/team-manager.js');
-    const config = await teamManager.getTeam(teamName);
-    return config?.leader || 'team-lead';
+    const { resolveLeaderName } = await import('../lib/team-manager.js');
+    return await resolveLeaderName(teamName);
   } catch {
-    return 'team-lead';
+    return teamName;
   }
 }
 

--- a/src/term-commands/init-flow.test.ts
+++ b/src/term-commands/init-flow.test.ts
@@ -20,6 +20,12 @@ mock.module('../genie-commands/setup.js', () => ({
   setupCommand: () => mockSetupCommand(),
 }));
 
+// Prevent workspace walk-up from detecting the host genie workspace
+mock.module('../lib/workspace.js', () => ({
+  findWorkspace: () => null,
+  scanAgents: () => [],
+}));
+
 const { registerInitCommands } = await import('./init.js');
 
 let originalCwd: string;

--- a/src/term-commands/msg.test.ts
+++ b/src/term-commands/msg.test.ts
@@ -39,12 +39,12 @@ afterAll(async () => {
 // Helper: insert team into PG
 // ---------------------------------------------------------------------------
 
-async function insertTeam(name: string, repo: string, members: string[]): Promise<void> {
+async function insertTeam(name: string, repo: string, members: string[], leader?: string): Promise<void> {
   const sql = await getConnection();
   await sql`
-    INSERT INTO teams (name, repo, base_branch, worktree_path, members, status, created_at)
-    VALUES (${name}, ${repo}, 'dev', ${join(repo, '.worktrees', name)}, ${JSON.stringify(members)}, 'in_progress', now())
-    ON CONFLICT (name) DO UPDATE SET members = ${JSON.stringify(members)}
+    INSERT INTO teams (name, repo, base_branch, worktree_path, leader, members, status, created_at)
+    VALUES (${name}, ${repo}, 'dev', ${join(repo, '.worktrees', name)}, ${leader ?? null}, ${JSON.stringify(members)}, 'in_progress', now())
+    ON CONFLICT (name) DO UPDATE SET members = ${JSON.stringify(members)}, leader = ${leader ?? null}
   `;
 }
 
@@ -188,30 +188,30 @@ describe.skipIf(!DB_AVAILABLE)('checkSendScope', () => {
     expect(error).toContain('outsider');
   });
 
-  test('team-lead can always send to team-lead recipient', async () => {
-    await insertTeam('my-team', tempDir, ['implementor']);
+  test('member can send to leader by name', async () => {
+    await insertTeam('my-team', tempDir, ['implementor'], 'my-leader');
 
-    // implementor (member) can send to team-lead
-    const error = await checkSendScope(tempDir, 'implementor', 'team-lead');
+    // implementor (member) can send to the leader by name
+    const error = await checkSendScope(tempDir, 'implementor', 'my-leader');
     expect(error).toBeNull();
   });
 
-  test('team-lead uses GENIE_TEAM for team lookup', async () => {
-    await insertTeam('leader-team', tempDir, ['worker-a', 'worker-b']);
+  test('leader uses GENIE_TEAM for team lookup', async () => {
+    await insertTeam('leader-team', tempDir, ['worker-a', 'worker-b'], 'boss');
 
     process.env.GENIE_TEAM = 'leader-team';
 
-    // team-lead can send to team member
-    const error = await checkSendScope(tempDir, 'team-lead', 'worker-a');
+    // leader can send to team member
+    const error = await checkSendScope(tempDir, 'boss', 'worker-a');
     expect(error).toBeNull();
   });
 
-  test('team-lead blocked from sending to non-member', async () => {
-    await insertTeam('leader-team', tempDir, ['worker-a']);
+  test('leader blocked from sending to non-member', async () => {
+    await insertTeam('leader-team', tempDir, ['worker-a'], 'boss');
 
     process.env.GENIE_TEAM = 'leader-team';
 
-    const error = await checkSendScope(tempDir, 'team-lead', 'outsider');
+    const error = await checkSendScope(tempDir, 'boss', 'outsider');
     expect(error).not.toBeNull();
     expect(error).toContain('Scope violation');
   });

--- a/src/term-commands/msg.ts
+++ b/src/term-commands/msg.ts
@@ -105,21 +105,18 @@ async function findMemberByPane(teamName: string, paneId: string): Promise<strin
 
 /**
  * Resolve the 'team-lead' alias to the actual leader name for a given team context.
- * Falls back to 'team-lead' for legacy teams without a leader set.
+ * Never returns 'team-lead' — falls back to teamName via resolveLeaderName().
  */
 async function resolveLeaderAlias(recipient: string, teamContext?: string): Promise<string> {
   if (recipient !== 'team-lead') return recipient;
 
-  const teamManager = await getTeamManager();
-
-  // Try explicit team context first
   const teamName = teamContext ?? process.env.GENIE_TEAM;
   if (teamName) {
-    const config = await teamManager.getTeam(teamName);
-    if (config?.leader) return config.leader;
+    const teamManager = await getTeamManager();
+    return teamManager.resolveLeaderName(teamName);
   }
 
-  return 'team-lead';
+  return recipient;
 }
 
 // ============================================================================
@@ -151,8 +148,9 @@ export async function checkSendScope(_repoPath: string, sender: string, recipien
 function resolveSenderTeams(teams: teamManagerTypes.TeamConfig[], sender: string): teamManagerTypes.TeamConfig[] {
   let senderTeams = teams.filter((t) => t.members.includes(sender));
 
-  // If sender is the leader (by name or 'team-lead' alias), include the leader's team
-  if (sender === 'team-lead' || teams.some((t) => t.leader === sender)) {
+  // If sender is the leader (by name or legacy 'team-lead' alias during transition), include the leader's team
+  const isLeader = teams.some((t) => t.leader === sender) || sender === 'team-lead';
+  if (isLeader) {
     const envTeam = process.env.GENIE_TEAM;
     if (envTeam) {
       const leaderTeam = teams.find((t) => t.name === envTeam);
@@ -167,8 +165,8 @@ function resolveSenderTeams(teams: teamManagerTypes.TeamConfig[], sender: string
 
 /** Check whether a recipient is reachable within a given team (direct member, leader, or prefixed name). */
 function isRecipientInTeam(team: teamManagerTypes.TeamConfig, recipient: string): boolean {
-  // Direct member, legacy team-lead alias, or actual leader name
-  if (team.members.includes(recipient) || recipient === 'team-lead' || recipient === team.leader) return true;
+  // Direct member, actual leader name, or legacy 'team-lead' alias (backwards compat)
+  if (team.members.includes(recipient) || recipient === team.leader || recipient === 'team-lead') return true;
   if (recipient.startsWith(`${team.name}-`)) {
     const roleOnly = recipient.slice(team.name.length + 1);
     if (team.members.includes(roleOnly)) return true;
@@ -186,7 +184,7 @@ async function findAgentTeam(_repoPath: string, agentName: string): Promise<team
   const memberTeam = teams.find((t) => t.members.includes(agentName));
   if (memberTeam) return memberTeam;
 
-  // Match by leader name or legacy 'team-lead' alias
+  // Match by leader name or legacy 'team-lead' alias (backwards compat)
   if (agentName === 'team-lead' || teams.some((t) => t.leader === agentName)) {
     const envTeam = process.env.GENIE_TEAM;
     if (envTeam) return teams.find((t) => t.name === envTeam) ?? null;
@@ -523,7 +521,7 @@ export function registerSendInboxCommands(program: Command): void {
   program
     .command('send <body>')
     .description('Send a direct message to an agent (PG-backed)')
-    .option('--to <agent>', 'Recipient agent name (default: team-lead)', 'team-lead')
+    .option('--to <agent>', 'Recipient agent name (default: team leader)', 'team-lead')
     .option('--from <sender>', 'Sender ID (auto-detected from context)')
     .option('--team <name>', 'Explicit team context for sender/recipient resolution')
     .addHelpText(

--- a/src/term-commands/state.ts
+++ b/src/term-commands/state.ts
@@ -236,7 +236,7 @@ function autoKillPane(): void {
 
 /**
  * Resolve the leader name and spawner for the current team context.
- * Falls back to 'team-lead' for legacy teams.
+ * Never returns 'team-lead' — falls back to teamName via resolveLeaderName().
  */
 async function resolveNotificationTargets(): Promise<{ leader: string; spawner?: string }> {
   const teamName = process.env.GENIE_TEAM;
@@ -244,13 +244,14 @@ async function resolveNotificationTargets(): Promise<{ leader: string; spawner?:
 
   try {
     const teamManager = await import('../lib/team-manager.js');
+    const leader = await teamManager.resolveLeaderName(teamName);
     const config = await teamManager.getTeam(teamName);
     return {
-      leader: config?.leader || 'team-lead',
+      leader,
       spawner: config?.spawner,
     };
   } catch {
-    return { leader: 'team-lead' };
+    return { leader: teamName };
   }
 }
 

--- a/src/tui/components/Nav.tsx
+++ b/src/tui/components/Nav.tsx
@@ -178,6 +178,23 @@ export function Nav({ onTmuxSessionSelect, workspaceRoot, initialAgent, keyboard
     if (target) onTmuxSessionSelect(target.sessionName, target.windowIndex);
   }, [flatNodes, selectedIndex, handleToggle, onTmuxSessionSelect]);
 
+  const handleRetry = useCallback(() => {
+    const node = flatNodes[selectedIndex]?.node;
+    if (!node || node.type !== 'agent') return;
+    if (node.wsAgentState !== 'spawning' && node.wsAgentState !== 'error') return;
+
+    // Reset stuck agents then respawn
+    void (async () => {
+      try {
+        const { reconcileStaleSpawns } = await import('../../lib/agent-registry.js');
+        await reconcileStaleSpawns();
+      } catch {
+        // best-effort
+      }
+      spawnAgent(node.label, onTmuxSessionSelect);
+    })();
+  }, [flatNodes, selectedIndex, onTmuxSessionSelect]);
+
   useKeyboard((key) => {
     if (keyboardDisabled) return;
     if (key.name === 'up' || key.name === 'k' || key.name === 'down' || key.name === 'j') {
@@ -186,6 +203,8 @@ export function Nav({ onTmuxSessionSelect, workspaceRoot, initialAgent, keyboard
       handleExpandCollapse(key.name);
     } else if (key.name === 'enter' || key.name === 'return') {
       handleEnter();
+    } else if (key.name === 'r') {
+      handleRetry();
     }
   });
 
@@ -249,7 +268,7 @@ export function Nav({ onTmuxSessionSelect, workspaceRoot, initialAgent, keyboard
       <box height={1} paddingX={1} backgroundColor={palette.bgLight}>
         <text>
           <span fg={palette.textMuted}>
-            {'\u2191\u2193'}:nav {'\u2190\u2192'}:expand Enter:{workspaceRoot ? 'spawn/attach' : 'attach'}
+            {'\u2191\u2193'}:nav {'\u2190\u2192'}:expand Enter:{workspaceRoot ? 'spawn/attach' : 'attach'} R:retry
           </span>
         </text>
       </box>

--- a/src/tui/components/TreeNode.tsx
+++ b/src/tui/components/TreeNode.tsx
@@ -132,6 +132,10 @@ function getPaneColor(node: TreeNodeType): string {
 
 function getNodeSuffix(node: TreeNodeType): string {
   if (node.type === 'agent') {
+    // Show retry hint for stuck agents (spawning with no live panes)
+    if (node.wsAgentState === 'spawning' && node.activePanes === 0) {
+      return ' [stuck — press R to retry]';
+    }
     const wc = node.data.windowCount as number;
     if (wc > 1) return ` (${wc} windows)`;
     if (wc === 1) return ' (1 window)';


### PR DESCRIPTION
## Summary
- Spawn watchdog: agents stuck in `spawning` >60s with no pane auto-reset to `offline`
- TUI retry: stuck agents can be retried with R key
- Dir validation: rejects non-path REPO values
- **41 hardcoded team-lead identity fallbacks replaced** with `resolveLeaderName()` shared helper
- `buildTeamLeadCommand()` accepts `leaderName` param — no more hardcoded `--agent-id team-lead@`
- Config reconciliation on startup: updates stale `team-lead@` leadAgentId entries

## Wish
`v4-spawn-resilience` — spawn stuck + leader identity fix

## Test plan
- [ ] Stuck agent (spawning, no pane, >60s) auto-resets
- [ ] `grep "|| 'team-lead'" src/lib/*.ts src/term-commands/*.ts` returns 0
- [ ] `bun test src/lib/agent-registry.test.ts`
- [ ] `bun test src/lib/team-lead-command.test.ts`