### PR TITLE
fix(db,dispatch): harden parallel wave dispatch against CONNECTION_ENDED (#1207)

### DIFF
--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -392,9 +392,82 @@ describe('pool error recovery', () => {
     // Find the cached client health check function
     const healthCheckIdx = source.indexOf('healthCheckCachedClient');
     expect(healthCheckIdx).toBeGreaterThan(-1);
-    const block = source.slice(healthCheckIdx, healthCheckIdx + 400);
+    const block = source.slice(healthCheckIdx, healthCheckIdx + 600);
     expect(block).toContain('sqlClient = null');
     expect(block).toContain('activePort = null');
+  });
+});
+
+describe('parallel dispatch race (issue #1207)', () => {
+  test('healthCheckCachedClient nulls sqlClient BEFORE calling .end()', () => {
+    // Regression guard: inverting these lines (or re-introducing `await
+    // sqlClient.end(...)` before the null assignment) resurrects the
+    // CONNECTION_ENDED race fixed by 74aaa022 + issue #1207.
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    const fnStart = source.indexOf('async function healthCheckCachedClient');
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnEnd = source.indexOf('\n}\n', fnStart);
+    const body = source.slice(fnStart, fnEnd);
+
+    const nullIdx = body.indexOf('sqlClient = null');
+    const endCallIdx = body.indexOf('.end(');
+    expect(nullIdx).toBeGreaterThan(-1);
+    expect(endCallIdx).toBeGreaterThan(-1);
+    // Null must come BEFORE the .end() call
+    expect(nullIdx).toBeLessThan(endCallIdx);
+  });
+
+  test('healthCheckCachedClient does not await .end() — fire-and-forget teardown', () => {
+    // If the teardown is awaited synchronously, concurrent in-flight queries
+    // on the shared pool get killed with CONNECTION_ENDED (issue #1207).
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    const fnStart = source.indexOf('async function healthCheckCachedClient');
+    const fnEnd = source.indexOf('\n}\n', fnStart);
+    const body = source.slice(fnStart, fnEnd);
+
+    // Should not have `await ... .end(` anywhere in the catch branch
+    const catchIdx = body.indexOf('catch');
+    expect(catchIdx).toBeGreaterThan(-1);
+    const catchBody = body.slice(catchIdx);
+    // Match `await <identifier>.end(` or `await this.end(` patterns
+    expect(catchBody).not.toMatch(/await\s+\w+\.end\(/);
+    // Should call .end() with a .catch(...) attached (fire-and-forget)
+    expect(catchBody).toMatch(/\.end\([^)]*\)\.catch\(/);
+  });
+
+  test('getConnection dedups concurrent rebuilds via buildPromise', () => {
+    // Without dedup, N parallel callers each race pgModule(...) and overwrite
+    // the singleton, leaking pools and triggering CONNECTION_ENDED on the
+    // orphaned ones. See issue #1207.
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    expect(source).toContain('let buildPromise');
+    // getConnection must check buildPromise before rebuilding
+    const getConnIdx = source.indexOf('export async function getConnection');
+    const nextFnIdx = source.indexOf('async function _buildConnection');
+    expect(getConnIdx).toBeGreaterThan(-1);
+    expect(nextFnIdx).toBeGreaterThan(getConnIdx);
+    const body = source.slice(getConnIdx, nextFnIdx);
+    expect(body).toContain('if (buildPromise) return buildPromise');
+    // Must reset buildPromise on both success and failure
+    expect(body).toMatch(/finally\s*\{[^}]*buildPromise\s*=\s*null/);
+  });
+
+  test('_buildConnection fire-and-forget teardown on post-connect failure', () => {
+    // Same pattern as healthCheckCachedClient — if runPostConnectSetup fails,
+    // tear down the doomed client without blocking concurrent work.
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    const fnStart = source.indexOf('async function _buildConnection');
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnEnd = source.indexOf('\n}\n', fnStart);
+    const body = source.slice(fnStart, fnEnd);
+
+    const catchIdx = body.indexOf('catch (err)');
+    expect(catchIdx).toBeGreaterThan(-1);
+    const catchBody = body.slice(catchIdx);
+    // Null before end, fire-and-forget teardown
+    expect(catchBody.indexOf('sqlClient = null')).toBeLessThan(catchBody.indexOf('.end('));
+    expect(catchBody).not.toMatch(/await\s+\w+\.end\(/);
+    expect(catchBody).toMatch(/\.end\([^)]*\)\.catch\(/);
   });
 });
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -167,6 +167,13 @@ let pgserveChild: ChildProcess | null = null;
 let sqlClient: any = null;
 let activePort: number | null = null;
 let ensurePromise: Promise<number> | null = null;
+/**
+ * Dedup concurrent rebuilds of sqlClient. N parallel getConnection() callers
+ * observing a null/stale client would each race pgModule(...) and leak pools.
+ * biome-ignore lint/suspicious/noExplicitAny: shared with sqlClient
+ */
+// biome-ignore lint/suspicious/noExplicitAny: postgres.js Sql type requires generics we don't need
+let buildPromise: Promise<any> | null = null;
 /** Whether this process spawned pgserve (and thus owns the lockfile) */
 let ownsLockfile = false;
 let exitHandlerRegistered = false;
@@ -444,20 +451,31 @@ function registerExitHandler(): void {
  * When GENIE_TEST_SCHEMA is set, all connections use that schema in their search_path.
  * This isolates test data from production tables.
  */
-/** Health-check the cached client. Returns it if alive, or resets and returns null. */
+/** Health-check the cached client. Returns it if alive, or resets and returns null.
+ *
+ * Mirrors the `resetConnection()` null-before-end pattern (commit 74aaa022): the
+ * global reference is cleared first so concurrent callers rebuild a fresh client
+ * instead of racing on the dying one. The teardown itself is fire-and-forget so
+ * concurrent in-flight queries on the shared pool are not killed synchronously
+ * with CONNECTION_ENDED. See issue #1207.
+ */
 async function healthCheckCachedClient() {
   if (!sqlClient) return null;
   try {
     await sqlClient`SELECT 1`;
     return sqlClient;
   } catch {
-    try {
-      await sqlClient.end({ timeout: 2 });
-    } catch {
-      /* ignore */
-    }
+    const dying = sqlClient;
     sqlClient = null;
     activePort = null;
+    // Fire-and-forget teardown — do not await. Concurrent callers holding the
+    // `dying` reference (via closures, iterators, in-flight Promises) will
+    // finish their current operation; the pool's internal connection reaper
+    // handles final cleanup. Awaiting here would cause CONNECTION_ENDED on
+    // queries that are still in flight from other callers.
+    dying.end({ timeout: 5 }).catch(() => {
+      /* ignore — teardown is best-effort */
+    });
     return null;
   }
 }
@@ -489,6 +507,23 @@ export async function getConnection() {
   const cached = await healthCheckCachedClient();
   if (cached) return cached;
 
+  // Dedup concurrent rebuilds. Without this, N parallel callers (e.g.
+  // workDispatchCommand fan-out in `genie work <slug>` when a wave has
+  // ≥2 parallel groups) each race pgModule(...) and overwrite sqlClient,
+  // leaking pools and triggering CONNECTION_ENDED on the orphaned ones.
+  // See issue #1207.
+  if (buildPromise) return buildPromise;
+
+  buildPromise = _buildConnection();
+  try {
+    return await buildPromise;
+  } finally {
+    buildPromise = null;
+  }
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: postgres.js Sql type requires generics we don't need
+async function _buildConnection(): Promise<any> {
   const _t0 = Date.now();
   const port = await ensurePgserve();
   const _t1 = Date.now();
@@ -514,13 +549,14 @@ export async function getConnection() {
   try {
     await runPostConnectSetup(sqlClient, testSchema, { t0: _t0, t1: _t1 });
   } catch (err) {
-    try {
-      await sqlClient.end({ timeout: 2 });
-    } catch {
-      /* ignore */
-    }
+    const dying = sqlClient;
     sqlClient = null;
     activePort = null;
+    // Fire-and-forget teardown — match healthCheckCachedClient so we never
+    // block on a dying pool while other work is in flight.
+    dying?.end({ timeout: 2 }).catch(() => {
+      /* ignore */
+    });
     throw err;
   }
 

--- a/src/term-commands/dispatch.test.ts
+++ b/src/term-commands/dispatch.test.ts
@@ -766,3 +766,65 @@ describe('detectWorkMode()', () => {
     expect(result).toEqual({ mode: 'manual', ref: 'auto-orchestrate#5', agent: 'reviewer' });
   });
 });
+
+// ============================================================================
+// autoOrchestrateCommand parallel dispatch resilience (issue #1207)
+// ============================================================================
+
+describe('autoOrchestrateCommand parallel dispatch (issue #1207)', () => {
+  it('uses Promise.allSettled — not Promise.all — for wave dispatch', async () => {
+    // Regression guard: Promise.all aborts the whole batch on the first failed
+    // post-dispatch SQL write (CONNECTION_ENDED from the singleton client race).
+    // Promise.allSettled lets sibling dispatches complete reporting even when
+    // one fails after its state mutation already landed.
+    const { readFileSync } = await import('node:fs');
+    const source = readFileSync(join(__dirname, 'dispatch.ts'), 'utf-8');
+
+    const fnStart = source.indexOf('async function autoOrchestrateCommand');
+    expect(fnStart).toBeGreaterThan(-1);
+    // Find the end of the function — next function definition or end of file
+    const nextFnIdx = source.indexOf('\nasync function ', fnStart + 1);
+    const fnEnd = nextFnIdx !== -1 ? nextFnIdx : source.length;
+    const body = source.slice(fnStart, fnEnd);
+
+    // Must use allSettled
+    expect(body).toContain('Promise.allSettled');
+    // Must NOT use bare Promise.all on the wave-dispatch loop
+    expect(body).not.toMatch(/await\s+Promise\.all\s*\(\s*nextWave/);
+  });
+
+  it('reports per-group failures and sets non-zero exit code', async () => {
+    const { readFileSync } = await import('node:fs');
+    const source = readFileSync(join(__dirname, 'dispatch.ts'), 'utf-8');
+    const fnStart = source.indexOf('async function autoOrchestrateCommand');
+    const nextFnIdx = source.indexOf('\nasync function ', fnStart + 1);
+    const body = source.slice(fnStart, nextFnIdx !== -1 ? nextFnIdx : source.length);
+
+    // Must surface per-group failures with the group name
+    expect(body).toMatch(/failed/i);
+    expect(body).toContain('process.exitCode');
+    // Must still print success summary for groups that did dispatch
+    expect(body).toContain('Agents dispatched for');
+  });
+
+  it('does not abort the success print on partial failure', async () => {
+    // If any group succeeds we print the success line for those groups even
+    // when others failed. Reads back the same function source and checks
+    // there is no `throw` or early-exit between the success-list build and
+    // the console.log of the success summary.
+    const { readFileSync } = await import('node:fs');
+    const source = readFileSync(join(__dirname, 'dispatch.ts'), 'utf-8');
+    const fnStart = source.indexOf('async function autoOrchestrateCommand');
+    const nextFnIdx = source.indexOf('\nasync function ', fnStart + 1);
+    const body = source.slice(fnStart, nextFnIdx !== -1 ? nextFnIdx : source.length);
+
+    const allSettledIdx = body.indexOf('Promise.allSettled');
+    const successPrintIdx = body.indexOf('Agents dispatched for');
+    expect(allSettledIdx).toBeGreaterThan(-1);
+    expect(successPrintIdx).toBeGreaterThan(allSettledIdx);
+    const between = body.slice(allSettledIdx, successPrintIdx);
+    // No early `throw` or `process.exit(` between allSettled and the success print
+    expect(between).not.toContain('throw ');
+    expect(between).not.toContain('process.exit(');
+  });
+});

--- a/src/term-commands/dispatch.ts
+++ b/src/term-commands/dispatch.ts
@@ -428,17 +428,48 @@ async function autoOrchestrateCommand(slug: string): Promise<void> {
 
   // Dispatch all groups in this wave concurrently.
   // workDispatchCommand spawns a tmux pane and returns immediately.
-  await Promise.all(
+  //
+  // Use Promise.allSettled so a single group's post-dispatch failure doesn't
+  // abort reporting for siblings whose state mutations already landed.
+  // See issue #1207 — CONNECTION_ENDED on one dispatch was rejecting the
+  // whole batch and suppressing the success print even when all groups
+  // transitioned to in_progress.
+  const results = await Promise.allSettled(
     nextWave.groups.map(({ group, agent }) => {
       const ref = `${slug}#${group}`;
       return workDispatchCommand(agent, ref);
     }),
   );
 
-  const groupList = nextWave.groups.map((g) => g.group).join(', ');
-  console.log(`\n✅ Agents dispatched for ${nextWave.name} (groups: ${groupList})`);
+  const succeeded: string[] = [];
+  const failed: { group: string; reason: string }[] = [];
+  results.forEach((r, i) => {
+    const groupName = nextWave.groups[i].group;
+    if (r.status === 'fulfilled') {
+      succeeded.push(groupName);
+    } else {
+      const reason = r.reason instanceof Error ? r.reason.message : String(r.reason);
+      failed.push({ group: groupName, reason });
+    }
+  });
+
+  if (succeeded.length > 0) {
+    console.log(`\n✅ Agents dispatched for ${nextWave.name} (groups: ${succeeded.join(', ')})`);
+  }
+  if (failed.length > 0) {
+    console.error(`\n❌ ${failed.length} group(s) failed to dispatch in ${nextWave.name}:`);
+    for (const { group, reason } of failed) {
+      console.error(`   • Group ${group}: ${reason}`);
+    }
+    console.error(`   Check state with: genie status ${slug}`);
+    console.error('   Some groups may have mutated state before failing — rerun genie work to retry.');
+  }
   console.log(`   Monitor: genie status ${slug}`);
   console.log('   Logs:    genie read <agent>');
+
+  if (failed.length > 0) {
+    process.exitCode = 1;
+  }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Closes #1207. `genie work <slug>` on a wave with N≥2 parallel groups exited non-zero with `write CONNECTION_ENDED 127.0.0.1:19642` even when wish state mutations landed. Three compounding causes, each fixed:

1. **`healthCheckCachedClient()` tore down the shared pool synchronously.** `await sqlClient.end(...)` on health failure killed concurrent in-flight queries from sibling `workDispatchCommand` calls. Mirrors the `resetConnection()` footgun fixed in 74aaa022 — that PR covered one call site, this covers the second.
2. **`getConnection()` had no dedup.** N parallel callers observing a null client each raced `pgModule(...)` and overwrote the singleton, leaking pools and triggering CONNECTION_ENDED on orphaned ones.
3. **`autoOrchestrateCommand` used `Promise.all`.** A single post-dispatch failure aborted reporting for siblings whose state mutations already succeeded.

## Changes

- `src/lib/db.ts`
  - `healthCheckCachedClient` — null `sqlClient`/`activePort` **before** teardown, then fire-and-forget `.end(...).catch(() => {})`. Concurrent callers rebuild a fresh client; the dying pool's in-flight queries finish naturally.
  - `getConnection` — dedup concurrent rebuilds via new `buildPromise` (same pattern as `ensurePromise` for `_ensurePgserve`). Rebuild path extracted to `_buildConnection()`. Post-connect failure uses the same null-before-fire-and-forget pattern.
- `src/term-commands/dispatch.ts`
  - `autoOrchestrateCommand` — `Promise.all` → `Promise.allSettled` with per-group success/failure summary. Exits non-zero (`process.exitCode = 1`) only when at least one dispatch fails, while still printing the success summary for groups that did dispatch.

## Regression coverage

- `src/lib/db.test.ts` — 4 source-based guards: null-before-end ordering, fire-and-forget teardown (no `await <ref>.end(`), `buildPromise` dedup + finally-reset, `_buildConnection` catch-path teardown.
- `src/term-commands/dispatch.test.ts` — 3 source-based guards: `Promise.allSettled` usage, per-group failure reporting + `process.exitCode`, no early abort between allSettled and the success print.

## Out of scope

Lockfile cleanup (recommendation #4 in the issue) — separate follow-up.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 errors (18 pre-existing warnings)
- [x] `bun test` — **2732 pass / 0 fail** (145 files, 59.8s)
- [x] `bun run build` — bundle rebuilt; verified it contains `healthCheckCachedClient`, `buildPromise`, `allSettled`

Refs: #1207