### PR TITLE
fix(tmux): enable OSC 52 clipboard passthrough in nested tmux layers

### DIFF
--- a/scripts/tmux/genie.tmux.conf
+++ b/scripts/tmux/genie.tmux.conf
@@ -18,7 +18,9 @@ set -g renumber-windows on
 set -g history-limit 50000
 set -g escape-time 0
 set -g focus-events on
-set -g set-clipboard on
+set -g set-clipboard external
+set -g allow-passthrough on
+set -ga terminal-overrides ",*:Ms=\\E]52;c;%p2%s\\7"
 
 # --- Mouse & vi mode ---
 set -g mouse on
@@ -97,9 +99,11 @@ bind r source-file ~/.tmux.conf \; display-message "Config reloaded"
 # Ctrl+T — new tab in current session
 bind -n C-t new-window -c "#{?session_path,#{session_path},#{pane_current_path}}"
 
-# Vi copy mode bindings
+# Vi copy mode bindings — pipe to osc52-copy.sh for clipboard over SSH
 bind -T copy-mode-vi v send-keys -X begin-selection
-bind -T copy-mode-vi y send-keys -X copy-selection-and-cancel
+bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "~/.genie/osc52-copy.sh"
+bind -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "~/.genie/osc52-copy.sh"
+bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "~/.genie/osc52-copy.sh"
 
 # Session switching — Alt+[ / Alt+] cycle sessions (works in all terminals)
 bind -n M-] switch-client -n

--- a/scripts/tmux/osc52-copy.sh
+++ b/scripts/tmux/osc52-copy.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# osc52-copy.sh — Write OSC 52 clipboard sequence directly to the SSH PTY,
+# bypassing nested tmux layers that may absorb the sequence.
+set -euo pipefail
+
+buf=$(cat "$@")
+encoded=$(printf '%s' "$buf" | base64 | tr -d '\n')
+seq=$(printf '\033]52;c;%s\a' "$encoded")
+
+# Try writing directly to the SSH connection's PTY
+for tty in $(who -m 2>/dev/null | awk '{print $2}'); do
+  printf '%s' "$seq" > "/dev/$tty" 2>/dev/null || true
+done
+
+# Fallback: emit to stdout (works if tmux allow-passthrough is on)
+printf '%s' "$seq"

--- a/scripts/tmux/tui-tmux.conf
+++ b/scripts/tmux/tui-tmux.conf
@@ -14,7 +14,7 @@ set -g destroy-unattached off
 set -g exit-empty off
 
 # Clipboard
-set -g set-clipboard on
+set -g set-clipboard external
 set -g allow-passthrough on
 set -ga terminal-overrides ",*:Ms=\\E]52;c;%p2%s\\7"
 
@@ -22,9 +22,11 @@ set -ga terminal-overrides ",*:Ms=\\E]52;c;%p2%s\\7"
 set -g mouse on
 setw -g mode-keys vi
 
-# Vi copy mode
+# Vi copy mode — pipe to osc52-copy.sh for clipboard over SSH
 bind -T copy-mode-vi v send-keys -X begin-selection
-bind -T copy-mode-vi y send-keys -X copy-selection-and-cancel
+bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "~/.genie/osc52-copy.sh"
+bind -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "~/.genie/osc52-copy.sh"
+bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "~/.genie/osc52-copy.sh"
 
 # NO status bars, NO pane-border shell probes — TUI renders its own UI
 set -g status off

--- a/src/__tests__/tmux-config.test.ts
+++ b/src/__tests__/tmux-config.test.ts
@@ -1,17 +1,23 @@
 /**
- * Regression tests for genie.tmux.conf
+ * Regression tests for genie.tmux.conf and tui-tmux.conf
  *
  * Ensures status-bar click handling works for both windows (single-click)
  * and sessions (double-click on any status area).
  * See: https://github.com/automagik-dev/genie/issues/784
+ *
+ * Also ensures OSC 52 clipboard passthrough works in nested tmux layers.
+ * See: https://github.com/automagik-dev/genie/issues/967
  */
 
 import { describe, expect, test } from 'bun:test';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const CONF_PATH = resolve(import.meta.dirname, '../../scripts/tmux/genie.tmux.conf');
 const conf = readFileSync(CONF_PATH, 'utf-8');
