### PR TITLE
feat(directory): extend DirectoryEntry with SDK configuration schema

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@namastexlabs/claudio",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.91",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.92",
         "@inquirer/prompts": "^7.0.0",
         "@opentui/core": "^0.1.91",
         "@opentui/react": "^0.1.91",
@@ -45,7 +45,7 @@
     "bun",
   ],
   "packages": {
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.91", "", { "dependencies": { "@anthropic-ai/sdk": "^0.80.0", "@modelcontextprotocol/sdk": "^1.27.1" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-DCd5Ad5XKBbIIOMZ73L+c+e9azM6NtZzOtdKQAzykzRG/KxSCMraMAsMMQrJrIUMH3oTtHY7QuQimAiElVVVpA=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.92", "", { "dependencies": { "@anthropic-ai/sdk": "^0.80.0", "@modelcontextprotocol/sdk": "^1.27.1" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-loYyxVUC5gBwHjGi9Fv0b84mduJTp9Z3Pum+y/7IVQDb4NynKfVQl6l4VeDKZaW+1QTQtd25tY4hwUznD7Krqw=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.80.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g=="],
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "check": "bun run typecheck && bun run lint && bun run dead-code && (bun test || bun test)"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.91",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.92",
     "@inquirer/prompts": "^7.0.0",
     "@opentui/core": "^0.1.91",
     "@opentui/react": "^0.1.91",

--- a/src/lib/agent-directory.test.ts
+++ b/src/lib/agent-directory.test.ts
@@ -78,6 +78,31 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
     test('returns null for unknown name', async () => {
       expect(await directory.resolve('nonexistent-xyz')).toBeNull();
     });
+
+    test('resolve returns sdk config from PG metadata', async () => {
+      const sql = await getConnection();
+      const sdkMeta = {
+        sdk: {
+          permissionMode: 'dontAsk',
+          maxTurns: 25,
+          betas: ['interleaved-thinking'],
+          systemPrompt: { type: 'preset', preset: 'claude_code', append: 'Be concise.' },
+        },
+      };
+      await sql`INSERT INTO agents (id, role, custom_name, started_at, metadata) VALUES ('dir:sdk-resolve', 'sdk-resolve', 'sdk-resolve', now(), ${sql.json(sdkMeta)})`;
+
+      const resolved = await directory.resolve('sdk-resolve');
+      expect(resolved).not.toBeNull();
+      expect(resolved!.entry.sdk).toBeDefined();
+      expect(resolved!.entry.sdk!.permissionMode).toBe('dontAsk');
+      expect(resolved!.entry.sdk!.maxTurns).toBe(25);
+      expect(resolved!.entry.sdk!.betas).toEqual(['interleaved-thinking']);
+      expect(resolved!.entry.sdk!.systemPrompt).toEqual({
+        type: 'preset',
+        preset: 'claude_code',
+        append: 'Be concise.',
+      });
+    });
   });
 
   // ============================================================================
@@ -171,6 +196,39 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
     test('rm returns false for non-existent', async () => {
       expect(await directory.rm('nonexistent')).toBe(false);
     });
+
+    test('add with sdk config persists to PG metadata', async () => {
+      const sdkConfig = {
+        permissionMode: 'bypassPermissions' as const,
+        allowDangerouslySkipPermissions: true,
+        maxTurns: 10,
+        model: 'claude-sonnet-4-20250514',
+        mcpServers: {
+          myServer: { command: 'node', args: ['server.js'] },
+        },
+      };
+
+      await directory.add({
+        name: 'sdk-add-agent',
+        dir: agentDir,
+        promptMode: 'append',
+        sdk: sdkConfig,
+      });
+
+      const sql = await getConnection();
+      const rows = await sql`SELECT metadata FROM agents WHERE id = 'dir:sdk-add-agent'`;
+      expect(rows.length).toBe(1);
+      const metadata = rows[0].metadata as Record<string, unknown>;
+      expect(metadata.sdk).toBeDefined();
+      const sdk = metadata.sdk as Record<string, unknown>;
+      expect(sdk.permissionMode).toBe('bypassPermissions');
+      expect(sdk.allowDangerouslySkipPermissions).toBe(true);
+      expect(sdk.maxTurns).toBe(10);
+      expect(sdk.model).toBe('claude-sonnet-4-20250514');
+      expect(sdk.mcpServers).toEqual({
+        myServer: { command: 'node', args: ['server.js'] },
+      });
+    });
   });
 
   // ============================================================================
@@ -249,6 +307,41 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
       expect(entry).not.toBeNull();
       expect(entry!.model).toBe('opus');
       expect(entry!.provider).toBe('codex');
