### PR TITLE
fix(council): route spawning through genie tmux topology

### DIFF
--- a/plugins/genie/agents/council--architect/AGENTS.md
+++ b/plugins/genie/agents/council--architect/AGENTS.md
@@ -5,8 +5,7 @@ model: haiku
 provider: claude
 color: blue
 promptMode: append
-tools: ["Read", "Glob", "Grep"]
-permissionMode: plan
+tools: ["Read", "Glob", "Grep", "Bash"]
 ---
 
 @SOUL.md

--- a/plugins/genie/agents/council--benchmarker/AGENTS.md
+++ b/plugins/genie/agents/council--benchmarker/AGENTS.md
@@ -5,8 +5,7 @@ model: haiku
 provider: claude
 color: orange
 promptMode: append
-tools: ["Read", "Glob", "Grep"]
-permissionMode: plan
+tools: ["Read", "Glob", "Grep", "Bash"]
 ---
 
 @SOUL.md

--- a/plugins/genie/agents/council--deployer/AGENTS.md
+++ b/plugins/genie/agents/council--deployer/AGENTS.md
@@ -5,8 +5,7 @@ model: haiku
 provider: claude
 color: green
 promptMode: append
-tools: ["Read", "Glob", "Grep"]
-permissionMode: plan
+tools: ["Read", "Glob", "Grep", "Bash"]
 ---
 
 @SOUL.md

--- a/plugins/genie/agents/council--ergonomist/AGENTS.md
+++ b/plugins/genie/agents/council--ergonomist/AGENTS.md
@@ -5,8 +5,7 @@ model: haiku
 provider: claude
 color: cyan
 promptMode: append
-tools: ["Read", "Glob", "Grep"]
-permissionMode: plan
+tools: ["Read", "Glob", "Grep", "Bash"]
 ---
 
 @SOUL.md

--- a/plugins/genie/agents/council--measurer/AGENTS.md
+++ b/plugins/genie/agents/council--measurer/AGENTS.md
@@ -5,8 +5,7 @@ model: haiku
 provider: claude
 color: yellow
 promptMode: append
-tools: ["Read", "Glob", "Grep"]
-permissionMode: plan
+tools: ["Read", "Glob", "Grep", "Bash"]
 ---
 
 @SOUL.md

--- a/plugins/genie/agents/council--operator/AGENTS.md
+++ b/plugins/genie/agents/council--operator/AGENTS.md
@@ -5,8 +5,7 @@ model: haiku
 provider: claude
 color: red
 promptMode: append
-tools: ["Read", "Glob", "Grep"]
-permissionMode: plan
+tools: ["Read", "Glob", "Grep", "Bash"]
 ---
 
 @SOUL.md

--- a/plugins/genie/agents/council--questioner/AGENTS.md
+++ b/plugins/genie/agents/council--questioner/AGENTS.md
@@ -5,8 +5,7 @@ model: haiku
 provider: claude
 color: magenta
 promptMode: append
-tools: ["Read", "Glob", "Grep"]
-permissionMode: plan
+tools: ["Read", "Glob", "Grep", "Bash"]
 ---
 
 @SOUL.md

--- a/plugins/genie/agents/council--sentinel/AGENTS.md
+++ b/plugins/genie/agents/council--sentinel/AGENTS.md
@@ -5,8 +5,7 @@ model: haiku
 provider: claude
 color: red
 promptMode: append
-tools: ["Read", "Glob", "Grep"]
-permissionMode: plan
+tools: ["Read", "Glob", "Grep", "Bash"]
 ---
 
 @SOUL.md

--- a/plugins/genie/agents/council--simplifier/AGENTS.md
+++ b/plugins/genie/agents/council--simplifier/AGENTS.md
@@ -5,8 +5,7 @@ model: haiku
 provider: claude
 color: green
 promptMode: append
-tools: ["Read", "Glob", "Grep"]
-permissionMode: plan
+tools: ["Read", "Glob", "Grep", "Bash"]
 ---
 
 @SOUL.md

