### PR TITLE
fix(teams): archive agent rows on team disband (closes #1215)

### DIFF
--- a/src/lib/agent-registry.test.ts
+++ b/src/lib/agent-registry.test.ts
@@ -661,6 +661,39 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
       await findOrCreateAgent('c', 'team2', 'engineer');
       expect((await listAgents({ team: 'team1', role: 'engineer' })).length).toBe(1);
     });
+
+    test('excludes archived rows by default (issue #1215)', async () => {
+      const archived = await findOrCreateAgent('stale', 'disbanded-team', 'engineer');
+      const live = await findOrCreateAgent('fresh', 'active-team', 'engineer');
+
+      // Flip the disbanded row to archived (mirrors archiveTeam/disbandTeam path)
+      const sql = await getConnection();
+      await sql`UPDATE agents SET state = 'archived' WHERE id = ${archived.id}`;
+
+      const names = (await listAgents()).map((a) => a.id);
+      expect(names).toContain(live.id);
+      expect(names).not.toContain(archived.id);
+
+      // Filter variants must also exclude archived by default
+      expect((await listAgents({ team: 'disbanded-team' })).length).toBe(0);
+      expect((await listAgents({ role: 'engineer' })).map((a) => a.id)).not.toContain(archived.id);
+      expect((await listAgents({ team: 'disbanded-team', role: 'engineer' })).length).toBe(0);
+    });
+
+    test('includeArchived=true surfaces archived rows for audit', async () => {
+      const archived = await findOrCreateAgent('stale', 'disbanded-team', 'engineer');
+      const live = await findOrCreateAgent('fresh', 'active-team', 'engineer');
+
+      const sql = await getConnection();
+      await sql`UPDATE agents SET state = 'archived' WHERE id = ${archived.id}`;
+
+      const ids = (await listAgents({ includeArchived: true })).map((a) => a.id);
+      expect(ids).toContain(live.id);
+      expect(ids).toContain(archived.id);
+
+      // Team scope + includeArchived returns the orphan
+      expect((await listAgents({ team: 'disbanded-team', includeArchived: true })).length).toBe(1);
+    });
   });
 
   // ==========================================================================

--- a/src/lib/agent-registry.ts
+++ b/src/lib/agent-registry.ts
@@ -693,36 +693,50 @@ export async function getAgentEffectiveState(agentId: string): Promise<ExecutorS
 interface ListAgentsFilter {
   team?: string;
   role?: string;
+  /**
+   * When true, include rows with `state = 'archived'`. Default false — the
+   * common case (`genie ls`, wish status, send/show) must NOT see orphan rows
+   * from disbanded teams. Pass `true` for audit/history listings (issue #1215).
+   */
+  includeArchived?: boolean;
 }
 
 /** List agent identities with optional filters. */
 export async function listAgents(filters?: ListAgentsFilter): Promise<AgentIdentity[]> {
   const sql = await getConnection();
+  const includeArchived = filters?.includeArchived ?? false;
   let rows: AgentIdentityRow[];
 
   if (filters?.team && filters?.role) {
     rows = await sql<AgentIdentityRow[]>`
       SELECT id, started_at, role, custom_name, team, native_agent_id, native_color,
              native_team_enabled, parent_session_id, current_executor_id, reports_to, title, created_at, updated_at
-      FROM agents WHERE team = ${filters.team} AND role = ${filters.role}
+      FROM agents
+      WHERE team = ${filters.team} AND role = ${filters.role}
+        AND (${includeArchived} OR state IS DISTINCT FROM 'archived')
     `;
   } else if (filters?.team) {
     rows = await sql<AgentIdentityRow[]>`
       SELECT id, started_at, role, custom_name, team, native_agent_id, native_color,
              native_team_enabled, parent_session_id, current_executor_id, reports_to, title, created_at, updated_at
-      FROM agents WHERE team = ${filters.team}
+      FROM agents
+      WHERE team = ${filters.team}
+        AND (${includeArchived} OR state IS DISTINCT FROM 'archived')
     `;
   } else if (filters?.role) {
     rows = await sql<AgentIdentityRow[]>`
       SELECT id, started_at, role, custom_name, team, native_agent_id, native_color,
              native_team_enabled, parent_session_id, current_executor_id, reports_to, title, created_at, updated_at
-      FROM agents WHERE role = ${filters.role}
+      FROM agents
+      WHERE role = ${filters.role}
+        AND (${includeArchived} OR state IS DISTINCT FROM 'archived')
     `;
   } else {
     rows = await sql<AgentIdentityRow[]>`
       SELECT id, started_at, role, custom_name, team, native_agent_id, native_color,
              native_team_enabled, parent_session_id, current_executor_id, reports_to, title, created_at, updated_at
       FROM agents
+      WHERE (${includeArchived} OR state IS DISTINCT FROM 'archived')
     `;
   }
 

--- a/src/lib/team-manager.test.ts
+++ b/src/lib/team-manager.test.ts
@@ -434,6 +434,30 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
         expect(disbanded).toBe(false);
       });
 
