### PR TITLE
fix(router): v4 stability — advisory locks prevent silent spawn failure + duplicate workers

### DIFF
--- a/src/lib/protocol-router-spawn.ts
+++ b/src/lib/protocol-router-spawn.ts
@@ -15,6 +15,7 @@ import { promisify } from 'node:util';
 import * as registry from './agent-registry.js';
 import type { WorkerTemplate } from './agent-registry.js';
 import * as nativeTeams from './claude-native-teams.js';
+import { getConnection } from './db.js';
 import * as executorRegistry from './executor-registry.js';
 import * as mailbox from './mailbox.js';
 import { buildLayoutCommand, resolveLayoutMode } from './mosaic-layout.js';
@@ -102,43 +103,49 @@ async function createExecutorForAutoSpawn(
   const agentName = template.role ?? 'worker';
   const agentIdentity = await registry.findOrCreateAgent(agentName, template.team, template.role);
 
-  // Concurrent guard: terminate active executor before creating new one
-  const currentExec = await executorRegistry.getCurrentExecutor(agentIdentity.id);
-  if (currentExec && currentExec.state !== 'terminated' && currentExec.state !== 'done') {
-    const providerImpl = getProvider(currentExec.provider);
-    if (providerImpl) {
-      try {
-        await providerImpl.terminate(currentExec);
-      } catch {
-        /* best-effort */
+  const sql = await getConnection();
+  await sql.begin(async (tx: typeof sql) => {
+    // Advisory lock on agent ID — prevents concurrent executor guard for same agent
+    await tx`SELECT pg_advisory_xact_lock(hashtext(${agentIdentity.id}))`;
+
+    // Concurrent guard: terminate active executor before creating new one
+    const currentExec = await executorRegistry.getCurrentExecutor(agentIdentity.id);
+    if (currentExec && currentExec.state !== 'terminated' && currentExec.state !== 'done') {
+      const providerImpl = getProvider(currentExec.provider);
+      if (providerImpl) {
+        try {
+          await providerImpl.terminate(currentExec);
+        } catch {
+          /* best-effort */
+        }
       }
+      await executorRegistry.terminateActiveExecutor(agentIdentity.id);
     }
-    await executorRegistry.terminateActiveExecutor(agentIdentity.id);
-  }
 
-  // Capture PID from tmux pane
-  let pid: number | null = null;
-  try {
-    const { stdout: pidOut } = await execAsync(genieTmuxCmd(`display -t '${paneId}' -p '#{pane_pid}'`));
-    const parsed = Number.parseInt(pidOut.trim(), 10);
-    if (parsed > 0) pid = parsed;
-  } catch {
-    /* best-effort */
-  }
+    // Capture PID from tmux pane
+    let pid: number | null = null;
+    try {
+      const { stdout: pidOut } = await execAsync(genieTmuxCmd(`display -t '${paneId}' -p '#{pane_pid}'`));
+      const parsed = Number.parseInt(pidOut.trim(), 10);
+      if (parsed > 0) pid = parsed;
+    } catch {
+      /* best-effort */
+    }
 
-  const executorTransport = template.provider === 'codex' ? ('api' as const) : ('tmux' as const);
-  const executor = await executorRegistry.createExecutor(agentIdentity.id, template.provider, executorTransport, {
-    pid,
-    tmuxSession: session,
-    tmuxPaneId: paneId,
-    tmuxWindow: teamWindow?.windowName ?? null,
-    tmuxWindowId: teamWindow?.windowId ?? null,
-    claudeSessionId: effectiveSessionId ?? null,
-    state: 'spawning',
-    repoPath,
-    paneColor: spawnColor ?? null,
+    const executorTransport = template.provider === 'codex' ? ('api' as const) : ('tmux' as const);
+    const executor = await executorRegistry.createExecutor(agentIdentity.id, template.provider, executorTransport, {
+      pid,
+      tmuxSession: session,
+      tmuxPaneId: paneId,
+      tmuxWindow: teamWindow?.windowName ?? null,
+      tmuxWindowId: teamWindow?.windowId ?? null,
+      claudeSessionId: effectiveSessionId ?? null,
+      state: 'spawning',
+      repoPath,
+      paneColor: spawnColor ?? null,
+    });
+    await registry.setCurrentExecutor(agentIdentity.id, executor.id);
   });
-  await registry.setCurrentExecutor(agentIdentity.id, executor.id);
 }
 
 /** Resolve target window and spawn a pane, returning pane ID and window info. */

--- a/src/lib/protocol-router.test.ts
+++ b/src/lib/protocol-router.test.ts
@@ -1,19 +1,73 @@
 /**
  * Protocol Router — Unit Tests
  *
- * Tests inbox retrieval and message routing logic.
+ * Tests inbox retrieval, message routing logic, and concurrent spawn dedup.
  * Full sendMessage tests require tmux (integration-level).
  *
  * Run with: bun test src/lib/protocol-router.test.ts
  */
 
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
-import { rm } from 'node:fs/promises';
-import { mkdtemp } from 'node:fs/promises';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import * as mailbox from './mailbox.js';
 import { DB_AVAILABLE, setupTestSchema } from './test-db.js';
+
+// ============================================================================
+// Module mocks — hoisted by bun:test, must be declared before describe blocks.
+// These only affect code paths that use tmux/auto-spawn; existing non-tmux
+// tests are unaffected because they never register workers or set TMUX.
+// ============================================================================
+
+/** Set of pane IDs that isPaneAlive should report as alive. */
+const alivePanes = new Set<string>();
+
+/** Count of spawnWorkerFromTemplate invocations (reset in beforeEach). */
+let spawnCallCount = 0;
+
+mock.module('./tmux.js', () => ({
+  isPaneAlive: async (paneId: string) => alivePanes.has(paneId),
+  capturePaneContent: async () => '> idle prompt',
+  executeTmux: async () => '',
+}));
+
+mock.module('./orchestrator/index.js', () => ({
+  detectState: () => ({ type: 'idle', confidence: 0.9, timestamp: Date.now(), rawOutput: '' }),
+}));
+
+mock.module('./protocol-router-spawn.js', () => ({
+  spawnWorkerFromTemplate: async (template: any, _resumeSessionId?: string) => {
+    spawnCallCount++;
+    // Simulate spawn latency to widen the race window
+    await new Promise((r) => setTimeout(r, 50));
+    const id = `spawned-${template.role ?? 'worker'}-${spawnCallCount}`;
+    const paneId = `%${900 + spawnCallCount}`;
+    const now = new Date().toISOString();
+    const workerEntry = {
+      id,
+      paneId,
+      session: 'test-session',
+      provider: template.provider ?? 'claude',
+      transport: 'tmux' as const,
+      role: template.role,
+      team: template.team,
+      state: 'spawning' as const,
+      startedAt: now,
+      lastStateChange: now,
+      repoPath: template.cwd ?? '/tmp',
+      worktree: null,
+      nativeTeamEnabled: false,
+    };
+    // Register in real PG registry so the double-check after lock can find it
+    const reg = await import('./agent-registry.js');
+    await reg.register(workerEntry);
+    // Mark pane as alive so isPaneAlive returns true for this worker
+    alivePanes.add(paneId);
+    return { worker: workerEntry, paneId, workerId: id };
+  },
+  injectResumeContext: async () => {},
+}));
 
 // ---------------------------------------------------------------------------
 // PG test schema (required since mailbox now uses PG)
@@ -48,6 +102,10 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
     // Disable tmux to prevent auto-spawn attempts
     process.env.TMUX = undefined as unknown as string;
     process.env.TMUX_PANE = undefined as unknown as string;
+
+    // Reset mock state
+    spawnCallCount = 0;
+    alivePanes.clear();
   });
 
   afterEach(async () => {
@@ -140,6 +198,62 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
       // be suppressed as a self-delivery
       const result = await sendMessage(tempDir, 'alice', 'bob', 'hello bob');
       expect(result.reason).not.toBe('Self-delivery suppressed');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Concurrent spawn dedup — advisory lock prevents duplicate workers
+  // ---------------------------------------------------------------------------
+
+  describe('concurrent spawn dedup', () => {
+    test('two concurrent messages to dead worker produce exactly one spawn', async () => {
+      const registry = await import('./agent-registry.js');
+
+      // Enable tmux path so auto-spawn is attempted
+      process.env.TMUX = '/tmp/tmux-test/default,123,0';
+
+      const now = new Date().toISOString();
+
+      // Register a dead worker (pane not in alivePanes → isPaneAlive returns false)
+      await registry.register({
+        id: 'dead-engineer',
+        paneId: '%0',
+        session: 'test-session',
+        provider: 'claude',
+        transport: 'tmux',
+        role: 'engineer',
+        team: 'test-team',
+        state: 'idle',
+        startedAt: now,
+        lastStateChange: now,
+        repoPath: tempDir,
+        worktree: null,
+      });
+
+      // Register a template so auto-spawn can find it
+      await registry.saveTemplate({
+        id: 'test-team-engineer',
+        team: 'test-team',
+        role: 'engineer',
+        provider: 'claude',
+        cwd: tempDir,
+        lastSpawnedAt: now,
+      });
+
+      const { sendMessage } = await import('./protocol-router.js');
+
+      // Fire two concurrent messages to the same dead worker
+      const [r1, r2] = await Promise.all([
+        sendMessage(tempDir, 'alice', 'engineer', 'message 1', 'test-team'),
+        sendMessage(tempDir, 'alice', 'engineer', 'message 2', 'test-team'),
+      ]);
+
+      // Exactly one spawn should have occurred — the advisory lock prevents the race
+      expect(spawnCallCount).toBe(1);
+
+      // Both messages should report successful delivery (one to respawned, one to existing)
+      const delivered = [r1.delivered, r2.delivered];
+      expect(delivered).toContain(true);
     });
   });
 });

--- a/src/lib/protocol-router.ts
+++ b/src/lib/protocol-router.ts
@@ -15,6 +15,7 @@
 
 import * as registry from './agent-registry.js';
 import * as nativeTeams from './claude-native-teams.js';
+import { getConnection } from './db.js';
 import * as mailbox from './mailbox.js';
 import { detectState } from './orchestrator/index.js';
 import { capturePaneContent, executeTmux, isPaneAlive } from './tmux.js';
@@ -135,32 +136,55 @@ async function ensureWorkerAlive(
     template.provider === 'claude' && worker?.claudeSessionId ? worker.claudeSessionId : undefined;
 
   try {
-    // Clean up ghost worker entries (dead panes) for this role before spawning
-    await cleanupDeadWorkers(recipientId, workerTeam);
+    const sql = await getConnection();
 
-    if (worker) {
-      await registry.unregister(worker.id);
+    // Advisory lock keyed on recipient — prevents concurrent cleanup+respawn
+    // for the same agent. Lock is held from cleanup through spawn return,
+    // released automatically on transaction commit/rollback.
+    const lockResult = await sql.begin(async (tx: typeof sql) => {
+      await tx`SELECT pg_advisory_xact_lock(hashtext(${recipientId}))`;
+
+      // Double-check: another process may have spawned while we waited for the lock
+      const postLockLive = await findLiveWorkerFuzzy(recipientId);
+      if (postLockLive) return { type: 'existing' as const, worker: postLockLive };
+
+      // Clean up ghost worker entries (dead panes) for this role before spawning
+      await cleanupDeadWorkers(recipientId, workerTeam);
+
+      if (worker) {
+        await registry.unregister(worker.id);
+      }
+
+      const { spawnWorkerFromTemplate } = await import('./protocol-router-spawn.js');
+      const spawnResult = await spawnWorkerFromTemplate(template, resumeSessionId);
+      return { type: 'spawned' as const, ...spawnResult };
+    });
+
+    if (lockResult.type === 'existing') {
+      return { worker: lockResult.worker, respawned: false };
     }
-
-    const { spawnWorkerFromTemplate } = await import('./protocol-router-spawn.js');
-    const result = await spawnWorkerFromTemplate(template, resumeSessionId);
 
     await registry.saveTemplate({
       ...template,
       lastSpawnedAt: new Date().toISOString(),
     });
 
-    await waitForWorkerReady(result.paneId);
+    await waitForWorkerReady(lockResult.paneId);
 
     // Verify the pane survived startup — if Claude exited (e.g. stale resume
     // or startup error), the pane is dead and delivery would silently fail.
-    if (!(await isPaneAlive(result.paneId))) {
-      await registry.unregister(result.worker.id);
+    if (!(await isPaneAlive(lockResult.paneId))) {
+      await registry.unregister(lockResult.worker.id);
       return null;
     }
 
-    return { worker: result.worker, respawned: true };
-  } catch {
+    return { worker: lockResult.worker, respawned: true };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[protocol-router] Spawn failed for "${recipientId}": ${msg}`);
+    if (worker) {
+      await registry.update(worker.id, { state: 'error' }).catch(() => {});
+    }
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- Add PG advisory lock around dead worker cleanup + respawn cycle (prevents duplicate workers)
- Log spawn failures and update worker state (was silently returning null)
- Advisory lock on agent ID during executor guard (prevents concurrent executor creation)

## Wish
`v4-message-routing` — Group 1 (spawn guard + dedup)

## Test plan
- [ ] `bun test src/lib/protocol-router.test.ts`
- [ ] Concurrent messages to dead worker produce exactly one respawn