### PR TITLE
fix: preserve model field on agent resume

### DIFF
--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -1516,6 +1516,7 @@ async function buildResumeParams(
     // biome-ignore lint/style/noNonNullAssertion: caller guarantees claudeSessionId exists
     resume: agent.claudeSessionId!,
     name: `${team}-${agentName}`,
+    model: dirEntry?.model,
     systemPromptFile,
     promptMode,
   };


### PR DESCRIPTION
## Summary
- Add `model: dirEntry?.model` to `buildResumeParams()` — agents were losing their configured model on resume, falling back to default

One-liner. Found by Vegapunk/Lilith + Shaka analysis.