### PR TITLE
fix(spawn): always set --permission-mode for native team workers

### DIFF
--- a/src/lib/provider-adapters.ts
+++ b/src/lib/provider-adapters.ts
@@ -237,7 +237,12 @@ function appendNativeTeamFlags(
   if (nt.parentSessionId) parts.push('--parent-session-id', escapeShellArg(nt.parentSessionId));
   if (nt.agentType) parts.push('--agent-type', escapeShellArg(nt.agentType));
   if (nt.planModeRequired) parts.push('--plan-mode-required');
-  if (nt.permissionMode) parts.push('--permission-mode', escapeShellArg(nt.permissionMode));
+  // Always set permission mode for native team workers. Without this, CC's native
+  // team layer routes tool approvals to the team lead (which is an AI agent that
+  // can't approve). --dangerously-skip-permissions alone isn't enough — the native
+  // team permission gate is a separate layer.
+  const effectivePermMode = nt.permissionMode ?? 'bypassPermissions';
+  parts.push('--permission-mode', escapeShellArg(effectivePermMode));
 }
 
 /**


### PR DESCRIPTION
## Summary
Native team workers hang forever when they need Bash/tool permission because CC routes the approval to the team lead (an AI agent that can't approve).

## Root Cause
`--dangerously-skip-permissions` bypasses CC's main permission system, but CC's **native team layer** has a separate permission gate. Without `--permission-mode bypassPermissions`, workers in native teams route tool approvals to the team lead via the agent messaging protocol. When the team lead is an AI, the approval request gets stuck — the AI can't call CC's internal approval API.

## Fix
Default `--permission-mode bypassPermissions` for all native team workers in `provider-adapters.ts`. This ensures workers get full tool access like the team lead, instead of routing approvals through the agent messaging layer.

One-line change: `nt.permissionMode ?? 'bypassPermissions'`

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun test src/lib/spawn-command.test.ts` — 24/24 pass
- [ ] Manual: spawn a native team worker → verify no "Waiting for team lead approval" prompt