### PR TITLE
fix(ls): check executor state for non-tmux (SDK/omni) agents

### DIFF
--- a/src/lib/executor-registry.test.ts
+++ b/src/lib/executor-registry.test.ts
@@ -17,6 +17,8 @@ import {
   findExecutorBySession,
   getCurrentExecutor,
   getExecutor,
+  getLiveExecutorState,
+  isExecutorAlive,
   listExecutors,
   terminateActiveExecutor,
   terminateExecutor,
@@ -997,6 +999,135 @@ describe.skipIf(!DB_AVAILABLE)('executor-registry', () => {
       // FK points to the last executor
       const agent = await getAgent(agentId);
       expect(agent!.currentExecutorId).toBe(active[0].id);
+    });
+  });
+
+  // ==========================================================================
+  // getLiveExecutorState / isExecutorAlive — liveness + display state for
+  // non-tmux transports (SDK, omni, process).
+  //
+  // Regression for `genie ls` showing SDK/omni-bridge agents as 'offline' while
+  // actively running. Tmux liveness (isPaneAlive) stays authoritative for tmux
+  // agents; `executors.state` is the authoritative source for everything else,
+  // and is returned directly so the display doesn't fall back to the stale
+  // `agents.state` column.
+  // ==========================================================================
+
+  describe('getLiveExecutorState', () => {
+    test('returns the executor state for each live state', async () => {
+      const liveStates: ExecutorState[] = ['spawning', 'running', 'working', 'idle', 'permission', 'question'];
+      for (const state of liveStates) {
+        const agentId = await seedAgent(`state-${state}`, 'live-team');
+        await createAndLinkExecutor(agentId, 'claude-sdk', 'process', { state });
+        expect(await getLiveExecutorState(agentId)).toBe(state);
+      }
+    });
+
+    test('returns null for terminal states (done / error / terminated)', async () => {
+      const terminalStates: ExecutorState[] = ['done', 'error', 'terminated'];
+      for (const terminal of terminalStates) {
+        const agentId = await seedAgent(`terminal-${terminal}`, 'terminal-team');
+        const exec = await createAndLinkExecutor(agentId, 'claude-sdk', 'process', { state: 'running' });
+        await updateExecutorState(exec.id, terminal);
+        expect(await getLiveExecutorState(agentId)).toBeNull();
+      }
+    });
+
+    test('returns null when agent has no current executor', async () => {
+      const agentId = await seedAgent();
+      expect(await getLiveExecutorState(agentId)).toBeNull();
+    });
+
+    test('returns null for nonexistent agent', async () => {
+      expect(await getLiveExecutorState('ghost-agent')).toBeNull();
+    });
+
+    test('tracks live → terminated transition', async () => {
+      const agentId = await seedAgent();
+      const exec = await createAndLinkExecutor(agentId, 'claude-sdk', 'process', { state: 'working' });
+      expect(await getLiveExecutorState(agentId)).toBe('working');
+
+      await updateExecutorState(exec.id, 'done');
+      expect(await getLiveExecutorState(agentId)).toBeNull();
+    });
+
+    test('works for process transport (SDK) with null pane id', async () => {
+      // Simulates the real bug: SDK agents register with paneId='sdk',
+      // omni auto-spawn with paneId=''. Neither matches /^%\d+$/ so
+      // isPaneAlive falsely reports offline. getLiveExecutorState bypasses that
+      // and returns the authoritative executor state.
+      const agentId = await seedAgent();
+      await createAndLinkExecutor(agentId, 'claude-sdk', 'process', {
+        state: 'working',
+        tmuxPaneId: null,
+      });
+      expect(await getLiveExecutorState(agentId)).toBe('working');
+    });
+  });
+
+  describe('isExecutorAlive', () => {
+    test('returns true when current executor is running', async () => {
+      const agentId = await seedAgent();
+      await createAndLinkExecutor(agentId, 'claude-sdk', 'process', { state: 'running' });
+      expect(await isExecutorAlive(agentId)).toBe(true);
+    });
+
+    test('returns true for each live state (working/idle/permission/question/spawning)', async () => {
+      const liveStates: ExecutorState[] = ['spawning', 'running', 'working', 'idle', 'permission', 'question'];
+      for (const state of liveStates) {
+        const agentId = await seedAgent(`agent-${state}`, 'live-team');
+        await createAndLinkExecutor(agentId, 'claude-sdk', 'process', { state });
+        expect(await isExecutorAlive(agentId)).toBe(true);
+      }
+    });
+
+    test('returns false when current executor is terminated', async () => {
+      const agentId = await seedAgent();
+      const exec = await createAndLinkExecutor(agentId, 'claude-sdk', 'process', { state: 'running' });
+      await updateExecutorState(exec.id, 'terminated');
+      expect(await isExecutorAlive(agentId)).toBe(false);
+    });
+
+    test('returns false for done / error terminal states', async () => {
+      const agent1 = await seedAgent('done-agent', 'terminal-team');
+      const e1 = await createAndLinkExecutor(agent1, 'claude-sdk', 'process', { state: 'running' });
+      await updateExecutorState(e1.id, 'done');
+      expect(await isExecutorAlive(agent1)).toBe(false);
+
+      const agent2 = await seedAgent('error-agent', 'terminal-team');
+      const e2 = await createAndLinkExecutor(agent2, 'claude-sdk', 'process', { state: 'running' });
+      await updateExecutorState(e2.id, 'error');
+      expect(await isExecutorAlive(agent2)).toBe(false);
+    });
+
+    test('returns false when agent has no current executor', async () => {
+      const agentId = await seedAgent();
+      expect(await isExecutorAlive(agentId)).toBe(false);
+    });
+
+    test('returns false for nonexistent agent', async () => {
+      expect(await isExecutorAlive('ghost-agent')).toBe(false);
+    });
+
+    test('tracks live → terminated transition', async () => {
+      const agentId = await seedAgent();
+      const exec = await createAndLinkExecutor(agentId, 'claude-sdk', 'process', { state: 'working' });
+      expect(await isExecutorAlive(agentId)).toBe(true);
+
+      await updateExecutorState(exec.id, 'done');
+      expect(await isExecutorAlive(agentId)).toBe(false);
+    });
+
+    test('works for process transport (SDK) with empty/synthetic pane ids', async () => {
+      // Simulates the real bug: SDK agents register with paneId='sdk',
+      // omni auto-spawn with paneId=''. Neither matches /^%\d+$/ so
+      // isPaneAlive falsely reports offline. isExecutorAlive bypasses that.
+      const agentId = await seedAgent();
+      await createAndLinkExecutor(agentId, 'claude-sdk', 'process', {
+        state: 'working',
+        tmuxPaneId: null,
+      });
+      expect(await isExecutorAlive(agentId)).toBe(true);
     });
   });
 });

