### PR TITLE
fix(otel): await server.stop(true) to release port in stopOtelReceiver

### DIFF
--- a/src/genie.ts
+++ b/src/genie.ts
@@ -697,7 +697,7 @@ if (sessionIdx !== -1 && sessionIdx + 1 < args.length) {
     try {
       await program.parseAsync(process.argv);
     } finally {
-      stopOtelReceiver();
+      await stopOtelReceiver().catch(() => {});
       await shutdownDb().catch(() => {});
     }
   }
@@ -708,7 +708,7 @@ if (sessionIdx !== -1 && sessionIdx + 1 < args.length) {
     if (process.env.GENIE_PROFILE_DB) console.error(`[profile] parseAsync=${Date.now() - _cmdStart}ms`);
   } finally {
     const _shutStart = Date.now();
-    stopOtelReceiver();
+    await stopOtelReceiver().catch(() => {});
     await shutdownDb().catch(() => {});
     if (process.env.GENIE_PROFILE_DB) console.error(`[profile] shutdown=${Date.now() - _shutStart}ms`);
   }

--- a/src/lib/otel-receiver.test.ts
+++ b/src/lib/otel-receiver.test.ts
@@ -11,8 +11,8 @@ describe('otel-receiver', () => {
     process.env.GENIE_OTEL_PORT = String(57000 + Math.floor(Math.random() * 7000));
   });
 
-  afterEach(() => {
-    stopOtelReceiver();
+  afterEach(async () => {
+    await stopOtelReceiver();
     if (origPort !== undefined) process.env.GENIE_OTEL_PORT = origPort;
     else process.env.GENIE_OTEL_PORT = undefined;
   });
@@ -41,15 +41,17 @@ describe('otel-receiver', () => {
   });
 
   test('stopOtelReceiver stops the server', async () => {
-    await startOtelReceiver();
+    const started = await startOtelReceiver();
+    expect(started).toBe(true);
     expect(isOtelReceiverRunning()).toBe(true);
 
-    stopOtelReceiver();
+    await stopOtelReceiver();
     expect(isOtelReceiverRunning()).toBe(false);
   });
 
   test('POST /v1/logs returns 200', async () => {
-    await startOtelReceiver();
+    const started = await startOtelReceiver();
+    expect(started).toBe(true);
     const port = getOtelPort();
 
     const res = await fetch(`http://127.0.0.1:${port}/v1/logs`, {
@@ -83,7 +85,8 @@ describe('otel-receiver', () => {
   });
 
   test('POST /v1/metrics returns 200', async () => {
-    await startOtelReceiver();
+    const started = await startOtelReceiver();
+    expect(started).toBe(true);
     const port = getOtelPort();
 
     const res = await fetch(`http://127.0.0.1:${port}/v1/metrics`, {
@@ -116,7 +119,8 @@ describe('otel-receiver', () => {
   });
 
   test('POST /v1/logs handles empty payload', async () => {
-    await startOtelReceiver();
+    const started = await startOtelReceiver();
+    expect(started).toBe(true);
     const port = getOtelPort();
 
     const res = await fetch(`http://127.0.0.1:${port}/v1/logs`, {
@@ -129,7 +133,8 @@ describe('otel-receiver', () => {
   });
 
   test('GET /health returns ok', async () => {
-    await startOtelReceiver();
+    const started = await startOtelReceiver();
+    expect(started).toBe(true);
     const port = getOtelPort();
 
     const res = await fetch(`http://127.0.0.1:${port}/health`);
@@ -139,7 +144,8 @@ describe('otel-receiver', () => {
   });
 
   test('unknown route returns 404', async () => {
-    await startOtelReceiver();
+    const started = await startOtelReceiver();
+    expect(started).toBe(true);
     const port = getOtelPort();
 
     const res = await fetch(`http://127.0.0.1:${port}/v1/unknown`, {

--- a/src/lib/otel-receiver.ts
+++ b/src/lib/otel-receiver.ts
@@ -370,10 +370,17 @@ export async function startOtelReceiver(): Promise<boolean> {
 
 /**
  * Stop the OTel receiver. Used in tests and graceful shutdown.
+ *
+ * Awaits `server.stop(true)` so the listening port is fully released before
+ * the next start attempt. Without the await, back-to-back start/stop cycles
+ * in tests (afterEach → next beforeEach) could race on the TCP port and
+ * produce EADDRINUSE when parallel tests randomly collide within the
+ * 7000-port window (57000-63999), which caused the intermittent push-event
+ * CI failure on `POST /v1/logs handles empty payload`.
  */
-export function stopOtelReceiver(): void {
+export async function stopOtelReceiver(): Promise<void> {
   if (server) {
-    server.stop();
+    await server.stop(true);
     server = null;
   }
 }


### PR DESCRIPTION
## Summary

Fixes the intermittent push-event CI failure on `otel-receiver > POST /v1/logs handles empty payload`.

**Root cause:** `stopOtelReceiver()` called `server.stop()` without awaiting the returned Promise. State was nulled synchronously, but the TCP port lingered. The next test's `beforeEach` picked a random port from the 7000-slot window (57000-63999); when the window was wide enough the previous suite's test and the next start raced on the same port, `startOtelReceiver()` hit EADDRINUSE, caught it as non-fatal, and silently returned `false`. `isOtelReceiverRunning()` stayed `true` (server variable still set from a prior run in pathological ordering), so downstream `fetch()` calls reached the wrong endpoint and returned unexpected status codes.

**Fix:**
- `stopOtelReceiver()` is now `async` and awaits `server.stop(true)` (force close) — see `src/lib/otel-receiver.ts:374-386`.
- `src/genie.ts:700,711` callers now `await stopOtelReceiver().catch(() => {})` in their finally blocks.
- `src/lib/otel-receiver.test.ts` `afterEach` awaits stop.
- Every `await startOtelReceiver()` call site gets `expect(started).toBe(true)` so future silent-false regressions surface immediately.

## Test plan

- [x] `bun test src/lib/otel-receiver.test.ts` — 9/9 pass (5 consecutive runs)
- [x] `bun test` — 2581/2581 pass
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — no new warnings on changed files
- [x] Pre-push hook passes

## Context

Blocks the auto-version bump that publishes PR #1175 (topology fix for auto-team-of-one) to the `@automagik/genie@next` dist-tag. Once this merges and CI goes green, the publish pipeline resumes and the team-of-one-auto-create wish can complete G-C verification.