### PR TITLE
feat(omni-bridge): NATS integration for Omni ↔ Genie messaging

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@tauri-apps/api": "^2.5.0",
         "commander": "^12.1.0",
         "js-yaml": "^4.1.1",
+        "nats": "^2.29.3",
         "pgserve": "^1.1.6",
         "postgres": "^3.4.8",
         "react": "^19.2.4",
@@ -711,6 +712,10 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
+    "nats": ["nats@2.29.3", "", { "dependencies": { "nkeys.js": "1.1.0" } }, "sha512-tOQCRCwC74DgBTk4pWZ9V45sk4d7peoE2njVprMRCBXrhJ5q5cYM7i6W+Uvw2qUrcfOSnuisrX7bEx3b3Wx4QA=="],
+
+    "nkeys.js": ["nkeys.js@1.1.0", "", { "dependencies": { "tweetnacl": "1.0.3" } }, "sha512-tB/a0shZL5UZWSwsoeyqfTszONTt4k2YS0tuQioMOD180+MbombYVgzDUYHlx+gejYK6rgf08n/2Df99WY0Sxg=="],
+
     "node-releases": ["node-releases@2.0.36", "", {}, "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA=="],
 
     "omggif": ["omggif@1.0.10", "", {}, "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="],
@@ -826,6 +831,8 @@
     "token-types": ["token-types@4.2.1", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 

--- a/knip.json
+++ b/knip.json
@@ -18,7 +18,9 @@
     "src/term-commands/task/index.ts",
     "src/term-commands/team/index.ts",
     "src/term-commands/exec/index.ts",
-    "src/term-commands/brief.ts"
+    "src/term-commands/brief.ts",
+    "src/services/omni-reply.ts",
+    "src/services/omni-bridge.ts"
   ],
   "project": ["src/**/*.ts", "src/**/*.tsx"],
   "ignoreBinaries": ["tmux", "which"],

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@tauri-apps/api": "^2.5.0",
     "commander": "^12.1.0",
     "js-yaml": "^4.1.1",
+    "nats": "^2.29.3",
     "pgserve": "^1.1.6",
     "postgres": "^3.4.8",
     "react": "^19.2.4",

--- a/src/genie.ts
+++ b/src/genie.ts
@@ -58,6 +58,7 @@ import { type LogOptions, logCommand } from './term-commands/log.js';
 import { registerMetricsCommands } from './term-commands/metrics.js';
 import { registerSendInboxCommands } from './term-commands/msg.js';
 import { registerNotifyCommands } from './term-commands/notify.js';
