### PR TITLE
feat(directory): agent identity sync — AGENTS.md as source of truth

### DIFF
--- a/src/db/migrations/020_agent_metadata.sql
+++ b/src/db/migrations/020_agent_metadata.sql
@@ -1,0 +1,8 @@
+-- 020_agent_metadata.sql — Add metadata JSONB column to agents table
+-- Stores frontmatter fields from AGENTS.md: model, promptMode, color, description, provider, dir, repo.
+-- Enables directory.edit() persistence and frontmatter sync from AGENTS.md.
+
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS metadata JSONB DEFAULT '{}'::jsonb;
+
+-- GIN index for JSONB containment queries (e.g. WHERE metadata @> '{"provider":"codex"}')
+CREATE INDEX IF NOT EXISTS idx_agents_metadata ON agents USING gin (metadata);

--- a/src/lib/agent-directory.test.ts
+++ b/src/lib/agent-directory.test.ts
@@ -99,6 +99,19 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
     test('returns empty array when no agents', async () => {
       expect(await directory.ls()).toEqual([]);
     });
+
+    test('ls includes metadata fields from PG', async () => {
+      const sql = await getConnection();
+      await sql`INSERT INTO agents (id, role, custom_name, started_at, metadata) VALUES ('dir:ls-meta', 'ls-meta', 'ls-meta', now(), '{"model":"opus","color":"green","provider":"codex","description":"Ls test"}')`;
+
+      const entries = await directory.ls();
+      const entry = entries.find((e) => e.name === 'ls-meta');
+      expect(entry).not.toBeNull();
+      expect(entry!.model).toBe('opus');
+      expect(entry!.color).toBe('green');
+      expect(entry!.provider).toBe('codex');
+      expect(entry!.description).toBe('Ls test');
+    });
   });
 
   // ============================================================================
@@ -130,6 +143,29 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
       const entry = await directory.add({ name: 'test-agent', dir: agentDir, promptMode: 'append' });
       expect(entry.name).toBe('test-agent');
       expect(entry.registeredAt).toBeTruthy();
+    });
+
+    test('add writes metadata to PG', async () => {
+      await directory.add({
+        name: 'meta-add-agent',
+        dir: agentDir,
+        promptMode: 'system',
+        model: 'opus',
+        color: 'red',
+        description: 'A test agent',
+        provider: 'codex',
+      });
+
+      const sql = await getConnection();
+      const rows = await sql`SELECT metadata FROM agents WHERE id = 'dir:meta-add-agent'`;
+      expect(rows.length).toBe(1);
+      const metadata = rows[0].metadata as Record<string, unknown>;
+      expect(metadata.model).toBe('opus');
+      expect(metadata.color).toBe('red');
+      expect(metadata.description).toBe('A test agent');
+      expect(metadata.provider).toBe('codex');
+      expect(metadata.promptMode).toBe('system');
+      expect(metadata.dir).toBe(agentDir);
     });
 
     test('rm returns false for non-existent', async () => {
@@ -168,6 +204,51 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
       await sql`INSERT INTO agents (id, pane_id, session, repo_path, state, role, started_at, last_state_change) VALUES ('dir:editable', '%1', 's', '/tmp', 'done', 'editable', now(), now())`;
 
       await expect(directory.edit('editable', { dir: '/nonexistent/path' })).rejects.toThrow('does not exist');
+    });
+
+    test('edit persists model to PG metadata', async () => {
+      const sql = await getConnection();
+      await sql`INSERT INTO agents (id, role, custom_name, started_at, metadata) VALUES ('dir:meta-agent', 'meta-agent', 'meta-agent', now(), '{}')`;
+
+      await directory.edit('meta-agent', { model: 'opus' });
+
+      // Read directly from PG to verify persistence
+      const rows = await sql`SELECT metadata FROM agents WHERE id = 'dir:meta-agent'`;
+      expect(rows.length).toBe(1);
+      const metadata = rows[0].metadata as Record<string, unknown>;
+      expect(metadata.model).toBe('opus');
+    });
+
+    test('edit persists multiple metadata fields to PG', async () => {
+      const sql = await getConnection();
+      await sql`INSERT INTO agents (id, role, custom_name, started_at, metadata) VALUES ('dir:multi-meta', 'multi-meta', 'multi-meta', now(), '{}')`;
+
+      await directory.edit('multi-meta', {
+        model: 'sonnet',
+        color: 'blue',
+        provider: 'codex',
+        description: 'Test agent',
+      });
+
+      const rows = await sql`SELECT metadata FROM agents WHERE id = 'dir:multi-meta'`;
+      const metadata = rows[0].metadata as Record<string, unknown>;
+      expect(metadata.model).toBe('sonnet');
+      expect(metadata.color).toBe('blue');
+      expect(metadata.provider).toBe('codex');
+      expect(metadata.description).toBe('Test agent');
+    });
+
+    test('get returns edited model after PG round-trip', async () => {
+      const sql = await getConnection();
+      await sql`INSERT INTO agents (id, role, custom_name, started_at, metadata) VALUES ('dir:roundtrip', 'roundtrip', 'roundtrip', now(), '{}')`;
+
+      await directory.edit('roundtrip', { model: 'opus', provider: 'codex' });
+
+      // Resolve fresh from PG — simulates process restart
+      const entry = await directory.get('roundtrip');
+      expect(entry).not.toBeNull();
+      expect(entry!.model).toBe('opus');
+      expect(entry!.provider).toBe('codex');
     });
   });
 

--- a/src/lib/agent-directory.ts
+++ b/src/lib/agent-directory.ts
@@ -33,6 +33,12 @@ export interface DirectoryEntry {
   omniAgentId?: string;
   /** ISO timestamp of registration. */
   registeredAt: string;
+  /** Agent description from AGENTS.md frontmatter. */
+  description?: string;
+  /** Display color for TUI/terminal output. */
+  color?: string;
+  /** AI provider: 'claude' | 'codex'. Resolved at spawn time. */
+  provider?: string;
 }
 
 export type DirectoryScope = 'project' | 'global' | 'built-in' | 'archived';
