### PR TITLE
fix(scheduler): exclude NULL-state + dead-pane zombies from resume concurrency cap

### DIFF
--- a/src/__tests__/resume.test.ts
+++ b/src/__tests__/resume.test.ts
@@ -254,11 +254,17 @@ describe.skipIf(!DB_AVAILABLE)('resume', () => {
   });
 
   test('concurrency cap: blocks resume when at max workers', async () => {
+    // NOTE (auto-resume-zombie-cap fix): cap filter now verifies pane
+    // liveness — "active workers" semantically require live panes, so we
+    // override the shared mock (isPaneAlive=false) to reflect that.
     const agent = makeWorker();
     const activeWorkers: WorkerInfo[] = Array.from({ length: 5 }, (_, i) =>
       makeWorker({ id: `active-${i}`, state: 'working' }),
     );
-    const { deps, logs } = createMockDeps({ listWorkers: async () => activeWorkers });
+    const { deps, logs } = createMockDeps({
+      listWorkers: async () => activeWorkers,
+      isPaneAlive: async () => true,
+    });
 
     const result = await attemptAgentResume(deps, defaultConfig, agent);
 

--- a/src/lib/__tests__/auto-resume-zombie-cap.test.ts
+++ b/src/lib/__tests__/auto-resume-zombie-cap.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Regression tests for auto-resume zombie-cap bug.
+ *
+ * Root cause (tracer, HIGH confidence): the concurrency-cap filter in
+ * `attemptAgentResume` counted NULL-state identity records and dead-pane
+ * zombies toward `activeCount`, inflating it to 142 on an observed
+ * machine (vs maxConcurrent=5). Every auto-resume attempt short-circuited
+ * with `reason=concurrency_cap` BEFORE the counter increment, leaving
+ * error-state agents stuck at 0/3 resume_attempts forever.
+ *
+ * Also covers:
+ *   - Change #2: periodic resume sweep (startup-only retry was insufficient)
+ *   - Change #3: `reconcileStaleSpawns` extended to flip idle+dead-pane
+ *     rows to `error` (previously only handled `state='spawning'`).
+ *
+ * Structural parallel to zombie-spawns.test.ts, extended from `spawning`
+ * to include `idle|working|permission|question` + NULL + dead-pane.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Agent, AgentState } from '../agent-registry.js';
+import {
+  type LogEntry,
+  type SchedulerConfig,
+  type SchedulerDeps,
+  type WorkerInfo,
+  attemptAgentResume,
+  runAgentRecoveryPass,
+} from '../scheduler-daemon.js';
+
+// ---------------------------------------------------------------------------
+// Helpers (mirrored from zombie-spawns.test.ts)
+// ---------------------------------------------------------------------------
+
+const defaultConfig: SchedulerConfig = {
+  maxConcurrent: 5,
+  pollIntervalMs: 30_000,
+  maxJitterMs: 30_000,
+  jitterThreshold: 3,
+  heartbeatIntervalMs: 60_000,
+  orphanCheckIntervalMs: 300_000,
+  deadHeartbeatThreshold: 2,
+  leaseRecoveryIntervalMs: 60_000,
+};
+
+function makeWorker(overrides: Partial<WorkerInfo> = {}): WorkerInfo {
+  return {
+    id: 'test-agent',
+    paneId: '%42',
+    state: 'error',
+    claudeSessionId: 'session-abc',
+    autoResume: true,
+    resumeAttempts: 0,
+    maxResumeAttempts: 3,
+    ...overrides,
+  };
+}
+
+function createMockSql() {
+  const sql: any = (_strings: TemplateStringsArray, ..._values: unknown[]) => [];
+  sql.begin = async (fn: (tx: typeof sql) => Promise<unknown>) => fn(sql);
+  sql.listen = async () => {};
+  sql.end = async () => {};
+  return sql;
+}
+
+function createMockDeps(overrides: Partial<SchedulerDeps> = {}) {
+  const logs: LogEntry[] = [];
+  const agentUpdates: { id: string; updates: Partial<Agent> }[] = [];
+  const resumedIds: string[] = [];
+  let idCounter = 0;
+
+  const deps: SchedulerDeps = {
+    getConnection: async () => createMockSql(),
+    spawnCommand: async () => ({ pid: 12345 }),
+    log: (entry) => logs.push(entry),
+    generateId: () => `test-id-${++idCounter}`,
+    now: () => new Date('2026-04-17T12:00:00Z'),
+    sleep: async () => {},
+    jitter: (maxMs) => Math.floor(maxMs / 2),
+    isPaneAlive: async () => false,
+    listWorkers: async () => [],
+    countTmuxSessions: async () => 0,
+    publishEvent: async () => {},
+    resumeAgent: async (id) => {
+      resumedIds.push(id);
+      return true;
+    },
+    updateAgent: async (id, u) => {
+      agentUpdates.push({ id, updates: u });
+    },
+    ...overrides,
+  };
+
+  return { deps, logs, agentUpdates, resumedIds };
+}
+
+// ---------------------------------------------------------------------------
+// Change #1 — concurrency cap excludes NULL-state + dead-pane zombies
+// ---------------------------------------------------------------------------
+
+describe('Change #1: concurrency cap excludes NULL-state + dead-pane rows', () => {
+  test('50 NULL-state + 30 dead-pane idle + 10 live working + 10 error yields activeCount=10', async () => {
+    // Mirror of the live-production observation: inflated `workers` list
+    // where only the 10 live-working rows should consume cap slots.
+    const liveWorkers: WorkerInfo[] = [
+      // 50 identity records with state=NULL (from findOrCreateAgent)
+      ...Array.from({ length: 50 }, (_, i) =>
+        makeWorker({
+          id: `identity-${i}`,
+          paneId: '',
+          state: null as unknown as AgentState,
+        }),
+      ),
+      // 30 dead-pane idle zombies (state='idle' but pane is dead)
+      ...Array.from({ length: 30 }, (_, i) =>
+        makeWorker({
+          id: `zombie-${i}`,
+          paneId: `%${1000 + i}`,
+          state: 'idle',
+        }),
+      ),
+      // 10 live-working agents (state='working', pane alive)
+      ...Array.from({ length: 10 }, (_, i) =>
+        makeWorker({
+          id: `live-${i}`,
+          paneId: `%${2000 + i}`,
+          state: 'working',
+        }),
+      ),
+      // 10 error-state agents (excluded by existing terminal-state filter)
+      ...Array.from({ length: 10 }, (_, i) =>
+        makeWorker({
+          id: `error-${i}`,
+          paneId: `%${3000 + i}`,
+          state: 'error',
+        }),
+      ),
+    ];
+
+    // isPaneAlive returns true only for panes in 2000-2999 (the live ones)
+    const { deps, logs } = createMockDeps({
+      listWorkers: async () => liveWorkers,
+      isPaneAlive: async (paneId: string) => {
+        const num = Number.parseInt(paneId.slice(1), 10);
+        return num >= 2000 && num < 3000;
+      },
+    });
+
+    // Resume attempt with cap=5 — before the fix this would skip
+    // (active=100, max=5). After the fix, activeCount=10 so the cap
+    // DOES apply and we expect 'skipped' with active=10 (not 100).
+    const agent = makeWorker({ id: 'needs-resume', state: 'error' });
+    const result = await attemptAgentResume(deps, defaultConfig, agent);
+
+    expect(result).toBe('skipped');
+    const skip = logs.find((l) => l.event === 'agent_resume_skipped');
+    expect(skip?.reason).toBe('concurrency_cap');
+    // Critical: active=10 proves NULL + dead-pane rows were excluded.
+    // Pre-fix would have shown active=90 (50 NULL + 30 idle + 10 working).
+    expect(skip?.active).toBe(10);
+  });
+
+  test('with 10 live-working rows and cap=20, resume proceeds', async () => {
+    const liveWorkers: WorkerInfo[] = Array.from({ length: 10 }, (_, i) =>
+      makeWorker({ id: `live-${i}`, paneId: `%${i}`, state: 'working' }),
+    );
+    const { deps, resumedIds } = createMockDeps({
+      listWorkers: async () => liveWorkers,
+      isPaneAlive: async () => true,
+    });
+
+    const cfg: SchedulerConfig = { ...defaultConfig, maxConcurrent: 20 };
+    const agent = makeWorker({ id: 'new-agent', state: 'error' });
+    const result = await attemptAgentResume(deps, cfg, agent);
+
+    expect(result).toBe('resumed');
+    expect(resumedIds).toContain('new-agent');
+  });
+
+  test('142-NULL scenario (production match): activeCount=0, resume proceeds', async () => {
+    // Exact reproduction of felipe's machine: 83 NULL + 59 idle dead-pane
+    // all excluded → activeCount=0 → resume is NOT blocked by cap.
+    const workers: WorkerInfo[] = [
+      ...Array.from({ length: 83 }, (_, i) =>
+        makeWorker({ id: `null-${i}`, paneId: '', state: null as unknown as AgentState }),
+      ),
+      ...Array.from({ length: 59 }, (_, i) =>
+        makeWorker({ id: `idle-dead-${i}`, paneId: `%${5000 + i}`, state: 'idle' }),
+      ),
+    ];
+    const { deps, resumedIds } = createMockDeps({
+      listWorkers: async () => workers,
+      isPaneAlive: async () => false, // all panes dead
+    });
+
+    const agent = makeWorker({ id: 'felipe-stuck', state: 'error' });
+    const result = await attemptAgentResume(deps, defaultConfig, agent);
+
+    expect(result).toBe('resumed');
+    expect(resumedIds).toContain('felipe-stuck');
+  });
+
+  test('tmux-unreachable is conservative: counts unknown-liveness rows toward cap', async () => {
+    // When isPaneAlive throws (tmux blip / transient failure), we must not
+    // silently under-count active slots — otherwise we'd over-spawn during
+    // a tmux outage. Verify the catch-block keeps the row in activeCount.
+    const workers: WorkerInfo[] = Array.from({ length: 5 }, (_, i) =>
+      makeWorker({ id: `working-${i}`, paneId: `%${i}`, state: 'working' }),
+    );
+    const { deps, logs } = createMockDeps({
+      listWorkers: async () => workers,
+      isPaneAlive: async () => {
+        throw new Error('tmux unreachable');
+      },
+    });
+
+    const agent = makeWorker({ id: 'overflow', state: 'error' });
+    const result = await attemptAgentResume(deps, defaultConfig, agent);
+
+    expect(result).toBe('skipped');
+    const skip = logs.find((l) => l.event === 'agent_resume_skipped');
+    expect(skip?.reason).toBe('concurrency_cap');
+    expect(skip?.active).toBe(5);
+  });
+
+  test('synthetic paneIds (non-tmux) skip the liveness check', async () => {
+    // Non-tmux transports use paneIds like 'sdk', 'inline', '' — those
+    // don't match the %\d+ pattern and must NOT be subjected to
+    // isPaneAlive (which is tmux-specific).
+    const workers: WorkerInfo[] = [
+      makeWorker({ id: 'sdk-worker', paneId: 'sdk', state: 'working' }),
+      makeWorker({ id: 'inline-worker', paneId: 'inline', state: 'working' }),
+    ];
+    let paneCalls = 0;
+    const { deps } = createMockDeps({
+      listWorkers: async () => workers,
+      isPaneAlive: async () => {
+        paneCalls++;
+        return false;
+      },
+    });
+
+    const agent = makeWorker({ id: 'probe', state: 'error' });
+    await attemptAgentResume(deps, defaultConfig, agent);
+
+    // isPaneAlive should not be called for synthetic paneIds
+    expect(paneCalls).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Change #2 — periodic resume sweep (not just startup)
+// ---------------------------------------------------------------------------
+
+describe('Change #2: periodic resume sweep for error-state agents', () => {
+  test('runAgentRecoveryPass is exported for periodic invocation', () => {
+    // The fix requires this function to be callable from a setInterval tick,
+    // so it must be exported from scheduler-daemon.
+    expect(typeof runAgentRecoveryPass).toBe('function');
+  });
+
+  test('runAgentRecoveryPass attempts resume for error-state agents with dead panes', async () => {
+    const workers: WorkerInfo[] = [
+      // Error-state agent with dead pane — should be resumed
+      makeWorker({ id: 'dead-error', paneId: '%99', state: 'error', claudeSessionId: 'sess-1' }),
+      // Done agent — should NOT be touched
+      makeWorker({ id: 'finished', paneId: '%98', state: 'done', claudeSessionId: 'sess-2' }),
+      // Suspended agent — should NOT be touched (explicit user intent)
+      makeWorker({ id: 'paused', paneId: '%97', state: 'suspended', claudeSessionId: 'sess-3' }),
+    ];
+    const { deps, resumedIds } = createMockDeps({
+      listWorkers: async () => workers,
+      isPaneAlive: async () => false, // all panes dead
+    });
+
+    await runAgentRecoveryPass(deps, 'daemon-test', defaultConfig);
+
+    expect(resumedIds).toContain('dead-error');
+    expect(resumedIds).not.toContain('finished');
+    expect(resumedIds).not.toContain('paused');
+  });
+
+  test('daemon startup wires the resume timer alongside lease recovery', () => {
+    // Source-level assertion: the startAgentResumeTimer must exist and
+    // be invoked in the daemon start flow. Without this, error-state
+    // agents created after daemon startup never retry.
+    const source = readFileSync(join(__dirname, '..', 'scheduler-daemon.ts'), 'utf-8');
+    expect(source).toContain('startAgentResumeTimer');
+    expect(source).toContain('agentResumeTimer = startAgentResumeTimer');
+    // Timer must call runAgentRecoveryPass
+    expect(source).toContain('await runAgentRecoveryPass(d, dId, cfg)');
+    // And must be cleaned up on stop
+    expect(source).toContain('if (agentResumeTimer)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Change #3 — reconcileStaleSpawns GCs idle+dead-pane zombies
+// ---------------------------------------------------------------------------
+
+describe('Change #3: reconcileStaleSpawns GCs dead-pane zombies in active states', () => {
+  test('source includes third-pass reconciliation for active states', () => {
+    const source = readFileSync(join(__dirname, '..', 'agent-registry.ts'), 'utf-8');
+
+    // Third pass selects active-state rows whose pane looks like a real
+    // tmux pane. Those with dead panes are flipped to 'error'.
+    expect(source).toContain("state IN ('idle', 'working', 'permission', 'question')");
+    // Uses the Postgres regex operator to match tmux pane IDs
+    expect(source).toContain("pane_id ~ '^%[0-9]+$'");
+    // Audit event uses a distinct reason for debugging
+    expect(source).toContain('dead_pane_zombie');
+    // Still calls isPaneAlive for authoritative liveness check
+    expect(source).toContain('isPaneAlive(row.pane_id)');
+    // Preserves previous state in the audit payload for forensics
+    expect(source).toContain('previous_state: prevState');
+  });
+
+  test('daemon periodic timer invokes reconcileStaleSpawns before resume pass', () => {
+    // The GC must run BEFORE runAgentRecoveryPass so the resume attempts
+    // see a clean worker set (zombies already flipped to 'error').
+    const source = readFileSync(join(__dirname, '..', 'scheduler-daemon.ts'), 'utf-8');
+    expect(source).toContain("import('./agent-registry.js')");
+    expect(source).toContain('await reconcileStaleSpawns()');
+    // Timer body must call the GC helper before the resume pass.
+    const timerStart = source.indexOf('function startAgentResumeTimer');
+    expect(timerStart).toBeGreaterThan(-1);
+    const afterTimerStart = source.slice(timerStart);
+    const nextFnIdx = afterTimerStart.slice(1).search(/\n\s{0,4}function\s/);
+    const timerBody = nextFnIdx > 0 ? afterTimerStart.slice(0, nextFnIdx) : afterTimerStart;
+    const reconcileIdx = timerBody.indexOf('reconcileDeadPaneZombies(d)');
+    const resumeCallIdx = timerBody.indexOf('runAgentRecoveryPass(d, dId, cfg)');
+    expect(reconcileIdx).toBeGreaterThan(-1);
+    expect(resumeCallIdx).toBeGreaterThan(reconcileIdx);
+  });
+
+  test('third pass uses conditional UPDATE to avoid racing with live state changes', () => {
+    // The UPDATE is guarded by `WHERE id = ? AND state = <previousState>`
+    // so if another process transitioned the row between SELECT and UPDATE
+    // (e.g. agent finished work, user resumed), we don't overwrite it.
+    const source = readFileSync(join(__dirname, '..', 'agent-registry.ts'), 'utf-8');
+    expect(source).toContain('WHERE id = ${row.id} AND state = ${prevState}');
+  });
+});

--- a/src/lib/__tests__/zombie-spawns.test.ts
+++ b/src/lib/__tests__/zombie-spawns.test.ts
@@ -134,12 +134,18 @@ describe('concurrency cap excludes spawning agents', () => {
   });
 
   test('actually-working agents still enforce the concurrency cap', async () => {
-    // 5 genuinely working agents should still block resume
+    // 5 genuinely working agents should still block resume.
+    // NOTE (auto-resume-zombie-cap fix): the cap filter now also verifies
+    // tmux pane liveness — "actually working" semantically requires a live
+    // pane, so we override the shared mock default (isPaneAlive=false) to
+    // reflect reality. Without this override the test would false-negative
+    // by treating 5 state='working' rows as dead-pane zombies.
     const working: WorkerInfo[] = Array.from({ length: 5 }, (_, i) =>
       makeWorker({ id: `worker-${i}`, state: 'working' }),
     );
     const { deps, logs } = createMockDeps({
       listWorkers: async () => working,
+      isPaneAlive: async () => true,
     });
 
     const agent = makeWorker({ id: 'overflow-agent', state: 'error' });

--- a/src/lib/agent-registry.test.ts
+++ b/src/lib/agent-registry.test.ts
@@ -338,6 +338,94 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
       const reset = await reconcileStaleSpawns(2);
       expect(reset).not.toContain(agent.id);
     });
+
+    test('flips idle+dead-pane rows to error (auto-resume-zombie-cap fix)', async () => {
+      // This is Change #3 of the auto-resume-zombie-cap fix: idle/working
+      // rows whose tmux pane is dead must be flipped to 'error' so they
+      // stop inflating the scheduler concurrency cap.
+      const { isPaneAlive } = await import('./tmux.js');
+      try {
+        await isPaneAlive('%1');
+      } catch {
+        return; // tmux server unreachable — nothing to assert
+      }
+
+      const oldChange = new Date(Date.now() - 5_000).toISOString();
+      // pane %42 does not exist → isPaneAlive returns false
+      await register(
+        makeAgent({
+          id: 'zombie-idle',
+          paneId: '%42',
+          state: 'idle',
+          startedAt: oldChange,
+          lastStateChange: oldChange,
+        }),
+      );
+      await register(
+        makeAgent({
+          id: 'zombie-working',
+          paneId: '%43',
+          state: 'working',
+          startedAt: oldChange,
+          lastStateChange: oldChange,
+        }),
+      );
+
+      const reset = await reconcileStaleSpawns(2);
+      expect(reset).toContain('zombie-idle');
+      expect(reset).toContain('zombie-working');
+
+      const a1 = await get('zombie-idle');
+      expect(a1!.state).toBe('error');
+      const a2 = await get('zombie-working');
+      expect(a2!.state).toBe('error');
+    });
+
+    test('does not touch idle rows whose pane is still alive', async () => {
+      // Only dead-pane rows should be GC'd. Live-pane idle rows are
+      // genuinely idle (e.g. between tasks) and must not be touched.
+      // Since we can't easily mock a live pane in this DB test, we use
+      // a recent last_state_change (under the threshold) as a proxy —
+      // the reconciler must also respect the time threshold.
+      const recent = new Date().toISOString();
+      await register(
+        makeAgent({
+          id: 'fresh-idle',
+          paneId: '%99',
+          state: 'idle',
+          startedAt: recent,
+          lastStateChange: recent,
+        }),
+      );
+
+      const reset = await reconcileStaleSpawns(2);
+      expect(reset).not.toContain('fresh-idle');
+
+      const a = await get('fresh-idle');
+      expect(a!.state).toBe('idle');
+    });
+
+    test('skips non-tmux (synthetic) paneIds in dead-pane pass', async () => {
+      // SDK/inline transports have paneIds like 'sdk', 'inline', '' — the
+      // regex `^%[0-9]+$` must NOT match those, so they are skipped here
+      // (their liveness is tracked by executor state, not tmux).
+      const oldChange = new Date(Date.now() - 5_000).toISOString();
+      await register(
+        makeAgent({
+          id: 'sdk-worker',
+          paneId: 'sdk',
+          state: 'working',
+          startedAt: oldChange,
+          lastStateChange: oldChange,
+        }),
+      );
+
+      const reset = await reconcileStaleSpawns(2);
+      expect(reset).not.toContain('sdk-worker');
+
+      const a = await get('sdk-worker');
+      expect(a!.state).toBe('working');
+    });
   });
 
   describe('templates', () => {

--- a/src/lib/agent-registry.ts
+++ b/src/lib/agent-registry.ts
@@ -239,6 +239,13 @@ export async function list(): Promise<Agent[]> {
 /**
  * Reconcile stale spawns: reset agents stuck in 'spawning' state
  * with no pane_id for longer than the threshold back to 'error'.
+ *
+ * Also reconciles dead-pane zombies — rows in active states (`idle`,
+ * `working`, `permission`, `question`) whose tmux pane no longer exists.
+ * Those rows otherwise accumulate forever and inflate the scheduler's
+ * concurrency cap (tracer observed activeCount=142 on one machine),
+ * silently blocking every auto-resume attempt.
+ *
  * Returns the IDs of agents that were reset.
  *
  * @param thresholdSeconds - How long an agent must be stuck before reset (default: 60)
@@ -287,6 +294,49 @@ export async function reconcileStaleSpawns(thresholdSeconds = 60): Promise<strin
             reason: 'stale_spawn_dead_pane',
           }).catch(() => {});
           resetIds.push(row.id);
+        }
+      } catch {
+        // TmuxUnreachableError or other — skip this agent, don't mark as dead
+        // when we can't verify pane status
+      }
+    }
+
+    // Third pass: dead-pane zombies in active (non-spawning) states.
+    // Rows whose state is idle/working/permission/question but whose tmux
+    // pane no longer exists (e.g. user killed the session, machine rebooted,
+    // process crashed without state update). These count toward the resume
+    // concurrency cap and permanently block auto-resume once accumulated.
+    // Only rows matching the tmux pane pattern `%\d+` are candidates —
+    // synthetic paneIds ('sdk', 'inline', etc.) are non-tmux transports
+    // with their own liveness source and must not be touched here.
+    const activeDeadCandidates = await sql<{ id: string; pane_id: string; state: string }[]>`
+      SELECT id, pane_id, state FROM agents
+      WHERE state IN ('idle', 'working', 'permission', 'question')
+        AND pane_id ~ '^%[0-9]+$'
+        AND last_state_change < now() - interval '1 second' * ${thresholdSeconds}
+    `;
+    for (const row of activeDeadCandidates) {
+      try {
+        const alive = await isPaneAlive(row.pane_id);
+        if (!alive) {
+          const prevState = row.state;
+          const updated = await sql<{ id: string }[]>`
+            UPDATE agents
+            SET state = 'error', last_state_change = now()
+            WHERE id = ${row.id} AND state = ${prevState}
+            RETURNING id
+          `;
+          if (updated.length > 0) {
+            console.error(
+              `[reconcile] Reset zombie agent ${row.id} (dead pane ${row.pane_id}) from ${prevState} → error`,
+            );
+            recordAuditEvent('worker', row.id, 'state_changed', 'reconciler', {
+              state: 'error',
+              reason: 'dead_pane_zombie',
+              previous_state: prevState,
+            }).catch(() => {});
+            resetIds.push(row.id);
+          }
         }
       } catch {
         // TmuxUnreachableError or other — skip this agent, don't mark as dead

--- a/src/lib/scheduler-daemon.ts
+++ b/src/lib/scheduler-daemon.ts
@@ -730,8 +730,12 @@ function scheduleRecoveryRetry(deps: SchedulerDeps, daemonId: string, config?: S
  * Each worker's `isPaneAlive` + `attemptAgentResume` is wrapped in try/catch,
  * so a single failure (for example, an unreachable tmux socket during early
  * boot) does not abort the recovery loop for the remaining workers.
+ *
+ * Exported so the periodic auto-resume timer can invoke the same pass mid-run
+ * (startAgentResumeTimer) — without it, agents that hit `error` while the
+ * daemon is up never retry until the next process restart.
  */
-async function runAgentRecoveryPass(
+export async function runAgentRecoveryPass(
   deps: SchedulerDeps,
   daemonId: string,
   config?: SchedulerConfig,
@@ -776,6 +780,45 @@ const RESUME_COOLDOWN_MS = 60_000;
 
 /** Default max auto-resume attempts. */
 const DEFAULT_MAX_RESUME_ATTEMPTS = 3;
+
+/** States that never consume a concurrency-cap slot (terminal or pre-active). */
+const INACTIVE_WORKER_STATES = new Set(['done', 'error', 'suspended', 'spawning']);
+
+/**
+ * Count workers genuinely consuming a concurrency-cap slot.
+ *
+ * Excludes rows that only appear active on paper:
+ *   1. `state == null` — identity records created by `findOrCreateAgent`
+ *      (see `agent-registry.ts:548-550`). They track liveness via the
+ *      `executors` table, not the legacy `state` column.
+ *   2. States in INACTIVE_WORKER_STATES (done/error/suspended/spawning).
+ *   3. tmux-pane rows whose pane is dead — zombie rows whose pane died
+ *      without a state update. Mirrors `term-commands/agents.ts:2475
+ *      resolveWorkerLiveness`. Synthetic paneIds (sdk, inline, empty) are
+ *      skipped because they have their own non-tmux liveness source.
+ *
+ * When `isPaneAlive` throws (tmux unreachable) we conservatively count the
+ * row — better to briefly over-count than to silently under-count during a
+ * tmux blip and over-spawn past the configured cap.
+ */
+async function countActiveWorkers(
+  workers: WorkerInfo[],
+  isPaneAlive: (paneId: string) => Promise<boolean>,
+): Promise<number> {
+  let count = 0;
+  for (const w of workers) {
+    if (w.state == null || INACTIVE_WORKER_STATES.has(w.state)) continue;
+    if (/^%\d+$/.test(w.paneId)) {
+      try {
+        if (!(await isPaneAlive(w.paneId))) continue;
+      } catch {
+        // Tmux unreachable — be conservative, count this row
+      }
+    }
+    count++;
+  }
+  return count;
+}
 
 /**
  * Result of an auto-resume attempt.
@@ -855,9 +898,12 @@ export async function attemptAgentResume(
     }
   }
 
-  // Concurrency cap: count active workers
+  // Concurrency cap: count active workers (see `countActiveWorkers` above).
+  // Without NULL-filter + dead-pane filter, accumulated identity rows and
+  // dead-pane zombies inflated activeCount to 142 on one observed machine,
+  // permanently blocking every auto-resume attempt (`active=142, max=5`).
   const workers = await deps.listWorkers();
-  const activeCount = workers.filter((w) => !['done', 'error', 'suspended', 'spawning'].includes(w.state)).length;
+  const activeCount = await countActiveWorkers(workers, deps.isPaneAlive);
   if (activeCount >= config.maxConcurrent) {
     deps.log({
       timestamp: now.toISOString(),
@@ -1319,6 +1365,7 @@ export function startDaemon(
   let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   let orphanTimer: ReturnType<typeof setInterval> | null = null;
   let leaseRecoveryTimer: ReturnType<typeof setInterval> | null = null;
+  let agentResumeTimer: ReturnType<typeof setInterval> | null = null;
   let inboxWatcherHandle: NodeJS.Timeout | null = null;
   let captureFallbackTimer: ReturnType<typeof setInterval> | null = null;
   let eventRouterHandle: EventRouterHandle | null = null;
@@ -1348,6 +1395,10 @@ export function startDaemon(
     if (leaseRecoveryTimer) {
       clearInterval(leaseRecoveryTimer);
       leaseRecoveryTimer = null;
+    }
+    if (agentResumeTimer) {
+      clearInterval(agentResumeTimer);
+      agentResumeTimer = null;
     }
     if (inboxWatcherHandle) {
       stopInboxWatcher(inboxWatcherHandle);
@@ -1475,6 +1526,61 @@ export function startDaemon(
     }, cfg.orphanCheckIntervalMs);
   }
 
+  /**
+   * GC dead-pane zombies via `reconcileStaleSpawns`. Runs before the resume
+   * pass each tick so the concurrency cap sees an accurate active set.
+   */
+  async function reconcileDeadPaneZombies(d: SchedulerDeps): Promise<void> {
+    try {
+      const { reconcileStaleSpawns } = await import('./agent-registry.js');
+      await reconcileStaleSpawns();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      d.log({
+        timestamp: d.now().toISOString(),
+        level: 'warn',
+        event: 'reconcile_stale_spawns_error',
+        error: message,
+      });
+    }
+  }
+
+  /**
+   * Periodic auto-resume sweep for error-state agents.
+   *
+   * Before this timer existed, `runAgentRecoveryPass` only ran at daemon
+   * startup (`recoverOnStartup`) plus one delayed retry. Agents that hit
+   * `error` state mid-run — the very failure mode auto-resume is designed
+   * to handle — never retried until the daemon process restarted.
+   *
+   * Interval reuses `leaseRecoveryIntervalMs` (60s default): same cadence as
+   * lease recovery, gentle enough not to thrash tmux on large worker sets,
+   * tight enough that a user sees the 1/3, 2/3, 3/3 resume progression
+   * within a few minutes rather than waiting for a daemon restart.
+   *
+   * Each tick first reconciles dead-pane zombies (idle/working/permission/
+   * question rows whose tmux pane is dead → error) via
+   * `reconcileDeadPaneZombies`, so the subsequent resume pass sees an
+   * accurate activeCount instead of the inflated zombie count.
+   */
+  function startAgentResumeTimer(d: SchedulerDeps, cfg: SchedulerConfig, dId: string): ReturnType<typeof setInterval> {
+    return setInterval(async () => {
+      if (!running) return;
+      try {
+        await reconcileDeadPaneZombies(d);
+        await runAgentRecoveryPass(d, dId, cfg);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        d.log({
+          timestamp: d.now().toISOString(),
+          level: 'error',
+          event: 'agent_resume_timer_error',
+          error: message,
+        });
+      }
+    }, cfg.leaseRecoveryIntervalMs);
+  }
+
   async function startEventRouterSafe(d: SchedulerDeps): Promise<ReturnType<typeof startEventRouter> | null> {
     try {
       const handle = await startEventRouter();
@@ -1585,6 +1691,7 @@ export function startDaemon(
     heartbeatTimer = setInterval(() => runHeartbeat(deps), config.heartbeatIntervalMs);
     orphanTimer = startOrphanTimer(deps, config);
     leaseRecoveryTimer = startLeaseRecoveryTimer(deps, config, daemonId);
+    agentResumeTimer = startAgentResumeTimer(deps, config, daemonId);
     inboxWatcherHandle = startInboxWatcherIfEnabled(deps);
     eventRouterHandle = await startEventRouterSafe(deps);
 


### PR DESCRIPTION
## Summary

Tracer (HIGH confidence) diagnosed auto-resume stuck at 0/3 forever on felipe's machine: the concurrency-cap filter in `attemptAgentResume` counted 83 NULL-state identity records + 59 dead-pane idle zombies as \"active\", inflating `activeCount = 142` vs `maxConcurrent = 5`. Every resume short-circuited with `reason=concurrency_cap` **before** the `resume_attempts` counter incremented, so the 3-attempt budget never advanced and error-state agents never respawned.

Live log evidence: `~/.genie/logs/scheduler.log` showed 301 `agent_resume_*` events — 298 `concurrency_cap` (active=142, max=5), 3 `auto_resume_disabled`, **zero** attempted/succeeded.

## Three changes (structural parallel to `zombie-spawns.test.ts`, extended from `spawning` to `idle|NULL`+dead-pane)

### Change 1 — Cap filter excludes NULL-state + dead-pane rows (`src/lib/scheduler-daemon.ts`)

Extracted `countActiveWorkers` helper. A row consumes a cap slot only when:
- `state != null` (identity records per `agent-registry.ts:548-550` have `state=NULL`)
- `state` is not in `{done, error, suspended, spawning}`
- For tmux paneIds (`/^%\d+$/`), `isPaneAlive(paneId)` returns true

Mirrors the pattern at [`term-commands/agents.ts:2475 resolveWorkerLiveness`](https://github.com/automagik-dev/genie/blob/dev/src/term-commands/agents.ts#L2475). Conservative on tmux-unreachable (counts unknown-liveness rows to avoid over-spawning during a blip). Synthetic paneIds (`sdk`, `inline`) skip the pane check — they use executor-state liveness.

### Change 2 — Periodic resume timer (`src/lib/scheduler-daemon.ts`)

`runAgentRecoveryPass` previously ran only at daemon startup + one delayed retry. Agents that hit `error` mid-run never retried until process restart. New `startAgentResumeTimer` invokes it every `leaseRecoveryIntervalMs` (60s default). Also exports `runAgentRecoveryPass` for test invocation.

> Interval choice: 60s via `leaseRecoveryIntervalMs` — same cadence as lease recovery, gentle on tmux for large worker sets, tight enough that users see `1/3 → 2/3 → 3/3` progression within minutes rather than waiting for daemon restart.

### Change 3 — Dead-pane GC (`src/lib/agent-registry.ts`)

Third pass in `reconcileStaleSpawns` flips `idle|working|permission|question` rows with dead tmux panes to `error`:
- Guarded by `WHERE id = ? AND state = <prevState>` to avoid racing with live transitions
- Only matches `pane_id ~ '^%[0-9]+$'` — synthetic paneIds untouched
- Audited under `reason=dead_pane_zombie` with `previous_state` for forensics

Wired into the new resume timer (`reconcileDeadPaneZombies` helper runs before each resume pass) so the concurrency cap sees an accurate active set.

## Tests (mandatory regression)

- **`src/lib/__tests__/auto-resume-zombie-cap.test.ts`** (new, 11 tests)
  - 50 NULL + 30 dead-idle + 10 live-working + 10 error → `activeCount=10` (not 90)
  - 142-NULL production scenario reproduction → `activeCount=0`, resume proceeds
  - tmux-unreachable conservatism, synthetic paneId skip
  - `runAgentRecoveryPass` exported + wired as timer
  - Change #3 source assertions (regex, state list, audit reason, ordering)
- **`src/lib/agent-registry.test.ts`** (+3 DB-backed tests)
  - Third pass flips zombie idle/working → error
  - Preserves fresh-idle (under time threshold)
  - Skips synthetic paneIds

## Flagged test adaptation (escalation per charter)

Two existing tests shared a `createMockDeps` default of `isPaneAlive: async () => false`. That mock was semantically meaningless before this fix (cap filter didn't call `isPaneAlive`). After the fix, \"actually working\" semantically requires a live pane:

- `src/lib/__tests__/zombie-spawns.test.ts` — \"actually-working agents still enforce the concurrency cap\" 
- `src/__tests__/resume.test.ts` — \"concurrency cap: blocks resume when at max workers\"

Both tests override `isPaneAlive: async () => true` with an explanatory comment. **Coverage is not weakened** — each still asserts the cap blocks resume when 5 live workers saturate. The change makes the mock align with the semantic intent (\"working\" = alive pane).

## Staged follow-up

If the daemon is already running with the inflated 142 zombie state at merge time, a **restart is required to flush the accumulated counter**. Alternatively the new `reconcileDeadPaneZombies` tick will GC them on its next scheduled sweep (within 60s), after which the cap filter will see the reduced activeCount and resume attempts will progress.

## Test plan
- [x] `bun test src/lib/__tests__/auto-resume-zombie-cap.test.ts` → 11 pass / 0 fail
- [x] `bun test src/lib/__tests__/zombie-spawns.test.ts` → 6 pass / 0 fail (no regression)
- [x] `bun test src/lib/scheduler-daemon.test.ts` → 62 pass / 0 fail
- [x] `bun test src/lib/agent-registry.test.ts` → 77 pass / 0 fail (includes 3 new)
- [x] `bun run check` → 2610 pass / 0 fail across 137 files
- [ ] Post-merge dogfood (felipe): install `@next`, watch `genie ls` for `1/3 → 2/3 → 3/3` progression; `grep agent_resume_attempted ~/.genie/logs/scheduler.log` should show NEW increments

🤖 Generated with [Claude Code](https://claude.com/claude-code)