### PR TITLE
ci(version): replace [skip ci] with [auto-version] on bump commits

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -23,7 +23,7 @@ jobs:
       (github.event_name == 'workflow_dispatch') ||
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event == 'push' &&
-       !contains(github.event.workflow_run.head_commit.message, '[skip ci]') &&
+       !contains(github.event.workflow_run.head_commit.message, '[auto-version]') &&
        (
          (github.event.workflow_run.head_branch == 'main' &&
           startsWith(github.event.workflow_run.head_commit.message, 'Merge pull request') &&
@@ -96,7 +96,7 @@ jobs:
           if git diff --cached --quiet; then
             echo "No version changes to commit"
           else
-            git commit -m "chore(version): bump to ${VERSION} [skip ci]"
+            git commit -m "chore(version): bump to ${VERSION} [auto-version]"
           fi
 
           git tag "v${VERSION}"


### PR DESCRIPTION
Closes #1139.

## Problem

Version-bump commits use GitHub's `[skip ci]` marker to prevent the Version workflow from re-triggering on its own output. Side effect: GitHub suppresses **all** workflow runs on those commits — including the CI and Commitlint checks that PR #1124 (rolling promotion `dev→main`) needs in its status rollup. Every single version bump stales the rollup, requiring manual intervention (empty retrigger commits, close+reopen attempts) to unblock the rolling PR.

Observed three times in 24 hours on 2026-04-11:
- `235d3ad9` (`4.260411.3 [skip ci]`) — staled rollup after #1138 merge
- `22bc0270` (`4.260412.1 [skip ci]`) — staled rollup after metrics commit
- Required manual `d7372252` → `6e38a17a` empty-commit push to retrigger

## Fix

Replace `[skip ci]` with a custom `[auto-version]` marker in two places in `version.yml`:

| Line | Before | After |
|------|--------|-------|
| 26 (guard) | `!contains(message, '[skip ci]')` | `!contains(message, '[auto-version]')` |
| 99 (commit) | `bump to ${VERSION} [skip ci]` | `bump to ${VERSION} [auto-version]` |

**How it works:**
1. Version bump commits now say `[auto-version]` — GitHub does **not** recognize this as a CI-skip marker, so CI + Commitlint fire normally on dev push.
2. Those CI completions trigger the Version workflow, but it checks `!contains(head_commit.message, '[auto-version]')` → **false** → self-guards. No infinite loop.
3. PR #1124's rollup always reflects the latest commit's Quality Gate + Commitlint state. No manual retrigger needed.

**Cost:** one extra ~60s CI run per version bump on the Blacksmith runner. Marginal vs the manual-intervention tax it eliminates.

**Not touched:** `release.yml`'s guard (`!startsWith(message, '[skip ci]')`) — it protects against a different edge case (direct `[skip ci]`-prefixed pushes to main) and version bumps are always pushed to `dev`, never directly to `main`.

## Test plan

- [ ] Merge this PR → Version workflow fires → emits `[auto-version]` bump commit
- [ ] CI fires on the `[auto-version]` bump commit (previously would not fire)
- [ ] Version workflow sees the `[auto-version]` CI completion and skips (no infinite loop)
- [ ] PR #1124's rollup shows Quality Gate + Commitlint on the bump commit
- [ ] No manual retrigger needed for next rolling promotion

🤖 Generated with [Claude Code](https://claude.com/claude-code)