+      test('archives agent rows belonging to the disbanded team (issue #1215)', async () => {
+        await createTeam('feat/archive-agents', TEST_REPO, 'dev');
+
+        // Insert two agent rows directly: one for this team, one for an unrelated team
+        const sql = await getConnection();
+        const theirId = `test-${Date.now()}-their`;
+        const otherId = `test-${Date.now()}-other`;
+        await sql`
+          INSERT INTO agents (id, pane_id, session, repo_path, state, team, role, started_at)
+          VALUES
+            (${theirId}, '', '', '', 'idle', ${'feat/archive-agents'}, 'engineer', now()),
+            (${otherId}, '', '', '', 'idle', 'feat/other-team', 'engineer', now())
+        `;
+
+        await disbandTeam('feat/archive-agents');
+
+        const theirRow = await sql`SELECT state FROM agents WHERE id = ${theirId}`;
+        const otherRow = await sql`SELECT state FROM agents WHERE id = ${otherId}`;
+
+        expect(theirRow[0].state).toBe('archived');
+        // Other teams' agents must stay untouched
+        expect(otherRow[0].state).toBe('idle');
+      });
+
       test('cleans up Claude teams settings directory', async () => {
         const CLAUDE_DIR = join(TEST_DIR, 'claude-config');
         process.env.CLAUDE_CONFIG_DIR = CLAUDE_DIR;

--- a/src/lib/team-manager.ts
+++ b/src/lib/team-manager.ts
@@ -611,13 +611,29 @@ export async function archiveTeam(teamName: string): Promise<boolean> {
   await cleanupTeamTmuxSession(config.tmuxSessionName ?? teamName, teamName);
 
   const sql = await getConnection();
-  const result = await sql`
-    UPDATE teams SET status = 'archived', archived_at = now(), updated_at = now()
-    WHERE name = ${teamName}
-  `;
-  if (result.count === 0) return false;
+  let archivedAgents = 0;
+  let updated = false;
+  await sql.begin(async (tx: typeof sql) => {
+    const result = await tx`
+      UPDATE teams SET status = 'archived', archived_at = now(), updated_at = now()
+      WHERE name = ${teamName}
+    `;
+    if (result.count === 0) return;
+    updated = true;
 
-  recordAuditEvent('team', teamName, 'archived', getActor(), { repo: config.repo }).catch(() => {});
+    // Archive agent rows owned by this team so listAgents (and all the
+    // dashboards that read it) stop serving orphans. State is preserved for
+    // audit; downstream callers pass includeArchived=true when they need
+    // history.
+    const agentResult = await tx`
+      UPDATE agents SET state = 'archived', updated_at = now()
+      WHERE team = ${teamName} AND state IS DISTINCT FROM 'archived'
+    `;
+    archivedAgents = agentResult.count ?? 0;
+  });
+  if (!updated) return false;
+
+  recordAuditEvent('team', teamName, 'archived', getActor(), { repo: config.repo, archivedAgents }).catch(() => {});
   return true;
 }
 
@@ -708,6 +724,16 @@ export async function disbandTeam(teamName: string): Promise<boolean> {
       WHERE name = ${teamName}
     `;
     disbanded = result.count > 0;
+
+    // Archive agent rows owned by this team in the same transaction. Without
+    // this, listAgents serves orphan rows forever (issue #1215). State is
+    // preserved for audit — callers pass includeArchived=true for history.
+    if (disbanded) {
+      await tx`
+        UPDATE agents SET state = 'archived', updated_at = now()
+        WHERE team = ${teamName} AND state IS DISTINCT FROM 'archived'
+      `;
+    }
   });
 
   if (!disbanded) return false;


### PR DESCRIPTION
Fixes #1215.

## Problem

When a team is disbanded or archived, its \`agents\` rows were never transitioned to \`state = 'archived'\` — they stayed in the DB forever. \`listAgents\` (used by \`genie ls --json\`, wish status Active Executors, events timeline joins, send/show/exec listings) had no state filter, so every row ever created kept surfacing alongside live agents. The composite unique \`(custom_name, team)\` from PR #1211 let new rows coexist with orphan ones — operators saw both in \`ls --json\`. Five BUGLESS-GENIE punch-list items collapsed into this root cause.

Migration 015 already added \`'archived'\` to the state CHECK and \`idx_agents_not_archived\`. Both were dead code — nothing wrote the state, nothing read past the index. This PR wires both.

## Fix

### Tier 1 — Write path (surgical)

**\`archiveTeam\`** now runs the team UPDATE inside a transaction and also flips the agent rows:

\`\`\`ts
UPDATE agents SET state = 'archived', updated_at = now()
WHERE team = \${teamName} AND state IS DISTINCT FROM 'archived'
\`\`\`

Audit event payload now includes \`archivedAgents\` count for observability.

**\`disbandTeam\`** adds the same UPDATE inside its existing transaction, guarded by the teams UPDATE matching (no ghost archival for nonexistent teams).

### Tier 2 — Read path

\`ListAgentsFilter\` gets a new optional \`includeArchived?: boolean\`. Default false — every call path defaults to excluding archived, so \`genie ls\`, wish status, send, show, etc. all immediately stop serving orphans without any caller changes. Pass \`includeArchived: true\` for audit/history listings.

All four query variants (no filter / team / role / team+role) now include \`AND (\${includeArchived} OR state IS DISTINCT FROM 'archived')\`. This activates the previously-unused \`idx_agents_not_archived\`.

### Not in this PR (follow-ups)

- **Tier 3 backfill migration** for pre-existing orphans — one-shot schema change, deserves its own review cycle.
- **Tier 4 observability hook** — belongs in the observability wish; audit event payload already includes \`archivedAgents\` count for now.
- **\`--all\` flag on \`genie ls\`** — no current caller needs archived, deferred until an explicit audit use-case lands.

## Test plan

- [x] \`src/lib/agent-registry.test.ts\` — default-excludes-archived, includeArchived=true surfaces orphans, team-scoped filter excludes archived.
- [x] \`src/lib/team-manager.test.ts\` — disbandTeam flips its agents to archived while leaving other teams' agents untouched.
- [x] \`bun run check\` — 3254 tests pass, no typecheck/biome regressions.

## Related

- PR #1211 — composite unique on \`(custom_name, team)\` (complementary; prevents cross-team collisions).
- Migration 015 — added the \`'archived'\` enum value and selective index this PR finally activates.