### PR TITLE
fix(spawn): remove hardcoded 'genie' default from --team

### DIFF
--- a/src/term-commands/agent/spawn.ts
+++ b/src/term-commands/agent/spawn.ts
@@ -20,7 +20,7 @@ export function registerAgentSpawn(parent: Command): void {
     .command('spawn <name>')
     .description('Spawn a new agent by name (resolves from directory or built-ins)')
     .option('--provider <provider>', 'Provider: claude, codex, or claude-sdk')
-    .option('--team <team>', 'Team name', process.env.GENIE_TEAM ?? 'genie')
+    .option('--team <team>', 'Team name')
     .option('--model <model>', 'Model override (e.g., sonnet, opus)')
     .option('--skill <skill>', 'Skill to load (optional)')
     .option('--layout <layout>', 'Layout mode: mosaic (default) or vertical')


### PR DESCRIPTION
## Summary

The CLI default `process.env.GENIE_TEAM ?? 'genie'` at `src/term-commands/agent/spawn.ts:23` was making the `spawnIntoCurrentWindow` code path architecturally unreachable. This 1-line removal restores the intended behavior: `genie spawn <name>` (no flags, inside tmux) splits into the current pane instead of forcibly creating/finding a team-named window.

## Root cause trace

| File:line | Behavior |
|---|---|
| `spawn.ts:23` | Commander pre-fills `options.team = 'genie'` even when user did not pass `--team` |
| `agents.ts:1605` | `teamWasExplicit = Boolean(options.team)` therefore always `true` |
| `agents.ts:1686` | `spawnIntoCurrentWindow = !teamWasExplicit && insideTmux && !options.session` therefore always `false` |
| `agents.ts:894-897` | `launchTmuxSpawn` always takes the `resolveSpawnTeamWindow` path, never the current-pane path |
| `agents.ts:690-708` | `resolveSpawnTeamWindow` calls `tmux.ensureTeamWindow(sessionName, team)` which creates/finds a window NAMED after the team |

Net effect: every CLI spawn lands in a team-named window even when the user obviously wants split-into-current-pane.

## Fix

Remove the commander default so `options.team` stays `undefined` when not provided, allowing `discoverTeamName()` (`claude-native-teams.ts:819-826`) to run its intended resolution strategy: `GENIE_TEAM` env var, then tmux session-id matching against team configs.

## Behavior change

Users who relied on the silent 'genie' fallback (running `genie spawn x` outside any tmux/team context) will now hit the explicit error at `agents.ts:1608`:
> Error: --team is required (or set GENIE_TEAM, or run inside a genie session)

Mitigation: `export GENIE_TEAM=genie` reproduces the old default.

## Test plan

- [ ] `bun run check` (full gate: typecheck + lint + dead-code + test)
- [ ] Manual: from inside tmux, run `genie spawn engineer` — expect split-pane in current window (not new team window)
- [ ] Manual: from outside tmux, run `genie spawn engineer` — expect explicit error
- [ ] Manual: `GENIE_TEAM=genie genie spawn engineer` from outside tmux — expect old behavior preserved
- [ ] Manual: `genie spawn engineer --team genie` — explicit team, expect team-window placement (current behavior)

## Follow-up (not in this PR)

Same `?? 'genie'` anti-pattern exists in `src/term-commands/dispatch.ts` at lines 478, 519, 613, 690. Worth a separate audit + fix once this PR's behavior is validated in dev.

Generated with Claude Code.