### PR TITLE
fix: tui lifecycle — navigate from inside + auto-terminate stale executors

### DIFF
--- a/src/genie.ts
+++ b/src/genie.ts
@@ -547,9 +547,30 @@ if (isTuiPane) {
 
 // Default command: genie (no args) → TUI + agent routing based on cwd.
 if (args.length === 0) {
-  // Guard against nested tmux cascade — running `genie` inside the TUI right pane
+  // Already inside the TUI — resolve agent from cwd and signal navigation instead of erroring.
   if (process.env.TMUX?.includes('genie-tui')) {
-    console.log('Already inside the genie TUI. Use Ctrl-b d to detach, or run genie commands directly.');
+    const { findWorkspace } = await import('./lib/workspace.js');
+    const ws = findWorkspace();
+    if (ws) {
+      const { resolveAgentFromCwd } = await import('./lib/resolve-agent-cwd.js');
+      const resolved = resolveAgentFromCwd(process.cwd(), ws.root);
+      if (resolved.source !== 'default') {
+        // Write signal file so the running TUI navigates to this agent
+        const { writeFileSync } = await import('node:fs');
+        const { join } = await import('node:path');
+        const home = process.env.GENIE_HOME ?? join((await import('node:os')).homedir(), '.genie');
+        try {
+          writeFileSync(join(home, 'tui-initial-agent'), resolved.agent, 'utf-8');
+        } catch {
+          // best-effort
+        }
+        console.log(`Navigating to ${resolved.agent}...`);
+      } else {
+        console.log('Already inside the genie TUI. Use Ctrl-b d to detach, or run genie commands directly.');
+      }
+    } else {
+      console.log('Already inside the genie TUI. Use Ctrl-b d to detach, or run genie commands directly.');
+    }
     process.exit(0);
   }
   if (process.env.TMUX) {

--- a/src/tui/components/Nav.tsx
+++ b/src/tui/components/Nav.tsx
@@ -685,8 +685,8 @@ function spawnAgent(name: string, onTmuxSessionSelect?: (sessionName: string, wi
     if (onTmuxSessionSelect) {
       attachSpawnedAgentWhenReady(sessionName, onTmuxSessionSelect);
     }
-  } catch {
-    // best-effort spawn
+  } catch (err) {
+    console.error(`TUI: spawn failed for ${name}:`, err instanceof Error ? err.message : err);
   }
 }
 

--- a/src/tui/diagnostics.ts
+++ b/src/tui/diagnostics.ts
@@ -229,6 +229,22 @@ export async function collectDiagnostics(): Promise<DiagnosticSnapshot> {
 
   const gaps = detectGaps(executors, sessions);
 
+  // Auto-terminate dead-PID executors so stale rows don't block re-spawning.
+  if (gaps.deadPidExecutors.length > 0) {
+    const { terminateExecutor } = await import('../lib/executor-registry.js');
+    const { getConnection } = await import('../lib/db.js');
+    const sql = await getConnection();
+    await Promise.allSettled(
+      gaps.deadPidExecutors.map(async (exec) => {
+        await terminateExecutor(exec.id);
+        // Clear the agent FK so the duplicate guard won't block new spawns
+        if (exec.agentId) {
+          await sql`UPDATE agents SET current_executor_id = NULL WHERE current_executor_id = ${exec.id}`;
+        }
+      }),
+    );
+  }
+
   return {
     sessions,
     executors,

--- a/src/tui/session-tree.test.ts
+++ b/src/tui/session-tree.test.ts
@@ -87,7 +87,7 @@ describe('buildWorkspaceTree', () => {
       sessionName: 'sofia',
       index: 1,
       name: 'work',
-      panes: [makePane({ sessionName: 'sofia', windowIndex: 1, paneId: '%1' })],
+      panes: [makePane({ sessionName: 'sofia', windowIndex: 1, paneId: '%1', command: 'claude', title: 'claude' })],
     });
     const sofiaSession = makeSession('sofia', [win0, win1]);
 
@@ -108,6 +108,26 @@ describe('buildWorkspaceTree', () => {
     const vegapunk = tree.find((n) => n.label === 'vegapunk')!;
     expect(vegapunk.wsAgentState).toBe('stopped');
     expect(vegapunk.children).toHaveLength(0);
+  });
+
+  test('session with only shell panes and no executors shows as stopped', () => {
+    const win0 = makeWindow({ sessionName: 'sofia', index: 0, name: 'home' });
+    const win1 = makeWindow({
+      sessionName: 'sofia',
+      index: 1,
+      name: 'work',
+      panes: [makePane({ sessionName: 'sofia', windowIndex: 1, paneId: '%1' })],
+    });
+    const sofiaSession = makeSession('sofia', [win0, win1]);
+
+    const tree = buildWorkspaceTree({
+      agentNames: ['sofia'],
+      sessions: [sofiaSession],
+      executors: [],
+    });
+
+    const sofia = tree.find((n) => n.label === 'sofia')!;
+    expect(sofia.wsAgentState).toBe('stopped');
   });
 
   test('executor state reflected on agent nodes', () => {

--- a/src/tui/session-tree.ts
+++ b/src/tui/session-tree.ts
@@ -217,6 +217,10 @@ function deriveWsAgentState(session: TmuxSession | undefined, agentExecutors: Tu
     if (exec.state === 'spawning') return 'spawning';
   }
 
+  // Session exists but no live Claude panes and no active executors — agent is stopped.
+  // This catches stale shell-only sessions left after Claude exits.
+  if (agentExecutors.length === 0) return 'stopped';
+
   return 'running';
 }
 


### PR DESCRIPTION
## Summary

- **Navigate from inside TUI**: Running `genie` from an agent directory inside the TUI now writes the initial-agent signal file and navigates the sidebar to that agent, instead of showing "Already inside the genie TUI" error
- **Auto-terminate stale executors**: `collectDiagnostics()` now calls `terminateExecutor()` for dead-PID executors on each refresh cycle (~2s), clearing stale DB rows that block re-spawning
- **Hardened state derivation**: Sessions with only shell panes and no active executors now show as "stopped" instead of incorrectly showing "running"
- **Spawn error visibility**: Spawn failures are logged to stderr instead of silently swallowed

## Root Cause

1. Guard at `genie.ts:551` exited before agent resolution/signal write
2. `detectGaps()` identified dead PIDs but never updated the DB
3. `deriveWsAgentState()` returned 'running' for stale shell-only sessions

Wish: `tui-lifecycle-fixes`

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 2447 pass, 0 fail
- [ ] Run `genie` from inside TUI in an agent directory — sidebar navigates
- [ ] Kill all agent panes, verify sidebar shows "stopped" within ~3s
- [ ] Click stopped agent — spawns successfully