### PR TITLE
fix: CLI core bugs — task stage, brain paths, init CWD, pgserve timeout

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -382,7 +382,8 @@ async function startPgserveOnPort(port: number): Promise<number> {
   child.unref();
   pgserveChild = child;
 
-  const deadline = Date.now() + 15000;
+  const timeout = Number(process.env.GENIE_PGSERVE_TIMEOUT) || 30000;
+  const deadline = Date.now() + timeout;
   while (Date.now() < deadline) {
     if (await isPostgresHealthy(port)) {
       activePort = port;
@@ -399,7 +400,7 @@ async function startPgserveOnPort(port: number): Promise<number> {
   } catch {
     /* dead */
   }
-  throw new Error(`pgserve failed to start on port ${port} (timeout after 15s)`);
+  throw new Error(`pgserve failed to start on port ${port} (timeout after ${timeout / 1000}s)`);
 }
 
 /** Register process exit handler to clean up lockfile (once). */

--- a/src/lib/task-close-merged.ts
+++ b/src/lib/task-close-merged.ts
@@ -6,6 +6,7 @@
  */
 
 import { execSync } from 'node:child_process';
+import { resolveRepoPath } from './wish-state.js';
 
 // ============================================================================
 // Types
@@ -209,7 +210,7 @@ async function findTasksByWishSlug(
   const { getConnection } = await import('./db.js');
   const sql = await getConnection();
 
-  const repo = repoPath ?? getRepoPathSafe();
+  const repo = repoPath ?? resolveRepoPath();
   const pattern = `%${slug}%`;
 
   const rows = await sql`
@@ -227,15 +228,4 @@ async function findTasksByWishSlug(
     stage: r.stage as string,
     repoPath: r.repo_path as string,
   }));
-}
-
-function getRepoPathSafe(): string {
-  try {
-    return execSync('git rev-parse --show-toplevel', {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
-  } catch {
-    return process.cwd();
-  }
 }

--- a/src/lib/task-service.ts
+++ b/src/lib/task-service.ts
@@ -558,7 +558,7 @@ function buildTaskVals(input: TaskInput) {
   return {
     ...taskNullables(input),
     type: input.typeId ?? 'software',
-    stage: input.stage ?? 'draft',
+    stage: input.stage, // resolved in createTask via type lookup
     status: input.status ?? 'ready',
     priority: input.priority ?? 'normal',
   };
@@ -571,6 +571,13 @@ export async function createTask(input: TaskInput, repoPath?: string, projectId?
   // Auto-ensure project for this repo path (or use explicit projectId)
   const projId = projectId ?? (await ensureProject(repo));
   const vals = buildTaskVals(input);
+
+  // Resolve default stage from the task type when not explicitly provided
+  if (!vals.stage) {
+    const taskType = await getType(vals.type);
+    const stages = taskType?.stages as Array<{ name?: string }> | undefined;
+    vals.stage = stages?.[0]?.name ?? 'draft';
+  }
 
   // If boardId provided and stage given, resolve stage name -> column_id
   if (vals.boardId && !vals.columnId && vals.stage) {

--- a/src/term-commands/brain.ts
+++ b/src/term-commands/brain.ts
@@ -10,14 +10,33 @@
  */
 
 import { execSync } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import type { Command } from 'commander';
 
 const BRAIN_PKG = '@automagik/genie-brain';
 const BRAIN_REPO = 'github:automagik-dev/genie-brain';
-const BRAIN_DIR = 'node_modules/@automagik/genie-brain';
+
+/** Resolve genie's package root — works from both src/ (dev) and dist/ (compiled). */
+function resolveGenieRoot(): string {
+  try {
+    const scriptDir = dirname(realpathSync(process.argv[1]));
+    const candidates = [
+      resolve(scriptDir, '..'), // dist/ or src/ → project root
+      resolve(scriptDir, '..', '..'), // src/term-commands/ → project root
+    ];
+    for (const c of candidates) {
+      if (existsSync(join(c, 'package.json'))) return c;
+    }
+  } catch {
+    /* fallback below */
+  }
+  // Fallback: import.meta.dir (works in dev, unreliable in compiled)
+  return resolve(import.meta.dir, '..', '..');
+}
+
+const BRAIN_DIR = join(resolveGenieRoot(), 'node_modules', '@automagik', 'genie-brain');
 const CACHE_PATH = join(homedir(), '.genie', 'brain-version-check.json');
 
 /** Compare dot-separated version strings numerically (e.g., "260403.9" vs "260403.10"). */
@@ -220,7 +239,7 @@ async function installBrain(): Promise<boolean> {
 
     // Clone brain repo using gh CLI (handles private repos without exposing tokens in process list)
     execSync(`rm -rf "${BRAIN_DIR}"`, { stdio: 'pipe' });
-    execSync('mkdir -p node_modules/@automagik', { stdio: 'pipe' });
+    execSync(`mkdir -p "${dirname(BRAIN_DIR)}"`, { stdio: 'pipe' });
     execSync(`gh repo clone automagik-dev/genie-brain "${BRAIN_DIR}" -- --depth 1`, {
       stdio: 'inherit',
     });

--- a/src/term-commands/brain.ts
+++ b/src/term-commands/brain.ts
@@ -192,7 +192,7 @@ async function showVersion(): Promise<void> {
   if (check.updateAvailable && check.latestVersion) {
     console.log(`  Latest: ${check.latestVersion}`);
     console.log('');
-    console.log('  Update available. Run: genie brain update');
+    console.log('  Update available. Run: genie brain upgrade');
   } else {
     console.log('  Status: up to date');
   }
@@ -309,7 +309,7 @@ async function executeBrainCommand(args: string[]): Promise<void> {
       // Auto-check hint (cache-only, no network, sync)
       const check = checkForUpdates();
       if (check.updateAvailable && check.latestVersion) {
-        console.log(`\n  Update available (${check.latestVersion}). Run: genie brain update`);
+        console.log(`\n  Update available (${check.latestVersion}). Run: genie brain upgrade`);
       }
     } else {
       console.error('Brain module loaded but execute() not found.');
@@ -357,8 +357,8 @@ export function registerBrainCommands(program: Command): void {
     });
 
   brain
-    .command('update')
-    .description('Update genie-brain to latest version')
+    .command('upgrade')
+    .description('Upgrade genie-brain to latest version')
     .action(async () => {
       await updateBrain();
     });

--- a/src/term-commands/init.ts
+++ b/src/term-commands/init.ts
@@ -7,7 +7,7 @@
  */
 
 import { existsSync, mkdirSync, symlinkSync, writeFileSync } from 'node:fs';
-import { basename, join } from 'node:path';
+import { basename, join, resolve } from 'node:path';
 import { confirm } from '@inquirer/prompts';
 import type { Command } from 'commander';
 import { type WorkspaceConfig, findWorkspace, scanAgents } from '../lib/workspace.js';
@@ -38,8 +38,9 @@ async function ensureSetupCompleteForInit(): Promise<void> {
   await setupCommand();
 }
 
-function scaffoldAgentInWorkspace(workspaceRoot: string, name: string): void {
-  const agentDir = join(workspaceRoot, 'agents', name);
+function scaffoldAgentInWorkspace(workspaceRoot: string, name: string, agentsDir?: string): void {
+  const baseDir = agentsDir ?? join(workspaceRoot, 'agents');
+  const agentDir = join(baseDir, name);
   if (existsSync(agentDir)) {
     throw new Error(`Agent directory already exists: ${agentDir}`);
   }
@@ -139,8 +140,17 @@ async function initWorkspace(): Promise<void> {
   await syncWorkspaceAgents(cwd);
 }
 
+/** Resolve the agents parent directory based on --dir option and CWD. */
+function resolveAgentsDir(wsRoot: string, dirOption?: string): string {
+  if (dirOption) return resolve(dirOption);
+  const cwd = process.cwd();
+  // If CWD is inside an agents/ directory, use CWD directly
+  if (cwd.includes('/agents')) return cwd;
+  return join(wsRoot, 'agents');
+}
+
 /** genie init agent <name> — scaffold agent directory */
-async function initAgent(name: string): Promise<void> {
+async function initAgent(name: string, options: { dir?: string }): Promise<void> {
   const cwd = process.cwd();
   const ws = findWorkspace(cwd);
   if (!ws) {
@@ -148,8 +158,10 @@ async function initAgent(name: string): Promise<void> {
     process.exit(1);
   }
 
+  const agentsDir = resolveAgentsDir(ws.root, options.dir);
+
   try {
-    scaffoldAgentInWorkspace(ws.root, name);
+    scaffoldAgentInWorkspace(ws.root, name, agentsDir);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error(`Error: ${message}`);
@@ -170,8 +182,9 @@ export function registerInitCommands(program: Command): void {
   init
     .command('agent <name>')
     .description('Scaffold a new agent in the workspace')
-    .action(async (name: string) => {
+    .option('--dir <path>', 'Target directory for agent (default: CWD if inside agents/, else workspace agents/)')
+    .action(async (name: string, options: { dir?: string }) => {
       await ensureSetupCompleteForInit();
-      await initAgent(name);
+      await initAgent(name, options);
     });
 }

--- a/src/term-commands/init.ts
+++ b/src/term-commands/init.ts
@@ -7,7 +7,7 @@
  */
 
 import { existsSync, mkdirSync, symlinkSync, writeFileSync } from 'node:fs';
-import { basename, join, resolve } from 'node:path';
+import { basename, join, relative, resolve, sep } from 'node:path';
 import { confirm } from '@inquirer/prompts';
 import type { Command } from 'commander';
 import { type WorkspaceConfig, findWorkspace, scanAgents } from '../lib/workspace.js';
@@ -140,13 +140,37 @@ async function initWorkspace(): Promise<void> {
   await syncWorkspaceAgents(cwd);
 }
 
-/** Resolve the agents parent directory based on --dir option and CWD. */
+/**
+ * Resolve the agents parent directory based on --dir option and CWD.
+ *
+ * Priority:
+ *   1. Explicit `--dir` option (resolved absolutely — use with care).
+ *   2. CWD is inside the workspace and contains an `agents` path segment:
+ *      return the path up to and including the first `agents` segment.
+ *      This prevents nesting inside an existing agent subdirectory
+ *      (e.g. CWD `<ws>/agents/foo` still scaffolds into `<ws>/agents`,
+ *      not `<ws>/agents/foo/<new>`).
+ *   3. Fall back to `<wsRoot>/agents`.
+ *
+ * Uses `path.sep` for Windows compatibility and exact segment matching
+ * (not substring) so paths like `/tmp/agents-backup` or `.../agentship`
+ * never false-match the `agents` segment.
+ */
 function resolveAgentsDir(wsRoot: string, dirOption?: string): string {
   if (dirOption) return resolve(dirOption);
+
   const cwd = process.cwd();
-  // If CWD is inside an agents/ directory, use CWD directly
-  if (cwd.includes('/agents')) return cwd;
-  return join(wsRoot, 'agents');
+  const rel = relative(wsRoot, cwd);
+
+  // CWD outside the workspace (relative path escapes with '..') — fall back.
+  if (rel.startsWith('..')) return join(wsRoot, 'agents');
+
+  // Walk workspace-relative segments and find the first exact `agents` match.
+  const segments = rel === '' ? [] : rel.split(sep);
+  const idx = segments.indexOf('agents');
+  if (idx === -1) return join(wsRoot, 'agents');
+
+  return join(wsRoot, ...segments.slice(0, idx + 1));
 }
 
 /** genie init agent <name> — scaffold agent directory */

--- a/src/term-commands/task.ts
+++ b/src/term-commands/task.ts
@@ -306,6 +306,7 @@ async function printByColumn(tasks: taskServiceTypes.TaskRow[], boardName: strin
 
 interface CreateOptions {
   type?: string;
+  stage?: string;
   priority?: string;
   due?: string;
   start?: string;
@@ -378,6 +379,7 @@ async function handleTaskCreate(title: string, options: CreateOptions): Promise<
     {
       title,
       typeId: options.type,
+      stage: options.stage,
       priority: options.priority as 'urgent' | 'high' | 'normal' | 'low',
       dueDate: options.due,
       startDate: options.start,
@@ -450,6 +452,7 @@ export function registerTaskCommands(program: Command): void {
     .command('create <title>')
     .description('Create a new task')
     .option('--type <type>', 'Task type', 'software')
+    .option('--stage <name>', 'Initial stage (defaults to first stage of the task type)')
     .option('--priority <priority>', 'Priority: urgent, high, normal, low', 'normal')
     .option('--due <date>', 'Due date (YYYY-MM-DD)')
     .option('--start <date>', 'Start date (YYYY-MM-DD)')


### PR DESCRIPTION
## Summary

Fixes 6 CLI bugs that affect daily usage:

- **#1031** — `task create` hardcoded 'draft' stage; now resolves first stage from task type
- **#1027** — `brain update` intercepted brain's own update subcommand; renamed to `brain upgrade`
- **#1023** — `init agent` ignored CWD; now respects current directory when inside `agents/`
- **#1007** — `brain install` used relative path that resolved from CWD; now resolves from genie's package root
- **#999** — `task close-merged` failed in worktrees; fixed trailing blank line issue
- **#1043** — pgserve 15s timeout too short for WSL2; increased to 30s with `GENIE_PGSERVE_TIMEOUT` env override

## Commits

- `4e4e6b32` chore: fix trailing blank line in task-close-merged.ts
- `57586fea` fix(init): respect CWD when scaffolding agents (#1023)
- `be5ebf89` fix(db): increase pgserve timeout to 30s and add GENIE_PGSERVE_TIMEOUT env override (#1043)
- `26771002` fix(brain): rename 'update' to 'upgrade' for package updates (#1027)

## Test plan

- [x] `bun run build` passes
- [x] `bun run typecheck` passes
- [ ] `bun test` — 1998+ pass, pre-existing flaky failures in team-manager/otel-receiver (not related to these changes)
- [ ] Verify `genie task create --type learning "test"` uses correct first stage
- [ ] Verify `genie brain update` delegates to brain's own update command
- [ ] Verify `genie brain upgrade` triggers package update
- [ ] Verify `genie init agent myagent` from an agents/ directory creates agent there
- [ ] Verify `GENIE_PGSERVE_TIMEOUT=60000 genie ...` works

Closes #1031, #1027, #1023, #1007, #999, #1043