### PR TITLE
feat: cascading model resolution with workspace defaults

### DIFF
--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -19,7 +19,6 @@
 import { execSync } from 'node:child_process';
 import { existsSync, watch as fsWatch, readFileSync, readdirSync, realpathSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { tmpdir } from 'node:os';
 import * as directory from './agent-directory.js';
 import { BUILTIN_DEFAULTS, type DefaultField, type ResolveContext, resolveFieldWithSource } from './defaults.js';
 import { parseFrontmatter } from './frontmatter.js';
@@ -365,10 +364,10 @@ async function syncSingleAgent(agent: AgentInfo, result: SyncResult, workspaceRo
   const fm = parseFrontmatter(content);
 
   // Compute resolved metadata if workspace root is available
-  let resolvedMeta: { declared: Record<string, unknown>; resolved: Record<string, unknown> } | undefined;
+  let _resolvedMeta: { declared: Record<string, unknown>; resolved: Record<string, unknown> } | undefined;
   if (workspaceRoot) {
     const ctx = buildResolveContext(workspaceRoot, agent.name);
-    resolvedMeta = computeResolvedMetadata(fm as Record<string, unknown>, ctx);
+    _resolvedMeta = computeResolvedMetadata(fm as Record<string, unknown>, ctx);
   }
 
   // Use resolve() to distinguish PG entries from built-ins.
@@ -441,7 +440,15 @@ async function syncSingleAgentByName(workspaceRoot: string, agentName: string): 
   const agent = discoverSingleAgent(workspaceRoot, agentName);
   if (!agent) return 'not-found';
 
-  const result: SyncResult = { registered: [], updated: [], unchanged: [], archived: [], reactivated: [], healed: [], errors: [] };
+  const result: SyncResult = {
+    registered: [],
+    updated: [],
+    unchanged: [],
+    archived: [],
+    reactivated: [],
+    healed: [],
+    errors: [],
+  };
   await syncSingleAgent(agent, result, workspaceRoot);
 
   if (result.registered.length > 0) return 'registered';

--- a/src/lib/providers/__tests__/claude-sdk.test.ts
+++ b/src/lib/providers/__tests__/claude-sdk.test.ts
@@ -1,30 +1,25 @@
-import { beforeEach, describe, expect, it, mock } from 'bun:test';
+// IMPORTANT: Import _sdk-mocks FIRST — it registers the process-global
+// mock.module for @anthropic-ai/claude-agent-sdk. Bun's mock.module is
+// process-global; the first file to register wins. Without this import,
+// this file's own mock registration races with _sdk-mocks.ts and whichever
+// loads first in CI (alphabetical order) determines which queryMock is live.
+// Sharing one registration eliminates the 9 CI-only flaky failures.
+import { queryMock, resetQueryMock } from '../../../services/executors/__tests__/_sdk-mocks.js';
+
+import { beforeEach, describe, expect, it, type mock } from 'bun:test';
 import type { SpawnContext } from '../../executor-types.js';
 
-// Mock the SDK query function before importing provider
-mock.module('@anthropic-ai/claude-agent-sdk', () => ({
-  query: mock(() => {
-    const gen = (async function* () {
-      yield { type: 'assistant', message: { content: [{ type: 'text', text: 'hello' }] } };
-    })();
-    return Object.assign(gen, {
-      interrupt: mock(),
-      setPermissionMode: mock(),
-      setModel: mock(),
-      return: mock(async () => ({ value: undefined, done: true })),
-      throw: mock(async () => ({ value: undefined, done: true })),
-    });
-  }),
-}));
-
 const { ClaudeSdkProvider } = await import('../claude-sdk.js');
-const sdk = await import('@anthropic-ai/claude-agent-sdk');
+
+// Alias for backward compat with assertions that used `sdk.query`
+const sdk = { query: queryMock } as { query: ReturnType<typeof mock> };
 
 describe('ClaudeSdkProvider', () => {
   let provider: InstanceType<typeof ClaudeSdkProvider>;
   let ctx: SpawnContext;
 
   beforeEach(() => {
+    resetQueryMock();
     provider = new ClaudeSdkProvider();
     ctx = {
       agentId: 'test-agent',

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -7,7 +7,7 @@
 
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { BUILTIN_DEFAULTS, type AgentDefaults, computeEffectiveDefaults } from '../lib/defaults.js';
+import { type AgentDefaults, BUILTIN_DEFAULTS, computeEffectiveDefaults } from '../lib/defaults.js';
 
 export const SOUL_TEMPLATE = `# Soul
 
@@ -78,10 +78,7 @@ Define your agent's mission here. What is their primary goal? What do they own?
  * Render the AGENTS_TEMPLATE with effective default values substituted into
  * the comment placeholders. Optionally prepends an active `name:` field.
  */
-function renderAgentsTemplate(
-  agentName?: string,
-  workspaceDefaults?: Partial<AgentDefaults>,
-): string {
+function renderAgentsTemplate(agentName?: string, workspaceDefaults?: Partial<AgentDefaults>): string {
   const effective = computeEffectiveDefaults(workspaceDefaults);
 
   let rendered = AGENTS_TEMPLATE;

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -13,10 +13,9 @@ import * as directory from '../lib/agent-directory.js';
 import * as registry from '../lib/agent-registry.js';
 import { getActor, recordAuditEvent } from '../lib/audit.js';
 import { resolveBuiltinAgentPath } from '../lib/builtin-agents.js';
-import { type ResolveContext, resolveField } from '../lib/defaults.js';
-import { getWorkspaceConfig, findWorkspace } from '../lib/workspace.js';
 import * as nativeTeams from '../lib/claude-native-teams.js';
 import { OTEL_RELAY_PORT, ensureCodexOtelConfig } from '../lib/codex-config.js';
+import { type ResolveContext, resolveField } from '../lib/defaults.js';
 import { tmuxBin } from '../lib/ensure-tmux.js';
 import * as executorRegistry from '../lib/executor-registry.js';
 import type { TransportType as ExecutorTransport } from '../lib/executor-types.js';
@@ -36,6 +35,7 @@ import * as teamManager from '../lib/team-manager.js';
 import { genieTmuxCmd } from '../lib/tmux-wrapper.js';
 import * as tmux from '../lib/tmux.js';
 import { executeTmux, isPaneAlive } from '../lib/tmux.js';
+import { findWorkspace, getWorkspaceConfig } from '../lib/workspace.js';
 
 // ============================================================================
 // Helper Functions
@@ -1276,7 +1276,7 @@ async function resolveAgentForSpawn(
 }
 
 /** Build a ResolveContext for spawn-time resolution (reads workspace.json fresh from disk). */
-function buildSpawnResolveContext(agentName: string, entry: directory.DirectoryEntry): ResolveContext {
+function buildSpawnResolveContext(agentName: string, _entry: directory.DirectoryEntry): ResolveContext {
   const ctx: ResolveContext = {};
 
   // Read workspace defaults fresh from disk

--- a/src/term-commands/dir.ts
+++ b/src/term-commands/dir.ts
@@ -22,12 +22,7 @@ import * as directory from '../lib/agent-directory.js';
 import { printSyncResult, syncAgentDirectory } from '../lib/agent-sync.js';
 import { getActor, recordAuditEvent } from '../lib/audit.js';
 import { ALL_BUILTINS } from '../lib/builtin-agents.js';
-import {
-  RESOLVED_FIELDS,
-  type ResolveContext,
-  type ResolvedSource,
-  resolveFieldWithSource,
-} from '../lib/defaults.js';
+import { RESOLVED_FIELDS, type ResolveContext, resolveFieldWithSource } from '../lib/defaults.js';
 import { parseFrontmatter } from '../lib/frontmatter.js';
 import { contractPath } from '../lib/genie-config.js';
 import type { SdkBeta, SdkDirectoryConfig, SdkThinkingConfig } from '../lib/sdk-directory-types.js';


### PR DESCRIPTION
## Summary
- Implement cascading defaults via sectioned `.genie/workspace.json` (`agents.defaults` + `tmux` + `sdk`)
- Generic `resolveField<K>(agent, field, ctx)` — single resolver for all SDK fields (model, color, effort, thinking, permissionMode, promptMode, provider)
- Zero-mandatory frontmatter: scaffold templates use `.env.example`-style YAML-commented defaults
- Sync-time cache + spawn-time refresh for effective defaults
- Auto-heal: `genie dir sync` deletes invalid `model: inherit` lines (atomic write-rename)
- LOCKED `dir ls` 4-column format with `source` taxonomy (declared/inherited/workspace/built-in)
- Workspace migration: auto-creates `agents.defaults` section on first sync

## Wish
`.genie/wishes/genie-model-resolution/WISH.md` — sub-wish 1 of 3 under onboarding-overhaul

## Test plan
- [x] `bun run tsc --noEmit` — clean
- [x] 73 new tests across 5 test files — all pass
- [x] `defaults.test.ts` — resolver chain, workspace fallback, built-in defaults
- [x] `dir-ls.test.ts` — 4-column format, source taxonomy
- [x] `heal.test.ts` — auto-heal invalid `model: inherit` lines
- [x] `scaffold.test.ts` — YAML-commented defaults in templates
- [x] `workspace-migration.test.ts` — auto-creates sections