### PR TITLE
fix(security): fix approval reaction filter + actor identity

### DIFF
--- a/src/lib/omni-approval-handler.ts
+++ b/src/lib/omni-approval-handler.ts
@@ -139,7 +139,7 @@ class OmniApprovalHandler {
       try {
         const data: ReactionEvent = JSON.parse(this.sc.decode(msg.data));
         if (data.type !== 'reaction') continue;
-        if (data.chatId !== this.permissions.omniChat && data.instanceId !== this.permissions.omniInstance) continue;
+        if (data.chatId !== this.permissions.omniChat || data.instanceId !== this.permissions.omniInstance) continue;
 
         if (data.emoji && data.messageId) {
           await this.handleReaction(data.emoji, data.messageId, data.sender ?? 'whatsapp-user');

--- a/src/term-commands/approval.ts
+++ b/src/term-commands/approval.ts
@@ -58,7 +58,9 @@ async function handleResolve(id: string, options: ResolveOptions): Promise<void>
     process.exit(1);
   }
 
-  const updated = await resolveApproval(id, options.decision as 'allow' | 'deny', options.by);
+  // Use actual agent identity or system user — --by is a display label, not an auth claim
+  const actor = process.env.GENIE_AGENT_NAME || options.by;
+  const updated = await resolveApproval(id, options.decision as 'allow' | 'deny', actor);
   if (updated) {
     console.log(`Approval ${id} resolved: ${options.decision} by ${options.by}`);
   } else {
@@ -124,7 +126,7 @@ export function registerApprovalCommands(program: Command): void {
     .command('resolve <id>')
     .description('Resolve a pending approval')
     .requiredOption('--decision <decision>', 'Decision: allow or deny')
-    .requiredOption('--by <actor>', 'Who made the decision')
+    .option('--by <actor>', 'Display label for decision maker (defaults to GENIE_AGENT_NAME or "cli")', 'cli')
     .action(async (id: string, options: ResolveOptions) => {
       try {
         await handleResolve(id, options);


### PR DESCRIPTION
## Summary
- **CRITICAL:** Fix De Morgan's law error in reaction event filtering (`&&` → `||`) — was accepting reactions from wrong chats/instances if either attribute matched
- **HIGH:** Default approval actor to `GENIE_AGENT_NAME` env var instead of trusting user-supplied `--by` flag for audit trail integrity

Found by council review of PR #1096 (dev → main promotion).

## Test plan
- [x] `bun run typecheck` — clean
- [x] 2389/2389 tests pass