### PR TITLE
fix(omni): deliver follow-up messages via tmux send-keys, not mailbox

### DIFF
--- a/src/services/executors/__tests__/claude-code-deliver.test.ts
+++ b/src/services/executors/__tests__/claude-code-deliver.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Regression tests for ClaudeCodeOmniExecutor.deliver().
+ *
+ * Bug: subsequent messages on an active tmux session were routed through
+ * mailbox.send() and never reached the running Claude pane. Fix: deliver()
+ * injects directly via tmux send-keys, same path as injectNudge()/spawn().
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const mockExecuteTmux = mock(async (_cmd: string) => '');
+
+mock.module('../../../lib/tmux-wrapper.js', () => ({
+  executeTmux: mockExecuteTmux,
+  genieTmuxPrefix: () => ['-L', 'genie'],
+  genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
+}));
+
+// isPaneAlive lives in tmux.ts and calls executeTmux internally; by stubbing
+// executeTmux above we control what isPaneAlive observes (`'0'` → alive).
+const { ClaudeCodeOmniExecutor } = await import('../claude-code.js');
+import type { ExecutorSession, OmniMessage } from '../../executor.js';
+
+function makeSession(overrides: Partial<ExecutorSession> = {}): ExecutorSession {
+  return {
+    id: 'simone:156354157260957@lid',
+    agentName: 'simone',
+    chatId: '156354157260957@lid',
+    executorType: 'tmux',
+    createdAt: Date.now(),
+    lastActivityAt: Date.now(),
+    tmux: { session: 'simone', window: 'wa-156354157260957lid', paneId: '%83' },
+    ...overrides,
+  };
+}
+
+function makeMessage(overrides: Partial<OmniMessage> = {}): OmniMessage {
+  return {
+    chatId: '156354157260957@lid',
+    instanceId: '5adc1ffe-9089-480a-9df0-2d3a79d5df69',
+    sender: 'Stéfani',
+    agent: 'simone',
+    content: 'Bem, descansando.',
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('ClaudeCodeOmniExecutor.deliver', () => {
+  let executor: InstanceType<typeof ClaudeCodeOmniExecutor>;
+
+  beforeEach(() => {
+    mockExecuteTmux.mockReset();
+    // Default: isPaneAlive check (display-message -p pane_dead) returns '0' (alive)
+    mockExecuteTmux.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('display-message')) return '0';
+      return '';
+    });
+    executor = new ClaudeCodeOmniExecutor();
+  });
+
+  test('injects framed body into pane via two-phase send-keys with 200ms settle', async () => {
+    const session = makeSession();
+    const message = makeMessage();
+
+    const start = Date.now();
+    await executor.deliver(session, message);
+    const elapsed = Date.now() - start;
+
+    // Two-phase pattern: body send-keys, settle, Enter send-keys.
+    const sendKeysCalls = mockExecuteTmux.mock.calls
+      .map((c) => c[0] as string)
+      .filter((cmd) => cmd.startsWith("send-keys -t '%83'"));
+    expect(sendKeysCalls).toHaveLength(2);
+
+    // First call sends the framed body (no Enter).
+    expect(sendKeysCalls[0]).toContain('[Stéfani]: Bem, descansando.');
+    expect(sendKeysCalls[0]).toContain('WhatsApp Turn');
+    expect(sendKeysCalls[0].endsWith(' Enter')).toBe(false);
+
+    // Second call is the Enter key alone.
+    expect(sendKeysCalls[1]).toBe("send-keys -t '%83' Enter");
+
+    // 200ms settle is load-bearing: Claude's TUI may drop a newline that
+    // arrives in the same tmux batch as the text body.
+    expect(elapsed).toBeGreaterThanOrEqual(180);
+  });
+
+  test('body contains turn context (senderName, instanceId, chatId)', async () => {
+    const session = makeSession();
+    const message = makeMessage({ sender: 'TestUser', content: 'hello world' });
+
+    await executor.deliver(session, message);
+
+    const body = (mockExecuteTmux.mock.calls[1]?.[0] as string) ?? '';
+    expect(body).toContain('TestUser');
+    expect(body).toContain('5adc1ffe-9089-480a-9df0-2d3a79d5df69');
+    expect(body).toContain('156354157260957@lid');
+    expect(body).toContain('[TestUser]: hello world');
+  });
+
+  test('falls back to "whatsapp-user" when sender is empty string', async () => {
+    const session = makeSession();
+    const message = makeMessage({ sender: '' });
+
+    await executor.deliver(session, message);
+
+    const body = (mockExecuteTmux.mock.calls[1]?.[0] as string) ?? '';
+    expect(body).toContain('[whatsapp-user]:');
+  });
+
+  test('no send-keys when paneId missing', async () => {
+    const session = makeSession({ tmux: undefined });
+    await executor.deliver(session, makeMessage());
+
+    const sendKeysCalls = mockExecuteTmux.mock.calls
+      .map((c) => c[0] as string)
+      .filter((cmd) => cmd.startsWith('send-keys'));
+    expect(sendKeysCalls).toHaveLength(0);
+  });
+
+  test('no send-keys when paneId malformed (shell-injection guard)', async () => {
+    const session = makeSession({
+      tmux: { session: 'simone', window: 'w', paneId: "%83'; rm -rf /" },
+    });
+    await executor.deliver(session, makeMessage());
+
+    const sendKeysCalls = mockExecuteTmux.mock.calls
+      .map((c) => c[0] as string)
+      .filter((cmd) => cmd.startsWith('send-keys'));
+    expect(sendKeysCalls).toHaveLength(0);
+  });
+
+  test('no send-keys when pane reported dead', async () => {
+    // isPaneAlive returns false when display-message outputs '1'
+    mockExecuteTmux.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('display-message')) return '1';
+      return '';
+    });
+
+    const session = makeSession();
+    await executor.deliver(session, makeMessage());
+
+    const sendKeysCalls = mockExecuteTmux.mock.calls
+      .map((c) => c[0] as string)
+      .filter((cmd) => cmd.startsWith('send-keys'));
+    expect(sendKeysCalls).toHaveLength(0);
+  });
+
+  test('updates lastActivityAt on success', async () => {
+    const session = makeSession({ lastActivityAt: 0 });
+    await executor.deliver(session, makeMessage());
+    expect(session.lastActivityAt).toBeGreaterThan(0);
+  });
+
+  test('does not throw when tmux send-keys fails', async () => {
+    mockExecuteTmux.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('display-message')) return '0';
+      if (cmd.startsWith('send-keys')) throw new Error('tmux boom');
+      return '';
+    });
+
+    const session = makeSession();
+    // Must not throw — failure is logged and swallowed.
+    await executor.deliver(session, makeMessage());
+  });
+});

