### PR TITLE
docs: fix corrupted chars and shell examples in sdk-executor-guide

### DIFF
--- a/docs/AGENT-FRONTMATTER.md
+++ b/docs/AGENT-FRONTMATTER.md
@@ -1,0 +1,174 @@
+# Agent Frontmatter Schema
+
+AGENTS.md files use YAML frontmatter to configure agent behavior. This document describes the schema, validation rules, and usage patterns.
+
+**Source of truth:** [`src/lib/frontmatter.ts`](../src/lib/frontmatter.ts) — `AgentFrontmatterSchema`
+
+## Schema Fields
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | `string` | No | — | Agent identifier. Used for spawn resolution and display. |
+| `description` | `string` | No | — | One-line summary of what the agent does. Shown in `genie agent directory` and agent listings. |
+| `model` | `string` | No | — | Model to use. Set to `"inherit"` to use the parent session's model. Any model string is accepted (e.g., `"sonnet"`, `"opus"`, `"haiku"`). |
+| `color` | `string` | No | — | Display color for the agent in team UIs and status output. |
+| `promptMode` | `"system"` \| `"append"` | No | — | How the AGENTS.md body is injected into the agent's prompt. `"system"` replaces the Claude Code default system prompt; `"append"` preserves it and appends the agent body. |
+| `provider` | `"claude"` \| `"codex"` \| `"claude-sdk"` | No | — | Which AI provider to use for spawn. Determines the executor backend. |
+| `tools` | `string[]` | No | — | List of tools the agent is allowed to use (e.g., `["Read", "Write", "Edit", "Bash", "Glob", "Grep"]`). |
+| `permissionMode` | `string` | No | — | Permission mode for the agent session (e.g., `"plan"`, `"auto"`, `"bypassPermissions"`). |
+| `sdk` | `Record<string, unknown>` | No | — | SDK configuration block. Accepts any key-value pairs so new SDK options don't require parser updates. Used for advanced settings like `maxTurns`, `effort`, thinking config, and beta features. |
+
+## Validation Behavior
+
+The frontmatter parser uses a **warn-not-reject** strategy:
+
+1. **Missing fields are fine.** All fields are optional. An AGENTS.md with no frontmatter (or empty frontmatter) produces an empty config object — the agent is still discoverable.
+
+2. **Unknown fields are warned, not rejected.** If you add a key not in the schema (e.g., `author: "Alice"`), the parser logs a warning (`[frontmatter] Unknown field "author" — ignored.`) but continues parsing.
+
+3. **Invalid enum values fall back to `undefined`.** If `promptMode` is set to an invalid value like `"prepend"`, the parser warns (`[frontmatter] Invalid value for "promptMode": "prepend" — using default.`) and treats the field as unset.
+
+4. **Never throws.** The parser catches YAML syntax errors, type mismatches, and malformed delimiters. Agents should always be discoverable even with broken frontmatter.
+
+### Parse flow
+
+```
+Content → extract YAML between --- delimiters
+       → warn on unknown keys
+       → validate with Zod schema
+       → if full validation passes: return parsed object
+       → if full validation fails: validate field-by-field, keeping valid ones
+       → return result (never throws)
+```
+
+## Examples
+
+### Minimal agent
+
+```yaml
+---
+name: my-agent
+description: "A simple task runner."
+---
+```
+
+### Standard role agent
+
+```yaml
+---
+name: engineer
+description: "Task execution agent. Reads wish from disk, implements deliverables, validates, and reports what was built."
+model: inherit
+color: blue
+promptMode: append
+tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+---
+```
+
+### Council agent (read-only tools, specific provider)
+
+```yaml
+---
+name: council--architect
+description: "Systems thinking, backwards compatibility, and long-term stability review."
+model: haiku
+color: yellow
+promptMode: append
+provider: claude
+tools: ["Read", "Glob", "Grep", "Bash"]
+---
+```
+
+### Agent with SDK configuration
+
+```yaml
+---
+name: deep-thinker
+description: "Extended reasoning agent with high effort."
+model: opus
+promptMode: system
+sdk:
+  maxTurns: 42
+  effort: high
+---
+```
+
+### Empty frontmatter (still valid)
+
+```yaml
+---
+---
+
+This agent has no configuration. It uses all defaults and is still
+discoverable by the agent system.
+```
+
+## Field Details
+
+### `promptMode`
+
+Controls how the AGENTS.md body text is injected into the agent's session:
+
+- **`system`** — Replaces the Claude Code default system prompt with the AGENTS.md body. Use when you want full control over the agent's instructions.
+- **`append`** — Preserves the Claude Code default system prompt and appends the AGENTS.md body. Use when you want the agent to retain standard Claude Code capabilities while adding role-specific instructions.
+
+### `provider`
+
+Determines which executor backend spawns the agent:
+
+- **`claude`** — Claude Code CLI (default). Spawns via `claude` command in a tmux pane.
+- **`codex`** — OpenAI Codex CLI. Spawns via `codex` command.
+- **`claude-sdk`** — Claude Agent SDK. Uses the programmatic SDK executor.
+
+### `sdk`
+
+A permissive record that passes configuration to the SDK executor. The schema intentionally uses `z.record(z.unknown())` so new SDK options can be used without updating the parser. Common keys include:
+
+- `maxTurns` — Maximum conversation turns
+- `effort` — Reasoning effort level (`"low"`, `"medium"`, `"high"`)
+- `permissionMode` — SDK-level permission mode
+- Thinking/beta configuration objects
+
+### `tools`
+
+An array of tool names the agent is allowed to use. This maps to the `--allowedTools` flag in Claude Code. Common tool names:
+
+- `Read`, `Write`, `Edit` — File operations
+- `Bash` — Shell command execution
+- `Glob`, `Grep` — File search
+- `Agent` — Sub-agent spawning
+
+## File Structure
+
+An AGENTS.md file follows this structure:
+
+```markdown
+---
+name: agent-name
+description: "What the agent does."
+model: inherit
+color: blue
+promptMode: append
+tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+---
+
+Agent body content goes here. This is the prompt injected
+according to the promptMode setting.
+```
+
+The frontmatter block must be at the very start of the file, delimited by `---` on its own line. Everything after the closing `---` is the agent's prompt body.
+
+## API
+
+The parser is exported from `src/lib/frontmatter.ts`:
+
+```typescript
+import { parseFrontmatter, AgentFrontmatterSchema } from './lib/frontmatter.js';
+
+// Parse frontmatter from markdown content
+const config = parseFrontmatter(fileContent);
+// config.name, config.model, config.promptMode, etc.
+
+// Access the Zod schema for programmatic use
+const fields = Object.keys(AgentFrontmatterSchema.shape);
+```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,299 @@
+# Genie Architecture
+
+This document describes the internal architecture of the Genie CLI, including the unified serve model, service topology, agent lifecycle, data flow, and hook system.
+
+## Serve/Daemon Unification
+
+The `genie serve` command is the **single infrastructure owner**. It starts and manages all background services in one process. The older `genie daemon` command is now a thin redirect to `genie serve --headless`.
+
+```
+genie serve             → foreground with TUI (default)
+genie serve --headless  → services only, no TUI
+genie serve --daemon    → background (detached)
+genie daemon start      → alias for genie serve --headless (deprecated)
+```
+
+**Key design decision:** The daemon was unified into `serve` so that a single PID file (`~/.genie/serve.pid`) governs all services. The legacy `scheduler.pid` is still checked for backward compatibility but `serve.pid` is canonical.
+
+**Source:** `src/term-commands/serve.ts`, `src/term-commands/daemon.ts`
+
+## Service Topology
+
+`genie serve` starts these services in order:
+
+```
+genie serve (PID file: ~/.genie/serve.pid)
+│
+├── 1. pgserve              Embedded PostgreSQL (data + state)
+│     └── port file: ~/.genie/pgserve.port
+│
+├── 2. tmux -L genie        Agent session server (eternal, survives serve restarts)
+│     └── sessions created on-demand by `genie spawn`
+│
+├── 3. tmux -L genie-tui    TUI session (only in non-headless mode)
+│     └── session: genie-tui (left=nav, right=agent display)
+│
+├── 4. Agent sync           Watches agents/ directory for AGENTS.md changes
+│     └── src/lib/agent-sync.ts
+│
+├── 5. Scheduler daemon     Claims and fires triggers from PG
+│     ├── Event router      Routes PG NOTIFY events to team members
+│     └── Inbox watcher     Polls native inboxes, auto-spawns offline leads
+│
+└── 6. Service registry     In-memory PID tracker for graceful shutdown
+```
+
+### Service Details
+
+| Service | Source | Description |
+|---------|--------|-------------|
+| **pgserve** | `src/lib/db.ts` | Embedded PostgreSQL. `genie serve` owns the process; CLI commands read `~/.genie/pgserve.port` and connect. Data lives at `~/.genie/data/pgserve/`. |
+| **Scheduler** | `src/lib/scheduler-daemon.ts` | Core loop: LISTEN on `genie_trigger_due` for real-time NOTIFY, 30s poll fallback. Uses `SELECT FOR UPDATE SKIP LOCKED` for lease-based claiming. Concurrency capped by `GENIE_MAX_CONCURRENT` (default 5). Collects heartbeats every 60s, reconciles orphans every 5m. |
+| **Event Router** | `src/lib/event-router.ts` | Subscribes to PG NOTIFY channels (`genie_task_stage`, `genie_executor_state`, `genie_message`). Routes actionable events (blocked, error, permission, request) to team-lead mailboxes and runtime event log. |
+| **Inbox Watcher** | `src/lib/inbox-watcher.ts` | Polls `~/.claude/teams/` for unread messages every 30s. Auto-spawns offline team-leads when unread messages are found. |
+| **Session Capture** | `src/lib/session-filewatch.ts`, `src/lib/session-capture.ts`, `src/lib/session-backfill.ts` | Event-driven JSONL capture via `fs.watch` on `~/.claude/projects/`. Reads incrementally from stored offsets, debounced 500ms. Backfill worker processes historical files (newest-first, 64KB chunks, yields to live work). |
+| **Omni Bridge** | `src/services/omni-bridge.ts` | NATS subscriber that routes inbound WhatsApp/Telegram messages to agent sessions via the `IExecutor` interface. Manages per-chat session lifecycle with idle timeout (15min), max concurrency (20), and message buffering. |
+| **Service Registry** | `src/lib/service-registry.ts` | In-memory PID registry for child processes. Used during shutdown: SIGTERM first, 3s grace, then SIGKILL survivors. |
+
+### Shutdown Sequence
+
+1. Stop agent directory watcher
+2. Stop scheduler (drains in-flight triggers)
+3. Kill registered services via service registry
+4. Kill TUI session (agent tmux server is **not** killed — sessions are eternal)
+5. Remove pgserve lockfile
+6. Remove PID file
+7. Force-kill timeout: 10s, then SIGKILL remaining
+
+## Agent Lifecycle
+
+Agents follow this lifecycle: **spawn → register → work → report → shutdown**.
+
+```
+                  ┌──────────┐
+                  │  spawn   │  genie spawn <name>
+                  └────┬─────┘
+                       │
+              ┌────────▼────────┐
+              │    register     │  Agent written to PG (agents table)
+              │  state: spawning│  Pane ID, session, team recorded
+              └────────┬────────┘
+                       │
+              ┌────────▼────────┐
+              │     working     │  Claude Code / Codex / SDK running
+              │  state: working │  Hooks emit runtime events
+              └────────┬────────┘
+                       │
+          ┌────────────┼────────────┐
+          ▼            ▼            ▼
+    ┌──────────┐ ┌──────────┐ ┌──────────┐
+    │   idle   │ │permission│ │ question │
+    │ (prompt) │ │ (awaiting│ │ (awaiting│
+    └────┬─────┘ │ approval)│ │  answer) │
+         │       └────┬─────┘ └────┬─────┘
+         │            │            │
+         └────────────┼────────────┘
+                      │
+              ┌───────▼────────┐
+              │  done / error  │  Task complete or failure
+              └───────┬────────┘
+                      │
+              ┌───────▼────────┐
+              │   suspended    │  Optional: idle timeout or manual stop
+              └───────┬────────┘
+                      │
+              ┌───────▼────────┐
+              │   shutdown     │  Pane killed, registry updated
+              └────────────────┘
+```
+
+### Agent States
+
+| State | Description |
+|-------|-------------|
+| `spawning` | Agent being initialized, pane created |
+| `working` | Actively producing output |
+| `idle` | At prompt, waiting for input |
+| `permission` | Waiting for permission approval |
+| `question` | Waiting for human answer |
+| `done` | Task completed successfully |
+| `error` | Encountered error |
+| `suspended` | Manually stopped or idle-timeout suspended |
+
+### Spawn Flow
+
+1. **Resolve agent** — Look up name in agent directory (`agents/` AGENTS.md files) or built-in roles
+2. **Create tmux pane** — Split in target session/window on `tmux -L genie` socket
+3. **Register in PG** — Insert into `agents` table with pane ID, session, team, role
+4. **Launch provider** — Start Claude Code, Codex, or Claude SDK in the pane
+5. **Inject identity** — Hooks inject `GENIE_AGENT_NAME` and team context via `identity-inject` handler
+
+### Auto-Resume
+
+When a pane dies unexpectedly, the scheduler's heartbeat collector detects the dead pane. If `autoResume` is enabled (default), the agent is respawned with its original configuration. Resume attempts are tracked (`resumeAttempts`, `maxResumeAttempts`) to prevent infinite loops.
+
+**Source:** `src/term-commands/agent/spawn.ts`, `src/lib/agent-registry.ts`, `src/lib/scheduler-daemon.ts`
+
+## Data Flow
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                        CLI Commands                               │
+│  genie spawn / work / send / task / team / ...                   │
+└───────────┬──────────────────────────────────────┬───────────────┘
+            │ write                                │ read
+            ▼                                      ▼
+┌──────────────────────────────────────────────────────────────────┐
+│                      PostgreSQL (pgserve)                         │
+│                                                                   │
+│  agents        — agent identity + state                          │
+│  agent_templates — spawn templates for re-spawn                  │
+│  executors     — executor instances (v4 model)                   │
+│  triggers      — scheduled trigger rows                          │
+│  runs          — trigger execution history                       │
+│  schedules     — cron/one-shot schedule definitions              │
+│  runtime_events — structured event log                           │
+│  sessions      — Claude session JSONL capture                    │
+│  tasks         — task/wish tracking                              │
+│  messages      — task conversation messages                      │
+│                                                                   │
+│  NOTIFY channels:                                                │
+│    genie_trigger_due    → scheduler claims                       │
+│    genie_task_stage     → event router                           │
+│    genie_executor_state → event router                           │
+│    genie_message        → event router                           │
+└───────────┬──────────────────────────────────────┬───────────────┘
+            │ NOTIFY                               │ query
+            ▼                                      ▼
+┌─────────────────────┐              ┌─────────────────────────────┐
+│   Scheduler Daemon  │              │        Event Router          │
+│                     │              │                              │
+│ • Claims triggers   │              │ Listens on NOTIFY channels:  │
+│ • Fires agents      │              │ • task stage changes         │
+│ • Heartbeat (60s)   │              │ • executor state changes     │
+│ • Orphan recon (5m) │              │ • new messages               │
+│ • Lease recovery    │              │                              │
+└─────────────────────┘              │ Routes to:                   │
+                                     │ 1. Task conversation         │
+                                     │ 2. Team-lead mailbox         │
+                                     │ 3. Runtime event log         │
+                                     └─────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────────┐
+│                         Hook System                               │
+│                                                                   │
+│  Claude Code invokes: genie hook dispatch                        │
+│  Reads JSON from stdin, runs handler chain, writes JSON to stdout │
+│                                                                   │
+│  Blocking hooks (PreToolUse):                                    │
+│    branch-guard        — Blocks pushes to main/master            │
+│    orchestration-guard — Blocks tmux scraping                    │
+│    identity-inject     — Injects agent name into SendMessage     │
+│    auto-spawn          — Auto-spawns teammates on SendMessage    │
+│    runtime-emit-tool   — Emits tool_call events to PG            │
+│                                                                   │
+│  Non-blocking hooks:                                             │
+│    runtime-emit-msg    — Emits message events (PostToolUse)      │
+│    runtime-emit-user   — Emits user prompt events                │
+│    runtime-emit-asst   — Emits assistant response events (Stop)  │
+└──────────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────────┐
+│                      Agent Sessions (tmux)                        │
+│                                                                   │
+│  tmux -L genie         Agent socket (eternal, survives restarts) │
+│    └── session per team/agent                                    │
+│         └── window per agent                                     │
+│              └── pane running Claude Code / Codex / SDK          │
+│                                                                   │
+│  tmux -L genie-tui     TUI socket (owned by serve)              │
+│    └── session: genie-tui                                        │
+│         └── window 0: left=nav (OpenTUI), right=agent display   │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### Event Flow Example: Agent Completes a Task
+
+1. Agent finishes work, Claude Code emits `Stop` event
+2. `runtime-emit-asst` hook fires, writes `assistant` event to `runtime_events` table
+3. Agent state updated to `done` in `agents` table
+4. PG fires `NOTIFY genie_executor_state` with `agent_id:old_state:done`
+5. Event router picks up the notification
+6. Event router delivers to team-lead mailbox (PG + native inbox)
+7. Event router writes event to runtime event log
+8. Inbox watcher detects unread message, ensures team-lead is spawned
+
+## Directory Structure
+
+```
+src/
+├── genie.ts                    CLI entry point (commander)
+├── genie-commands/             Setup/utility commands (setup, doctor, update)
+├── term-commands/              CLI command handlers
+│   ├── agent/                  genie agent namespace (spawn, stop, resume, ...)
+│   ├── serve.ts                genie serve — infrastructure owner
+│   ├── daemon.ts               genie daemon — deprecated alias for serve
+│   ├── team.ts                 genie team — create, hire, fire, list, disband
+│   ├── task.ts                 genie task — CRUD + board + project + releases
+│   ├── agents.ts               Legacy top-level agent commands
+│   └── ...                     Other command files
+├── lib/                        Core modules
+│   ├── db.ts                   PostgreSQL connection + pgserve management
+│   ├── agent-registry.ts       Agent identity CRUD (PG-backed)
+│   ├── scheduler-daemon.ts     Trigger claiming + heartbeats + orphan recon
+│   ├── event-router.ts         PG NOTIFY → mailbox/event-log routing
+│   ├── inbox-watcher.ts        Native inbox polling + auto-spawn
+│   ├── service-registry.ts     In-memory PID registry for shutdown
+│   ├── runtime-events.ts       Structured event log (PG)
+│   ├── session-capture.ts      JSONL ingestion core (filewatch + backfill)
+│   ├── session-filewatch.ts    fs.watch on ~/.claude/projects/
+│   ├── session-backfill.ts     Lazy historical JSONL ingestion
+│   ├── team-manager.ts         Team configuration management
+│   ├── mailbox.ts              Message delivery (disk + tmux injection)
+│   ├── tmux.ts                 tmux pane/session helpers
+│   └── ...                     Other modules
+├── services/                   External service integrations
+│   ├── omni-bridge.ts          NATS → agent session routing (WhatsApp, etc.)
+│   ├── executor.ts             IExecutor interface for Omni bridge
+│   └── executors/              Executor implementations (claude-code, claude-sdk)
+├── hooks/                      Git hook system
+│   ├── index.ts                Handler registry + dispatch logic
+│   ├── types.ts                Hook payload/result types
+│   ├── inject.ts               Hook installation into Claude Code settings
+│   ├── dispatch-command.ts     `genie hook dispatch` CLI command
+│   └── resolve-agent-name.ts   Agent name resolution from env
+├── tui/                        Terminal UI (OpenTUI-based)
+│   ├── app.tsx                 TUI application root
+│   └── ...                     TUI components
+├── types/                      Shared types (genie-config Zod schema)
+└── skills/                     Skill prompt files
+
+~/.genie/                       Global state directory (GENIE_HOME)
+├── serve.pid                   Canonical PID file for genie serve
+├── scheduler.pid               Legacy PID file (backward compat)
+├── pgserve.port                Port lockfile for pgserve
+├── data/pgserve/               PostgreSQL data directory
+├── logs/scheduler.log          Structured JSON scheduler log
+├── workers.json                Global worker registry (legacy)
+├── teams/                      Team configuration files
+├── sessions.json               Global session store
+└── prompts/                    Generated system prompts for teams
+
+<repo>/.genie/                  Per-repo state (shared across worktrees)
+├── state/<slug>.json           Wish state files
+├── mailbox/<worker>.json       Worker mailboxes
+├── chat/<team>.jsonl           Team chat logs
+└── wishes/                     Wish definitions
+```
+
+## Key Design Decisions
+
+1. **pgserve as single source of truth** — All agent state, events, tasks, and sessions are in PostgreSQL. File-based state (`workers.json`, `mailbox/`) exists for backward compatibility and edge cases (mailbox delivery when PG is unavailable).
+
+2. **Eternal agent tmux server** — `tmux -L genie` is never killed by `genie serve stop`. Agent sessions survive serve restarts. Only the TUI session (`tmux -L genie-tui`) is owned by serve.
+
+3. **Hook system as event bus** — Claude Code's hook protocol is leveraged to emit runtime events, enforce branch protection, inject identity, and auto-spawn teammates. All hooks have a 15s hard timeout.
+
+4. **Lease-based scheduling** — Triggers use `SELECT FOR UPDATE SKIP LOCKED` for distributed claiming. Idempotency keys prevent double-fire. Jitter is applied when >3 triggers fire simultaneously to prevent thundering herd.
+
+5. **Session capture is lazy** — Live filewatch has priority. Backfill processes historical files in background, yielding to live work. Offsets are committed in the same PG transaction as content.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -251,6 +251,9 @@ src/
 │   ├── team-manager.ts         Team configuration management
 │   ├── mailbox.ts              Message delivery (disk + tmux injection)
 │   ├── tmux.ts                 tmux pane/session helpers
