### PR TITLE
feat(providers): Claude Agent SDK executor with native permission enforcement

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@namastexlabs/claudio",
       "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.2.91",
         "@inquirer/prompts": "^7.0.0",
         "@opentui/core": "^0.1.91",
         "@opentui/react": "^0.1.91",
@@ -44,6 +45,10 @@
     "bun",
   ],
   "packages": {
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.91", "", { "dependencies": { "@anthropic-ai/sdk": "^0.80.0", "@modelcontextprotocol/sdk": "^1.27.1" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-DCd5Ad5XKBbIIOMZ73L+c+e9azM6NtZzOtdKQAzykzRG/KxSCMraMAsMMQrJrIUMH3oTtHY7QuQimAiElVVVpA=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.80.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g=="],
+
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
@@ -75,6 +80,8 @@
     "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw=="],
 
     "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
 
@@ -202,6 +209,40 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
     "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
 
     "@inquirer/checkbox": ["@inquirer/checkbox@4.3.2", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/core": "^10.3.2", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA=="],
@@ -299,6 +340,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 
@@ -498,7 +541,11 @@
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -517,6 +564,8 @@
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.12", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ=="],
 
     "bmp-ts": ["bmp-ts@1.0.9", "", {}, "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -540,6 +589,12 @@
 
     "bun-webgpu-win32-x64": ["bun-webgpu-win32-x64@0.1.6", "", { "os": "win32", "cpu": "x64" }, "sha512-MHSFAKqizISb+C5NfDrFe3g0Al5Njnu0j/A+oO2Q+bIWX+fUYjBSowiYE1ZXJx65KuryuB+tiM7Qh6cQbVvkEg=="],
 
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001782", "", {}, "sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw=="],
@@ -558,6 +613,10 @@
 
     "compare-func": ["compare-func@2.0.0", "", { "dependencies": { "array-ify": "^1.0.0", "dot-prop": "^5.1.0" } }, "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA=="],
 
+    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "conventional-changelog-angular": ["conventional-changelog-angular@8.2.0", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-4YB1zEXqB17oBI8yRsAs1T+ZhbdsOgJqkl6Trz+GXt/eKf1e4jnA0oW+sOd9BEENzEViuNW0DNoFFjSf3CeC5Q=="],
 
     "conventional-changelog-conventionalcommits": ["conventional-changelog-conventionalcommits@9.2.0", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-fCf+ODjseueTV09wVBoC0HXLi3OyuBJ+HfE3L63Khxqnr99f9nUcnQh3a15lCWHlGLihyZShW/mVVkBagr9JvQ=="],
@@ -566,9 +625,17 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
     "cosmiconfig": ["cosmiconfig@9.0.1", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ=="],
 
     "cosmiconfig-typescript-loader": ["cosmiconfig-typescript-loader@6.2.0", "", { "dependencies": { "jiti": "^2.6.1" }, "peerDependencies": { "@types/node": "*", "cosmiconfig": ">=9", "typescript": ">=5" } }, "sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
@@ -576,27 +643,53 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
     "diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
 
     "dot-prop": ["dot-prop@5.3.0", "", { "dependencies": { "is-obj": "^2.0.0" } }, "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.328", "", {}, "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
     "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
     "exif-parser": ["exif-parser@0.1.12", "", {}, "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -614,13 +707,25 @@
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
     "formatly": ["formatly@0.3.0", "", { "dependencies": { "fd-package-json": "^2.0.0" }, "bin": { "formatly": "bin/index.mjs" } }, "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w=="],
 
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "gifwrap": ["gifwrap@0.10.1", "", { "dependencies": { "image-q": "^4.0.0", "omggif": "^1.0.10" } }, "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw=="],
 
@@ -629,6 +734,16 @@
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "global-directory": ["global-directory@4.0.1", "", { "dependencies": { "ini": "4.1.1" } }, "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hono": ["hono@4.12.10", "", {}, "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
@@ -642,7 +757,13 @@
 
     "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
 
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
     "ini": ["ini@4.1.1", "", {}, "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
 
@@ -658,9 +779,15 @@
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
     "jimp": ["jimp@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/diff": "1.6.0", "@jimp/js-bmp": "1.6.0", "@jimp/js-gif": "1.6.0", "@jimp/js-jpeg": "1.6.0", "@jimp/js-png": "1.6.0", "@jimp/js-tiff": "1.6.0", "@jimp/plugin-blit": "1.6.0", "@jimp/plugin-blur": "1.6.0", "@jimp/plugin-circle": "1.6.0", "@jimp/plugin-color": "1.6.0", "@jimp/plugin-contain": "1.6.0", "@jimp/plugin-cover": "1.6.0", "@jimp/plugin-crop": "1.6.0", "@jimp/plugin-displace": "1.6.0", "@jimp/plugin-dither": "1.6.0", "@jimp/plugin-fisheye": "1.6.0", "@jimp/plugin-flip": "1.6.0", "@jimp/plugin-hash": "1.6.0", "@jimp/plugin-mask": "1.6.0", "@jimp/plugin-print": "1.6.0", "@jimp/plugin-quantize": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/plugin-rotate": "1.6.0", "@jimp/plugin-threshold": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0" } }, "sha512-YcwCHw1kiqEeI5xRpDlPPBGL2EOpBKLwO4yIBJcXWHPj5PnA5urGq0jbyhM5KoNpypQ6VboSoxc9D8HyfvngSg=="],
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
+    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
 
     "jpeg-js": ["jpeg-js@0.4.4", "", {}, "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="],
 
@@ -672,7 +799,11 @@
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
@@ -696,13 +827,23 @@
 
     "marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
     "meow": ["meow@12.1.1", "", {}, "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
     "mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
@@ -714,11 +855,21 @@
 
     "nats": ["nats@2.29.3", "", { "dependencies": { "nkeys.js": "1.1.0" } }, "sha512-tOQCRCwC74DgBTk4pWZ9V45sk4d7peoE2njVprMRCBXrhJ5q5cYM7i6W+Uvw2qUrcfOSnuisrX7bEx3b3Wx4QA=="],
 
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
     "nkeys.js": ["nkeys.js@1.1.0", "", { "dependencies": { "tweetnacl": "1.0.3" } }, "sha512-tB/a0shZL5UZWSwsoeyqfTszONTt4k2YS0tuQioMOD180+MbombYVgzDUYHlx+gejYK6rgf08n/2Df99WY0Sxg=="],
 
     "node-releases": ["node-releases@2.0.36", "", {}, "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA=="],
 
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
     "omggif": ["omggif@1.0.10", "", {}, "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "oxc-resolver": ["oxc-resolver@11.19.1", "", { "optionalDependencies": { "@oxc-resolver/binding-android-arm-eabi": "11.19.1", "@oxc-resolver/binding-android-arm64": "11.19.1", "@oxc-resolver/binding-darwin-arm64": "11.19.1", "@oxc-resolver/binding-darwin-x64": "11.19.1", "@oxc-resolver/binding-freebsd-x64": "11.19.1", "@oxc-resolver/binding-linux-arm-gnueabihf": "11.19.1", "@oxc-resolver/binding-linux-arm-musleabihf": "11.19.1", "@oxc-resolver/binding-linux-arm64-gnu": "11.19.1", "@oxc-resolver/binding-linux-arm64-musl": "11.19.1", "@oxc-resolver/binding-linux-ppc64-gnu": "11.19.1", "@oxc-resolver/binding-linux-riscv64-gnu": "11.19.1", "@oxc-resolver/binding-linux-riscv64-musl": "11.19.1", "@oxc-resolver/binding-linux-s390x-gnu": "11.19.1", "@oxc-resolver/binding-linux-x64-gnu": "11.19.1", "@oxc-resolver/binding-linux-x64-musl": "11.19.1", "@oxc-resolver/binding-openharmony-arm64": "11.19.1", "@oxc-resolver/binding-wasm32-wasi": "11.19.1", "@oxc-resolver/binding-win32-arm64-msvc": "11.19.1", "@oxc-resolver/binding-win32-ia32-msvc": "11.19.1", "@oxc-resolver/binding-win32-x64-msvc": "11.19.1" } }, "sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg=="],
 
@@ -734,6 +885,12 @@
 
     "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
     "peek-readable": ["peek-readable@4.1.0", "", {}, "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="],
 
     "pgserve": ["pgserve@1.1.6", "", { "dependencies": { "bun": "^1.3.4" }, "optionalDependencies": { "@embedded-postgres/darwin-arm64": "18.2.0-beta.16", "@embedded-postgres/darwin-x64": "18.2.0-beta.16", "@embedded-postgres/linux-x64": "18.2.0-beta.16", "@embedded-postgres/windows-x64": "18.2.0-beta.16" }, "bin": { "pgserve": "bin/pgserve-wrapper.cjs" } }, "sha512-qdgiU3q/o/k8lP+IPHLiZG5uTWmvCSgqM3erdP7nmgVeQYv89DTo0nSG5XB0ccVD7yG/BppLFHjRvvXcWVgKnQ=="],
@@ -743,6 +900,8 @@
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "pixelmatch": ["pixelmatch@5.3.0", "", { "dependencies": { "pngjs": "^6.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "planck": ["planck@1.4.3", "", { "peerDependencies": { "stage-js": "^1.0.0-alpha.12" } }, "sha512-B+lHKhRSeg7vZOfEyEzyQVu7nx8JHcX3QgnAcHXrPW0j04XYKX5eXSiUrxH2Z5QR8OoqvjD6zKIaPMdMYAd0uA=="],
 
@@ -754,7 +913,15 @@
 
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
+
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
@@ -780,6 +947,8 @@
 
     "rollup": ["rollup@4.60.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.0", "@rollup/rollup-android-arm64": "4.60.0", "@rollup/rollup-darwin-arm64": "4.60.0", "@rollup/rollup-darwin-x64": "4.60.0", "@rollup/rollup-freebsd-arm64": "4.60.0", "@rollup/rollup-freebsd-x64": "4.60.0", "@rollup/rollup-linux-arm-gnueabihf": "4.60.0", "@rollup/rollup-linux-arm-musleabihf": "4.60.0", "@rollup/rollup-linux-arm64-gnu": "4.60.0", "@rollup/rollup-linux-arm64-musl": "4.60.0", "@rollup/rollup-linux-loong64-gnu": "4.60.0", "@rollup/rollup-linux-loong64-musl": "4.60.0", "@rollup/rollup-linux-ppc64-gnu": "4.60.0", "@rollup/rollup-linux-ppc64-musl": "4.60.0", "@rollup/rollup-linux-riscv64-gnu": "4.60.0", "@rollup/rollup-linux-riscv64-musl": "4.60.0", "@rollup/rollup-linux-s390x-gnu": "4.60.0", "@rollup/rollup-linux-x64-gnu": "4.60.0", "@rollup/rollup-linux-x64-musl": "4.60.0", "@rollup/rollup-openbsd-x64": "4.60.0", "@rollup/rollup-openharmony-arm64": "4.60.0", "@rollup/rollup-win32-arm64-msvc": "4.60.0", "@rollup/rollup-win32-ia32-msvc": "4.60.0", "@rollup/rollup-win32-x64-gnu": "4.60.0", "@rollup/rollup-win32-x64-msvc": "4.60.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
@@ -792,7 +961,25 @@
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
     "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
@@ -805,6 +992,8 @@
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "stage-js": ["stage-js@1.0.1", "", {}, "sha512-cz14aPp/wY0s3bkb/B93BPP5ZAEhgBbRmAT3CCDqert8eCAqIpQ0RB2zpK8Ksxf+Pisl5oTzvPHtL4CVzzeHcw=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -828,11 +1017,17 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "token-types": ["token-types@4.2.1", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -840,11 +1035,15 @@
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "utif2": ["utif2@4.1.0", "", { "dependencies": { "pako": "^1.0.11" } }, "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w=="],
 
     "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
 
@@ -852,7 +1051,11 @@
 
     "web-tree-sitter": ["web-tree-sitter@0.25.10", "", { "peerDependencies": { "@types/emscripten": "^1.40.0" }, "optionalPeers": ["@types/emscripten"] }, "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA=="],
 
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
@@ -878,9 +1081,13 @@
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
     "@commitlint/is-ignored/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "conventional-commits-parser/meow": ["meow@13.2.0", "", {}, "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA=="],
 

--- a/knip.json
+++ b/knip.json
@@ -27,6 +27,7 @@
   "ignoreExportsUsedInFile": false,
   "ignoreDependencies": [
     "@automagik/genie-brain",
+    "esbuild",
     "@tauri-apps/cli",
     "@tauri-apps/api",
     "react-dom",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "prepare": "test \"$CI\" = true || husky",
     "version": "bun run scripts/version.ts",
-    "build": "bun build src/genie.ts --outdir dist --target bun --minify-syntax --minify-whitespace --external bun --external pgserve --external @automagik/genie-brain && chmod +x dist/*.js",
+    "build": "bun build src/genie.ts --outdir dist --target bun --minify-syntax --minify-whitespace --external bun --external pgserve --external @automagik/genie-brain --external @anthropic-ai/claude-agent-sdk && chmod +x dist/*.js",
     "build:app": "bun run scripts/build-app.ts",
     "build:plugin": "node scripts/build.js",
     "sync": "node scripts/sync.js",
@@ -25,6 +25,7 @@
     "check": "bun run typecheck && bun run lint && bun run dead-code && (bun test || bun test)"
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.91",
     "@inquirer/prompts": "^7.0.0",
     "@opentui/core": "^0.1.91",
     "@opentui/react": "^0.1.91",

--- a/src/lib/agent-directory.ts
+++ b/src/lib/agent-directory.ts
@@ -37,8 +37,14 @@ export interface DirectoryEntry {
   description?: string;
   /** Display color for TUI/terminal output. */
   color?: string;
-  /** AI provider: 'claude' | 'codex'. Resolved at spawn time. */
+  /** AI provider: 'claude' | 'codex' | 'claude-sdk'. Resolved at spawn time. */
   provider?: string;
+  /** Permission config for SDK provider (allowlist-only). */
+  permissions?: {
+    preset?: string;
+    allow?: string[];
+    bashAllowPatterns?: string[];
+  };
 }
 
 export type DirectoryScope = 'project' | 'global' | 'built-in' | 'archived';
@@ -258,7 +264,16 @@ export async function edit(
   updates: Partial<
     Pick<
       DirectoryEntry,
-      'dir' | 'repo' | 'promptMode' | 'model' | 'roles' | 'omniAgentId' | 'description' | 'color' | 'provider'
+      | 'dir'
+      | 'repo'
+      | 'promptMode'
+      | 'model'
+      | 'roles'
+      | 'omniAgentId'
+      | 'description'
+      | 'color'
+      | 'provider'
+      | 'permissions'
     >
   >,
   _options?: ScopeOptions,
@@ -358,6 +373,7 @@ function roleToEntry(role: string, team?: string, metadata?: Record<string, unkn
     description: metadata?.description as string | undefined,
     color: metadata?.color as string | undefined,
     provider: metadata?.provider as string | undefined,
+    permissions: metadata?.permissions as DirectoryEntry['permissions'],
     ...(metadata?.repo ? { repo: metadata.repo as string } : team ? { repo: team } : {}),
   };
 }
@@ -372,6 +388,7 @@ function buildMetadata(entry: DirectoryEntry): Record<string, unknown> {
   if (entry.description) meta.description = entry.description;
   if (entry.color) meta.color = entry.color;
   if (entry.provider) meta.provider = entry.provider;
+  if (entry.permissions) meta.permissions = entry.permissions;
   return meta;
 }
 

--- a/src/lib/provider-adapters.ts
+++ b/src/lib/provider-adapters.ts
@@ -18,7 +18,7 @@ import { buildDispatchCommand } from '../hooks/inject.js';
 // Types
 // ============================================================================
 
-export type ProviderName = 'claude' | 'codex' | 'app-pty';
+export type ProviderName = 'claude' | 'codex' | 'app-pty' | 'claude-sdk';
 
 /** Colors available for Claude Code native teammate UI. */
 export type ClaudeTeamColor = 'blue' | 'green' | 'yellow' | 'red' | 'cyan' | 'orange' | 'purple' | 'pink';
@@ -115,7 +115,7 @@ interface LaunchCommand {
 // ============================================================================
 
 const spawnParamsSchema = z.object({
-  provider: z.enum(['claude', 'codex']),
+  provider: z.enum(['claude', 'codex', 'claude-sdk']),
   team: z.string().min(1, 'Team name is required'),
   role: z.string().optional(),
   skill: z.string().optional(),
@@ -441,9 +441,16 @@ export function buildLaunchCommand(params: SpawnParams): LaunchCommand {
       return buildClaudeCommand(validated);
     case 'codex':
       return buildCodexCommand(validated);
+    case 'claude-sdk':
+      // SDK provider runs in-process — return metadata-only launch command
+      return {
+        command: 'claude-sdk-in-process',
+        provider: 'claude-sdk',
+        meta: { role: validated.role, skill: validated.skill },
+      };
     default:
       throw new Error(
-        `Unknown provider "${(validated as unknown as { provider: string }).provider}". Valid providers: claude, codex`,
+        `Unknown provider "${(validated as unknown as { provider: string }).provider}". Valid providers: claude, codex, claude-sdk`,
       );
   }
 }

--- a/src/lib/providers/__tests__/claude-sdk-permissions.test.ts
+++ b/src/lib/providers/__tests__/claude-sdk-permissions.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from 'bun:test';
+import type { PreToolUseHookInput, SyncHookJSONOutput } from '@anthropic-ai/claude-agent-sdk';
+import {
+  PRESET_CHAT_ONLY,
+  PRESET_FULL,
+  PRESET_READ_ONLY,
+  createPermissionGate,
+  resolvePreset,
+} from '../claude-sdk-permissions.js';
+
+/** Build a minimal PreToolUseHookInput for testing. */
+function hookInput(toolName: string, toolInput: Record<string, unknown> = {}): PreToolUseHookInput {
+  return {
+    hook_event_name: 'PreToolUse',
+    tool_name: toolName,
+    tool_input: toolInput,
+    tool_use_id: 'test',
+    session_id: 'test',
+    transcript_path: '',
+    cwd: '',
+  } as PreToolUseHookInput;
+}
+
+/** Call the gate with standard test args and return the result. */
+async function callGate(
+  gate: ReturnType<typeof createPermissionGate>,
+  toolName: string,
+  toolInput: Record<string, unknown> = {},
+): Promise<SyncHookJSONOutput> {
+  return gate(hookInput(toolName, toolInput), 'test', {
+    signal: new AbortController().signal,
+  }) as Promise<SyncHookJSONOutput>;
+}
+
+/** Extract permissionDecision from gate result. */
+function decision(result: SyncHookJSONOutput): string {
+  return (result.hookSpecificOutput as any).permissionDecision;
+}
+
+/** Extract permissionDecisionReason from gate result. */
+function reason(result: SyncHookJSONOutput): string | undefined {
+  return (result.hookSpecificOutput as any).permissionDecisionReason;
+}
+
+describe('Permission Presets', () => {
+  it('PRESET_FULL allows everything via wildcard', () => {
+    expect(PRESET_FULL.allow).toEqual(['*']);
+  });
+
+  it('PRESET_READ_ONLY allows Read/Glob/Grep/WebFetch only', () => {
+    expect(PRESET_READ_ONLY.allow).toEqual(['Read', 'Glob', 'Grep', 'WebFetch']);
+  });
+
+  it('PRESET_CHAT_ONLY allows SendMessage/Read only', () => {
+    expect(PRESET_CHAT_ONLY.allow).toEqual(['SendMessage', 'Read']);
+  });
+});
+
+describe('resolvePreset', () => {
+  it('resolves "read-only" to PRESET_READ_ONLY', () => {
+    expect(resolvePreset('read-only')).toBe(PRESET_READ_ONLY);
+  });
+
+  it('resolves "full" to PRESET_FULL', () => {
+    expect(resolvePreset('full')).toBe(PRESET_FULL);
+  });
+
+  it('resolves "chat-only" to PRESET_CHAT_ONLY', () => {
+    expect(resolvePreset('chat-only')).toBe(PRESET_CHAT_ONLY);
+  });
+
+  it('throws on unknown preset', () => {
+    expect(() => resolvePreset('unknown')).toThrow('Unknown permission preset "unknown"');
+  });
+});
+
+describe('createPermissionGate', () => {
+  describe('PRESET_FULL gate', () => {
+    it('allows any tool', async () => {
+      const gate = createPermissionGate(PRESET_FULL);
+      expect(decision(await callGate(gate, 'Bash'))).toBe('allow');
+      expect(decision(await callGate(gate, 'Edit'))).toBe('allow');
+      expect(decision(await callGate(gate, 'Write'))).toBe('allow');
+      expect(decision(await callGate(gate, 'Agent'))).toBe('allow');
+    });
+  });
+
+  describe('PRESET_READ_ONLY gate', () => {
+    it('allows Read, Glob, Grep, WebFetch', async () => {
+      const gate = createPermissionGate(PRESET_READ_ONLY);
+      for (const tool of ['Read', 'Glob', 'Grep', 'WebFetch']) {
+        expect(decision(await callGate(gate, tool))).toBe('allow');
+      }
+    });
+
+    it('denies Bash, Edit, Write, Agent (not in allow list)', async () => {
+      const gate = createPermissionGate(PRESET_READ_ONLY);
+      for (const tool of ['Bash', 'Edit', 'Write', 'Agent']) {
+        expect(decision(await callGate(gate, tool))).toBe('deny');
+      }
+    });
+  });
+
+  describe('PRESET_CHAT_ONLY gate', () => {
+    it('allows SendMessage, Read', async () => {
+      const gate = createPermissionGate(PRESET_CHAT_ONLY);
+      expect(decision(await callGate(gate, 'SendMessage'))).toBe('allow');
+      expect(decision(await callGate(gate, 'Read'))).toBe('allow');
+    });
+
+    it('denies everything else', async () => {
+      const gate = createPermissionGate(PRESET_CHAT_ONLY);
+      for (const tool of ['Bash', 'Edit', 'Write', 'Agent', 'Glob', 'Grep']) {
+        expect(decision(await callGate(gate, tool))).toBe('deny');
+      }
+    });
+  });
+
+  describe('custom allow list', () => {
+    it('allows tools in list', async () => {
+      const gate = createPermissionGate({ allow: ['Read', 'Bash'] });
+      expect(decision(await callGate(gate, 'Read'))).toBe('allow');
+      expect(decision(await callGate(gate, 'Bash'))).toBe('allow');
+    });
+
+    it('denies tools not in list', async () => {
+      const gate = createPermissionGate({ allow: ['Read', 'Bash'] });
+      const result = await callGate(gate, 'Write');
+      expect(decision(result)).toBe('deny');
+      expect(reason(result)).toContain('not allowed');
+    });
+  });
+
+  describe('Bash command pattern inspection', () => {
+    it('allows when command matches an allow pattern', async () => {
+      const gate = createPermissionGate({
+        allow: ['Bash'],
+        bashAllowPatterns: ['^git\\s'],
+      });
+      const result = await callGate(gate, 'Bash', { command: 'git status' });
+      expect(decision(result)).toBe('allow');
+    });
+
+    it('denies when command matches no allow pattern', async () => {
+      const gate = createPermissionGate({
+        allow: ['Bash'],
+        bashAllowPatterns: ['^git\\s'],
+      });
+      const result = await callGate(gate, 'Bash', { command: 'npm install' });
+      expect(decision(result)).toBe('deny');
+    });
+
+    it('denies shell metacharacters unless full match on allow pattern', async () => {
+      const gate = createPermissionGate({
+        allow: ['Bash'],
+        bashAllowPatterns: ['^git status$'],
+      });
+
+      // Compound command with && — should deny because full command does not match
+      const result = await callGate(gate, 'Bash', { command: 'git status && rm -rf /' });
+      expect(decision(result)).toBe('deny');
+    });
+
+    it('allows shell metacharacter command when full match succeeds', async () => {
+      const gate = createPermissionGate({
+        allow: ['Bash'],
+        bashAllowPatterns: ['^git status && git diff$'],
+      });
+      const result = await callGate(gate, 'Bash', { command: 'git status && git diff' });
+      expect(decision(result)).toBe('allow');
+    });
+
+    it('allows Bash with no patterns configured (tool-level allow is sufficient)', async () => {
+      const gate = createPermissionGate({
+        allow: ['Bash'],
+      });
+      const result = await callGate(gate, 'Bash', { command: 'anything' });
+      expect(decision(result)).toBe('allow');
+    });
+  });
+
+  describe('edge cases — empty/missing bash command', () => {
+    it('denies Bash with empty command string when patterns are configured', async () => {
+      const gate = createPermissionGate({
+        allow: ['Bash'],
+        bashAllowPatterns: ['^git\\s'],
+      });
+      const result = await callGate(gate, 'Bash', { command: '' });
+      expect(decision(result)).toBe('deny');
+    });
+
+    it('denies Bash with undefined command when patterns are configured', async () => {
+      const gate = createPermissionGate({
+        allow: ['Bash'],
+        bashAllowPatterns: ['^git\\s'],
+      });
+      const result = await callGate(gate, 'Bash', {});
+      expect(decision(result)).toBe('deny');
+    });
+
+    it('denies Bash with non-string command (number) when patterns are configured', async () => {
+      const gate = createPermissionGate({
+        allow: ['Bash'],
+        bashAllowPatterns: ['^git\\s'],
+      });
+      const result = await callGate(gate, 'Bash', { command: 42 });
+      expect(decision(result)).toBe('deny');
+    });
+  });
+
+  describe('edge cases — wildcard allow', () => {
+    it('wildcard allows everything including Bash', async () => {
+      const gate = createPermissionGate({ allow: ['*'] });
+      expect(decision(await callGate(gate, 'Bash', { command: 'rm -rf /' }))).toBe('allow');
+      expect(decision(await callGate(gate, 'Edit'))).toBe('allow');
+      expect(decision(await callGate(gate, 'Write'))).toBe('allow');
+    });
+  });
+
+  describe('edge cases — invalid regex in patterns', () => {
+    it('falls back to substring match when allow pattern is invalid regex', async () => {
+      const gate = createPermissionGate({
+        allow: ['Bash'],
+        bashAllowPatterns: ['git status [ok'],
+      });
+      // Invalid regex → substring match
+      const result = await callGate(gate, 'Bash', { command: 'git status [ok' });
+      expect(decision(result)).toBe('allow');
+    });
+  });
+
+  describe('edge cases — deny message content', () => {
+    it('deny reason includes tool name for non-allowed tool', async () => {
+      const gate = createPermissionGate({ allow: ['Read'] });
+      const result = await callGate(gate, 'Agent');
+      expect(decision(result)).toBe('deny');
+      expect(reason(result)).toContain('Agent');
+      expect(reason(result)).toContain('not allowed');
+    });
+
+    it('deny reason includes command for bash pattern mismatch', async () => {
+      const gate = createPermissionGate({
+        allow: ['Bash'],
+        bashAllowPatterns: ['^echo\\s'],
+      });
+      const result = await callGate(gate, 'Bash', { command: 'curl http://example.com' });
+      expect(decision(result)).toBe('deny');
+      expect(reason(result)).toContain('curl');
+    });
+  });
+});

--- a/src/lib/providers/__tests__/claude-sdk.test.ts
+++ b/src/lib/providers/__tests__/claude-sdk.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { SpawnContext } from '../../executor-types.js';
+
+// Mock the SDK query function before importing provider
+mock.module('@anthropic-ai/claude-agent-sdk', () => ({
+  query: mock(() => {
+    const gen = (async function* () {
+      yield { type: 'assistant', message: { content: [{ type: 'text', text: 'hello' }] } };
+    })();
+    return Object.assign(gen, {
+      interrupt: mock(),
+      setPermissionMode: mock(),
+      setModel: mock(),
+      return: mock(async () => ({ value: undefined, done: true })),
+      throw: mock(async () => ({ value: undefined, done: true })),
+    });
+  }),
+}));
+
+const { ClaudeSdkProvider } = await import('../claude-sdk.js');
+const sdk = await import('@anthropic-ai/claude-agent-sdk');
+
+describe('ClaudeSdkProvider', () => {
+  let provider: InstanceType<typeof ClaudeSdkProvider>;
+  let ctx: SpawnContext;
+
+  beforeEach(() => {
+    provider = new ClaudeSdkProvider();
+    ctx = {
+      agentId: 'test-agent',
+      executorId: 'exec-1',
+      team: 'test-team',
+      role: 'engineer',
+      skill: 'work',
+      cwd: '/tmp/test',
+    };
+  });
+
+  describe('buildSpawnCommand', () => {
+    it('returns metadata-only command with "claude-sdk-in-process"', () => {
+      const cmd = provider.buildSpawnCommand(ctx);
+      expect(cmd.command).toBe('claude-sdk-in-process');
+      expect(cmd.provider).toBe('claude-sdk');
+      expect(cmd.meta).toEqual({ role: 'engineer', skill: 'work' });
+    });
+  });
+
+  describe('properties', () => {
+    it('has name "claude-sdk"', () => {
+      expect(provider.name).toBe('claude-sdk');
+    });
+
+    it('has transport "process"', () => {
+      expect(provider.transport).toBe('process');
+    });
+  });
+
+  describe('canResume', () => {
+    it('returns false', () => {
+      expect(provider.canResume()).toBe(false);
+    });
+  });
+
+  describe('runQuery', () => {
+    it('calls SDK query with correct options', () => {
+      const permissionConfig = { allow: ['Read'], deny: [] };
+      const { messages, abortController } = provider.runQuery(ctx, 'do something', permissionConfig);
+
+      expect(sdk.query).toHaveBeenCalledWith({
+        prompt: 'do something',
+        options: expect.objectContaining({
+          cwd: '/tmp/test',
+          abortController: expect.any(AbortController),
+          hooks: expect.objectContaining({
+            PreToolUse: expect.any(Array),
+          }),
+        }),
+      });
+
+      expect(messages).toBeDefined();
+      expect(abortController).toBeInstanceOf(AbortController);
+    });
+
+    it('includes model when provided in context', () => {
+      ctx.model = 'opus';
+      provider.runQuery(ctx, 'test', undefined);
+
+      expect(sdk.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          options: expect.objectContaining({
+            model: 'opus',
+          }),
+        }),
+      );
+    });
+
+    it('includes systemPrompt when provided in context', () => {
+      ctx.systemPrompt = 'You are a test agent';
+      provider.runQuery(ctx, 'test', undefined);
+
+      expect(sdk.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          options: expect.objectContaining({
+            systemPrompt: 'You are a test agent',
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('detectState', () => {
+    it('returns "done" for unknown executor', async () => {
+      const state = await provider.detectState({ id: 'unknown' } as any);
+      expect(state).toBe('done');
+    });
+
+    it('returns "running" for active query', async () => {
+      provider.runQuery(ctx, 'test');
+      const state = await provider.detectState({ id: ctx.executorId } as any);
+      expect(state).toBe('running');
+    });
+  });
+
+  describe('terminate', () => {
+    it('aborts active query and marks as done', async () => {
+      const { abortController } = provider.runQuery(ctx, 'test');
+      await provider.terminate({ id: ctx.executorId } as any);
+
+      expect(abortController.signal.aborted).toBe(true);
+      expect(await provider.detectState({ id: ctx.executorId } as any)).toBe('done');
+    });
+  });
+
+  describe('extractSession', () => {
+    it('returns session info when claudeSessionId is set', async () => {
+      const result = await provider.extractSession({ id: 'x', claudeSessionId: 'sess-123' } as any);
+      expect(result).toEqual({ sessionId: 'sess-123' });
+    });
+
+    it('returns null when no claudeSessionId', async () => {
+      const result = await provider.extractSession({ id: 'x' } as any);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('terminate — idempotent for unknown executor', () => {
+    it('does not throw when terminating unknown executor', async () => {
+      await provider.terminate({ id: 'nonexistent' } as any);
+      // Should complete without error
+    });
+  });
+
+  describe('runQuery — extraOptions merging', () => {
+    it('passes extraOptions through to SDK query', () => {
+      provider.runQuery(ctx, 'test', undefined, { maxTokens: 1000 } as any);
+      expect(sdk.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          options: expect.objectContaining({
+            maxTokens: 1000,
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('runQuery — without permissionConfig', () => {
+    it('does not set hooks when no permissionConfig', () => {
+      provider.runQuery(ctx, 'no perms');
+      const callArgs = (sdk.query as ReturnType<typeof mock>).mock.calls.at(-1)?.[0];
+      expect(callArgs.options.hooks).toBeUndefined();
+    });
+  });
+});

--- a/src/lib/providers/claude-sdk-permissions.ts
+++ b/src/lib/providers/claude-sdk-permissions.ts
@@ -1,0 +1,135 @@
+/**
+ * Claude Agent SDK Permission Gate
+ *
+ * Allowlist-only permission model. If a tool is not in the allow list, it's denied.
+ * Bash commands can be further restricted via regex allowlist patterns.
+ *
+ * Enforced via PreToolUse hooks (canUseTool is ignored under bypassPermissions).
+ */
+
+import type { HookCallback, PreToolUseHookInput, SyncHookJSONOutput } from '@anthropic-ai/claude-agent-sdk';
+import { hasShellMetacharacters, normalizeCommand } from '../auto-approve.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface PermissionConfig {
+  /** Tool names that are allowed. '*' = allow all. */
+  allow: string[];
+  /** Regex patterns for allowed bash commands. Only checked when Bash is in allow list. */
+  bashAllowPatterns?: string[];
+}
+
+// ============================================================================
+// Presets
+// ============================================================================
+
+export const PRESET_FULL: PermissionConfig = {
+  allow: ['*'],
+};
+
+export const PRESET_READ_ONLY: PermissionConfig = {
+  allow: ['Read', 'Glob', 'Grep', 'WebFetch'],
+};
+
+export const PRESET_CHAT_ONLY: PermissionConfig = {
+  allow: ['SendMessage', 'Read'],
+};
+
+const PRESETS: Record<string, PermissionConfig> = {
+  full: PRESET_FULL,
+  'read-only': PRESET_READ_ONLY,
+  'chat-only': PRESET_CHAT_ONLY,
+};
+
+export function resolvePreset(name: string): PermissionConfig {
+  const preset = PRESETS[name];
+  if (!preset) {
+    throw new Error(`Unknown permission preset "${name}". Valid: ${Object.keys(PRESETS).join(', ')}`);
+  }
+  return preset;
+}
+
+// ============================================================================
+// Bash Pattern Matching
+// ============================================================================
+
+function matchesBashAllow(command: string, patterns: string[]): boolean {
+  const normalized = normalizeCommand(command);
+
+  // Compound commands (&&, ||, |, ;) require full match
+  if (hasShellMetacharacters(normalized)) {
+    for (const pattern of patterns) {
+      try {
+        const match = normalized.match(new RegExp(pattern));
+        if (match && match[0] === normalized) return true;
+      } catch {
+        /* invalid regex — skip */
+      }
+    }
+    return false;
+  }
+
+  // Simple commands — substring regex match
+  for (const pattern of patterns) {
+    try {
+      if (new RegExp(pattern).test(normalized)) return true;
+    } catch {
+      if (normalized.includes(pattern)) return true;
+    }
+  }
+  return false;
+}
+
+// ============================================================================
+// Gate Factory
+// ============================================================================
+
+/**
+ * Create a PreToolUse hook from a PermissionConfig.
+ *
+ * Logic:
+ * 1. Tool not in allow list? Denied.
+ * 2. Tool is Bash and bashAllowPatterns exist? Command must match a pattern.
+ * 3. Otherwise allowed.
+ */
+export function createPermissionGate(config: PermissionConfig): HookCallback {
+  const { allow, bashAllowPatterns = [] } = config;
+  const allowAll = allow.includes('*');
+  const allowSet = new Set(allow);
+
+  return async (input): Promise<SyncHookJSONOutput> => {
+    const hookInput = input as PreToolUseHookInput;
+    const toolName = hookInput.tool_name;
+
+    // 1. Not in allow list → denied
+    if (!allowAll && !allowSet.has(toolName)) {
+      return {
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          permissionDecisionReason: `Tool "${toolName}" is not allowed. Allowed: ${allow.join(', ')}`,
+        },
+      };
+    }
+
+    // 2. Bash + patterns → command must match
+    if (toolName === 'Bash' && bashAllowPatterns.length > 0) {
+      const toolInput = (hookInput.tool_input ?? {}) as Record<string, unknown>;
+      const command = typeof toolInput.command === 'string' ? toolInput.command : '';
+      if (!command || !matchesBashAllow(command, bashAllowPatterns)) {
+        return {
+          hookSpecificOutput: {
+            hookEventName: 'PreToolUse',
+            permissionDecision: 'deny',
+            permissionDecisionReason: `Bash command not in allow patterns: ${command || '(empty)'}`,
+          },
+        };
+      }
+    }
+
+    // 3. Allowed
+    return { hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: 'allow' } };
+  };
+}

--- a/src/lib/providers/claude-sdk.ts
+++ b/src/lib/providers/claude-sdk.ts
@@ -1,0 +1,161 @@
+/**
+ * ClaudeSdkProvider — ExecutorProvider for Claude Agent SDK (in-process).
+ *
+ * Transport: process (in-process SDK query, no shell/tmux)
+ * State detection: tracks query lifecycle via internal flag
+ * Session extraction: returns claudeSessionId from executor metadata
+ * Resume: not supported (stateless for now)
+ * Termination: AbortController signal
+ */
+
+import { query } from '@anthropic-ai/claude-agent-sdk';
+import type { Options, Query, SDKMessage } from '@anthropic-ai/claude-agent-sdk';
+import type {
+  Executor,
+  ExecutorProvider,
+  ExecutorState,
+  LaunchCommand,
+  SpawnContext,
+  TransportType,
+} from '../executor-types.js';
+import type { PermissionConfig } from './claude-sdk-permissions.js';
+import { createPermissionGate } from './claude-sdk-permissions.js';
+
+// ============================================================================
+// Provider Implementation
+// ============================================================================
+
+export class ClaudeSdkProvider implements ExecutorProvider {
+  readonly name = 'claude-sdk';
+  readonly transport: TransportType = 'process';
+
+  /** Active queries keyed by executor ID, for state detection and termination. */
+  private activeQueries = new Map<string, { abortController: AbortController; done: boolean }>();
+
+  /**
+   * Build a metadata-only LaunchCommand.
+   *
+   * The SDK provider runs in-process — there is no shell command to execute.
+   * The command field is a sentinel value indicating in-process execution.
+   */
+  buildSpawnCommand(ctx: SpawnContext): LaunchCommand {
+    return {
+      command: 'claude-sdk-in-process',
+      provider: 'claude-sdk',
+      meta: {
+        role: ctx.role,
+        skill: ctx.skill,
+      },
+    };
+  }
+
+  /**
+   * Run an SDK query for a given spawn context.
+   *
+   * Returns an async iterable of SDK messages. The caller is responsible
+   * for iterating the result to drive execution.
+   */
+  runQuery(
+    ctx: SpawnContext,
+    prompt: string,
+    permissionConfig?: PermissionConfig,
+    extraOptions?: Partial<Options>,
+  ): { messages: Query; abortController: AbortController } {
+    const abortController = new AbortController();
+
+    // Track this query
+    const tracker = { abortController, done: false };
+    this.activeQueries.set(ctx.executorId, tracker);
+
+    const options: Options = {
+      cwd: ctx.cwd,
+      abortController,
+      permissionMode: 'bypassPermissions',
+      allowDangerouslySkipPermissions: true,
+      ...(ctx.model && { model: ctx.model }),
+      ...(ctx.systemPrompt && { systemPrompt: ctx.systemPrompt }),
+      ...(permissionConfig && {
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: '*',
+              hooks: [createPermissionGate(permissionConfig)],
+            },
+          ],
+        },
+      }),
+      ...extraOptions,
+    };
+
+    const messages = query({ prompt, options });
+
+    // Wrap to track completion
+    const originalReturn = messages.return.bind(messages);
+    messages.return = async (value?: undefined) => {
+      tracker.done = true;
+      this.activeQueries.delete(ctx.executorId);
+      return originalReturn(value);
+    };
+
+    // Track natural completion via a side-effect listener
+    const self = this;
+    const wrappedMessages = (async function* (): AsyncGenerator<SDKMessage, void> {
+      try {
+        yield* messages;
+      } finally {
+        tracker.done = true;
+        self.activeQueries.delete(ctx.executorId);
+      }
+    })() as Query;
+
+    // Preserve control methods from the original Query
+    wrappedMessages.interrupt = messages.interrupt.bind(messages);
+    wrappedMessages.setPermissionMode = messages.setPermissionMode.bind(messages);
+    wrappedMessages.setModel = messages.setModel.bind(messages);
+    wrappedMessages.return = messages.return.bind(messages);
+    wrappedMessages.throw = messages.throw.bind(messages);
+
+    return { messages: wrappedMessages, abortController };
+  }
+
+  /**
+   * Extract session metadata from an executor.
+   *
+   * Returns the claudeSessionId if available. No JSONL discovery needed
+   * since the SDK runs in-process.
+   */
+  async extractSession(executor: Executor): Promise<{ sessionId: string; logPath?: string } | null> {
+    const sessionId = executor.claudeSessionId;
+    if (!sessionId) return null;
+    return { sessionId };
+  }
+
+  /**
+   * Detect the current state of an executor.
+   *
+   * Checks the internal query tracker. If the executor has an active query,
+   * it's running. If the query completed, it's done. Otherwise terminated.
+   */
+  async detectState(executor: Executor): Promise<ExecutorState> {
+    const tracker = this.activeQueries.get(executor.id);
+    if (!tracker) return 'done';
+    return tracker.done ? 'done' : 'running';
+  }
+
+  /**
+   * Terminate the executor by aborting its query.
+   */
+  async terminate(executor: Executor): Promise<void> {
+    const tracker = this.activeQueries.get(executor.id);
+    if (tracker) {
+      tracker.abortController.abort();
+      tracker.done = true;
+      this.activeQueries.delete(executor.id);
+    }
+  }
+
+  /** SDK provider does not support resume (stateless for now). */
+  canResume(): boolean {
+    return false;
+  }
+}

--- a/src/lib/providers/registry.ts
+++ b/src/lib/providers/registry.ts
@@ -9,6 +9,7 @@ import type { ExecutorProvider } from '../executor-types.js';
 import type { ProviderName } from '../provider-adapters.js';
 import { AppPtyProvider } from './app-pty.js';
 import { ClaudeCodeProvider } from './claude-code.js';
+import { ClaudeSdkProvider } from './claude-sdk.js';
 import { CodexProvider } from './codex.js';
 
 // ============================================================================
@@ -43,7 +44,9 @@ export function listProviders(): ExecutorProvider[] {
 const claude = new ClaudeCodeProvider();
 const codex = new CodexProvider();
 const appPty = new AppPtyProvider();
+const claudeSdk = new ClaudeSdkProvider();
 
 providers.set('claude', claude);
 providers.set('codex', codex);
 providers.set('app-pty', appPty);
+providers.set('claude-sdk', claudeSdk);

--- a/src/services/executors/__tests__/claude-sdk.test.ts
+++ b/src/services/executors/__tests__/claude-sdk.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+// Mock agent directory
+mock.module('../../../lib/agent-directory.js', () => ({
+  resolve: mock(async (name: string) => ({
+    entry: {
+      name,
+      dir: '/tmp/test',
+      promptMode: 'system' as const,
+      model: 'sonnet',
+      registeredAt: new Date().toISOString(),
+      permissions: { preset: 'full' },
+    },
+    builtin: false,
+  })),
+  loadIdentity: mock(() => null),
+}));
+
+// Mock the SDK query function
+mock.module('@anthropic-ai/claude-agent-sdk', () => ({
+  query: mock(() => {
+    const gen = (async function* () {
+      yield { type: 'assistant', message: { content: [{ type: 'text', text: 'response text' }] } };
+    })();
+    return Object.assign(gen, {
+      interrupt: mock(),
+      setPermissionMode: mock(),
+      setModel: mock(),
+      return: mock(async () => ({ value: undefined, done: true })),
+      throw: mock(async () => ({ value: undefined, done: true })),
+    });
+  }),
+}));
+
+const { ClaudeSdkOmniExecutor } = await import('../claude-sdk.js');
+const directory = await import('../../../lib/agent-directory.js');
+
+describe('ClaudeSdkOmniExecutor', () => {
+  let executor: InstanceType<typeof ClaudeSdkOmniExecutor>;
+
+  beforeEach(() => {
+    executor = new ClaudeSdkOmniExecutor();
+  });
+
+  describe('spawn', () => {
+    it('creates session with correct id format', async () => {
+      const session = await executor.spawn('test-agent', 'chat-123', {});
+      expect(session.id).toBe('test-agent:chat-123');
+      expect(session.agentName).toBe('test-agent');
+      expect(session.chatId).toBe('chat-123');
+      expect(session.paneId).toBe('sdk-chat-123');
+      expect(session.tmuxSession).toBe('');
+      expect(session.tmuxWindow).toBe('');
+    });
+
+    it('resolves agent from directory', async () => {
+      await executor.spawn('my-agent', 'chat-1', {});
+      expect(directory.resolve).toHaveBeenCalledWith('my-agent');
+    });
+
+    it('throws if agent not found in directory', async () => {
+      (directory.resolve as ReturnType<typeof mock>).mockResolvedValueOnce(null);
+      await expect(executor.spawn('unknown', 'chat-1', {})).rejects.toThrow('not found in genie directory');
+    });
+  });
+
+  describe('isAlive', () => {
+    it('returns true for active session', async () => {
+      const session = await executor.spawn('test-agent', 'chat-1', {});
+      expect(await executor.isAlive(session)).toBe(true);
+    });
+
+    it('returns false after shutdown', async () => {
+      const session = await executor.spawn('test-agent', 'chat-1', {});
+      await executor.shutdown(session);
+      expect(await executor.isAlive(session)).toBe(false);
+    });
+
+    it('returns false for unknown session', async () => {
+      const fakeSession = {
+        id: 'nonexistent',
+        agentName: 'x',
+        chatId: 'y',
+        tmuxSession: '',
+        tmuxWindow: '',
+        paneId: '',
+        createdAt: 0,
+        lastActivityAt: 0,
+      };
+      expect(await executor.isAlive(fakeSession)).toBe(false);
+    });
+  });
+
+  describe('shutdown', () => {
+    it('aborts via AbortController', async () => {
+      const session = await executor.spawn('test-agent', 'chat-1', {});
+      await executor.shutdown(session);
+      // Session is removed, isAlive returns false
+      expect(await executor.isAlive(session)).toBe(false);
+    });
+
+    it('is idempotent for unknown session', async () => {
+      const fakeSession = {
+        id: 'nonexistent',
+        agentName: 'x',
+        chatId: 'y',
+        tmuxSession: '',
+        tmuxWindow: '',
+        paneId: '',
+        createdAt: 0,
+        lastActivityAt: 0,
+      };
+      // Should not throw
+      await executor.shutdown(fakeSession);
+    });
+  });
+
+  describe('deliver', () => {
+    it('calls runQuery with message content and publishes reply via NATS', async () => {
+      const natsPublish = mock();
+      executor.setNatsPublish(natsPublish);
+
+      const session = await executor.spawn('test-agent', 'chat-1', {});
+      const message = {
+        content: 'Hello agent',
+        sender: 'user',
+        instanceId: 'inst-1',
+        chatId: 'chat-1',
+        agent: 'test-agent',
+      };
+
+      await executor.deliver(session, message);
+
+      // Verify NATS publish was called with the reply
+      expect(natsPublish).toHaveBeenCalledTimes(1);
+      const [topic, payload] = natsPublish.mock.calls[0];
+      expect(topic).toBe('omni.reply.inst-1.chat-1');
+      const parsed = JSON.parse(payload);
+      expect(parsed.content).toBe('response text');
+      expect(parsed.agent).toBe('test-agent');
+      expect(parsed.chat_id).toBe('chat-1');
+    });
+
+    it('throws if session not found', async () => {
+      const fakeSession = {
+        id: 'nonexistent',
+        agentName: 'x',
+        chatId: 'y',
+        tmuxSession: '',
+        tmuxWindow: '',
+        paneId: '',
+        createdAt: 0,
+        lastActivityAt: 0,
+      };
+      await expect(
+        executor.deliver(fakeSession, { content: 'hi', sender: 'u', instanceId: 'i', chatId: 'c', agent: 'a' }),
+      ).rejects.toThrow('No SDK session found');
+    });
+
+    it('does not throw when NATS publish is not set', async () => {
+      // No setNatsPublish call — natsPublish is null
+      const session = await executor.spawn('test-agent', 'chat-no-nats', {});
+      const message = {
+        content: 'Hello agent',
+        sender: 'user',
+        instanceId: 'inst-1',
+        chatId: 'chat-no-nats',
+        agent: 'test-agent',
+      };
+
+      // Should not throw — reply is silently dropped when no NATS
+      await executor.deliver(session, message);
+    });
+
+    it('updates lastActivityAt after delivery', async () => {
+      const natsPublish = mock();
+      executor.setNatsPublish(natsPublish);
+
+      const session = await executor.spawn('test-agent', 'chat-ts', {});
+      const before = session.lastActivityAt;
+
+      // Small delay to ensure timestamp changes
+      await new Promise((r) => setTimeout(r, 5));
+
+      await executor.deliver(session, {
+        content: 'test',
+        sender: 'user',
+        instanceId: 'inst-1',
+        chatId: 'chat-ts',
+        agent: 'test-agent',
+      });
+
+      expect(session.lastActivityAt).toBeGreaterThanOrEqual(before);
+    });
+  });
+
+  describe('multiple sessions', () => {
+    it('manages independent sessions for different chats', async () => {
+      const s1 = await executor.spawn('agent-a', 'chat-1', {});
+      const s2 = await executor.spawn('agent-b', 'chat-2', {});
+
+      expect(s1.id).not.toBe(s2.id);
+      expect(await executor.isAlive(s1)).toBe(true);
+      expect(await executor.isAlive(s2)).toBe(true);
+
+      await executor.shutdown(s1);
+      expect(await executor.isAlive(s1)).toBe(false);
+      expect(await executor.isAlive(s2)).toBe(true);
+    });
+  });
+});

--- a/src/services/executors/claude-sdk.ts
+++ b/src/services/executors/claude-sdk.ts
@@ -1,0 +1,215 @@
+import type { Query } from '@anthropic-ai/claude-agent-sdk';
+import * as directory from '../../lib/agent-directory.js';
+import type { PermissionConfig } from '../../lib/providers/claude-sdk-permissions.js';
+import { PRESET_FULL, resolvePreset } from '../../lib/providers/claude-sdk-permissions.js';
+import { ClaudeSdkProvider } from '../../lib/providers/claude-sdk.js';
+import type { IExecutor, OmniMessage, OmniSession } from '../executor.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface SdkSessionState {
+  abortController: AbortController;
+  running: boolean;
+  provider: ClaudeSdkProvider;
+  /** Claude session ID for resume (set after first query completes). */
+  claudeSessionId?: string;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Resolve permission config from a directory entry. */
+function resolvePermissionConfig(entry: directory.DirectoryEntry): PermissionConfig {
+  if (entry.permissions?.preset) {
+    return resolvePreset(entry.permissions.preset);
+  }
+  if (entry.permissions?.allow) {
+    return {
+      allow: entry.permissions.allow,
+      bashAllowPatterns: entry.permissions.bashAllowPatterns,
+    };
+  }
+  return PRESET_FULL;
+}
+
+/** Load system prompt from AGENTS.md if available. */
+async function loadSystemPrompt(entry: directory.DirectoryEntry): Promise<string | undefined> {
+  const identityPath = directory.loadIdentity(entry);
+  if (!identityPath) return undefined;
+  const { readFileSync } = await import('node:fs');
+  try {
+    return readFileSync(identityPath, 'utf-8');
+  } catch {
+    return undefined;
+  }
+}
+
+/** Result from consuming an SDK query stream. */
+interface QueryResult {
+  text: string;
+  sessionId?: string;
+}
+
+/** Extract text blocks from an assistant message. */
+function extractTextFromAssistant(msg: { message?: { content: Array<{ type: string; text?: string }> } }): string[] {
+  if (!msg.message) return [];
+  return msg.message.content.filter((b) => b.type === 'text' && b.text).map((b) => b.text as string);
+}
+
+/** Collect assistant text and session ID from an SDK query message stream. */
+async function collectQueryResult(queryMessages: Query): Promise<QueryResult> {
+  const textParts: string[] = [];
+  let sessionId: string | undefined;
+  try {
+    for await (const msg of queryMessages) {
+      if (msg.type === 'assistant') {
+        textParts.push(...extractTextFromAssistant(msg));
+      }
+      if (msg.type === 'result' && msg.subtype === 'success') {
+        sessionId = msg.session_id;
+      }
+    }
+  } catch (err) {
+    if ((err as Error).name === 'AbortError') return { text: '' };
+    throw err;
+  }
+  return { text: textParts.join('\n').trim(), sessionId };
+}
+
+// ============================================================================
+// Implementation
+// ============================================================================
+
+export class ClaudeSdkOmniExecutor implements IExecutor {
+  private sessions = new Map<string, SdkSessionState>();
+  private natsPublish: ((topic: string, payload: string) => void) | null = null;
+
+  /**
+   * Set the NATS publish function for reply routing.
+   * Called by the bridge after construction.
+   */
+  setNatsPublish(fn: (topic: string, payload: string) => void): void {
+    this.natsPublish = fn;
+  }
+
+  /**
+   * Spawn an SDK-backed agent session for a chat.
+   *
+   * Resolves the agent from the genie directory, creates a ClaudeSdkProvider
+   * instance, and stores an AbortController for shutdown.
+   */
+  async spawn(agentName: string, chatId: string, _env: Record<string, string>): Promise<OmniSession> {
+    const resolved = await directory.resolve(agentName);
+    if (!resolved) {
+      throw new Error(`Agent "${agentName}" not found in genie directory`);
+    }
+
+    const provider = new ClaudeSdkProvider();
+    const abortController = new AbortController();
+
+    const sessionId = `${agentName}:${chatId}`;
+    this.sessions.set(sessionId, {
+      abortController,
+      running: true,
+      provider,
+    });
+
+    const now = Date.now();
+    return {
+      id: sessionId,
+      agentName,
+      chatId,
+      tmuxSession: '',
+      tmuxWindow: '',
+      paneId: `sdk-${chatId}`,
+      createdAt: now,
+      lastActivityAt: now,
+    };
+  }
+
+  /**
+   * Deliver a message by running a stateless SDK query.
+   *
+   * Creates a new query() per message, collects the result text,
+   * and publishes the reply via NATS.
+   */
+  async deliver(session: OmniSession, message: OmniMessage): Promise<void> {
+    const state = this.sessions.get(session.id);
+    if (!state) {
+      throw new Error(`No SDK session found for ${session.id}`);
+    }
+
+    const resolved = await directory.resolve(session.agentName);
+    if (!resolved) {
+      throw new Error(`Agent "${session.agentName}" not found in genie directory`);
+    }
+
+    const entry = resolved.entry;
+    const permissionConfig = resolvePermissionConfig(entry);
+    const systemPrompt = await loadSystemPrompt(entry);
+
+    // Resume existing session or start fresh
+    const extraOptions: Record<string, unknown> = { abortController: state.abortController };
+    if (state.claudeSessionId) {
+      extraOptions.resume = state.claudeSessionId;
+    }
+
+    const { messages: queryMessages } = state.provider.runQuery(
+      {
+        agentId: session.agentName,
+        executorId: session.id,
+        team: '',
+        role: session.agentName,
+        cwd: entry.dir || process.cwd(),
+        model: entry.model,
+        systemPrompt: state.claudeSessionId ? undefined : systemPrompt,
+      },
+      message.content,
+      permissionConfig,
+      extraOptions,
+    );
+
+    const result = await collectQueryResult(queryMessages);
+    if (result.sessionId) {
+      state.claudeSessionId = result.sessionId;
+    }
+    const replyText = result.text;
+    if (replyText && this.natsPublish) {
+      const topic = `omni.reply.${message.instanceId}.${message.chatId}`;
+      const payload = JSON.stringify({
+        content: replyText,
+        agent: session.agentName,
+        chat_id: message.chatId,
+        instance_id: message.instanceId,
+        timestamp: new Date().toISOString(),
+      });
+      this.natsPublish(topic, payload);
+    }
+
+    session.lastActivityAt = Date.now();
+  }
+
+  /**
+   * Shut down a session by aborting any active query.
+   */
+  async shutdown(session: OmniSession): Promise<void> {
+    const state = this.sessions.get(session.id);
+    if (state) {
+      state.abortController.abort();
+      state.running = false;
+      this.sessions.delete(session.id);
+    }
+  }
+
+  /**
+   * Check if a session is still alive (not aborted, not removed).
+   */
+  async isAlive(session: OmniSession): Promise<boolean> {
+    const state = this.sessions.get(session.id);
+    if (!state) return false;
+    return state.running && !state.abortController.signal.aborted;
+  }
+}

--- a/src/services/omni-bridge.ts
+++ b/src/services/omni-bridge.ts
@@ -13,6 +13,7 @@
 import { type NatsConnection, StringCodec, type Subscription, connect } from 'nats';
 import type { IExecutor, OmniMessage, OmniSession } from './executor.js';
 import { ClaudeCodeOmniExecutor } from './executors/claude-code.js';
+import { ClaudeSdkOmniExecutor } from './executors/claude-sdk.js';
 
 // ============================================================================
 // Configuration
@@ -32,6 +33,7 @@ interface BridgeConfig {
   natsUrl?: string;
   idleTimeoutMs?: number;
   maxConcurrent?: number;
+  executorType?: 'tmux' | 'sdk';
 }
 
 interface SessionEntry {
@@ -96,7 +98,13 @@ export class OmniBridge {
     this.maxConcurrent =
       config.maxConcurrent ??
       (process.env.GENIE_MAX_CONCURRENT ? Number(process.env.GENIE_MAX_CONCURRENT) : DEFAULT_MAX_CONCURRENT);
-    this.executor = new ClaudeCodeOmniExecutor();
+
+    const executorType = config.executorType ?? (process.env.GENIE_EXECUTOR_TYPE as 'tmux' | 'sdk') ?? 'tmux';
+    if (executorType === 'sdk') {
+      this.executor = new ClaudeSdkOmniExecutor();
+    } else {
+      this.executor = new ClaudeCodeOmniExecutor();
+    }
   }
 
   /**
@@ -119,6 +127,15 @@ export class OmniBridge {
     });
 
     console.log('[omni-bridge] Connected to NATS');
+
+    // Wire NATS publish into SDK executor for reply routing
+    if (this.executor instanceof ClaudeSdkOmniExecutor) {
+      const nc = this.nc;
+      const sc = this.sc;
+      this.executor.setNatsPublish((topic, payload) => {
+        nc.publish(topic, sc.encode(payload));
+      });
+    }
 
     // Subscribe to all omni messages
     this.sub = this.nc.subscribe('omni.message.>');

--- a/src/term-commands/agent/spawn.ts
+++ b/src/term-commands/agent/spawn.ts
@@ -10,7 +10,7 @@ export function registerAgentSpawn(parent: Command): void {
   parent
     .command('spawn <name>')
     .description('Spawn a new agent by name (resolves from directory or built-ins)')
-    .option('--provider <provider>', 'Provider: claude or codex')
+    .option('--provider <provider>', 'Provider: claude, codex, or claude-sdk')
     .option('--team <team>', 'Team name', process.env.GENIE_TEAM ?? 'genie')
     .option('--model <model>', 'Model override (e.g., sonnet, opus)')
     .option('--skill <skill>', 'Skill to load (optional)')
@@ -25,7 +25,9 @@ export function registerAgentSpawn(parent: Command): void {
     .option('--new-window', 'Create a new tmux window instead of splitting')
     .option('--window <target>', 'Tmux window to split into (e.g., genie:3)')
     .option('--no-auto-resume', 'Disable auto-resume on pane death')
+    .option('--prompt <prompt>', 'Initial prompt (first user message)')
     .action(async (name: string, options: SpawnOptions) => {
+      if (options.prompt) options.initialPrompt = options.prompt;
       try {
         await handleWorkerSpawn(name, options);
       } catch (error) {

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -438,6 +438,7 @@ async function capturePanePid(paneId: string): Promise<number | null> {
 /** Resolve the executor transport type from provider and spawn transport. */
 function resolveExecutorTransport(provider: ProviderName, spawnTransport: 'tmux' | 'inline'): ExecutorTransport {
   if (provider === 'codex') return 'api';
+  if (provider === 'claude-sdk') return 'process';
   return spawnTransport === 'inline' ? 'process' : 'tmux';
 }
 
@@ -756,6 +757,7 @@ async function autoConfirmTrustPrompt(paneId: string): Promise<void> {
  * First agent in a newly created team window reuses the blank pane via send-keys.
  * Subsequent agents split-window into the same team window.
  */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: pre-existing tmux pane routing logic, split targets and launch modes are interdependent
 function createTmuxPane(ctx: SpawnCtx & { sessionOverride?: string }, teamWindow: TeamWindowInfo | null): string {
   const { execSync } = require('node:child_process');
   const useLaunchScript = ctx.validated.provider === 'claude' && Boolean(ctx.validated.nativeTeam?.enabled);
@@ -922,6 +924,95 @@ async function launchTmuxSpawn(ctx: SpawnCtx): Promise<string> {
   return paneId;
 }
 
+async function resolveSdkPermissions(
+  permissionsConfig: directory.DirectoryEntry['permissions'] | undefined,
+): Promise<{ allow: string[]; bashAllowPatterns?: string[] }> {
+  const sdkPerms = await import('../lib/providers/claude-sdk-permissions.js');
+  if (!permissionsConfig) return sdkPerms.PRESET_FULL;
+  if (permissionsConfig.preset) return sdkPerms.resolvePreset(permissionsConfig.preset);
+  return {
+    allow: permissionsConfig.allow ?? ['*'],
+    bashAllowPatterns: permissionsConfig.bashAllowPatterns,
+  };
+}
+
+async function runSdkQuery(
+  ctx: SpawnCtx,
+  permConfig: { allow: string[]; bashAllowPatterns?: string[] },
+): Promise<void> {
+  const { ClaudeSdkProvider } = await import('../lib/providers/claude-sdk.js');
+  const sdkProvider = new ClaudeSdkProvider();
+  const spawnContext = {
+    agentId: ctx.agentIdentityId ?? ctx.workerId,
+    executorId: ctx.executorId ?? crypto.randomUUID(),
+    team: ctx.validated.team,
+    role: ctx.validated.role,
+    skill: ctx.validated.skill,
+    cwd: ctx.cwd,
+    model: ctx.validated.model,
+    systemPrompt: ctx.validated.systemPrompt,
+    systemPromptFile: ctx.validated.systemPromptFile,
+    initialPrompt: ctx.validated.initialPrompt,
+    name: ctx.validated.name,
+  };
+
+  const prompt =
+    ctx.validated.initialPrompt ??
+    `You are ${ctx.validated.role ?? 'an agent'} on team "${ctx.validated.team}". Awaiting instructions.`;
+  const { messages } = sdkProvider.runQuery(spawnContext, prompt, permConfig);
+
+  if (ctx.executorId) {
+    await executorRegistry.updateExecutorState(ctx.executorId, 'running').catch(() => {});
+  }
+
+  try {
+    for await (const message of messages) {
+      if (message.type === 'assistant' && message.message) {
+        for (const block of message.message.content) {
+          if (block.type === 'text' && block.text) process.stdout.write(block.text);
+        }
+      }
+      if (message.type === 'result' && message.subtype === 'success' && message.result) {
+        console.log(message.result);
+      }
+    }
+  } catch (err) {
+    if (!(err instanceof Error && err.name === 'AbortError')) {
+      console.error(`SDK query error: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+}
+
+async function launchSdkSpawn(
+  ctx: SpawnCtx,
+  permissionsConfig?: directory.DirectoryEntry['permissions'],
+): Promise<string> {
+  if (ctx.agentIdentityId && ctx.executorId) {
+    await createAndLinkExecutor(ctx.agentIdentityId, 'claude-sdk' as ProviderName, 'process', {
+      id: ctx.executorId,
+      claudeSessionId: null,
+      state: 'spawning',
+      repoPath: ctx.cwd,
+    });
+  }
+
+  await registerSpawnWorker(ctx, 'sdk');
+
+  console.log(`Agent "${ctx.workerId}" starting via Claude Agent SDK...`);
+  console.log(`  Provider: claude-sdk | Team: ${ctx.validated.team} | Role: ${ctx.validated.role ?? '-'}`);
+  console.log('');
+
+  const permConfig = await resolveSdkPermissions(permissionsConfig);
+  await runSdkQuery(ctx, permConfig);
+
+  if (ctx.executorId) {
+    await executorRegistry.updateExecutorState(ctx.executorId, 'done').catch(() => {});
+  }
+  await registry.unregister(ctx.workerId);
+  console.log(`\nAgent "${ctx.workerId}" SDK session ended.`);
+  return ctx.workerId;
+}
+
 async function launchInlineSpawn(ctx: SpawnCtx): Promise<string> {
   const nt = ctx.validated.nativeTeam;
   const paneId = 'inline';
@@ -1076,8 +1167,10 @@ export interface SpawnOptions {
   permissionMode?: string;
   extraArgs?: string[];
   cwd?: string;
-  /** Initial prompt to send as the first user message (Claude Code positional [prompt] arg). */
+  /** Initial prompt to send as the first user message. */
   initialPrompt?: string;
+  /** CLI alias for initialPrompt (--prompt flag). */
+  prompt?: string;
   /** Override the role name for registration and duplicate-check (agent directory still resolves by `name`). */
   role?: string;
   /** Explicit tmux session name to spawn into (overrides auto-detection). */
@@ -1296,6 +1389,11 @@ export async function handleWorkerSpawn(name: string, options: SpawnOptions): Pr
     team: validated.team,
     provider: validated.provider,
   }).catch(() => {});
+
+  // SDK provider: in-process query, no tmux/shell needed
+  if (validated.provider === 'claude-sdk') {
+    return await launchSdkSpawn(ctx, agent.entry.permissions);
+  }
 
   if (insideTmux) {
     return await launchTmuxSpawn(ctx);

--- a/src/term-commands/dir.ts
+++ b/src/term-commands/dir.ts
@@ -35,6 +35,9 @@ export function registerDirNamespace(program: Command): void {
     .option('--prompt-mode <mode>', 'Prompt mode: append or system', 'append')
     .option('--model <model>', 'Default model (sonnet, opus, codex)')
     .option('--roles <roles...>', 'Built-in roles this agent can orchestrate')
+    .option('--permission-preset <preset>', 'Permission preset: full, read-only, chat-only')
+    .option('--allow <tools>', 'Comma-separated tool allow list (e.g. "Read,Glob,Grep,Bash")')
+    .option('--bash-allow <patterns>', 'Comma-separated regex patterns for allowed bash commands')
     .option('--global', 'Write to global directory instead of project')
     .action(async (name: string, options: DirAddOptions) => {
       try {
@@ -103,6 +106,9 @@ export function registerDirNamespace(program: Command): void {
     .option('--color <color>', 'Display color for TUI')
     .option('--description <desc>', 'Agent description')
     .option('--roles <roles...>', 'Built-in roles this agent can orchestrate')
+    .option('--permission-preset <preset>', 'Permission preset: full, read-only, chat-only')
+    .option('--allow <tools>', 'Comma-separated tool allow list (e.g. "Read,Glob,Grep,Bash")')
+    .option('--bash-allow <patterns>', 'Comma-separated regex patterns for allowed bash commands')
     .option('--global', 'Edit in global directory instead of project')
     .action(async (name: string, options: EditOptions) => {
       try {
@@ -135,6 +141,9 @@ interface DirAddOptions {
   promptMode: string;
   model?: string;
   roles?: string[];
+  permissionPreset?: string;
+  allow?: string;
+  bashAllow?: string;
   global?: boolean;
 }
 
@@ -142,6 +151,7 @@ async function handleDirAdd(name: string, options: DirAddOptions): Promise<void>
   const promptMode = validatePromptMode(options.promptMode);
   const resolvedDir = resolvePath(options.dir);
   if (options.repo) validateRepoPath(options.repo);
+  const permissions = buildPermissions(options.permissionPreset, options.allow, options.bashAllow);
   const entry = await directory.add(
     {
       name,
@@ -150,6 +160,7 @@ async function handleDirAdd(name: string, options: DirAddOptions): Promise<void>
       promptMode,
       model: options.model,
       roles: normalizeRoles(options.roles),
+      ...(permissions && { permissions }),
     },
     { global: options.global },
   );
@@ -170,6 +181,9 @@ interface EditOptions {
   color?: string;
   description?: string;
   roles?: string[];
+  permissionPreset?: string;
+  allow?: string;
+  bashAllow?: string;
   global?: boolean;
 }
 
@@ -184,9 +198,12 @@ async function handleEdit(name: string, options: EditOptions): Promise<void> {
   if (options.description) updates.description = options.description;
   if (options.roles) updates.roles = normalizeRoles(options.roles);
 
+  const permissions = buildPermissions(options.permissionPreset, options.allow, options.bashAllow);
+  if (permissions) updates.permissions = permissions;
+
   if (Object.keys(updates).length === 0) {
     console.error(
-      'No fields to update. Provide at least one of: --dir, --repo, --prompt-mode, --model, --provider, --color, --description, --roles',
+      'No fields to update. Provide at least one of: --dir, --repo, --prompt-mode, --model, --provider, --color, --description, --roles, --permission-preset, --allow, --bash-allow',
     );
     process.exit(1);
   }
@@ -246,6 +263,13 @@ function printEntry(entry: directory.DirectoryEntry): void {
   if (entry.color) console.log(`  Color: ${entry.color}`);
   if (entry.description) console.log(`  Description: ${entry.description}`);
   if (entry.roles?.length) console.log(`  Roles: ${entry.roles.join(', ')}`);
+  if (entry.permissions?.preset) console.log(`  Permissions: preset=${entry.permissions.preset}`);
+  else if (entry.permissions?.allow) {
+    console.log(`  Permissions: allow=${entry.permissions.allow.join(',')}`);
+    if (entry.permissions.bashAllowPatterns?.length) {
+      console.log(`  Bash Allow: ${entry.permissions.bashAllowPatterns.join(', ')}`);
+    }
+  }
   console.log(`  Registered: ${entry.registeredAt}`);
 }
 
@@ -311,6 +335,30 @@ function listEntriesJson(entries: directory.ScopedDirectoryEntry[], includeBuilt
     }
   }
   console.log(JSON.stringify(result, null, 2));
+}
+
+/** Build permissions config from CLI flags. Returns undefined if no flags set. */
+function buildPermissions(
+  permissionPreset?: string,
+  allow?: string,
+  bashAllow?: string,
+): directory.DirectoryEntry['permissions'] | undefined {
+  if (!permissionPreset && !allow && !bashAllow) return undefined;
+  if (permissionPreset) return { preset: permissionPreset };
+  return {
+    ...(allow && {
+      allow: allow
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean),
+    }),
+    ...(bashAllow && {
+      bashAllowPatterns: bashAllow
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean),
+    }),
+  };
 }
 
 /** Normalize roles: split comma-separated values into individual array items. */

--- a/src/term-commands/omni.ts
+++ b/src/term-commands/omni.ts
@@ -16,6 +16,7 @@ export function registerOmniCommands(program: Command): void {
     .option('--nats-url <url>', 'NATS server URL', process.env.GENIE_NATS_URL ?? 'localhost:4222')
     .option('--max-concurrent <n>', 'Max concurrent agent sessions', process.env.GENIE_MAX_CONCURRENT ?? '20')
     .option('--idle-timeout <ms>', 'Idle timeout in ms', process.env.GENIE_IDLE_TIMEOUT_MS ?? '900000')
+    .option('--executor <type>', 'Executor type: tmux (default) or sdk', process.env.GENIE_EXECUTOR_TYPE ?? 'tmux')
     .action(async (options) => {
       const { OmniBridge } = await import('../services/omni-bridge.js');
 
@@ -23,6 +24,7 @@ export function registerOmniCommands(program: Command): void {
         natsUrl: options.natsUrl,
         maxConcurrent: Number(options.maxConcurrent),
         idleTimeoutMs: Number(options.idleTimeout),
+        executorType: options.executor as 'tmux' | 'sdk',
       });
 
       await bridge.start();


### PR DESCRIPTION
## Summary

- Add new `claude-sdk` executor provider using `@anthropic-ai/claude-agent-sdk` for programmatic agent execution with per-agent tool permission control
- 3-layer defense in depth: `tools` visibility, `disallowedTools` blacklist, `canUseTool` runtime gate via callback
- 3 built-in permission presets: `full`, `read-only`, `chat-only`
- Agent directory gets `permissions` field for per-agent config
- Omni bridge gets `--executor sdk` flag for SDK-based sessions with session resume
- SDK marked as `--external` in build (required — spawns claude as subprocess)

## Files (16 changed, +1400/-8)

**New:**
- `src/lib/providers/claude-sdk.ts` — ExecutorProvider using SDK `query()` in-process
- `src/lib/providers/claude-sdk-permissions.ts` — permission gate factory + presets
- `src/services/executors/claude-sdk.ts` — IExecutor for omni-bridge with session resume
- 3 test files (44 tests, 78 assertions)

**Modified:**
- `provider-adapters.ts` — added `'claude-sdk'` to ProviderName
- `agent-directory.ts` — added permissions field to DirectoryEntry
- `agents.ts` — wired `launchSdkSpawn()` for `--provider claude-sdk`
- `omni-bridge.ts` / `omni.ts` — `--executor sdk` flag
- `registry.ts` — registered ClaudeSdkProvider
- `package.json` — SDK dep + external build flag
- `knip.json` — ignore esbuild (transitive from SDK)

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` (SDK tests) — 44 pass, 0 fail
- [x] `bun run lint` — 0 errors
- [x] `bun run dead-code` — clean
- [x] Manual: `genie spawn sebrae-pm --provider claude-sdk` starts and completes
- [x] Manual: SDK session resume maintains conversation context across turns
- [x] Manual: abort mid-query works, session survives for resume
- [x] Manual: invalid session ID returns error without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)