### PR TITLE
fix(task): resolve JSON truncation at 8KB + honor --project with --all

### DIFF
--- a/src/lib/task-service.test.ts
+++ b/src/lib/task-service.test.ts
@@ -1099,6 +1099,39 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
       await sql`DELETE FROM tasks WHERE repo_path = ${autoRepo}`;
       await sql`DELETE FROM projects WHERE repo_path = ${autoRepo}`;
     });
+
+    it('should honor projectName filter even when allProjects is true (#971)', async () => {
+      const projNameA = `test-all-proj-a-${Date.now()}`;
+      const projNameB = `test-all-proj-b-${Date.now()}`;
+      const repoA = `${REPO}-all-proj-a`;
+      const repoB = `${REPO}-all-proj-b`;
+
+      // Create two projects with tasks
+      const projectA = await createProject({ name: projNameA });
+      const projectB = await createProject({ name: projNameB });
+      await createTask({ title: 'Task in A' }, repoA, projectA.id);
+      await createTask({ title: 'Task in B' }, repoB, projectB.id);
+
+      // allProjects=true + projectName should return ONLY tasks in that project
+      const filtered = await listTasks({ allProjects: true, projectName: projNameA });
+      expect(filtered.length).toBeGreaterThanOrEqual(1);
+      for (const t of filtered) {
+        expect(t.projectId).toBe(projectA.id);
+      }
+
+      // Same for listTasksForActor
+      await assignTask(filtered[0].id, actor, 'assignee', {}, repoA);
+      const actorFiltered = await listTasksForActor(actor, { allProjects: true, projectName: projNameA });
+      expect(actorFiltered.length).toBeGreaterThanOrEqual(1);
+      for (const t of actorFiltered) {
+        expect(t.projectId).toBe(projectA.id);
+      }
+
+      // Cleanup
+      await sql`DELETE FROM task_actors WHERE task_id = ${filtered[0].id}`;
+      await sql`DELETE FROM tasks WHERE repo_path IN (${repoA}, ${repoB})`;
+      await sql`DELETE FROM projects WHERE name IN (${projNameA}, ${projNameB})`;
+    });
   });
 
   // ============================================================================

--- a/src/lib/task-service.ts
+++ b/src/lib/task-service.ts
@@ -643,11 +643,12 @@ export async function getTask(idOrSeq: string, repoPath?: string): Promise<TaskR
 /** Build scope conditions for task listing (project/repo/all). */
 function buildScopeConditions(filters: TaskFilters, conditions: string[], values: unknown[], startIdx: number): number {
   let paramIdx = startIdx;
-  if (filters.allProjects) {
-    // No repo scoping — show all projects
-  } else if (filters.projectName) {
+  if (filters.projectName) {
+    // Explicit project filter always applies (even with --all)
     conditions.push(`project_id = (SELECT id FROM projects WHERE name = $${paramIdx++})`);
     values.push(filters.projectName);
+  } else if (filters.allProjects) {
+    // No repo scoping — show all projects
   } else {
     conditions.push(`repo_path = $${paramIdx++}`);
     values.push(filters.repoPath ?? getRepoPath());
@@ -1816,11 +1817,12 @@ export async function listTasksForActor(actor: Actor, filters: TaskFilters = {})
   let paramIdx = 1;
 
   // Scope conditions (project/repo/all) — mirrors buildScopeConditions with t. prefix
-  if (filters.allProjects) {
-    // No repo scoping — show all projects
-  } else if (filters.projectName) {
+  if (filters.projectName) {
+    // Explicit project filter always applies (even with --all)
     conditions.push(`t.project_id = (SELECT id FROM projects WHERE name = $${paramIdx++})`);
     values.push(filters.projectName);
+  } else if (filters.allProjects) {
+    // No repo scoping — show all projects
   } else {
     conditions.push(`t.repo_path = $${paramIdx++}`);
     values.push(filters.repoPath ?? getRepoPath());

--- a/src/term-commands/task.ts
+++ b/src/term-commands/task.ts
@@ -513,7 +513,8 @@ export function registerTaskCommands(program: Command): void {
     }
 
     if (options.json) {
-      console.log(JSON.stringify(tasks, null, 2));
+      const indent = process.stdout.isTTY ? 2 : 0;
+      process.stdout.write(`${JSON.stringify(tasks, null, indent)}\n`);
       return;
     }
 


### PR DESCRIPTION
## Summary
- Fix `genie task list --json` output truncation at 8KB by using `process.stdout.write()` instead of `console.log()` which has a buffer limit when piped
- Fix `--project` filter being ignored when `--all` is also passed — reorder condition checks so explicit project filter always takes priority

Closes #971