### PR TITLE
Fix #1004: docs: PG LISTEN/NOTIFY migration should be documented in s...

### DIFF
--- a/src/lib/mailbox.ts
+++ b/src/lib/mailbox.ts
@@ -1,13 +1,30 @@
 /**
  * Mailbox — Durable message store with unread/read semantics.
  *
+ * ## Migration note (commit 44a153a3)
+ *
+ * Previously messages were written to `.genie/mailbox/<worker>.json` files and
+ * delivered by a polling loop that woke up every few seconds to check for new
+ * entries. This introduced latency proportional to the poll interval and made
+ * cross-process coordination fragile.
+ *
+ * The current implementation replaced file-based polling with PostgreSQL:
+ *  - Messages are persisted to the `mailbox` table (durable, queryable).
+ *  - A `AFTER INSERT` trigger fires `pg_notify('genie_mailbox_delivery', …)`
+ *    with payload `<to_worker>:<message_id>`.
+ *  - `subscribeDelivery()` calls `sql.listen('genie_mailbox_delivery', …)` so
+ *    the scheduler daemon receives the notification instantly — no polling.
+ *  - A 30-second fallback poll catches any notifications missed during
+ *    reconnects or daemon restarts.
+ *
+ * `.genie/mailbox/` JSON files are no longer written or read; references to
+ * that path in older docs are outdated.
+ *
  * Messages persist to PostgreSQL `mailbox` table before any push delivery
  * attempt. This ensures durability (DEC-7).
  *
  * Delivery is state-aware: messages are queued and pushed to tmux
  * panes only when the worker is idle (not mid-turn).
- *
- * PG LISTEN/NOTIFY triggers instant delivery notification on new inserts.
  */
 
 import { v4 as uuidv4 } from 'uuid';


### PR DESCRIPTION
Closes #1004

Expands the module-level JSDoc in `src/lib/mailbox.ts` to document the architectural migration from `.genie/mailbox/<worker>.json` file polling to PG LISTEN/NOTIFY that landed in commit `44a153a3`. The previous one-liner (`PG LISTEN/NOTIFY triggers instant delivery notification on new inserts`) was moved and replaced with a full migration note explaining what was replaced, why (polling latency and fragile cross-process coordination), and how the new system works (`AFTER INSERT` trigger fires `pg_notify('genie_mailbox_delivery', <to_worker>:<message_id>)`, consumed by `subscribeDelivery()` via `sql.listen`, with a 30-second fallback poll for reconnect safety).

- `src/lib/mailbox.ts` — module docblock only; no runtime logic touched.

Verified by reviewing the rendered JSDoc output and confirming the comment accurately matches the live implementation of `subscribeDelivery()` and the `mailbox` table trigger.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated mailbox delivery system documentation to reflect the shift from file-based storage to PostgreSQL-backed delivery signaling, including LISTEN/NOTIFY notifications and fallback polling mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->