### PR TITLE
fix(native-teams): unregisterNativeMember actually removes the entry

### DIFF
--- a/src/lib/claude-native-teams.test.ts
+++ b/src/lib/claude-native-teams.test.ts
@@ -24,6 +24,7 @@ import {
   resolveNativeMemberName,
   resolveOrMintLeadSessionId,
   sanitizeTeamName,
+  unregisterNativeMember,
   writeNativeInbox,
 } from './claude-native-teams.js';
 
@@ -294,6 +295,75 @@ describe('discoverClaudeParentSessionId', () => {
 
     const result = await discoverClaudeParentSessionId(cwd);
     expect(result).toBe('historical-lead');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// unregisterNativeMember — removes entry from members array
+// See automagik-dev/genie#1179: prior impl marked isActive=false and left
+// stale entries in the config, which silently routed new spawns and messages
+// to dead workers via resolveNativeMemberName and findTeamsContainingAgent.
+// ---------------------------------------------------------------------------
+
+describe('unregisterNativeMember', () => {
+  test('removes the member entry entirely (not just isActive flip)', async () => {
+    await createTestTeamConfig('my-team', [
+      { agentId: 'engineer@my-team', name: 'engineer' },
+      { agentId: 'reviewer@my-team', name: 'reviewer' },
+    ]);
+
+    await unregisterNativeMember('my-team', 'engineer');
+
+    const config = await loadConfig('my-team');
+    expect(config).not.toBeNull();
+    expect(config!.members).toHaveLength(1);
+    expect(config!.members[0].name).toBe('reviewer');
+    expect(config!.members.some((m) => m.name === 'engineer')).toBe(false);
+  });
+
+  test('is a no-op when the member does not exist', async () => {
+    await createTestTeamConfig('my-team', [{ agentId: 'engineer@my-team', name: 'engineer' }]);
+
+    await unregisterNativeMember('my-team', 'nonexistent');
+
+    const config = await loadConfig('my-team');
+    expect(config!.members).toHaveLength(1);
+    expect(config!.members[0].name).toBe('engineer');
+  });
+
+  test('is a no-op when the team does not exist', async () => {
+    // Should not throw; should not create the config.
+    await expect(unregisterNativeMember('nonexistent-team', 'engineer')).resolves.toBeUndefined();
+    const config = await loadConfig('nonexistent-team');
+    expect(config).toBeNull();
+  });
+
+  test('findTeamsContainingAgent stops matching after unregister (regression)', async () => {
+    // Reproducer for #1179: before the fix, an unregistered member still
+    // matched `findTeamsContainingAgent`, routing spawn-team resolution to
+    // the wrong team.
+    await createTestTeamConfig('team-a', [{ agentId: 'simone@team-a', name: 'simone' }]);
+    await createTestTeamConfig('team-b', [{ agentId: 'simone@team-b', name: 'simone' }]);
+
+    expect(await findTeamsContainingAgent('simone')).toEqual(expect.arrayContaining(['team-a', 'team-b']));
+
+    await unregisterNativeMember('team-a', 'simone');
+
+    const matches = await findTeamsContainingAgent('simone');
+    expect(matches).toEqual(['team-b']);
+  });
+
+  test('resolveNativeMemberName stops resolving after unregister (regression)', async () => {
+    // Before the fix, the active→inactive fallback in resolveNativeMemberName
+    // would still return the unregistered member's name, causing messages
+    // addressed to that name to be silently delivered to a dead worker.
+    await createTestTeamConfig('my-team', [{ agentId: 'engineer@my-team', name: 'engineer' }]);
+
+    expect(await resolveNativeMemberName('my-team', 'engineer')).toBe('engineer');
+
+    await unregisterNativeMember('my-team', 'engineer');
+
+    expect(await resolveNativeMemberName('my-team', 'engineer')).toBeNull();
   });
 });
 

--- a/src/lib/claude-native-teams.ts
+++ b/src/lib/claude-native-teams.ts
@@ -488,7 +488,19 @@ export async function registerNativeMember(
 
 /**
  * Unregister a member from the native team config.json.
- * Marks them as inactive rather than removing (preserves history).
+ *
+ * Removes the member entry from the `members` array. The prior implementation
+ * marked `isActive: false` "to preserve history", but no call site ever
+ * consults inactive members for history — meanwhile two active readers
+ * (`resolveNativeMemberName`'s active→inactive fallback and
+ * `findTeamsContainingAgent`'s team-resolver tier 5) silently pick up stale
+ * entries, routing messages and spawn-team resolution to the wrong worker.
+ *
+ * The per-member inbox at `~/.claude/teams/<team>/inboxes/<name>.json` is
+ * cleared by `clearNativeInbox` (called alongside this function in the kill
+ * path), so there's no residual state worth preserving.
+ *
+ * See automagik-dev/genie#1179.
  */
 export async function unregisterNativeMember(teamName: string, agentName: string): Promise<void> {
   const config = await loadConfig(teamName);
@@ -497,10 +509,9 @@ export async function unregisterNativeMember(teamName: string, agentName: string
   const sanitized = sanitizeTeamName(teamName);
   const agentId = `${sanitizeTeamName(agentName)}@${sanitized}`;
 
-  const member = config.members.find((m) => m.agentId === agentId);
-  if (member) {
-    member.isActive = false;
-  }
+  const before = config.members.length;
+  config.members = config.members.filter((m) => m.agentId !== agentId);
+  if (config.members.length === before) return; // no-op: no entry matched
 
   await saveConfig(teamName, config);
 }


### PR DESCRIPTION
Closes #1179.

## Summary

\`unregisterNativeMember\` marked \`isActive: false\` and left the member in the array. No reader consults inactive entries for history, but two active readers silently pick them up:

1. **\`resolveNativeMemberName\`** has an explicit active→inactive fallback (see existing test \"prefers active members over inactive\"). A stale entry from a prior team membership silently claims messages addressed by name.
2. **\`findTeamsContainingAgent\`** — the spawn-resolver tier 5 from #1172 — matches members by \`name\` regardless of \`isActive\`. A stale entry routes future spawns into the wrong team.

Observed live: \`~/.claude/teams/genie/config.json\` had 5 members after a spawn-storm — 2 real plus 3 killed workers all \`isActive: false\`. Every bare \`genie spawn <name>\` hit the stale fallback chain before resolving. Manually purging the file stopped the ghost \`teammate-message\` announcements.

## Fix

\`unregisterNativeMember\` now removes the member from the array. The per-member inbox at \`~/.claude/teams/<team>/inboxes/<name>.json\` is already cleared by \`clearNativeInbox\` (called sibling to this in the kill path), so no residual state is worth preserving.

## Tests

5 new cases in \`claude-native-teams.test.ts\`:

- \`removes the member entry entirely (not just isActive flip)\`
- \`is a no-op when the member does not exist\`
- \`is a no-op when the team does not exist\`
- \`findTeamsContainingAgent stops matching after unregister (regression)\`
- \`resolveNativeMemberName stops resolving after unregister (regression)\`

The existing \`'prefers active members over inactive'\` test still passes — \`resolveNativeMemberName\`'s fallback logic is unchanged; it just never fires because unregistered members are no longer in the array.

Full suite: **2601 pass / 0 fail**.

## Test plan

- [x] Unit tests cover the 5 cases above
- [x] Full repo test suite passes locally
- [ ] CI on \`dev\` target green
- [ ] Manual verification: spawn a worker, kill it, inspect \`~/.claude/teams/<team>/config.json\` — the worker's entry is gone (previously was \`isActive: false\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)