### PR TITLE
fix(spawn): add home keeper window so isolated sessions survive agent death

### DIFF
--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -781,9 +781,16 @@ function createTmuxPane(ctx: SpawnCtx & { sessionOverride?: string }, teamWindow
   // --new-window: create a dedicated window instead of splitting.
   // When the target session doesn't exist yet (e.g. cold-start spawn from the TUI
   // for an offline agent), `new-window -t <session>:` would fail with "can't find
-  // session". Bootstrap with `new-session` in that case — it creates both the
-  // session and its first pane in one call. Pass `-n claude` so that first
-  // window has a meaningful name instead of tmux's default `bash`.
+  // session". Bootstrap with `new-session` in that case — but create a persistent
+  // `home` keeper window first, so the session survives after the agent window
+  // is closed. Without this keeper, tmux tears down the session when its sole
+  // window (claude) exits, breaking subsequent resume/respawn attempts which
+  // fall through to the caller's current TMUX session (see the khal-os bug:
+  // resume inherited `genie-configure` as the target session after the original
+  // dedicated session died). The keeper is cheap (one bash shell) and restores
+  // the invariant that a team's session is a persistent home for its members.
+  // The claude window is created with `-n claude`; navigation-wise `home` is
+  // window 0 and `claude` is window 1, matching the multi-member team layout.
   if (ctx.validated.newWindow) {
     const session = ctx.sessionOverride ?? teamWindow?.windowId?.split(':')[0] ?? ctx.validated.team;
     const cwdFlag = ctx.cwd ? ` -c ${shellQuote(ctx.cwd)}` : '';
@@ -794,9 +801,14 @@ function createTmuxPane(ctx: SpawnCtx & { sessionOverride?: string }, teamWindow
     } catch {
       sessionExists = false;
     }
-    const cmd = sessionExists
-      ? `${tmuxPrefix}new-window -a -d -t ${shellQuote(`${session}:`)} -n claude${cwdFlag} -P -F '#{pane_id}' ${tmuxCommand}`
-      : `${tmuxPrefix}new-session -d -s ${shellQuote(session)} -n claude${cwdFlag} -P -F '#{pane_id}' ${tmuxCommand}`;
+    if (!sessionExists) {
+      // Bootstrap session with a `home` keeper window (bash shell). `-d` keeps
+      // the new session detached. No command → default shell. stdio:'ignore'
+      // because we don't need the session name back (we already have it).
+      execSync(`${tmuxPrefix}new-session -d -s ${shellQuote(session)} -n home${cwdFlag}`, { stdio: 'ignore' });
+    }
+    // Add the claude window (either to the just-bootstrapped or pre-existing session).
+    const cmd = `${tmuxPrefix}new-window -a -d -t ${shellQuote(`${session}:`)} -n claude${cwdFlag} -P -F '#{pane_id}' ${tmuxCommand}`;
     return execSync(cmd, { encoding: 'utf-8' }).trim();
   }
 


### PR DESCRIPTION
## Symptom (Felipe's report)

> Pressed Enter on khal-os in TUI (attached to `genie-configure` session) and it spawned the agent **inside** `genie-configure:2` as a window. The original dedicated `khal-os` session was gone. Empty sessions should stay alive so registered agents have a home to respawn into.

## Root cause

PR #1175 correctly made `--new-window --session <name>` always spawn into its own tmux session for team-of-one / TUI per-agent spawns. But the bootstrap path created the session with only the `claude` window:

```ts
// Old — src/term-commands/agents.ts:797-799
const cmd = sessionExists
  ? `new-window -a -d -t ${session}: -n claude ${cwdFlag} -P ...`
  : `new-session -d -s ${session} -n claude ${cwdFlag} -P ...`;
```

When that `claude` window closed — `genie kill`, crash, or natural exit — tmux tore the session down. The next resume then fell through `resolveRepoSession` tier 1 (session gone) → tier 2 (caller's current TMUX), placing the respawned agent in `genie-configure` instead of returning to its dedicated home.

## Fix

Bootstrap the session with a `home` keeper window (bash shell) **before** the `claude` agent window. The keeper survives the agent's lifecycle — closing claude leaves `home` behind so the session stays alive. Future resumes find the exact-match session via tier 1 and return the agent to its home.

For existing sessions the branch is unchanged — we still just add the `claude` window.

### Topology

| State | Windows |
|-------|---------|
| After first spawn | `home` (bash) + `claude` (agent) |
| After `kill` / agent exit | `home` (session alive) |
| After next respawn | `home` + `claude` (in original session) |

### Tmux semantics verified

```bash
$ tmux new-session -d -s probe -n home
$ tmux new-window -a -d -t probe: -n claude 'sleep 120'
$ tmux list-windows -t probe
0: home*  (1 panes)
1: claude (1 panes)
$ tmux kill-window -t probe:claude
$ tmux list-windows -t probe
0: home*  (1 panes)   # session survives ✓
```

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean on changed file
- [x] `bun test` — 2634/2634 pass
- [x] Tmux semantics probe confirmed keeper behavior
- [ ] Live verification: after merge + publish, kill khal-os, press Enter in TUI, confirm it respawns into the standalone `khal-os` session (not genie-configure)

## Context

Complements PR #1174 (auto-team-of-one), PR #1175 (topology fix), PR #1177 (otel flake). Fourth PR in the team-of-one-auto-create chain — closes the gap where the isolation guarantee didn't survive the agent's first death.