### PR TITLE
refactor: replace OmniSession with transport-agnostic ExecutorSession

### DIFF
--- a/src/services/__tests__/omni-bridge.test.ts
+++ b/src/services/__tests__/omni-bridge.test.ts
@@ -22,7 +22,7 @@
 
 import { describe, expect, it } from 'bun:test';
 import type { NatsConnection, Subscription } from 'nats';
-import type { IExecutor, OmniMessage, OmniSession } from '../executor.js';
+import type { ExecutorSession, IExecutor, OmniMessage } from '../executor.js';
 
 import { OmniBridge } from '../omni-bridge.js';
 
@@ -391,24 +391,23 @@ function makeFakeNatsWithPublish() {
 
 /** Mock executor that tracks all calls. */
 function makeMockExecutor(overrides?: {
-  spawnFn?: (agentName: string, chatId: string, env: Record<string, string>) => Promise<OmniSession>;
+  spawnFn?: (agentName: string, chatId: string, env: Record<string, string>) => Promise<ExecutorSession>;
   isAliveResult?: boolean;
 }) {
   const calls = {
     spawn: [] as Array<{ agentName: string; chatId: string }>,
-    deliver: [] as Array<{ session: OmniSession; message: OmniMessage }>,
-    shutdown: [] as OmniSession[],
+    deliver: [] as Array<{ session: ExecutorSession; message: OmniMessage }>,
+    shutdown: [] as ExecutorSession[],
   };
 
-  const makeSession = (agentName: string, chatId: string): OmniSession => ({
+  const makeSession = (agentName: string, chatId: string): ExecutorSession => ({
     id: `session-${chatId}`,
     agentName,
     chatId,
-    tmuxSession: 'test',
-    tmuxWindow: `win-${chatId}`,
-    paneId: `%${chatId}`,
+    executorType: 'tmux',
     createdAt: Date.now(),
     lastActivityAt: Date.now(),
+    tmux: { session: 'test', window: `win-${chatId}`, paneId: `%${chatId}` },
   });
 
   const executor: IExecutor = {
@@ -716,7 +715,7 @@ describe('OmniBridge — session reset (#1089)', () => {
     bridge: OmniBridge,
     key: string,
     instanceId: string,
-    session: OmniSession,
+    session: ExecutorSession,
   ): { entry: { idleTimer: ReturnType<typeof setTimeout> | null } } {
     const idleTimer = setTimeout(() => {}, 60_000);
     const entry = {
@@ -898,8 +897,8 @@ describe('OmniBridge — session reset (#1089)', () => {
 
   it('cancels a spawning session on reset and tears down the freshly-spawned executor', async () => {
     // Hold the spawn promise open so we can fire reset mid-spawn.
-    let releaseSpawn!: (s: OmniSession) => void;
-    const spawnGate = new Promise<OmniSession>((resolve) => {
+    let releaseSpawn!: (s: ExecutorSession) => void;
+    const spawnGate = new Promise<ExecutorSession>((resolve) => {
       releaseSpawn = resolve;
     });
 

--- a/src/services/executor.ts
+++ b/src/services/executor.ts
@@ -10,17 +10,22 @@
 // SafePgCallFn relocated to lib/safe-pg-call.ts — re-export for back-compat.
 export type { SafePgCallFn } from '../lib/safe-pg-call.js';
 
-/** Opaque session handle returned by spawn(). TODO: replace with Executor from lib/executor-types. */
-export interface OmniSession {
+/** Transport-agnostic session handle returned by spawn(). */
+export interface ExecutorSession {
   id: string;
   agentName: string;
   chatId: string;
-  tmuxSession: string;
-  tmuxWindow: string;
-  paneId: string;
+  executorType: 'tmux' | 'sdk';
   createdAt: number;
   lastActivityAt: number;
+  tmux?: { session: string; window: string; paneId: string };
+  sdk?: { claudeSessionId?: string; executorId?: string };
 }
+
+/**
+ * @deprecated Use `ExecutorSession` instead. Will be removed in a future release.
+ */
+export type OmniSession = ExecutorSession;
 
 /** Inbound message from Omni via NATS. */
 export interface OmniMessage {
@@ -37,13 +42,13 @@ export type NatsPublishFn = (topic: string, payload: string) => void;
 
 /** Pluggable executor backend for the Omni bridge. TODO: merge into ExecutorProvider. */
 export interface IExecutor {
-  spawn(agentName: string, chatId: string, env: Record<string, string>): Promise<OmniSession>;
-  deliver(session: OmniSession, message: OmniMessage): Promise<void>;
-  shutdown(session: OmniSession): Promise<void>;
-  isAlive(session: OmniSession): Promise<boolean>;
+  spawn(agentName: string, chatId: string, env: Record<string, string>): Promise<ExecutorSession>;
+  deliver(session: ExecutorSession, message: OmniMessage): Promise<void>;
+  shutdown(session: ExecutorSession): Promise<void>;
+  isAlive(session: ExecutorSession): Promise<boolean>;
   setSafePgCall(fn: import('../lib/safe-pg-call.js').SafePgCallFn): void;
   /** Inject NATS publish function for in-process reply delivery. */
   setNatsPublish(fn: NatsPublishFn): void;
   /** Inject a nudge message into an active session (for turn timeout warnings). */
-  injectNudge(session: OmniSession, text: string): Promise<void>;
+  injectNudge(session: ExecutorSession, text: string): Promise<void>;
 }

--- a/src/services/executor.ts
+++ b/src/services/executor.ts
@@ -24,6 +24,7 @@ export interface ExecutorSession {
 
 /**
  * @deprecated Use `ExecutorSession` instead. Will be removed in a future release.
+ * @public
  */
 export type OmniSession = ExecutorSession;
 

--- a/src/services/executors/__tests__/claude-sdk.test.ts
+++ b/src/services/executors/__tests__/claude-sdk.test.ts
@@ -42,9 +42,9 @@ describe('ClaudeSdkOmniExecutor', () => {
       expect(session.id).toBe('test-agent:chat-123');
       expect(session.agentName).toBe('test-agent');
       expect(session.chatId).toBe('chat-123');
-      expect(session.paneId).toBe('sdk-chat-123');
-      expect(session.tmuxSession).toBe('');
-      expect(session.tmuxWindow).toBe('');
+      expect(session.executorType).toBe('sdk');
+      expect(session.sdk).toBeDefined();
+      expect(session.tmux).toBeUndefined();
     });
 
     it('resolves agent from directory', async () => {
@@ -75,9 +75,7 @@ describe('ClaudeSdkOmniExecutor', () => {
         id: 'nonexistent',
         agentName: 'x',
         chatId: 'y',
-        tmuxSession: '',
-        tmuxWindow: '',
-        paneId: '',
+        executorType: 'sdk' as const,
         createdAt: 0,
         lastActivityAt: 0,
       };
@@ -98,9 +96,7 @@ describe('ClaudeSdkOmniExecutor', () => {
         id: 'nonexistent',
         agentName: 'x',
         chatId: 'y',
-        tmuxSession: '',
-        tmuxWindow: '',
-        paneId: '',
+        executorType: 'sdk' as const,
         createdAt: 0,
         lastActivityAt: 0,
       };
@@ -147,9 +143,7 @@ describe('ClaudeSdkOmniExecutor', () => {
         id: 'nonexistent',
         agentName: 'x',
         chatId: 'y',
-        tmuxSession: '',
-        tmuxWindow: '',
-        paneId: '',
+        executorType: 'sdk' as const,
         createdAt: 0,
         lastActivityAt: 0,
       };

--- a/src/services/executors/claude-code.ts
+++ b/src/services/executors/claude-code.ts
@@ -18,7 +18,7 @@ import { buildLaunchCommand } from '../../lib/provider-adapters.js';
 import type { SpawnParams } from '../../lib/provider-adapters.js';
 import { shellQuote } from '../../lib/team-lead-command.js';
 import { ensureTeamWindow, executeTmux, isPaneAlive, isPaneProcessRunning, killWindow } from '../../lib/tmux.js';
-import type { IExecutor, OmniMessage, OmniSession, SafePgCallFn } from '../executor.js';
+import type { ExecutorSession, IExecutor, OmniMessage, SafePgCallFn } from '../executor.js';
 import { buildTurnBasedPrompt } from './turn-based-prompt.js';
 
 interface TmuxSessionState {
@@ -75,12 +75,14 @@ export class ClaudeCodeOmniExecutor implements IExecutor {
     // No-op: tmux executor replies via tmux pane, not NATS
   }
 
-  async injectNudge(session: OmniSession, text: string): Promise<void> {
+  async injectNudge(session: ExecutorSession, text: string): Promise<void> {
+    const paneId = session.tmux?.paneId;
+    if (!paneId) return;
     const nudgeText = `[system] ${text}`;
-    await executeTmux(`send-keys -t '${session.paneId}' ${shellQuote(nudgeText)} Enter`);
+    await executeTmux(`send-keys -t '${paneId}' ${shellQuote(nudgeText)} Enter`);
   }
 
-  async spawn(agentName: string, chatId: string, env: Record<string, string>): Promise<OmniSession> {
+  async spawn(agentName: string, chatId: string, env: Record<string, string>): Promise<ExecutorSession> {
     const resolved = await directory.resolve(agentName);
     if (!resolved) throw new Error(`Agent "${agentName}" not found in genie directory`);
 
@@ -120,11 +122,10 @@ export class ClaudeCodeOmniExecutor implements IExecutor {
       id: sessionKey,
       agentName,
       chatId,
-      tmuxSession,
-      tmuxWindow: windowName,
-      paneId,
+      executorType: 'tmux' as const,
       createdAt: now,
       lastActivityAt: now,
+      tmux: { session: tmuxSession, window: windowName, paneId },
     };
   }
 
@@ -170,13 +171,14 @@ export class ClaudeCodeOmniExecutor implements IExecutor {
     );
   }
 
-  async deliver(session: OmniSession, message: OmniMessage): Promise<void> {
+  async deliver(session: ExecutorSession, message: OmniMessage): Promise<void> {
     const state = this.sessions.get(session.id);
     if (state?.executorId) await this.updateState(state.executorId, 'working', session.chatId);
+    const tmuxSessionName = session.tmux?.session ?? session.agentName;
     const inboxDir = join(
       process.env.CLAUDE_CONFIG_DIR ?? join(homedir(), '.claude'),
       'teams',
-      session.tmuxSession,
+      tmuxSessionName,
       'inboxes',
     );
     mkdirSync(inboxDir, { recursive: true });
@@ -200,10 +202,10 @@ export class ClaudeCodeOmniExecutor implements IExecutor {
     if (state?.executorId) await this.updateState(state.executorId, 'idle', session.chatId);
   }
 
-  async shutdown(session: OmniSession): Promise<void> {
+  async shutdown(session: ExecutorSession): Promise<void> {
     const state = this.sessions.get(session.id);
     try {
-      await killWindow(session.tmuxSession, session.tmuxWindow);
+      if (session.tmux) await killWindow(session.tmux.session, session.tmux.window);
     } finally {
       if (state?.executorId && this.safePgCall) {
         await this.safePgCall(
@@ -217,11 +219,13 @@ export class ClaudeCodeOmniExecutor implements IExecutor {
     }
   }
 
-  async isAlive(session: OmniSession): Promise<boolean> {
+  async isAlive(session: ExecutorSession): Promise<boolean> {
+    const paneId = session.tmux?.paneId;
+    if (!paneId) return false;
     try {
-      const paneAlive = await isPaneAlive(session.paneId);
+      const paneAlive = await isPaneAlive(paneId);
       if (!paneAlive) return false;
-      return await isPaneProcessRunning(session.paneId, 'claude');
+      return await isPaneProcessRunning(paneId, 'claude');
     } catch {
       return false;
     }

--- a/src/services/executors/claude-sdk.ts
+++ b/src/services/executors/claude-sdk.ts
@@ -13,7 +13,7 @@ import { recordAuditEvent } from '../../lib/audit-events.js';
 import * as registry from '../../lib/executor-registry.js';
 import { resolvePermissionConfig } from '../../lib/providers/claude-sdk-permissions.js';
 import { ClaudeSdkProvider } from '../../lib/providers/claude-sdk.js';
-import type { IExecutor, NatsPublishFn, OmniMessage, OmniSession, SafePgCallFn } from '../executor.js';
+import type { ExecutorSession, IExecutor, NatsPublishFn, OmniMessage, SafePgCallFn } from '../executor.js';
 import { endSession, recordTurn, startSession, updateTurnCount } from './sdk-session-capture.js';
 import { buildTurnBasedPrompt } from './turn-based-prompt.js';
 
@@ -292,12 +292,12 @@ export class ClaudeSdkOmniExecutor implements IExecutor {
     this.natsPublish = fn;
   }
 
-  async injectNudge(session: OmniSession, text: string): Promise<void> {
+  async injectNudge(session: ExecutorSession, text: string): Promise<void> {
     if (!this.sessions.has(session.id)) return;
     this.pendingNudges.set(session.id, text);
   }
 
-  async spawn(agentName: string, chatId: string, env: Record<string, string>): Promise<OmniSession> {
+  async spawn(agentName: string, chatId: string, env: Record<string, string>): Promise<ExecutorSession> {
     const resolved = await directory.resolve(agentName);
     if (!resolved) {
       throw new Error(`Agent "${agentName}" not found in genie directory`);
@@ -329,11 +329,13 @@ export class ClaudeSdkOmniExecutor implements IExecutor {
       id: sessionId,
       agentName,
       chatId,
-      tmuxSession: '',
-      tmuxWindow: '',
-      paneId: `sdk-${chatId}`,
+      executorType: 'sdk' as const,
       createdAt: now,
       lastActivityAt: now,
+      sdk: {
+        claudeSessionId: registration?.claudeSessionId,
+        executorId: registration?.executorId,
+      },
     };
   }
 
@@ -408,7 +410,7 @@ export class ClaudeSdkOmniExecutor implements IExecutor {
     );
   }
 
-  async deliver(session: OmniSession, message: OmniMessage): Promise<void> {
+  async deliver(session: ExecutorSession, message: OmniMessage): Promise<void> {
     const state = this.sessions.get(session.id);
     if (!state) {
       throw new Error(`No SDK session found for ${session.id}`);
@@ -423,7 +425,11 @@ export class ClaudeSdkOmniExecutor implements IExecutor {
     );
   }
 
-  private async _processDelivery(session: OmniSession, state: SdkSessionState, message: OmniMessage): Promise<void> {
+  private async _processDelivery(
+    session: ExecutorSession,
+    state: SdkSessionState,
+    message: OmniMessage,
+  ): Promise<void> {
     const resolved = await directory.resolve(session.agentName);
     if (!resolved) {
       throw new Error(`Agent "${session.agentName}" not found in genie directory`);
@@ -513,7 +519,7 @@ export class ClaudeSdkOmniExecutor implements IExecutor {
 
   private async reconcileSessionId(
     state: SdkSessionState,
-    session: OmniSession,
+    session: ExecutorSession,
     returnedSessionId: string,
   ): Promise<void> {
     const isResumeRejected = state.claudeSessionId && returnedSessionId !== state.claudeSessionId;
@@ -581,7 +587,7 @@ export class ClaudeSdkOmniExecutor implements IExecutor {
     }
   }
 
-  async shutdown(session: OmniSession): Promise<void> {
+  async shutdown(session: ExecutorSession): Promise<void> {
     const state = this.sessions.get(session.id);
     if (!state) return;
 
@@ -605,7 +611,7 @@ export class ClaudeSdkOmniExecutor implements IExecutor {
     this.deliveryQueues.delete(session.id);
   }
 
-  async isAlive(session: OmniSession): Promise<boolean> {
+  async isAlive(session: ExecutorSession): Promise<boolean> {
     const state = this.sessions.get(session.id);
     if (!state) return false;
     return state.running && !state.abortController.signal.aborted;

--- a/src/services/omni-bridge.ts
+++ b/src/services/omni-bridge.ts
@@ -13,7 +13,7 @@
 import { type NatsConnection, StringCodec, type Subscription, connect } from 'nats';
 import type { Sql } from '../lib/db.js';
 import { resolveExecutorType } from '../lib/executor-config.js';
-import type { IExecutor, OmniMessage, OmniSession } from './executor.js';
+import type { ExecutorSession, IExecutor, OmniMessage } from './executor.js';
 import { ClaudeCodeOmniExecutor } from './executors/claude-code.js';
 import { ClaudeSdkOmniExecutor } from './executors/claude-sdk.js';
 import { TurnTracker } from './omni-turn.js';
@@ -58,7 +58,7 @@ interface BridgeConfig {
 }
 
 interface SessionEntry {
-  session: OmniSession;
+  session: ExecutorSession;
   instanceId: string;
   spawning: boolean;
   buffer: OmniMessage[];
@@ -89,7 +89,7 @@ export interface BridgeStatus {
     agentName: string;
     chatId: string;
     instanceId: string;
-    paneId: string;
+    executorType: 'tmux' | 'sdk';
     spawning: boolean;
     idleMs: number;
     bufferSize: number;
@@ -386,7 +386,7 @@ export class OmniBridge {
         agentName: entry.session.agentName,
         chatId: entry.session.chatId,
         instanceId: entry.instanceId,
-        paneId: entry.session.paneId,
+        executorType: entry.session.executorType,
         spawning: entry.spawning,
         idleMs: now - entry.session.lastActivityAt,
         bufferSize: entry.buffer.length,
@@ -747,7 +747,7 @@ export class OmniBridge {
 
     // Create placeholder entry (spawning state)
     const placeholder: SessionEntry = {
-      session: null as unknown as OmniSession, // Will be set after spawn
+      session: null as unknown as ExecutorSession, // Will be set after spawn
       instanceId: message.instanceId,
       spawning: true,
       buffer: [message], // Buffer the triggering message too
@@ -797,7 +797,8 @@ export class OmniBridge {
       // Start idle timer
       this.resetIdleTimer(key);
 
-      console.log(`[omni-bridge] Session active: ${key} (pane=${session.paneId})`);
+      const sessionTag = session.executorType === 'tmux' ? `(tmux pane=${session.tmux?.paneId})` : '(executor=sdk)';
+      console.log(`[omni-bridge] Session active: ${key} ${sessionTag}`);
     } catch (err) {
       console.error(`[omni-bridge] Failed to spawn session for ${key}:`, err);
       // Re-queue buffered messages before deleting the placeholder

--- a/src/term-commands/omni.ts
+++ b/src/term-commands/omni.ts
@@ -35,7 +35,8 @@ function printStatus(s: BridgeStatus): void {
     for (const sess of s.sessions) {
       const idleSec = Math.round(sess.idleMs / 1000);
       const status = sess.spawning ? 'spawning' : `idle ${idleSec}s`;
-      console.log(`    ${sess.agentName}:${sess.chatId} — pane=${sess.paneId} (${status})`);
+      const tag = sess.executorType === 'tmux' ? 'tmux' : 'sdk';
+      console.log(`    ${sess.agentName}:${sess.chatId} — executor=${tag} (${status})`);
     }
   }
   console.log('');


### PR DESCRIPTION
## Summary
- Replaces `OmniSession` with `ExecutorSession` interface using `executorType: "tmux" | "sdk"` discriminant
- tmux-specific fields moved to optional `tmux?: { session, window, paneId }` bag
- SDK-specific fields in optional `sdk?: { claudeSessionId, executorId }` bag
- No more fake `tmuxSession: ""` or `paneId: "sdk-..."` values in SDK executor
- Bridge logging now shows `(tmux pane=%6)` or `(executor=sdk)` instead of `(pane=sdk-...)`
- `OmniSession` kept as `@deprecated` type alias for backward compat

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun test src/services/executors/` — 76 pass, 0 fail
- [x] `bun test src/services/__tests__/omni-bridge.test.ts` — 27 pass, 0 fail
- [x] `bun test src/services/` — 113 pass, 0 fail

Wish: `omni-genie-onboarding` Group 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)