### PR TITLE
docs(skills): fix genie task status verb drift + add Verb Anatomy section

### DIFF
--- a/skills/dream/SKILL.md
+++ b/skills/dream/SKILL.md
@@ -87,7 +87,7 @@ genie team hire qa             # for QA loop on dev
    - Same-layer wishes dispatch in parallel.
    - Dispatch workers via `genie work <agent> <slug>#<group>` — gets state tracking for free.
    - Parallel groups within a wish dispatched simultaneously.
-3. Monitor via `genie task status <slug>`. Mark groups done via `genie task done <ref>`.
+3. Monitor via `genie wish status <slug>`. Mark groups done via `genie wish done <slug>#<group>` (and, when PG tasks exist, `genie task done #<seq>`).
 4. **Track progress (v4):** as each wish starts execution, move its child task:
    ```bash
    genie task move #<wish-seq> --to build --comment "Execution started"
@@ -192,4 +192,4 @@ When PG is available, the dream run is fully tracked in the task system:
 - Do not expand scope beyond what WISH.md defines.
 - Always write DREAM-REPORT.md, even if all wishes BLOCKED.
 - Poll CI status instead of sleeping — never use `sleep` in CI retry loops.
-- Use `genie task done`, `genie task status`, and `genie reset` for state tracking.
+- Use `genie wish done`, `genie wish status`, and `genie wish reset` for wish-group state; use `genie task …` subcommands for PG task tracking. The two namespaces are distinct — do not substitute one for the other.

--- a/skills/genie-hacks/SKILL.md
+++ b/skills/genie-hacks/SKILL.md
@@ -69,8 +69,8 @@ The canonical hacks live in the docs at `genie/hacks.mdx`. Below is the embedded
   genie team create api-v2 --repo . --wish api-v2
 
   # Monitor both
-  genie task status auth-refactor
-  genie task status api-v2
+  genie wish status auth-refactor
+  genie wish status api-v2
 
   # Cross-team messaging
   genie agent send 'auth-refactor is done, you can proceed' --to api-v2-team-lead
@@ -227,7 +227,7 @@ The canonical hacks live in the docs at `genie/hacks.mdx`. Below is the embedded
 
   # Check team status
   genie team ls my-team
-  genie task status my-wish-slug
+  genie wish status my-wish-slug
 
   # Unstick a blocked group
   genie wish reset my-wish-slug#2

--- a/skills/genie/SKILL.md
+++ b/skills/genie/SKILL.md
@@ -74,14 +74,23 @@ Then invoke the skill using the Skill tool, or run the command via Bash.
 
 ## Operational Command Mapping
 
-When the user's intent is **operational**, map natural language to genie CLI commands:
+When the user's intent is **operational**, map natural language to genie CLI commands. **The CLI has two distinct lifecycle namespaces — don't confuse them:**
+
+- **`genie wish …`** — wish-group state (progress, reset, done per `<slug>#<group>`). Source of truth for execution waves.
+- **`genie task …`** — PG task lifecycle (checkout, move, comment, done per `#<seq>`). Source of truth for backlog + board.
 
 | User says | Command |
 |-----------|---------|
 | "check team status" / "how's the team" | `genie team ls` |
 | "spawn an engineer" / "start an engineer" | `genie spawn engineer` |
 | "list agents" / "show agents" | `genie ls` |
-| "show wish progress" / "status of [slug]" | `genie task status [slug]` |
+| **"show wish progress" / "status of [slug]"** | **`genie wish status <slug>`** (NOT `genie task status` — that verb does not exist) |
+| "mark wish group done" | `genie wish done <slug>#<group>` |
+| "reset a stuck group" | `genie wish reset <slug>#<group>` |
+| "list all wishes" | `genie wish list` |
+| "show my tasks" / "backlog" | `genie task list` |
+| "claim a task" / "start working on #N" | `genie task checkout #<seq>` |
+| "mark task done" | `genie task done #<seq>` |
 | "kill agent X" / "stop X" | `genie kill X` or `genie stop X` |
 | "send message to X" | `genie send 'msg' --to X` |
 | "create a team for X" | `genie team create X --repo .` |
@@ -89,7 +98,29 @@ When the user's intent is **operational**, map natural language to genie CLI com
 
 ## CLI Commands (live)
 
-!`genie --help 2>/dev/null | head -50`
+Top-level verb listing — consult this on every session after `genie update` (see Rules):
+
+!`genie --help 2>/dev/null`
+
+## Verb Anatomy (subcommand trees)
+
+Top-level `--help` shows namespaces but hides their subcommands. These four namespaces carry 80% of orchestration traffic — re-read after any CLI version bump, because verbs migrate (`genie task status` → `genie wish status` happened in 4.260420.x).
+
+### `genie wish` — wish-group lifecycle
+
+!`genie wish --help 2>/dev/null`
+
+### `genie task` — PG task lifecycle
+
+!`genie task --help 2>/dev/null`
+
+### `genie team` — team lifecycle
+
+!`genie team --help 2>/dev/null`
+
+### `genie agent` — agent lifecycle
+
+!`genie agent --help 2>/dev/null`
 
 ## Reference
 
