### PR TITLE
fix(test): isolate buildClaudeCommand tests from host ~/.genie/config.json

### DIFF
--- a/src/genie-commands/__tests__/session.test.ts
+++ b/src/genie-commands/__tests__/session.test.ts
@@ -7,9 +7,14 @@
  * Run with: bun test src/genie-commands/__tests__/session.test.ts
  */
 
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test';
 import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
+// Import the real genie-config module so we can spyOn individual exports.
+// Using spyOn instead of mock.module avoids leaking an incomplete mock to
+// other test files (bun 1.3.x leaks mock.module across parallel workers —
+// see PR #1169). Pattern mirrors src/term-commands/init-bootstrap.test.ts.
+import * as genieConfig from '../../lib/genie-config.js';
 import { HEARTBEAT_TEMPLATE, SOUL_TEMPLATE, scaffoldAgentFiles } from '../../templates/index.js';
 import { buildClaudeCommand, getAgentsFilePath, sanitizeWindowName } from '../session.js';
 
@@ -18,6 +23,23 @@ import { buildClaudeCommand, getAgentsFilePath, sanitizeWindowName } from '../se
 // ============================================================================
 
 describe('buildClaudeCommand', () => {
+  // Pin promptMode so tests asserting --append-system-prompt-file don't depend
+  // on the host's ~/.genie/config.json. Without this, a host configured with
+  // promptMode: "system" causes buildTeamLeadCommand to emit --system-prompt-file
+  // instead, failing the append-system-prompt-file assertions below.
+  // Closes the tail surfaced during PR #1169 QA.
+  let loadGenieConfigSyncSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    loadGenieConfigSyncSpy = spyOn(genieConfig, 'loadGenieConfigSync').mockReturnValue({
+      promptMode: 'append',
+    } as ReturnType<typeof genieConfig.loadGenieConfigSync>);
+  });
+
+  afterEach(() => {
+    loadGenieConfigSyncSpy.mockRestore();
+  });
+
   test('always contains --team-name flag', () => {
     const cmd = buildClaudeCommand('genie');
     expect(cmd).toContain('--team-name');


### PR DESCRIPTION
## Summary

Two tests in `src/genie-commands/__tests__/session.test.ts` — `buildClaudeCommand > with system prompt file references it via --append-system-prompt-file` and `buildClaudeCommand > file path is passed directly, no content inlined` — implicitly assumed the host machine's `~/.genie/config.json` had `promptMode` unset or `"append"`. On any host configured with `promptMode: "system"`, `buildTeamLeadCommand` emits `--system-prompt-file` instead, and the assertions fail.

This fragility was previously masked by the leaking `mock.module('../lib/genie-config.js', ...)` from `init-*.test.ts` that PR #1169 replaced with `spyOn`. Removing the leak unmasked this latent weakness.

**Closes the tail surfaced during PR #1169 QA — tests no longer depend on host ~/.genie/config.json.**

## Fix

Mirror PR #1169's `spyOn` pattern inside the `buildClaudeCommand` `describe` block:

- Import `* as genieConfig from '../../lib/genie-config.js'`
- `spyOn(genieConfig, 'loadGenieConfigSync').mockReturnValue({ promptMode: 'append' })` in `beforeEach`
- `loadGenieConfigSyncSpy.mockRestore()` in `afterEach`

Scope: **1 file touched** (`src/genie-commands/__tests__/session.test.ts`). Production code in `src/lib/team-lead-command.ts` is untouched — this is a test-only hygiene fix.

## BEFORE / AFTER reproducer

### BEFORE (on `origin/dev`, host `~/.genie/config.json` has `promptMode: "system"`)

```
$ bun test src/genie-commands/__tests__/session.test.ts
...
(fail) buildClaudeCommand > with system prompt file references it via --append-system-prompt-file [3.00ms]
  Expected to contain: "--append-system-prompt-file"
  Received: "... --system-prompt-file '/tmp/test-agents.md'"

(fail) buildClaudeCommand > file path is passed directly, no content inlined [1.00ms]
  Expected to contain: "--append-system-prompt-file"
  Received: "... --system-prompt-file '/path/to/AGENTS.md'"

 29 pass
 2 fail
```

### AFTER (this branch, both host scenarios)

```
# host config contains promptMode: "system"
$ bun test src/genie-commands/__tests__/session.test.ts
 31 pass
 0 fail
 52 expect() calls
Ran 31 tests across 1 file. [2.45s]

# host config moved aside
$ mv ~/.genie/config.json ~/.genie/config.json.bak
$ bun test src/genie-commands/__tests__/session.test.ts
 31 pass
 0 fail
 52 expect() calls
Ran 31 tests across 1 file. [2.37s]
```

## Full suite

```
$ bun run check
 2501 pass
 0 fail
 5714 expect() calls
Ran 2501 tests across 128 files. [52.13s]
```

## Test plan

- [x] Reproduce failure on `origin/dev` with host `promptMode: "system"` (29/2)
- [x] Apply fix — confirm 31/0 with host `promptMode: "system"`
- [x] Confirm 31/0 with host config moved aside (no regression on clean machines)
- [x] `bun run check` — 2501/0
- [x] Diff review — 1 file, +23/-1, no production code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)