### PR TITLE
fix(metrics): clean README hero markdown + embed commits chart

### DIFF
--- a/.genie/agents/metrics-updater/tools/generate-readme-hero.py
+++ b/.genie/agents/metrics-updater/tools/generate-readme-hero.py
@@ -101,16 +101,26 @@ def main():
         f"**{contributors} contributors**"
     )
 
+    # Full block lives INSIDE the markers — nothing after END so GitHub
+    # markdown renders cleanly. Includes the commits chart as a visual
+    # showpiece and a clean "full dashboard" link on its own line.
     replacement = (
         "<!-- METRICS:START -->\n"
         f"{hero_line}\n"
-        "<!-- METRICS:END --> · [Full dashboard](VELOCITY.md)"
+        "\n"
+        "![Commits per day (30d, all branches)](.genie/assets/commits-30d.svg)\n"
+        "\n"
+        "[📊 Full velocity dashboard →](VELOCITY.md)\n"
+        "<!-- METRICS:END -->"
     )
 
     with open(args.readme, "r") as f:
         content = f.read()
 
-    pattern = r"<!-- METRICS:START -->.*?<!-- METRICS:END -->(?:\s*·\s*\[Full dashboard\]\(VELOCITY\.md\))?"
+    # Match the full block including any trailing stray text that previous
+    # broken versions may have placed after the END marker on the same
+    # line (self-healing from the earlier "END --> · [Full dashboard]" bug).
+    pattern = r"<!-- METRICS:START -->.*?<!-- METRICS:END -->[^\n]*"
     new_content, count = re.subn(pattern, replacement, content, flags=re.DOTALL)
 
     if count == 0:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@
 
 <!-- METRICS:START -->
 **🚀 234 commits** this week · **40 releases** · **+49.3K LoC** · **7 contributors**
-<!-- METRICS:END --> · [Full dashboard](VELOCITY.md)
+
+![Commits per day (30d, all branches)](.genie/assets/commits-30d.svg)
+
+[📊 Full velocity dashboard →](VELOCITY.md)
+<!-- METRICS:END -->
 
 Genie is a CLI that turns one sentence into a finished pull request. You describe what you want — Genie interviews you, writes a plan, spawns parallel agents in isolated worktrees, reviews the code, and opens a PR. You approve. You merge. That's it.
 


### PR DESCRIPTION
Follow-up to PR #1142 (velocity-dashboard). The README METRICS hero block had two rendering bugs that I caught after merge:

## Problems

1. **`<!-- METRICS:END --> · [Full dashboard](VELOCITY.md)`** put the "Full dashboard" link on the same line as the closing HTML comment. GitHub markdown rendered this as a stray floating "· [Full dashboard]" paragraph that ran into the next section with no separation:

    ```
    🚀 234 commits this week · 40 releases · +49.3K LoC · 7 contributors

    · [Full dashboard](VELOCITY.md)
    Genie is a CLI that turns one sentence...
    ```

2. **No visual in the README** — only a numbers line — despite the brainstorm asking for visible charts in the README itself.

## Fix

- Move the dashboard link to its own line **inside** the METRICS markers with proper blank-line separation
- Embed `.genie/assets/commits-30d.svg` between the hero line and the link as a visual showpiece
- Tighten the regex to `<!-- METRICS:START -->.*?<!-- METRICS:END -->[^\n]*` so re-runs self-heal from the prior broken format

Rendered block now:

```markdown
<!-- METRICS:START -->
**🚀 234 commits** this week · **40 releases** · **+49.3K LoC** · **7 contributors**

![Commits per day (30d, all branches)](.genie/assets/commits-30d.svg)

[📊 Full velocity dashboard →](VELOCITY.md)
<!-- METRICS:END -->
```

Everything lives inside the markers, blank lines between elements, commits chart visible, clean separation from the next section.

## Test plan

- [x] `python3 generate-readme-hero.py` emits the clean block
- [x] Regex self-heals from the broken format (re-running on a broken README converges to clean output)
- [ ] GitHub renders the SVG inline from the relative path (visual verification on branch)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