--- a/src/lib/executor-registry.ts
+++ b/src/lib/executor-registry.ts
@@ -253,3 +253,34 @@ export async function updateClaudeSessionId(executorId: string, sessionId: strin
   const sql = await getConnection();
   await sql`UPDATE executors SET claude_session_id = ${sessionId} WHERE id = ${executorId}`;
 }
+
+/**
+ * Return an agent's current executor state iff it is live, else null.
+ *
+ * Used by `genie ls` to determine liveness for non-tmux transports (SDK, omni,
+ * process) where `isPaneAlive` cannot apply — these agents carry synthetic pane
+ * IDs like 'sdk' or '' that do not match tmux's `%N` format. The `executors.state`
+ * column is the authoritative signal, updated by each transport's own heartbeat
+ * (e.g., claude-sdk updates it on every message). Returning the state — not just
+ * a boolean — lets the caller display it directly without a second query; the
+ * cached `agents.state` column is stale for non-tmux transports.
+ *
+ * Treats `spawning|running|working|idle|permission|question` as live;
+ * `done|error|terminated` and missing rows return null.
+ */
+export async function getLiveExecutorState(agentId: string): Promise<ExecutorState | null> {
+  const sql = await getConnection();
+  const rows = await sql<{ state: ExecutorState }[]>`
+    SELECT e.state FROM executors e
+    JOIN agents a ON a.current_executor_id = e.id
+    WHERE a.id = ${agentId}
+      AND e.state IN ('spawning', 'running', 'working', 'idle', 'permission', 'question')
+    LIMIT 1
+  `;
+  return rows.length > 0 ? rows[0].state : null;
+}
+
+/** Boolean convenience wrapper around {@link getLiveExecutorState}. */
+export async function isExecutorAlive(agentId: string): Promise<boolean> {
+  return (await getLiveExecutorState(agentId)) !== null;
+}

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -2134,14 +2134,32 @@ type WorkerStatus = {
   autoResume?: boolean;
 };
 
