### PR TITLE
feat(omni): PG-backed request queue for SDK executor

### DIFF
--- a/src/db/migrations/029_omni_requests.sql
+++ b/src/db/migrations/029_omni_requests.sql
@@ -1,0 +1,33 @@
+-- 029_omni_requests.sql — PG-backed request queue for SDK executor (zero message loss)
+
+CREATE TABLE IF NOT EXISTS omni_requests (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent         TEXT NOT NULL,
+  chat_id       TEXT NOT NULL,
+  instance_id   TEXT NOT NULL DEFAULT '',
+  content       TEXT NOT NULL,
+  sender        TEXT NOT NULL DEFAULT '',
+  env           JSONB NOT NULL DEFAULT '{}',
+  status        TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'done', 'failed')),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  started_at    TIMESTAMPTZ,
+  completed_at  TIMESTAMPTZ,
+  attempts      INTEGER NOT NULL DEFAULT 0,
+  max_attempts  INTEGER NOT NULL DEFAULT 3,
+  next_retry_at TIMESTAMPTZ
+);
+
+-- Worker poll: claim oldest pending, skip locked rows
+CREATE INDEX IF NOT EXISTS idx_omni_requests_pending
+  ON omni_requests (created_at ASC)
+  WHERE status = 'pending';
+
+-- Recovery: find processing rows that may be stale after restart
+CREATE INDEX IF NOT EXISTS idx_omni_requests_processing
+  ON omni_requests (started_at ASC)
+  WHERE status = 'processing';
+
+-- Rate limiting: count recent completions per agent
+CREATE INDEX IF NOT EXISTS idx_omni_requests_agent_completed
+  ON omni_requests (agent, completed_at DESC)
+  WHERE status = 'done';

--- a/src/services/__tests__/omni-bridge.test.ts
+++ b/src/services/__tests__/omni-bridge.test.ts
@@ -22,7 +22,7 @@
 
 import { describe, expect, it } from 'bun:test';
 import type { NatsConnection, Subscription } from 'nats';
-import type { IExecutor, OmniMessage, OmniSession } from '../executor.js';
+import type { ExecutorSession, IExecutor, OmniMessage } from '../executor.js';
 
 import { OmniBridge } from '../omni-bridge.js';
 
