### PR TITLE
fix(ci): hardcoded v3 prefix in version and release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,9 @@ jobs:
             echo "Release ${TAG} already exists — deriving hotfix version."
             TODAY=$(date -u +%y%m%d)
             EXISTING=$(gh release list --limit 100 --json tagName \
-              -q "[.[].tagName | select(startswith(\"v3.${TODAY}.\"))] | length")
+              -q "[.[].tagName | select(startswith(\"v4.${TODAY}.\"))] | length")
             BUILD=$((EXISTING + 1))
-            VERSION="3.${TODAY}.${BUILD}"
+            VERSION="4.${TODAY}.${BUILD}"
             echo "Hotfix version: v${VERSION}"
             echo "hotfix=true" >> "$GITHUB_OUTPUT"
           else
@@ -77,7 +77,7 @@ jobs:
         run: |
           TAG="${{ steps.ver.outputs.tag }}"
           if [ -z "$RELEASE_NOTES" ]; then
-            RELEASE_NOTES="Initial release of genie v3 CLI."
+            RELEASE_NOTES="Initial release of genie v4 CLI."
           fi
           printf '%s' "$RELEASE_NOTES" > /tmp/release-notes.md
           if gh release view "${TAG}" > /dev/null 2>&1; then

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -39,14 +39,14 @@ jobs:
           BRANCH="${{ github.event.workflow_run.head_branch || 'dev' }}"
           if [ "$BRANCH" = "main" ]; then
             echo "branch=dev" >> "$GITHUB_OUTPUT"
-            echo "prefix=3" >> "$GITHUB_OUTPUT"
+            echo "prefix=4" >> "$GITHUB_OUTPUT"
             echo "npm_tag=latest" >> "$GITHUB_OUTPUT"
           else
             echo "branch=dev" >> "$GITHUB_OUTPUT"
             echo "prefix=4" >> "$GITHUB_OUTPUT"
             echo "npm_tag=next" >> "$GITHUB_OUTPUT"
           fi
-          echo "Resolved: branch=dev, prefix=$([ "$BRANCH" = "main" ] && echo 3 || echo 4)"
+          echo "Resolved: branch=dev, prefix=4"
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
version.yml used prefix=3 for main branch, prefix=4 for dev. release.yml hotfix path generated v3.YYMMDD.N instead of v4.

This caused v3.260403.1 to be created on top of v4.260402.18 when a direct merge to main triggered the release workflow.

All three v3 references updated to v4:
- version.yml: main branch prefix 3 → 4
- release.yml: hotfix version prefix 3 → 4
- release.yml: fallback release notes "v3" → "v4"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to use v4 versioning scheme for all automated releases and builds, replacing the previous v3 versioning approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->