### PR TITLE
feat(spawn): auto-create team-of-one for globally registered teamless agents

### DIFF
--- a/src/lib/claude-native-teams.test.ts
+++ b/src/lib/claude-native-teams.test.ts
@@ -19,6 +19,7 @@ import {
   discoverClaudeParentSessionId,
   discoverTeamName,
   ensureNativeTeamWithSessionId,
+  findTeamsContainingAgent,
   loadConfig,
   resolveNativeMemberName,
   resolveOrMintLeadSessionId,
@@ -607,5 +608,41 @@ describe('discoverTeamName', () => {
     });
     const result = await discoverTeamName('/repo/no-jsonl-here');
     expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findTeamsContainingAgent tests — the spawn-fallback scan relied on by
+// `resolveTeamAndResume` when GENIE_TEAM and parent-session context are both
+// missing. Guards against regressions in the agent-name vs agent-type match
+// and the no-match path that must fail closed (so callers can decide whether
+// to auto-create a team-of-one or surface the --team-is-required error).
+// ---------------------------------------------------------------------------
+
+describe('findTeamsContainingAgent', () => {
+  test('returns an empty array when no team lists the agent', async () => {
+    await createTestTeamConfig('team-alpha', [{ agentId: 'other@team-alpha', name: 'other' }]);
+    const result = await findTeamsContainingAgent('khal-os');
+    expect(result).toEqual([]);
+  });
+
+  test('returns the team when the agent is a member by name', async () => {
+    await createTestTeamConfig('team-bravo', [{ agentId: 'khal-os@team-bravo', name: 'khal-os' }]);
+    const result = await findTeamsContainingAgent('khal-os');
+    expect(result).toEqual(['team-bravo']);
+  });
+
+  test('returns every team listing the agent when multiple ghost teams exist', async () => {
+    await createTestTeamConfig('team-gamma', [{ agentId: 'khal-os@team-gamma', name: 'khal-os' }]);
+    await createTestTeamConfig('team-delta', [{ agentId: 'khal-os@team-delta', name: 'khal-os' }]);
+    const result = (await findTeamsContainingAgent('khal-os')).sort();
+    expect(result).toEqual(['team-delta', 'team-gamma']);
+  });
+
+  test('returns empty array when teams dir does not exist', async () => {
+    // Fresh tempDir with no teams/ subdir — mirrors a pristine server where
+    // no team config has ever been written.
+    const result = await findTeamsContainingAgent('khal-os');
+    expect(result).toEqual([]);
   });
 });

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -1644,6 +1644,17 @@ async function resolveTeamAndResume(
     }
   }
 
+  // Auto-create team-of-one for globally registered agents with no team.
+  // Lets the TUI (and other detached spawns) start a standalone agent like
+  // `khal-os` without requiring Felipe to hand-wire a team name. The team
+  // config is materialized downstream by `resolveNativeTeam` → `ensureNativeTeam`.
+  if (!team) {
+    const directoryEntry = await directory.get(effectiveRole);
+    if (directoryEntry) {
+      team = nativeTeams.sanitizeTeamName(effectiveRole);
+    }
+  }
+
   if (!team) {
     console.error(
       `Error: --team is required for agent "${effectiveRole}" (or set GENIE_TEAM, run inside a genie session, or register the agent in a team config).`,


### PR DESCRIPTION
## Summary
- When a detached `genie spawn` can't resolve a team (no `--team`, no `GENIE_TEAM`, no parent session, no on-disk team already listing the agent), fall back to auto-creating a team-of-one named after the agent — **only** if that agent is registered in the global agent directory.
- Unblocks the TUI flow where pressing Enter on an offline, teamless, globally registered agent (e.g. `khal-os` after ghost-team cleanup) was failing silently with `"--team is required"`.
- Unknown agents still fail closed; typos can't materialize bogus teams.

## Trace that motivated this
From a read-only investigation:
- `Nav.tsx:707` spawns detached with `--session <name> --new-window` and strips `GENIE_TEAM` from env.
- `resolveTeamAndResume` (`agents.ts:1647-1652`) used to exit 1 with `--team is required` when `discoverTeamName()` and `findTeamsContainingAgent()` both came back empty.
- The detached child's stderr now routes to `~/.genie/logs/tui-spawn/<session>-<ts>.log` (PR #1170), but the TUI pane doesn't surface that to the user, so the failure looked like "TUI refuses to start the agent".

With this change: if the agent exists in the directory, spawn creates a team-of-one named after it. `resolveNativeTeam` → `ensureNativeTeam` materializes the config downstream exactly like any other team, so no new plumbing is introduced.

## Changes
- `src/term-commands/agents.ts`: +11 lines in `resolveTeamAndResume` — directory-gated auto-team-of-one branch between the on-disk scan and the final `--team is required` error.
- `src/lib/claude-native-teams.test.ts`: +37 lines — regression tests for `findTeamsContainingAgent` (empty dir, no-match, single match, multiple ghost teams). Guards the scan the new branch sits on top of.

## Test plan
- [x] `bun test src/lib/claude-native-teams.test.ts` — 37 pass, 0 fail (4 new)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — no new warnings (1 pre-existing complexity warning at `agents.ts:1096` untouched)
- [x] `bun run build` — 4.6 MB bundle produced
- [x] Pre-push hook: full suite 2505 pass, 0 fail
- [ ] Live verification on the Felipe server: after ghost-team cleanup, TUI Enter on offline `khal-os` starts it under team `khal-os` (planned as G-C of wish `team-of-one-auto-create`)