### PR TITLE
fix: SDK executor correctness — 4 bug fixes (#1037, #1038, #1039, #1046)

### DIFF
--- a/src/genie.ts
+++ b/src/genie.ts
@@ -95,6 +95,15 @@ try {
   // Not in a git repo — that's fine
 }
 
+/** Commander option parser that rejects NaN for numeric flags. */
+function parseNumericFlag(flagName: string): (value: string) => number {
+  return (value: string) => {
+    const n = Number(value);
+    if (Number.isNaN(n)) throw new Error(`${flagName} must be a number, got: ${value}`);
+    return n;
+  };
+}
+
 const program = new Command();
 
 program.name('genie').description('Genie CLI - AI-assisted development').version(VERSION);
@@ -280,8 +289,8 @@ program
   .option('--no-auto-resume', 'Disable auto-resume on pane death')
   .option('--stream', 'Stream SDK messages to stdout in real-time (claude-sdk provider)')
   .option('--stream-format <format>', 'Streaming output format: text, json, ndjson (default: text)', 'text')
-  .option('--sdk-max-turns <n>', 'SDK: max conversation turns', Number)
-  .option('--sdk-max-budget <usd>', 'SDK: max budget in USD', Number)
+  .option('--sdk-max-turns <n>', 'SDK: max conversation turns', parseNumericFlag('--sdk-max-turns'))
+  .option('--sdk-max-budget <usd>', 'SDK: max budget in USD', parseNumericFlag('--sdk-max-budget'))
   .option('--sdk-stream', 'SDK: enable streaming output (shortcut for --stream)')
   .option('--sdk-effort <level>', 'SDK: reasoning effort level (low, medium, high, max)')
   .addHelpText(

--- a/src/lib/protocol-router-spawn.ts
+++ b/src/lib/protocol-router-spawn.ts
@@ -52,7 +52,7 @@ function buildSpawnParams(
   spawnColor: ClaudeTeamColor | undefined,
   resumeSessionId?: string,
 ): SpawnParams {
-  const isClaude = template.provider === 'claude';
+  const isClaude = template.provider === 'claude' || template.provider === 'claude-sdk';
   const sessionName = template.role ? `${template.team}-${template.role}` : undefined;
   // Generate a new session ID for fresh spawns, or use stored ID for resume
   const newSessionId = isClaude && !resumeSessionId ? crypto.randomUUID() : undefined;
@@ -139,7 +139,12 @@ async function createExecutorForAutoSpawn(
       /* best-effort */
     }
 
-    const executorTransport = template.provider === 'codex' ? ('api' as const) : ('tmux' as const);
+    const executorTransport =
+      template.provider === 'codex'
+        ? ('api' as const)
+        : template.provider === 'claude-sdk'
+          ? ('process' as const)
+          : ('tmux' as const);
     const executor = await executorRegistry.createExecutor(agentIdentity.id, template.provider, executorTransport, {
       pid,
       tmuxSession: session,
@@ -213,7 +218,7 @@ export async function spawnWorkerFromTemplate(
 
   const now = new Date().toISOString();
   const agentName = template.role ?? 'worker';
-  const isClaude = template.provider === 'claude';
+  const isClaude = template.provider === 'claude' || template.provider === 'claude-sdk';
   const effectiveSessionId = resumeSessionId ?? params.sessionId;
 
   const workerEntry: registry.Agent = {

--- a/src/lib/provider-adapters.ts
+++ b/src/lib/provider-adapters.ts
@@ -115,7 +115,7 @@ interface LaunchCommand {
 // ============================================================================
 
 const spawnParamsSchema = z.object({
-  provider: z.enum(['claude', 'codex', 'claude-sdk']),
+  provider: z.enum(['claude', 'codex', 'claude-sdk', 'app-pty']),
   team: z.string().min(1, 'Team name is required'),
   role: z.string().optional(),
   skill: z.string().optional(),

--- a/src/lib/providers/claude-sdk.ts
+++ b/src/lib/providers/claude-sdk.ts
@@ -62,14 +62,14 @@ export function translateSdkConfig(sdkConfig: SdkDirectoryConfig): Partial<Optio
 
   // Session & checkpointing
   if (sdkConfig.persistSession != null) opts.persistSession = sdkConfig.persistSession;
-  if (sdkConfig.enableFileCheckpointing) opts.enableFileCheckpointing = sdkConfig.enableFileCheckpointing;
+  if (sdkConfig.enableFileCheckpointing != null) opts.enableFileCheckpointing = sdkConfig.enableFileCheckpointing;
 
   // Output & streaming
   if (sdkConfig.outputFormat) opts.outputFormat = sdkConfig.outputFormat as Options['outputFormat'];
-  if (sdkConfig.includePartialMessages) opts.includePartialMessages = sdkConfig.includePartialMessages;
+  if (sdkConfig.includePartialMessages != null) opts.includePartialMessages = sdkConfig.includePartialMessages;
   if (sdkConfig.includeHookEvents != null) opts.includeHookEvents = sdkConfig.includeHookEvents;
-  if (sdkConfig.promptSuggestions) opts.promptSuggestions = sdkConfig.promptSuggestions;
-  if (sdkConfig.agentProgressSummaries) opts.agentProgressSummaries = sdkConfig.agentProgressSummaries;
+  if (sdkConfig.promptSuggestions != null) opts.promptSuggestions = sdkConfig.promptSuggestions;
+  if (sdkConfig.agentProgressSummaries != null) opts.agentProgressSummaries = sdkConfig.agentProgressSummaries;
 
   // System prompt
   if (sdkConfig.systemPrompt) opts.systemPrompt = sdkConfig.systemPrompt;

--- a/src/services/executors/claude-sdk.ts
+++ b/src/services/executors/claude-sdk.ts
@@ -179,6 +179,7 @@ export class ClaudeSdkOmniExecutor implements IExecutor {
       message.content,
       permissionConfig,
       extraOptions,
+      entry.sdk,
     );
 
     const result = await collectQueryResult(queryMessages);

--- a/src/term-commands/agent/spawn.ts
+++ b/src/term-commands/agent/spawn.ts
@@ -6,6 +6,15 @@
 import type { Command } from 'commander';
 import { type SpawnOptions, handleWorkerSpawn } from '../agents.js';
 
+/** Commander option parser that rejects NaN for numeric flags. */
+function parseNumericFlag(flagName: string): (value: string) => number {
+  return (value: string) => {
+    const n = Number(value);
+    if (Number.isNaN(n)) throw new Error(`${flagName} must be a number, got: ${value}`);
+    return n;
+  };
+}
+
 export function registerAgentSpawn(parent: Command): void {
   parent
     .command('spawn <name>')
@@ -26,8 +35,8 @@ export function registerAgentSpawn(parent: Command): void {
     .option('--window <target>', 'Tmux window to split into (e.g., genie:3)')
     .option('--no-auto-resume', 'Disable auto-resume on pane death')
     .option('--prompt <prompt>', 'Initial prompt (first user message)')
-    .option('--sdk-max-turns <n>', 'SDK: max conversation turns', Number)
-    .option('--sdk-max-budget <usd>', 'SDK: max budget in USD', Number)
+    .option('--sdk-max-turns <n>', 'SDK: max conversation turns', parseNumericFlag('--sdk-max-turns'))
+    .option('--sdk-max-budget <usd>', 'SDK: max budget in USD', parseNumericFlag('--sdk-max-budget'))
     .option('--sdk-stream', 'SDK: enable streaming output (shortcut for --stream)')
     .option('--sdk-effort <level>', 'SDK: reasoning effort level (low, medium, high, max)')
     .action(async (name: string, options: SpawnOptions) => {

--- a/src/term-commands/dir.ts
+++ b/src/term-commands/dir.ts
@@ -478,6 +478,13 @@ export function buildSdkConfig(options: SdkDirOptions): SdkDirectoryConfig | und
   return Object.keys(config).length > 0 ? config : undefined;
 }
 
+/** Parse a string to a number, throwing if NaN. */
+function toSafeNumber(value: string, flagName: string): number {
+  const n = Number(value);
+  if (Number.isNaN(n)) throw new Error(`${flagName} must be a number, got: ${value}`);
+  return n;
+}
+
 /** Apply scalar (string/number) SDK options to the config. */
 function applyScalarSdkOptions(config: SdkDirectoryConfig, options: SdkDirOptions): void {
   if (options.sdkPermissionMode !== undefined) {
@@ -486,8 +493,8 @@ function applyScalarSdkOptions(config: SdkDirectoryConfig, options: SdkDirOption
   if (options.sdkTools !== undefined) config.tools = splitComma(options.sdkTools);
   if (options.sdkAllowedTools !== undefined) config.allowedTools = splitComma(options.sdkAllowedTools);
   if (options.sdkDisallowedTools !== undefined) config.disallowedTools = splitComma(options.sdkDisallowedTools);
-  if (options.sdkMaxTurns !== undefined) config.maxTurns = Number(options.sdkMaxTurns);
-  if (options.sdkMaxBudget !== undefined) config.maxBudgetUsd = Number(options.sdkMaxBudget);
+  if (options.sdkMaxTurns !== undefined) config.maxTurns = toSafeNumber(options.sdkMaxTurns, '--sdk-max-turns');
+  if (options.sdkMaxBudget !== undefined) config.maxBudgetUsd = toSafeNumber(options.sdkMaxBudget, '--sdk-max-budget');
   if (options.sdkEffort !== undefined) config.effort = options.sdkEffort as SdkDirectoryConfig['effort'];
   if (options.sdkThinking !== undefined) config.thinking = parseThinkingConfig(options.sdkThinking);
   if (options.sdkBetas !== undefined) config.betas = splitComma(options.sdkBetas) as SdkBeta[];
@@ -554,7 +561,7 @@ function parseThinkingConfig(value: string): SdkThinkingConfig {
   if (value === 'disabled') return { type: 'disabled' };
   if (value === 'enabled') return { type: 'enabled' };
   if (value.startsWith('enabled:')) {
-    const budget = Number(value.slice('enabled:'.length));
+    const budget = toSafeNumber(value.slice('enabled:'.length), '--sdk-thinking budgetTokens');
     return { type: 'enabled', budgetTokens: budget };
   }
   throw new Error(`Invalid --sdk-thinking value: "${value}". Expected adaptive|disabled|enabled[:budgetTokens].`);


### PR DESCRIPTION
## Summary

Four bugs collectively break the SDK executor pipeline. This PR fixes all of them:

- **Pass `entry.sdk` to `runQuery`** (#1046) — SDK agents spawned via Omni now receive their directory config (settingSources, maxTurns, effort, thinking)
- **Add `claude-sdk` provider routing** (#1039) — SDK agents route through in-process SDK path instead of falling through to tmux; `app-pty` added to Zod schema
- **Fix boolean preservation** (#1037) — Truthiness checks changed to `!= null` so `false` booleans are preserved in SDK config
- **NaN guards for numeric CLI flags** (#1038) — `--sdk-max-turns` and `--sdk-max-budget` now reject non-numeric input with clear errors

## Test plan

- [x] `bun run build` — passes
- [x] `bun run typecheck` — passes  
- [x] `bun test` on affected files (protocol-router, providers, agents, dispatch) — 256/256 pass
- [x] Pre-existing team-manager/team test flakiness confirmed on `dev` (not from this PR)

Closes #1037, #1038, #1039, #1046
Wish: fix-sdk-executor-correctness