### PR TITLE
fix(cli): drop GENIE_TEAM filter from `agent show`

### DIFF
--- a/src/lib/protocol-router.test.ts
+++ b/src/lib/protocol-router.test.ts
@@ -46,6 +46,16 @@ mock.module('./tmux-wrapper.js', () => ({
   },
   genieTmuxPrefix: () => ['-L', 'genie', '-f', '/dev/null'],
   genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
+  // Passthrough matches the real implementation (issue #1223): the mock
+  // must preserve behavior because Bun's mock.module is process-global,
+  // so tmux-wrapper.test.ts can race and see this stub.
+  prependEnvVars: (command: string, env?: Record<string, string>) => {
+    if (!env || Object.keys(env).length === 0) return command;
+    const envArgs = Object.entries(env)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ');
+    return `env ${envArgs} ${command}`;
+  },
 }));
 
 mock.module('./orchestrator/index.js', () => ({

--- a/src/lib/spawn-command.test.ts
+++ b/src/lib/spawn-command.test.ts
@@ -214,6 +214,16 @@ mock.module('./tmux-wrapper.js', () => ({
   },
   genieTmuxPrefix: () => ['-L', 'genie', '-f', '/dev/null'],
   genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
+  // Passthrough matches the real implementation (issue #1223): the mock
+  // must preserve behavior because Bun's mock.module is process-global,
+  // so tmux-wrapper.test.ts can race and see this stub.
+  prependEnvVars: (command: string, env?: Record<string, string>) => {
+    if (!env || Object.keys(env).length === 0) return command;
+    const envArgs = Object.entries(env)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ');
+    return `env ${envArgs} ${command}`;
+  },
 }));
 
 mock.module('./orchestrator/index.js', () => ({

--- a/src/lib/tmux-alive.test.ts
+++ b/src/lib/tmux-alive.test.ts
@@ -10,6 +10,16 @@ mock.module('./tmux-wrapper.js', () => ({
   executeTmux: mockExecuteTmux,
   genieTmuxPrefix: () => ['-L', 'genie', '-f', '/dev/null'],
   genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
+  // Passthrough matches the real implementation (issue #1223): the mock
+  // must preserve behavior because Bun's mock.module is process-global,
+  // so tmux-wrapper.test.ts can race and see this stub.
+  prependEnvVars: (command: string, env?: Record<string, string>) => {
+    if (!env || Object.keys(env).length === 0) return command;
+    const envArgs = Object.entries(env)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ');
+    return `env ${envArgs} ${command}`;
+  },
 }));
 
 const { isPaneAlive, isPaneProcessRunning, TmuxUnreachableError } = await import('./tmux.js');

--- a/src/lib/tmux-resolve.test.ts
+++ b/src/lib/tmux-resolve.test.ts
@@ -14,6 +14,16 @@ mock.module('./tmux-wrapper.js', () => ({
   executeTmux: mockExecuteTmux,
   genieTmuxPrefix: () => ['-L', 'genie', '-f', '/dev/null'],
   genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
+  // Passthrough matches the real implementation (issue #1223): the mock
+  // must preserve behavior because Bun's mock.module is process-global,
+  // so tmux-wrapper.test.ts can race and see this stub.
+  prependEnvVars: (command: string, env?: Record<string, string>) => {
+    if (!env || Object.keys(env).length === 0) return command;
+    const envArgs = Object.entries(env)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ');
+    return `env ${envArgs} ${command}`;
+  },
 }));
 
 const { resolveRepoSession } = await import('./tmux.js');

--- a/src/lib/tmux.test.ts
+++ b/src/lib/tmux.test.ts
@@ -12,6 +12,16 @@ mock.module('./tmux-wrapper.js', () => ({
   executeTmux: mockExecuteTmux,
   genieTmuxPrefix: () => ['-L', 'genie', '-f', '/dev/null'],
   genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
+  // Passthrough matches the real implementation (issue #1223): the mock
+  // must preserve behavior because Bun's mock.module is process-global,
+  // so tmux-wrapper.test.ts can race and see this stub.
+  prependEnvVars: (command: string, env?: Record<string, string>) => {
+    if (!env || Object.keys(env).length === 0) return command;
+    const envArgs = Object.entries(env)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ');
+    return `env ${envArgs} ${command}`;
+  },
 }));
 
 // Must import after mock.module

--- a/src/services/executors/__tests__/claude-code-deliver.test.ts
+++ b/src/services/executors/__tests__/claude-code-deliver.test.ts
@@ -14,6 +14,18 @@ mock.module('../../../lib/tmux-wrapper.js', () => ({
   executeTmux: mockExecuteTmux,
   genieTmuxPrefix: () => ['-L', 'genie'],
   genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
+  // Must mirror real export surface — omitting any export poisons Bun's
+  // module cache globally and breaks concurrent tests that import it
+  // (issue #1223). Passthrough matches the real implementation so the
+  // tmux-wrapper.test.ts suite still sees correct behavior when its
+  // import happens to win the mock-cache race.
+  prependEnvVars: (command: string, env?: Record<string, string>) => {
+    if (!env || Object.keys(env).length === 0) return command;
+    const envArgs = Object.entries(env)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ');
+    return `env ${envArgs} ${command}`;
+  },
 }));
 
 // isPaneAlive lives in tmux.ts and calls executeTmux internally; by stubbing

--- a/src/term-commands/agent/show.ts
+++ b/src/term-commands/agent/show.ts
@@ -39,8 +39,13 @@ async function showAgent(name: string, json?: boolean): Promise<void> {
   const registry = await import('../../lib/agent-registry.js');
   const executorRegistry = await import('../../lib/executor-registry.js');
 
-  const agents = await registry.listAgents({ team: process.env.GENIE_TEAM });
-  const agent = agents.find((a) => a.customName === name || a.role === name || a.id === name);
+  // Lookup is global (matches `genie ls` semantics) — filtering by GENIE_TEAM
+  // made cross-team agents invisible when the env was set. If the name is
+  // ambiguous across teams, prefer the one matching GENIE_TEAM, then any match.
+  const agents = await registry.listAgents();
+  const matches = agents.filter((a) => a.customName === name || a.role === name || a.id === name);
+  const preferredTeam = process.env.GENIE_TEAM;
+  const agent = (preferredTeam && matches.find((a) => a.team === preferredTeam)) ?? matches[0];
 
   if (!agent) {
     console.error(`Agent "${name}" not found.`);


### PR DESCRIPTION
## Summary
- Fixes #1222 — `genie agent show <name>` returned "agent not found" for cross-team agents when `GENIE_TEAM` was set in the environment.
- Root cause: `show.ts` filtered `registry.listAgents()` by `GENIE_TEAM` before matching, hiding agents from other teams.
- Fix: lookup is now global (matches `genie ls` semantics). On name ambiguity, prefer the match with `team === GENIE_TEAM`, else first match.

## Changes
- `src/term-commands/agent/show.ts` — remove team filter, add preferred-team tiebreaker.
- Cherry-picked `b7b5e5b2` (PR #1224, mock fixes) so the pre-push gate passes. Will be absorbed when #1224 merges.

## Test plan
- [x] `bun run check` — 3251 pass / 0 fail (pre-push gate green)
- [x] Manual: `GENIE_TEAM=genie genie agent show simone` resolves correctly across teams

Closes #1222