### PR TITLE
feat(brain): chain brain install wizard after install (closes #1203)

### DIFF
--- a/src/term-commands/brain.test.ts
+++ b/src/term-commands/brain.test.ts
@@ -118,3 +118,28 @@ describe('compareVersions', () => {
     expect(compareVersions('260404.1', '260403.99')).toBeGreaterThan(0);
   });
 });
+
+/**
+ * Closes khal-os/brain wish brain-v2-onboarding-overhaul Grupo G.
+ *
+ * Source-grep guard verifying installBrain chains the brain-side
+ * install wizard. We use a structural test rather than mocking the
+ * dynamic brain import (which is brittle across genie test envs).
+ */
+describe('installBrain → brain install wizard chain', () => {
+  test('source extracts wizard call into runBrainInstallWizard helper', () => {
+    const { readFileSync } = require('node:fs') as typeof import('node:fs');
+    const { dirname, join } = require('node:path') as typeof import('node:path');
+    const src = readFileSync(join(dirname(import.meta.path), 'brain.ts'), 'utf-8');
+
+    // Helper exists and chains via brain.execute(['install', '--apply', '--yes']).
+    expect(src).toContain('async function runBrainInstallWizard()');
+    expect(src).toMatch(/brain\.execute\(\['install', '--apply', '--yes'\]\)/);
+    // installBrain calls the helper after the migrations + before the
+    // final "Get started" line.
+    expect(src).toContain('await runBrainInstallWizard();');
+    // Best-effort: failure is non-fatal (try/catch with skip message).
+    expect(src).toMatch(/Install wizard skipped/);
+    expect(src).toMatch(/brain install --apply --yes/);
+  });
+});

--- a/src/term-commands/brain.ts
+++ b/src/term-commands/brain.ts
@@ -420,6 +420,8 @@ async function installBrain(): Promise<boolean> {
       console.log('  Auto-migration skipped. Run: genie brain migrate');
     }
 
+    await runBrainInstallWizard();
+
     // Auto-start daemon if a vault is found
     const vaultPath = findBrainVault();
     if (vaultPath) {
@@ -456,6 +458,33 @@ async function installBrain(): Promise<boolean> {
       console.log('');
     }
     return false;
+  }
+}
+
+/**
+ * Closes khal-os/brain wish brain-v2-onboarding-overhaul Grupo G:
+ * chain the brain-side install wizard after the binary is installed
+ * + migrations have run. The wizard does:
+ *   - diagnose (wraps `brain doctor`)
+ *   - auto-install rlmx if missing (`bun install -g @automagik/rlmx`)
+ *   - run a smoke test (`brain doctor --json` parse)
+ *
+ * Idempotent: re-run on a healthy env is a no-op. Best-effort: any
+ * failure here is non-fatal because the binary itself is already
+ * installed and usable. Operator can re-run manually with
+ * `brain install --apply --yes`.
+ */
+async function runBrainInstallWizard(): Promise<void> {
+  try {
+    const brain = await import(BRAIN_PKG);
+    if (brain.execute) {
+      console.log('');
+      console.log('  Running brain install wizard (rlmx + smoke test)...');
+      await brain.execute(['install', '--apply', '--yes']);
+    }
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.log(`  Install wizard skipped (${msg.split('\n')[0]}). Run manually: brain install --apply --yes`);
   }
 }
 


### PR DESCRIPTION
Closes #1203.

Wires the brain-side install wizard (\`brain install\`, shipped in @khal-os/brain v1.47.0) into \`genie brain install\` so first-time install becomes a single end-to-end flow instead of two manual steps.

## Behavior change

\`genie brain install\` now:

1. Downloads the latest brain release tarball (existing)
2. Runs brain migrations (existing)
3. **NEW** — invokes \`brain.execute(['install', '--apply', '--yes'])\` which auto-installs rlmx if missing and runs a smoke test
4. Auto-starts the daemon if a vault is found (existing)
5. Prints \"Get started: genie brain init …\" (existing)

Wizard is idempotent + best-effort. Failure non-fatal because the binary itself is already installed at that point.

## Implementation

Extracted the wizard call into a dedicated \`runBrainInstallWizard()\` helper to keep \`installBrain\`'s cognitive complexity at biome's threshold of 15.

## Tests

- New source-grep guard verifies the chain is wired correctly (helper exists, calls \`brain.execute\` with right args, \`installBrain\` calls the helper).
- All 12 brain.test.ts tests pass.
- Full \`bun run check\` passes (2725/2725).

## Cross-repo

- Brain wizard PR: [khal-os/brain#242](https://github.com/khal-os/brain/pull/242) (merged)
- Brain wizard release: v1.47.0
- Wish: \`brain-v2-onboarding-overhaul\` Phase 3 Grupo G

## Test plan

- [x] \`bun run check\` clean
- [x] Source-grep test passes
- [x] No behavior change when brain.execute is unavailable (older brain version)