### PR TITLE
fix(directory): resolve() and ls() prefer dir: rows over stale runtime rows

### DIFF
--- a/src/lib/agent-directory.test.ts
+++ b/src/lib/agent-directory.test.ts
@@ -79,6 +79,22 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
     test('returns null for unknown name', async () => {
       expect(await directory.resolve('nonexistent-xyz')).toBeNull();
     });
+
+    test('prefers dir: row over stale runtime rows with same role', async () => {
+      const sql = await getConnection();
+      // Insert stale runtime row (empty metadata, older started_at)
+      await sql`INSERT INTO agents (id, pane_id, session, repo_path, state, role, started_at, last_state_change, metadata) VALUES ('stale-uuid', '%1', 's', '/tmp', 'done', 'my-dup', now() - interval '1 hour', now(), '{}')`;
+      // Insert another stale runtime row (empty metadata, recent started_at — would win ORDER BY started_at DESC)
+      await sql`INSERT INTO agents (id, pane_id, session, repo_path, state, role, started_at, last_state_change, metadata) VALUES ('recent-uuid', '%2', 's', '/tmp', 'done', 'my-dup', now(), now(), '{}')`;
+      // Insert directory row (has real metadata — oldest started_at, but should still win via dir: prefix)
+      await sql`INSERT INTO agents (id, role, custom_name, started_at, metadata) VALUES ('dir:my-dup', 'my-dup', 'my-dup', now() - interval '2 hours', '{"dir":"/some/path","model":"opus","color":"teal","description":"The real entry"}')`;
+
+      const resolved = await directory.resolve('my-dup');
+      expect(resolved).not.toBeNull();
+      expect(resolved!.entry.model).toBe('opus');
+      expect(resolved!.entry.color).toBe('teal');
+      expect(resolved!.entry.description).toBe('The real entry');
+    });
   });
 
   // ============================================================================
@@ -99,6 +115,18 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
 
     test('returns empty array when no agents', async () => {
       expect(await directory.ls()).toEqual([]);
+    });
+
+    test('ls prefers dir: row over stale runtime rows', async () => {
+      const sql = await getConnection();
+      await sql`INSERT INTO agents (id, pane_id, session, repo_path, state, role, started_at, last_state_change, metadata) VALUES ('runtime-1', '%1', 's', '/tmp', 'done', 'ls-dup', now(), now(), '{}')`;
+      await sql`INSERT INTO agents (id, role, custom_name, started_at, metadata) VALUES ('dir:ls-dup', 'ls-dup', 'ls-dup', now() - interval '1 hour', '{"dir":"/real/dir","model":"sonnet","description":"Directory entry"}')`;
+
+      const entries = await directory.ls();
+      const entry = entries.find((e) => e.name === 'ls-dup');
+      expect(entry).not.toBeNull();
+      expect(entry!.model).toBe('sonnet');
+      expect(entry!.description).toBe('Directory entry');
     });
 
     test('ls includes metadata fields from PG', async () => {

--- a/src/lib/agent-directory.ts
+++ b/src/lib/agent-directory.ts
@@ -163,7 +163,12 @@ export async function resolve(name: string): Promise<ResolvedAgent | null> {
   try {
     const { getConnection } = await import('./db.js');
     const sql = await getConnection();
-    const rows = await sql`SELECT role, metadata FROM agents WHERE role = ${name} LIMIT 1`;
+    const rows = await sql`
+      SELECT role, metadata FROM agents
+      WHERE role = ${name}
+      ORDER BY (CASE WHEN id LIKE 'dir:%' THEN 0 ELSE 1 END), started_at DESC
+      LIMIT 1
+    `;
     if (rows.length > 0) {
       const meta = parseMetadata(rows[0].metadata);
       return { entry: roleToEntry(name, undefined, meta), builtin: false };
@@ -228,7 +233,7 @@ export async function ls(): Promise<ScopedDirectoryEntry[]> {
       FROM agents a
       LEFT JOIN executors e ON a.current_executor_id = e.id
       WHERE a.role IS NOT NULL
-      ORDER BY a.role, a.started_at DESC
+      ORDER BY a.role, (CASE WHEN a.id LIKE 'dir:%' THEN 0 ELSE 1 END), a.started_at DESC
     `;
     for (const row of rows) {
       const name = row.role as string;


### PR DESCRIPTION
## The bug

After #1056 fixed the sync subsystem and agents got registered, `genie dir ls omni` still showed an empty entry — no dir, no model, no color, no description, `promptMode: append` instead of `system`. Meanwhile the same sync reported `Updated: omni` successfully.

Direct PG inspection revealed **3 rows** for the `omni` role:

| id | metadata |
|----|----------|
| `dir:omni` | Full metadata (dir, model, color, etc.) |
| `0debcf13-...` | `{}` (stale runtime row) |
| `genie-omni` | `{}` (stale runtime row) |

`resolve()` at `agent-directory.ts:166` does:
```sql
SELECT role, metadata FROM agents WHERE role = 'omni' LIMIT 1
```

No ordering — PG picks whichever row it wants. If it picks a stale row, the agent appears unregistered. This is a **coin-flip bug** that affects nearly every agent: `engineer-2` has 18 duplicate rows, most agents have 2–3.

## The fix

Two queries changed, same pattern:

### `resolve()` (line 166)
```sql
SELECT role, metadata FROM agents
WHERE role = $name
ORDER BY (CASE WHEN id LIKE 'dir:%' THEN 0 ELSE 1 END), started_at DESC
LIMIT 1
```

### `ls()` (line 231)
```sql
SELECT DISTINCT ON (a.role) ...
ORDER BY a.role, (CASE WHEN a.id LIKE 'dir:%' THEN 0 ELSE 1 END), a.started_at DESC
```

Directory-managed rows (`dir:` prefix) always win. Among non-directory rows, most recent wins. No schema changes, no data migration, no cleanup needed.

## Verified end-to-end

Before fix:
```json
{"name":"omni","dir":"","promptMode":"append","roles":[],"builtin":false}
```

After fix:
```json
{"name":"omni","dir":"/home/genie/workspace/agents/omni","promptMode":"system","model":"opus","color":"teal","description":"Omni — event-driven omnichannel platform orchestrator...","repo":"namastexlabs/genie-omni"}
```

## Tests added

- `resolve > prefers dir: row over stale runtime rows with same role` — inserts 2 stale runtime rows (one with newer `started_at` that would win the old query) plus a `dir:` row, asserts `dir:` metadata wins.
- `ls > ls prefers dir: row over stale runtime rows` — same pattern for the `ls()` path.

## Verification

- `bun test src/lib/agent-directory.test.ts` → 32 pass, 0 fail (was 30, +2 new)
- `bunx tsc --noEmit` → clean
- `bunx biome check` → clean
- Pre-push full suite: 2082 tests, 0 fail

## Test plan

- [x] Agent directory tests pass (including 2 new regression tests)
- [x] Type-check clean
- [x] Lint clean
- [x] Full test suite passes (2082/2082)
- [x] Manual: `resolve('omni')` returns full metadata from dir: row
- [x] Manual: `ls()` returns full metadata for omni
- [ ] Manual: `genie spawn omni` resolves correctly with model, color, and system prompt