### PR TITLE
feat(turn-session-contract): atomic turn close + turn-aware reconciler + pane-exit trap

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,28 @@ an external dead-man's switch. Consumer-compat promises are published at
 [docs/observability-contract.md](docs/observability-contract.md); the 5-phase
 rollout plan at [docs/observability-rollout.md](docs/observability-rollout.md).
 
+### Executor read endpoint
+
+External consumers (e.g. the omni scope-enforcer) can query ground-truth turn
+state directly from `genie serve`. Two paths are supported:
+
+**HTTP** — `GET http://127.0.0.1:<port>/executors/:id/state` returns
+`{state, outcome, closed_at}` as JSON. The default port is `pgserve_port + 2`;
+override with `GENIE_EXECUTOR_READ_PORT`. Returns 404 for unknown IDs, 400 for
+non-UUID IDs, 200 otherwise. No authz — executor IDs are random UUIDs and the
+view exposes no secrets.
+
+**Direct SQL** — connect to genie-PG as the read-only `executors_reader` role
+and `SELECT state, outcome, closed_at FROM executors_public_state WHERE id = $1`.
+Layer login credentials on top:
+
+```sql
+CREATE ROLE omni_scope_enforcer LOGIN PASSWORD '…' IN ROLE executors_reader;
+```
+
+Response shape (`state` / `outcome` / `closed_at`) is the stable boundary
+contract; removing or renaming fields is a coordinated breaking change.
+
 ---
 
 <p align="center">

--- a/scripts/reconcile-orphans.test.ts
+++ b/scripts/reconcile-orphans.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Tests for scripts/reconcile-orphans.ts — the Group 7 one-shot.
+ *
+ * Covers:
+ *   • Dry-run lists orphans and spares live agents.
+ *   • --apply with correct confirmation terminalizes orphans.
+ *   • --apply with wrong confirmation aborts without writing.
+ *   • Re-running --apply is a no-op (idempotent).
+ *   • An audit row is emitted per terminalized agent.
+ *   • The ghost-loop scenario (stale pane, state=idle, >1h old) is
+ *     terminalized rather than resumed.
+ *   • CLI flag parsing honors flags-before-positionals and unknown flags.
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { getConnection } from '../src/lib/db.js';
+import { DB_AVAILABLE, setupTestSchema } from '../src/lib/test-db.js';
+import {
+  type Candidate,
+  type PaneAliveFn,
+  findOrphans,
+  parseCliArgs,
+  run,
+  terminalizeOrphans,
+} from './reconcile-orphans.ts';
+
+async function insertAgent(opts: {
+  id: string;
+  state: string | null;
+  paneId: string | null;
+  lastStateChange: string;
+}): Promise<void> {
+  const sql = await getConnection();
+  await sql`
+    INSERT INTO agents (id, pane_id, session, repo_path, state, started_at, last_state_change)
+    VALUES (${opts.id}, ${opts.paneId}, ${'sess'}, ${'/tmp'}, ${opts.state}, ${opts.lastStateChange},
+            ${opts.lastStateChange})
+  `;
+}
+
+const deadAlways: PaneAliveFn = async () => false;
+
+describe('parseCliArgs', () => {
+  test('defaults to dry-run', () => {
+    const { apply, help, unknown } = parseCliArgs([]);
+    expect(apply).toBe(false);
+    expect(help).toBe(false);
+    expect(unknown).toEqual([]);
+  });
+
+  test('--apply enables apply mode', () => {
+    expect(parseCliArgs(['--apply']).apply).toBe(true);
+  });
+
+  test('later --dry-run wins over earlier --apply (flag order preserved)', () => {
+    expect(parseCliArgs(['--apply', '--dry-run']).apply).toBe(false);
+    expect(parseCliArgs(['--dry-run', '--apply']).apply).toBe(true);
+  });
+
+  test('captures unknown flags so main() can reject them', () => {
+    expect(parseCliArgs(['--oops', 'pos']).unknown).toEqual(['--oops', 'pos']);
+  });
+
+  test('--help and -h set the help flag', () => {
+    expect(parseCliArgs(['--help']).help).toBe(true);
+    expect(parseCliArgs(['-h']).help).toBe(true);
+  });
+});
+
+describe.skipIf(!DB_AVAILABLE)('reconcile-orphans (integration)', () => {
+  let cleanup: () => Promise<void>;
+
+  beforeAll(async () => {
+    cleanup = await setupTestSchema();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  beforeEach(async () => {
+    const sql = await getConnection();
+    await sql`DELETE FROM audit_events`;
+    await sql`DELETE FROM agents`;
+  });
+
+  afterEach(async () => {
+    const sql = await getConnection();
+    await sql`DELETE FROM audit_events`;
+    await sql`DELETE FROM agents`;
+  });
+
+  const twoHoursAgo = () => new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+  const tenMinAgo = () => new Date(Date.now() - 10 * 60 * 1000).toISOString();
+
+  test('dry-run lists orphans and spares live agents', async () => {
+    await insertAgent({ id: 'orphan-1', state: 'idle', paneId: '%42', lastStateChange: twoHoursAgo() });
+    await insertAgent({ id: 'alive-1', state: 'idle', paneId: '%1', lastStateChange: twoHoursAgo() });
+    await insertAgent({ id: 'young-1', state: 'idle', paneId: '%99', lastStateChange: tenMinAgo() });
+    await insertAgent({ id: 'done-1', state: 'done', paneId: '%99', lastStateChange: twoHoursAgo() });
+
+    const onlyOrphan1Dead: PaneAliveFn = async (p) => p !== '%42';
+    const candidates = await findOrphans({ isPaneAlive: onlyOrphan1Dead });
+
+    expect(candidates.map((c) => c.id)).toEqual(['orphan-1']);
+    expect(candidates[0].state).toBe('idle');
+    expect(candidates[0].action).toBe('terminalize');
+
+    const sql = await getConnection();
+    const [alive] = await sql<{ state: string }[]>`SELECT state FROM agents WHERE id = 'alive-1'`;
+    expect(alive.state).toBe('idle'); // untouched
+  });
+
+  test('identity-only (state IS NULL) rows are skipped', async () => {
+    await insertAgent({ id: 'identity', state: null, paneId: '', lastStateChange: twoHoursAgo() });
+    const found = await findOrphans({ isPaneAlive: deadAlways });
+    expect(found.map((c) => c.id)).toEqual([]);
+  });
+
+  test('recent rows (< 1h) are spared even with a dead pane', async () => {
+    await insertAgent({ id: 'recent', state: 'working', paneId: '%2', lastStateChange: tenMinAgo() });
+    const found = await findOrphans({ isPaneAlive: deadAlways });
+    expect(found.map((c) => c.id)).toEqual([]);
+  });
+
+  test('run() in dry-run mode does not write', async () => {
+    await insertAgent({ id: 'orphan-dry', state: 'idle', paneId: '%1', lastStateChange: twoHoursAgo() });
+
+    const logged: string[] = [];
+    const result = await run({
+      apply: false,
+      isPaneAlive: deadAlways,
+      log: (line) => logged.push(line),
+    });
+
+    expect(result.mode).toBe('dry-run');
+    expect(result.candidates.length).toBe(1);
+    expect(result.terminalized).toBe(0);
+
+    const sql = await getConnection();
+    const [row] = await sql<{ state: string }[]>`SELECT state FROM agents WHERE id = 'orphan-dry'`;
+    expect(row.state).toBe('idle');
+    const audits = await sql<{ id: number }[]>`SELECT id FROM audit_events WHERE entity_id = 'orphan-dry'`;
+    expect(audits.length).toBe(0);
+  });
+
+  test('apply with correct confirmation terminalizes orphans + emits audit', async () => {
+    await insertAgent({ id: 'orphan-apply', state: 'idle', paneId: '%1', lastStateChange: twoHoursAgo() });
+    await insertAgent({ id: 'stay-alive', state: 'idle', paneId: '%2', lastStateChange: twoHoursAgo() });
+
+    const aliveOnly2: PaneAliveFn = async (p) => p === '%2';
+    const result = await run({
+      apply: true,
+      isPaneAlive: aliveOnly2,
+      readConfirmation: async () => 'I UNDERSTAND',
+      actor: 'test-reconciler',
+      log: () => {},
+    });
+
+    expect(result.mode).toBe('apply');
+    expect(result.aborted).toBe(false);
+    expect(result.terminalized).toBe(1);
+
+    const sql = await getConnection();
+    const [orphan] = await sql<{ state: string }[]>`SELECT state FROM agents WHERE id = 'orphan-apply'`;
+    expect(orphan.state).toBe('error');
+
+    const [alive] = await sql<{ state: string }[]>`SELECT state FROM agents WHERE id = 'stay-alive'`;
+    expect(alive.state).toBe('idle');
+
+    const audits = await sql<{ event_type: string; actor: string; details: unknown }[]>`
+      SELECT event_type, actor, details FROM audit_events
+      WHERE entity_type = 'agent' AND entity_id = 'orphan-apply'
+    `;
+    expect(audits.length).toBe(1);
+    expect(audits[0].event_type).toBe('reconcile.terminalize');
+    expect(audits[0].actor).toBe('test-reconciler');
+    const details = audits[0].details as Record<string, unknown>;
+    expect(details.state_before).toBe('idle');
+    expect(details.pane_id).toBe('%1');
+  });
+
+  test('apply with wrong confirmation aborts without writing', async () => {
+    await insertAgent({ id: 'unconfirmed', state: 'idle', paneId: '%5', lastStateChange: twoHoursAgo() });
+
+    const result = await run({
+      apply: true,
+      isPaneAlive: deadAlways,
+      readConfirmation: async () => 'yes please',
+      log: () => {},
+    });
+
+    expect(result.aborted).toBe(true);
+    expect(result.terminalized).toBe(0);
+
+    const sql = await getConnection();
+    const [row] = await sql<{ state: string }[]>`SELECT state FROM agents WHERE id = 'unconfirmed'`;
+    expect(row.state).toBe('idle');
+    const audits = await sql<{ id: number }[]>`SELECT id FROM audit_events WHERE entity_id = 'unconfirmed'`;
+    expect(audits.length).toBe(0);
+  });
+
+  test('re-running apply is a no-op (idempotent)', async () => {
+    await insertAgent({ id: 'idem', state: 'idle', paneId: '%9', lastStateChange: twoHoursAgo() });
+
+    const first = await run({
+      apply: true,
+      isPaneAlive: deadAlways,
+      readConfirmation: async () => 'I UNDERSTAND',
+      log: () => {},
+    });
+    expect(first.terminalized).toBe(1);
+
+    const second = await run({
+      apply: true,
+      isPaneAlive: deadAlways,
+      readConfirmation: async () => 'I UNDERSTAND',
+      log: () => {},
+    });
+    expect(second.terminalized).toBe(0);
+    expect(second.candidates.length).toBe(0);
+
+    const sql = await getConnection();
+    const audits = await sql<{ id: number }[]>`
+      SELECT id FROM audit_events WHERE entity_id = 'idem'
+    `;
+    expect(audits.length).toBe(1); // only the first run wrote an audit row
+  });
+
+  test('ghost-loop regression: stale pane_id + state=idle → terminalized, not resumed', async () => {
+    // Replay of the 2026-04-19 scenario from the wish: an agent with
+    // auto_resume=true, state=idle, stale pane_id pointing at a long-dead
+    // tmux pane that was the impetus for this whole wish.
+    const sql = await getConnection();
+    await sql`
+      INSERT INTO agents (id, pane_id, session, repo_path, state, started_at, last_state_change, auto_resume)
+      VALUES ('ghost-loop', '%ancient', 'sess', '/tmp', 'idle',
+              now() - interval '3 hours', now() - interval '3 hours', true)
+    `;
+
+    const result = await run({
+      apply: true,
+      isPaneAlive: deadAlways,
+      readConfirmation: async () => 'I UNDERSTAND',
+      log: () => {},
+    });
+
+    expect(result.terminalized).toBe(1);
+    const [row] = await sql<{ state: string }[]>`SELECT state FROM agents WHERE id = 'ghost-loop'`;
+    expect(row.state).toBe('error'); // terminalized — no resume possible
+  });
+
+  test('tmux unreachable → row is skipped, not wrongly terminalized', async () => {
+    await insertAgent({ id: 'tmux-down', state: 'idle', paneId: '%1', lastStateChange: twoHoursAgo() });
+    const throwsUnreachable: PaneAliveFn = async () => {
+      throw new Error('no server running');
+    };
+
+    const found = await findOrphans({ isPaneAlive: throwsUnreachable });
+    expect(found.map((c) => c.id)).toEqual([]);
+  });
+
+  test('terminalizeOrphans skips rows whose state flipped between find and apply', async () => {
+    await insertAgent({ id: 'racey', state: 'idle', paneId: '%1', lastStateChange: twoHoursAgo() });
+    const candidate: Candidate = {
+      id: 'racey',
+      state: 'idle',
+      paneId: '%1',
+      lastStateChange: twoHoursAgo(),
+      action: 'terminalize',
+      reason: 'pane_id=%1 dead',
+    };
+
+    const sql = await getConnection();
+    await sql`UPDATE agents SET state = 'done' WHERE id = 'racey'`;
+
+    const changed = await terminalizeOrphans([candidate], 'test');
+    expect(changed).toBe(0);
+
+    const [row] = await sql<{ state: string }[]>`SELECT state FROM agents WHERE id = 'racey'`;
+    expect(row.state).toBe('done'); // preserved — idempotent skip
+    const audits = await sql<{ id: number }[]>`SELECT id FROM audit_events WHERE entity_id = 'racey'`;
+    expect(audits.length).toBe(0);
+  });
+});

--- a/scripts/reconcile-orphans.ts
+++ b/scripts/reconcile-orphans.ts
@@ -1,0 +1,295 @@
+#!/usr/bin/env bun
+/**
+ * reconcile-orphans — one-shot cleanup script for the turn-session contract.
+ *
+ * Wish: turn-session-contract (Group 7). Before the new reconciler ships
+ * (Group 4) and before the default-flip lands (Group 8), the agents table
+ * can contain rows whose tmux pane is long dead but whose state never
+ * reached a terminal value. The legacy reconciler would happily resume
+ * those rows, producing ghost loops.
+ *
+ * This script terminalizes orphans in a single one-shot pass. It is the
+ * manual step wedged between Phase A (schema) and Phase B (default flip)
+ * of the staged migration — see DESIGN.md D7.
+ *
+ * Candidate predicate (all must hold):
+ *   • agents.state IS NOT NULL                    — skip identity-only rows
+ *   • agents.state NOT IN (done,error,suspended)  — already-terminal rows are left alone
+ *   • agents.last_state_change < now() - 1 hour   — never touch recently-active rows
+ *   • pane is gone: pane_id is NULL, the empty
+ *     string, 'inline', or !isPaneAlive(pane_id)  — live panes are spared
+ *
+ * Default mode is --dry-run. --apply writes, and requires the operator
+ * to type `I UNDERSTAND` on stdin as an interlock.
+ *
+ * Each terminalized row emits `reconcile.terminalize` to audit_events
+ * with {state_before, pane_id, reason} so the audit trail is complete.
+ *
+ * Idempotent: a second run finds zero candidates because the previous
+ * run moved them all to state='error'.
+ */
+
+import { createInterface } from 'node:readline/promises';
+import { type Sql, getConnection } from '../src/lib/db.js';
+import { isPaneAlive as tmuxIsPaneAlive } from '../src/lib/tmux.js';
+
+export type PaneAliveFn = (paneId: string) => Promise<boolean>;
+
+export interface OrphanRow {
+  id: string;
+  state: string;
+  paneId: string | null;
+  lastStateChange: string;
+}
+
+export interface Candidate extends OrphanRow {
+  action: 'terminalize';
+  reason: string;
+}
+
+export interface ReconcileOptions {
+  apply: boolean;
+  /** Override for tests. Defaults to the real tmux probe. */
+  isPaneAlive?: PaneAliveFn;
+  /**
+   * Provides the typed confirmation for --apply. Defaults to reading
+   * from stdin. Tests can pass a pre-supplied string.
+   */
+  readConfirmation?: () => Promise<string>;
+  /** Audit actor. Defaults to env GENIE_AGENT_NAME or 'reconcile-orphans'. */
+  actor?: string;
+  /** Optional logger. Defaults to console.log. */
+  log?: (line: string) => void;
+}
+
+export interface ReconcileResult {
+  mode: 'dry-run' | 'apply';
+  candidates: Candidate[];
+  terminalized: number;
+  aborted: boolean;
+}
+
+const CONFIRMATION_PHRASE = 'I UNDERSTAND';
+const TERMINAL_STATES = ['done', 'error', 'suspended'];
+const DEAD_PANE_SENTINELS = new Set(['', 'inline']);
+
+interface AgentQueryRow {
+  id: string;
+  state: string;
+  pane_id: string | null;
+  last_state_change: Date | string;
+}
+
+/**
+ * Select agents rows matching the coarse predicates (state, age). The
+ * finer pane-liveness check happens in TypeScript so we can stub it
+ * cleanly from tests.
+ */
+async function loadCandidateRows(sql: Sql): Promise<AgentQueryRow[]> {
+  return sql<AgentQueryRow[]>`
+    SELECT id, state, pane_id, last_state_change
+    FROM agents
+    WHERE state IS NOT NULL
+      AND state NOT IN ('done', 'error', 'suspended')
+      AND last_state_change < now() - interval '1 hour'
+    ORDER BY last_state_change ASC
+  `;
+}
+
+function toIso(v: Date | string): string {
+  return v instanceof Date ? v.toISOString() : v;
+}
+
+/**
+ * Determine whether a row is orphan-eligible based on its pane. A row is
+ * orphan when the pane is NULL, an inline sentinel, or not alive under tmux.
+ * Returns a human-readable reason explaining why the row qualified.
+ */
+async function paneVerdict(paneId: string | null, alive: PaneAliveFn): Promise<{ orphan: boolean; reason: string }> {
+  if (paneId === null) return { orphan: true, reason: 'pane_id IS NULL' };
+  if (DEAD_PANE_SENTINELS.has(paneId)) return { orphan: true, reason: `pane_id='${paneId}'` };
+  try {
+    const ok = await alive(paneId);
+    if (ok) return { orphan: false, reason: `pane_id=${paneId} is alive` };
+    return { orphan: true, reason: `pane_id=${paneId} dead` };
+  } catch (err) {
+    // tmux server unreachable — be conservative, skip this row.
+    const msg = err instanceof Error ? err.message : String(err);
+    return { orphan: false, reason: `tmux unreachable: ${msg}` };
+  }
+}
+
+export async function findOrphans(opts: { isPaneAlive?: PaneAliveFn } = {}): Promise<Candidate[]> {
+  const alive = opts.isPaneAlive ?? tmuxIsPaneAlive;
+  const sql = await getConnection();
+  const rows = await loadCandidateRows(sql);
+  const out: Candidate[] = [];
+  for (const r of rows) {
+    const verdict = await paneVerdict(r.pane_id, alive);
+    if (!verdict.orphan) continue;
+    out.push({
+      id: r.id,
+      state: r.state,
+      paneId: r.pane_id,
+      lastStateChange: toIso(r.last_state_change),
+      action: 'terminalize',
+      reason: verdict.reason,
+    });
+  }
+  return out;
+}
+
+/**
+ * Terminalize a set of candidates inside a single transaction per row.
+ * We do one transaction per row (not one for the whole batch) so a
+ * single failing row cannot block the rest — this matches the
+ * "idempotent one-shot" contract.
+ *
+ * Returns the number of rows actually updated (skips rows that changed
+ * state between the find and the apply step, which is the idempotency
+ * guarantee).
+ */
+export async function terminalizeOrphans(candidates: Candidate[], actor: string): Promise<number> {
+  const sql = await getConnection();
+  let changed = 0;
+  for (const c of candidates) {
+    await sql.begin(async (tx: Sql) => {
+      const rows = await tx<{ state: string | null }[]>`
+        SELECT state FROM agents WHERE id = ${c.id} FOR UPDATE
+      `;
+      if (rows.length === 0) return;
+      const current = rows[0].state;
+      if (current === null || TERMINAL_STATES.includes(current)) {
+        // Another writer terminalized between find and apply — idempotent skip.
+        return;
+      }
+      await tx`
+        UPDATE agents
+        SET state = 'error',
+            last_state_change = now()
+        WHERE id = ${c.id}
+      `;
+      await tx`
+        INSERT INTO audit_events (entity_type, entity_id, event_type, actor, details)
+        VALUES (
+          'agent',
+          ${c.id},
+          'reconcile.terminalize',
+          ${actor},
+          ${tx.json({ state_before: current, pane_id: c.paneId, reason: c.reason })}
+        )
+      `;
+      changed += 1;
+    });
+  }
+  return changed;
+}
+
+function formatTable(candidates: Candidate[]): string {
+  if (candidates.length === 0) return '(no orphans)';
+  const header = ['id', 'state', 'pane_id', 'last_state_change', 'action'];
+  const rows = candidates.map((c) => [
+    c.id,
+    c.state,
+    c.paneId ?? '∅',
+    c.lastStateChange,
+    `${c.action} (${c.reason})`,
+  ]);
+  const widths = header.map((h, i) => Math.max(h.length, ...rows.map((r) => r[i].length)));
+  const fmt = (r: string[]) => r.map((cell, i) => cell.padEnd(widths[i])).join('  ');
+  const sep = widths.map((w) => '-'.repeat(w)).join('  ');
+  return [fmt(header), sep, ...rows.map(fmt)].join('\n');
+}
+
+async function readStdinLine(): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stderr, terminal: false });
+  const line = await rl.question(`Type "${CONFIRMATION_PHRASE}" to continue: `);
+  rl.close();
+  return line;
+}
+
+export async function run(opts: ReconcileOptions): Promise<ReconcileResult> {
+  const log = opts.log ?? ((line: string) => console.log(line));
+  const actor = opts.actor ?? process.env.GENIE_AGENT_NAME ?? 'reconcile-orphans';
+  const candidates = await findOrphans({ isPaneAlive: opts.isPaneAlive });
+
+  log(`reconcile-orphans: ${candidates.length} orphan candidate(s)`);
+  log(formatTable(candidates));
+
+  if (!opts.apply) {
+    log('');
+    log('Mode: --dry-run. Re-run with --apply to terminalize these rows.');
+    return { mode: 'dry-run', candidates, terminalized: 0, aborted: false };
+  }
+
+  if (candidates.length === 0) {
+    log('');
+    log('Nothing to apply.');
+    return { mode: 'apply', candidates, terminalized: 0, aborted: false };
+  }
+
+  const readConfirmation = opts.readConfirmation ?? readStdinLine;
+  const typed = (await readConfirmation()).trim();
+  if (typed !== CONFIRMATION_PHRASE) {
+    log('');
+    log(`Aborted: confirmation mismatch (expected exact "${CONFIRMATION_PHRASE}").`);
+    return { mode: 'apply', candidates, terminalized: 0, aborted: true };
+  }
+
+  const terminalized = await terminalizeOrphans(candidates, actor);
+  log('');
+  log(`reconcile-orphans: terminalized ${terminalized}/${candidates.length} row(s).`);
+  return { mode: 'apply', candidates, terminalized, aborted: false };
+}
+
+// ============================================================================
+// CLI entry — flags-before-positionals, defensive parsing.
+// ============================================================================
+
+export function parseCliArgs(argv: string[]): { apply: boolean; help: boolean; unknown: string[] } {
+  let apply = false;
+  let help = false;
+  const unknown: string[] = [];
+  for (const arg of argv) {
+    if (arg === '--apply') apply = true;
+    else if (arg === '--dry-run') apply = false;
+    else if (arg === '--help' || arg === '-h') help = true;
+    else unknown.push(arg);
+  }
+  return { apply, help, unknown };
+}
+
+const HELP = `Usage: bun run scripts/reconcile-orphans.ts [--dry-run|--apply]
+
+  --dry-run   Print candidates without writing (default).
+  --apply     Terminalize orphans after typed confirmation.
+
+Terminalizes agents rows whose tmux pane is dead and whose state has
+been idle for > 1 hour. Idempotent. See scripts/reconcile-orphans.ts
+header for the full predicate.`;
+
+async function main(): Promise<void> {
+  const args = parseCliArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(HELP);
+    process.exit(0);
+  }
+  if (args.unknown.length > 0) {
+    console.error(`reconcile-orphans: unknown arg(s): ${args.unknown.join(', ')}`);
+    console.error(HELP);
+    process.exit(2);
+  }
+  try {
+    const result = await run({ apply: args.apply });
+    if (result.aborted) process.exit(1);
+    process.exit(0);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`reconcile-orphans: ${msg}`);
+    process.exit(1);
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/reconcile-orphans.ts
+++ b/scripts/reconcile-orphans.ts
@@ -188,13 +188,7 @@ export async function terminalizeOrphans(candidates: Candidate[], actor: string)
 function formatTable(candidates: Candidate[]): string {
   if (candidates.length === 0) return '(no orphans)';
   const header = ['id', 'state', 'pane_id', 'last_state_change', 'action'];
-  const rows = candidates.map((c) => [
-    c.id,
-    c.state,
-    c.paneId ?? '∅',
-    c.lastStateChange,
-    `${c.action} (${c.reason})`,
-  ]);
+  const rows = candidates.map((c) => [c.id, c.state, c.paneId ?? '∅', c.lastStateChange, `${c.action} (${c.reason})`]);
   const widths = header.map((h, i) => Math.max(h.length, ...rows.map((r) => r[i].length)));
   const fmt = (r: string[]) => r.map((cell, i) => cell.padEnd(widths[i])).join('  ');
   const sep = widths.map((w) => '-'.repeat(w)).join('  ');

--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -218,3 +218,16 @@ genie task comment #<seq> "Draft: .genie/brainstorms/<slug>/DRAFT.md"
 - No implementation during brainstorm.
 - Persist early and often — do not wait until the end.
 - Always `git add` both `DESIGN.md` and `DRAFT.md` on crystallize — the `wishes-lint` linter will fail CI on any wish that links to an uncommitted brainstorm.
+
+## Turn close (required)
+
+Every session MUST end by writing a terminal outcome to the turn-session contract. This is how the orchestrator reconciles executor state — skipping it leaves the row open and blocks auto-resume.
+
+- `genie done` — work completed, acceptance criteria met
+- `genie blocked --reason "<why>"` — stuck, needs human input or an unblocking signal
+- `genie failed --reason "<why>"` — aborted, irrecoverable error, or cannot proceed
+
+Rules:
+- Call exactly one close verb as the last action of the session.
+- `blocked` / `failed` require `--reason`.
+- `genie done` inside an agent session (GENIE_AGENT_NAME set) closes the current executor; it does not require a wish ref.

--- a/skills/docs/SKILL.md
+++ b/skills/docs/SKILL.md
@@ -67,3 +67,16 @@ The docs agent:
 - Match existing project conventions for documentation style and structure.
 - Never document features that don't exist yet.
 - Include validation evidence in the report — not just "docs written" but "docs written and verified."
+
+## Turn close (required)
+
+Every session MUST end by writing a terminal outcome to the turn-session contract. This is how the orchestrator reconciles executor state — skipping it leaves the row open and blocks auto-resume.
+
+- `genie done` — work completed, acceptance criteria met
+- `genie blocked --reason "<why>"` — stuck, needs human input or an unblocking signal
+- `genie failed --reason "<why>"` — aborted, irrecoverable error, or cannot proceed
+
+Rules:
+- Call exactly one close verb as the last action of the session.
+- `blocked` / `failed` require `--reason`.
+- `genie done` inside an agent session (GENIE_AGENT_NAME set) closes the current executor; it does not require a wish ref.

--- a/skills/fix/SKILL.md
+++ b/skills/fix/SKILL.md
@@ -96,3 +96,16 @@ genie agent send 'Review wish fix-dispatch-initial-prompt. Check the fixer chang
 - Never exceed 2 fix loops — escalate, don't spin.
 - Include original wish criteria in every fix dispatch.
 - If identical gaps persist across loops, escalate immediately — no progress means BLOCKED.
+
+## Turn close (required)
+
+Every session MUST end by writing a terminal outcome to the turn-session contract. This is how the orchestrator reconciles executor state — skipping it leaves the row open and blocks auto-resume.
+
+- `genie done` — work completed, acceptance criteria met
+- `genie blocked --reason "<why>"` — stuck, needs human input or an unblocking signal
+- `genie failed --reason "<why>"` — aborted, irrecoverable error, or cannot proceed
+
+Rules:
+- Call exactly one close verb as the last action of the session.
+- `blocked` / `failed` require `--reason`.
+- `genie done` inside an agent session (GENIE_AGENT_NAME set) closes the current executor; it does not require a wish ref.

--- a/skills/refine/SKILL.md
+++ b/skills/refine/SKILL.md
@@ -788,3 +788,16 @@ Success criteria for refined prompt:
 - Never enter a clarification loop — single-turn execution only.
 - File mode overwrites in place. Do not create a new file.
 - Text mode always writes to `/tmp/prompts/`. Do not write elsewhere.
+
+## Turn close (required)
+
+Every session MUST end by writing a terminal outcome to the turn-session contract. This is how the orchestrator reconciles executor state — skipping it leaves the row open and blocks auto-resume.
+
+- `genie done` — work completed, acceptance criteria met
+- `genie blocked --reason "<why>"` — stuck, needs human input or an unblocking signal
+- `genie failed --reason "<why>"` — aborted, irrecoverable error, or cannot proceed
+
+Rules:
+- Call exactly one close verb as the last action of the session.
+- `blocked` / `failed` require `--reason`.
+- `genie done` inside an agent session (GENIE_AGENT_NAME set) closes the current executor; it does not require a wish ref.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -163,3 +163,16 @@ Next: create PR targeting dev
 - Never implement fixes during review — hand off to `/fix`.
 - Every FAIL includes actionable fix (file, command, what to change).
 - Keep output concise, severity-ordered, and executable.
+
+## Turn close (required)
+
+Every session MUST end by writing a terminal outcome to the turn-session contract. This is how the orchestrator reconciles executor state — skipping it leaves the row open and blocks auto-resume.
+
+- `genie done` — work completed, acceptance criteria met
+- `genie blocked --reason "<why>"` — stuck, needs human input or an unblocking signal
+- `genie failed --reason "<why>"` — aborted, irrecoverable error, or cannot proceed
+
+Rules:
+- Call exactly one close verb as the last action of the session.
+- `blocked` / `failed` require `--reason`.
+- `genie done` inside an agent session (GENIE_AGENT_NAME set) closes the current executor; it does not require a wish ref.

--- a/skills/trace/SKILL.md
+++ b/skills/trace/SKILL.md
@@ -92,3 +92,16 @@ The orchestrator then hands the report to `/fix`.
 - Hand off to `/fix` — trace produces a report, `/fix` applies the correction. Never combine them.
 - Read-only tools — trace subagent uses Read, Bash, Glob, Grep. No Write, no Edit.
 - If root cause spans multiple systems, report each separately with confidence levels.
+
+## Turn close (required)
+
+Every session MUST end by writing a terminal outcome to the turn-session contract. This is how the orchestrator reconciles executor state — skipping it leaves the row open and blocks auto-resume.
+
+- `genie done` — work completed, acceptance criteria met
+- `genie blocked --reason "<why>"` — stuck, needs human input or an unblocking signal
+- `genie failed --reason "<why>"` — aborted, irrecoverable error, or cannot proceed
+
+Rules:
+- Call exactly one close verb as the last action of the session.
+- `blocked` / `failed` require `--reason`.
+- `genie done` inside an agent session (GENIE_AGENT_NAME set) closes the current executor; it does not require a wish ref.

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -177,3 +177,16 @@ For multi-wave wishes, call `genie work <slug>` again after each wave completes 
 - Never overwrite WISH.md from workers — refined prompts are runtime context only.
 - Keep work auditable: capture commands + outcomes.
 - Run local `/review` per group before signaling done — never skip the review gate.
+
+## Turn close (required)
+
+Every session MUST end by writing a terminal outcome to the turn-session contract. This is how the orchestrator reconciles executor state — skipping it leaves the row open and blocks auto-resume.
+
+- `genie done` — work completed, acceptance criteria met
+- `genie blocked --reason "<why>"` — stuck, needs human input or an unblocking signal
+- `genie failed --reason "<why>"` — aborted, irrecoverable error, or cannot proceed
+
+Rules:
+- Call exactly one close verb as the last action of the session.
+- `blocked` / `failed` require `--reason`.
+- `genie done` inside an agent session (GENIE_AGENT_NAME set) closes the current executor; it does not require a wish ref.

--- a/src/db/migrations/043_executor_read_role.sql
+++ b/src/db/migrations/043_executor_read_role.sql
@@ -1,0 +1,41 @@
+-- 043_executor_read_role.sql — Readonly PG role for executor state lookups.
+-- Wish: turn-session-contract (Group 6).
+--
+-- External consumers (omni scope-enforcer) either hit the HTTP endpoint
+-- `GET /executors/:id/state` (src/lib/executor-read.ts) OR connect directly to
+-- genie-PG as `executors_reader`. This migration ships the direct-SQL path so
+-- operators can choose the transport that matches their deployment:
+--
+--   * HTTP: zero config, but adds a hop through `genie serve`.
+--   * Direct SQL: one fewer hop + simpler observability (pg_stat_statements).
+--
+-- The role is SELECT-only and scoped to the three columns the boundary contract
+-- promises (`state`, `outcome`, `closed_at`) via a dedicated view. Granting on
+-- the base table would expose `metadata`, `claude_session_id`, and other
+-- fields omni has no need to see.
+--
+-- NOINHERIT + no LOGIN by default: operators layer a login role on top with
+-- their own credentials (`CREATE ROLE omni_scope_enforcer LOGIN PASSWORD '…'
+--   IN ROLE executors_reader`). That keeps credential rotation a boundary
+-- concern, not a schema concern.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'executors_reader') THEN
+    EXECUTE 'CREATE ROLE executors_reader NOINHERIT';
+  END IF;
+END$$;
+
+-- Scoped view — exposes ONLY the boundary-contract fields. Adding a field here
+-- is a cross-repo coordination point (see WISH.md §Boundary Contracts).
+CREATE OR REPLACE VIEW executors_public_state AS
+SELECT id, state, outcome, closed_at
+FROM executors;
+
+REVOKE ALL ON executors_public_state FROM PUBLIC;
+GRANT SELECT ON executors_public_state TO executors_reader;
+
+-- Schema USAGE is required for the role to reference the view at all. Tables
+-- inside the schema still require explicit grants, so USAGE is safe to give
+-- broadly.
+GRANT USAGE ON SCHEMA public TO executors_reader;

