### PR TITLE
feat: bridge persistence, graceful shutdown & CodeRabbit fixes

### DIFF
--- a/src/db/migrations/035_bridge_sessions.sql
+++ b/src/db/migrations/035_bridge_sessions.sql
@@ -25,3 +25,9 @@ CREATE INDEX IF NOT EXISTS idx_bridge_sessions_instance_chat
 CREATE INDEX IF NOT EXISTS idx_bridge_sessions_active
   ON genie_bridge_sessions(status, last_activity_at)
   WHERE status = 'active';
+
+-- Prevent duplicate active sessions for the same logical key.
+-- Recovery code assumes at most one active row per instance+agent+chat.
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_bridge_sessions_active_key
+  ON genie_bridge_sessions(instance_id, agent_name, chat_id)
+  WHERE status = 'active';

--- a/src/services/bridge-session-store.ts
+++ b/src/services/bridge-session-store.ts
@@ -114,17 +114,19 @@ export class BridgeSessionStore {
    */
   async list(status?: 'active' | 'closed' | 'orphaned'): Promise<BridgeSessionRow[]> {
     if (status) {
+      // No LIMIT for status-filtered queries — recoverSessions() needs ALL active rows.
+      // A hard limit here would silently abandon older sessions on crash recovery.
       return this.sql<BridgeSessionRow[]>`
         SELECT * FROM genie_bridge_sessions
         WHERE status = ${status}
         ORDER BY started_at DESC
-        LIMIT 100
       `;
     }
+    // Unfiltered list (CLI display) keeps a reasonable cap
     return this.sql<BridgeSessionRow[]>`
       SELECT * FROM genie_bridge_sessions
       ORDER BY started_at DESC
-      LIMIT 100
+      LIMIT 500
     `;
   }
 

--- a/src/services/omni-bridge.ts
+++ b/src/services/omni-bridge.ts
@@ -857,7 +857,7 @@ export class OmniBridge {
       entry.cancelled = true;
       entry.buffer = []; // Drop buffered messages — user explicitly reset.
       this.turnTracker.close(sessionKey, 'reset');
-      this.removeSession(sessionKey);
+      await this.removeSession(sessionKey);
       await this.drainQueue();
       return;
     }
@@ -871,7 +871,7 @@ export class OmniBridge {
     } catch (err) {
       console.warn(`[omni-bridge] Error shutting down reset session ${sessionKey}:`, err);
     }
-    this.removeSession(sessionKey);
+    await this.removeSession(sessionKey);
     await this.drainQueue();
   }
 
@@ -943,7 +943,7 @@ export class OmniBridge {
       }
 
       // Session dead — remove and respawn
-      this.removeSession(key);
+      await this.removeSession(key);
     }
 
     // Need to spawn a new session
@@ -1081,7 +1081,7 @@ export class OmniBridge {
       } catch {
         // Already dead — that's fine
       }
-      this.removeSession(key);
+      await this.removeSession(key);
 
       // Process queued messages now that a slot is free
       await this.drainQueue();
@@ -1100,7 +1100,7 @@ export class OmniBridge {
       const alive = await this.executor.isAlive(entry.session);
       if (!alive) {
         console.log(`[omni-bridge] Dead session detected: ${key}`);
-        this.removeSession(key);
+        await this.removeSession(key);
         continue;
       }
 
@@ -1113,21 +1113,23 @@ export class OmniBridge {
         } catch {
           /* already dead */
         }
-        this.removeSession(key);
+        await this.removeSession(key);
       }
     }
   }
 
   /**
    * Remove a session and clean up its idle timer.
+   * Awaits PG close before deleting the in-memory entry to prevent
+   * a replacement session from being created while the old row is still active.
    */
-  private removeSession(key: string): void {
+  private async removeSession(key: string): Promise<void> {
     const entry = this.sessions.get(key);
     if (entry?.idleTimer) clearTimeout(entry.idleTimer);
-    // Close session in PG
+    // Close session in PG — await to prevent duplicate active rows
     const closeId = entry?.pgBridgeSessionId;
     if (closeId && this.sessionStore) {
-      this.safePgCall('session_close', (sql) => new BridgeSessionStore(sql).close(closeId), undefined);
+      await this.safePgCall('session_close', (sql) => new BridgeSessionStore(sql).close(closeId), undefined);
     }
     this.sessions.delete(key);
   }


### PR DESCRIPTION
## Summary
- Bridge serve integration, PG session persistence, graceful shutdown (SIGTERM detach)
- Session recovery on startup for surviving tmux panes
- SDK log aggregation in unified-log
- CodeRabbit review fixes: unique index, remove LIMIT 100, async removeSession

## Wish
`turn-mgmt-bridge-resilience` — Groups 3-5

## Test plan
- [x] `bun test` — 2424 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] Bridge session store tests pass
- [x] Omni bridge tests pass (including graceful shutdown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)