@@ -113,13 +119,16 @@ export async function add(
     throw new Error(`Agent "${entry.name}" already exists. Use "genie dir edit" to update or "genie dir rm" first.`);
   }
 
-  // Store as a directory agent in PG (identity columns only)
+  // Build metadata JSONB from frontmatter fields
+  const metadata = buildMetadata(full);
+
+  // Store as a directory agent in PG with metadata
   const { getConnection } = await import('./db.js');
   const sql = await getConnection();
   await sql`
-    INSERT INTO agents (id, role, custom_name, started_at)
-    VALUES (${`dir:${entry.name}`}, ${entry.name}, ${entry.name}, now())
-    ON CONFLICT (id) DO NOTHING
+    INSERT INTO agents (id, role, custom_name, started_at, metadata)
+    VALUES (${`dir:${entry.name}`}, ${entry.name}, ${entry.name}, now(), ${sql.json(metadata)})
+    ON CONFLICT (id) DO UPDATE SET metadata = ${sql.json(metadata)}
   `;
 
   return full;
@@ -140,13 +149,14 @@ export async function rm(name: string, _options?: ScopeOptions): Promise<boolean
  * Resolution order: PG agents (by role) → built-in roles → built-in council.
  */
 export async function resolve(name: string): Promise<ResolvedAgent | null> {
-  // 1. Check PG agents table — look for agents with matching role
+  // 1. Check PG agents table — look for agents with matching role, include metadata
   try {
     const { getConnection } = await import('./db.js');
     const sql = await getConnection();
-    const rows = await sql`SELECT DISTINCT role FROM agents WHERE role = ${name} LIMIT 1`;
+    const rows = await sql`SELECT role, metadata FROM agents WHERE role = ${name} LIMIT 1`;
     if (rows.length > 0) {
-      return { entry: roleToEntry(name), builtin: false };
+      const meta = parseMetadata(rows[0].metadata);
+      return { entry: roleToEntry(name, undefined, meta), builtin: false };
     }
   } catch {
     /* PG unavailable — fall through to built-ins */
@@ -204,7 +214,7 @@ export async function ls(): Promise<ScopedDirectoryEntry[]> {
     const { getConnection } = await import('./db.js');
     const sql = await getConnection();
     const rows = await sql`
-      SELECT DISTINCT ON (a.role) a.role, a.team, e.repo_path, e.provider
+      SELECT DISTINCT ON (a.role) a.role, a.team, a.metadata, e.repo_path, e.provider
       FROM agents a
       LEFT JOIN executors e ON a.current_executor_id = e.id
       WHERE a.role IS NOT NULL
@@ -213,7 +223,8 @@ export async function ls(): Promise<ScopedDirectoryEntry[]> {
     for (const row of rows) {
       const name = row.role as string;
       if (!seen.has(name)) {
-        const entry = roleToEntry(name, row.team as string);
+        const meta = parseMetadata(row.metadata);
+        const entry = roleToEntry(name, row.team as string, meta);
         const repoPath = row.repo_path as string;
         if (repoPath) {
           entry.dir = repoPath;
@@ -244,7 +255,12 @@ export async function get(name: string, _options?: ScopeOptions): Promise<Direct
  */
 export async function edit(
   name: string,
-  updates: Partial<Pick<DirectoryEntry, 'dir' | 'repo' | 'promptMode' | 'model' | 'roles' | 'omniAgentId'>>,
+  updates: Partial<
+    Pick<
+      DirectoryEntry,
+      'dir' | 'repo' | 'promptMode' | 'model' | 'roles' | 'omniAgentId' | 'description' | 'color' | 'provider'
+    >
+  >,
   _options?: ScopeOptions,
 ): Promise<DirectoryEntry> {
   if (updates.dir) {
@@ -262,7 +278,23 @@ export async function edit(
     throw new Error(`Agent "${name}" not found in directory.`);
   }
 
-  return Object.assign(existing, updates);
+  const updated = Object.assign(existing, updates);
+
+  // Build metadata patch from updated entry and persist to PG
+  const metadataPatch = buildMetadata(updated);
+  try {
+    const { getConnection } = await import('./db.js');
+    const sql = await getConnection();
+    await sql`
+      UPDATE agents
+      SET metadata = metadata || ${sql.json(metadataPatch)}
+      WHERE id = ${`dir:${name}`}
+    `;
+  } catch {
+    /* PG unavailable — in-memory update still applied */
+  }
+
+  return updated;
 }
 
 /**
@@ -295,17 +327,48 @@ function builtinToEntry(agent: BuiltinAgent): DirectoryEntry {
   };
 }
 
-/** Convert a PG agent role to a synthetic DirectoryEntry. */
-function roleToEntry(role: string, team?: string): DirectoryEntry {
+/** Convert a PG agent role to a synthetic DirectoryEntry, enriched with metadata. */
+function roleToEntry(role: string, team?: string, metadata?: Record<string, unknown>): DirectoryEntry {
   const builtin = [...BUILTIN_ROLES, ...BUILTIN_COUNCIL_MEMBERS].find((b) => b.name === role);
   if (builtin) return builtinToEntry(builtin);
 
   return {
     name: role,
-    dir: '',
-    promptMode: 'append',
+    dir: (metadata?.dir as string) || '',
+    promptMode: (metadata?.promptMode as PromptMode) || 'append',
+    model: metadata?.model as string | undefined,
     roles: [],
     registeredAt: new Date().toISOString(),
-    ...(team ? { repo: team } : {}),
+    description: metadata?.description as string | undefined,
+    color: metadata?.color as string | undefined,
+    provider: metadata?.provider as string | undefined,
+    ...(metadata?.repo ? { repo: metadata.repo as string } : team ? { repo: team } : {}),
   };
+}
+
+/** Build a metadata JSONB object from a DirectoryEntry's frontmatter fields. */
+function buildMetadata(entry: DirectoryEntry): Record<string, unknown> {
+  const meta: Record<string, unknown> = {};
+  if (entry.dir) meta.dir = entry.dir;
+  if (entry.repo) meta.repo = entry.repo;
+  if (entry.model) meta.model = entry.model;
+  if (entry.promptMode && entry.promptMode !== 'append') meta.promptMode = entry.promptMode;
+  if (entry.description) meta.description = entry.description;
+  if (entry.color) meta.color = entry.color;
+  if (entry.provider) meta.provider = entry.provider;
+  return meta;
+}
+
+/** Parse a JSONB metadata value — handles both parsed objects and string-encoded JSON. */
+function parseMetadata(raw: unknown): Record<string, unknown> {
+  if (!raw) return {};
+  if (typeof raw === 'object' && !Array.isArray(raw)) return raw as Record<string, unknown>;
+  if (typeof raw === 'string') {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return {};
+    }
+  }
+  return {};
 }

--- a/src/lib/agent-identity-sync.test.ts
+++ b/src/lib/agent-identity-sync.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Integration test for Agent Identity Sync — end-to-end flow.
+ *
+ * Creates a temp workspace with an agent directory + AGENTS.md frontmatter,
+ * then verifies:
+ *   1. genie dir sync populates metadata from frontmatter
+ *   2. genie dir ls returns all frontmatter fields
+ *   3. genie dir edit persists changes to PG
+ *   4. Re-sync overwrites edit changes (AGENTS.md wins)
+ *
+ * Run with: bun test src/lib/agent-identity-sync.test.ts
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as directory from './agent-directory.js';
+import { syncAgentDirectory } from './agent-sync.js';
+import { getConnection } from './db.js';
+import { DB_AVAILABLE, setupTestSchema } from './test-db.js';
+
+describe.skipIf(!DB_AVAILABLE)('agent identity sync — integration', () => {
+  let cleanup: () => Promise<void>;
+  let workspaceRoot: string;
+
+  beforeAll(async () => {
+    cleanup = await setupTestSchema();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  afterEach(async () => {
+    const sql = await getConnection();
+    await sql`DELETE FROM agents`;
+    try {
+      rmSync(workspaceRoot, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  /**
+   * Helper: create a workspace with an agent dir + AGENTS.md.
+   */
+  function createWorkspace(agentName: string, frontmatter: string, body = '# Agent'): string {
+    workspaceRoot = join(tmpdir(), `genie-sync-int-${Date.now()}`);
+    const agentDir = join(workspaceRoot, 'agents', agentName);
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'AGENTS.md'), `${frontmatter}\n${body}`);
+    return agentDir;
+  }
+
+  // ============================================================================
+  // Sync populates metadata from frontmatter
+  // ============================================================================
+
+  test('sync populates all frontmatter fields into directory', async () => {
+    createWorkspace(
+      'vegapunk-atlas',
+      `---
+name: vegapunk/atlas
+description: Deep research agent
+model: opus
+color: blue
+promptMode: system
+provider: codex
+---`,
+    );
+
+    const result = await syncAgentDirectory(workspaceRoot);
+    expect(result.registered).toContain('vegapunk-atlas');
+    expect(result.errors).toHaveLength(0);
+
+    const entry = await directory.get('vegapunk-atlas');
+    expect(entry).not.toBeNull();
+    expect(entry!.model).toBe('opus');
+    expect(entry!.promptMode).toBe('system');
+    expect(entry!.color).toBe('blue');
+    expect(entry!.provider).toBe('codex');
+    expect(entry!.description).toBe('Deep research agent');
+  });
+
+  // ============================================================================
+  // ls returns all frontmatter fields
+  // ============================================================================
+
+  test('ls returns entries with all metadata fields', async () => {
+    createWorkspace(
+      'vegapunk-lilith',
+      `---
+description: Design agent
+model: sonnet
+color: red
+provider: claude
+---`,
+    );
+
+    await syncAgentDirectory(workspaceRoot);
+
+    const entries = await directory.ls();
+    const entry = entries.find((e) => e.name === 'vegapunk-lilith');
+    expect(entry).not.toBeNull();
+    expect(entry!.model).toBe('sonnet');
+    expect(entry!.color).toBe('red');
+    expect(entry!.provider).toBe('claude');
+    expect(entry!.description).toBe('Design agent');
+  });
+
+  // ============================================================================
+  // edit persists changes to PG
+  // ============================================================================
+
+  test('edit persists changes and get reads them back', async () => {
+    createWorkspace(
+      'vegapunk-edison',
+      `---
+model: opus
+provider: claude
+---`,
+    );
+
+    await syncAgentDirectory(workspaceRoot);
+
+    // Edit the model via directory.edit
+    await directory.edit('vegapunk-edison', { model: 'sonnet', provider: 'codex' });
+
+    // Read directly from PG to verify persistence
+    const sql = await getConnection();
+    const rows = await sql`SELECT metadata FROM agents WHERE id = 'dir:vegapunk-edison'`;
+    expect(rows.length).toBe(1);
+    const metadata = rows[0].metadata as Record<string, unknown>;
+    expect(metadata.model).toBe('sonnet');
+    expect(metadata.provider).toBe('codex');
+
+    // Also verify via directory.get round-trip
+    const entry = await directory.get('vegapunk-edison');
+    expect(entry).not.toBeNull();
+    expect(entry!.model).toBe('sonnet');
+    expect(entry!.provider).toBe('codex');
+  });
+
+  // ============================================================================
+  // Re-sync overwrites edit changes — AGENTS.md wins
+  // ============================================================================
+
+  test('re-sync overwrites dir edit changes with AGENTS.md values', async () => {
+    createWorkspace(
+      'vegapunk-shaka',
+      `---
+model: opus
+color: green
+provider: codex
+description: Wisdom agent
+---`,
+    );
+
+    // Initial sync
+    const firstSync = await syncAgentDirectory(workspaceRoot);
+    expect(firstSync.registered).toContain('vegapunk-shaka');
+
+    // Edit model and provider via directory.edit
+    await directory.edit('vegapunk-shaka', { model: 'haiku', provider: 'claude', color: 'yellow' });
+
+    // Verify edit took effect
+    const edited = await directory.get('vegapunk-shaka');
+    expect(edited!.model).toBe('haiku');
+    expect(edited!.provider).toBe('claude');
+    expect(edited!.color).toBe('yellow');
+
+    // Re-sync — AGENTS.md values should overwrite the edit
+    const secondSync = await syncAgentDirectory(workspaceRoot);
+    expect(secondSync.updated).toContain('vegapunk-shaka');
+
+    // Verify AGENTS.md values restored
+    const restored = await directory.get('vegapunk-shaka');
+    expect(restored).not.toBeNull();
+    expect(restored!.model).toBe('opus');
+    expect(restored!.color).toBe('green');
+    expect(restored!.provider).toBe('codex');
+    expect(restored!.description).toBe('Wisdom agent');
+  });
+
+  // ============================================================================
+  // Sync with no frontmatter — defaults applied
+  // ============================================================================
+
+  test('sync with minimal AGENTS.md uses defaults', async () => {
+    createWorkspace('minimal-agent', '');
+
+    const result = await syncAgentDirectory(workspaceRoot);
+    expect(result.registered).toContain('minimal-agent');
+
+    const entry = await directory.get('minimal-agent');
+    expect(entry).not.toBeNull();
+    expect(entry!.promptMode).toBe('append');
+    expect(entry!.model).toBeUndefined();
+    expect(entry!.provider).toBeUndefined();
+    expect(entry!.color).toBeUndefined();
+    expect(entry!.description).toBeUndefined();
+  });
+
+  // ============================================================================
+  // Sync unchanged — idempotent
+  // ============================================================================
+
+  test('re-sync with no changes reports unchanged', async () => {
+    createWorkspace(
+      'stable-agent',
+      `---
+model: opus
+---`,
+    );
+
+    await syncAgentDirectory(workspaceRoot);
+    const result = await syncAgentDirectory(workspaceRoot);
+    expect(result.unchanged).toContain('stable-agent');
+    expect(result.registered).toHaveLength(0);
+    expect(result.updated).toHaveLength(0);
+  });
+
+  // ============================================================================
+  // Sync updates when AGENTS.md changes
+  // ============================================================================
+
+  test('sync detects AGENTS.md frontmatter changes', async () => {
+    const agentDir = createWorkspace(
+      'evolving-agent',
+      `---
+model: sonnet
+color: blue
+---`,
+    );
+
+    await syncAgentDirectory(workspaceRoot);
+
+    // Update AGENTS.md
+    writeFileSync(
+      join(agentDir, 'AGENTS.md'),
+      `---
+model: opus
+color: red
+provider: codex
+description: Evolved agent
+---
+# Agent`,
+    );
+
+    const result = await syncAgentDirectory(workspaceRoot);
+    expect(result.updated).toContain('evolving-agent');
+
+    const entry = await directory.get('evolving-agent');
+    expect(entry!.model).toBe('opus');
+    expect(entry!.color).toBe('red');
+    expect(entry!.provider).toBe('codex');
+    expect(entry!.description).toBe('Evolved agent');
+  });
+
+  // ============================================================================
+  // PG metadata survives fresh resolve (simulates process restart)
+  // ============================================================================
+
+  test('metadata survives PG round-trip (simulates restart)', async () => {
+    createWorkspace(
+      'persistent-agent',
+      `---
+model: opus
+color: purple
+provider: codex
+description: Persistent test
+promptMode: system
+---`,
+    );
+
+    await syncAgentDirectory(workspaceRoot);
+
+    // Resolve fresh from PG — simulates reading after process restart
+    const entry = await directory.get('persistent-agent');
+    expect(entry).not.toBeNull();
+    expect(entry!.model).toBe('opus');
+    expect(entry!.color).toBe('purple');
+    expect(entry!.provider).toBe('codex');
+    expect(entry!.description).toBe('Persistent test');
+    expect(entry!.promptMode).toBe('system');
+  });
+});

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -17,9 +17,10 @@
  */
 
 import { execSync } from 'node:child_process';
