### PR TITLE
feat(agents): behavioral engineering uplift from superpowers analysis

### DIFF
--- a/plugins/genie/agents/engineer/AGENTS.md
+++ b/plugins/genie/agents/engineer/AGENTS.md
@@ -61,10 +61,11 @@ After completing all deliverables and validation:
 1. Run validation commands from the wish
 2. Commit and push your work
 3. Determine your **Implementer Status** (see below)
-4. Call: `genie done <slug>#<group>` — marks the group complete in state (source of truth)
-5. Call: `genie send 'Group <N> <STATUS>. <summary>' --to team-lead` — sends durable notification
+4. **If DONE or DONE_WITH_CONCERNS:** Call `genie done <slug>#<group>` — marks the group complete in state
+5. **If NEEDS_CONTEXT or BLOCKED:** Do NOT call `genie done` — the group is not complete. Escalate to team-lead only.
+6. Call: `genie send 'Group <N> <STATUS>. <summary>' --to team-lead` — sends durable notification
 
-The slug and group are in your initial prompt. Both commands are mandatory — state is how the orchestrator tracks progress, the message is how team-lead gets notified.
+The slug and group are in your initial prompt. `genie done` is only for successful completion — calling it on a blocked group falsely advances orchestration state.
 </process>
 
 <success_criteria>
@@ -123,6 +124,8 @@ Report when complete using the Implementer Status Protocol above:
 - **Criteria** satisfied with evidence (file:line, test output)
 - **Validation** command output (full, not summarized)
 - **Concerns** if DONE_WITH_CONCERNS — what specifically worries you
+- **Missing** if NEEDS_CONTEXT — what information is required and from whom
+- **Blocker** if BLOCKED — what is preventing progress and what would unblock
 </done_report>
 
 <red_flags>


### PR DESCRIPTION
## Summary
- Add anti-rationalization Red Flags tables to engineer, reviewer, and fix agents
- Add "evidence before assertions" rule — engineers must run validation and confirm output before claiming done
- Add implementer status protocol (DONE / DONE_WITH_CONCERNS / NEEDS_CONTEXT / BLOCKED)
- Add two-phase review to reviewer (spec compliance → code quality, sequential)
- Add "verify before implementing" rule to fix agent
- Add context curation to /work skill — team-lead extracts and pastes group criteria instead of "read WISH.md"
- Add spec self-review, scope-size detection, and design-for-isolation to /brainstorm skill

## Context
Cherry-picked behavioral engineering patterns from [obra/superpowers](https://github.com/obra/superpowers) analysis. Zero new skills, zero new agents — all improvements fit into existing files.

## Test plan
- [x] `bun run check` passes (1651 tests, 0 failures)
- [ ] Verify engineer agent loads correctly via `genie spawn engineer`
- [ ] Verify reviewer agent loads correctly via `genie spawn reviewer`
- [ ] Verify `/brainstorm` and `/work` skills trigger in Claude Code