### PR TITLE
fix(teams): back-fill PG teams row from ensureNativeTeam

### DIFF
--- a/src/lib/claude-native-teams.ts
+++ b/src/lib/claude-native-teams.ts
@@ -227,7 +227,13 @@ export async function ensureNativeTeam(
   ensureTeammateBypassPermissions();
 
   const existing = await loadConfig(teamName);
-  if (existing) return existing;
+  if (existing) {
+    // Back-fill the PG teams row if it's missing (e.g. after a pgserve reset
+    // where the on-disk native team survived but the `teams` row did not).
+    // Best-effort — never block the native team code path on PG failures.
+    await backfillTeamRow(sanitizeTeamName(teamName));
+    return existing;
+  }
 
   const sanitized = sanitizeTeamName(teamName);
   const resolvedLeader = sanitizeTeamName(leaderName ?? teamName);
@@ -241,7 +247,26 @@ export async function ensureNativeTeam(
   };
 
   await saveConfig(teamName, config);
+  // Mirror the newly created native team into the PG `teams` registry so
+  // `genie team ls` reflects reality. Idempotent and best-effort.
+  await backfillTeamRow(sanitized);
   return config;
+}
+
+/**
+ * Best-effort mirror of a native team into the PG `teams` registry.
+ *
+ * Loaded via dynamic import to avoid a circular dependency with
+ * `./team-manager.ts` (which imports this module). Failures are swallowed:
+ * the native team code path must not be blocked by PG issues.
+ */
+async function backfillTeamRow(name: string): Promise<void> {
+  try {
+    const { ensureTeamRow } = await import('./team-manager.js');
+    await ensureTeamRow(name);
+  } catch {
+    // best-effort — PG unavailable, circular-import edge case, etc.
+  }
 }
 
 /**

--- a/src/lib/team-manager.test.ts
+++ b/src/lib/team-manager.test.ts
@@ -12,6 +12,7 @@ import { getConnection } from './db.js';
 import {
   createTeam,
   disbandTeam,
+  ensureTeamRow,
   fireAgent,
   getTeam,
   hireAgent,
@@ -205,6 +206,48 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
       test('returns null for non-existent team', async () => {
         const config = await getTeam('nonexistent');
         expect(config).toBeNull();
+      });
+    });
+
+    describe('ensureTeamRow', () => {
+      test('inserts a minimal row when no team exists in PG', async () => {
+        const name = 'feat/ensure-new';
+        // Confirm pre-state
+        expect(await getTeam(name)).toBeNull();
+
+        const result = await ensureTeamRow(name, { repo: TEST_REPO });
+        expect(result).not.toBeNull();
+        expect(result!.name).toBe(name);
+        expect(result!.repo).toBe(TEST_REPO);
+        expect(result!.worktreePath).toBe(TEST_REPO);
+        expect(result!.nativeTeamsEnabled).toBe(true);
+        expect(result!.status).toBe('in_progress');
+      });
+
+      test('is idempotent — returns existing row on re-run', async () => {
+        const name = 'feat/ensure-idempotent';
+        const first = await ensureTeamRow(name, { repo: TEST_REPO });
+        const second = await ensureTeamRow(name, { repo: TEST_REPO });
+
+        expect(first).not.toBeNull();
+        expect(second).not.toBeNull();
+        expect(second!.createdAt).toBe(first!.createdAt);
+      });
+
+      test('does not clobber a row created via createTeam', async () => {
+        const name = 'feat/ensure-after-create';
+        const created = await createTeam(name, TEST_REPO, 'dev');
+        expect(created.worktreePath).toContain('feat/ensure-after-create');
+
+        // Back-fill after createTeam should be a no-op — same worktreePath preserved
+        const backfilled = await ensureTeamRow(name, { repo: TEST_REPO });
+        expect(backfilled).not.toBeNull();
+        expect(backfilled!.worktreePath).toBe(created.worktreePath);
+      });
+
+      test('returns null for invalid branch names', async () => {
+        const result = await ensureTeamRow('spaces here', { repo: TEST_REPO });
+        expect(result).toBeNull();
       });
     });
 

--- a/src/lib/team-manager.ts
+++ b/src/lib/team-manager.ts
@@ -421,6 +421,75 @@ export async function createTeam(name: string, repo: string, baseBranch = 'dev')
 }
 
 /**
+ * Ensure a PG row exists for a team that was created via the native
+ * `~/.claude/teams/<name>/config.json` path (e.g. the implicit team created
+ * by {@link ./claude-native-teams#ensureNativeTeam} during a spawn flow).
+ *
+ * This is the back-fill that rescues the PG registry after a reboot where
+ * the pgserve data dir was reset (or any scenario that leaves the native
+ * team file in place but the `teams` row absent). Without it,
+ * {@link listTeams} returns an empty list even though the team is fully
+ * functional on disk.
+ *
+ * Intentionally lightweight:
+ *   - Idempotent via `ON CONFLICT (name) DO NOTHING` — never overwrites an
+ *     explicit `createTeam` row.
+ *   - Does NOT create a git worktree; `worktreePath` defaults to `repo`.
+ *     If the user later runs `genie team create <name>`, that command's
+ *     own `getTeam` check returns this bootstrap row and skips worktree
+ *     creation — callers who need a real worktree should run `createTeam`
+ *     explicitly BEFORE spawning.
+ *   - Best-effort: SQL errors are caught and returned as null so a bad
+ *     PG session never blocks the native-team code path.
+ *
+ * @param name         Team name (must pass `validateBranchName`).
+ * @param opts.repo    Absolute path to the repo. Defaults to `process.cwd()`.
+ * @returns The resulting TeamConfig, or null if the insert failed.
+ */
+export async function ensureTeamRow(name: string, opts?: { repo?: string }): Promise<TeamConfig | null> {
+  try {
+    validateBranchName(name);
+  } catch {
+    return null;
+  }
+
+  const existing = await getTeam(name);
+  if (existing) return existing;
+
+  const repoPath = path.resolve(opts?.repo ?? process.cwd());
+  const now = new Date().toISOString();
+  const config: TeamConfig = {
+    name,
+    repo: repoPath,
+    baseBranch: 'dev',
+    worktreePath: repoPath,
+    members: [],
+    status: 'in_progress',
+    createdAt: now,
+    nativeTeamsEnabled: true,
+  };
+
+  try {
+    const sql = await getConnection();
+    await sql`
+      INSERT INTO teams (
+        name, repo, base_branch, worktree_path, leader,
+        members, status, native_teams_enabled, created_at
+      ) VALUES (
+        ${config.name}, ${config.repo}, ${config.baseBranch},
+        ${config.worktreePath}, ${null},
+        ${JSON.stringify(config.members)}, ${config.status},
+        ${config.nativeTeamsEnabled ?? false}, ${config.createdAt}
+      ) ON CONFLICT (name) DO NOTHING
+    `;
+    recordAuditEvent('team', name, 'backfilled', getActor(), { repo: repoPath, source: 'native-team' }).catch(() => {});
+    return (await getTeam(name)) ?? config;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Add an agent to a team's members list.
  *
  * Special case: if agentName is "council", hires all 10 built-in council members.


### PR DESCRIPTION
## Summary

Genie keeps two parallel team registries: PG `teams` (queried by `genie team ls`, `listTeams`, etc.) and on-disk `~/.claude/teams/<name>/config.json` (used by the Claude Code native-team IPC protocol). Only `genie team create` writes to both. Every other spawn path that reaches `ensureNativeTeam` (implicit team creation during `genie agent spawn`) writes ONLY to disk.

After a reboot that resets pgserve data (or any PG-loss scenario with the native team file intact), `genie team ls` returns empty even though the team is fully operational on disk. No code path reconciles the two sources — this was observed on a real reboot as part of the same incident that motivated #1163 and #1164.

## Fix

Add `ensureTeamRow(name, { repo })` in `team-manager.ts` as a lightweight, idempotent back-fill. Call it from `ensureNativeTeam` after the native config is either loaded or freshly saved.

### Design — minimal by intent

- `ensureTeamRow` does **not** create a git worktree. `worktreePath` defaults to `repo` (the current cwd). If a user later runs `genie team create <same-name>`, the existing `getTeam` check returns this back-filled row and skips worktree creation. Callers who need a real worktree must run `createTeam` explicitly **before** spawning.
- `INSERT ... ON CONFLICT (name) DO NOTHING` — never clobbers an explicit `createTeam` row.
- The callback in `claude-native-teams.ts` uses `await import('./team-manager.js')` to avoid a circular dependency (team-manager already imports claude-native-teams), and swallows all errors so the native-team code path is never blocked by PG issues.
- Invalid branch names return `null` silently rather than throwing, because the caller is on a hot spawn path.

## Not in scope

Unifying the two registries into a single source of truth is a bigger design change and is **deliberately not attempted here**. This PR only eliminates the empty-`team ls` drift after reboot. A full unification needs a separate design discussion — e.g. should native-team files become a projection of the PG table, or vice versa, or should `genie team ls` merge both?

## Tests

Four new cases in `team-manager.test.ts`:
- inserts a minimal row when no team exists in PG
- is idempotent — returns existing row on re-run
- does not clobber a row created via `createTeam`
- returns null for invalid branch names

Full suite: 2487/2487 pass. Team + native-teams files alone: 75/75.

## Test plan

- [x] Unit tests cover insert / idempotency / non-clobber / invalid name
- [x] Full repo test suite passes locally
- [ ] CI on \`dev\` passes
- [ ] Manual verification: delete a row from the \`teams\` table with an on-disk native-team file still present → next spawn triggers back-fill → \`genie team ls\` lists the team again

🤖 Generated with [Claude Code](https://claude.com/claude-code)