+import { registerOmniCommands } from './term-commands/omni.js';
 import * as orchestrateCmd from './term-commands/orchestrate.js';
 import { registerProjectCommands } from './term-commands/project.js';
 import {
@@ -216,6 +217,7 @@ registerImportCommands(program);
 registerTemplateCommands(program);
 registerBrainCommands(program);
 registerBriefCommands(program);
+registerOmniCommands(program);
 
 // ============================================================================
 // CLI audit hooks — record every command execution to audit_events

--- a/src/services/executor.ts
+++ b/src/services/executor.ts
@@ -1,0 +1,74 @@
+/**
+ * IExecutor — Executor interface for the Omni bridge.
+ *
+ * Simpler than the internal ExecutorProvider: this interface is what
+ * the NATS bridge uses to spawn/manage agent sessions per chat.
+ * Claude Code tmux is the first implementation. Claude SDK (1 process,
+ * N chats) is the scaling path.
+ *
+ * The executor is stateless — Genie (omni-bridge) manages session
+ * lifecycle, idle timeouts, and concurrency limits. The executor
+ * just runs agents.
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Opaque session handle returned by spawn(). */
+export interface OmniSession {
+  /** Unique session key (typically `${agentName}:${chatId}`). */
+  id: string;
+  /** Agent name (from genie directory). */
+  agentName: string;
+  /** Chat ID from Omni (WhatsApp thread). */
+  chatId: string;
+  /** Tmux session name hosting this window. */
+  tmuxSession: string;
+  /** Tmux window name. */
+  tmuxWindow: string;
+  /** Tmux pane ID (e.g., "%5"). */
+  paneId: string;
+  /** Timestamp of session creation. */
+  createdAt: number;
+  /** Timestamp of last message delivered. */
+  lastActivityAt: number;
+}
+
+/** Inbound message from Omni via NATS. */
+export interface OmniMessage {
+  content: string;
+  sender: string;
+  /** Omni instance ID. */
+  instanceId: string;
+  /** Chat/thread ID. */
+  chatId: string;
+  /** Agent role to route to. */
+  agent: string;
+  /** ISO timestamp. */
+  timestamp?: string;
+}
+
+// ============================================================================
+// Interface
+// ============================================================================
+
+/**
+ * IExecutor — pluggable executor backend for the Omni bridge.
+ *
+ * Each executor type handles reply routing its own way but always
+ * publishes to `omni.reply.{instance}.{chat_id}`.
+ */
+export interface IExecutor {
+  /** Spawn an agent session for a chat. */
+  spawn(agentName: string, chatId: string, env: Record<string, string>): Promise<OmniSession>;
+
+  /** Deliver a message to an already-running session. */
+  deliver(session: OmniSession, message: OmniMessage): Promise<void>;
+
+  /** Shut down a session (kill tmux window). */
+  shutdown(session: OmniSession): Promise<void>;
+
+  /** Check if a session is still alive. */
+  isAlive(session: OmniSession): Promise<boolean>;
+}

--- a/src/services/executors/claude-code.ts
+++ b/src/services/executors/claude-code.ts
@@ -1,0 +1,234 @@
+/**
+ * ClaudeCodeOmniExecutor — First IExecutor implementation.
+ *
+ * Spawns Claude Code processes in tmux windows (one per chat),
+ * delivers messages via Claude Code's native team inbox, and
+ * injects env vars for NATS reply routing.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { chmodSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import * as directory from '../../lib/agent-directory.js';
+import { shellQuote } from '../../lib/team-lead-command.js';
+import { ensureTeamWindow, executeTmux, isPaneAlive, killWindow } from '../../lib/tmux.js';
+import type { IExecutor, OmniMessage, OmniSession } from '../executor.js';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Sanitize a string for use as a tmux window name. */
+function sanitizeWindowName(chatId: string): string {
+  return chatId.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 40) || 'chat';
+}
+
+/** Path to the omni-reply script installed at spawn time. */
+function getReplyScriptPath(): string {
+  return join(homedir(), '.genie', 'bin', 'omni-reply');
+}
+
+// ============================================================================
+// Implementation
+// ============================================================================
+
+export class ClaudeCodeOmniExecutor implements IExecutor {
+  /**
+   * Spawn a Claude Code process in a tmux window for a specific chat.
+   *
+   * - Resolves agent from genie directory
+   * - Creates tmux window in agent's session
+   * - Starts Claude Code with env vars for NATS reply routing
+   */
+  async spawn(agentName: string, chatId: string, env: Record<string, string>): Promise<OmniSession> {
+    // Resolve agent from directory
+    const resolved = await directory.resolve(agentName);
+    if (!resolved) {
+      throw new Error(`Agent "${agentName}" not found in genie directory`);
+    }
+
+    const entry = resolved.entry;
+    const tmuxSession = agentName;
+    const windowName = sanitizeWindowName(chatId);
+
+    // Ensure the reply script is available
+    ensureReplyScript();
+
+    // Create tmux window
+    const { paneId, created } = await ensureTeamWindow(tmuxSession, windowName, entry.dir);
+
+    if (created) {
+      // Build env vars string for the tmux command
+      const envVars = {
+        ...env,
+        GENIE_OMNI_CHAT_ID: chatId,
+        GENIE_OMNI_AGENT: agentName,
+      };
+
+      const envPrefix = Object.entries(envVars)
+        .map(([k, v]) => `${k}=${shellQuote(v)}`)
+        .join(' ');
+
+      // Build Claude Code command
+      const systemPromptFile = join(entry.dir, 'AGENTS.md');
+      const promptFlag = entry.promptMode === 'system' ? '--system-prompt-file' : '--append-system-prompt-file';
+      const modelFlag = entry.model ? `--model ${shellQuote(entry.model)}` : '';
+      const sessionId = randomUUID();
+
+      const cmd = [
+        envPrefix,
+        'claude',
+        promptFlag,
+        shellQuote(systemPromptFile),
+        modelFlag,
+        '--session-id',
+        shellQuote(sessionId),
+        '--dangerously-skip-permissions',
+      ]
+        .filter(Boolean)
+        .join(' ');
+
+      // Send the command to the pane
+      await executeTmux(`send-keys -t '${paneId}' ${shellQuote(cmd)} Enter`);
+    }
+
+    const now = Date.now();
+    return {
+      id: `${agentName}:${chatId}`,
+      agentName,
+      chatId,
+      tmuxSession,
+      tmuxWindow: windowName,
+      paneId,
+      createdAt: now,
+      lastActivityAt: now,
+    };
+  }
+
+  /**
+   * Deliver a message to a running Claude Code session via native team inbox.
+   *
+   * Writes to ~/.claude/teams/<team>/inboxes/<agent>.json so Claude Code
+   * picks it up natively.
+   */
+  async deliver(session: OmniSession, message: OmniMessage): Promise<void> {
+    const inboxDir = join(
+      process.env.CLAUDE_CONFIG_DIR ?? join(homedir(), '.claude'),
+      'teams',
+      session.tmuxSession,
+      'inboxes',
+    );
+    mkdirSync(inboxDir, { recursive: true });
+
+    const inboxFile = join(inboxDir, `${sanitizeWindowName(session.chatId)}.json`);
+
+    // Read existing messages
+    let messages: { from: string; text: string; summary: string; timestamp: string; read: boolean }[] = [];
+    try {
+      const { readFileSync } = await import('node:fs');
+      messages = JSON.parse(readFileSync(inboxFile, 'utf-8'));
+    } catch {
+      // File doesn't exist or invalid JSON — start fresh
+    }
+
+    // Append new message
+    messages.push({
+      from: message.sender || 'whatsapp-user',
+      text: message.content,
+      summary: message.content.slice(0, 120),
+      timestamp: message.timestamp || new Date().toISOString(),
+      read: false,
+    });
+
+    writeFileSync(inboxFile, JSON.stringify(messages, null, 2));
+    session.lastActivityAt = Date.now();
+  }
+
+  /**
+   * Shut down a session by killing its tmux window.
+   */
+  async shutdown(session: OmniSession): Promise<void> {
+    await killWindow(session.tmuxSession, session.tmuxWindow);
+  }
+
+  /**
+   * Check if a session's tmux pane is still alive.
+   */
+  async isAlive(session: OmniSession): Promise<boolean> {
+    try {
+      return await isPaneAlive(session.paneId);
+    } catch {
+      return false;
+    }
+  }
+}
+
+// ============================================================================
+// Reply Script Management
+// ============================================================================
+
+/**
+ * Ensure the omni-reply bash script exists in ~/.genie/bin/.
+ *
+ * This script is injected into agent's PATH at spawn time. Agents call
+ * `echo 'message' | omni-reply` to publish replies to NATS.
+ */
+function ensureReplyScript(): void {
+  const scriptPath = getReplyScriptPath();
+  const binDir = join(homedir(), '.genie', 'bin');
+
+  if (existsSync(scriptPath)) return;
+
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(
+    scriptPath,
+    `#!/bin/bash
+# omni-reply — Publish agent reply to NATS for Omni delivery.
+# Usage: echo 'message' | omni-reply
+#   or:  omni-reply 'message'
+#
+# Required env vars (injected by genie omni bridge at spawn):
+#   OMNI_REPLY_TOPIC  — e.g., omni.reply.60a466a7.chat123
+#   OMNI_NATS_URL     — e.g., localhost:4222
+
+set -euo pipefail
+
+TOPIC="\${OMNI_REPLY_TOPIC:?OMNI_REPLY_TOPIC not set — are you running inside an omni-bridged agent?}"
+NATS_URL="\${OMNI_NATS_URL:-localhost:4222}"
+
+# Read message from args or stdin
+if [ $# -gt 0 ]; then
+  MSG="$*"
+else
+  MSG=$(cat)
+fi
+
+[ -z "$MSG" ] && exit 0
+
+# Build JSON payload
+PAYLOAD=$(printf '{"content":"%s","agent":"%s","chat_id":"%s","timestamp":"%s"}' \\
+  "$(echo "$MSG" | sed 's/"/\\\\"/g' | tr '\\n' ' ')" \\
+  "\${GENIE_OMNI_AGENT:-unknown}" \\
+  "\${GENIE_OMNI_CHAT_ID:-unknown}" \\
+  "$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)")
+
+# Publish to NATS (try nats CLI first, fall back to nc)
+if command -v nats &>/dev/null; then
+  echo "$PAYLOAD" | nats pub "$TOPIC" --server "$NATS_URL"
+elif command -v natscli &>/dev/null; then
+  echo "$PAYLOAD" | natscli pub "$TOPIC" --server "$NATS_URL"
+else
+  # Fallback: use the genie omni-reply TypeScript publisher
+  SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+  if [ -f "$SCRIPT_DIR/../src/services/omni-reply.ts" ]; then
+    echo "$PAYLOAD" | bun run "$SCRIPT_DIR/../src/services/omni-reply.ts"
+  else
+    echo "[omni-reply] ERROR: nats CLI not found and no fallback available" >&2
+    exit 1
+  fi
+fi
+`,
+  );
+  chmodSync(scriptPath, 0o755);
+}

