### PR TITLE
fix(ci): ignore historical wip commit to unblock #1059

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -12,5 +12,10 @@ export default {
     (message: string) =>
       /\(#\d+\)/.test(message.split('\n')[0]) &&
       !/^(feat|fix|chore|refactor|docs|style|test|perf|ci|build|revert)/.test(message),
+    // Historical exception: one `wip:` commit landed on dev via #1065 before
+    // pre-commit hooks caught it (commit 2b226b3b). Ignoring it here unblocks
+    // the rolling promotion PRs without rewriting dev history. Do NOT add
+    // more `wip:` commits — type-enum still rejects them for new commits.
+    (message: string) => message.startsWith('wip: fix-omni-bridge-hardening#1'),
   ],
 };


### PR DESCRIPTION
## Summary

Adds a surgical commitlint ignore for commit `2b226b3b` (`wip: fix-omni-bridge-hardening#1`) which landed on dev via #1065 with a non-conventional type prefix. This blocks the rolling promotion PR #1059.

The ignore matches only this exact message — `type-enum` still rejects `wip:` for all new commits.

## Context
- PR #1063 (Wave 1) already merged to dev with the test mock.module fixes
- This is the remaining piece needed to unblock #1059's Commit Messages CI