### PR TITLE
fix(test): replace leaking mock.module for genie-config with spyOn

### DIFF
--- a/src/term-commands/init-bootstrap.test.ts
+++ b/src/term-commands/init-bootstrap.test.ts
@@ -3,21 +3,17 @@ import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Command } from 'commander';
-// Import the real workspace module so we can spyOn individual exports.
-// Using spyOn instead of mock.module avoids leaking an incomplete mock to
-// other test files (bun 1.3.x leaks mock.module across parallel workers).
+// Import the real workspace + genie-config modules so we can spyOn individual
+// exports. Using spyOn instead of mock.module avoids leaking an incomplete
+// mock to other test files (bun 1.3.x leaks mock.module across parallel
+// workers — see https://github.com/oven-sh/bun/issues bun-test-mock-leak).
+import * as genieConfig from '../lib/genie-config.js';
 import * as workspace from '../lib/workspace.js';
 
 const mockConfirm = mock<(options: { message: string; default?: boolean }) => Promise<boolean>>(async () => true);
-const mockIsSetupComplete = mock(() => true);
 
 mock.module('@inquirer/prompts', () => ({
   confirm: (options: { message: string; default?: boolean }) => mockConfirm(options),
-}));
-
-mock.module('../lib/genie-config.js', () => ({
-  isSetupComplete: () => mockIsSetupComplete(),
-  loadGenieConfigSync: () => ({ promptMode: 'append' }),
 }));
 
 const { registerInitCommands } = await import('./init.js');
@@ -27,6 +23,8 @@ let testDir: string;
 let cwdSpy: ReturnType<typeof spyOn>;
 let findWorkspaceSpy: ReturnType<typeof spyOn>;
 let scanAgentsSpy: ReturnType<typeof spyOn>;