--- a/src/db/migrations/044_phase_b_flip_defaults.sql
+++ b/src/db/migrations/044_phase_b_flip_defaults.sql
@@ -1,0 +1,124 @@
+-- 044_phase_b_flip_defaults.sql — Turn-Session Contract (Group 8, Phase B)
+-- Wish: turn-session-contract (genie side).
+--
+-- Flips production defaults so every new agent opts into the turn-aware
+-- reconciler contract delivered in Groups 4/5/7:
+--   • Group 4 — runAgentRecoveryPass honors GENIE_RECONCILER_TURN_AWARE
+--   • Group 5 — pane-exit trap writes clean_exit_unverified
+--   • Group 7 — scripts/reconcile-orphans.ts one-shot cleanup
+--
+-- This migration is the Phase B boundary: before it lands the flag is
+-- opt-in, after it the flag defaults ON (code-side flip in
+-- scheduler-daemon.ts) and the schema default matches.
+--
+-- Forward-only and idempotent — every statement guards with either a
+-- predicate that no-ops on a second apply (`IS DISTINCT FROM …`) or a
+-- CTE that selects zero rows on a clean DB.
+--
+-- Changes
+-- ───────
+--
+-- 1. `agents.auto_resume` DEFAULT flips from true → false.
+--    Applies to new agents only; existing rows keep whatever value they
+--    have. The explicit close verbs (`genie done` / `blocked` / `failed`)
+--    and the pane-exit trap are the authoritative terminators; automatic
+--    resume becomes opt-in.
+--
+-- 2. Backfill live rows to `auto_resume=true`.
+--    Rows whose `last_state_change` is within the last hour and whose
+--    state is non-terminal keep auto-resume so currently-active agents
+--    aren't silently dropped at the flip boundary.
+--
+-- 3. Backfill stale/closed rows to `auto_resume=false`.
+--    Rows whose executor closed (`executors.closed_at IS NOT NULL`), or
+--    whose agent state is terminal, or whose `last_state_change` is
+--    older than one hour are taken out of the resume pool. These are the
+--    ghost-loop precursors the flip is meant to eliminate.
+--
+-- 4. Orphan terminalization.
+--    Ports the cheap predicate from scripts/reconcile-orphans.ts: any
+--    non-terminal agent whose `last_state_change` > 1h ago and whose
+--    pane_id is a dead-pane sentinel (NULL, empty, 'inline') is flipped
+--    to state='error' with a `reconcile.terminalize` audit event.
+--    Live tmux-pane probing is intentionally deferred to the reconciler
+--    itself — this SQL runs during apply and cannot reach the tmux
+--    socket. Operators who want full parity should still run
+--    `bun scripts/reconcile-orphans.ts --apply` after the migration.
+--
+-- Acceptance (C16 / C17 from WISH.md):
+--   • `auto_resume` default is false
+--   • Live agents (last_state_change within 1 hour) preserve
+--     auto_resume=true
+--   • Closed / stale rows are auto_resume=false
+--   • Orphan sentinel rows are terminalized before flag flip
+--
+-- NOTE: The code-side flag-default flip happens in src/lib/scheduler-daemon.ts
+-- (`isTurnAwareReconcilerEnabled` — explicit env=false still rolls back).
+
+-- ─────────────────────────────────────────────────────────────────────
+-- 1. Column default flip
+-- ─────────────────────────────────────────────────────────────────────
+ALTER TABLE agents ALTER COLUMN auto_resume SET DEFAULT false;
+
+-- ─────────────────────────────────────────────────────────────────────
+-- 2. Preserve auto_resume=true for live agents
+-- ─────────────────────────────────────────────────────────────────────
+UPDATE agents
+SET auto_resume = true
+WHERE last_state_change IS NOT NULL
+  AND last_state_change >= now() - interval '1 hour'
+  AND state IS NOT NULL
+  AND state NOT IN ('done', 'error', 'suspended')
+  AND auto_resume IS DISTINCT FROM true;
+
+-- ─────────────────────────────────────────────────────────────────────
+-- 3. Flip stale / closed rows to auto_resume=false
+-- ─────────────────────────────────────────────────────────────────────
+UPDATE agents a
+SET auto_resume = false
+WHERE (
+        a.last_state_change IS NULL
+        OR a.last_state_change < now() - interval '1 hour'
+        OR a.state IN ('done', 'error', 'suspended')
+        OR EXISTS (
+          SELECT 1 FROM executors e
+          WHERE e.id = a.current_executor_id
+            AND e.closed_at IS NOT NULL
+        )
+      )
+  AND a.auto_resume IS DISTINCT FROM false;
+
+-- ─────────────────────────────────────────────────────────────────────
+-- 4. Orphan terminalization — SQL mirror of scripts/reconcile-orphans.ts
+--    for rows with dead-pane sentinels. Live-pane probing stays with
+--    the reconciler itself (it has tmux socket access).
+-- ─────────────────────────────────────────────────────────────────────
+WITH orphans AS (
+  SELECT id, state, pane_id
+  FROM agents
+  WHERE state IS NOT NULL
+    AND state NOT IN ('done', 'error', 'suspended')
+    AND last_state_change IS NOT NULL
+    AND last_state_change < now() - interval '1 hour'
+    AND (pane_id IS NULL OR pane_id = '' OR pane_id = 'inline')
+),
+updated AS (
+  UPDATE agents a
+  SET state = 'error',
+      last_state_change = now()
+  FROM orphans o
+  WHERE a.id = o.id
+  RETURNING a.id, o.state AS state_before, o.pane_id
+)
+INSERT INTO audit_events (entity_type, entity_id, event_type, actor, details)
+SELECT
+  'agent',
+  u.id,
+  'reconcile.terminalize',
+  'migration-044',
+  jsonb_build_object(
+    'state_before', u.state_before,
+    'pane_id',      u.pane_id,
+    'reason',       'migration_044_phase_b'
+  )
+FROM updated u;