--- a/src/services/omni-bridge.ts
+++ b/src/services/omni-bridge.ts
@@ -1,0 +1,419 @@
+/**
+ * Omni Bridge — NATS subscriber + router + session manager.
+ *
+ * Subscribes to `omni.message.>` and routes inbound WhatsApp messages
+ * to agent sessions via the IExecutor interface. Manages:
+ *   - Per-chat session lifecycle (spawn/deliver/shutdown)
+ *   - Idle timeout (15min default, configurable)
+ *   - Max concurrency (20 default, configurable)
+ *   - Message buffering during spawn
+ *   - Auto-respawn on window death
+ */
+
+import { type NatsConnection, StringCodec, type Subscription, connect } from 'nats';
+import type { IExecutor, OmniMessage, OmniSession } from './executor.js';
+import { ClaudeCodeOmniExecutor } from './executors/claude-code.js';
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+const DEFAULT_NATS_URL = 'localhost:4222';
+const DEFAULT_IDLE_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
+const DEFAULT_MAX_CONCURRENT = 20;
+const MAX_BUFFER_PER_CHAT = 50;
+const IDLE_CHECK_INTERVAL_MS = 30_000; // Check idle sessions every 30s
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface BridgeConfig {
+  natsUrl?: string;
+  idleTimeoutMs?: number;
+  maxConcurrent?: number;
+}
+
+interface SessionEntry {
+  session: OmniSession;
+  instanceId: string;
+  spawning: boolean;
+  buffer: OmniMessage[];
+  idleTimer: ReturnType<typeof setTimeout> | null;
+}
+
+export interface BridgeStatus {
+  connected: boolean;
+  natsUrl: string;
+  activeSessions: number;
+  maxConcurrent: number;
+  idleTimeoutMs: number;
+  queueDepth: number;
+  sessions: Array<{
+    id: string;
+    agentName: string;
+    chatId: string;
+    instanceId: string;
+    paneId: string;
+    spawning: boolean;
+    idleMs: number;
+    bufferSize: number;
+  }>;
+}
+
+// ============================================================================
+// Singleton Bridge
+// ============================================================================
+
+let bridgeInstance: OmniBridge | null = null;
+
+export function getBridge(): OmniBridge | null {
+  return bridgeInstance;
+}
+
+// ============================================================================
+// Bridge
+// ============================================================================
+
+export class OmniBridge {
+  private nc: NatsConnection | null = null;
+  private sub: Subscription | null = null;
+  private executor: IExecutor;
+  private sessions = new Map<string, SessionEntry>();
+  private messageQueue: OmniMessage[] = [];
+  private idleCheckTimer: ReturnType<typeof setInterval> | null = null;
+  private sc = StringCodec();
+
+  readonly natsUrl: string;
+  readonly idleTimeoutMs: number;
+  readonly maxConcurrent: number;
+
+  constructor(config: BridgeConfig = {}) {
+    this.natsUrl = config.natsUrl ?? process.env.GENIE_NATS_URL ?? DEFAULT_NATS_URL;
+    this.idleTimeoutMs =
+      config.idleTimeoutMs ??
+      (process.env.GENIE_IDLE_TIMEOUT_MS ? Number(process.env.GENIE_IDLE_TIMEOUT_MS) : DEFAULT_IDLE_TIMEOUT_MS);
+    this.maxConcurrent =
+      config.maxConcurrent ??
+      (process.env.GENIE_MAX_CONCURRENT ? Number(process.env.GENIE_MAX_CONCURRENT) : DEFAULT_MAX_CONCURRENT);
+    this.executor = new ClaudeCodeOmniExecutor();
+  }
+
+  /**
+   * Start the bridge: connect to NATS and subscribe to omni.message.>
+   */
+  async start(): Promise<void> {
+    if (this.nc) {
+      console.log('[omni-bridge] Already running');
+      return;
+    }
+
+    console.log(`[omni-bridge] Connecting to NATS at ${this.natsUrl}...`);
+
+    this.nc = await connect({
+      servers: this.natsUrl,
+      name: 'genie-omni-bridge',
+      reconnect: true,
+      maxReconnectAttempts: -1, // Unlimited reconnects
+      reconnectTimeWait: 2000,
+    });
+
+    console.log('[omni-bridge] Connected to NATS');
+
+    // Subscribe to all omni messages
+    this.sub = this.nc.subscribe('omni.message.>');
+    this.processSubscription();
+
+    // Start idle session checker
+    this.idleCheckTimer = setInterval(() => this.checkIdleSessions(), IDLE_CHECK_INTERVAL_MS);
+
+    // Register singleton
+    bridgeInstance = this;
+
+    console.log(
+      `[omni-bridge] Listening on omni.message.> (max_concurrent=${this.maxConcurrent}, idle_timeout=${this.idleTimeoutMs}ms)`,
+    );
+  }
+
+  /**
+   * Stop the bridge: unsubscribe, drain, and disconnect.
+   */
+  async stop(): Promise<void> {
+    if (!this.nc) {
+      console.log('[omni-bridge] Not running');
+      return;
+    }
+
+    console.log('[omni-bridge] Shutting down...');
+
+    // Stop idle checker
+    if (this.idleCheckTimer) {
+      clearInterval(this.idleCheckTimer);
+      this.idleCheckTimer = null;
+    }
+
+    // Clear all idle timers
+    for (const entry of this.sessions.values()) {
+      if (entry.idleTimer) clearTimeout(entry.idleTimer);
+    }
+
+    // Unsubscribe
+    if (this.sub) {
+      this.sub.unsubscribe();
+      this.sub = null;
+    }
+
+    // Drain and close
+    try {
+      await this.nc.drain();
+    } catch {
+      // Connection may already be closed
+    }
+    this.nc = null;
+    bridgeInstance = null;
+
+    console.log('[omni-bridge] Stopped');
+  }
+
+  /**
+   * Get current bridge status for `genie omni status`.
+   */
+  status(): BridgeStatus {
+    const now = Date.now();
+    return {
+      connected: this.nc !== null,
+      natsUrl: this.natsUrl,
+      activeSessions: this.sessions.size,
+      maxConcurrent: this.maxConcurrent,
+      idleTimeoutMs: this.idleTimeoutMs,
+      queueDepth: this.messageQueue.length,
+      sessions: Array.from(this.sessions.entries()).map(([key, entry]) => ({
+        id: key,
+        agentName: entry.session.agentName,
+        chatId: entry.session.chatId,
+        instanceId: entry.instanceId,
+        paneId: entry.session.paneId,
+        spawning: entry.spawning,
+        idleMs: now - entry.session.lastActivityAt,
+        bufferSize: entry.buffer.length,
+      })),
+    };
+  }
+
+  // ==========================================================================
+  // Internal
+  // ==========================================================================
+
+  /**
+   * Process incoming NATS messages from the subscription.
+   */
+  private async processSubscription(): Promise<void> {
+    if (!this.sub) return;
+
+    for await (const msg of this.sub) {
+      try {
+        const data = this.sc.decode(msg.data);
+        const parsed: OmniMessage = JSON.parse(data);
+
+        // Extract instance_id and chat_id from subject: omni.message.{instance}.{chat_id}
+        const parts = msg.subject.split('.');
+        if (parts.length >= 4) {
+          parsed.instanceId = parsed.instanceId || parts[2];
+          parsed.chatId = parsed.chatId || parts[3];
+        }
+
+        if (!parsed.chatId || !parsed.agent) {
+          console.warn('[omni-bridge] Dropping message: missing chatId or agent', msg.subject);
+          continue;
+        }
+
+        await this.routeMessage(parsed);
+      } catch (err) {
+        console.error('[omni-bridge] Error processing message:', err);
+      }
+    }
+  }
+
+  /**
+   * Route a message to the appropriate session.
+   */
+  private async routeMessage(message: OmniMessage): Promise<void> {
+    const key = `${message.agent}:${message.chatId}`;
+    const entry = this.sessions.get(key);
+
+    if (entry) {
+      // Session exists — check if still alive
+      if (entry.spawning) {
+        // Still spawning — buffer the message
+        if (entry.buffer.length < MAX_BUFFER_PER_CHAT) {
+          entry.buffer.push(message);
+        }
+        return;
+      }
+
+      const alive = await this.executor.isAlive(entry.session);
+      if (alive) {
+        // Deliver to running session
+        await this.executor.deliver(entry.session, message);
+        this.resetIdleTimer(key);
+        return;
+      }
+
+      // Session dead — remove and respawn
+      this.removeSession(key);
+    }
+
+    // Need to spawn a new session
+    await this.spawnSession(message);
+  }
+
+  /**
+   * Spawn a new agent session for a chat.
+   */
+  private async spawnSession(message: OmniMessage): Promise<void> {
+    const key = `${message.agent}:${message.chatId}`;
+
+    // Check concurrency limit
+    const activeCount = Array.from(this.sessions.values()).filter((e) => !e.spawning).length;
+    if (activeCount >= this.maxConcurrent) {
+      // Queue the message and send auto-reply
+      this.messageQueue.push(message);
+      await this.publishAutoReply(message);
+      console.log(`[omni-bridge] Max concurrent (${this.maxConcurrent}) reached, queued message for ${key}`);
+      return;
+    }
+
+    // Create placeholder entry (spawning state)
+    const placeholder: SessionEntry = {
+      session: null as unknown as OmniSession, // Will be set after spawn
+      instanceId: message.instanceId,
+      spawning: true,
+      buffer: [message], // Buffer the triggering message too
+      idleTimer: null,
+    };
+    this.sessions.set(key, placeholder);
+
+    try {
+      const env: Record<string, string> = {
+        OMNI_REPLY_TOPIC: `omni.reply.${message.instanceId}.${message.chatId}`,
+        OMNI_NATS_URL: this.natsUrl,
+        OMNI_INSTANCE_ID: message.instanceId,
+        OMNI_CHAT_ID: message.chatId,
+      };
+
+      console.log(`[omni-bridge] Spawning session for ${key}...`);
+      const session = await this.executor.spawn(message.agent, message.chatId, env);
+
+      placeholder.session = session;
+      placeholder.spawning = false;
+
+      // Deliver buffered messages
+      for (const buffered of placeholder.buffer) {
+        await this.executor.deliver(session, buffered);
+      }
+      placeholder.buffer = [];
+
+      // Start idle timer
+      this.resetIdleTimer(key);
+
+      console.log(`[omni-bridge] Session active: ${key} (pane=${session.paneId})`);
+    } catch (err) {
+      console.error(`[omni-bridge] Failed to spawn session for ${key}:`, err);
+      this.sessions.delete(key);
+    }
+  }
+
+  /**
+   * Reset the idle timer for a session.
+   */
+  private resetIdleTimer(key: string): void {
+    const entry = this.sessions.get(key);
+    if (!entry) return;
+
+    if (entry.idleTimer) clearTimeout(entry.idleTimer);
+
+    entry.idleTimer = setTimeout(async () => {
+      console.log(`[omni-bridge] Idle timeout for ${key}, shutting down...`);
+      try {
+        await this.executor.shutdown(entry.session);
+      } catch {
+        // Already dead — that's fine
+      }
+      this.removeSession(key);
+
+      // Process queued messages now that a slot is free
+      await this.drainQueue();
+    }, this.idleTimeoutMs);
+  }
+
+  /**
+   * Check for idle sessions and terminate them.
+   */
+  private async checkIdleSessions(): Promise<void> {
+    const now = Date.now();
+    for (const [key, entry] of this.sessions) {
+      if (entry.spawning) continue;
+
+      // Check if session pane died
+      const alive = await this.executor.isAlive(entry.session);
+      if (!alive) {
+        console.log(`[omni-bridge] Dead session detected: ${key}`);
+        this.removeSession(key);
+        continue;
+      }
+
+      // Check idle time (belt-and-suspenders — main timeout is via resetIdleTimer)
+      const idleMs = now - entry.session.lastActivityAt;
+      if (idleMs > this.idleTimeoutMs) {
+        console.log(`[omni-bridge] Forcing idle shutdown: ${key} (idle ${Math.round(idleMs / 1000)}s)`);
+        try {
+          await this.executor.shutdown(entry.session);
+        } catch {
+          /* already dead */
+        }
+        this.removeSession(key);
+      }
+    }
+  }
+
+  /**
+   * Remove a session and clean up its idle timer.
+   */
+  private removeSession(key: string): void {
+    const entry = this.sessions.get(key);
+    if (entry?.idleTimer) clearTimeout(entry.idleTimer);
+    this.sessions.delete(key);
+  }
+
+  /**
+   * Drain the message queue — process queued messages when a slot opens.
+   */
+  private async drainQueue(): Promise<void> {
+    while (this.messageQueue.length > 0) {
+      const activeCount = Array.from(this.sessions.values()).filter((e) => !e.spawning).length;
+      if (activeCount >= this.maxConcurrent) break;
+
+      const message = this.messageQueue.shift();
+      if (message) await this.spawnSession(message);
+    }
+  }
+
+  /**
+   * Publish an auto-reply when max concurrent is reached.
+   */
+  private async publishAutoReply(message: OmniMessage): Promise<void> {
+    if (!this.nc) return;
+
+    const topic = `omni.reply.${message.instanceId}.${message.chatId}`;
+    const reply = {
+      content: 'Aguarde um momento, estou atendendo outros clientes.',
+      agent: message.agent,
+      chat_id: message.chatId,
+      instance_id: message.instanceId,
+      timestamp: new Date().toISOString(),
+      auto_reply: true,
+    };
+
+    this.nc.publish(topic, this.sc.encode(JSON.stringify(reply)));
+  }
+}