-import { existsSync, watch as fsWatch, readdirSync, realpathSync } from 'node:fs';
+import { existsSync, watch as fsWatch, readFileSync, readdirSync, realpathSync } from 'node:fs';
 import { join } from 'node:path';
 import * as directory from './agent-directory.js';
+import { parseFrontmatter } from './frontmatter.js';
 
 // ============================================================================
 // Types
@@ -221,6 +222,11 @@ async function syncSingleAgent(agent: AgentInfo, result: SyncResult): Promise<vo
   const orgRepo = agent.repoUrl ? extractOrgRepo(agent.repoUrl) : null;
   const repoPath = orgRepo ?? agent.repoUrl ?? agent.dir;
 
+  // Read and parse AGENTS.md frontmatter for identity fields
+  const agentsMdPath = join(agent.dir, 'AGENTS.md');
+  const content = readFileSync(agentsMdPath, 'utf-8');
+  const fm = parseFrontmatter(content);
+
   const existing = await directory.get(agent.name);
 
   if (!existing) {
@@ -228,20 +234,39 @@ async function syncSingleAgent(agent: AgentInfo, result: SyncResult): Promise<vo
       name: agent.name,
       dir: agent.dir,
       repo: repoPath,
-      promptMode: 'append',
+      promptMode: fm.promptMode ?? 'append',
+      model: fm.model,
+      description: fm.description,
+      color: fm.color,
+      provider: fm.provider,
     });
     result.registered.push(agent.name);
     return;
   }
 
