### PR TITLE
feat: agent stability hardening + remote approval system

### DIFF
--- a/.genie/wishes/agent-stability-hardening/WISH.md
+++ b/.genie/wishes/agent-stability-hardening/WISH.md
@@ -1,0 +1,346 @@
+# Wish: Agent Stability Hardening + Remote Approval
+
+| Field | Value |
+|-------|-------|
+| **Status** | APPROVED |
+| **Slug** | `agent-stability-hardening` |
+| **Date** | 2026-04-08 |
+| **Design** | [DESIGN.md](../../brainstorms/agent-stability-hardening/DESIGN.md) |
+| **GitHub Issues** | #1094, #1093, #1064 |
+| **Repo** | automagik-dev/genie |
+
+## Summary
+
+Fix three agent runtime reliability bugs (permission deadlock, clipboard breakage, silent message loss) and introduce a new `remoteApproval` permission mode that routes tool-use approval requests to humans via Omni (WhatsApp) and the Genie desktop app. This transforms the broken permission system from a source of deadlocks into a powerful human-in-the-loop control plane.
+
+## Scope
+
+### IN
+- Fix `permissionMode` spread override that causes agent deadlock (#1094)
+- Change scaffold default from `permissionMode: default` to `bypassPermissions`
+- Defense-in-depth: strip `permissionMode` from `translateSdkConfig`, call `ensureTeammateBypassPermissions` at SDK spawn
+- New `permissionMode: remoteApproval` with PG-backed approval queue
+- Omni approval frontend: WhatsApp message + reaction/text reply approval
+- App approval frontend: toast notification + interactive chat message with Approve/Deny/Preview
+- Configurable approve/deny tokens in `workspace.json`
+- Fix `osc52-copy.sh` to use `$SSH_TTY` as primary clipboard target (#1093)
+- Add `GENIE_TMUX_MOUSE=off` env var opt-out
+- Inbox delivery retry (3x) with escalation to team-lead (#1064)
+- Fix `isTeamActive` to check per-agent pane liveness
+
+### OUT
+- WhatsApp interactive buttons (requires Business API — text reply + reactions are universal)
+- Per-agent approval config (workspace-level is sufficient)
+- Approval audit dashboard UI (PG table is queryable, UI deferred)
+- Full inbox-watcher redesign (incremental fix only)
+- OSC52 terminal compatibility matrix testing (fix the script, document Shift workaround)
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | Strip `permissionMode` from `translateSdkConfig()` | SDK executor must always bypass — frontmatter `permissionMode` only meaningful for tmux CLI path |
+| D2 | Scaffold default `bypassPermissions` | Current `default` causes deadlock for every new agent |
+| D3 | PG LISTEN/NOTIFY for approval resolution | Proven pattern (mailbox delivery), works cross-process |
+| D4 | Accept both text reply and reaction emoji | Channel-agnostic — works on WhatsApp, Telegram, Slack |
+| D5 | Configurable approve/deny tokens in `workspace.json` | Multilingual support ("sim"/"nao"), custom emoji |
+| D6 | Timeout 300s default, `defaultAction: deny` | Safe default — no unauthorized tool use |
+| D7 | Mode name: `remoteApproval` | Transport-agnostic — works via Omni, app, future channels |
+| D8 | Toast + in-chat for app UI | Toast alerts from any tab, chat message is persistent and actionable |
+| D9 | Medium preview for Omni, full via app Preview button | WhatsApp can't handle 500-line diffs |
+| D10 | `$SSH_TTY` as primary OSC52 target | More reliable than `who -m` in nested tmux |
+| D11 | `GENIE_TMUX_MOUSE=off` env opt-out, default on | Preserves behavior, escape hatch for SSH users |
+| D12 | 3 delivery retries then escalate to team-lead | Matches existing `spawnFailures` pattern |
+
+## Success Criteria
+
+- [ ] Agent with `permissionMode: bypassPermissions` (new scaffold default) executes tools without approval prompt
+- [ ] Agent with `permissionMode: remoteApproval` blocks on tool use, writes approval to PG
+- [ ] Approval request appears in genie-app chat as interactive message with Approve/Deny/Preview
+- [ ] Approval request delivered via Omni to configured WhatsApp chat
+- [ ] Human approves via WhatsApp reaction (configurable, default 👍) — agent resumes within 2s
+- [ ] Human approves via WhatsApp text reply (configurable, default "y") — agent resumes within 2s
+- [ ] Human approves via app Approve button — agent resumes within 1s
+- [ ] Timeout (300s default) with no response — auto-deny
+- [ ] Custom approve/deny tokens work from `workspace.json`
+- [ ] `osc52-copy.sh` uses `$SSH_TTY` as primary clipboard target
+- [ ] `GENIE_TMUX_MOUSE=off` disables mouse capture, native Cmd+C works
+- [ ] `deliverToPane()` failure triggers retry (3x) then escalation to team-lead
+- [ ] `translateSdkConfig()` never copies `permissionMode` into SDK options
+- [ ] `ensureTeammateBypassPermissions()` called at SDK executor spawn path
+- [ ] Existing tests pass (`tsc --noEmit` + `biome check`)
+
+## Execution Strategy
+
+### Wave 1 (parallel — independent bug fixes)
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 1 | engineer | Permission fix: spread order, strip translateSdkConfig, scaffold default, ensureTeammate |
+| 5 | engineer | OSC52 clipboard: `$SSH_TTY` in osc52-copy.sh, `GENIE_TMUX_MOUSE` env opt-out |
+| 6 | engineer | Inbox retry: delivery_status column, retry loop, escalation, isAgentAlive |
+
+### Wave 2 (after Group 1 — approval core depends on permission system)
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 2 | engineer | Remote approval core: PG table, migration, hook factory, workspace config, CLI command |
+| review-w1 | reviewer | Review Groups 1, 5, 6 |
+
+### Wave 3 (after Group 2 — frontends depend on approval core)
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 3 | engineer | Omni approval frontend: message handler, reaction/text matching, rate limiting |
+| 4 | engineer | App approval frontend: toast, chat message component, sidecar NATS subjects |
+| review-w2 | reviewer | Review Group 2 |
+
+### Wave 4 (final)
+| Group | Agent | Description |
+|-------|-------|-------------|
+| review-w3 | reviewer | Review Groups 3, 4 |
+| qa | qa | End-to-end QA: all success criteria |
+
+## Execution Groups
+
+### Group 1: Permission Fix
+**Goal:** Eliminate the `permissionMode` spread override that causes agent deadlock.
+
+**Deliverables:**
+1. `src/lib/providers/claude-sdk.ts` — Delete line that copies `permissionMode` from `translateSdkConfig()` (line 42). Reorder options spread so `permissionMode: 'bypassPermissions'` and `allowDangerouslySkipPermissions: true` come AFTER `...translatedSdk` and `...extraOptions`.
+2. `src/lib/providers/claude-sdk.ts` — Call `ensureTeammateBypassPermissions()` at top of `runQuery()`.
+3. `src/templates/index.ts` — Change `permissionMode: default` to `permissionMode: bypassPermissions` (line ~93).
+4. `src/templates/genie-agents.md` — Change `permissionMode: default` to `permissionMode: bypassPermissions` (line ~9).
+5. `src/lib/defaults.ts` — Change `permissionMode: 'default'` to `permissionMode: 'bypassPermissions'` (line ~27).
+6. Update existing tests that assert `permissionMode: default` or the old spread order.
+
+**Acceptance Criteria:**
+- [ ] `translateSdkConfig()` output never contains `permissionMode` key
+- [ ] Options object has `permissionMode: 'bypassPermissions'` after all spreads
+- [ ] New scaffolded agent has `permissionMode: bypassPermissions` in frontmatter
+- [ ] `ensureTeammateBypassPermissions()` called before SDK query
+
+**Validation:**
+```bash
+cd repos/genie && npx tsc --noEmit && npx biome check src/
+grep -r "permissionMode: 'default'" src/templates/ src/lib/defaults.ts && echo "FAIL: default still present" && exit 1 || echo "PASS"
+```
+
+**depends-on:** none
+
+---
+
+### Group 2: Remote Approval Core
+**Goal:** Build the PG-backed approval queue and SDK hook that blocks until a human decides.
+
+**Deliverables:**
+1. `src/db/migrations/030_approvals.sql` — Create `approvals` table with columns: `id`, `executor_id`, `agent_name`, `tool_name`, `tool_input_preview`, `decision` (pending/allow/deny), `decided_by`, `decided_at`, `timeout_at`, `created_at`. Add trigger `notify_approval_resolved` that fires `pg_notify('genie_approval_resolved', id)` on decision change from pending.
+2. `src/lib/providers/claude-sdk-remote-approval.ts` — New file. Export `createRemoteApprovalGate(config)` that returns a PreToolUse hook. Hook inserts approval row, subscribes to LISTEN channel, safety-net polls every 5s, returns allow/deny on resolution or timeout.
+3. `src/lib/providers/claude-sdk.ts` — When `sdkConfig.permissionMode === 'remoteApproval'`, wire `createRemoteApprovalGate` as PreToolUse hook instead of the standard permission gate. Keep `permissionMode: 'bypassPermissions'` in SDK options (the hook handles blocking).
+4. `src/lib/workspace.ts` — Add `permissions` section to workspace schema: `approveTokens`, `denyTokens`, `timeout`, `defaultAction`, `omniChat`, `omniInstance`.
+5. `src/term-commands/approval.ts` — New CLI command `genie approval request --tool <name> --input <preview> --agent <name> --wait` for tmux-path agents. Writes to same PG approvals table, blocks until resolved. Also `genie approval resolve <id> --decision allow|deny --by <actor>`.
+6. Register approval CLI commands in `src/genie.ts`.
+
+**Acceptance Criteria:**
+- [ ] `approvals` table created by migration
+- [ ] `genie approval request --tool Write --input "test" --agent test-agent --wait` blocks and returns on resolve
+- [ ] `genie approval resolve <id> --decision allow --by human` resolves pending approval within 2s
+- [ ] Timeout auto-resolves with configured `defaultAction`
+- [ ] Hook returns `{ permissionDecision: 'allow' }` or `'deny'` correctly
+
+**Validation:**
+```bash
+cd repos/genie && npx tsc --noEmit && npx biome check src/
+```
+
+**depends-on:** Group 1
+
+---
+
+### Group 3: Omni Approval Frontend
+**Goal:** Route approval requests to WhatsApp and accept human decisions via text reply or reaction.
+
+**Deliverables:**
+1. `src/lib/providers/claude-sdk-remote-approval.ts` — Add Omni send on approval creation: format message with tool name + target + ~200 char preview. Read `omniChat` and `omniInstance` from workspace config. Use `omni send` CLI.
+2. Omni incoming message handler — Match incoming text replies against `approveTokens`/`denyTokens` from workspace config. Match reaction emoji on the approval message. On match, call `genie approval resolve <id> --decision allow|deny --by <sender>`.
+3. Rate limiting — If >3 pending approvals within 10s, batch into single summary message with count.
+
+**Acceptance Criteria:**
+- [ ] Approval request sends formatted WhatsApp message via Omni
+- [ ] Reply "y" on WhatsApp resolves approval as allow
+- [ ] Reply "n" resolves as deny
+- [ ] Reaction 👍 resolves as allow
+- [ ] Reaction 👎 resolves as deny
+- [ ] Custom tokens from workspace.json work
+- [ ] >3 rapid approvals are batched
+
+**Validation:**
+```bash
+cd repos/genie && npx tsc --noEmit && npx biome check src/
+```
+
+**depends-on:** Group 2
+
+---
+
+### Group 4: App Approval Frontend
+**Goal:** Show approval requests in the Genie desktop app as toasts and interactive chat messages.
+
+**Deliverables:**
+1. `packages/genie-app/src-backend/index.ts` — Add NATS subjects: `genie.approval.request` (subscribe to PG LISTEN, publish to frontend), `genie.approval.resolve` (req/reply — update PG), `genie.approval.list` (req/reply — list pending).
+2. `packages/genie-app/views/shared/ApprovalToast.tsx` — New component. Non-blocking toast notification when approval arrives. Shows agent name + tool name + "View in Chat" link. Auto-dismisses after 10s.
+3. `packages/genie-app/views/` (chat view) — New `ApprovalMessage.tsx` component. Renders in chat as interactive card: tool info, Approve/Deny buttons, Preview expand. Buttons send NATS `genie.approval.resolve` request.
+4. Wire toast into `App.tsx` — subscribe to `events.approval_request` NATS event, render `ApprovalToast`.
+
+**Acceptance Criteria:**
+- [ ] Toast appears when approval request fires
+- [ ] Chat message renders with Approve/Deny/Preview buttons
+- [ ] Approve button resolves approval, agent resumes within 1s
+- [ ] Deny button resolves approval, agent gets deny
+- [ ] Preview button shows full tool input
+- [ ] Agent state shows `permission` in AgentsView during pending approval
+
+**Validation:**
+```bash
+cd repos/genie && npx tsc --noEmit && npx biome check src/ packages/
+```
+
+**depends-on:** Group 2
+
+---
+
+### Group 5: OSC52 Clipboard Fix
+**Goal:** Fix clipboard copy over SSH and add mouse capture opt-out.
+
+**Deliverables:**
+1. `scripts/tmux/osc52-copy.sh` — Add `$SSH_TTY` as primary target before `who -m` fallback:
+   ```bash
+   if [ -n "$SSH_TTY" ]; then
+     printf '%s' "$seq" > "$SSH_TTY" 2>/dev/null || true
+   fi
+   ```
+2. `scripts/tmux/genie.tmux.conf` — Wrap mouse setting: `if-shell '[ "$GENIE_TMUX_MOUSE" != "off" ]' 'set -g mouse on'`
+3. `scripts/tmux/tui-tmux.conf` — Same conditional mouse wrapping.
+4. `src/term-commands/serve.ts` — Conditional `set-option mouse on` only when `GENIE_TMUX_MOUSE !== 'off'`.
+5. Update `src/__tests__/tmux-config.test.ts` if tests assert unconditional `mouse on`.
+
+**Acceptance Criteria:**
+- [ ] `osc52-copy.sh` tries `$SSH_TTY` before `who -m`
+- [ ] `GENIE_TMUX_MOUSE=off genie serve` starts without mouse capture
+- [ ] Default (no env var) preserves current mouse-on behavior
+- [ ] Existing tmux config tests pass
+
+**Validation:**
+```bash
+cd repos/genie && grep -q 'SSH_TTY' scripts/tmux/osc52-copy.sh && echo "PASS: SSH_TTY present" || exit 1
+grep -q 'GENIE_TMUX_MOUSE' scripts/tmux/genie.tmux.conf && echo "PASS: mouse opt-out present" || exit 1
+npx tsc --noEmit && npx biome check src/
+```
+
+**depends-on:** none
+
+---
+
+### Group 6: Inbox Delivery Retry + Escalation
+**Goal:** Stop messages from silently vanishing when target agent is unreachable.
+
+**Deliverables:**
+1. `src/db/migrations/031_mailbox_delivery_status.sql` — Add columns to `mailbox` table: `delivery_status TEXT DEFAULT 'pending'` (pending/delivered/failed/escalated), `delivery_attempts INT DEFAULT 0`. Backfill: set existing rows with `delivered_at IS NOT NULL` to `delivery_status = 'delivered'`.
+2. `src/lib/mailbox.ts` — Add `markFailed(messageId)` (increment attempts, set status=failed), `getRetryable(maxAttempts)` (return failed messages with attempts < max), `markEscalated(messageId)`.
+3. `src/lib/protocol-router.ts` — In `deliverToPane()`, on failure call `mailbox.markFailed()` instead of silent return.
+4. `src/lib/scheduler-daemon.ts` — New retry loop every 60s: `getRetryable(3)` → attempt `deliverToPane()` → on 3rd failure call `mailbox.markEscalated()` + send escalation to team-lead via mailbox.
+5. `src/lib/team-auto-spawn.ts` — Add `isAgentAlive(agentName): Promise<boolean>` that checks if the specific agent's pane exists (not just the team window). Export for use by inbox-watcher.
+6. `src/lib/inbox-watcher.ts` — Use `isAgentAlive` for per-recipient check alongside existing `isTeamActive`.
+
+**Acceptance Criteria:**
+- [ ] Failed delivery increments `delivery_attempts` and sets `delivery_status = 'failed'`
+- [ ] Retry loop picks up failed messages and re-attempts delivery
+- [ ] After 3 failures, message is escalated to team-lead
+- [ ] `isAgentAlive` correctly detects dead agent panes
+- [ ] Existing mailbox tests pass
+
+**Validation:**
+```bash
+cd repos/genie && npx tsc --noEmit && npx biome check src/
+```
+
+**depends-on:** none
+
+---
+
+## QA Criteria
+
+_What must be verified on dev after merge._
+
+- [ ] Spawn agent with default frontmatter → tools execute without approval prompt (no deadlock)
+- [ ] Spawn agent with `permissionMode: remoteApproval` → tool use triggers approval request in PG
+- [ ] Approve via app chat → agent resumes, tool executes
+- [ ] Approve via WhatsApp reply "y" → agent resumes within 2s
+- [ ] Deny via WhatsApp reaction 👎 → agent gets deny, continues gracefully
+- [ ] Timeout with no response → auto-deny after configured timeout
+- [ ] SSH session: drag-select text, Cmd+C copies to clipboard (via OSC52)
+- [ ] `GENIE_TMUX_MOUSE=off` → Cmd+C works natively without OSC52
+- [ ] Send message to dead agent → message retried 3x → escalated to team-lead
+- [ ] No regressions: `tsc --noEmit`, `biome check`, existing test suite green
+
+## Assumptions / Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| PG LISTEN missed → hook blocks forever | High | 300s timeout + safety-net polling every 5s |
+| Multiple approvals flood WhatsApp | Medium | Rate limit: batch if >3 pending within 10s |
+| Approval latency slows agent execution | Medium | Only `remoteApproval` mode — `bypassPermissions` remains default |
+| PG approvals table grows unbounded | Low | TTL cleanup: resolved approvals >7d auto-purged by scheduler |
+| `$SSH_TTY` not set in all SSH configs | Low | Fallback chain: `$SSH_TTY` → `who -m` → stdout passthrough |
+| Inbox retry storms on dead agents | Low | Max 3 retries then escalate once and stop |
+| Omni not configured | Low | App UI works independently. If neither configured, timeout auto-denies. |
+
+## Review Results
+
+_Populated by `/review` after execution completes._
+
+---
+
+## Files to Create/Modify
+
+```
+# Group 1 — Permission Fix
+src/lib/providers/claude-sdk.ts                    (modify — spread order, strip permissionMode, ensureTeammate)
+src/templates/index.ts                             (modify — scaffold default)
+src/templates/genie-agents.md                      (modify — scaffold default)
+src/lib/defaults.ts                                (modify — builtin default)
+src/lib/providers/__tests__/claude-sdk.test.ts     (modify — update assertions)
+src/__tests__/defaults.test.ts                     (modify — update assertions)
+src/__tests__/mini-wizard.test.ts                  (modify — update assertions)
+
+# Group 2 — Remote Approval Core
+src/db/migrations/030_approvals.sql                (create)
+src/lib/providers/claude-sdk-remote-approval.ts    (create)
+src/lib/providers/claude-sdk.ts                    (modify — wire remoteApproval hook)
+src/lib/workspace.ts                               (modify — permissions schema)
+src/term-commands/approval.ts                      (create)
+src/genie.ts                                       (modify — register approval commands)
+
+# Group 3 — Omni Approval Frontend
+src/lib/providers/claude-sdk-remote-approval.ts    (modify — add Omni send)
+src/lib/omni-approval-handler.ts                   (create — incoming message matching)
+
+# Group 4 — App Approval Frontend
+packages/genie-app/src-backend/index.ts            (modify — approval NATS subjects)
+packages/genie-app/views/shared/ApprovalToast.tsx  (create)
+packages/genie-app/views/shared/ApprovalMessage.tsx (create)
+packages/genie-app/src/App.tsx                     (modify — wire toast subscription)
+packages/genie-app/lib/subjects.ts                 (modify — add approval subjects)
+
+# Group 5 — OSC52 Clipboard Fix
+scripts/tmux/osc52-copy.sh                         (modify — SSH_TTY primary)
+scripts/tmux/genie.tmux.conf                       (modify — conditional mouse)
+scripts/tmux/tui-tmux.conf                         (modify — conditional mouse)
+src/term-commands/serve.ts                          (modify — conditional mouse)
+src/__tests__/tmux-config.test.ts                  (modify — update assertions)
+
+# Group 6 — Inbox Delivery Retry
+src/db/migrations/031_mailbox_delivery_status.sql  (create)
+src/lib/mailbox.ts                                 (modify — markFailed, getRetryable, markEscalated)
+src/lib/protocol-router.ts                         (modify — call markFailed on delivery failure)
+src/lib/scheduler-daemon.ts                        (modify — retry loop)
+src/lib/team-auto-spawn.ts                         (modify — isAgentAlive)
+src/lib/inbox-watcher.ts                           (modify — per-agent check)
+```

--- a/packages/genie-app/lib/subjects.ts
+++ b/packages/genie-app/lib/subjects.ts
@@ -103,6 +103,14 @@ export const GENIE_SUBJECTS = {
     write: (orgId: string) => s(orgId, 'fs.write'),
   },
 
+  // ---- Approval (remote human-in-the-loop) ----
+  approval: {
+    /** Resolve a pending approval (req/reply). Payload: { id, decision, decided_by } */
+    resolve: (orgId: string) => s(orgId, 'approval.resolve'),
+    /** List pending approvals (req/reply). Payload: { agent_name? } */
+    list: (orgId: string) => s(orgId, 'approval.list'),
+  },
+
   // ---- Events (PG LISTEN/NOTIFY bridged to NATS pub/sub) ----
   events: {
     agentState: (orgId: string) => s(orgId, 'events.agent_state'),
@@ -114,6 +122,8 @@ export const GENIE_SUBJECTS = {
     mailbox: (orgId: string) => s(orgId, 'events.mailbox'),
     taskDep: (orgId: string) => s(orgId, 'events.task_dep'),
     trigger: (orgId: string) => s(orgId, 'events.trigger'),
+    approvalRequest: (orgId: string) => s(orgId, 'events.approval_request'),
+    approvalResolved: (orgId: string) => s(orgId, 'events.approval_resolved'),
   },
 } as const;
 

--- a/packages/genie-app/src-backend/index.ts
+++ b/packages/genie-app/src-backend/index.ts
@@ -13,6 +13,7 @@ import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { type NatsConnection, StringCodec, connect } from 'nats';
 import { getConnection } from '../../../src/lib/db.js';
+import { listPendingApprovals, resolveApproval } from '../../../src/lib/providers/claude-sdk-remote-approval.js';
 import { GENIE_SUBJECTS } from '../lib/subjects.js';
 import * as pgBridge from './pg-bridge.js';
 import * as pty from './pty.js';
@@ -132,7 +133,7 @@ async function start(): Promise<void> {
 
   // 4. Set up PG LISTEN/NOTIFY bridging to NATS
   await pgBridge.startListening(nc, ORG_ID);
-  console.log('[genie-app] PG LISTEN/NOTIFY active (9 channels)');
+  console.log('[genie-app] PG LISTEN/NOTIFY active (11 channels)');
 
   // 5. Wire PTY events to NATS publish (session-scoped subjects)
   pty.onPtyData((sessionId, data) => {
@@ -718,6 +719,20 @@ function registerHandlers(sql: any): void {
     } catch (err) {
       return { error: err instanceof Error ? err.message : String(err) };
     }
+  });
+
+  // ---- Approval (remote human-in-the-loop) ----
+
+  reply(
+    sub.approval.resolve(ORG_ID),
+    async (params: { id: string; decision: 'allow' | 'deny'; decided_by: string }) => {
+      const updated = await resolveApproval(params.id, params.decision, params.decided_by);
+      return { ok: updated };
+    },
+  );
+
+  reply(sub.approval.list(ORG_ID), async (params: { agent_name?: string }) => {
+    return listPendingApprovals(params.agent_name);
   });
 
   console.log('[genie-app] All request/reply handlers registered');

--- a/packages/genie-app/src-backend/ipc.ts
+++ b/packages/genie-app/src-backend/ipc.ts
@@ -5,6 +5,7 @@
  * Returns JSON-serializable results for the webview frontend.
  */
 
+import { listPendingApprovals, resolveApproval } from '../../../src/lib/providers/claude-sdk-remote-approval.js';
 import * as pgBridge from './pg-bridge.js';
 import * as pty from './pty.js';
 import * as workspace from './workspace.js';
@@ -129,6 +130,19 @@ export async function remove_workspace(params: { path: string }) {
 }
 
 // ============================================================================
+// Approval Commands
+// ============================================================================
+
+export async function resolve_approval(params: { id: string; decision: 'allow' | 'deny'; decided_by: string }) {
+  const updated = await resolveApproval(params.id, params.decision, params.decided_by);
+  return { ok: updated };
+}
+
+export async function list_approvals(params: { agent_name?: string }) {
+  return listPendingApprovals(params.agent_name);
+}
+
+// ============================================================================
 // Command Map
 // ============================================================================
 
@@ -150,4 +164,6 @@ export const commands: Record<string, (params: never) => unknown> = {
   open_workspace,
   init_workspace,
   remove_workspace,
+  resolve_approval,
+  list_approvals,
 };

--- a/packages/genie-app/src-backend/pg-bridge.ts
+++ b/packages/genie-app/src-backend/pg-bridge.ts
@@ -35,7 +35,9 @@ export type BridgeEventType =
   | 'message'
   | 'mailbox-delivery'
   | 'task-dep-changed'
-  | 'trigger-due';
+  | 'trigger-due'
+  | 'approval-request'
+  | 'approval-resolved';
 
 export interface BridgeEvent {
   type: BridgeEventType;
@@ -387,6 +389,16 @@ const CHANNEL_MAP: Array<{
   { channel: 'genie_mailbox_delivery', eventType: 'mailbox-delivery', natsSubject: GENIE_SUBJECTS.events.mailbox },
   { channel: 'genie_task_dep', eventType: 'task-dep-changed', natsSubject: GENIE_SUBJECTS.events.taskDep },
   { channel: 'genie_trigger_due', eventType: 'trigger-due', natsSubject: GENIE_SUBJECTS.events.trigger },
+  {
+    channel: 'genie_approval_request',
+    eventType: 'approval-request',
+    natsSubject: GENIE_SUBJECTS.events.approvalRequest,
+  },
+  {
+    channel: 'genie_approval_resolved',
+    eventType: 'approval-resolved',
+    natsSubject: GENIE_SUBJECTS.events.approvalResolved,
+  },
 ];
 
 let listenersActive = false;

--- a/packages/genie-app/src/App.tsx
+++ b/packages/genie-app/src/App.tsx
@@ -1,7 +1,9 @@
 import { Suspense, useCallback, useEffect, useState } from 'react';
 import { components } from '../components';
+import { onEvent } from '../lib/ipc';
 import { theme } from '../lib/theme';
 import type { AppComponentProps } from '../lib/types';
+import { ApprovalToastContainer, type ApprovalToastData } from '../views/shared/ApprovalToast';
 import { LoadingState } from '../views/shared/LoadingState';
 
 // ============================================================================
@@ -160,6 +162,25 @@ export function App() {
   const [collapsed, setCollapsed] = useState(window.innerWidth < COLLAPSE_BREAKPOINT);
   const [agentCount, setAgentCount] = useState<number | null>(null);
   const [connected, setConnected] = useState(true);
+  const [approvalToasts, setApprovalToasts] = useState<ApprovalToastData[]>([]);
+
+  // Subscribe to approval request events (PG LISTEN → bridge → Tauri event)
+  useEffect(() => {
+    return onEvent('approval-request', (payload) => {
+      const toast = payload as unknown as ApprovalToastData;
+      if (toast.id) {
+        setApprovalToasts((prev) => {
+          // Deduplicate by id
+          if (prev.some((t) => t.id === toast.id)) return prev;
+          return [...prev, toast];
+        });
+      }
+    });
+  }, []);
+
+  const dismissToast = useCallback((id: string) => {
+    setApprovalToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
 
   // Responsive collapse
   useEffect(() => {
@@ -275,6 +296,9 @@ export function App() {
 
       {/* Status Bar */}
       <AppStatusBar activeView={activeLabel} agentCount={agentCount} connected={connected} />
+
+      {/* Approval Toast Overlay */}
+      <ApprovalToastContainer toasts={approvalToasts} onDismiss={dismissToast} />
     </div>
   );
 }

--- a/packages/genie-app/views/shared/ApprovalMessage.tsx
+++ b/packages/genie-app/views/shared/ApprovalMessage.tsx
@@ -1,0 +1,273 @@
+import { useCallback, useState } from 'react';
+import { invoke } from '../../lib/ipc';
+import { theme } from '../../lib/theme';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ApprovalData {
+  id: string;
+  executor_id: string;
+  agent_name: string;
+  tool_name: string;
+  tool_input_preview: string;
+  timeout_at: string;
+  created_at: string;
+}
+
+type Decision = 'allow' | 'deny';
+type CardState = 'pending' | 'resolving' | 'resolved' | 'error';
+
+interface ApprovalMessageProps {
+  approval: ApprovalData;
+  /** Called after successful resolution so parent can update state. */
+  onResolved?: (id: string, decision: Decision) => void;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function formatTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+  } catch {
+    return '';
+  }
+}
+
+function timeRemaining(timeoutAt: string): string {
+  const ms = new Date(timeoutAt).getTime() - Date.now();
+  if (ms <= 0) return 'expired';
+  const secs = Math.floor(ms / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  return `${mins}m ${secs % 60}s`;
+}
+
+function resolvedBorderColor(decision: Decision | null): string {
+  return decision === 'allow' ? theme.emerald : theme.error;
+}
+
+function headerLabel(isResolved: boolean, decision: Decision | null): string {
+  if (!isResolved) return 'Approval Required';
+  return decision === 'allow' ? 'Approved' : 'Denied';
+}
+
+// ============================================================================
+// Sub-components (extracted to reduce cognitive complexity)
+// ============================================================================
+
+function ApprovalHeader({
+  borderColor,
+  label,
+  timeoutAt,
+  showTimeout,
+}: { borderColor: string; label: string; timeoutAt: string; showTimeout: boolean }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+        <span
+          style={{
+            width: '8px',
+            height: '8px',
+            borderRadius: '50%',
+            backgroundColor: borderColor,
+            flexShrink: 0,
+            boxShadow: showTimeout ? `0 0 6px ${borderColor}66` : 'none',
+          }}
+        />
+        <span
+          style={{
+            fontSize: '11px',
+            fontWeight: 600,
+            color: borderColor,
+            textTransform: 'uppercase',
+            letterSpacing: '0.05em',
+          }}
+        >
+          {label}
+        </span>
+      </div>
+      {showTimeout && <span style={{ fontSize: '10px', color: theme.textMuted }}>{timeRemaining(timeoutAt)}</span>}
+    </div>
+  );
+}
+
+function ApprovalPreview({ preview }: { preview: string }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        style={{
+          background: 'none',
+          border: 'none',
+          color: theme.textDim,
+          cursor: 'pointer',
+          fontSize: '11px',
+          fontFamily: theme.fontFamily,
+          padding: 0,
+          display: 'flex',
+          alignItems: 'center',
+          gap: '4px',
+        }}
+      >
+        <span
+          style={{
+            fontSize: '10px',
+            transition: 'transform 0.15s',
+            transform: open ? 'rotate(90deg)' : 'rotate(0deg)',
+          }}
+        >
+          {'\u25b6'}
+        </span>
+        Preview
+      </button>
+      {open && (
+        <pre
+          style={{
+            marginTop: '6px',
+            padding: '8px 10px',
+            backgroundColor: theme.bg,
+            border: `1px solid ${theme.border}`,
+            borderRadius: theme.radiusSm,
+            fontSize: '11px',
+            color: theme.textDim,
+            overflow: 'auto',
+            maxHeight: '200px',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-all',
+            lineHeight: 1.4,
+          }}
+        >
+          {preview}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function ActionButtons({ isResolving, onResolve }: { isResolving: boolean; onResolve: (d: Decision) => void }) {
+  const btnBase = {
+    flex: 1,
+    padding: '6px 12px',
+    fontSize: '12px',
+    fontWeight: 600,
+    fontFamily: theme.fontFamily,
+    borderRadius: theme.radiusSm,
+    cursor: isResolving ? ('wait' as const) : ('pointer' as const),
+    opacity: isResolving ? 0.6 : 1,
+    transition: 'background-color 0.15s ease',
+  };
+  return (
+    <div style={{ display: 'flex', gap: '8px', marginTop: '2px' }}>
+      <button
+        type="button"
+        onClick={() => onResolve('allow')}
+        disabled={isResolving}
+        style={{
+          ...btnBase,
+          border: `1px solid ${theme.emerald}`,
+          backgroundColor: 'rgba(52, 211, 153, 0.1)',
+          color: theme.emerald,
+        }}
+      >
+        {isResolving ? '...' : 'Approve'}
+      </button>
+      <button
+        type="button"
+        onClick={() => onResolve('deny')}
+        disabled={isResolving}
+        style={{
+          ...btnBase,
+          border: `1px solid ${theme.error}`,
+          backgroundColor: 'rgba(248, 113, 113, 0.1)',
+          color: theme.error,
+        }}
+      >
+        {isResolving ? '...' : 'Deny'}
+      </button>
+    </div>
+  );
+}
+
+// ============================================================================
+// ApprovalMessage Component
+// ============================================================================
+
+export function ApprovalMessage({ approval, onResolved }: ApprovalMessageProps) {
+  const [cardState, setCardState] = useState<CardState>('pending');
+  const [decision, setDecision] = useState<Decision | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleResolve = useCallback(
+    async (d: Decision) => {
+      setCardState('resolving');
+      setError(null);
+      try {
+        await invoke<{ ok: boolean }>('resolve_approval', {
+          id: approval.id,
+          decision: d,
+          decided_by: 'app-user',
+        });
+        setDecision(d);
+        setCardState('resolved');
+        onResolved?.(approval.id, d);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+        setCardState('error');
+      }
+    },
+    [approval.id, onResolved],
+  );
+
+  const isResolved = cardState === 'resolved';
+  const borderColor = isResolved ? resolvedBorderColor(decision) : theme.warning;
+
+  return (
+    <div
+      style={{
+        backgroundColor: theme.bgCard,
+        border: `1px solid ${borderColor}`,
+        borderRadius: theme.radiusMd,
+        padding: '14px 16px',
+        fontFamily: theme.fontFamily,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '10px',
+        maxWidth: '520px',
+        opacity: isResolved ? 0.7 : 1,
+        transition: 'opacity 0.2s ease, border-color 0.2s ease',
+      }}
+    >
+      <ApprovalHeader
+        borderColor={borderColor}
+        label={headerLabel(isResolved, decision)}
+        timeoutAt={approval.timeout_at}
+        showTimeout={!isResolved}
+      />
+
+      {/* Tool info */}
+      <div style={{ fontSize: '13px', color: theme.text, lineHeight: 1.5 }}>
+        <span style={{ color: theme.purple, fontWeight: 500 }}>{approval.agent_name}</span>
+        {' wants to use '}
+        <span style={{ color: theme.cyan, fontWeight: 500 }}>{approval.tool_name}</span>
+      </div>
+
+      {approval.tool_input_preview && <ApprovalPreview preview={approval.tool_input_preview} />}
+
+      {!isResolved && <ActionButtons isResolving={cardState === 'resolving'} onResolve={handleResolve} />}
+
+      {error && (
+        <div style={{ fontSize: '11px', color: theme.error, padding: '4px 0' }}>Failed to resolve: {error}</div>
+      )}
+
+      <div style={{ fontSize: '10px', color: theme.textMuted, textAlign: 'right' }}>
+        {formatTime(approval.created_at)}
+      </div>
+    </div>
+  );
+}

--- a/packages/genie-app/views/shared/ApprovalToast.tsx
+++ b/packages/genie-app/views/shared/ApprovalToast.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useState } from 'react';
+import { theme } from '../../lib/theme';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ApprovalToastData {
+  id: string;
+  agent_name: string;
+  tool_name: string;
+  tool_input_preview?: string;
+  timeout_at: string;
+  created_at: string;
+}
+
+interface ApprovalToastProps {
+  approval: ApprovalToastData;
+  onDismiss: (id: string) => void;
+  onViewInChat?: (id: string) => void;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const AUTO_DISMISS_MS = 10_000;
+
+// ============================================================================
+// ApprovalToast Component
+// ============================================================================
+
+export function ApprovalToast({ approval, onDismiss, onViewInChat }: ApprovalToastProps) {
+  const [opacity, setOpacity] = useState(0);
+  const [exiting, setExiting] = useState(false);
+
+  // Fade in on mount
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => setOpacity(1));
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
+  // Auto-dismiss after 10s
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setExiting(true);
+      setTimeout(() => onDismiss(approval.id), 200);
+    }, AUTO_DISMISS_MS);
+    return () => clearTimeout(timer);
+  }, [approval.id, onDismiss]);
+
+  const handleDismiss = () => {
+    setExiting(true);
+    setTimeout(() => onDismiss(approval.id), 200);
+  };
+
+  return (
+    <div
+      style={{
+        opacity: exiting ? 0 : opacity,
+        transform: exiting ? 'translateX(20px)' : opacity === 1 ? 'translateX(0)' : 'translateX(20px)',
+        transition: 'opacity 0.2s ease, transform 0.2s ease',
+        backgroundColor: theme.bgCard,
+        border: `1px solid ${theme.warning}`,
+        borderRadius: theme.radiusMd,
+        padding: '12px 16px',
+        minWidth: '280px',
+        maxWidth: '360px',
+        boxShadow: `0 4px 16px rgba(0, 0, 0, 0.4), 0 0 0 1px ${theme.border}`,
+        fontFamily: theme.fontFamily,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '8px',
+      }}
+    >
+      {/* Header row */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <span
+            style={{
+              width: '8px',
+              height: '8px',
+              borderRadius: '50%',
+              backgroundColor: theme.warning,
+              flexShrink: 0,
+              boxShadow: `0 0 6px ${theme.warning}66`,
+            }}
+          />
+          <span
+            style={{
+              fontSize: '12px',
+              fontWeight: 600,
+              color: theme.warning,
+              textTransform: 'uppercase',
+              letterSpacing: '0.05em',
+            }}
+          >
+            Approval Required
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={handleDismiss}
+          style={{
+            background: 'none',
+            border: 'none',
+            color: theme.textMuted,
+            cursor: 'pointer',
+            fontSize: '14px',
+            padding: '0 2px',
+            lineHeight: 1,
+            fontFamily: theme.fontFamily,
+          }}
+        >
+          {'\u00d7'}
+        </button>
+      </div>
+
+      {/* Agent + tool info */}
+      <div style={{ fontSize: '13px', color: theme.text, lineHeight: 1.4 }}>
+        <span style={{ color: theme.purple, fontWeight: 500 }}>{approval.agent_name}</span>
+        {' wants to use '}
+        <span style={{ color: theme.cyan, fontWeight: 500 }}>{approval.tool_name}</span>
+      </div>
+
+      {/* View in Chat link */}
+      {onViewInChat && (
+        <button
+          type="button"
+          onClick={() => onViewInChat(approval.id)}
+          style={{
+            background: 'none',
+            border: 'none',
+            color: theme.violet,
+            cursor: 'pointer',
+            fontSize: '11px',
+            fontFamily: theme.fontFamily,
+            padding: 0,
+            textAlign: 'left',
+            textDecoration: 'underline',
+            textUnderlineOffset: '2px',
+          }}
+        >
+          View in Chat
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Toast Container — renders multiple toasts stacked vertically
+// ============================================================================
+
+interface ApprovalToastContainerProps {
+  toasts: ApprovalToastData[];
+  onDismiss: (id: string) => void;
+  onViewInChat?: (id: string) => void;
+}
+
+export function ApprovalToastContainer({ toasts, onDismiss, onViewInChat }: ApprovalToastContainerProps) {
+  if (toasts.length === 0) return null;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: '16px',
+        right: '16px',
+        zIndex: 9999,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '8px',
+        pointerEvents: 'auto',
+      }}
+    >
+      {toasts.map((toast) => (
+        <ApprovalToast key={toast.id} approval={toast} onDismiss={onDismiss} onViewInChat={onViewInChat} />
+      ))}
+    </div>
+  );
+}

--- a/scripts/tmux/genie.tmux.conf
+++ b/scripts/tmux/genie.tmux.conf
@@ -23,7 +23,7 @@ set -g allow-passthrough on
 set -ga terminal-overrides ",*:Ms=\\E]52;c;%p2%s\\7"
 
 # --- Mouse & vi mode ---
-set -g mouse on
+if-shell '[ "$GENIE_TMUX_MOUSE" != "off" ]' 'set -g mouse on'
 setw -g mode-keys vi
 
 # --- Genie dark theme palette ---

--- a/scripts/tmux/osc52-copy.sh
+++ b/scripts/tmux/osc52-copy.sh
@@ -8,6 +8,10 @@ encoded=$(printf '%s' "$buf" | base64 | tr -d '\n')
 seq=$(printf '\033]52;c;%s\a' "$encoded")
 
 # Try writing directly to the SSH connection's PTY
+# Prefer $SSH_TTY (reliable in nested tmux) before falling back to who -m
+if [ -n "$SSH_TTY" ]; then
+  printf '%s' "$seq" > "$SSH_TTY" 2>/dev/null || true
+fi
 for tty in $(who -m 2>/dev/null | awk '{print $2}'); do
   printf '%s' "$seq" > "/dev/$tty" 2>/dev/null || true
 done

--- a/scripts/tmux/tui-tmux.conf
+++ b/scripts/tmux/tui-tmux.conf
@@ -19,7 +19,7 @@ set -g allow-passthrough on
 set -ga terminal-overrides ",*:Ms=\\E]52;c;%p2%s\\7"
 
 # Mouse on — needed for clicking between left nav and right terminal panes
-set -g mouse on
+if-shell '[ "$GENIE_TMUX_MOUSE" != "off" ]' 'set -g mouse on'
 setw -g mode-keys vi
 
 # Vi copy mode — pipe to osc52-copy.sh for clipboard over SSH

--- a/src/__tests__/mini-wizard.test.ts
+++ b/src/__tests__/mini-wizard.test.ts
@@ -23,14 +23,14 @@ describe('formatDefaults()', () => {
 
     expect(output).toContain('model: opus');
     expect(output).toContain('built-in');
-    expect(output).toContain('permissionMode: default');
+    expect(output).toContain('permissionMode: bypassPermissions');
   });
 
   test('shows workspace overrides', () => {
     const output = formatDefaults({ model: 'sonnet' });
 
     expect(output).toContain('model: sonnet');
-    expect(output).toContain('permissionMode: default');
+    expect(output).toContain('permissionMode: bypassPermissions');
   });
 });
 

--- a/src/__tests__/sdk-integration.test.ts
+++ b/src/__tests__/sdk-integration.test.ts
@@ -91,7 +91,7 @@ describe('Full config roundtrip', () => {
         autoAllowBashIfSandboxed: true,
         network: { allowLocalBinding: true },
       },
-      permissionMode: 'acceptEdits' as const,
+      permissionMode: 'acceptEdits' as const, // translateSdkConfig should strip this
       tools: ['Bash', 'Read'] as string[],
       allowedTools: ['Bash'] as string[],
       disallowedTools: ['Write'] as string[],
@@ -134,7 +134,8 @@ describe('Full config roundtrip', () => {
       autoAllowBashIfSandboxed: true,
       network: { allowLocalBinding: true },
     });
-    expect(result.permissionMode).toBe('acceptEdits');
+    // permissionMode must NOT be copied — SDK executor always bypasses
+    expect(result.permissionMode).toBeUndefined();
     expect(result.tools).toEqual(['Bash', 'Read']);
     expect(result.allowedTools).toEqual(['Bash']);
     expect(result.disallowedTools).toEqual(['Write']);

--- a/src/__tests__/tmux-config.test.ts
+++ b/src/__tests__/tmux-config.test.ts
@@ -53,8 +53,8 @@ describe('tmux config — status bar click handling', () => {
     expect(hits.length).toBeGreaterThanOrEqual(1);
   });
 
-  test('mouse is enabled globally', () => {
-    const hits = activeLines(/set\s+-g\s+mouse\s+on/);
+  test('mouse is conditionally enabled (GENIE_TMUX_MOUSE opt-out)', () => {
+    const hits = activeLines(/GENIE_TMUX_MOUSE.*set\s+-g\s+mouse\s+on/);
     expect(hits.length).toBeGreaterThanOrEqual(1);
   });
 

--- a/src/db/migrations/031_mailbox_delivery_status.sql
+++ b/src/db/migrations/031_mailbox_delivery_status.sql
@@ -1,0 +1,24 @@
+-- 031_mailbox_delivery_status.sql — Add delivery retry tracking to mailbox
+--
+-- Adds delivery_status and delivery_attempts columns to support automatic
+-- retry of failed pane deliveries with escalation after max attempts.
+
+-- Add delivery tracking columns
+ALTER TABLE mailbox
+  ADD COLUMN IF NOT EXISTS delivery_status TEXT NOT NULL DEFAULT 'pending',
+  ADD COLUMN IF NOT EXISTS delivery_attempts INT NOT NULL DEFAULT 0;
+
+-- Constraint: valid delivery statuses
+ALTER TABLE mailbox
+  ADD CONSTRAINT chk_mailbox_delivery_status
+  CHECK (delivery_status IN ('pending', 'delivered', 'failed', 'escalated'));
+
+-- Index for retry queries: find failed messages that haven't exceeded max attempts
+CREATE INDEX IF NOT EXISTS idx_mailbox_delivery_retry
+  ON mailbox(delivery_status, delivery_attempts)
+  WHERE delivery_status = 'failed';
+
+-- Backfill: mark already-delivered rows
+UPDATE mailbox
+  SET delivery_status = 'delivered'
+  WHERE delivered_at IS NOT NULL AND delivery_status = 'pending';

--- a/src/db/migrations/032_approvals.sql
+++ b/src/db/migrations/032_approvals.sql
@@ -1,0 +1,51 @@
+-- 032_approvals.sql — Remote approval queue for human-in-the-loop tool gating
+--
+-- Stores pending/resolved approval requests. Agents block on tool use until
+-- a human approves or denies via Omni (WhatsApp), the desktop app, or CLI.
+-- PG LISTEN/NOTIFY enables sub-second resolution delivery.
+
+-- ============================================================================
+-- Approvals table
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS approvals (
+  id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  executor_id TEXT NOT NULL,
+  agent_name TEXT NOT NULL,
+  tool_name TEXT NOT NULL,
+  tool_input_preview TEXT NOT NULL DEFAULT '',
+  decision TEXT NOT NULL DEFAULT 'pending'
+    CHECK (decision IN ('pending', 'allow', 'deny')),
+  decided_by TEXT,
+  decided_at TIMESTAMPTZ,
+  timeout_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_approvals_pending
+  ON approvals(decision, created_at)
+  WHERE decision = 'pending';
+
+CREATE INDEX IF NOT EXISTS idx_approvals_executor
+  ON approvals(executor_id);
+
+CREATE INDEX IF NOT EXISTS idx_approvals_agent
+  ON approvals(agent_name);
+
+-- ============================================================================
+-- LISTEN/NOTIFY trigger — fires when decision changes from 'pending'
+-- ============================================================================
+CREATE OR REPLACE FUNCTION notify_approval_resolved()
+RETURNS trigger AS $$
+BEGIN
+  IF OLD.decision = 'pending' AND NEW.decision != 'pending' THEN
+    PERFORM pg_notify('genie_approval_resolved', NEW.id);
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_notify_approval_resolved ON approvals;
+
+CREATE TRIGGER trg_notify_approval_resolved
+  AFTER UPDATE ON approvals
+  FOR EACH ROW EXECUTE FUNCTION notify_approval_resolved();

--- a/src/db/migrations/033_approval_request_notify.sql
+++ b/src/db/migrations/033_approval_request_notify.sql
@@ -1,0 +1,28 @@
+-- 033_approval_request_notify.sql — Notify on new approval requests
+--
+-- Fires pg_notify('genie_approval_request', ...) on INSERT to approvals table.
+-- Enables the desktop app to show real-time toast notifications for new approvals.
+
+CREATE OR REPLACE FUNCTION notify_approval_request()
+RETURNS trigger AS $$
+BEGIN
+  PERFORM pg_notify('genie_approval_request',
+    json_build_object(
+      'id', NEW.id,
+      'executor_id', NEW.executor_id,
+      'agent_name', NEW.agent_name,
+      'tool_name', NEW.tool_name,
+      'tool_input_preview', LEFT(NEW.tool_input_preview, 200),
+      'timeout_at', NEW.timeout_at,
+      'created_at', NEW.created_at
+    )::text
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_notify_approval_request ON approvals;
+
+CREATE TRIGGER trg_notify_approval_request
+  AFTER INSERT ON approvals
+  FOR EACH ROW EXECUTE FUNCTION notify_approval_request();

--- a/src/db/migrations/034_approvals_omni_message_id.sql
+++ b/src/db/migrations/034_approvals_omni_message_id.sql
@@ -1,0 +1,11 @@
+-- 034_approvals_omni_message_id.sql — Track Omni message IDs for reaction matching
+--
+-- When an approval notification is sent via Omni (WhatsApp), the returned
+-- message ID is stored so that reaction emoji on that message can be
+-- correlated back to the approval row.
+
+ALTER TABLE approvals ADD COLUMN IF NOT EXISTS omni_message_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_approvals_omni_message
+  ON approvals(omni_message_id)
+  WHERE omni_message_id IS NOT NULL;

--- a/src/genie.ts
+++ b/src/genie.ts
@@ -44,6 +44,7 @@ import {
   handleWorkerStop,
 } from './term-commands/agents.js';
 import { registerAppCommand } from './term-commands/app.js';
+import { registerApprovalCommands } from './term-commands/approval.js';
 import { registerEventsCommands } from './term-commands/audit-events.js';
 import { registerBoardCommands } from './term-commands/board.js';
 import { registerBrainCommands } from './term-commands/brain.js';
@@ -232,6 +233,7 @@ registerImportCommands(program);
 registerTemplateCommands(program);
 registerBrainCommands(program);
 registerBriefCommands(program);
+registerApprovalCommands(program);
 registerOmniCommands(program);
 
 // ============================================================================

--- a/src/lib/defaults.ts
+++ b/src/lib/defaults.ts
@@ -24,7 +24,7 @@ export const BUILTIN_DEFAULTS: AgentDefaults = {
   color: 'blue',
   effort: 'high',
   thinking: 'enabled',
-  permissionMode: 'default',
+  permissionMode: 'bypassPermissions',
 };
 
 /** Type of the built-in defaults object. Runtime values can be any string (not just the defaults). */

--- a/src/lib/inbox-watcher.test.ts
+++ b/src/lib/inbox-watcher.test.ts
@@ -20,10 +20,11 @@ function makeDeps(overrides: Partial<InboxWatcherDeps> = {}): InboxWatcherDeps {
   return {
     listTeamsWithUnreadInbox: async () => [],
     isTeamActive: async () => false,
+    isAgentAlive: async () => false,
     ensureTeamLead: async () => ({ created: true }),
     warn: () => {},
     ...overrides,
-  };
+  } as InboxWatcherDeps;
 }
 
 // ============================================================================

--- a/src/lib/inbox-watcher.ts
+++ b/src/lib/inbox-watcher.ts
@@ -8,7 +8,7 @@
 
 import { listTeamsWithUnreadInbox } from './claude-native-teams.js';
 import { parseRoutingHeader, resolveSessionKey } from './routing-header.js';
-import { ensureTeamLead, isTeamActive } from './team-auto-spawn.js';
+import { ensureTeamLead, isAgentAlive, isTeamActive } from './team-auto-spawn.js';
 
 // ============================================================================
 // Dependency injection (testability without real filesystem/tmux)
@@ -18,6 +18,7 @@ import { ensureTeamLead, isTeamActive } from './team-auto-spawn.js';
 export interface InboxWatcherDeps {
   listTeamsWithUnreadInbox: typeof listTeamsWithUnreadInbox;
   isTeamActive: (teamName: string) => Promise<boolean>;
+  isAgentAlive: (agentName: string) => Promise<boolean>;
   ensureTeamLead: (teamName: string, workingDir: string) => Promise<{ created: boolean }>;
   warn: (msg: string) => void;
 }
@@ -26,6 +27,7 @@ export interface InboxWatcherDeps {
 const defaultDeps: InboxWatcherDeps = {
   listTeamsWithUnreadInbox,
   isTeamActive: (teamName) => isTeamActive(teamName),
+  isAgentAlive: (agentName) => isAgentAlive(agentName),
   ensureTeamLead: (teamName, workingDir) => ensureTeamLead(teamName, workingDir),
   warn: (msg) => console.warn(msg),
 };

--- a/src/lib/mailbox.ts
+++ b/src/lib/mailbox.ts
@@ -243,6 +243,52 @@ export function toNativeInboxMessage(msg: MailboxMessage, color = 'blue'): Nativ
 }
 
 /**
+ * Increment delivery attempts and set status to 'failed'.
+ * Called when pane injection fails during instant delivery.
+ */
+export async function markFailed(messageId: string): Promise<boolean> {
+  const sql = await getConnection();
+  const result = await sql`
+    UPDATE mailbox
+    SET delivery_status = 'failed',
+        delivery_attempts = delivery_attempts + 1
+    WHERE id = ${messageId}
+    RETURNING id
+  `;
+  return result.length > 0;
+}
+
+/**
+ * Get failed messages that haven't exceeded max retry attempts.
+ * Used by the scheduler daemon's retry loop.
+ */
+export async function getRetryable(maxAttempts: number): Promise<MailboxMessage[]> {
+  const sql = await getConnection();
+  const rows = await sql`
+    SELECT * FROM mailbox
+    WHERE delivery_status = 'failed'
+      AND delivery_attempts < ${maxAttempts}
+    ORDER BY created_at ASC
+    LIMIT 50
+  `;
+  return rows.map(rowToMessage);
+}
+
+/**
+ * Mark a message as escalated (delivery exhausted all retries).
+ */
+export async function markEscalated(messageId: string): Promise<boolean> {
+  const sql = await getConnection();
+  const result = await sql`
+    UPDATE mailbox
+    SET delivery_status = 'escalated'
+    WHERE id = ${messageId}
+    RETURNING id
+  `;
+  return result.length > 0;
+}
+
+/**
  * Subscribe to mailbox delivery notifications via PG LISTEN/NOTIFY.
  * Calls the callback with (toWorker, messageId) on each new insert.
  * Returns an unsubscribe function.

--- a/src/lib/omni-approval-handler.ts
+++ b/src/lib/omni-approval-handler.ts
@@ -1,0 +1,256 @@
+/**
+ * Omni Approval Handler — matches incoming WhatsApp messages and reactions
+ * against pending approvals and resolves them.
+ *
+ * Architecture:
+ *   - Subscribes to NATS `omni.message.{instance}.{chat}` for text replies
+ *   - Subscribes to `omni.event.>` for reaction events
+ *   - Text replies are matched against configurable approve/deny tokens
+ *   - Reactions are matched by emoji and correlated via omni_message_id
+ *   - Resolved via the same PG approval queue used by the SDK hook
+ */
+
+import { type NatsConnection, StringCodec, type Subscription, connect } from 'nats';
+import { getConnection } from './db.js';
+import { listPendingApprovals, resolveApproval } from './providers/claude-sdk-remote-approval.js';
+import { type PermissionsConfig, findWorkspace, getWorkspaceConfig } from './workspace.js';
+
+// ============================================================================
+// Defaults
+// ============================================================================
+
+const DEFAULT_APPROVE_TOKENS = ['y', 'yes', 'approve', 'sim'];
+const DEFAULT_DENY_TOKENS = ['n', 'no', 'deny', 'nao'];
+const DEFAULT_APPROVE_REACTIONS = ['\u{1F44D}', '\u{2705}', '\u{1F44C}']; // 👍 ✅ 👌
+const DEFAULT_DENY_REACTIONS = ['\u{1F44E}', '\u{274C}', '\u{1F6AB}']; // 👎 ❌ 🚫
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface OmniApprovalHandlerConfig {
+  natsUrl?: string;
+  permissions: PermissionsConfig;
+}
+
+/** Inbound NATS message payload from Omni. */
+interface InboundMessage {
+  content?: string;
+  sender?: string;
+  instanceId?: string;
+  chatId?: string;
+  agent?: string;
+}
+
+/** Inbound reaction event from Omni event stream. */
+interface ReactionEvent {
+  type?: string;
+  emoji?: string;
+  messageId?: string;
+  chatId?: string;
+  instanceId?: string;
+  sender?: string;
+}
+
+// ============================================================================
+// Handler
+// ============================================================================
+
+let handlerInstance: OmniApprovalHandler | null = null;
+
+function getApprovalHandler(): OmniApprovalHandler | null {
+  return handlerInstance;
+}
+
+class OmniApprovalHandler {
+  private nc: NatsConnection | null = null;
+  private subs: Subscription[] = [];
+  private sc = StringCodec();
+  private readonly permissions: PermissionsConfig;
+  private readonly natsUrl: string;
+  private readonly approveTokens: string[];
+  private readonly denyTokens: string[];
+
+  constructor(config: OmniApprovalHandlerConfig) {
+    this.permissions = config.permissions;
+    this.natsUrl = config.natsUrl ?? 'localhost:4222';
+    this.approveTokens = (config.permissions.approveTokens ?? DEFAULT_APPROVE_TOKENS).map((t) => t.toLowerCase());
+    this.denyTokens = (config.permissions.denyTokens ?? DEFAULT_DENY_TOKENS).map((t) => t.toLowerCase());
+  }
+
+  async start(): Promise<void> {
+    const { omniChat, omniInstance } = this.permissions;
+    if (!omniChat || !omniInstance) return;
+
+    this.nc = await connect({ servers: this.natsUrl });
+
+    // Subscribe to messages on the approval chat
+    // WhatsApp chat JIDs contain dots, so use `>` wildcard after instance
+    const messageTopic = `omni.message.${omniInstance}.>`;
+    const msgSub = this.nc.subscribe(messageTopic);
+    this.subs.push(msgSub);
+    this.processMessages(msgSub);
+
+    // Subscribe to event stream for reactions
+    const eventSub = this.nc.subscribe('omni.event.>');
+    this.subs.push(eventSub);
+    this.processEvents(eventSub);
+
+    handlerInstance = this;
+    console.log(`[omni-approval] Listening for approval replies on ${messageTopic}`);
+  }
+
+  async stop(): Promise<void> {
+    for (const sub of this.subs) {
+      sub.unsubscribe();
+    }
+    this.subs = [];
+    if (this.nc) {
+      await this.nc.close();
+      this.nc = null;
+    }
+    if (handlerInstance === this) handlerInstance = null;
+  }
+
+  // --------------------------------------------------------------------------
+  // Message processing
+  // --------------------------------------------------------------------------
+
+  private async processMessages(sub: Subscription): Promise<void> {
+    for await (const msg of sub) {
+      try {
+        const data: InboundMessage = JSON.parse(this.sc.decode(msg.data));
+
+        // Filter: only process messages from the configured approval chat
+        const chatId = data.chatId ?? this.extractChatIdFromSubject(msg.subject);
+        if (chatId !== this.permissions.omniChat) continue;
+
+        if (data.content) {
+          await this.handleTextReply(data.content, data.sender ?? 'whatsapp-user');
+        }
+      } catch {
+        /* skip malformed messages */
+      }
+    }
+  }
+
+  private async processEvents(sub: Subscription): Promise<void> {
+    for await (const msg of sub) {
+      try {
+        const data: ReactionEvent = JSON.parse(this.sc.decode(msg.data));
+        if (data.type !== 'reaction') continue;
+        if (data.chatId !== this.permissions.omniChat && data.instanceId !== this.permissions.omniInstance) continue;
+
+        if (data.emoji && data.messageId) {
+          await this.handleReaction(data.emoji, data.messageId, data.sender ?? 'whatsapp-user');
+        }
+      } catch {
+        /* skip non-JSON or irrelevant events */
+      }
+    }
+  }
+
+  /** Extract chat ID from NATS subject: omni.message.{instance}.{chatId...} */
+  private extractChatIdFromSubject(subject: string): string | undefined {
+    const parts = subject.split('.');
+    // subject: omni.message.{instance}.{chat} — chat may contain dots
+    if (parts.length >= 4) return parts.slice(3).join('.');
+    return undefined;
+  }
+
+  // --------------------------------------------------------------------------
+  // Token matching
+  // --------------------------------------------------------------------------
+
+  /**
+   * Match text content against approve/deny tokens.
+   * Resolves the oldest pending approval on match.
+   */
+  async handleTextReply(content: string, sender: string): Promise<boolean> {
+    const normalized = content.trim().toLowerCase();
+    if (!normalized) return false;
+
+    let decision: 'allow' | 'deny' | null = null;
+    if (this.approveTokens.includes(normalized)) decision = 'allow';
+    else if (this.denyTokens.includes(normalized)) decision = 'deny';
+    if (!decision) return false;
+
+    // Resolve the oldest pending approval (FIFO)
+    const pending = await listPendingApprovals();
+    if (pending.length === 0) return false;
+
+    const oldest = pending[0]; // Already sorted by created_at ASC
+    const resolved = await resolveApproval(oldest.id, decision, sender);
+    if (resolved) {
+      console.log(`[omni-approval] Resolved ${oldest.id} as ${decision} by ${sender} (text: "${normalized}")`);
+    }
+    return resolved;
+  }
+
+  /**
+   * Match reaction emoji against approval message.
+   * Looks up the approval by omni_message_id, falls back to oldest pending.
+   */
+  async handleReaction(emoji: string, messageId: string, sender: string): Promise<boolean> {
+    let decision: 'allow' | 'deny' | null = null;
+    if (DEFAULT_APPROVE_REACTIONS.includes(emoji)) decision = 'allow';
+    else if (DEFAULT_DENY_REACTIONS.includes(emoji)) decision = 'deny';
+    if (!decision) return false;
+
+    // Try exact match via omni_message_id
+    try {
+      const sql = await getConnection();
+      const [approval] = await sql`
+        SELECT id FROM approvals
+        WHERE omni_message_id = ${messageId} AND decision = 'pending'
+      `;
+      if (approval) {
+        const resolved = await resolveApproval(approval.id, decision, sender);
+        if (resolved) {
+          console.log(`[omni-approval] Resolved ${approval.id} via reaction ${emoji} by ${sender}`);
+        }
+        return resolved;
+      }
+    } catch {
+      /* column may not exist yet — fall through to FIFO */
+    }
+
+    // Fallback: resolve the oldest pending approval
+    const pending = await listPendingApprovals();
+    if (pending.length === 0) return false;
+
+    const resolved = await resolveApproval(pending[0].id, decision, sender);
+    if (resolved) {
+      console.log(`[omni-approval] Resolved ${pending[0].id} via reaction ${emoji} by ${sender} (fallback)`);
+    }
+    return resolved;
+  }
+}
+
+// ============================================================================
+// Lifecycle helpers
+// ============================================================================
+
+/** Start the Omni approval handler using workspace config. */
+export async function startOmniApprovalHandler(natsUrl?: string): Promise<OmniApprovalHandler | null> {
+  const ws = findWorkspace();
+  if (!ws) return null;
+
+  const config = getWorkspaceConfig(ws.root);
+  if (!config.permissions?.omniChat || !config.permissions?.omniInstance) return null;
+
+  const handler = new OmniApprovalHandler({
+    natsUrl,
+    permissions: config.permissions,
+  });
+
+  await handler.start();
+  return handler;
+}
+
+/** Stop the running handler if active. */
+async function stopOmniApprovalHandler(): Promise<void> {
+  if (handlerInstance) {
+    await handlerInstance.stop();
+  }
+}

--- a/src/lib/protocol-router.ts
+++ b/src/lib/protocol-router.ts
@@ -490,8 +490,14 @@ async function injectToTmuxPane(worker: registry.Agent, message: mailbox.Mailbox
  */
 export async function deliverToPane(toWorker: string, messageId: string): Promise<boolean> {
   const worker = await registry.get(toWorker);
-  if (!worker || !worker.paneId) return false;
-  if (!(await _deps.isPaneAlive(worker.paneId))) return false;
+  if (!worker || !worker.paneId) {
+    await mailbox.markFailed(messageId);
+    return false;
+  }
+  if (!(await _deps.isPaneAlive(worker.paneId))) {
+    await mailbox.markFailed(messageId);
+    return false;
+  }
 
   const message = await mailbox.getById(messageId);
   if (!message || message.deliveredAt) return false;
@@ -499,6 +505,8 @@ export async function deliverToPane(toWorker: string, messageId: string): Promis
   const injected = await injectToTmuxPane(worker, message);
   if (injected && worker.repoPath) {
     await mailbox.markDelivered(worker.repoPath, worker.id, messageId);
+  } else {
+    await mailbox.markFailed(messageId);
   }
   return injected;
 }

--- a/src/lib/providers/__tests__/claude-sdk.test.ts
+++ b/src/lib/providers/__tests__/claude-sdk.test.ts
@@ -241,7 +241,8 @@ describe('translateSdkConfig', () => {
       settings: '/path/to/settings.json',
     });
 
-    expect(result.permissionMode).toBe('acceptEdits');
+    // permissionMode must NOT be copied — SDK executor always bypasses
+    expect(result.permissionMode).toBeUndefined();
     expect(result.tools).toEqual(['Bash', 'Read']);
     expect(result.allowedTools).toEqual(['Bash']);
     expect(result.disallowedTools).toEqual(['Write']);

--- a/src/lib/providers/claude-sdk-remote-approval.ts
+++ b/src/lib/providers/claude-sdk-remote-approval.ts
@@ -1,0 +1,316 @@
+/**
+ * Remote Approval Gate — PG-backed human-in-the-loop tool approval.
+ *
+ * When an agent uses `permissionMode: 'remoteApproval'`, every tool use
+ * blocks until a human approves or denies via Omni (WhatsApp), the desktop
+ * app, or CLI (`genie approval resolve`).
+ *
+ * Resolution delivery uses PG LISTEN/NOTIFY with a 5s safety-net poll.
+ * Timeout auto-resolves with the configured `defaultAction` (default: deny).
+ */
+
+import type { HookCallback, PreToolUseHookInput, SyncHookJSONOutput } from '@anthropic-ai/claude-agent-sdk';
+import { getConnection } from '../db.js';
+import type { PermissionsConfig } from '../workspace.js';
+
+// ============================================================================
+// Omni notification — send approval requests to WhatsApp via Omni CLI
+// ============================================================================
+
+/** Recent Omni send timestamps for rate limiting. */
+const recentOmniSends: number[] = [];
+const BATCH_WINDOW_MS = 10_000;
+const BATCH_THRESHOLD = 3;
+
+function pruneRecentSends(): void {
+  const cutoff = Date.now() - BATCH_WINDOW_MS;
+  while (recentOmniSends.length > 0 && recentOmniSends[0] < cutoff) {
+    recentOmniSends.shift();
+  }
+}
+
+/** Format an approval request as a WhatsApp-friendly message. */
+function formatApprovalMessage(approvalId: string, agentName: string, toolName: string, preview: string): string {
+  const shortPreview = preview.length > 200 ? `${preview.slice(0, 197)}...` : preview;
+  return [
+    '\u{1F514} *Approval Required*',
+    '',
+    `Agent: *${agentName}*`,
+    `Tool: \`${toolName}\``,
+    `Preview: ${shortPreview}`,
+    '',
+    'Reply *y* to approve or *n* to deny',
+    'Or react \u{1F44D} / \u{1F44E}',
+    '',
+    `_ID: ${approvalId}_`,
+  ].join('\n');
+}
+
+function formatBatchMessage(pendingCount: number): string {
+  return [
+    `\u{1F514} *${pendingCount} Approvals Pending*`,
+    '',
+    'Multiple tool approvals are queued.',
+    'Reply *y* to approve next or *n* to deny.',
+    'Use `genie approval list` for details.',
+  ].join('\n');
+}
+
+/** Store the Omni message ID for reaction matching. Best-effort. */
+async function updateOmniMessageId(approvalId: string, omniMessageId: string): Promise<void> {
+  try {
+    const sql = await getConnection();
+    await sql`UPDATE approvals SET omni_message_id = ${omniMessageId} WHERE id = ${approvalId}`;
+  } catch {
+    /* best-effort — reaction matching degrades to text-only */
+  }
+}
+
+/**
+ * Send approval notification to WhatsApp via Omni CLI. Fire-and-forget.
+ *
+ * Rate limiting: if >3 approval sends within 10s, sends a batched summary
+ * instead of individual messages to avoid flooding the chat.
+ */
+export async function sendApprovalToOmni(
+  approvalId: string,
+  agentName: string,
+  toolName: string,
+  preview: string,
+  permissions: PermissionsConfig,
+): Promise<void> {
+  const { omniChat, omniInstance } = permissions;
+  if (!omniChat || !omniInstance) return;
+
+  pruneRecentSends();
+
+  let text: string;
+  if (recentOmniSends.length >= BATCH_THRESHOLD) {
+    const sql = await getConnection();
+    const [row] = await sql`SELECT count(*)::int AS count FROM approvals WHERE decision = 'pending'`;
+    text = formatBatchMessage(row.count);
+  } else {
+    text = formatApprovalMessage(approvalId, agentName, toolName, preview);
+  }
+
+  recentOmniSends.push(Date.now());
+
+  try {
+    const proc = Bun.spawn(['omni', 'send', '--instance', omniInstance, '--to', omniChat, '--text', text, '--json'], {
+      stdout: 'pipe',
+      stderr: 'ignore',
+    });
+    const stdout = await new Response(proc.stdout).text();
+    await proc.exited;
+
+    // Capture message ID for reaction matching
+    try {
+      const result = JSON.parse(stdout);
+      const messageId = result.messageId ?? result.message_id ?? result.id;
+      if (messageId) await updateOmniMessageId(approvalId, String(messageId));
+    } catch {
+      /* JSON parse failed — message sent, ID not captured */
+    }
+  } catch (err) {
+    console.warn(`[remote-approval] Omni notification failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface RemoteApprovalConfig {
+  /** Executor ID for the agent session. */
+  executorId: string;
+  /** Human-readable agent name. */
+  agentName: string;
+  /** Workspace-level permissions config (tokens, timeout, defaultAction, omni). */
+  permissions?: PermissionsConfig;
+}
+
+// ============================================================================
+// Approval DB Operations
+// ============================================================================
+
+/** Insert a pending approval row. Returns the generated approval ID. */
+export async function insertApproval(
+  executorId: string,
+  agentName: string,
+  toolName: string,
+  toolInputPreview: string,
+  timeoutAt: Date,
+): Promise<string> {
+  const sql = await getConnection();
+  const [row] = await sql`
+    INSERT INTO approvals (executor_id, agent_name, tool_name, tool_input_preview, timeout_at)
+    VALUES (${executorId}, ${agentName}, ${toolName}, ${toolInputPreview}, ${timeoutAt})
+    RETURNING id
+  `;
+  return row.id;
+}
+
+/** Resolve a pending approval. Returns true if a row was updated. */
+export async function resolveApproval(
+  approvalId: string,
+  decision: 'allow' | 'deny',
+  decidedBy: string,
+): Promise<boolean> {
+  const sql = await getConnection();
+  const result = await sql`
+    UPDATE approvals
+    SET decision = ${decision}, decided_by = ${decidedBy}, decided_at = now()
+    WHERE id = ${approvalId} AND decision = 'pending'
+  `;
+  return result.count > 0;
+}
+
+/** List pending approvals, optionally filtered by agent name. */
+export async function listPendingApprovals(agentName?: string) {
+  const sql = await getConnection();
+  if (agentName) {
+    return sql`
+      SELECT id, executor_id, agent_name, tool_name, tool_input_preview, timeout_at, created_at
+      FROM approvals WHERE decision = 'pending' AND agent_name = ${agentName}
+      ORDER BY created_at ASC
+    `;
+  }
+  return sql`
+    SELECT id, executor_id, agent_name, tool_name, tool_input_preview, timeout_at, created_at
+    FROM approvals WHERE decision = 'pending'
+    ORDER BY created_at ASC
+  `;
+}
+
+// ============================================================================
+// Wait for Resolution
+// ============================================================================
+
+type Decision = 'allow' | 'deny';
+
+/**
+ * Query PG for the current state of an approval.
+ * Returns the decision if resolved, or null if still pending.
+ * Auto-resolves if the timeout has passed.
+ */
+async function pollApprovalState(approvalId: string, defaultAction: Decision): Promise<Decision | null> {
+  const sql = await getConnection();
+  const [approval] = await sql`
+    SELECT decision, timeout_at FROM approvals WHERE id = ${approvalId}
+  `;
+  if (!approval) return 'deny';
+  if (approval.decision === 'allow' || approval.decision === 'deny') return approval.decision;
+  if (new Date(approval.timeout_at) <= new Date()) {
+    await resolveApproval(approvalId, defaultAction, 'timeout');
+    return defaultAction;
+  }
+  return null;
+}
+
+/**
+ * Wait for an approval to be resolved via LISTEN/NOTIFY + polling safety net.
+ * Returns the decision ('allow' or 'deny').
+ */
+export async function waitForResolution(
+  approvalId: string,
+  timeoutAt: Date,
+  defaultAction: Decision,
+): Promise<Decision> {
+  const sql = await getConnection();
+
+  return new Promise<Decision>((resolve) => {
+    let resolved = false;
+    let listener: { unlisten: () => Promise<void> } | null = null;
+    let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+    const finish = (decision: Decision) => {
+      if (resolved) return;
+      resolved = true;
+      if (listener) listener.unlisten().catch(() => {});
+      if (pollTimer) clearInterval(pollTimer);
+      resolve(decision);
+    };
+
+    const checkResolution = async () => {
+      if (resolved) return;
+      try {
+        const result = await pollApprovalState(approvalId, defaultAction);
+        if (result !== null) finish(result);
+      } catch {
+        finish('deny');
+      }
+    };
+
+    // Subscribe to LISTEN channel
+    sql
+      .listen('genie_approval_resolved', (payload: string) => {
+        if (payload === approvalId) checkResolution();
+      })
+      .then((l: { unlisten: () => Promise<void> }) => {
+        listener = l;
+        if (resolved) l.unlisten().catch(() => {});
+      })
+      .catch(() => {
+        // LISTEN failed — rely on polling only
+      });
+
+    // Safety-net poll every 5s
+    pollTimer = setInterval(checkResolution, 5000);
+
+    // Hard timeout failsafe
+    const msUntilTimeout = Math.max(0, timeoutAt.getTime() - Date.now() + 1000);
+    setTimeout(() => {
+      if (!resolved) {
+        resolveApproval(approvalId, defaultAction, 'timeout').catch(() => {});
+        finish(defaultAction);
+      }
+    }, msUntilTimeout).unref();
+
+    // Initial check (handles race between insert and listen)
+    checkResolution();
+  });
+}
+
+// ============================================================================
+// Hook Factory
+// ============================================================================
+
+/**
+ * Create a PreToolUse hook that blocks until a human approves or denies.
+ *
+ * Inserts an approval row into PG, subscribes to LISTEN/NOTIFY for
+ * resolution, and polls every 5s as a safety net. Returns the human's
+ * decision as `permissionDecision: 'allow' | 'deny'`.
+ */
+export function createRemoteApprovalGate(config: RemoteApprovalConfig): HookCallback {
+  const timeoutSec = config.permissions?.timeout ?? 300;
+  const defaultAction = config.permissions?.defaultAction ?? 'deny';
+
+  return async (input): Promise<SyncHookJSONOutput> => {
+    const hookInput = input as PreToolUseHookInput;
+    const toolName = hookInput.tool_name;
+    const toolInput = hookInput.tool_input ?? {};
+
+    // Generate truncated preview for display
+    const preview = JSON.stringify(toolInput).slice(0, 500);
+    const timeoutAt = new Date(Date.now() + timeoutSec * 1000);
+
+    // Insert pending approval
+    const approvalId = await insertApproval(config.executorId, config.agentName, toolName, preview, timeoutAt);
+
+    // Fire-and-forget Omni notification (WhatsApp)
+    if (config.permissions?.omniChat && config.permissions?.omniInstance) {
+      sendApprovalToOmni(approvalId, config.agentName, toolName, preview, config.permissions).catch(() => {});
+    }
+
+    // Block until resolved
+    const decision = await waitForResolution(approvalId, timeoutAt, defaultAction);
+
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: decision,
+      },
+    };
+  };
+}

--- a/src/lib/providers/claude-sdk.ts
+++ b/src/lib/providers/claude-sdk.ts
@@ -11,6 +11,7 @@
 import { readFileSync } from 'node:fs';
 import { query } from '@anthropic-ai/claude-agent-sdk';
 import type { HookCallbackMatcher, Options, Query, SDKMessage } from '@anthropic-ai/claude-agent-sdk';
+import { ensureTeammateBypassPermissions } from '../claude-settings.js';
 import type {
   Executor,
   ExecutorProvider,
@@ -20,9 +21,11 @@ import type {
   TransportType,
 } from '../executor-types.js';
 import type { SdkDirectoryConfig } from '../sdk-directory-types.js';
+import { findWorkspace, getWorkspaceConfig } from '../workspace.js';
 import { routeSdkMessage } from './claude-sdk-events.js';
 import type { PermissionConfig } from './claude-sdk-permissions.js';
 import { createPermissionGate } from './claude-sdk-permissions.js';
+import { createRemoteApprovalGate } from './claude-sdk-remote-approval.js';
 
 // ============================================================================
 // SdkDirectoryConfig -> SDK Options translation
@@ -37,7 +40,6 @@ import { createPermissionGate } from './claude-sdk-permissions.js';
  */
 /** Fields that can be copied directly when truthy (non-null, non-undefined). */
 const SDK_TRUTHY_FIELDS = [
-  'permissionMode',
   'tools',
   'allowedTools',
   'disallowedTools',
@@ -148,6 +150,9 @@ export class ClaudeSdkProvider implements ExecutorProvider {
     extraOptions?: Partial<Options>,
     sdkConfig?: SdkDirectoryConfig,
   ): { messages: Query; abortController: AbortController } {
+    // Defense-in-depth: ensure Claude Code global settings allow bypass
+    ensureTeammateBypassPermissions();
+
     const abortController = new AbortController();
 
     // Track this query
@@ -155,16 +160,36 @@ export class ClaudeSdkProvider implements ExecutorProvider {
     this.activeQueries.set(ctx.executorId, tracker);
 
     // Build permission gate hooks
-    const permHooks: Partial<Record<string, HookCallbackMatcher[]>> | undefined = permissionConfig
-      ? {
-          PreToolUse: [
-            {
-              matcher: '*',
-              hooks: [createPermissionGate(permissionConfig)],
-            },
-          ],
-        }
-      : undefined;
+    let permHooks: Partial<Record<string, HookCallbackMatcher[]>> | undefined;
+
+    if (sdkConfig?.permissionMode === 'remoteApproval') {
+      // Remote approval: block on every tool use until a human decides
+      const ws = findWorkspace(ctx.cwd);
+      const permissions = ws ? getWorkspaceConfig(ws.root).permissions : undefined;
+      permHooks = {
+        PreToolUse: [
+          {
+            matcher: '*',
+            hooks: [
+              createRemoteApprovalGate({
+                executorId: ctx.executorId,
+                agentName: ctx.agentId ?? ctx.role ?? 'unknown',
+                permissions,
+              }),
+            ],
+          },
+        ],
+      };
+    } else if (permissionConfig) {
+      permHooks = {
+        PreToolUse: [
+          {
+            matcher: '*',
+            hooks: [createPermissionGate(permissionConfig)],
+          },
+        ],
+      };
+    }
 
     // Translate directory-level SDK config
     const translatedSdk = sdkConfig ? translateSdkConfig(sdkConfig) : undefined;
@@ -186,8 +211,6 @@ export class ClaudeSdkProvider implements ExecutorProvider {
     const options: Options = {
       cwd: ctx.cwd,
       abortController,
-      permissionMode: 'bypassPermissions',
-      allowDangerouslySkipPermissions: true,
       ...(ctx.model && { model: ctx.model }),
       ...(resolvedSystemPrompt && { systemPrompt: resolvedSystemPrompt }),
       // Layer 1: directory-level SDK config (lowest priority)
@@ -196,6 +219,10 @@ export class ClaudeSdkProvider implements ExecutorProvider {
       ...extraOptions,
       // Hooks are always merged, never overwritten
       ...(hasHooks && { hooks: mergedHooks }),
+      // MUST come last — SDK executor always bypasses permissions.
+      // No spread above may override these.
+      permissionMode: 'bypassPermissions',
+      allowDangerouslySkipPermissions: true,
     };
 
     const messages = query({ prompt, options });

--- a/src/lib/scheduler-daemon.ts
+++ b/src/lib/scheduler-daemon.ts
@@ -24,7 +24,7 @@ import type { Agent } from './agent-registry.js';
 import { computeNextCronDue, parseDuration } from './cron.js';
 import { type EventRouterHandle, startEventRouter } from './event-router.js';
 import { getInboxPollIntervalMs, startInboxWatcher, stopInboxWatcher } from './inbox-watcher.js';
-import { subscribeDelivery } from './mailbox.js';
+import { getRetryable, markEscalated, subscribeDelivery } from './mailbox.js';
 import { type RunSpec, resolveRunSpec } from './run-spec.js';
 
 // ============================================================================
@@ -1238,6 +1238,7 @@ export function startDaemon(
   let captureFallbackTimer: ReturnType<typeof setInterval> | null = null;
   let eventRouterHandle: EventRouterHandle | null = null;
   let deliveryUnsub: (() => Promise<void>) | null = null;
+  let deliveryRetryTimer: ReturnType<typeof setInterval> | null = null;
 
   // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: stop() is a flat cleanup sequence for all daemon resources
   const stop = () => {
@@ -1277,6 +1278,10 @@ export function startDaemon(
     }
     eventRouterHandle?.stop().catch(() => {});
     eventRouterHandle = null;
+    if (deliveryRetryTimer) {
+      clearInterval(deliveryRetryTimer);
+      deliveryRetryTimer = null;
+    }
     if (deliveryUnsub) {
       deliveryUnsub().catch(() => {});
       deliveryUnsub = null;
@@ -1512,6 +1517,60 @@ export function startDaemon(
     } catch {
       // PG LISTEN not available — inbox-watcher polling remains the fallback
     }
+
+    // Mailbox delivery retry loop: retry failed deliveries every 60s
+    const MAX_DELIVERY_ATTEMPTS = 3;
+    deliveryRetryTimer = setInterval(async () => {
+      try {
+        const retryable = await getRetryable(MAX_DELIVERY_ATTEMPTS);
+        for (const msg of retryable) {
+          try {
+            const { deliverToPane } = await import('./protocol-router.js');
+            const delivered = await deliverToPane(msg.to, msg.id);
+            if (delivered) {
+              deps.log({
+                timestamp: deps.now().toISOString(),
+                level: 'info',
+                event: 'mailbox_delivery_retried',
+                messageId: msg.id,
+                to: msg.to,
+              });
+              continue;
+            }
+            // deliverToPane already called markFailed — check if max attempts reached
+            const sql = await deps.getConnection();
+            const rows = await sql`SELECT delivery_attempts, repo_path FROM mailbox WHERE id = ${msg.id} LIMIT 1`;
+            const attempts = rows[0]?.delivery_attempts ?? 0;
+            if (attempts >= MAX_DELIVERY_ATTEMPTS) {
+              await markEscalated(msg.id);
+              const repoPath = rows[0]?.repo_path;
+              if (repoPath) {
+                const { send } = await import('./mailbox.js');
+                await send(
+                  repoPath,
+                  'scheduler',
+                  'team-lead',
+                  `[escalation] Message ${msg.id} from "${msg.from}" to "${msg.to}" failed delivery after ${MAX_DELIVERY_ATTEMPTS} attempts. Body: "${msg.body.slice(0, 200)}"`,
+                );
+              }
+              deps.log({
+                timestamp: deps.now().toISOString(),
+                level: 'warn',
+                event: 'mailbox_delivery_escalated',
+                messageId: msg.id,
+                to: msg.to,
+                attempts,
+              });
+            }
+          } catch {
+            // Individual message retry failed — will be retried next cycle
+          }
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        deps.log({ timestamp: deps.now().toISOString(), level: 'error', event: 'mailbox_retry_error', error: message });
+      }
+    }, 60_000);
 
     captureFallbackTimer = await initSessionCapture(deps, config);
 

--- a/src/lib/sdk-directory-types.ts
+++ b/src/lib/sdk-directory-types.ts
@@ -13,7 +13,14 @@
 // ============================================================================
 
 /** Permission mode controlling how tool executions are handled. */
-export type SdkPermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan' | 'dontAsk' | 'auto';
+export type SdkPermissionMode =
+  | 'default'
+  | 'acceptEdits'
+  | 'bypassPermissions'
+  | 'plan'
+  | 'dontAsk'
+  | 'auto'
+  | 'remoteApproval';
 
 /** Reasoning effort level. Named level or an integer 0-100. */
 export type SdkEffortLevel = ('low' | 'medium' | 'high' | 'max') | number;

--- a/src/lib/team-auto-spawn.ts
+++ b/src/lib/team-auto-spawn.ts
@@ -98,6 +98,28 @@ export async function isTeamActive(teamName: string): Promise<boolean> {
 }
 
 /**
+ * Check if a specific agent's tmux pane is alive.
+ *
+ * Unlike `isTeamActive` which checks for the team window, this checks
+ * whether a specific agent's pane exists and is responsive.
+ * Used by inbox-watcher for per-recipient liveness checks.
+ *
+ * @param agentName - Agent name or ID to look up in the registry
+ * @returns true if the agent has a live pane
+ */
+export async function isAgentAlive(agentName: string): Promise<boolean> {
+  try {
+    const { list } = await import('./agent-registry.js');
+    const agents = await list();
+    const match = agents.find((a) => a.id === agentName || a.role === agentName);
+    if (!match?.paneId) return false;
+    return tmux.isPaneAlive(match.paneId);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Ensure a team has an active Claude Code team-lead.
  *
  * 1. If team is already active (config + tmux window exist), returns immediately.

--- a/src/lib/workspace.ts
+++ b/src/lib/workspace.ts
@@ -29,6 +29,22 @@ export interface SdkConfig {
   includeHookEvents?: boolean;
 }
 
+/** Remote approval permission configuration. */
+export interface PermissionsConfig {
+  /** Tokens that resolve an approval as allow (default: ['y', 'yes', 'approve', 'sim']). */
+  approveTokens?: string[];
+  /** Tokens that resolve an approval as deny (default: ['n', 'no', 'deny', 'nao']). */
+  denyTokens?: string[];
+  /** Timeout in seconds before auto-resolving (default: 300). */
+  timeout?: number;
+  /** Action taken on timeout (default: 'deny'). */
+  defaultAction?: 'allow' | 'deny';
+  /** Omni chat JID for WhatsApp approval delivery. */
+  omniChat?: string;
+  /** Omni instance ID for WhatsApp approval delivery. */
+  omniInstance?: string;
+}
+
 export interface WorkspaceConfig {
   name: string;
   pgUrl?: string;
@@ -43,6 +59,8 @@ export interface WorkspaceConfig {
   tmux?: TmuxConfig;
   /** SDK transport settings. */
   sdk?: SdkConfig;
+  /** Remote approval settings for permissionMode: remoteApproval. */
+  permissions?: PermissionsConfig;
 }
 
 interface WorkspaceInfo {

--- a/src/templates/genie-agents.md
+++ b/src/templates/genie-agents.md
@@ -6,7 +6,7 @@ promptMode: append
 color: cyan
 effort: high
 thinking: enabled
-permissionMode: default
+permissionMode: bypassPermissions
 ---
 
 @HEARTBEAT.md

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -90,7 +90,7 @@ promptMode: append
 color: cyan
 effort: high
 thinking: enabled
-permissionMode: default
+permissionMode: bypassPermissions
 ---
 
 @HEARTBEAT.md

--- a/src/term-commands/agent/inbox.ts
+++ b/src/term-commands/agent/inbox.ts
@@ -100,6 +100,10 @@ export function registerAgentInbox(parent: Command): void {
           const { isTeamActive } = await import('../../lib/team-auto-spawn.js');
           return isTeamActive(teamName);
         },
+        isAgentAlive: async (agentName) => {
+          const { isAgentAlive } = await import('../../lib/team-auto-spawn.js');
+          return isAgentAlive(agentName);
+        },
         ensureTeamLead: async (teamName, workingDir) => {
           const { ensureTeamLead } = await import('../../lib/team-auto-spawn.js');
           const result = await ensureTeamLead(teamName, workingDir);

--- a/src/term-commands/approval.ts
+++ b/src/term-commands/approval.ts
@@ -1,0 +1,150 @@
+/**
+ * Approval commands — CLI interface for remote approval queue management.
+ *
+ * Commands:
+ *   genie approval request --tool <name> --input <preview> --agent <name> --wait
+ *   genie approval resolve <id> --decision allow|deny --by <actor>
+ *   genie approval list [--agent <name>] [--json]
+ */
+
+import type { Command } from 'commander';
+import {
+  insertApproval,
+  listPendingApprovals,
+  resolveApproval,
+  waitForResolution,
+} from '../lib/providers/claude-sdk-remote-approval.js';
+import { findWorkspace, getWorkspaceConfig } from '../lib/workspace.js';
+
+// ============================================================================
+// Handlers
+// ============================================================================
+
+interface RequestOptions {
+  tool: string;
+  input: string;
+  agent: string;
+  wait?: boolean;
+  timeout?: string;
+}
+
+async function handleRequest(options: RequestOptions): Promise<void> {
+  const ws = findWorkspace();
+  const permissions = ws ? getWorkspaceConfig(ws.root).permissions : undefined;
+  const timeoutSec = options.timeout ? Number(options.timeout) : (permissions?.timeout ?? 300);
+  const defaultAction = permissions?.defaultAction ?? 'deny';
+  const timeoutAt = new Date(Date.now() + timeoutSec * 1000);
+
+  const approvalId = await insertApproval(`cli-${process.pid}`, options.agent, options.tool, options.input, timeoutAt);
+
+  console.log(`Approval created: ${approvalId}`);
+
+  if (options.wait) {
+    console.log(`Waiting for resolution (timeout: ${timeoutSec}s, default: ${defaultAction})...`);
+    const decision = await waitForResolution(approvalId, timeoutAt, defaultAction);
+    console.log(`Decision: ${decision}`);
+    if (decision === 'deny') process.exit(1);
+  }
+}
+
+interface ResolveOptions {
+  decision: string;
+  by: string;
+}
+
+async function handleResolve(id: string, options: ResolveOptions): Promise<void> {
+  if (options.decision !== 'allow' && options.decision !== 'deny') {
+    console.error('Error: --decision must be "allow" or "deny"');
+    process.exit(1);
+  }
+
+  const updated = await resolveApproval(id, options.decision as 'allow' | 'deny', options.by);
+  if (updated) {
+    console.log(`Approval ${id} resolved: ${options.decision} by ${options.by}`);
+  } else {
+    console.error(`Error: Approval ${id} not found or already resolved`);
+    process.exit(1);
+  }
+}
+
+interface ListOptions {
+  agent?: string;
+  json?: boolean;
+}
+
+async function handleList(options: ListOptions): Promise<void> {
+  const rows = await listPendingApprovals(options.agent);
+
+  if (options.json) {
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
+
+  if (rows.length === 0) {
+    console.log('No pending approvals.');
+    return;
+  }
+
+  console.log(`  ${'ID'.padEnd(38)} ${'AGENT'.padEnd(20)} ${'TOOL'.padEnd(15)} ${'TIMEOUT'}`);
+  console.log(`  ${'─'.repeat(85)}`);
+  for (const row of rows) {
+    const timeout = new Date(row.timeout_at).toLocaleTimeString();
+    console.log(
+      `  ${String(row.id).padEnd(38)} ${String(row.agent_name).padEnd(20)} ${String(row.tool_name).padEnd(15)} ${timeout}`,
+    );
+  }
+  console.log(`\n  ${rows.length} pending approval${rows.length === 1 ? '' : 's'}`);
+}
+
+// ============================================================================
+// Registration
+// ============================================================================
+
+export function registerApprovalCommands(program: Command): void {
+  const approval = program.command('approval').description('Remote approval queue management');
+
+  approval
+    .command('request')
+    .description('Create an approval request (for tmux-path agents)')
+    .requiredOption('--tool <name>', 'Tool name requiring approval')
+    .requiredOption('--input <preview>', 'Tool input preview text')
+    .requiredOption('--agent <name>', 'Agent name requesting approval')
+    .option('--wait', 'Block until the approval is resolved')
+    .option('--timeout <seconds>', 'Timeout in seconds (overrides workspace config)')
+    .action(async (options: RequestOptions) => {
+      try {
+        await handleRequest(options);
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    });
+
+  approval
+    .command('resolve <id>')
+    .description('Resolve a pending approval')
+    .requiredOption('--decision <decision>', 'Decision: allow or deny')
+    .requiredOption('--by <actor>', 'Who made the decision')
+    .action(async (id: string, options: ResolveOptions) => {
+      try {
+        await handleResolve(id, options);
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    });
+
+  approval
+    .command('list')
+    .description('List pending approvals')
+    .option('--agent <name>', 'Filter by agent name')
+    .option('--json', 'Output as JSON')
+    .action(async (options: ListOptions) => {
+      try {
+        await handleList(options);
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    });
+}

--- a/src/term-commands/msg.ts
+++ b/src/term-commands/msg.ts
@@ -642,6 +642,10 @@ Examples:
           const { isTeamActive } = await import('../lib/team-auto-spawn.js');
           return isTeamActive(teamName);
         },
+        isAgentAlive: async (agentName) => {
+          const { isAgentAlive } = await import('../lib/team-auto-spawn.js');
+          return isAgentAlive(agentName);
+        },
         ensureTeamLead: async (teamName, workingDir) => {
           const { ensureTeamLead } = await import('../lib/team-auto-spawn.js');
           const result = await ensureTeamLead(teamName, workingDir);

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -150,7 +150,7 @@ function applyTuiStyle(): void {
   const cmds = [
     `set-option -t ${TUI_SESSION} pane-border-style 'fg=${TUI_STYLE.inactiveBorder}'`,
     `set-option -t ${TUI_SESSION} pane-active-border-style 'fg=${TUI_STYLE.activeBorder}'`,
-    `set-option -t ${TUI_SESSION} mouse on`,
+    ...(process.env.GENIE_TMUX_MOUSE !== 'off' ? [`set-option -t ${TUI_SESSION} mouse on`] : []),
     `set-option -t ${TUI_SESSION} status off`,
     `set-option -t ${TUI_SESSION} pane-border-status off`,
   ];
@@ -354,9 +354,15 @@ interface DaemonHandles {
   schedulerHandle: { stop: () => void; done: Promise<void> } | null;
   agentWatcher: { close: () => void } | null;
   brainHandle: { stop: () => Promise<void>; port: number } | null;
+  omniApprovalHandler: { stop: () => Promise<void> } | null;
 }
 
-const handles: DaemonHandles = { schedulerHandle: null, agentWatcher: null, brainHandle: null };
+const handles: DaemonHandles = {
+  schedulerHandle: null,
+  agentWatcher: null,
+  brainHandle: null,
+  omniApprovalHandler: null,
+};
 
 /** Sync agent directory from workspace and start file watcher. */
 async function startAgentSync(): Promise<{ close: () => void } | null> {
@@ -550,6 +556,18 @@ async function startForeground(headless?: boolean): Promise<void> {
   // 4. Start scheduler + event-router + inbox-watcher
   await startScheduler();
 
+  // 5. Start Omni approval handler (if workspace has approval config)
+  try {
+    const { startOmniApprovalHandler } = await import('../lib/omni-approval-handler.js');
+    const handler = await startOmniApprovalHandler();
+    if (handler) {
+      handles.omniApprovalHandler = handler;
+      console.log('  Omni approval handler started');
+    }
+  } catch {
+    // NATS or workspace not configured — non-fatal
+  }
+
   const stopMsg = headless ? 'Send SIGTERM to stop.' : 'Press Ctrl+C to stop.';
   console.log(`\ngenie serve is running (${mode}). ${stopMsg}`);
 
@@ -567,7 +585,13 @@ async function startForeground(headless?: boolean): Promise<void> {
     // 2. Stop scheduler (drains in-flight)
     handles.schedulerHandle?.stop();
 
-    // 2.5. Stop brain server (best-effort — signal handlers call process.exit()
+    // 2.5. Stop Omni approval handler
+    if (handles.omniApprovalHandler) {
+      handles.omniApprovalHandler.stop().catch(() => {});
+      handles.omniApprovalHandler = null;
+    }
+
+    // 2.6. Stop brain server (best-effort — signal handlers call process.exit()
     // immediately after shutdown(), so this is fire-and-forget like all other
     // services. The OS reclaims sockets/connections on process exit.)
     if (handles.brainHandle) {


### PR DESCRIPTION
## Summary

Complete implementation of wish agent-stability-hardening — fixes 3 stability bugs AND adds a new permissionMode: remoteApproval feature for human-in-the-loop tool approval via WhatsApp and the Genie desktop app. 39 files, ~2000 lines.

### Wave 1 — Bug Fixes
- **Group 1:** Permission spread fix (#1094) — strip permissionMode from translateSdkConfig, move bypass after spreads, change scaffold default
- **Group 5:** Inbox delivery retry (#1064) — markFailed, 60s retry loop, escalation after 3 failures, isAgentAlive
- **Group 6:** OSC52 clipboard + tmux mouse (#1093) — SSH_TTY primary target, GENIE_TMUX_MOUSE opt-out

### Wave 2 — Remote Approval Core
- **Group 2:** PG approvals table + LISTEN/NOTIFY triggers, createRemoteApprovalGate hook, CLI commands, workspace.json permissions config

### Wave 3 — Approval Frontends
- **Group 3:** Omni WhatsApp — message on approval, text/reaction matching, rate limiting
- **Group 4:** Genie App — ApprovalToast, ApprovalMessage with Approve/Deny/Preview, NATS subjects, sidecar bridge

### Integration Fix
- Wire Omni approval handler into genie serve lifecycle (start after scheduler, stop on shutdown)
- Remove unused exports from omni-approval-handler.ts (knip dead-code compliance)

## Validation
- bun run check — all green (typecheck + lint + dead-code + 2367 tests pass)
- CI: Quality Gate, Commitlint, Secrets Scan, CodeRabbit — all SUCCESS

## Test plan
- [ ] Spawn agent with default frontmatter — tools execute without approval prompt
- [ ] Spawn agent with permissionMode: remoteApproval — tool use triggers approval in PG
- [ ] Approve via WhatsApp reply "y" — agent resumes within 2s
- [ ] Deny via reaction — agent gets deny
- [ ] Timeout (300s) with no response — auto-deny
- [ ] GENIE_TMUX_MOUSE=off — native Cmd+C works
- [ ] Send message to dead agent — retried 3x — escalated to team-lead
- [ ] No regressions: full test suite green

Closes #1094, #1093, #1064 | Wish: agent-stability-hardening (all 6 groups)