--- a/src/services/omni-reply.ts
+++ b/src/services/omni-reply.ts
@@ -1,0 +1,70 @@
+/**
+ * Omni Reply Publisher — Publish agent replies to NATS.
+ *
+ * Two modes:
+ *   1. Library: import and call publishReply() from TypeScript
+ *   2. CLI: pipe JSON via stdin (used by omni-reply.sh fallback)
+ *
+ * The reply is published to `omni.reply.{instance}.{chat_id}` so
+ * Omni's NATS subscriber can route it to the correct WhatsApp chat.
+ */
+
+import { StringCodec, connect } from 'nats';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface OmniReply {
+  content: string;
+  agent: string;
+  chat_id: string;
+  instance_id: string;
+  timestamp: string;
+  auto_reply?: boolean;
+}
+
+// ============================================================================
+// Publisher
+// ============================================================================
+
+/**
+ * Publish a reply to NATS for Omni delivery.
+ *
+ * @param reply - The reply payload
+ * @param natsUrl - NATS server URL (default: localhost:4222)
+ */
+export async function publishReply(reply: OmniReply, natsUrl?: string): Promise<void> {
+  const url = natsUrl ?? process.env.OMNI_NATS_URL ?? 'localhost:4222';
+  const topic = process.env.OMNI_REPLY_TOPIC ?? `omni.reply.${reply.instance_id}.${reply.chat_id}`;
+
+  const nc = await connect({ servers: url, name: 'genie-omni-reply' });
+  const sc = StringCodec();
+
+  nc.publish(topic, sc.encode(JSON.stringify(reply)));
+  await nc.flush();
+  await nc.close();
+}
+
+// ============================================================================
+// CLI Mode — read JSON from stdin
+// ============================================================================
+
+if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('omni-reply.ts')) {
+  (async () => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) {
+      chunks.push(chunk);
+    }
+    const input = Buffer.concat(chunks).toString('utf-8').trim();
+    if (!input) process.exit(0);
+
+    try {
+      const reply: OmniReply = JSON.parse(input);
+      await publishReply(reply);
+    } catch (err) {
+      console.error('[omni-reply] Failed to publish:', err);
+      process.exit(1);
+    }
+  })();
+}

