### PR TITLE
fix(agent-sync): surface workspace resolution failures, stop tmp path poisoning

### DIFF
--- a/src/lib/workspace.test.ts
+++ b/src/lib/workspace.test.ts
@@ -1,18 +1,30 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { findWorkspace, getWorkspaceConfig, scanAgents } from './workspace.js';
 
 let testDir: string;
+let fakeGenieHome: string;
+const originalGenieHome = process.env.GENIE_HOME;
 
 beforeEach(() => {
   testDir = join(tmpdir(), `genie-workspace-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
   mkdirSync(testDir, { recursive: true });
+  // Isolate ~/.genie/config.json from the developer's real config for every test.
+  fakeGenieHome = join(testDir, '.fake-genie-home');
+  mkdirSync(fakeGenieHome, { recursive: true });
+  process.env.GENIE_HOME = fakeGenieHome;
 });
 
 afterEach(() => {
   rmSync(testDir, { recursive: true, force: true });
+  if (originalGenieHome === undefined) {
+    // biome-ignore lint/performance/noDelete: process.env assignment coerces undefined→"undefined"; delete is the only correct unset
+    delete process.env.GENIE_HOME;
+  } else {
+    process.env.GENIE_HOME = originalGenieHome;
+  }
 });
 
 function makeWorkspace(root: string, config: Record<string, unknown> = { name: 'test-ws' }) {
@@ -92,6 +104,39 @@ describe('getWorkspaceConfig', () => {
     const config = getWorkspaceConfig(testDir);
     expect(config.name).toBe('my-ws');
     expect(config.pgUrl).toBe('postgres://localhost:5432/genie');
+  });
+});
+
+describe('workspaceRoot persistence', () => {
+  test('does not persist workspaces under tmpdir() to GENIE_HOME config', () => {
+    // testDir is under tmpdir() by construction — walk-up will succeed, but
+    // saveWorkspaceRoot must refuse to write it, so the global config stays clean.
+    makeWorkspace(testDir);
+    findWorkspace(testDir);
+
+    const configPath = join(fakeGenieHome, 'config.json');
+    if (existsSync(configPath)) {
+      const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+      expect(config.workspaceRoot).toBeUndefined();
+    }
+    // (if the file doesn't exist at all, that's also a pass — nothing was persisted)
+  });
+
+  test('clears stale workspaceRoot from config when the saved path is gone', () => {
+    // Simulate a prior run that persisted a path which has since vanished.
+    const vanished = join(testDir, 'was-here-now-gone');
+    const configPath = join(fakeGenieHome, 'config.json');
+    writeFileSync(configPath, JSON.stringify({ workspaceRoot: vanished }));
+
+    // findWorkspace from an unrelated dir triggers the fallback → stale path detected → cleared.
+    const unrelated = join(testDir, 'unrelated');
+    mkdirSync(unrelated, { recursive: true });
+    const result = findWorkspace(unrelated);
+    expect(result).toBeNull();
+
+    // The poisoned entry should be scrubbed from the config so future calls don't keep hitting it.
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(config.workspaceRoot).toBeUndefined();
   });
 });
 

--- a/src/lib/workspace.ts
+++ b/src/lib/workspace.ts
@@ -6,7 +6,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { dirname, join, resolve, sep } from 'node:path';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -62,15 +62,43 @@ export function findWorkspace(cwd?: string): WorkspaceInfo | null {
   return null;
 }
 
-const GENIE_HOME = process.env.GENIE_HOME ?? join(homedir(), '.genie');
+/** Resolved lazily so GENIE_HOME env overrides in tests take effect. */
+function genieHome(): string {
+  return process.env.GENIE_HOME ?? join(homedir(), '.genie');
+}
+
+/** True if `root` is under the OS temp directory (avoids persisting test workspaces). */
+function isTempPath(root: string): boolean {
+  const normalizedTmp = resolve(tmpdir());
+  const normalizedRoot = resolve(root);
+  return normalizedRoot === normalizedTmp || normalizedRoot.startsWith(normalizedTmp + sep);
+}
 
 function saveWorkspaceRoot(root: string): void {
+  // Never persist tmp paths — tests run from tmpdir() and would poison the
+  // global fallback, causing subsequent daemons to resolve a stale path.
+  if (isTempPath(root)) return;
   try {
-    const configPath = join(GENIE_HOME, 'config.json');
+    const home = genieHome();
+    const configPath = join(home, 'config.json');
     const config = existsSync(configPath) ? JSON.parse(readFileSync(configPath, 'utf-8')) : {};
     if (config.workspaceRoot === root) return;
     config.workspaceRoot = root;
-    mkdirSync(GENIE_HOME, { recursive: true });
+    mkdirSync(home, { recursive: true });
+    writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf-8');
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** Clear the saved workspaceRoot from <GENIE_HOME>/config.json. */
+function clearWorkspaceRoot(): void {
+  try {
+    const configPath = join(genieHome(), 'config.json');
+    if (!existsSync(configPath)) return;
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    if (config.workspaceRoot === undefined) return;
+    config.workspaceRoot = undefined;
     writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf-8');
   } catch {
     /* best-effort */
@@ -79,10 +107,20 @@ function saveWorkspaceRoot(root: string): void {
 
 function loadWorkspaceRoot(): string | null {
   try {
-    const configPath = join(GENIE_HOME, 'config.json');
+    const configPath = join(genieHome(), 'config.json');
     if (!existsSync(configPath)) return null;
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
-    return typeof config.workspaceRoot === 'string' ? config.workspaceRoot : null;
+    const saved = typeof config.workspaceRoot === 'string' ? config.workspaceRoot : null;
+    if (!saved) return null;
+
+    // Self-heal: if the saved path no longer has a workspace marker (e.g. a
+    // test cleanup removed it, or the workspace was moved), clear it rather
+    // than keep returning a broken fallback.
+    if (!existsSync(join(saved, WORKSPACE_MARKER))) {
+      clearWorkspaceRoot();
+      return null;
+    }
+    return saved;
   } catch {
     return null;
   }

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -371,13 +371,29 @@ async function startAgentSync(): Promise<{ close: () => void } | null> {
   try {
     const { findWorkspace } = require('../lib/workspace.js') as typeof import('../lib/workspace.js');
     const ws = findWorkspace();
-    if (!ws) return null;
+    if (!ws) {
+      // Loud failure — silent return used to hide the whole discovery subsystem
+      // when serve booted from outside a workspace (or with a stale saved root).
+      console.warn('  Agent sync: DISABLED — no workspace found from cwd or ~/.genie/config.json');
+      console.warn('    Fix: `cd <workspace> && genie serve restart`, or run `genie init` to bootstrap one');
+      return null;
+    }
 
     const { syncAgentDirectory, watchAgentDirectory } = await import('../lib/agent-sync.js');
     const syncResult = await syncAgentDirectory(ws.root);
     const synced = syncResult.registered.length + syncResult.updated.length;
     if (synced > 0) {
-      console.log(`  Agent sync: ${syncResult.registered.length} registered, ${syncResult.updated.length} updated`);
+      console.log(
+        `  Agent sync: ${syncResult.registered.length} registered, ${syncResult.updated.length} updated (workspace: ${ws.root})`,
+      );
+    } else {
+      console.log(`  Agent sync: up to date (workspace: ${ws.root})`);
+    }
+    if (syncResult.errors.length > 0) {
+      console.warn(`  Agent sync: ${syncResult.errors.length} error(s) — these agents were NOT registered:`);
+      for (const e of syncResult.errors) {
+        console.warn(`    ${e.name}: ${e.error}`);
+      }
     }
 
     const watcher = watchAgentDirectory(ws.root, {
@@ -387,6 +403,8 @@ async function startAgentSync(): Promise<{ close: () => void } | null> {
     });
     if (watcher) {
       console.log('  Agent watcher started (watching agents/ directory)');
+    } else {
+      console.warn('  Agent watcher: FAILED to start — new agents will not be auto-registered');
     }
     return watcher;
   } catch (err) {


### PR DESCRIPTION
## The bug I hit

I have a real agent on disk at `workspace/agents/omni/AGENTS.md`. Every other agent in that directory shows up in `genie ls`. Omni doesn't. `genie spawn omni` says:

```
Error: Agent "omni" not found in directory or built-ins.
  Register with: genie dir add omni --dir <path>
```

Running `genie dir sync` manually instantly registered 15 agents that had been invisible — omni plus `totvs`, `helena`, `researchers`, 5 sub-agents, etc. So the sync code works. Something was preventing it from running on serve startup.

## Root cause

`startAgentSync()` in `serve.ts` silently returned `null` when `findWorkspace()` returned `null`. That disabled the **entire auto-discovery subsystem** — both the startup sync and the file watcher — for the whole serve lifetime. No warning, no log, no entry in `genie serve status`.

Why was `findWorkspace()` returning null? Because `~/.genie/config.json` had this persisted from an old test run:

```json
"workspaceRoot": "/tmp/genie-workspace-test-1775349146465-185rx3i66o8"
```

`saveWorkspaceRoot()` had written it, `/tmp` got cleaned, and the fallback path in `findWorkspace()` has been returning a dead path ever since. Any `genie serve` booted from outside the real workspace walked up, failed, fell back to the stale path, `existsSync` returned false, returned null, `startAgentSync` silently exited. **For however long that serve instance ran.**

## The fix

Three small, contained changes — all behind existing function boundaries:

### `src/lib/workspace.ts`
- **`saveWorkspaceRoot()` refuses to persist paths under `os.tmpdir()`.** Test workspaces can no longer poison the global fallback. Future test runs write their tmp path and the guard drops it on the floor.
- **`loadWorkspaceRoot()` self-heals** — if the saved path no longer has a `.genie/workspace.json` marker, scrub it from config instead of returning a dead fallback forever.
- **`GENIE_HOME` is now resolved lazily via `genieHome()`** instead of a module-level `const`. Tests can override it per-test via `process.env.GENIE_HOME`. Without this change, the previous module-level capture meant test env overrides were silently ignored — I caught it because my first test run ended up scrubbing my real `~/.genie/config.json` (which, happy accident, was exactly the stale tmp path that originally caused this bug).

### `src/term-commands/serve.ts`
- **`startAgentSync()` logs loudly when workspace is unresolved**, with actionable fix guidance, instead of silently returning null:
  ```
  Agent sync: DISABLED — no workspace found from cwd or ~/.genie/config.json
    Fix: `cd <workspace> && genie serve restart`, or run `genie init` to bootstrap one
  ```
- **Surfaces per-agent errors from `syncResult.errors[]`** so a single agent with bad frontmatter doesn't vanish silently. Today those errors are collected by `syncAgentDirectory()` and never printed on the serve-startup path.
- **Includes the resolved workspace root in the success log** so "which workspace did serve attach to" is visible at a glance, and flags watcher install failures with a warning instead of swallowing them.

### `src/lib/workspace.test.ts`
- Two new tests covering the tmp-path guard and stale-path self-heal.
- All tests now isolate `GENIE_HOME` per-test so they don't touch (or get contaminated by) the developer's real `~/.genie/config.json`.

## Scope I deliberately did NOT include

While diagnosing this with the user, we identified 6 DX improvements. This PR implements only the 3 that directly address the silent-failure root cause. The other 3 — which are good ideas but larger surface-area changes — are left for follow-ups:

1. `genie spawn <name>` should fall back to scanning disk when PG returns null (friendlier error with "found but not registered" message).
2. `genie serve status` should expose agent-sync/watcher health as a first-class line.
3. `genie ls` should have an "UNREGISTERED (on disk, not in directory)" section for agents that exist but failed validation.

These are each worth a separate focused PR.

## Verification

- `bun test src/lib/workspace.test.ts` → 12 pass, 0 fail (10 existing + 2 new)
- `bun test src/lib/` → 1571 pass, 0 fail
- `bunx tsc --noEmit` → clean
- `bunx biome check src/lib/workspace.ts src/lib/workspace.test.ts src/term-commands/serve.ts` → 0 errors, 1 pre-existing warning on `startForeground` complexity (unrelated, confirmed present on base `dev` before my changes via `git stash` round-trip)
- Pre-push hook ran the full 2073-test suite: 0 fail
- Manually verified the omni case end-to-end: `genie dir sync` from the real workspace root registered 15 previously-invisible agents including omni; `genie spawn omni` now resolves

## Test plan

- [x] `bun test src/lib/workspace.test.ts` passes
- [x] Full `bun test` passes (2073/2073)
- [x] `bunx tsc --noEmit` clean
- [x] `bunx biome check` 0 errors on changed files
- [ ] Manual: start `genie serve` from outside a workspace → see `Agent sync: DISABLED` warning with fix guidance
- [ ] Manual: start `genie serve` from inside a workspace → see `Agent sync: up to date (workspace: …)` line
- [ ] Manual: add an invalid frontmatter AGENTS.md, run `genie dir sync` or restart serve → see the per-agent error line instead of the file silently going missing