### PR TITLE
feat: bridge session resilience — serve integration, PG persistence, graceful shutdown

### DIFF
--- a/src/db/migrations/035_bridge_sessions.sql
+++ b/src/db/migrations/035_bridge_sessions.sql
@@ -1,0 +1,27 @@
+-- 035_bridge_sessions.sql — Dedicated bridge session tracking
+-- Persists omni bridge sessions so they survive process restarts.
+-- Complements the executors table with bridge-specific fields.
+
+CREATE TABLE IF NOT EXISTS genie_bridge_sessions (
+  id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  executor_id TEXT REFERENCES executors(id) ON DELETE SET NULL,
+  instance_id TEXT NOT NULL,
+  chat_id TEXT NOT NULL,
+  agent_name TEXT NOT NULL,
+  tmux_pane_id TEXT,
+  claude_session_id TEXT,
+  status TEXT NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active', 'closed', 'orphaned')),
+  started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_activity_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  closed_at TIMESTAMPTZ,
+  metadata JSONB DEFAULT '{}'
+);
+
+CREATE INDEX IF NOT EXISTS idx_bridge_sessions_status
+  ON genie_bridge_sessions(status);
+CREATE INDEX IF NOT EXISTS idx_bridge_sessions_instance_chat
+  ON genie_bridge_sessions(instance_id, chat_id);
+CREATE INDEX IF NOT EXISTS idx_bridge_sessions_active
+  ON genie_bridge_sessions(status, last_activity_at)
+  WHERE status = 'active';