--- a/src/term-commands/omni.ts
+++ b/src/term-commands/omni.ts
@@ -1,0 +1,97 @@
+/**
+ * Omni Commands — genie omni start/stop/status
+ *
+ * Manages the NATS bridge service that connects Omni (WhatsApp)
+ * to Genie agent sessions.
+ */
+
+import type { Command } from 'commander';
+
+export function registerOmniCommands(program: Command): void {
+  const omni = program.command('omni').description('Manage the Omni ↔ Genie NATS bridge');
+
+  omni
+    .command('start')
+    .description('Start the NATS bridge (subscribe to omni.message.>)')
+    .option('--nats-url <url>', 'NATS server URL', process.env.GENIE_NATS_URL ?? 'localhost:4222')
+    .option('--max-concurrent <n>', 'Max concurrent agent sessions', process.env.GENIE_MAX_CONCURRENT ?? '20')
+    .option('--idle-timeout <ms>', 'Idle timeout in ms', process.env.GENIE_IDLE_TIMEOUT_MS ?? '900000')
+    .action(async (options) => {
+      const { OmniBridge } = await import('../services/omni-bridge.js');
+
+      const bridge = new OmniBridge({
+        natsUrl: options.natsUrl,
+        maxConcurrent: Number(options.maxConcurrent),
+        idleTimeoutMs: Number(options.idleTimeout),
+      });
+
+      await bridge.start();
+
+      // Keep the process alive
+      console.log('[genie omni] Bridge running. Press Ctrl+C to stop.');
+
+      const shutdown = async () => {
+        await bridge.stop();
+        process.exit(0);
+      };
+
+      process.on('SIGINT', shutdown);
+      process.on('SIGTERM', shutdown);
+
+      // Block forever
+      await new Promise(() => {});
+    });
+
+  omni
+    .command('stop')
+    .description('Stop the running NATS bridge')
+    .action(async () => {
+      const { getBridge } = await import('../services/omni-bridge.js');
+      const bridge = getBridge();
+      if (!bridge) {
+        console.log('No running bridge found in this process.');
+        console.log('If the bridge is running in another terminal, use Ctrl+C to stop it.');
+        return;
+      }
+      await bridge.stop();
+    });
+
+  omni
+    .command('status')
+    .description('Show bridge status: active sessions, queue depth, idle timers')
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      const { getBridge } = await import('../services/omni-bridge.js');
+      const bridge = getBridge();
+
+      if (!bridge) {
+        console.log('Bridge is not running in this process.');
+        return;
+      }
+
+      const s = bridge.status();
+
+      if (options.json) {
+        console.log(JSON.stringify(s, null, 2));
+        return;
+      }
+
+      console.log('\nOmni Bridge Status');
+      console.log('─'.repeat(50));
+      console.log(`  Connected:      ${s.connected ? '✓ yes' : '✗ no'}`);
+      console.log(`  NATS URL:       ${s.natsUrl}`);
+      console.log(`  Active:         ${s.activeSessions} / ${s.maxConcurrent}`);
+      console.log(`  Queue depth:    ${s.queueDepth}`);
+      console.log(`  Idle timeout:   ${Math.round(s.idleTimeoutMs / 1000)}s`);
+
+      if (s.sessions.length > 0) {
+        console.log('\n  Sessions:');
+        for (const sess of s.sessions) {
+          const idleSec = Math.round(sess.idleMs / 1000);
+          const status = sess.spawning ? 'spawning' : `idle ${idleSec}s`;
+          console.log(`    ${sess.agentName}:${sess.chatId} — pane=${sess.paneId} (${status})`);
+        }
+      }
+      console.log('');
+    });
+}


