### PR TITLE
fix(test): eliminate mock.module leaks breaking CI full-suite runs

### DIFF
--- a/src/lib/tmux-alive.test.ts
+++ b/src/lib/tmux-alive.test.ts
@@ -1,7 +1,10 @@
-import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
 
 const mockExecuteTmux = mock(async (_cmd: string) => '');
-const mockExecSync = mock((_cmd: string, _opts?: object) => '');
+// execSync is injected per-test rather than mocked via mock.module('node:child_process', ...).
+// Module-level mocking of node:child_process is process-global and leaks into any test
+// file that runs after this one (audit-context, freshness, pg resolveRepoPath all use execSync).
+const mockExecSync = mock((_cmd: string, _opts?: object): string => '');
 
 mock.module('./tmux-wrapper.js', () => ({
   executeTmux: mockExecuteTmux,
@@ -9,15 +12,7 @@ mock.module('./tmux-wrapper.js', () => ({
   genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
 }));
 
-mock.module('node:child_process', () => ({
-  execSync: mockExecSync,
-}));
-
 const { isPaneAlive, isPaneProcessRunning, TmuxUnreachableError } = await import('./tmux.js');
-
-afterAll(() => {
-  mock.restore();
-});
 
 describe('isPaneAlive', () => {
   beforeEach(() => {
@@ -74,42 +69,42 @@ describe('isPaneProcessRunning', () => {
   });
 
   test('returns false for invalid pane ids', async () => {
-    expect(await isPaneProcessRunning('', 'claude')).toBe(false);
-    expect(await isPaneProcessRunning('inline', 'claude')).toBe(false);
-    expect(await isPaneProcessRunning('pane-1', 'claude')).toBe(false);
+    expect(await isPaneProcessRunning('', 'claude', mockExecSync)).toBe(false);
+    expect(await isPaneProcessRunning('inline', 'claude', mockExecSync)).toBe(false);
+    expect(await isPaneProcessRunning('pane-1', 'claude', mockExecSync)).toBe(false);
   });
 
   test('returns false when pane pid is empty', async () => {
     mockExecuteTmux.mockResolvedValueOnce('');
-    expect(await isPaneProcessRunning('%2', 'claude')).toBe(false);
+    expect(await isPaneProcessRunning('%2', 'claude', mockExecSync)).toBe(false);
   });
 
   test('returns false when pane pid is non-numeric', async () => {
     mockExecuteTmux.mockResolvedValueOnce('notanumber');
-    expect(await isPaneProcessRunning('%2', 'claude')).toBe(false);
+    expect(await isPaneProcessRunning('%2', 'claude', mockExecSync)).toBe(false);
   });
 
   test('returns true when target process found in descendants', async () => {
     mockExecuteTmux.mockResolvedValueOnce('12345');
     mockExecSync.mockReturnValueOnce('12346 claude --session-id abc\n');
-    expect(await isPaneProcessRunning('%2', 'claude')).toBe(true);
+    expect(await isPaneProcessRunning('%2', 'claude', mockExecSync)).toBe(true);
   });
 
   test('returns false when target process not in descendants', async () => {
     mockExecuteTmux.mockResolvedValueOnce('12345');
     mockExecSync.mockReturnValueOnce('12346 bash\n12347 vim\n');
-    expect(await isPaneProcessRunning('%2', 'claude')).toBe(false);
+    expect(await isPaneProcessRunning('%2', 'claude', mockExecSync)).toBe(false);
   });
 
   test('matches process name case-insensitively', async () => {
     mockExecuteTmux.mockResolvedValueOnce('12345');
     mockExecSync.mockReturnValueOnce('12346 Claude --dangerously-skip-permissions\n');
-    expect(await isPaneProcessRunning('%2', 'claude')).toBe(true);
+    expect(await isPaneProcessRunning('%2', 'claude', mockExecSync)).toBe(true);
   });
 
   test('returns false when tmux command fails', async () => {
     mockExecuteTmux.mockRejectedValueOnce(new Error("can't find pane %99"));
-    expect(await isPaneProcessRunning('%99', 'claude')).toBe(false);
+    expect(await isPaneProcessRunning('%99', 'claude', mockExecSync)).toBe(false);
   });
 
   test('returns false when execSync throws', async () => {
@@ -117,6 +112,6 @@ describe('isPaneProcessRunning', () => {
     mockExecSync.mockImplementationOnce(() => {
       throw new Error('command failed');
     });
-    expect(await isPaneProcessRunning('%2', 'claude')).toBe(false);
+    expect(await isPaneProcessRunning('%2', 'claude', mockExecSync)).toBe(false);
   });
 });

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -568,12 +568,26 @@ export async function isPaneAlive(paneId: string): Promise<boolean> {
 }
 
 /**
+ * execSync signature for dependency injection in tests.
+ * Accepting execSync as a parameter lets tests stub it without
+ * `mock.module('node:child_process', ...)`, which is process-global
+ * and leaks across test files (breaks audit-context, freshness, pg tests).
+ */
+type ExecSyncFn = (cmd: string, opts: { encoding: 'utf-8'; timeout: number }) => string;
+
+/**
  * Check if a tmux pane has a running descendant process matching the given name.
  * Walks two levels of the process tree (shell -> process -> subprocess) to handle
  * cases where the target runs under a wrapper script.
  * Returns false if the pane doesn't exist or the process is not found.
+ *
+ * @param execSyncFn - injected for testing; defaults to node:child_process.execSync
  */
-export async function isPaneProcessRunning(paneId: string, processName: string): Promise<boolean> {
+export async function isPaneProcessRunning(
+  paneId: string,
+  processName: string,
+  execSyncFn?: ExecSyncFn,
+): Promise<boolean> {
   if (!paneId || paneId === 'inline') return false;
   if (!/^%\d+$/.test(paneId)) return false;
 
@@ -581,9 +595,9 @@ export async function isPaneProcessRunning(paneId: string, processName: string):
     const panePid = (await executeTmux(`display-message -t '${paneId}' -p '#{pane_pid}'`)).trim();
     if (!panePid || !/^\d+$/.test(panePid)) return false;
 
-    const { execSync } = await import('node:child_process');
+    const exec: ExecSyncFn = execSyncFn ?? ((await import('node:child_process')).execSync as ExecSyncFn);
     // Check direct children and grandchildren for the target process name
-    const output = execSync(
+    const output = exec(
       `pgrep -la -P ${panePid} 2>/dev/null; for cpid in $(pgrep -P ${panePid} 2>/dev/null); do pgrep -la -P "$cpid" 2>/dev/null; done; true`,
       { encoding: 'utf-8', timeout: 5000 },
     );

--- a/src/services/executors/__tests__/claude-sdk.test.ts
+++ b/src/services/executors/__tests__/claude-sdk.test.ts
@@ -39,18 +39,19 @@ mock.module('@anthropic-ai/claude-agent-sdk', () => ({
   }),
 }));
 
-// Mock audit-events (Group 5 + 7 — writes audit via safePgCall)
-mock.module('../../../lib/audit-events.js', () => ({
-  recordAuditEvent: mock(async () => {}),
-}));
+// NOTE: audit-events is intentionally NOT mocked via mock.module.
+// Bun's mock.module is process-global and mock.restore() does NOT
+// undo module-level registrations. Mocking audit-events here leaks
+// into claude-sdk-resume.test.ts (which captures audit events via
+// safePgCall) and breaks its audit assertions.
+//
+// Real audit-events is safe to use: recordAuditEvent() just calls
+// safePgCall('audit:<type>', ...), and safePgCall is already mocked
+// per-test via setSafePgCall() below (or guarded null for no-bridge tests).
 
-// Mock sdk-session-capture (Group 5 — session content capture)
-mock.module('../sdk-session-capture.js', () => ({
-  startSession: mock(async () => null),
-  recordTurn: mock(async () => {}),
-  updateTurnCount: mock(async () => {}),
-  endSession: mock(async () => {}),
-}));
+// NOTE: sdk-session-capture is intentionally NOT mocked via mock.module
+// for the same reason. The real module calls safePgCall which is mocked
+// per-test — safe.
 
 // Mock agent-registry and executor-registry so spawn()/shutdown() never touch real PG.
 // The tests override these with fresh mocks per-test for call-count assertions.


### PR DESCRIPTION
## Summary

Fixes the 7-9 tests that fail in the full suite but pass individually, blocking PR #1059 (rolling promotion dev→main) and PR #1063.

## Root Cause

Two `mock.module()` calls were leaking process-globally into subsequent test files. Bun's `mock.restore()` does NOT undo module-level registrations — once a file mocks a module with `mock.module()`, every file that runs after it sees the mock.

### Leak 1: `audit-events.js` in `claude-sdk.test.ts`
Mocked `recordAuditEvent` to a no-op. This broke `claude-sdk-resume.test.ts` which captures audit events via `safePgCall` — 5 tests failed with `Received: []`.

### Leak 2: `node:child_process` in `tmux-alive.test.ts`
Mocked `execSync` to return `''`. This broke any test using execSync that ran after:
- `audit-context.test.ts` — git log returned empty → handler returned undefined
- `freshness.test.ts` — same pattern
- `pg > resolveRepoPath` tests — git rev-parse returned empty

## Fix

### Leak 1
Removed the `mock.module('.../audit-events.js', ...)` from `claude-sdk.test.ts`. The real module is safe because `recordAuditEvent` routes through `safePgCall`, which is already mocked per-test via `setSafePgCall()`.

### Leak 2
Added optional `execSyncFn` parameter to `isPaneProcessRunning()`. Tests now pass their own mock directly instead of poisoning `node:child_process` globally.

## Validation

```
Before (dev): 2149 pass, 4 fail
After (this PR): 2153 pass, 0 fail
```

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun test` — 2153 pass, 0 fail
- [x] Full suite runs deterministically (no cross-file pollution)
- [ ] CI green on this PR