### PR TITLE
fix(test): add prependEnvVars to tmux-wrapper mocks

### DIFF
--- a/src/lib/protocol-router.test.ts
+++ b/src/lib/protocol-router.test.ts
@@ -46,6 +46,16 @@ mock.module('./tmux-wrapper.js', () => ({
   },
   genieTmuxPrefix: () => ['-L', 'genie', '-f', '/dev/null'],
   genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
+  // Passthrough matches the real implementation (issue #1223): the mock
+  // must preserve behavior because Bun's mock.module is process-global,
+  // so tmux-wrapper.test.ts can race and see this stub.
+  prependEnvVars: (command: string, env?: Record<string, string>) => {
+    if (!env || Object.keys(env).length === 0) return command;
+    const envArgs = Object.entries(env)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ');
+    return `env ${envArgs} ${command}`;
+  },
 }));
 
 mock.module('./orchestrator/index.js', () => ({

--- a/src/lib/spawn-command.test.ts
+++ b/src/lib/spawn-command.test.ts
@@ -214,6 +214,16 @@ mock.module('./tmux-wrapper.js', () => ({
   },
   genieTmuxPrefix: () => ['-L', 'genie', '-f', '/dev/null'],
   genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
+  // Passthrough matches the real implementation (issue #1223): the mock
+  // must preserve behavior because Bun's mock.module is process-global,
+  // so tmux-wrapper.test.ts can race and see this stub.
+  prependEnvVars: (command: string, env?: Record<string, string>) => {
+    if (!env || Object.keys(env).length === 0) return command;
+    const envArgs = Object.entries(env)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ');
+    return `env ${envArgs} ${command}`;
+  },
 }));
 
 mock.module('./orchestrator/index.js', () => ({

--- a/src/lib/tmux-alive.test.ts
+++ b/src/lib/tmux-alive.test.ts
@@ -10,6 +10,16 @@ mock.module('./tmux-wrapper.js', () => ({
   executeTmux: mockExecuteTmux,
   genieTmuxPrefix: () => ['-L', 'genie', '-f', '/dev/null'],
   genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
+  // Passthrough matches the real implementation (issue #1223): the mock
+  // must preserve behavior because Bun's mock.module is process-global,
+  // so tmux-wrapper.test.ts can race and see this stub.
+  prependEnvVars: (command: string, env?: Record<string, string>) => {
+    if (!env || Object.keys(env).length === 0) return command;
+    const envArgs = Object.entries(env)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ');
+    return `env ${envArgs} ${command}`;
+  },
 }));
 
 const { isPaneAlive, isPaneProcessRunning, TmuxUnreachableError } = await import('./tmux.js');

--- a/src/lib/tmux-resolve.test.ts
+++ b/src/lib/tmux-resolve.test.ts
@@ -14,6 +14,16 @@ mock.module('./tmux-wrapper.js', () => ({
   executeTmux: mockExecuteTmux,
   genieTmuxPrefix: () => ['-L', 'genie', '-f', '/dev/null'],
   genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
+  // Passthrough matches the real implementation (issue #1223): the mock
+  // must preserve behavior because Bun's mock.module is process-global,
+  // so tmux-wrapper.test.ts can race and see this stub.
+  prependEnvVars: (command: string, env?: Record<string, string>) => {
+    if (!env || Object.keys(env).length === 0) return command;
+    const envArgs = Object.entries(env)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ');
+    return `env ${envArgs} ${command}`;
+  },
 }));
 
 const { resolveRepoSession } = await import('./tmux.js');

--- a/src/lib/tmux.test.ts
+++ b/src/lib/tmux.test.ts
@@ -12,6 +12,16 @@ mock.module('./tmux-wrapper.js', () => ({
   executeTmux: mockExecuteTmux,
   genieTmuxPrefix: () => ['-L', 'genie', '-f', '/dev/null'],
   genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
+  // Passthrough matches the real implementation (issue #1223): the mock
+  // must preserve behavior because Bun's mock.module is process-global,
+  // so tmux-wrapper.test.ts can race and see this stub.
+  prependEnvVars: (command: string, env?: Record<string, string>) => {
+    if (!env || Object.keys(env).length === 0) return command;
+    const envArgs = Object.entries(env)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ');
+    return `env ${envArgs} ${command}`;
+  },
 }));
 
 // Must import after mock.module

--- a/src/services/executors/__tests__/claude-code-deliver.test.ts
+++ b/src/services/executors/__tests__/claude-code-deliver.test.ts
@@ -14,6 +14,18 @@ mock.module('../../../lib/tmux-wrapper.js', () => ({
   executeTmux: mockExecuteTmux,
   genieTmuxPrefix: () => ['-L', 'genie'],
   genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
+  // Must mirror real export surface — omitting any export poisons Bun's
+  // module cache globally and breaks concurrent tests that import it
+  // (issue #1223). Passthrough matches the real implementation so the
+  // tmux-wrapper.test.ts suite still sees correct behavior when its
+  // import happens to win the mock-cache race.
+  prependEnvVars: (command: string, env?: Record<string, string>) => {
+    if (!env || Object.keys(env).length === 0) return command;
+    const envArgs = Object.entries(env)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ');
+    return `env ${envArgs} ${command}`;
+  },
 }));
 
 // isPaneAlive lives in tmux.ts and calls executeTmux internally; by stubbing


### PR DESCRIPTION
## Summary
Six test files mock `src/lib/tmux-wrapper.js` but none of them expose `prependEnvVars`. Because Bun's `mock.module` replaces the module cache **globally**, any concurrent test that imports the real `prependEnvVars` observed the stubbed module and failed module-load:

```
SyntaxError: Export named 'prependEnvVars' not found in module
'.../src/lib/tmux-wrapper.ts'.
```

The cascade broke ~10 tests across 8 files and made the husky pre-push hook permanently red — every local push would be rejected.

## Fix
Each mock now exposes `prependEnvVars` with a passthrough implementation that matches the real function body. Passthrough (not identity) because `tmux-wrapper.test.ts`'s own `prependEnvVars` suite observes the mock when the races go the other way.

## Evidence

**Before** (on `dev` at `f1b307c0`):
```
3106 pass / 11 fail / 7 errors
Ran 3117 tests across 181 files. [107.7s]
```

**After** (this PR):
```
3251 pass / 0 fail / 0 errors
Ran 3251 tests across 181 files. [112.2s]
```

The post-fix total is higher (3251 vs 3117) because the cascading module-load errors were preventing ~140 tests from even being counted.

## Files touched
- `src/services/executors/__tests__/claude-code-deliver.test.ts`
- `src/lib/tmux-resolve.test.ts`
- `src/lib/tmux.test.ts`
- `src/lib/spawn-command.test.ts`
- `src/lib/tmux-alive.test.ts`
- `src/lib/protocol-router.test.ts`

No production code changed.

## Test plan
- [x] `bun test` → 3251 pass, 0 fail
- [x] `bun run typecheck` → clean
- [x] `bun run lint` → no new warnings on touched files (pre-existing 42 unrelated)
- [x] `bun run check` passes → pre-push hook works again
- [x] `git push` succeeds

Closes #1223.