### PR TITLE
fix(dir): rm aligns with ls storage; stop fabricating registeredAt at read time

### DIFF
--- a/src/lib/agent-directory.test.ts
+++ b/src/lib/agent-directory.test.ts
@@ -197,8 +197,120 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
       expect(metadata.dir).toBe(agentDir);
     });
 
-    test('rm returns false for non-existent', async () => {
-      expect(await directory.rm('nonexistent')).toBe(false);
+    test('rm returns removed=false with no message for truly non-existent', async () => {
+      const result = await directory.rm('nonexistent');
+      expect(result.removed).toBe(false);
+      expect(result.message).toBeUndefined();
+    });
+
+    test('rm returns removed=false + guidance message when runtime rows exist but no dir: row', async () => {
+      // Simulate a spawn-created row (id shape: <team>-<role>) that `ls()` would
+      // show but the old `rm` could not delete because it only tried 'dir:<name>'.
+      const sql = await getConnection();
+      await sql`
+        INSERT INTO agents (id, pane_id, session, repo_path, state, role, started_at, last_state_change)
+        VALUES ('team1-spawn-agent', '%1', 's', '/tmp', 'working', 'spawn-agent', now(), now())
+      `;
+
+      const result = await directory.rm('spawn-agent');
+      expect(result.removed).toBe(false);
+      expect(result.message).toBeDefined();
+      expect(result.message).toContain('team1-spawn-agent');
+      expect(result.message).toContain('--force');
+
+      // Confirm ls() still shows the row — rm did NOT silently remove it.
+      const entries = await directory.ls();
+      expect(entries.some((e) => e.name === 'spawn-agent')).toBe(true);
+    });
+
+    test('rm with force=true wipes runtime rows sharing role', async () => {
+      const sql = await getConnection();
+      await sql`
+        INSERT INTO agents (id, pane_id, session, repo_path, state, role, started_at, last_state_change)
+        VALUES ('team1-force-agent', '%1', 's', '/tmp', 'working', 'force-agent', now(), now())
+      `;
+      await sql`
+        INSERT INTO agents (id, pane_id, session, repo_path, state, role, started_at, last_state_change)
+        VALUES ('uuid-force-agent', '%2', 's', '/tmp', 'working', 'force-agent', now(), now())
+      `;
+
+      const result = await directory.rm('force-agent', { force: true });
+      expect(result.removed).toBe(true);
+      expect(result.message).toBeUndefined();
+
+      const rows = await sql`SELECT id FROM agents WHERE role = 'force-agent'`;
+      expect(rows.length).toBe(0);
+    });
+
+    test('rm removes dir: row even without force', async () => {
+      // Canonical path: dir:<name> is still a single-hop delete.
+      await directory.add({ name: 'canonical-rm', dir: agentDir, promptMode: 'append' });
+      const result = await directory.rm('canonical-rm');
+      expect(result.removed).toBe(true);
+
+      const sql = await getConnection();
+      const rows = await sql`SELECT id FROM agents WHERE id = 'dir:canonical-rm'`;
+      expect(rows.length).toBe(0);
+    });
+  });
+
+  // ============================================================================
+  // roleToEntry() — registeredAt stability (sub-bug B)
+  // ============================================================================
+
+  describe('registeredAt stability', () => {
+    test('ls returns stable registeredAt across successive reads (sourced from PG created_at)', async () => {
+      const sql = await getConnection();
+      // Pin created_at to a past timestamp so a fabricated now() would clearly drift.
+      await sql`
+        INSERT INTO agents (id, role, custom_name, started_at, created_at, metadata)
+        VALUES (
+          'dir:stable-ts',
+          'stable-ts',
+          'stable-ts',
+          now() - interval '1 hour',
+          now() - interval '1 hour',
+          '{}'
+        )
+      `;
+
+      const first = await directory.ls();
+      // Small wall-clock gap — enough that a `new Date().toISOString()` fabrication
+      // would produce a different value on the second read.
+      await new Promise((r) => setTimeout(r, 50));
+      const second = await directory.ls();
+
+      const a = first.find((e) => e.name === 'stable-ts');
+      const b = second.find((e) => e.name === 'stable-ts');
+      expect(a).toBeDefined();
+      expect(b).toBeDefined();
+      expect(a!.registeredAt).toBe(b!.registeredAt);
+      // And it must reflect the pinned past created_at, not wall-clock now().
+      const ts = Date.parse(a!.registeredAt);
+      expect(Number.isNaN(ts)).toBe(false);
+      expect(Date.now() - ts).toBeGreaterThan(30 * 60 * 1000); // > 30min old
+    });
+
+    test('resolve returns stable registeredAt matching ls', async () => {
+      const sql = await getConnection();
+      await sql`
+        INSERT INTO agents (id, role, custom_name, started_at, created_at, metadata)
+        VALUES (
+          'dir:stable-resolve',
+          'stable-resolve',
+          'stable-resolve',
+          now() - interval '2 hours',
+          now() - interval '2 hours',
+          '{}'
+        )
+      `;
+
+      const resolved = await directory.resolve('stable-resolve');
+      const entries = await directory.ls();
+      const listed = entries.find((e) => e.name === 'stable-resolve');
+      expect(resolved).not.toBeNull();
+      expect(listed).toBeDefined();
+      expect(resolved!.entry.registeredAt).toBe(listed!.registeredAt);
     });
   });
 