-  // Check if update needed
-  const needsUpdate = existing.repo !== repoPath || existing.dir !== agent.dir;
+  // AGENTS.md always wins — update identity fields from frontmatter on every sync
+  const identityUpdate: Parameters<typeof directory.edit>[1] = {
+    dir: agent.dir,
+    repo: repoPath,
+    promptMode: fm.promptMode ?? 'append',
+    model: fm.model,
+    description: fm.description,
+    color: fm.color,
+    provider: fm.provider,
+  };
+
+  // Check if any field actually changed
+  const needsUpdate =
+    existing.repo !== repoPath ||
+    existing.dir !== agent.dir ||
+    existing.promptMode !== (fm.promptMode ?? 'append') ||
+    existing.model !== fm.model ||
+    existing.description !== fm.description ||
+    existing.color !== fm.color ||
+    existing.provider !== fm.provider;
 
   if (needsUpdate) {
-    await directory.edit(agent.name, {
-      dir: agent.dir,
-      repo: repoPath,
-    });
+    await directory.edit(agent.name, identityUpdate);
     result.updated.push(agent.name);
   } else {
     result.unchanged.push(agent.name);

--- a/src/lib/builtin-agents.ts
+++ b/src/lib/builtin-agents.ts
@@ -11,8 +11,8 @@
 
 import { existsSync, readFileSync, readdirSync, realpathSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
-import * as yaml from 'js-yaml';
 import type { PromptMode } from './agent-directory.js';
+import { parseFrontmatter } from './frontmatter.js';
 
 // ============================================================================
 // Types
@@ -65,32 +65,6 @@ function resolvePackageRoot(): string {
 }
 
 // ============================================================================
-// Frontmatter Parser
-// ============================================================================
-
-interface AgentFrontmatter {
-  name?: string;
-  description?: string;
-  model?: string;
-  color?: string;
-  promptMode?: string;
-}
-
-/**
- * Parse YAML frontmatter from a markdown file.
- * Returns an empty object if no frontmatter is found.
- */
-function parseFrontmatter(content: string): AgentFrontmatter {
-  const match = content.match(/^---\n([\s\S]*?)\n---/);
-  if (!match) return {};
-  try {
-    return (yaml.load(match[1]) as AgentFrontmatter) ?? {};
-  } catch {
-    return {};
-  }
-}
-
-// ============================================================================
 // Agent Scanner
 // ============================================================================
 
@@ -125,7 +99,7 @@ function scanAgents(agentsDir: string): BuiltinAgent[] {
       description: fm.description || '',
       agentPath: agentsPath,
       model: fm.model === 'inherit' ? undefined : fm.model,
-      promptMode: (fm.promptMode as PromptMode) || undefined,
+      promptMode: fm.promptMode || undefined,
       category: isCouncil ? 'council' : 'role',
       color: fm.color,
     });

--- a/src/lib/frontmatter.test.ts
+++ b/src/lib/frontmatter.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Tests for shared frontmatter parser + Zod validation.
+ *
+ * Covers: valid input, missing fields, invalid enum values,
+ * unknown fields, malformed YAML, and edge cases.
+ *
+ * Run with: bun test src/lib/frontmatter.test.ts
+ */
+
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { AgentFrontmatterSchema, parseFrontmatter } from './frontmatter.js';
+
+// Capture console.warn calls for assertion
+const warnMock = mock(() => {});
+const originalWarn = console.warn;
+
+function captureWarnings() {
+  warnMock.mockReset();
+  console.warn = warnMock;
+}
+
+afterEach(() => {
+  console.warn = originalWarn;
+});
+
+// ============================================================================
+// Valid input
+// ============================================================================
+
+describe('parseFrontmatter — valid input', () => {
+  test('parses all known fields', () => {
+    const content = `---
+name: vegapunk/atlas
+description: A research agent
+model: opus
+color: blue
+promptMode: system
+provider: claude
+---
+
+# Agent identity below...
+`;
+    const result = parseFrontmatter(content);
+    expect(result.name).toBe('vegapunk/atlas');
+    expect(result.description).toBe('A research agent');
+    expect(result.model).toBe('opus');
+    expect(result.color).toBe('blue');
+    expect(result.promptMode).toBe('system');
+    expect(result.provider).toBe('claude');
+  });
+
+  test('parses codex provider', () => {
+    const content = `---
+provider: codex
+---
+`;
+    const result = parseFrontmatter(content);
+    expect(result.provider).toBe('codex');
+  });
+
+  test('parses append promptMode', () => {
+    const content = `---
+promptMode: append
+---
+`;
+    const result = parseFrontmatter(content);
+    expect(result.promptMode).toBe('append');
+  });
+
+  test('handles model: inherit as a valid string', () => {
+    const content = `---
+model: inherit
+---
+`;
+    const result = parseFrontmatter(content);
+    expect(result.model).toBe('inherit');
+  });
+
+  test('handles model: sonnet', () => {
+    const content = `---
+model: sonnet
+---
+`;
+    const result = parseFrontmatter(content);
+    expect(result.model).toBe('sonnet');
+  });
+});
+
+// ============================================================================
+// Missing fields
+// ============================================================================
+
+describe('parseFrontmatter — missing fields', () => {
+  test('returns empty object for no frontmatter', () => {
+    const content = '# Just a heading\nSome content';
+    const result = parseFrontmatter(content);
+    expect(result).toEqual({});
+  });
+
+  test('returns empty object for empty frontmatter', () => {
+    const content = `---
+---
+# Content`;
+    // yaml.load of empty string returns undefined
+    const result = parseFrontmatter(content);
+    expect(result).toEqual({});
+  });
+
+  test('returns partial when only some fields present', () => {
+    const content = `---
+name: test-agent
+model: haiku
+---
+`;
+    const result = parseFrontmatter(content);
+    expect(result.name).toBe('test-agent');
+    expect(result.model).toBe('haiku');
+    expect(result.description).toBeUndefined();
+    expect(result.color).toBeUndefined();
+    expect(result.promptMode).toBeUndefined();
+    expect(result.provider).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// Invalid values
+// ============================================================================
+
+describe('parseFrontmatter — invalid values', () => {
+  test('invalid promptMode falls back to undefined with warning', () => {
+    captureWarnings();
+    const content = `---
+name: test
+promptMode: invalid
+---
+`;
+    const result = parseFrontmatter(content);
+    expect(result.name).toBe('test');
+    expect(result.promptMode).toBeUndefined();
+    expect(warnMock).toHaveBeenCalled();
+    const warnMsg = warnMock.mock.calls.flat().join(' ');
+    expect(warnMsg).toContain('promptMode');
+  });
+
+  test('invalid provider falls back to undefined with warning', () => {
+    captureWarnings();
+    const content = `---
+name: test
+provider: openai
+---
+`;
+    const result = parseFrontmatter(content);
+    expect(result.name).toBe('test');
+    expect(result.provider).toBeUndefined();
+    expect(warnMock).toHaveBeenCalled();
+    const warnMsg = warnMock.mock.calls.flat().join(' ');
+    expect(warnMsg).toContain('provider');
+  });
+
+  test('invalid model: opuss still passes (model is free-form string)', () => {
+    captureWarnings();
+    const content = `---
+model: opuss
+---
+`;
+    const result = parseFrontmatter(content);
+    // model is a free-form string, not an enum — typos pass through
+    // The consuming code (spawn resolution) handles unknown models
+    expect(result.model).toBe('opuss');
+  });
+
+  test('multiple invalid fields produce multiple warnings', () => {
+    captureWarnings();
+    const content = `---
+promptMode: bad
+provider: bad
+---
+`;
+    const result = parseFrontmatter(content);
+    expect(result.promptMode).toBeUndefined();
+    expect(result.provider).toBeUndefined();
+    expect(warnMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ============================================================================
+// Unknown fields
+// ============================================================================
+
+describe('parseFrontmatter — unknown fields', () => {
+  test('unknown field produces warning and is ignored', () => {
+    captureWarnings();
+    const content = `---
+name: test
+foo: bar
+---
+`;
+    const result = parseFrontmatter(content);
+    expect(result.name).toBe('test');
+    expect((result as Record<string, unknown>).foo).toBeUndefined();
+    expect(warnMock).toHaveBeenCalled();
+    const warnMsg = warnMock.mock.calls.flat().join(' ');
+    expect(warnMsg).toContain('foo');
+  });
+
+  test('multiple unknown fields produce multiple warnings', () => {
+    captureWarnings();
+    const content = `---
+name: test
+foo: bar
+baz: qux
+---
+`;
+    const result = parseFrontmatter(content);
+    expect(result.name).toBe('test');
+    const allWarns = warnMock.mock.calls.flat().join(' ');
+    expect(allWarns).toContain('foo');
+    expect(allWarns).toContain('baz');
+  });
+});
+
+// ============================================================================
+// Malformed YAML
+// ============================================================================
+
+describe('parseFrontmatter — malformed YAML', () => {
+  test('invalid YAML returns empty object', () => {
+    const content = `---
+: invalid: yaml: [
+---
+`;
+    const result = parseFrontmatter(content);
+    expect(result).toEqual({});
+  });
+
+  test('non-object YAML returns empty object', () => {
+    const content = `---
+just a string
+---
+`;
+    const result = parseFrontmatter(content);
+    expect(result).toEqual({});
+  });
+
+  test('content without closing --- returns empty', () => {
+    const content = `---
+name: test
+no closing delimiter`;
+    const result = parseFrontmatter(content);
+    expect(result).toEqual({});
+  });
+});
+
+// ============================================================================
+// Zod schema direct tests
+// ============================================================================
+
+describe('AgentFrontmatterSchema', () => {
+  test('accepts empty object', () => {
+    const result = AgentFrontmatterSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  test('accepts full valid object', () => {
+    const result = AgentFrontmatterSchema.safeParse({
+      name: 'test',
+      description: 'A test agent',
+      model: 'opus',
+      color: 'red',
+      promptMode: 'system',
+      provider: 'codex',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects invalid promptMode', () => {
+    const result = AgentFrontmatterSchema.safeParse({ promptMode: 'invalid' });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects invalid provider', () => {
+    const result = AgentFrontmatterSchema.safeParse({ provider: 'openai' });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/lib/frontmatter.ts
+++ b/src/lib/frontmatter.ts
@@ -1,0 +1,107 @@
+/**
+ * Frontmatter Parser — Shared YAML frontmatter extraction + Zod validation.
+ *
+ * Single source of truth for parsing AGENTS.md frontmatter.
+ * Used by both builtin-agents.ts (built-in discovery) and agent-sync.ts (user agent sync).
+ *
+ * Validation strategy: warn on invalid/unknown fields, never reject.
+ * Agents should always be discoverable even with malformed frontmatter.
+ */
+
+import * as yaml from 'js-yaml';
+import { z } from 'zod';
+
+// ============================================================================
+// Schema
+// ============================================================================
+
+/** Known prompt modes for agent identity injection. */
+const promptModeValues = ['system', 'append'] as const;
+
+/** Known provider values for spawn resolution. */
+const providerValues = ['claude', 'codex'] as const;
+
+/**
+ * Zod schema for AGENTS.md frontmatter.
+ * Uses .optional() on all fields — missing fields are fine.
+ * Invalid enum values fall back to undefined (with a warning).
+ */
+export const AgentFrontmatterSchema = z.object({
+  name: z.string().optional(),
+  description: z.string().optional(),
+  model: z.string().optional(),
+  color: z.string().optional(),
+  promptMode: z.enum(promptModeValues).optional(),
+  provider: z.enum(providerValues).optional(),
+  tools: z.array(z.string()).optional(),
+  permissionMode: z.string().optional(),
+});
+
+type AgentFrontmatter = z.infer<typeof AgentFrontmatterSchema>;
+
+const knownKeys = new Set(Object.keys(AgentFrontmatterSchema.shape));
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Extract raw YAML object from frontmatter delimiters. Returns null on failure. */
+function extractRawYaml(content: string): Record<string, unknown> | null {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return null;
+  try {
+    const parsed = yaml.load(match[1]);
+    if (typeof parsed !== 'object' || parsed === null) return null;
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+/** Log warnings for keys not in the schema. */
+function warnUnknownFields(raw: Record<string, unknown>): void {
+  for (const key of Object.keys(raw)) {
+    if (!knownKeys.has(key)) {
+      console.warn(`[frontmatter] Unknown field "${key}" — ignored.`);
+    }
+  }
+}
+
+/** Validate field-by-field, warning on invalid values and collecting valid ones. */
+function validateFieldByField(raw: Record<string, unknown>): AgentFrontmatter {
+  const out: Record<string, unknown> = {};
+  for (const key of knownKeys) {
+    const fieldSchema = AgentFrontmatterSchema.shape[key as keyof typeof AgentFrontmatterSchema.shape];
+    const fieldResult = fieldSchema.safeParse(raw[key]);
+    if (fieldResult.success) {
+      if (fieldResult.data !== undefined) out[key] = fieldResult.data;
+    } else if (raw[key] !== undefined) {
+      console.warn(`[frontmatter] Invalid value for "${key}": ${JSON.stringify(raw[key])} — using default.`);
+    }
+  }
+  return out as AgentFrontmatter;
+}
+
+// ============================================================================
+// Parser
+// ============================================================================
+
+/**
+ * Parse YAML frontmatter from a markdown file and validate against schema.
+ *
+ * - Returns empty object if no frontmatter found or YAML is malformed.
+ * - Warns on unknown fields (extra keys not in schema).
+ * - Warns on invalid enum values and falls back to undefined for that field.
+ * - Never throws — agents should always be discoverable.
+ */
+export function parseFrontmatter(content: string): AgentFrontmatter {
+  const raw = extractRawYaml(content);
+  if (!raw) return {};
+
+  warnUnknownFields(raw);
+
+  const result = AgentFrontmatterSchema.safeParse(raw);
+  if (result.success) return result.data;
+
+  return validateFieldByField(raw);
+}

--- a/src/term-commands/agent/spawn.ts
+++ b/src/term-commands/agent/spawn.ts
@@ -10,7 +10,7 @@ export function registerAgentSpawn(parent: Command): void {
   parent
     .command('spawn <name>')
     .description('Spawn a new agent by name (resolves from directory or built-ins)')
-    .option('--provider <provider>', 'Provider: claude or codex', 'claude')
+    .option('--provider <provider>', 'Provider: claude or codex')
     .option('--team <team>', 'Team name', process.env.GENIE_TEAM ?? 'genie')
     .option('--model <model>', 'Model override (e.g., sonnet, opus)')
     .option('--skill <skill>', 'Skill to load (optional)')

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -1016,7 +1016,7 @@ async function resolveNativeTeam(
 }
 
 export interface SpawnOptions {
-  provider: string;
+  provider?: string;
   team: string;
   model?: string;
   skill?: string;
@@ -1093,8 +1093,11 @@ async function buildSpawnParams(
   options: SpawnOptions,
   agent: Awaited<ReturnType<typeof resolveAgentForSpawn>>,
 ): Promise<{ params: SpawnParams; parentSessionId: string; spawnColor: ClaudeTeamColor }> {
+  // Provider resolution chain: CLI --provider > directory entry > default 'claude'
+  const resolvedProvider = (options.provider ?? agent.entry.provider ?? 'claude') as ProviderName;
+
   const params: SpawnParams = {
-    provider: options.provider as ProviderName,
+    provider: resolvedProvider,
     team,
     role: name,
     skill: options.skill,
@@ -1107,6 +1110,7 @@ async function buildSpawnParams(
 
   const { parentSessionId, spawnColor, nativeTeam } = await resolveNativeTeam(team, agent.repoPath, {
     ...options,
+    provider: resolvedProvider,
     role: name,
   });
   if (nativeTeam) params.nativeTeam = nativeTeam;

--- a/src/term-commands/dir.ts
+++ b/src/term-commands/dir.ts
@@ -99,6 +99,9 @@ export function registerDirNamespace(program: Command): void {
     .option('--repo <path>', 'Default git repo')
     .option('--prompt-mode <mode>', 'Prompt mode: append or system')
     .option('--model <model>', 'Default model')
+    .option('--provider <provider>', 'AI provider: claude or codex')
+    .option('--color <color>', 'Display color for TUI')
+    .option('--description <desc>', 'Agent description')
     .option('--roles <roles...>', 'Built-in roles this agent can orchestrate')
     .option('--global', 'Edit in global directory instead of project')
     .action(async (name: string, options: EditOptions) => {
@@ -162,6 +165,9 @@ interface EditOptions {
   repo?: string;
   promptMode?: string;
   model?: string;
+  provider?: string;
+  color?: string;
+  description?: string;
   roles?: string[];
   global?: boolean;
 }
@@ -172,10 +178,15 @@ async function handleEdit(name: string, options: EditOptions): Promise<void> {
   if (options.repo) updates.repo = resolvePath(options.repo);
   if (options.promptMode) updates.promptMode = validatePromptMode(options.promptMode);
   if (options.model) updates.model = options.model;
+  if (options.provider) updates.provider = options.provider;
+  if (options.color) updates.color = options.color;
+  if (options.description) updates.description = options.description;
   if (options.roles) updates.roles = normalizeRoles(options.roles);
 
   if (Object.keys(updates).length === 0) {
-    console.error('No fields to update. Provide at least one of: --dir, --repo, --prompt-mode, --model, --roles');
+    console.error(
+      'No fields to update. Provide at least one of: --dir, --repo, --prompt-mode, --model, --provider, --color, --description, --roles',
+    );
     process.exit(1);
   }
 
@@ -216,8 +227,11 @@ function printEntry(entry: directory.DirectoryEntry): void {
   console.log(`  Name: ${entry.name}`);
   console.log(`  Dir: ${contractPath(entry.dir)}`);
   if (entry.repo) console.log(`  Repo: ${contractPath(entry.repo)}`);
-  console.log(`  Prompt mode: ${entry.promptMode}`);
+  console.log(`  PromptMode: ${entry.promptMode}`);
   if (entry.model) console.log(`  Model: ${entry.model}`);
+  if (entry.provider) console.log(`  Provider: ${entry.provider}`);
+  if (entry.color) console.log(`  Color: ${entry.color}`);
+  if (entry.description) console.log(`  Description: ${entry.description}`);
   if (entry.roles?.length) console.log(`  Roles: ${entry.roles.join(', ')}`);
   console.log(`  Registered: ${entry.registeredAt}`);
 }
@@ -298,7 +312,8 @@ function normalizeRoles(roles?: string[]): string[] | undefined {
 function printRegisteredTable(entries: directory.ScopedDirectoryEntry[]): void {
   const nameW = 22;
   const scopeW = 10;
-  const modelW = 8;
+  const modelW = 10;
+  const providerW = 10;
 
   // Compute repo paths and roles upfront for dynamic sizing
   const repoValues: string[] = [];
@@ -310,7 +325,7 @@ function printRegisteredTable(entries: directory.ScopedDirectoryEntry[]): void {
 
   // Size REPO column to fit longest value, capped to leave room for ROLES
   const termW = process.stdout.columns || 120;
-  const fixedW = 2 + nameW + scopeW + modelW; // leading indent + fixed columns
+  const fixedW = 2 + nameW + scopeW + modelW + providerW; // leading indent + fixed columns
   const maxRepoLen = Math.max('REPO'.length, ...repoValues.map((v) => v.length));
   const repoW = Math.min(maxRepoLen + 2, Math.max(30, termW - fixedW - 20));
 
@@ -320,10 +335,10 @@ function printRegisteredTable(entries: directory.ScopedDirectoryEntry[]): void {
   console.log('REGISTERED AGENTS');
   console.log('-'.repeat(Math.max(90, totalW)));
   console.log(
-    `  ${'NAME'.padEnd(nameW)}${'SCOPE'.padEnd(scopeW)}${'REPO'.padEnd(repoW)}${'MODEL'.padEnd(modelW)}ROLES`,
+    `  ${'NAME'.padEnd(nameW)}${'SCOPE'.padEnd(scopeW)}${'REPO'.padEnd(repoW)}${'MODEL'.padEnd(modelW)}${'PROVIDER'.padEnd(providerW)}ROLES`,
   );
   console.log(
-    `  ${'-'.repeat(nameW - 2)}  ${'-'.repeat(scopeW - 2)}  ${'-'.repeat(repoW - 2)}  ${'-'.repeat(modelW - 2)}  ${'-'.repeat(20)}`,
+    `  ${'-'.repeat(nameW - 2)}  ${'-'.repeat(scopeW - 2)}  ${'-'.repeat(repoW - 2)}  ${'-'.repeat(modelW - 2)}  ${'-'.repeat(providerW - 2)}  ${'-'.repeat(20)}`,
   );
 
   for (let i = 0; i < entries.length; i++) {
@@ -331,7 +346,7 @@ function printRegisteredTable(entries: directory.ScopedDirectoryEntry[]): void {
     const repo = repoValues[i];
     const roles = roleValues[i];
     console.log(
-      `  ${entry.name.padEnd(nameW)}${entry.scope.padEnd(scopeW)}${repo.padEnd(repoW)}${(entry.model || '-').padEnd(modelW)}${roles}`,
+      `  ${entry.name.padEnd(nameW)}${entry.scope.padEnd(scopeW)}${repo.padEnd(repoW)}${(entry.model || '-').padEnd(modelW)}${(entry.provider || '-').padEnd(providerW)}${roles}`,
     );
   }
   console.log('');


### PR DESCRIPTION
## Summary
- Add `metadata JSONB` column to `agents` table (migration 020)
- Fix `directory.edit()` to actually persist to PG (was a no-op — mutated in-memory only)
- Extract shared `parseFrontmatter()` into `src/lib/frontmatter.ts` with Zod validation
- Wire frontmatter parsing into `syncSingleAgent()` — model, promptMode, color, description, provider all populated from AGENTS.md
- Add `provider` field to `DirectoryEntry` — resolves at spawn time (CLI flag > entry > default 'claude')
- Update `genie dir ls` to display all frontmatter fields
- 34 new tests (integration + unit)

## Context
After converting Vegapunk's satellites into subagents, `genie dir sync` discovered them but ignored their AGENTS.md frontmatter. Required 6 manual `genie dir edit` commands — which turned out to be no-ops (edit never wrote to PG). This fixes both the storage layer and the sync pipeline.

## Test plan
- [x] `bun run check` passes (1685 tests, 0 failures, +34 new)
- [ ] `genie dir sync` populates model/promptMode/color/description/provider from frontmatter
- [ ] `genie dir ls` shows all fields
- [ ] `genie spawn <agent>` resolves provider from directory entry
- [ ] Re-syncing overwrites manual edits (AGENTS.md wins)