--- a/src/services/executors/claude-code.ts
+++ b/src/services/executors/claude-code.ts
@@ -1,10 +1,10 @@
 /**
  * ClaudeCodeOmniExecutor -- tmux-based IExecutor implementation.
  *
- * Spawns Claude Code processes in tmux windows (one per chat),
- * delivers follow-up messages via genie's PG mailbox pipeline
- * (mailbox.send → PG LISTEN/NOTIFY → scheduler → deliverToPane),
- * and injects env vars so agents can call `omni say/done` directly.
+ * Spawns Claude Code processes in tmux windows (one per chat) and delivers
+ * follow-up messages directly via tmux send-keys — the same injection path
+ * that delivers the spawn's initial prompt. Injects env vars so agents can
+ * call `omni say/done` directly.
  */
 
 import { randomUUID } from 'node:crypto';
@@ -14,7 +14,6 @@ import * as directory from '../../lib/agent-directory.js';
 import type { DirectoryEntry } from '../../lib/agent-directory.js';
 import * as agents from '../../lib/agent-registry.js';
 import * as registry from '../../lib/executor-registry.js';
-import * as mailbox from '../../lib/mailbox.js';
 import { buildLaunchCommand } from '../../lib/provider-adapters.js';
 import type { SpawnParams } from '../../lib/provider-adapters.js';
 import { shellQuote } from '../../lib/team-lead-command.js';
@@ -24,9 +23,7 @@ import { buildTurnBasedPrompt } from './turn-based-prompt.js';
 
 interface TmuxSessionState {
   executorId: string | null;
-  /** Agent ID in genie's agents table (for mailbox delivery). */
   agentId: string | null;
-  /** Agent repo/working directory (for mailbox repoPath). */
   repoPath: string | null;
 }
 
@@ -244,8 +241,9 @@ export class ClaudeCodeOmniExecutor implements IExecutor {
     );
     if (!agent) return null;
 
