### PR TITLE
fix(brain): numeric version comparison + subprocess migrations

### DIFF
--- a/src/term-commands/brain.test.ts
+++ b/src/term-commands/brain.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:tes
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { checkForUpdates } from './brain.js';
+import { checkForUpdates, compareVersions } from './brain.js';
 
 /**
  * Tests for the cache-only checkForUpdates function.
@@ -86,5 +86,35 @@ describe('checkForUpdates', () => {
     // updateAvailable is string 'yes' which is truthy but latestVersion is undefined
     const result = checkForUpdates(cachePath);
     expect(result.updateAvailable).toBe(false);
+  });
+});
+
+describe('compareVersions', () => {
+  test('equal versions return 0', () => {
+    expect(compareVersions('260403.1', '260403.1')).toBe(0);
+  });
+
+  test('a > b returns positive', () => {
+    expect(compareVersions('260403.2', '260403.1')).toBeGreaterThan(0);
+  });
+
+  test('a < b returns negative', () => {
+    expect(compareVersions('260403.1', '260403.2')).toBeLessThan(0);
+  });
+
+  test('handles multi-digit segments correctly (the bug)', () => {
+    // String comparison: "260403.9" > "260403.10" → true (wrong)
+    // Numeric comparison: 9 < 10 → correct
+    expect(compareVersions('260403.10', '260403.9')).toBeGreaterThan(0);
+    expect(compareVersions('260403.9', '260403.10')).toBeLessThan(0);
+  });
+
+  test('handles different segment counts', () => {
+    expect(compareVersions('260403.1.1', '260403.1')).toBeGreaterThan(0);
+    expect(compareVersions('260403', '260403.0')).toBe(0);
+  });
+
+  test('handles major version differences', () => {
+    expect(compareVersions('260404.1', '260403.99')).toBeGreaterThan(0);
   });
 });

--- a/src/term-commands/brain.ts
+++ b/src/term-commands/brain.ts
@@ -20,6 +20,17 @@ const BRAIN_REPO = 'github:automagik-dev/genie-brain';
 const BRAIN_DIR = 'node_modules/@automagik/genie-brain';
 const CACHE_PATH = join(homedir(), '.genie', 'brain-version-check.json');
 
+/** Compare dot-separated version strings numerically (e.g., "260403.9" vs "260403.10"). */
+export function compareVersions(a: string, b: string): number {
+  const partsA = a.split('.').map(Number);
+  const partsB = b.split('.').map(Number);
+  for (let i = 0; i < Math.max(partsA.length, partsB.length); i++) {
+    const diff = (partsA[i] ?? 0) - (partsB[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
 // ── Helpers ────────────────────────────────────────────────────────────────
 
 /** Read brain version from its local package.json. Returns undefined on failure. */
@@ -76,7 +87,7 @@ function refreshVersionCache(localVersion?: string): void {
     // Compare: strip prefix digit for comparison (dev uses 1.x, main uses 0.x)
     const localCore = version.replace(/^\d+\./, '');
     const latestCore = latestVersion.replace(/^\d+\./, '');
-    const updateAvailable = latestCore > localCore;
+    const updateAvailable = compareVersions(latestCore, localCore) > 0;
 
     // Write cache
     const cacheDir = join(homedir(), '.genie');
@@ -138,13 +149,13 @@ async function updateBrain(): Promise<boolean> {
 
   console.log(`\n  Updated: ${oldVersion} → ${newVersion}`);
 
-  // Run migrations (warn on failure, don't abort)
+  // Run migrations via subprocess — import() cache returns stale pre-update
+  // module, so new migrations would be skipped. A fresh bun process loads
+  // the rebuilt code from disk.
   try {
-    const brain = await import(BRAIN_PKG);
-    if (brain.runAllMigrations) {
-      await brain.runAllMigrations();
-      console.log('  Migrations applied.');
-    }
+    const migrateScript = `const b = require('${BRAIN_PKG}'); if (b.runAllMigrations) b.runAllMigrations().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); }); else process.exit(0);`;
+    execSync(`bun -e "${migrateScript}"`, { cwd: BRAIN_DIR, stdio: 'inherit' });
+    console.log('  Migrations applied.');
   } catch {
     console.log('  Migration skipped. Run: genie brain migrate');
   }


### PR DESCRIPTION
## Summary

Two bugs found during /review of PR #1010 (dev→main):

### 1. [HIGH] Module cache — migrations run stale code
`await import('@automagik/genie-brain')` after git pull + rebuild returns the **cached pre-update module**. New migrations from the pulled version are silently skipped.

**Fix:** Run migrations via `bun -e` subprocess which loads the rebuilt code from disk, bypassing the import cache.

### 2. [MEDIUM] Lexicographic version comparison
`latestCore > localCore` is string comparison. `"260403.9" > "260403.10"` → `true` (wrong, because `"9" > "1"`).

**Fix:** Added `compareVersions()` that splits on `.` and compares segments numerically.

## Test plan
- [x] 1824 tests pass (6 new for compareVersions)
- [x] Typecheck, lint, dead-code clean
- [x] Multi-digit segment test: `compareVersions('260403.10', '260403.9') > 0` ✓
- [x] Equal versions: `compareVersions('260403.1', '260403.1') === 0` ✓
- [x] Different segment counts: `compareVersions('260403', '260403.0') === 0` ✓