### PR TITLE
feat: add PG-based readiness detection for spawned agents

### DIFF
--- a/.genie/wishes/daily-metrics-agent/WISH.md
+++ b/.genie/wishes/daily-metrics-agent/WISH.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | APPROVED |
+| **Status** | SHIPPED |
 | **Slug** | `daily-metrics-agent` |
 | **Date** | 2026-03-24 |
 

--- a/src/lib/executor-registry.ts
+++ b/src/lib/executor-registry.ts
@@ -145,6 +145,14 @@ export async function updateExecutorState(id: string, state: ExecutorState): Pro
   recordAuditEvent('executor', id, 'state_changed', process.env.GENIE_AGENT_NAME ?? 'cli', {
     state,
   }).catch(() => {});
+
+  // Emit a dedicated ready event when executor reaches 'running' state
+  if (state === 'running') {
+    recordAuditEvent('executor', id, 'executor.ready', process.env.GENIE_AGENT_NAME ?? 'cli', {
+      state,
+      readiness_source: 'state_transition',
+    }).catch(() => {});
+  }
 }
 
 /** Terminate an executor: set state='terminated', ended_at=now(). */

--- a/src/lib/protocol-router.ts
+++ b/src/lib/protocol-router.ts
@@ -16,9 +16,10 @@
 import * as registry from './agent-registry.js';
 import * as nativeTeams from './claude-native-teams.js';
 import { getConnection } from './db.js';
-import { getCurrentExecutor } from './executor-registry.js';
+import { findExecutorByPane, getCurrentExecutor } from './executor-registry.js';
 import * as mailbox from './mailbox.js';
 import { detectState } from './orchestrator/index.js';
+import { waitForExecutorReady } from './spawn-command.js';
 import { capturePaneContent, executeTmux, isPaneAlive } from './tmux.js';
 
 // ============================================================================
