### PR TITLE
feat(executors): turn-session-contract Group 1 — executor close columns + reconciler flag scaffolding

### DIFF
--- a/.genie/wishes/turn-session-contract/WISH.md
+++ b/.genie/wishes/turn-session-contract/WISH.md
@@ -67,32 +67,32 @@ Dependency graph: G1 → {G2, G6, G7}; G2 → {G3, G4, G5}; {G4, G5, G7} → G8;
 ### Wave 1 (solo — schema + flag foundation)
 | Group | Agent | Description |
 |-------|-------|-------------|
-| G1 | engineer | Schema migration: add `turn_id`, `outcome`, `closed_at`, `close_reason` on `executors` + `GENIE_RECONCILER_TURN_AWARE` flag scaffolding |
+| 1 | engineer | Schema migration: add `turn_id`, `outcome`, `closed_at`, `close_reason` on `executors` + `GENIE_RECONCILER_TURN_AWARE` flag scaffolding |
 
-### Wave 2 (parallel — G1 consumers)
+### Wave 2 (parallel — Group 1 consumers)
 | Group | Agent | Description |
 |-------|-------|-------------|
-| G2 | engineer | Turn-close verbs: `genie done` / `blocked` / `failed` with context-dispatch parser |
-| G6 | engineer | Executor read endpoint (HTTP GET `/executors/:id/state` or readonly PG role) |
-| G7 | engineer | `reconcile-orphans` script with `--dry-run` and `--apply` modes |
+| 2 | engineer | Turn-close verbs: `genie done` / `blocked` / `failed` with context-dispatch parser |
+| 6 | engineer | Executor read endpoint (HTTP GET `/executors/:id/state` or readonly PG role) |
+| 7 | engineer | `reconcile-orphans` script with `--dry-run` and `--apply` modes |
 
-### Wave 3 (parallel — G2 consumers, behavior behind flag)
+### Wave 3 (parallel — Group 2 consumers, behavior behind flag)
 | Group | Agent | Description |
 |-------|-------|-------------|
-| G3 | engineer | `GENIE_EXECUTOR_ID` env propagation across all spawn paths + skill contract enforcement |
-| G4 | engineer | New reconciler logic behind `GENIE_RECONCILER_TURN_AWARE` flag (flag off default) |
-| G5 | engineer | Pane-exit trap (tmux + shell) writes `clean_exit_unverified` if verb didn't fire |
+| 3 | engineer | `GENIE_EXECUTOR_ID` env propagation across all spawn paths + skill contract enforcement |
+| 4 | engineer | New reconciler logic behind `GENIE_RECONCILER_TURN_AWARE` flag (flag off default) |
+| 5 | engineer | Pane-exit trap (tmux + shell) writes `clean_exit_unverified` if verb didn't fire |
 
 ### Wave 4 (solo — phase B flip)
 | Group | Agent | Description |
 |-------|-------|-------------|
-| G8 | engineer | Phase B migration: flip `auto_resume DEFAULT false`, backfill live rows, enable flag by default |
+| 8 | engineer | Phase B migration: flip `auto_resume DEFAULT false`, backfill live rows, enable flag by default |
 | review | reviewer | Review Groups 1-8 against Success Criteria |
 
 ### Wave 5 (after ≥7-day soak on Wave 4 — flag removal)
 | Group | Agent | Description |
 |-------|-------|-------------|
-| G9 | engineer | Phase C migration: remove `GENIE_RECONCILER_TURN_AWARE` flag entirely |
+| 9 | engineer | Phase C migration: remove `GENIE_RECONCILER_TURN_AWARE` flag entirely |
 
 ## Execution Groups
 

