### PR TITLE
fix(omni): pass permissions/disallowedTools through tmux executor

### DIFF
--- a/src/services/executors/claude-code.test.ts
+++ b/src/services/executors/claude-code.test.ts
@@ -157,4 +157,57 @@ describe('buildOmniSpawnParams', () => {
     const params = buildOmniSpawnParams('simone', 'chat123', entryWithProvider, {});
     expect(params.provider).toBe('codex');
   });
+
+  test('propagates entry.permissions.allow/deny for turn-sandbox enforcement', () => {
+    const entryWithPermissions = {
+      ...fakeEntry,
+      permissions: {
+        allow: ['Bash(omni say *)', 'Bash(omni done)'],
+        deny: ['Bash(omni chats *)', 'Bash(rm *)'],
+      },
+    };
+    const params = buildOmniSpawnParams('simone', 'chat123', entryWithPermissions, {});
+    expect(params.permissions?.allow).toEqual(['Bash(omni say *)', 'Bash(omni done)']);
+    expect(params.permissions?.deny).toEqual(['Bash(omni chats *)', 'Bash(rm *)']);
+  });
+
+  test('propagates entry.disallowedTools', () => {
+    const entryWithTools = {
+      ...fakeEntry,
+      disallowedTools: ['Edit', 'Write', 'Agent'],
+    };
+    const params = buildOmniSpawnParams('simone', 'chat123', entryWithTools, {});
+    expect(params.disallowedTools).toEqual(['Edit', 'Write', 'Agent']);
+  });
+
+  test('omits permissions when entry has none (no false sense of security)', () => {
+    const params = buildOmniSpawnParams('simone', 'chat123', fakeEntry, {});
+    expect(params.permissions).toBeUndefined();
+    expect(params.disallowedTools).toBeUndefined();
+  });
+
+  test('omits permissions when allow/deny are empty arrays', () => {
+    const entryWithEmpty = {
+      ...fakeEntry,
+      permissions: { allow: [], deny: [] },
+    };
+    const params = buildOmniSpawnParams('simone', 'chat123', entryWithEmpty, {});
+    expect(params.permissions).toBeUndefined();
+  });
+
+  test('ignores SDK-only preset/bashAllowPatterns (CLI path uses allow/deny only)', () => {
+    const entryWithSdkFields = {
+      ...fakeEntry,
+      permissions: {
+        preset: 'turn-sandbox',
+        allow: ['Bash(omni say *)'],
+        bashAllowPatterns: ['^omni say .*$'],
+      },
+    };
+    const params = buildOmniSpawnParams('simone', 'chat123', entryWithSdkFields, {});
+    // SpawnParams.permissions only carries allow/deny — preset and bashAllowPatterns
+    // are SDK-specific and handled in claude-sdk-permissions.ts, not here.
+    expect(params.permissions?.allow).toEqual(['Bash(omni say *)']);
+    expect(params.permissions?.deny).toBeUndefined();
+  });
 });

--- a/src/services/executors/claude-code.ts
+++ b/src/services/executors/claude-code.ts
@@ -120,6 +120,15 @@ export function buildOmniSpawnParams(
   // Turn context = operational instructions for this specific interaction.
   const fullInitialPrompt = initialMessage ? `${turnContext}\n\n---\n\n${initialMessage}` : turnContext;
 
+  // Pass agent permissions through to Claude Code via --settings so the tmux
+  // executor honors AGENTS.md frontmatter permissions. Without this, WhatsApp
+  // turn agents run under bypassPermissions with zero Bash-level enforcement,
+  // defeating the unified per-agent permission system.
+  const permissions =
+    entry.permissions?.allow?.length || entry.permissions?.deny?.length
+      ? { allow: entry.permissions.allow, deny: entry.permissions.deny }
+      : undefined;
+
   return {
     provider: (entry.provider as SpawnParams['provider']) ?? 'claude',
     team: agentName,
@@ -130,6 +139,8 @@ export function buildOmniSpawnParams(
     systemPromptFile: join(entry.dir, 'AGENTS.md'),
     initialPrompt: fullInitialPrompt,
     skipHooks: true,
+    permissions,
+    disallowedTools: entry.disallowedTools,
     nativeTeam: {
       enabled: true,
       agentName,


### PR DESCRIPTION
## Summary

Closes the last gap in the `turn-sandbox-scope-enforcement` wish. `buildOmniSpawnParams` in `claude-code.ts:107-139` (the tmux executor's SpawnParams constructor for WhatsApp turn agents) silently dropped `entry.permissions` and `entry.disallowedTools` from `DirectoryEntry`.

`c5251d17 feat(lib): unified agent permission system` wired permissions into `buildClaudeCommand`'s `--settings` JSON emission, but never populated those SpawnParams fields from the omni tmux path. So WhatsApp turn agents ran with **zero Bash-level enforcement** despite having permissions declared in their AGENTS.md frontmatter.

The Claude Agent SDK path already honors frontmatter permissions via `resolvePermissionConfig(entry.permissions)` at `claude-sdk.ts:450`. This change brings the tmux path to parity.

## Evidence

Traced by a read-only investigator against dev HEAD:
- Wish claims Groups 1-3 shipped: CONFIRMED on dev (`agent-directory.ts:52-63,528-530`, `provider-adapters.ts:373-376`, `claude-sdk.ts:450`)
- Gap: `buildOmniSpawnParams` returns SpawnParams missing `permissions` + `disallowedTools` — confirmed by reading lines 107-139 of `claude-code.ts`

## Changes

- `src/services/executors/claude-code.ts` — add `permissions` + `disallowedTools` passthrough in `buildOmniSpawnParams`; empty arrays resolve to `undefined` so we never emit a misleading empty permissions block
- `src/services/executors/claude-code.test.ts` — 5 new tests: allow/deny propagation, disallowedTools propagation, absence preserved, empty arrays → undefined, SDK-only fields (preset/bashAllowPatterns) ignored in CLI path

## Test plan

- [x] `bun test src/services/executors/claude-code.test.ts` — 27 pass (5 new)
- [x] `bun run check` — 2669 pass, 0 fail
- [ ] Live: spawn a turn agent with `AGENTS.md` declaring `permissions.deny: ["Bash(rm *)"]` → confirm `rm` is denied
- [ ] Live: verify existing agents without `permissions` still spawn normally (no regression)