### PR TITLE
feat(wish-state): detect WISH.md drift and fail loud on stale state

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -9,4 +9,6 @@ while read local_ref local_oid remote_ref remote_oid; do
   fi
 done
 
+# Strip git env inherited from the push so tests that spawn git in tmpdirs work
+unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_QUARANTINE_PATH GIT_PREFIX GIT_INTERNAL_GETTEXT_SH_SCHEME
 bun run check

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -540,8 +540,9 @@ export function isConnected(): boolean {
  */
 export async function resetConnection(): Promise<void> {
   if (sqlClient) {
-    await sqlClient.end({ timeout: 5 });
+    const dying = sqlClient;
     sqlClient = null;
+    await dying.end({ timeout: 5 });
   }
 }
 

--- a/src/lib/wish-state.test.ts
+++ b/src/lib/wish-state.test.ts
@@ -10,10 +10,13 @@ import { execSync } from 'node:child_process';
 import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { getConnection } from './db.js';
 import { DB_AVAILABLE, setupTestSchema } from './test-db.js';
 import {
   type GroupDefinition,
+  WishStateMismatchError,
   completeGroup,
+  computeGroupsSignature,
   createState,
   findAnyGroupByAssignee,
   findGroupByAssignee,
@@ -25,6 +28,7 @@ import {
   resetInProgressGroups,
   resolveRepoPath,
   startGroup,
+  wipeState,
 } from './wish-state.js';
 
 let cwd: string;
@@ -658,6 +662,174 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
       await createState('reset-none', [{ name: '1' }], cwd);
       const count = await resetInProgressGroups('reset-none', cwd);
       expect(count).toBe(0);
+    });
+  });
+
+  // ============================================================================
+  // computeGroupsSignature + getOrCreateState invalidation
+  // ============================================================================
+
+  describe('computeGroupsSignature', () => {
+    test('is stable across calls for the same input', () => {
+      const sig1 = computeGroupsSignature(sampleGroups);
+      const sig2 = computeGroupsSignature(sampleGroups);
+      expect(sig1).toBe(sig2);
+      expect(sig1).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    test('is order-insensitive on dependsOn', () => {
+      const a: GroupDefinition[] = [{ name: '4', dependsOn: ['2', '3'] }, { name: '2' }, { name: '3' }];
+      const b: GroupDefinition[] = [{ name: '2' }, { name: '3' }, { name: '4', dependsOn: ['3', '2'] }];
+      expect(computeGroupsSignature(a)).toBe(computeGroupsSignature(b));
+    });
+
+    test('changes when a group is added', () => {
+      const before: GroupDefinition[] = [{ name: '1' }];
+      const after: GroupDefinition[] = [{ name: '1' }, { name: '2', dependsOn: ['1'] }];
+      expect(computeGroupsSignature(before)).not.toBe(computeGroupsSignature(after));
+    });
+
+    test('changes when a dep is changed', () => {
+      const before: GroupDefinition[] = [{ name: '1' }, { name: '2', dependsOn: ['1'] }];
+      const after: GroupDefinition[] = [{ name: '1' }, { name: '2', dependsOn: [] }];
+      expect(computeGroupsSignature(before)).not.toBe(computeGroupsSignature(after));
+    });
+  });
+
+  describe('getOrCreateState invalidation', () => {
+    test('writes groupsSignature to parent metadata on createState', async () => {
+      await createState('sig-write', sampleGroups, cwd);
+      const sql = await getConnection();
+      const rows = await sql`
+        SELECT metadata FROM tasks
+        WHERE wish_file = ${'.genie/wishes/sig-write/WISH.md'} AND repo_path = ${cwd} AND parent_id IS NULL
+      `;
+      expect(rows.length).toBe(1);
+      const metadata = typeof rows[0].metadata === 'string' ? JSON.parse(rows[0].metadata) : rows[0].metadata;
+      expect(metadata.groupsSignature).toBe(computeGroupsSignature(sampleGroups));
+    });
+
+    test('returns existing state when signature matches', async () => {
+      await createState('sig-match', sampleGroups, cwd);
+      const state = await getOrCreateState('sig-match', sampleGroups, cwd);
+      expect(state.wish).toBe('sig-match');
+      expect(Object.keys(state.groups)).toEqual(['1', '2', '3', '4']);
+    });
+
+    test('throws WishStateMismatchError when a group is added', async () => {
+      await createState('sig-add', sampleGroups, cwd);
+      const edited: GroupDefinition[] = [...sampleGroups, { name: '5', dependsOn: ['4'] }];
+
+      let caught: unknown;
+      try {
+        await getOrCreateState('sig-add', edited, cwd);
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(WishStateMismatchError);
+      const err = caught as WishStateMismatchError;
+      expect(err.added).toEqual(['5']);
+      expect(err.removed).toEqual([]);
+      expect(err.changed).toEqual([]);
+      expect(err.message).toContain('genie reset sig-add');
+    });
+
+    test('throws WishStateMismatchError when a group is removed', async () => {
+      await createState('sig-remove', sampleGroups, cwd);
+      const edited: GroupDefinition[] = [
+        { name: '1' },
+        { name: '2', dependsOn: ['1'] },
+        { name: '3', dependsOn: ['1'] },
+      ];
+
+      let caught: unknown;
+      try {
+        await getOrCreateState('sig-remove', edited, cwd);
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(WishStateMismatchError);
+      expect((caught as WishStateMismatchError).removed).toEqual(['4']);
+    });
+
+    test('throws WishStateMismatchError when a dep changes', async () => {
+      await createState('sig-change', sampleGroups, cwd);
+      const edited: GroupDefinition[] = [
+        { name: '1' },
+        { name: '2', dependsOn: ['1'] },
+        { name: '3', dependsOn: ['1'] },
+        { name: '4', dependsOn: ['2'] }, // dropped '3'
+      ];
+
+      let caught: unknown;
+      try {
+        await getOrCreateState('sig-change', edited, cwd);
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(WishStateMismatchError);
+      expect((caught as WishStateMismatchError).changed).toEqual(['4']);
+    });
+
+    test('does NOT throw when group structure is unchanged (prose-only edit)', async () => {
+      await createState('sig-prose', sampleGroups, cwd);
+      // Same group definitions — represents WISH.md prose edits that don't touch
+      // group structure (Summary, Decisions, etc.).
+      const state = await getOrCreateState('sig-prose', sampleGroups, cwd);
+      expect(state.wish).toBe('sig-prose');
+    });
+
+    test('does NOT throw when state exists without signature (backfill-free)', async () => {
+      // Simulate pre-existing state from before this feature landed
+      await createState('sig-backfill', sampleGroups, cwd);
+      const sql = await getConnection();
+      await sql`
+        UPDATE tasks
+        SET metadata = '{}'::jsonb
+        WHERE wish_file = ${'.genie/wishes/sig-backfill/WISH.md'} AND parent_id IS NULL
+      `;
+
+      // Even with structurally different groups, no throw — we treat absent
+      // signature as "valid, never validated".
+      const edited: GroupDefinition[] = [{ name: 'totally-different' }];
+      const state = await getOrCreateState('sig-backfill', edited, cwd);
+      expect(state.wish).toBe('sig-backfill');
+      // Returns the existing (stale) state — backfill-free path
+      expect(Object.keys(state.groups)).toEqual(['1', '2', '3', '4']);
+    });
+  });
+
+  describe('wipeState + reset recovery', () => {
+    test('wipeState returns false when no state exists', async () => {
+      expect(await wipeState('never-existed', cwd)).toBe(false);
+    });
+
+    test('wipeState deletes parent and cascades to children', async () => {
+      await createState('wipe-me', sampleGroups, cwd);
+      expect(await getState('wipe-me', cwd)).not.toBeNull();
+
+      const wiped = await wipeState('wipe-me', cwd);
+      expect(wiped).toBe(true);
+      expect(await getState('wipe-me', cwd)).toBeNull();
+    });
+
+    test('reset flow: invalidation → wipe → recreate produces fresh state', async () => {
+      await createState('reset-flow', sampleGroups, cwd);
+
+      const edited: GroupDefinition[] = [...sampleGroups, { name: '5', dependsOn: ['4'] }];
+
+      // 1. Invalidation fires
+      await expect(getOrCreateState('reset-flow', edited, cwd)).rejects.toBeInstanceOf(WishStateMismatchError);
+
+      // 2. Wipe + recreate (what `genie reset <slug>` does)
+      await wipeState('reset-flow', cwd);
+      const recreated = await createState('reset-flow', edited, cwd);
+
+      expect(Object.keys(recreated.groups)).toEqual(['1', '2', '3', '4', '5']);
+
+      // 3. getOrCreateState now succeeds against the new structure
+      const state = await getOrCreateState('reset-flow', edited, cwd);
+      expect(state.groups['5'].status).toBe('blocked');
     });
   });
 

--- a/src/lib/wish-state.ts
+++ b/src/lib/wish-state.ts
@@ -12,6 +12,7 @@
  */
 
 import { execSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { z } from 'zod';
@@ -47,6 +48,80 @@ type WishState = z.infer<typeof WishStateSchema>;
 export interface GroupDefinition {
   name: string;
   dependsOn?: string[];
+}
+
+// ============================================================================
+// Group-structure signature (drift detection)
+// ============================================================================
+
+/**
+ * Compute a deterministic signature of a wish's group structure.
+ *
+ * Captures group names + sorted `dependsOn` per group. Order of groups in the
+ * input array does not affect the result (groups are sorted by name first), and
+ * dep order within a group does not matter either. Prose changes to WISH.md
+ * (Summary, Decisions, etc.) leave the signature untouched — only structural
+ * changes that affect dispatch flip it.
+ */
+export function computeGroupsSignature(groups: GroupDefinition[]): string {
+  const canonical = groups
+    .map((g) => ({ name: g.name, dependsOn: [...(g.dependsOn ?? [])].sort() }))
+    .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  return createHash('sha256').update(JSON.stringify(canonical)).digest('hex');
+}
+
+/**
+ * Thrown by `getOrCreateState` when the WISH.md group structure has drifted
+ * from the cached signature. Callers can pattern-match on this type to render
+ * remediation UI; the `.message` already contains a human-readable diff and the
+ * remediation command.
+ */
+export class WishStateMismatchError extends Error {
+  readonly slug: string;
+  readonly added: string[];
+  readonly removed: string[];
+  readonly changed: string[];
+
+  constructor(slug: string, added: string[], removed: string[], changed: string[]) {
+    const lines: string[] = [`Wish "${slug}" group structure has changed since state was created.`];
+    if (added.length > 0) lines.push(`  + added: ${added.join(', ')}`);
+    if (removed.length > 0) lines.push(`  - removed: ${removed.join(', ')}`);
+    if (changed.length > 0) lines.push(`  ~ changed deps: ${changed.join(', ')}`);
+    lines.push('');
+    lines.push(`Run \`genie reset ${slug}\` to recreate state from the current WISH.md.`);
+    super(lines.join('\n'));
+    this.name = 'WishStateMismatchError';
+    this.slug = slug;
+    this.added = added;
+    this.removed = removed;
+    this.changed = changed;
+  }
+}
+
+/** Diff two group-definition arrays into added/removed/changed names. */
+function diffGroups(
+  prev: GroupDefinition[],
+  next: GroupDefinition[],
+): { added: string[]; removed: string[]; changed: string[] } {
+  const prevMap = new Map(prev.map((g) => [g.name, [...(g.dependsOn ?? [])].sort()]));
+  const nextMap = new Map(next.map((g) => [g.name, [...(g.dependsOn ?? [])].sort()]));
+
+  const added: string[] = [];
+  const removed: string[] = [];
+  const changed: string[] = [];
+
+  for (const [name, deps] of nextMap) {
+    if (!prevMap.has(name)) {
+      added.push(name);
+    } else if (JSON.stringify(prevMap.get(name)) !== JSON.stringify(deps)) {
+      changed.push(name);
+    }
+  }
+  for (const name of prevMap.keys()) {
+    if (!nextMap.has(name)) removed.push(name);
+  }
+
+  return { added: added.sort(), removed: removed.sort(), changed: changed.sort() };
 }
 
 // ============================================================================
@@ -211,10 +286,16 @@ export async function createState(slug: string, groups: GroupDefinition[], cwd?:
     await sql`DELETE FROM tasks WHERE id = ${existingParent.id as string}`;
   }
 
-  // Create parent task (the wish itself)
+  // Create parent task (the wish itself).
+  // Stash the group-structure signature so getOrCreateState can detect drift
+  // when WISH.md gets edited after state was first created.
+  const groupsSignature = computeGroupsSignature(groups);
   const [parent] = await sql`
-    INSERT INTO tasks (repo_path, title, wish_file, type_id, stage, status)
-    VALUES (${repoPath}, ${slug}, ${wishFile}, 'software', 'draft', 'ready')
+    INSERT INTO tasks (repo_path, title, wish_file, type_id, stage, status, metadata)
+    VALUES (
+      ${repoPath}, ${slug}, ${wishFile}, 'software', 'draft', 'ready',
+      ${sql.json({ groupsSignature })}
+    )
     RETURNING *
   `;
 
@@ -499,11 +580,85 @@ export async function findAnyGroupByAssignee(
 /**
  * Get existing state or create it from group definitions.
  * Avoids the "no state file" gap that causes polling loops.
+ *
+ * If state already exists and the parent task carries a `groupsSignature` in
+ * `metadata`, we recompute the signature from the supplied `groups` and throw
+ * `WishStateMismatchError` if they don't match — protects against silently
+ * dispatching against a stale plan after WISH.md was edited.
+ *
+ * Pre-existing state without a `groupsSignature` is treated as "valid, never
+ * validated" (backfill-free path) — first successful invalidation requires a
+ * `genie reset <slug>`.
  */
 export async function getOrCreateState(slug: string, groups: GroupDefinition[], cwd?: string): Promise<WishState> {
   const existing = await getState(slug, cwd);
-  if (existing) return existing;
+  if (existing) {
+    await validateSignatureOrThrow(slug, groups, cwd);
+    return existing;
+  }
   return createState(slug, groups, cwd);
+}
+
+/**
+ * Read the parent task's stored signature and compare to a fresh one.
+ * Throws `WishStateMismatchError` on mismatch; no-op if the parent has no
+ * stored signature (pre-existing state from before this feature landed).
+ */
+async function validateSignatureOrThrow(slug: string, groups: GroupDefinition[], cwd?: string): Promise<void> {
+  const sql = await getConnection();
+  const repoPath = resolveRepoPath(cwd);
+  const parent = await findParent(sql, slug, repoPath);
+  if (!parent) return;
+
+  const stored = readStoredSignature(parent.metadata);
+  if (!stored) return; // backfill-free: no signature → no validation
+
+  const fresh = computeGroupsSignature(groups);
+  if (stored === fresh) return;
+
+  // Reconstruct previous group definitions from existing child tasks for diffing.
+  const prevGroups = await readGroupDefinitions(sql, parent.id as string);
+  const { added, removed, changed } = diffGroups(prevGroups, groups);
+  throw new WishStateMismatchError(slug, added, removed, changed);
+}
+
+/** Extract `groupsSignature` from a parent's metadata column (string or object). */
+function readStoredSignature(metadata: unknown): string | null {
+  if (metadata == null) return null;
+  let parsed: unknown = metadata;
+  if (typeof metadata === 'string') {
+    try {
+      parsed = JSON.parse(metadata);
+    } catch {
+      return null;
+    }
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const sig = (parsed as Record<string, unknown>).groupsSignature;
+  return typeof sig === 'string' ? sig : null;
+}
+
+/** Reconstruct the GroupDefinition[] for an existing parent (for diff messages). */
+async function readGroupDefinitions(sql: Sql, parentId: string): Promise<GroupDefinition[]> {
+  const children = await sql`SELECT id, group_name FROM tasks WHERE parent_id = ${parentId} ORDER BY created_at`;
+  if (children.length === 0) return [];
+  const childIds = children.map((c: Record<string, unknown>) => c.id as string);
+  const deps = await sql`
+    SELECT td.task_id, t.group_name AS dep_group
+    FROM task_dependencies td
+    JOIN tasks t ON t.id = td.depends_on_id
+    WHERE td.task_id = ANY(${childIds})
+  `;
+  const depsByTask: Record<string, string[]> = {};
+  for (const dep of deps) {
+    const taskId = dep.task_id as string;
+    if (!depsByTask[taskId]) depsByTask[taskId] = [];
+    depsByTask[taskId].push(dep.dep_group as string);
+  }
+  return children.map((c: Record<string, unknown>) => ({
+    name: c.group_name as string,
+    dependsOn: depsByTask[c.id as string] ?? [],
+  }));
 }
 
 /** Read current state. Returns null if no state exists for this wish. */
@@ -584,6 +739,22 @@ export async function isWishComplete(slug: string, cwd?: string): Promise<boolea
   if (!state) return false;
   const groups = Object.values(state.groups);
   return groups.length > 0 && groups.every((g) => g.status === 'done');
+}
+
+/**
+ * Wipe all wish state for a slug — deletes the parent task (FK cascade
+ * removes children + dependencies + actors). Returns true if anything was
+ * deleted, false if no state existed.
+ *
+ * Used by `genie reset <slug>` to recover from a `WishStateMismatchError`.
+ */
+export async function wipeState(slug: string, cwd?: string): Promise<boolean> {
+  const sql = await getConnection();
+  const repoPath = resolveRepoPath(cwd);
+  const parent = await findParent(sql, slug, repoPath);
+  if (!parent) return false;
+  await sql`DELETE FROM tasks WHERE id = ${parent.id as string}`;
+  return true;
 }
 
 /**

--- a/src/term-commands/state.ts
+++ b/src/term-commands/state.ts
@@ -13,6 +13,7 @@ import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import type { Command } from 'commander';
+import { isInteractive } from '../lib/interactivity.js';
 import { formatTimestamp, padRight } from '../lib/term-format.js';
 import * as wishState from '../lib/wish-state.js';
 import { parseExecutionStrategy, parseWishGroups } from './dispatch.js';
@@ -465,19 +466,82 @@ export function registerStateCommands(program: Command): void {
 
   program
     .command('reset <ref>')
-    .description('Reset an in-progress group back to ready (format: <slug>#<group>)')
+    .description(
+      'Reset wish state. <slug>#<group> resets one in-progress group; bare <slug> wipes the wish and recreates from current WISH.md',
+    )
     .action(async (ref: string) => {
       try {
-        const { slug, group } = parseRef(ref);
-        const result = await wishState.resetGroup(slug, group);
-        console.log(`🔄 Group "${group}" reset to ready in wish "${slug}"`);
-        if (result.status === 'ready') {
-          console.log('   Status: ready (assignee cleared)');
+        if (ref.includes('#')) {
+          const { slug, group } = parseRef(ref);
+          const result = await wishState.resetGroup(slug, group);
+          console.log(`🔄 Group "${group}" reset to ready in wish "${slug}"`);
+          if (result.status === 'ready') {
+            console.log('   Status: ready (assignee cleared)');
+          }
+          return;
         }
+        await resetWishCommand(ref);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         console.error(`❌ ${message}`);
         process.exit(1);
       }
     });
+}
+
+/**
+ * `genie reset <slug>` (bare slug, no `#group`) — wipe all wish state and
+ * recreate it from the current WISH.md. Use to recover from
+ * `WishStateMismatchError` after the wish's group structure was edited.
+ */
+async function resetWishCommand(slug: string): Promise<void> {
+  const wishPath = resolveWishPath(slug);
+  if (!wishPath) {
+    throw new Error(`No WISH.md found for "${slug}" — searched cwd and repo root`);
+  }
+
+  const content = await readFile(wishPath, 'utf-8');
+  const groups = parseWishGroups(content);
+  if (groups.length === 0) {
+    throw new Error(`No execution groups found in ${wishPath}`);
+  }
+
+  const existing = await wishState.getState(slug);
+  if (existing) {
+    const groupCount = Object.keys(existing.groups).length;
+    const inProgress = Object.values(existing.groups).filter((g) => g.status === 'in_progress').length;
+    const summary = `Wipe all state for "${slug}" (${groupCount} groups, ${inProgress} in-progress)?`;
+
+    if (!isInteractive()) {
+      if (!process.argv.includes('--yes') && !process.argv.includes('-y')) {
+        console.error(`❌ ${summary}`);
+        console.error('   Refusing to wipe in non-interactive mode. Pass --yes to confirm.');
+        process.exit(2);
+      }
+    } else {
+      const { confirm } = await import('@inquirer/prompts');
+      const ok = await confirm({ message: summary, default: false });
+      if (!ok) {
+        console.log('Aborted.');
+        return;
+      }
+    }
+  }
+
+  const wiped = await wishState.wipeState(slug);
+  if (wiped) {
+    console.log(`🗑️  Wiped existing state for wish "${slug}"`);
+  } else {
+    console.log(`ℹ️  No existing state for wish "${slug}" — creating fresh`);
+  }
+
+  const state = await wishState.createState(slug, groups);
+  console.log(`📝 Recreated state from ${wishPath} (${groups.length} groups)`);
+  console.log('');
+  console.log(`Wish: ${state.wish}`);
+  console.log('─'.repeat(60));
+  for (const [name, group] of Object.entries(state.groups)) {
+    const icon = STATUS_ICONS[group.status] ?? '❓';
+    console.log(`  ${name}  ${icon} ${group.status}`);
+  }
 }


### PR DESCRIPTION
## Summary

Fix silent wish-state staleness. `getOrCreateState` used to parse WISH.md once at creation, cache the groups in PG, and never re-check. Editing WISH.md — adding groups, removing groups, changing deps — was silently ignored, so `genie work` dispatched against stale plans.

- `createState` now writes a sha256 signature of the canonical group structure (`{name, dependsOn: sorted}[]`) to `parent_task.metadata.groupsSignature`. No migration — uses existing `tasks.metadata` jsonb column.
- `getOrCreateState` recomputes the signature from the current WISH.md and throws a typed `WishStateMismatchError` with a diff summary (groups added / removed / deps changed) and the literal remediation command.
- `genie reset <slug>` (bare, no `#group` suffix) wipes the parent task — FK cascades to children, deps, actors — and recreates state from the current WISH.md. Interactive callers get `Wipe all state for "<slug>" (N groups, M in-progress)?` via `@inquirer/prompts`; non-interactive callers must pass `--yes` (defaults to refuse with exit 2).
- `getState` (read-only callers like `genie status`) does not validate the signature — only the dispatch path enforces.
- Pre-existing parents without a signature are treated as "valid, never validated" — backfill-free. First successful `createState` after this lands writes the signature; subsequent calls validate.

## Scope rejected (deferred)

- Auto-recreate on mismatch — silently nukes in-flight work.
- Reconcile-in-place (add/remove/update groups while preserving in-progress status) — deferred to a future `wish-state-reconcile` wish.
- Hashing raw WISH.md content — prose edits (Summary, Decisions) would invalidate state unnecessarily.

## Also in this PR

- `.husky/pre-push` unsets `GIT_DIR` / `GIT_WORK_TREE` / etc before running `bun run check`. Git exports those into the hook environment, and tests that shell out to `execSync('git ...')` in tmpdirs inherit them and trip `fatal: core.bare and core.worktree do not make sense`. 27 phantom failures in `freshness.test.ts`, `state.test.ts`, `init-flow.test.ts`, and others — all green in a normal shell. One-line fix in the hook, not the tests.

## Validation

- `bun run typecheck` clean
- `bun run lint` — only pre-existing complexity warnings
- `bun test src/lib/wish-state.test.ts` — 76 pass / 0 fail
- `bun run check` (full gate) — 2438 pass / 0 fail
- Pre-push hook passes on the env-stripped run

## Release note

Pre-existing wish state from before this release carries no signature; the first invalidation after upgrade requires a manual `genie reset <slug>`.

## Test plan

- [ ] Edit a WISH.md group structure on an existing wish → `genie work` fails with `WishStateMismatchError` listing the diff
- [ ] Prose-only WISH.md edits (Summary, Decisions) do NOT trigger the error
- [ ] `genie reset <slug>` prompts confirmation in interactive mode, wipes parent task, recreates state from current WISH.md
- [ ] `genie reset <slug>` in non-interactive mode exits 2 unless `--yes` passed
- [ ] `genie reset <slug>#<group>` (existing per-group reset) still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `genie reset` command: now supports full wish state reset (bare slug) with confirmation prompts, in addition to per-group reset.
  * Added wish group structure validation: detects and reports added/removed/changed groups when definitions drift.

* **Chores**
  * Updated git hooks to prevent environment variable leakage during pre-push checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->