### PR TITLE
fix(scheduler): stop escalation recursion — guard mailbox loop (was 181K events over 8 days)

### DIFF
--- a/src/lib/scheduler-daemon.test.ts
+++ b/src/lib/scheduler-daemon.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import type { AgentState } from './agent-registry.js';
+import type { MailboxMessage } from './mailbox.js';
 import {
+  ESCALATION_RECIPIENT,
   type LogEntry,
+  MAX_DELIVERY_ATTEMPTS,
   type SchedulerConfig,
   type SchedulerDeps,
   type WorkerInfo,
@@ -13,6 +16,7 @@ import {
   emitWorkerEvents,
   fireTrigger,
   logToFile,
+  processMailboxRetryMessage,
   reclaimExpiredLeases,
   reconcileOrphanedRuns,
   reconcileOrphans,
@@ -1842,6 +1846,160 @@ describe('scheduler-daemon', () => {
         );
         expect(leaseUntilValue).toBeDefined();
       }
+    });
+  });
+
+  // ============================================================================
+  // Mailbox delivery retry — escalation recursion guards
+  // ============================================================================
+  //
+  // Regression coverage for the 181K-event escalation loop observed on
+  // felipe's machine over 8 days (2026-04-10 → 2026-04-17). The daemon's
+  // retry loop escalated failed-delivery messages by posting a new mailbox
+  // row `from='scheduler'`, `to='team-lead'`. Because `'team-lead'` is a
+  // bare, unresolvable recipient, that escalation row itself hit
+  // MAX_DELIVERY_ATTEMPTS and was escalated again → infinite chain.
+  // `processMailboxRetryMessage` now applies 3 guards to break the loop.
+  describe('processMailboxRetryMessage — escalation recursion guards', () => {
+    function createRetryableMsg(overrides: Partial<MailboxMessage> = {}): MailboxMessage {
+      return {
+        id: 'msg-1',
+        from: 'genie-configure',
+        to: 'genie-reviewer',
+        body: 'please review the draft',
+        createdAt: '2026-04-17T12:00:00Z',
+        read: false,
+        deliveredAt: null,
+        ...overrides,
+      };
+    }
+
+    /**
+     * Mock connection whose mailbox SELECT returns `delivery_attempts ===
+     * MAX_DELIVERY_ATTEMPTS` so the retry logic hits the escalation branch.
+     */
+    function createExhaustedDeps(repoPath: string | null = '/tmp/repo') {
+      const logs: LogEntry[] = [];
+      const sentRows: { repoPath: string; from: string; to: string; body: string }[] = [];
+
+      const sql: any = (strings: TemplateStringsArray, ..._values: unknown[]) => {
+        const query = strings.join('?');
+        if (query.includes('SELECT delivery_attempts, repo_path FROM mailbox')) {
+          return [{ delivery_attempts: MAX_DELIVERY_ATTEMPTS, repo_path: repoPath }];
+        }
+        return [];
+      };
+      sql.begin = async (fn: (tx: typeof sql) => Promise<unknown>) => fn(sql);
+      sql.listen = async () => {};
+      sql.end = async () => {};
+
+      const deps: SchedulerDeps = {
+        getConnection: async () => sql,
+        spawnCommand: async () => ({ pid: 0 }),
+        log: (entry) => logs.push(entry),
+        generateId: () => 'test-id',
+        now: () => new Date('2026-04-17T12:00:00Z'),
+        sleep: async () => {},
+        jitter: (maxMs) => Math.floor(maxMs / 2),
+        isPaneAlive: async () => true,
+        listWorkers: async () => [],
+        countTmuxSessions: async () => 0,
+        publishEvent: async () => {},
+        resumeAgent: async () => true,
+        updateAgent: async () => {},
+      };
+
+      const deliverFn = async () => false; // delivery always fails — forces escalation branch
+      const sendFn = async (repoArg: string, from: string, to: string, body: string) => {
+        sentRows.push({ repoPath: repoArg, from, to, body });
+        return { id: `msg-sent-${sentRows.length}`, from, to, body, createdAt: '', read: false, deliveredAt: null };
+      };
+
+      return { deps, logs, sentRows, deliverFn, sendFn };
+    }
+
+    test('Guard 1: scheduler-authored message does not produce a new escalation row', async () => {
+      const { deps, logs, sentRows, deliverFn, sendFn } = createExhaustedDeps();
+      const msg = createRetryableMsg({ from: 'scheduler', to: 'team-lead', body: '[escalation] older failure' });
+
+      await processMailboxRetryMessage(deps, msg, { deliverFn, sendFn });
+
+      expect(sentRows).toHaveLength(0);
+      const dropped = logs.find((l) => l.event === 'mailbox_delivery_escalation_dropped');
+      expect(dropped).toBeDefined();
+      expect(dropped?.reason).toBe('already_escalated_by_scheduler');
+      expect(dropped?.messageId).toBe('msg-1');
+      expect(logs.find((l) => l.event === 'mailbox_delivery_escalated')).toBeUndefined();
+    });
+
+    test('Guard 2: [escalation]-prefixed body is dropped even without scheduler authorship', async () => {
+      const { deps, logs, sentRows, deliverFn, sendFn } = createExhaustedDeps();
+      const msg = createRetryableMsg({
+        from: 'genie-configure',
+        to: 'some-other-worker',
+        body: '[escalation] replayed escalation from another sender',
+      });
+
+      await processMailboxRetryMessage(deps, msg, { deliverFn, sendFn });
+
+      expect(sentRows).toHaveLength(0);
+      const dropped = logs.find((l) => l.event === 'mailbox_delivery_escalation_dropped');
+      expect(dropped).toBeDefined();
+      expect(dropped?.reason).toBe('body_prefix');
+    });
+
+    test('Guard 3: message addressed to ESCALATION_RECIPIENT from a non-scheduler sender is dropped', async () => {
+      const { deps, logs, sentRows, deliverFn, sendFn } = createExhaustedDeps();
+      const msg = createRetryableMsg({
+        from: 'genie-configure',
+        to: ESCALATION_RECIPIENT,
+        body: 'direct message to team-lead that exhausted retries',
+      });
+
+      await processMailboxRetryMessage(deps, msg, { deliverFn, sendFn });
+
+      expect(sentRows).toHaveLength(0);
+      const dropped = logs.find((l) => l.event === 'mailbox_delivery_escalation_dropped');
+      expect(dropped).toBeDefined();
+      expect(dropped?.reason).toBe('same_recipient');
+    });
+
+    test('positive path: legitimate worker→worker failure still produces an escalation row', async () => {
+      const { deps, logs, sentRows, deliverFn, sendFn } = createExhaustedDeps();
+      const msg = createRetryableMsg({
+        from: 'genie-configure',
+        to: 'genie-reviewer',
+        body: 'please review this draft',
+      });
+
+      await processMailboxRetryMessage(deps, msg, { deliverFn, sendFn });
+
+      expect(sentRows).toHaveLength(1);
+      expect(sentRows[0].from).toBe('scheduler');
+      expect(sentRows[0].to).toBe(ESCALATION_RECIPIENT);
+      expect(sentRows[0].body.startsWith('[escalation] ')).toBe(true);
+      expect(logs.find((l) => l.event === 'mailbox_delivery_escalated')).toBeDefined();
+      expect(logs.find((l) => l.event === 'mailbox_delivery_escalation_dropped')).toBeUndefined();
+    });
+
+    test('regression: 10 consecutive 3-fail cycles on scheduler-authored team-lead row produce 0 new rows', async () => {
+      const { deps, logs, sentRows, deliverFn, sendFn } = createExhaustedDeps();
+      const msg = createRetryableMsg({
+        from: 'scheduler',
+        to: 'team-lead',
+        body: '[escalation] Message msg-orig from "x" to "y" failed delivery',
+      });
+
+      for (let i = 0; i < 10; i++) {
+        await processMailboxRetryMessage(deps, msg, { deliverFn, sendFn });
+      }
+
+      // Zero new mailbox rows from 10 cycles — this is the property that keeps
+      // the mailbox table from growing by 1500/h indefinitely.
+      expect(sentRows).toHaveLength(0);
+      const dropped = logs.filter((l) => l.event === 'mailbox_delivery_escalation_dropped');
+      expect(dropped).toHaveLength(10);
+      expect(dropped.every((l) => l.reason === 'already_escalated_by_scheduler')).toBe(true);
     });
   });
 });

