### PR TITLE
fix(spawn): remove --session <team> override that breaks tmux topology

### DIFF
--- a/plugins/genie/agents/team-lead/AGENTS.md
+++ b/plugins/genie/agents/team-lead/AGENTS.md
@@ -118,6 +118,7 @@ Specialist spawns are ADDITIONS to the default flow (except refactor replacing e
 - NEVER write code. `genie work` dispatches engineers who write code.
 - NEVER push to main or master.
 - NEVER use the Agent tool — use `genie work` to dispatch.
+- NEVER pass `--session` to `genie spawn` — the team config resolves the correct tmux session automatically. Passing `--session <team>` creates a separate session, breaking topology.
 - NEVER poll faster than every 60 seconds. Always `sleep 60` before `genie status`.
 - NEVER run more than 10 status checks per wave without progress.
 - If `genie status` returns "No state found" → run `genie work <slug>` immediately.

--- a/plugins/genie/rules/genie-orchestration.md
+++ b/plugins/genie/rules/genie-orchestration.md
@@ -19,6 +19,20 @@ genie ls --json                                        # Agent state from PG
 NEVER use `Agent` to spawn agents — use `genie spawn` instead.
 NEVER use `TeamCreate` or `TeamDelete` — use `genie team create` / `genie team disband` instead.
 
+## Spawn Session Rule
+
+NEVER pass `--session <team-name>` to `genie spawn`. The team config already stores the correct `tmuxSessionName` (resolved at team creation from the parent session). Passing `--session` overrides this and creates a separate tmux session, breaking the topology.
+
+```bash
+# WRONG — creates separate session
+genie spawn reviewer --team my-team --session my-team
+
+# CORRECT — uses team's configured session
+genie spawn reviewer --team my-team
+```
+
+The `--session` flag is for rare manual overrides only. When `--team` is set, let genie resolve the session from the team config.
+
 ## Post-Dispatch Monitoring
 
 After `genie team create` or `genie spawn`, use ONLY structured primitives. A hook enforces this automatically.

--- a/skills/council/SKILL.md
+++ b/skills/council/SKILL.md
@@ -69,7 +69,7 @@ Execute all phases sequentially. YOU run every command, read every output, and m
 Spawn each selected member. Use the double-dash naming convention (`council--<member>`):
 
 ```bash
-genie spawn council--<member> --team <team> --session <team>
+genie spawn council--<member> --team <team>
 ```
 
 Run spawn commands in parallel (multiple Bash calls in one message). Read the output of each. If a spawn fails, note it and continue -- proceed as long as at least 2 members spawned successfully. If fewer than 2 succeed, clean up and report failure.

--- a/skills/council/members/config.md
+++ b/skills/council/members/config.md
@@ -23,7 +23,7 @@ Override per-session at spawn time:
 
 ```bash
 # Use codex/o3 for the architect
-genie spawn council--architect --team <team> --session <team> --provider codex --model o3
+genie spawn council--architect --team <team> --provider codex --model o3
 
 # Use haiku for all members (faster, cheaper)
 # Pass --model haiku to the dispatch script


### PR DESCRIPTION
## Summary

- Remove `--session <team>` from council SKILL.md spawn commands — this overrides `resolveSpawnTeamWindow` (agents.ts:693) and creates a separate tmux session instead of using the team's configured parent session
- Add "Spawn Session Rule" to genie-orchestration.md — agents must never pass `--session` when `--team` is set
- Add `--session` prohibition to team-lead constraints — prevents AI from hallucinating `--session <team>` on spawn commands

## Root cause

`resolveSpawnTeamWindow` checks `sessionOverride` first (line 693). When `--session review-waves` is passed, it skips the team config lookup entirely and creates/uses a session called `review-waves` — a separate session from the parent project.

Without `--session`, line 695 reads `teamConfig.tmuxSessionName` which was correctly set at team creation time from the parent session.

## Test plan

- [x] 1818 tests pass
- [x] Typecheck, lint, dead-code clean
- [ ] Verify workers land in parent session when spawned with `--team` only