### PR TITLE
fix(scheduler): mark unresumable + exhausted agents as terminal (stop re-processing)

### DIFF
--- a/src/lib/scheduler-daemon.test.ts
+++ b/src/lib/scheduler-daemon.test.ts
@@ -20,7 +20,9 @@ import {
   reclaimExpiredLeases,
   reconcileOrphanedRuns,
   reconcileOrphans,
+  reconcileUnresumable,
   recoverOnStartup,
+  runAgentRecoveryPass,
   startDaemon,
 } from './scheduler-daemon.js';
 
@@ -1324,6 +1326,10 @@ describe('scheduler-daemon', () => {
       // Pre-fix this path was unreachable because the counter was always 0 on
       // re-entry. Post-fix the increment persists, so after 3 attempts the
       // next tick hits the early-exit `attempts >= maxAttempts` branch.
+      //
+      // Post-fix/wedged-terminal-state: the early-exit branch also persists
+      // `autoResume=false` so the next cycle's resumable filter excludes the
+      // agent (prevents `agent_resume_exhausted` re-logging every 60s).
       const agent = makeWorker({ resumeAttempts: 3, maxResumeAttempts: 3 });
       const updates: { id: string; updates: Record<string, unknown> }[] = [];
       const { deps, logs } = createMockDeps(
@@ -1342,9 +1348,13 @@ describe('scheduler-daemon', () => {
       const exhausted = logs.find((l) => l.event === 'agent_resume_exhausted');
       expect(exhausted).toBeDefined();
       expect(exhausted?.resume_attempts).toBe(3);
-      // No updateAgent calls on early-exit exhaustion — we do NOT re-increment
-      // or reset when the budget is already depleted.
-      expect(updates).toHaveLength(0);
+      // Exactly one updateAgent call on early-exit exhaustion: the terminal
+      // `autoResume=false` flip. We do NOT re-increment or reset counters
+      // when the budget is already depleted.
+      expect(updates).toHaveLength(1);
+      expect(updates[0].updates.autoResume).toBe(false);
+      // Critical invariant: no counter mutation on the early-exit branch.
+      expect(updates[0].updates.resumeAttempts).toBeUndefined();
     });
 
     test('success path explicitly resets counter to 0', async () => {
@@ -1412,6 +1422,202 @@ describe('scheduler-daemon', () => {
       // counter mid-flight, lastResumeAttempt would also be absent).
       expect(row.resumeAttempts).toBe(0);
       expect(row.lastResumeAttempt).toBeDefined();
+    });
+  });
+
+  // ==========================================================================
+  // Regression: fix/wedged-terminal-state
+  //
+  // Two bugs, same architectural shape — terminal-state agents that the
+  // scheduler kept re-processing every cycle.
+  //
+  //  - Bug A: Rows in `state='error', auto_resume=true, claude_session_id=null`
+  //    were dropped by the resumable filter (no session id), but stayed in
+  //    `auto_resume=true` forever, misleading `genie ls` ("auto-resume: on")
+  //    and polluting the worker list. The `reconcileUnresumable` pass flips
+  //    those rows to `auto_resume=false`.
+  //
+  //  - Bug B: The `attempts >= maxAttempts` early-exit in `attemptAgentResume`
+  //    logged `agent_resume_exhausted` and returned, but did NOT set
+  //    `auto_resume=false`. Next scheduler tick (60s later) re-entered the
+  //    same branch and re-logged the same exhaustion event — 9 agents on
+  //    felipe's machine produced ~12K redundant events over a day. The fix
+  //    persists `auto_resume=false` at the terminal boundary.
+  //
+  // Prior art: PR #1181 (zombie concurrency cap) + PR #1187 (counter
+  // persistence). This is the final cleanup pass closing the
+  // "terminal states should be terminal" theme.
+  // ==========================================================================
+
+  describe('reconcileUnresumable — Bug A: mark null-session error rows unresumable', () => {
+    test('flips auto_resume to false for error-state agent with null session id', async () => {
+      const workers: WorkerInfo[] = [
+        {
+          id: 'wedged-agent',
+          paneId: '',
+          state: 'error',
+          autoResume: true,
+          // claudeSessionId intentionally undefined — simulates the DB NULL
+          // observed on felipe's machine (genie-docs directory placeholders
+          // + omni workers that died before capturing a Claude session).
+          claudeSessionId: undefined,
+        },
+      ];
+      const updates: { id: string; updates: Record<string, unknown> }[] = [];
+      const { deps, logs } = createMockDeps(
+        {},
+        {
+          listWorkers: async () => workers,
+          updateAgent: async (id, u) => {
+            updates.push({ id, updates: u });
+          },
+        },
+      );
+
+      const flipped = await reconcileUnresumable(deps);
+
+      expect(flipped).toBe(1);
+      expect(updates).toHaveLength(1);
+      expect(updates[0].id).toBe('wedged-agent');
+      expect(updates[0].updates.autoResume).toBe(false);
+
+      const marked = logs.find((l) => l.event === 'agent_marked_unresumable');
+      expect(marked).toBeDefined();
+      expect(marked?.agent_id).toBe('wedged-agent');
+      expect(marked?.reason).toBe('no_session_id');
+    });
+
+    test('leaves error-state agents with a valid claude_session_id untouched', async () => {
+      const workers: WorkerInfo[] = [
+        {
+          id: 'resumable-agent',
+          paneId: '%42',
+          state: 'error',
+          autoResume: true,
+          // Valid session id — the scheduler CAN still retry this agent.
+          // The reconciler must NOT flip auto_resume here.
+          claudeSessionId: 'abcd-1234-valid-uuid',
+        },
+        {
+          id: 'already-disabled',
+          paneId: '%43',
+          state: 'error',
+          autoResume: false,
+          claudeSessionId: undefined,
+        },
+        {
+          id: 'healthy-working',
+          paneId: '%44',
+          state: 'working',
+          autoResume: true,
+          claudeSessionId: undefined,
+        },
+      ];
+      const updates: { id: string; updates: Record<string, unknown> }[] = [];
+      const { deps, logs } = createMockDeps(
+        {},
+        {
+          listWorkers: async () => workers,
+          updateAgent: async (id, u) => {
+            updates.push({ id, updates: u });
+          },
+        },
+      );
+
+      const flipped = await reconcileUnresumable(deps);
+
+      // None of the three rows match the (error + auto_resume=true + null-session) triple.
+      expect(flipped).toBe(0);
+      expect(updates).toHaveLength(0);
+      const marked = logs.find((l) => l.event === 'agent_marked_unresumable');
+      expect(marked).toBeUndefined();
+    });
+  });
+
+  describe('attemptAgentResume exhaustion — Bug B: persist auto_resume=false', () => {
+    function makeWorker(overrides: Partial<WorkerInfo> = {}): WorkerInfo {
+      return {
+        id: 'test-agent',
+        paneId: '%42',
+        state: 'error',
+        claudeSessionId: 'session-abc',
+        autoResume: true,
+        resumeAttempts: 0,
+        maxResumeAttempts: 3,
+        ...overrides,
+      };
+    }
+
+    test('exhaustion branch persists auto_resume=false alongside the log event', async () => {
+      // Direct reproduction of the Bug B observation: an already-exhausted
+      // agent (attempts==max) re-entering attemptAgentResume must (1) still
+      // fire `agent_resume_exhausted` for backward compat, AND (2) write
+      // `auto_resume=false` so the next cycle's resumable filter excludes it.
+      const agent = makeWorker({ resumeAttempts: 3, maxResumeAttempts: 3 });
+      const updates: { id: string; updates: Record<string, unknown> }[] = [];
+      const { deps, logs } = createMockDeps(
+        {},
+        {
+          updateAgent: async (id, u) => {
+            updates.push({ id, updates: u });
+          },
+        },
+      );
+
+      const result = await attemptAgentResume(deps, defaultConfig, agent);
+
+      expect(result).toBe('exhausted');
+      // Backward compat: exhaustion event still fires.
+      const exhausted = logs.find((l) => l.event === 'agent_resume_exhausted');
+      expect(exhausted).toBeDefined();
+      expect(exhausted?.resume_attempts).toBe(3);
+      // New invariant: auto_resume=false was persisted.
+      const flip = updates.find((u) => u.updates.autoResume === false);
+      expect(flip).toBeDefined();
+      expect(flip?.id).toBe('test-agent');
+    });
+
+    test('subsequent recovery cycle excludes the now-unresumable agent (no new event)', async () => {
+      // Simulate two consecutive scheduler ticks. On tick 1 the agent is
+      // exhausted → auto_resume flipped to false. On tick 2 runAgentRecoveryPass
+      // must exclude the agent entirely (the resumable filter already drops
+      // `autoResume=false` implicitly via attemptAgentResume's early-skip,
+      // but we test the end-to-end exclusion: no new `agent_resume_exhausted`
+      // fires).
+      let row: WorkerInfo = {
+        id: 'exhausted-agent',
+        paneId: '%99',
+        state: 'error',
+        claudeSessionId: 'sess-valid',
+        autoResume: true,
+        resumeAttempts: 3,
+        maxResumeAttempts: 3,
+      };
+
+      const { deps, logs } = createMockDeps(
+        {},
+        {
+          listWorkers: async () => [row],
+          isPaneAlive: async () => false,
+          updateAgent: async (_id, u) => {
+            row = { ...row, ...u } as WorkerInfo;
+          },
+        },
+      );
+
+      // Tick 1: runs the full recovery pass. Agent is exhausted → flipped.
+      await runAgentRecoveryPass(deps, 'daemon-t1', defaultConfig);
+      const exhaustedCountAfterT1 = logs.filter((l) => l.event === 'agent_resume_exhausted').length;
+      expect(exhaustedCountAfterT1).toBe(1);
+      expect(row.autoResume).toBe(false);
+
+      // Tick 2: same agent, now with auto_resume=false from tick 1. The
+      // recovery pass must NOT re-log `agent_resume_exhausted` — the agent
+      // is filtered out before reaching the exhaustion check. Before the
+      // Bug B fix, this count would grow by 1 on every 60s tick forever.
+      await runAgentRecoveryPass(deps, 'daemon-t2', defaultConfig);
+      const exhaustedCountAfterT2 = logs.filter((l) => l.event === 'agent_resume_exhausted').length;
+      expect(exhaustedCountAfterT2).toBe(1);
     });
   });
 

--- a/src/lib/scheduler-daemon.ts
+++ b/src/lib/scheduler-daemon.ts
@@ -813,6 +813,64 @@ export async function runAgentRecoveryPass(
   return { resumed, failed };
 }
 
+/**
+ * Reconcile agents that can never be auto-resumed.
+ *
+ * Rows in `state='error'` with `autoResume=true` but no `claudeSessionId` are
+ * permanently wedged: the resume filter in {@link runAgentRecoveryPass} drops
+ * them (no session id to resume from), so they are never attempted, their
+ * counter never advances, and `genie ls` keeps displaying `auto-resume: on`
+ * — a lie to the operator since the scheduler cannot possibly try.
+ *
+ * Observed live on felipe's machine: 9 such rows (8 `genie-docs` directory
+ * placeholders + 2 omni workers that died before capturing a Claude session
+ * id). Root cause for why those rows end up in `error` state without a
+ * session id is tracked as a separate investigation (dir:-row state
+ * mutation + omni session capture).
+ *
+ * The fix here is the terminal-boundary invariant: mark them `auto_resume=false`
+ * so subsequent scheduler ticks ignore them and the UI reflects reality.
+ * Each flipped row logs `agent_marked_unresumable` for observability.
+ *
+ * Exported so the periodic timer can invoke it alongside the existing
+ * `reconcileDeadPaneZombies` + `runAgentRecoveryPass` pair.
+ */
+export async function reconcileUnresumable(deps: SchedulerDeps): Promise<number> {
+  const workers = await deps.listWorkers();
+  let flipped = 0;
+  for (const worker of workers) {
+    // Terminal boundary condition: error-state, auto-resume on, no session id.
+    // `!worker.claudeSessionId` matches both `null` (DB) and `undefined`
+    // (listWorkers mapping for missing column).
+    if (worker.state !== 'error') continue;
+    if (worker.autoResume === false) continue;
+    if (worker.claudeSessionId) continue;
+
+    try {
+      await deps.updateAgent(worker.id, { autoResume: false });
+      deps.log({
+        timestamp: deps.now().toISOString(),
+        level: 'warn',
+        event: 'agent_marked_unresumable',
+        agent_id: worker.id,
+        reason: 'no_session_id',
+        state: worker.state,
+      });
+      flipped++;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      deps.log({
+        timestamp: deps.now().toISOString(),
+        level: 'warn',
+        event: 'agent_marked_unresumable_failed',
+        agent_id: worker.id,
+        error: message,
+      });
+    }
+  }
+  return flipped;
+}
+
 // ============================================================================
 // Agent auto-resume
 // ============================================================================
@@ -911,8 +969,16 @@ export async function attemptAgentResume(
   const maxAttempts = agent.maxResumeAttempts ?? DEFAULT_MAX_RESUME_ATTEMPTS;
   const attempts = agent.resumeAttempts ?? 0;
 
-  // Retry budget exhausted
+  // Retry budget exhausted — mark terminal so the scheduler filter excludes
+  // the agent next cycle. Prior to this write, `attempts >= maxAttempts` rows
+  // kept passing the resumable filter, so `agent_resume_exhausted` fired on
+  // every tick (60s) for the same agent without any new delivery attempt. The
+  // log-once invariant requires `auto_resume=false` to persist at the terminal
+  // boundary (mirrors the Bug A unresumable reconciler below). We only reach
+  // this branch when `autoResume !== false` (the earlier early-skip handles
+  // the disabled case), so the write is unconditional here.
   if (attempts >= maxAttempts) {
+    await deps.updateAgent(agentId, { autoResume: false });
     deps.log({
       timestamp: now.toISOString(),
       level: 'warn',
@@ -1002,8 +1068,13 @@ export async function attemptAgentResume(
     max_resume_attempts: maxAttempts,
   });
 
-  // If this was the last attempt, mark exhausted
+  // If this was the last attempt, mark exhausted AND persist
+  // `auto_resume=false` so the next scheduler tick's resumable filter excludes
+  // this agent. Without the flip, subsequent cycles would hit the early-exit
+  // `attempts >= maxAttempts` branch and re-log `agent_resume_exhausted` every
+  // 60s forever.
   if (newAttempts >= maxAttempts) {
+    await deps.updateAgent(agentId, { autoResume: false });
     deps.log({
       timestamp: now.toISOString(),
       level: 'warn',
@@ -1756,7 +1827,14 @@ export function startDaemon(
     return setInterval(async () => {
       if (!running) return;
       try {
+        // Order matters: (1) GC dead-pane zombies so activeCount is accurate;
+        // (2) flip unresumable rows to `auto_resume=false` so they are
+        // excluded from the resumable filter in this same tick; (3) run the
+        // resume pass. Step 2 is the Bug A fix — without it, error rows with
+        // null session ids stayed in `auto_resume=true` forever, misleading
+        // `genie ls` and cluttering the worker list.
         await reconcileDeadPaneZombies(d);
+        await reconcileUnresumable(d);
         await runAgentRecoveryPass(d, dId, cfg);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary

Two related bugs, one cohesive PR — both variants of **terminal-state agents the scheduler kept re-processing every cycle**.

- **Bug A (Category 2 /trace, HIGH confidence):** Rows in `state='error', auto_resume=true, claude_session_id=null` are permanently wedged — the resumable filter drops them (no session id), yet they keep `auto_resume=true` forever. 9 such rows observed live on felipe's machine (8 `genie-docs` dir-placeholders + 2 omni workers that died pre-session-capture). `genie ls` misleadingly showed `auto-resume: on` + `0/3` forever.
- **Bug B (observed live):** The `attempts >= maxAttempts` early-exit in `attemptAgentResume` logged `agent_resume_exhausted` and returned, but did NOT persist `auto_resume=false`. Next tick (60s) re-entered the same branch → redundant event spam for every exhausted agent, every minute, forever.

Both fixes apply the same **terminal-boundary invariant**: set `auto_resume=false` at the point the scheduler concludes the agent is unrecoverable. Shared primitive (`deps.updateAgent`), shared filter semantics (the `autoResume === false` early-skip already exists in `attemptAgentResume`).

## Files touched

- `src/lib/scheduler-daemon.ts` — new exported `reconcileUnresumable(deps)`, wired into `startAgentResumeTimer` between the existing zombie GC and the resume pass. Both exhaustion branches in `attemptAgentResume` now `await deps.updateAgent(id, { autoResume: false })` before logging.
- `src/lib/scheduler-daemon.test.ts` — 4 new regression tests + 1 existing test updated to assert the new terminal-flag write.

## Prior art

- PR #1181 — zombie concurrency cap (tracked the resume filter's `claudeSessionId` predicate)
- PR #1187 — counter persistence (`--no-reset-attempts`, made exhaustion actually reachable)

This is the **final cleanup pass** closing the "terminal states should be terminal" theme.

## Staged follow-ups (explicitly out of scope)

- Root cause for how `dir:` registry rows end up in `state='error'` — separate `/trace` (tui-spawn `--team is required` failure path)
- Fix for why omni transport agents don't capture `claudeSessionId` — separate `/trace`
- Ops cleanup of the 9 already-wedged rows on felipe's live machine — handled by the new reconciler on next daemon restart

## Test plan

- [x] `bun run typecheck` — 0 errors
- [x] `bun run check` — 2668 pass / 0 fail
- [x] New regression test: `reconcileUnresumable` flips null-session error rows + logs `agent_marked_unresumable`
- [x] New regression test: `reconcileUnresumable` leaves valid-session / already-disabled / healthy rows untouched
- [x] New regression test: exhaustion branch persists `auto_resume=false` alongside the `agent_resume_exhausted` log event
- [x] New regression test: subsequent `runAgentRecoveryPass` tick does NOT re-log `agent_resume_exhausted` for the same agent
- [x] Existing test `exhaustion check fires on re-entry` updated: now asserts exactly 1 `updateAgent` call with `autoResume: false` + no counter mutation
- [ ] Post-merge dogfood: `genie ls | grep -E "genie-docs|omni"` should flip to `auto-resume: off` within one `leaseRecoveryIntervalMs` cycle; `tail -30 ~/.genie/logs/scheduler.log | grep agent_resume_exhausted | wc -l` should show each agent ONLY ONCE

🤖 Generated with [Claude Code](https://claude.com/claude-code)