### PR TITLE
feat: inject turn-based WhatsApp prompt for omni bridge agents

### DIFF
--- a/src/services/executors/__tests__/claude-sdk.test.ts
+++ b/src/services/executors/__tests__/claude-sdk.test.ts
@@ -444,4 +444,60 @@ describe('ClaudeSdkOmniExecutor', () => {
       expect(createAndLinkExecutorMock).not.toHaveBeenCalled();
     });
   });
+
+  // ==========================================================================
+  // Turn-based prompt injection (Group 4 — omni-turn-based-dx)
+  // ==========================================================================
+
+  describe('turn-based prompt injection', () => {
+    beforeEach(() => {
+      resetAllMocks();
+    });
+
+    it('includes turn-based instructions in system prompt when OMNI_INSTANCE is set', async () => {
+      const env = { OMNI_INSTANCE: 'inst-wb', OMNI_CHAT: 'chat-wb', OMNI_AGENT: 'bot' };
+      const session = await executor.spawn('test-agent', 'chat-wb', env);
+
+      await executor.deliver(session, {
+        content: 'Hello from WhatsApp',
+        sender: 'Alice',
+        instanceId: 'inst-wb',
+        chatId: 'chat-wb',
+        agent: 'test-agent',
+      });
+      await executor.waitForDeliveries(session.id);
+
+      expect(queryMock).toHaveBeenCalledTimes(1);
+      const callArgs = (queryMock.mock.calls[0] as unknown as [{ options?: { systemPrompt?: string } }])[0];
+      const systemPrompt = callArgs.options?.systemPrompt ?? '';
+
+      // Verify turn-based prompt content
+      expect(systemPrompt).toContain('WhatsApp');
+      expect(systemPrompt).toContain('Alice');
+      expect(systemPrompt).toContain('omni say');
+      expect(systemPrompt).toContain('omni done');
+      expect(systemPrompt).toContain('inst-wb');
+    });
+
+    it('does NOT include turn-based instructions when OMNI_INSTANCE is absent', async () => {
+      const session = await executor.spawn('test-agent', 'chat-plain', {});
+
+      await executor.deliver(session, {
+        content: 'Hello from CLI',
+        sender: 'bob',
+        instanceId: 'inst-1',
+        chatId: 'chat-plain',
+        agent: 'test-agent',
+      });
+      await executor.waitForDeliveries(session.id);
+
+      expect(queryMock).toHaveBeenCalledTimes(1);
+      const callArgs = (queryMock.mock.calls[0] as unknown as [{ options?: { systemPrompt?: string } }])[0];
+      const systemPrompt = callArgs.options?.systemPrompt ?? '';
+
+      expect(systemPrompt).not.toContain('WhatsApp');
+      expect(systemPrompt).not.toContain('omni say');
+      expect(systemPrompt).not.toContain('omni done');
+    });
+  });
 });

--- a/src/services/executors/claude-sdk.ts
+++ b/src/services/executors/claude-sdk.ts
@@ -41,6 +41,28 @@ async function loadSystemPrompt(entry: directory.DirectoryEntry): Promise<string
   }
 }
 
