### PR TITLE
fix(brain): checkout main before pulling in brain update

### DIFF
--- a/src/term-commands/brain.ts
+++ b/src/term-commands/brain.ts
@@ -131,7 +131,9 @@ async function updateBrain(): Promise<boolean> {
 
   console.log('  Updating brain from GitHub...');
 
-  // git pull origin main
+  // Ensure we're on main before pulling — if the clone is on dev,
+  // `git pull origin main` merges main INTO dev, keeping the dev version.
+  execSync(`git -C "${BRAIN_DIR}" checkout main`, { stdio: 'pipe' });
   execSync(`git -C "${BRAIN_DIR}" pull origin main`, { stdio: 'inherit' });
 
   // Rebuild


### PR DESCRIPTION
## Summary
- **Root cause:** `genie brain update` runs `git pull origin main` without first checking out `main`. If the local brain clone is on `dev`, this merges main INTO dev — keeping the dev-prefix version (`1.*`). The version display then shows a wrong transition like `Updated: 0.260403.2 → 1.260403.6`.
- **Fix:** Add `git checkout main` before `git pull origin main` in `updateBrain()`.

## Test plan
- [x] `bun run typecheck` — passes
- [x] `bun run lint` — passes (14 pre-existing warnings, none from this change)
- [x] `bun test` — 1835 tests pass