### PR TITLE
fix: auto-configure memory when scaffolding agent workspace

### DIFF
--- a/src/term-commands/init.test.ts
+++ b/src/term-commands/init.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { scaffoldAgentFiles } from '../templates/index.js';
+import { scaffoldAgentInWorkspace } from './init.js';
 
 let testDir: string;
 
@@ -35,5 +36,30 @@ describe('scaffoldAgentFiles', () => {
     const content = readFileSync(join(testDir, 'AGENTS.md'), 'utf-8');
     // With the new template, name derives from directory — no active name: field
     expect(content).not.toMatch(/^name:/m);
+  });
+});
+
+describe('scaffoldAgentInWorkspace', () => {
+  test('writes settings.local.json with auto-memory enabled and seeds MEMORY.md', () => {
+    // Minimal workspace.json so getWorkspaceConfig doesn't crash
+    mkdirSync(join(testDir, '.genie'), { recursive: true });
+    writeFileSync(join(testDir, '.genie', 'workspace.json'), `${JSON.stringify({ name: 'test-ws' }, null, 2)}\n`);
+
+    scaffoldAgentInWorkspace(testDir, 'atlas');
+
+    const settingsPath = join(testDir, 'agents', 'atlas', '.claude', 'settings.local.json');
+    expect(existsSync(settingsPath)).toBe(true);
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    expect(settings).toEqual({
+      agentName: 'atlas',
+      autoMemoryEnabled: true,
+      autoMemoryDirectory: './brain/memory',
+    });
+
+    const memoryPath = join(testDir, 'agents', 'atlas', 'brain', 'memory', 'MEMORY.md');
+    expect(existsSync(memoryPath)).toBe(true);
+    const memory = readFileSync(memoryPath, 'utf-8');
+    expect(memory).toContain('# Memory Index');
+    expect(memory).toContain('auto-memory system');
   });
 });

--- a/src/term-commands/init.ts
+++ b/src/term-commands/init.ts
@@ -43,7 +43,7 @@ async function ensureSetupCompleteForInit(): Promise<void> {
   await setupCommand();
 }
 
-function scaffoldAgentInWorkspace(workspaceRoot: string, name: string, agentsDir?: string): void {
+export function scaffoldAgentInWorkspace(workspaceRoot: string, name: string, agentsDir?: string): void {
   const baseDir = agentsDir ?? join(workspaceRoot, 'agents');
   const agentDir = join(baseDir, name);
   if (existsSync(agentDir)) {
@@ -64,7 +64,18 @@ function scaffoldAgentInWorkspace(workspaceRoot: string, name: string, agentsDir
   }
 
   scaffoldAgentFiles(agentDir, name, workspaceDefaults);
-  writeFileSync(join(agentDir, '.claude', 'settings.local.json'), `${JSON.stringify({ agentName: name }, null, 2)}\n`);
+
+  const settings = {
+    agentName: name,
+    autoMemoryEnabled: true,
+    autoMemoryDirectory: './brain/memory',
+  };
+  writeFileSync(join(agentDir, '.claude', 'settings.local.json'), `${JSON.stringify(settings, null, 2)}\n`);
+
+  writeFileSync(
+    join(agentDir, 'brain', 'memory', 'MEMORY.md'),
+    '# Memory Index\n\n_This file is maintained by the auto-memory system. New memories are added automatically._\n',
+  );
 
   const reposTarget = join(workspaceRoot, 'repos');
   if (existsSync(reposTarget)) {
@@ -77,8 +88,8 @@ function scaffoldAgentInWorkspace(workspaceRoot: string, name: string, agentsDir
 
   console.log(`Agent scaffolded: agents/${name}/`);
   console.log('  AGENTS.md, SOUL.md, HEARTBEAT.md');
-  console.log('  brain/memory/');
-  console.log('  .claude/settings.local.json');
+  console.log('  brain/memory/MEMORY.md (seeded)');
+  console.log('  .claude/settings.local.json (auto-memory enabled)');
   if (existsSync(join(agentDir, 'repos'))) {
     console.log('  repos -> ../repos (symlink)');
   }


### PR DESCRIPTION
## Summary
- Wire `autoMemoryEnabled` + `autoMemoryDirectory` into `.claude/settings.local.json` when `genie init agent <name>` scaffolds
- Seed `brain/memory/MEMORY.md` index so the directory isn't empty
- Export `scaffoldAgentInWorkspace` and add a unit test covering both new behaviors
- Update scaffold console output to advertise the new files

## Context
`autoMemoryEnabled` is a claude-agent-sdk setting — stock Claude Code CLI ignores it. Seeding is harmless for stock CLI users and functional for SDK users.

Closes automagik-dev/genie#1106

## Test plan
- [x] `bun test src/term-commands/init.test.ts` — 4 pass / 0 fail
- [x] `bun run typecheck` — clean
- [x] Pre-push hook: full `bun test` — 2436 pass / 0 fail