### PR TITLE
fix(runtime-events): plug waitForRuntimeEvent handle leak (CONNECTION_ENDED race)

### DIFF
--- a/src/lib/runtime-events.ts
+++ b/src/lib/runtime-events.ts
@@ -353,8 +353,16 @@ export async function followRuntimeEvents(
     stop: async () => {
       active = false;
       clearInterval(pollTimer);
-      await drainChain;
-      await listener.unlisten();
+      try {
+        await drainChain;
+      } catch {
+        /* swallow — connection may already be torn down */
+      }
+      try {
+        await listener.unlisten();
+      } catch {
+        /* swallow — connection may already be torn down */
+      }
     },
   };
 }
@@ -366,7 +374,7 @@ export async function waitForRuntimeEvent(
 ): Promise<RuntimeEvent | null> {
   const afterId = query.afterId ?? 0;
 
-  return new Promise<RuntimeEvent | null>((resolve) => {
+  return new Promise<RuntimeEvent | null>((resolve, reject) => {
     let settled = false;
     let handle: FollowRuntimeEventsHandle | null = null;
     let timer: ReturnType<typeof setTimeout> | null = null;
@@ -375,23 +383,42 @@ export async function waitForRuntimeEvent(
       if (settled) return;
       settled = true;
       if (timer) clearTimeout(timer);
-      if (handle) await handle.stop();
+      try {
+        if (handle) await handle.stop();
+      } catch {
+        /* swallow — connection may already be torn down */
+      }
       resolve(event);
     };
 
     void (async () => {
-      handle = await followRuntimeEvents(
-        { ...query, afterId },
-        (event) => {
-          if (predicate && !predicate(event)) return;
-          void finish(event);
-        },
-        { pollIntervalMs: 250 },
-      );
-
-      timer = setTimeout(() => {
-        void finish(null);
-      }, timeoutMs);
+      try {
+        handle = await followRuntimeEvents(
+          { ...query, afterId },
+          (event) => {
+            if (predicate && !predicate(event)) return;
+            void finish(event);
+          },
+          { pollIntervalMs: 250 },
+        );
+        if (settled) {
+          // initial drain already resolved us — stop the late-arriving handle
+          try {
+            await handle.stop();
+          } catch {
+            /* swallow — connection may already be torn down */
+          }
+          return;
+        }
+        timer = setTimeout(() => {
+          void finish(null);
+        }, timeoutMs);
+      } catch (err) {
+        if (!settled) {
+          settled = true;
+          reject(err);
+        }
+      }
     })();
   });
 }


### PR DESCRIPTION
## Summary

Plugs the leak that produced the rare `CONNECTION_ENDED` flake on PR #1171's push-CI (run 24589853586). HIGH-confidence tracer diagnosis pinned to `waitForRuntimeEvent` in `src/lib/runtime-events.ts`.

### Root cause (tracer, 1-2 sentences)

`waitForRuntimeEvent`'s IIFE awaits `followRuntimeEvents`, which internally drains before returning. When the awaited event matches during that initial drain, `finish()` resolves the outer Promise with `handle` still `null`; the IIFE then assigns the handle (active 250ms poller) but `settled === true`, so `handle.stop()` never runs. The leaked poller calls `listRuntimeEvents → getConnection()` for the rest of the test process and races `resetConnection()` calls from later test files, occasionally landing a `CONNECTION_ENDED` rejection on a real test's `mailbox.send()`.

### Changes (one file: `src/lib/runtime-events.ts`)

1. **`waitForRuntimeEvent`**: handle the late-handle case (stop the just-arrived handle when `settled` was already flipped during drain), and `try/catch` the IIFE so `followRuntimeEvents` exceptions reject the outer Promise instead of becoming unhandled rejections.
2. **`followRuntimeEvents.stop()`**: wrap `await drainChain` and `await listener.unlisten()` in `try/catch` so `stop()` never throws `CONNECTION_ENDED`. Mirrors the swallow pattern at `src/lib/audit.ts:170-174`.

### Relation to upstream `74aaa022 fix(db): null sqlClient before ending`

Related but incomplete. `74aaa022` narrowed the window where `resetConnection()` would expose torn-down clients via `getConnection()`, but it does not cover `sql` references already captured into closures by leaked pollers. This fix removes the leak source, so even captured-then-stale references stop being created.

### Regression coverage

Regression test for the rare race is **staged follow-up** — would require forced-race fixtures (controllable `resetConnection()` timing relative to an in-flight `followRuntimeEvents` poll). Out of scope for this minimal correctness fix.

## Test plan

- [x] `bun test src/lib/runtime-events.test.ts` — 7 pass / 0 fail
- [x] `bun test src/lib/runtime-events.test.ts src/term-commands/log.test.ts src/lib/mailbox.test.ts` — 21 pass / 0 fail
- [x] `bun run check` — 2581 pass / 0 fail
- [x] Full suite x5: 4 clean, 1 unrelated `SpawnTargetPicker > Esc` flake (confirmed pre-existing on baseline `origin/dev`: 3/8 fails on the same TUI test without this patch)
- [x] Scope confirmed: 1 file touched (`src/lib/runtime-events.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)