### PR TITLE
chore: bump pgserve to ^1.1.8

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "ignore": "^7.0.5",
         "js-yaml": "^4.1.1",
         "nats": "^2.29.3",
-        "pgserve": "^1.1.6",
+        "pgserve": "^1.1.8",
         "postgres": "^3.4.8",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -896,7 +896,7 @@
 
     "peek-readable": ["peek-readable@4.1.0", "", {}, "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="],
 
-    "pgserve": ["pgserve@1.1.6", "", { "dependencies": { "bun": "^1.3.4" }, "optionalDependencies": { "@embedded-postgres/darwin-arm64": "18.2.0-beta.16", "@embedded-postgres/darwin-x64": "18.2.0-beta.16", "@embedded-postgres/linux-x64": "18.2.0-beta.16", "@embedded-postgres/windows-x64": "18.2.0-beta.16" }, "bin": { "pgserve": "bin/pgserve-wrapper.cjs" } }, "sha512-qdgiU3q/o/k8lP+IPHLiZG5uTWmvCSgqM3erdP7nmgVeQYv89DTo0nSG5XB0ccVD7yG/BppLFHjRvvXcWVgKnQ=="],
+    "pgserve": ["pgserve@1.1.8", "", { "dependencies": { "bun": "^1.3.4" }, "optionalDependencies": { "@embedded-postgres/darwin-arm64": "18.2.0-beta.16", "@embedded-postgres/darwin-x64": "18.2.0-beta.16", "@embedded-postgres/linux-x64": "18.2.0-beta.16", "@embedded-postgres/windows-x64": "18.2.0-beta.16" }, "bin": { "pgserve": "bin/pgserve-wrapper.cjs" } }, "sha512-CZJK6uWqua50Bz/l4T9hubGWdWfycJfWN0UptnhMhvGVmdKBOC9qQTleBr4HaF6ESTaHBBfq/WuWpKfscGhxNA=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ignore": "^7.0.5",
     "js-yaml": "^4.1.1",
     "nats": "^2.29.3",
-    "pgserve": "^1.1.6",
+    "pgserve": "^1.1.8",
     "postgres": "^3.4.8",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",


### PR DESCRIPTION
## Summary

Bumps `pgserve` from `^1.1.6` to `^1.1.8` to pick up the pgvector auto-install regex fix from [namastexlabs/pgserve#20](https://github.com/namastexlabs/pgserve/pull/20).

## Why this matters

On PG 14+, previous pgserve versions silently fell back to a hardcoded `'17'` PG major when parsing `postgres --version` output (`postgres (PostgreSQL) 18.2`). The old regex `/PostgreSQL (\d+)/` expected a digit immediately after `PostgreSQL ` and failed to match past the closing `)`, so the fallback kicked in and downloaded `postgresql-17-pgvector.deb` into a PG18 lib dir.

Everything looked fine until `CREATE EXTENSION vector`, which died with:

```
ERROR: incompatible library version: server is version 18, library is version 17
```

1.1.8 fixes the regex to `/PostgreSQL\)?\s+(\d+)/`, throws loudly on unparseable output instead of silently defaulting, and logs the detected major at info level.

## Heads up: existing stale installs

This bump alone **does not heal deployments that already have a broken `vector.so` on disk** — those stay broken until someone manually wipes `~/.pgserve/bin/linux-x64/lib/vector.so` or the auto-heal feature from [namastexlabs/pgserve#21](https://github.com/namastexlabs/pgserve/pull/21) lands as `1.1.9`.

If you hit "incompatible library version" after this merge, run:

```bash
rm ~/.pgserve/bin/linux-x64/lib/vector.so
rm -f ~/.pgserve/bin/linux-x64/share/postgresql/extension/vector*
```

…and restart. The corrected 1.1.8 code will re-download the right `.deb` on next `CREATE EXTENSION`.

## Changes

- `package.json`: `pgserve ^1.1.6` → `^1.1.8`
- `bun.lock`: refreshed pgserve entry (sha512 + version string)

## Test plan

- [ ] CI passes
- [ ] Local smoke test: start the embedded PG + create a pgvector-enabled database
