### PR TITLE
fix: auto-resume Claude session on genie spawn

### DIFF
--- a/src/lib/team-lead-command.ts
+++ b/src/lib/team-lead-command.ts
@@ -133,7 +133,11 @@ export function sessionExists(name: string, cwd?: string): boolean {
     }
 
     const needle = name.toLowerCase();
-    return files.some((file) => fileHasSessionName(join(projectPath, file), needle));
+    return files.some((file) => {
+      const full = join(projectPath, file);
+      // Check exact name and {team}-{name} format (CC stores team-prefixed names)
+      return fileHasSessionName(full, needle) || fileHasSessionName(full, `${needle}-${needle}`);
+    });
   } catch {
     return false;
   }

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -974,6 +974,21 @@ function prependEnvVars(command: string, env?: Record<string, string>): string {
 }
 
 /**
+ * Find a dead worker with a resumable Claude session for the given role/team.
+ * Must run BEFORE rejectDuplicateRole which would unregister the dead worker
+ * and lose the claudeSessionId needed for resume.
+ */
+async function findDeadResumable(team: string, role: string): Promise<registry.Agent | null> {
+  const existing = await registry.list();
+  const candidate = existing.find(
+    (w) => w.role === role && w.team === team && w.claudeSessionId && w.provider === 'claude',
+  );
+  if (!candidate) return null;
+  const alive = await isPaneAlive(candidate.paneId);
+  return alive ? null : candidate;
+}
+
+/**
  * Reject spawn if a live worker with the same role already exists in the team.
  * Dead/suspended workers (pane gone) are auto-cleaned from registry — only live panes block.
  */
@@ -1193,22 +1208,13 @@ export async function handleWorkerSpawn(name: string, options: SpawnOptions): Pr
     return process.exit(1) as never;
   }
   // Auto-resume: if a dead worker exists with a Claude session, resume instead of fresh spawn.
-  // Must run BEFORE rejectDuplicateRole which would unregister the dead worker and lose the sessionId.
-  {
-    const existing = await registry.list();
-    const deadResumable = existing.find(
-      (w) => w.role === effectiveRole && w.team === team && w.claudeSessionId && w.provider === 'claude',
+  const deadResumable = await findDeadResumable(team, effectiveRole);
+  if (deadResumable) {
+    console.log(
+      `Resuming existing session for "${effectiveRole}" (session: ${deadResumable.claudeSessionId!.slice(0, 8)}...)`,
     );
-    if (deadResumable) {
-      const alive = await isPaneAlive(deadResumable.paneId);
-      if (!alive) {
-        console.log(
-          `Resuming existing session for "${effectiveRole}" (session: ${deadResumable.claudeSessionId.slice(0, 8)}...)`,
-        );
-        await resumeAgent(deadResumable);
-        return deadResumable.id;
-      }
-    }
+    await resumeAgent(deadResumable);
+    return deadResumable.id;
   }
 
   await rejectDuplicateRole(team, effectiveRole);

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -1211,7 +1211,7 @@ export async function handleWorkerSpawn(name: string, options: SpawnOptions): Pr
   const deadResumable = await findDeadResumable(team, effectiveRole);
   if (deadResumable) {
     console.log(
-      `Resuming existing session for "${effectiveRole}" (session: ${deadResumable.claudeSessionId!.slice(0, 8)}...)`,
+      `Resuming existing session for "${effectiveRole}" (session: ${deadResumable.claudeSessionId?.slice(0, 8)}...)`,
     );
     await resumeAgent(deadResumable);
     return deadResumable.id;

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -1192,6 +1192,25 @@ export async function handleWorkerSpawn(name: string, options: SpawnOptions): Pr
     console.error('Error: --team is required (or set GENIE_TEAM, or run inside a genie session)');
     return process.exit(1) as never;
   }
+  // Auto-resume: if a dead worker exists with a Claude session, resume instead of fresh spawn.
+  // Must run BEFORE rejectDuplicateRole which would unregister the dead worker and lose the sessionId.
+  {
+    const existing = await registry.list();
+    const deadResumable = existing.find(
+      (w) => w.role === effectiveRole && w.team === team && w.claudeSessionId && w.provider === 'claude',
+    );
+    if (deadResumable) {
+      const alive = await isPaneAlive(deadResumable.paneId);
+      if (!alive) {
+        console.log(
+          `Resuming existing session for "${effectiveRole}" (session: ${deadResumable.claudeSessionId.slice(0, 8)}...)`,
+        );
+        await resumeAgent(deadResumable);
+        return deadResumable.id;
+      }
+    }
+  }
+
   await rejectDuplicateRole(team, effectiveRole);
 
   // 2b. Override CWD with team worktree path if available.


### PR DESCRIPTION
## Summary

- **Auto-resume dead workers**: When `genie spawn` is called for an agent that previously had a running Claude Code session (now dead), it now resumes the existing session instead of creating a new one, preserving all conversation context.
- **Fix sessionExists name mismatch**: `sessionExists()` in `team-lead-command.ts` now also checks for `{name}-{name}` format, matching how Claude Code stores team-prefixed session names.
- **Extract helper for lint compliance**: Moved dead-worker detection into a standalone `findDeadResumable()` helper to keep `handleWorkerSpawn` under the cognitive complexity threshold.

### Root cause
`handleWorkerSpawn()` always generated a new `sessionId` via `crypto.randomUUID()`, and `rejectDuplicateRole()` unregistered dead workers before their `claudeSessionId` could be used for resume. The new logic runs **before** `rejectDuplicateRole` to detect and resume dead workers that have a saved Claude session.

### Files changed
- `src/term-commands/agents.ts` — auto-resume detection + `findDeadResumable` helper
- `src/lib/team-lead-command.ts` — `sessionExists()` name format fix

## Test plan
- [x] `bun run build` passes
- [x] `bun test src/term-commands/agents.test.ts` — 9 tests pass
- [x] `bun test src/lib/team-lead-command.test.ts` — 16 tests pass
- [ ] Manual: spawn an agent, stop it, spawn again — verify it resumes the existing session
- [ ] Manual: spawn a fresh agent with no prior session — verify normal fresh spawn works