### PR TITLE
fix: resume prior CC sessions in 3 broken launch paths

### DIFF
--- a/src/genie-commands/session.ts
+++ b/src/genie-commands/session.ts
@@ -228,8 +228,15 @@ async function createSession(
   await tmux.executeTmux(`send-keys -t ${shellQuote(target)} ${shellQuote(cdCmd)} Enter`);
 
   const agentName = basename(workspaceDir);
-  // First run — no session to continue, just start fresh with --name
-  const cmd = buildClaudeCommand(windowName, systemPromptFile || undefined, undefined, leaderName);
+  // Check for prior CC session to resume, start fresh only if none found
+  const continueName = sanitizeTeamName(windowName);
+  const hasPriorSession = sessionExists(continueName);
+  const cmd = buildClaudeCommand(
+    windowName,
+    systemPromptFile || undefined,
+    hasPriorSession ? continueName : undefined,
+    leaderName,
+  );
   await tmux.executeTmux(`send-keys -t ${shellQuote(target)} ${shellQuote(cmd)} Enter`);
   console.log(`Started Claude Code as ${agentName} in ${workspaceDir}`);
 
@@ -423,6 +430,39 @@ async function reconcileLeaderConfigs(): Promise<void> {
   }
 }
 
+/**
+ * Launch Claude Code inside an existing tmux pane (the "inside-tmux" path).
+ *
+ * Checks for a prior CC session to resume. If one exists, reuses the window
+ * name and passes --resume. Otherwise creates a fresh session with a unique
+ * suffix to avoid window-name collisions.
+ */
+async function launchInsideTmux(
+  windowName: string,
+  workspaceDir: string,
+  systemPromptFile: string | null,
+  leaderName?: string,
+): Promise<void> {
+  const continueName = sanitizeTeamName(windowName);
+  const hasPriorSession = sessionExists(continueName);
+  if (hasPriorSession) {
+    // Resume existing session — don't create a new suffixed window
+    await ensureNativeTeamForLeader(windowName, workspaceDir);
+    const cmd = buildClaudeCommand(windowName, systemPromptFile || undefined, continueName, leaderName);
+    const { execSync: execSyncCmd } = require('node:child_process');
+    execSyncCmd(cmd, { stdio: 'inherit', cwd: workspaceDir });
+  } else {
+    // No prior session — create fresh with suffix for uniqueness
+    const suffix = Date.now().toString(36).slice(-4);
+    const currentWindowName = `${windowName}-${suffix}`;
+    await tmux.executeTmux(`rename-window ${shellQuote(currentWindowName)}`);
+    await ensureNativeTeamForLeader(currentWindowName, workspaceDir);
+    const cmd = buildClaudeCommand(currentWindowName, systemPromptFile || undefined, undefined, leaderName);
+    const { execSync: execSyncCmd } = require('node:child_process');
+    execSyncCmd(cmd, { stdio: 'inherit', cwd: workspaceDir });
+  }
+}
+
 export async function sessionCommand(options: SessionOptions = {}): Promise<void> {
   // One-shot startup reconciliation: reset agents stuck in 'spawning' with no pane for >60s
   await reconcileStaleSpawns();
@@ -462,14 +502,7 @@ export async function sessionCommand(options: SessionOptions = {}): Promise<void
       attachToWindow(sessionName, windowName);
     } else if (process.env.TMUX) {
       // Already inside tmux — launch Claude Code in the CURRENT pane
-      const suffix = Date.now().toString(36).slice(-4);
-      const currentWindowName = `${windowName}-${suffix}`;
-      await tmux.executeTmux(`rename-window ${shellQuote(currentWindowName)}`);
-      await ensureNativeTeamForLeader(currentWindowName, workspaceDir);
-      // Fresh session — random suffix means no prior conversation to continue
-      const cmd = buildClaudeCommand(currentWindowName, systemPromptFile || undefined, undefined, leaderName);
-      const { execSync: execSyncCmd } = require('node:child_process');
-      execSyncCmd(cmd, { stdio: 'inherit', cwd: workspaceDir });
+      await launchInsideTmux(windowName, workspaceDir, systemPromptFile, leaderName);
     } else {
       // Outside tmux — attach to existing session
       console.log(`Session "${sessionName}" already exists`);

--- a/src/lib/team-auto-spawn.ts
+++ b/src/lib/team-auto-spawn.ts
@@ -13,7 +13,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { sanitizeWindowName } from '../genie-commands/session.js';
 import { ensureNativeTeam, loadConfig, registerNativeMember, sanitizeTeamName } from './claude-native-teams.js';
-import { buildTeamLeadCommand, shellQuote } from './team-lead-command.js';
+import { buildTeamLeadCommand, sessionExists, shellQuote } from './team-lead-command.js';
 import * as tmux from './tmux.js';
 
 interface EnsureTeamLeadResult {
@@ -140,7 +140,13 @@ export async function ensureTeamLead(teamName: string, workingDir: string): Prom
     const target = `${session}:${windowName}`;
     const cdCmd = `cd ${shellQuote(workingDir)}`;
     await tmux.executeTmux(`send-keys -t ${shellQuote(target)} ${shellQuote(cdCmd)} Enter`);
-    const cmd = buildTeamLeadCommand(teamName, { systemPromptFile: systemPromptFile ?? undefined, leaderName });
+    const continueName = sanitizeTeamName(teamName);
+    const hasPriorSession = sessionExists(continueName, workingDir);
+    const cmd = buildTeamLeadCommand(teamName, {
+      systemPromptFile: systemPromptFile ?? undefined,
+      leaderName,
+      continueName: hasPriorSession ? continueName : undefined,
+    });
     await tmux.executeTmux(`send-keys -t ${shellQuote(target)} ${shellQuote(cmd)} Enter`);
   }
 


### PR DESCRIPTION
## Summary

Fixes 3 code paths that launched Claude Code without checking for an existing session, causing "session amnesia" — agents lose conversation history after tmux restarts.

- **Path 1** (`createSession()` in `session.ts`): First-run path now calls `sessionExists()` before building the launch command, passing `--resume` when a prior session is found.
- **Path 2** (`ensureTeamLead()` in `team-auto-spawn.ts`): Auto-spawn path now imports `sessionExists` and passes `continueName` when a prior session exists (using `workingDir` for the cwd lookup).
- **Path 3** (inside-tmux path in `session.ts`): Extracted to `launchInsideTmux()` helper. Checks for a resumable session first; only falls back to the random-suffix fresh session when no prior session exists.

All three paths now follow the same pattern established in `launchWithContinueFallback()`: sanitize the name, check `sessionExists()`, and pass `continueName` when available.

Closes #848

## Test plan

- [x] `bun run build` compiles successfully
- [x] `bun test --filter session` — all 59 tests pass
- [x] Full test suite — all 1787 tests pass
- [ ] Manual: run `genie` in a workspace, exit CC, restart tmux, run `genie` again — verify conversation history is preserved
- [ ] Manual: run `genie` inside an existing tmux pane — verify prior session is resumed
- [ ] Manual: trigger `genie team ensure <name>` for a team with prior sessions — verify resume