--- a/src/db/migrations/042_executor_turn_columns.sql
+++ b/src/db/migrations/042_executor_turn_columns.sql
@@ -1,0 +1,37 @@
+-- 042_executor_turn_columns.sql — Turn-Session Contract (Group 1)
+-- Wish: turn-session-contract (genie side).
+--
+-- Adds four nullable columns to `executors` to record the explicit close
+-- contract written by `genie done` / `blocked` / `failed` verbs and the
+-- pane-exit trap safety net. All columns are additive and nullable so this
+-- Phase A migration produces zero behavior change on its own — consumers
+-- (Groups 2, 4, 5, 7) read/write these columns only when the reconciler
+-- feature flag `GENIE_RECONCILER_TURN_AWARE` is enabled.
+--
+-- Column semantics (from DESIGN.md):
+--   turn_id       UUID        — identifier for the current turn; set at turn
+--                               open, preserved across close. NULL for
+--                               pre-contract executors.
+--   outcome       TEXT        — explicit outcome word written by the close
+--                               verb: 'done' | 'blocked' | 'failed' |
+--                               'clean_exit_unverified' (trap-written).
+--                               NULL while the turn is still open.
+--   closed_at     TIMESTAMPTZ — monotonic close timestamp; set by the single
+--                               close transaction in Group 2.
+--   close_reason  TEXT        — free-form rationale supplied with
+--                               `--reason` on `genie blocked` / `genie failed`,
+--                               or the sentinel 'clean_exit_unverified' for
+--                               trap-written rows.
+--
+-- Indexes:
+--   idx_executors_outcome enables fast filtering for the reconciler's
+--   "skip terminalized" predicate and for analytics (`SELECT outcome,
+--   COUNT(*) FROM executors GROUP BY outcome`).
+
+ALTER TABLE executors ADD COLUMN IF NOT EXISTS turn_id UUID;
+ALTER TABLE executors ADD COLUMN IF NOT EXISTS outcome TEXT;
+ALTER TABLE executors ADD COLUMN IF NOT EXISTS closed_at TIMESTAMPTZ;
+ALTER TABLE executors ADD COLUMN IF NOT EXISTS close_reason TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_executors_outcome ON executors(outcome) WHERE outcome IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_executors_closed_at ON executors(closed_at) WHERE closed_at IS NOT NULL;

--- a/src/lib/executor-types.ts
+++ b/src/lib/executor-types.ts
@@ -30,6 +30,14 @@ export type TransportType = 'tmux' | 'api' | 'process';
 /** Outcome of a completed assignment. */
 export type AssignmentOutcome = 'completed' | 'failed' | 'reassigned' | 'abandoned';
 
+/**
+ * Turn close outcome written by the turn-close contract (migration 042).
+ * - 'done' / 'blocked' / 'failed' are written by the explicit close verbs.
+ * - 'clean_exit_unverified' is the sentinel written by the pane-exit trap
+ *   when a pane dies without any verb firing.
+ */
+export type TurnOutcome = 'done' | 'blocked' | 'failed' | 'clean_exit_unverified';
+
 // ============================================================================
 // Data Interfaces
 // ============================================================================
@@ -81,6 +89,14 @@ export interface Executor {
   endedAt: string | null;
   createdAt: string;
   updatedAt: string;
+  /** Turn identifier — set at turn open, preserved across close. NULL for pre-contract executors. */
+  turnId: string | null;
+  /** Explicit close outcome. NULL while the turn is still open. */
+  outcome: TurnOutcome | null;
+  /** Monotonic close timestamp written by the single close transaction. */
+  closedAt: string | null;
+  /** Free-form rationale supplied with `--reason`, or 'clean_exit_unverified' for trap-written rows. */
+  closeReason: string | null;
 }
 
 /** DB row shape for the executors table (snake_case). */