-    // Update agent record with pane_id and repo_path so the scheduler daemon's
-    // deliverToPane() (via PG LISTEN/NOTIFY) can resolve this agent for mailbox delivery.
+    // Update agent record with pane_id and repo_path. Used by inter-agent
+    // SendMessage (protocol-router) and observability — not by omni-turn
+    // delivery, which now injects directly via tmux send-keys.
     await this.safePgCall(
       'tmux-update-agent-pane',
       async () => {
@@ -295,26 +293,31 @@ export class ClaudeCodeOmniExecutor implements IExecutor {
     const state = this.sessions.get(session.id);
     if (state?.executorId) await this.updateState(state.executorId, 'working', session.chatId);
 
-    // Build turn context + user message for the follow-up turn
     const senderName = message.sender || 'whatsapp-user';
     const turnContext = buildTurnBasedPrompt(senderName, message.instanceId, session.chatId);
     const body = `${turnContext}\n\n---\n\n[${senderName}]: ${message.content}`;
 
-    // Deliver via genie's PG mailbox pipeline:
-    //   mailbox.send() → PG INSERT + NOTIFY → scheduler daemon → deliverToPane() → tmux send-keys
-    // This provides: durability, observability (runtime_events), retry on missed NOTIFY (30s poll),
-    // and delivery confirmation (delivered_at timestamp).
-    const agentId = state?.agentId;
-    const repoPath = state?.repoPath;
-
-    if (agentId && repoPath) {
+    // Inject directly into the tmux pane — same path spawn() uses for the
+    // initial prompt (see line 197) and injectNudge() uses for system nudges.
+    // Two-phase send-keys with a 200ms settle between body and Enter: Claude's
+    // TUI input buffer can drop the newline if it arrives in the same tmux
+    // batch as the text. Matches injectToTmuxPane in protocol-router.ts.
+    const paneId = session.tmux?.paneId;
+    if (paneId && /^%\d+$/.test(paneId) && (await isPaneAlive(paneId))) {
       try {
-        await mailbox.send(repoPath, `omni:${senderName}`, agentId, body);
+        await executeTmux(`send-keys -t '${paneId}' ${shellQuote(body)}`);
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        await executeTmux(`send-keys -t '${paneId}' Enter`);
       } catch (err) {
-        console.error(`[claude-code] mailbox.send failed for ${session.id}:`, err instanceof Error ? err.message : err);
+        console.error(
+          `[claude-code] deliver: send-keys failed for ${session.id} (pane ${paneId}):`,
+          err instanceof Error ? err.message : err,
+        );
       }
     } else {
-      console.error(`[claude-code] deliver: no agentId/repoPath for session ${session.id}, message lost`);
+      console.error(
+        `[claude-code] deliver: pane unavailable for ${session.id} (paneId=${paneId ?? 'null'}), message lost`,
+      );
     }
 
     session.lastActivityAt = Date.now();


### PR DESCRIPTION
## Summary

- `ClaudeCodeOmniExecutor.deliver()` now injects follow-up omni messages directly into the running Claude pane via `tmux send-keys`, matching the existing `spawn()` (line 197) and `injectNudge()` (line 164) patterns.
- Two-phase send-keys with a 200 ms settle between body and Enter — mirrors `injectToTmuxPane()` in `protocol-router.ts:547-551`. The settle is load-bearing: Claude's TUI input buffer can drop the newline if it arrives in the same tmux batch as the text.
- New `claude-code-deliver.test.ts` — existing suite had zero coverage for `deliver()`, which is why the regression shipped silently.

## Bug

Under normal production load, only the **first** message of any omni-turn reached the Claude Code pane. Every subsequent inbound on the same chat was silently dropped:

- `audit_events` showed clean `working → idle` cycles for every dispatch.
- `genie_mailbox` table had **zero** rows for the target agent.
- `mailbox.send()` either threw and logged to a stderr that was redirected to `/dev/null`, or inserted into a table that has no live consumer in the tmux-executor path. The downstream pipeline (`PG NOTIFY → scheduler → deliverToPane`) was designed for inter-agent SendMessage relay, not omni-turn delivery.

The first message only landed because `spawn()` packs the triggering message into `--append-system-prompt-file` as a CLI positional arg — a completely different code path that is used once per session.

Regression introduced in `c5251d17` ("feat(lib): unified agent permission system"), which replaced the earlier file-based inbox write with `mailbox.send()`.

## Fix

```ts
async deliver(session, message) {
  // ... state → 'working'
  const paneId = session.tmux?.paneId;
  if (paneId && /^%\d+$/.test(paneId) && (await isPaneAlive(paneId))) {
    await executeTmux(`send-keys -t '${paneId}' ${shellQuote(body)}`);
    await new Promise((r) => setTimeout(r, 200));
    await executeTmux(`send-keys -t '${paneId}' Enter`);
  }
  // ... state → 'idle'
}
```

- Shell-injection guard (`/^%\d+$/`) + `isPaneAlive` re-check before send.
- Error branch logs with context (session id, paneId, cause) — no silent drops.

## Blast radius

- **SDK executor unaffected** — separate class, has its own `deliveryQueues`/`_processDelivery` loop that already works.
- **PG mailbox infrastructure unchanged** — still used by inter-agent `SendMessage` relay (`protocol-router.ts`). Only the tmux-executor omni-turn path stops depending on it.
- `TmuxSessionState.agentId`/`repoPath` become unused for delivery but are still populated by `registerInWorldA` for observability. Left in place as harmless dead code — cleanup can come later.

## Test plan

- [x] `bun test src/services/executors/__tests__/claude-code-deliver.test.ts` — 8/8
- [x] `bun test` — 3132/3132 across 172 files (no regressions)
- [x] `bun run typecheck`
- [x] `bunx biome check` — clean
- [x] Local bundle swap + live repro: Claude running in tmux pane receives follow-up messages after first turn ends (confirmed in production instance)
- [ ] Integration: reviewer to confirm no adverse interaction with new observability substrate from #1213

🤖 Generated with [Claude Code](https://claude.com/claude-code)