@@ -52,6 +53,19 @@ const AUTO_SPAWN_READY_TIMEOUT_MS = 15000;
 const AUTO_SPAWN_POLL_INTERVAL_MS = 1000;
 
 async function waitForWorkerReady(paneId: string, timeoutMs = AUTO_SPAWN_READY_TIMEOUT_MS): Promise<boolean> {
+  // Try PG-based readiness detection first (faster, cross-process)
+  try {
+    const executor = await findExecutorByPane(paneId);
+    if (executor && executor.state !== 'terminated' && executor.state !== 'error') {
+      const result = await waitForExecutorReady(executor.id, { timeoutMs });
+      if (result.ready) return true;
+      // PG readiness timed out — fall through to tmux scraping as safety net
+    }
+  } catch {
+    // PG unavailable — fall through to tmux scraping
+  }
+
+  // Fallback: original tmux pane scraping
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     try {

--- a/src/lib/spawn-command.test.ts
+++ b/src/lib/spawn-command.test.ts
@@ -8,8 +8,10 @@ import {
   DEFAULT_SPAWN_TIMEOUT_MS,
   READINESS_POLL_INTERVAL_MS,
   type WorkerProfile,
+  _pgDeps,
   buildSpawnCommand,
   waitForAgentReady,
+  waitForExecutorReady,
 } from './spawn-command.js';
 
 // ============================================================================
@@ -344,5 +346,86 @@ describe('waitForAgentReady', () => {
     await waitForAgentReady('%42', { timeoutMs: 500, pollIntervalMs: 50 });
 
     expect(mockCapturePaneContent).toHaveBeenCalledWith('%42', 50);
+  });
+});
+
+// ============================================================================
+// PG-Based Readiness Detection — waitForExecutorReady
+// ============================================================================
+
+describe('waitForExecutorReady', () => {
+  // Save original deps for restore
+  const origIsAvailable = _pgDeps.isAvailable;
+  const origGetConnection = _pgDeps.getConnection;
+  const origGetExecutor = _pgDeps.getExecutor;
+
+  afterEach(() => {
+    // Restore real deps
+    _pgDeps.isAvailable = origIsAvailable;
+    _pgDeps.getConnection = origGetConnection;
+    _pgDeps.getExecutor = origGetExecutor;
+  });
+
+  test('returns ready immediately if executor already in running state', async () => {
+    _pgDeps.isAvailable = async () => true;
+    _pgDeps.getExecutor = async () => ({ id: 'exec-1', state: 'running' });
+
+    const result = await waitForExecutorReady('exec-1', { timeoutMs: 500 });
+
+    expect(result.ready).toBe(true);
+    expect(result.elapsedMs).toBeLessThan(500);
+  });
+
+  test('returns ready immediately if executor already in idle state', async () => {
+    _pgDeps.isAvailable = async () => true;
+    _pgDeps.getExecutor = async () => ({ id: 'exec-1', state: 'idle' });
+
+    const result = await waitForExecutorReady('exec-1', { timeoutMs: 500 });
+
+    expect(result.ready).toBe(true);
+    expect(result.elapsedMs).toBeLessThan(500);
+  });
+
+  test('returns not ready if PG is unavailable (graceful degradation)', async () => {
+    _pgDeps.isAvailable = async () => false;
+
+    const result = await waitForExecutorReady('exec-1', { timeoutMs: 500 });
+
+    expect(result.ready).toBe(false);
+    expect(result.elapsedMs).toBe(0);
+  });
+
+  test('times out if executor stays in spawning state', async () => {
+    _pgDeps.isAvailable = async () => true;
+    _pgDeps.getExecutor = async () => ({ id: 'exec-1', state: 'spawning' });
+    _pgDeps.getConnection = async () => ({
+      listen: async () => ({ unlisten: async () => {} }),
+    });
+
+    const result = await waitForExecutorReady('exec-1', { timeoutMs: 300 });
+
+    expect(result.ready).toBe(false);
+    expect(result.elapsedMs).toBeGreaterThanOrEqual(300);
+  });
+
+  test('returns ready when executor transitions to running during poll', async () => {
+    _pgDeps.isAvailable = async () => true;
+
+    let callCount = 0;
+    _pgDeps.getExecutor = async () => {
+      callCount++;
+      // First call (initial check): spawning
+      // Second call (poll): running
+      if (callCount <= 1) return { id: 'exec-1', state: 'spawning' };
+      return { id: 'exec-1', state: 'running' };
+    };
+    _pgDeps.getConnection = async () => ({
+      listen: async () => ({ unlisten: async () => {} }),
+    });
+
+    const result = await waitForExecutorReady('exec-1', { timeoutMs: 5000 });
+
+    expect(result.ready).toBe(true);
+    expect(callCount).toBeGreaterThanOrEqual(2);
   });
 });

--- a/src/lib/spawn-command.ts
+++ b/src/lib/spawn-command.ts
@@ -5,6 +5,8 @@
  * Also provides readiness detection for freshly-spawned agents via tmux pane inspection.
  */
 
+import { getConnection, isAvailable } from './db.js';
+import { getExecutor } from './executor-registry.js';
 import { detectState } from './orchestrator/index.js';
 import { capturePaneContent } from './tmux.js';
 
@@ -146,4 +148,120 @@ export async function waitForAgentReady(
   }
 
   return { ready: false, elapsedMs: Date.now() - start };