+/**
+ * Resolve the system prompt for a delivery, optionally prepending turn-based
+ * WhatsApp instructions when the session is running via the Omni bridge.
+ *
+ * Returns `{ prompt, isTurnBased }` so the caller can decide whether to
+ * send the prompt on resume deliveries.
+ */
+async function resolveSystemPrompt(
+  entry: directory.DirectoryEntry,
+  state: SdkSessionState,
+  message: OmniMessage,
+  chatId: string,
+): Promise<{ prompt: string | undefined; isTurnBased: boolean }> {
+  let prompt = await loadSystemPrompt(entry);
+  const isTurnBased = Boolean(state.env.OMNI_INSTANCE);
+  if (isTurnBased) {
+    const turnPrompt = buildTurnBasedPrompt(message.sender, state.env.OMNI_INSTANCE, state.env.OMNI_CHAT ?? chatId);
+    prompt = prompt ? `${turnPrompt}\n\n${prompt}` : turnPrompt;
+  }
+  return { prompt, isTurnBased };
+}
+
 interface QueryResult {
   text: string;
   sessionId?: string;
@@ -314,20 +336,7 @@ export class ClaudeSdkOmniExecutor implements IExecutor {
 
     const entry = resolved.entry;
     const permissionConfig = resolvePermissionConfig(entry.permissions);
-    let systemPrompt = await loadSystemPrompt(entry);
-
-    // Inject turn-based WhatsApp instructions when running via Omni bridge.
-    // Prepended on every delivery because the system prompt may not persist
-    // across SDK resume calls.
-    const isTurnBased = Boolean(state.env.OMNI_INSTANCE);
-    if (isTurnBased) {
-      const turnPrompt = buildTurnBasedPrompt(
-        message.sender,
-        state.env.OMNI_INSTANCE,
-        state.env.OMNI_CHAT ?? session.chatId,
-      );
-      systemPrompt = systemPrompt ? `${turnPrompt}\n\n${systemPrompt}` : turnPrompt;
-    }
+    const { prompt: systemPrompt, isTurnBased } = await resolveSystemPrompt(entry, state, message, session.chatId);
 
     if (state.executorId) await this.updateState(state.executorId, 'working', session.chatId);
 

--- a/src/services/executors/claude-sdk.ts
+++ b/src/services/executors/claude-sdk.ts
@@ -9,6 +9,7 @@ import { resolvePermissionConfig } from '../../lib/providers/claude-sdk-permissi
 import { ClaudeSdkProvider } from '../../lib/providers/claude-sdk.js';
 import type { IExecutor, NatsPublishFn, OmniMessage, OmniSession, SafePgCallFn } from '../executor.js';
 import { endSession, recordTurn, startSession, updateTurnCount } from './sdk-session-capture.js';
+import { buildTurnBasedPrompt } from './turn-based-prompt.js';
 
 // ============================================================================
 // Types
@@ -313,7 +314,20 @@ export class ClaudeSdkOmniExecutor implements IExecutor {
 
     const entry = resolved.entry;
     const permissionConfig = resolvePermissionConfig(entry.permissions);
-    const systemPrompt = await loadSystemPrompt(entry);
+    let systemPrompt = await loadSystemPrompt(entry);
+
+    // Inject turn-based WhatsApp instructions when running via Omni bridge.
+    // Prepended on every delivery because the system prompt may not persist
+    // across SDK resume calls.
+    const isTurnBased = Boolean(state.env.OMNI_INSTANCE);
+    if (isTurnBased) {
+      const turnPrompt = buildTurnBasedPrompt(
+        message.sender,
+        state.env.OMNI_INSTANCE,
+        state.env.OMNI_CHAT ?? session.chatId,
+      );
+      systemPrompt = systemPrompt ? `${turnPrompt}\n\n${systemPrompt}` : turnPrompt;
+    }
 
     if (state.executorId) await this.updateState(state.executorId, 'working', session.chatId);
 
@@ -350,7 +364,7 @@ export class ClaudeSdkOmniExecutor implements IExecutor {
         role: session.agentName,
         cwd: entry.dir || process.cwd(),
         model: entry.model,
-        systemPrompt: state.claudeSessionId ? undefined : systemPrompt,
+        systemPrompt: state.claudeSessionId && !isTurnBased ? undefined : systemPrompt,
       },
       queryContent,
       permissionConfig,

--- a/src/services/executors/turn-based-prompt.ts
+++ b/src/services/executors/turn-based-prompt.ts
@@ -1,0 +1,30 @@
+/**
+ * Turn-based WhatsApp system prompt for agents spawned via the Omni bridge.
+ *
+ * Injected on every delivery when OMNI_INSTANCE is present in the executor env.
+ * Teaches the agent how to reply via omni CLI verbs and close the turn.
+ */
+
+export function buildTurnBasedPrompt(senderName: string, instanceId: string, chatId: string): string {
+  return `
+# WhatsApp Turn-Based Conversation
+
+You are responding to a WhatsApp message from ${senderName}.
+Your context is pre-set (instance: ${instanceId}, chat: ${chatId}) — do NOT use \`omni use\` or \`omni open\`.
+
+## Available Commands
+
+- \`omni say 'text'\` — reply with a text message
+- \`omni speak 'text'\` — reply with a voice note
+- \`omni imagine 'prompt'\` — generate and send an image
+- \`omni react 'emoji' --message <id>\` — react to a message
+- \`omni history\` — see recent messages for context
+
+## Rules
+
+1. Use \`omni say\` to send your response. You can send multiple messages.
+2. Use \`omni history\` to see recent messages if you need context.
+3. ALWAYS call \`omni done\` as your LAST action to close the turn.
+4. Do NOT generate bare text as your reply — it will go nowhere. Use \`omni say\` or the \`done\` tool.
+`.trim();
+}

--- a/src/services/executors/turn-based-prompt.ts
+++ b/src/services/executors/turn-based-prompt.ts
@@ -26,6 +26,6 @@ Your context is pre-set (instance: ${instanceId}, chat: ${chatId}) — do NOT us
 1. Use \`omni say\` to send your response. You can send multiple messages.
 2. Use \`omni history\` to see recent messages if you need context.
 3. ALWAYS call \`omni done\` as your LAST action to close the turn.
-4. Do NOT generate bare text as your reply — it will go nowhere. Use \`omni say\` or the \`done\` tool.
+4. Do NOT generate bare text as your reply — it will go nowhere. Use omni say or omni done.
 `.trim();
 }

--- a/src/services/executors/turn-based-prompt.ts
+++ b/src/services/executors/turn-based-prompt.ts
@@ -14,11 +14,12 @@ Your context is pre-set (instance: ${instanceId}, chat: ${chatId}) — do NOT us
 
 ## Available Commands
 
-- \`omni say 'text'\` — reply with a text message
-- \`omni speak 'text'\` — reply with a voice note
-- \`omni imagine 'prompt'\` — generate and send an image
-- \`omni react 'emoji' --message <id>\` — react to a message
-- \`omni history\` — see recent messages for context
+- omni say 'text' — reply with a text message
+- omni speak 'text' — reply with a voice note
+- omni imagine 'prompt' — generate and send an image
+- omni react 'emoji' --message <id> — react to a message
+- omni history — see recent messages for context
+- omni done — end your turn (REQUIRED as the last action)
 
 ## Rules
 


### PR DESCRIPTION
## Summary

- Adds `src/services/executors/turn-based-prompt.ts` exporting `buildTurnBasedPrompt()` — a concise system prompt that teaches agents spawned via the omni bridge how to use `omni say`, `omni speak`, `omni imagine`, `omni react`, `omni history`, and `omni done` to participate in WhatsApp conversations.
- Modifies `_processDelivery()` in `claude-sdk.ts` to prepend the turn-based prompt to the system prompt on every delivery when `OMNI_INSTANCE` is present in the executor env. This ensures the prompt persists even across SDK resume boundaries.
- Adds 2 tests verifying prompt injection is conditional on `OMNI_INSTANCE`.

## Context

During QA, agents spawned via the bridge responded but never called `omni done` or `omni say` — they just generated text that went nowhere. This prompt gives them the vocabulary and protocol to actually participate in the WhatsApp conversation.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` has no errors from changed files (pre-existing warnings only)
- [x] `bun test src/services/executors/__tests__/claude-sdk.test.ts` — all 24 tests pass
- [x] Full test suite: 2170 tests pass