+│   ├── orchestrator/           Session monitoring + state detection
+│   ├── providers/              Provider implementations (claude, codex, sdk, pty)
+│   │   └── registry.ts         Auto-registering provider lookup
 │   └── ...                     Other modules
 ├── services/                   External service integrations
 │   ├── omni-bridge.ts          NATS → agent session routing (WhatsApp, etc.)
@@ -285,6 +288,41 @@ src/
 ├── chat/<team>.jsonl           Team chat logs
 └── wishes/                     Wish definitions
 ```
+
+## Provider System
+
+The provider system abstracts how agents are launched. Each provider implements the `ExecutorProvider` interface and is auto-registered at import time.
+
+```
+Provider Registry (src/lib/providers/registry.ts)
+│
+├── claude      ClaudeCodeProvider   — Claude Code CLI in a tmux pane
+├── claude-sdk  ClaudeSdkProvider    — Claude SDK (streaming API, no CLI)
+├── codex       CodexProvider        — OpenAI Codex CLI
+└── app-pty     AppPtyProvider       — Generic PTY process (any CLI tool)
+```
+
+| Provider | Source | Description |
+|----------|--------|-------------|
+| **claude** | `src/lib/providers/claude-code.ts` | Default. Builds a Claude Code command with flags (`--model`, `--allowedTools`, `--continue`, etc.), launches in tmux pane, injects system prompt. |
+| **claude-sdk** | `src/lib/providers/claude-sdk.ts` | Programmatic Claude API. Uses streaming with tool-use support. SDK events, permissions, and stream handling are split into dedicated modules (`claude-sdk-events.ts`, `claude-sdk-permissions.ts`, `claude-sdk-stream.ts`). |
+| **codex** | `src/lib/providers/codex.ts` | OpenAI Codex CLI. Builds command with Codex-specific flags. |
+| **app-pty** | `src/lib/providers/app-pty.ts` | Generic PTY wrapper for arbitrary CLI tools. Used for non-AI processes that need tmux pane management. |
+
+### Provider Selection
+
+Provider is determined by the `model` field in agent templates. The `executor-types.ts` module defines the `ExecutorProvider` interface that all providers implement: `name`, `buildCommand()`, `detectState()`, and lifecycle hooks.
+
+## Orchestrator
+
+The orchestrator module (`src/lib/orchestrator/`) monitors and controls Claude Code sessions running in tmux panes.
+
+| Module | Description |
+|--------|-------------|
+| `state-detector.ts` | Analyzes terminal output to determine agent state (`idle`, `working`, `permission`, `question`, `error`, `complete`, `tool_use`). Uses regex pattern matching with confidence scoring (0–1). |
+| `patterns.ts` | Pattern library for detecting permission prompts, errors, idle states, working indicators, and completion markers from Claude Code terminal output. |
+
+The state detector reads the last N lines of a pane's output (default 50) and matches against the pattern library. This is used by the auto-approve engine, idle timeout detection, and the `genie agent answer` command.
 
 ## Key Design Decisions
 

--- a/docs/CLI-REFERENCE.md
+++ b/docs/CLI-REFERENCE.md
@@ -1,0 +1,1570 @@
+# Genie CLI Reference
+
+Complete command reference generated from `src/term-commands/`. Organized by category.
+
+---
+
+## Table of Contents
+
+- [Core Commands](#core-commands) -- spawn, kill, stop, resume, ls, send, broadcast, status, done, reset, work, review
+- [Agent Namespace](#agent-namespace) -- genie agent spawn/stop/resume/kill/list/show/log/send/inbox/answer/brief/register/directory
+- [Task Management](#task-management) -- genie task create/list/show/move/assign/tag/comment/block/unblock/done/link/checkout/release/unlock/close-merged/archive/unarchive/dep
+- [Team Management](#team-management) -- genie team create/hire/fire/ls/archive/unarchive/disband/done/blocked/cleanup
+- [Board & Pipeline](#board--pipeline) -- genie board create/list/show/edit/delete/columns/use/export/import/reconcile/archive + templates
+- [Project Management](#project-management) -- genie project list/create/show
+- [Events & Observability](#events--observability) -- genie events list/errors/costs/tools/timeline/summary/scan
+- [Sessions & History](#sessions--history) -- genie sessions list/replay/search/sync, genie history, genie log, genie read
+- [Database](#database) -- genie db status/migrate/query/url/backup/restore
+- [Scheduling](#scheduling) -- genie schedule create/list/cancel/retry/history
+- [Daemon](#daemon) -- genie daemon install/start/stop/status/logs
+- [Infrastructure](#infrastructure) -- genie serve start/stop/status
+- [Brain (Enterprise)](#brain-enterprise) -- genie brain install/uninstall/update/version + passthrough
+- [Omni Bridge](#omni-bridge) -- genie omni start/stop/status
+- [Import/Export](#importexport) -- genie export/import
+- [Dispatch](#dispatch) -- genie brainstorm/wish/work/review
+- [QA System](#qa-system) -- genie qa run/status/history/check, genie qa-report
+- [Tags](#tags) -- genie tag list/create
+- [Types](#types) -- genie type list/show/create
+- [Releases](#releases) -- genie release create/list
+- [Templates](#templates) -- genie template list/show/delete
+- [Metrics](#metrics) -- genie metrics now/history/agents
+- [Notifications](#notifications) -- genie notify set/list/remove
+- [Hooks](#hooks) -- genie hook dispatch
+- [Utility Commands](#utility-commands) -- genie setup/doctor/update/uninstall/init/shortcuts/app
+
+---
+
+## Core Commands
+
+Top-level shortcuts for common operations. These are aliases for commands in the `agent` namespace or other namespaces.
+
+### `genie spawn <name>`
+
+Spawn a new agent by name (resolves from directory or built-ins).
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--provider <provider>` | string | `claude` | Provider: claude or codex |
+| `--team <team>` | string | `$GENIE_TEAM` or `genie` | Team name |
+| `--model <model>` | string | | Model override (e.g., sonnet, opus) |
+| `--skill <skill>` | string | | Skill to load |
+| `--layout <layout>` | string | `mosaic` | Layout mode: mosaic or vertical |
+| `--color <color>` | string | | Teammate pane border color |
+| `--plan-mode` | boolean | | Start teammate in plan mode |
+| `--permission-mode <mode>` | string | | Permission mode (e.g., acceptEdits) |
+| `--extra-args <args...>` | string[] | | Extra CLI args forwarded to provider |
+| `--cwd <path>` | string | | Working directory for the agent |
+| `--session <session>` | string | | Tmux session name to spawn into |
+| `--role <role>` | string | | Override role name for registration |
+| `--new-window` | boolean | | Create a new tmux window instead of splitting |
+| `--window <target>` | string | | Tmux window to split into (e.g., genie:3) |
+| `--no-auto-resume` | boolean | | Disable auto-resume on pane death |
+| `--stream` | boolean | | Stream SDK messages to stdout in real-time |
+| `--stream-format <format>` | string | `text` | Streaming output format: text, json, ndjson |
+| `--sdk-max-turns <n>` | number | | SDK: max conversation turns |
+| `--sdk-max-budget <usd>` | number | | SDK: max budget in USD |
+| `--sdk-stream` | boolean | | SDK: enable streaming output |
+| `--sdk-effort <level>` | string | | SDK: reasoning effort level (low, medium, high, max) |
+
+```bash
+genie spawn engineer                              # Spawn built-in engineer role
+genie spawn researcher --model sonnet             # Spawn with model override
+genie spawn my-agent --team my-feature            # Spawn into a specific team
+genie spawn council--questioner --provider codex  # Use Codex provider
+```
+
+### `genie kill <name>`
+
+Force kill an agent by name.
+
+### `genie stop <name>`
+
+Stop an agent (preserves session for resume).
+
+### `genie resume [name]`
+
+Resume a suspended/failed agent with its Claude session.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--all` | boolean | Resume all eligible agents |
+
+### `genie ls`
+
+List registered agents with runtime status.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--json` | boolean | Output as JSON |
+
+### `genie send <body>`
+
+Send a direct message to an agent (PG-backed).
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--to <agent>` | string | `team-lead` | Recipient agent name |
+| `--from <sender>` | string | auto-detected | Sender ID |
+| `--team <name>` | string | | Explicit team context |
+
+```bash
+genie send 'start task #3' --to engineer      # Message a specific agent
+genie send 'status update' --to team-lead      # Report to team lead
+genie send 'deploy ready' --team my-feature    # Message within team context
+```
+
+### `genie broadcast <body>`
+
+Send a message to your team conversation (PG-backed).
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--from <sender>` | string | Sender ID (auto-detected) |
+| `--team <name>` | string | Team name (auto-detected) |
+
+### `genie done <ref>`
+
+Mark a wish group as done. Format: `<slug>#<group>`.
+
+### `genie status <slug>`
+
+Show wish state overview for all groups.
+
+### `genie reset <ref>`
+
+Reset an in-progress group back to ready. Format: `<slug>#<group>`.
+
+### `genie read <name>`
+
+Read terminal output from an agent pane.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `-n, --lines <number>` | string | Number of lines to read |
+| `--from <line>` | string | Start line |
+| `--to <line>` | string | End line |
+| `--range <range>` | string | Line range (e.g., "10-20") |
+| `--search <text>` | string | Search for text |
+| `--grep <pattern>` | string | Grep for pattern |
+| `-f, --follow` | boolean | Follow mode (like tail -f) |
+| `--all` | boolean | Show all output |
+| `-r, --reverse` | boolean | Reverse order |
+| `--json` | boolean | Output as JSON |
+
+### `genie answer <name> <choice>`
+
+Answer a question for an agent (use `text:...` for text input).
+
+### `genie history <name>`
+
+Show compressed session history for an agent.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--full` | boolean | Show full conversation without compression |
+| `--since <n>` | number | Show last N user/assistant exchanges |
+| `--last <n>` | number | Show last N transcript entries |
+| `--type <role>` | string | Filter by role (user, assistant, tool_call) |
+| `--after <timestamp>` | string | Only entries after ISO timestamp |
+| `--json` | boolean | Output as JSON |
+| `--ndjson` | boolean | Output as newline-delimited JSON |
+| `--raw` | boolean | Output raw JSONL entries |
+| `--log-file <path>` | string | Direct path to log file |
+
+### `genie log [agent]`
+
+Unified observability feed -- aggregates transcript, DMs, team chat.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--team <name>` | string | Show interleaved feed for all agents in a team |
+| `--type <kind>` | string | Filter by event kind (transcript, message, tool_call, state, system) |
+| `--since <timestamp>` | string | Only events after ISO timestamp |
+| `--last <n>` | number | Show last N events |
+| `--ndjson` | boolean | Output as newline-delimited JSON |
+| `--json` | boolean | Output as pretty JSON |
+| `-f, --follow` | boolean | Follow mode -- real-time streaming |
+
+---
+
+## Agent Namespace
+
+All commands under `genie agent`. Top-level shortcuts (spawn, kill, stop, etc.) are aliases for these.
+
+### `genie agent spawn <name>`
+
+Spawn a new agent by name (resolves from directory or built-ins). Same options as `genie spawn`.
+
+Additional options only on the agent namespace version:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--prompt <prompt>` | string | Initial prompt (first user message) |
+
+### `genie agent stop <name>`
+
+Stop an agent (preserves session for resume).
+
+### `genie agent resume [name]`
+
+Resume a suspended/failed agent with its Claude session.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--all` | boolean | Resume all eligible agents |
+
+### `genie agent kill <name>`
+
+Force kill an agent by name.
+
+### `genie agent list` (alias: `ls`)
+
+List registered agents with runtime status.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--json` | boolean | Output as JSON |
+
+### `genie agent show <name>`
+
+Show agent identity and current executor detail.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--json` | boolean | Output as JSON |
+
+### `genie agent log [agent]`
+
+Unified observability feed -- aggregates transcript, DMs, team chat.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--team <name>` | string | Show interleaved feed for all agents in a team |
+| `--type <kind>` | string | Filter by event kind |
+| `--since <timestamp>` | string | Only events after ISO timestamp |
+| `--last <n>` | number | Show last N events |
+| `--ndjson` | boolean | Output as newline-delimited JSON |
+| `--json` | boolean | Output as pretty JSON |
+| `-f, --follow` | boolean | Follow mode -- real-time streaming |
+| `--raw` | boolean | Show raw pane capture (was `genie read`) |
+| `--transcript` | boolean | Show compressed transcript (was `genie history`) |
+| `--full` | boolean | Show full conversation (with --transcript) |
+| `--search <query>` | string | Search across sessions |
+| `-n, --lines <number>` | string | Number of lines to read (with --raw) |
+
+### `genie agent send <body>`
+
+Send a direct message to an agent (hierarchy-enforced).
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--to <agent>` | string | `team-lead` | Recipient agent name |
+| `--from <sender>` | string | auto-detected | Sender ID |
+| `--team <name>` | string | | Explicit team context |
+| `--broadcast` | boolean | | Send to all direct reports |
+
+### `genie agent inbox`
+
+Inbox management -- list messages or watch for new ones.
+
+#### `genie agent inbox list [agent]`
+
+List conversations with recent messages (default subcommand).
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--json` | boolean | Output as JSON |
+
+#### `genie agent inbox watch`
+
+Run inbox watcher in foreground (Ctrl+C to stop).
+
+### `genie agent answer <name> <choice>`
+
+Answer a question for an agent (use `text:...` for text input).
+
+### `genie agent brief`
+
+Show startup brief -- aggregated context since last session.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--team <name>` | string | Team name (default: GENIE_TEAM) |
+| `--agent <name>` | string | Agent name (default: GENIE_AGENT_NAME) |
+| `--since <iso>` | string | Start timestamp (default: last executor end) |
+
+### `genie agent register <name>`
+
+Register an agent locally and auto-register in Omni when configured.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--dir <path>` | string | **required** | Agent folder (CWD + AGENTS.md) |
+| `--repo <path>` | string | | Default git repo |
+| `--prompt-mode <mode>` | string | `append` | Prompt mode: append or system |
+| `--model <model>` | string | | Default model (sonnet, opus, codex) |
+| `--roles <roles...>` | string[] | | Built-in roles this agent can orchestrate |
+| `--global` | boolean | | Write to global directory |
+| `--skip-omni` | boolean | | Skip Omni auto-registration |
+
+### `genie agent directory [name]` (alias: `dir`)
+
+List all agents or show single entry details from directory.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--json` | boolean | Output as JSON |
+| `--builtins` | boolean | Include built-in roles and council members |
+| `--all` | boolean | Include archived agents |
+
+Special: passing `sync` as the name runs directory synchronization.
+
+---
+
+## Task Management
+
+Commands under `genie task`.
+
+### `genie task create <title>`
+
+Create a new task.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--type <type>` | string | `software` | Task type |
+| `--priority <priority>` | string | `normal` | Priority: urgent, high, normal, low |
+| `--due <date>` | string | | Due date (YYYY-MM-DD) |
+| `--start <date>` | string | | Start date (YYYY-MM-DD) |
+| `--tags <tags>` | string | | Comma-separated tag IDs |
+| `--parent <id>` | string | | Parent task ID or #seq |
+| `--assign <name>` | string | | Assign to local actor |
+| `--description <text>` | string | | Task description |
+| `--effort <effort>` | string | | Estimated effort (e.g., "2h", "3 points") |
+| `--comment <msg>` | string | | Initial comment on the task |
+| `--project <name>` | string | | Create task in a specific project |
+| `--board <name>` | string | | Board name to assign task to |
+| `--gh <owner/repo#N>` | string | | Link to GitHub issue |
+| `--external-id <id>` | string | | External tracker ID |
+| `--external-url <url>` | string | | External tracker URL |
+
+### `genie task list`
+
+List tasks with filters.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--stage <stage>` | string | | Filter by stage |
+| `--type <type>` | string | | Filter by type |
+| `--status <status>` | string | | Filter by status |
+| `--priority <priority>` | string | | Filter by priority |
+| `--release <release>` | string | | Filter by release |
+| `--due-before <date>` | string | | Filter by due date |
+| `--mine` | boolean | | Show only tasks assigned to me |
+| `--project <name>` | string | | Show tasks for a specific project |
+| `--board <name>` | string | | Filter by board name |
+| `--gh <owner/repo#N>` | string | | Filter by GitHub issue link |
+| `--by-column` | boolean | | Group tasks by board column (kanban view) |
+| `--include-done` | boolean | | Include done tasks in kanban view |
+| `--all` | boolean | | Show tasks from ALL projects |
+| `--limit <n>` | string | `100` | Max number of tasks |
+| `--offset <n>` | string | `0` | Skip first N tasks |
+| `--json` | boolean | | Output as JSON |
+
+### `genie task show <id>`
+
+Show task detail (accepts task-id or #seq).
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--json` | boolean | Output as JSON |
+
+### `genie task move <id>`
+
+Move task to a new stage.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--to <stage>` | string | **required** -- Target stage |
+| `--comment <msg>` | string | Comment on the move |
+
+### `genie task assign <id>`
+
+Assign an actor to a task.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--to <name>` | string | **required** | Actor name |
+| `--role <role>` | string | `assignee` | Actor role |
+| `--comment <msg>` | string | | Comment on the assignment |
+
+### `genie task tag <id> <tags...>`
+
+Add tags to a task.
+
+### `genie task comment <id> <message>`
+
+Add a comment to a task.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--reply-to <msgId>` | string | Reply to a specific message ID |
+
+### `genie task block <id>`
+
+Mark task as blocked.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--reason <reason>` | string | **required** -- Reason for blocking |
+| `--comment <msg>` | string | Additional comment |
+
+### `genie task unblock <id>`
+
+Unblock a task.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--comment <msg>` | string | Comment on unblock |
+
+### `genie task done <id>`
+
+Mark task as done.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--comment <msg>` | string | Comment on completion |
+
+### `genie task link <id>`
+
+Link task to an external tracker (GitHub, Jira, etc.).
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--gh <owner/repo#N>` | string | Link to GitHub issue |
+| `--external-id <id>` | string | External tracker ID |
+| `--external-url <url>` | string | External tracker URL |
+
+### `genie task checkout <id>`
+
+Atomically claim a task for execution.
+
+### `genie task release <id>`
+
+Release task checkout claim.
+
+### `genie task unlock <id>`
+
+Force-release a stale checkout (admin override).
+
+### `genie task close-merged`
+
+Auto-close tasks whose wish slugs match recently merged PRs.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--since <duration>` | string | `24h` | Time window for merged PRs |
+| `--dry-run` | boolean | | Show what would be closed |
+| `--repo <owner/repo>` | string | | Override GitHub remote detection |
+
+### `genie task archive <id>`
+
+Archive a task (soft-delete -- preserves all data).
+
+### `genie task unarchive <id>`
+
+Restore an archived task to its previous status.
+
+### `genie task dep <id>`
+
+Manage task dependencies.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--depends-on <id2>` | string | This task depends on id2 |
+| `--blocks <id2>` | string | This task blocks id2 |
+| `--relates-to <id2>` | string | This task relates to id2 |
+| `--remove <id2>` | string | Remove dependency on id2 |
+
+---
+
+## Team Management
+
+Commands under `genie team`.
+
+### `genie team create <name>`
+
+Create a new team with a git worktree.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--repo <path>` | string | **required** | Path to the git repository |
+| `--branch <branch>` | string | `dev` | Base branch to create from |
+| `--wish <slug>` | string | | Wish slug -- auto-spawns a task leader |
+| `--tmux-session <name>` | string | derived from repo | Tmux session to place team window in |
+| `--session <name>` | string | | Alias for --tmux-session (deprecated) |
+| `--no-spawn` | boolean | | Create team without spawning the leader |
+
+```bash
+genie team create my-feature --repo .                          # Create team in current repo
+genie team create my-feature --repo . --wish my-feature-slug   # Create team with a wish
+genie team create hotfix --repo . --branch main                # Create from main branch
+```
+
+### `genie team hire <agent>`
+
+Add an agent to a team. Passing `council` hires all 10 council members.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--team <name>` | string | Team name (auto-detects from context) |
+
+### `genie team fire <agent>`
+
+Remove an agent from a team.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--team <name>` | string | Team name (auto-detects from context) |
+
+### `genie team ls [name]` (alias: `list`)
+
+List teams (no arg) or members of a specific team.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--all` | boolean | Include archived teams |
+| `--json` | boolean | Output as JSON |
+
+### `genie team archive <name>`
+
+Archive a team (preserves all data, kills members).
+
+### `genie team unarchive <name>`
+
+Restore an archived team.
+
+### `genie team disband <name>`
+
+Disband a team (archives -- preserves data). Alias for `genie team archive`.
+
+### `genie team done <name>`
+
+Mark a team as done and kill all members.
+
+### `genie team blocked <name>`
+
+Mark a team as blocked and kill all members.
+
+### `genie team cleanup`
+
+Kill tmux windows for done/archived teams.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--dry-run` | boolean | Show what would be cleaned without acting |
+
+---
+
+## Board & Pipeline
+
+Commands under `genie board`.
+
+### `genie board create <name>`
+
+Create a new board.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--project <project>` | string | Project name |
+| `--from <template>` | string | Create from template name |
+| `--columns <columns>` | string | Comma-separated column names |
+| `--description <text>` | string | Board description |
+
+### `genie board list`
+
+List all boards.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--project <project>` | string | Filter by project |
+| `--all` | boolean | Include archived boards |
+| `--json` | boolean | Output as JSON |
+
+### `genie board show <name...>`
+
+Show board detail.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--project <project>` | string | Disambiguate by project |
+| `--json` | boolean | Output as JSON |
+
+### `genie board edit <name...>`
+
+Edit board or column properties.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--project <project>` | string | Disambiguate by project |
+| `--column <col>` | string | Column name to edit |
+| `--gate <gate>` | string | New gate value (human\|agent\|human+agent) |
+| `--action <action>` | string | New action skill |
+| `--color <color>` | string | New color hex |
+| `--rename <new>` | string | Rename the column |
+| `--name <new>` | string | Rename the board itself |
+| `--description <text>` | string | Update description |
+
+### `genie board delete <name...>`
+
+Delete a board.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--project <project>` | string | Disambiguate by project |
+| `--force` | boolean | Skip confirmation |
+
+### `genie board columns <name...>`
+
+Show board column pipeline.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--project <project>` | string | Disambiguate by project |
+| `--json` | boolean | Output as JSON |
+
+### `genie board use <name...>`
+
+Set active board for current repo.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--project <project>` | string | Disambiguate by project |
+
+### `genie board export <name...>`
+
+Export board as JSON.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--project <project>` | string | Disambiguate by project |
+| `--output <file>` | string | Write to file instead of stdout |
+
+### `genie board import`
+
+Import board from JSON file.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--json <file>` | string | **required** -- JSON file to import |
+| `--project <project>` | string | **required** -- Target project |
+
+### `genie board reconcile <name...>`
+
+Fix orphaned column_ids by matching task stage to board columns.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--project <project>` | string | Disambiguate by project |
+| `--json` | boolean | Output as JSON |
+
+### `genie board archive <name...>`
+
+Archive a board and its unfinished tasks.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--project <project>` | string | Disambiguate by project |
+
+### Board Templates
+
+Commands under `genie board template`.
+
+#### `genie board template list`
+
+List all board templates.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--json` | boolean | Output as JSON |
+
+#### `genie board template show <name>`
+
+Show template detail with pipeline view.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--json` | boolean | Output as JSON |
+
+#### `genie board template create <name>`
+
+Create a board template.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--from-board <board>` | string | Create from existing board |
+| `--columns <columns>` | string | Comma-separated column names |
+| `--description <text>` | string | Template description |
+
+#### `genie board template edit <name>`
+
+Edit a template column.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--column <col>` | string | Column name to edit |
+| `--gate <gate>` | string | New gate value |
+| `--action <action>` | string | New action skill |
+| `--rename <new>` | string | Rename the column |
+| `--color <color>` | string | New color hex |
+
+#### `genie board template rename <old> <new>`
+
+Rename a template.
+
+#### `genie board template delete <name>`
+
+Delete a template.
+
+---
+
+## Project Management
+
+Commands under `genie project`.
+
+### `genie project list`
+
+List all projects.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--all` | boolean | Include archived projects |
+| `--json` | boolean | Output as JSON |
+
+### `genie project create <name>`
+
+Create a new project.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--virtual` | boolean | Create a virtual project (not tied to a repo) |
+| `--repo <path>` | string | Repo path for the project |
+| `--description <text>` | string | Project description |
+
+### `genie project show <name>`
+
+Show project detail with task stats.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--json` | boolean | Output as JSON |
+
+---
+
+## Events & Observability
+
+Commands under `genie events`. Queries audit events from PG.
+
+### `genie events list` (default)
+
+List recent audit events.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--type <type>` | string | | Filter by event_type |
+| `--entity <entity>` | string | | Filter by entity_type or entity_id |
+| `--since <duration>` | string | `1h` | Time window (e.g., 1h, 30m, 2d) |
+| `--errors-only` | boolean | | Show only error events |
+| `--limit <n>` | string | `50` | Max rows to return |
+| `--json` | boolean | | Output as JSON |
+
+### `genie events errors`
+
+Show aggregated error patterns.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--since <duration>` | string | Time window (e.g., 1h, 24h, 7d) |
+| `--json` | boolean | Output as JSON |
+
+### `genie events costs`
+
+Cost breakdown from OTel API request events.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--today` | boolean | | Show costs from the last 24h |
+| `--since <duration>` | string | `24h` | Time window |
+| `--by-agent` | boolean | | Group by agent |
+| `--by-wish` | boolean | | Group by wish |
+| `--by-model` | boolean | | Group by model |
+| `--json` | boolean | | Output as JSON |
+
+### `genie events tools`
+
+Tool usage analytics from OTel tool events.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--since <duration>` | string | `24h` | Time window |
+| `--by-tool` | boolean | | Group by tool name (default) |
+| `--by-agent` | boolean | | Group by agent |
+| `--json` | boolean | | Output as JSON |
+
+### `genie events timeline <entity-id>`
+
+Full event timeline for a task, agent, wish, or traceId.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--json` | boolean | Output as JSON |
+
+### `genie events summary`
+
+High-level stats: agents spawned, tasks moved, costs, errors.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--today` | boolean | | Show summary for the last 24h |
+| `--since <duration>` | string | `24h` | Time window |
+| `--json` | boolean | | Output as JSON |
+
+### `genie events scan`
+
+Full server cost scan via ccusage (all CC sessions, not just genie-spawned).
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--since <date>` | string | Start date in YYYYMMDD format |
+| `--json` | boolean | Output as JSON |
+| `--breakdown` | boolean | Show per-model breakdown |
+
+---
+
+## Sessions & History
+
+### `genie sessions list` (default)
+
+List Claude Code sessions.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--active` | boolean | Show only active sessions |
+| `--orphaned` | boolean | Show only orphaned sessions |
+| `--agent <name>` | string | Filter by agent |
+| `--limit <n>` | string | Max number of sessions (default: 50) |
+| `--json` | boolean | Output as JSON |
+
+### `genie sessions replay <session-id>`
+
+Replay a session -- interleave content + events.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--json` | boolean | Output as JSON |
+
+### `genie sessions search <query>`
+
+Full-text search across session content.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--json` | boolean | | Output as JSON |
+| `--limit <n>` | string | `20` | Max results |
+
+### `genie sessions sync`
+
+Check session backfill progress.
+
+---
+
+## Database
+
+Commands under `genie db`. Manages pgserve.
+
+### `genie db status`
+
+Show pgserve health, port, data dir, and table counts.
+
+### `genie db migrate`
+
+Run pending database migrations.
+
+### `genie db query <sql>`
+
+Execute arbitrary SQL and print results.
+
+### `genie db url`
+
+Print postgres connection URL for direct access.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--quiet` | boolean | Print URL only, no trailing newline (for scripts) |
+
+### `genie db backup`
+
+Dump database to `.genie/snapshot.sql.gz`.
+
+### `genie db restore [file]`
+
+Restore database from snapshot (default: `.genie/snapshot.sql.gz`).
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `-y, --yes` | boolean | Skip confirmation prompt |
+
+---
+
+## Scheduling
+
+Commands under `genie schedule`.
+
+### `genie schedule create <name>`
+
+Create a new schedule.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--command <cmd>` | string | **required** | Command to execute |
+| `--at <time>` | string | | One-time schedule at absolute time (ISO 8601) |
+| `--every <interval>` | string | | Repeating: duration (10m, 2h) or cron expression |
+| `--after <duration>` | string | | One-time schedule after delay |
+| `--timezone <tz>` | string | `UTC` | Timezone for schedule |
+| `--lease-timeout <duration>` | string | `5m` | Lease timeout for runs |
+
+### `genie schedule list`
+
+List schedules with next due trigger.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--json` | boolean | Output as JSON |
+| `--watch` | boolean | Refresh every 2s |
+
+### `genie schedule cancel <name>`
+
+Cancel a schedule and skip pending triggers.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--filter <expr>` | string | Filter expression (e.g., status=pending) |
+
+### `genie schedule retry <name>`
+
+Reset a failed trigger to pending.
+
+### `genie schedule history <name>`
+
+Show past executions for a schedule.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--limit <n>` | number | `20` | Max rows to show |
+
+---
+
+## Daemon
+
+Commands under `genie daemon`. Manages the scheduler daemon lifecycle (redirects to `genie serve --headless`).
+
+### `genie daemon install`
+
+Generate systemd service unit and enable it.
+
+### `genie daemon start`
+
+Start the scheduler daemon.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--foreground` | boolean | Run in foreground (for systemd ExecStart) |
+
+### `genie daemon stop`
+
+Stop genie serve gracefully.
+
+### `genie daemon status`
+
+Show daemon state, PID, uptime, and trigger stats.
+
+### `genie daemon logs`
+
+Tail structured JSON scheduler log.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--follow, -f` | boolean | Follow log output |
+| `--lines <n>` | number | Number of lines to show (default: 20) |
+
+---
+
+## Infrastructure
+
+Commands under `genie serve`. Starts all genie infrastructure (pgserve, tmux, scheduler).
+
+### `genie serve start` (default)
+
+Start genie serve.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--daemon` | boolean | Run in background |
+| `--foreground` | boolean | Run in foreground (default) |
+| `--headless` | boolean | Run without TUI (services only: pgserve, scheduler, inbox-watcher) |
+
+### `genie serve stop`
+
+Stop genie serve and all services.
+
+### `genie serve status`
+
+Show service health.
+
+---
+
+## Brain (Enterprise)
+
+`genie brain` -- Knowledge graph engine (enterprise). Delegates to `@automagik/genie-brain`.
+
+Brain is never a hard dependency. Genie works the same without it.
+
+### `genie brain install`
+
+Install genie-brain from GitHub. Requires automagik-dev org membership.
+
+### `genie brain uninstall`
+
+Remove genie-brain installation.
+
+### `genie brain update`
+
+Update genie-brain to latest version from GitHub.
+
+### `genie brain version`
+
+Show installed brain version and check for updates.
+
+### `genie brain <subcommand>`
+
+All other arguments are passed through to the brain module's `execute()` function.
+
+---
+
+## Omni Bridge
+
+Commands under `genie omni`. Manages the NATS bridge connecting Omni (WhatsApp) to Genie agent sessions.
+
+### `genie omni start`
+
+Start the NATS bridge (subscribe to `omni.message.>`).
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--nats-url <url>` | string | `localhost:4222` | NATS server URL |
+| `--max-concurrent <n>` | string | `20` | Max concurrent agent sessions |
+| `--idle-timeout <ms>` | string | `900000` | Idle timeout in ms |
+| `--executor <type>` | string | `tmux` | Executor type: tmux or sdk |
+
+### `genie omni stop`
+
+Stop the running NATS bridge.
+
+### `genie omni status`
+
+Show bridge status: active sessions, queue depth, idle timers.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--json` | boolean | Output as JSON |
+
+---
+
+## Import/Export
+
+### `genie export`
+
+Export genie data as JSON.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--output <file>` | string | Write to file instead of stdout |
+| `-o <file>` | string | Alias for --output |
+| `--pretty` | boolean | Pretty-print JSON |
+
+Subcommands:
+
+- `genie export all` -- Full backup (all present tables)
+- `genie export boards [name]` -- Export boards, templates, and task types
+- `genie export tasks` -- Export tasks with deps, actors, and stage log (`--project <name>` to filter)
+- `genie export tags` -- Export tags
+
+### `genie import <file>`
+
+Import genie data from JSON export.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--fail` | boolean | Abort on any conflict (default) |
+| `--merge` | boolean | Skip existing rows, import new ones |
+| `--overwrite` | boolean | Replace existing rows with imported data |
+| `--groups <list>` | string | Comma-separated groups to import |
+
+---
+
+## Dispatch
+
+Wish lifecycle commands for spawning agents with context.
+
+### `genie brainstorm <agent> <slug>`
+
+Spawn agent with brainstorm DRAFT.md context.
+
+### `genie wish <agent> <slug>`
+
+Spawn agent with wish DESIGN.md context.
+
+### `genie work <ref> [agent]`
+
+Auto-orchestrate a wish, or dispatch work on a specific group.
+
+- If `ref` is a slug (no `#`): auto-orchestrate the entire wish
+- If `ref` is `slug#group` with an agent: dispatch that specific group
+
+### `genie review <agent> <ref>`
+
+Spawn agent with review scope for a wish group. Format: `<slug>#<group>`.
+
+---
+
+## QA System
+
+Commands under `genie qa`. Self-testing system for genie CLI.
+
+### `genie qa run [target]` (default)
+
+Run QA specs (all, a domain, or a single spec).
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--timeout <seconds>` | number | `3600` | Max seconds per spec |
+| `--parallel <n>` | number | `5` | Max specs to run in parallel |
+| `--verbose` | boolean | | Show all collected events |
+| `--ndjson` | boolean | | Machine-readable NDJSON output |
+
+```bash
+genie qa                          # Run all QA specs
+genie qa messaging                # Run a domain
+genie qa messaging/round-trip     # Run one spec
+```
+
+### `genie qa status`
+
+Show QA dashboard with last results per spec.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--json` | boolean | Output as JSON |
+
+### `genie qa history`
+
+Show recent QA runs.
+
+### `genie qa check <specFile>`
+
+Evaluate a QA spec against current team logs and publish qa-report.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--team <name>` | string | Team name (defaults to GENIE_TEAM) |
+| `--since <timestamp>` | string | Only consider events after this ISO timestamp |
+| `--since-file <path>` | string | Read the lower-bound timestamp from a file |
+
+### `genie qa-report <json>`
+
+Publish QA result to the PG event log (called by QA team-lead).
+
+---
+
+## Tags
+
+Commands under `genie tag`.
+
+### `genie tag list`
+
+List all tags.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--type <typeId>` | string | Filter by task type |
+| `--json` | boolean | Output as JSON |
+
+### `genie tag create <name>`
+
+Create a custom tag.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--color <hex>` | string | `#9ca3af` | Tag color (hex) |
+| `--type <typeId>` | string | | Associate with a task type |
+
+---
+
+## Types
+
+Commands under `genie type`. Task type management.
+
+### `genie type list`
+
+List all task types.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--json` | boolean | Output as JSON |
+
+### `genie type show <id>`
+
+Show task type detail with stage pipeline.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--json` | boolean | Output as JSON |
+
+### `genie type create <name>`
+
+Create a custom task type.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--stages <json>` | string | **required** -- Stages JSON array |
+| `--description <text>` | string | Type description |
+| `--icon <icon>` | string | Type icon |
+
+---
+
+## Releases
+
+Commands under `genie release`.
+
+### `genie release create <name>`
+
+Create a release and assign tasks to it.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--tasks <ids...>` | string[] | **required** -- Task IDs or #seqs to include |
+
+### `genie release list`
+
+List all releases.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--json` | boolean | Output as JSON |
+
+---
+
+## Templates
+
+Commands under `genie template`. Board template management.
+
+### `genie template list` (default)
+
+List available templates.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--json` | boolean | Output as JSON |
+
+### `genie template show <name>`
+
+Show template details.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--json` | boolean | Output as JSON |
+
+### `genie template delete <name>`
+
+Delete a template.
+
+---
+
+## Metrics
+
+Commands under `genie metrics`. Machine metrics -- snapshots, heartbeats, agents.
+
+### `genie metrics now` (default)
+
+Current machine state.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--json` | boolean | Output as JSON |
+
+### `genie metrics history`
+
+Machine snapshot history.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--since <duration>` | string | `1h` | Time window (e.g., 1h, 6h, 1d) |
+| `--json` | boolean | | Output as JSON |
+
+### `genie metrics agents`
+
+Per-agent heartbeat summary.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--json` | boolean | Output as JSON |
+
+---
+
+## Notifications
+
+Commands under `genie notify`. Notification preference management.
+
+### `genie notify set`
+
+Set notification preference for a channel.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--channel <channel>` | string | **required** | Channel: whatsapp, telegram, email, slack, discord, tmux |
+| `--priority <priority>` | string | `normal` | Minimum priority threshold |
+| `--default` | boolean | | Set as default channel |
+
+### `genie notify list`
+
+List notification preferences.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--json` | boolean | Output as JSON |
+
+### `genie notify remove`
+
+Remove a notification preference.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--channel <channel>` | string | **required** -- Channel to remove |
+
+---
+
+## Hooks
+
+Commands under `genie hook`. Hook middleware for Claude Code integration.
+
+### `genie hook dispatch`
+
+Dispatch a CC hook event. Reads JSON from stdin, writes decision to stdout.
+
+---
+
+## Directory Management
+
+Commands under `genie dir`. Agent directory CRUD.
+
+### `genie dir add <name>`
+
+Register an agent in the directory.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--dir <path>` | string | **required** | Agent folder (CWD + AGENTS.md) |
+| `--repo <path>` | string | | Default git repo |
+| `--prompt-mode <mode>` | string | `append` | Prompt mode: append or system |
+| `--model <model>` | string | | Default model |
+| `--roles <roles...>` | string[] | | Built-in roles |
+| `--permission-preset <preset>` | string | | Permission preset: full, read-only, chat-only |
+| `--allow <tools>` | string | | Comma-separated tool allow list |
+| `--bash-allow <patterns>` | string | | Comma-separated regex patterns for allowed bash commands |
+| `--global` | boolean | | Write to global directory |
+| `--sdk-*` | various | | SDK configuration flags (see below) |
+
+### `genie dir rm <name>`
+
+Remove an agent from the directory.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--global` | boolean | Remove from global directory |
+
+### `genie dir ls [name]`
+
+List all agents or show single entry details.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--json` | boolean | Output as JSON |
+| `--builtins` | boolean | Include built-in roles and council members |
+| `--all` | boolean | Include archived agents |
+
+### `genie dir edit <name>`
+
+Update an agent directory entry.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--dir <path>` | string | Agent folder |
+| `--repo <path>` | string | Default git repo |
+| `--prompt-mode <mode>` | string | Prompt mode: append or system |
+| `--model <model>` | string | Default model |
+| `--provider <provider>` | string | AI provider: claude or codex |
+| `--color <color>` | string | Display color for TUI |
+| `--description <desc>` | string | Agent description |
+| `--roles <roles...>` | string[] | Built-in roles |
+| `--permission-preset <preset>` | string | Permission preset |
+| `--allow <tools>` | string | Comma-separated tool allow list |
+| `--bash-allow <patterns>` | string | Regex patterns for allowed bash commands |
+| `--global` | boolean | Edit in global directory |
+| `--sdk-*` | various | SDK configuration flags (see below) |
+
+### `genie dir sync`
+
+Sync agents from workspace `agents/` directory.
+
+### `genie dir export <name>`
+
+Print full AGENTS.md frontmatter for an agent from PG state.
+
+### SDK Configuration Flags
+
+Available on `genie dir add` and `genie dir edit`:
+
+| Flag | Description |
+|------|-------------|
+| `--sdk-permission-mode <mode>` | SDK permission mode: default\|acceptEdits\|bypassPermissions\|plan\|dontAsk\|auto |
+| `--sdk-tools <list>` | Comma-separated tool names |
+| `--sdk-allowed-tools <list>` | Auto-approved tools |
+| `--sdk-disallowed-tools <list>` | Blacklisted tools |
+| `--sdk-max-turns <n>` | Max conversation turns |
+| `--sdk-max-budget <usd>` | Max budget in USD |
+| `--sdk-effort <level>` | Effort: low\|medium\|high\|max |
+| `--sdk-thinking <config>` | Thinking: adaptive\|disabled\|enabled[:budgetTokens] |
+| `--sdk-persist-session` | Enable session persistence |
+| `--sdk-file-checkpointing` | Enable file checkpointing |
+| `--sdk-output-format <path>` | Path to JSON schema file for output format |
+| `--sdk-stream-partial` | Include partial messages in stream |
+| `--sdk-hook-events` | Include hook events in stream |
+| `--sdk-prompt-suggestions` | Enable prompt suggestions |
+| `--sdk-progress-summaries` | Enable agent progress summaries |
+| `--sdk-sandbox` | Enable sandbox |
+| `--sdk-betas <list>` | Beta flags (comma-separated) |
+| `--sdk-system-prompt <string>` | System prompt text |
+| `--sdk-mcp-server <spec>` | MCP server: name:command:args (repeatable) |
+| `--sdk-plugin <path>` | Plugin path (repeatable) |
+| `--sdk-agent <name>` | Main agent name |
+| `--sdk-subagent <spec>` | Subagent: name:json (repeatable) |
+
+---
+
+## Utility Commands
+
+### `genie setup`
+
+Configure genie settings.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--quick` | boolean | Accept all defaults |
+| `--shortcuts` | boolean | Only configure keyboard shortcuts |
+| `--codex` | boolean | Only configure Codex integration |
+| `--terminal` | boolean | Only configure terminal defaults |
+| `--session` | boolean | Only configure session settings |
+| `--reset` | boolean | Reset configuration to defaults |
+| `--show` | boolean | Show current configuration |
+
+### `genie doctor`
+
+Run diagnostic checks on genie installation.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--fix` | boolean | Auto-fix: kill zombie postgres, clean shared memory, restart daemon |
+
+### `genie update`
+
+Update Genie CLI to the latest version.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--next` | boolean | Switch to dev builds (npm @next tag) |
+| `--stable` | boolean | Switch to stable releases (npm @latest tag) |
+
+### `genie uninstall`
+
+Remove Genie CLI and clean up hooks.
+
+### `genie init`
+
+Initialize a genie workspace.
+
+#### `genie init agent <name>`
+
+Scaffold a new agent in the workspace.
+
+### `genie shortcuts`
+
+Show available shortcuts and installation status (default action).
+
+#### `genie shortcuts show`
+
+Show available shortcuts and installation status.
+
+#### `genie shortcuts install`
+
+Install shortcuts to config files (`~/.tmux.conf`, shell rc).
+
+#### `genie shortcuts uninstall`
+
+Remove shortcuts from config files.
+
+### `genie app`
+
+Launch Genie desktop app (backend sidecar + views).
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--backend-only` | boolean | Start only the backend sidecar (IPC on stdin/stdout) |
+| `--tui` | boolean | Fall back to terminal UI mode |
+| `--dev` | boolean | Development mode |
+
+### `genie brief`
+
+Show startup brief -- aggregated context since last session.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--team <name>` | string | Team name (default: GENIE_TEAM) |
+| `--agent <name>` | string | Agent name (default: GENIE_AGENT_NAME) |
+| `--since <iso>` | string | Start timestamp (default: last executor end) |
+
+---
+
+## Executor Debug
+
+Commands under `genie exec`.
+
+### `genie exec list` (alias: `ls`)
+
+List all executors.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--agent <name>` | string | Filter by agent name/ID |
+| `--state <state>` | string | Filter by state (running, idle, terminated, etc.) |
+| `--json` | boolean | Output as JSON |
+
+### `genie exec show <id>`
+
+Show executor detail (pid, tmux, provider).
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--json` | boolean | Output as JSON |
+
+### `genie exec terminate <id>`
+
+Terminate an executor.

--- a/docs/CO-ORCHESTRATION-GUIDE.md
+++ b/docs/CO-ORCHESTRATION-GUIDE.md
@@ -27,8 +27,8 @@ Human (Orchestrator)
 ## Quick Start
 
 ```bash
-# 1. Start the genie daemon for auto-sync
-genie daemon start
+# 1. Start genie serve (manages all background services)
+genie serve --daemon
 
 # 2. Create wishes to work on (via the /wish skill in a genie session)
 # /wish "Implement user authentication"
@@ -85,12 +85,12 @@ genie work next
 ```
 
 **What happens when you run `genie work wish-1`:**
-1. Daemon starts (if not running) for auto-sync
+1. `genie serve` auto-starts if not running (pgserve + scheduler + services)
 2. Wish is claimed (status → in_progress)
 3. Worktree created for the wish
-4. New tmux pane spawned in the worktree directory
-5. Claude CLI launched with initial prompt
-6. Work bound to agent via slot system
+4. New tmux pane spawned on `tmux -L genie` socket
+5. Claude Code launched with initial prompt and identity hooks
+6. Agent registered in PostgreSQL with pane ID, team, and role
 
 ### Phase 3: Monitoring Workers
 
@@ -156,20 +156,24 @@ genie kill wish-1
 
 Note: This does NOT close the wish. The task remains `in_progress`.
 
-## Daemon Management
+## Service Management
 
-The daemon auto-commits and syncs changes:
+`genie serve` is the unified infrastructure owner. It manages pgserve (database), the scheduler, event router, inbox watcher, and the TUI. The old `genie daemon` commands still work as aliases.
 
 ```bash
-genie daemon start     # Start with auto-commit
-genie daemon status    # Check if running
-genie daemon stop      # Stop daemon
-genie daemon restart   # Restart with fresh config
+genie serve              # Start foreground with TUI (default)
+genie serve --headless   # Services only, no TUI
+genie serve --daemon     # Start in background
+genie serve stop         # Stop all services gracefully
+genie serve status       # Show service health
 
-# Options for start/restart:
-#   --no-auto-commit  Disable auto-commit
-#   --auto-push       Enable auto-push to remote
+# Legacy aliases (redirect to genie serve --headless):
+genie daemon start       # → genie serve --headless
+genie daemon stop        # Stop genie serve
+genie daemon status      # Show daemon state
 ```
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for full service topology details.
 
 ## Multi-Worker Patterns
 
@@ -247,15 +251,16 @@ git worktree remove .worktrees/<wish-id> --force
 | `genie kill <id>` | Force kill worker |
 | `genie read <id>` | Read worker pane output |
 | `genie exec <id> <cmd>` | Execute command in worker pane |
-| `genie daemon start` | Start daemon |
-| `genie daemon stop` | Stop daemon |
-| `genie daemon status` | Show daemon status |
+| `genie serve` | Start foreground with TUI |
+| `genie serve --daemon` | Start in background |
+| `genie serve stop` | Stop all services |
+| `genie serve status` | Show service health |
 
 ## Architecture
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                         Human Terminal                          │
+│                     tmux -L genie (eternal)                      │
 │  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐             │
 │  │  Worker 1   │  │  Worker 2   │  │  Worker 3   │  ...        │
 │  │  (Claude)   │  │  (Claude)   │  │  (Claude)   │             │
@@ -271,22 +276,26 @@ git worktree remove .worktrees/<wish-id> --force
 │         └────────────────┼────────────────┘                     │
 │                          ▼                                      │
 │                   ┌─────────────┐                               │
-│                   │   .genie/   │  ◀── Shared via redirect     │
+│                   │   .genie/   │  ◀── Shared across worktrees │
 │                   │   wishes/   │                               │
 │                   └──────┬──────┘                               │
 │                          │                                      │
 │                          ▼                                      │
-│                   ┌─────────────┐                               │
-│                   │ genie daemon│  ◀── Auto-commit & sync      │
-│                   └─────────────┘                               │
+│  ┌──────────────────────────────────────────────────────┐       │
+│  │              genie serve (unified)                    │       │
+│  │  pgserve │ scheduler │ event-router │ inbox-watcher  │       │
+│  └──────────────────────────────────────────────────────┘       │
 └─────────────────────────────────────────────────────────────────┘
 ```
+
+For detailed architecture documentation, see [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ## Next Steps
 
 After reading this guide:
-1. Start with `genie daemon start`
+1. Start with `genie serve --daemon` (or `genie serve` for TUI mode)
 2. Launch a session with `genie` and create wishes via `/wish`
 3. Try `genie work <id>` to spawn your first worker
 4. Practice the workflow with simple tasks
 5. Scale up to multi-worker orchestration
+6. Read [ARCHITECTURE.md](ARCHITECTURE.md) for internals

--- a/docs/SPAWN-AUTO-RESUME.md
+++ b/docs/SPAWN-AUTO-RESUME.md
@@ -1,0 +1,129 @@
+# Spawn Auto-Resume
+
+Auto-resume automatically restores agent sessions when their tmux pane dies unexpectedly (crash, OOM, terminal close). Instead of losing the entire conversation context, Genie detects the dead pane and respawns the agent using its preserved Claude session ID.
+
+## How It Works
+
+Auto-resume operates at two levels:
+
+### 1. Spawn-time resume (immediate)
+
+When you run `genie spawn <name>`, Genie checks if a dead worker with the same role and team already exists in the registry. If that worker has a saved `claudeSessionId` (Claude provider only), Genie resumes the existing session instead of starting fresh.
+
+```
+genie spawn engineer --team my-feature
+# If engineer previously crashed:
+#   Resuming existing session for "engineer" (session: a1b2c3d4...)
+# Otherwise: spawns a new agent as normal
+```
+
+This check runs *before* the duplicate-role guard, so a crashed agent doesn't block re-spawning.
+
+**Source:** `src/term-commands/agents.ts` — `findDeadResumable()` and `handleWorkerSpawn()`
+
+### 2. Daemon auto-resume (background)
+
+The scheduler daemon continuously monitors agent health via heartbeats. When it detects consecutive dead heartbeats (default: 2 cycles), it attempts to auto-resume the agent.
+
+The daemon also runs recovery on startup, resuming any agents whose panes died while the daemon was down.
+
+**Source:** `src/lib/scheduler-daemon.ts` — `attemptAgentResume()`, `reconcileOrphans()`, `recoverOnStartup()`
+
+## Session Matching
+
+An agent is eligible for auto-resume when **all** of these are true:
+
+| Condition | Detail |
+|-----------|--------|
+| Has a `claudeSessionId` | Only Claude provider agents store session IDs. Codex agents cannot be resumed. |
+| Pane is dead | The tmux pane (`w.paneId`) no longer exists or was recycled to a different session. |
+| State is not `done` | Completed agents are never resumed. |
+| `autoResume` is not `false` | Must not have been spawned with `--no-auto-resume`. |
+
+For spawn-time resume specifically, the match also requires the same **role** and **team** as the agent being spawned.
+
+## Resume vs Fresh Spawn
+
+| Scenario | Behavior |
+|----------|----------|
+| Dead worker with matching role/team and session ID | **Resume** — reattaches to existing Claude session |
+| Dead worker with no session ID (e.g., Codex provider) | **Fresh spawn** — starts a new agent |
+| No dead worker found | **Fresh spawn** — normal spawn flow |
+| Live worker with same role/team | **Rejected** — duplicate role error |
+| Agent spawned with `--no-auto-resume` | **Fresh spawn** — daemon won't auto-resume on crash |
+
+## The `--no-auto-resume` Flag
+
+Disables daemon-level auto-resume for this agent. The agent's `autoResume` field is set to `false` in the registry and database.
+
+```bash
+# Spawn an agent that won't be auto-resumed on crash
+genie spawn engineer --team my-feature --no-auto-resume
+```
+
+When auto-resume is disabled:
+- The daemon skips the agent during `reconcileOrphans()` cycles
+- The agent is marked as permanently failed instead of being retried
+- You can still manually resume with `genie resume <name>`
+
+This is useful for one-off tasks or agents you don't want restarting automatically.
+
+## Dead Session Definition
+
+An agent's session is considered "dead" when:
+
+1. **Pane check fails** — `tmux display-message -t '<paneId>'` returns an error, meaning the pane no longer exists.
+2. **Pane was recycled** — The pane ID exists but belongs to a different tmux session than the one recorded at spawn time. Genie detects this by comparing `#{session_name}` to the stored session.
+
+In both cases, the worker is treated as dead and eligible for cleanup or resume.
+
+## Resume Budget and Cooldown
+
+The daemon enforces limits to prevent infinite resume loops:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| Max resume attempts | 3 | After 3 consecutive failed resumes, the agent is marked permanently failed ("exhausted"). |
+| Cooldown | 60 seconds | Minimum time between resume attempts for the same agent. |
+| Concurrency cap | `maxConcurrent` config | Resumes are skipped if the active worker count is at the limit. |
+
+Resume attempts and state are tracked in the registry:
+
+```
+genie ls
+# engineer   working (1/3 resumes, auto-resume: on)   my-feature
+```
+
+### Resetting the budget
+
+Use `genie resume <name>` to manually resume an agent. The `genie resume` command does not consume the auto-resume budget — it directly respawns the agent regardless of attempt count.
+
+## Manual Resume
+
+You can manually resume any agent that has a saved Claude session:
+
+```bash
+# Resume a specific agent
+genie resume engineer
+
+# Resume all eligible agents
+genie resume --all
+```
+
+Eligible agents for `--all` are those with:
+- A saved `claudeSessionId`
+- State not `done`
+- Dead pane (not currently running)
+
+This includes agents in `suspended`, `error`, `working`, `idle`, or `spawning` states whose panes have died.
+
+## Related Commands
+
+| Command | Description |
+|---------|-------------|
+| `genie spawn <name>` | Spawns or auto-resumes an agent |
+| `genie stop <name>` | Kills pane but preserves session for later resume |
+| `genie kill <name>` | Force kills agent (session preserved in registry) |
+| `genie resume <name>` | Manually resume a stopped/crashed agent |
+| `genie resume --all` | Resume all eligible agents |
+| `genie ls` | Shows agent status including resume attempts and auto-resume state |

--- a/docs/sdk-executor-guide.md
+++ b/docs/sdk-executor-guide.md
@@ -323,11 +323,15 @@ genie dir export my-agent
 genie spawn my-agent
 
 # Runtime overrides (highest priority — beats directory config)
+# Override directory maxTurns
+# Override directory maxBudgetUsd
+# Override directory effort
+# Enable streaming output
 genie spawn my-agent \
-  --sdk-max-turns 10 \       # Override directory maxTurns
-  --sdk-max-budget 2.0 \     # Override directory maxBudgetUsd
-  --sdk-effort medium \       # Override directory effort
-  --sdk-stream                # Enable streaming output
+  --sdk-max-turns 10 \
+  --sdk-max-budget 2.0 \
+  --sdk-effort medium \
+  --sdk-stream
 ```
 
 ---
@@ -511,7 +515,7 @@ genie events errors --type sdk_message
 ```
 AGENTS.md frontmatter (source of truth)
     │
-    ��� parseFrontmatter()
+    ▼ parseFrontmatter()
 AgentFrontmatter { sdk: Record<string, unknown> }
     │
     ▼ agent-sync.ts → directory.add()/edit()

--- a/src/term-commands/brain.ts
+++ b/src/term-commands/brain.ts
@@ -326,30 +326,47 @@ async function executeBrainCommand(args: string[]): Promise<void> {
 }
 
 export function registerBrainCommands(program: Command): void {
-  program
+  const brain = program
     .command('brain')
     .description('Knowledge graph engine (enterprise)')
     .allowUnknownOption()
     .allowExcessArguments()
     .action(async (_options: Record<string, unknown>, cmd: Command) => {
+      // Fallback: delegate unrecognized subcommands to the enterprise brain module
+      // (e.g. init, search, ingest, analyze, etc.)
       const args = cmd.args;
-
-      if (args[0] === 'install') {
-        await installBrain();
-        return;
-      }
-      if (args[0] === 'uninstall') {
-        uninstallBrain();
-        return;
-      }
-      if (args[0] === 'update') {
-        await updateBrain();
-        return;
-      }
-      if (args[0] === 'version') {
-        await showVersion();
+      if (args.length === 0) {
+        brain.help();
         return;
       }
       await executeBrainCommand(args);
+    });
+
+  brain
+    .command('install')
+    .description('Install genie-brain from GitHub')
+    .action(async () => {
+      await installBrain();
+    });
+
+  brain
+    .command('uninstall')
+    .description('Remove genie-brain installation')
+    .action(() => {
+      uninstallBrain();
+    });
+
+  brain
+    .command('update')
+    .description('Update genie-brain to latest version')
+    .action(async () => {
+      await updateBrain();
+    });
+
+  brain
+    .command('version')
+    .description('Show installed brain version')
+    .action(async () => {
+      await showVersion();
     });
 }


### PR DESCRIPTION
## Summary

Documentation hygiene fix on top of recent docs additions already merged to dev:

- Remove corrupted U+FFFD replacement characters from `docs/sdk-executor-guide.md`
- Fix broken shell examples in the same guide

## Context

Branch was assembled from already-merged docs PRs (#872, #1005, #1006) plus one targeted fix commit (`6113ffe2`) that cleans up residual rendering issues in `sdk-executor-guide.md`.

Only the trailing commit `6113ffe2` is new work vs `dev` HEAD at branch time — the preceding commits are already on dev.

## Test plan

- [x] `bun run check` passes (2045/2045 tests, via pre-push hook)
- [x] `bun run build` succeeds
- [x] `bun run lint` — only pre-existing complexity warnings, no errors