### PR TITLE
fix: path traversal in init agent + FK cascade for event pruning

### DIFF
--- a/src/db/migrations/026_events_trace_id.sql
+++ b/src/db/migrations/026_events_trace_id.sql
@@ -1,5 +1,5 @@
 -- 026_events_trace_id.sql — Add trace_id and parent_event_id for distributed tracing (#859)
 
 ALTER TABLE genie_runtime_events ADD COLUMN IF NOT EXISTS trace_id UUID;
-ALTER TABLE genie_runtime_events ADD COLUMN IF NOT EXISTS parent_event_id BIGINT REFERENCES genie_runtime_events(id);
+ALTER TABLE genie_runtime_events ADD COLUMN IF NOT EXISTS parent_event_id BIGINT REFERENCES genie_runtime_events(id) ON DELETE SET NULL;
 CREATE INDEX IF NOT EXISTS idx_runtime_events_trace_id ON genie_runtime_events(trace_id) WHERE trace_id IS NOT NULL;

--- a/src/term-commands/init.ts
+++ b/src/term-commands/init.ts
@@ -175,6 +175,12 @@ function resolveAgentsDir(wsRoot: string, dirOption?: string): string {
 
 /** genie init agent <name> — scaffold agent directory */
 async function initAgent(name: string, options: { dir?: string }): Promise<void> {
+  // Guard against path traversal — name is CLI input and lands in join(baseDir, name)
+  if (!name || /[\/\\]/.test(name) || name === '.' || name === '..' || name.includes('..')) {
+    console.error('Error: Agent name must not contain path separators or traversal sequences.');
+    process.exit(1);
+  }
+
   const cwd = process.cwd();
   const ws = findWorkspace(cwd);
   if (!ws) {


### PR DESCRIPTION
## Summary

Two fixes from bot review findings on PR #1059 (rolling promotion):

### [CRITICAL] Path traversal in `genie init agent`
`genie init agent <name>` passed CLI input directly to `join(baseDir, name)` without validation. Names like `../outside` or absolute paths would write agent scaffolding to arbitrary filesystem locations.

**Fix:** Reject names containing `/`, `\`, `..`, or empty strings before they reach the path join.

### [HIGH] FK blocks event retention pruning  
`parent_event_id` FK on `genie_runtime_events` used default `NO ACTION` delete behavior. When `genie db prune-events` deletes old parent events, child events referencing them would cause the delete to fail.

**Fix:** `ON DELETE SET NULL` — parent can be pruned while children retain their own data with a nulled-out parent reference.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun test` — 2163 pass, 0 fail
- [x] Init tests pass (`init-flow.test.ts`, `init-bootstrap.test.ts`)