--- a/src/lib/scheduler-daemon.ts
+++ b/src/lib/scheduler-daemon.ts
@@ -24,8 +24,28 @@ import type { Agent } from './agent-registry.js';
 import { computeNextCronDue, parseDuration } from './cron.js';
 import { type EventRouterHandle, startEventRouter } from './event-router.js';
 import { getInboxPollIntervalMs, startInboxWatcher, stopInboxWatcher } from './inbox-watcher.js';
-import { getRetryable, markEscalated, subscribeDelivery } from './mailbox.js';
+import { type MailboxMessage, getRetryable, markEscalated, subscribeDelivery } from './mailbox.js';
 import { type RunSpec, resolveRunSpec } from './run-spec.js';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Recipient used when the mailbox retry loop escalates a permanently-failed
+ * message. Extracted as a constant so the escalation writer and the guard
+ * that prevents re-escalation reference the same literal.
+ *
+ * NOTE: This is a bare string today; there is no resolver that maps it to an
+ * actual worker ID like `team-lead:<session>:<team>`. Delivering to this
+ * bare string fails and, without the guards in `processMailboxRetryMessage`,
+ * recursively produces more escalation messages. A follow-up wish will
+ * replace this with a resolver that locates the real team-lead agent.
+ */
+export const ESCALATION_RECIPIENT = 'team-lead';
+
+/** Maximum delivery attempts before the mailbox retry loop escalates a message. */
+export const MAX_DELIVERY_ATTEMPTS = 3;
 
 // ============================================================================
 // Types
