### PR TITLE
fix(cli): diagnose root cause when `genie stop` can't suspend

### DIFF
--- a/src/lib/protocol-router.test.ts
+++ b/src/lib/protocol-router.test.ts
@@ -46,6 +46,16 @@ mock.module('./tmux-wrapper.js', () => ({
   },
   genieTmuxPrefix: () => ['-L', 'genie', '-f', '/dev/null'],
   genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
+  // Passthrough matches the real implementation (issue #1223): the mock
+  // must preserve behavior because Bun's mock.module is process-global,
+  // so tmux-wrapper.test.ts can race and see this stub.
+  prependEnvVars: (command: string, env?: Record<string, string>) => {
+    if (!env || Object.keys(env).length === 0) return command;
+    const envArgs = Object.entries(env)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ');
+    return `env ${envArgs} ${command}`;
+  },
 }));
 
 mock.module('./orchestrator/index.js', () => ({

--- a/src/lib/spawn-command.test.ts
+++ b/src/lib/spawn-command.test.ts
@@ -214,6 +214,16 @@ mock.module('./tmux-wrapper.js', () => ({
   },
   genieTmuxPrefix: () => ['-L', 'genie', '-f', '/dev/null'],
   genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
+  // Passthrough matches the real implementation (issue #1223): the mock
+  // must preserve behavior because Bun's mock.module is process-global,
+  // so tmux-wrapper.test.ts can race and see this stub.
+  prependEnvVars: (command: string, env?: Record<string, string>) => {
+    if (!env || Object.keys(env).length === 0) return command;
+    const envArgs = Object.entries(env)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ');
+    return `env ${envArgs} ${command}`;
+  },
 }));
 
 mock.module('./orchestrator/index.js', () => ({

--- a/src/lib/tmux-alive.test.ts
+++ b/src/lib/tmux-alive.test.ts
@@ -10,6 +10,16 @@ mock.module('./tmux-wrapper.js', () => ({
   executeTmux: mockExecuteTmux,
   genieTmuxPrefix: () => ['-L', 'genie', '-f', '/dev/null'],
   genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
+  // Passthrough matches the real implementation (issue #1223): the mock
+  // must preserve behavior because Bun's mock.module is process-global,
+  // so tmux-wrapper.test.ts can race and see this stub.
+  prependEnvVars: (command: string, env?: Record<string, string>) => {
+    if (!env || Object.keys(env).length === 0) return command;
+    const envArgs = Object.entries(env)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ');
+    return `env ${envArgs} ${command}`;
+  },
 }));
 
 const { isPaneAlive, isPaneProcessRunning, TmuxUnreachableError } = await import('./tmux.js');

--- a/src/lib/tmux-resolve.test.ts
+++ b/src/lib/tmux-resolve.test.ts
@@ -14,6 +14,16 @@ mock.module('./tmux-wrapper.js', () => ({
   executeTmux: mockExecuteTmux,
   genieTmuxPrefix: () => ['-L', 'genie', '-f', '/dev/null'],
   genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
+  // Passthrough matches the real implementation (issue #1223): the mock
+  // must preserve behavior because Bun's mock.module is process-global,
+  // so tmux-wrapper.test.ts can race and see this stub.
+  prependEnvVars: (command: string, env?: Record<string, string>) => {
+    if (!env || Object.keys(env).length === 0) return command;
+    const envArgs = Object.entries(env)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ');
+    return `env ${envArgs} ${command}`;
+  },
 }));
 
 const { resolveRepoSession } = await import('./tmux.js');

--- a/src/lib/tmux.test.ts
+++ b/src/lib/tmux.test.ts
@@ -12,6 +12,16 @@ mock.module('./tmux-wrapper.js', () => ({
   executeTmux: mockExecuteTmux,
   genieTmuxPrefix: () => ['-L', 'genie', '-f', '/dev/null'],
   genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
+  // Passthrough matches the real implementation (issue #1223): the mock
+  // must preserve behavior because Bun's mock.module is process-global,
+  // so tmux-wrapper.test.ts can race and see this stub.
+  prependEnvVars: (command: string, env?: Record<string, string>) => {
+    if (!env || Object.keys(env).length === 0) return command;
+    const envArgs = Object.entries(env)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ');
+    return `env ${envArgs} ${command}`;
+  },
 }));
 
 // Must import after mock.module

--- a/src/services/executors/__tests__/claude-code-deliver.test.ts
+++ b/src/services/executors/__tests__/claude-code-deliver.test.ts
@@ -14,6 +14,18 @@ mock.module('../../../lib/tmux-wrapper.js', () => ({
   executeTmux: mockExecuteTmux,
   genieTmuxPrefix: () => ['-L', 'genie'],
   genieTmuxCmd: (sub: string) => `tmux -L genie ${sub}`,
+  // Must mirror real export surface — omitting any export poisons Bun's
+  // module cache globally and breaks concurrent tests that import it
+  // (issue #1223). Passthrough matches the real implementation so the
+  // tmux-wrapper.test.ts suite still sees correct behavior when its
+  // import happens to win the mock-cache race.
+  prependEnvVars: (command: string, env?: Record<string, string>) => {
+    if (!env || Object.keys(env).length === 0) return command;
+    const envArgs = Object.entries(env)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ');
+    return `env ${envArgs} ${command}`;
+  },
 }));
 
 // isPaneAlive lives in tmux.ts and calls executeTmux internally; by stubbing

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -2173,8 +2173,19 @@ export async function handleWorkerStop(name: string): Promise<void> {
     return;
   }
 
+  // suspendWorker operates on executor IDs, not agent IDs. If the agent has no
+  // current executor linked (native-spawn path, or already terminated but not
+  // archived), we can't suspend it — explain why instead of failing silently.
+  if (!w.currentExecutorId) {
+    console.error(`Cannot stop agent "${w.id}" — no active executor linked.`);
+    console.error('  The agent may have already exited, or was spawned without');
+    console.error('  executor tracking (e.g. native Claude Code teammate).');
+    console.error(`  To remove the agent row, use: genie kill ${w.id}`);
+    process.exit(1);
+  }
+
   const { suspendWorker } = await import('../lib/idle-timeout.js');
-  const ok = await suspendWorker(w.id);
+  const ok = await suspendWorker(w.currentExecutorId);
   if (ok) {
     console.log(`Agent "${w.id}" stopped.`);
     if (w.claudeSessionId) {
@@ -2183,7 +2194,9 @@ export async function handleWorkerStop(name: string): Promise<void> {
     console.log(`  Send a message to auto-resume: genie send '...' --to ${w.id}`);
     recordAuditEvent('worker', w.id, 'stop', getActor(), { name }).catch(() => {});
   } else {
-    console.error(`Failed to stop agent "${w.id}".`);
+    console.error(`Failed to stop agent "${w.id}" — executor ${w.currentExecutorId} not found in executors table.`);
+    console.error('  This indicates a stale current_executor_id FK. Try:');
+    console.error(`    genie kill ${w.id}    # force remove the agent row`);
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary
Fixes #1189 — `genie stop <name>` used to print a generic "Failed to stop agent" and exit 1 with no diagnostic info.

## Root cause
`handleWorkerStop` passed `agent.id` to `suspendWorker`, which expects an `executorId` (executors.id, not agents.id). When the two diverge — canonical agents, native-spawn teammates, or a stale `current_executor_id` FK — `suspendWorker`'s `executors.find(e.id === agentId)` returned undefined → false → silent failure.

## Fix
- Pass `w.currentExecutorId` to `suspendWorker`.
- Surface each failure mode with an actionable stderr message:
  - No executor linked → suggest `genie kill` to remove the row.
  - Stale FK → explain and suggest `genie kill`.
- Cherry-picks #1224 (mock passthrough) so the pre-push gate passes; those 6 lines are absorbed when #1224 merges.

## Test plan
- [x] `bun run check` — 3251 pass / 0 fail
- [x] Manual path-check: `handleWorkerStop` still early-returns on `suspended`, still records audit event on success.
- [ ] Manual: reproduce the #1189 scenario against a canonical agent after merge.

Closes #1189