### PR TITLE
feat(tui): ctrl+T spawns parallel worker

### DIFF
--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -127,8 +127,8 @@ export function getTuiKeybindings(sessionName = TUI_SESSION): string[] {
     `bind-key -T root C-2 select-pane -t ${sessionName}:0.1`,
     // Ctrl+B: toggle sidebar width (collapse/expand)
     `bind-key -T root C-b if-shell "[ $(tmux display-message -p '#\\{pane_width\\}' -t ${sessionName}:0.0) -gt 5 ]" "resize-pane -t ${sessionName}:0.0 -x 0" "resize-pane -t ${sessionName}:0.0 -x ${NAV_WIDTH}"`,
-    // Ctrl+T: new window in agent session (sends C-b c to the nested tmux in right pane)
-    `bind-key -T root C-t send-keys -t ${sessionName}:0.1 C-b c`,
+    // Ctrl+T: focus nav pane + pass through — TUI handles new agent window via useKeyboard
+    `bind-key -T root C-t select-pane -t ${sessionName}:0.0 \\; send-keys -t ${sessionName}:0.0 C-t`,
     // Ctrl+D: detach from TUI (leave running)
     'bind-key -T root C-d detach-client',
     // Ctrl+Q: focus nav pane + pass through for quit confirmation popup

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -7,7 +7,7 @@ import { useKeyboard } from '@opentui/react';
 import { useCallback, useState } from 'react';
 import { Nav } from './components/Nav.js';
 import { QuitDialog } from './components/QuitDialog.js';
-import { attachProjectWindow } from './tmux.js';
+import { attachProjectWindow, newAgentWindow } from './tmux.js';
 
 interface AppProps {
   rightPane?: string;
@@ -59,6 +59,7 @@ export function App({ rightPane, workspaceRoot, initialAgent }: AppProps) {
     <box width="100%" height="100%">
       <Nav
         onTmuxSessionSelect={handleTmuxSessionSelect}
+        onNewAgentWindow={newAgentWindow}
         workspaceRoot={workspaceRoot}
         initialAgent={initialAgent}
         keyboardDisabled={showQuit}

--- a/src/tui/components/Nav.tsx
+++ b/src/tui/components/Nav.tsx
@@ -19,8 +19,8 @@ import { TreeNodeRow } from './TreeNode.js';
 
 interface NavProps {
   onTmuxSessionSelect: (sessionName: string, windowIndex?: number) => void;
-  /** Create a new claude window in an agent's session */
-  onNewAgentWindow?: (sessionName: string) => void;
+  /** Spawn a parallel worker of the same agent type */
+  onNewAgentWindow?: (agentName: string) => void;
   /** Workspace root path — enables workspace mode (merged agent tree) */
   workspaceRoot?: string;
   /** Pre-select this agent on initial render */
@@ -214,11 +214,10 @@ export function Nav({
     } else if (key.name === 'r') {
       handleRetry();
     } else if (key.ctrl && key.name === 't') {
-      // Ctrl+T: new claude window for the selected running agent
+      // Ctrl+T: spawn a parallel worker of the selected agent
       const node = flatNodes[selectedIndex]?.node;
       if (node?.type === 'agent' && node.wsAgentState === 'running' && onNewAgentWindow) {
-        const target = getSessionTarget(node);
-        if (target) onNewAgentWindow(target.sessionName);
+        onNewAgentWindow(agentNameFromNode(node));
       }
     }
   });

--- a/src/tui/components/Nav.tsx
+++ b/src/tui/components/Nav.tsx
@@ -19,6 +19,8 @@ import { TreeNodeRow } from './TreeNode.js';
 
 interface NavProps {
   onTmuxSessionSelect: (sessionName: string, windowIndex?: number) => void;
+  /** Create a new claude window in an agent's session */
+  onNewAgentWindow?: (sessionName: string) => void;
   /** Workspace root path — enables workspace mode (merged agent tree) */
   workspaceRoot?: string;
   /** Pre-select this agent on initial render */
@@ -27,7 +29,13 @@ interface NavProps {
   keyboardDisabled?: boolean;
 }
 
-export function Nav({ onTmuxSessionSelect, workspaceRoot, initialAgent, keyboardDisabled = false }: NavProps) {
+export function Nav({
+  onTmuxSessionSelect,
+  onNewAgentWindow,
+  workspaceRoot,
+  initialAgent,
+  keyboardDisabled = false,
+}: NavProps) {
   const [diagnostics, setDiagnostics] = useState<DiagnosticSnapshot | null>(null);
   const [sessionTree, setSessionTree] = useState<TreeNode[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -205,6 +213,13 @@ export function Nav({ onTmuxSessionSelect, workspaceRoot, initialAgent, keyboard
       handleEnter();
     } else if (key.name === 'r') {
       handleRetry();
+    } else if (key.ctrl && key.name === 't') {
+      // Ctrl+T: new claude window for the selected running agent
+      const node = flatNodes[selectedIndex]?.node;
+      if (node?.type === 'agent' && node.wsAgentState === 'running' && onNewAgentWindow) {
+        const target = getSessionTarget(node);
+        if (target) onNewAgentWindow(target.sessionName);
+      }
     }
   });
 
@@ -268,7 +283,8 @@ export function Nav({ onTmuxSessionSelect, workspaceRoot, initialAgent, keyboard
       <box height={1} paddingX={1} backgroundColor={palette.bgLight}>
         <text>
           <span fg={palette.textMuted}>
-            {'\u2191\u2193'}:nav {'\u2190\u2192'}:expand Enter:{workspaceRoot ? 'spawn/attach' : 'attach'} R:retry
+            {'\u2191\u2193'}:nav {'\u2190\u2192'}:expand Enter:{workspaceRoot ? 'spawn/attach' : 'attach'} ^T:new
+            R:retry
           </span>
         </text>
       </box>

--- a/src/tui/tmux.ts
+++ b/src/tui/tmux.ts
@@ -83,24 +83,28 @@ export function attachTuiSession(): void {
   runTuiTmux(['attach-session', '-t', SESSION_NAME], 'inherit');
 }
 
-/** Create a new claude window in an agent's session on the genie tmux server. */
-export function newAgentWindow(sessionName: string): void {
-  // Find the spawn script for this agent — it contains the full claude command with all flags
-  const { readdirSync } = require('node:fs') as typeof import('node:fs');
-  const { join } = require('node:path') as typeof import('node:path');
-  const scriptsDir = join(process.env.GENIE_HOME ?? `${process.env.HOME}/.genie`, 'spawn-scripts');
-  try {
-    const scripts = readdirSync(scriptsDir);
-    // Match spawn script by session name prefix (e.g., "genie-ceo-*.sh" for session "ceo")
-    const prefix = `genie-${sessionName}-`;
-    const script = scripts.find((f: string) => f.startsWith(prefix) && f.endsWith('.sh'));
-    if (script) {
-      runAgentTmux(['new-window', '-t', sessionName, 'sh', '-c', join(scriptsDir, script)]);
-      return;
-    }
-  } catch {
-    // scripts dir missing — fall back
+/** Spawn a fresh parallel worker of the same agent type via `genie spawn`. */
+export function newAgentWindow(agentName: string): void {
+  const { spawn } = require('node:child_process') as typeof import('node:child_process');
+  const { join, resolve } = require('node:path') as typeof import('node:path');
+  const { existsSync } = require('node:fs') as typeof import('node:fs');
+  const bunPath = process.execPath || 'bun';
+  const genieBin = process.argv[1];
+  const wsRoot = process.env.GENIE_TUI_WORKSPACE;
+
+  let cwd: string | undefined;
+  if (wsRoot) {
+    const parentName = agentName.includes('/') ? agentName.slice(0, agentName.indexOf('/')) : agentName;
+    const agentDir = resolve(join(wsRoot, 'agents', parentName));
+    if (existsSync(agentDir)) cwd = agentDir;
   }
-  // Fallback: create a plain window (better than nothing)
-  runAgentTmux(['new-window', '-t', sessionName]);
+
+  // No --session: genie spawn assigns a unique session ID automatically.
+  // This creates a parallel worker of the same role, not a resume.
+  const args = ['spawn', agentName];
+  const child =
+    genieBin && genieBin !== 'genie'
+      ? spawn(bunPath, [genieBin, ...args], { detached: true, stdio: 'ignore', cwd })
+      : spawn('genie', args, { detached: true, stdio: 'ignore', cwd });
+  child.unref();
 }

--- a/src/tui/tmux.ts
+++ b/src/tui/tmux.ts
@@ -82,3 +82,25 @@ export function attachProjectWindow(rightPane: string, targetSession: string, wi
 export function attachTuiSession(): void {
   runTuiTmux(['attach-session', '-t', SESSION_NAME], 'inherit');
 }
+
+/** Create a new claude window in an agent's session on the genie tmux server. */
+export function newAgentWindow(sessionName: string): void {
+  // Find the spawn script for this agent — it contains the full claude command with all flags
+  const { readdirSync } = require('node:fs') as typeof import('node:fs');
+  const { join } = require('node:path') as typeof import('node:path');
+  const scriptsDir = join(process.env.GENIE_HOME ?? `${process.env.HOME}/.genie`, 'spawn-scripts');
+  try {
+    const scripts = readdirSync(scriptsDir);
+    // Match spawn script by session name prefix (e.g., "genie-ceo-*.sh" for session "ceo")
+    const prefix = `genie-${sessionName}-`;
+    const script = scripts.find((f: string) => f.startsWith(prefix) && f.endsWith('.sh'));
+    if (script) {
+      runAgentTmux(['new-window', '-t', sessionName, 'sh', '-c', join(scriptsDir, script)]);
+      return;
+    }
+  } catch {
+    // scripts dir missing — fall back
+  }
+  // Fallback: create a plain window (better than nothing)
+  runAgentTmux(['new-window', '-t', sessionName]);
+}


### PR DESCRIPTION
## Summary
Ctrl+T on a running agent in the TUI spawns a **fresh parallel worker** of the same type via `genie spawn <name>` — no `--session`, so it gets a unique session ID automatically.

**Use case:** You're looking at `genie` in the nav, press Ctrl+T, and a second `genie` instance spawns in its own tmux session for parallel work.

## What changed
- `tmux.ts`: Replaced spawn-script filesystem glob with direct `genie spawn` call
- `Nav.tsx`: Passes agent name (not session name) to the handler

## What this fixes vs PR #970's approach
| Issue | PR #970 | This PR |
|-------|---------|---------|
| Hardcoded `genie-` prefix | Yes | No — uses agent name directly |
| Stale spawn scripts | Yes — unordered readdirSync | No — no filesystem lookup |
| Unquoted paths | Yes — `sh -c` with raw path | No — args passed as array |
| `process.env.HOME` | Yes | No — uses same pattern as `spawnAgent()` |

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun test src/tui/` — 31 pass, 0 fail
- [ ] Manual: select running agent → Ctrl+T → verify new parallel session spawns