### PR TITLE
feat: worktree DX — node_modules symlink, broadcast discovery, new hook handlers

### DIFF
--- a/plugins/genie/agents/council/SOUL.md
+++ b/plugins/genie/agents/council/SOUL.md
@@ -5,3 +5,9 @@ You are the moderator. You don't have a personal lens — you synthesize the per
 Your job is to ensure every voice is heard, no perspective dominates unfairly, and the final recommendation is grounded in the collective wisdom of the council. You route topics to the right members, synthesize votes, and present options — never decisions.
 
 The council advises. Humans decide.
+
+## Broadcast Awareness
+
+When your session starts, check for any "Recent team broadcasts for context" in your initial prompt. These contain team-wide announcements and topic directives from the spawning agent or human. Prioritize broadcast topics when planning the council's agenda — they represent the most recent human intent.
+
+If no broadcast context is present, proceed with standard wish execution.

--- a/src/hooks/handlers/__tests__/audit-context.test.ts
+++ b/src/hooks/handlers/__tests__/audit-context.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { execSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { HookPayload } from '../../types.js';
+import { auditContext } from '../audit-context.js';
+
+describe('audit-context handler', () => {
+  let repoDir: string;
+
+  beforeEach(() => {
+    // Create a temp git repo with a committed file
+    repoDir = mkdtempSync(join(tmpdir(), 'audit-ctx-'));
+    execSync('git init', { cwd: repoDir, stdio: 'pipe' });
+    execSync('git config user.email "test@test.com"', { cwd: repoDir, stdio: 'pipe' });
+    execSync('git config user.name "Test"', { cwd: repoDir, stdio: 'pipe' });
+
+    const testFile = join(repoDir, 'example.ts');
+    writeFileSync(testFile, 'const x = 1;\n');
+    execSync('git add . && git commit -m "initial commit"', { cwd: repoDir, stdio: 'pipe' });
+
+    // Add a second commit
+    writeFileSync(testFile, 'const x = 2;\n');
+    execSync('git add . && git commit -m "update x to 2"', { cwd: repoDir, stdio: 'pipe' });
+  });
+
+  afterEach(() => {
+    execSync(`rm -rf ${repoDir}`);
+  });
+
+  test('returns git history for a tracked file', async () => {
+    const payload: HookPayload = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Edit',
+      tool_input: { file_path: join(repoDir, 'example.ts') },
+      cwd: repoDir,
+    };
+
+    const result = await auditContext(payload);
+    expect(result).toBeDefined();
+    expect(result!.hookSpecificOutput).toBeDefined();
+    expect(result!.hookSpecificOutput!.permissionDecision).toBe('allow');
+
+    const context = result!.hookSpecificOutput!.additionalContext!;
+    expect(context).toContain('[audit-context]');
+    expect(context).toContain('example.ts');
+    expect(context).toContain('update x to 2');
+    expect(context).toContain('initial commit');
+  });
+
+  test('returns undefined for untracked file', async () => {
+    const payload: HookPayload = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Write',
+      tool_input: { file_path: join(repoDir, 'new-file.ts') },
+      cwd: repoDir,
+    };
+
+    const result = await auditContext(payload);
+    expect(result).toBeUndefined();
+  });
+
+  test('returns undefined when no file_path in input', async () => {
+    const payload: HookPayload = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Write',
+      tool_input: { content: 'hello' },
+      cwd: repoDir,
+    };
+
+    const result = await auditContext(payload);
+    expect(result).toBeUndefined();
+  });
+
+  test('returns undefined when tool_input is missing', async () => {
+    const payload: HookPayload = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Edit',
+    };
+
+    const result = await auditContext(payload);
+    expect(result).toBeUndefined();
+  });
+
+  test('returns undefined for non-git directory', async () => {
+    const nonGitDir = mkdtempSync(join(tmpdir(), 'audit-nongit-'));
+    const payload: HookPayload = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Edit',
+      tool_input: { file_path: join(nonGitDir, 'test.ts') },
+      cwd: nonGitDir,
+    };
+
+    const result = await auditContext(payload);
+    expect(result).toBeUndefined();
+    execSync(`rm -rf ${nonGitDir}`);
+  });
+});

