### PR TITLE
fix(ci): detect cross-tag version collisions in publish-next skip check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,9 +98,17 @@ jobs:
             exit 0
           fi
           LOCAL=$(jq -r '.version' package.json)
-          PUBLISHED=$(npm view @automagik/genie@next version 2>/dev/null || echo "none")
-          if [ "$LOCAL" = "$PUBLISHED" ]; then
-            echo "Version $LOCAL already published to @next — skipping"
+          # Check whether the exact version exists in the registry under ANY
+          # tag, not just @next. After a dev→main merge, version.yml bumps dev
+          # to a new version, publishes it as @latest, and commits the bump
+          # back to dev. The next dev push then reads that already-published
+          # version from package.json. Querying only the @next tag misses this
+          # cross-tag collision and causes a 403 when bun publish runs.
+          # Query by exact version so collisions from any tag short-circuit
+          # this step; version.yml will derive a fresh version and publish it.
+          if [ -n "$(npm view "@automagik/genie@${LOCAL}" version 2>/dev/null)" ]; then
+            echo "Version ${LOCAL} already published to npm — skipping @next publish"
+            echo "(version.yml will bump to a new version and publish it as @next)"
             exit 0
           fi
           bun publish --tag next --access public


### PR DESCRIPTION
## Summary

- `ci.yml` / `publish-next` job was comparing `package.json` version only against the `@next` dist-tag, missing cross-tag collisions.
- After a dev→main merge, `version.yml` bumps dev to a new version (e.g. `4.260404.2`), publishes it as `@latest`, and commits the bump back to dev.
- The next dev push then reads that already-published version, the skip check fails to match (because `@next` still points at the previous version), and `bun publish` fails with **403 Forbidden — cannot publish over previously published versions**.
- Fix: query by exact version (`npm view <pkg>@<version>`) so any tag collision short-circuits the step. `version.yml` still derives a fresh version and publishes it as `@next` on the same CI run.

## Evidence — this has been silently broken for days

| Date (UTC) | Dev merge | Publish @next result |
|-----------|-----------|---------------------|
| 2026-04-05 00:40 | PR #1051 (omni-fix)  | ❌ 403 — `4.260404.2` already on `@latest` |
| 2026-04-04 23:20 | PR #1054 (dx-fix)    | ❌ (CI failure) |
| 2026-04-04 22:53 | PR #1049 (sdk-fix)   | ❌ (CI failure) |
| 2026-04-04 22:52 | PR #1052 (docs-fix)  | ❌ (CI cancelled) |

Silent because **Publish @next is not a required status check** — the reds were invisible unless you looked at CI manually.

### Resulting npm deviation (before this PR)
```
@latest: 4.260405.1  (from PR #1041 merge to main)
@next:   4.260404.1  (frozen from yesterday's dev push — 2 days stale)
```

## Local verification

```bash
# Simulated skip path (version already published)
LOCAL=4.260405.1
if [ -n "$(npm view "@automagik/genie@${LOCAL}" version 2>/dev/null)" ]; then
  echo "SKIP: already published"
else
  echo "PUBLISH"
fi
# → SKIP: already published ✅

# Simulated publish path (new version)
LOCAL=99.99.99
# → PUBLISH ✅
```

## Test plan

- [ ] Merge this PR to dev
- [ ] Watch next dev-push CI: `Publish @next` should either SKIP cleanly (if version already exists) or PUBLISH successfully (if version.yml bumped first)
- [ ] Watch `version.yml`: should still derive a fresh version, commit, tag, and publish `@next` — restoring `@next` to the current dev version and closing the deviation gap
- [ ] After another dev→main cycle, confirm `@next ≥ @latest` holds

## What this does NOT fix (follow-up needed)

- **Does not address the one-time current deviation** — `@next=4.260404.1` will auto-heal on the next successful dev push (because `version.yml` will bump to `4.260405.2` or later and publish `@next`).
- Does not change `version.yml` architecture. The two-step (ci.yml@push + version.yml@workflow_run) pattern is preserved; only the skip check is made cross-tag-aware.