### PR TITLE
fix(tui): pass --new-window when spawning agents from Nav

### DIFF
--- a/src/tui/components/Nav.tsx
+++ b/src/tui/components/Nav.tsx
@@ -552,8 +552,8 @@ function spawnAgent(name: string, onTmuxSessionSelect?: (sessionName: string, wi
     const spawnOpts = { detached: true, stdio: 'ignore' as const, cwd, env: cleanEnv };
     const child =
       genieBin && genieBin !== 'genie'
-        ? spawn(bunPath, [genieBin, 'spawn', name, '--session', sessionName], spawnOpts)
-        : spawn('genie', ['spawn', name, '--session', sessionName], spawnOpts);
+        ? spawn(bunPath, [genieBin, 'spawn', name, '--session', sessionName, '--new-window'], spawnOpts)
+        : spawn('genie', ['spawn', name, '--session', sessionName, '--new-window'], spawnOpts);
     child.unref();
     if (onTmuxSessionSelect) {
       attachSpawnedAgentWhenReady(sessionName, onTmuxSessionSelect);


### PR DESCRIPTION
## Summary
- TUI's `spawnAgent()` was missing `--new-window` flag, causing new agents to spawn as panes in the current window instead of dedicated windows
- Fixed by aligning with the existing correct pattern in `src/tui/tmux.ts:140` (`newAgentWindow()`)

## Root Cause
Without `--new-window`, `handleWorkerSpawn` falls through `resolveSpawnTeamWindow` → `ensureTeamWindow` → returns `created=true` → `createTmuxPane` executes `split-window` instead of routing through the new-window path in `agents.ts:778`.

## Test plan
- [x] `bun run typecheck` — clean
- [x] Pre-commit hooks pass
- [x] Single-line change in `src/tui/components/Nav.tsx:555`