### PR TITLE
fix(spawn): fall back to on-disk team config when GENIE_TEAM unresolved

### DIFF
--- a/src/lib/claude-native-teams.ts
+++ b/src/lib/claude-native-teams.ts
@@ -184,6 +184,26 @@ export async function loadConfig(teamName: string): Promise<NativeTeamConfig | n
   }
 }
 
+/**
+ * Find all teams whose config.json lists the given agent name as a member.
+ *
+ * Used by the spawn path as a last-resort fallback to resolve `--team` when
+ * neither an explicit flag nor `GENIE_TEAM` nor a parent session is available
+ * (e.g. detached spawns from the TUI after a DB reset). Returns team names
+ * sanitized exactly as they appear on disk.
+ */
+export async function findTeamsContainingAgent(agentName: string): Promise<string[]> {
+  const teams = await listTeams();
+  const matches: string[] = [];
+  for (const teamName of teams) {
+    const config = await loadConfig(teamName);
+    if (!config) continue;
+    const hit = config.members.some((m) => m.name === agentName || m.agentType === agentName);
+    if (hit) matches.push(teamName);
+  }
+  return matches;
+}
+
 async function saveConfig(teamName: string, config: NativeTeamConfig): Promise<void> {
   await writeFile(configPath(teamName), JSON.stringify(config, null, 2));
 }

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -1616,9 +1616,28 @@ async function resolveTeamAndResume(
   options: SpawnOptions,
 ): Promise<{ team: string; teamWasExplicit: boolean; resumed?: string }> {
   const teamWasExplicit = Boolean(options.team);
-  const team = options.team || (await nativeTeams.discoverTeamName());
+  let team = options.team || (await nativeTeams.discoverTeamName());
+
+  // Fallback: scan on-disk team configs for one that lists this agent as a
+  // member. Unblocks detached spawns (e.g. from the TUI after a DB reset) that
+  // can't inherit GENIE_TEAM or a parent session context but where the agent
+  // is unambiguously registered to a team on disk.
   if (!team) {
-    console.error('Error: --team is required (or set GENIE_TEAM, or run inside a genie session)');
+    const candidates = await nativeTeams.findTeamsContainingAgent(effectiveRole);
+    if (candidates.length === 1) {
+      team = candidates[0];
+    } else if (candidates.length > 1) {
+      console.error(
+        `Error: agent "${effectiveRole}" is a member of multiple teams (${candidates.join(', ')}). Pass --team <name> to disambiguate.`,
+      );
+      return process.exit(1) as never;
+    }
+  }
+
+  if (!team) {
+    console.error(
+      `Error: --team is required for agent "${effectiveRole}" (or set GENIE_TEAM, run inside a genie session, or register the agent in a team config).`,
+    );
     return process.exit(1) as never;
   }
   const deadResumable = await findDeadResumable(team, effectiveRole);

--- a/src/tui/components/Nav.tsx
+++ b/src/tui/components/Nav.tsx
@@ -654,7 +654,8 @@ function spawnAgent(name: string, onTmuxSessionSelect?: (sessionName: string, wi
   try {
     const { spawn } = require('node:child_process') as typeof import('node:child_process');
     const { join, resolve } = require('node:path') as typeof import('node:path');
-    const { existsSync } = require('node:fs') as typeof import('node:fs');
+    const { existsSync, mkdirSync, openSync } = require('node:fs') as typeof import('node:fs');
+    const { homedir } = require('node:os') as typeof import('node:os');
     const bunPath = process.execPath || 'bun';
     const genieBin = process.argv[1];
     const wsRoot = process.env.GENIE_TUI_WORKSPACE;
@@ -676,11 +677,43 @@ function spawnAgent(name: string, onTmuxSessionSelect?: (sessionName: string, wi
       GENIE_IS_DAEMON: _d,
       ...cleanEnv
     } = process.env;
-    const spawnOpts = { detached: true, stdio: 'ignore' as const, cwd, env: cleanEnv };
+    // Route stdout/stderr to a per-spawn log file instead of /dev/null so that
+    // silent failures (e.g. team resolution errors) become discoverable. The
+    // detached child still survives the TUI process exiting.
+    const logDir = join(homedir(), '.genie', 'logs', 'tui-spawn');
+    try {
+      mkdirSync(logDir, { recursive: true });
+    } catch {
+      // best-effort — fall back to ignore if we can't create the dir
+    }
+    const logPath = join(logDir, `${sessionName}-${Date.now()}.log`);
+    let logFd: number | undefined;
+    try {
+      logFd = openSync(logPath, 'a');
+    } catch {
+      logFd = undefined;
+    }
+    const spawnOpts =
+      logFd !== undefined
+        ? ({
+            detached: true,
+            stdio: ['ignore', logFd, logFd] as ['ignore', number, number],
+            cwd,
+            env: cleanEnv,
+          } as const)
+        : ({ detached: true, stdio: 'ignore' as const, cwd, env: cleanEnv } as const);
     const child =
       genieBin && genieBin !== 'genie'
         ? spawn(bunPath, [genieBin, 'spawn', name, '--session', sessionName, '--new-window'], spawnOpts)
         : spawn('genie', ['spawn', name, '--session', sessionName, '--new-window'], spawnOpts);
+    child.on('exit', (code) => {
+      if (code && code !== 0) {
+        console.error(`TUI: spawn "${name}" exited ${code}. See ${logPath}`);
+      }
+    });
+    child.on('error', (err) => {
+      console.error(`TUI: spawn "${name}" error: ${err.message}. See ${logPath}`);
+    });
     child.unref();
     if (onTmuxSessionSelect) {
       attachSpawnedAgentWhenReady(sessionName, onTmuxSessionSelect);


### PR DESCRIPTION
## Summary

When \`genie spawn <name>\` is invoked without \`--team\`, without \`GENIE_TEAM\` in env, and without a parent genie session (the typical detached spawn path from the TUI), the CLI used to exit with \`Error: --team is required\`. Combined with the TUI using \`stdio: 'ignore'\` for its detached child, this produced a **silent failure**: pressing Enter / right-click Start on an agent in the Nav sidebar did nothing and left no discoverable trace.

This regression surfaced right after #1168 (cold-start tmux session bootstrap) — that fix was correct, but uncovered a second layer of the same \"TUI spawn dies silently\" bug. Reliably reproducible after a DB reset: the TUI process keeps running with its original (stripped) env, but the fresh serve has no session-linked team for \`discoverTeamName()\` to match, so every Enter/Start dies inside the detached child with no breadcrumb.

## Repro (before this PR)

\`\`\`bash
# Bare env — no GENIE_TEAM, no TMUX, no parent session (matches TUI's spawnAgent child)
env -i HOME=\$HOME PATH=/home/genie/.bun/bin:/usr/bin:/bin \\
  bun dist/genie.js spawn khal-os --session khal-os --new-window
# → Error: --team is required (or set GENIE_TEAM, or run inside a genie session)
# → exit 1
# TUI stdio:'ignore' eats the error. User sees nothing.
\`\`\`

## Fix (two parts)

### 1. CLI — structural (\`src/lib/claude-native-teams.ts\`, \`src/term-commands/agents.ts\`)

- Export \`findTeamsContainingAgent(name)\` which scans \`~/.claude/teams/*/config.json\` for teams listing the given agent as a member.
- In \`resolveTeamAndResume\`, after \`discoverTeamName()\` returns null, fall back to the on-disk scan:
  - **exactly one match** → use it silently (the common case)
  - **multiple matches** → error with the list, asking for \`--team\` to disambiguate
  - **zero matches** → error mentions the agent name and the registration path as the resolution

### 2. TUI — ergonomic (\`src/tui/components/Nav.tsx\`)

- Replace \`stdio: 'ignore'\` with per-spawn log files under \`~/.genie/logs/tui-spawn/<session>-<ts>.log\` so failures are discoverable.
- Wire \`child.on('exit')\` and \`child.on('error')\` to print a breadcrumb pointing at the log when the spawn fails.
- Detached child still survives TUI exit (FDs are dup'd, child is \`unref()\`'d).

## Verification

\`\`\`bash
# Same bare-env repro — now succeeds:
env -i HOME=\$HOME PATH=... bun dist/genie.js spawn khal-os --session khal-os --new-window
# → resolves team=v4-session-executor from on-disk config
# → ✓ Agent ready (0.0s)
# → exit 0
\`\`\`

Also confirmed the TUI flow end-to-end: Enter on a stopped agent node now spawns correctly, attaches via \`attachSpawnedAgentWhenReady\`, and on the failure path writes to the log.

## Test plan

- [x] Typecheck passes
- [x] Build passes
- [x] Full unit suite passes (2501 tests, 0 failures on pre-push hook)
- [x] Manual repro: bare-env spawn resolves team via on-disk fallback
- [x] Manual repro: same spawn with no matching team errors clearly with the agent name
- [ ] Manual verification in TUI after merge + publish: Enter on stopped \`khal-os\` agent node starts the agent without needing \`GENIE_TEAM\` preset

## Related

- Follow-up to #1168. Together, those two PRs eliminate the silent-failure mode where pressing Enter in the TUI Nav \"does nothing\" after a DB reset.