### PR TITLE
fix: TUI start button + instant message delivery via PG LISTEN/NOTIFY

### DIFF
--- a/src/lib/mailbox.ts
+++ b/src/lib/mailbox.ts
@@ -184,6 +184,18 @@ export async function getUnread(repoPath: string, workerId: string | string[]): 
 }
 
 /**
+ * Get a single message by ID.
+ */
+export async function getById(messageId: string): Promise<MailboxMessage | null> {
+  const sql = await getConnection();
+  const rows = await sql`
+    SELECT * FROM mailbox WHERE id = ${messageId} LIMIT 1
+  `;
+  if (rows.length === 0) return null;
+  return rowToMessage(rows[0]);
+}
+
+/**
  * Mark a message as read.
  */
 export async function markRead(messageId: string): Promise<boolean> {
@@ -218,10 +230,9 @@ export function toNativeInboxMessage(msg: MailboxMessage, color = 'blue'): Nativ
  * Calls the callback with (toWorker, messageId) on each new insert.
  * Returns an unsubscribe function.
  *
- * Internal for now — will be exported when inbox-watcher integration lands.
+ * Used by the scheduler daemon for instant message delivery.
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- future inbox-watcher integration
-async function _subscribeDelivery(
+export async function subscribeDelivery(
   callback: (toWorker: string, messageId: string) => void,
 ): Promise<() => Promise<void>> {
   const sql = await getConnection();

--- a/src/lib/protocol-router.ts
+++ b/src/lib/protocol-router.ts
@@ -458,6 +458,28 @@ async function injectToTmuxPane(worker: registry.Agent, message: mailbox.Mailbox
 }
 
 /**
+ * Attempt instant pane delivery for a specific message.
+ * Used by the scheduler daemon's PG LISTEN/NOTIFY handler to push
+ * messages into tmux panes without waiting for the next poll cycle.
+ *
+ * Returns true if the message was injected into the pane.
+ */
+export async function deliverToPane(toWorker: string, messageId: string): Promise<boolean> {
+  const worker = await registry.get(toWorker);
+  if (!worker || !worker.paneId) return false;
+  if (!(await _deps.isPaneAlive(worker.paneId))) return false;
+
+  const message = await mailbox.getById(messageId);
+  if (!message || message.deliveredAt) return false;
+
+  const injected = await injectToTmuxPane(worker, message);
+  if (injected && worker.repoPath) {
+    await mailbox.markDelivered(worker.repoPath, worker.id, messageId);
+  }
+  return injected;
+}
+
+/**
  * Get the inbox for a worker (all messages, with read/unread status).
  */
 export async function getInbox(repoPath: string, workerId: string): Promise<mailbox.MailboxMessage[]> {

--- a/src/lib/scheduler-daemon.ts
+++ b/src/lib/scheduler-daemon.ts
@@ -24,6 +24,7 @@ import type { Agent } from './agent-registry.js';
 import { computeNextCronDue, parseDuration } from './cron.js';
 import { type EventRouterHandle, startEventRouter } from './event-router.js';
 import { getInboxPollIntervalMs, startInboxWatcher, stopInboxWatcher } from './inbox-watcher.js';
+import { subscribeDelivery } from './mailbox.js';
 import { type RunSpec, resolveRunSpec } from './run-spec.js';
 
 // ============================================================================
@@ -1236,6 +1237,7 @@ export function startDaemon(
   let inboxWatcherHandle: NodeJS.Timeout | null = null;
   let captureFallbackTimer: ReturnType<typeof setInterval> | null = null;
   let eventRouterHandle: EventRouterHandle | null = null;
+  let deliveryUnsub: (() => Promise<void>) | null = null;
 
   // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: stop() is a flat cleanup sequence for all daemon resources
   const stop = () => {
@@ -1275,6 +1277,10 @@ export function startDaemon(
     }
     eventRouterHandle?.stop().catch(() => {});
     eventRouterHandle = null;
+    if (deliveryUnsub) {
+      deliveryUnsub().catch(() => {});
+      deliveryUnsub = null;
+    }
     // Stop session capture layers
     import('./session-filewatch.js').then((m) => m.stopFilewatch()).catch(() => {});
     import('./session-backfill.js').then((m) => m.stopBackfill()).catch(() => {});
@@ -1491,6 +1497,22 @@ export function startDaemon(
     leaseRecoveryTimer = startLeaseRecoveryTimer(deps, config, daemonId);
     inboxWatcherHandle = startInboxWatcherIfEnabled(deps);
     eventRouterHandle = await startEventRouterSafe(deps);
+
+    // Subscribe to PG LISTEN/NOTIFY for instant message delivery
+    try {
+      deliveryUnsub = await subscribeDelivery(async (toWorker, messageId) => {
+        try {
+          const { deliverToPane } = await import('./protocol-router.js');
+          await deliverToPane(toWorker, messageId);
+        } catch {
+          // Fallback: inbox-watcher will pick it up on next poll cycle
+        }
+      });
+      deps.log({ timestamp: deps.now().toISOString(), level: 'info', event: 'mailbox_delivery_listen_started' });
+    } catch {
+      // PG LISTEN not available — inbox-watcher polling remains the fallback
+    }
+
     captureFallbackTimer = await initSessionCapture(deps, config);
 
     // Initial trigger check

--- a/src/tui/context-menu-items.ts
+++ b/src/tui/context-menu-items.ts
@@ -23,14 +23,14 @@ function buildAgentItems(node: TreeNode): MenuItem[] {
 
   if (ws === 'running') {
     return [
-      { label: 'New agent', shortcut: 'N', action: 'agent-new-window' },
+      { label: 'Clone', shortcut: 'N', action: 'agent-new-window' },
       { label: 'New window', shortcut: 'W', action: 'new-empty-window' },
       { label: 'Rename...', shortcut: 'R', action: 'rename-session', needsInput: true, separator: true },
       { label: 'Remove', shortcut: 'K', action: 'kill' },
     ];
   }
 
-  return [{ label: 'Spawn agent', shortcut: 'S', action: 'spawn' }];
+  return [{ label: 'Start', shortcut: 'S', action: 'spawn' }];
 }
 
 function buildSessionItems(): MenuItem[] {


### PR DESCRIPTION
## Summary

- **TUI context menu labels**: Rename "Spawn agent" → "Start" for stopped agents, "New agent" → "Clone" for running agents — cleaner UX that aligns with session resume semantics
- **PG LISTEN/NOTIFY wiring**: Export `subscribeDelivery` from mailbox, add `deliverToPane` in protocol-router, and wire the subscription into the scheduler daemon for instant message delivery to tmux panes
- **mailbox.getById()**: New helper to fetch a single message by ID, used by `deliverToPane`

## Details

### Task 1 — TUI labels
The `action: 'spawn'` handler already calls `genie spawn` which benefits from session resume (PR #987). The label "Start" is more intuitive. "Clone" distinguishes spawning a parallel worker from the stopped-agent start flow.

### Task 2 — Instant delivery
The PG LISTEN/NOTIFY infrastructure was built in mailbox.ts but never connected. This PR:
1. Exports `subscribeDelivery` (was `_subscribeDelivery`)
2. Adds `deliverToPane(toWorker, messageId)` in protocol-router that looks up the worker, fetches the message, injects into tmux, and marks delivered
3. Subscribes in the scheduler daemon's startup, with cleanup in the stop handler
4. Falls back gracefully — if PG LISTEN is unavailable or injection fails, the inbox-watcher polling picks it up

Closes #964

## Test plan
- [x] `bun run build` passes
- [x] `bun test` — all 1787 tests pass
- [x] Typecheck clean, lint clean, dead-code clean
- [ ] Manual: verify stopped agent context menu shows "Start"
- [ ] Manual: verify running agent context menu shows "Clone"
- [ ] Manual: send a message between agents, verify instant delivery via scheduler logs (`mailbox_delivery_listen_started`)