--- a/plugins/genie/agents/council--tracer/AGENTS.md
+++ b/plugins/genie/agents/council--tracer/AGENTS.md
@@ -5,8 +5,7 @@ model: haiku
 provider: claude
 color: cyan
 promptMode: append
-tools: ["Read", "Glob", "Grep"]
-permissionMode: plan
+tools: ["Read", "Glob", "Grep", "Bash"]
 ---
 
 @SOUL.md

--- a/plugins/genie/agents/council/AGENTS.md
+++ b/plugins/genie/agents/council/AGENTS.md
@@ -5,8 +5,7 @@ model: haiku
 provider: claude
 color: purple
 promptMode: append
-tools: ["Read", "Glob", "Grep"]
-permissionMode: plan
+tools: ["Read", "Glob", "Grep", "Bash"]
 ---
 
 @SOUL.md
@@ -16,6 +15,32 @@ Orchestrate real multi-agent deliberation by spawning council members via genie 
 
 Architectural decisions are expensive to reverse. Shallow review misses failure modes. Real multi-agent deliberation with distinct reasoning chains catches what single viewpoints miss.
 </mission>
+
+<spawning>
+Council members MUST be spawned via `genie spawn` — this routes through genie's tmux topology management and places members in the correct session/window.
+
+**Spawn each selected member:**
+```bash
+genie spawn council--<member> --team $GENIE_TEAM
+```
+
+**NEVER use the Agent tool to spawn council members.** The Agent tool creates a separate tmux session, breaking the session topology. All spawning goes through `genie spawn`.
+
+**Post topic to team chat after spawning:**
+```bash
+genie broadcast "COUNCIL TOPIC: <topic>" --team $GENIE_TEAM
+```
+
+**Send instructions to members:**
+```bash
+genie send "<instructions>" --to council--<member> --team $GENIE_TEAM
+```
+
+**Read team chat for responses:**
+```bash
+genie chat read <convId>
+```
+</spawning>
 
 <routing>
 Not every topic needs all 10 perspectives. Route based on topic:
@@ -70,4 +95,6 @@ The council produces a structured report with:
 - Always synthesize — raw perspectives without interpretation are not useful
 - No voting — no APPROVE/REJECT/MODIFY verdicts. The council thinks; `/review` judges.
 - Dissent is preserved — minority views are captured, never suppressed
+- **NEVER use the Agent tool to spawn members** — always `genie spawn`
+- **NEVER create teams** — use the team you were spawned into (`$GENIE_TEAM`)
 </constraints>


### PR DESCRIPTION
## Summary

- **Council orchestrator** AGENTS.md had `tools: ["Read", "Glob", "Grep"]` — no Bash, so it couldn't run `genie spawn` and fell back to CC's native Agent tool, which creates a separate tmux session for members
- **All 10 council members** had the same limitation — couldn't run `genie chat send/read` despite their `<deliberation>` sections requiring it
- Added `Bash` to all 11 council agent definitions
- Added explicit `<spawning>` section to council orchestrator with `genie spawn` instructions and constraint to never use the Agent tool for member spawning
- Removed `permissionMode: plan` from members so they can execute genie chat commands autonomously

## Root Cause

When spawned as a CC agent (via Agent tool), the council orchestrator had no Bash tool. The only available spawning mechanism was CC's native Agent tool, which uses `--team-name` to create a **new tmux session** — completely bypassing genie's `resolveSpawnTeamWindow → ensureTeamWindow` topology management.

The SKILL.md already had the correct architecture (`genie spawn council--<member> --team <team> --session <team>`), but the AGENTS.md was disconnected from it.

## Test plan

- [x] All 1818 tests pass
- [x] Typecheck, lint, dead-code clean
- [ ] Spawn a council from a project session and verify members land in the same tmux session (not a separate one)
- [ ] Verify council members can run `genie chat send/read` during deliberation