### PR TITLE
chore: bump version to 4.260404.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/genie",
-  "version": "4.260403.4",
+  "version": "4.260404.1",
   "description": "Collaborative terminal toolkit for human + AI workflows",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Version bump from `4.260403.4` → `4.260404.1` to trigger `@next` publish
- Previous version was already published; the SDK executor merge (#1033) needs a new version to land on npm

## Test plan
- [x] 2041 tests pass
- [x] CI will publish `@next` on merge