--- a/src/lib/agent-directory.ts
+++ b/src/lib/agent-directory.ts
@@ -75,6 +75,30 @@ interface ScopeOptions {
   global?: boolean;
 }
 
+/**
+ * Options for {@link rm}.
+ *
+ * `force`: when true, also delete non-`dir:` agent rows (spawn/runtime rows
+ * with id shapes like `<team>-<role>` or UUID) whose `role` matches `name`.
+ * Without this flag, `rm` only removes the `dir:<name>` row and returns a
+ * warning message listing the live instance ids if any exist.
+ */
+interface RmOptions extends ScopeOptions {
+  force?: boolean;
+}
+
+/**
+ * Result of {@link rm}.
+ *
+ * `message`: human-readable explanation when `removed=false` and live runtime
+ * rows exist for the same role (so the caller can print guidance instead of a
+ * generic "not found" message).
+ */
+interface RmResult {
+  removed: boolean;
+  message?: string;
+}
+
 /** Resolved agent — either a user directory entry or a built-in. */
 interface ResolvedAgent {
   /** The agent entry (user or synthetic built-in). */
@@ -160,12 +184,46 @@ export async function add(
 
 /**
  * Remove an agent from the directory.
+ *
+ * Storage symmetry with {@link ls}:
+ *   - `ls()` surfaces rows by `role`, regardless of id shape (dir:, team-role, UUID).
+ *   - `rm()` first tries the canonical `dir:<name>` row. If that row exists, it is
+ *     deleted and we are done.
+ *   - If no `dir:` row exists but runtime rows with matching `role` do, we return
+ *     `removed: false` plus a `message` naming the live instance ids and pointing
+ *     the user at `genie kill <id>` or `--force`. Without this, `rm` used to
+ *     report "not found" on agents that `ls` was happily displaying.
+ *   - With `force: true`, we additionally wipe every row whose `role = name`,
+ *     which is how users can reclaim a name whose directory entry was lost but
+ *     whose runtime/spawn rows linger.
  */
-export async function rm(name: string, _options?: ScopeOptions): Promise<boolean> {
+export async function rm(name: string, options?: RmOptions): Promise<RmResult> {
   const { getConnection } = await import('./db.js');
   const sql = await getConnection();
-  const result = await sql`DELETE FROM agents WHERE id = ${`dir:${name}`}`;
-  return result.count > 0;
+
+  // 1. Canonical directory row: id = 'dir:<name>'
+  const dirDelete = await sql`DELETE FROM agents WHERE id = ${`dir:${name}`}`;
+  const dirRemoved = dirDelete.count > 0;
+
+  if (options?.force) {
+    // --force: also purge any runtime/spawn rows sharing this role.
+    const roleDelete = await sql`DELETE FROM agents WHERE role = ${name}`;
+    return { removed: dirRemoved || roleDelete.count > 0 };
+  }
+
+  if (dirRemoved) return { removed: true };
+
+  // 2. No dir: row — check for runtime rows that `ls()` would surface.
+  const instances = await sql`SELECT id FROM agents WHERE role = ${name}`;
+  if (instances.length === 0) {
+    return { removed: false };
+  }
+
+  const idList = instances.map((r: { id: string }) => r.id).join(', ');
+  return {
+    removed: false,
+    message: `No directory entry for "${name}". Active instances: ${idList}. Use 'genie kill <id>' to terminate, or re-run with --force to remove all.`,
+  };
 }
 
 /**
@@ -182,14 +240,18 @@ export async function resolve(name: string): Promise<ResolvedAgent | null> {
     const { getConnection } = await import('./db.js');
     const sql = await getConnection();
     const rows = await sql`
-      SELECT role, metadata FROM agents
+      SELECT role, metadata, created_at FROM agents
       WHERE role = ${name}
       ORDER BY (CASE WHEN id LIKE 'dir:%' THEN 0 ELSE 1 END), started_at DESC
       LIMIT 1
     `;
     if (rows.length > 0) {
       const meta = parseMetadata(rows[0].metadata);
-      const entry = roleToEntry(name, undefined, meta);
+      const createdAt =
+        rows[0].created_at instanceof Date
+          ? rows[0].created_at.toISOString()
+          : (rows[0].created_at as string | undefined);
+      const entry = roleToEntry(name, undefined, meta, createdAt);
       if (templateTeam) entry.team = templateTeam;
       return { entry, builtin: false };
     }
@@ -272,7 +334,7 @@ export async function ls(): Promise<ScopedDirectoryEntry[]> {
     const { getConnection } = await import('./db.js');
     const sql = await getConnection();
     const rows = await sql`
-      SELECT DISTINCT ON (a.role) a.role, a.team, a.metadata, e.repo_path, e.provider
+      SELECT DISTINCT ON (a.role) a.role, a.team, a.metadata, a.created_at, e.repo_path, e.provider
       FROM agents a
       LEFT JOIN executors e ON a.current_executor_id = e.id
       WHERE a.role IS NOT NULL
@@ -282,7 +344,9 @@ export async function ls(): Promise<ScopedDirectoryEntry[]> {
       const name = row.role as string;
       if (!seen.has(name)) {
         const meta = parseMetadata(row.metadata);
-        const entry = roleToEntry(name, row.team as string, meta);
+        const createdAt =
+          row.created_at instanceof Date ? row.created_at.toISOString() : (row.created_at as string | undefined);
+        const entry = roleToEntry(name, row.team as string, meta, createdAt);
         const repoPath = row.repo_path as string;
         if (repoPath) {
           entry.dir = repoPath;
@@ -409,8 +473,18 @@ function builtinToEntry(agent: BuiltinAgent): DirectoryEntry {
 
 /** Convert a PG agent role to a synthetic DirectoryEntry, enriched with metadata.
  *  When metadata is present, it takes priority over built-in defaults
- *  (PG entries represent user overrides or directory-synced agents). */
-function roleToEntry(role: string, team?: string, metadata?: Record<string, unknown>): DirectoryEntry {
+ *  (PG entries represent user overrides or directory-synced agents).
+ *
+ *  `registeredAt` is sourced from the caller-provided `createdAt` (PG
+ *  `agents.created_at`) or `metadata.registeredAt` if present — never
+ *  fabricated at read time. Two reads of the same row must produce the
+ *  same `registeredAt`, otherwise the UI implies a phantom re-registration. */
+function roleToEntry(
+  role: string,
+  team?: string,
+  metadata?: Record<string, unknown>,
+  createdAt?: string,
+): DirectoryEntry {
   const hasMetadata = metadata && Object.keys(metadata).length > 0;
 
   // Only fall back to built-in when there's no PG metadata to use
@@ -419,13 +493,16 @@ function roleToEntry(role: string, team?: string, metadata?: Record<string, unkn
     if (builtin) return builtinToEntry(builtin);
   }
 
+  const registeredAt =
+    (typeof metadata?.registeredAt === 'string' ? (metadata.registeredAt as string) : undefined) ?? createdAt ?? '';
+
   return {
     name: role,
     dir: (metadata?.dir as string) || '',
     promptMode: (metadata?.promptMode as PromptMode) || 'append',
     model: metadata?.model as string | undefined,
     roles: [],
-    registeredAt: new Date().toISOString(),
+    registeredAt,
     description: metadata?.description as string | undefined,
     color: metadata?.color as string | undefined,
     provider: metadata?.provider as string | undefined,

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -345,7 +345,7 @@ async function removeMissingAgents(discoveredNames: Set<string>, result: SyncRes
       if (entry.scope === 'built-in') continue;
       if (!entry.dir || !entry.dir.includes('/agents/')) continue; // only remove auto-synced
 
-      const removed = await directory.rm(entry.name);
+      const { removed } = await directory.rm(entry.name);
       if (removed) result.archived.push(entry.name);
     }
   } catch {
@@ -533,7 +533,7 @@ async function processWatchedAgent(workspaceRoot: string, agentsDir: string, nam
     return action !== 'unchanged' && action !== 'not-found' ? action : null;
   }
   if (!existsSync(agentDir)) {
-    const removed = await directory.rm(name);
+    const { removed } = await directory.rm(name);
     if (removed) return 'removed';
   }
   return null;

--- a/src/term-commands/dir.ts
+++ b/src/term-commands/dir.ts
@@ -60,14 +60,23 @@ export function registerDirNamespace(program: Command): void {
     .command('rm <name>')
     .description('Remove an agent from the directory')
     .option('--global', 'Remove from global directory instead of project')
-    .action(async (name: string, options: { global?: boolean }) => {
+    .option('--force', 'Also remove runtime/spawn rows sharing this role (id shapes: <team>-<role>, UUID)')
+    .action(async (name: string, options: { global?: boolean; force?: boolean }) => {
       try {
-        const removed = await directory.rm(name, { global: options.global });
-        recordAuditEvent('item', name, 'item_removed', getActor(), { type: 'agent', source: 'dir_rm' }).catch(() => {});
+        const result = await directory.rm(name, { global: options.global, force: options.force });
 
-        if (removed) {
+        if (result.removed) {
           const scope = options.global ? 'global' : 'project';
           console.log(`Agent "${name}" removed from ${scope} directory.`);
+          // Only emit the audit event on actual removal — previously we logged
+          // "item_removed" even when the DELETE matched zero rows.
+          recordAuditEvent('item', name, 'item_removed', getActor(), { type: 'agent', source: 'dir_rm' }).catch(
+            () => {},
+          );
+        } else if (result.message) {
+          // Runtime rows exist but no directory entry — surface guidance.
+          console.error(result.message);
+          process.exit(1);
         } else {
           console.error(`Agent "${name}" not found in directory.`);
           process.exit(1);


### PR DESCRIPTION
## Summary

Fixes two sub-bugs in `src/lib/agent-directory.ts` that surfaced as: (a) `genie dir rm <name>` reporting "not found" on agents that `genie dir ls` was happily displaying, and (b) the "Registered" timestamp advancing on every `dir ls` call, implying a phantom re-registration by some daemon that does not actually exist.

- **Sub-bug A — storage asymmetry**: `ls()` queries by `role` (surfacing id shapes `dir:<name>`, `<team>-<role>`, and UUID). `rm()` hard-coded `DELETE WHERE id = 'dir:<name>'` — only the first id shape was removable, so spawn-created or findOrCreateAgent rows showed up in `ls` but `rm` returned count=0 → "not found."
- **Sub-bug B — fabricated read-time timestamp**: `roleToEntry()` set `registeredAt: new Date().toISOString()` every time a row was read. Two back-to-back `ls` calls produced different "Registered" values even though the PG row never changed. No daemon writes this field — the clock-drift was purely a read-time artifact.

## Fix

### `src/lib/agent-directory.ts`
- `rm(name, options)` now: tries the canonical `dir:<name>` delete first, falls back to checking for runtime rows with matching `role`, and returns either the successful-delete result, a guidance message naming the live instance ids (without touching them), or a clean "not found." With `--force`, it additionally wipes every row whose `role = name`. Return type widened from `boolean` to `{ removed: boolean; message?: string }`.
- `ls()` and `resolve()` now `SELECT a.created_at` and pass it to `roleToEntry()`.
- `roleToEntry()` sources `registeredAt` from `metadata.registeredAt ?? createdAt ?? ''`. Read-time `new Date()` is gone.
- Two internal callers in `src/lib/agent-sync.ts` updated to destructure `{ removed }`.

### `src/term-commands/dir.ts`
- `dir rm <name>` gains `--force`. `--global` retained for backward compat.
- Prints `result.message` when rm returns guidance.
- `recordAuditEvent('item_removed', ...)` is now called **after** the success check — previously it fired even when the DELETE matched zero rows, polluting the audit trail with false removals.

### `src/lib/agent-directory.test.ts` (+116 lines)
Six new/updated assertions:
1. `rm` of truly non-existent name → `{ removed: false }`, no message
2. `rm` when runtime rows exist but no `dir:` row → guidance message listing the live ids and the `--force` hint; `ls` still shows the row afterwards
3. `rm` with `force: true` → wipes all role-matching rows
4. `rm` of a `dir:`-prefixed row still works without force (canonical path)
5. `ls` `registeredAt` stable across back-to-back reads (sourced from pinned PG `created_at`, confirmed >30min-old after a 50ms sleep — a fabricated `now()` would fail this)
6. `resolve` `registeredAt` matches `ls` `registeredAt`

## Reproducer (BEFORE / AFTER)

```bash
# BEFORE
$ genie dir ls qa-wish-9          # shows the row
$ genie dir rm qa-wish-9          # "Agent \"qa-wish-9\" not found in directory." ← wrong
$ genie dir ls felipe-3           # Registered: 2026-04-17T09:15:22Z
$ sleep 3
$ genie dir ls felipe-3           # Registered: 2026-04-17T09:15:25Z ← advanced by 3s, no write happened

# AFTER
$ genie dir rm qa-wish-9
No directory entry for "qa-wish-9". Active instances: team-qa-wish-9. Use 'genie kill <id>' to terminate, or re-run with --force to remove all.
$ genie dir rm qa-wish-9 --force
Agent "qa-wish-9" removed from project directory.

$ genie dir ls felipe-3           # Registered: 2026-04-17T09:10:00Z  (= PG created_at)
$ sleep 3
$ genie dir ls felipe-3           # Registered: 2026-04-17T09:10:00Z  ← stable
```

## --global vs --force semantics

Clarified (both retained, no breaking change):
- `--global` — historical flag, currently a no-op pass-through in the DB layer since the PG-backed directory has no project/global split. Kept for backward compat with existing scripts. Does **not** alter delete scope.
- `--force` — new. Opts into wiping runtime/spawn rows that share the role name (id shapes `<team>-<role>`, UUID).

A future cleanup could either collapse `--global` into `--force` or re-purpose it once a project-scoped schema exists.

## Validation

```
$ bun run check
…
 2620 pass
 0 fail
 6019 expect() calls
Ran 2620 tests across 137 files. [57.26s]
```

Charter target was 2610+ — we're at 2620 pass / 0 fail.

## Files touched

4 files:
- `src/lib/agent-directory.ts`       — rm() + roleToEntry() + ls/resolve SELECTs
- `src/lib/agent-sync.ts`            — destructure new rm() return at 2 call sites
- `src/term-commands/dir.ts`         — --force flag + message printing + audit-after-success
- `src/lib/agent-directory.test.ts`  — 6 regression tests

Charter expected 3 (source + dir.ts + test); the extra file is the 2-line adjustment in `agent-sync.ts` to destructure the wider return type — the minimum needed for a clean signature change.

## Follow-up (out of scope)

The charter notes "false audit events elsewhere in dir.ts may exist — audit separately if needed." `recordAuditEvent` calls for `item_registered` in `handleDirAdd` and `item_updated` in `handleEdit` were **not** audited in this PR; they sit inside try/catch blocks that already `process.exit(1)` on error, so the risk profile is lower than the `rm` case, but a holistic pass is worth a dedicated follow-up.

## Test plan

- [x] `bun run check` passes (2620 pass / 0 fail)
- [x] New tests assert both sub-bug fixes (rm storage symmetry, registeredAt stability)
- [ ] Reviewer dogfoods: spawn an agent with a known role, run `dir ls` + `dir rm` without `--force` (expect guidance), then `--force` (expect removal)
- [ ] Reviewer runs `dir ls <agent>` twice with a sleep; confirm Registered is stable