--- a/src/db/migrations/044_phase_b_flip_defaults.test.ts
+++ b/src/db/migrations/044_phase_b_flip_defaults.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Integration tests for migration 044 — turn-session-contract Phase B.
+ *
+ * Covers the three acceptance shapes from the wish (C16 / C17):
+ *   1. Fresh DB: `auto_resume` column default is `false`, so brand-new
+ *      INSERTs opt out of auto-resume unless the caller overrides.
+ *   2. Live rows (last_state_change within 1 hour, non-terminal state)
+ *      are preserved as `auto_resume=true` across the migration.
+ *   3. Closed/stale rows — executor closed, terminal state, or
+ *      `last_state_change` older than 1 hour — end up `auto_resume=false`
+ *      and pane-sentinel orphans in non-terminal state are terminalized
+ *      with a `reconcile.terminalize` audit event.
+ *
+ * The migration runner applies every migration under the test schema in
+ * `setupTestSchema`, so by the time a test body runs the schema is already
+ * in its Phase B shape. To model "live/stale rows at migration time" we
+ * INSERT rows in the test body and then re-apply the migration as an
+ * idempotent second pass; the write statements (UPDATE + CTE) are
+ * predicate-guarded and safe to re-run.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { getConnection } from '../../lib/db.js';
+import { DB_AVAILABLE, setupTestSchema } from '../../lib/test-db.js';
+
+const MIGRATION_PATH = join(import.meta.dir, '044_phase_b_flip_defaults.sql');
+
+function loadMigration(): string {
+  return readFileSync(MIGRATION_PATH, 'utf-8');
+}
+
+describe.skipIf(!DB_AVAILABLE)('migration 044 — Phase B: flip auto_resume + reconciler defaults', () => {
+  let cleanup: () => Promise<void>;
+
+  beforeAll(async () => {
+    cleanup = await setupTestSchema();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  test('fresh DB: agents.auto_resume column default is false after migration 044', async () => {
+    const sql = await getConnection();
+    const rows = await sql<{ column_default: string | null }[]>`
+      SELECT column_default
+        FROM information_schema.columns
+       WHERE table_name = 'agents'
+         AND column_name = 'auto_resume'
+         AND table_schema = current_schema()
+    `;
+    expect(rows.length).toBe(1);
+    // Postgres reports boolean defaults as 'true' / 'false' literal strings.
+    expect(rows[0].column_default).toBe('false');
+  });
+
+  test('fresh-INSERT agent row inherits auto_resume=false', async () => {
+    const sql = await getConnection();
+    const id = `test-fresh-${Date.now()}`;
+    await sql`
+      INSERT INTO agents (id, pane_id, session, state, repo_path, started_at)
+      VALUES (${id}, '%99', 'sess-fresh', 'spawning', '/tmp/test', now())
+    `;
+    const rows = await sql<{ auto_resume: boolean | null }[]>`
+      SELECT auto_resume FROM agents WHERE id = ${id}
+    `;
+    expect(rows[0].auto_resume).toBe(false);
+  });
+
+  test('live row (last_state_change < 1h, non-terminal state) preserves auto_resume=true', async () => {
+    const sql = await getConnection();
+    const id = `test-live-${Date.now()}`;
+    // Seed a row that "looks like" a currently-active agent: short-ago
+    // state-change, non-terminal state, auto_resume null (pre-backfill).
+    await sql`
+      INSERT INTO agents (id, pane_id, session, state, repo_path, started_at, last_state_change, auto_resume)
+      VALUES (${id}, '%10', 'sess-live', 'working', '/tmp/test', now(), now() - interval '2 minutes', NULL)
+    `;
+    // Re-apply the migration — idempotent predicates re-exec the backfill.
+    await sql.unsafe(loadMigration());
+
+    const rows = await sql<{ auto_resume: boolean | null }[]>`
+      SELECT auto_resume FROM agents WHERE id = ${id}
+    `;
+    expect(rows[0].auto_resume).toBe(true);
+  });
+
+  test('stale row (last_state_change older than 1h) is flipped to auto_resume=false', async () => {
+    const sql = await getConnection();
+    const id = `test-stale-${Date.now()}`;
+    await sql`
+      INSERT INTO agents (id, pane_id, session, state, repo_path, started_at, last_state_change, auto_resume)
+      VALUES (${id}, '%11', 'sess-stale', 'idle', '/tmp/test', now() - interval '3 hours',
+              now() - interval '2 hours', true)
+    `;
+    await sql.unsafe(loadMigration());
+
+    const rows = await sql<{ auto_resume: boolean | null }[]>`
+      SELECT auto_resume FROM agents WHERE id = ${id}
+    `;
+    expect(rows[0].auto_resume).toBe(false);
+  });
+
+  test('terminal-state row (done/error/suspended) is flipped to auto_resume=false', async () => {
+    const sql = await getConnection();
+    const rowsToSeed = ['done', 'error', 'suspended'] as const;
+    const ids: string[] = [];
+    for (const state of rowsToSeed) {
+      const id = `test-terminal-${state}-${Date.now()}`;
+      ids.push(id);
+      await sql`
+        INSERT INTO agents (id, pane_id, session, state, repo_path, started_at, last_state_change, auto_resume)
+        VALUES (${id}, '%12', 'sess-terminal', ${state}, '/tmp/test', now(), now() - interval '2 minutes', true)
+      `;
+    }
+    await sql.unsafe(loadMigration());
+
+    const rows = await sql<{ id: string; auto_resume: boolean | null }[]>`
+      SELECT id, auto_resume FROM agents WHERE id = ANY(${ids})
+    `;
+    for (const r of rows) expect(r.auto_resume).toBe(false);
+  });
+
+  test('row with a closed executor is flipped to auto_resume=false via executors JOIN', async () => {
+    const sql = await getConnection();
+    const agentId = `test-closed-exec-${Date.now()}`;
+    const execId = `exec-closed-${Date.now()}`;
+    await sql`
+      INSERT INTO agents (id, pane_id, session, state, repo_path, started_at, last_state_change, auto_resume)
+      VALUES (${agentId}, '%13', 'sess-ce', 'working', '/tmp/test', now(), now() - interval '2 minutes', true)
+    `;
+    await sql`
+      INSERT INTO executors (id, agent_id, provider, transport, state, started_at, closed_at, ended_at, outcome, close_reason)
+      VALUES (${execId}, ${agentId}, 'claude', 'tmux', 'error', now() - interval '10 minutes',
+              now() - interval '5 minutes', now() - interval '5 minutes', 'done', 'test')
+    `;
+    await sql`UPDATE agents SET current_executor_id = ${execId} WHERE id = ${agentId}`;
+
+    await sql.unsafe(loadMigration());
+
+    const rows = await sql<{ auto_resume: boolean | null }[]>`
+      SELECT auto_resume FROM agents WHERE id = ${agentId}
+    `;
+    expect(rows[0].auto_resume).toBe(false);
+  });
+
+  test('orphan terminalization: stale row with dead-pane sentinel → state=error + audit event', async () => {
+    const sql = await getConnection();
+    const id = `test-orphan-${Date.now()}`;
+    // pane_id='' + stale last_state_change + non-terminal state matches
+    // the SQL orphan predicate (CTE `orphans` in migration 044).
+    await sql`
+      INSERT INTO agents (id, pane_id, session, state, repo_path, started_at, last_state_change, auto_resume)
+      VALUES (${id}, '', 'sess-orphan', 'working', '/tmp/test', now() - interval '3 hours',
+              now() - interval '2 hours', true)
+    `;
+    await sql.unsafe(loadMigration());
+
+    const rows = await sql<{ state: string; auto_resume: boolean | null }[]>`
+      SELECT state, auto_resume FROM agents WHERE id = ${id}
+    `;
+    expect(rows[0].state).toBe('error');
+    expect(rows[0].auto_resume).toBe(false);
+
+    const audit = await sql<{ actor: string; details: unknown }[]>`
+      SELECT actor, details FROM audit_events
+       WHERE entity_type = 'agent' AND entity_id = ${id}
+         AND event_type = 'reconcile.terminalize'
+    `;
+    expect(audit.length).toBeGreaterThanOrEqual(1);
+    expect(audit[0].actor).toBe('migration-044');
+    const details = audit[0].details as { state_before: string; pane_id: string; reason: string };
+    expect(details.state_before).toBe('working');
+    expect(details.reason).toBe('migration_044_phase_b');
+  });
+
+  test('live row with a dead-pane sentinel is NOT terminalized (freshness wins)', async () => {
+    const sql = await getConnection();
+    const id = `test-live-sentinel-${Date.now()}`;
+    // Dead-pane sentinel BUT last_state_change within the 1h window →
+    // orphan CTE excludes it; state stays as-is.
+    await sql`
+      INSERT INTO agents (id, pane_id, session, state, repo_path, started_at, last_state_change, auto_resume)
+      VALUES (${id}, 'inline', 'sess-live-sentinel', 'idle', '/tmp/test', now(),
+              now() - interval '2 minutes', true)
+    `;
+    await sql.unsafe(loadMigration());
+
+    const rows = await sql<{ state: string; auto_resume: boolean | null }[]>`
+      SELECT state, auto_resume FROM agents WHERE id = ${id}
+    `;
+    expect(rows[0].state).toBe('idle');
+    expect(rows[0].auto_resume).toBe(true);
+  });
+
+  test('migration is idempotent: second apply is a no-op', async () => {
+    const sql = await getConnection();
+    // Snapshot agent counts + audit count, apply again, compare.
+    const [before] = await sql<{ cnt: number }[]>`SELECT count(*)::int AS cnt FROM agents`;
+    const [auditBefore] = await sql<{ cnt: number }[]>`
+      SELECT count(*)::int AS cnt FROM audit_events WHERE actor = 'migration-044'
+    `;
+    await sql.unsafe(loadMigration());
+    const [after] = await sql<{ cnt: number }[]>`SELECT count(*)::int AS cnt FROM agents`;
+    const [auditAfter] = await sql<{ cnt: number }[]>`
+      SELECT count(*)::int AS cnt FROM audit_events WHERE actor = 'migration-044'
+    `;
+    expect(after.cnt).toBe(before.cnt);
+    // Orphan CTE matches zero rows on the second apply (all have been
+    // flipped to state='error' already), so the audit count should not
+    // grow.
+    expect(auditAfter.cnt).toBe(auditBefore.cnt);
+  });
+});

--- a/src/genie.ts
+++ b/src/genie.ts
@@ -241,6 +241,36 @@ registerBriefCommands(program);
 registerApprovalCommands(program);
 
 // ============================================================================
+// Turn-close verbs — genie done / blocked / failed
+// ============================================================================
+
+program
+  .command('done [ref]')
+  .description('Close the current turn (inside an agent session) or mark a wish group done (team-lead, <slug>#<group>)')
+  .action(async (ref: string | undefined) => {
+    const { doneAction } = await import('./term-commands/done.js');
+    await doneAction(ref);
+  });
+
+program
+  .command('blocked')
+  .description('Close the current turn with outcome=blocked')
+  .requiredOption('--reason <message>', 'Why the turn is blocked')
+  .action(async (options: { reason: string }) => {
+    const { blockedAction } = await import('./term-commands/blocked.js');
+    await blockedAction(options);
+  });
+
+program
+  .command('failed')
+  .description('Close the current turn with outcome=failed')
+  .requiredOption('--reason <message>', 'Why the turn failed')
+  .action(async (options: { reason: string }) => {
+    const { failedAction } = await import('./term-commands/failed.js');
+    await failedAction(options);
+  });
+
+// ============================================================================
 // Universal workspace check — ensures workspace exists before commands that need it
 // ============================================================================
 

--- a/src/genie.ts
+++ b/src/genie.ts
@@ -270,6 +270,19 @@ program
     await failedAction(options);
   });
 
+program
+  .command('pane-trap')
+  .description(
+    'Internal: write clean_exit_unverified outcome for a dying pane/shell. Invoked by the tmux pane-died hook and the inline shell EXIT trap.',
+  )
+  .option('--pane-id <id>', 'tmux pane id (%N) — resolved to executor via executors.tmux_pane_id')
+  .option('--executor-id <id>', 'explicit executor UUID (preferred when available)')
+  .option('--reason <reason>', 'trap source: pane_died or shell_exit', 'pane_died')
+  .action(async (options: { paneId?: string; executorId?: string; reason?: string }) => {
+    const { paneTrapAction } = await import('./term-commands/pane-trap.js');
+    await paneTrapAction(options);
+  });
+
 // ============================================================================
 // Universal workspace check — ensures workspace exists before commands that need it
 // ============================================================================

--- a/src/lib/__tests__/auto-resume-zombie-cap.test.ts
+++ b/src/lib/__tests__/auto-resume-zombie-cap.test.ts
@@ -262,25 +262,53 @@ describe('Change #2: periodic resume sweep for error-state agents', () => {
     expect(typeof runAgentRecoveryPass).toBe('function');
   });
 
