### PR TITLE
fix: bridge session isolation — NATS queues, per-chat agents, dedup, cleanup

### DIFF
--- a/src/lib/provider-adapters.ts
+++ b/src/lib/provider-adapters.ts
@@ -97,6 +97,8 @@ export interface SpawnParams {
   newWindow?: boolean;
   /** Tmux window target to split into (e.g., "genie:3"). */
   windowTarget?: string;
+  /** Skip genie hook dispatch injection (e.g., omni-originated sessions that shouldn't trigger orchestration hooks). */
+  skipHooks?: boolean;
 }
 
 /** Result of a successful launch-command build. */
@@ -353,17 +355,20 @@ export function buildClaudeCommand(params: SpawnParams): LaunchCommand {
 
   appendSystemPromptFlags(parts, params);
 
-  // Inject hook dispatch + permissions via --settings (deep-merges with existing settings)
-  const dispatchCmd = buildDispatchCommand();
-  const hookEntry = { type: 'command', command: dispatchCmd, timeout: 15 };
-  const settingsObj: Record<string, unknown> = {
-    hooks: {
+  // Inject hook dispatch + permissions via --settings (deep-merges with existing settings).
+  // Skip hooks for omni-originated sessions to prevent orchestration side-effects
+  // (e.g., auto-spawning qa/configure agents from seller sessions).
+  const settingsObj: Record<string, unknown> = {};
+  if (!params.skipHooks) {
+    const dispatchCmd = buildDispatchCommand();
+    const hookEntry = { type: 'command', command: dispatchCmd, timeout: 15 };
+    settingsObj.hooks = {
       PreToolUse: [{ matcher: '*', hooks: [hookEntry] }],
       PostToolUse: [{ matcher: '*', hooks: [hookEntry] }],
       UserPromptSubmit: [{ hooks: [hookEntry] }],
       Stop: [{ hooks: [hookEntry] }],
-    },
-  };
+    };
+  }
   // Merge permissions into settings when provided
   if (params.permissions) {
     const perms: Record<string, string[]> = {};
@@ -371,7 +376,9 @@ export function buildClaudeCommand(params: SpawnParams): LaunchCommand {
     if (params.permissions.deny?.length) perms.deny = params.permissions.deny;
     if (Object.keys(perms).length > 0) settingsObj.permissions = perms;
   }
-  parts.push('--settings', escapeShellArg(JSON.stringify(settingsObj)));
+  if (Object.keys(settingsObj).length > 0) {
+    parts.push('--settings', escapeShellArg(JSON.stringify(settingsObj)));
+  }
 
   // Emit --disallowedTools when the agent declares tool restrictions
   if (params.disallowedTools?.length) {

--- a/src/services/executors/claude-code.ts
+++ b/src/services/executors/claude-code.ts
@@ -129,6 +129,7 @@ export function buildOmniSpawnParams(
     promptMode: entry.promptMode,
     systemPromptFile: join(entry.dir, 'AGENTS.md'),
     initialPrompt: fullInitialPrompt,
+    skipHooks: true,
     nativeTeam: {
       enabled: true,
       agentName,
@@ -226,7 +227,7 @@ export class ClaudeCodeOmniExecutor implements IExecutor {
     if (!this.safePgCall) return null;
     const agent = await this.safePgCall(
       'tmux-find-or-create-agent',
-      () => agents.findOrCreateAgent(agentName, 'omni', 'omni'),
+      () => agents.findOrCreateAgent(`${agentName}:${chatId}`, 'omni', 'omni'),
       null,
       { chatId },
     );

--- a/src/services/omni-bridge.ts
+++ b/src/services/omni-bridge.ts
@@ -13,7 +13,6 @@
 import { type NatsConnection, StringCodec, type Subscription, connect } from 'nats';
 import type { Sql } from '../lib/db.js';
 import { resolveExecutorType } from '../lib/executor-config.js';
-import { isPaneAlive } from '../lib/tmux.js';
 import { BridgeSessionStore } from './bridge-session-store.js';
 import type { ExecutorSession, IExecutor, OmniMessage } from './executor.js';
 import { ClaudeCodeOmniExecutor } from './executors/claude-code.js';
@@ -188,6 +187,8 @@ export class OmniBridge {
    */
   private sessions = new Map<string, SessionEntry>();
   private messageQueue: OmniMessage[] = [];
+  /** Dedup cache: messageId → receive timestamp. Prevents JetStream redelivery duplicates. */
+  private recentMessageIds = new Map<string, number>();
   private idleCheckTimer: ReturnType<typeof setInterval> | null = null;
   private sc = StringCodec();
 
@@ -288,13 +289,13 @@ export class OmniBridge {
     });
 
     // Subscribe to all omni messages
-    this.sub = this.nc.subscribe('omni.message.>');
+    this.sub = this.nc.subscribe('omni.message.>', { queue: 'genie-bridge' });
     this.processSubscription();
 
     // Turn lifecycle events from Omni
     const turnSubs = ['omni.turn.open.>', 'omni.turn.done.>', 'omni.turn.nudge.>', 'omni.turn.timeout.>'];
     for (const topic of turnSubs) {
-      const sub = this.nc.subscribe(topic);
+      const sub = this.nc.subscribe(topic, { queue: 'genie-bridge' });
       this.processTurnEvents(sub);
     }
 
@@ -302,7 +303,7 @@ export class OmniBridge {
     // sends a reset token (e.g. 🗑️). Paired with omni-side publisher in
     // automagik-dev/omni#361. Subject hierarchy: omni.session.reset.{instance}.{chat}
     // (recursive `>` because WhatsApp chat ids contain dots).
-    const sessionResetSub = this.nc.subscribe('omni.session.reset.>');
+    const sessionResetSub = this.nc.subscribe('omni.session.reset.>', { queue: 'genie-bridge' });
     this.processSessionResetEvents(sessionResetSub);
 
     // Start idle session checker
@@ -500,94 +501,23 @@ export class OmniBridge {
   }
 
   /**
-   * Recover sessions that survived a bridge restart.
+   * Clean up stale sessions from previous bridge runs.
    *
-   * Queries PG for active sessions, checks whether their tmux panes are still
-   * alive, and re-populates the in-memory sessions Map for live ones. Dead
-   * panes and SDK sessions (which can't survive a process restart) are marked
-   * orphaned. This runs once during start(), after sessionStore is initialized.
+   * Orphans ALL active sessions on startup. Live panes will be re-created
+   * on demand when the next message arrives. This prevents duplicate key
+   * errors and misrouting from stale session state.
    */
   private async recoverSessions(): Promise<void> {
     if (!this.sessionStore) return;
 
-    const activeSessions = await this.safePgCall(
-      'recover_list_active',
-      (sql) => new BridgeSessionStore(sql).list('active'),
-      [],
+    const orphanedCount = await this.safePgCall(
+      'recover_orphan_all',
+      (sql) => new BridgeSessionStore(sql).markAllOrphaned(),
+      0,
     );
 
-    if (activeSessions.length === 0) return;
-
-    console.log(`[omni-bridge] Found ${activeSessions.length} active session(s) from previous run, recovering...`);
-
-    const orphanIds: string[] = [];
-
-    for (const row of activeSessions) {
-      const key = `${row.agent_name}:${row.chat_id}`;
-
-      // SDK sessions can't survive a process restart — always orphan them.
-      if (!row.tmux_pane_id) {
-        orphanIds.push(row.id);
-        continue;
-      }
-
-      // Duplicate guard: if another row already recovered this chat, orphan the older one.
-      if (this.sessions.has(key)) {
-        orphanIds.push(row.id);
-        continue;
-      }
-
-      // Check if the tmux pane is still alive.
-      let alive = false;
-      try {
-        alive = await isPaneAlive(row.tmux_pane_id);
-      } catch {
-        // tmux not available or pane check failed — treat as dead.
-      }
-
-      if (!alive) {
-        orphanIds.push(row.id);
-        continue;
-      }
-
-      // Pane is alive — reconstruct the in-memory session entry.
-      const session: ExecutorSession = {
-        id: row.executor_id ?? row.id,
-        agentName: row.agent_name,
-        chatId: row.chat_id,
-        executorType: 'tmux',
-        createdAt: new Date(row.started_at).getTime(),
-        lastActivityAt: new Date(row.last_activity_at).getTime(),
-        tmux: { session: '', window: '', paneId: row.tmux_pane_id },
-      };
-
-      const entry: SessionEntry = {
-        session,
-        instanceId: row.instance_id,
-        spawning: false,
-        buffer: [],
-        idleTimer: null,
-        pgBridgeSessionId: row.id,
-      };
-
-      this.sessions.set(key, entry);
-      this.resetIdleTimer(key);
-
-      console.log(`[omni-bridge] Recovered session ${key} (pane=${row.tmux_pane_id})`);
-    }
-
-    // Mark dead/SDK sessions as orphaned in one batch.
-    if (orphanIds.length > 0) {
-      await this.safePgCall(
-        'recover_mark_orphaned',
-        (sql) => new BridgeSessionStore(sql).markOrphaned(orphanIds),
-        undefined,
-      );
-      console.log(`[omni-bridge] Marked ${orphanIds.length} stale session(s) as orphaned`);
-    }
-
-    if (this.sessions.size > 0) {
-      console.log(`[omni-bridge] Recovered ${this.sessions.size} live session(s)`);
+    if (orphanedCount > 0) {
+      console.log(`[omni-bridge] Startup cleanup: orphaned ${orphanedCount} stale session(s) from previous run`);
     }
   }
 
@@ -657,6 +587,24 @@ export class OmniBridge {
         }
 
         console.log(`[omni-bridge] NATS message received: ${msg.subject} agent=${parsed.agent} chat=${parsed.chatId}`);
+
+        // Dedup: skip messages already processed (JetStream redelivery protection)
+        // biome-ignore lint/suspicious/noExplicitAny: NATS payload has extra fields beyond OmniMessage
+        const messageId = (parsed as any).messageId as string | undefined;
+        if (messageId && this.recentMessageIds.has(messageId)) {
+          console.log(`[omni-bridge] Dedup: skipping duplicate messageId=${messageId}`);
+          continue;
+        }
+        if (messageId) {
+          this.recentMessageIds.set(messageId, Date.now());
+          // Prune stale entries when cache grows large (TTL 60s)
+          if (this.recentMessageIds.size > 1000) {
+            const cutoff = Date.now() - 60_000;
+            for (const [id, ts] of this.recentMessageIds) {
+              if (ts < cutoff) this.recentMessageIds.delete(id);
+            }
+          }
+        }
 
         if (!parsed.chatId || !parsed.agent) {
           console.warn('[omni-bridge] Dropping message: missing chatId or agent', msg.subject);
@@ -999,7 +947,7 @@ export class OmniBridge {
         OMNI_INSTANCE: payloadEnv?.OMNI_INSTANCE ?? message.instanceId,
         OMNI_CHAT: payloadEnv?.OMNI_CHAT ?? message.chatId,
         OMNI_MESSAGE: payloadEnv?.OMNI_MESSAGE ?? (raw.messageId as string) ?? '',
-        OMNI_TURN_ID: payloadEnv?.OMNI_TURN_ID ?? '',
+        OMNI_TURN_ID: payloadEnv?.OMNI_TURN_ID || '',
         OMNI_SENDER_NAME: payloadEnv?.OMNI_SENDER_NAME ?? message.sender ?? '',
       };
 


### PR DESCRIPTION
## Summary

Comprehensive fix for genie omni-bridge session isolation defect. Addresses 7 root causes from session mixing trace:

1. NATS queue groups — ensure only one bridge processes each message
2. Per-chat agent identity — separate PG records prevent pane_id overwrites
3. Message dedup cache — prevent JetStream redelivery duplicates
4. Stale session cleanup — orphan-all on startup instead of per-row recovery
5. Empty OMNI_TURN_ID coercion — defense-in-depth for CLI fix
6. Hook scoping for omni-spawned agents — prevent unintended orchestration spawns

## Changes

**src/services/omni-bridge.ts:**
- Add `{ queue: 'genie-bridge' }` to all 6 NATS subscriptions (G1)
- Add `recentMessageIds` dedup cache with 60s TTL + 1000 entry pruning (G4)
- Replace per-row recovery with `markAllOrphaned()` (G5)
- Coerce empty OMNI_TURN_ID with `||` (G3, defense-in-depth)

**src/services/executors/claude-code.ts:**
- Use chat-scoped agent names: `${agentName}:${chatId}` (G2)
- Pass `skipHooks: true` in omni spawn params (G6)

**src/lib/provider-adapters.ts:**
- Add `skipHooks?: boolean` to `SpawnParams` (G6)
- Guard hook injection: `if (!params.skipHooks)` (G6)

## Test Plan
- [x] All NATS subscriptions have queue group
- [x] Per-chat agents create separate PG records
- [x] Message dedup skips duplicate messageIds
- [x] Session recovery uses orphan-all (no per-row loop)
- [x] Empty OMNI_TURN_ID handled gracefully
- [x] Omni-spawned agents don't trigger orchestration hooks

## Related
- Fixes data breach: WhatsApp users mixed in agent sessions (trace 2026-04-09)
- Complements omni/389 (OMNI_TURN_ID CLI fix)