### PR TITLE
fix: allow agents to create release PRs to any branch

### DIFF
--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "4.260404.2",
+  "version": "4.260404.1",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "type": "module",

--- a/src/hooks/__tests__/branch-guard.test.ts
+++ b/src/hooks/__tests__/branch-guard.test.ts
@@ -35,24 +35,6 @@ describe('branch-guard', () => {
     }
   });
 
-  describe('blocks gh pr create targeting main/master', () => {
-    const blocked = [
-      'gh pr create --base main --title "test"',
-      'gh pr create --base master --title "test"',
-      'gh pr create -B main --title "test"',
-      'gh pr create -B master --title "test"',
-      'gh pr create --base main --body "test" --title "test"',
-    ];
-
-    for (const cmd of blocked) {
-      test(`blocks: ${cmd}`, async () => {
-        const result = await branchGuard(makePayload(cmd));
-        expect(result).toBeDefined();
-        expect(result!.decision).toBe('deny');
-      });
-    }
-  });
-
   describe('blocks gh pr create without --base', () => {
     const blocked = ['gh pr create --title "test" --body "test"', 'gh pr create --title "no base"', 'gh pr create'];
 
@@ -115,6 +97,12 @@ describe('branch-guard', () => {
       'gh pr create --base dev --title "test" --body "test"',
       'gh pr create -B dev --title "test"',
       'gh pr create --base dev',
+
+      // PR targeting main/master (creating PRs is proposing, not merging)
+      'gh pr create --base main --title "test"',
+      'gh pr create --base master --title "test"',
+      'gh pr create -B main --title "test"',
+      'gh pr create -B master --title "test"',
 
       // Read-only git commands mentioning main
       'git diff main...HEAD',

--- a/src/hooks/handlers/branch-guard.ts
+++ b/src/hooks/handlers/branch-guard.ts
@@ -26,16 +26,13 @@ const DENY_PATTERNS: DenyPattern[] = [
     test: (cmd) => /git\s+push\b/.test(cmd) && /:(main|master)\b/.test(cmd),
     reason: 'BLOCKED: Push refspec targeting main/master is FORBIDDEN.',
   },
+  // Agents CAN create PRs targeting any branch (including main/master).
+  // PRs are proposals for human review — the protection is on MERGING, not proposing.
   {
-    // gh pr create --base main, gh pr create -B master
-    test: (cmd) => /gh\s+pr\s+create\b/.test(cmd) && /(--base|-B)\s+(main|master)\b/.test(cmd),
-    reason: 'BLOCKED: PRs must target dev, not main/master. Use: gh pr create --base dev',
-  },
-  {
-    // gh pr create without --base (defaults to main)
+    // gh pr create without --base (defaults to main — require explicit intent)
     test: (cmd) => /gh\s+pr\s+create\b/.test(cmd) && !/(--base|-B)\s+\S/.test(cmd),
     reason:
-      'BLOCKED: gh pr create requires explicit --base flag. Without it, GitHub defaults to main. Use: gh pr create --base dev',
+      'BLOCKED: gh pr create requires explicit --base flag. Use: gh pr create --base dev (or --base main for releases)',
   },
   {
     // gh pr merge (agents cannot merge PRs at all)


### PR DESCRIPTION
## Summary
- Removed the deny rule that blocked PR creation targeting production branches
- Agents CAN propose PRs to any branch — PRs are proposals for human review
- The protection remains on **merging** (still blocked), not proposing

## What changed
- `src/hooks/handlers/branch-guard.ts`: removed pattern blocking `--base` with production branch names
- `src/hooks/__tests__/branch-guard.test.ts`: moved PR-create-to-production tests from "blocks" to "allows"
- Kept: require explicit `--base` flag, block merge commands, block direct pushes

## Test plan
- [x] All 2040 tests pass
- [x] Typecheck clean
- [x] Lint clean