+
+const TUI_CONF_PATH = resolve(import.meta.dirname, '../../scripts/tmux/tui-tmux.conf');
+const tuiConf = readFileSync(TUI_CONF_PATH, 'utf-8');
 
 /** Return non-comment, non-empty lines that match a pattern. */
 function activeLines(pattern: RegExp): string[] {
@@ -62,5 +68,55 @@ describe('tmux config — status bar click handling', () => {
     expect(activeLines(/DoubleClick1StatusDefault/).length).toBe(1);
     expect(activeLines(/DoubleClick1StatusLeft/).length).toBe(1);
     expect(activeLines(/DoubleClick1StatusRight/).length).toBe(1);
+  });
+});
+
+/** Return non-comment, non-empty lines from a config that match a pattern. */
+function activeLinesIn(config: string, pattern: RegExp): string[] {
+  return config
+    .split('\n')
+    .filter((l) => !l.trimStart().startsWith('#') && l.trim() !== '')
+    .filter((l) => pattern.test(l));
+}
+
+describe('tmux config — OSC 52 clipboard passthrough (#967)', () => {
+  test('genie.tmux.conf uses set-clipboard external (not on)', () => {
+    const hits = activeLinesIn(conf, /set\s+-g\s+set-clipboard\s+external/);
+    expect(hits.length).toBe(1);
+    // Must NOT have "set-clipboard on"
+    const bad = activeLinesIn(conf, /set\s+-g\s+set-clipboard\s+on/);
+    expect(bad.length).toBe(0);
+  });
+
+  test('genie.tmux.conf has allow-passthrough on', () => {
+    const hits = activeLinesIn(conf, /set\s+-g\s+allow-passthrough\s+on/);
+    expect(hits.length).toBe(1);
+  });
+
+  test('genie.tmux.conf has terminal-overrides for Ms (OSC 52)', () => {
+    const hits = activeLinesIn(conf, /terminal-overrides.*Ms=/);
+    expect(hits.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('genie.tmux.conf uses copy-pipe-and-cancel with osc52-copy.sh', () => {
+    const hits = activeLinesIn(conf, /copy-pipe-and-cancel.*osc52-copy\.sh/);
+    expect(hits.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('tui-tmux.conf uses set-clipboard external (not on)', () => {
+    const hits = activeLinesIn(tuiConf, /set\s+-g\s+set-clipboard\s+external/);
+    expect(hits.length).toBe(1);
+    const bad = activeLinesIn(tuiConf, /set\s+-g\s+set-clipboard\s+on/);
+    expect(bad.length).toBe(0);
+  });
+
+  test('tui-tmux.conf uses copy-pipe-and-cancel with osc52-copy.sh', () => {
+    const hits = activeLinesIn(tuiConf, /copy-pipe-and-cancel.*osc52-copy\.sh/);
+    expect(hits.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('osc52-copy.sh helper script exists and is executable', () => {
+    const scriptPath = resolve(import.meta.dirname, '../../scripts/tmux/osc52-copy.sh');
+    expect(existsSync(scriptPath)).toBe(true);
   });
 });

--- a/src/genie-commands/setup.ts
+++ b/src/genie-commands/setup.ts
@@ -431,8 +431,8 @@ export async function setupCommand(options: SetupOptions = {}): Promise<void> {
 
 /** Copy shipped genie.tmux.conf to ~/.genie/tmux.conf if it doesn't exist yet. */
 function installGenieTmuxConf(): void {
-  const { existsSync, copyFileSync, mkdirSync } = require('node:fs') as typeof import('node:fs');
-  const { resolve } = require('node:path') as typeof import('node:path');
+  const { existsSync, copyFileSync, mkdirSync, chmodSync } = require('node:fs') as typeof import('node:fs');
+  const { resolve, dirname } = require('node:path') as typeof import('node:path');
   const genieHome = process.env.GENIE_HOME ?? join(homedir(), '.genie');
   const dest = join(genieHome, 'tmux.conf');
   if (existsSync(dest)) return; // already installed
@@ -451,5 +451,17 @@ function installGenieTmuxConf(): void {
     console.log(`\x1b[32m\u2713\x1b[0m Installed genie tmux config to ${dest}`);
   } catch {
     // non-fatal
+  }
+
+  // Install osc52-copy.sh clipboard helper alongside the tmux config
+  const osc52Src = join(dirname(src), 'osc52-copy.sh');
+  const osc52Dest = join(genieHome, 'osc52-copy.sh');
+  if (existsSync(osc52Src)) {
+    try {
+      copyFileSync(osc52Src, osc52Dest);
+      chmodSync(osc52Dest, 0o755);
+    } catch {
+      // non-fatal
+    }
   }
 }

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -439,6 +439,19 @@ function syncTmuxConf(tmuxScriptsSrc: string): void {
       // Read/write failed — non-fatal
     }
   }
+
+  // Install osc52-copy.sh → ~/.genie/osc52-copy.sh (clipboard helper for nested tmux)
+  const osc52Src = join(tmuxScriptsSrc, 'osc52-copy.sh');
+  const osc52Dest = join(GENIE_HOME, 'osc52-copy.sh');
+  if (existsSync(osc52Src)) {
+    try {
+      copyFileSync(osc52Src, osc52Dest);
+      chmodSync(osc52Dest, 0o755);
+      success(`Installed OSC 52 clipboard helper to ${osc52Dest}`);
+    } catch {
+      // Read/write failed — non-fatal
+    }
+  }
 }
 
 /** Copy tmux scripts from the global package to ~/.genie/scripts/ */


### PR DESCRIPTION
## Summary
- Switch both `genie.tmux.conf` and `tui-tmux.conf` from `set-clipboard on` to `set-clipboard external` so tmux forwards OSC 52 sequences instead of consuming them
- Add `allow-passthrough on` and `Ms` terminal-override to the inner (agent) tmux layer, which was missing both
- Create `osc52-copy.sh` helper script that writes OSC 52 directly to the SSH PTY, bypassing nested tmux absorption
- Replace `copy-selection-and-cancel` with `copy-pipe-and-cancel` bindings piping through `osc52-copy.sh` in both configs
- Update `update.ts` and `setup.ts` to install `osc52-copy.sh` to `~/.genie/` during setup/update

## Root Cause
`set-clipboard on` tells tmux to handle the clipboard internally (via `Ms` capability), which means it **consumes** OSC 52 sequences rather than passing them through to the terminal emulator. In a nested tmux setup (TUI outer layer + agent inner layer), this double-consumption completely prevents clipboard sync from reaching the user's terminal.

## Test plan
- [x] All 1812 existing tests pass (0 regressions)
- [x] 7 new regression tests added in `tmux-config.test.ts` covering all 5 defects
- [x] `bun run build` succeeds
- [x] `bun run check` passes (typecheck + lint + dead-code + tests)

Closes #967