### PR TITLE
fix(spawn): bootstrap tmux session when cold-starting with --new-window

### DIFF
--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -777,11 +777,24 @@ function createTmuxPane(ctx: SpawnCtx & { sessionOverride?: string }, teamWindow
     return execSync(cmd, { encoding: 'utf-8' }).trim();
   }
 
-  // --new-window: create a dedicated window instead of splitting
+  // --new-window: create a dedicated window instead of splitting.
+  // When the target session doesn't exist yet (e.g. cold-start spawn from the TUI
+  // for an offline agent), `new-window -t <session>:` would fail with "can't find
+  // session". Bootstrap with `new-session` in that case — it creates both the
+  // session and its first pane in one call.
   if (ctx.validated.newWindow) {
     const session = ctx.sessionOverride ?? teamWindow?.windowId?.split(':')[0] ?? ctx.validated.team;
     const cwdFlag = ctx.cwd ? ` -c ${shellQuote(ctx.cwd)}` : '';
-    const cmd = `${tmuxPrefix}new-window -a -d -t ${shellQuote(`${session}:`)}${cwdFlag} -P -F '#{pane_id}' ${tmuxCommand}`;
+    let sessionExists = false;
+    try {
+      execSync(`${tmuxPrefix}has-session -t ${shellQuote(`=${session}`)}`, { stdio: 'ignore' });
+      sessionExists = true;
+    } catch {
+      sessionExists = false;
+    }
+    const cmd = sessionExists
+      ? `${tmuxPrefix}new-window -a -d -t ${shellQuote(`${session}:`)}${cwdFlag} -P -F '#{pane_id}' ${tmuxCommand}`
+      : `${tmuxPrefix}new-session -d -s ${shellQuote(session)}${cwdFlag} -P -F '#{pane_id}' ${tmuxCommand}`;
     return execSync(cmd, { encoding: 'utf-8' }).trim();
   }
 


### PR DESCRIPTION
## Summary
- `genie spawn <agent> --session <name> --new-window` failed silently when the target tmux session didn't exist yet — tmux rejects `new-window -t <session>:` with `can't find session`.
- This is the cold-start path used by the TUI (`Nav.tsx` → `spawnAgent` → `genie spawn … --new-window`) to launch an offline agent. The TUI invokes the child with `stdio: 'ignore'`, so the error was swallowed and the user saw nothing happen when clicking "start" on an offline agent.
- Patch checks `has-session` first; if the session doesn't exist, bootstraps with `new-session -d -s <name>` (creates session + first pane in one call). Existing behaviour preserved when the session is already present.

## Repro (before fix)
```
$ tmux -L genie new-window -d -t 'khal-os:' -P -F '#{pane_id}' 'echo'
can't find session: khal-os
exit=1
```

After the fix, the same cold-start path takes the `new-session` branch and the pane is created correctly.

## Test plan
- [x] \`bun run typecheck\` — clean
- [x] \`bun run lint\` — no new warnings in \`createTmuxPane\` (12 pre-existing complexity warnings unchanged)
- [x] \`bun test\` — 2501 pass / 0 fail
- [ ] Manual: launch TUI, click start on an offline agent whose tmux session doesn't exist, confirm a new window/session appears