@@ -391,24 +391,23 @@ function makeFakeNatsWithPublish() {
 
 /** Mock executor that tracks all calls. */
 function makeMockExecutor(overrides?: {
-  spawnFn?: (agentName: string, chatId: string, env: Record<string, string>) => Promise<OmniSession>;
+  spawnFn?: (agentName: string, chatId: string, env: Record<string, string>) => Promise<ExecutorSession>;
   isAliveResult?: boolean;
 }) {
   const calls = {
     spawn: [] as Array<{ agentName: string; chatId: string }>,
-    deliver: [] as Array<{ session: OmniSession; message: OmniMessage }>,
-    shutdown: [] as OmniSession[],
+    deliver: [] as Array<{ session: ExecutorSession; message: OmniMessage }>,
+    shutdown: [] as ExecutorSession[],
   };
 
-  const makeSession = (agentName: string, chatId: string): OmniSession => ({
+  const makeSession = (agentName: string, chatId: string): ExecutorSession => ({
     id: `session-${chatId}`,
     agentName,
     chatId,
-    tmuxSession: 'test',
-    tmuxWindow: `win-${chatId}`,
-    paneId: `%${chatId}`,
+    executorType: 'tmux',
     createdAt: Date.now(),
     lastActivityAt: Date.now(),
+    tmux: { session: 'test', window: `win-${chatId}`, paneId: `%${chatId}` },
   });
 
   const executor: IExecutor = {
@@ -716,7 +715,7 @@ describe('OmniBridge — session reset (#1089)', () => {
     bridge: OmniBridge,
     key: string,
     instanceId: string,
-    session: OmniSession,
+    session: ExecutorSession,
   ): { entry: { idleTimer: ReturnType<typeof setTimeout> | null } } {
     const idleTimer = setTimeout(() => {}, 60_000);
     const entry = {
@@ -898,8 +897,8 @@ describe('OmniBridge — session reset (#1089)', () => {
 
   it('cancels a spawning session on reset and tears down the freshly-spawned executor', async () => {
     // Hold the spawn promise open so we can fire reset mid-spawn.
-    let releaseSpawn!: (s: OmniSession) => void;
-    const spawnGate = new Promise<OmniSession>((resolve) => {
+    let releaseSpawn!: (s: ExecutorSession) => void;
+    const spawnGate = new Promise<ExecutorSession>((resolve) => {
       releaseSpawn = resolve;
     });
 

--- a/src/services/__tests__/omni-queue.test.ts
+++ b/src/services/__tests__/omni-queue.test.ts
@@ -1,0 +1,277 @@
+/**
+ * OmniQueue tests — PG-backed request queue for SDK executor.
+ *
+ * Uses real pgserve (bun:test preload boots a RAM-backed instance)
+ * to exercise the actual SQL queries: enqueue, claim, retry, recovery.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { getConnection } from '../../lib/db.js';
+import type { Sql } from '../../lib/db.js';
+import type { OmniMessage } from '../executor.js';
+import { OmniQueue, type QueuedRequest } from '../omni-queue.js';
+
+let sql: Sql;
+
+beforeEach(async () => {
+  sql = (await getConnection()) as Sql;
+  // Ensure migration is applied
+  await sql`
+    CREATE TABLE IF NOT EXISTS omni_requests (
+      id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      agent         TEXT NOT NULL,
+      chat_id       TEXT NOT NULL,
+      instance_id   TEXT NOT NULL DEFAULT '',
+      content       TEXT NOT NULL,
+      sender        TEXT NOT NULL DEFAULT '',
+      env           JSONB NOT NULL DEFAULT '{}',
+      status        TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'done', 'failed')),
+      created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+      started_at    TIMESTAMPTZ,
+      completed_at  TIMESTAMPTZ,
+      attempts      INTEGER NOT NULL DEFAULT 0,
+      max_attempts  INTEGER NOT NULL DEFAULT 3,
+      next_retry_at TIMESTAMPTZ
+    )
+  `;
+  // Clean slate
+  await sql`DELETE FROM omni_requests`;
+});
+
+afterEach(async () => {
+  await sql`DELETE FROM omni_requests`;
+});
+
+function makeMessage(overrides: Partial<OmniMessage> = {}): OmniMessage {
+  return {
+    content: 'hello',
+    sender: 'user@test',
+    instanceId: 'inst-1',
+    chatId: 'chat-1',
+    agent: 'test-agent',
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Enqueue
+// ============================================================================
+
+describe('OmniQueue — enqueue', () => {
+  it('persists a message and returns an id', async () => {
+    const handler = async () => {};
+    const queue = new OmniQueue(sql, handler);
+
+    const id = await queue.enqueue(makeMessage());
+    expect(id).toBeDefined();
+    expect(id).toMatch(/^[0-9a-f-]{36}$/);
+
+    const rows = await sql`SELECT * FROM omni_requests WHERE id = ${id}`;
+    expect(rows.length).toBe(1);
+    expect(rows[0].agent).toBe('test-agent');
+    expect(rows[0].chat_id).toBe('chat-1');
+    expect(rows[0].content).toBe('hello');
+    expect(rows[0].status).toBe('pending');
+    expect(rows[0].attempts).toBe(0);
+  });
+
+  it('stores env as JSONB', async () => {
+    const handler = async () => {};
+    const queue = new OmniQueue(sql, handler);
+
+    const id = await queue.enqueue(makeMessage(), { OMNI_INSTANCE: 'inst-1', OMNI_CHAT: 'chat-1' });
+    const rows = await sql`SELECT env FROM omni_requests WHERE id = ${id}`;
+    // postgres.js may return JSONB as string depending on driver config — parse defensively
+    const env = typeof rows[0].env === 'string' ? JSON.parse(rows[0].env) : rows[0].env;
+    expect(env).toEqual({ OMNI_INSTANCE: 'inst-1', OMNI_CHAT: 'chat-1' });
+  });
+});
+
+// ============================================================================
+// Processing
+// ============================================================================
+
+describe('OmniQueue — processing', () => {
+  it('processes a pending request via handler', async () => {
+    const processed: QueuedRequest[] = [];
+    const handler = async (req: QueuedRequest) => {
+      processed.push(req);
+    };
+    const queue = new OmniQueue(sql, handler, { pollIntervalMs: 50 });
+
+    await queue.enqueue(makeMessage({ content: 'test-msg' }));
+    queue.start();
+
+    // Wait for poll to pick it up
+    await new Promise((r) => setTimeout(r, 200));
+    queue.stop();
+
+    expect(processed.length).toBe(1);
+    expect(processed[0].content).toBe('test-msg');
+    expect(processed[0].agent).toBe('test-agent');
+
+    // Verify marked as done in PG
+    const rows = await sql`SELECT status FROM omni_requests WHERE agent = 'test-agent'`;
+    expect(rows[0].status).toBe('done');
+  });
+
+  it('retries failed requests with exponential backoff', async () => {
+    let callCount = 0;
+    const handler = async () => {
+      callCount++;
+      if (callCount <= 2) throw new Error('transient failure');
+    };
+    // Use very short poll + override backoff by setting next_retry_at to now after failure
+    const queue = new OmniQueue(sql, handler, { pollIntervalMs: 50 });
+
+    const id = await queue.enqueue(makeMessage());
+    queue.start();
+
+    // Wait for first attempt + failure
+    await new Promise((r) => setTimeout(r, 200));
+
+    // First attempt fails, gets scheduled for retry with backoff.
+    // Force retry to be immediate for testing.
+    await sql`UPDATE omni_requests SET next_retry_at = now() WHERE id = ${id}`;
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Second attempt fails too.
+    await sql`UPDATE omni_requests SET next_retry_at = now() WHERE id = ${id}`;
+    await new Promise((r) => setTimeout(r, 200));
+
+    queue.stop();
+
+    // Third attempt should succeed
+    expect(callCount).toBe(3);
+    const rows = await sql`SELECT status, attempts FROM omni_requests WHERE id = ${id}`;
+    expect(rows[0].status).toBe('done');
+    expect(rows[0].attempts).toBe(3);
+  });
+
+  it('marks request as failed after max_attempts exhausted', async () => {
+    const handler = async () => {
+      throw new Error('permanent failure');
+    };
+    const queue = new OmniQueue(sql, handler, { pollIntervalMs: 50 });
+
+    // Insert with max_attempts=1 so first failure is terminal
+    await sql`
+      INSERT INTO omni_requests (agent, chat_id, instance_id, content, sender, max_attempts)
+      VALUES ('test-agent', 'chat-1', 'inst-1', 'doomed', 'user', 1)
+    `;
+
+    queue.start();
+    await new Promise((r) => setTimeout(r, 200));
+    queue.stop();
+
+    const rows = await sql`SELECT status FROM omni_requests WHERE content = 'doomed'`;
+    expect(rows[0].status).toBe('failed');
+  });
+});
+
+// ============================================================================
+// Rate limiting
+// ============================================================================
+
+describe('OmniQueue — rate limiting', () => {
+  it('respects per-agent rate limit', async () => {
+    const processed: string[] = [];
+    const handler = async (req: QueuedRequest) => {
+      processed.push(req.id);
+    };
+    // Rate limit: 2 per minute
+    const queue = new OmniQueue(sql, handler, { pollIntervalMs: 50, maxPerMinute: 2 });
+
+    // Enqueue 4 messages
+    for (let i = 0; i < 4; i++) {
+      await queue.enqueue(makeMessage({ content: `msg-${i}` }));
+    }
+
+    queue.start();
+    await new Promise((r) => setTimeout(r, 500));
+    queue.stop();
+
+    // Only 2 should have been processed (rate limited)
+    expect(processed.length).toBe(2);
+
+    // Remaining 2 should still be pending
+    const pending = await sql`SELECT count(*)::int as c FROM omni_requests WHERE status = 'pending'`;
+    expect(pending[0].c).toBe(2);
+  });
+});
+
+// ============================================================================
+// Recovery
+// ============================================================================
+
+describe('OmniQueue — recovery', () => {
+  it('recovers stale processing rows', async () => {
+    const handler = async () => {};
+    const queue = new OmniQueue(sql, handler, { staleTimeoutMs: 1_000 });
+
+    // Insert a "processing" row that started 10 seconds ago (stale at 1s threshold)
+    await sql`
+      INSERT INTO omni_requests (agent, chat_id, instance_id, content, sender, status, started_at)
+      VALUES ('test-agent', 'chat-1', 'inst-1', 'stale', 'user', 'processing', now() - interval '10 seconds')
+    `;
+
+    const recovered = await queue.recoverStale();
+    expect(recovered).toBe(1);
+
+    const rows = await sql`SELECT status, started_at FROM omni_requests WHERE content = 'stale'`;
+    expect(rows[0].status).toBe('pending');
+    expect(rows[0].started_at).toBeNull();
+  });
+
+  it('does not recover recently started processing rows', async () => {
+    const handler = async () => {};
+    const queue = new OmniQueue(sql, handler, { staleTimeoutMs: 60_000 });
+
+    // Insert a "processing" row that just started
+    await sql`
+      INSERT INTO omni_requests (agent, chat_id, instance_id, content, sender, status, started_at)
+      VALUES ('test-agent', 'chat-1', 'inst-1', 'fresh', 'user', 'processing', now())
+    `;
+
+    const recovered = await queue.recoverStale();
+    expect(recovered).toBe(0);
+
+    const rows = await sql`SELECT status FROM omni_requests WHERE content = 'fresh'`;
+    expect(rows[0].status).toBe('processing');
+  });
+});
+
+// ============================================================================
+// Stats
+// ============================================================================
+
+describe('OmniQueue — stats', () => {
+  it('returns correct counts per status', async () => {
+    const handler = async () => {};
+    const queue = new OmniQueue(sql, handler);
+
+    // Insert various statuses
+    await sql`INSERT INTO omni_requests (agent, chat_id, content, sender, status) VALUES ('a', 'c', 'x', 's', 'pending')`;
+    await sql`INSERT INTO omni_requests (agent, chat_id, content, sender, status) VALUES ('a', 'c', 'x', 's', 'pending')`;
+    await sql`INSERT INTO omni_requests (agent, chat_id, content, sender, status, started_at) VALUES ('a', 'c', 'x', 's', 'processing', now())`;
+    await sql`INSERT INTO omni_requests (agent, chat_id, content, sender, status, completed_at) VALUES ('a', 'c', 'x', 's', 'done', now())`;
+    await sql`INSERT INTO omni_requests (agent, chat_id, content, sender, status, completed_at) VALUES ('a', 'c', 'x', 's', 'failed', now())`;
+
+    const stats = await queue.stats();
+    expect(stats.pending).toBe(2);
+    expect(stats.processing).toBe(1);
+    expect(stats.done).toBe(1);
+    expect(stats.failed).toBe(1);
+  });
+
+  it('returns zeros when queue is empty', async () => {
+    const handler = async () => {};
+    const queue = new OmniQueue(sql, handler);
+
+    const stats = await queue.stats();
+    expect(stats.pending).toBe(0);
+    expect(stats.processing).toBe(0);
+    expect(stats.done).toBe(0);
+    expect(stats.failed).toBe(0);
+  });
+});

--- a/src/services/executor.ts
+++ b/src/services/executor.ts
@@ -10,17 +10,22 @@
 // SafePgCallFn relocated to lib/safe-pg-call.ts — re-export for back-compat.
 export type { SafePgCallFn } from '../lib/safe-pg-call.js';
 
-/** Opaque session handle returned by spawn(). TODO: replace with Executor from lib/executor-types. */
-export interface OmniSession {
+/** Transport-agnostic session handle returned by spawn(). */
+export interface ExecutorSession {
   id: string;
   agentName: string;
   chatId: string;
-  tmuxSession: string;
-  tmuxWindow: string;
-  paneId: string;
+  executorType: 'tmux' | 'sdk';
   createdAt: number;
   lastActivityAt: number;
+  tmux?: { session: string; window: string; paneId: string };
+  sdk?: { claudeSessionId?: string; executorId?: string };
 }
+
+/**
+ * @deprecated Use `ExecutorSession` instead. Will be removed in a future release.
+ */
+export type OmniSession = ExecutorSession;
 
 /** Inbound message from Omni via NATS. */
 export interface OmniMessage {
@@ -37,13 +42,13 @@ export type NatsPublishFn = (topic: string, payload: string) => void;
 
 /** Pluggable executor backend for the Omni bridge. TODO: merge into ExecutorProvider. */
 export interface IExecutor {
-  spawn(agentName: string, chatId: string, env: Record<string, string>): Promise<OmniSession>;
-  deliver(session: OmniSession, message: OmniMessage): Promise<void>;
-  shutdown(session: OmniSession): Promise<void>;
-  isAlive(session: OmniSession): Promise<boolean>;
+  spawn(agentName: string, chatId: string, env: Record<string, string>): Promise<ExecutorSession>;
+  deliver(session: ExecutorSession, message: OmniMessage): Promise<void>;
+  shutdown(session: ExecutorSession): Promise<void>;
+  isAlive(session: ExecutorSession): Promise<boolean>;
   setSafePgCall(fn: import('../lib/safe-pg-call.js').SafePgCallFn): void;
   /** Inject NATS publish function for in-process reply delivery. */
   setNatsPublish(fn: NatsPublishFn): void;
   /** Inject a nudge message into an active session (for turn timeout warnings). */
-  injectNudge(session: OmniSession, text: string): Promise<void>;
+  injectNudge(session: ExecutorSession, text: string): Promise<void>;
 }

--- a/src/services/executor.ts
+++ b/src/services/executor.ts
@@ -24,6 +24,7 @@ export interface ExecutorSession {
 
 /**
  * @deprecated Use `ExecutorSession` instead. Will be removed in a future release.
+ * @public
  */
 export type OmniSession = ExecutorSession;
 

--- a/src/services/executors/__tests__/claude-sdk.test.ts
+++ b/src/services/executors/__tests__/claude-sdk.test.ts
@@ -42,9 +42,9 @@ describe('ClaudeSdkOmniExecutor', () => {
       expect(session.id).toBe('test-agent:chat-123');
       expect(session.agentName).toBe('test-agent');
       expect(session.chatId).toBe('chat-123');
-      expect(session.paneId).toBe('sdk-chat-123');
-      expect(session.tmuxSession).toBe('');
-      expect(session.tmuxWindow).toBe('');
+      expect(session.executorType).toBe('sdk');
+      expect(session.sdk).toBeDefined();
+      expect(session.tmux).toBeUndefined();
     });
 
     it('resolves agent from directory', async () => {
@@ -75,9 +75,7 @@ describe('ClaudeSdkOmniExecutor', () => {
         id: 'nonexistent',
         agentName: 'x',
         chatId: 'y',
-        tmuxSession: '',
-        tmuxWindow: '',
-        paneId: '',
+        executorType: 'sdk' as const,
         createdAt: 0,
         lastActivityAt: 0,
       };
@@ -98,9 +96,7 @@ describe('ClaudeSdkOmniExecutor', () => {
         id: 'nonexistent',
         agentName: 'x',
         chatId: 'y',
-        tmuxSession: '',
-        tmuxWindow: '',
-        paneId: '',
+        executorType: 'sdk' as const,
         createdAt: 0,
         lastActivityAt: 0,
       };
@@ -147,9 +143,7 @@ describe('ClaudeSdkOmniExecutor', () => {
         id: 'nonexistent',
         agentName: 'x',
         chatId: 'y',
-        tmuxSession: '',
-        tmuxWindow: '',
-        paneId: '',
+        executorType: 'sdk' as const,
         createdAt: 0,
         lastActivityAt: 0,
       };

--- a/src/services/executors/claude-code.ts
+++ b/src/services/executors/claude-code.ts
@@ -18,7 +18,7 @@ import { buildLaunchCommand } from '../../lib/provider-adapters.js';
 import type { SpawnParams } from '../../lib/provider-adapters.js';
 import { shellQuote } from '../../lib/team-lead-command.js';
 import { ensureTeamWindow, executeTmux, isPaneAlive, isPaneProcessRunning, killWindow } from '../../lib/tmux.js';
-import type { IExecutor, OmniMessage, OmniSession, SafePgCallFn } from '../executor.js';
+import type { ExecutorSession, IExecutor, OmniMessage, SafePgCallFn } from '../executor.js';
 import { buildTurnBasedPrompt } from './turn-based-prompt.js';
 
 interface TmuxSessionState {
@@ -75,12 +75,14 @@ export class ClaudeCodeOmniExecutor implements IExecutor {
     // No-op: tmux executor replies via tmux pane, not NATS
   }
 
-  async injectNudge(session: OmniSession, text: string): Promise<void> {
+  async injectNudge(session: ExecutorSession, text: string): Promise<void> {
+    const paneId = session.tmux?.paneId;
+    if (!paneId) return;
     const nudgeText = `[system] ${text}`;
-    await executeTmux(`send-keys -t '${session.paneId}' ${shellQuote(nudgeText)} Enter`);
+    await executeTmux(`send-keys -t '${paneId}' ${shellQuote(nudgeText)} Enter`);
   }
 
-  async spawn(agentName: string, chatId: string, env: Record<string, string>): Promise<OmniSession> {
+  async spawn(agentName: string, chatId: string, env: Record<string, string>): Promise<ExecutorSession> {
     const resolved = await directory.resolve(agentName);
     if (!resolved) throw new Error(`Agent "${agentName}" not found in genie directory`);
 
@@ -120,11 +122,10 @@ export class ClaudeCodeOmniExecutor implements IExecutor {
       id: sessionKey,
       agentName,
       chatId,
-      tmuxSession,
-      tmuxWindow: windowName,
-      paneId,
+      executorType: 'tmux' as const,
       createdAt: now,
       lastActivityAt: now,
+      tmux: { session: tmuxSession, window: windowName, paneId },
     };
   }
 
@@ -170,13 +171,14 @@ export class ClaudeCodeOmniExecutor implements IExecutor {
     );
   }
 
-  async deliver(session: OmniSession, message: OmniMessage): Promise<void> {
+  async deliver(session: ExecutorSession, message: OmniMessage): Promise<void> {
     const state = this.sessions.get(session.id);
     if (state?.executorId) await this.updateState(state.executorId, 'working', session.chatId);
+    const tmuxSessionName = session.tmux?.session ?? session.agentName;
     const inboxDir = join(
       process.env.CLAUDE_CONFIG_DIR ?? join(homedir(), '.claude'),
       'teams',
-      session.tmuxSession,
+      tmuxSessionName,
       'inboxes',
     );
     mkdirSync(inboxDir, { recursive: true });
@@ -200,10 +202,10 @@ export class ClaudeCodeOmniExecutor implements IExecutor {
     if (state?.executorId) await this.updateState(state.executorId, 'idle', session.chatId);
   }
 
-  async shutdown(session: OmniSession): Promise<void> {
+  async shutdown(session: ExecutorSession): Promise<void> {
     const state = this.sessions.get(session.id);
     try {
-      await killWindow(session.tmuxSession, session.tmuxWindow);
+      if (session.tmux) await killWindow(session.tmux.session, session.tmux.window);
     } finally {
       if (state?.executorId && this.safePgCall) {
         await this.safePgCall(
@@ -217,11 +219,13 @@ export class ClaudeCodeOmniExecutor implements IExecutor {
     }
   }
 
-  async isAlive(session: OmniSession): Promise<boolean> {
+  async isAlive(session: ExecutorSession): Promise<boolean> {
+    const paneId = session.tmux?.paneId;
+    if (!paneId) return false;
     try {
-      const paneAlive = await isPaneAlive(session.paneId);
+      const paneAlive = await isPaneAlive(paneId);
       if (!paneAlive) return false;
-      return await isPaneProcessRunning(session.paneId, 'claude');
+      return await isPaneProcessRunning(paneId, 'claude');
     } catch {
       return false;
     }

--- a/src/services/executors/claude-sdk.ts
+++ b/src/services/executors/claude-sdk.ts
@@ -13,7 +13,7 @@ import { recordAuditEvent } from '../../lib/audit-events.js';
 import * as registry from '../../lib/executor-registry.js';
 import { resolvePermissionConfig } from '../../lib/providers/claude-sdk-permissions.js';
 import { ClaudeSdkProvider } from '../../lib/providers/claude-sdk.js';
-import type { IExecutor, NatsPublishFn, OmniMessage, OmniSession, SafePgCallFn } from '../executor.js';
+import type { ExecutorSession, IExecutor, NatsPublishFn, OmniMessage, SafePgCallFn } from '../executor.js';
 import { endSession, recordTurn, startSession, updateTurnCount } from './sdk-session-capture.js';
 import { buildTurnBasedPrompt } from './turn-based-prompt.js';
 
@@ -292,12 +292,12 @@ export class ClaudeSdkOmniExecutor implements IExecutor {
     this.natsPublish = fn;
   }
 
-  async injectNudge(session: OmniSession, text: string): Promise<void> {
+  async injectNudge(session: ExecutorSession, text: string): Promise<void> {
     if (!this.sessions.has(session.id)) return;
     this.pendingNudges.set(session.id, text);
   }
 
-  async spawn(agentName: string, chatId: string, env: Record<string, string>): Promise<OmniSession> {
+  async spawn(agentName: string, chatId: string, env: Record<string, string>): Promise<ExecutorSession> {
     const resolved = await directory.resolve(agentName);
     if (!resolved) {
       throw new Error(`Agent "${agentName}" not found in genie directory`);
@@ -329,11 +329,13 @@ export class ClaudeSdkOmniExecutor implements IExecutor {
       id: sessionId,
       agentName,
       chatId,
-      tmuxSession: '',
-      tmuxWindow: '',
-      paneId: `sdk-${chatId}`,
+      executorType: 'sdk' as const,
       createdAt: now,
       lastActivityAt: now,
+      sdk: {
+        claudeSessionId: registration?.claudeSessionId,
+        executorId: registration?.executorId,
+      },
     };
   }
 
@@ -408,7 +410,7 @@ export class ClaudeSdkOmniExecutor implements IExecutor {
     );
   }
 
-  async deliver(session: OmniSession, message: OmniMessage): Promise<void> {
+  async deliver(session: ExecutorSession, message: OmniMessage): Promise<void> {
     const state = this.sessions.get(session.id);
     if (!state) {
       throw new Error(`No SDK session found for ${session.id}`);
@@ -423,7 +425,11 @@ export class ClaudeSdkOmniExecutor implements IExecutor {
     );
   }
 
-  private async _processDelivery(session: OmniSession, state: SdkSessionState, message: OmniMessage): Promise<void> {
+  private async _processDelivery(
+    session: ExecutorSession,
+    state: SdkSessionState,
+    message: OmniMessage,
+  ): Promise<void> {
     const resolved = await directory.resolve(session.agentName);
     if (!resolved) {
       throw new Error(`Agent "${session.agentName}" not found in genie directory`);
@@ -513,7 +519,7 @@ export class ClaudeSdkOmniExecutor implements IExecutor {
 
   private async reconcileSessionId(
     state: SdkSessionState,
-    session: OmniSession,
+    session: ExecutorSession,
     returnedSessionId: string,
   ): Promise<void> {
     const isResumeRejected = state.claudeSessionId && returnedSessionId !== state.claudeSessionId;
@@ -581,7 +587,7 @@ export class ClaudeSdkOmniExecutor implements IExecutor {
     }
   }
 
-  async shutdown(session: OmniSession): Promise<void> {
+  async shutdown(session: ExecutorSession): Promise<void> {
     const state = this.sessions.get(session.id);
     if (!state) return;
 
@@ -605,7 +611,7 @@ export class ClaudeSdkOmniExecutor implements IExecutor {
     this.deliveryQueues.delete(session.id);
   }
 
-  async isAlive(session: OmniSession): Promise<boolean> {
+  async isAlive(session: ExecutorSession): Promise<boolean> {
     const state = this.sessions.get(session.id);
     if (!state) return false;
     return state.running && !state.abortController.signal.aborted;

--- a/src/services/omni-bridge.ts
+++ b/src/services/omni-bridge.ts
@@ -13,7 +13,7 @@
 import { type NatsConnection, StringCodec, type Subscription, connect } from 'nats';
 import type { Sql } from '../lib/db.js';
 import { resolveExecutorType } from '../lib/executor-config.js';
-import type { IExecutor, OmniMessage, OmniSession } from './executor.js';
+import type { ExecutorSession, IExecutor, OmniMessage } from './executor.js';
 import { ClaudeCodeOmniExecutor } from './executors/claude-code.js';
 import { ClaudeSdkOmniExecutor } from './executors/claude-sdk.js';
 import { TurnTracker } from './omni-turn.js';
@@ -58,7 +58,7 @@ interface BridgeConfig {
 }
 
 interface SessionEntry {
-  session: OmniSession;
+  session: ExecutorSession;
   instanceId: string;
   spawning: boolean;
   buffer: OmniMessage[];
@@ -89,7 +89,7 @@ export interface BridgeStatus {
     agentName: string;
     chatId: string;
     instanceId: string;
-    paneId: string;
+    executorType: 'tmux' | 'sdk';
     spawning: boolean;
     idleMs: number;
     bufferSize: number;
@@ -386,7 +386,7 @@ export class OmniBridge {
         agentName: entry.session.agentName,
         chatId: entry.session.chatId,
         instanceId: entry.instanceId,
-        paneId: entry.session.paneId,
+        executorType: entry.session.executorType,
         spawning: entry.spawning,
         idleMs: now - entry.session.lastActivityAt,
         bufferSize: entry.buffer.length,
@@ -747,7 +747,7 @@ export class OmniBridge {
 
     // Create placeholder entry (spawning state)
     const placeholder: SessionEntry = {
-      session: null as unknown as OmniSession, // Will be set after spawn
+      session: null as unknown as ExecutorSession, // Will be set after spawn
       instanceId: message.instanceId,
       spawning: true,
       buffer: [message], // Buffer the triggering message too
@@ -797,7 +797,8 @@ export class OmniBridge {
       // Start idle timer
       this.resetIdleTimer(key);
 
-      console.log(`[omni-bridge] Session active: ${key} (pane=${session.paneId})`);
+      const sessionTag = session.executorType === 'tmux' ? `(tmux pane=${session.tmux?.paneId})` : '(executor=sdk)';
+      console.log(`[omni-bridge] Session active: ${key} ${sessionTag}`);
     } catch (err) {
       console.error(`[omni-bridge] Failed to spawn session for ${key}:`, err);
       // Re-queue buffered messages before deleting the placeholder

--- a/src/services/omni-bridge.ts
+++ b/src/services/omni-bridge.ts
@@ -16,6 +16,7 @@ import { resolveExecutorType } from '../lib/executor-config.js';
 import type { ExecutorSession, IExecutor, OmniMessage } from './executor.js';
 import { ClaudeCodeOmniExecutor } from './executors/claude-code.js';
 import { ClaudeSdkOmniExecutor } from './executors/claude-sdk.js';
+import { OmniQueue, type QueueConfig, type QueueStats } from './omni-queue.js';
 import { TurnTracker } from './omni-turn.js';
 
 // ============================================================================
@@ -55,6 +56,8 @@ interface BridgeConfig {
   pgProvider?: PgProvider;
   /** Test/DI hook: override the NATS connect function. Defaults to the real `connect` from the nats package. */
   natsConnectFn?: NatsConnectFn;
+  /** Queue config for SDK executor. Only used when executorType is 'sdk' and PG is available. */
+  queue?: QueueConfig;
 }
 
 interface SessionEntry {
@@ -84,6 +87,8 @@ export interface BridgeStatus {
   executorType: 'tmux' | 'sdk';
   /** Executor IDs from PG (omni source, not ended). Empty in degraded mode. */
   executorIds: string[];
+  /** PG-backed queue stats (SDK executor only). Null when queue is not active. */
+  pgQueue: QueueStats | null;
   sessions: Array<{
     id: string;
     agentName: string;
@@ -188,6 +193,10 @@ export class OmniBridge {
   private pgAvailable = false;
   private readonly pgProvider: PgProvider;
   private readonly natsConnectFn: NatsConnectFn;
+  private readonly queueConfig: QueueConfig;
+
+  /** PG-backed request queue for SDK executor. Null when PG unavailable or executor is tmux. */
+  private queue: OmniQueue | null = null;
 
   readonly natsUrl: string;
   readonly idleTimeoutMs: number;
@@ -210,6 +219,7 @@ export class OmniBridge {
         return (await getConnection()) as Sql;
       });
     this.natsConnectFn = config.natsConnectFn ?? connect;
+    this.queueConfig = config.queue ?? {};
 
     this.executorType = resolveExecutorType(config.executorType);
     if (this.executorType === 'sdk') {
@@ -244,6 +254,13 @@ export class OmniBridge {
     // Group 3 scaffolding; Group 4 consumers (SDK + tmux executors) receive a
     // bound `safePgCall` reference below.
     await this.probePg();
+
+    // Initialize PG-backed queue for SDK executor when PG is available.
+    if (this.executorType === 'sdk' && this.pgAvailable && this.sql) {
+      this.queue = new OmniQueue(this.sql, (_req, msg) => this.routeMessage(msg), this.queueConfig);
+      await this.queue.recoverStale();
+      this.queue.start();
+    }
 
     // Inject the bridge's safePgCall into the executor so its World A registry
     // writes are guarded by the same pgAvailable / connection-loss logic as
@@ -297,6 +314,12 @@ export class OmniBridge {
     }
 
     console.log('[omni-bridge] Shutting down...');
+
+    // Stop queue worker
+    if (this.queue) {
+      this.queue.stop();
+      this.queue = null;
+    }
 
     // Stop idle checker
     if (this.idleCheckTimer) {
@@ -371,6 +394,16 @@ export class OmniBridge {
       }
     }
 
+    // PG queue stats when available.
+    let pgQueue: QueueStats | null = null;
+    if (this.queue) {
+      pgQueue = await this.safePgCall(
+        'status_queue_stats',
+        (_sql) => this.queue?.stats() ?? Promise.resolve(null),
+        null,
+      );
+    }
+
     return {
       connected: this.nc !== null,
       natsUrl: this.natsUrl,
@@ -378,9 +411,10 @@ export class OmniBridge {
       activeSessions: activeFromPg ?? this.sessions.size,
       maxConcurrent: this.maxConcurrent,
       idleTimeoutMs: this.idleTimeoutMs,
-      queueDepth: this.messageQueue.length,
+      queueDepth: pgQueue ? pgQueue.pending + pgQueue.processing : this.messageQueue.length,
       executorType: this.executorType,
       executorIds,
+      pgQueue,
       sessions: Array.from(this.sessions.entries()).map(([key, entry]) => ({
         id: key,
         agentName: entry.session.agentName,
@@ -507,7 +541,16 @@ export class OmniBridge {
           continue;
         }
 
-        await this.routeMessage(parsed);
+        // SDK executor with PG queue: persist to queue for durable processing.
+        // Tmux executor or degraded mode: route directly (fire-and-forget).
+        if (this.queue) {
+          // biome-ignore lint/suspicious/noExplicitAny: NATS payload may have extra fields
+          const raw = parsed as any;
+          const env = (raw.env as Record<string, string>) ?? {};
+          await this.queue.enqueue(parsed, env);
+        } else {
+          await this.routeMessage(parsed);
+        }
       } catch (err) {
         console.error('[omni-bridge] Error processing message:', err);
       }

--- a/src/services/omni-queue.ts
+++ b/src/services/omni-queue.ts
@@ -1,0 +1,296 @@
+/**
+ * OmniQueue — PG-backed request queue for SDK executor.
+ *
+ * Guarantees zero message loss: inbound NATS messages are persisted to PG
+ * before acknowledgement, then processed by a poll-based worker loop.
+ *
+ * Features:
+ *   - Durable persistence (survives bridge restart)
+ *   - Claim-based concurrency (FOR UPDATE SKIP LOCKED)
+ *   - Per-agent rate limiting (configurable requests/minute)
+ *   - Exponential backoff retry (max 3 attempts)
+ *   - Recovery of stale processing rows on restart
+ */
+
+import type { Sql } from '../lib/db.js';
+import type { OmniMessage } from './executor.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface QueueConfig {
+  /** Max requests per minute per agent. Default: 60. */
+  maxPerMinute?: number;
+  /** Poll interval in ms. Default: 1000. */
+  pollIntervalMs?: number;
+  /** Max concurrent processing. Default: 5. */
+  maxConcurrent?: number;
+  /** Stale processing timeout in ms. Default: 5 minutes. */
+  staleTimeoutMs?: number;
+}
+
+export interface QueueStats {
+  pending: number;
+  processing: number;
+  done: number;
+  failed: number;
+}
+
+export interface QueuedRequest {
+  id: string;
+  agent: string;
+  chatId: string;
+  instanceId: string;
+  content: string;
+  sender: string;
+  env: Record<string, string>;
+  attempts: number;
+  maxAttempts: number;
+}
+
+/** Callback invoked for each claimed request. */
+export type RequestHandler = (request: QueuedRequest, message: OmniMessage) => Promise<void>;
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DEFAULT_MAX_PER_MINUTE = 60;
+const DEFAULT_POLL_INTERVAL_MS = 1_000;
+const DEFAULT_MAX_CONCURRENT = 5;
+const DEFAULT_STALE_TIMEOUT_MS = 5 * 60 * 1000;
+
+/** Backoff base for retries: 2^attempt * BASE_MS. */
+const BACKOFF_BASE_MS = 5_000;
+
+// ============================================================================
+// Queue Manager
+// ============================================================================
+
+export class OmniQueue {
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private processing = 0;
+  private stopped = false;
+
+  readonly maxPerMinute: number;
+  readonly pollIntervalMs: number;
+  readonly maxConcurrent: number;
+  readonly staleTimeoutMs: number;
+
+  constructor(
+    private readonly sql: Sql,
+    private readonly handler: RequestHandler,
+    config: QueueConfig = {},
+  ) {
+    this.maxPerMinute = config.maxPerMinute ?? DEFAULT_MAX_PER_MINUTE;
+    this.pollIntervalMs = config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.maxConcurrent = config.maxConcurrent ?? DEFAULT_MAX_CONCURRENT;
+    this.staleTimeoutMs = config.staleTimeoutMs ?? DEFAULT_STALE_TIMEOUT_MS;
+  }
+
+  // ==========================================================================
+  // Enqueue
+  // ==========================================================================
+
+  /**
+   * Persist an inbound message to the queue. Returns the request ID.
+   * This is the durable write — once this returns, the message survives restarts.
+   */
+  async enqueue(message: OmniMessage, env: Record<string, string> = {}): Promise<string> {
+    const envJson = JSON.stringify(env);
+    const rows = await this.sql<{ id: string }[]>`
+      INSERT INTO omni_requests (agent, chat_id, instance_id, content, sender, env)
+      VALUES (${message.agent}, ${message.chatId}, ${message.instanceId}, ${message.content}, ${message.sender}, ${envJson}::jsonb)
+      RETURNING id
+    `;
+    return rows[0].id;
+  }
+
+  // ==========================================================================
+  // Worker loop
+  // ==========================================================================
+
+  /** Start the poll-based worker loop. */
+  start(): void {
+    if (this.pollTimer) return;
+    this.stopped = false;
+    this.pollTimer = setInterval(() => this.poll(), this.pollIntervalMs);
+    // Immediate first poll
+    this.poll();
+    console.log(
+      `[omni-queue] Started (poll=${this.pollIntervalMs}ms, max_concurrent=${this.maxConcurrent}, rate=${this.maxPerMinute}/min)`,
+    );
+  }
+
+  /** Stop the worker loop. In-flight processing continues to completion. */
+  stop(): void {
+    this.stopped = true;
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+    console.log('[omni-queue] Stopped');
+  }
+
+  /** Recover stale processing rows from a previous crash. */
+  async recoverStale(): Promise<number> {
+    const staleThreshold = new Date(Date.now() - this.staleTimeoutMs).toISOString();
+    const rows = await this.sql<{ id: string }[]>`
+      UPDATE omni_requests
+      SET status = 'pending', started_at = NULL
+      WHERE status = 'processing' AND started_at < ${staleThreshold}
+      RETURNING id
+    `;
+    if (rows.length > 0) {
+      console.log(`[omni-queue] Recovered ${rows.length} stale request(s)`);
+    }
+    return rows.length;
+  }
+
+  // ==========================================================================
+  // Stats
+  // ==========================================================================
+
+  async stats(): Promise<QueueStats> {
+    const rows = await this.sql<{ status: string; count: string }[]>`
+      SELECT status, count(*)::text as count
+      FROM omni_requests
+      GROUP BY status
+    `;
+    const result: QueueStats = { pending: 0, processing: 0, done: 0, failed: 0 };
+    for (const row of rows) {
+      if (row.status in result) {
+        result[row.status as keyof QueueStats] = Number(row.count);
+      }
+    }
+    return result;
+  }
+
+  // ==========================================================================
+  // Internal
+  // ==========================================================================
+
+  private async poll(): Promise<void> {
+    if (this.stopped) return;
+    if (this.processing >= this.maxConcurrent) return;
+
+    try {
+      const claimed = await this.claimNext();
+      if (!claimed) return;
+
+      this.processing++;
+      // Fire-and-forget — don't block the poll loop
+      this.processRequest(claimed).finally(() => {
+        this.processing--;
+      });
+    } catch (err) {
+      console.warn('[omni-queue] Poll error:', err instanceof Error ? err.message : err);
+    }
+  }
+
+  /**
+   * Claim the next pending request using FOR UPDATE SKIP LOCKED.
+   * Respects per-agent rate limits by checking recent completions.
+   */
+  private async claimNext(): Promise<QueuedRequest | null> {
+    const rows = await this.sql<
+      {
+        id: string;
+        agent: string;
+        chat_id: string;
+        instance_id: string;
+        content: string;
+        sender: string;
+        env: Record<string, string>;
+        attempts: number;
+        max_attempts: number;
+      }[]
+    >`
+      UPDATE omni_requests
+      SET status = 'processing', started_at = now(), attempts = attempts + 1
+      WHERE id = (
+        SELECT r.id FROM omni_requests r
+        WHERE r.status = 'pending'
+          AND (r.next_retry_at IS NULL OR r.next_retry_at <= now())
+          AND (
+            SELECT count(*) FROM omni_requests c
+            WHERE c.agent = r.agent
+              AND c.status = 'done'
+              AND c.completed_at > now() - interval '1 minute'
+          ) < ${this.maxPerMinute}
+        ORDER BY r.created_at ASC
+        LIMIT 1
+        FOR UPDATE SKIP LOCKED
+      )
+      RETURNING id, agent, chat_id, instance_id, content, sender, env, attempts, max_attempts
+    `;
+
+    if (rows.length === 0) return null;
+
+    const row = rows[0];
+    return {
+      id: row.id,
+      agent: row.agent,
+      chatId: row.chat_id,
+      instanceId: row.instance_id,
+      content: row.content,
+      sender: row.sender,
+      env: typeof row.env === 'string' ? JSON.parse(row.env) : (row.env ?? {}),
+      attempts: row.attempts,
+      maxAttempts: row.max_attempts,
+    };
+  }
+
+  private async processRequest(request: QueuedRequest): Promise<void> {
+    const message: OmniMessage = {
+      content: request.content,
+      sender: request.sender,
+      instanceId: request.instanceId,
+      chatId: request.chatId,
+      agent: request.agent,
+    };
+
+    try {
+      await this.handler(request, message);
+      await this.markDone(request.id);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(
+        `[omni-queue] Request ${request.id} failed (attempt ${request.attempts}/${request.maxAttempts}): ${msg}`,
+      );
+
+      if (request.attempts >= request.maxAttempts) {
+        await this.markFailed(request.id);
+      } else {
+        await this.markRetry(request.id, request.attempts);
+      }
+    }
+  }
+
+  private async markDone(id: string): Promise<void> {
+    await this.sql`
+      UPDATE omni_requests
+      SET status = 'done', completed_at = now()
+      WHERE id = ${id}
+    `;
+  }
+
+  private async markFailed(id: string): Promise<void> {
+    await this.sql`
+      UPDATE omni_requests
+      SET status = 'failed', completed_at = now()
+      WHERE id = ${id}
+    `;
+  }
+
+  private async markRetry(id: string, attempt: number): Promise<void> {
+    const backoffMs = BACKOFF_BASE_MS * 2 ** (attempt - 1);
+    const nextRetry = new Date(Date.now() + backoffMs).toISOString();
+    await this.sql`
+      UPDATE omni_requests
+      SET status = 'pending', started_at = NULL, next_retry_at = ${nextRetry}
+      WHERE id = ${id}
+    `;
+  }
+}

--- a/src/services/omni-queue.ts
+++ b/src/services/omni-queue.ts
@@ -49,7 +49,7 @@ export interface QueuedRequest {
   maxAttempts: number;
 }
 
-/** Callback invoked for each claimed request. */
+/** Callback invoked for each claimed request. @public */
 export type RequestHandler = (request: QueuedRequest, message: OmniMessage) => Promise<void>;
 
 // ============================================================================

--- a/src/term-commands/omni.ts
+++ b/src/term-commands/omni.ts
@@ -35,7 +35,8 @@ function printStatus(s: BridgeStatus): void {
     for (const sess of s.sessions) {
       const idleSec = Math.round(sess.idleMs / 1000);
       const status = sess.spawning ? 'spawning' : `idle ${idleSec}s`;
-      console.log(`    ${sess.agentName}:${sess.chatId} — pane=${sess.paneId} (${status})`);
+      const tag = sess.executorType === 'tmux' ? 'tmux' : 'sdk';
+      console.log(`    ${sess.agentName}:${sess.chatId} — executor=${tag} (${status})`);
     }
   }
   console.log('');

--- a/src/term-commands/omni.ts
+++ b/src/term-commands/omni.ts
@@ -8,20 +8,14 @@
 import type { Command } from 'commander';
 import type { BridgeStatus } from '../services/omni-bridge.js';
 
-function printStatus(s: BridgeStatus): void {
-  const pgTag = s.pgAvailable ? '✓ connected' : '✗ degraded';
-  const connTag = s.connected ? '✓ connected' : '✗ disconnected';
-  const activeSource = s.pgAvailable ? ' (PG-backed)' : ' (in-memory)';
-
-  console.log('\nOmni Bridge Status');
-  console.log('─'.repeat(50));
-  console.log(`  Bridge:         ${connTag}`);
-  console.log(`  NATS URL:       ${s.natsUrl}`);
-  console.log(`  PG:             ${pgTag}`);
-  console.log(`  Executor type:  ${s.executorType}`);
-  console.log(`  Active:         ${s.activeSessions} / ${s.maxConcurrent}${activeSource}`);
-  console.log(`  Queue depth:    ${s.queueDepth}`);
-  console.log(`  Idle timeout:   ${Math.round(s.idleTimeoutMs / 1000)}s`);
+function printStatusDetails(s: BridgeStatus): void {
+  if (s.pgQueue) {
+    console.log('\n  PG Queue:');
+    console.log(`    Pending:      ${s.pgQueue.pending}`);
+    console.log(`    Processing:   ${s.pgQueue.processing}`);
+    console.log(`    Done:         ${s.pgQueue.done}`);
+    console.log(`    Failed:       ${s.pgQueue.failed}`);
+  }
 
   if (s.executorIds.length > 0) {
     console.log('\n  Executors (PG):');
@@ -39,6 +33,24 @@ function printStatus(s: BridgeStatus): void {
       console.log(`    ${sess.agentName}:${sess.chatId} — executor=${tag} (${status})`);
     }
   }
+}
+
+function printStatus(s: BridgeStatus): void {
+  const pgTag = s.pgAvailable ? '✓ connected' : '✗ degraded';
+  const connTag = s.connected ? '✓ connected' : '✗ disconnected';
+  const activeSource = s.pgAvailable ? ' (PG-backed)' : ' (in-memory)';
+
+  console.log('\nOmni Bridge Status');
+  console.log('─'.repeat(50));
+  console.log(`  Bridge:         ${connTag}`);
+  console.log(`  NATS URL:       ${s.natsUrl}`);
+  console.log(`  PG:             ${pgTag}`);
+  console.log(`  Executor type:  ${s.executorType}`);
+  console.log(`  Active:         ${s.activeSessions} / ${s.maxConcurrent}${activeSource}`);
+  console.log(`  Queue depth:    ${s.queueDepth}`);
+  console.log(`  Idle timeout:   ${Math.round(s.idleTimeoutMs / 1000)}s`);
+
+  printStatusDetails(s);
   console.log('');
 }
 


### PR DESCRIPTION
## Summary
- New `omni_requests` PG table for guaranteed message delivery via SDK executor
- Queue manager (`OmniQueue`) with FOR UPDATE SKIP LOCKED claim pattern
- Rate limiting: configurable max requests per minute per agent (default 60)
- Exponential backoff retry (max 3 attempts) for failed deliveries
- Bridge restart recovers stale processing rows from PG
- `genie omni status` shows queue depth and processing stats

## Test plan
- [x] `bun test src/services/__tests__/omni-queue.test.ts` — 10 pass
- [x] `bun test src/services/__tests__/omni-bridge.test.ts` — 27 pass
- [x] Enqueue, claim, retry, max_attempts, rate limit, stale recovery all covered

Wish: `omni-genie-onboarding` Group 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)