+    });
+
+    test('edit with sdk config round-trips through PG', async () => {
+      const sql = await getConnection();
+      await sql`INSERT INTO agents (id, role, custom_name, started_at, metadata) VALUES ('dir:sdk-edit', 'sdk-edit', 'sdk-edit', now(), '{}')`;
+
+      const sdkConfig = {
+        permissionMode: 'acceptEdits' as const,
+        maxBudgetUsd: 5.0,
+        effort: 'high' as const,
+        allowedTools: ['Read', 'Write', 'Bash'],
+        sandbox: { enabled: true, autoAllowBashIfSandboxed: true },
+      };
+
+      await directory.edit('sdk-edit', { sdk: sdkConfig });
+
+      // Read directly from PG to verify persistence
+      const rows = await sql`SELECT metadata FROM agents WHERE id = 'dir:sdk-edit'`;
+      expect(rows.length).toBe(1);
+      const metadata = rows[0].metadata as Record<string, unknown>;
+      expect(metadata.sdk).toBeDefined();
+      const sdk = metadata.sdk as Record<string, unknown>;
+      expect(sdk.permissionMode).toBe('acceptEdits');
+      expect(sdk.maxBudgetUsd).toBe(5.0);
+      expect(sdk.effort).toBe('high');
+      expect(sdk.allowedTools).toEqual(['Read', 'Write', 'Bash']);
+      expect(sdk.sandbox).toEqual({ enabled: true, autoAllowBashIfSandboxed: true });
+
+      // Verify round-trip via get()
+      const entry = await directory.get('sdk-edit');
+      expect(entry).not.toBeNull();
+      expect(entry!.sdk).toBeDefined();
+      expect(entry!.sdk!.permissionMode).toBe('acceptEdits');
+      expect(entry!.sdk!.maxBudgetUsd).toBe(5.0);
+      expect(entry!.sdk!.effort).toBe('high');
     });
   });
 

--- a/src/lib/agent-directory.ts
+++ b/src/lib/agent-directory.ts
@@ -9,6 +9,7 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { BUILTIN_COUNCIL_MEMBERS, BUILTIN_ROLES, type BuiltinAgent } from './builtin-agents.js';
+import type { SdkDirectoryConfig } from './sdk-directory-types.js';
 
 // ============================================================================
 // Types
@@ -45,6 +46,8 @@ export interface DirectoryEntry {
     allow?: string[];
     bashAllowPatterns?: string[];
   };
+  /** Claude Agent SDK configuration. Persisted as JSONB in PG. */
+  sdk?: SdkDirectoryConfig;
 }
 
 export type DirectoryScope = 'project' | 'global' | 'built-in' | 'archived';
@@ -274,6 +277,7 @@ export async function edit(
       | 'color'
       | 'provider'
       | 'permissions'
+      | 'sdk'
     >
   >,
   _options?: ScopeOptions,
@@ -374,6 +378,7 @@ function roleToEntry(role: string, team?: string, metadata?: Record<string, unkn
     color: metadata?.color as string | undefined,
     provider: metadata?.provider as string | undefined,
     permissions: metadata?.permissions as DirectoryEntry['permissions'],
+    sdk: metadata?.sdk as SdkDirectoryConfig | undefined,
     ...(metadata?.repo ? { repo: metadata.repo as string } : team ? { repo: team } : {}),
   };
 }
@@ -389,6 +394,7 @@ function buildMetadata(entry: DirectoryEntry): Record<string, unknown> {
   if (entry.color) meta.color = entry.color;
   if (entry.provider) meta.provider = entry.provider;
   if (entry.permissions) meta.permissions = entry.permissions;
+  if (entry.sdk) meta.sdk = entry.sdk;
   return meta;
 }
 

