### PR TITLE
fix(reset): prevent data loss in resetWishCommand — let createState own delete+create atomically

### DIFF
--- a/src/term-commands/state.ts
+++ b/src/term-commands/state.ts
@@ -529,9 +529,8 @@ async function resetWishCommand(slug: string, confirmed: boolean): Promise<void>
     }
   }
 
-  const wiped = await wishState.wipeState(slug);
-  if (wiped) {
-    console.log(`🗑️  Wiped existing state for wish "${slug}"`);
+  if (existing) {
+    console.log(`🗑️  Replacing existing state for wish "${slug}"`);
   } else {
     console.log(`ℹ️  No existing state for wish "${slug}" — creating fresh`);
   }


### PR DESCRIPTION
## Summary

Addresses the HIGH-severity data-loss risk flagged by CodeRabbit on PR #1155 (`src/term-commands/state.ts:531-538`). Removes the redundant `wishState.wipeState(slug)` call that ran BEFORE `wishState.createState(slug, groups)`, creating a window where state was destroyed before recreate validation completed.

## Root cause

`resetWishCommand` previously did:

```typescript
const wiped = await wishState.wipeState(slug);   // ← DESTRUCTIVE
if (wiped) {
  console.log('Wiped existing state for wish');
} else {
  console.log('No existing state — creating fresh');
}

const state = await wishState.createState(slug, groups);  // ← could throw
```

`createState()` at `src/lib/wish-state.ts:276-289` already does the safe flow itself:

1. `validateGroups(groups)` — throws if invalid (pre-delete)
2. Find existing parent task
3. `DELETE` existing parent (cascade children) ONLY if validation passed
4. `INSERT` new parent + child tasks

The explicit `wipeState()` was redundant AND dangerous — if validation failed in step 1, state was already gone with nothing to recover.

## Fix

Delete the explicit wipe. Use the pre-existing `existing` variable (loaded earlier via `wishState.getState(slug)`) to drive the user-facing log message. Let createState own the atomic validate then delete then insert flow.

```diff
-  const wiped = await wishState.wipeState(slug);
-  if (wiped) {
-    console.log('Wiped existing state for wish');
+  if (existing) {
+    console.log('Replacing existing state for wish');
   } else {
     console.log('No existing state for wish — creating fresh');
   }
```

## Behavior change

Console message changes from \"Wiped existing state\" to \"Replacing existing state\" — because the operation is now an atomic replace inside createState() rather than a two-step wipe-then-create.

If validateGroups() or any insert fails, the existing state is preserved (previously it was destroyed). Users get an explicit error AND retain their wish state.

## Test plan

- [x] bun run check — full gate (passed locally, 2461 tests, 0 fail)
- [ ] Manual: genie reset \\<slug\\> against a wish with valid WISH.md → state replaced, no data loss
- [ ] Manual: genie reset \\<slug\\> against a wish with INVALID WISH.md (e.g. duplicate group names) → existing state preserved, error surfaced

## Sequencing note re PR #1155

PR #1155 (dev → main release) currently contains the buggy version of this code. After this PR merges to dev, PR #1155 should be re-cut (or updated via merge from dev) so the data-loss bug does not flow into main.

Generated with Claude Code.