### PR TITLE
feat(brain): add update, version commands and auto-check hint

### DIFF
--- a/src/term-commands/brain.test.ts
+++ b/src/term-commands/brain.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { checkForUpdates } from './brain.js';
+
+/**
+ * Tests for the cache-only checkForUpdates function.
+ *
+ * checkForUpdates reads ~/.genie/brain-version-check.json synchronously.
+ * It never makes network calls and never throws.
+ *
+ * We test it by writing/removing a temp cache file and overriding CACHE_PATH
+ * is not possible (module-level const), so we test the exported function
+ * against the real cache path. We save/restore the file around the tests.
+ */
+
+// The real cache path is ~/.genie/brain-version-check.json
+// We test the function's behavior with various cache states.
+// Since we can't easily override the const, we test the contract:
+// - Returns { updateAvailable: false } when cache doesn't exist or is invalid
+// - Returns { updateAvailable: true, latestVersion } when cache says so
+
+describe('checkForUpdates', () => {
+  const realCachePath = join(process.env.HOME ?? '/tmp', '.genie', 'brain-version-check.json');
+  let savedCache: string | null = null;
+
+  beforeEach(() => {
+    // Save existing cache if any
+    try {
+      const { readFileSync } = require('node:fs');
+      savedCache = readFileSync(realCachePath, 'utf-8');
+    } catch {
+      savedCache = null;
+    }
+  });
+
+  afterEach(() => {
+    // Restore original cache
+    if (savedCache !== null) {
+      writeFileSync(realCachePath, savedCache);
+    } else {
+      try {
+        rmSync(realCachePath);
+      } catch {
+        /* didn't exist */
+      }
+    }
+  });
+
+  test('returns updateAvailable false when cache does not exist', () => {
+    try {
+      rmSync(realCachePath);
+    } catch {
+      /* ok */
+    }
+    const result = checkForUpdates();
+    expect(result).toEqual({ updateAvailable: false });
+  });
+
+  test('returns updateAvailable true when cache says so', () => {
+    mkdirSync(join(process.env.HOME ?? '/tmp', '.genie'), { recursive: true });
+    writeFileSync(
+      realCachePath,
+      JSON.stringify({
+        checkedAt: new Date().toISOString(),
+        localVersion: '1.260401.1',
+        latestTag: 'v0.260403.2',
+        latestVersion: '0.260403.2',
+        updateAvailable: true,
+      }),
+    );
+    const result = checkForUpdates();
+    expect(result).toEqual({ updateAvailable: true, latestVersion: '0.260403.2' });
+  });
+
+  test('returns updateAvailable false when cache says no update', () => {
+    mkdirSync(join(process.env.HOME ?? '/tmp', '.genie'), { recursive: true });
+    writeFileSync(
+      realCachePath,
+      JSON.stringify({
+        checkedAt: new Date().toISOString(),
+        localVersion: '1.260403.2',
+        latestTag: 'v0.260403.2',
+        latestVersion: '0.260403.2',
+        updateAvailable: false,
+      }),
+    );
+    const result = checkForUpdates();
+    expect(result).toEqual({ updateAvailable: false });
+  });
+
+  test('returns updateAvailable false when cache is invalid JSON', () => {
+    mkdirSync(join(process.env.HOME ?? '/tmp', '.genie'), { recursive: true });
+    writeFileSync(realCachePath, 'not valid json{{{');
+    const result = checkForUpdates();
+    expect(result).toEqual({ updateAvailable: false });
+  });
+
+  test('never throws regardless of cache content', () => {
+    mkdirSync(join(process.env.HOME ?? '/tmp', '.genie'), { recursive: true });
+    writeFileSync(realCachePath, JSON.stringify({ random: 'garbage', updateAvailable: 'yes' }));
+    // Should not throw
+    const result = checkForUpdates();
+    // updateAvailable is string 'yes' which is truthy but latestVersion is undefined
+    // so it should return updateAvailable: false
+    expect(result.updateAvailable).toBe(false);
+  });
+});