@@ -104,6 +120,10 @@ export interface ExecutorRow {
   ended_at: Date | string | null;
   created_at: Date | string;
   updated_at: Date | string;
+  turn_id: string | null;
+  outcome: TurnOutcome | null;
+  closed_at: Date | string | null;
+  close_reason: string | null;
 }
 
 /**
@@ -167,6 +187,10 @@ export function rowToExecutor(r: ExecutorRow): Executor {
     endedAt: r.ended_at ? ts(r.ended_at) : null,
     createdAt: ts(r.created_at),
     updatedAt: ts(r.updated_at),
+    turnId: r.turn_id ?? null,
+    outcome: r.outcome ?? null,
+    closedAt: r.closed_at ? ts(r.closed_at) : null,
+    closeReason: r.close_reason ?? null,
   };
 }
 

--- a/src/lib/idle-timeout.test.ts
+++ b/src/lib/idle-timeout.test.ts
@@ -59,6 +59,10 @@ function makeExecutor(overrides: Partial<Executor> = {}): Executor {
     endedAt: null,
     createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
     updatedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(), // 1h ago
+    turnId: null,
+    outcome: null,
+    closedAt: null,
+    closeReason: null,
     ...overrides,
   };
 }

--- a/src/lib/providers/claude-code.test.ts
+++ b/src/lib/providers/claude-code.test.ts
@@ -31,6 +31,10 @@ function makeExecutor(overrides: Partial<Executor> = {}): Executor {
     endedAt: null,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
+    turnId: null,
+    outcome: null,
+    closedAt: null,
+    closeReason: null,
     ...overrides,
   };
 }

--- a/src/lib/providers/codex.test.ts
+++ b/src/lib/providers/codex.test.ts
@@ -31,6 +31,10 @@ function makeExecutor(overrides: Partial<Executor> = {}): Executor {
     endedAt: null,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
+    turnId: null,
+    outcome: null,
+    closedAt: null,
+    closeReason: null,
     ...overrides,
   };
 }

--- a/src/lib/scheduler-daemon.test.ts
+++ b/src/lib/scheduler-daemon.test.ts
@@ -7,6 +7,7 @@ import {
   MAX_DELIVERY_ATTEMPTS,
   type SchedulerConfig,
   type SchedulerDeps,
+  TURN_AWARE_RECONCILER_FLAG,
   type WorkerInfo,
   _resetWorkerStatesForTesting,
   attemptAgentResume,
@@ -15,6 +16,8 @@ import {
   collectMachineSnapshot,
   emitWorkerEvents,
   fireTrigger,
+  isTurnAwareReconcilerEnabled,
+  logReconcilerMode,
   logToFile,
   processMailboxRetryMessage,
   reclaimExpiredLeases,
@@ -2207,5 +2210,62 @@ describe('scheduler-daemon', () => {
       expect(dropped).toHaveLength(10);
       expect(dropped.every((l) => l.reason === 'already_escalated_by_scheduler')).toBe(true);
     });
+  });
+});
+
+// ============================================================================
+// Turn-session-contract (Group 1) — reconciler flag scaffolding
+// ============================================================================
+
+describe('turn-aware reconciler flag', () => {
+  const prev = process.env[TURN_AWARE_RECONCILER_FLAG];
+
+  afterEach(() => {
+    if (prev === undefined) delete process.env[TURN_AWARE_RECONCILER_FLAG];
+    else process.env[TURN_AWARE_RECONCILER_FLAG] = prev;
+  });
+
+  test('flag constant matches expected name', () => {
+    expect(TURN_AWARE_RECONCILER_FLAG).toBe('GENIE_RECONCILER_TURN_AWARE');
+  });
+
+  test('isTurnAwareReconcilerEnabled returns false when unset', () => {
+    expect(isTurnAwareReconcilerEnabled({})).toBe(false);
+  });
+
+  test('isTurnAwareReconcilerEnabled returns false for empty and falsy values', () => {
+    expect(isTurnAwareReconcilerEnabled({ [TURN_AWARE_RECONCILER_FLAG]: '' })).toBe(false);
+    expect(isTurnAwareReconcilerEnabled({ [TURN_AWARE_RECONCILER_FLAG]: '0' })).toBe(false);
+    expect(isTurnAwareReconcilerEnabled({ [TURN_AWARE_RECONCILER_FLAG]: 'false' })).toBe(false);
+    expect(isTurnAwareReconcilerEnabled({ [TURN_AWARE_RECONCILER_FLAG]: 'no' })).toBe(false);
+  });
+
+  test('isTurnAwareReconcilerEnabled accepts "1" and "true" (case-insensitive)', () => {
+    expect(isTurnAwareReconcilerEnabled({ [TURN_AWARE_RECONCILER_FLAG]: '1' })).toBe(true);
+    expect(isTurnAwareReconcilerEnabled({ [TURN_AWARE_RECONCILER_FLAG]: 'true' })).toBe(true);
+    expect(isTurnAwareReconcilerEnabled({ [TURN_AWARE_RECONCILER_FLAG]: 'TRUE' })).toBe(true);
+    expect(isTurnAwareReconcilerEnabled({ [TURN_AWARE_RECONCILER_FLAG]: ' True ' })).toBe(true);
+  });
+
+  test('logReconcilerMode emits flag-off message with legacy event when unset', () => {
+    delete process.env[TURN_AWARE_RECONCILER_FLAG];
+    const logs: LogEntry[] = [];
+    logReconcilerMode({ log: (e) => logs.push(e), now: () => new Date('2026-04-20T00:00:00Z') }, 'daemon-abc');
+    expect(logs).toHaveLength(1);
+    expect(logs[0].event).toBe('reconciler_mode_legacy');
+    expect(logs[0].enabled).toBe(false);
+    expect(logs[0].flag).toBe('GENIE_RECONCILER_TURN_AWARE');
+    expect(logs[0].message).toContain('flag off');
+    expect(logs[0].daemon_id).toBe('daemon-abc');
+  });
+
+  test('logReconcilerMode emits turn-aware event when flag set to truthy value', () => {
+    process.env[TURN_AWARE_RECONCILER_FLAG] = '1';
+    const logs: LogEntry[] = [];
+    logReconcilerMode({ log: (e) => logs.push(e), now: () => new Date('2026-04-20T00:00:00Z') }, 'daemon-xyz');
+    expect(logs).toHaveLength(1);
+    expect(logs[0].event).toBe('reconciler_mode_turn_aware');
+    expect(logs[0].enabled).toBe(true);
+    expect(logs[0].message).toContain('turn-aware reconciler enabled');
   });
 });

--- a/src/lib/scheduler-daemon.ts
+++ b/src/lib/scheduler-daemon.ts
@@ -48,6 +48,38 @@ export const ESCALATION_RECIPIENT = 'team-lead';
 /** Maximum delivery attempts before the mailbox retry loop escalates a message. */
 export const MAX_DELIVERY_ATTEMPTS = 3;
 
