### PR TITLE
fix(omni-bridge): isolate GENIE_HOME in tests + arm idle timer last

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dead-code": "bunx knip",
     "skills:lint": "bun run scripts/skills-lint.ts",
     "skills:audit": "bun run scripts/skills-audit.ts",
-    "check": "bun run typecheck && bun run lint && bun run dead-code && (bun test || bun test)"
+    "check": "bun run typecheck && bun run lint && bun run dead-code && bun test"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.91",

--- a/src/services/__tests__/omni-bridge.test.ts
+++ b/src/services/__tests__/omni-bridge.test.ts
@@ -20,11 +20,44 @@
  * pgserve, but this file deliberately avoids it to exercise the error paths).
  */
 
-import { describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { NatsConnection, Subscription } from 'nats';
 import type { ExecutorSession, IExecutor, OmniMessage } from '../executor.js';
 
 import { OmniBridge } from '../omni-bridge.js';
+
+// ----------------------------------------------------------------------------
+// Test hygiene — isolate GENIE_HOME per test
+// ----------------------------------------------------------------------------
+// OmniBridge.start() writes a pidfile to `${GENIE_HOME}/state/omni-bridge.json`
+// (via getBridgePidfilePath()). Without per-test isolation the tests collide
+// with any live `genie serve` on the host, triggering deterministic
+// "pidfile locked" failures. Mirrors the pattern used in
+// omni-bridge-pidfile.test.ts. See issue #1137.
+let __tmpGenieHome: string;
+let __origGenieHome: string | undefined;
+
+beforeEach(() => {
+  __tmpGenieHome = mkdtempSync(join(tmpdir(), 'omni-bridge-test-'));
+  __origGenieHome = process.env.GENIE_HOME;
+  process.env.GENIE_HOME = __tmpGenieHome;
+});
+
+afterEach(() => {
+  if (__origGenieHome === undefined) {
+    process.env.GENIE_HOME = undefined;
+  } else {
+    process.env.GENIE_HOME = __origGenieHome;
+  }
+  try {
+    rmSync(__tmpGenieHome, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
 
 // ----------------------------------------------------------------------------
 // Fakes

--- a/src/services/omni-bridge.ts
+++ b/src/services/omni-bridge.ts
@@ -308,9 +308,6 @@ export class OmniBridge {
     const sessionResetSub = this.nc.subscribe('omni.session.reset.>', { queue: 'genie-bridge' });
     this.processSessionResetEvents(sessionResetSub);
 
-    // Start idle session checker
-    this.idleCheckTimer = setInterval(() => this.checkIdleSessions(), IDLE_CHECK_INTERVAL_MS);
-
     // Set uptime anchor before subscribing the ping handler so the first pong
     // reports a non-negative value.
     this.startedAtMs = Date.now();
@@ -430,6 +427,13 @@ export class OmniBridge {
       process.removeListener('SIGTERM', onSignal);
       process.removeListener('SIGINT', onSignal);
     };
+
+    // Arm the idle session checker LAST — after the pidfile write has
+    // succeeded and all prior rollback paths are past. This guarantees
+    // that if any earlier step throws, no timer handle has been created
+    // and there is nothing for the caller (or test harness) to leak.
+    // See issue #1137 for the bun-test-hang this ordering prevents.
+    this.idleCheckTimer = setInterval(() => this.checkIdleSessions(), IDLE_CHECK_INTERVAL_MS);
 
     console.log(
       `[omni-bridge] Listening on omni.message.> (max_concurrent=${this.maxConcurrent}, idle_timeout=${this.idleTimeoutMs}ms)`,


### PR DESCRIPTION
Closes #1137.

## Summary

Two compounding defects (plus a leftover from #1136) produced 25 deterministic \`bun test\` failures — and, on pre-1.3.11 Bun, indefinite test-runner hangs with orphaned processes.

### Defect A — \`omni-bridge.test.ts\` never isolated \`GENIE_HOME\`
\`OmniBridge.start()\` writes a pidfile at \`\${GENIE_HOME}/state/omni-bridge.json\` via \`getBridgePidfilePath()\`. Without per-test isolation, 25 tests in this file collided with production \`~/.genie/state/omni-bridge.json\` and failed deterministically with \`pidfile locked by PID <live-daemon-pid>\` whenever a \`genie serve\` daemon was running on the host.

**Fix:** add \`beforeEach\`/\`afterEach\` at module scope that point \`GENIE_HOME\` at a unique \`mkdtempSync\` under \`os.tmpdir()\` and restore the prior value on teardown. Mirrors the working pattern already used in \`omni-bridge-pidfile.test.ts\`.

### Defect B — \`idleCheckTimer\` registered before the pidfile write
\`OmniBridge.start()\` called:
\`\`\`ts
this.idleCheckTimer = setInterval(checkIdleSessions, 30_000);
\`\`\`
**before** the pidfile write block. The pidfile step's catch clause rolls back NATS but does **not** \`clearInterval\` the timer. If the pidfile throws (locked or otherwise), the \`setInterval\` handle leaks, pinning Bun's event loop until forced exit. Under pre-1.3.11 Bun's exit semantics this caused \`bun test\` to hang indefinitely — observed as 13 orphaned \`bun test\` processes with 11+ hours CPU time each on the shared self-hosted runner.

**Fix:** move the \`setInterval\` registration to the very end of \`start()\`, after the pidfile write, signal handler install, and final console log. Now any exception before that point leaves no timer to leak.

### Defect C — \`package.json\` \`check\` script still had the \`bun test\` retry
PR #1136 removed \`bun test || bun test\` from \`.github/workflows/ci.yml\` but missed \`package.json:27\`, so \`.husky/pre-push\` still ran the same retry dance locally — masking flakes and producing the orphan-process cascade on every failed push.

**Fix:** drop the \`|| bun test\` fallback from the \`check\` script. Local hook now fails fast on the first test failure just like CI does.

## Validation

\`\`\`
$ bun test src/services/__tests__/omni-bridge.test.ts
 27 pass
  0 fail
 82 expect() calls
Ran 27 tests across 1 file. [4.66s]

$ bun test  # full suite
 2446 pass
    0 fail
 5609 expect() calls
Ran 2446 tests across 128 files. [56.52s]
\`\`\`

Before: 2 421 pass / **25 fail**. After: 2 446 pass / **0 fail**.

## Trace report

Full root-cause analysis, causal chain, and confidence ratings were produced by \`/trace\` session on 2026-04-11 and drive this PR's fix ordering. Key finding: the hang symptom and the \`pidfile locked\` symptom share the same three defects — fixing any one is necessary but not sufficient; all three are needed for the class of failures to actually go away across past, present, and future Bun versions.

## Test plan

- [x] \`bun test src/services/__tests__/omni-bridge.test.ts\` — green (27/27)
- [x] Full \`bun test\` — green (2446/2446)
- [ ] CI Quality Gate on this PR — should also pass (#1136's scratch cache is already in place on \`dev\`)
- [ ] Verify \`bun run check\` no longer leaves orphan \`bun test\` processes on a deliberately failing run (manual)

## Related

- Issue #1137 — the bug this PR closes
- PR #1136 — prior CI hygiene fix that removed \`|| bun test\` from the workflow only (this PR finishes the job in \`package.json\`)
- Commit \`0bcb971e\` — prior Bun 1.3.11 bump that fixed the upstream \`loadGenieConfigSync\` export-resolution bug in the same failure surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)