### PR TITLE
fix(tui): sub-agent session matching + selection stability + env restore

### DIFF
--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "4.260402.1",
+  "version": "4.260402.2",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "type": "module",

--- a/src/genie.ts
+++ b/src/genie.ts
@@ -490,6 +490,7 @@ const args = process.argv.slice(2);
 // launch a second TUI nav (note: `= undefined` sets the STRING "undefined",
 // only `delete` actually removes the var from the environment).
 const isTuiPane = process.env.GENIE_TUI_PANE === 'left' && args.length === 0;
+const tuiRightPane = process.env.GENIE_TUI_RIGHT;
 // biome-ignore lint/performance/noDelete: process.env requires delete — assignment sets the string "undefined"
 delete process.env.GENIE_TUI_PANE;
 // biome-ignore lint/performance/noDelete: process.env requires delete
@@ -497,6 +498,10 @@ delete process.env.GENIE_TUI_RIGHT;
 // biome-ignore lint/performance/noDelete: process.env requires delete
 delete process.env.GENIE_IS_DAEMON;
 if (isTuiPane) {
+  // Restore GENIE_TUI_RIGHT so the TUI renderer can read it (we deleted it
+  // from the environment to prevent child process inheritance, but the TUI
+  // itself still needs it to control the right pane).
+  if (tuiRightPane) process.env.GENIE_TUI_RIGHT = tuiRightPane;
   const { launchTui } = await import('./tui/index.js');
   await launchTui();
   process.exit(0);

--- a/src/tui/components/Nav.tsx
+++ b/src/tui/components/Nav.tsx
@@ -2,7 +2,7 @@
 /** Sessions panel — single tree view of tmux sessions > windows > panes */
 
 import { useKeyboard } from '@opentui/react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { scanAgents } from '../../lib/workspace.js';
 import { buildMenuItems } from '../context-menu-items.js';
 import { type DiagnosticSnapshot, collectDiagnostics } from '../diagnostics.js';
@@ -44,6 +44,7 @@ export function Nav({
   const [requestedInitialAgent, setRequestedInitialAgent] = useState<string | undefined>(initialAgent);
   const [contextMenuNodeId, setContextMenuNodeId] = useState<string | null>(null);
   const lastTarget = useRef<string | null>(null);
+  const selectedNodeId = useRef<string | null>(null);
 
   // Refresh diagnostics every 2s
   useEffect(() => {
@@ -94,12 +95,29 @@ export function Nav({
 
   const flatNodes = useMemo(() => flattenTree(sessionTree), [sessionTree]);
 
-  // Clamp selectedIndex when tree shrinks
+  // Keep selectedNodeId in sync with the current selection
   useEffect(() => {
-    if (flatNodes.length > 0 && selectedIndex >= flatNodes.length) {
+    const node = flatNodes[selectedIndex]?.node;
+    if (node) selectedNodeId.current = node.id;
+  }, [selectedIndex, flatNodes]);
+
+  // Stabilize selection across tree rebuilds: if the node at selectedIndex changed,
+  // find the previously selected node by ID and restore the correct index.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: selectedIndex intentionally excluded — including it creates infinite loop since effect calls setSelectedIndex
+  useLayoutEffect(() => {
+    if (flatNodes.length === 0) return;
+    if (selectedIndex >= flatNodes.length) {
       setSelectedIndex(flatNodes.length - 1);
+      return;
     }
-  }, [flatNodes.length, selectedIndex]);
+    if (!selectedNodeId.current) return;
+    const currentAtIndex = flatNodes[selectedIndex]?.node;
+    if (currentAtIndex && currentAtIndex.id === selectedNodeId.current) return;
+    const restored = flatNodes.findIndex((n) => n.node.id === selectedNodeId.current);
+    if (restored >= 0) {
+      setSelectedIndex(restored);
+    }
+  }, [flatNodes]);
 
   // Initial agent selection / auto-spawn. Triggered by startup env or file signal.
   useEffect(() => {

--- a/src/tui/session-tree.test.ts
+++ b/src/tui/session-tree.test.ts
@@ -311,14 +311,15 @@ describe('buildWorkspaceTree', () => {
   });
 
   test('sub-agents with running sessions show correct state', () => {
-    const qaWin0 = makeWindow({ sessionName: 'genie/qa', index: 0, name: 'zsh' });
+    // Tmux session names use dashes (slashes are forbidden in tmux session names)
+    const qaWin0 = makeWindow({ sessionName: 'genie-qa', index: 0, name: 'zsh' });
     const qaWin1 = makeWindow({
-      sessionName: 'genie/qa',
+      sessionName: 'genie-qa',
       index: 1,
       name: 'qa',
-      panes: [makePane({ sessionName: 'genie/qa', windowIndex: 1, paneId: '%5', command: 'claude', title: 'claude' })],
+      panes: [makePane({ sessionName: 'genie-qa', windowIndex: 1, paneId: '%5', command: 'claude', title: 'claude' })],
     });
-    const qaSession = makeSession('genie/qa', [qaWin0, qaWin1]);
+    const qaSession = makeSession('genie-qa', [qaWin0, qaWin1]);
 
     const tree = buildWorkspaceTree({
       agentNames: ['genie', 'genie/qa'],

--- a/src/tui/session-tree.ts
+++ b/src/tui/session-tree.ts
@@ -14,6 +14,11 @@ import type { AgentState, TreeNode, TuiExecutor } from './types.js';
 /** The TUI's own session name — filtered from the tree to prevent self-attach loops */
 const TUI_SESSION = 'genie-tui';
 
+/** Normalize agent name to tmux session name (slashes → dashes, since tmux forbids slashes). */
+function toSessionName(agentName: string): string {
+  return agentName.replace(/\//g, '-');
+}
+
 // ─── Legacy Mode (no workspace) ──────────────────────────────────────────────
 
 /** Build a TreeNode tree from tmux sessions, enriched with executor state. */
@@ -72,15 +77,20 @@ export function buildWorkspaceTree(input: WorkspaceTreeInput): TreeNode[] {
   const { topLevel, subsByParent } = groupAgentNames(agentNames);
 
   const nodes = topLevel.map((name) => {
-    const node = buildAgentNode(name, sessionByName.get(name), executorsByAgent.get(name) ?? [], executorByPaneId);
+    const node = buildAgentNode(
+      name,
+      sessionByName.get(toSessionName(name)),
+      executorsByAgent.get(name) ?? [],
+      executorByPaneId,
+    );
     appendSubAgentNodes(node, subsByParent.get(name), sessionByName, executorsByAgent, executorByPaneId);
     return node;
   });
 
   // Add orphan sessions (tmux sessions with no matching agent in filesystem)
-  const agentNameSet = new Set(agentNames);
+  const claimedSessions = new Set(agentNames.map(toSessionName));
   for (const [name, session] of sessionByName) {
-    if (!agentNameSet.has(name)) {
+    if (!claimedSessions.has(name)) {
       nodes.push(sessionToNode(session, executorByPaneId));
     }
   }
@@ -140,7 +150,7 @@ function appendSubAgentNodes(
     const subLabel = subName.slice(subName.indexOf('/') + 1);
     const subNode = buildAgentNode(
       subName,
-      sessionByName.get(subName),
+      sessionByName.get(toSessionName(subName)),
       executorsByAgent.get(subName) ?? [],
       executorByPaneId,
     );
@@ -182,7 +192,7 @@ function buildAgentNode(
     expanded: children.length > 0,
     children,
     data: {
-      sessionName: name,
+      sessionName: toSessionName(name),
       windowCount: session ? session.windows.length : 0,
       attachWindowIndex,
       provider: agentExecutors[0]?.provider ?? null,


### PR DESCRIPTION
## Summary
Three TUI fixes found during live testing:

1. **Sub-agent session matching**: Agent names with slashes (`genie/qa`) now correctly map to tmux session names with dashes (`genie-qa`). Tmux forbids slashes — orphan detection also uses the normalized name.

2. **Selection stability**: Nav selection no longer jumps on tree rebuild (every 2s poll). Tracks `selectedNodeId` by ref and restores via `useLayoutEffect`.

3. **GENIE_TUI_RIGHT env restore**: Env var was deleted to prevent child inheritance but broke TUI's own right-pane control. Now saved before delete and restored for the renderer.

## Test plan
- [x] `bun test` — 1787 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] session-tree tests updated for dash-based session names