### PR TITLE
fix(workspace): canonicalize tmp paths, dynamic config path in serve warning

### DIFF
--- a/src/lib/workspace.test.ts
+++ b/src/lib/workspace.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { findWorkspace, getWorkspaceConfig, scanAgents } from './workspace.js';
+import { findWorkspace, genieHome, getWorkspaceConfig, scanAgents } from './workspace.js';
 
 let testDir: string;
 let fakeGenieHome: string;
@@ -120,6 +120,41 @@ describe('workspaceRoot persistence', () => {
       expect(config.workspaceRoot).toBeUndefined();
     }
     // (if the file doesn't exist at all, that's also a pass — nothing was persisted)
+  });
+
+  test('canonicalizes symlinked tmp paths so the guard cannot be bypassed', () => {
+    // Regression guard for the macOS /tmp → /private/tmp case. path.resolve()
+    // does NOT follow symlinks, so a naive prefix check against a non-canonical
+    // path would miss. realpathSync() canonicalizes both sides.
+    const real = join(testDir, 'real-workspace');
+    const link = join(testDir, 'linked-workspace');
+    mkdirSync(real, { recursive: true });
+    makeWorkspace(real);
+    try {
+      symlinkSync(real, link, 'dir');
+    } catch {
+      // Some CI environments disallow symlink creation; skip gracefully.
+      return;
+    }
+
+    // findWorkspace called via the symlink path — without realpathSync the
+    // tmp-guard would fail to match, with realpathSync it matches correctly.
+    const result = findWorkspace(link);
+    expect(result).not.toBeNull();
+
+    // Either the config file doesn't exist at all, or it exists with no workspaceRoot.
+    // Both mean "nothing was persisted" — which is what we want.
+    const configPath = join(fakeGenieHome, 'config.json');
+    if (existsSync(configPath)) {
+      const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+      expect(config.workspaceRoot).toBeUndefined();
+    }
+  });
+
+  test('genieHome() reflects GENIE_HOME env override', () => {
+    // Sanity check: the exported helper resolves dynamically so callers in other
+    // modules (e.g. serve.ts warning messages) see the same value as workspace.ts.
+    expect(genieHome()).toBe(fakeGenieHome);
   });
 
   test('clears stale workspaceRoot from config when the saved path is gone', () => {

--- a/src/lib/workspace.ts
+++ b/src/lib/workspace.ts
@@ -5,7 +5,7 @@
  * If the cwd passes through `agents/<name>/`, the agent name is extracted.
  */
 
-import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, readdirSync, realpathSync, writeFileSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, join, resolve, sep } from 'node:path';
 
@@ -63,15 +63,29 @@ export function findWorkspace(cwd?: string): WorkspaceInfo | null {
 }
 
 /** Resolved lazily so GENIE_HOME env overrides in tests take effect. */
-function genieHome(): string {
+export function genieHome(): string {
   return process.env.GENIE_HOME ?? join(homedir(), '.genie');
 }
 
-/** True if `root` is under the OS temp directory (avoids persisting test workspaces). */
+/**
+ * True if `root` is under the OS temp directory (avoids persisting test workspaces).
+ *
+ * Uses `realpathSync` to canonicalize both paths before comparing — on macOS
+ * `/tmp` is a symlink to `/private/tmp`, and `tmpdir()` returns `/var/folders/…`,
+ * so a plain string prefix check against non-canonical paths would bypass the guard.
+ *
+ * Fails CLOSED: if canonicalization fails (path doesn't exist, permission error),
+ * treat as temp and refuse to persist — the saveWorkspaceRoot caller's goal is
+ * to be conservative about what lands in the global config.
+ */
 function isTempPath(root: string): boolean {
-  const normalizedTmp = resolve(tmpdir());
-  const normalizedRoot = resolve(root);
-  return normalizedRoot === normalizedTmp || normalizedRoot.startsWith(normalizedTmp + sep);
+  try {
+    const canonicalTmp = realpathSync(tmpdir());
+    const canonicalRoot = realpathSync(root);
+    return canonicalRoot === canonicalTmp || canonicalRoot.startsWith(canonicalTmp + sep);
+  } catch {
+    return true;
+  }
 }
 
 function saveWorkspaceRoot(root: string): void {

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -369,12 +369,14 @@ const handles: DaemonHandles = { schedulerHandle: null, agentWatcher: null };
 /** Sync agent directory from workspace and start file watcher. */
 async function startAgentSync(): Promise<{ close: () => void } | null> {
   try {
-    const { findWorkspace } = require('../lib/workspace.js') as typeof import('../lib/workspace.js');
+    const { findWorkspace, genieHome } = require('../lib/workspace.js') as typeof import('../lib/workspace.js');
     const ws = findWorkspace();
     if (!ws) {
       // Loud failure — silent return used to hide the whole discovery subsystem
       // when serve booted from outside a workspace (or with a stale saved root).
-      console.warn('  Agent sync: DISABLED — no workspace found from cwd or ~/.genie/config.json');
+      const { join } = require('node:path') as typeof import('node:path');
+      const configPath = join(genieHome(), 'config.json');
+      console.warn(`  Agent sync: DISABLED — no workspace found from cwd or ${configPath}`);
       console.warn('    Fix: `cd <workspace> && genie serve restart`, or run `genie init` to bootstrap one');
       return null;
     }


### PR DESCRIPTION
Follow-up to #1056 addressing two review comments from `gemini-code-assist` bot.

#1056 was already merged before the review comments landed, so these fixes ship as a separate small PR.

## Comment 1 — `isTempPath` didn't handle symlinked temp dirs (HIGH)

> On macOS, `/tmp` is often a symlink to `/private/tmp`. Since `path.resolve()` does not follow symlinks, `isTempPath` may return `false` for paths accessed via their non-canonical form, bypassing the guard.

**Accepted.** Real cross-platform bug. `os.tmpdir()` on macOS returns `/var/folders/.../T/`, while user-facing paths often come through `/tmp` (symlink). `path.resolve()` only normalizes `..` and makes paths absolute — it does not canonicalize symlinks. A literal `/tmp/foo` would not prefix-match `/var/folders/.../T/`, so the guard against writing test workspaces into the global `~/.genie/config.json` could be silently bypassed on macOS.

Fix in `src/lib/workspace.ts`:
- Added `realpathSync` to the existing `node:fs` top-level import (cleaner than the bot's suggested dynamic `require`).
- `isTempPath` now canonicalizes both `tmpdir()` and `root` via `realpathSync` before comparing.
- **Fails closed** on canonicalization errors — if the path doesn't exist or can't be resolved, treat it as temp and refuse to persist. The whole point of the guard is to be conservative about what lands in the global config; failing open would defeat it.

## Comment 2 — warning message hardcoded `~/.genie/config.json` (LOW)

> The warning message hardcodes `~/.genie/config.json`, which may be inaccurate if `GENIE_HOME` is set.

**Accepted.** Cosmetic accuracy. Users who set `GENIE_HOME` (CI, test harnesses, multi-workspace setups) would see a misleading fix suggestion.

Fix in `src/term-commands/serve.ts`:
- Exported `genieHome()` from `workspace.ts` (was private).
- `startAgentSync()` now resolves the config path dynamically: `join(genieHome(), 'config.json')`.

## Tests added

- **Symlink regression test** in `workspace.test.ts`: creates a real symlink within the test's `tmpdir()` pointing at a real workspace dir, calls `findWorkspace(symlinkPath)`, and asserts nothing was persisted to the isolated fake `GENIE_HOME` config. Skips gracefully (returns early) on CI environments that disallow symlink creation — we'd rather no coverage than a flaky test.
- **`genieHome()` env override test**: sanity check that the newly-exported helper honors `process.env.GENIE_HOME` dynamically, so callers in other modules (e.g. the serve warning) see the same value as `workspace.ts` does internally.

## Verification

- `bun test src/lib/workspace.test.ts` → 14 pass, 0 fail (was 12)
- `bun test src/lib/` → 1573 pass, 0 fail (was 1571, +2 from this PR)
- `bunx tsc --noEmit` → clean
- `bunx biome check` on changed files → 0 errors, 1 pre-existing warning on `startForeground` complexity (unchanged, not introduced here)
- Pre-push hook ran full 2075-test suite: 0 fail

## Test plan

- [x] Workspace tests pass (including new symlink regression test)
- [x] Full lib tests pass
- [x] Type-check clean
- [x] Biome clean on changed files
- [ ] Manual verification on macOS: create a literal `/tmp/test-workspace/.genie/workspace.json`, run `findWorkspace('/tmp/test-workspace')`, confirm `~/.genie/config.json` does NOT receive the path (previously would have been persisted on macOS)
- [ ] Manual: start `genie serve` with `GENIE_HOME=/custom/path` from outside a workspace → warning should show `/custom/path/config.json` not `~/.genie/config.json`