--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -307,6 +307,57 @@ async function checkWorkerProfiles(): Promise<CheckResult[]> {
 }
 
 /**
+ * Check Omni bridge health
+ */
+async function checkBridge(): Promise<CheckResult[]> {
+  const results: CheckResult[] = [];
+
+  try {
+    const { getBridge } = await import('../services/omni-bridge.js');
+    const bridge = getBridge();
+
+    if (!bridge) {
+      results.push({
+        name: 'Bridge running',
+        status: 'warn',
+        message: 'not running in this process',
+        suggestion: 'Bridge starts automatically with: genie serve',
+      });
+      return results;
+    }
+
+    const s = await bridge.status();
+
+    results.push({
+      name: 'NATS connection',
+      status: s.connected ? 'pass' : 'fail',
+      message: s.connected ? `connected (${s.natsUrl})` : `disconnected (${s.natsUrl})`,
+      suggestion: s.connected ? undefined : 'Check NATS server: nats-server or omni start',
+    });
+
+    results.push({
+      name: 'Active sessions',
+      status: 'pass',
+      message: `${s.activeSessions} / ${s.maxConcurrent} (queue: ${s.queueDepth})`,
+    });
+
+    results.push({
+      name: 'PG backing',
+      status: s.pgAvailable ? 'pass' : 'warn',
+      message: s.pgAvailable ? 'connected' : 'degraded (in-memory)',
+    });
+  } catch {
+    results.push({
+      name: 'Bridge module',
+      status: 'warn',
+      message: 'could not load omni-bridge',
+    });
+  }
+
+  return results;
+}
+
+/**
  * Main doctor command
  */
 function runCheckSection(label: string, results: CheckResult[], counts: { errors: boolean; warnings: boolean }): void {
@@ -334,6 +385,7 @@ export async function doctorCommand(options?: { fix?: boolean }): Promise<void> 
   runCheckSection('Configuration', await checkConfiguration(), counts);
   runCheckSection('Tmux', await checkTmux(), counts);
   runCheckSection('Worker Profiles', await checkWorkerProfiles(), counts);
+  runCheckSection('Omni Bridge', await checkBridge(), counts);
 
   // Summary
   console.log();

--- a/src/services/__tests__/omni-bridge.test.ts
+++ b/src/services/__tests__/omni-bridge.test.ts
@@ -530,10 +530,9 @@ describe('OmniBridge — session lifecycle (Group 2)', () => {
 
     await bridge.stop();
 
-    // Both sessions must have been shut down
-    expect(calls.shutdown.length).toBe(2);
-    const shutdownIds = calls.shutdown.map((s) => s.chatId).sort();
-    expect(shutdownIds).toEqual(['chat-1', 'chat-2']);
+    // Tmux sessions are detached (not shut down) during graceful stop
+    // so they can be recovered on restart. Shutdown is NOT called for tmux sessions.
+    expect(calls.shutdown.length).toBe(0);
     // Sessions map must be cleared
     expect((bridge as any).sessions.size).toBe(0);
   });

--- a/src/services/bridge-session-store.ts
+++ b/src/services/bridge-session-store.ts
@@ -1,0 +1,178 @@
+/**
+ * Bridge Session Store — PG persistence for omni bridge sessions.
+ *
+ * Tracks session lifecycle in genie_bridge_sessions table so sessions
+ * survive process restarts. Uses the bridge's safePgCall pattern for
+ * graceful degradation when PG is unavailable.
+ */
+
+import type { Sql } from '../lib/db.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface BridgeSessionRow {
+  id: string;
+  executor_id: string | null;
+  instance_id: string;
+  chat_id: string;
+  agent_name: string;
+  tmux_pane_id: string | null;
+  claude_session_id: string | null;
+  status: 'active' | 'closed' | 'orphaned';
+  started_at: Date;
+  last_activity_at: Date;
+  closed_at: Date | null;
+  metadata: Record<string, unknown>;
+}
+
+export interface CreateSessionOpts {
+  instanceId: string;
+  chatId: string;
+  agentName: string;
+  executorId?: string;
+  tmuxPaneId?: string;
+  claudeSessionId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+// ============================================================================
+// Store
+// ============================================================================
+
+export class BridgeSessionStore {
+  constructor(private sql: Sql) {}
+
+  /**
+   * Record a new session on spawn.
+   */
+  async create(opts: CreateSessionOpts): Promise<string> {
+    const [row] = await this.sql<{ id: string }[]>`
+      INSERT INTO genie_bridge_sessions (
+        instance_id, chat_id, agent_name, executor_id,
+        tmux_pane_id, claude_session_id, metadata
+      ) VALUES (
+        ${opts.instanceId}, ${opts.chatId}, ${opts.agentName},
+        ${opts.executorId ?? null}, ${opts.tmuxPaneId ?? null},
+        ${opts.claudeSessionId ?? null}, ${JSON.stringify(opts.metadata ?? {})}::jsonb
+      )
+      RETURNING id
+    `;
+    return row.id;
+  }
+
+  /**
+   * Update last_activity_at on message delivery.
+   */
+  async recordActivity(sessionId: string): Promise<void> {
+    await this.sql`
+      UPDATE genie_bridge_sessions
+      SET last_activity_at = now()
+      WHERE id = ${sessionId} AND status = 'active'
+    `;
+  }
+
+  /**
+   * Close a session (agent ended or idle timeout).
+   */
+  async close(sessionId: string): Promise<void> {
+    await this.sql`
+      UPDATE genie_bridge_sessions
+      SET status = 'closed', closed_at = now()
+      WHERE id = ${sessionId} AND status = 'active'
+    `;
+  }
+
+  /**
+   * Mark sessions as orphaned (bridge restart detected stale active sessions).
+   */
+  async markOrphaned(sessionIds: string[]): Promise<void> {
+    if (sessionIds.length === 0) return;
+    await this.sql`
+      UPDATE genie_bridge_sessions
+      SET status = 'orphaned'
+      WHERE id = ANY(${sessionIds}) AND status = 'active'
+    `;
+  }
+
+  /**
+   * Mark all active sessions as orphaned (bridge startup cleanup).
+   */
+  async markAllOrphaned(): Promise<number> {
+    const rows = await this.sql<{ id: string }[]>`
+      UPDATE genie_bridge_sessions
+      SET status = 'orphaned'
+      WHERE status = 'active'
+      RETURNING id
+    `;
+    return rows.length;
+  }
+
+  /**
+   * List sessions by status for the status command.
+   */
+  async list(status?: 'active' | 'closed' | 'orphaned'): Promise<BridgeSessionRow[]> {
+    if (status) {
+      return this.sql<BridgeSessionRow[]>`
+        SELECT * FROM genie_bridge_sessions
+        WHERE status = ${status}
+        ORDER BY started_at DESC
+        LIMIT 100
+      `;
+    }
+    return this.sql<BridgeSessionRow[]>`
+      SELECT * FROM genie_bridge_sessions
+      ORDER BY started_at DESC
+      LIMIT 100
+    `;
+  }
+
+  /**
+   * Get active session for a given instance+chat pair.
+   */
+  async getActive(instanceId: string, chatId: string): Promise<BridgeSessionRow | null> {
+    const [row] = await this.sql<BridgeSessionRow[]>`
+      SELECT * FROM genie_bridge_sessions
+      WHERE instance_id = ${instanceId}
+        AND chat_id = ${chatId}
+        AND status = 'active'
+      LIMIT 1
+    `;
+    return row ?? null;
+  }
+
+  /**
+   * Update executor details (e.g., after tmux pane is created).
+   */
+  async updateExecutorInfo(
+    sessionId: string,
+    info: { executorId?: string; tmuxPaneId?: string; claudeSessionId?: string },
+  ): Promise<void> {
+    const sets: string[] = [];
+    const values: unknown[] = [];
+    if (info.executorId !== undefined) {
+      sets.push('executor_id');
+      values.push(info.executorId);
+    }
+    if (info.tmuxPaneId !== undefined) {
+      sets.push('tmux_pane_id');
+      values.push(info.tmuxPaneId);
+    }
+    if (info.claudeSessionId !== undefined) {
+      sets.push('claude_session_id');
+      values.push(info.claudeSessionId);
+    }
+    if (sets.length === 0) return;
+
+    // Use individual SET clauses — postgres.js tagged templates don't support dynamic column lists
+    await this.sql`
+      UPDATE genie_bridge_sessions SET
+        executor_id = COALESCE(${info.executorId ?? null}, executor_id),
+        tmux_pane_id = COALESCE(${info.tmuxPaneId ?? null}, tmux_pane_id),
+        claude_session_id = COALESCE(${info.claudeSessionId ?? null}, claude_session_id),
+        last_activity_at = now()
+      WHERE id = ${sessionId}
+    `;
+  }
+}

--- a/src/services/bridge-session-store.ts
+++ b/src/services/bridge-session-store.ts
@@ -12,7 +12,7 @@ import type { Sql } from '../lib/db.js';
 // Types
 // ============================================================================
 
-export interface BridgeSessionRow {
+interface BridgeSessionRow {
   id: string;
   executor_id: string | null;
   instance_id: string;
@@ -27,7 +27,7 @@ export interface BridgeSessionRow {
   metadata: Record<string, unknown>;
 }
 
-export interface CreateSessionOpts {
+interface CreateSessionOpts {
   instanceId: string;
   chatId: string;
   agentName: string;

--- a/src/services/omni-bridge.ts
+++ b/src/services/omni-bridge.ts
@@ -13,6 +13,7 @@
 import { type NatsConnection, StringCodec, type Subscription, connect } from 'nats';
 import type { Sql } from '../lib/db.js';
 import { resolveExecutorType } from '../lib/executor-config.js';
+import { isPaneAlive } from '../lib/tmux.js';
 import { BridgeSessionStore } from './bridge-session-store.js';
 import type { ExecutorSession, IExecutor, OmniMessage } from './executor.js';
 import { ClaudeCodeOmniExecutor } from './executors/claude-code.js';
@@ -260,17 +261,10 @@ export class OmniBridge {
     // bound `safePgCall` reference below.
     await this.probePg();
 
-    // Initialize PG-backed session store and mark stale sessions as orphaned.
+    // Initialize PG-backed session store and recover surviving sessions.
     if (this.pgAvailable && this.sql) {
       this.sessionStore = new BridgeSessionStore(this.sql);
-      const orphaned = await this.safePgCall(
-        'mark_all_orphaned',
-        (sql) => new BridgeSessionStore(sql).markAllOrphaned(),
-        0,
-      );
-      if (orphaned > 0) {
-        console.log(`[omni-bridge] Marked ${orphaned} stale session(s) as orphaned`);
-      }
+      await this.recoverSessions();
     }
 
     // Initialize PG-backed queue for SDK executor when PG is available.
@@ -324,6 +318,10 @@ export class OmniBridge {
 
   /**
    * Stop the bridge: unsubscribe, drain, and disconnect.
+   *
+   * Tmux sessions are left running (graceful detach) so they survive a bridge
+   * restart. On next start(), recoverSessions() re-attaches to live panes.
+   * SDK sessions are shut down normally since they can't outlive the process.
    */
   async stop(): Promise<void> {
     if (!this.nc) {
@@ -345,14 +343,25 @@ export class OmniBridge {
       this.idleCheckTimer = null;
     }
 
-    // Shut down all active executor sessions and clear idle timers
+    // Clear idle timers and shut down non-tmux sessions.
+    // Tmux sessions are left running — their PG rows stay 'active' so
+    // recoverSessions() can re-attach after restart.
     for (const [key, entry] of this.sessions) {
       if (entry.idleTimer) clearTimeout(entry.idleTimer);
       if (!entry.spawning && entry.session) {
-        try {
-          await this.executor.shutdown(entry.session);
-        } catch (err) {
-          console.warn(`[omni-bridge] Error shutting down session ${key}:`, err);
+        if (entry.session.executorType === 'tmux') {
+          console.log(`[omni-bridge] Detaching from tmux session ${key} (pane stays alive)`);
+        } else {
+          try {
+            await this.executor.shutdown(entry.session);
+          } catch (err) {
+            console.warn(`[omni-bridge] Error shutting down session ${key}:`, err);
+          }
+          // Close SDK sessions in PG since they can't survive restart
+          const closeId = entry.pgBridgeSessionId;
+          if (closeId && this.sessionStore) {
+            await this.safePgCall('session_close_sdk', (sql) => new BridgeSessionStore(sql).close(closeId), undefined);
+          }
         }
       }
     }
@@ -487,6 +496,98 @@ export class OmniBridge {
       // permission denied, or similar. Fail-fast with an actionable message.
       const hint = 'Run `bun run migrate` (or the equivalent migration command) and retry.';
       throw new Error(`[omni-bridge] PG schema mismatch or setup error: ${msg}. ${hint}`);
+    }
+  }
+
+  /**
+   * Recover sessions that survived a bridge restart.
+   *
+   * Queries PG for active sessions, checks whether their tmux panes are still
+   * alive, and re-populates the in-memory sessions Map for live ones. Dead
+   * panes and SDK sessions (which can't survive a process restart) are marked
+   * orphaned. This runs once during start(), after sessionStore is initialized.
+   */
+  private async recoverSessions(): Promise<void> {
+    if (!this.sessionStore) return;
+
+    const activeSessions = await this.safePgCall(
+      'recover_list_active',
+      (sql) => new BridgeSessionStore(sql).list('active'),
+      [],
+    );
+
+    if (activeSessions.length === 0) return;
+
+    console.log(`[omni-bridge] Found ${activeSessions.length} active session(s) from previous run, recovering...`);
+
+    const orphanIds: string[] = [];
+
+    for (const row of activeSessions) {
+      const key = `${row.agent_name}:${row.chat_id}`;
+
+      // SDK sessions can't survive a process restart — always orphan them.
+      if (!row.tmux_pane_id) {
+        orphanIds.push(row.id);
+        continue;
+      }
+
+      // Duplicate guard: if another row already recovered this chat, orphan the older one.
+      if (this.sessions.has(key)) {
+        orphanIds.push(row.id);
+        continue;
+      }
+
+      // Check if the tmux pane is still alive.
+      let alive = false;
+      try {
+        alive = await isPaneAlive(row.tmux_pane_id);
+      } catch {
+        // tmux not available or pane check failed — treat as dead.
+      }
+
+      if (!alive) {
+        orphanIds.push(row.id);
+        continue;
+      }
+
+      // Pane is alive — reconstruct the in-memory session entry.
+      const session: ExecutorSession = {
+        id: row.executor_id ?? row.id,
+        agentName: row.agent_name,
+        chatId: row.chat_id,
+        executorType: 'tmux',
+        createdAt: new Date(row.started_at).getTime(),
+        lastActivityAt: new Date(row.last_activity_at).getTime(),
+        tmux: { session: '', window: '', paneId: row.tmux_pane_id },
+      };
+
+      const entry: SessionEntry = {
+        session,
+        instanceId: row.instance_id,
+        spawning: false,
+        buffer: [],
+        idleTimer: null,
+        pgBridgeSessionId: row.id,
+      };
+
+      this.sessions.set(key, entry);
+      this.resetIdleTimer(key);
+
+      console.log(`[omni-bridge] Recovered session ${key} (pane=${row.tmux_pane_id})`);
+    }
+
+    // Mark dead/SDK sessions as orphaned in one batch.
+    if (orphanIds.length > 0) {
+      await this.safePgCall(
+        'recover_mark_orphaned',
+        (sql) => new BridgeSessionStore(sql).markOrphaned(orphanIds),
+        undefined,
+      );
+      console.log(`[omni-bridge] Marked ${orphanIds.length} stale session(s) as orphaned`);
+    }
+
+    if (this.sessions.size > 0) {
+      console.log(`[omni-bridge] Recovered ${this.sessions.size} live session(s)`);
     }
   }
 

--- a/src/services/omni-bridge.ts
+++ b/src/services/omni-bridge.ts
@@ -13,6 +13,7 @@
 import { type NatsConnection, StringCodec, type Subscription, connect } from 'nats';
 import type { Sql } from '../lib/db.js';
 import { resolveExecutorType } from '../lib/executor-config.js';
+import { BridgeSessionStore } from './bridge-session-store.js';
 import type { ExecutorSession, IExecutor, OmniMessage } from './executor.js';
 import { ClaudeCodeOmniExecutor } from './executors/claude-code.js';
 import { ClaudeSdkOmniExecutor } from './executors/claude-sdk.js';
@@ -72,6 +73,8 @@ interface SessionEntry {
    * down the freshly-created session instead of putting it into rotation.
    */
   cancelled?: boolean;
+  /** PG bridge session row ID, set after store.create() succeeds. */
+  pgBridgeSessionId?: string;
 }
 
 export interface BridgeStatus {
@@ -197,6 +200,8 @@ export class OmniBridge {
 
   /** PG-backed request queue for SDK executor. Null when PG unavailable or executor is tmux. */
   private queue: OmniQueue | null = null;
+  /** PG-backed session persistence. Null when PG unavailable. */
+  private sessionStore: BridgeSessionStore | null = null;
 
   readonly natsUrl: string;
   readonly idleTimeoutMs: number;
@@ -254,6 +259,19 @@ export class OmniBridge {
     // Group 3 scaffolding; Group 4 consumers (SDK + tmux executors) receive a
     // bound `safePgCall` reference below.
     await this.probePg();
+
+    // Initialize PG-backed session store and mark stale sessions as orphaned.
+    if (this.pgAvailable && this.sql) {
+      this.sessionStore = new BridgeSessionStore(this.sql);
+      const orphaned = await this.safePgCall(
+        'mark_all_orphaned',
+        (sql) => new BridgeSessionStore(sql).markAllOrphaned(),
+        0,
+      );
+      if (orphaned > 0) {
+        console.log(`[omni-bridge] Marked ${orphaned} stale session(s) as orphaned`);
+      }
+    }
 
     // Initialize PG-backed queue for SDK executor when PG is available.
     if (this.executorType === 'sdk' && this.pgAvailable && this.sql) {
@@ -358,6 +376,7 @@ export class OmniBridge {
     // the actual client lifecycle, so we only clear our local references.
     this.sql = null;
     this.pgAvailable = false;
+    this.sessionStore = null;
 
     bridgeInstance = null;
 
@@ -812,6 +831,13 @@ export class OmniBridge {
         // Deliver to running session
         await this.executor.deliver(entry.session, message);
         this.resetIdleTimer(key);
+        // Update last_activity_at in PG
+        const bsId = entry.pgBridgeSessionId;
+        if (bsId && this.sessionStore) {
+          this.safePgCall('session_activity', (sql) => new BridgeSessionStore(sql).recordActivity(bsId), undefined, {
+            chatId: message.chatId,
+          });
+        }
         return;
       }
 
@@ -893,6 +919,25 @@ export class OmniBridge {
 
       placeholder.session = session;
       placeholder.spawning = false;
+
+      // Record session in PG for crash recovery
+      if (this.sessionStore) {
+        const pgId = await this.safePgCall(
+          'session_create',
+          (sql) =>
+            new BridgeSessionStore(sql).create({
+              instanceId: message.instanceId,
+              chatId: message.chatId,
+              agentName: message.agent,
+              executorId: session.sdk?.executorId,
+              tmuxPaneId: session.tmux?.paneId,
+              claudeSessionId: session.sdk?.claudeSessionId,
+            }),
+          undefined,
+          { chatId: message.chatId },
+        );
+        if (pgId) placeholder.pgBridgeSessionId = pgId;
+      }
 
       // Deliver buffered messages
       for (const buffered of placeholder.buffer) {
@@ -978,6 +1023,11 @@ export class OmniBridge {
   private removeSession(key: string): void {
     const entry = this.sessions.get(key);
     if (entry?.idleTimer) clearTimeout(entry.idleTimer);
+    // Close session in PG
+    const closeId = entry?.pgBridgeSessionId;
+    if (closeId && this.sessionStore) {
+      this.safePgCall('session_close', (sql) => new BridgeSessionStore(sql).close(closeId), undefined);
+    }
     this.sessions.delete(key);
   }
 

--- a/src/term-commands/omni.ts
+++ b/src/term-commands/omni.ts
@@ -59,12 +59,21 @@ export function registerOmniCommands(program: Command): void {
 
   omni
     .command('start')
-    .description('Start the NATS bridge (subscribe to omni.message.>)')
+    .description('Start the NATS bridge (prefer genie serve for managed lifecycle)')
     .option('--nats-url <url>', 'NATS server URL', process.env.GENIE_NATS_URL ?? 'localhost:4222')
     .option('--max-concurrent <n>', 'Max concurrent agent sessions', process.env.GENIE_MAX_CONCURRENT ?? '20')
     .option('--idle-timeout <ms>', 'Idle timeout in ms', process.env.GENIE_IDLE_TIMEOUT_MS ?? '900000')
     .option('--executor <type>', 'Executor type: tmux (default) or sdk')
+    .option('--standalone', 'Force standalone mode (skip serve check)')
     .action(async (options) => {
+      // Check if serve is already managing a bridge
+      const { getBridge } = await import('../services/omni-bridge.js');
+      if (!options.standalone && getBridge()) {
+        console.log('[genie omni] Bridge is already managed by genie serve.');
+        console.log('  Use `genie omni status` to check, or `genie omni start --standalone` to force.');
+        return;
+      }
+
       const { OmniBridge } = await import('../services/omni-bridge.js');
 
       const bridge = new OmniBridge({
@@ -77,7 +86,8 @@ export function registerOmniCommands(program: Command): void {
       await bridge.start();
 
       // Keep the process alive
-      console.log('[genie omni] Bridge running. Press Ctrl+C to stop.');
+      console.log('[genie omni] Bridge running (standalone). Press Ctrl+C to stop.');
+      console.log('  Tip: Use `genie serve` to auto-manage the bridge lifecycle.');
 
       const shutdown = async () => {
         await bridge.stop();

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -355,6 +355,7 @@ interface DaemonHandles {
   agentWatcher: { close: () => void } | null;
   brainHandle: { stop: () => Promise<void>; port: number } | null;
   omniApprovalHandler: { stop: () => Promise<void> } | null;
+  omniBridge: { stop: () => Promise<void> } | null;
 }
 
 const handles: DaemonHandles = {
@@ -362,6 +363,7 @@ const handles: DaemonHandles = {
   agentWatcher: null,
   brainHandle: null,
   omniApprovalHandler: null,
+  omniBridge: null,
 };
 
 /** Sync agent directory from workspace and start file watcher. */
@@ -568,6 +570,24 @@ async function startForeground(headless?: boolean): Promise<void> {
     // NATS or workspace not configured — non-fatal
   }
 
+  // 6. Start Omni bridge (NATS → agent session router)
+  try {
+    const { OmniBridge } = await import('../services/omni-bridge.js');
+    const bridge = new OmniBridge({
+      natsUrl: process.env.GENIE_NATS_URL ?? 'localhost:4222',
+      maxConcurrent: Number(process.env.GENIE_MAX_CONCURRENT ?? '20'),
+      idleTimeoutMs: Number(process.env.GENIE_IDLE_TIMEOUT_MS ?? '900000'),
+      executorType: (process.env.GENIE_EXECUTOR_TYPE as 'tmux' | 'sdk') ?? undefined,
+    });
+    await bridge.start();
+    handles.omniBridge = bridge;
+    console.log('  Omni bridge started');
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`  Omni bridge: FAILED — ${msg}`);
+    // Non-fatal: bridge failure should not block serve startup
+  }
+
   const stopMsg = headless ? 'Send SIGTERM to stop.' : 'Press Ctrl+C to stop.';
   console.log(`\ngenie serve is running (${mode}). ${stopMsg}`);
 
@@ -589,6 +609,12 @@ async function startForeground(headless?: boolean): Promise<void> {
     if (handles.omniApprovalHandler) {
       handles.omniApprovalHandler.stop().catch(() => {});
       handles.omniApprovalHandler = null;
+    }
+
+    // 2.55. Stop Omni bridge (graceful: detach sessions, don't kill them)
+    if (handles.omniBridge) {
+      handles.omniBridge.stop().catch(() => {});
+      handles.omniBridge = null;
     }
 
     // 2.6. Stop brain server (best-effort — signal handlers call process.exit()
@@ -856,6 +882,23 @@ async function printDaemonStatus(serveRunning: boolean): Promise<void> {
   }
 }
 
+/** Print Omni bridge status */
+async function printBridgeStatus(): Promise<void> {
+  try {
+    const { getBridge } = await import('../services/omni-bridge.js');
+    const bridge = getBridge();
+    if (bridge) {
+      const s = await bridge.status();
+      const tag = s.connected ? 'connected' : 'disconnected';
+      console.log(`  omni-bridge: ${tag} (${s.activeSessions} sessions, queue: ${s.queueDepth})`);
+    } else {
+      console.log('  omni-bridge: stopped');
+    }
+  } catch {
+    console.log('  omni-bridge: unavailable');
+  }
+}
+
 /** Show service health */
 async function statusServe(): Promise<void> {
   const pid = readServePid();
@@ -872,6 +915,7 @@ async function statusServe(): Promise<void> {
   await printPgserveStatus();
   printTmuxStatus();
   await printDaemonStatus(running);
+  await printBridgeStatus();
 
   console.log(`  PID file:   ${servePidPath()}`);
   console.log('');


### PR DESCRIPTION
## Summary

- **Bridge into genie serve**: Register bridge as subprocess alongside pgserve, tmux, scheduler. `genie doctor` checks bridge health.
- **Session persistence**: `genie_bridge_sessions` PG table tracks active sessions across restarts.
- **Graceful shutdown**: SIGTERM detaches from tmux panes without killing Claude Code sessions.
- **Session recovery**: On startup, recovers active sessions from PG, verifies tmux panes alive, re-attaches survivors.

## Wish

`turn-mgmt-bridge-resilience` — Groups 3, 4, 5 (Waves 2+3)

## Test plan

- [x] `bun run check` — 2424 tests pass, 0 fail
- [x] `bunx biome check` — clean
- [x] `bunx tsc --noEmit` — clean
- [ ] `genie serve` starts bridge automatically
- [ ] `genie doctor` reports bridge health
- [ ] Bridge restart preserves active sessions
- [ ] Orphaned sessions cleaned up on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)