### PR TITLE
docs(brain): advertise passthrough commands in --help output

### DIFF
--- a/src/term-commands/brain.ts
+++ b/src/term-commands/brain.ts
@@ -521,7 +521,7 @@ async function executeBrainCommand(args: string[]): Promise<void> {
 export function registerBrainCommands(program: Command): void {
   const brain = program
     .command('brain')
-    .description('Knowledge graph engine (enterprise)')
+    .description('Knowledge graph engine (enterprise) — forwards unknown subcommands to @khal-os/brain')
     .allowUnknownOption()
     .allowExcessArguments()
     .action(async (_options: Record<string, unknown>, cmd: Command) => {
@@ -533,7 +533,29 @@ export function registerBrainCommands(program: Command): void {
         return;
       }
       await executeBrainCommand(args);
-    });
+    })
+    .addHelpText(
+      'after',
+      `
+Forwarded commands (require @khal-os/brain installed):
+  status              Show running brain server status
+  health              Show brain health score
+  init                Initialize a new brain vault
+  search <query>      Search the brain knowledge graph
+  ingest <path>       Ingest files into the brain
+  analyze <path>      Analyze a file against the brain
+  config              Manage brain configuration
+  mount/unmount       Mount brains
+  graph               Explore the knowledge graph
+  traces              View reasoning traces
+
+Examples:
+  $ genie brain status
+  $ genie brain search "how does login work"
+  $ genie brain init --name my-brain --path ./brain
+
+Install brain: genie brain install`,
+    );
 
   brain
     .command('install')


### PR DESCRIPTION
## Summary
- Add `.addHelpText('after', ...)` footer to `genie brain` listing forwarded commands (status, health, init, search, ingest, analyze, config, mount, graph, traces)
- Include 3 concrete usage examples
- Update `.description()` to mention passthrough
- Action handler, real subcommands, and runtime passthrough are untouched — pure help-text change

## Context
Runtime passthrough via `.allowUnknownOption().allowExcessArguments()` already worked. Users hitting `genie brain --help` saw only install/uninstall/upgrade/version and filed bugs claiming the feature was missing. This fixes the help-text gap that caused the confusion.

Closes automagik-dev/genie#1118

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun test src/term-commands/brain.test.ts` — 11 pass / 0 fail
- [x] `bun run build && ./dist/genie.js brain --help` — forwarded commands, examples, and install hint all present