### PR TITLE
chore: wish housekeeping — mark 14 shipped, 3 obsolete

### DIFF
--- a/.genie/wishes/auto-orchestrate/WISH.md
+++ b/.genie/wishes/auto-orchestrate/WISH.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | DRAFT |
+| **Status** | SHIPPED |
 | **Slug** | `auto-orchestrate` |
 | **Date** | 2026-03-17 |
 

--- a/.genie/wishes/docs-overhaul/WISH.md
+++ b/.genie/wishes/docs-overhaul/WISH.md
@@ -1,6 +1,6 @@
 # Wish: Documentation & Prompt Overhaul
 
-**Status:** DRAFT
+**Status:** SHIPPED
 **Slug:** `docs-overhaul`
 **Created:** 2026-03-16
 

--- a/.genie/wishes/fix-depends-parser/WISH.md
+++ b/.genie/wishes/fix-depends-parser/WISH.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | DRAFT |
+| **Status** | SHIPPED |
 | **Slug** | `fix-depends-parser` |
 | **Date** | 2026-03-17 |
 

--- a/.genie/wishes/fix-omni-bridge-hardening/WISH.md
+++ b/.genie/wishes/fix-omni-bridge-hardening/WISH.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | ready |
+| **Status** | SHIPPED |
 | **Slug** | `fix-omni-bridge-hardening` |
 | **Date** | 2026-04-04 |
 | **Priority** | P1 |

--- a/.genie/wishes/fix-session-uuid-resume/WISH.md
+++ b/.genie/wishes/fix-session-uuid-resume/WISH.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | DRAFT |
+| **Status** | OBSOLETE |
 | **Slug** | `fix-session-uuid-resume` |
 | **Date** | 2026-03-25 |
 | **Design** | N/A (trace-driven — root cause fully identified) |

--- a/.genie/wishes/genie-hacks-community-docs/WISH.md
+++ b/.genie/wishes/genie-hacks-community-docs/WISH.md
@@ -1,7 +1,7 @@
 ---
 title: "Wish: Genie Hacks + Community-Driven Documentation"
 date: 2026-03-24
-status: APPROVED
+status: SHIPPED
 slug: genie-hacks-community-docs
 ---
 

--- a/.genie/wishes/genie-omni-marriage/WISH.md
+++ b/.genie/wishes/genie-omni-marriage/WISH.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | approved |
+| **Status** | OBSOLETE |
 | **Slug** | `genie-omni-marriage` |
 | **Date** | 2026-03-24 |
 | **Design** | Brainstorm session 2026-03-24 (see memory: project_genie_omni_architecture.md) |

--- a/.genie/wishes/multi-agent-session-isolation/WISH.md
+++ b/.genie/wishes/multi-agent-session-isolation/WISH.md
@@ -1,5 +1,7 @@
 # Multi-Agent Session Isolation — WhatsApp Multi-Agent Routing
 
+**Status:** SHIPPED
+
 ## Summary
 Enable clean multi-agent coexistence on a single WhatsApp number. When Omni routes different chats to different agents (Sofia vs Claudia), each agent's genie session must spawn in the correct tmux session. Currently all windows land in the wrong session because `genie spawn` ignores the `sessionName` from the provider config.
 

--- a/.genie/wishes/parallel-execution/WISH.md
+++ b/.genie/wishes/parallel-execution/WISH.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | DRAFT |
+| **Status** | SHIPPED |
 | **Slug** | `parallel-execution` |
 | **Date** | 2026-03-17 |
 | **Design** | [DESIGN.md](../../brainstorms/parallel-execution/DESIGN.md) |

--- a/.genie/wishes/qa-dev-to-main/WISH.md
+++ b/.genie/wishes/qa-dev-to-main/WISH.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | DRAFT |
+| **Status** | OBSOLETE |
 | **Slug** | `qa-dev-to-main` |
 | **Date** | 2026-03-20 |
 | **PRs Included** | #673 (pgserve-embed), #674 (fire-and-forget), #675 (genie-scheduler) |

--- a/.genie/wishes/session-auto-create/WISH.md
+++ b/.genie/wishes/session-auto-create/WISH.md
@@ -1,5 +1,7 @@
 # Wish: --session flag auto-creates tmux session
 
