### PR TITLE
fix(tmux): disable default right-click menus corrupting TUI render

### DIFF
--- a/scripts/tmux/genie.tmux.conf
+++ b/scripts/tmux/genie.tmux.conf
@@ -133,3 +133,15 @@ bind -n DoubleClick1Status choose-tree -s
 bind -n DoubleClick1StatusDefault choose-tree -s
 bind -n DoubleClick1StatusLeft choose-tree -s
 bind -n DoubleClick1StatusRight choose-tree -s
+
+# Disable tmux 3.3+ default right-click context menus (issue #1153).
+# Agent panes are shells, but the menus still confuse the "tmux is invisible"
+# mental model. Keeping the agent server in lockstep with the TUI server.
+unbind -n MouseDown3Pane
+unbind -n MouseDown3Status
+unbind -n MouseDown3StatusLeft
+unbind -n MouseDown3StatusRight
+unbind -n MouseDown3StatusDefault
+unbind -n M-MouseDown3Pane
+unbind -n M-MouseDown3Status
+unbind -n M-MouseDown3StatusLeft

--- a/scripts/tmux/tui-tmux.conf
+++ b/scripts/tmux/tui-tmux.conf
@@ -43,3 +43,15 @@ set -g pane-active-border-style "fg=#7b2ff7"
 # TUI keybindings are set in the root table by serve.ts
 set -g prefix None
 unbind C-b
+
+# Disable tmux 3.3+ default right-click context menus (issue #1153).
+# The TUI renders its own UI — display-menu overlays corrupt that render
+# and aren't redrawn when dismissed, leaving stale glyphs behind.
+unbind -n MouseDown3Pane
+unbind -n MouseDown3Status
+unbind -n MouseDown3StatusLeft
+unbind -n MouseDown3StatusRight
+unbind -n MouseDown3StatusDefault
+unbind -n M-MouseDown3Pane
+unbind -n M-MouseDown3Status
+unbind -n M-MouseDown3StatusLeft


### PR DESCRIPTION
## Summary
Fixes #1153. tmux 3.3+ ships default `MouseDown3*` bindings that invoke `display-menu` ("Horizontal Split / Vertical Split / Kill / ..."). The TUI renders its own UI — the menu overlays on top of that UI and isn't redrawn when dismissed, leaving stale glyphs and misaligned columns until a forced redraw.

## Changes
Unbind `MouseDown3Pane`, `MouseDown3Status{,Left,Right,Default}`, and corresponding `M-` variants in:
- `scripts/tmux/tui-tmux.conf` (TUI display server `-L genie-tui`) — where the corruption is visible.
- `scripts/tmux/genie.tmux.conf` (agent server `-L genie`) — keep servers in lockstep with the "tmux is invisible" mental model.

## Test plan
- [x] `bun run check` — 3251 pass / 0 fail
- [x] Config lint: both files parse cleanly via `tmux new-session -d ... source-file ... kill-server` (exit 0)
- [ ] Manual: right-click inside `genie` TUI no longer pops display-menu

## User workaround
Append the same block to `~/.genie/tui-tmux.conf` and `~/.genie/tmux.conf`, then `tmux -L <server> source-file <path>` to reload.

Closes #1153