### PR TITLE
fix(spawn): eliminate cruft windows for isolated-session --new-window

### DIFF
--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -781,7 +781,8 @@ function createTmuxPane(ctx: SpawnCtx & { sessionOverride?: string }, teamWindow
   // When the target session doesn't exist yet (e.g. cold-start spawn from the TUI
   // for an offline agent), `new-window -t <session>:` would fail with "can't find
   // session". Bootstrap with `new-session` in that case — it creates both the
-  // session and its first pane in one call.
+  // session and its first pane in one call. Pass `-n claude` so that first
+  // window has a meaningful name instead of tmux's default `bash`.
   if (ctx.validated.newWindow) {
     const session = ctx.sessionOverride ?? teamWindow?.windowId?.split(':')[0] ?? ctx.validated.team;
     const cwdFlag = ctx.cwd ? ` -c ${shellQuote(ctx.cwd)}` : '';
@@ -793,8 +794,8 @@ function createTmuxPane(ctx: SpawnCtx & { sessionOverride?: string }, teamWindow
       sessionExists = false;
     }
     const cmd = sessionExists
-      ? `${tmuxPrefix}new-window -a -d -t ${shellQuote(`${session}:`)}${cwdFlag} -P -F '#{pane_id}' ${tmuxCommand}`
-      : `${tmuxPrefix}new-session -d -s ${shellQuote(session)}${cwdFlag} -P -F '#{pane_id}' ${tmuxCommand}`;
+      ? `${tmuxPrefix}new-window -a -d -t ${shellQuote(`${session}:`)} -n claude${cwdFlag} -P -F '#{pane_id}' ${tmuxCommand}`
+      : `${tmuxPrefix}new-session -d -s ${shellQuote(session)} -n claude${cwdFlag} -P -F '#{pane_id}' ${tmuxCommand}`;
     return execSync(cmd, { encoding: 'utf-8' }).trim();
   }
 
@@ -905,9 +906,18 @@ async function awaitAgentReadiness(paneId: string): Promise<void> {
 }
 
 async function launchTmuxSpawn(ctx: SpawnCtx): Promise<string> {
-  const teamWindow = ctx.spawnIntoCurrentWindow
-    ? null
-    : await resolveSpawnTeamWindow(ctx.validated.team, ctx.cwd, ctx.sessionOverride);
+  // Skip team-window creation for isolated-session spawns. When the caller asks
+  // for `--new-window` with an explicit `--session <name>` that differs from
+  // the team name (the TUI's per-agent spawn path), the team window has no
+  // purpose — the agent runs in its own window in its own session. Creating
+  // one anyway leaves behind an empty bash pane and a ghost team-named window
+  // beside the real agent window.
+  const isolatedSessionSpawn =
+    ctx.validated.newWindow === true && Boolean(ctx.sessionOverride) && ctx.sessionOverride !== ctx.validated.team;
+  const teamWindow =
+    ctx.spawnIntoCurrentWindow || isolatedSessionSpawn
+      ? null
+      : await resolveSpawnTeamWindow(ctx.validated.team, ctx.cwd, ctx.sessionOverride);
 
   let paneId: string;
   try {


### PR DESCRIPTION
## Summary

When the TUI spawns an agent — \`genie spawn <name> --session <name> --new-window\` — it ends up with a 3-window tmux session where only one window is the real agent:

\`\`\`
khal-os:0  bash                   ← tmux default from new-session, empty
khal-os:1  v4-session-executor    ← team window, never used (orphan bash)
khal-os:2  claude                 ← THE actual agent
\`\`\`

Windows 0 and 1 are pure dead weight. Both come from pre-existing code paths that were designed for the \"multi-agent team session\" topology but fire indiscriminately in the \"single-agent isolated session\" path the TUI actually uses. Before #1170 the spawn silently failed, so nobody saw this — #1170 unblocked the spawn and this cruft became visible.

## Root cause

1. \`ensureSessionExists(session)\` inside \`ensureTeamWindow\` creates session \`khal-os\` on first touch. tmux's \`new-session\` always creates a first window (shell default) → **window 0 bash**.
2. \`ensureTeamWindow('khal-os', 'v4-session-executor')\` then creates a second window named after the team, intended for the team lead → **window 1 v4-session-executor**. For isolated-session per-agent spawns the team lead never runs here — it stays orphaned.
3. \`createTmuxPane\` with \`--new-window\` appends the real agent window → **window 2 claude**.

## Fix

### 1. \`launchTmuxSpawn\` — skip team window for isolated-session spawns
Detect the shape \`newWindow === true && sessionOverride && sessionOverride !== team\` and pass \`teamWindow = null\` to the pane creator. Downstream consumers (\`createTmuxExecutor\`, \`applySpawnLayout\`, \`registerSpawnWorker\`, \`finalizeTmuxSpawn\`) already handle \`null\` via optional-chaining — same shape as the existing \`spawnIntoCurrentWindow\` path.

### 2. \`createTmuxPane\` — name the bootstrapped window
Pass \`-n claude\` to both branches of the \`--new-window\` flow (cold-start \`new-session\` and warm \`new-window\` append). Replaces tmux's default shell-named window with a meaningful name that matches the running process.

## Verification

\`\`\`bash
env -i HOME=\$HOME PATH=/home/genie/.bun/bin:/usr/bin:/bin \\
  bun dist/genie.js spawn khal-os --session khal-os-fresh-test --new-window
\`\`\`

Before this PR (after #1170): 3 windows (bash + v4-session-executor + claude).
After this PR: **1 window**, named \`claude\`, running the agent. Nothing else.

\`\`\`
\$ tmux -L genie list-windows -t khal-os-fresh-test
0 claude (1 panes, cmd=claude)
\`\`\`

## Test plan

- [x] Typecheck passes
- [x] Build passes
- [x] Full unit suite passes (2501 tests, 0 failures on pre-push hook)
- [x] Manual repro: bare-env isolated-session spawn produces exactly one window named \`claude\`
- [x] No regression for normal team spawns (\`sessionOverride == team\` path unchanged)
- [ ] Manual verification in TUI after merge + publish: pressing Enter on a stopped agent produces a single clean \`claude\` window under that agent's session in the tree view

## Related

- Builds on #1168 (cold-start session bootstrap) and #1170 (team fallback for detached spawn).
- Together, these three PRs fix the full user-visible path: Enter on a stopped TUI agent → clean single-window spawn that actually reflects the caller's intent.