--- a/src/lib/sdk-directory-types.ts
+++ b/src/lib/sdk-directory-types.ts
@@ -1,0 +1,112 @@
+/**
+ * SDK Directory Types — Claude Agent SDK configuration persisted in the agent directory.
+ *
+ * These types mirror a curated subset of the Claude Agent SDK `Options` type,
+ * excluding runtime-only fields (resume, sessionId, cwd, env, stderr, etc.).
+ * Persisted as JSONB in the PG agents.metadata column under the `sdk` key.
+ */
+
+/** Claude Agent SDK configuration persisted in the agent directory. */
+export interface SdkDirectoryConfig {
+  /** Permission mode for the session. */
+  permissionMode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan' | 'dontAsk';
+  /** Allow bypassing all permission checks. Required when permissionMode is 'bypassPermissions'. */
+  allowDangerouslySkipPermissions?: boolean;
+  /** Base set of available built-in tools, or a preset. */
+  tools?: string[] | { type: 'preset'; preset: 'claude_code' };
+  /** Tools auto-allowed without prompting. */
+  allowedTools?: string[];
+  /** Tools removed from model context entirely. */
+  disallowedTools?: string[];
+  /** Max conversation turns before stopping. */
+  maxTurns?: number;
+  /** Max budget in USD. */
+  maxBudgetUsd?: number;
+  /** Effort level: 'low' | 'medium' | 'high' | 'max'. */
+  effort?: 'low' | 'medium' | 'high' | 'max';
+  /** Thinking/reasoning configuration. */
+  thinking?: { type: 'enabled'; budgetTokens: number } | { type: 'adaptive' } | { type: 'disabled' };
+  /** Named main agent to use. */
+  agent?: string;
+  /** Subagent definitions keyed by name. */
+  agents?: Record<string, SdkAgentDefinition>;
+  /** MCP server configurations keyed by name. */
+  mcpServers?: Record<string, SdkMcpServerConfig>;
+  /** Plugin configurations. */
+  plugins?: SdkPluginConfig[];
+  /** Persist conversation across restarts. */
+  persistSession?: boolean;
+  /** Enable file-based checkpointing. */
+  enableFileCheckpointing?: boolean;
+  /** Output format for structured responses. */
+  outputFormat?: { type: 'json_schema'; schema: Record<string, unknown> };
+  /** Include partial messages in stream. */
+  includePartialMessages?: boolean;
+  /** Include hook events in stream. */
+  includeHookEvents?: boolean;
+  /** Enable prompt suggestions after each turn. */
+  promptSuggestions?: boolean;
+  /** Enable AI-generated progress summaries for subagents. */
+  agentProgressSummaries?: boolean;
+  /** Sandbox settings for command execution isolation. */
+  sandbox?: SdkSandboxSettings;
+  /** Beta features to enable. */
+  betas?: string[];
+  /** Which filesystem settings to load: 'user', 'project', 'local'. */
+  settingSources?: Array<'user' | 'project' | 'local'>;
+  /** Additional settings (inline object or path to JSON file). */
+  settings?: string | Record<string, unknown>;
+  /** Hook callbacks keyed by event name. */
+  hooks?: Record<string, SdkHookMatcher[]>;
+  /** System prompt: plain string or preset with optional append. */
+  systemPrompt?: string | { type: 'preset'; preset: 'claude_code'; append?: string };
+  /** Custom tool definitions. */
+  customTools?: SdkCustomToolDefinition[];
+  /** Model override. */
+  model?: string;
+  /** Fallback model. */
+  fallbackModel?: string;
+  /** API-side task budget in tokens. */
+  taskBudget?: { total: number };
+  /** MCP tool name for permission prompts. */
+  permissionPromptToolName?: string;
+}
+
+export interface SdkAgentDefinition {
+  description: string;
+  prompt?: string;
+  tools?: string[];
+  model?: string;
+}
+
+export interface SdkMcpServerConfig {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+}
+
+export interface SdkPluginConfig {
+  type: 'local';
+  path: string;
+}
+
+export interface SdkSandboxSettings {
+  enabled?: boolean;
+  autoAllowBashIfSandboxed?: boolean;
+  network?: {
+    allowLocalBinding?: boolean;
+    allowUnixSockets?: string[];
+  };
+}
+
+export interface SdkHookMatcher {
+  matcher: string;
+  hooks: Array<{ type: 'command'; command: string }>;
+}
+
+export interface SdkCustomToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}


### PR DESCRIPTION
## Summary
- Add `SdkDirectoryConfig` type in `src/lib/sdk-directory-types.ts` mirroring a curated subset of Claude Agent SDK `Options` (excluding runtime-only fields)
- Extend `DirectoryEntry` with optional `sdk` field, persisted as JSONB in PG `agents.metadata`
- Wire `sdk` through `add()`, `edit()`, `resolve()`, and `roleToEntry()` for full round-trip persistence
- Add 3 tests covering add/edit/resolve with SDK config

## Test plan
- [x] `bun test src/lib/agent-directory.test.ts` passes (28 tests, 0 failures)
- [x] Type import compiles: `bun -e "import type { SdkDirectoryConfig } from './src/lib/sdk-directory-types.js'; console.log('types OK');"`
- [x] All existing tests continue to pass (pre-existing timeouts in context-enrichment and db-backup are unrelated)