+/**
+ * Resolve liveness + display state for a worker.
+ *
+ * - Tmux transport: `isPaneAlive(%N)` is authoritative and `agents.state` is
+ *   kept in sync, so we preserve the legacy behavior exactly.
+ * - Non-tmux transports (SDK, omni, inline): pane IDs are synthetic ('sdk', '',
+ *   'inline') and fail tmux's regex, so we query `executors.state` directly.
+ *   The cached `agents.state` is stale for these transports — we use the live
+ *   executor state for display as well.
+ */
+async function resolveWorkerLiveness(w: registry.Agent): Promise<{ alive: boolean; state: string }> {
+  if (/^%\d+$/.test(w.paneId)) {
+    return { alive: await isPaneAlive(w.paneId), state: w.state };
+  }
+  const execState = await executorRegistry.getLiveExecutorState(w.id);
+  return { alive: execState !== null, state: execState ?? w.state };
+}
+
 /** Build a name → status map from registry workers, including resume info for dead agents. */
 async function buildWorkerStatusMap(workers: registry.Agent[]): Promise<Map<string, WorkerStatus>> {
   const statusMap = new Map<string, WorkerStatus>();
   for (const w of workers) {
     const name = w.role || w.id;
-    const alive = await isPaneAlive(w.paneId);
+    const { alive, state } = await resolveWorkerLiveness(w);
     if (alive) {
-      statusMap.set(name, { state: w.state, team: w.team || '-' });
+      statusMap.set(name, { state, team: w.team || '-' });
     } else if (w.state === 'suspended' || w.state === 'error') {
       const attempts = w.resumeAttempts ?? 0;
       const max = w.maxResumeAttempts ?? 3;


### PR DESCRIPTION
## Summary

- `genie ls` was rendering SDK/omni-bridge/process agents as `offline` (or the misleading `error (0/3 resumes, auto-resume: on)`) while they were actively running.
- Root cause: `buildWorkerStatusMap` (src/term-commands/agents.ts:2138) gated liveness entirely on `isPaneAlive(w.paneId)`, which requires a `%N` tmux pane ID. Non-tmux transports carry synthetic tokens (`'sdk'`, `'inline'`, `''`) that fail the regex, so they were silently dropped from the status map.
- Fix: gate on transport. Tmux agents still use `isPaneAlive` (legacy behavior preserved exactly). Non-tmux agents consult the new `getLiveExecutorState(agentId)` helper — `executors.state` is the authoritative signal (claude-sdk updates it on every message) and is also used for display since `agents.state` isn't kept in sync for these transports.

## Changes

- `src/lib/executor-registry.ts` — new `getLiveExecutorState(agentId): Promise<ExecutorState | null>` + boolean wrapper `isExecutorAlive`.
- `src/term-commands/agents.ts` — `buildWorkerStatusMap` delegates to a new `resolveWorkerLiveness` helper that picks the right liveness source.
- `src/lib/executor-registry.test.ts` — 14 new tests covering both functions across all executor states, missing-executor, and terminal transitions.

## Scope

Intentionally narrow. The tracer flagged parallel `isPaneAlive(w.paneId)` sites in `agents.ts:1291/1835/1886`, `scheduler-daemon.ts:595/667`, `team-auto-spawn.ts:122`, `auto-spawn.ts:84` — those are **out of scope** and belong in a follow-up wish. This PR is a surgical UX visibility fix, not a lifecycle refactor.

## Evidence

Live against a running daemon, same agent (`trace`) in both runs:

```
# BEFORE (dev)
$ genie ls --json | jq '.[] | select(.name=="trace")'
{ "name": "trace", "status": "error (0/3 resumes, auto-resume: on)", ... }

# AFTER (this branch)
$ ./dist/genie.js ls --json | jq '.[] | select(.name=="trace")'
{ "name": "trace", "status": "spawning", ... }
```

Status distribution shift (same daemon, same instant):

| status | before | after |
|---|---|---|
| `offline` | 48 | 48 |
| `error (0/3 resumes, auto-resume: on)` | 19 | 18 |
| `idle` | 2 | 2 |
| `spawning` | 0 | **1** |

Tmux agents (`felipe-3`, `fix-genie-ls-status`) unchanged — still `idle` — confirming the legacy path is preserved.

## Test plan

- [x] `bun test src/lib/executor-registry.test.ts` → 79 pass, 0 fail (14 new)
- [x] `bun run check` → EXIT=0, 2495/0 across 128 files
- [x] Pre-push hook full suite → 2501/0
- [x] Live before/after on running daemon (shown above)
- [x] `bunx biome check` on changed files → no new warnings (one pre-existing `processMessage` complexity warning at agents.ts:1073 unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)