### PR TITLE
fix(security): sanitize column names in import prepareRow()

### DIFF
--- a/src/term-commands/import.test.ts
+++ b/src/term-commands/import.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect, test } from 'bun:test';
 import { GROUP_TABLES } from '../lib/export-format.js';
-import { assertValidTable } from './import.js';
+import { assertValidColumnName, assertValidTable } from './import.js';
 
 describe('assertValidTable', () => {
   test('accepts all tables from GROUP_TABLES', () => {
@@ -38,5 +38,54 @@ describe('assertValidTable', () => {
 
   test('error message includes the invalid table name', () => {
     expect(() => assertValidTable('evil_table')).toThrow('Invalid table name: "evil_table"');
+  });
+});
+
+describe('assertValidColumnName', () => {
+  test('accepts normal column names', () => {
+    for (const name of ['id', 'name', 'created_at', 'parent_id', '_private', 'Col123']) {
+      expect(() => assertValidColumnName(name)).not.toThrow();
+    }
+  });
+
+  test('rejects column name with embedded double quote (SQL injection)', () => {
+    expect(() => assertValidColumnName('foo"; DROP TABLE x; --')).toThrow('disallowed characters');
+  });
+
+  test('rejects column name with spaces', () => {
+    expect(() => assertValidColumnName('column name')).toThrow('disallowed characters');
+  });
+
+  test('rejects column name with semicolon', () => {
+    expect(() => assertValidColumnName('col;DELETE')).toThrow('disallowed characters');
+  });
+
+  test('rejects column name starting with a digit', () => {
+    expect(() => assertValidColumnName('1column')).toThrow('disallowed characters');
+  });
+
+  test('rejects empty string', () => {
+    expect(() => assertValidColumnName('')).toThrow('disallowed characters');
+  });
+
+  test('rejects column with parentheses', () => {
+    expect(() => assertValidColumnName('col()')).toThrow('disallowed characters');
+  });
+
+  test('rejects column with single quotes', () => {
+    expect(() => assertValidColumnName("col'val")).toThrow('disallowed characters');
+  });
+
+  test('truncates long malicious names in error message', () => {
+    const longName = `${'a'.repeat(100)}"injection`;
+    try {
+      assertValidColumnName(longName);
+      throw new Error('Expected to throw');
+    } catch (e) {
+      const msg = (e as Error).message;
+      // Should be truncated to 60 chars in the error message
+      expect(msg.length).toBeLessThan(200);
+      expect(msg).toContain('disallowed characters');
+    }
   });
 });

--- a/src/term-commands/import.ts
+++ b/src/term-commands/import.ts
@@ -32,6 +32,21 @@ export function assertValidTable(name: string): void {
 
 type Sql = postgres.Sql;
 
+/** Regex for valid SQL identifiers: starts with letter or underscore, then alphanumerics/underscores. */
+const VALID_COLUMN_RE = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+/**
+ * Validates a column name to prevent SQL injection via malicious JSON keys.
+ * Rejects any name that isn't a plain alphanumeric identifier.
+ */
+export function assertValidColumnName(name: string): void {
+  if (!VALID_COLUMN_RE.test(name)) {
+    throw new Error(
+      `Invalid column name: "${name.slice(0, 60)}" contains disallowed characters. Column names must match /^[a-zA-Z_][a-zA-Z0-9_]*$/.`,
+    );
+  }
+}
+
 // ============================================================================
 // Lazy loaders
 // ============================================================================
@@ -103,6 +118,11 @@ function prepareRow(
   const entries = Object.entries(row);
   const columns = entries.map(([k]) => k);
   const values = entries.map(([, v]) => v);
+
+  // Validate all column names before they touch SQL (defense against injection via JSON keys)
+  for (const col of columns) {
+    assertValidColumnName(col);
+  }
 
   // Null out self-referential column for first pass
   if (selfRefCol && row[selfRefCol] != null) {


### PR DESCRIPTION
## Summary
- **SQL injection via column names** in `prepareRow()` — user-supplied JSON keys were interpolated into SQL with `"${c}"` quoting but no escaping or validation, allowing a malicious column name like `foo"; DROP TABLE x; --` to escape the identifier quoting
- Added `assertValidColumnName()` that rejects any column name not matching `/^[a-zA-Z_][a-zA-Z0-9_]*$/` (strict allowlist, defense-in-depth)
- Added 9 regression tests covering injection attempts, edge cases, and error message truncation

Closes #955

## Test plan
- [x] `bun test src/term-commands/import.test.ts` — 16/16 pass (7 existing + 9 new)
- [x] `bun run build` — clean
- [x] `biome check` on changed files — clean
- [x] Full test suite — 1796 pass, 0 fail