+let isSetupCompleteSpy: ReturnType<typeof spyOn>;
+let loadGenieConfigSyncSpy: ReturnType<typeof spyOn>;
 
 beforeEach(() => {
   originalCwd = process.cwd();
@@ -43,16 +41,22 @@ beforeEach(() => {
   findWorkspaceSpy = spyOn(workspace, 'findWorkspace').mockReturnValue(null);
   scanAgentsSpy = spyOn(workspace, 'scanAgents').mockReturnValue([]);
 
+  // Spy on genie-config exports (avoids mock.module cross-file leak).
+  isSetupCompleteSpy = spyOn(genieConfig, 'isSetupComplete').mockReturnValue(true);
+  loadGenieConfigSyncSpy = spyOn(genieConfig, 'loadGenieConfigSync').mockReturnValue({
+    promptMode: 'append',
+  } as ReturnType<typeof genieConfig.loadGenieConfigSync>);
+
   mockConfirm.mockReset();
-  mockIsSetupComplete.mockReset();
   mockConfirm.mockResolvedValue(true);
-  mockIsSetupComplete.mockReturnValue(true);
 });
 
 afterEach(() => {
   findWorkspaceSpy.mockRestore();
   scanAgentsSpy.mockRestore();
   cwdSpy.mockRestore();
+  isSetupCompleteSpy.mockRestore();
+  loadGenieConfigSyncSpy.mockRestore();
   process.chdir(originalCwd);
   rmSync(testDir, { recursive: true, force: true });
 });

--- a/src/term-commands/init-flow.test.ts
+++ b/src/term-commands/init-flow.test.ts
@@ -3,21 +3,18 @@ import { existsSync, mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Command } from 'commander';
-// Import the real workspace module so we can spyOn individual exports.
-// Using spyOn instead of mock.module avoids leaking an incomplete mock to
-// other test files (bun 1.3.x leaks mock.module across parallel workers).
+// Import the real workspace + genie-config modules so we can spyOn individual
+// exports. Using spyOn instead of mock.module avoids leaking an incomplete
+// mock to other test files (bun 1.3.x leaks mock.module across parallel
+// workers — see https://github.com/oven-sh/bun/issues bun-test-mock-leak).
+import * as genieConfig from '../lib/genie-config.js';
 import * as workspace from '../lib/workspace.js';
 
 const mockConfirm = mock<(options: { message: string; default?: boolean }) => Promise<boolean>>(async () => false);
-const mockIsSetupComplete = mock<() => boolean>(() => true);
 const mockSetupCommand = mock(async () => {});
 
 mock.module('@inquirer/prompts', () => ({
   confirm: (options: { message: string; default?: boolean }) => mockConfirm(options),
-}));
-
-mock.module('../lib/genie-config.js', () => ({
-  isSetupComplete: () => mockIsSetupComplete(),
 }));
 
 mock.module('../genie-commands/setup.js', () => ({
@@ -30,6 +27,7 @@ let originalCwd: string;
 let testDir: string;
 let findWorkspaceSpy: ReturnType<typeof spyOn>;
 let scanAgentsSpy: ReturnType<typeof spyOn>;
+let isSetupCompleteSpy: ReturnType<typeof spyOn>;
 
 describe('genie init setup gating', () => {
   beforeEach(() => {
@@ -42,23 +40,25 @@ describe('genie init setup gating', () => {
     findWorkspaceSpy = spyOn(workspace, 'findWorkspace').mockReturnValue(null);
     scanAgentsSpy = spyOn(workspace, 'scanAgents').mockReturnValue([]);
 
+    // Spy on genie-config.isSetupComplete (avoids mock.module cross-file leak)
+    isSetupCompleteSpy = spyOn(genieConfig, 'isSetupComplete').mockReturnValue(true);
+
     mockConfirm.mockReset();
-    mockIsSetupComplete.mockReset();
     mockSetupCommand.mockReset();
 
     mockConfirm.mockResolvedValue(false);
-    mockIsSetupComplete.mockReturnValue(true);
   });
 
   afterEach(() => {
     findWorkspaceSpy.mockRestore();
     scanAgentsSpy.mockRestore();
+    isSetupCompleteSpy.mockRestore();
     process.chdir(originalCwd);
     rmSync(testDir, { recursive: true, force: true });
   });
 
   test('runs setup flow before init when setup is incomplete', async () => {
-    mockIsSetupComplete.mockReturnValue(false);
+    isSetupCompleteSpy.mockReturnValue(false);
 
     const program = new Command();
     registerInitCommands(program);


### PR DESCRIPTION
## Summary

Bun 1.3.x leaks `mock.module()` registrations across test-file boundaries. Two test files (`init-flow.test.ts`, `init-bootstrap.test.ts`) registered *incomplete* genie-config.js mocks (only 1–2 of 12 real exports). When CI test scheduling placed a victim test (e.g. `dir.test.ts`) after them, the victim's `import { contractPath } from '../lib/genie-config.js'` resolved to the stale partial mock and crashed with:

```
SyntaxError: Export named 'contractPath' not found in module /src/lib/genie-config.ts
```

This intermittently broke the Quality Gate → blocked the publish pipeline.

### Irony
Both offender files already carried this comment about `workspace.js`:

```ts
// Using spyOn instead of mock.module avoids leaking an incomplete mock to
// other test files (bun 1.3.x leaks mock.module across parallel workers).
```

They applied the fix to `workspace.js` (spyOn, correct) and then used the exact anti-pattern they warn against for `genie-config.js`. This PR applies the same spyOn pattern the files already advertise, leaving the real module intact for every other test.

## Changes (2 files touched)

- `src/term-commands/init-flow.test.ts` — drop `mock.module('../lib/genie-config.js', ...)`; add `spyOn(genieConfig, 'isSetupComplete')` per-test with matching `mockRestore` in `afterEach`
- `src/term-commands/init-bootstrap.test.ts` — drop `mock.module('../lib/genie-config.js', ...)`; add `spyOn(genieConfig, 'isSetupComplete')` + `spyOn(genieConfig, 'loadGenieConfigSync')` per-test with matching `mockRestore` in `afterEach`

No new test files. No workflow changes. No semantics changes — only the mocking mechanism.

## Reproducer (BEFORE vs AFTER)

**BEFORE (on `origin/dev` @ `40df308f`):**

```bash
bun test src/term-commands/init-bootstrap.test.ts src/term-commands/dir.test.ts
# → 3 pass / 1 fail / 1 error
# → SyntaxError: Export named 'contractPath' not found in module genie-config.ts
```

**AFTER (on this branch):**

```bash
bun test src/term-commands/init-flow.test.ts src/term-commands/dir.test.ts
# → 33 pass / 0 fail

bun test src/term-commands/init-bootstrap.test.ts src/term-commands/dir.test.ts
# → 34 pass / 0 fail

bun test src/term-commands/init-flow.test.ts src/term-commands/team.test.ts
# → 16 pass / 0 fail

bun run check
# → 2501 pass / 0 fail  (typecheck + lint + dead-code + skills:lint + wishes:lint + bun test)
```

## Scope

Hard scope per fix-genie-mock-leak charter: ONLY the 2 offender test files.

## H2 follow-up: Version.yml workflow_run gate lacks cross-trigger fallback — staged separately

Tracer also flagged that `.github/workflows/version.yml`'s `workflow_run` gate has no cross-trigger fallback, meaning a Quality-Gate pass on `pull_request` does not satisfy the gate for the subsequent `push` event. This is a workflow redesign concern, out of scope for this surgical test-mock fix, and will be handled in a separate PR.

## Test plan

- [x] `bun test src/term-commands/init-flow.test.ts` (isolated) — 2/2 pass
- [x] `bun test src/term-commands/init-bootstrap.test.ts` (isolated) — 3/3 pass
- [x] All 3 ordering combos from charter — clean pass
- [x] `bun run check` — 2501/0 pass
- [x] Pre-push hook `bun run check` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)