@@ -1367,6 +1387,149 @@ interface DaemonHandle {
 }
 
 /**
+ * Dependency overrides for `processMailboxRetryMessage`. The retry loop uses
+ * dynamic imports for `deliverToPane` and `send` to avoid circular-import
+ * risk; tests can inject mocks here instead of going through the real
+ * protocol-router / mailbox modules.
+ */
+interface MailboxRetryOverrides {
+  /** Pane delivery function. Defaults to `protocol-router.deliverToPane`. */
+  deliverFn?: (toWorker: string, messageId: string) => Promise<boolean>;
+  /** Mailbox writer used to post the escalation row. Defaults to `mailbox.send`. */
+  sendFn?: (repoPath: string, from: string, to: string, body: string) => Promise<unknown>;
+}
+
+/**
+ * Process a single retryable mailbox message. Extracted from the scheduler
+ * daemon's 60s retry loop so guards and edge cases can be unit-tested.
+ *
+ * Attempts instant pane delivery via `deliverFn`. If delivery fails and the
+ * message has now hit `MAX_DELIVERY_ATTEMPTS`, escalate it — BUT only if
+ * none of the three recursion guards match. The guards exist because the
+ * escalation row (`from=scheduler`, `to=ESCALATION_RECIPIENT`) is itself
+ * subject to the same retry+escalate cycle; without them, a single
+ * unresolvable escalation spawns an infinite chain (observed: 181K rows
+ * over 8 days before the guards shipped).
+ *
+ * Guards (in order, any match short-circuits before `sendFn` is called):
+ *   1. `msg.from === 'scheduler'` — message was ALREADY authored by the
+ *      escalation path. Re-escalating it would grow the chain by one each
+ *      retry cycle. Mandatory guard.
+ *   2. `msg.body.startsWith('[escalation] ')` — body-prefix defense for any
+ *      escalation message that somehow lost the scheduler authorship (e.g.
+ *      manual replay, future sender rename).
+ *   3. `msg.to === ESCALATION_RECIPIENT` — same-recipient defense. The bare
+ *      `'team-lead'` recipient is unresolvable; escalating to it cannot
+ *      ever succeed, so re-escalating it only amplifies the problem.
+ *
+ * All three guards log `mailbox_delivery_escalation_dropped` with a
+ * `reason` field so ops can distinguish dropped-by-guard from
+ * delivered-successfully in the scheduler log.
+ */
+export async function processMailboxRetryMessage(
+  deps: SchedulerDeps,
+  msg: MailboxMessage,
+  overrides: MailboxRetryOverrides = {},
+): Promise<void> {
+  const deliverFn =
+    overrides.deliverFn ??
+    (async (toWorker: string, messageId: string) => {
+      const { deliverToPane } = await import('./protocol-router.js');
+      return deliverToPane(toWorker, messageId);
+    });
+  const sendFn =
+    overrides.sendFn ??
+    (async (repoPath: string, from: string, to: string, body: string) => {
+      const { send } = await import('./mailbox.js');
+      return send(repoPath, from, to, body);
+    });
+
+  const delivered = await deliverFn(msg.to, msg.id);
+  if (delivered) {
+    deps.log({
+      timestamp: deps.now().toISOString(),
+      level: 'info',
+      event: 'mailbox_delivery_retried',
+      messageId: msg.id,
+      to: msg.to,
+    });
+    return;
+  }
+
+  // deliverToPane already called markFailed — check if max attempts reached.
+  const sql = await deps.getConnection();
+  const rows = await sql`SELECT delivery_attempts, repo_path FROM mailbox WHERE id = ${msg.id} LIMIT 1`;
+  const attempts = rows[0]?.delivery_attempts ?? 0;
+  if (attempts < MAX_DELIVERY_ATTEMPTS) return;
+
+  await markEscalated(msg.id);
+
+  // Guard 1 (MANDATORY): message already authored by the scheduler means it
+  // IS an escalation; re-escalating it is the exact loop we saw in prod.
+  if (msg.from === 'scheduler') {
+    deps.log({
+      timestamp: deps.now().toISOString(),
+      level: 'warn',
+      event: 'mailbox_delivery_escalation_dropped',
+      reason: 'already_escalated_by_scheduler',
+      messageId: msg.id,
+      to: msg.to,
+      attempts,
+    });
+    return;
+  }
+
+  // Guard 2 (defense-in-depth): body-prefix check catches any escalation row
+  // that arrives without scheduler authorship (manual replay, sender rename).
+  if (msg.body.startsWith('[escalation] ')) {
+    deps.log({
+      timestamp: deps.now().toISOString(),
+      level: 'warn',
+      event: 'mailbox_delivery_escalation_dropped',
+      reason: 'body_prefix',
+      messageId: msg.id,
+      to: msg.to,
+      attempts,
+    });
+    return;
+  }
+
+  // Guard 3 (defense-in-depth): the bare escalation recipient is
+  // unresolvable today, so escalating to it can never succeed. Drop and
+  // log rather than append another doomed row.
+  if (msg.to === ESCALATION_RECIPIENT) {
+    deps.log({
+      timestamp: deps.now().toISOString(),
+      level: 'warn',
+      event: 'mailbox_delivery_escalation_dropped',
+      reason: 'same_recipient',
+      messageId: msg.id,
+      to: msg.to,
+      attempts,
+    });
+    return;
+  }
+
+  const repoPath = rows[0]?.repo_path;
+  if (repoPath) {
+    await sendFn(
+      repoPath,
+      'scheduler',
+      ESCALATION_RECIPIENT,
+      `[escalation] Message ${msg.id} from "${msg.from}" to "${msg.to}" failed delivery after ${MAX_DELIVERY_ATTEMPTS} attempts. Body: "${msg.body.slice(0, 200)}"`,
+    );
+  }
+  deps.log({
+    timestamp: deps.now().toISOString(),
+    level: 'warn',
+    event: 'mailbox_delivery_escalated',
+    messageId: msg.id,
+    to: msg.to,
+    attempts,
+  });
+}
+
+/**
  * Start the scheduler daemon.
  *
  * Flow:
@@ -1736,50 +1899,15 @@ export function startDaemon(
       // PG LISTEN not available — inbox-watcher polling remains the fallback
     }
 
-    // Mailbox delivery retry loop: retry failed deliveries every 60s
-    const MAX_DELIVERY_ATTEMPTS = 3;
+    // Mailbox delivery retry loop: retry failed deliveries every 60s.
+    // Per-message logic lives in `processMailboxRetryMessage` so guards
+    // against escalation recursion are unit-testable.
     deliveryRetryTimer = setInterval(async () => {
       try {
         const retryable = await getRetryable(MAX_DELIVERY_ATTEMPTS);
         for (const msg of retryable) {
           try {
-            const { deliverToPane } = await import('./protocol-router.js');
-            const delivered = await deliverToPane(msg.to, msg.id);
-            if (delivered) {
-              deps.log({
-                timestamp: deps.now().toISOString(),
-                level: 'info',
-                event: 'mailbox_delivery_retried',
-                messageId: msg.id,
-                to: msg.to,
-              });
-              continue;
-            }
-            // deliverToPane already called markFailed — check if max attempts reached
-            const sql = await deps.getConnection();
-            const rows = await sql`SELECT delivery_attempts, repo_path FROM mailbox WHERE id = ${msg.id} LIMIT 1`;
-            const attempts = rows[0]?.delivery_attempts ?? 0;
-            if (attempts >= MAX_DELIVERY_ATTEMPTS) {
-              await markEscalated(msg.id);
-              const repoPath = rows[0]?.repo_path;
-              if (repoPath) {
-                const { send } = await import('./mailbox.js');
-                await send(
-                  repoPath,
-                  'scheduler',
-                  'team-lead',
-                  `[escalation] Message ${msg.id} from "${msg.from}" to "${msg.to}" failed delivery after ${MAX_DELIVERY_ATTEMPTS} attempts. Body: "${msg.body.slice(0, 200)}"`,
-                );
-              }
-              deps.log({
-                timestamp: deps.now().toISOString(),
-                level: 'warn',
-                event: 'mailbox_delivery_escalated',
-                messageId: msg.id,
-                to: msg.to,
-                attempts,
-              });
-            }
+            await processMailboxRetryMessage(deps, msg);
           } catch {
             // Individual message retry failed — will be retried next cycle
           }


### PR DESCRIPTION
## Tracer summary (HIGH confidence)

The 60s mailbox delivery retry loop in `src/lib/scheduler-daemon.ts` escalates a permanently-failed message by posting a **new** mailbox row `from='scheduler'`, `to='team-lead'`. But `'team-lead'` is a bare, unresolvable string — real team-leads have suffixed IDs like `team-lead:<session>:<team>` — so the escalation row itself cannot deliver, hits `MAX_DELIVERY_ATTEMPTS=3`, and is escalated AGAIN. The chain is unbounded.

## Scale at diagnosis (felipe's machine)

- **181,914** stale `[escalation]`-prefixed rows in `mailbox` (99.999% from `scheduler` → `team-lead`)
- **181,887** log events since `2026-04-10T03:10:05Z` (8 days)
- Growth rate: ~1500 rows/h = **~12MB/day** on mailbox + `scheduler.log`
- ~34MB `scheduler.log`, ~61MB DB rows at time of diagnosis

## Guards — all 3 shipped together

Per-message retry logic extracted from the inline `setInterval` into an exported `processMailboxRetryMessage(deps, msg, overrides?)` in `scheduler-daemon.ts`, so the guards are unit-testable. Each guard that fires logs `mailbox_delivery_escalation_dropped` with a `reason` field (observability distinguishes dropped-by-guard vs delivered-successfully).

| # | Condition | Rationale |
|---|-----------|-----------|
| **1 (MANDATORY)** | `msg.from === 'scheduler'` | Scheduler-authored messages are already escalations. This alone closes the loop at its source. |
| 2 (defense) | `msg.body.startsWith('[escalation] ')` | Catches escalation rows that lose scheduler authorship (manual replay, sender rename). |
| 3 (defense) | `msg.to === ESCALATION_RECIPIENT` | The bare recipient is unresolvable today; escalating to it can never succeed. |

`ESCALATION_RECIPIENT = 'team-lead'` is extracted as a top-of-file constant so the Guard 3 check and the `send(...)` call reference the same literal — drift-safe.

## Validation

```
bun run check   # → 2639 pass / 0 fail / exit 0   (was 2634; +5 regression tests)
```

New tests in `src/lib/scheduler-daemon.test.ts`:

1. Guard 1: scheduler-authored → no new row, `reason='already_escalated_by_scheduler'`
2. Guard 2: `[escalation]`-prefixed body from non-scheduler sender → dropped, `reason='body_prefix'`
3. Guard 3: recipient = `team-lead` from non-scheduler sender → dropped, `reason='same_recipient'`
4. Positive path: legitimate worker→worker 3-fail → escalation row IS created
5. **Infinite-loop regression**: 10 consecutive 3-fail cycles on a scheduler-authored `team-lead` message → zero new rows (this is the property that keeps the table from growing 1500/h indefinitely)

## Scope (2 files — `src/lib/scheduler-daemon.ts` + `.test.ts`)

Intentionally NOT in this PR (per charter):
- Replacing bare `'team-lead'` with a resolver that finds the real team-lead ID (separate wish)
- `protocol-router.deliverToPane` (unresolvable-recipient-returns-null is correct — only the escalation writer was wrong)
- Mailbox schema changes or dead-letter tables

## Operational cleanup for merger (after merge + restart)

Once the daemon is restarted with the fix, felipe should drain the stale rows:

```sql
DELETE FROM mailbox
WHERE to_worker = 'team-lead'
  AND (from_worker = 'scheduler' OR body LIKE '[escalation]%');
```

Without this the 181K-row backlog remains queryable (the fix only prevents *new* escalation rows; existing ones are already `delivery_status='escalated'` and no longer retried, so they are inert but take space).

Log rotation (`scheduler.log`) is felipe's call post-merge.

## Staged follow-up (separate wish)

Replace bare `'team-lead'` with a resolver that locates the actual team-lead agent ID for the originating session/team. Until then Guards 2 and 3 are defense-in-depth; Guard 1 alone kills the specific `scheduler`-authored loop.

## Test plan

- [x] `bun run check` passes (2639/0)
- [x] All 5 new tests target the guards they claim to target
- [x] Positive escalation path (worker → worker, non-`[escalation]` body, non-`team-lead` recipient) still creates an escalation row
- [x] 10-cycle regression: scheduler-authored team-lead row produces exactly 0 new rows
- [ ] Post-merge: felipe confirms scheduler.log stops growing the `mailbox_delivery_escalated` event stream
- [ ] Post-merge: felipe runs the `DELETE FROM mailbox` cleanup and confirms table size drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)