### PR TITLE
refactor: rename brain import to @khal-os/brain + tarball install

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# Brain installs from release tarballs, not registry.
+# Override global @khal-os scope that points to GitHub Packages.
+# Other @khal-os packages (ui, etc.) come from npmjs.org (default).
+@khal-os:registry=https://registry.npmjs.org

--- a/docs/CLI-REFERENCE.md
+++ b/docs/CLI-REFERENCE.md
@@ -1024,7 +1024,7 @@ Show service health.
 
 ## Brain (Enterprise)
 
-`genie brain` -- Knowledge graph engine (enterprise). Delegates to `@automagik/genie-brain`.
+`genie brain` -- Knowledge graph engine (enterprise). Delegates to `@khal-os/brain`.
 
 Brain is never a hard dependency. Genie works the same without it.
 

--- a/knip.json
+++ b/knip.json
@@ -29,7 +29,7 @@
   "ignoreBinaries": ["which"],
   "ignoreExportsUsedInFile": false,
   "ignoreDependencies": [
-    "@automagik/genie-brain",
+    "@khal-os/brain",
     "@tauri-apps/cli",
     "@tauri-apps/api",
     "react-dom",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "prepare": "test \"$CI\" = true || husky",
     "version": "bun run scripts/version.ts",
-    "build": "bun build src/genie.ts --outdir dist --target bun --minify-syntax --minify-whitespace --external bun --external pgserve --external @automagik/genie-brain --external @anthropic-ai/claude-agent-sdk && chmod +x dist/*.js",
+    "build": "bun build src/genie.ts --outdir dist --target bun --minify-syntax --minify-whitespace --external bun --external pgserve --external @khal-os/brain --external @anthropic-ai/claude-agent-sdk && chmod +x dist/*.js",
     "build:app": "bun run scripts/build-app.ts",
     "build:plugin": "node scripts/build.js",
     "sync": "node scripts/sync.js",

--- a/src/hooks/handlers/brain-inject.ts
+++ b/src/hooks/handlers/brain-inject.ts
@@ -16,8 +16,8 @@ import { existsSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import type { HandlerResult, HookPayload } from '../types.js';
 
-const BRAIN_PKG = '@automagik/genie-brain';
-const BRAIN_DIR = 'node_modules/@automagik/genie-brain';
+const BRAIN_PKG = '@khal-os/brain';
+const BRAIN_DIR = 'node_modules/@khal-os/brain';
 
 /** Track which sessions have already been enriched. */
 const enrichedSessions = new Set<string>();

--- a/src/lib/protocol-router-spawn.ts
+++ b/src/lib/protocol-router-spawn.ts
@@ -299,7 +299,7 @@ export async function spawnWorkerFromTemplate(
   // Auto-brain: discover brain/ dir → register in knowledge graph
   try {
     // @ts-expect-error — brain is enterprise-only, not in genie's deps
-    const brain = await import('@automagik/genie-brain');
+    const brain = await import('@khal-os/brain');
     if (brain.autoBrain) {
       await brain.autoBrain({ agentId: workerId, workdir: repoPath });
     }

--- a/src/lib/task-service.ts
+++ b/src/lib/task-service.ts
@@ -624,7 +624,7 @@ export async function createTask(input: TaskInput, repoPath?: string, projectId?
   if (input.metadata?.brain) {
     try {
       // @ts-expect-error — brain is enterprise-only, not in genie's deps
-      const brain = await import('@automagik/genie-brain');
+      const brain = await import('@khal-os/brain');
       if (brain.taskBrain) {
         await brain.taskBrain({ taskId: String(task.id), workdir: repo });
       }

--- a/src/term-commands/brain.ts
+++ b/src/term-commands/brain.ts
@@ -1,9 +1,9 @@
 /**
- * genie brain — delegate to @automagik/genie-brain (enterprise).
+ * genie brain — delegate to @khal-os/brain (enterprise).
  *
- * Brain installs directly from the private GitHub repo.
+ * Brain installs from a release tarball on the private GitHub repo.
  * Only people with repo access can install = enterprise license.
- * Source code stays in git, never published to npm.
+ * Published to GitHub Packages + release tarballs, never to npmjs.
  *
  * Brain is NEVER a hard dependency. genie works exactly the same
  * without it. Zero behavior change for OSS users.
@@ -15,8 +15,8 @@ import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import type { Command } from 'commander';
 
-const BRAIN_PKG = '@automagik/genie-brain';
-const BRAIN_REPO = 'github:automagik-dev/genie-brain';
+const BRAIN_PKG = '@khal-os/brain';
+const BRAIN_REPO = 'khal-os/brain';
 
 /** Resolve genie's package root — works from both src/ (dev) and dist/ (compiled). */
 function resolveGenieRoot(): string {
@@ -219,13 +219,13 @@ async function showVersion(): Promise<void> {
 
 // ── Install brain ──────────────────────────────────────────────────────────
 
-/** Install brain package directly from GitHub repo */
+/** Install brain package from GitHub release tarball */
 async function installBrain(): Promise<boolean> {
   console.log('');
-  console.log('  Installing genie-brain from GitHub (enterprise)...');
+  console.log('  Installing brain from GitHub release (enterprise)...');
   console.log('');
-  console.log('  Source: https://github.com/automagik-dev/genie-brain');
-  console.log('  Requires: GitHub org membership (automagik-dev)');
+  console.log('  Source: https://github.com/khal-os/brain');
+  console.log('  Requires: GitHub org membership (khal-os)');
   console.log('');
 
   try {
@@ -237,19 +237,41 @@ async function installBrain(): Promise<boolean> {
       return false;
     }
 
-    // Clone brain repo using gh CLI (handles private repos without exposing tokens in process list)
-    execSync(`rm -rf "${BRAIN_DIR}"`, { stdio: 'pipe' });
-    execSync(`mkdir -p "${dirname(BRAIN_DIR)}"`, { stdio: 'pipe' });
-    execSync(`gh repo clone automagik-dev/genie-brain "${BRAIN_DIR}" -- --depth 1`, {
+    // Resolve latest release tag and download tarball via gh (handles private repo auth)
+    const tag = execSync(`gh release view --repo ${BRAIN_REPO} --json tagName -q .tagName`, {
+      stdio: 'pipe',
+      encoding: 'utf-8',
+    }).trim();
+    const version = tag.replace(/^v/, '');
+
+    console.log(`  Latest release: ${tag}`);
+    console.log('');
+
+    // Download tarball via gh (handles private repo auth) and extract to node_modules.
+    // We bypass `bun add` because .npmrc scope config causes bun to verify against
+    // GitHub Packages registry even for local tarballs, triggering 401 on machines
+    // without registry tokens.
+    const root = resolveGenieRoot();
+    const brainDir = join(root, 'node_modules', '@khal-os', 'brain');
+    const tmpDir = join(homedir(), '.cache', 'genie-brain');
+    mkdirSync(tmpDir, { recursive: true });
+
+    execSync(`gh release download ${tag} --repo ${BRAIN_REPO} --pattern '*.tgz' --dir "${tmpDir}" --clobber`, {
       stdio: 'inherit',
     });
 
-    // Install brain's deps + build
-    execSync('bun install', { cwd: BRAIN_DIR, stdio: 'inherit' });
-    execSync('bun run build', { cwd: BRAIN_DIR, stdio: 'inherit' });
+    // Extract tarball — npm tarballs contain a `package/` prefix
+    execSync(`rm -rf "${brainDir}"`, { stdio: 'pipe' });
+    mkdirSync(brainDir, { recursive: true });
+    execSync(`tar xzf "${tmpDir}/khal-os-brain-${version}.tgz" -C "${brainDir}" --strip-components=1`, {
+      stdio: 'inherit',
+    });
+
+    // Install brain's runtime deps (postgres, pgserve, etc.)
+    execSync('bun install', { cwd: brainDir, stdio: 'inherit' });
 
     console.log('');
-    console.log('  Brain installed from GitHub.');
+    console.log(`  Brain ${version} installed from GitHub release.`);
     console.log('');
 
     // Auto-run migrations
@@ -276,17 +298,21 @@ async function installBrain(): Promise<boolean> {
       console.error('  Access denied. Brain is enterprise-only.');
       console.log('');
       console.log('  You need:');
-      console.log('    1. Membership in the automagik-dev GitHub org');
-      console.log('    2. SSH key or GH token configured for git');
+      console.log('    1. Membership in the khal-os GitHub org');
+      console.log('    2. GitHub CLI authenticated: gh auth login');
       console.log('');
       console.log('  Manual install:');
-      console.log(`    bun add ${BRAIN_REPO}`);
+      console.log(
+        `    gh release download --repo ${BRAIN_REPO} --pattern '*.tgz' && bun add ${BRAIN_PKG}@./khal-os-brain-*.tgz`,
+      );
       console.log('');
     } else {
       console.error(`  Install failed: ${msg}`);
       console.log('');
       console.log('  Manual install:');
-      console.log(`    bun add ${BRAIN_REPO}`);
+      console.log(
+        `    gh release download --repo ${BRAIN_REPO} --pattern '*.tgz' && bun add ${BRAIN_PKG}@./khal-os-brain-*.tgz`,
+      );
       console.log('');
     }
     return false;
@@ -295,10 +321,11 @@ async function installBrain(): Promise<boolean> {
 
 function uninstallBrain(): void {
   try {
-    execSync(`rm -rf "${BRAIN_DIR}"`, { stdio: 'pipe' });
+    const root = resolveGenieRoot();
+    execSync(`bun remove ${BRAIN_PKG}`, { cwd: root, stdio: 'pipe' });
     console.log('  Brain uninstalled.');
   } catch {
-    console.error('  Uninstall failed. Manual: rm -rf node_modules/@automagik/genie-brain');
+    console.error(`  Uninstall failed. Manual: rm -rf ${BRAIN_DIR}`);
   }
 }
 

--- a/src/term-commands/brain.ts
+++ b/src/term-commands/brain.ts
@@ -36,7 +36,7 @@ function resolveGenieRoot(): string {
   return resolve(import.meta.dir, '..', '..');
 }
 
-const BRAIN_DIR = join(resolveGenieRoot(), 'node_modules', '@automagik', 'genie-brain');
+const BRAIN_DIR = join(resolveGenieRoot(), 'node_modules', '@khal-os', 'brain');
 const CACHE_PATH = join(homedir(), '.genie', 'brain-version-check.json');
 
 /** Compare dot-separated version strings numerically (e.g., "260403.9" vs "260403.10"). */
@@ -87,20 +87,15 @@ export function checkForUpdates(cachePath?: string): UpdateCheck {
 
 function refreshVersionCache(localVersion?: string): void {
   try {
-    if (!existsSync(join(BRAIN_DIR, '.git'))) return;
-
     // Resolve local version from param or package.json
     const version = localVersion ?? readLocalBrainVersion();
     if (!version) return;
 
-    // Fetch latest tags from remote
-    execSync(`git -C "${BRAIN_DIR}" fetch origin --tags`, { stdio: 'pipe' });
-
-    // Find latest v0.* tag via version sort
-    const tagsOutput = execSync(`git -C "${BRAIN_DIR}" tag -l "v0.*" --sort=-version:refname`, {
+    // Query latest release from GitHub via gh CLI (works for private repos)
+    const latestTag = execSync(`gh release view --repo ${BRAIN_REPO} --json tagName -q .tagName`, {
+      stdio: 'pipe',
       encoding: 'utf-8',
-    });
-    const latestTag = tagsOutput.trim().split('\n')[0] ?? '';
+    }).trim();
     const latestVersion = latestTag.replace(/^v/, '');
 
     // Compare: strip prefix digit for comparison (dev uses 1.x, main uses 0.x)
@@ -133,40 +128,55 @@ function refreshVersionCache(localVersion?: string): void {
 // ── Update brain from GitHub ───────────────────────────────────────────────
 
 async function updateBrain(): Promise<boolean> {
-  // Check brain is installed (has .git dir from clone)
-  if (!existsSync(join(BRAIN_DIR, '.git'))) {
+  // Check brain is installed (has package.json from tarball extract)
+  if (!existsSync(join(BRAIN_DIR, 'package.json'))) {
     console.log('  Brain is not installed. Run: genie brain install');
     return false;
   }
 
-  // Get old version before pull
-  let oldVersion = 'unknown';
+  // Get old version before update
+  const oldVersion = readLocalBrainVersion() ?? 'unknown';
+
+  console.log('  Checking for updates...');
+
+  // Query latest release from GitHub
+  let tag: string;
   try {
-    const brain = await import(BRAIN_PKG);
-    oldVersion = brain.getVersion?.() ?? 'unknown';
+    tag = execSync(`gh release view --repo ${BRAIN_REPO} --json tagName -q .tagName`, {
+      stdio: 'pipe',
+      encoding: 'utf-8',
+    }).trim();
   } catch {
-    /* ok */
+    console.error('  Failed to check latest release. Ensure: gh auth login');
+    return false;
   }
 
-  console.log('  Updating brain from GitHub...');
+  const newVersion = tag.replace(/^v/, '');
+  if (compareVersions(newVersion, oldVersion) <= 0) {
+    console.log(`  Already at latest version (${oldVersion}).`);
+    return true;
+  }
 
-  // Ensure we're on main before pulling — if the clone is on dev,
-  // `git pull origin main` merges main INTO dev, keeping the dev version.
-  execSync(`git -C "${BRAIN_DIR}" checkout main`, { stdio: 'pipe' });
-  execSync(`git -C "${BRAIN_DIR}" pull origin main`, { stdio: 'inherit' });
+  console.log(`  Upgrading: ${oldVersion} → ${newVersion}`);
+  console.log('');
 
-  // Rebuild
+  // Download and extract new tarball (same flow as install)
+  const tmpDir = join(homedir(), '.cache', 'genie-brain');
+  mkdirSync(tmpDir, { recursive: true });
+
+  execSync(`gh release download ${tag} --repo ${BRAIN_REPO} --pattern '*.tgz' --dir "${tmpDir}" --clobber`, {
+    stdio: 'inherit',
+  });
+
+  // Replace existing install
+  execSync(`rm -rf "${BRAIN_DIR}"`, { stdio: 'pipe' });
+  mkdirSync(BRAIN_DIR, { recursive: true });
+  execSync(`tar xzf "${tmpDir}/khal-os-brain-${newVersion}.tgz" -C "${BRAIN_DIR}" --strip-components=1`, {
+    stdio: 'inherit',
+  });
+
+  // Install runtime deps
   execSync('bun install', { cwd: BRAIN_DIR, stdio: 'inherit' });
-  execSync('bun run build', { cwd: BRAIN_DIR, stdio: 'inherit' });
-
-  // Get new version (read from package.json since module cache won't refresh)
-  let newVersion = 'unknown';
-  try {
-    const pkg = JSON.parse(readFileSync(join(BRAIN_DIR, 'package.json'), 'utf-8'));
-    newVersion = pkg.version ?? 'unknown';
-  } catch {
-    /* ok */
-  }
 
   console.log(`\n  Updated: ${oldVersion} → ${newVersion}`);
 
@@ -302,17 +312,15 @@ async function installBrain(): Promise<boolean> {
       console.log('    2. GitHub CLI authenticated: gh auth login');
       console.log('');
       console.log('  Manual install:');
-      console.log(
-        `    gh release download --repo ${BRAIN_REPO} --pattern '*.tgz' && bun add ${BRAIN_PKG}@./khal-os-brain-*.tgz`,
-      );
+      console.log(`    gh release download --repo ${BRAIN_REPO} --pattern '*.tgz'`);
+      console.log('    tar xzf khal-os-brain-*.tgz -C node_modules/@khal-os/brain --strip-components=1');
       console.log('');
     } else {
       console.error(`  Install failed: ${msg}`);
       console.log('');
       console.log('  Manual install:');
-      console.log(
-        `    gh release download --repo ${BRAIN_REPO} --pattern '*.tgz' && bun add ${BRAIN_PKG}@./khal-os-brain-*.tgz`,
-      );
+      console.log(`    gh release download --repo ${BRAIN_REPO} --pattern '*.tgz'`);
+      console.log('    tar xzf khal-os-brain-*.tgz -C node_modules/@khal-os/brain --strip-components=1');
       console.log('');
     }
     return false;
@@ -321,8 +329,11 @@ async function installBrain(): Promise<boolean> {
 
 function uninstallBrain(): void {
   try {
-    const root = resolveGenieRoot();
-    execSync(`bun remove ${BRAIN_PKG}`, { cwd: root, stdio: 'pipe' });
+    if (!existsSync(BRAIN_DIR)) {
+      console.log('  Brain is not installed.');
+      return;
+    }
+    execSync(`rm -rf "${BRAIN_DIR}"`, { stdio: 'pipe' });
     console.log('  Brain uninstalled.');
   } catch {
     console.error(`  Uninstall failed. Manual: rm -rf ${BRAIN_DIR}`);
@@ -342,7 +353,7 @@ function printNotInstalledMessage(): void {
   console.log('');
   console.log('    genie brain install');
   console.log('');
-  console.log('  Requires GitHub org membership (automagik-dev).');
+  console.log('  Requires GitHub org membership (khal-os).');
   console.log('');
 }
 


### PR DESCRIPTION
## Summary
- Renames all brain imports from `@automagik/genie-brain` to `@khal-os/brain` (the actual published package name)
- `genie brain install` now downloads release tarball via `gh` CLI and extracts to `node_modules/` — no full repo clone, no build step
- Avoids scope conflicts with public `@khal-os/*` packages on npmjs.org (brain is private on GitHub Packages)
- Added local `.npmrc` to override global `@khal-os` scope pointing to GitHub Packages

## Files changed
- `src/hooks/handlers/brain-inject.ts` — BRAIN_PKG + BRAIN_DIR constants
- `src/term-commands/brain.ts` — install flow, constants, error messages
- `src/lib/task-service.ts` — dynamic import
- `src/lib/protocol-router-spawn.ts` — dynamic import
- `package.json` — build --external, removed stale dependency
- `knip.json` — ignore list
- `docs/CLI-REFERENCE.md` — doc reference
- `.npmrc` — scope override

## Test plan
- [x] `import('@khal-os/brain')` resolves correctly after tarball extract
- [x] Zero references to `@automagik/genie-brain` remaining
- [x] Pre-commit hooks pass (biome format + lint)
- [ ] Companion PR: khal-os/brain#114 (adds tarball to releases)