+}
+
+// ============================================================================
+// PG-Based Readiness Detection
+// ============================================================================
+
+/** Overridable deps for PG-based readiness — avoids mock.module leaking across test files in bun. */
+export const _pgDeps = {
+  isAvailable: isAvailable as () => Promise<boolean>,
+  getConnection: getConnection as () => Promise<any>,
+  getExecutor: getExecutor as (id: string) => Promise<any>,
+};
+
+/**
+ * Wait for an executor to become ready via PG LISTEN/NOTIFY.
+ * Subscribes to `genie_executor_state` channel and waits for the executor
+ * to transition from 'spawning' to 'running' or 'idle'.
+ * Falls back to polling the executors table every 2s (safety net).
+ *
+ * @param executorId - The executor ID to wait for.
+ * @param opts.timeoutMs - Max wait time (default: DEFAULT_SPAWN_TIMEOUT_MS = 30s).
+ * @returns ReadinessResult with ready flag and elapsed time.
+ */
+export async function waitForExecutorReady(
+  executorId: string,
+  opts?: { timeoutMs?: number },
+): Promise<ReadinessResult> {
+  const timeoutMs = opts?.timeoutMs ?? DEFAULT_SPAWN_TIMEOUT_MS;
+  const start = Date.now();
+
+  // Graceful degradation: if PG is unavailable, return immediately
+  if (!(await _pgDeps.isAvailable())) {
+    return { ready: false, elapsedMs: 0 };
+  }
+
+  // First check: is executor already in a ready state?
+  try {
+    const executor = await _pgDeps.getExecutor(executorId);
+    if (executor && (executor.state === 'running' || executor.state === 'idle')) {
+      return { ready: true, elapsedMs: Date.now() - start };
+    }
+  } catch {
+    return { ready: false, elapsedMs: Date.now() - start };
+  }
+
+  // Subscribe to PG NOTIFY on genie_executor_state channel
+  // biome-ignore lint/suspicious/noExplicitAny: postgres.js Sql type requires generics we don't need
+  let sql: any;
+  try {
+    sql = await _pgDeps.getConnection();
+  } catch {
+    return { ready: false, elapsedMs: Date.now() - start };
+  }
+
+  return new Promise<ReadinessResult>((resolve) => {
+    let resolved = false;
+    let listener: { unlisten: () => Promise<void> } | null = null;
+    let pollInterval: ReturnType<typeof setInterval> | null = null;
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+
+    const cleanup = async () => {
+      if (pollInterval) clearInterval(pollInterval);
+      if (timeout) clearTimeout(timeout);
+      if (listener) {
+        try {
+          await listener.unlisten();
+        } catch {
+          /* best effort */
+        }
+      }
+    };
+
+    const finish = (ready: boolean) => {
+      if (resolved) return;
+      resolved = true;
+      cleanup().then(() => resolve({ ready, elapsedMs: Date.now() - start }));
+    };
+
+    // Timeout handler
+    timeout = setTimeout(() => finish(false), timeoutMs);
+
+    // LISTEN for executor state changes
+    sql
+      .listen('genie_executor_state', (payload: string) => {
+        // Payload format: executorId:agentId:oldState:newState
+        const parts = payload.split(':');
+        if (parts.length < 4) return;
+        const [notifyExecId, , , newState] = parts;
+        if (notifyExecId === executorId && (newState === 'running' || newState === 'idle')) {
+          finish(true);
+        }
+      })
+      .then((l: { unlisten: () => Promise<void> }) => {
+        listener = l;
+        // If already resolved before listener was set up, clean up immediately
+        if (resolved) {
+          l.unlisten().catch(() => {});
+        }
+      })
+      .catch(() => {
+        // LISTEN failed — rely on polling only
+      });
+
+    // Safety-net polling every 2s (handles missed NOTIFYs)
+    pollInterval = setInterval(async () => {
+      if (resolved) return;
+      try {
+        const executor = await _pgDeps.getExecutor(executorId);
+        if (executor && (executor.state === 'running' || executor.state === 'idle')) {
+          finish(true);
+        }
+      } catch {
+        /* transient error — keep polling */
+      }
+    }, READINESS_POLL_INTERVAL_MS);
+  });
 }


### PR DESCRIPTION
## Summary
- Add `waitForExecutorReady()` — PG LISTEN/NOTIFY readiness detection for spawned agents, with polling fallback
- Emit `executor.ready` audit event on state transition to `running`
- Wire PG-based readiness into `protocol-router.ts` `waitForWorkerReady()` as primary detection, falling back to tmux pane scraping
- 5 new tests for PG readiness (immediate ready, graceful degradation, timeout, poll transition)

Closes #712

## Test plan
- [x] `bun test src/lib/spawn-command.test.ts` — 29 pass
- [x] `bun test src/term-commands/dispatch.test.ts` — 54 pass
- [x] `bun run check` — 2168/2168 tests pass, typecheck clean