--- a/src/term-commands/brain.test.ts
+++ b/src/term-commands/brain.test.ts
@@ -1,66 +1,53 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { checkForUpdates } from './brain.js';
 
 /**
  * Tests for the cache-only checkForUpdates function.
  *
- * checkForUpdates reads ~/.genie/brain-version-check.json synchronously.
+ * checkForUpdates reads a JSON cache file synchronously.
  * It never makes network calls and never throws.
  *
- * We test it by writing/removing a temp cache file and overriding CACHE_PATH
- * is not possible (module-level const), so we test the exported function
- * against the real cache path. We save/restore the file around the tests.
+ * We use a temp directory so tests never touch the real ~/.genie/
+ * and work in CI without permission issues.
  */
 
-// The real cache path is ~/.genie/brain-version-check.json
-// We test the function's behavior with various cache states.
-// Since we can't easily override the const, we test the contract:
-// - Returns { updateAvailable: false } when cache doesn't exist or is invalid
-// - Returns { updateAvailable: true, latestVersion } when cache says so
-
 describe('checkForUpdates', () => {
-  const realCachePath = join(process.env.HOME ?? '/tmp', '.genie', 'brain-version-check.json');
-  let savedCache: string | null = null;
+  let tempDir: string;
+  let cachePath: string;
 
-  beforeEach(() => {
-    // Save existing cache if any
+  beforeAll(() => {
+    tempDir = join(tmpdir(), `brain-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    cachePath = join(tempDir, 'brain-version-check.json');
+  });
+
+  afterAll(() => {
     try {
-      const { readFileSync } = require('node:fs');
-      savedCache = readFileSync(realCachePath, 'utf-8');
+      rmSync(tempDir, { recursive: true, force: true });
     } catch {
-      savedCache = null;
+      /* best effort */
     }
   });
 
-  afterEach(() => {
-    // Restore original cache
-    if (savedCache !== null) {
-      writeFileSync(realCachePath, savedCache);
-    } else {
-      try {
-        rmSync(realCachePath);
-      } catch {
-        /* didn't exist */
-      }
+  beforeEach(() => {
+    try {
+      rmSync(cachePath);
+    } catch {
+      /* ok */
     }
   });
 
   test('returns updateAvailable false when cache does not exist', () => {
-    try {
-      rmSync(realCachePath);
-    } catch {
-      /* ok */
-    }
-    const result = checkForUpdates();
+    const result = checkForUpdates(cachePath);
     expect(result).toEqual({ updateAvailable: false });
   });
 
   test('returns updateAvailable true when cache says so', () => {
-    mkdirSync(join(process.env.HOME ?? '/tmp', '.genie'), { recursive: true });
     writeFileSync(
-      realCachePath,
+      cachePath,
       JSON.stringify({
         checkedAt: new Date().toISOString(),
         localVersion: '1.260401.1',
@@ -69,14 +56,13 @@ describe('checkForUpdates', () => {
         updateAvailable: true,
       }),
     );
-    const result = checkForUpdates();
+    const result = checkForUpdates(cachePath);
     expect(result).toEqual({ updateAvailable: true, latestVersion: '0.260403.2' });
   });
 
   test('returns updateAvailable false when cache says no update', () => {
-    mkdirSync(join(process.env.HOME ?? '/tmp', '.genie'), { recursive: true });
     writeFileSync(
-      realCachePath,
+      cachePath,
       JSON.stringify({
         checkedAt: new Date().toISOString(),
         localVersion: '1.260403.2',
@@ -85,24 +71,20 @@ describe('checkForUpdates', () => {
         updateAvailable: false,
       }),
     );
-    const result = checkForUpdates();
+    const result = checkForUpdates(cachePath);
     expect(result).toEqual({ updateAvailable: false });
   });
 
   test('returns updateAvailable false when cache is invalid JSON', () => {
-    mkdirSync(join(process.env.HOME ?? '/tmp', '.genie'), { recursive: true });
-    writeFileSync(realCachePath, 'not valid json{{{');
-    const result = checkForUpdates();
+    writeFileSync(cachePath, 'not valid json{{{');
+    const result = checkForUpdates(cachePath);
     expect(result).toEqual({ updateAvailable: false });
   });
 
   test('never throws regardless of cache content', () => {
-    mkdirSync(join(process.env.HOME ?? '/tmp', '.genie'), { recursive: true });
-    writeFileSync(realCachePath, JSON.stringify({ random: 'garbage', updateAvailable: 'yes' }));
-    // Should not throw
-    const result = checkForUpdates();
+    writeFileSync(cachePath, JSON.stringify({ random: 'garbage', updateAvailable: 'yes' }));
     // updateAvailable is string 'yes' which is truthy but latestVersion is undefined
-    // so it should return updateAvailable: false
+    const result = checkForUpdates(cachePath);
     expect(result.updateAvailable).toBe(false);
   });
 });

--- a/src/term-commands/brain.ts
+++ b/src/term-commands/brain.ts
@@ -39,10 +39,11 @@ interface UpdateCheck {
   latestVersion?: string;
 }
 
-export function checkForUpdates(): UpdateCheck {
+export function checkForUpdates(cachePath?: string): UpdateCheck {
   try {
-    if (!existsSync(CACHE_PATH)) return { updateAvailable: false };
-    const cache = JSON.parse(readFileSync(CACHE_PATH, 'utf-8'));
+    const p = cachePath ?? CACHE_PATH;
+    if (!existsSync(p)) return { updateAvailable: false };
+    const cache = JSON.parse(readFileSync(p, 'utf-8'));
     if (cache.updateAvailable && cache.latestVersion) {
       return { updateAvailable: true, latestVersion: cache.latestVersion };
     }

--- a/src/term-commands/brain.ts
+++ b/src/term-commands/brain.ts
@@ -10,10 +10,181 @@
  */
 
 import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import type { Command } from 'commander';
 
 const BRAIN_PKG = '@automagik/genie-brain';
 const BRAIN_REPO = 'github:automagik-dev/genie-brain';
+const BRAIN_DIR = 'node_modules/@automagik/genie-brain';
+const CACHE_PATH = join(homedir(), '.genie', 'brain-version-check.json');
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/** Read brain version from its local package.json. Returns undefined on failure. */
+function readLocalBrainVersion(): string | undefined {
+  try {
+    const pkg = JSON.parse(readFileSync(join(BRAIN_DIR, 'package.json'), 'utf-8'));
+    return (pkg.version as string | undefined) ?? 'unknown';
+  } catch {
+    return undefined;
+  }
+}
+
+// ── Cache-only update check (no network, sync, never throws) ──────────────
+
+interface UpdateCheck {
+  updateAvailable: boolean;
+  latestVersion?: string;
+}
+
+export function checkForUpdates(): UpdateCheck {
+  try {
+    if (!existsSync(CACHE_PATH)) return { updateAvailable: false };
+    const cache = JSON.parse(readFileSync(CACHE_PATH, 'utf-8'));
+    if (cache.updateAvailable && cache.latestVersion) {
+      return { updateAvailable: true, latestVersion: cache.latestVersion };
+    }
+    return { updateAvailable: false };
+  } catch {
+    return { updateAvailable: false };
+  }
+}
+
+// ── Refresh version cache (called by update and version commands) ──────────
+
+function refreshVersionCache(localVersion?: string): void {
+  try {
+    if (!existsSync(join(BRAIN_DIR, '.git'))) return;
+
+    // Resolve local version from param or package.json
+    const version = localVersion ?? readLocalBrainVersion();
+    if (!version) return;
+
+    // Fetch latest tags from remote
+    execSync(`git -C "${BRAIN_DIR}" fetch origin --tags`, { stdio: 'pipe' });
+
+    // Find latest v0.* tag via version sort
+    const tagsOutput = execSync(`git -C "${BRAIN_DIR}" tag -l "v0.*" --sort=-version:refname`, {
+      encoding: 'utf-8',
+    });
+    const latestTag = tagsOutput.trim().split('\n')[0] ?? '';
+    const latestVersion = latestTag.replace(/^v/, '');
+
+    // Compare: strip prefix digit for comparison (dev uses 1.x, main uses 0.x)
+    const localCore = version.replace(/^\d+\./, '');
+    const latestCore = latestVersion.replace(/^\d+\./, '');
+    const updateAvailable = latestCore > localCore;
+
+    // Write cache
+    const cacheDir = join(homedir(), '.genie');
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(
+      CACHE_PATH,
+      JSON.stringify(
+        {
+          checkedAt: new Date().toISOString(),
+          localVersion: version,
+          latestTag,
+          latestVersion,
+          updateAvailable,
+        },
+        null,
+        2,
+      ),
+    );
+  } catch {
+    // Never throw — cache refresh is best-effort
+  }
+}
+
+// ── Update brain from GitHub ───────────────────────────────────────────────
+
+async function updateBrain(): Promise<boolean> {
+  // Check brain is installed (has .git dir from clone)
+  if (!existsSync(join(BRAIN_DIR, '.git'))) {
+    console.log('  Brain is not installed. Run: genie brain install');
+    return false;
+  }
+
+  // Get old version before pull
+  let oldVersion = 'unknown';
+  try {
+    const brain = await import(BRAIN_PKG);
+    oldVersion = brain.getVersion?.() ?? 'unknown';
+  } catch {
+    /* ok */
+  }
+
+  console.log('  Updating brain from GitHub...');
+
+  // git pull origin main
+  execSync(`git -C "${BRAIN_DIR}" pull origin main`, { stdio: 'inherit' });
+
+  // Rebuild
+  execSync('bun install', { cwd: BRAIN_DIR, stdio: 'inherit' });
+  execSync('bun run build', { cwd: BRAIN_DIR, stdio: 'inherit' });
+
+  // Get new version (read from package.json since module cache won't refresh)
+  let newVersion = 'unknown';
+  try {
+    const pkg = JSON.parse(readFileSync(join(BRAIN_DIR, 'package.json'), 'utf-8'));
+    newVersion = pkg.version ?? 'unknown';
+  } catch {
+    /* ok */
+  }
+
+  console.log(`\n  Updated: ${oldVersion} → ${newVersion}`);
+
+  // Run migrations (warn on failure, don't abort)
+  try {
+    const brain = await import(BRAIN_PKG);
+    if (brain.runAllMigrations) {
+      await brain.runAllMigrations();
+      console.log('  Migrations applied.');
+    }
+  } catch {
+    console.log('  Migration skipped. Run: genie brain migrate');
+  }
+
+  // Refresh version cache
+  refreshVersionCache(newVersion);
+
+  return true;
+}
+
+// ── Show version ───────────────────────────────────────────────────────────
+
+async function showVersion(): Promise<void> {
+  let localVersion = 'not installed';
+  try {
+    const brain = await import(BRAIN_PKG);
+    localVersion = brain.getVersion?.() ?? brain.VERSION ?? 'unknown';
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (isModuleNotFound(msg)) {
+      console.log('  Brain is not installed. Run: genie brain install');
+      return;
+    }
+  }
+
+  console.log(`  Local:  ${localVersion}`);
+
+  // Force fresh check (does network call via refreshVersionCache)
+  refreshVersionCache(localVersion);
+  const check = checkForUpdates();
+
+  if (check.updateAvailable && check.latestVersion) {
+    console.log(`  Latest: ${check.latestVersion}`);
+    console.log('');
+    console.log('  Update available. Run: genie brain update');
+  } else {
+    console.log('  Status: up to date');
+  }
+}
+
+// ── Install brain ──────────────────────────────────────────────────────────
 
 /** Install brain package directly from GitHub repo */
 async function installBrain(): Promise<boolean> {
@@ -29,24 +200,23 @@ async function installBrain(): Promise<boolean> {
     try {
       execSync('gh auth token', { stdio: 'pipe' });
     } catch {
-      console.error('  ✗ GitHub CLI not authenticated. Run: gh auth login');
+      console.error('  GitHub CLI not authenticated. Run: gh auth login');
       return false;
     }
 
     // Clone brain repo using gh CLI (handles private repos without exposing tokens in process list)
-    const brainDir = 'node_modules/@automagik/genie-brain';
-    execSync(`rm -rf "${brainDir}"`, { stdio: 'pipe' });
+    execSync(`rm -rf "${BRAIN_DIR}"`, { stdio: 'pipe' });
     execSync('mkdir -p node_modules/@automagik', { stdio: 'pipe' });
-    execSync(`gh repo clone automagik-dev/genie-brain "${brainDir}" -- --depth 1`, {
+    execSync(`gh repo clone automagik-dev/genie-brain "${BRAIN_DIR}" -- --depth 1`, {
       stdio: 'inherit',
     });
 
     // Install brain's deps + build
-    execSync('bun install', { cwd: brainDir, stdio: 'inherit' });
-    execSync('bun run build', { cwd: brainDir, stdio: 'inherit' });
+    execSync('bun install', { cwd: BRAIN_DIR, stdio: 'inherit' });
+    execSync('bun run build', { cwd: BRAIN_DIR, stdio: 'inherit' });
 
     console.log('');
-    console.log('  ✓ Brain installed from GitHub.');
+    console.log('  Brain installed from GitHub.');
     console.log('');
 
     // Auto-run migrations
@@ -55,10 +225,10 @@ async function installBrain(): Promise<boolean> {
       if (brain.runAllMigrations) {
         console.log('  Running brain migrations...');
         await brain.runAllMigrations();
-        console.log('  ✓ Brain tables created in Postgres.');
+        console.log('  Brain tables created in Postgres.');
       }
     } catch {
-      console.log('  ⚠ Auto-migration skipped. Run: genie brain migrate');
+      console.log('  Auto-migration skipped. Run: genie brain migrate');
     }
 
     console.log('');
@@ -70,7 +240,7 @@ async function installBrain(): Promise<boolean> {
     const msg = err instanceof Error ? err.message : String(err);
 
     if (msg.includes('Authentication') || msg.includes('permission') || msg.includes('404')) {
-      console.error('  ✗ Access denied. Brain is enterprise-only.');
+      console.error('  Access denied. Brain is enterprise-only.');
       console.log('');
       console.log('  You need:');
       console.log('    1. Membership in the automagik-dev GitHub org');
@@ -80,7 +250,7 @@ async function installBrain(): Promise<boolean> {
       console.log(`    bun add ${BRAIN_REPO}`);
       console.log('');
     } else {
-      console.error(`  ✗ Install failed: ${msg}`);
+      console.error(`  Install failed: ${msg}`);
       console.log('');
       console.log('  Manual install:');
       console.log(`    bun add ${BRAIN_REPO}`);
@@ -92,9 +262,8 @@ async function installBrain(): Promise<boolean> {
 
 function uninstallBrain(): void {
   try {
-    const brainDir = 'node_modules/@automagik/genie-brain';
-    execSync(`rm -rf "${brainDir}"`, { stdio: 'pipe' });
-    console.log('  ✓ Brain uninstalled.');
+    execSync(`rm -rf "${BRAIN_DIR}"`, { stdio: 'pipe' });
+    console.log('  Brain uninstalled.');
   } catch {
     console.error('  Uninstall failed. Manual: rm -rf node_modules/@automagik/genie-brain');
   }
@@ -122,6 +291,12 @@ async function executeBrainCommand(args: string[]): Promise<void> {
     const brain = await import(BRAIN_PKG);
     if (brain.execute) {
       await brain.execute(args);
+
+      // Auto-check hint (cache-only, no network, sync)
+      const check = checkForUpdates();
+      if (check.updateAvailable && check.latestVersion) {
+        console.log(`\n  Update available (${check.latestVersion}). Run: genie brain update`);
+      }
     } else {
       console.error('Brain module loaded but execute() not found.');
       console.error('Update: genie brain install');
@@ -151,6 +326,14 @@ export function registerBrainCommands(program: Command): void {
       }
       if (args[0] === 'uninstall') {
         uninstallBrain();
+        return;
+      }
+      if (args[0] === 'update') {
+        await updateBrain();
+        return;
+      }
+      if (args[0] === 'version') {
+        await showVersion();
         return;
       }
       await executeBrainCommand(args);


### PR DESCRIPTION
## Summary
- Add `genie brain update` command: pulls latest from GitHub, rebuilds, runs migrations, shows version change
- Add `genie brain version` command: shows local version and checks for available updates
- Add cache-only auto-check hint after brain commands when an update is available (no network latency added)
- Add `checkForUpdates()` unit tests covering cache states (missing, valid, invalid JSON, garbage data)

## Test plan
- [x] `bun run check` passes (typecheck + lint + dead-code + 1818 tests)
- [x] `checkForUpdates()` returns correct results for all cache states
- [x] Auto-check reads cache synchronously with no network calls
- [x] Existing commands (`init`, `search`, `health`, etc.) still delegate to brain correctly
- [x] No new dependencies added - only uses node:fs, node:path, node:os, node:child_process