+/**
+ * Env flag gating the turn-session-contract reconciler.
+ *
+ * Phase A (this wish, Group 1): flag read exists; default `false`; logged once
+ * at daemon startup; no behavior change. Subsequent groups wire the new
+ * reconciler passes behind this flag. Phase B (Group 8) flips the default to
+ * `true` after the migration completes; Phase C (Group 9) removes the flag.
+ */
+export const TURN_AWARE_RECONCILER_FLAG = 'GENIE_RECONCILER_TURN_AWARE';
+
+/** Read the turn-aware reconciler flag from env. Accepts '1' | 'true' (case-insensitive). */
+export function isTurnAwareReconcilerEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env[TURN_AWARE_RECONCILER_FLAG];
+  if (!raw) return false;
+  const v = raw.trim().toLowerCase();
+  return v === '1' || v === 'true';
+}
+
+/** Log the turn-aware reconciler mode once at daemon startup. */
+export function logReconcilerMode(deps: Pick<SchedulerDeps, 'log' | 'now'>, daemonId: string): void {
+  const enabled = isTurnAwareReconcilerEnabled();
+  deps.log({
+    timestamp: deps.now().toISOString(),
+    level: 'info',
+    event: enabled ? 'reconciler_mode_turn_aware' : 'reconciler_mode_legacy',
+    daemon_id: daemonId,
+    flag: TURN_AWARE_RECONCILER_FLAG,
+    enabled,
+    message: enabled ? 'turn-aware reconciler enabled' : 'flag off, using legacy reconciler',
+  });
+}
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -1953,6 +1985,8 @@ export function startDaemon(
       max_concurrent: config.maxConcurrent,
       poll_interval_ms: config.pollIntervalMs,
     });
+
+    logReconcilerMode(deps, daemonId);
 
     // Startup recovery: reclaim expired leases + reconcile orphans
     try {


### PR DESCRIPTION
## Summary

Ship Group 1 of the `turn-session-contract` wish — the CLOSE half of the agent-turn primitive. Phase A is additive-only: no behavior change with flag off.

## What's in

- **Migration `042_executor_turn_columns.sql`** — adds `turn_id UUID`, `outcome TEXT`, `closed_at TIMESTAMPTZ`, `close_reason TEXT` to `executors`; all nullable; partial indexes on `outcome` and `closed_at`. Idempotent via `IF NOT EXISTS`.
- **`GENIE_RECONCILER_TURN_AWARE` flag scaffolding** in `src/lib/scheduler-daemon.ts` — `isTurnAwareReconcilerEnabled()` reads env (accepts `1`/`true`), **defaults OFF**. `logReconcilerMode()` logs once at daemon startup.
- **Type exports** in `src/lib/executor-types.ts` — `TurnOutcome` + `ExecutorRow` expanded with the four new nullable fields; serializer exposes `turnId`, `outcome`, `closedAt`, `closeReason`.
- Supporting test/type updates in `idle-timeout.test.ts`, `claude-code.test.ts`, `codex.test.ts`.

## Out of scope (later groups in this wish)

- G2 turn-close verbs (`genie done / blocked / failed`) — consumes this schema
- G4 reconciler rewrite behind the flag
- G5 pane-exit trap
- G6 executor read endpoint (consumed by omni scope-enforcer)
- G7 `reconcile-orphans` script

## Validation

- `bun run typecheck` — clean
- `bun test` — **3124 pass / 0 fail** (171 files, pre-push hook)
- Flag defaults OFF (`src/lib/scheduler-daemon.ts:64`) — zero behavior change on deploy

## Wish

\`.genie/wishes/turn-session-contract/WISH.md\` — Group 1 only; subsequent groups land in follow-up PRs.

## Test plan

- [x] Migration applies cleanly (idempotent \`IF NOT EXISTS\`)
- [x] Nullable columns — no data-loss risk
- [x] Typecheck green
- [x] Full \`bun test\` suite green (3124/0)
- [ ] Manual smoke on dev after merge — restart daemon, verify \`reconciler_mode_legacy\` log line