### PR TITLE
feat(brain): opt-out via brain.embedded config for power-user dogfood

### DIFF
--- a/src/term-commands/brain.ts
+++ b/src/term-commands/brain.ts
@@ -355,6 +355,28 @@ async function showVersion(): Promise<void> {
 
 /** Install brain package from GitHub release tarball */
 async function installBrain(): Promise<boolean> {
+  // Honour the brain.embedded=false opt-out. Power-users manage brain as a
+  // standalone global install (typically from the @next dev channel) and do
+  // not want genie fetching a release tarball behind their back.
+  const { loadGenieConfigSync } = await import('../lib/genie-config.js');
+  if (!loadGenieConfigSync().brain.embedded) {
+    console.log('');
+    console.log('  Brain is configured as external (brain.embedded=false).');
+    console.log('  Genie will not install brain into its node_modules.');
+    console.log('');
+    console.log('  Install brain standalone instead:');
+    console.log('    bun install -g @khal-os/brain@next    # dev channel');
+    console.log('    bun install -g @khal-os/brain         # stable channel');
+    console.log('');
+    console.log('  Then run your own brain serve:');
+    console.log('    brain serve --brain-path <path> [--port <port>]');
+    console.log('');
+    console.log('  To re-enable embedded management, remove brain.embedded from');
+    console.log('  ~/.genie/config.json (or set it to true).');
+    console.log('');
+    return true;
+  }
+
   console.log('');
   console.log('  Installing brain from GitHub release (enterprise)...');
   console.log('');

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -482,47 +482,57 @@ async function startForeground(headless?: boolean): Promise<void> {
   await startPgserve();
 
   // 1.5. Start brain server (if @automagik/genie-brain is installed)
-  try {
-    // Dynamic import — brain is optional. If not installed, this throws
-    // and we silently skip. Zero behavior change for users without brain.
-    // @ts-expect-error — brain is enterprise-only, not in genie's deps
-    const brain = await import('@khal-os/brain');
-    if (brain.startEmbeddedBrainServer) {
-      const { getActivePort } = await import('../lib/db.js');
-      const pgPort = getActivePort();
-      if (pgPort) {
-        console.log('  Starting brain server...');
-        // Find brain path — check workspace for a brain/ dir
-        let brainPath: string | undefined;
-        try {
-          const { findWorkspace } = require('../lib/workspace.js') as typeof import('../lib/workspace.js');
-          const ws = findWorkspace();
-          if (ws?.root) {
-            const bp = join(ws.root, 'brain');
-            if (existsSync(bp) && existsSync(join(bp, 'brain.json'))) {
-              brainPath = bp;
+  //
+  // Gated by `brain.embedded` config (default: true). Set `brain.embedded=false`
+  // in ~/.genie/config.json to opt out — power-users can then run `brain serve`
+  // standalone with custom settings (port, brain-path, @next dev channel).
+  const { loadGenieConfigSync } = await import('../lib/genie-config.js');
+  const brainEmbedded = loadGenieConfigSync().brain.embedded;
+  if (!brainEmbedded) {
+    console.log('  Brain server: skipped (brain.embedded=false — managed externally)');
+  } else {
+    try {
+      // Dynamic import — brain is optional. If not installed, this throws
+      // and we silently skip. Zero behavior change for users without brain.
+      // @ts-expect-error — brain is enterprise-only, not in genie's deps
+      const brain = await import('@khal-os/brain');
+      if (brain.startEmbeddedBrainServer) {
+        const { getActivePort } = await import('../lib/db.js');
+        const pgPort = getActivePort();
+        if (pgPort) {
+          console.log('  Starting brain server...');
+          // Find brain path — check workspace for a brain/ dir
+          let brainPath: string | undefined;
+          try {
+            const { findWorkspace } = require('../lib/workspace.js') as typeof import('../lib/workspace.js');
+            const ws = findWorkspace();
+            if (ws?.root) {
+              const bp = join(ws.root, 'brain');
+              if (existsSync(bp) && existsSync(join(bp, 'brain.json'))) {
+                brainPath = bp;
+              }
             }
+          } catch {
+            // No workspace — skip
           }
-        } catch {
-          // No workspace — skip
-        }
 
-        if (brainPath) {
-          const handle = await brain.startEmbeddedBrainServer({
-            brainPath,
-            geniePgPort: pgPort,
-          });
-          handles.brainHandle = { stop: handle.stop, port: handle.port };
-          console.log(`  Brain server ready on port ${handle.port}`);
+          if (brainPath) {
+            const handle = await brain.startEmbeddedBrainServer({
+              brainPath,
+              geniePgPort: pgPort,
+            });
+            handles.brainHandle = { stop: handle.stop, port: handle.port };
+            console.log(`  Brain server ready on port ${handle.port}`);
+          } else {
+            console.log('  Brain server: no brain/ found in workspace (skipped)');
+          }
         } else {
-          console.log('  Brain server: no brain/ found in workspace (skipped)');
+          console.log('  Brain server: pgserve not available (skipped)');
         }
-      } else {
-        console.log('  Brain server: pgserve not available (skipped)');
       }
+    } catch {
+      // Brain not installed — fine, skip silently
     }
-  } catch {
-    // Brain not installed — fine, skip silently
   }
 
   // 2. Report agent tmux server state (don't create empty sessions —

--- a/src/types/genie-config.ts
+++ b/src/types/genie-config.ts
@@ -74,6 +74,23 @@ const OmniConfigSchema = z.object({
   executor: z.enum(['tmux', 'sdk']).optional(),
 });
 
+// Brain integration configuration (@khal-os/brain, enterprise)
+const BrainConfigSchema = z.object({
+  /**
+   * Whether genie manages brain embedded in its own node_modules.
+   *
+   * - `true` (default) — `genie serve` auto-starts `startEmbeddedBrainServer` and
+   *   `genie brain install` downloads the latest release tarball into node_modules.
+   *   Best for non-technical users who want brain "just working".
+   *
+   * - `false` — genie skips all embedded brain lifecycle. Power-users install brain
+   *   standalone (`bun install -g @khal-os/brain@next`) and run `brain serve` with
+   *   their own settings (custom port, brain-path, dev channel, etc.).
+   *   `genie brain install` becomes a no-op that points at the manual install command.
+   */
+  embedded: z.boolean().default(true),
+});
+
 // Council preset configuration
 // Defines a pair of profiles for dual-model deliberation
 const CouncilPresetSchema = z.object({
@@ -119,6 +136,8 @@ export const GenieConfigSchema = z.object({
   otel: OtelConfigSchema.optional(),
   // Omni integration (optional — multi-channel messaging)
   omni: OmniConfigSchema.optional(),
+  // Brain integration (optional — enterprise @khal-os/brain)
+  brain: BrainConfigSchema.default({}),
 });
 
 // Inferred types


### PR DESCRIPTION
## Problem

\`@automagik/genie\` currently auto-installs \`@khal-os/brain\` (from GitHub release tarball, always \`@latest\`) and auto-starts \`startEmbeddedBrainServer\` in \`genie serve\`. Great for non-technical users — **competes with power-user dogfood** who want to run \`@khal-os/brain@next\` standalone with custom flags (port, brain-path, dev channel).

## Solution

One config key. No env var, no CLI flag, no migration prompt.

\`\`\`jsonc
// ~/.genie/config.json
{
  "brain": { "embedded": false }
}
\`\`\`

| Value | \`genie serve\` | \`genie brain install\` |
|-------|-----------------|------------------------|
| \`true\` (default) | Auto-starts embedded server | Downloads tarball + installs |
| \`false\` | Skips embedded server, logs reason | Prints standalone install instructions, exits 0 |

Default preserves existing behavior exactly. Non-technical users unaffected.

## What changed

- **\`src/types/genie-config.ts\`** — \`BrainConfigSchema\` with \`embedded: boolean (default: true)\`; added to \`GenieConfigSchema\`.
- **\`src/term-commands/serve.ts\`** — the existing \`try { import('@khal-os/brain'); ... }\` block now lives inside \`if (brainEmbedded) { ... } else { log skip }\`. (Diff looks big because of re-indentation; net new logic is ~10 lines.)
- **\`src/term-commands/brain.ts\`** — \`installBrain()\` early-returns with standalone install instructions when \`brain.embedded=false\`.

## Power-user workflow (what this enables)

\`\`\`bash
# One-time setup
echo '{"brain":{"embedded":false}}' > ~/.genie/config.json
bun install -g @khal-os/brain@next

# Run brain however you want
brain serve --brain-path ~/my-vault --port 9999

# Genie stays out of the way
genie serve
#   Brain server: skipped (brain.embedded=false — managed externally)
\`\`\`

## Design decision rationale

Plan was reviewed via \`/council\` (questioner, simplifier, architect on Opus). Consensus:
- **Over-engineered rejected:** 3-mode enum (\`auto\`/\`external\`/\`off\`) collapsed to boolean — \`off\` mode serves a user that doesn't exist (they'd just uninstall).
- **Dropped:** env var (\`GENIE_BRAIN_MODE\`), CLI flag (\`--brain-mode\`), migration prompt for stale embedded install.
- **Kept in scope:** config-file only, boolean, zero changes in \`@khal-os/brain\`.

**Deferred to a separate wish (trigger: brain adds 2nd hook beyond \`startEmbeddedBrainServer\`):** architect's \`capabilities.json\` manifest pattern for declarative hook discovery. Solves the silent import-and-introspect smell properly but was judged premature optimization for today's 2-user dogfood need.

## Validation

\`\`\`bash
bun run typecheck       # clean
bun test src/term-commands/brain.test.ts   # 12/12 pass
bunx biome check <touched-files>   # 3 warnings, ALL pre-existing on dev
\`\`\`

## Scope boundary (explicitly out)

- No changes to \`@khal-os/brain\` package itself.
- No env var, no CLI flag, no migration prompt.
- No \`off\` mode.
- No capabilities.json manifest (follow-up wish).