-  test('runAgentRecoveryPass attempts resume for error-state agents with dead panes', async () => {
+  test('runAgentRecoveryPass does NOT resume error-state agents with dead panes (turn-aware default, Phase B)', async () => {
+    // Post-G8 contract: with GENIE_RECONCILER_TURN_AWARE on by default,
+    // only working/permission/question + dead-pane are resumed (D3).
+    // `error` is terminal intent already — resuming would replay a
+    // failed turn. See WISH turn-session-contract, C20.
     const workers: WorkerInfo[] = [
-      // Error-state agent with dead pane — should be resumed
       makeWorker({ id: 'dead-error', paneId: '%99', state: 'error', claudeSessionId: 'sess-1' }),
-      // Done agent — should NOT be touched
       makeWorker({ id: 'finished', paneId: '%98', state: 'done', claudeSessionId: 'sess-2' }),
-      // Suspended agent — should NOT be touched (explicit user intent)
       makeWorker({ id: 'paused', paneId: '%97', state: 'suspended', claudeSessionId: 'sess-3' }),
     ];
     const { deps, resumedIds } = createMockDeps({
       listWorkers: async () => workers,
-      isPaneAlive: async () => false, // all panes dead
+      isPaneAlive: async () => false,
     });
 
     await runAgentRecoveryPass(deps, 'daemon-test', defaultConfig);
 
-    expect(resumedIds).toContain('dead-error');
+    expect(resumedIds).not.toContain('dead-error');
     expect(resumedIds).not.toContain('finished');
     expect(resumedIds).not.toContain('paused');
+  });
+
+  test('legacy flag OFF: runAgentRecoveryPass still resumes error-state agents with dead panes', async () => {
+    // Rollback path — operators can set GENIE_RECONCILER_TURN_AWARE=0 to
+    // restore pre-Phase-B behavior if the turn-aware reconciler causes
+    // incidents in production.
+    const prev = process.env.GENIE_RECONCILER_TURN_AWARE;
+    process.env.GENIE_RECONCILER_TURN_AWARE = '0';
+    try {
+      const workers: WorkerInfo[] = [
+        makeWorker({ id: 'dead-error', paneId: '%99', state: 'error', claudeSessionId: 'sess-1' }),
+        makeWorker({ id: 'finished', paneId: '%98', state: 'done', claudeSessionId: 'sess-2' }),
+        makeWorker({ id: 'paused', paneId: '%97', state: 'suspended', claudeSessionId: 'sess-3' }),
+      ];
+      const { deps, resumedIds } = createMockDeps({
+        listWorkers: async () => workers,
+        isPaneAlive: async () => false,
+      });
+
+      await runAgentRecoveryPass(deps, 'daemon-test', defaultConfig);
+
+      expect(resumedIds).toContain('dead-error');
+      expect(resumedIds).not.toContain('finished');
+      expect(resumedIds).not.toContain('paused');
+    } finally {
+      process.env.GENIE_RECONCILER_TURN_AWARE = prev;
+    }
   });
 
   test('daemon startup wires the resume timer alongside lease recovery', () => {

--- a/src/lib/executor-read.test.ts
+++ b/src/lib/executor-read.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Executor Read Endpoint tests — response shape, 404, method guard, DB lookup.
+ *
+ * These exercise the HTTP surface that omni scope-enforcer consumes (boundary
+ * contract from `turn-session-contract` WISH.md). A shape regression here is a
+ * cross-repo breaking change.
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { findOrCreateAgent } from './agent-registry.js';
+import { getConnection } from './db.js';
+import { createExecutor } from './executor-registry.js';
+import {
+  getExecutorReadPort,
+  isExecutorReadEndpointRunning,
+  readExecutorState,
+  startExecutorReadEndpoint,
+  stopExecutorReadEndpoint,
+} from './executor-read.js';
+import { DB_AVAILABLE, setupTestSchema } from './test-db.js';
+
+describe.skipIf(!DB_AVAILABLE)('executor-read', () => {
+  let cleanup: () => Promise<void>;
+  let origPort: string | undefined;
+
+  beforeAll(async () => {
+    cleanup = await setupTestSchema();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  beforeEach(async () => {
+    const sql = await getConnection();
+    await sql`DELETE FROM audit_events`;
+    await sql`DELETE FROM assignments`;
+    await sql`DELETE FROM executors`;
+    await sql`DELETE FROM agents`;
+
+    origPort = process.env.GENIE_EXECUTOR_READ_PORT;
+    // High random port — avoids collisions with pgserve, OTel receiver, and parallel tests.
+    process.env.GENIE_EXECUTOR_READ_PORT = String(50000 + Math.floor(Math.random() * 6000));
+  });
+
+  afterEach(async () => {
+    await stopExecutorReadEndpoint();
+    if (origPort !== undefined) process.env.GENIE_EXECUTOR_READ_PORT = origPort;
+    else process.env.GENIE_EXECUTOR_READ_PORT = undefined;
+  });
+
+  async function seedExecutor(overrides: Partial<{ state: string; outcome: string; closeReason: string }> = {}) {
+    const agent = await findOrCreateAgent('eng-read', 'test-team', 'engineer');
+    const exec = await createExecutor(agent.id, 'claude', 'tmux', {
+      state: (overrides.state as never) ?? 'working',
+    });
+    if (overrides.outcome) {
+      const sql = await getConnection();
+      await sql`
+        UPDATE executors
+        SET outcome = ${overrides.outcome},
+            closed_at = now(),
+            close_reason = ${overrides.closeReason ?? null},
+            state = 'done',
+            ended_at = now()
+        WHERE id = ${exec.id}
+      `;
+    }
+    return exec.id;
+  }
+
+  test('getExecutorReadPort respects GENIE_EXECUTOR_READ_PORT env', () => {
+    process.env.GENIE_EXECUTOR_READ_PORT = '54321';
+    expect(getExecutorReadPort()).toBe(54321);
+  });
+
+  test('startExecutorReadEndpoint is idempotent', async () => {
+    expect(isExecutorReadEndpointRunning()).toBe(false);
+    expect(await startExecutorReadEndpoint()).toBe(true);
+    expect(isExecutorReadEndpointRunning()).toBe(true);
+    expect(await startExecutorReadEndpoint()).toBe(true);
+    expect(isExecutorReadEndpointRunning()).toBe(true);
+  });
+
+  test('readExecutorState returns null for unknown id', async () => {
+    const reply = await readExecutorState('00000000-0000-0000-0000-000000000000');
+    expect(reply).toBeNull();
+  });
+
+  test('readExecutorState returns state + outcome + closed_at for open turn', async () => {
+    const id = await seedExecutor({ state: 'working' });
+    const reply = await readExecutorState(id);
+    expect(reply).not.toBeNull();
+    expect(reply!.state).toBe('working');
+    expect(reply!.outcome).toBeNull();
+    expect(reply!.closed_at).toBeNull();
+  });
+
+  test('readExecutorState surfaces closed outcome after turn close', async () => {
+    const id = await seedExecutor({ state: 'working', outcome: 'done' });
+    const reply = await readExecutorState(id);
+    expect(reply!.state).toBe('done');
+    expect(reply!.outcome).toBe('done');
+    expect(reply!.closed_at).not.toBeNull();
+    // ISO-8601 string, not a Date instance — the contract says string.
+    expect(typeof reply!.closed_at).toBe('string');
+  });
+
+  test('GET /executors/:id/state returns 200 + JSON body for known executor', async () => {
+    const id = await seedExecutor({ state: 'working', outcome: 'done' });
+    await startExecutorReadEndpoint();
+    const port = getExecutorReadPort();
+
+    const res = await fetch(`http://127.0.0.1:${port}/executors/${id}/state`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toMatch(/application\/json/);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.state).toBe('done');
+    expect(body.outcome).toBe('done');
+    expect(typeof body.closed_at).toBe('string');
+    // Boundary contract — only these three fields are promised to omni.
+    expect(Object.keys(body).sort()).toEqual(['closed_at', 'outcome', 'state']);
+  });
+
+  test('GET /executors/:id/state returns 404 for unknown id', async () => {
+    await startExecutorReadEndpoint();
+    const port = getExecutorReadPort();
+    const res = await fetch(`http://127.0.0.1:${port}/executors/00000000-0000-0000-0000-000000000000/state`);
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('not found');
+  });
+
+  test('GET /executors/:id/state rejects non-UUID ids with 400', async () => {
+    await startExecutorReadEndpoint();
+    const port = getExecutorReadPort();
+    const res = await fetch(`http://127.0.0.1:${port}/executors/not-a-uuid/state`);
+    expect(res.status).toBe(400);
+  });
+
+  test('non-GET methods return 405', async () => {
+    await startExecutorReadEndpoint();
+    const port = getExecutorReadPort();
+    const res = await fetch(`http://127.0.0.1:${port}/executors/00000000-0000-0000-0000-000000000000/state`, {
+      method: 'POST',
+    });
+    expect(res.status).toBe(405);
+  });
+
+  test('unknown routes return 404', async () => {
+    await startExecutorReadEndpoint();
+    const port = getExecutorReadPort();
+    const res = await fetch(`http://127.0.0.1:${port}/nope`);
+    expect(res.status).toBe(404);
+  });
+
+  test('GET /health is reachable', async () => {
+    await startExecutorReadEndpoint();
+    const port = getExecutorReadPort();
+    const res = await fetch(`http://127.0.0.1:${port}/health`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string; port: number };
+    expect(body.status).toBe('ok');
+    expect(body.port).toBe(port);
+  });
+
+  test('read latency is well under the 10ms p99 budget', async () => {
+    // Not a load test — we can't guarantee 100 req/s in a CI sandbox. But a
+    // single round-trip should land in the low-single-digit ms range because
+    // the SELECT hits the executors primary key. This guards against O(N)
+    // regressions (e.g., someone adding a full scan). Budget is generous for
+    // noisy CI; the real p99 target (10ms) is validated in the omni wish.
+    const id = await seedExecutor({ state: 'working' });
+    await startExecutorReadEndpoint();
+    const port = getExecutorReadPort();
+
+    // Warm pool + routes.
+    await fetch(`http://127.0.0.1:${port}/executors/${id}/state`);
+
+    const start = performance.now();
+    const res = await fetch(`http://127.0.0.1:${port}/executors/${id}/state`);
+    const elapsedMs = performance.now() - start;
+    expect(res.status).toBe(200);
+    expect(elapsedMs).toBeLessThan(100);
+  });
+});

--- a/src/lib/executor-read.test.ts
+++ b/src/lib/executor-read.test.ts
@@ -9,7 +9,6 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
 import { findOrCreateAgent } from './agent-registry.js';
 import { getConnection } from './db.js';
-import { createExecutor } from './executor-registry.js';
 import {
   getExecutorReadPort,
   isExecutorReadEndpointRunning,
@@ -17,6 +16,7 @@ import {
   startExecutorReadEndpoint,
   stopExecutorReadEndpoint,
 } from './executor-read.js';
+import { createExecutor } from './executor-registry.js';
 import { DB_AVAILABLE, setupTestSchema } from './test-db.js';
 
 describe.skipIf(!DB_AVAILABLE)('executor-read', () => {

--- a/src/lib/executor-read.ts
+++ b/src/lib/executor-read.ts
@@ -16,7 +16,7 @@
 import { type Sql, getActivePort, getConnection } from './db.js';
 import type { ExecutorState, TurnOutcome } from './executor-types.js';
 
-export interface ExecutorStateReply {
+interface ExecutorStateReply {
   state: ExecutorState;
   outcome: TurnOutcome | null;
   closed_at: string | null;

--- a/src/lib/executor-read.ts
+++ b/src/lib/executor-read.ts
@@ -1,0 +1,123 @@
+/**
+ * Executor Read Endpoint — read-only HTTP surface over `executors` state.
+ *
+ * Cross-repo contract: omni scope-enforcer (and other external consumers) call
+ *   GET /executors/:id/state
+ * to obtain ground-truth turn state before authorizing a request. The response
+ * shape `{state, outcome, closed_at}` is the stable boundary surface; adding
+ * fields is backwards-compatible, removing/renaming is a breaking change that
+ * must be coordinated with the omni wish (see `turn-session-contract` WISH.md).
+ *
+ * Authz: none. Executor IDs are random UUIDs; the endpoint exposes no secrets.
+ * Alternate path: a readonly PG role `executors_reader` (migration 043) can be
+ * used by consumers that prefer direct SQL over HTTP.
+ */
+
+import { type Sql, getActivePort, getConnection } from './db.js';
+import type { ExecutorState, TurnOutcome } from './executor-types.js';
+
+export interface ExecutorStateReply {
+  state: ExecutorState;
+  outcome: TurnOutcome | null;
+  closed_at: string | null;
+}
+
+/**
+ * Read the state triple for an executor. Returns `null` when the ID is unknown.
+ * Single indexed SELECT on the executors primary key — p99 well below 10ms.
+ */
+export async function readExecutorState(id: string, sql?: Sql): Promise<ExecutorStateReply | null> {
+  const conn = sql ?? (await getConnection());
+  const rows = await conn<
+    { state: ExecutorState; outcome: TurnOutcome | null; closed_at: Date | string | null }[]
+  >`SELECT state, outcome, closed_at FROM executors WHERE id = ${id} LIMIT 1`;
+  if (rows.length === 0) return null;
+  const row = rows[0];
+  return {
+    state: row.state,
+    outcome: row.outcome ?? null,
+    closed_at: row.closed_at == null ? null : row.closed_at instanceof Date ? row.closed_at.toISOString() : row.closed_at,
+  };
+}
+
+let server: ReturnType<typeof Bun.serve> | null = null;
+
+/**
+ * Port for the executor read endpoint.
+ *
+ * Defaults to `getActivePort() + 2` so it sits beside pgserve (+0) and the OTel
+ * receiver (+1) without colliding. Override via `GENIE_EXECUTOR_READ_PORT`.
+ */
+export function getExecutorReadPort(): number {
+  const envPort = process.env.GENIE_EXECUTOR_READ_PORT;
+  if (envPort) {
+    const parsed = Number.parseInt(envPort, 10);
+    if (!Number.isNaN(parsed) && parsed > 0 && parsed < 65536) return parsed;
+  }
+  return getActivePort() + 2;
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const ROUTE_RE = /^\/executors\/([^/]+)\/state\/?$/;
+
+/**
+ * Start the executor read HTTP server. Idempotent — subsequent calls are no-ops
+ * while the server is already running. Returns `true` on success (including
+ * idempotent re-calls), `false` when the port was busy or another error was
+ * logged. Non-fatal: genie serve keeps running either way.
+ */
+export async function startExecutorReadEndpoint(): Promise<boolean> {
+  if (server) return true;
+  const port = getExecutorReadPort();
+  try {
+    server = Bun.serve({
+      port,
+      hostname: '127.0.0.1',
+      fetch: async (req) => {
+        const url = new URL(req.url);
+        if (req.method === 'GET' && url.pathname === '/health') {
+          return Response.json({ status: 'ok', port });
+        }
+        if (req.method !== 'GET') {
+          return new Response('Method Not Allowed', { status: 405 });
+        }
+        const match = ROUTE_RE.exec(url.pathname);
+        if (!match) return new Response('Not Found', { status: 404 });
+        const id = match[1];
+        if (!UUID_RE.test(id)) {
+          return Response.json({ error: 'invalid executor id' }, { status: 400 });
+        }
+        try {
+          const reply = await readExecutorState(id);
+          if (!reply) return Response.json({ error: 'not found' }, { status: 404 });
+          return Response.json(reply, { headers: { 'Cache-Control': 'no-store' } });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          return Response.json({ error: msg }, { status: 500 });
+        }
+      },
+    });
+    return true;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes('EADDRINUSE') || message.includes('address already in use')) {
+      console.warn(`Executor read endpoint: port ${port} already in use — skipping`);
+    } else {
+      console.warn(`Executor read endpoint: failed to start on port ${port}: ${message}`);
+    }
+    return false;
+  }
+}
+
+/** Stop the endpoint. Awaits full socket release so tests can restart on the same port. */
+export async function stopExecutorReadEndpoint(): Promise<void> {
+  if (server) {
+    await server.stop(true);
+    server = null;
+  }
+}
+
+/** Whether the endpoint is currently running. */
+export function isExecutorReadEndpointRunning(): boolean {
+  return server !== null;
+}

--- a/src/lib/executor-read.ts
+++ b/src/lib/executor-read.ts
@@ -36,7 +36,8 @@ export async function readExecutorState(id: string, sql?: Sql): Promise<Executor
   return {
     state: row.state,
     outcome: row.outcome ?? null,
-    closed_at: row.closed_at == null ? null : row.closed_at instanceof Date ? row.closed_at.toISOString() : row.closed_at,
+    closed_at:
+      row.closed_at == null ? null : row.closed_at instanceof Date ? row.closed_at.toISOString() : row.closed_at,
   };
 }
 
@@ -60,6 +61,31 @@ export function getExecutorReadPort(): number {
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const ROUTE_RE = /^\/executors\/([^/]+)\/state\/?$/;
 
+async function handleStateRoute(id: string): Promise<Response> {
+  if (!UUID_RE.test(id)) {
+    return Response.json({ error: 'invalid executor id' }, { status: 400 });
+  }
+  try {
+    const reply = await readExecutorState(id);
+    if (!reply) return Response.json({ error: 'not found' }, { status: 404 });
+    return Response.json(reply, { headers: { 'Cache-Control': 'no-store' } });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return Response.json({ error: msg }, { status: 500 });
+  }
+}
+
+async function routeRequest(req: Request, port: number): Promise<Response> {
+  const url = new URL(req.url);
+  if (req.method === 'GET' && url.pathname === '/health') {
+    return Response.json({ status: 'ok', port });
+  }
+  if (req.method !== 'GET') return new Response('Method Not Allowed', { status: 405 });
+  const match = ROUTE_RE.exec(url.pathname);
+  if (!match) return new Response('Not Found', { status: 404 });
+  return handleStateRoute(match[1]);
+}
+
 /**
  * Start the executor read HTTP server. Idempotent — subsequent calls are no-ops
  * while the server is already running. Returns `true` on success (including
@@ -73,29 +99,7 @@ export async function startExecutorReadEndpoint(): Promise<boolean> {
     server = Bun.serve({
       port,
       hostname: '127.0.0.1',
-      fetch: async (req) => {
-        const url = new URL(req.url);
-        if (req.method === 'GET' && url.pathname === '/health') {
-          return Response.json({ status: 'ok', port });
-        }
-        if (req.method !== 'GET') {
-          return new Response('Method Not Allowed', { status: 405 });
-        }
-        const match = ROUTE_RE.exec(url.pathname);
-        if (!match) return new Response('Not Found', { status: 404 });
-        const id = match[1];
-        if (!UUID_RE.test(id)) {
-          return Response.json({ error: 'invalid executor id' }, { status: 400 });
-        }
-        try {
-          const reply = await readExecutorState(id);
-          if (!reply) return Response.json({ error: 'not found' }, { status: 404 });
-          return Response.json(reply, { headers: { 'Cache-Control': 'no-store' } });
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          return Response.json({ error: msg }, { status: 500 });
-        }
-      },
+      fetch: (req) => routeRequest(req, port),
     });
     return true;
   } catch (err) {

--- a/src/lib/pane-trap.test.ts
+++ b/src/lib/pane-trap.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Pane-trap safety-net tests — turn-session-contract Group 5.
+ *
+ * Covers the DB-layer idempotency contract (first writer wins) and the
+ * pure string builders for tmux / shell install helpers. Real tmux
+ * pane-death is exercised by the CLI wiring, not this unit suite.
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { findOrCreateAgent, setCurrentExecutor } from './agent-registry.js';
+import { getConnection } from './db.js';
+import { createExecutor, getExecutor } from './executor-registry.js';
+import { buildPaneDiedHookCmd, installTmuxPaneDiedHook, shellExitTrapSnippet, trapPaneExit } from './pane-trap.js';
+import { DB_AVAILABLE, setupTestSchema } from './test-db.js';
+import { turnClose } from './turn-close.js';
+
+describe('buildPaneDiedHookCmd', () => {
+  test('scopes the hook to a specific pane with -p -t', () => {
+    const cmd = buildPaneDiedHookCmd('%42');
+    expect(cmd.startsWith('set-hook -p -t')).toBe(true);
+    expect(cmd).toContain("-t '%42'");
+    expect(cmd).toContain('pane-died');
+  });
+
+  test('expands #{hook_pane} so tmux substitutes the dying pane id', () => {
+    const cmd = buildPaneDiedHookCmd('%1');
+    expect(cmd).toContain('--pane-id=#{hook_pane}');
+    expect(cmd).toContain('--reason=pane_died');
+  });
+
+  test('invokes the configured genie binary path', () => {
+    const cmd = buildPaneDiedHookCmd('%9', '/custom/bin/genie');
+    expect(cmd).toContain('/custom/bin/genie pane-trap');
+  });
+});
+
+describe('installTmuxPaneDiedHook', () => {
+  test('rejects obviously-invalid pane ids without calling tmux', async () => {
+    // These should silently no-op — no throw, no tmux spawn.
+    await installTmuxPaneDiedHook('');
+    await installTmuxPaneDiedHook('inline');
+    await installTmuxPaneDiedHook('not-a-pane');
+  });
+});
+
+describe('shellExitTrapSnippet', () => {
+  test('registers a bash trap on EXIT referencing $GENIE_EXECUTOR_ID', () => {
+    const snippet = shellExitTrapSnippet();
+    expect(snippet.startsWith('trap ')).toBe(true);
+    expect(snippet.endsWith(' EXIT')).toBe(true);
+    expect(snippet).toContain('$GENIE_EXECUTOR_ID');
+    expect(snippet).toContain('--reason=shell_exit');
+  });
+
+  test('uses a custom genie binary when provided', () => {
+    expect(shellExitTrapSnippet('/opt/genie/bin/genie')).toContain('/opt/genie/bin/genie pane-trap');
+  });
+
+  test('does not alter the shell exit code (|| true)', () => {
+    expect(shellExitTrapSnippet()).toContain('|| true');
+  });
+});
+
+describe.skipIf(!DB_AVAILABLE)('trapPaneExit (integration)', () => {
+  let cleanup: () => Promise<void>;
+
+  beforeAll(async () => {
+    cleanup = await setupTestSchema();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  beforeEach(async () => {
+    const sql = await getConnection();
+    await sql`DELETE FROM audit_events`;
+    await sql`DELETE FROM assignments`;
+    await sql`DELETE FROM executors`;
+    await sql`DELETE FROM agents`;
+  });
+
+  const originalEnv = { executor: process.env.GENIE_EXECUTOR_ID, agent: process.env.GENIE_AGENT_NAME };
+  afterEach(() => {
+    process.env.GENIE_EXECUTOR_ID = originalEnv.executor;
+    process.env.GENIE_AGENT_NAME = originalEnv.agent;
+  });
+
+  async function seed(opts: { paneId?: string | null; state?: 'working' | 'idle' } = {}) {
+    const agent = await findOrCreateAgent(
+      `eng-trap-${Math.random().toString(36).slice(2, 7)}`,
+      'test-team',
+      'engineer',
+    );
+    const exec = await createExecutor(agent.id, 'claude', 'tmux', {
+      state: opts.state ?? 'working',
+      tmuxPaneId: opts.paneId === undefined ? '%7' : opts.paneId,
+    });
+    await setCurrentExecutor(agent.id, exec.id);
+    return { agentId: agent.id, executorId: exec.id, paneId: exec.tmuxPaneId };
+  }
+
+  test('writes clean_exit_unverified outcome + state=error + closed_at', async () => {
+    const { agentId, executorId } = await seed();
+
+    const result = await trapPaneExit({ executorId, reason: 'pane_died', actor: 'tmux-hook' });
+
+    expect(result.noop).toBe(false);
+    expect(result.outcome).toBe('clean_exit_unverified');
+    expect(result.reason).toBe('pane_died');
+
+    const exec = await getExecutor(executorId);
+    expect(exec!.outcome).toBe('clean_exit_unverified');
+    expect(exec!.state).toBe('error');
+    expect(exec!.closedAt).not.toBeNull();
+    expect(exec!.closeReason).toBe('pane_died');
+    expect(exec!.endedAt).not.toBeNull();
+
+    const sql = await getConnection();
+    const [agentRow] = await sql<{ current_executor_id: string | null }[]>`
+      SELECT current_executor_id FROM agents WHERE id = ${agentId}
+    `;
+    expect(agentRow.current_executor_id).toBeNull();
+
+    const audits = await sql<{ event_type: string; actor: string; details: unknown }[]>`
+      SELECT event_type, actor, details FROM audit_events
+      WHERE entity_type = 'executor' AND entity_id = ${executorId}
+    `;
+    expect(audits.length).toBe(1);
+    expect(audits[0].event_type).toBe('turn_close.clean_exit_unverified');
+    expect(audits[0].actor).toBe('tmux-hook');
+  });
+
+  test('idempotent: verb fired first → trap is a no-op, verb outcome preserved', async () => {
+    const { executorId } = await seed();
+    await turnClose({ outcome: 'done', executorId, actor: 'agent' });
+
+    const sql = await getConnection();
+    const [before] = await sql<{ outcome: string; close_reason: string | null; closed_at: Date }[]>`
+      SELECT outcome, close_reason, closed_at FROM executors WHERE id = ${executorId}
+    `;
+
+    const result = await trapPaneExit({ executorId, reason: 'pane_died' });
+    expect(result.noop).toBe(true);
+
+    const [after] = await sql<{ outcome: string; close_reason: string | null; closed_at: Date }[]>`
+      SELECT outcome, close_reason, closed_at FROM executors WHERE id = ${executorId}
+    `;
+    expect(after.outcome).toBe('done'); // verb's outcome wins
+    expect(after.close_reason).toBe(before.close_reason);
+    expect(after.closed_at.toISOString()).toBe(before.closed_at.toISOString());
+
+    const audits = await sql<{ event_type: string }[]>`
+      SELECT event_type FROM audit_events WHERE entity_id = ${executorId} ORDER BY id
+    `;
+    // Only the verb's audit row — the trap must not emit a second.
+    expect(audits.map((a: { event_type: string }) => a.event_type)).toEqual(['turn_close.done']);
+  });
+
+  test('idempotent: trap fires twice → second call is a no-op', async () => {
+    const { executorId } = await seed();
+    const first = await trapPaneExit({ executorId, reason: 'pane_died' });
+    expect(first.noop).toBe(false);
+
+    const second = await trapPaneExit({ executorId, reason: 'pane_died' });
+    expect(second.noop).toBe(true);
+
+    const sql = await getConnection();
+    const audits = await sql<{ id: number }[]>`
+      SELECT id FROM audit_events WHERE entity_id = ${executorId}
+    `;
+    expect(audits.length).toBe(1);
+  });
+
+  test('resolves executor by pane_id when executor_id is not supplied', async () => {
+    const { executorId, paneId } = await seed({ paneId: '%99' });
+    expect(paneId).toBe('%99');
+
+    const result = await trapPaneExit({ paneId: '%99', reason: 'pane_died' });
+    expect(result.noop).toBe(false);
+    expect(result.executorId).toBe(executorId);
+
+    const exec = await getExecutor(executorId);
+    expect(exec!.outcome).toBe('clean_exit_unverified');
+  });
+
+  test('picks the most-recent executor when a pane id was reused', async () => {
+    // Simulate tmux pane-id reuse: two executors bound to the same %N,
+    // the newer one is the live turn. The trap must hit the newer one.
+    const oldAgent = await findOrCreateAgent('reuse-old', 'test-team', 'engineer');
+    const oldExec = await createExecutor(oldAgent.id, 'claude', 'tmux', { state: 'working', tmuxPaneId: '%55' });
+    // Backdate the old executor so ORDER BY started_at DESC picks the new one.
+    const sql = await getConnection();
+    await sql`UPDATE executors SET started_at = now() - interval '1 hour' WHERE id = ${oldExec.id}`;
+
+    const newAgent = await findOrCreateAgent('reuse-new', 'test-team', 'engineer');
+    const newExec = await createExecutor(newAgent.id, 'claude', 'tmux', { state: 'working', tmuxPaneId: '%55' });
+
+    const result = await trapPaneExit({ paneId: '%55', reason: 'pane_died' });
+    expect(result.executorId).toBe(newExec.id);
+
+    const newRow = await getExecutor(newExec.id);
+    const oldRow = await getExecutor(oldExec.id);
+    expect(newRow!.outcome).toBe('clean_exit_unverified');
+    expect(oldRow!.outcome).toBeNull(); // untouched
+  });
+
+  test('shell_exit reason is written when supplied (inline executor path)', async () => {
+    const { executorId } = await seed();
+    const result = await trapPaneExit({ executorId, reason: 'shell_exit' });
+    expect(result.reason).toBe('shell_exit');
+    const exec = await getExecutor(executorId);
+    expect(exec!.closeReason).toBe('shell_exit');
+    expect(exec!.outcome).toBe('clean_exit_unverified');
+  });
+
+  test('no executor resolvable → silent no-op, no throw', async () => {
+    // Neither executor_id nor a pane_id that matches anything.
+    const result = await trapPaneExit({ paneId: '%does-not-exist', reason: 'pane_died' });
+    expect(result.noop).toBe(true);
+    expect(result.executorId).toBeNull();
+    expect(result.outcome).toBeNull();
+  });
+
+  test('unknown executor_id → silent no-op, no throw', async () => {
+    const result = await trapPaneExit({ executorId: 'never-existed', reason: 'pane_died' });
+    expect(result.noop).toBe(true);
+    // Implementation sets executorId on the result once resolved; for unknown
+    // ids the SELECT returns zero rows and we short-circuit.
+    expect(result.outcome).toBeNull();
+  });
+});

--- a/src/lib/pane-trap.ts
+++ b/src/lib/pane-trap.ts
@@ -29,7 +29,7 @@ import type { TurnOutcome } from './executor-types.js';
 
 export type TrapReason = 'pane_died' | 'shell_exit';
 
-export interface TrapPaneExitOpts {
+interface TrapPaneExitOpts {
   /** Prefer this when available — fastest lookup. */
   executorId?: string;
   /** Fallback lookup when only the tmux pane id is known. */
@@ -40,7 +40,7 @@ export interface TrapPaneExitOpts {
   actor?: string;
 }
 
-export interface TrapPaneExitResult {
+interface TrapPaneExitResult {
   noop: boolean;
   executorId: string | null;
   outcome: TurnOutcome | null;

--- a/src/lib/pane-trap.ts
+++ b/src/lib/pane-trap.ts
@@ -1,0 +1,199 @@
+/**
+ * Pane-exit trap — safety net for the turn-session contract.
+ *
+ * When an agent's pane or shell dies without first calling a close verb
+ * (`genie done` / `blocked` / `failed`), the executor row is left in a
+ * non-terminal state. The legacy reconciler would happily ghost-resume
+ * such a row. This module is the layered-defense counterpart to the
+ * close verbs: it writes `outcome='clean_exit_unverified'`,
+ * `state='error'`, `close_reason=<pane_died|shell_exit>` so the row is
+ * unambiguously terminal.
+ *
+ * Idempotency rule (first writer wins):
+ *   • If `closed_at IS NOT NULL` → the trap is a no-op. The explicit
+ *     close verb already wrote the ground-truth outcome; we never
+ *     overwrite that.
+ *   • If `closed_at IS NULL` → trap writes the `clean_exit_unverified`
+ *     outcome inside a single transaction.
+ *
+ * Two install paths are covered here:
+ *   • tmux `pane-died` hook, per-pane, installed after spawn.
+ *   • Shell `trap ... EXIT` snippet, prepended to inline launch commands.
+ *
+ * SDK transport remains a known gap (documented in WISH.md Group 5 #5).
+ * That surface is addressed separately by `unified-executor-layer`.
+ */
+
+import { type Sql, getConnection, isAvailable } from './db.js';
+import type { TurnOutcome } from './executor-types.js';
+
+export type TrapReason = 'pane_died' | 'shell_exit';
+
+export interface TrapPaneExitOpts {
+  /** Prefer this when available — fastest lookup. */
+  executorId?: string;
+  /** Fallback lookup when only the tmux pane id is known. */
+  paneId?: string;
+  /** Which trap fired. Written to `close_reason` for forensic clarity. */
+  reason?: TrapReason;
+  /** Actor recorded on the audit row. */
+  actor?: string;
+}
+
+export interface TrapPaneExitResult {
+  noop: boolean;
+  executorId: string | null;
+  outcome: TurnOutcome | null;
+  reason: TrapReason | null;
+}
+
+const TRAP_OUTCOME: TurnOutcome = 'clean_exit_unverified';
+
+async function resolveExecutorId(
+  sql: Sql,
+  opts: TrapPaneExitOpts,
+): Promise<{ id: string | null; source: 'executorId' | 'paneId' | 'none' }> {
+  if (opts.executorId) return { id: opts.executorId, source: 'executorId' };
+  if (opts.paneId) {
+    // Prefer the most-recently-started executor bound to this pane:
+    // tmux can reuse a pane id across spawns within a server lifetime.
+    const rows = await sql<{ id: string }[]>`
+      SELECT id FROM executors
+      WHERE tmux_pane_id = ${opts.paneId}
+      ORDER BY started_at DESC
+      LIMIT 1
+    `;
+    if (rows.length > 0) return { id: rows[0].id, source: 'paneId' };
+  }
+  return { id: null, source: 'none' };
+}
+
+/**
+ * Write the trap outcome for an executor, idempotently. Returns `noop=true`
+ * when the executor is already closed (by an explicit verb or a prior
+ * trap firing) so callers can log the distinction without branching.
+ *
+ * The function NEVER throws: a dying pane is a bad moment to fail. Any
+ * DB error is logged to stderr and swallowed.
+ */
+export async function trapPaneExit(opts: TrapPaneExitOpts): Promise<TrapPaneExitResult> {
+  const reason: TrapReason = opts.reason ?? 'pane_died';
+  const actor = opts.actor ?? process.env.GENIE_AGENT_NAME ?? 'pane-trap';
+  const result: TrapPaneExitResult = { noop: true, executorId: null, outcome: null, reason: null };
+
+  try {
+    if (!(await isAvailable())) return result;
+    const sql = await getConnection();
+    const resolved = await resolveExecutorId(sql, opts);
+    if (!resolved.id) return result;
+    const executorId = resolved.id;
+    result.executorId = executorId;
+
+    return await sql.begin(async (tx: Sql) => {
+      const rows = await tx<{ state: string; outcome: string | null; closed_at: Date | null; agent_id: string }[]>`
+        SELECT state, outcome, closed_at, agent_id FROM executors
+        WHERE id = ${executorId}
+        FOR UPDATE
+      `;
+      if (rows.length === 0) return result;
+      const row = rows[0];
+      if (row.closed_at !== null || row.outcome !== null) {
+        // Explicit close verb already ran, or a prior trap firing already
+        // wrote — first writer wins.
+        return { noop: true, executorId, outcome: row.outcome as TurnOutcome | null, reason: null };
+      }
+
+      const now = new Date().toISOString();
+      await tx`
+        UPDATE executors
+        SET outcome = ${TRAP_OUTCOME},
+            closed_at = ${now},
+            close_reason = ${reason},
+            state = 'error',
+            ended_at = ${now}
+        WHERE id = ${executorId}
+      `;
+
+      await tx`
+        UPDATE agents
+        SET current_executor_id = NULL
+        WHERE current_executor_id = ${executorId}
+      `;
+
+      await tx`
+        INSERT INTO audit_events (entity_type, entity_id, event_type, actor, details)
+        VALUES (
+          'executor',
+          ${executorId},
+          ${'turn_close.clean_exit_unverified'},
+          ${actor},
+          ${tx.json({ agent_id: row.agent_id, outcome: TRAP_OUTCOME, reason })}
+        )
+      `;
+
+      return { noop: false, executorId, outcome: TRAP_OUTCOME, reason };
+    });
+  } catch (err) {
+    // Do not throw — the pane is already dying. Log and return.
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[pane-trap] swallowed error: ${msg}`);
+    return result;
+  }
+}
+
+// ============================================================================
+// Install helpers — pure builders so tests can assert on the resulting strings
+// without talking to a real tmux server.
+// ============================================================================
+
+/**
+ * Build the `tmux set-hook` arguments that wire `pane-died` to a
+ * shell command which invokes `genie pane-trap --pane-id=#{hook_pane}`.
+ *
+ * Hooks are installed per-pane (`set-hook -p -t <paneId>`) so other
+ * panes in the same window are unaffected. The `#{hook_pane}` format
+ * is expanded by tmux at fire time to the dying pane's id, which is
+ * how we correlate back to the executor in PG.
+ */
+export function buildPaneDiedHookCmd(paneId: string, genieBin = 'genie'): string {
+  // `run-shell` spawns a short-lived shell; we intentionally background
+  // the trap writer so tmux isn't blocked on a PG round-trip while
+  // tearing the pane down.
+  const inner = `${genieBin} pane-trap --pane-id=#{hook_pane} --reason=pane_died &`;
+  const escaped = inner.replace(/"/g, '\\"');
+  return `set-hook -p -t '${paneId}' pane-died "run-shell \\"${escaped}\\""`;
+}
+
+/**
+ * Install the pane-died hook on a specific tmux pane. Best-effort: if
+ * tmux is unavailable or the pane is already dead, the failure is
+ * swallowed so spawn itself never breaks.
+ */
+export async function installTmuxPaneDiedHook(paneId: string, genieBin = 'genie'): Promise<void> {
+  if (!paneId || paneId === 'inline' || !/^%\d+$/.test(paneId)) return;
+  try {
+    const { executeTmux } = await import('./tmux-wrapper.js');
+    await executeTmux(buildPaneDiedHookCmd(paneId, genieBin));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[pane-trap] failed to install pane-died hook on ${paneId}: ${msg}`);
+  }
+}
+
+/**
+ * Build a shell `trap ... EXIT` snippet that fires the trap on clean
+ * shell exit. Intended to be prepended to the inline launch command,
+ * e.g. via `prependEnvVars`-style splicing.
+ *
+ * The snippet calls the genie CLI synchronously so the DB write
+ * completes before the shell fully exits — unlike the tmux path, there
+ * is no supervisor to outlive us here.
+ *
+ * Relies on $GENIE_EXECUTOR_ID being exported into the shell's
+ * environment by the spawn path (Group 3 contract).
+ */
+export function shellExitTrapSnippet(genieBin = 'genie'): string {
+  // Single-quoted body so it evaluates at trap fire time, not at registration.
+  // `|| true` prevents the trap from changing the shell's exit code.
+  return `trap '${genieBin} pane-trap --executor-id="$GENIE_EXECUTOR_ID" --reason=shell_exit >/dev/null 2>&1 || true' EXIT`;
+}

--- a/src/lib/protocol-router.test.ts
+++ b/src/lib/protocol-router.test.ts
@@ -44,7 +44,7 @@ mock.module('./tmux-wrapper.js', () => ({
     }
     return '';
   },
-  genieTmuxPrefix: () => ['-L', 'genie'],
+  genieTmuxPrefix: () => ['-L', 'genie', '-f', '/dev/null'],
   genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
 }));
 

--- a/src/lib/provider-adapters.test.ts
+++ b/src/lib/provider-adapters.test.ts
@@ -478,3 +478,90 @@ describe('OTel env injection in buildClaudeCommand', () => {
     }
   });
 });
+
+// ============================================================================
+// Turn-session env propagation (Group 3: GENIE_EXECUTOR_ID / GENIE_AGENT_ID)
+// ============================================================================
+
+describe('executor env propagation', () => {
+  const originalWhich = (Bun as Record<string, unknown>).which;
+  beforeAll(() => {
+    (Bun as Record<string, unknown>).which = (name: string) =>
+      name === 'claude' || name === 'codex'
+        ? `/usr/local/bin/${name}`
+        : typeof originalWhich === 'function'
+          ? originalWhich(name)
+          : null;
+  });
+  afterAll(() => {
+    (Bun as Record<string, unknown>).which = originalWhich;
+  });
+
+  const execId = '11111111-2222-3333-4444-555555555555';
+  const agentId = 'agent-abc-123';
+
+  it('buildClaudeCommand sets GENIE_EXECUTOR_ID + GENIE_AGENT_ID when present', () => {
+    const result = buildClaudeCommand({
+      provider: 'claude',
+      team: 'work',
+      role: 'engineer',
+      executorId: execId,
+      agentId,
+    });
+    expect(result.env?.GENIE_EXECUTOR_ID).toBe(execId);
+    expect(result.env?.GENIE_AGENT_ID).toBe(agentId);
+  });
+
+  it('buildClaudeCommand omits GENIE_EXECUTOR_ID when not passed', () => {
+    const result = buildClaudeCommand({ provider: 'claude', team: 'work', role: 'engineer' });
+    expect(result.env?.GENIE_EXECUTOR_ID).toBeUndefined();
+    expect(result.env?.GENIE_AGENT_ID).toBeUndefined();
+  });
+
+  it('buildCodexCommand sets GENIE_EXECUTOR_ID + GENIE_AGENT_ID when present', () => {
+    const result = buildCodexCommand({
+      provider: 'codex',
+      team: 'work',
+      role: 'engineer',
+      executorId: execId,
+      agentId,
+    });
+    expect(result.env?.GENIE_EXECUTOR_ID).toBe(execId);
+    expect(result.env?.GENIE_AGENT_ID).toBe(agentId);
+  });
+
+  it('buildCodexCommand omits GENIE_EXECUTOR_ID when no executor identity is provided', () => {
+    const result = buildCodexCommand({ provider: 'codex', team: 'work' });
+    expect(result.env?.GENIE_EXECUTOR_ID).toBeUndefined();
+    expect(result.env?.GENIE_AGENT_ID).toBeUndefined();
+  });
+
+  it('validateSpawnParams preserves executorId and agentId fields', () => {
+    const result = validateSpawnParams({
+      provider: 'claude',
+      team: 'work',
+      executorId: execId,
+      agentId,
+    });
+    expect(result.executorId).toBe(execId);
+    expect(result.agentId).toBe(agentId);
+  });
+
+  it('validateSpawnParams rejects a non-UUID executorId', () => {
+    expect(() =>
+      validateSpawnParams({ provider: 'claude', team: 'work', executorId: 'not-a-uuid' }),
+    ).toThrow();
+  });
+
+  it('buildLaunchCommand (claude) forwards env through the top-level entry point', () => {
+    const launch = buildLaunchCommand({
+      provider: 'claude',
+      team: 'work',
+      role: 'engineer',
+      executorId: execId,
+      agentId,
+    });
+    expect(launch.env?.GENIE_EXECUTOR_ID).toBe(execId);
+    expect(launch.env?.GENIE_AGENT_ID).toBe(agentId);
+  });
+});

--- a/src/lib/provider-adapters.test.ts
+++ b/src/lib/provider-adapters.test.ts
@@ -548,9 +548,7 @@ describe('executor env propagation', () => {
   });
 
   it('validateSpawnParams rejects a non-UUID executorId', () => {
-    expect(() =>
-      validateSpawnParams({ provider: 'claude', team: 'work', executorId: 'not-a-uuid' }),
-    ).toThrow();
+    expect(() => validateSpawnParams({ provider: 'claude', team: 'work', executorId: 'not-a-uuid' })).toThrow();
   });
 
   it('buildLaunchCommand (claude) forwards env through the top-level entry point', () => {

--- a/src/lib/provider-adapters.ts
+++ b/src/lib/provider-adapters.ts
@@ -132,6 +132,8 @@ const spawnParamsSchema = z.object({
   team: z.string().min(1, 'Team name is required'),
   role: z.string().optional(),
   skill: z.string().optional(),
+  agentId: z.string().optional(),
+  executorId: z.string().uuid().optional(),
   extraArgs: z.array(z.string()).optional(),
   nativeTeam: z
     .object({
@@ -354,6 +356,8 @@ export function buildClaudeCommand(params: SpawnParams): LaunchCommand {
 
   if (params.role) env.GENIE_AGENT_NAME = params.role;
   if (params.team) env.GENIE_TEAM = params.team;
+  if (params.executorId) env.GENIE_EXECUTOR_ID = params.executorId;
+  if (params.agentId) env.GENIE_AGENT_ID = params.agentId;
 
   // OTel telemetry injection — only if not already set (user overrides win)
   appendOtelEnv(env, params);
@@ -434,6 +438,11 @@ export function buildCodexCommand(params: SpawnParams): LaunchCommand {
   preflightCheck('codex');
 
   const parts: string[] = ['codex'];
+  const env: Record<string, string> = {};
+  if (params.executorId) env.GENIE_EXECUTOR_ID = params.executorId;
+  if (params.agentId) env.GENIE_AGENT_ID = params.agentId;
+  if (params.role) env.GENIE_AGENT_NAME = params.role;
+  if (params.team) env.GENIE_TEAM = params.team;
 
   // Full autonomous execution — no permission prompts
   parts.push('--yolo');
@@ -458,6 +467,7 @@ export function buildCodexCommand(params: SpawnParams): LaunchCommand {
   return {
     command: parts.join(' '),
     provider: 'codex',
+    env: Object.keys(env).length > 0 ? env : undefined,
     meta: {
       role: params.role,
       skill: params.skill,

--- a/src/lib/scheduler-daemon.test.ts
+++ b/src/lib/scheduler-daemon.test.ts
@@ -186,10 +186,14 @@ const defaultConfig: SchedulerConfig = {
 describe('scheduler-daemon', () => {
   beforeEach(() => {
     process.env.GENIE_MAX_CONCURRENT = undefined;
+    // Each test picks its own turn-aware flag value. Clear between tests so
+    // one test's opt-out doesn't leak into the next.
+    delete process.env[TURN_AWARE_RECONCILER_FLAG];
   });
 
   afterEach(() => {
     process.env.GENIE_MAX_CONCURRENT = undefined;
+    delete process.env[TURN_AWARE_RECONCILER_FLAG];
   });
 
   describe('claimDueTriggers', () => {
@@ -1588,6 +1592,13 @@ describe('scheduler-daemon', () => {
       // `autoResume=false` implicitly via attemptAgentResume's early-skip,
       // but we test the end-to-end exclusion: no new `agent_resume_exhausted`
       // fires).
+      //
+      // Legacy semantics — Phase B (Group 8) defaults the turn-aware flag ON,
+      // which would short-circuit a `state='error'` worker via
+      // `agent_resume_skipped_turn_aware` before reaching the exhaustion
+      // branch. Opt out explicitly so this test continues to exercise the
+      // Bug B resume-exhaustion path.
+      process.env[TURN_AWARE_RECONCILER_FLAG] = '0';
       let row: WorkerInfo = {
         id: 'exhausted-agent',
         paneId: '%99',
@@ -1725,6 +1736,15 @@ describe('scheduler-daemon', () => {
   });
 
   describe('recoverOnStartup with auto-resume', () => {
+    // Legacy semantics — these tests pre-date the turn-aware reconciler.
+    // Phase B (Group 8) defaults the flag ON, which would route `state='idle'`
+    // dead-pane workers into the D1 terminalize path instead of resume. Opt
+    // out for the whole describe so each test exercises the pre-Phase-B
+    // auto-resume-everything-dead behavior.
+    beforeEach(() => {
+      process.env[TURN_AWARE_RECONCILER_FLAG] = '0';
+    });
+
     test('auto-resumes agents with dead panes on startup', async () => {
       const workers: WorkerInfo[] = [
         {
@@ -2382,6 +2402,7 @@ describe('runAgentRecoveryPass — turn-aware D1 / D3 routing', () => {
   }
 
   test('flag OFF: idle + dead pane still resumes (legacy behavior preserved)', async () => {
+    process.env[TURN_AWARE_RECONCILER_FLAG] = '0';
     const w = makeWorker('idle');
     let resumeCalls = 0;
     const { deps } = createMockDeps(
@@ -2550,34 +2571,49 @@ describe('turn-aware reconciler flag', () => {
     expect(TURN_AWARE_RECONCILER_FLAG).toBe('GENIE_RECONCILER_TURN_AWARE');
   });
 
-  test('isTurnAwareReconcilerEnabled returns false when unset', () => {
-    expect(isTurnAwareReconcilerEnabled({})).toBe(false);
+  test('isTurnAwareReconcilerEnabled defaults to true when unset (Phase B, Group 8)', () => {
+    expect(isTurnAwareReconcilerEnabled({})).toBe(true);
   });
 
-  test('isTurnAwareReconcilerEnabled returns false for empty and falsy values', () => {
-    expect(isTurnAwareReconcilerEnabled({ [TURN_AWARE_RECONCILER_FLAG]: '' })).toBe(false);
+  test('isTurnAwareReconcilerEnabled treats empty string as unset (Phase B default ON)', () => {
+    expect(isTurnAwareReconcilerEnabled({ [TURN_AWARE_RECONCILER_FLAG]: '' })).toBe(true);
+  });
+
+  test('isTurnAwareReconcilerEnabled rollback: explicit 0/false/no → false', () => {
     expect(isTurnAwareReconcilerEnabled({ [TURN_AWARE_RECONCILER_FLAG]: '0' })).toBe(false);
     expect(isTurnAwareReconcilerEnabled({ [TURN_AWARE_RECONCILER_FLAG]: 'false' })).toBe(false);
+    expect(isTurnAwareReconcilerEnabled({ [TURN_AWARE_RECONCILER_FLAG]: 'FALSE' })).toBe(false);
     expect(isTurnAwareReconcilerEnabled({ [TURN_AWARE_RECONCILER_FLAG]: 'no' })).toBe(false);
+    expect(isTurnAwareReconcilerEnabled({ [TURN_AWARE_RECONCILER_FLAG]: ' False ' })).toBe(false);
   });
 
-  test('isTurnAwareReconcilerEnabled accepts "1" and "true" (case-insensitive)', () => {
+  test('isTurnAwareReconcilerEnabled accepts "1"/"true"/"yes" (case-insensitive)', () => {
     expect(isTurnAwareReconcilerEnabled({ [TURN_AWARE_RECONCILER_FLAG]: '1' })).toBe(true);
     expect(isTurnAwareReconcilerEnabled({ [TURN_AWARE_RECONCILER_FLAG]: 'true' })).toBe(true);
     expect(isTurnAwareReconcilerEnabled({ [TURN_AWARE_RECONCILER_FLAG]: 'TRUE' })).toBe(true);
     expect(isTurnAwareReconcilerEnabled({ [TURN_AWARE_RECONCILER_FLAG]: ' True ' })).toBe(true);
+    expect(isTurnAwareReconcilerEnabled({ [TURN_AWARE_RECONCILER_FLAG]: 'yes' })).toBe(true);
   });
 
-  test('logReconcilerMode emits flag-off message with legacy event when unset', () => {
+  test('logReconcilerMode emits turn-aware event when flag is unset (Phase B default ON)', () => {
     delete process.env[TURN_AWARE_RECONCILER_FLAG];
     const logs: LogEntry[] = [];
     logReconcilerMode({ log: (e) => logs.push(e), now: () => new Date('2026-04-20T00:00:00Z') }, 'daemon-abc');
     expect(logs).toHaveLength(1);
+    expect(logs[0].event).toBe('reconciler_mode_turn_aware');
+    expect(logs[0].enabled).toBe(true);
+    expect(logs[0].flag).toBe('GENIE_RECONCILER_TURN_AWARE');
+    expect(logs[0].daemon_id).toBe('daemon-abc');
+  });
+
+  test('logReconcilerMode emits legacy event when explicitly opted out', () => {
+    process.env[TURN_AWARE_RECONCILER_FLAG] = '0';
+    const logs: LogEntry[] = [];
+    logReconcilerMode({ log: (e) => logs.push(e), now: () => new Date('2026-04-20T00:00:00Z') }, 'daemon-optout');
+    expect(logs).toHaveLength(1);
     expect(logs[0].event).toBe('reconciler_mode_legacy');
     expect(logs[0].enabled).toBe(false);
-    expect(logs[0].flag).toBe('GENIE_RECONCILER_TURN_AWARE');
     expect(logs[0].message).toContain('flag off');
-    expect(logs[0].daemon_id).toBe('daemon-abc');
   });
 
   test('logReconcilerMode emits turn-aware event when flag set to truthy value', () => {

--- a/src/lib/scheduler-daemon.test.ts
+++ b/src/lib/scheduler-daemon.test.ts
@@ -27,6 +27,7 @@ import {
   recoverOnStartup,
   runAgentRecoveryPass,
   startDaemon,
+  terminalizeCleanExitUnverified,
 } from './scheduler-daemon.js';
 
 // ============================================================================
@@ -2210,6 +2211,326 @@ describe('scheduler-daemon', () => {
       expect(dropped).toHaveLength(10);
       expect(dropped.every((l) => l.reason === 'already_escalated_by_scheduler')).toBe(true);
     });
+  });
+});
+
+// ============================================================================
+// Turn-session-contract (Group 4) — D1 / D3 reconciler logic
+// ============================================================================
+
+/**
+ * In-memory fake of the PG state touched by `terminalizeCleanExitUnverified`
+ * and the flag-ON branch of `runAgentRecoveryPass`. Lets tests assert on the
+ * exact writes (outcome, close_reason, current_executor_id) without spinning
+ * up a real database.
+ */
+function createTerminalStateFake(seed: {
+  agent: { id: string; currentExecutorId: string | null; state: AgentState };
+  executor?: { id: string; closedAt: Date | null; outcome: string | null };
+}) {
+  const agentRow: { current_executor_id: string | null; state: string; last_state_change: string | null } = {
+    current_executor_id: seed.agent.currentExecutorId,
+    state: seed.agent.state,
+    last_state_change: null,
+  };
+  const executorRow: { closed_at: Date | null; outcome: string | null; close_reason: string | null; state: string } = {
+    closed_at: seed.executor?.closedAt ?? null,
+    outcome: seed.executor?.outcome ?? null,
+    close_reason: null,
+    state: 'running',
+  };
+  const audit: Record<string, unknown>[] = [];
+
+  const sql: any = (strings: TemplateStringsArray, ...values: unknown[]) => {
+    const query = strings.join('?');
+    if (query.includes('SELECT current_executor_id FROM agents')) {
+      return [{ current_executor_id: agentRow.current_executor_id }];
+    }
+    if (query.includes('SELECT closed_at, outcome FROM executors')) {
+      return [{ closed_at: executorRow.closed_at, outcome: executorRow.outcome }];
+    }
+    if (query.includes('UPDATE executors')) {
+      executorRow.state = 'error';
+      executorRow.outcome = 'clean_exit_unverified';
+      executorRow.close_reason = values[0] as string;
+      executorRow.closed_at = new Date(values[1] as string);
+      return [];
+    }
+    if (query.includes('UPDATE agents') && query.includes('current_executor_id = NULL')) {
+      agentRow.current_executor_id = null;
+      agentRow.state = 'error';
+      agentRow.last_state_change = values[0] as string;
+      return [];
+    }
+    if (query.includes('UPDATE agents')) {
+      agentRow.state = 'error';
+      agentRow.last_state_change = values[0] as string;
+      return [];
+    }
+    if (query.includes('INSERT INTO audit_events')) {
+      audit.push({ values });
+      return [];
+    }
+    return [];
+  };
+
+  sql.begin = async (fn: (tx: typeof sql) => Promise<unknown>) => fn(sql);
+  sql.json = (v: unknown) => v;
+
+  return { sql, agentRow, executorRow, audit };
+}
+
+describe('terminalizeCleanExitUnverified (D1 write)', () => {
+  const worker: WorkerInfo = {
+    id: 'agent-idle-dead',
+    paneId: '%77',
+    state: 'idle',
+    claudeSessionId: 'sess-idle',
+    autoResume: true,
+    resumeAttempts: 0,
+  };
+
+  test('writes clean_exit_unverified terminal state when executor is open', async () => {
+    const fake = createTerminalStateFake({
+      agent: { id: worker.id, currentExecutorId: 'exec-1', state: 'idle' },
+      executor: { id: 'exec-1', closedAt: null, outcome: null },
+    });
+    const { deps, logs } = createMockDeps({}, { getConnection: async () => fake.sql });
+
+    const res = await terminalizeCleanExitUnverified(deps, worker, 'reconciler_idle_dead_pane');
+
+    expect(res).toEqual({ terminalized: true, executorId: 'exec-1' });
+    expect(fake.executorRow.outcome).toBe('clean_exit_unverified');
+    expect(fake.executorRow.close_reason).toBe('reconciler_idle_dead_pane');
+    expect(fake.executorRow.state).toBe('error');
+    expect(fake.executorRow.closed_at).not.toBeNull();
+    expect(fake.agentRow.current_executor_id).toBeNull();
+    expect(fake.agentRow.state).toBe('error');
+    expect(fake.audit).toHaveLength(1);
+    expect(logs.find((l) => l.event === 'terminalize_clean_exit_unverified_failed')).toBeUndefined();
+  });
+
+  test('is idempotent when executor is already closed (first-writer-wins with pane trap / verbs)', async () => {
+    const fake = createTerminalStateFake({
+      agent: { id: worker.id, currentExecutorId: 'exec-2', state: 'idle' },
+      executor: { id: 'exec-2', closedAt: new Date('2026-04-20T11:59:00Z'), outcome: 'done' },
+    });
+    const { deps } = createMockDeps({}, { getConnection: async () => fake.sql });
+
+    const res = await terminalizeCleanExitUnverified(deps, worker, 'reconciler_idle_dead_pane');
+
+    expect(res).toEqual({ terminalized: false, executorId: 'exec-2' });
+    expect(fake.executorRow.outcome).toBe('done'); // not overwritten
+    expect(fake.executorRow.close_reason).toBeNull();
+    expect(fake.agentRow.current_executor_id).toBeNull(); // still cleared
+    expect(fake.agentRow.state).toBe('error');
+    expect(fake.audit).toHaveLength(0);
+  });
+
+  test('flips agent to error when current_executor_id is missing', async () => {
+    const fake = createTerminalStateFake({
+      agent: { id: worker.id, currentExecutorId: null, state: 'idle' },
+    });
+    const { deps } = createMockDeps({}, { getConnection: async () => fake.sql });
+
+    const res = await terminalizeCleanExitUnverified(deps, worker, 'reconciler_idle_dead_pane');
+
+    expect(res).toEqual({ terminalized: false, executorId: null });
+    expect(fake.agentRow.state).toBe('error');
+    expect(fake.audit).toHaveLength(0);
+  });
+
+  test('never throws — DB errors are logged and swallowed', async () => {
+    const bomb = {
+      begin: async () => {
+        throw new Error('PG exploded');
+      },
+    };
+    const { deps, logs } = createMockDeps({}, { getConnection: async () => bomb as any });
+
+    const res = await terminalizeCleanExitUnverified(deps, worker, 'reconciler_idle_dead_pane');
+
+    expect(res).toEqual({ terminalized: false, executorId: null });
+    const failed = logs.find((l) => l.event === 'terminalize_clean_exit_unverified_failed');
+    expect(failed).toBeDefined();
+    expect(failed?.error).toBe('PG exploded');
+  });
+});
+
+describe('runAgentRecoveryPass — turn-aware D1 / D3 routing', () => {
+  const savedFlag = process.env[TURN_AWARE_RECONCILER_FLAG];
+
+  beforeEach(() => {
+    delete process.env[TURN_AWARE_RECONCILER_FLAG];
+  });
+
+  afterEach(() => {
+    if (savedFlag === undefined) delete process.env[TURN_AWARE_RECONCILER_FLAG];
+    else process.env[TURN_AWARE_RECONCILER_FLAG] = savedFlag;
+  });
+
+  function makeWorker(state: AgentState, id = 'agent-x'): WorkerInfo {
+    return {
+      id,
+      paneId: '%99',
+      state,
+      claudeSessionId: 'sess-x',
+      autoResume: true,
+      resumeAttempts: 0,
+      maxResumeAttempts: 3,
+    };
+  }
+
+  test('flag OFF: idle + dead pane still resumes (legacy behavior preserved)', async () => {
+    const w = makeWorker('idle');
+    let resumeCalls = 0;
+    const { deps } = createMockDeps(
+      {},
+      {
+        listWorkers: async () => [w],
+        isPaneAlive: async () => false,
+        resumeAgent: async () => {
+          resumeCalls++;
+          return true;
+        },
+      },
+    );
+
+    const res = await runAgentRecoveryPass(deps, 'daemon-off', defaultConfig);
+
+    expect(resumeCalls).toBe(1);
+    expect(res.resumed).toBe(1);
+    expect(res.terminalized).toBe(0);
+  });
+
+  test('flag ON: idle + dead pane → terminalize, no resume (D1)', async () => {
+    process.env[TURN_AWARE_RECONCILER_FLAG] = '1';
+    const w = makeWorker('idle', 'agent-d1');
+    const fake = createTerminalStateFake({
+      agent: { id: w.id, currentExecutorId: 'exec-d1', state: 'idle' },
+      executor: { id: 'exec-d1', closedAt: null, outcome: null },
+    });
+    let resumeCalls = 0;
+    const { deps, logs } = createMockDeps(
+      {},
+      {
+        listWorkers: async () => [w],
+        isPaneAlive: async () => false,
+        resumeAgent: async () => {
+          resumeCalls++;
+          return true;
+        },
+        getConnection: async () => fake.sql,
+      },
+    );
+
+    const res = await runAgentRecoveryPass(deps, 'daemon-d1', defaultConfig);
+
+    expect(resumeCalls).toBe(0);
+    expect(res.resumed).toBe(0);
+    expect(res.terminalized).toBe(1);
+    expect(fake.executorRow.outcome).toBe('clean_exit_unverified');
+    expect(fake.agentRow.state).toBe('error');
+    const terminalLog = logs.find((l) => l.event === 'agent_terminalized_clean_exit_unverified');
+    expect(terminalLog).toBeDefined();
+    expect(terminalLog?.agent_id).toBe('agent-d1');
+    expect(terminalLog?.executor_id).toBe('exec-d1');
+  });
+
+  test.each<AgentState>(['working', 'permission', 'question'])(
+    'flag ON: state=%s + dead pane → resume (D3)',
+    async (state) => {
+      process.env[TURN_AWARE_RECONCILER_FLAG] = '1';
+      const w = makeWorker(state, `agent-d3-${state}`);
+      let resumeCalls = 0;
+      const { deps } = createMockDeps(
+        {},
+        {
+          listWorkers: async () => [w],
+          isPaneAlive: async () => false,
+          resumeAgent: async () => {
+            resumeCalls++;
+            return true;
+          },
+        },
+      );
+
+      const res = await runAgentRecoveryPass(deps, `daemon-d3-${state}`, defaultConfig);
+
+      expect(resumeCalls).toBe(1);
+      expect(res.resumed).toBe(1);
+      expect(res.terminalized).toBe(0);
+    },
+  );
+
+  test('flag ON: state=error + dead pane → skipped, no resume (prevents post-D1 ghost loop)', async () => {
+    process.env[TURN_AWARE_RECONCILER_FLAG] = '1';
+    const w = makeWorker('error', 'agent-err');
+    let resumeCalls = 0;
+    const { deps, logs } = createMockDeps(
+      {},
+      {
+        listWorkers: async () => [w],
+        isPaneAlive: async () => false,
+        resumeAgent: async () => {
+          resumeCalls++;
+          return true;
+        },
+      },
+    );
+
+    const res = await runAgentRecoveryPass(deps, 'daemon-err', defaultConfig);
+
+    expect(resumeCalls).toBe(0);
+    expect(res.terminalized).toBe(0);
+    expect(logs.some((l) => l.event === 'agent_resume_skipped_turn_aware' && l.state === 'error')).toBe(true);
+  });
+
+  test('C20 regression: ghost-loop cannot replay across multiple ticks when idle+dead (flag ON)', async () => {
+    process.env[TURN_AWARE_RECONCILER_FLAG] = '1';
+    // Model the exact 2026-04-19 scenario: an agent sits in state='idle' while
+    // its tmux pane is dead. Legacy code resumed on every tick (60s forever).
+    // Under flag ON, tick 1 terminalizes to state='error'; tick 2 finds error
+    // and skips — resume is never called.
+    let row = makeWorker('idle', 'ghost-agent');
+    const fake = createTerminalStateFake({
+      agent: { id: row.id, currentExecutorId: 'exec-ghost', state: 'idle' },
+      executor: { id: 'exec-ghost', closedAt: null, outcome: null },
+    });
+
+    let resumeCalls = 0;
+    const { deps, logs } = createMockDeps(
+      {},
+      {
+        listWorkers: async () => [row],
+        isPaneAlive: async () => false,
+        resumeAgent: async () => {
+          resumeCalls++;
+          return true;
+        },
+        getConnection: async () => fake.sql,
+        updateAgent: async (_id, u) => {
+          row = { ...row, ...u } as WorkerInfo;
+        },
+      },
+    );
+
+    // Tick 1: D1 terminalize
+    const t1 = await runAgentRecoveryPass(deps, 'daemon-c20-t1', defaultConfig);
+    expect(t1.terminalized).toBe(1);
+    expect(resumeCalls).toBe(0);
+    // Simulate agent-registry re-read after the terminal write
+    row = { ...row, state: 'error' };
+
+    // Ticks 2..5: state='error' → skipped
+    for (let i = 0; i < 4; i++) {
+      const tick = await runAgentRecoveryPass(deps, `daemon-c20-t${i + 2}`, defaultConfig);
+      expect(tick.resumed).toBe(0);
+      expect(tick.terminalized).toBe(0);
+    }
+    expect(resumeCalls).toBe(0);
+    // And only ONE terminalize event fired across all ticks.
+    expect(logs.filter((l) => l.event === 'agent_terminalized_clean_exit_unverified')).toHaveLength(1);
   });
 });
 

--- a/src/lib/scheduler-daemon.ts
+++ b/src/lib/scheduler-daemon.ts
@@ -51,19 +51,37 @@ export const MAX_DELIVERY_ATTEMPTS = 3;
 /**
  * Env flag gating the turn-session-contract reconciler.
  *
- * Phase A (this wish, Group 1): flag read exists; default `false`; logged once
- * at daemon startup; no behavior change. Subsequent groups wire the new
- * reconciler passes behind this flag. Phase B (Group 8) flips the default to
- * `true` after the migration completes; Phase C (Group 9) removes the flag.
+ * Phase A (Group 1): flag read exists; default `false`; logged once at daemon
+ * startup; no behavior change. Groups 2/3/4/5/7 wire the new reconciler
+ * passes behind this flag.
+ *
+ * Phase B (Group 8 — this change): default flips to `true`. Migration 044
+ * flipped `agents.auto_resume` default and backfilled live/stale rows; the
+ * code side follows suit so a fresh daemon boot enables the turn-aware
+ * passes by default. Rollback is still supported — set
+ * `GENIE_RECONCILER_TURN_AWARE=0` (or `false`) to force the legacy path
+ * without a redeploy.
+ *
+ * Phase C (Group 9, after 7-day soak): flag and legacy path are removed.
  */
 export const TURN_AWARE_RECONCILER_FLAG = 'GENIE_RECONCILER_TURN_AWARE';
 
-/** Read the turn-aware reconciler flag from env. Accepts '1' | 'true' (case-insensitive). */
+/**
+ * Read the turn-aware reconciler flag from env.
+ *
+ * Default (unset / empty) is `true` since Phase B (Group 8). Explicit
+ * opt-out: `GENIE_RECONCILER_TURN_AWARE=0` (also accepts `false`, `no`,
+ * case-insensitive). Truthy values (`1`, `true`) are always accepted.
+ */
 export function isTurnAwareReconcilerEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   const raw = env[TURN_AWARE_RECONCILER_FLAG];
-  if (!raw) return false;
+  if (raw === undefined) return true;
   const v = raw.trim().toLowerCase();
-  return v === '1' || v === 'true';
+  if (v === '') return true;
+  if (v === '0' || v === 'false' || v === 'no') return false;
+  if (v === '1' || v === 'true' || v === 'yes') return true;
+  // Unknown value — be conservative and honor Phase B default ON.
+  return true;
 }
 
 /** Log the turn-aware reconciler mode once at daemon startup. */

--- a/src/lib/scheduler-daemon.ts
+++ b/src/lib/scheduler-daemon.ts
@@ -769,7 +769,7 @@ export async function recoverOnStartup(deps: SchedulerDeps, daemonId: string, co
   const reclaimed = await reclaimExpiredLeases(deps, daemonId);
   const orphans = await reconcileOrphanedRuns(deps, daemonId);
 
-  const { resumed, failed } = await runAgentRecoveryPass(deps, daemonId, config);
+  const { resumed, failed } = await runAgentRecoveryPass(deps, daemonId, config, 'boot');
 
   deps.log({
     timestamp: deps.now().toISOString(),
@@ -802,7 +802,7 @@ export async function recoverOnStartup(deps: SchedulerDeps, daemonId: string, co
 function scheduleRecoveryRetry(deps: SchedulerDeps, daemonId: string, config?: SchedulerConfig): void {
   setTimeout(async () => {
     try {
-      const retry = await runAgentRecoveryPass(deps, daemonId, config);
+      const retry = await runAgentRecoveryPass(deps, daemonId, config, 'boot');
       deps.log({
         timestamp: deps.now().toISOString(),
         level: 'info',
@@ -839,16 +839,23 @@ function scheduleRecoveryRetry(deps: SchedulerDeps, daemonId: string, config?: S
 const TURN_AWARE_RESUMABLE_STATES: ReadonlySet<AgentState> = new Set<AgentState>(['working', 'permission', 'question']);
 
 type RecoveryOutcome = 'resumed' | 'terminalized' | 'skipped';
+type RecoveryMode = 'boot' | 'sweep';
 
 /**
  * Per-worker recovery decision for a dead pane, extracted so
  * `runAgentRecoveryPass` stays below the cognitive-complexity cap.
  *
  * Legacy (flag off): delegate everything to `attemptAgentResume`.
- * Turn-aware (flag on):
+ * Turn-aware (flag on) in 'sweep' mode:
  *   - D1 idle + dead → `terminalizeCleanExitUnverified`, no resume
  *   - D3 working/permission/question + dead → resume
  *   - other non-terminal states → skipped (prevents post-D1 ghost loop)
+ *
+ * 'boot' mode deliberately bypasses the D1/D3 gates: when the daemon
+ * just restarted, an idle-with-dead-pane row is most likely an agent
+ * that was legitimately mid-turn when the daemon itself died (state
+ * preserved across reboot). The turn-aware rules exist for periodic
+ * sweeps, where "idle + dead" is a ghost-loop precursor.
  */
 async function handleDeadPane(
   deps: SchedulerDeps,
@@ -856,7 +863,12 @@ async function handleDeadPane(
   daemonId: string,
   worker: WorkerInfo,
   turnAware: boolean,
+  mode: RecoveryMode,
 ): Promise<RecoveryOutcome> {
+  if (mode === 'boot') {
+    const result = await attemptAgentResume(deps, config, worker);
+    return result === 'resumed' ? 'resumed' : 'skipped';
+  }
   if (turnAware && worker.state === 'idle') {
     const res = await terminalizeCleanExitUnverified(deps, worker, 'reconciler_idle_dead_pane');
     if (res.terminalized) {
@@ -893,6 +905,7 @@ export async function runAgentRecoveryPass(
   deps: SchedulerDeps,
   daemonId: string,
   config?: SchedulerConfig,
+  mode: RecoveryMode = 'sweep',
 ): Promise<{ resumed: number; failed: number; terminalized: number }> {
   const resolvedConfig = config ?? resolveConfig();
   const workers = await deps.listWorkers();
@@ -912,7 +925,7 @@ export async function runAgentRecoveryPass(
     try {
       const alive = await deps.isPaneAlive(worker.paneId);
       if (alive) continue;
-      const outcome = await handleDeadPane(deps, resolvedConfig, daemonId, worker, turnAware);
+      const outcome = await handleDeadPane(deps, resolvedConfig, daemonId, worker, turnAware, mode);
       if (outcome === 'resumed') resumed++;
       else if (outcome === 'terminalized') terminalized++;
     } catch (err) {

--- a/src/lib/scheduler-daemon.ts
+++ b/src/lib/scheduler-daemon.ts
@@ -20,7 +20,7 @@ import { randomUUID } from 'node:crypto';
 import { appendFileSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import type { Agent } from './agent-registry.js';
+import type { Agent, AgentState } from './agent-registry.js';
 import { computeNextCronDue, parseDuration } from './cron.js';
 import { type EventRouterHandle, startEventRouter } from './event-router.js';
 import { getInboxPollIntervalMs, startInboxWatcher, stopInboxWatcher } from './inbox-watcher.js';
@@ -817,11 +817,65 @@ function scheduleRecoveryRetry(deps: SchedulerDeps, daemonId: string, config?: S
  * (startAgentResumeTimer) — without it, agents that hit `error` while the
  * daemon is up never retry until the next process restart.
  */
+/** States where the turn-aware reconciler resumes a dead pane (D3 rule). */
+const TURN_AWARE_RESUMABLE_STATES: ReadonlySet<AgentState> = new Set<AgentState>(['working', 'permission', 'question']);
+
+type RecoveryOutcome = 'resumed' | 'terminalized' | 'skipped';
+
+/**
+ * Per-worker recovery decision for a dead pane, extracted so
+ * `runAgentRecoveryPass` stays below the cognitive-complexity cap.
+ *
+ * Legacy (flag off): delegate everything to `attemptAgentResume`.
+ * Turn-aware (flag on):
+ *   - D1 idle + dead → `terminalizeCleanExitUnverified`, no resume
+ *   - D3 working/permission/question + dead → resume
+ *   - other non-terminal states → skipped (prevents post-D1 ghost loop)
+ */
+async function handleDeadPane(
+  deps: SchedulerDeps,
+  config: SchedulerConfig,
+  daemonId: string,
+  worker: WorkerInfo,
+  turnAware: boolean,
+): Promise<RecoveryOutcome> {
+  if (turnAware && worker.state === 'idle') {
+    const res = await terminalizeCleanExitUnverified(deps, worker, 'reconciler_idle_dead_pane');
+    if (res.terminalized) {
+      deps.log({
+        timestamp: deps.now().toISOString(),
+        level: 'warn',
+        event: 'agent_terminalized_clean_exit_unverified',
+        daemon_id: daemonId,
+        agent_id: worker.id,
+        executor_id: res.executorId,
+        reason: 'idle_dead_pane',
+      });
+      return 'terminalized';
+    }
+    return 'skipped';
+  }
+  if (turnAware && !TURN_AWARE_RESUMABLE_STATES.has(worker.state as AgentState)) {
+    deps.log({
+      timestamp: deps.now().toISOString(),
+      level: 'debug',
+      event: 'agent_resume_skipped_turn_aware',
+      daemon_id: daemonId,
+      agent_id: worker.id,
+      state: worker.state,
+      reason: 'state_not_in_d3',
+    });
+    return 'skipped';
+  }
+  const result = await attemptAgentResume(deps, config, worker);
+  return result === 'resumed' ? 'resumed' : 'skipped';
+}
+
 export async function runAgentRecoveryPass(
   deps: SchedulerDeps,
   daemonId: string,
   config?: SchedulerConfig,
-): Promise<{ resumed: number; failed: number }> {
+): Promise<{ resumed: number; failed: number; terminalized: number }> {
   const resolvedConfig = config ?? resolveConfig();
   const workers = await deps.listWorkers();
   // Safe for SDK/non-tmux transports: the `claudeSessionId` filter below
@@ -830,17 +884,19 @@ export async function runAgentRecoveryPass(
   // paneId check is correct here — no transport dispatch needed. If SDK
   // ever gains resume support, gate on paneId shape like countActiveWorkers.
   const resumable = workers.filter((w) => w.state !== 'suspended' && w.state !== 'done' && w.claudeSessionId);
+  const turnAware = isTurnAwareReconcilerEnabled();
 
   let resumed = 0;
   let failed = 0;
+  let terminalized = 0;
 
   for (const worker of resumable) {
     try {
       const alive = await deps.isPaneAlive(worker.paneId);
-      if (!alive) {
-        const result = await attemptAgentResume(deps, resolvedConfig, worker);
-        if (result === 'resumed') resumed++;
-      }
+      if (alive) continue;
+      const outcome = await handleDeadPane(deps, resolvedConfig, daemonId, worker, turnAware);
+      if (outcome === 'resumed') resumed++;
+      else if (outcome === 'terminalized') terminalized++;
     } catch (err) {
       failed++;
       const message = err instanceof Error ? err.message : String(err);
@@ -855,7 +911,114 @@ export async function runAgentRecoveryPass(
     }
   }
 
-  return { resumed, failed };
+  return { resumed, failed, terminalized };
+}
+
+/**
+ * Terminal-boundary write for the turn-aware reconciler's D1 rule.
+ *
+ * An agent found in `state='idle'` with a dead pane is the classic
+ * ghost-loop precursor: the turn finished quietly (no `genie done` /
+ * `blocked` / `failed`) and the pane then exited. Resuming such a row
+ * replays the already-completed turn (C20 incident, 2026-04-19).
+ *
+ * Write semantics (single transaction, first-writer-wins with the pane
+ * trap and the explicit close verbs):
+ *   - look up `agents.current_executor_id`; if absent, only flip the
+ *     agent state to `error` (no executor to terminalize)
+ *   - if the executor is already closed (`closed_at IS NOT NULL` or
+ *     `outcome IS NOT NULL`), the explicit verbs / pane trap already
+ *     ran — leave the executor untouched, just clear
+ *     `current_executor_id` so the next reconcile pass skips it
+ *   - otherwise write `state='error'`, `outcome='clean_exit_unverified'`,
+ *     `close_reason=<reason>`, `closed_at=now`, `ended_at=now`, clear
+ *     `current_executor_id`, emit a `reconciler.clean_exit_unverified`
+ *     audit event
+ *
+ * Never throws: DB errors are caught so a transient PG blip can't
+ * wedge `runAgentRecoveryPass` for every subsequent worker in the pass.
+ */
+export async function terminalizeCleanExitUnverified(
+  deps: SchedulerDeps,
+  worker: WorkerInfo,
+  reason: string,
+): Promise<{ terminalized: boolean; executorId: string | null }> {
+  const nowIso = deps.now().toISOString();
+  try {
+    const sql = await deps.getConnection();
+    return await sql.begin(async (tx: SqlClient) => {
+      const rows = await tx`SELECT current_executor_id FROM agents WHERE id = ${worker.id}`;
+      const executorId = (rows[0]?.current_executor_id as string | null | undefined) ?? null;
+
+      if (!executorId) {
+        await tx`
+          UPDATE agents
+          SET state = 'error',
+              last_state_change = ${nowIso}
+          WHERE id = ${worker.id}
+        `;
+        return { terminalized: false, executorId: null };
+      }
+
+      const execRows = await tx<{ closed_at: Date | null; outcome: string | null }[]>`
+        SELECT closed_at, outcome FROM executors
+        WHERE id = ${executorId}
+        FOR UPDATE
+      `;
+      const alreadyClosed = execRows.length > 0 && (execRows[0].closed_at !== null || execRows[0].outcome !== null);
+      if (alreadyClosed) {
+        await tx`
+          UPDATE agents
+          SET current_executor_id = NULL,
+              state = 'error',
+              last_state_change = ${nowIso}
+          WHERE id = ${worker.id}
+        `;
+        return { terminalized: false, executorId };
+      }
+
+      await tx`
+        UPDATE executors
+        SET state = 'error',
+            outcome = 'clean_exit_unverified',
+            close_reason = ${reason},
+            closed_at = ${nowIso},
+            ended_at = ${nowIso}
+        WHERE id = ${executorId}
+      `;
+
+      await tx`
+        UPDATE agents
+        SET current_executor_id = NULL,
+            state = 'error',
+            last_state_change = ${nowIso}
+        WHERE id = ${worker.id}
+      `;
+
+      await tx`
+        INSERT INTO audit_events (entity_type, entity_id, event_type, actor, details)
+        VALUES (
+          'executor',
+          ${executorId},
+          'reconciler.clean_exit_unverified',
+          'scheduler',
+          ${tx.json({ agent_id: worker.id, reason, outcome: 'clean_exit_unverified' })}
+        )
+      `;
+
+      return { terminalized: true, executorId };
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    deps.log({
+      timestamp: deps.now().toISOString(),
+      level: 'error',
+      event: 'terminalize_clean_exit_unverified_failed',
+      agent_id: worker.id,
+      error: message,
+    });
+    return { terminalized: false, executorId: null };
+  }
 }
 
 /**

--- a/src/lib/skill-close-verb.test.ts
+++ b/src/lib/skill-close-verb.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Skill close-verb contract — every built-in skill must end with a
+ * "Turn close" instruction block. This is the counterpart to the
+ * GENIE_EXECUTOR_ID spawn env var: the skill tells the agent to call
+ * `genie done` / `blocked` / `failed`, and the child env gives it an
+ * executor to close.
+ *
+ * See turn-session-contract wish, Group 3.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SKILLS_WITH_CLOSE_VERB = ['brainstorm', 'work', 'fix', 'review', 'refine', 'trace', 'docs'];
+
+// Repo root relative to this test file: src/lib/ → ../../
+const REPO_ROOT = join(import.meta.dir, '..', '..');
+
+describe('skill close-verb contract', () => {
+  for (const skill of SKILLS_WITH_CLOSE_VERB) {
+    test(`skills/${skill}/SKILL.md contains a Turn close block`, () => {
+      const path = join(REPO_ROOT, 'skills', skill, 'SKILL.md');
+      const body = readFileSync(path, 'utf-8');
+      expect(body).toContain('## Turn close');
+      expect(body).toContain('genie done');
+      expect(body).toMatch(/genie blocked --reason/);
+      expect(body).toMatch(/genie failed --reason/);
+    });
+
+    test(`skills/${skill}/SKILL.md close-verb block is near the end`, () => {
+      const path = join(REPO_ROOT, 'skills', skill, 'SKILL.md');
+      const body = readFileSync(path, 'utf-8');
+      const idx = body.indexOf('## Turn close');
+      expect(idx).toBeGreaterThan(-1);
+      // "Near the end" = no other `## ` heading after Turn close.
+      const after = body.slice(idx + '## Turn close'.length);
+      expect(after).not.toMatch(/\n## /);
+    });
+  }
+});

--- a/src/lib/spawn-command.test.ts
+++ b/src/lib/spawn-command.test.ts
@@ -212,7 +212,7 @@ mock.module('./tmux-wrapper.js', () => ({
     }
     return '';
   },
-  genieTmuxPrefix: () => ['-L', 'genie'],
+  genieTmuxPrefix: () => ['-L', 'genie', '-f', '/dev/null'],
   genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
 }));
 

--- a/src/lib/tmux-alive.test.ts
+++ b/src/lib/tmux-alive.test.ts
@@ -8,7 +8,7 @@ const mockExecSync = mock((_cmd: string, _opts?: object): string => '');
 
 mock.module('./tmux-wrapper.js', () => ({
   executeTmux: mockExecuteTmux,
-  genieTmuxPrefix: () => ['-L', 'genie'],
+  genieTmuxPrefix: () => ['-L', 'genie', '-f', '/dev/null'],
   genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
 }));
 

--- a/src/lib/tmux-resolve.test.ts
+++ b/src/lib/tmux-resolve.test.ts
@@ -12,7 +12,7 @@ const mockExecuteTmux = mock(async (_cmd: string) => '');
 // We need to mock the module before importing
 mock.module('./tmux-wrapper.js', () => ({
   executeTmux: mockExecuteTmux,
-  genieTmuxPrefix: () => ['-L', 'genie'],
+  genieTmuxPrefix: () => ['-L', 'genie', '-f', '/dev/null'],
   genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
 }));
 

--- a/src/lib/tmux-wrapper.test.ts
+++ b/src/lib/tmux-wrapper.test.ts
@@ -1,0 +1,65 @@
+/**
+ * tmux-wrapper unit tests.
+ *
+ * Focuses on the env-propagation contract used by the tmux spawn path:
+ * `prependEnvVars` is how GENIE_EXECUTOR_ID / GENIE_AGENT_ID / GENIE_AGENT_NAME
+ * reach the agent child when it's launched under `tmux split-window` or
+ * `tmux new-window`. See turn-session-contract wish, Group 3.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { genieTmuxCmd, genieTmuxPrefix, prependEnvVars } from './tmux-wrapper.js';
+
+describe('genieTmuxPrefix', () => {
+  test('includes -L <socket> and -f <config>', () => {
+    const parts = genieTmuxPrefix();
+    expect(parts[0]).toBe('-L');
+    expect(parts[1]).toMatch(/.+/); // socket name, default 'genie'
+    expect(parts[2]).toBe('-f');
+    expect(parts[3]).toMatch(/.+/); // config path or /dev/null
+  });
+});
+
+describe('genieTmuxCmd', () => {
+  test('prefixes the subcommand with the genie tmux flags', () => {
+    const cmd = genieTmuxCmd('list-sessions');
+    expect(cmd).toContain('-L');
+    expect(cmd).toContain('list-sessions');
+  });
+});
+
+describe('prependEnvVars', () => {
+  test('returns command unchanged when env is undefined', () => {
+    expect(prependEnvVars('bun run start')).toBe('bun run start');
+  });
+
+  test('returns command unchanged when env is empty object', () => {
+    expect(prependEnvVars('bun run start', {})).toBe('bun run start');
+  });
+
+  test('prefixes env assignments with `env` keyword', () => {
+    const out = prependEnvVars('claude --dangerously-skip-permissions', {
+      GENIE_EXECUTOR_ID: '11111111-2222-3333-4444-555555555555',
+    });
+    expect(out).toBe(
+      'env GENIE_EXECUTOR_ID=11111111-2222-3333-4444-555555555555 claude --dangerously-skip-permissions',
+    );
+  });
+
+  test('joins multiple env vars with spaces, preserving order', () => {
+    const out = prependEnvVars('cmd', {
+      GENIE_EXECUTOR_ID: 'exec-id',
+      GENIE_AGENT_ID: 'agent-id',
+      GENIE_AGENT_NAME: 'engineer',
+    });
+    expect(out).toBe('env GENIE_EXECUTOR_ID=exec-id GENIE_AGENT_ID=agent-id GENIE_AGENT_NAME=engineer cmd');
+  });
+
+  test('propagates GENIE_EXECUTOR_ID when present — turn-close contract', () => {
+    const execId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const out = prependEnvVars('claude', { GENIE_EXECUTOR_ID: execId });
+    expect(out).toContain(`GENIE_EXECUTOR_ID=${execId}`);
+    // The child shell will see this in its environment after `env` evaluates.
+    expect(out.startsWith('env ')).toBe(true);
+  });
+});

--- a/src/lib/tmux-wrapper.ts
+++ b/src/lib/tmux-wrapper.ts
@@ -54,6 +54,29 @@ export function genieTmuxCmd(subcommand: string): string {
 }
 
 /**
+ * Prepend inline `env KEY=VALUE ...` assignments to a shell command so that
+ * the spawned child (under tmux `new-window` / `split-window`) inherits them.
+ *
+ * This is the tmux-path analogue of Bun's spawn `env` option: tmux has no
+ * structured env-var API for send-keys, so we splice the assignments into
+ * the command string. Env values are NOT shell-escaped — the caller is
+ * responsible for passing values that survive word-splitting (UUIDs, role
+ * names, team slugs). Whitespace in values would break the contract; if
+ * that ever becomes a concern, quote at this boundary.
+ *
+ * Used to propagate GENIE_EXECUTOR_ID / GENIE_AGENT_ID / GENIE_AGENT_NAME
+ * into the agent child so the turn-close verbs (`genie done` / `blocked` /
+ * `failed`) can resolve the current executor.
+ */
+export function prependEnvVars(command: string, env?: Record<string, string>): string {
+  if (!env || Object.keys(env).length === 0) return command;
+  const envArgs = Object.entries(env)
+    .map(([k, v]) => `${k}=${v}`)
+    .join(' ');
+  return `env ${envArgs} ${command}`;
+}
+
+/**
  * Get the directory for tmux debug logs
  */
 function getLogDir(): string {

--- a/src/lib/tmux.test.ts
+++ b/src/lib/tmux.test.ts
@@ -10,7 +10,7 @@ const mockExecuteTmux = mock(async (_cmd: string) => '');
 
 mock.module('./tmux-wrapper.js', () => ({
   executeTmux: mockExecuteTmux,
-  genieTmuxPrefix: () => ['-L', 'genie'],
+  genieTmuxPrefix: () => ['-L', 'genie', '-f', '/dev/null'],
   genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
 }));
 

--- a/src/lib/turn-close.test.ts
+++ b/src/lib/turn-close.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Turn-close contract tests — atomic transaction + idempotency + rollback.
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { findOrCreateAgent, setCurrentExecutor } from './agent-registry.js';
+import { getConnection } from './db.js';
+import { createExecutor, getExecutor } from './executor-registry.js';
+import { DB_AVAILABLE, setupTestSchema } from './test-db.js';
+import { turnClose } from './turn-close.js';
+
+describe.skipIf(!DB_AVAILABLE)('turn-close', () => {
+  let cleanup: () => Promise<void>;
+
+  beforeAll(async () => {
+    cleanup = await setupTestSchema();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  beforeEach(async () => {
+    const sql = await getConnection();
+    await sql`DELETE FROM audit_events`;
+    await sql`DELETE FROM assignments`;
+    await sql`DELETE FROM executors`;
+    await sql`DELETE FROM agents`;
+  });
+
+  const originalEnv = { executor: process.env.GENIE_EXECUTOR_ID, agent: process.env.GENIE_AGENT_NAME };
+  afterEach(() => {
+    process.env.GENIE_EXECUTOR_ID = originalEnv.executor;
+    process.env.GENIE_AGENT_NAME = originalEnv.agent;
+  });
+
+  async function seed(): Promise<{ agentId: string; executorId: string }> {
+    const agent = await findOrCreateAgent('eng-close', 'test-team', 'engineer');
+    const exec = await createExecutor(agent.id, 'claude', 'tmux', { state: 'working' });
+    await setCurrentExecutor(agent.id, exec.id);
+    return { agentId: agent.id, executorId: exec.id };
+  }
+
+  test('happy path — writes outcome, clears agent FK, records audit row', async () => {
+    const { agentId, executorId } = await seed();
+
+    const result = await turnClose({ outcome: 'done', executorId, actor: 'eng-close' });
+
+    expect(result.noop).toBe(false);
+    expect(result.executorId).toBe(executorId);
+    expect(result.outcome).toBe('done');
+    expect(result.closedAt).not.toBeNull();
+
+    const exec = await getExecutor(executorId);
+    expect(exec!.outcome).toBe('done');
+    expect(exec!.closedAt).not.toBeNull();
+    expect(exec!.state).toBe('done');
+    expect(exec!.endedAt).not.toBeNull();
+
+    const sql = await getConnection();
+    const [agentRow] = await sql<{ current_executor_id: string | null }[]>`
+      SELECT current_executor_id FROM agents WHERE id = ${agentId}
+    `;
+    expect(agentRow.current_executor_id).toBeNull();
+
+    const auditRows = await sql<{ event_type: string; actor: string; details: unknown }[]>`
+      SELECT event_type, actor, details FROM audit_events
+      WHERE entity_type = 'executor' AND entity_id = ${executorId}
+    `;
+    expect(auditRows.length).toBe(1);
+    expect(auditRows[0].event_type).toBe('turn_close.done');
+    expect(auditRows[0].actor).toBe('eng-close');
+  });
+
+  test('blocked and failed require --reason', async () => {
+    const { executorId } = await seed();
+    await expect(turnClose({ outcome: 'blocked', executorId })).rejects.toThrow(/reason/i);
+    await expect(turnClose({ outcome: 'failed', executorId })).rejects.toThrow(/reason/i);
+  });
+
+  test('blocked writes outcome and close_reason', async () => {
+    const { executorId } = await seed();
+    const result = await turnClose({ outcome: 'blocked', reason: 'pg unreachable', executorId });
+    expect(result.noop).toBe(false);
+    const exec = await getExecutor(executorId);
+    expect(exec!.outcome).toBe('blocked');
+    expect(exec!.closeReason).toBe('pg unreachable');
+  });
+
+  test('failed writes outcome and close_reason', async () => {
+    const { executorId } = await seed();
+    const result = await turnClose({ outcome: 'failed', reason: 'test assertion broke', executorId });
+    expect(result.noop).toBe(false);
+    const exec = await getExecutor(executorId);
+    expect(exec!.outcome).toBe('failed');
+    expect(exec!.closeReason).toBe('test assertion broke');
+  });
+
+  test('idempotent — second call on already-closed executor is a no-op', async () => {
+    const { executorId } = await seed();
+    await turnClose({ outcome: 'done', executorId });
+
+    const sql = await getConnection();
+    const [first] = await sql<{ closed_at: Date }[]>`SELECT closed_at FROM executors WHERE id = ${executorId}`;
+    const firstClosed = first.closed_at;
+
+    const second = await turnClose({ outcome: 'done', executorId });
+    expect(second.noop).toBe(true);
+
+    const [after] = await sql<{ closed_at: Date }[]>`SELECT closed_at FROM executors WHERE id = ${executorId}`;
+    expect(after.closed_at.toISOString()).toBe(firstClosed.toISOString());
+
+    const auditRows = await sql<{ id: number }[]>`
+      SELECT id FROM audit_events WHERE entity_type = 'executor' AND entity_id = ${executorId}
+    `;
+    expect(auditRows.length).toBe(1);
+  });
+
+  test('idempotent — no-op when executor is already in terminal state', async () => {
+    const agent = await findOrCreateAgent('eng-terminal', 'test-team', 'engineer');
+    const exec = await createExecutor(agent.id, 'claude', 'tmux', { state: 'terminated' });
+
+    const result = await turnClose({ outcome: 'done', executorId: exec.id });
+    expect(result.noop).toBe(true);
+
+    const sql = await getConnection();
+    const [row] = await sql<{ outcome: string | null }[]>`SELECT outcome FROM executors WHERE id = ${exec.id}`;
+    expect(row.outcome).toBeNull();
+  });
+
+  test('throws when executor not found', async () => {
+    await expect(turnClose({ outcome: 'done', executorId: 'does-not-exist' })).rejects.toThrow(/not found/i);
+  });
+
+  test('rollback — audit INSERT failure reverts executors + agents', async () => {
+    const { agentId, executorId } = await seed();
+
+    await expect(
+      turnClose({
+        outcome: 'done',
+        executorId,
+        auditInsert: async () => {
+          throw new Error('simulated audit failure');
+        },
+      }),
+    ).rejects.toThrow(/simulated audit failure/);
+
+    const sql = await getConnection();
+    const [execRow] = await sql<{ outcome: string | null; state: string; closed_at: Date | null }[]>`
+      SELECT outcome, state, closed_at FROM executors WHERE id = ${executorId}
+    `;
+    expect(execRow.outcome).toBeNull();
+    expect(execRow.state).toBe('working');
+    expect(execRow.closed_at).toBeNull();
+
+    const [agentRow] = await sql<{ current_executor_id: string | null }[]>`
+      SELECT current_executor_id FROM agents WHERE id = ${agentId}
+    `;
+    expect(agentRow.current_executor_id).toBe(executorId);
+
+    const auditRows = await sql<{ id: number }[]>`
+      SELECT id FROM audit_events WHERE entity_id = ${executorId}
+    `;
+    expect(auditRows.length).toBe(0);
+  });
+
+  test('resolves executor id from GENIE_EXECUTOR_ID env', async () => {
+    const { executorId } = await seed();
+    process.env.GENIE_EXECUTOR_ID = executorId;
+    const result = await turnClose({ outcome: 'done' });
+    expect(result.executorId).toBe(executorId);
+  });
+
+  test('errors loudly when no executor id is resolvable', async () => {
+    process.env.GENIE_EXECUTOR_ID = undefined;
+    await expect(turnClose({ outcome: 'done' })).rejects.toThrow(/GENIE_EXECUTOR_ID/);
+  });
+});

--- a/src/lib/turn-close.ts
+++ b/src/lib/turn-close.ts
@@ -1,0 +1,135 @@
+/**
+ * Turn-close contract — write terminal outcome for the current executor.
+ *
+ * `genie done` / `genie blocked` / `genie failed` all funnel through this
+ * function. It performs a single atomic transaction:
+ *   1. Lock + read the executor row.
+ *   2. If the executor is already closed (outcome set or terminal state),
+ *      the call is a no-op and returns `{ noop: true }`.
+ *   3. Otherwise UPDATE executors + UPDATE agents (clear FK) +
+ *      INSERT audit_events in one transaction so a failure on any step
+ *      rolls all writes back.
+ *
+ * The executor is resolved from `GENIE_EXECUTOR_ID` unless passed
+ * explicitly. Callers that cannot resolve an executor (env unset)
+ * receive a loud error.
+ */
+
+import { type Sql, getConnection } from './db.js';
+import type { TurnOutcome } from './executor-types.js';
+
+interface TurnCloseOpts {
+  outcome: TurnOutcome;
+  /** Free-form rationale. Required for 'blocked' and 'failed'. */
+  reason?: string;
+  /** Override env-resolved executor. Primarily for tests. */
+  executorId?: string;
+  /** Actor recorded on audit_events. Defaults to GENIE_AGENT_NAME or 'cli'. */
+  actor?: string;
+  /**
+   * Optional audit insert hook. Used by tests to inject a failure and
+   * verify transaction rollback. Default writes a real audit row inside
+   * the transaction.
+   */
+  auditInsert?: (tx: Sql, payload: AuditPayload) => Promise<void>;
+}
+
+interface AuditPayload {
+  executorId: string;
+  agentId: string;
+  outcome: TurnOutcome;
+  reason: string | null;
+  actor: string;
+}
+
+export interface TurnCloseResult {
+  noop: boolean;
+  executorId: string;
+  outcome: TurnOutcome;
+  closedAt: string | null;
+}
+
+const TERMINAL_STATES = new Set(['done', 'terminated', 'error']);
+
+function resolveExecutorId(opts: TurnCloseOpts): string {
+  const id = opts.executorId ?? process.env.GENIE_EXECUTOR_ID;
+  if (!id) {
+    throw new Error(
+      'turnClose: no executor id — set GENIE_EXECUTOR_ID or pass opts.executorId. ' +
+        'This usually means the close verb was invoked outside an agent session.',
+    );
+  }
+  return id;
+}
+
+async function defaultAuditInsert(tx: Sql, p: AuditPayload): Promise<void> {
+  await tx`
+    INSERT INTO audit_events (entity_type, entity_id, event_type, actor, details)
+    VALUES (
+      'executor',
+      ${p.executorId},
+      ${`turn_close.${p.outcome}`},
+      ${p.actor},
+      ${tx.json({ agent_id: p.agentId, outcome: p.outcome, reason: p.reason })}
+    )
+  `;
+}
+
+export async function turnClose(opts: TurnCloseOpts): Promise<TurnCloseResult> {
+  if ((opts.outcome === 'blocked' || opts.outcome === 'failed') && !opts.reason?.trim()) {
+    throw new Error(`turnClose: --reason is required for outcome '${opts.outcome}'`);
+  }
+
+  const executorId = resolveExecutorId(opts);
+  const actor = opts.actor ?? process.env.GENIE_AGENT_NAME ?? 'cli';
+  const reason = opts.reason?.trim() || null;
+  const auditInsert = opts.auditInsert ?? defaultAuditInsert;
+  const sql = await getConnection();
+
+  return sql.begin(async (tx: Sql) => {
+    const rows = await tx<{ state: string; outcome: string | null; agent_id: string }[]>`
+      SELECT state, outcome, agent_id FROM executors
+      WHERE id = ${executorId}
+      FOR UPDATE
+    `;
+    if (rows.length === 0) {
+      throw new Error(`turnClose: executor ${executorId} not found`);
+    }
+    const row = rows[0];
+    if (row.outcome !== null || TERMINAL_STATES.has(row.state)) {
+      return {
+        noop: true,
+        executorId,
+        outcome: (row.outcome as TurnOutcome | null) ?? opts.outcome,
+        closedAt: null,
+      };
+    }
+
+    const now = new Date().toISOString();
+    await tx`
+      UPDATE executors
+      SET outcome = ${opts.outcome},
+          closed_at = ${now},
+          close_reason = ${reason},
+          state = 'done',
+          ended_at = ${now}
+      WHERE id = ${executorId}
+    `;
+
+    await tx`
+      UPDATE agents
+      SET current_executor_id = NULL
+      WHERE current_executor_id = ${executorId}
+    `;
+
+    await auditInsert(tx, {
+      executorId,
+      agentId: row.agent_id,
+      outcome: opts.outcome,
+      reason,
+      actor,
+    });
+
+    return { noop: false, executorId, outcome: opts.outcome, closedAt: now };
+  });
+}

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -33,7 +33,7 @@ import {
 import { getProvider } from '../lib/providers/registry.js';
 import { waitForAgentReady } from '../lib/spawn-command.js';
 import * as teamManager from '../lib/team-manager.js';
-import { genieTmuxCmd } from '../lib/tmux-wrapper.js';
+import { genieTmuxCmd, prependEnvVars } from '../lib/tmux-wrapper.js';
 import * as tmux from '../lib/tmux.js';
 import { executeTmux, isPaneAlive } from '../lib/tmux.js';
 import { findWorkspace, getWorkspaceConfig } from '../lib/workspace.js';
@@ -1309,14 +1309,6 @@ async function launchInlineSpawn(ctx: SpawnCtx): Promise<string> {
   return process.exit(result.status ?? 0) as never;
 }
 
-function prependEnvVars(command: string, env?: Record<string, string>): string {
-  if (!env || Object.keys(env).length === 0) return command;
-  const envArgs = Object.entries(env)
-    .map(([k, v]) => `${k}=${v}`)
-    .join(' ');
-  return `env ${envArgs} ${command}`;
-}
-
 /**
  * Find a dead worker with a resumable Claude session for the given role/team.
  * Must run BEFORE rejectDuplicateRole which would unregister the dead worker
@@ -2424,8 +2416,7 @@ async function createResumeExecutor(
   // here. Fall back to a fresh mint only if the caller forgot to seed them.
   const resumeAgentName = agent.role ?? agent.id;
   const resumeTeam = agent.team ?? params.team;
-  const agentId =
-    params.agentId ?? (await registry.findOrCreateAgent(resumeAgentName, resumeTeam, agent.role)).id;
+  const agentId = params.agentId ?? (await registry.findOrCreateAgent(resumeAgentName, resumeTeam, agent.role)).id;
   await terminateActiveExecutorWithCleanup(agentId);
 
   const pid = await capturePanePid(paneId);

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -1995,6 +1995,19 @@ export async function handleWorkerSpawn(name: string, options: SpawnOptions): Pr
   if (!params.name) {
     params.name = `${params.team}-${effectiveRole}`;
   }
+
+  // Executor model: find/create durable agent identity + concurrent guard.
+  // Must happen BEFORE buildLaunchCommand so executorId/agentId propagate
+  // into the child env (GENIE_EXECUTOR_ID / GENIE_AGENT_ID) — needed by the
+  // turn-close verbs (genie done/blocked/failed).
+  const nt = params.nativeTeam;
+  const agentName = nt?.agentName ?? effectiveRole;
+  const agentIdentity = await registry.findOrCreateAgent(agentName, team, effectiveRole);
+  await terminateActiveExecutorWithCleanup(agentIdentity.id);
+  const executorId = crypto.randomUUID();
+  params.agentId = agentIdentity.id;
+  params.executorId = executorId;
+
   const validated = validateSpawnParams(params);
   const launch = buildLaunchCommand(validated);
   const layoutMode = resolveLayoutMode(options.layout);
@@ -2014,14 +2027,7 @@ export async function handleWorkerSpawn(name: string, options: SpawnOptions): Pr
   // An explicit session target means "spawn in tmux" even when the caller is outside tmux.
   // This matters for orchestrators like QA, which need detached workers instead of a blocking inline session.
   const insideTmux = Boolean(process.env.TMUX || options.session);
-  const nt = validated.nativeTeam;
   const now = new Date().toISOString();
-  const agentName = nt?.agentName ?? effectiveRole;
-
-  // Executor model: find/create durable agent identity + concurrent guard
-  const agentIdentity = await registry.findOrCreateAgent(agentName, team, effectiveRole);
-  await terminateActiveExecutorWithCleanup(agentIdentity.id);
-  const executorId = crypto.randomUUID();
 
   const otelRelayActive = await maybeStartOtelRelay(nt, validated, insideTmux);
 
@@ -2413,13 +2419,18 @@ async function createResumeExecutor(
   cwd: string,
   spawnColor: string,
 ): Promise<void> {
+  // params.agentId / params.executorId are pre-minted by resumeAgent so the
+  // same UUIDs that landed in the child env (GENIE_EXECUTOR_ID) are written
+  // here. Fall back to a fresh mint only if the caller forgot to seed them.
   const resumeAgentName = agent.role ?? agent.id;
   const resumeTeam = agent.team ?? params.team;
-  const agentIdentity = await registry.findOrCreateAgent(resumeAgentName, resumeTeam, agent.role);
-  await terminateActiveExecutorWithCleanup(agentIdentity.id);
+  const agentId =
+    params.agentId ?? (await registry.findOrCreateAgent(resumeAgentName, resumeTeam, agent.role)).id;
+  await terminateActiveExecutorWithCleanup(agentId);
 
   const pid = await capturePanePid(paneId);
-  await createAndLinkExecutor(agentIdentity.id, params.provider, resolveExecutorTransport(params.provider, 'tmux'), {
+  await createAndLinkExecutor(agentId, params.provider, resolveExecutorTransport(params.provider, 'tmux'), {
+    id: params.executorId,
     pid,
     tmuxSession: params.team,
     tmuxPaneId: paneId,
@@ -2454,6 +2465,16 @@ async function resumeAgent(agent: registry.Agent, opts: { resetAttempts?: boolea
 
   const params = await buildFullResumeParams(agent, template);
 
+  // Mint executor identity BEFORE buildLaunchCommand so GENIE_EXECUTOR_ID /
+  // GENIE_AGENT_ID propagate into the resumed child env. The same executorId
+  // is later reused when createResumeExecutor INSERTs the executor row.
+  const resumeAgentName = agent.role ?? agent.id;
+  const resumeTeam = agent.team ?? params.team;
+  const agentIdentity = await registry.findOrCreateAgent(resumeAgentName, resumeTeam, agent.role);
+  const executorId = crypto.randomUUID();
+  params.agentId = agentIdentity.id;
+  params.executorId = executorId;
+
   const validated = validateSpawnParams(params);
   const launch = buildLaunchCommand(validated);
   const fullCommand = prependEnvVars(launch.command, launch.env);
@@ -2481,6 +2502,8 @@ async function resumeAgent(agent: registry.Agent, opts: { resetAttempts?: boolea
     cwd: template?.cwd ?? agent.repoPath,
     spawnIntoCurrentWindow: false,
     autoResume: agent.autoResume,
+    agentIdentityId: agentIdentity.id,
+    executorId,
   };
 
   const teamWindow = await resolveSpawnTeamWindow(validated.team, ctx.cwd);

--- a/src/term-commands/blocked.ts
+++ b/src/term-commands/blocked.ts
@@ -1,0 +1,27 @@
+/**
+ * `genie blocked --reason "..."` — close the current turn with outcome='blocked'.
+ * Requires GENIE_EXECUTOR_ID (set by every spawn path).
+ */
+
+import { turnClose } from '../lib/turn-close.js';
+
+interface BlockedActionDeps {
+  turnCloseFn?: typeof turnClose;
+}
+
+export async function blockedAction(options: { reason?: string }, deps: BlockedActionDeps = {}): Promise<void> {
+  const reason = options.reason?.trim();
+  if (!reason) {
+    console.error('❌ genie blocked requires --reason "<message>"');
+    process.exit(2);
+  }
+
+  const fn = deps.turnCloseFn ?? turnClose;
+  const result = await fn({ outcome: 'blocked', reason });
+  if (result.noop) {
+    console.log(`ℹ️  Executor ${result.executorId} already closed — no-op.`);
+  } else {
+    console.log(`🔒 Turn closed: outcome=blocked, executor=${result.executorId}`);
+    console.log(`   Reason: ${reason}`);
+  }
+}

--- a/src/term-commands/done.test.ts
+++ b/src/term-commands/done.test.ts
@@ -1,0 +1,104 @@
+/**
+ * `genie done` command dispatch — agent-session path vs wish-group path.
+ *
+ * Uses injected deps (no DB) to isolate routing behavior.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { TurnCloseResult } from '../lib/turn-close.js';
+import { doneAction } from './done.js';
+
+describe('doneAction dispatch', () => {
+  const originalAgent = process.env.GENIE_AGENT_NAME;
+
+  beforeEach(() => {
+    process.env.GENIE_AGENT_NAME = undefined;
+  });
+
+  afterEach(() => {
+    process.env.GENIE_AGENT_NAME = originalAgent;
+  });
+
+  test('agent session + no ref → calls turnClose(outcome=done)', async () => {
+    process.env.GENIE_AGENT_NAME = 'engineer-g2';
+    const calls: Array<{ outcome: string }> = [];
+    const turnCloseFn = async (opts: { outcome: string }): Promise<TurnCloseResult> => {
+      calls.push({ outcome: opts.outcome });
+      return { noop: false, executorId: 'exec-1', outcome: 'done', closedAt: new Date().toISOString() };
+    };
+    let wishCalls = 0;
+    const wishDone = async () => {
+      wishCalls++;
+    };
+
+    await doneAction(undefined, { turnCloseFn: turnCloseFn as never, wishDone });
+
+    expect(calls).toEqual([{ outcome: 'done' }]);
+    expect(wishCalls).toBe(0);
+  });
+
+  test('positional ref → delegates to wish-group doneCommand', async () => {
+    process.env.GENIE_AGENT_NAME = 'engineer-g2';
+    let turnCalls = 0;
+    const turnCloseFn = async (): Promise<TurnCloseResult> => {
+      turnCalls++;
+      return { noop: false, executorId: 'x', outcome: 'done', closedAt: null };
+    };
+    const wishRefs: string[] = [];
+    const wishDone = async (ref: string) => {
+      wishRefs.push(ref);
+    };
+
+    await doneAction('my-wish#2', { turnCloseFn: turnCloseFn as never, wishDone });
+
+    expect(turnCalls).toBe(0);
+    expect(wishRefs).toEqual(['my-wish#2']);
+  });
+
+  test('positional ref without GENIE_AGENT_NAME → still delegates to wish path', async () => {
+    let turnCalls = 0;
+    const turnCloseFn = async (): Promise<TurnCloseResult> => {
+      turnCalls++;
+      return { noop: false, executorId: 'x', outcome: 'done', closedAt: null };
+    };
+    const wishRefs: string[] = [];
+    const wishDone = async (ref: string) => {
+      wishRefs.push(ref);
+    };
+
+    await doneAction('other-wish#1', { turnCloseFn: turnCloseFn as never, wishDone });
+
+    expect(turnCalls).toBe(0);
+    expect(wishRefs).toEqual(['other-wish#1']);
+  });
+
+  test('no ref + no GENIE_AGENT_NAME → exits with error', async () => {
+    const originalExit = process.exit;
+    let exitCode: number | undefined;
+    // biome-ignore lint/suspicious/noExplicitAny: test override
+    process.exit = ((code?: number) => {
+      exitCode = code;
+      throw new Error('process.exit stub');
+    }) as never;
+
+    try {
+      await expect(doneAction(undefined)).rejects.toThrow(/process.exit stub/);
+      expect(exitCode).toBe(2);
+    } finally {
+      process.exit = originalExit;
+    }
+  });
+
+  test('turnClose noop result is reported to user, not treated as error', async () => {
+    process.env.GENIE_AGENT_NAME = 'engineer-g2';
+    const turnCloseFn = async (): Promise<TurnCloseResult> => ({
+      noop: true,
+      executorId: 'exec-already-closed',
+      outcome: 'done',
+      closedAt: null,
+    });
+
+    // Should complete without throwing
+    await doneAction(undefined, { turnCloseFn: turnCloseFn as never });
+  });
+});

--- a/src/term-commands/done.ts
+++ b/src/term-commands/done.ts
@@ -1,0 +1,52 @@
+/**
+ * `genie done` — context-dispatched close verb.
+ *
+ * Two paths:
+ *   1. Agent session (GENIE_AGENT_NAME set) + no positional ref →
+ *      write terminal state to the current executor via turnClose().
+ *   2. Wish group (positional ref like `slug#group`) →
+ *      delegate to the existing wish-group-done flow in state.ts.
+ *
+ * If neither a ref nor GENIE_AGENT_NAME is provided we error loudly —
+ * the verb is ambiguous and silently picking one path hides bugs.
+ */
+
+import { turnClose } from '../lib/turn-close.js';
+
+interface DoneActionDeps {
+  /** Wish-group-done fallback. Injected for tests. */
+  wishDone?: (ref: string) => Promise<void>;
+  /** Turn-close path. Injected for tests. */
+  turnCloseFn?: typeof turnClose;
+}
+
+export async function doneAction(ref: string | undefined, deps: DoneActionDeps = {}): Promise<void> {
+  const agentName = process.env.GENIE_AGENT_NAME;
+
+  if (!ref && agentName) {
+    const fn = deps.turnCloseFn ?? turnClose;
+    const result = await fn({ outcome: 'done' });
+    if (result.noop) {
+      console.log(`ℹ️  Executor ${result.executorId} already closed — no-op.`);
+    } else {
+      console.log(`✅ Turn closed: outcome=done, executor=${result.executorId}`);
+    }
+    return;
+  }
+
+  if (ref) {
+    const fallback =
+      deps.wishDone ??
+      (async (r: string) => {
+        const { doneCommand } = await import('./state.js');
+        await doneCommand(r);
+      });
+    await fallback(ref);
+    return;
+  }
+
+  console.error(
+    '❌ genie done requires either a <slug>#<group> ref (team-lead) or GENIE_AGENT_NAME (inside agent session).',
+  );
+  process.exit(2);
+}

--- a/src/term-commands/failed.ts
+++ b/src/term-commands/failed.ts
@@ -1,0 +1,27 @@
+/**
+ * `genie failed --reason "..."` — close the current turn with outcome='failed'.
+ * Requires GENIE_EXECUTOR_ID (set by every spawn path).
+ */
+
+import { turnClose } from '../lib/turn-close.js';
+
+interface FailedActionDeps {
+  turnCloseFn?: typeof turnClose;
+}
+
+export async function failedAction(options: { reason?: string }, deps: FailedActionDeps = {}): Promise<void> {
+  const reason = options.reason?.trim();
+  if (!reason) {
+    console.error('❌ genie failed requires --reason "<message>"');
+    process.exit(2);
+  }
+
+  const fn = deps.turnCloseFn ?? turnClose;
+  const result = await fn({ outcome: 'failed', reason });
+  if (result.noop) {
+    console.log(`ℹ️  Executor ${result.executorId} already closed — no-op.`);
+  } else {
+    console.log(`🛑 Turn closed: outcome=failed, executor=${result.executorId}`);
+    console.log(`   Reason: ${reason}`);
+  }
+}

--- a/src/term-commands/pane-trap.ts
+++ b/src/term-commands/pane-trap.ts
@@ -1,0 +1,44 @@
+/**
+ * `genie pane-trap` — internal verb invoked by the tmux `pane-died`
+ * hook and the inline shell `EXIT` trap.
+ *
+ * This is part of the turn-session contract safety net (Group 5). It
+ * never fails loudly: a dying pane is already an error surface, and
+ * throwing here would clobber tmux's cleanup sequence.
+ */
+
+import { type TrapReason, trapPaneExit } from '../lib/pane-trap.js';
+
+export interface PaneTrapCliOpts {
+  paneId?: string;
+  executorId?: string;
+  reason?: string;
+}
+
+function normalizeReason(raw: string | undefined): TrapReason {
+  return raw === 'shell_exit' ? 'shell_exit' : 'pane_died';
+}
+
+export async function paneTrapAction(opts: PaneTrapCliOpts): Promise<void> {
+  const result = await trapPaneExit({
+    executorId: opts.executorId,
+    paneId: opts.paneId,
+    reason: normalizeReason(opts.reason),
+  });
+
+  if (result.executorId === null) {
+    // No executor resolved — nothing to terminalize. This is common when
+    // the trap fires on a pane that never had an executor bound (e.g.
+    // a bare shell). Exit silently.
+    return;
+  }
+
+  if (result.noop) {
+    console.error(`[pane-trap] no-op for ${result.executorId} (already closed)`);
+    return;
+  }
+
+  console.error(
+    `[pane-trap] terminalized executor=${result.executorId} outcome=${result.outcome} reason=${result.reason}`,
+  );
+}

--- a/src/term-commands/pane-trap.ts
+++ b/src/term-commands/pane-trap.ts
@@ -9,7 +9,7 @@
 
 import { type TrapReason, trapPaneExit } from '../lib/pane-trap.js';
 
-export interface PaneTrapCliOpts {
+interface PaneTrapCliOpts {
   paneId?: string;
   executorId?: string;
   reason?: string;

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -558,6 +558,18 @@ async function startForeground(headless?: boolean): Promise<void> {
   // 4. Start scheduler + event-router + inbox-watcher
   await startScheduler();
 
+  // 4b. Start executor-read endpoint (Group 6 of turn-session-contract).
+  // Non-fatal: if the port is busy or Bun.serve errors, the endpoint logs and
+  // skips. Direct-SQL consumers fall back to `executors_reader` role.
+  try {
+    const { startExecutorReadEndpoint, getExecutorReadPort } = await import('../lib/executor-read.js');
+    const ok = await startExecutorReadEndpoint();
+    if (ok) console.log(`  Executor read endpoint ready on port ${getExecutorReadPort()}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`  Executor read endpoint: failed — ${msg}`);
+  }
+
   // 5. Start Omni approval handler (if workspace has approval config)
   try {
     const { startOmniApprovalHandler } = await import('../lib/omni-approval-handler.js');
@@ -619,6 +631,9 @@ async function startForeground(headless?: boolean): Promise<void> {
       handles.omniBridge.stop().catch(() => {});
       handles.omniBridge = null;
     }
+
+    // 2.58. Stop executor-read endpoint
+    void import('../lib/executor-read.js').then((m) => m.stopExecutorReadEndpoint().catch(() => {}));
 
     // 2.6. Stop brain server (best-effort — signal handlers call process.exit()
     // immediately after shutdown(), so this is fire-and-forget like all other


### PR DESCRIPTION
## Summary

Genie-side close half of the turn-session contract. Ships Waves 1–4 (Groups G1–G8) from `.genie/wishes/turn-session-contract/WISH.md`. G9 (phase-C flag removal) is explicitly deferred per wish — requires a 7-day soak after G8 lands.

## What this delivers

- **G1 — state machine**: formalize `idle/working/permission/question/error/dead → terminalized` transitions with an atomic close transaction (executors + agents + audit_events, single txn).
- **G2 — idempotent close**: `closeTurn()` primitive wrapping the atomic transaction. Callers no longer race on multi-table updates.
- **G3 — close-verb contract**: `GENIE_EXECUTOR_ID` propagated through spawn; skills that terminate sessions use the close verb.
- **G4 — turn-aware reconciler**: behind `GENIE_RECONCILER_TURN_AWARE` flag. D1 (idle+dead → terminalize, no resume) and D3 (error+dead → no resume) implemented. Sweep path only — daemon boot recovery retains legacy behavior to avoid regressing the reboot path.
- **G5 — pane-exit trap**: tmux `pane-died` hook + shell `EXIT` trap writes `clean_exit_unverified` via new `genie pane-trap` verb. Catches panes that die between heartbeats.
- **G6 — executor-state read API**: single indexed SELECT on the executors PK; p99 target <10ms.
- **G7 — tmux wrapper restore**: `genieTmuxPrefix()` restores the `-f <configPath>` arg so the pane-died hook is actually loaded when genie spawns panes.
- **G8 — phase-B flag flip**: defaults for `auto_resume` and `GENIE_RECONCILER_TURN_AWARE` flipped on. Now observable in dev.

## Scope exclusions

- **G9 / phase-C**: removing the `GENIE_RECONCILER_TURN_AWARE` feature flag entirely is deferred until the new path has soaked on dev for 7 days (per wish C17).
- Omni-side contract (executor-state event writer) is NOT in this PR — it's a sibling wish.

## Validation

- `bun test` → 3238 pass, 0 fail
- `bun run typecheck` → clean
- `bun run check` → exit 0 (biome complexity warnings are pre-existing on origin/dev, not introduced here; knip clean after the last commit)
- Last commits on the branch:
  - `a9b00739` chore(knip): drop unused exports on file-local interfaces
  - `d81c7062` fix(reconciler,tmux): scope turn-aware rules + restore tmux -f arg — post-G8 FIX-FIRST

## Test plan

- [x] All 3238 unit tests pass
- [x] TypeScript strict build clean
- [x] Biome + knip green
- [ ] Soak on dev for 7 days before cutting G9 (phase-C flag removal)
- [ ] Watch `genie events` for unexpected `clean_exit_unverified` spikes in first 48h after merge

## Wish / criteria reference

`.genie/wishes/turn-session-contract/WISH.md` — success criteria C1..C20 all satisfied except C17 (phase-C removal, deferred by design).