+**Status:** SHIPPED
+
 Fixes: https://github.com/automagik-dev/genie/issues/691
 
 ## Problem

--- a/.genie/wishes/task-auto-close-on-merge/WISH.md
+++ b/.genie/wishes/task-auto-close-on-merge/WISH.md
@@ -1,7 +1,7 @@
 ---
 title: "Auto-advance tasks when PRs merge via wish slug matching"
 date: 2026-03-29
-status: APPROVED
+status: SHIPPED
 slug: task-auto-close-on-merge
 github_issue: 797
 priority: P1

--- a/.genie/wishes/task-projects/WISH.md
+++ b/.genie/wishes/task-projects/WISH.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | DRAFT |
+| **Status** | SHIPPED |
 | **Slug** | `task-projects` |
 | **Date** | 2026-03-23 |
 

--- a/.genie/wishes/test-pg-ram-isolation/WISH.md
+++ b/.genie/wishes/test-pg-ram-isolation/WISH.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | DRAFT |
+| **Status** | SHIPPED |
 | **Slug** | `test-pg-ram-isolation` |
 | **Date** | 2026-04-04 |
 | **Priority** | P1 |

--- a/.genie/wishes/unified-executor-layer/WISH.md
+++ b/.genie/wishes/unified-executor-layer/WISH.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | DRAFT |
+| **Status** | SHIPPED |
 | **Slug** | `unified-executor-layer` |
 | **Date** | 2026-04-04 |
 | **Supersedes** | `automagik-dev/genie#1042` (close, do not merge) |

--- a/.genie/wishes/unified-omni-bridge/WISH.md
+++ b/.genie/wishes/unified-omni-bridge/WISH.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | READY |
+| **Status** | SHIPPED |
 | **Slug** | `unified-omni-bridge` |
 | **Date** | 2026-04-05 |
 | **Priority** | P1 |

--- a/.genie/wishes/worktree-out-of-repo/WISH.md
+++ b/.genie/wishes/worktree-out-of-repo/WISH.md
@@ -1,6 +1,6 @@
 # Wish: Move worktrees out of repo to ~/.genie/worktrees/
 
-**Status:** DRAFT
+**Status:** SHIPPED
 **Slug:** `worktree-out-of-repo`
 **Created:** 2026-03-16
 


### PR DESCRIPTION
## Summary
- Audited all 80+ wishes against the current dev codebase
- Marked **14 wishes as SHIPPED** that were still showing DRAFT/APPROVED/READY despite being fully merged
- Marked **3 wishes as OBSOLETE** that were superseded or time-bound

## SHIPPED (14)
- `unified-omni-bridge` (PRs #1063, #1065)
- `fix-omni-bridge-hardening` (PR #1065)
- `unified-executor-layer` (PR #1062)
- `auto-orchestrate`, `fix-depends-parser`, `parallel-execution`
- `task-projects`, `test-pg-ram-isolation`, `task-auto-close-on-merge`
- `worktree-out-of-repo`, `docs-overhaul`, `genie-hacks-community-docs`
- `multi-agent-session-isolation`, `session-auto-create`

## OBSOLETE (3)
- `genie-omni-marriage` — superseded by individual smaller wishes
- `fix-session-uuid-resume` — UUID approach replaced by `--continue` by session name
- `qa-dev-to-main` — time-bound QA wish from March 20

## Remaining actionable wishes
After this cleanup, the backlog is:
- **APPROVED (4):** fix-agent-join-delay, daily-metrics-agent, agent-flexibility-guide, feature-matrix-page, messaging-refresh, voice-personality-pass
- **DRAFT still valid (8):** fix-trust-prompt, genie-base-skill, genie-stats-command, resilient-messaging, team-lead-minimal, tmux-split-tabbar, tmux-tui, workflow-engine-runtime
- **PARTIAL (5):** genie-hardening, hook-only-first-install, skills-v4-upgrade, v4-critical-fixes, genie-orchestration-fix

## Test plan
- [x] `bun test` — 2163 pass, 0 fail
- [x] Only `.genie/wishes/*/WISH.md` status fields changed — no code changes