### PR TITLE
fix(spawn): honor --new-window --session even when session equals team

### DIFF
--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -907,13 +907,15 @@ async function awaitAgentReadiness(paneId: string): Promise<void> {
 
 async function launchTmuxSpawn(ctx: SpawnCtx): Promise<string> {
   // Skip team-window creation for isolated-session spawns. When the caller asks
-  // for `--new-window` with an explicit `--session <name>` that differs from
-  // the team name (the TUI's per-agent spawn path), the team window has no
-  // purpose — the agent runs in its own window in its own session. Creating
-  // one anyway leaves behind an empty bash pane and a ghost team-named window
-  // beside the real agent window.
-  const isolatedSessionSpawn =
-    ctx.validated.newWindow === true && Boolean(ctx.sessionOverride) && ctx.sessionOverride !== ctx.validated.team;
+  // for `--new-window` with an explicit `--session <name>`, the agent runs in
+  // its own window in that session — the team window has no purpose.
+  //
+  // The original heuristic required `sessionOverride !== team` as a proxy for
+  // "TUI per-agent spawn", but auto-team-of-one (see resolveTeamAndResume) now
+  // makes them equal for globally-registered teamless agents. Honoring the
+  // explicit `--session` flag unconditionally covers both cases and avoids
+  // the 3-window (bash + team-named + claude) cruft topology.
+  const isolatedSessionSpawn = ctx.validated.newWindow === true && Boolean(ctx.sessionOverride);
   const teamWindow =
     ctx.spawnIntoCurrentWindow || isolatedSessionSpawn
       ? null


### PR DESCRIPTION
## Summary
- Follow-up to #1174. Without this, auto-team-of-one spawns (where session==team) regress into the 3-window topology (`bash` + team-named + `claude`) that #1173 set out to kill.
- One-line semantic fix in `launchTmuxSpawn`: treat any spawn with explicit `--new-window` + `--session` as isolated, regardless of whether session happens to equal team.

## Why the old proxy broke
`#1173` used `sessionOverride !== team` as a heuristic for "TUI per-agent spawn". When #1174 added auto-team-of-one, globally registered teamless agents (e.g. `khal-os`) now auto-create a team named after themselves — so the TUI call `genie spawn khal-os --session khal-os --new-window` has `sessionOverride === team`, `isolatedSessionSpawn` goes false, `resolveSpawnTeamWindow` runs, and you get the same cruft:

```
khal-os: 3 windows
  0: bash#  (bootstrap session default window)
  1: claude (real agent)
  2: khal-os (ghost team window)
```

## The fix
Drop the `!== team` clause. Rationale: the explicit `--session` flag IS the signal that the caller wants isolation; team-window organization exists to group multi-member teams that share a session, which is orthogonal to the per-agent TUI spawn path.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun test src/term-commands/agents.test.ts` — 9/9 pass
- [x] Pre-push full suite — 2505/2505 pass
- [ ] Live: after install, `genie spawn khal-os --session khal-os --new-window` from a teamless state produces exactly one tmux window named `claude`, no `bash` or team-named cruft.