### PR DESCRIPTION
## Summary

Replace the fragile filesystem-based Omni ↔ Genie integration with native NATS pub/sub message transport. This is Group 1 (Genie side) of the `omni-genie-native-integration` wish.

- **IExecutor interface** (`src/services/executor.ts`) — pluggable executor backend with `spawn/deliver/shutdown/isAlive` methods
- **ClaudeCodeOmniExecutor** (`src/services/executors/claude-code.ts`) — first executor: tmux windows + Claude Code processes per chat
- **OmniBridge** (`src/services/omni-bridge.ts`) — NATS subscriber for `omni.message.>`, per-chat session manager with idle timeout (15min) and max concurrency (20) with auto-reply queuing
- **omni-reply publisher** (`src/services/omni-reply.ts`) — NATS reply publisher for agent → Omni routing
- **`genie omni start/stop/status`** (`src/term-commands/omni.ts`) — CLI commands for bridge lifecycle
- **nats dependency** added to package.json

### Key design decisions
- Executor interface is separate from existing `ExecutorProvider` — simpler abstraction focused on Omni bridge use case
- Per-chat tmux windows within agent session (not per-chat sessions) to avoid session explosion
- Idle timeout via dual mechanism: per-session timer + periodic health check
- Max concurrent with "Aguarde" auto-reply when at capacity
- Message buffering during spawn (max 50 per chat)

Closes #1025

## Test plan
- [x] TypeScript type check passes
- [x] Linter passes (no new errors in added files)
- [x] All 1835 existing tests pass
- [x] Dead code check (knip) passes
- [x] Build succeeds
- [ ] Integration test: `nats pub omni.message.test.chat '{"content":"oi","sender":"Test","agent":"eugenia-seller"}'` → tmux window created
- [ ] Idle timeout: session killed after 15min inactivity
- [ ] Max concurrent: 21st chat gets auto-reply