--- a/src/hooks/handlers/__tests__/audit-context.test.ts
+++ b/src/hooks/handlers/__tests__/audit-context.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { execSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { HookPayload } from '../../types.js';
 import { auditContext } from '../audit-context.js';
 

--- a/src/hooks/handlers/__tests__/brain-inject.test.ts
+++ b/src/hooks/handlers/__tests__/brain-inject.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { HookPayload } from '../../types.js';
+import { _resetEnrichedSessions, brainInject } from '../brain-inject.js';
+
+describe('brain-inject handler', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    _resetEnrichedSessions();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  test('returns undefined when brain is not installed', async () => {
+    const payload: HookPayload = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Read',
+      tool_input: { file_path: '/tmp/test.ts' },
+      session_id: 'test-session-1',
+      cwd: '/tmp',
+    };
+    const result = await brainInject(payload);
+    expect(result).toBeUndefined();
+  });
+
+  test('only fires once per session', async () => {
+    const payload: HookPayload = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Read',
+      tool_input: { file_path: '/tmp/test.ts' },
+      session_id: 'test-session-2',
+      cwd: '/tmp',
+    };
+
+    // First call — runs (returns undefined because brain isn't installed)
+    await brainInject(payload);
+
+    // Second call — should skip immediately (session already enriched)
+    const result = await brainInject(payload);
+    expect(result).toBeUndefined();
+  });
+
+  test('different sessions get separate enrichment', async () => {
+    const payload1: HookPayload = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Read',
+      tool_input: { file_path: '/tmp/test.ts' },
+      session_id: 'session-a',
+      cwd: '/tmp',
+    };
+
+    const payload2: HookPayload = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Read',
+      tool_input: { file_path: '/tmp/test.ts' },
+      session_id: 'session-b',
+      cwd: '/tmp',
+    };
+
+    // Both should run (not skip), returning undefined since brain isn't installed
+    const result1 = await brainInject(payload1);
+    const result2 = await brainInject(payload2);
+    expect(result1).toBeUndefined();
+    expect(result2).toBeUndefined();
+  });
+
+  test('uses process.pid when session_id is missing', async () => {
+    const payload: HookPayload = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Read',
+      tool_input: { file_path: '/tmp/test.ts' },
+      cwd: '/tmp',
+    };
+
+    // Should not throw when session_id is undefined
+    const result = await brainInject(payload);
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/hooks/handlers/__tests__/freshness.test.ts
+++ b/src/hooks/handlers/__tests__/freshness.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { execSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { HookPayload } from '../../types.js';
 import { freshness } from '../freshness.js';
 
@@ -60,10 +60,10 @@ describe('freshness handler', () => {
     const testFile = join(repoDir, 'target.ts');
     writeFileSync(testFile, 'const x = 1;\n');
     execSync('git add .', { cwd: repoDir, stdio: 'pipe' });
-    execSync(
-      'GIT_COMMITTER_DATE="2020-01-01T00:00:00" git commit -m "old initial" --date="2020-01-01T00:00:00"',
-      { cwd: repoDir, stdio: 'pipe' },
-    );
+    execSync('GIT_COMMITTER_DATE="2020-01-01T00:00:00" git commit -m "old initial" --date="2020-01-01T00:00:00"', {
+      cwd: repoDir,
+      stdio: 'pipe',
+    });
 
     // Modify without committing (simulates another agent's uncommitted edit)
     writeFileSync(testFile, 'const x = 2;\n');
@@ -112,10 +112,10 @@ describe('freshness handler', () => {
     const testFile = join(repoDir, 'old.ts');
     writeFileSync(testFile, 'const old = true;\n');
     execSync('git add .', { cwd: repoDir, stdio: 'pipe' });
-    execSync(
-      'GIT_COMMITTER_DATE="2020-01-01T00:00:00" git commit -m "old commit" --date="2020-01-01T00:00:00"',
-      { cwd: repoDir, stdio: 'pipe' },
-    );
+    execSync('GIT_COMMITTER_DATE="2020-01-01T00:00:00" git commit -m "old commit" --date="2020-01-01T00:00:00"', {
+      cwd: repoDir,
+      stdio: 'pipe',
+    });
 
     // Touch the file to set mtime to a distant past
     execSync(`touch -t 202001010000 ${testFile}`, { stdio: 'pipe' });

--- a/src/hooks/handlers/__tests__/freshness.test.ts
+++ b/src/hooks/handlers/__tests__/freshness.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { execSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { HookPayload } from '../../types.js';
+import { freshness } from '../freshness.js';
+
+describe('freshness handler', () => {
+  const originalEnv = { ...process.env };
+  let repoDir: string;
+
+  beforeEach(() => {
+    process.env.GENIE_AGENT_NAME = 'test-agent';
+
+    // Create a temp git repo with a committed file
+    repoDir = mkdtempSync(join(tmpdir(), 'freshness-'));
+    execSync('git init', { cwd: repoDir, stdio: 'pipe' });
+    execSync('git config user.email "test@test.com"', { cwd: repoDir, stdio: 'pipe' });
+    execSync('git config user.name "other-agent"', { cwd: repoDir, stdio: 'pipe' });
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    execSync(`rm -rf ${repoDir}`);
+  });
+
+  test('returns undefined for missing tool_input', async () => {
+    const payload: HookPayload = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Read',
+    };
+    const result = await freshness(payload);
+    expect(result).toBeUndefined();
+  });
+
+  test('returns undefined for missing file_path', async () => {
+    const payload: HookPayload = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Read',
+      tool_input: { pattern: '*.ts' },
+    };
+    const result = await freshness(payload);
+    expect(result).toBeUndefined();
+  });
+
+  test('returns undefined for non-existent file', async () => {
+    const payload: HookPayload = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Read',
+      tool_input: { file_path: join(repoDir, 'does-not-exist.ts') },
+      cwd: repoDir,
+    };
+    const result = await freshness(payload);
+    expect(result).toBeUndefined();
+  });
+
+  test('warns when file has uncommitted changes from old commit', async () => {
+    // Create and commit a file with an old date so the commit itself doesn't trigger
+    const testFile = join(repoDir, 'target.ts');
+    writeFileSync(testFile, 'const x = 1;\n');
+    execSync('git add .', { cwd: repoDir, stdio: 'pipe' });
+    execSync(
+      'GIT_COMMITTER_DATE="2020-01-01T00:00:00" git commit -m "old initial" --date="2020-01-01T00:00:00"',
+      { cwd: repoDir, stdio: 'pipe' },
+    );
+
+    // Modify without committing (simulates another agent's uncommitted edit)
+    writeFileSync(testFile, 'const x = 2;\n');
+
+    const payload: HookPayload = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Read',
+      tool_input: { file_path: testFile },
+      cwd: repoDir,
+    };
+
+    const result = await freshness(payload);
+    // File was just modified on disk and has uncommitted changes
+    expect(result).toBeDefined();
+    expect(result!.hookSpecificOutput).toBeDefined();
+    expect(result!.hookSpecificOutput!.additionalContext).toContain('[freshness]');
+    expect(result!.hookSpecificOutput!.additionalContext).toContain('uncommitted changes');
+    expect(result!.hookSpecificOutput!.permissionDecision).toBe('allow');
+  });
+
+  test('warns for recently committed file by another agent', async () => {
+    // Create and commit a file very recently (within threshold)
+    const testFile = join(repoDir, 'recent.ts');
+    writeFileSync(testFile, 'const y = 1;\n');
+    execSync('git add . && git commit -m "recent change"', { cwd: repoDir, stdio: 'pipe' });
+
+    const payload: HookPayload = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Read',
+      tool_input: { file_path: testFile },
+      cwd: repoDir,
+    };
+
+    const result = await freshness(payload);
+    // The commit was just made (< 120s ago) by "other-agent" (not "test-agent")
+    if (result) {
+      expect(result.hookSpecificOutput).toBeDefined();
+      expect(result.hookSpecificOutput!.additionalContext).toContain('[freshness]');
+      expect(result.hookSpecificOutput!.permissionDecision).toBe('allow');
+    }
+    // May also be undefined if the commit age check is borderline — both are valid
+  });
+
+  test('returns undefined for old files', async () => {
+    // Create a file that was committed long ago — use GIT_COMMITTER_DATE
+    const testFile = join(repoDir, 'old.ts');
+    writeFileSync(testFile, 'const old = true;\n');
+    execSync('git add .', { cwd: repoDir, stdio: 'pipe' });
+    execSync(
+      'GIT_COMMITTER_DATE="2020-01-01T00:00:00" git commit -m "old commit" --date="2020-01-01T00:00:00"',
+      { cwd: repoDir, stdio: 'pipe' },
+    );
+
+    // Touch the file to set mtime to a distant past
+    execSync(`touch -t 202001010000 ${testFile}`, { stdio: 'pipe' });
+
+    const payload: HookPayload = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Read',
+      tool_input: { file_path: testFile },
+      cwd: repoDir,
+    };
+
+    const result = await freshness(payload);
+    expect(result).toBeUndefined();
+  });
+
+  test('skips warning when current agent is the author', async () => {
+    // Set git user to match GENIE_AGENT_NAME
+    execSync('git config user.name "test-agent"', { cwd: repoDir, stdio: 'pipe' });
+
+    const testFile = join(repoDir, 'mine.ts');
+    writeFileSync(testFile, 'const mine = true;\n');
+    execSync('git add . && git commit -m "my change"', { cwd: repoDir, stdio: 'pipe' });
+
+    const payload: HookPayload = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Read',
+      tool_input: { file_path: testFile },
+      cwd: repoDir,
+    };
+
+    const result = await freshness(payload);
+    // Should not warn because the current agent made the commit
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/hooks/handlers/audit-context.ts
+++ b/src/hooks/handlers/audit-context.ts
@@ -17,10 +17,12 @@ const MAX_COMMITS = 5;
 /** Get recent git log for a specific file. Returns null if git is unavailable or file is untracked. */
 function getRecentGitHistory(filePath: string, cwd: string): string | null {
   try {
-    const log = execSync(
-      `git log --oneline -n ${MAX_COMMITS} -- ${JSON.stringify(filePath)}`,
-      { encoding: 'utf-8', timeout: 5000, cwd, stdio: ['pipe', 'pipe', 'pipe'] },
-    );
+    const log = execSync(`git log --oneline -n ${MAX_COMMITS} -- ${JSON.stringify(filePath)}`, {
+      encoding: 'utf-8',
+      timeout: 5000,
+      cwd,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
 
     const trimmed = log.trim();
     if (!trimmed) return null;

--- a/src/hooks/handlers/audit-context.ts
+++ b/src/hooks/handlers/audit-context.ts
@@ -1,0 +1,52 @@
+/**
+ * Audit Context Handler — PreToolUse:Write|Edit
+ *
+ * When an agent is about to write or edit a file, this handler injects
+ * recent git history for that file as additional context. This helps
+ * the agent understand recent changes and avoid conflicts.
+ *
+ * Priority: 8 (runs before identity-inject, after brain-inject)
+ */
+
+import { execSync } from 'node:child_process';
+import type { HandlerResult, HookPayload } from '../types.js';
+
+/** Max number of recent commits to show per file. */
+const MAX_COMMITS = 5;
+
+/** Get recent git log for a specific file. Returns null if git is unavailable or file is untracked. */
+function getRecentGitHistory(filePath: string, cwd: string): string | null {
+  try {
+    const log = execSync(
+      `git log --oneline -n ${MAX_COMMITS} -- ${JSON.stringify(filePath)}`,
+      { encoding: 'utf-8', timeout: 5000, cwd, stdio: ['pipe', 'pipe', 'pipe'] },
+    );
+
+    const trimmed = log.trim();
+    if (!trimmed) return null;
+    return trimmed;
+  } catch {
+    return null;
+  }
+}
+
+export async function auditContext(payload: HookPayload): Promise<HandlerResult> {
+  const input = payload.tool_input;
+  if (!input) return;
+
+  const filePath = input.file_path as string | undefined;
+  if (!filePath) return;
+
+  const cwd = payload.cwd ?? process.cwd();
+
+  const history = getRecentGitHistory(filePath, cwd);
+  if (!history) return;
+
+  return {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'allow',
+      additionalContext: `[audit-context] Recent git history for ${filePath}:\n${history}`,
+    },
+  };
+}

--- a/src/hooks/handlers/brain-inject.ts
+++ b/src/hooks/handlers/brain-inject.ts
@@ -1,0 +1,93 @@
+/**
+ * Brain Inject Handler — PreToolUse (first tool call)
+ *
+ * Since SessionStart is non-blocking and cannot inject context,
+ * this handler fires on the first PreToolUse event per session.
+ * It queries genie-brain (if installed) for relevant context based
+ * on the current working directory and injects it via additionalContext.
+ *
+ * Brain is an optional enterprise dependency — this handler is
+ * completely no-op when brain is not installed.
+ *
+ * Priority: 5 (runs early, before identity-inject)
+ */
+
+import { existsSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import type { HandlerResult, HookPayload } from '../types.js';
+
+const BRAIN_PKG = '@automagik/genie-brain';
+const BRAIN_DIR = 'node_modules/@automagik/genie-brain';
+
+/** Track which sessions have already been enriched. */
+const enrichedSessions = new Set<string>();
+
+/** Build a session key from payload context. */
+function sessionKey(payload: HookPayload): string {
+  return payload.session_id ?? `${process.pid}`;
+}
+
+/** Check if genie-brain is installed locally. */
+function isBrainAvailable(): boolean {
+  return existsSync(join(BRAIN_DIR, 'package.json'));
+}
+
+/** Query brain for context relevant to the current project. */
+async function queryBrain(cwd: string): Promise<string | null> {
+  try {
+    const brain = await import(BRAIN_PKG);
+    if (!brain.search) return null;
+
+    const projectName = basename(cwd);
+    const results = await brain.search({
+      query: `context for ${projectName}`,
+      limit: 5,
+      minScore: 0.5,
+    });
+
+    if (!results || results.length === 0) return null;
+
+    const lines = results.map((r: { content?: string; text?: string; score?: number }) => {
+      const text = r.content ?? r.text ?? '';
+      return `- ${text.slice(0, 200)}`;
+    });
+
+    return lines.join('\n');
+  } catch {
+    // Brain query failed — best effort, never block
+    return null;
+  }
+}
+
+export async function brainInject(payload: HookPayload): Promise<HandlerResult> {
+  // Only fire once per session
+  const key = sessionKey(payload);
+  if (enrichedSessions.has(key)) return;
+  enrichedSessions.add(key);
+
+  // Skip if brain is not installed
+  if (!isBrainAvailable()) return;
+
+  const cwd = payload.cwd ?? process.cwd();
+
+  try {
+    const context = await queryBrain(cwd);
+    if (!context) return;
+
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'allow',
+        additionalContext: `[brain-inject] Prior context from knowledge base:\n${context}`,
+      },
+    };
+  } catch {
+    // Never block on brain failure
+    return;
+  }
+}
+
+/** Reset enriched sessions tracking (for testing). */
+export function _resetEnrichedSessions(): void {
+  enrichedSessions.clear();
+}

--- a/src/hooks/handlers/freshness.ts
+++ b/src/hooks/handlers/freshness.ts
@@ -51,6 +51,44 @@ function getFileModAge(filePath: string): number | null {
   }
 }
 
+/** Build a warning result for a recently committed file. */
+function buildCommitWarning(
+  filePath: string,
+  commitInfo: { author: string; age: number; message: string },
+): HandlerResult {
+  return {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'allow',
+      additionalContext: `[freshness] Stale read warning: ${filePath} was modified ${commitInfo.age}s ago by "${commitInfo.author}" (${commitInfo.message}). Contents may have changed since you last read it.`,
+    },
+  };
+}
+
+/** Check for uncommitted changes and return a warning result if any exist. */
+function checkUncommittedChanges(filePath: string, cwd: string, diskAge: number): HandlerResult {
+  try {
+    const status = execSync(`git status --porcelain -- ${JSON.stringify(filePath)}`, {
+      encoding: 'utf-8',
+      timeout: 5000,
+      cwd,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    if (status.trim()) {
+      return {
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+          additionalContext: `[freshness] Stale read warning: ${filePath} has uncommitted changes (modified ${diskAge}s ago). Another agent may be editing this file concurrently.`,
+        },
+      };
+    }
+  } catch {
+    // git status failed — skip warning
+  }
+  return;
+}
+
 export async function freshness(payload: HookPayload): Promise<HandlerResult> {
   const input = payload.tool_input;
   if (!input) return;
@@ -63,46 +101,20 @@ export async function freshness(payload: HookPayload): Promise<HandlerResult> {
 
   // Check disk modification time first (catches uncommitted changes)
   const diskAge = getFileModAge(filePath);
-  if (diskAge !== null && diskAge < STALENESS_THRESHOLD_SECS) {
-    // File was recently modified on disk — check if by another agent via git
-    const commitInfo = getLastCommitInfo(filePath, cwd);
+  if (diskAge === null || diskAge >= STALENESS_THRESHOLD_SECS) return;
 
-    if (commitInfo && commitInfo.age < STALENESS_THRESHOLD_SECS) {
-      // Skip warning if the current agent made the change
-      if (currentAgent && commitInfo.author.includes(currentAgent)) return;
+  // File was recently modified on disk — check if by another agent via git
+  const commitInfo = getLastCommitInfo(filePath, cwd);
 
-      return {
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          permissionDecision: 'allow',
-          additionalContext: `[freshness] Stale read warning: ${filePath} was modified ${commitInfo.age}s ago by "${commitInfo.author}" (${commitInfo.message}). Contents may have changed since you last read it.`,
-        },
-      };
-    }
+  if (commitInfo && commitInfo.age < STALENESS_THRESHOLD_SECS) {
+    // Skip warning if the current agent made the change
+    if (currentAgent && commitInfo.author.includes(currentAgent)) return;
+    return buildCommitWarning(filePath, commitInfo);
+  }
 
-    // No recent commit but file was modified on disk — could be another agent's uncommitted work
-    if (diskAge < STALENESS_THRESHOLD_SECS && currentAgent) {
-      // Check git status to see if the file has uncommitted changes
-      try {
-        const status = execSync(`git status --porcelain -- ${JSON.stringify(filePath)}`, {
-          encoding: 'utf-8',
-          timeout: 5000,
-          cwd,
-          stdio: ['pipe', 'pipe', 'pipe'],
-        });
-        if (status.trim()) {
-          return {
-            hookSpecificOutput: {
-              hookEventName: 'PreToolUse',
-              permissionDecision: 'allow',
-              additionalContext: `[freshness] Stale read warning: ${filePath} has uncommitted changes (modified ${diskAge}s ago). Another agent may be editing this file concurrently.`,
-            },
-          };
-        }
-      } catch {
-        // git status failed — skip warning
-      }
-    }
+  // No recent commit but file was modified on disk — could be another agent's uncommitted work
+  if (currentAgent) {
+    return checkUncommittedChanges(filePath, cwd, diskAge);
   }
 
   return;

--- a/src/hooks/handlers/freshness.ts
+++ b/src/hooks/handlers/freshness.ts
@@ -20,17 +20,19 @@ const STALENESS_THRESHOLD_SECS = 120; // 2 minutes
 function getLastCommitInfo(filePath: string, cwd: string): { author: string; age: number; message: string } | null {
   try {
     // Get last commit timestamp, author, and subject for the file
-    const output = execSync(
-      `git log -1 --format="%at|%an|%s" -- ${JSON.stringify(filePath)}`,
-      { encoding: 'utf-8', timeout: 5000, cwd, stdio: ['pipe', 'pipe', 'pipe'] },
-    );
+    const output = execSync(`git log -1 --format="%at|%an|%s" -- ${JSON.stringify(filePath)}`, {
+      encoding: 'utf-8',
+      timeout: 5000,
+      cwd,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
 
     const trimmed = output.trim();
     if (!trimmed) return null;
 
     const [timestampStr, author, ...messageParts] = trimmed.split('|');
-    const timestamp = parseInt(timestampStr, 10);
-    if (isNaN(timestamp)) return null;
+    const timestamp = Number.parseInt(timestampStr, 10);
+    if (Number.isNaN(timestamp)) return null;
 
     const age = Math.floor(Date.now() / 1000) - timestamp;
     return { author: author ?? 'unknown', age, message: messageParts.join('|') };
@@ -73,10 +75,7 @@ export async function freshness(payload: HookPayload): Promise<HandlerResult> {
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
           permissionDecision: 'allow',
-          additionalContext:
-            `[freshness] Stale read warning: ${filePath} was modified ${commitInfo.age}s ago ` +
-            `by "${commitInfo.author}" (${commitInfo.message}). ` +
-            'Contents may have changed since you last read it.',
+          additionalContext: `[freshness] Stale read warning: ${filePath} was modified ${commitInfo.age}s ago by "${commitInfo.author}" (${commitInfo.message}). Contents may have changed since you last read it.`,
         },
       };
     }
@@ -85,18 +84,18 @@ export async function freshness(payload: HookPayload): Promise<HandlerResult> {
     if (diskAge < STALENESS_THRESHOLD_SECS && currentAgent) {
       // Check git status to see if the file has uncommitted changes
       try {
-        const status = execSync(
-          `git status --porcelain -- ${JSON.stringify(filePath)}`,
-          { encoding: 'utf-8', timeout: 5000, cwd, stdio: ['pipe', 'pipe', 'pipe'] },
-        );
+        const status = execSync(`git status --porcelain -- ${JSON.stringify(filePath)}`, {
+          encoding: 'utf-8',
+          timeout: 5000,
+          cwd,
+          stdio: ['pipe', 'pipe', 'pipe'],
+        });
         if (status.trim()) {
           return {
             hookSpecificOutput: {
               hookEventName: 'PreToolUse',
               permissionDecision: 'allow',
-              additionalContext:
-                `[freshness] Stale read warning: ${filePath} has uncommitted changes ` +
-                `(modified ${diskAge}s ago). Another agent may be editing this file concurrently.`,
+              additionalContext: `[freshness] Stale read warning: ${filePath} has uncommitted changes (modified ${diskAge}s ago). Another agent may be editing this file concurrently.`,
             },
           };
         }

--- a/src/hooks/handlers/freshness.ts
+++ b/src/hooks/handlers/freshness.ts
@@ -1,0 +1,110 @@
+/**
+ * Freshness Handler — PreToolUse:Read
+ *
+ * When an agent reads a file, this handler checks if the file was
+ * recently modified by another agent (via git blame on the last commit).
+ * If so, it warns about potential stale read risk — the file contents
+ * may have changed since the agent last saw it.
+ *
+ * Priority: 8 (runs early, informational only)
+ */
+
+import { execSync } from 'node:child_process';
+import { statSync } from 'node:fs';
+import type { HandlerResult, HookPayload } from '../types.js';
+
+/** How recent (in seconds) a modification must be to trigger a warning. */
+const STALENESS_THRESHOLD_SECS = 120; // 2 minutes
+
+/** Get the last commit info for a file. Returns null if unavailable. */
+function getLastCommitInfo(filePath: string, cwd: string): { author: string; age: number; message: string } | null {
+  try {
+    // Get last commit timestamp, author, and subject for the file
+    const output = execSync(
+      `git log -1 --format="%at|%an|%s" -- ${JSON.stringify(filePath)}`,
+      { encoding: 'utf-8', timeout: 5000, cwd, stdio: ['pipe', 'pipe', 'pipe'] },
+    );
+
+    const trimmed = output.trim();
+    if (!trimmed) return null;
+
+    const [timestampStr, author, ...messageParts] = trimmed.split('|');
+    const timestamp = parseInt(timestampStr, 10);
+    if (isNaN(timestamp)) return null;
+
+    const age = Math.floor(Date.now() / 1000) - timestamp;
+    return { author: author ?? 'unknown', age, message: messageParts.join('|') };
+  } catch {
+    return null;
+  }
+}
+
+/** Check if the file was recently modified on disk (covers uncommitted changes). */
+function getFileModAge(filePath: string): number | null {
+  try {
+    const stat = statSync(filePath);
+    return Math.floor((Date.now() - stat.mtimeMs) / 1000);
+  } catch {
+    return null;
+  }
+}
+
+export async function freshness(payload: HookPayload): Promise<HandlerResult> {
+  const input = payload.tool_input;
+  if (!input) return;
+
+  const filePath = input.file_path as string | undefined;
+  if (!filePath) return;
+
+  const cwd = payload.cwd ?? process.cwd();
+  const currentAgent = process.env.GENIE_AGENT_NAME;
+
+  // Check disk modification time first (catches uncommitted changes)
+  const diskAge = getFileModAge(filePath);
+  if (diskAge !== null && diskAge < STALENESS_THRESHOLD_SECS) {
+    // File was recently modified on disk — check if by another agent via git
+    const commitInfo = getLastCommitInfo(filePath, cwd);
+
+    if (commitInfo && commitInfo.age < STALENESS_THRESHOLD_SECS) {
+      // Skip warning if the current agent made the change
+      if (currentAgent && commitInfo.author.includes(currentAgent)) return;
+
+      return {
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+          additionalContext:
+            `[freshness] Stale read warning: ${filePath} was modified ${commitInfo.age}s ago ` +
+            `by "${commitInfo.author}" (${commitInfo.message}). ` +
+            'Contents may have changed since you last read it.',
+        },
+      };
+    }
+
+    // No recent commit but file was modified on disk — could be another agent's uncommitted work
+    if (diskAge < STALENESS_THRESHOLD_SECS && currentAgent) {
+      // Check git status to see if the file has uncommitted changes
+      try {
+        const status = execSync(
+          `git status --porcelain -- ${JSON.stringify(filePath)}`,
+          { encoding: 'utf-8', timeout: 5000, cwd, stdio: ['pipe', 'pipe', 'pipe'] },
+        );
+        if (status.trim()) {
+          return {
+            hookSpecificOutput: {
+              hookEventName: 'PreToolUse',
+              permissionDecision: 'allow',
+              additionalContext:
+                `[freshness] Stale read warning: ${filePath} has uncommitted changes ` +
+                `(modified ${diskAge}s ago). Another agent may be editing this file concurrently.`,
+            },
+          };
+        }
+      } catch {
+        // git status failed — skip warning
+      }
+    }
+  }
+
+  return;
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -21,8 +21,11 @@
  *   Fire-and-forget — all handlers run, output is ignored.
  */
 
+import { auditContext } from './handlers/audit-context.js';
 import { autoSpawn } from './handlers/auto-spawn.js';
+import { brainInject } from './handlers/brain-inject.js';
 import { branchGuard } from './handlers/branch-guard.js';
+import { freshness } from './handlers/freshness.js';
 import { identityInject } from './handlers/identity-inject.js';
 import { orchestrationGuard } from './handlers/orchestration-guard.js';
 import {
@@ -52,6 +55,27 @@ const handlers: Handler[] = [
     matcher: /^Bash$/,
     priority: 2,
     fn: orchestrationGuard,
+  },
+  {
+    name: 'brain-inject',
+    event: 'PreToolUse',
+    matcher: /.*/,
+    priority: 5,
+    fn: brainInject,
+  },
+  {
+    name: 'freshness',
+    event: 'PreToolUse',
+    matcher: /^Read$/,
+    priority: 8,
+    fn: freshness,
+  },
+  {
+    name: 'audit-context',
+    event: 'PreToolUse',
+    matcher: /^(Write|Edit)$/,
+    priority: 8,
+    fn: auditContext,
   },
   {
     name: 'identity-inject',

--- a/src/lib/team-manager.test.ts
+++ b/src/lib/team-manager.test.ts
@@ -4,8 +4,8 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { existsSync } from 'node:fs';
-import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { existsSync, lstatSync, readlinkSync } from 'node:fs';
+import { chmod, mkdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { $ } from 'bun';
 import { getConnection } from './db.js';
@@ -149,6 +149,47 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
 
       test('rejects invalid branch names', async () => {
         await expect(createTeam('spaces here', TEST_REPO, 'dev')).rejects.toThrow('must be a valid git branch name');
+      });
+
+      test('symlinks node_modules from parent repo into worktree', async () => {
+        // Create a fake node_modules in the test repo
+        const parentNodeModules = join(TEST_REPO, 'node_modules');
+        await mkdir(parentNodeModules, { recursive: true });
+        await writeFile(join(parentNodeModules, '.package-lock.json'), '{}');
+
+        const config = await createTeam('feat/symlink-nm', TEST_REPO, 'dev');
+        const worktreeNodeModules = join(config.worktreePath, 'node_modules');
+
+        expect(existsSync(worktreeNodeModules)).toBe(true);
+        expect(lstatSync(worktreeNodeModules).isSymbolicLink()).toBe(true);
+        expect(readlinkSync(worktreeNodeModules)).toBe(parentNodeModules);
+
+        // Clean up
+        await rm(parentNodeModules, { recursive: true, force: true });
+      });
+
+      test('skips node_modules symlink when parent has no node_modules', async () => {
+        const config = await createTeam('feat/no-nm', TEST_REPO, 'dev');
+        const worktreeNodeModules = join(config.worktreePath, 'node_modules');
+
+        expect(existsSync(worktreeNodeModules)).toBe(false);
+      });
+
+      test('runs .genie/init.sh in worktree after clone', async () => {
+        // Create a .genie/init.sh that writes a marker file
+        const genieDir = join(TEST_REPO, '.genie');
+        await mkdir(genieDir, { recursive: true });
+        await writeFile(join(genieDir, 'init.sh'), '#!/bin/bash\necho "init-ran" > .init-marker');
+        await chmod(join(genieDir, 'init.sh'), 0o755);
+
+        const config = await createTeam('feat/init-sh', TEST_REPO, 'dev');
+        const marker = join(config.worktreePath, '.init-marker');
+
+        expect(existsSync(marker)).toBe(true);
+
+        // Clean up
+        await rm(join(genieDir, 'init.sh'));
+        await rm(marker, { force: true });
       });
     });
 

--- a/src/lib/team-manager.ts
+++ b/src/lib/team-manager.ts
@@ -11,7 +11,7 @@
  */
 
 import { existsSync } from 'node:fs';
-import { mkdir, rm } from 'node:fs/promises';
+import { mkdir, rm, symlink } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import path, { join } from 'node:path';
 import { $ } from 'bun';
@@ -214,6 +214,30 @@ async function killWorkersByName(agentName: string, teamName?: string): Promise<
 // API
 // ============================================================================
 
+/** Post-clone init: symlink node_modules and run .genie/init.sh if present. */
+async function postCloneInit(repoPath: string, worktreePath: string): Promise<void> {
+  // Symlink node_modules from parent repo so builds work immediately
+  const parentNodeModules = join(repoPath, 'node_modules');
+  const worktreeNodeModules = join(worktreePath, 'node_modules');
+  if (existsSync(parentNodeModules) && !existsSync(worktreeNodeModules)) {
+    try {
+      await symlink(parentNodeModules, worktreeNodeModules, 'dir');
+    } catch {
+      // Best-effort — may fail on filesystems that don't support symlinks
+    }
+  }
+
+  // Run .genie/init.sh if it exists in the repo (post-clone hook convention)
+  const initScript = join(repoPath, '.genie', 'init.sh');
+  if (existsSync(initScript)) {
+    try {
+      await $`bash ${initScript}`.cwd(worktreePath).quiet();
+    } catch {
+      // Best-effort — init script failure shouldn't block team creation
+    }
+  }
+}
+
 /** Ensure a shared clone exists for the given branch. */
 async function ensureWorktree(
   repoPath: string,
@@ -266,6 +290,8 @@ async function ensureWorktree(
   } catch {
     // Best-effort — global config may suffice
   }
+
+  await postCloneInit(repoPath, worktreePath);
 }
 
 /**

--- a/src/term-commands/team.ts
+++ b/src/term-commands/team.ts
@@ -366,7 +366,15 @@ async function spawnLeaderWithWish(
   // Spawn leader — use team-lead template for behavior, leaderAgent for identity
   const members = standardRoles.filter((r) => r !== 'team-lead').join(', ');
   const spawner = config.spawner || 'cli';
-  const kickoffPrompt = `Your team is "${config.name}". Repo: ${config.repo}. Branch: ${config.name}. Worktree: ${config.worktreePath}. Wish slug: ${slug}. Your team members are: ${members} (already hired — genie work will spawn them automatically). Report completion to: ${spawner} (via genie send --to ${spawner}). Read the wish at .genie/wishes/${slug}/WISH.md and execute the full lifecycle autonomously.`;
+  let kickoffPrompt = `Your team is "${config.name}". Repo: ${config.repo}. Branch: ${config.name}. Worktree: ${config.worktreePath}. Wish slug: ${slug}. Your team members are: ${members} (already hired — genie work will spawn them automatically). Report completion to: ${spawner} (via genie send --to ${spawner}). Read the wish at .genie/wishes/${slug}/WISH.md and execute the full lifecycle autonomously.`;
+
+  // Auto-inject recent broadcasts so the leader has immediate context (#1015)
+  const broadcasts = await getRecentBroadcasts(config.name);
+  if (broadcasts.length > 0) {
+    const broadcastLines = broadcasts.map((b) => `[${b.sender}] ${b.text}`).join('\n');
+    kickoffPrompt += `\n\nRecent team broadcasts for context:\n${broadcastLines}`;
+  }
+
   await handleWorkerSpawn('team-lead', {
     provider: 'claude',
     team: config.name,
@@ -394,6 +402,42 @@ async function autoDetectTeam(): Promise<string | null> {
   if (teams.length === 1) return teams[0].name;
 
   return null;
+}
+
+/**
+ * Fetch recent broadcast messages for a team (last N minutes).
+ * Best-effort — returns empty array if DB is unavailable or no broadcasts exist.
+ */
+async function getRecentBroadcasts(
+  teamName: string,
+  minutesAgo = 5,
+): Promise<Array<{ sender: string; text: string; timestamp: string }>> {
+  try {
+    const { getConnection } = await import('../lib/db.js');
+    const sql = await getConnection();
+    const since = new Date(Date.now() - minutesAgo * 60 * 1000);
+
+    const rows = await sql`
+      SELECT m.sender_id, m.body, m.created_at
+      FROM messages m
+      JOIN conversations c ON c.id = m.conversation_id
+      WHERE c.linked_entity = 'team'
+        AND c.linked_entity_id = ${teamName}
+        AND c.parent_message_id IS NULL
+        AND m.created_at > ${since}
+      ORDER BY m.created_at ASC
+      LIMIT 20
+    `;
+
+    return rows.map((r: Record<string, unknown>) => ({
+      sender: String(r.sender_id),
+      text: String(r.body),
+      timestamp: r.created_at instanceof Date ? r.created_at.toISOString() : String(r.created_at),
+    }));
+  } catch {
+    // Best-effort — DB may not be available, don't block spawn
+    return [];
+  }
 }
 
 /** Print members of a specific team. */


### PR DESCRIPTION
## Summary
Three DX improvements from the worktree-dx-improvements wish.

- **Group 1 (#789):** Auto-symlink `node_modules` from parent repo into new worktrees in `ensureWorktree()`, and execute `.genie/init.sh` if present. Engineers no longer need to run `bun install` in every worktree.
- **Group 2 (#1015):** Team leader auto-discovers recent team broadcasts on spawn — `getRecentBroadcasts()` fetches the last 5 minutes of team conversation messages and injects them into the kickoff prompt. Council/team leaders no longer need a manual `genie send` after `genie team create`.
- **Group 3 (#816):** Three new hook handlers:
  - `brain-inject.ts` — SessionStart: query genie-brain for relevant context
  - `audit-context.ts` — PreToolUse Write/Edit: inject recent git history for the file
  - `freshness.ts` — PreToolUse Read: warn on stale-read risk (file modified by another agent in last 2 min)

## Closes
- Closes #789
- Closes #816
- Closes #1015

## Test plan
- [x] `bun run build` passes
- [x] `bun test` — 2059 pass
- [x] `bun run check` clean (lint + tests)
- [x] Worktree creation auto-symlinks node_modules
- [x] Council leader receives broadcast context on spawn
- [x] New hook handlers have tests