@@ -107,3 +138,5 @@ For questions about the wish lifecycle, skill descriptions, or how genie works, 
 - For prompt refinement, suggest `/refine`.
 - NEVER use the Agent tool to spawn agents — use `genie spawn` instead.
 - NEVER use TeamCreate/TeamDelete — use `genie team create` / `genie team disband`.
+- **Wish progress uses `genie wish status <slug>` — NOT `genie task status`.** The `task` subcommand has no `status` verb; it will error with `unknown command 'status'`. `genie task` is for PG tasks (`list`, `show`, `checkout`, `move`, `done`, `comment`, `block`).
+- **After any `genie update` / version bump, re-read `genie wish --help` and `genie task --help` before typing yesterday's verbs.** Verb namespaces evolve (`genie done`, `genie wish done`, `genie task done` all exist and do different things). Muscle memory is a landmine; the live `--help` output in the sections above is the only source of truth.

--- a/skills/genie/reference/lifecycle.md
+++ b/skills/genie/reference/lifecycle.md
@@ -39,7 +39,7 @@ This creates a git worktree, hires default agents (team-lead, engineer, reviewer
 ```bash
 genie team ls                         # List all teams
 genie team ls my-feature              # Show team members
-genie task status my-feature-slug     # Wish group progress
+genie wish status my-feature-slug     # Wish group progress
 genie agent log team-lead             # Unified log
 genie agent log team-lead --raw       # Raw pane output
 ```

--- a/skills/pm/SKILL.md
+++ b/skills/pm/SKILL.md
@@ -342,8 +342,8 @@ genie team disband <name>
 ```bash
 genie agent spawn <role>
 genie work <slug>
-genie task status <slug>
-genie task done <slug>#<group>
+genie wish status <slug>
+genie wish done <slug>#<group>
 genie wish reset <slug>#<group>
 ```
 
@@ -368,7 +368,7 @@ genie task move #42 --to build
 genie team create rate-limiting --repo . --wish rate-limiting
 
 # 5. Monitor: track progress
-genie task status rate-limiting
+genie wish status rate-limiting
 genie events summary --today
 
 # 6. Review: validate work

--- a/skills/report/SKILL.md
+++ b/skills/report/SKILL.md
@@ -246,7 +246,7 @@ genie agent send 'Trace: genie work dispatches engineers but they start idle. Ch
 
 # 3. Capture evidence
 # Screenshot of idle engineer pane showing empty ❯ prompt
-# Output of: genie task status <slug> showing "in_progress" but no actual progress
+# Output of: genie wish status <slug> showing "in_progress" but no actual progress
 
 # 4. Create GitHub issue with all findings
 gh issue create --title "bug: genie work dispatch — engineers spawn idle without initial task prompt" --body "$(cat <<'EOF'
@@ -259,7 +259,7 @@ protocolRouter.sendMessage fails silently under concurrent dispatch (4/6 enginee
 
 ## Evidence
 - [Screenshot: idle engineer pane]
-- genie task status shows in_progress but engineers at empty prompt
+- genie wish status shows in_progress but engineers at empty prompt
 - Native inbox files: engineer-1 through engineer-4 have no dispatch message
 
 ## Steps to Reproduce

--- a/skills/trace/SKILL.md
+++ b/skills/trace/SKILL.md
@@ -66,7 +66,7 @@ An engineer reports that `genie work` dispatches engineers but they sit idle. Th
 genie agent spawn tracer
 
 # 2. Send the symptoms
-genie agent send 'Trace: genie work dispatches engineers but they start idle at the prompt. No task received. genie task status shows in_progress but nothing happens. Check dispatch.ts workDispatchCommand and protocol-router.ts sendMessage.' --to tracer
+genie agent send 'Trace: genie work dispatches engineers but they start idle at the prompt. No task received. genie wish status shows in_progress but nothing happens. Check dispatch.ts workDispatchCommand and protocol-router.ts sendMessage.' --to tracer
 
 # 3. Wait for findings
 sleep 60 && genie agent log tracer --raw

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -112,7 +112,7 @@ Depends-on: <group refs or "none">
 ## State Management
 
 - **Workers signal** completion via `genie agent send` to the leader when a group is done.
-- **Leader tracks** state via `genie task status <slug>` and marks groups complete via `genie task done <ref>`.
+- **Leader tracks** wish-group state via `genie wish status <slug>` and marks groups complete via `genie wish done <slug>#<group>` (and, when PG tasks exist, `genie task done #<seq>`).
 - Workers do NOT call `genie task done` — that is the leader's responsibility after verifying the work.
 - If a group gets stuck, the leader can use `genie wish reset <ref>` to retry.
 
@@ -150,11 +150,11 @@ genie work fix-dispatch-initial-prompt
 #         🔧 Dispatching work to engineer for "fix-dispatch-initial-prompt#1"
 
 # 2. Monitor (ALWAYS sleep 60 between checks)
-sleep 60 && genie task status fix-dispatch-initial-prompt
+sleep 60 && genie wish status fix-dispatch-initial-prompt
 # Output: Group 1: 🔄 in_progress
 
 # 3. Check again
-sleep 60 && genie task status fix-dispatch-initial-prompt
+sleep 60 && genie wish status fix-dispatch-initial-prompt
 # Output: Group 1: ✅ done — Progress: 1/1 done
 
 # 4. All groups done → local review


### PR DESCRIPTION
## Summary

Every \`genie task status <slug>\` in the skills corpus was a **broken command** — the \`task\` subcommand has no \`status\` verb (errors with \`unknown command 'status'\`). The correct namespace is \`genie wish status\`, introduced in 4.260420.x. This PR fixes 14 stale references across 8 skill files **and** adds a structural defense so the trap doesn't re-surface on the next verb migration.

## Why this happened

\`skills/genie/SKILL.md\` (the root skill that teaches every agent) was truncating its live help output with \`!\`genie --help 2>/dev/null | head -50\`\`. The top-level verb listing hides subcommand trees by design — and the \`wish\` namespace lives below the 50-line cut on modern CLI versions. Agents loading the skill saw the namespaces but never the subcommand anatomy, so \`wish status\` stayed invisible while stale \`task status\` muscle memory from older examples won.

## Changes

### Root cause (primary)

**skills/genie/SKILL.md**:
1. **Operational Command Mapping table** — split \`wish\` vs \`task\` namespaces upfront with an explicit disambiguation header. Row for \`status of [slug]\` now reads \`genie wish status <slug>\` with an inline anti-pattern callout: \`(NOT genie task status — that verb does not exist)\`. Added new rows for \`wish done\`, \`wish reset\`, \`wish list\`, \`task list\`, \`task checkout\`, \`task done\`.
2. **CLI Commands section** — removed \`| head -50\` truncation that was hiding subcommands from live help.
3. **NEW Verb Anatomy section** — inline \`genie wish --help\`, \`genie task --help\`, \`genie team --help\`, \`genie agent --help\` so the full subcommand trees are visible on every skill load.
4. **Rules** — added two new rules:
   - \`Wish progress uses genie wish status <slug> — NOT genie task status.\` (trap warning)
   - \`After any genie update, re-read genie wish --help and genie task --help before typing yesterday's verbs.\` (reload-after-update discipline)

### Cascade (example + prescriptive text across downstream skills)

| File | Sites | Change |
|------|-------|--------|
| \`skills/work/SKILL.md\` | 3 | State Management line + 2 example monitor loops |
| \`skills/dream/SKILL.md\` | 2 | Phase 1 monitor + Rules state-tracking line |
| \`skills/pm/SKILL.md\` | 2 | Agent Dispatch block + PM Workflow example |
| \`skills/genie-hacks/SKILL.md\` | 3 | Parallel team monitor + debug pattern |
| \`skills/genie/reference/lifecycle.md\` | 1 | Monitoring section |
| \`skills/trace/SKILL.md\` | 1 | Example bug-report quote |
| \`skills/report/SKILL.md\` | 2 | Example bug-report output |

Even example text is corrected: leaving broken verbs inside examples models bad muscle memory. The lesson needs to be everywhere the old wrong thing was.

## Verification

\`\`\`bash
# Residual grep — only intentional anti-pattern callouts remain
$ grep -rn 'genie task status' skills/
skills/genie/SKILL.md:87: (NOT \`genie task status\` — that verb does not exist)
skills/genie/SKILL.md:107: (\`genie task status\` → \`genie wish status\` happened in 4.260420.x)
skills/genie/SKILL.md:141: **Wish progress uses \`genie wish status <slug>\` — NOT \`genie task status\`.**
\`\`\`

Three remaining mentions are pedagogical: they teach the trap by name instead of silently deleting it.

## Why this belongs in the self-healing roadmap

This is BUGLESS-GENIE adjacent: verb-drift between CLI and skill docs is a class of silent-failure bug that bites every agent on every version bump. The Verb Anatomy section removes the truncation mechanism, the new Rules line creates an explicit reload discipline, and the anti-pattern callouts mean the next agent who reaches for \`genie task status\` hits a teaching moment instead of a broken shell command.

## Test plan

- [x] \`grep -rn 'genie task status' skills/\` shows only the 3 intentional anti-pattern references
- [x] Each corrected command runs cleanly against genie 4.260420.9 (\`genie wish status --help\`, \`genie wish done --help\`, \`genie wish reset --help\`)
- [x] Commit authored as \`namastex888\` via one-shot override, no global config changes
- [x] No \`--no-verify\` anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)