### PR TITLE
fix(spawn): remove last '?? genie' literal — buildResumeParams hierarchy (truly 100%)

### DIFF
--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -1898,7 +1898,12 @@ async function buildResumeParams(
 ): Promise<SpawnParams> {
   const agentName = agent.role ?? agent.id;
   const provider = (template?.provider ?? agent.provider ?? 'claude') as ProviderName;
-  const team = template?.team ?? agent.team ?? 'genie';
+  const team = template?.team ?? agent.team ?? (await nativeTeams.discoverTeamName());
+  if (!team) {
+    throw new Error(
+      `Cannot resume agent "${agent.id}": no team context (template, agent record, env, or session). Pass --team or set GENIE_TEAM, or run inside a registered tmux session.`,
+    );
+  }
 
   // Restore identity file on resume so the agent keeps its AGENTS.md identity
   // instead of falling back to CWD-based discovery (which walks up and may find


### PR DESCRIPTION
## Summary

Final cleanup of the `?? 'genie'` team-fallback anti-pattern. Trace investigation after PRs #1154 / #1156 / #1157 merged found **one remaining site** the prior audits missed because it lived on the RESUME path, not the spawn path.

## The remaining site

`src/term-commands/agents.ts:1901` (`buildResumeParams`):

```typescript
// Before
const team = template?.team ?? agent.team ?? 'genie';
```

When BOTH `template?.team` and `agent.team` are undefined (registry corruption, pre-team-tracking record, or template missing team), the literal `'genie'` silently captured the resumed agent into the wrong team — same drift the spawn-path fixes targeted, just on a different code path.

## Fix

Use the same hierarchical resolution chain as `handleWorkerSpawn` at `agents.ts:1606`:

```diff
-  const team = template?.team ?? agent.team ?? 'genie';
+  const team = template?.team ?? agent.team ?? (await nativeTeams.discoverTeamName());
+  if (!team) {
+    throw new Error(
+      `Cannot resume agent "${agent.id}": no team context (template, agent record, env, or session). Pass --team or set GENIE_TEAM, or run inside a registered tmux session.`,
+    );
+  }
```

Resolution chain becomes:
1. `template?.team` (immediate)
2. `agent.team` (stored on registration)
3. `discoverTeamName()` (env → tmux session-id matching)
4. Explicit error if all fail (matches the pattern at `agents.ts:1607-1609`)

## Behavior change

Resume operations that previously fell back silently to `'genie'` team now either resolve hierarchically OR fail loudly with a recovery hint. No more silent team-misattribution on resume.

## Verification

After this commit lands: **0 occurrences of `?? 'genie'`** (or any literal `'genie'` team-fallback shape) remain in `src/`. Full 100% removal.

The remaining `'genie'` literals in the codebase are NOT anti-patterns:
- `process.argv[1] ?? 'genie'` — CLI binary name (correct)
- `process.env.GENIE_TMUX_SOCKET || 'genie'` — tmux socket name (correct)

## Test plan

- [x] `bun run check` — full gate: 2461 tests, 0 fail, lint clean (modulo pre-existing complexity warning at line 1073)
- [ ] Manual: kill an agent, then `genie resume <name>` from inside tmux session → should resume with discovered team
- [ ] Manual: kill an agent, then `genie resume <name>` from outside tmux with no GENIE_TEAM → should error with recovery hint, not silently fall back to 'genie' team

## Sequencing

Fourth and final PR in the spawn-hierarchy cleanup arc. Order:
- #1154 (merged) — spawn.ts:23 (`genie agent spawn` long form)
- #1156 (merged) — genie.ts:292 (`genie spawn` top-level alias) + dispatch.ts (4 sub-spawns) + SpawnOptions.team optional + ci.yml 8vcpu
- #1157 (merged) — resetWishCommand data-loss
- **#this** — buildResumeParams (resume path)

After this lands, the `'genie'` literal team-fallback drift is fully eliminated.

Generated with Claude Code.