### PR TITLE
fix(serve): make Omni bridge optional so serve survives NATS-less dev

### DIFF
--- a/.genie/wishes/genie-serve-stability/WISH.md
+++ b/.genie/wishes/genie-serve-stability/WISH.md
@@ -1,0 +1,234 @@
+# Wish: Serve Stability — Proven Bug Fixes
+
+| Field | Value |
+|-------|-------|
+| **Status** | DRAFT |
+| **Slug** | `genie-serve-stability` |
+| **Date** | 2026-04-19 |
+| **Design** | _No brainstorm — direct wish_ |
+
+## Summary
+`genie serve` silently exits with code 1 whenever the Omni bridge fails to connect to NATS, which is the default state on any dev machine without NATS running. This makes every CLI command (`genie team create`, `genie ls`, etc.) hang for 16 seconds and fail with a misleading error, which blocks testing genie — which in turn blocks review of PR #1202. This wish fixes the root cause and four related defensive bugs so serve stays up, crashes become visible, and stale-state never silently blocks a CLI call again.
+
+## Scope
+### IN
+- **Bug 0** — Stop `process.exit(1)` on Omni bridge failure; degrade to optional unless `GENIE_OMNI_REQUIRED=1`
+- **Bug 1** — Clean `serve.pid` on normal exit, SIGTERM, SIGINT, and uncaught exception
+- **Bug 2** — Verify PID identity (not just PID existence) in `autoStartDaemon`; reject recycled PIDs
+- **Bug 3** — Ensure `daemon_stopped` event fires on graceful shutdown (regression test)
+- **Bug 4** — Distinguish "tmux socket missing" (permanent) from "pane not found" (transient) in worker reconciliation; unregister workers whose socket no longer exists
+- **Bug 5** — Replace single timeout error with branched message that names the actual failure mode
+- End-to-end repro script: `scripts/tests/repro-serve-stability.sh`
+
+### OUT
+- Redesigning the Omni bridge itself (just making it optional for now)
+- NATS setup documentation / install automation
+- The 54 PR #1202 CodeRabbit/Gemini/Codex comments (separate wish after this unblocks testing)
+- pgserve cold-start performance tuning (16s timeout is fine once Bug 0 is fixed)
+- `tmux -L genie` socket auto-creation on serve start (surfaced during investigation but out of scope)
+
+## Decisions
+| Decision | Rationale |
+|----------|-----------|
+| Omni bridge failure is a `console.warn` + continue, not `process.exit(1)` | The adjacent omni-approval-handler (serve.ts:569) is already wrapped in `try/catch {}` with "non-fatal" comment. The bridge got the wrong classification. Matching the existing pattern is less surprising than a new flag. |
+| Behind `GENIE_OMNI_REQUIRED=1` env var for strict deployments | Production environments that genuinely require omni can opt in without changing the default |
+| PID identity via **process start time** (not random token) | Tokens require IPC to verify. Start-time is already kernel-held and readable via `ps -p <pid> -o lstart=` (macOS) / `/proc/<pid>/stat` (Linux). Store as `{pid}:{startTime}` in serve.pid. |
+| Dead-socket reconciliation is keyed on tmux socket existence, not error string | `TmuxUnreachableError` can be socket-missing OR a transient blip. Check `ls /tmp/tmux-<uid>/genie` separately — if the socket file doesn't exist, every worker on it is permanently dead. |
+| Branched error message in db.ts names 3 concrete cases | *"serve not running"*, *"serve running but pgserve unreachable"*, *"stale PID"* — each suggests a different remediation |
+| Repro script lives at `scripts/tests/repro-serve-stability.sh` | Matches existing `scripts/tests/repro-*.sh` convention for this repo |
+
+## Success Criteria
+- [ ] `genie serve start` stays running when NATS is not available (default dev setup)
+- [ ] `genie serve stop` / SIGTERM emits `daemon_stopped` to `~/.genie/logs/scheduler.log`
+- [ ] `genie serve stop` / SIGTERM / crash removes `~/.genie/serve.pid`
+- [ ] With a live non-serve PID in `serve.pid`, CLI commands do not hang 16s — they spawn a new serve
+- [ ] `GENIE_OMNI_REQUIRED=1 genie serve start` exits non-zero if NATS is down (preserves old strict behavior)
+- [ ] Repro script `scripts/tests/repro-serve-stability.sh` exits 0 (all 5 scenarios verified)
+- [ ] Workers registered on a tmux socket that no longer exists are cleaned in ≤1 scheduler tick
+- [ ] Bun tests added for each bug pass: `bun test src/term-commands/serve.test.ts src/lib/db.test.ts src/lib/agent-registry.test.ts`
+- [ ] `bun run check` passes (typecheck + lint + dead-code + test)
+
+## Execution Strategy
+
+### Wave 1 (parallel — all three groups independent)
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 1 | engineer | Bug 0 + Bug 1 + Bug 3 — serve.ts lifecycle: make bridge optional, wire exit/signal handlers, verify daemon_stopped fires |
+| 2 | engineer | Bug 2 + Bug 5 — db.ts + serve.ts: `{pid}:{startTime}` PID format + identity check + branched timeout message. Backward-compat: reads old single-PID format as stale. |
+| 3 | engineer | Bug 4 — agent-registry.ts: distinguish socket-missing from transient tmux errors, unregister dead-socket workers |
+
+Group 1 and Group 2 both touch `serve.ts` but in different functions (`startForeground` lifecycle vs `writeServePid` format). Merge conflicts are limited to imports; resolve at wave end.
+
+### Wave 2 (validation)
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 4 | qa | End-to-end repro script + manual QA: serve survives no-NATS, CLI doesn't hang on stale PID, dead-socket workers cleaned |
+| review | reviewer | Full review of all changes against success criteria |
+
+## Execution Groups
+
+### Group 1: Serve lifecycle — Bug 0 + Bug 1 + Bug 3
+**Goal:** Serve process no longer exits on bridge failure; all shutdown paths clean up PID file and emit `daemon_stopped`.
+
+**Deliverables:**
+1. `src/term-commands/serve.ts:583-589` — replace `process.exit(1)` on bridge failure with `console.warn('  Omni bridge: degraded — <msg>'); // continue`, gated by `if (process.env.GENIE_OMNI_REQUIRED === '1') process.exit(1)` for strict mode.
+2. `src/term-commands/serve.ts` in `startForeground()` — register cleanup handlers for `SIGTERM`, `SIGINT`, `SIGHUP`, `exit`, and `uncaughtException` that call `removeServePid()` + invoke the existing `shutdown()` sequence.
+3. `src/term-commands/serve.ts` — ensure existing `shutdown()` at line 599 awaits `schedulerHandle.stop()` and its `done` promise so `daemon_stopped` is flushed before exit.
+4. `src/term-commands/serve.test.ts` — new test: spawn `genie serve start --foreground` with `GENIE_NATS_URL=nats://127.0.0.1:1` (refused), assert process stays alive for ≥3s and writes PID file; send SIGTERM, assert PID file removed and `daemon_stopped` appears in scheduler log.
+
+**Acceptance Criteria:**
+- [ ] `genie serve start --foreground` with no NATS running does not exit; prints `Omni bridge: degraded — CONNECTION_REFUSED` and continues
+- [ ] `GENIE_OMNI_REQUIRED=1 genie serve start --foreground` with no NATS exits 1
+- [ ] After SIGTERM, `~/.genie/serve.pid` is gone
+- [ ] After SIGTERM, `~/.genie/logs/scheduler.log` contains a `daemon_stopped` event for the just-stopped daemon
+- [ ] New bun test passes
+
+**Validation:**
+```bash
+bun test src/term-commands/serve.test.ts -t "bridge failure"
+bun test src/term-commands/serve.test.ts -t "graceful shutdown"
+```
+
+**depends-on:** none
+
+---
+
+### Group 2: Auto-start identity — Bug 2 + Bug 5
+**Goal:** `autoStartDaemon` rejects stale `serve.pid` entries whose PID was recycled to a different process; CLI error message names the actual failure mode.
+
+**Deliverables:**
+1. `src/term-commands/serve.ts` — `writeServePid` writes `{pid}:{startTime}` where `startTime` comes from `ps -o lstart= -p $$` (macOS) or `/proc/self/stat` field 22 (Linux). Add a small helper `getProcessStartTime(pid)` covering both.
+2. `src/lib/db.ts:227-257` — `autoStartDaemon` reads `{pid}:{startTime}` from serve.pid. Calls `process.kill(pid, 0)` AND `getProcessStartTime(pid)`. If either fails OR start times don't match, treat as stale and proceed to spawn. Backward compatible: if file has old format (just PID), treat as stale (forces one-time respawn on upgrade).
+3. `src/lib/db.ts:332` — replace single error with branched message:
+   - no serve.pid file → *"genie serve not running. Run: genie serve start"*
+   - serve.pid valid but pgserve unreachable → *"genie serve is running (PID N) but pgserve did not start within 16s. Try: genie serve restart, or check ~/.genie/logs/scheduler.log"*
+   - serve.pid refers to recycled/dead PID → *"Stale ~/.genie/serve.pid (PID N is not our serve process). Removing and retrying…"* and retry once
+4. `src/lib/db.test.ts` — tests for each branch: stale PID + recycled PID + no PID file + valid PID + unhealthy pgserve. Use a mock `getProcessStartTime` to simulate mismatch.
+
+**Acceptance Criteria:**
+- [ ] Writing a live non-serve PID to `serve.pid` no longer causes 16s timeout; serve spawns fresh
+- [ ] Upgrade path: old single-PID format in `serve.pid` is treated as stale, respawn succeeds
+- [ ] Each of the 3 timeout branches produces the named message
+- [ ] Bun tests pass on macOS and Linux (CI matrix)
+
+**Validation:**
+```bash
+bun test src/lib/db.test.ts -t "autoStartDaemon"
+# Manual repro (macOS):
+echo "$$:stub" > ~/.genie/serve.pid  # current shell PID, wrong identity
+time genie ls --json  # must NOT hang 16s
+```
+
+**depends-on:** none — runs in parallel with Group 1. Reads old single-PID format as "stale" for one-time respawn on upgrade; no structural dependency on Group 1's changes.
+
+---
+
+### Group 3: Worker reconciliation — Bug 4
+**Goal:** Workers registered on a tmux socket that no longer exists are marked `error` and cleaned on the next reconciliation tick, instead of failing forever in `recovery_worker_failed`.
+
+**Deliverables:**
+1. `src/lib/agent-registry.ts:304-345` — extend reconciliation: before per-worker `isPaneAlive(pane_id)`, check whether the tmux socket for that worker exists (via `fs.existsSync('/tmp/tmux-<uid>/<socketName>')` — socketName from the worker's session metadata or the global `-L genie` default). If socket is missing, mark ALL workers on that socket as `error`, clear `pane_id`, emit an audit event, and skip the per-worker check.
+2. `src/lib/tmux.ts` (or wherever socket discovery lives) — small helper `isTmuxSocketAlive(name)` that stats the socket file. Share between reconciliation and status command.
+3. `src/lib/agent-registry.test.ts` — test: register worker with a fake `pane_id` on a non-existent socket, run `reconcileStaleSpawns`, assert worker transitions to `error` and `pane_id` is cleared. **Write the test first and verify it FAILS against current `main` — this proves Bug 4 is a real defect, not a refactoring target.** Then apply the fix and confirm the test passes.
+4. Verify scheduler log stops emitting `recovery_worker_failed` for these workers after the fix.
+
+**Acceptance Criteria:**
+- [ ] Worker with dead-socket pane gets `error` state after one reconciliation pass
+- [ ] Scheduler log no longer spams `recovery_worker_failed` for dead-socket workers
+- [ ] Workers on live sockets still get the transient-retry protection (existing behavior preserved)
+- [ ] Bun test passes
+
+**Validation:**
+```bash
+bun test src/lib/agent-registry.test.ts -t "dead socket"
+```
+
+**depends-on:** none
+
+---
+
+### Group 4: End-to-end repro + QA
+**Goal:** One script that exits 0 iff all five bugs are demonstrably fixed, and manual QA confirms genie is usable without NATS.
+
+**Deliverables:**
+1. `scripts/tests/repro-serve-stability.sh` — shell script that runs five scenarios in sequence with temporary `GENIE_HOME`:
+   - **S1 (Bug 0):** start serve with unreachable NATS, sleep 5s, verify process still alive and `serve.pid` present.
+   - **S2 (Bug 1):** kill serve via SIGTERM, verify `serve.pid` removed and `daemon_stopped` in log.
+   - **S3 (Bug 2):** write a live non-serve PID to `serve.pid`, run `genie ls --json`, assert exit 0 within 5s (not 32s).
+   - **S4 (Bug 4):** insert a worker row on a fake tmux socket, run scheduler one tick, assert worker state is `error`.
+   - **S5 (Bug 5):** three timeout scenarios, assert each stderr matches the expected branched message.
+2. Document manual QA checklist in the wish's QA Criteria section.
+
+**Acceptance Criteria:**
+- [ ] `bash scripts/tests/repro-serve-stability.sh` exits 0 on macOS and Linux
+- [ ] Each scenario prints a clear ✅ / ❌ line so failures are easy to identify
+- [ ] Script cleans up its `GENIE_HOME` directory on both success and failure
+
+**Validation:**
+```bash
+bash scripts/tests/repro-serve-stability.sh
+```
+
+**depends-on:** Group 1, Group 2, Group 3
+
+---
+
+## QA Criteria
+
+_Tested on dev after merge before declaring the wish done._
+
+- [ ] Fresh machine (no NATS): `genie serve start` — serve stays up, `genie ls` returns in <3s
+- [ ] `genie serve stop` cleanly exits — no stale PID, `daemon_stopped` logged
+- [ ] Kill serve with SIGKILL (simulates crash): next CLI call auto-starts a new serve within 5s
+- [ ] `genie team create test-xyz --repo $(pwd)` completes successfully without NATS (regression check for the user-visible symptom)
+- [ ] No scheduler log spam over a 5-minute idle window (regression for Bug 3+Bug 4)
+- [ ] PR #1202 test suite can run end-to-end (original blocker)
+
+---
+
+## Assumptions / Risks
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `ps -o lstart=` format differs across macOS versions | Low | Parse defensively; fall back to "unknown" → treat as stale. Test on current macOS + Ubuntu. |
+| Someone is actually running with NATS in production and expects bridge to be mandatory | Medium | `GENIE_OMNI_REQUIRED=1` preserves strict behavior; document in commit message and CHANGELOG. |
+| Dead-socket reconciliation wrongly classifies a transient tmux socket permission blip as permanent | Low | Stat the socket path AND run one retry after 100ms before flipping workers to `error`. |
+| Existing `~/.genie/serve.pid` in old single-PID format after upgrade causes one unnecessary respawn | Low (accepted) | Design intent; documented. |
+| PID file race between shutdown-handler-removing-it and new serve writing it | Low | `writeServePid` uses atomic write (`.tmp` + rename) already; shutdown removes only if the file's PID matches `process.pid`. |
+| Fixing Bug 0 reveals downstream bugs that were masked by early serve death | Medium | Allocate buffer in Group 4 QA to surface and triage. If new bugs appear, file separately rather than expand this wish's scope. |
+
+---
+
+## Review Results
+
+### Plan Review — 2026-04-19 — Round 1
+
+**Verdict:** FIX-FIRST → resolved inline → **SHIP (plan)**
+
+**Gaps addressed:**
+- [HIGH] Wave 2 parallelization — Group 2's "depends-on: Group 1" was overstated; Group 1 only adds exit handlers that call existing `removeServePid`, not the format change. → Fixed: Group 2 moved into Wave 1, now runs parallel with Groups 1 and 3.
+- [MEDIUM] Bug 4 test should fail-first to prove bug is real → Fixed: Group 3 deliverable 3 now mandates failing-test-first verification.
+
+All Plan Review checklist items (problem statement, scope IN/OUT, testable acceptance criteria, bite-sized tasks, dependencies, validation commands) passed on Round 1. Decisions-table calls (GENIE_OMNI_REQUIRED env var, `{pid}:{startTime}` identity, socket-existence reconciliation, branched error, repro-script location) all confirmed sound by reviewer. No scope creep, no missing bug coverage, no correctness concerns in the plan itself.
+
+_Execution review — populated after `/work` completes._
+
+---
+
+## Files to Create/Modify
+
+```
+Modify:
+  src/term-commands/serve.ts         # Bug 0, Bug 1, Bug 2 write-side
+  src/lib/db.ts                      # Bug 2 read-side, Bug 5
+  src/lib/agent-registry.ts          # Bug 4
+  src/lib/tmux.ts                    # (new helper: isTmuxSocketAlive)
+
+Create:
+  src/term-commands/serve.test.ts    # lifecycle tests (may append to existing)
+  scripts/tests/repro-serve-stability.sh
+  .genie/wishes/genie-serve-stability/WISH.md (this file)
+
+Test additions (may be in existing files):
+  src/lib/db.test.ts                 # autoStartDaemon branches
+  src/lib/agent-registry.test.ts     # dead-socket reconciliation
+```

--- a/src/__tests__/migrate.test.ts
+++ b/src/__tests__/migrate.test.ts
@@ -6,6 +6,7 @@ import {
   readFileSync,
   readdirSync,
   readlinkSync,
+  realpathSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -27,8 +28,11 @@ import {
 let testDir: string;
 
 beforeEach(() => {
-  testDir = join(tmpdir(), `genie-migrate-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-  mkdirSync(testDir, { recursive: true });
+  const raw = join(tmpdir(), `genie-migrate-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(raw, { recursive: true });
+  // macOS: tmpdir() lives under /var → /private/var symlink; realpath so
+  // computed paths match what migrate.ts returns after resolving links.
+  testDir = realpathSync(raw);
 });
 
 afterEach(() => {

--- a/src/lib/agent-registry.test.ts
+++ b/src/lib/agent-registry.test.ts
@@ -516,6 +516,100 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
       const a = await get('sdk-worker');
       expect(a!.state).toBe('working');
     });
+
+    test('flips workers registered on a dead socket to error (Bug 4)', async () => {
+      // Bug 4 repro: workers recorded on a tmux socket that no longer exists
+      // were stuck in 'idle'/'working' forever because reconcileStaleSpawns
+      // catches the TmuxUnreachableError from isPaneAlive and skips the worker.
+      // After the fix, a dead socket is detected once up-front and every
+      // worker on it is transitioned to 'error' with pane_id cleared.
+      //
+      // We pick a socket name that we can guarantee does NOT exist under
+      // /tmp/tmux-<uid>/ — any random UUID works.
+      const deadSocketName = `genie-dead-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+      process.env.GENIE_TMUX_SOCKET = deadSocketName;
+      try {
+        const oldChange = new Date(Date.now() - 5_000).toISOString();
+        await register(
+          makeAgent({
+            id: 'dead-socket-worker-1',
+            paneId: '%9999',
+            state: 'idle',
+            startedAt: oldChange,
+            lastStateChange: oldChange,
+          }),
+        );
+        await register(
+          makeAgent({
+            id: 'dead-socket-worker-2',
+            paneId: '%9998',
+            state: 'working',
+            startedAt: oldChange,
+            lastStateChange: oldChange,
+          }),
+        );
+
+        const reset = await reconcileStaleSpawns(2);
+        expect(reset).toContain('dead-socket-worker-1');
+        expect(reset).toContain('dead-socket-worker-2');
+
+        const a1 = await get('dead-socket-worker-1');
+        expect(a1!.state).toBe('error');
+        expect(a1!.paneId).toBe('');
+        const a2 = await get('dead-socket-worker-2');
+        expect(a2!.state).toBe('error');
+        expect(a2!.paneId).toBe('');
+      } finally {
+        // biome-ignore lint/performance/noDelete: assigning undefined would set the string "undefined"
+        delete process.env.GENIE_TMUX_SOCKET;
+      }
+    });
+
+    test('dead socket reconciliation preserves existing behavior on live sockets', async () => {
+      // Sanity check: when the tmux socket DOES exist, the dead-socket
+      // fast path must not fire — workers must go through the normal
+      // per-pane isPaneAlive check (which remains transient-blip-safe).
+      // We force the socket to appear alive by pointing GENIE_TMUX_SOCKET
+      // at a socket file we create in /tmp/tmux-<uid>/.
+      const { existsSync, mkdirSync, writeFileSync, unlinkSync } = await import('node:fs');
+      const { join } = await import('node:path');
+      const { tmpdir } = await import('node:os');
+      const uid = process.getuid?.() ?? 501;
+      const socketDir = `/tmp/tmux-${uid}`;
+      const stubSocketName = `genie-live-stub-${Date.now()}`;
+      const stubPath = join(socketDir, stubSocketName);
+      mkdirSync(socketDir, { recursive: true });
+      writeFileSync(stubPath, '');
+      process.env.GENIE_TMUX_SOCKET = stubSocketName;
+      try {
+        // A fresh (recent) idle row: must NOT be reset because the socket
+        // is alive AND lastStateChange is inside the threshold. This
+        // exercises the preserved transient-retry path.
+        await register(
+          makeAgent({
+            id: 'live-socket-fresh-idle',
+            paneId: '%8888',
+            state: 'idle',
+            lastStateChange: new Date().toISOString(),
+          }),
+        );
+        const reset = await reconcileStaleSpawns(2);
+        expect(reset).not.toContain('live-socket-fresh-idle');
+        const a = await get('live-socket-fresh-idle');
+        expect(a!.state).toBe('idle');
+      } finally {
+        // biome-ignore lint/performance/noDelete: assigning undefined would set the string "undefined"
+        delete process.env.GENIE_TMUX_SOCKET;
+        try {
+          unlinkSync(stubPath);
+        } catch {
+          /* best-effort cleanup */
+        }
+        // silence unused-import warnings if any
+        void existsSync;
+        void tmpdir;
+      }
+    });
   });
 
   describe('templates', () => {

--- a/src/lib/agent-registry.ts
+++ b/src/lib/agent-registry.ts
@@ -20,7 +20,20 @@ import { recordAuditEvent } from './audit.js';
 import { type Sql, getConnection } from './db.js';
 import type { AgentIdentity, ExecutorState } from './executor-types.js';
 import type { ProviderName } from './provider-adapters.js';
-import { isPaneAlive } from './tmux.js';
+import { isPaneAlive, isTmuxSocketAlive } from './tmux.js';
+
+/**
+ * Resolve the tmux socket name a worker row is expected to live on.
+ *
+ * The agents schema does not record a per-worker socket column — every
+ * genie worker runs on the global `-L <socket>` server whose name comes
+ * from `GENIE_TMUX_SOCKET` (default `genie`). This helper exists so the
+ * reconciliation loop has a single source of truth and legacy rows
+ * missing any future per-row socket column fall back safely.
+ */
+function resolveWorkerSocketName(): string {
+  return process.env.GENIE_TMUX_SOCKET || 'genie';
+}
 
 export type AgentState = 'spawning' | 'working' | 'idle' | 'permission' | 'question' | 'done' | 'error' | 'suspended';
 export type TransportType = 'tmux' | 'inline';
@@ -284,6 +297,7 @@ export async function list(): Promise<Agent[]> {
  *
  * @param thresholdSeconds - How long an agent must be stuck before reset (default: 60)
  */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: three sequential reconciliation passes with socket-grouping fast path
 export async function reconcileStaleSpawns(thresholdSeconds = 60): Promise<string[]> {
   try {
     const sql = await getConnection();
@@ -313,7 +327,102 @@ export async function reconcileStaleSpawns(thresholdSeconds = 60): Promise<strin
         AND pane_id IS NOT NULL AND pane_id != ''
         AND started_at < now() - interval '1 second' * ${thresholdSeconds}
     `;
+
+    // Third pass (query): dead-pane zombies in active (non-spawning) states.
+    // Rows whose state is idle/working/permission/question but whose tmux
+    // pane no longer exists (e.g. user killed the session, machine rebooted,
+    // process crashed without state update). These count toward the resume
+    // concurrency cap and permanently block auto-resume once accumulated.
+    // Only rows matching the tmux pane pattern `%\d+` are candidates —
+    // synthetic paneIds ('sdk', 'inline', etc.) are non-tmux transports
+    // with their own liveness source and must not be touched here.
+    const activeDeadCandidates = await sql<{ id: string; pane_id: string; state: string }[]>`
+      SELECT id, pane_id, state FROM agents
+      WHERE state IN ('idle', 'working', 'permission', 'question')
+        AND pane_id ~ '^%[0-9]+$'
+        AND last_state_change < now() - interval '1 second' * ${thresholdSeconds}
+    `;
+
+    // Dead-socket short-circuit (Bug 4).
+    //
+    // Before touching tmux, group the 2nd+3rd pass candidates by the tmux
+    // socket they live on and check the socket file once per unique name.
+    // If the socket is gone, every worker on it is permanently dead —
+    // no need to probe `isPaneAlive` (which would just raise
+    // `TmuxUnreachableError` and cause the per-row catch to skip the
+    // worker forever, as reported in the Bug 4 scheduler-log spam).
+    //
+    // Workers on a LIVE socket keep the existing per-worker
+    // isPaneAlive + try/catch behaviour — that path is correct for
+    // "socket up but pane gone" and for transient tmux blips.
+    type SpawningRow = { id: string; pane_id: string };
+    type ActiveRow = { id: string; pane_id: string; state: string };
+    const socketBuckets = new Map<string, { spawning: SpawningRow[]; active: ActiveRow[] }>();
     for (const row of staleWithPane) {
+      const socket = resolveWorkerSocketName();
+      const bucket = socketBuckets.get(socket) ?? { spawning: [], active: [] };
+      bucket.spawning.push(row);
+      socketBuckets.set(socket, bucket);
+    }
+    for (const row of activeDeadCandidates) {
+      const socket = resolveWorkerSocketName();
+      const bucket = socketBuckets.get(socket) ?? { spawning: [], active: [] };
+      bucket.active.push(row);
+      socketBuckets.set(socket, bucket);
+    }
+
+    const liveSpawning: SpawningRow[] = [];
+    const liveActive: ActiveRow[] = [];
+    for (const [socketName, bucket] of socketBuckets) {
+      if (isTmuxSocketAlive(socketName)) {
+        liveSpawning.push(...bucket.spawning);
+        liveActive.push(...bucket.active);
+        continue;
+      }
+      // Socket is dead — mark every candidate on it as error in one pass.
+      const allIds = [...bucket.spawning.map((r) => r.id), ...bucket.active.map((r) => r.id)];
+      if (allIds.length === 0) continue;
+
+      // Per-row state-guarded UPDATE preserves the concurrent-transition
+      // race protection from the original code.
+      for (const row of bucket.spawning) {
+        const updated = await sql<{ id: string }[]>`
+          UPDATE agents
+          SET state = 'error', last_state_change = now(), pane_id = ''
+          WHERE id = ${row.id} AND state = 'spawning'
+          RETURNING id
+        `;
+        if (updated.length > 0) {
+          console.error(
+            `[reconcile] Reset agent ${row.id} (dead socket ${socketName}, pane ${row.pane_id}) from spawning → error`,
+          );
+          resetIds.push(row.id);
+        }
+      }
+      for (const row of bucket.active) {
+        const prevState = row.state;
+        const updated = await sql<{ id: string }[]>`
+          UPDATE agents
+          SET state = 'error', last_state_change = now(), pane_id = ''
+          WHERE id = ${row.id} AND state = ${prevState}
+          RETURNING id
+        `;
+        if (updated.length > 0) {
+          console.error(
+            `[reconcile] Reset agent ${row.id} (dead socket ${socketName}, pane ${row.pane_id}) from ${prevState} → error`,
+          );
+          resetIds.push(row.id);
+        }
+      }
+      recordAuditEvent('worker', socketName, 'recovery_socket_dead', 'reconciler', {
+        socket: socketName,
+        worker_ids: allIds,
+        worker_count: allIds.length,
+      }).catch(() => {});
+    }
+
+    // Workers on live sockets: run the original per-row liveness probe.
+    for (const row of liveSpawning) {
       try {
         const alive = await isPaneAlive(row.pane_id);
         if (!alive) {
@@ -334,22 +443,7 @@ export async function reconcileStaleSpawns(thresholdSeconds = 60): Promise<strin
         // when we can't verify pane status
       }
     }
-
-    // Third pass: dead-pane zombies in active (non-spawning) states.
-    // Rows whose state is idle/working/permission/question but whose tmux
-    // pane no longer exists (e.g. user killed the session, machine rebooted,
-    // process crashed without state update). These count toward the resume
-    // concurrency cap and permanently block auto-resume once accumulated.
-    // Only rows matching the tmux pane pattern `%\d+` are candidates —
-    // synthetic paneIds ('sdk', 'inline', etc.) are non-tmux transports
-    // with their own liveness source and must not be touched here.
-    const activeDeadCandidates = await sql<{ id: string; pane_id: string; state: string }[]>`
-      SELECT id, pane_id, state FROM agents
-      WHERE state IN ('idle', 'working', 'permission', 'question')
-        AND pane_id ~ '^%[0-9]+$'
-        AND last_state_change < now() - interval '1 second' * ${thresholdSeconds}
-    `;
-    for (const row of activeDeadCandidates) {
+    for (const row of liveActive) {
       try {
         const alive = await isPaneAlive(row.pane_id);
         if (!alive) {

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -486,3 +486,167 @@ describe('migration directory resolution', () => {
     expect(source).toContain('getPackageRootMigrationsDir()');
   });
 });
+
+// ===========================================================================
+// process-identity helper
+// ===========================================================================
+
+describe('getProcessStartTime', () => {
+  test('returns a non-null string for process.pid on macOS and Linux', async () => {
+    const { getProcessStartTime } = await import('./process-identity.js');
+    if (process.platform !== 'darwin' && process.platform !== 'linux') {
+      // Unsupported platform — helper should still return null safely; nothing else to assert.
+      expect(getProcessStartTime(process.pid)).toBeNull();
+      return;
+    }
+    const t = getProcessStartTime(process.pid);
+    expect(t).not.toBeNull();
+    expect(typeof t).toBe('string');
+    expect((t as string).length).toBeGreaterThan(0);
+  });
+
+  test('returns null for a definitely-dead PID', async () => {
+    const { getProcessStartTime } = await import('./process-identity.js');
+    // PID 999999 is almost certainly not in use; even if it is, the kernel
+    // start time lookup on an unrelated process still returns *some* string,
+    // but the most common case is "no such process" → null. On systems
+    // where this PID happens to exist we accept either null or a string.
+    const t = getProcessStartTime(999_999);
+    expect(t === null || typeof t === 'string').toBe(true);
+  });
+
+  test('returns null for non-positive PIDs', async () => {
+    const { getProcessStartTime } = await import('./process-identity.js');
+    expect(getProcessStartTime(0)).toBeNull();
+    expect(getProcessStartTime(-1)).toBeNull();
+    expect(getProcessStartTime(Number.NaN)).toBeNull();
+  });
+});
+
+// ===========================================================================
+// autoStartDaemon identity check (Bug 2)
+// ===========================================================================
+
+describe('autoStartDaemon identity check', () => {
+  let testHome: string;
+  let pidPath: string;
+  let origGenieHome: string | undefined;
+  let spawnCount = 0;
+
+  beforeEach(() => {
+    testHome = join(tmpdir(), `genie-autostart-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(testHome, { recursive: true });
+    pidPath = join(testHome, 'serve.pid');
+    origGenieHome = process.env.GENIE_HOME;
+    process.env.GENIE_HOME = testHome;
+    spawnCount = 0;
+  });
+
+  afterEach(async () => {
+    // Always restore the real spawn fn so other tests aren't affected.
+    const { __setSpawnDaemonForTest } = await import('./db.js');
+    __setSpawnDaemonForTest(null);
+    if (origGenieHome !== undefined) {
+      process.env.GENIE_HOME = origGenieHome;
+    } else {
+      process.env.GENIE_HOME = undefined;
+    }
+    try {
+      const { rmSync } = require('node:fs');
+      rmSync(testHome, { recursive: true, force: true });
+    } catch {}
+  });
+
+  test('spawns when serve.pid is absent', async () => {
+    const { autoStartDaemon, __setSpawnDaemonForTest } = await import('./db.js');
+    __setSpawnDaemonForTest(() => {
+      spawnCount++;
+    });
+    expect(existsSync(pidPath)).toBe(false);
+    await autoStartDaemon();
+    expect(spawnCount).toBe(1);
+  });
+
+  test('returns early when serve.pid identity matches (live PID + matching start time)', async () => {
+    const { autoStartDaemon, __setSpawnDaemonForTest } = await import('./db.js');
+    const { getProcessStartTime } = await import('./process-identity.js');
+
+    const startTime = getProcessStartTime(process.pid);
+    if (startTime === null) {
+      // Can't run this test on an unsupported platform — nothing to verify.
+      return;
+    }
+    writeFileSync(pidPath, `${process.pid}:${startTime}`, 'utf-8');
+
+    __setSpawnDaemonForTest(() => {
+      spawnCount++;
+    });
+    await autoStartDaemon();
+    // Identity matched → no spawn, file left in place.
+    expect(spawnCount).toBe(0);
+    expect(existsSync(pidPath)).toBe(true);
+  });
+
+  test('unlinks and spawns when start time does not match (recycled PID)', async () => {
+    const { autoStartDaemon, __setSpawnDaemonForTest } = await import('./db.js');
+    writeFileSync(pidPath, `${process.pid}:definitely-wrong-start-time`, 'utf-8');
+
+    __setSpawnDaemonForTest(() => {
+      spawnCount++;
+    });
+    await autoStartDaemon();
+    expect(spawnCount).toBe(1);
+    expect(existsSync(pidPath)).toBe(false);
+  });
+
+  test('treats legacy single-PID format as stale', async () => {
+    const { autoStartDaemon, __setSpawnDaemonForTest } = await import('./db.js');
+    // Old format — just a PID, no colon.
+    writeFileSync(pidPath, String(process.pid), 'utf-8');
+
+    __setSpawnDaemonForTest(() => {
+      spawnCount++;
+    });
+    await autoStartDaemon();
+    expect(spawnCount).toBe(1);
+    expect(existsSync(pidPath)).toBe(false);
+  });
+
+  test('unlinks and spawns when PID is dead', async () => {
+    const { autoStartDaemon, __setSpawnDaemonForTest } = await import('./db.js');
+    // PID 999999 is almost certainly dead.
+    writeFileSync(pidPath, '999999:whatever', 'utf-8');
+
+    __setSpawnDaemonForTest(() => {
+      spawnCount++;
+    });
+    await autoStartDaemon();
+    expect(spawnCount).toBe(1);
+    expect(existsSync(pidPath)).toBe(false);
+  });
+
+  test('unlinks and spawns on unparseable content', async () => {
+    const { autoStartDaemon, __setSpawnDaemonForTest } = await import('./db.js');
+    writeFileSync(pidPath, 'not-a-pid:nope', 'utf-8');
+
+    __setSpawnDaemonForTest(() => {
+      spawnCount++;
+    });
+    await autoStartDaemon();
+    expect(spawnCount).toBe(1);
+    expect(existsSync(pidPath)).toBe(false);
+  });
+});
+
+// ===========================================================================
+// Branched timeout error messages (Bug 5)
+// ===========================================================================
+
+describe('autoStartDaemon branched timeout messages', () => {
+  test('db.ts source contains each branch label', () => {
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    expect(source).toContain('genie serve not running. Run: genie serve start');
+    expect(source).toContain('pgserve did not respond on port');
+    expect(source).toContain('Stale ~/.genie/serve.pid');
+  });
+});

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -13,6 +13,7 @@ import { join } from 'node:path';
 import type postgres from 'postgres';
 import { runMigrations } from './db-migrations.js';
 import { needsSeed, runSeed } from './pg-seed.js';
+import { getProcessStartTime } from './process-identity.js';
 
 /**
  * Re-export Sql type for callers that need to annotate sql connection parameters.
@@ -230,37 +231,144 @@ export async function ensurePgserve(): Promise<number> {
   }
 }
 
-/** Auto-start genie serve (headless) if not already running. */
-async function autoStartDaemon(): Promise<void> {
-  // Check if serve is already running via PID file (serve.pid is the canonical source)
-  for (const pidName of ['serve.pid', 'scheduler.pid']) {
-    const pidPath = join(GENIE_HOME, pidName);
-    try {
-      const pidStr = readFileSync(pidPath, 'utf-8').trim();
-      const pid = Number.parseInt(pidStr, 10);
-      if (!Number.isNaN(pid) && pid > 0) {
-        try {
-          process.kill(pid, 0); // Check if alive
-          return; // Already running, just wait for port file
-        } catch {
-          // Stale PID — proceed to start
-        }
-      }
-    } catch {
-      // No PID file — continue checking next
-    }
-  }
+/**
+ * Outcome of the most recent autoStartDaemon() call. Consumed by the branched
+ * timeout error in _ensurePgserve so the user gets a message naming the
+ * actual failure mode instead of a generic timeout.
+ *
+ *   - `missing`   — serve.pid absent; spawned a fresh serve
+ *   - `stale`     — serve.pid existed but its PID was recycled or dead;
+ *                   unlinked the file and spawned a fresh serve
+ *   - `alive`     — serve.pid points at a live serve process whose kernel
+ *                   start time still matches; did NOT respawn
+ *
+ * A module-level variable is acceptable here because autoStartDaemon is only
+ * called from the single-flight _ensurePgserve path (guarded by ensurePromise).
+ */
+type AutoStartOutcome = 'missing' | 'stale' | 'alive';
+let lastAutoStartOutcome: AutoStartOutcome | null = null;
+/** PID that was in serve.pid at the time of the most recent autoStartDaemon() call. */
+let lastAutoStartPid: number | null = null;
 
-  // Start genie serve --headless in background
+/**
+ * Spawn `genie serve start --headless` in the background.
+ * Overridable for tests via {@link __setSpawnDaemonForTest}.
+ */
+let spawnDaemon: () => void = () => {
   const bunPath = process.execPath ?? 'bun';
   const genieBin = process.argv[1] ?? 'genie';
-
   const child = spawn(bunPath, [genieBin, 'serve', 'start', '--headless'], {
     detached: true,
     stdio: 'ignore',
     env: { ...process.env },
   });
   child.unref();
+};
+
+/** Test-only hook: swap the spawn implementation so tests don't launch real serves. */
+export function __setSpawnDaemonForTest(fn: (() => void) | null): void {
+  spawnDaemon =
+    fn ??
+    (() => {
+      const bunPath = process.execPath ?? 'bun';
+      const genieBin = process.argv[1] ?? 'genie';
+      const child = spawn(bunPath, [genieBin, 'serve', 'start', '--headless'], {
+        detached: true,
+        stdio: 'ignore',
+        env: { ...process.env },
+      });
+      child.unref();
+    });
+}
+
+/**
+ * Auto-start genie serve (headless) if it is not already running, validating
+ * PID identity so a recycled PID can't masquerade as a live serve.
+ *
+ * Format of `~/.genie/serve.pid`:
+ *   `{pid}:{startTime}` — new format written by writeServePid
+ *   `{pid}`             — legacy format (always treated as stale on read)
+ *
+ * A file is considered "live" only if BOTH:
+ *   - `process.kill(pid, 0)` succeeds (PID exists), AND
+ *   - `getProcessStartTime(pid)` returns the exact string recorded in the file
+ *
+ * Any other state → treat as stale, unlink, spawn fresh.
+ */
+export async function autoStartDaemon(): Promise<void> {
+  // Resolve GENIE_HOME at call time (not from the module-level constant) so
+  // tests that toggle process.env.GENIE_HOME see the override.
+  const home = process.env.GENIE_HOME ?? GENIE_HOME;
+  const pidPath = join(home, 'serve.pid');
+
+  let raw: string | null = null;
+  try {
+    raw = readFileSync(pidPath, 'utf-8').trim();
+  } catch {
+    raw = null;
+  }
+
+  if (!raw) {
+    lastAutoStartOutcome = 'missing';
+    lastAutoStartPid = null;
+    spawnDaemon();
+    return;
+  }
+
+  const sepIdx = raw.indexOf(':');
+  let pid: number;
+  let recordedStartTime: string | null;
+  if (sepIdx < 0) {
+    // Legacy single-PID format from an older install — always stale.
+    pid = Number.parseInt(raw, 10);
+    recordedStartTime = null;
+  } else {
+    pid = Number.parseInt(raw.slice(0, sepIdx), 10);
+    const tail = raw.slice(sepIdx + 1).trim();
+    recordedStartTime = tail === '' || tail === 'unknown' ? null : tail;
+  }
+
+  if (Number.isNaN(pid) || pid <= 0) {
+    // Unparseable file — treat as stale.
+    try {
+      unlinkSync(pidPath);
+    } catch {
+      /* already gone */
+    }
+    lastAutoStartOutcome = 'stale';
+    lastAutoStartPid = null;
+    spawnDaemon();
+    return;
+  }
+
+  let pidAlive = false;
+  try {
+    process.kill(pid, 0);
+    pidAlive = true;
+  } catch {
+    pidAlive = false;
+  }
+
+  if (pidAlive && recordedStartTime !== null) {
+    const currentStartTime = getProcessStartTime(pid);
+    if (currentStartTime !== null && currentStartTime === recordedStartTime) {
+      lastAutoStartOutcome = 'alive';
+      lastAutoStartPid = pid;
+      return; // Already running with matching identity.
+    }
+  }
+
+  // Either the PID is dead, the start time changed (PID recycled), the
+  // recorded start time was missing (legacy format), or we couldn't look
+  // one up. Treat as stale across the board.
+  try {
+    unlinkSync(pidPath);
+  } catch {
+    /* already gone */
+  }
+  lastAutoStartOutcome = 'stale';
+  lastAutoStartPid = pid;
+  spawnDaemon();
 }
 
 /**
@@ -325,6 +433,8 @@ async function _ensurePgserve(): Promise<number> {
 
   // 4b. CLI command — auto-start genie serve --headless, wait for port file.
   await autoStartDaemon();
+  const outcomeAtStart = lastAutoStartOutcome;
+  const pidAtStart = lastAutoStartPid;
   const deadline = Date.now() + 16000;
   while (Date.now() < deadline) {
     const p = readLockfile();
@@ -336,7 +446,24 @@ async function _ensurePgserve(): Promise<number> {
     await new Promise((r) => setTimeout(r, 500));
   }
   process.env.GENIE_PG_AVAILABLE = 'false';
-  throw new Error('Timed out waiting for genie serve to start pgserve (16s). Run: genie serve');
+
+  // Branch the timeout error so the user sees the actual failure mode.
+  const home = process.env.GENIE_HOME ?? GENIE_HOME;
+  const pidPath = join(home, 'serve.pid');
+  const hasPidFile = existsSync(pidPath);
+  const currentPort = readLockfile() ?? getPort();
+  if (outcomeAtStart === 'stale') {
+    throw new Error(
+      `Stale ~/.genie/serve.pid (PID ${pidAtStart ?? 'unknown'} was not our serve). Removed and retried — if this persists, run: genie serve start`,
+    );
+  }
+  if (!hasPidFile) {
+    throw new Error('genie serve not running. Run: genie serve start');
+  }
+  const pidLabel = pidAtStart ?? outcomeAtStart ?? 'unknown';
+  throw new Error(
+    `genie serve is running (PID ${pidLabel}) but pgserve did not respond on port ${currentPort} within 16s. Try: genie serve restart, or check ~/.genie/logs/scheduler.log`,
+  );
 }
 
 /** Resolve the pgserve CLI binary path — checks local dep, global, then PATH. */

--- a/src/lib/process-identity.ts
+++ b/src/lib/process-identity.ts
@@ -1,0 +1,63 @@
+/**
+ * Process identity helpers — kernel-derived facts about a PID that survive the
+ * PID being recycled to a different process.
+ *
+ * The start time is held by the kernel and cannot be spoofed by a later
+ * process that inherits the same PID. Pairing `{pid}:{startTime}` in
+ * `~/.genie/serve.pid` lets us detect "PID is alive but it's not our serve"
+ * without needing IPC or an extra token file.
+ *
+ * Platforms:
+ *   macOS  — `ps -o lstart= -p <pid>` returns a long-form start-time string
+ *            like "Thu Apr 17 10:22:11 2026". Stable across `ps` versions.
+ *   Linux  — field 22 of `/proc/<pid>/stat` is `starttime` in clock ticks
+ *            since boot. Stable for the lifetime of the process.
+ *
+ * On any unsupported platform or on failure we return null. Callers treat
+ * null as "cannot prove identity → assume stale", which is the safe default
+ * (forces a respawn rather than silently skipping one).
+ */
+
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+/**
+ * Look up a stable, kernel-derived start-time token for the given PID.
+ * Returns null if the PID is gone, the platform is unsupported, or the
+ * lookup fails for any reason.
+ */
+export function getProcessStartTime(pid: number): string | null {
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+
+  try {
+    if (process.platform === 'darwin') {
+      const raw = execSync(`ps -o lstart= -p ${pid}`, {
+        encoding: 'utf8',
+        timeout: 1000,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+      return raw === '' ? null : raw;
+    }
+
+    if (process.platform === 'linux') {
+      const raw = readFileSync(`/proc/${pid}/stat`, 'utf-8');
+      // /proc/<pid>/stat format: "<pid> (<comm>) <state> ...". `comm` may
+      // contain spaces/parens, so slice from the final ')' to avoid splitting
+      // through the process name.
+      const closeParen = raw.lastIndexOf(')');
+      if (closeParen < 0) return null;
+      const rest = raw
+        .slice(closeParen + 1)
+        .trim()
+        .split(/\s+/);
+      // After `)` the remaining fields are: state(3) ppid(4) ... starttime(22).
+      // Index in `rest` is field_number - 3, so starttime → index 19.
+      const starttime = rest[19];
+      return starttime && starttime.length > 0 ? starttime : null;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -1,4 +1,5 @@
-import { basename } from 'node:path';
+import { existsSync } from 'node:fs';
+import { basename, join } from 'node:path';
 import { tmuxBin } from './ensure-tmux.js';
 import { shellQuote } from './team-lead-command.js';
 // tmux-wrapper imported dynamically inside executeTmux for test mockability
@@ -537,6 +538,25 @@ export class TmuxUnreachableError extends Error {
     super(message);
     this.name = 'TmuxUnreachableError';
   }
+}
+
+/**
+ * Check if a tmux socket file exists on disk.
+ *
+ * tmux stores per-user sockets at `/tmp/tmux-<uid>/<socketName>`. If the
+ * file is missing, the tmux server for that socket is not running and
+ * every pane registered against it is permanently dead — no amount of
+ * transient-retry will recover. Callers use this to distinguish
+ * "socket permanently gone" from the transient `TmuxUnreachableError`
+ * surfaced by `isPaneAlive`.
+ *
+ * Returns `false` for empty/undefined socket names (safer default than
+ * assuming `true` and then trying to probe a non-existent server).
+ */
+export function isTmuxSocketAlive(socketName: string | undefined | null): boolean {
+  if (!socketName) return false;
+  const uid = process.getuid?.() ?? 501;
+  return existsSync(join(`/tmp/tmux-${uid}`, socketName));
 }
 
 /**

--- a/src/term-commands/serve.test.ts
+++ b/src/term-commands/serve.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { type ChildProcess, spawn } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { getTuiKeybindings, getTuiQuitBindingArgs } from './serve.js';
 
 describe('getTuiKeybindings', () => {
@@ -32,4 +36,184 @@ describe('getTuiKeybindings', () => {
       'C-q',
     ]);
   });
+});
+
+// ============================================================================
+// Lifecycle tests: bridge failure + shutdown
+//
+// These spawn the real CLI (`bun src/genie.ts serve start --foreground --headless`)
+// as a child process against a refused NATS URL. The child inherits the test
+// pgserve via GENIE_TEST_PG_PORT so it doesn't touch the user's real data.
+// ============================================================================
+
+const GENIE_ENTRY = resolve(__dirname, '..', 'genie.ts');
+const BUN_PATH = process.execPath;
+
+let testDir: string;
+let genieHome: string;
+let child: ChildProcess | null = null;
+
+function waitFor(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Wait until `predicate` returns true or the deadline elapses.
+ * Returns true if predicate ever returned true, false on timeout.
+ */
+async function waitUntil(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs: number,
+  pollMs = 100,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return true;
+    await waitFor(pollMs);
+  }
+  return false;
+}
+
+function isAlive(pid: number | undefined): boolean {
+  if (!pid) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+interface SpawnResult {
+  child: ChildProcess;
+  stdout: { buffer: string };
+  stderr: { buffer: string };
+  exit: Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
+}
+
+function spawnServe(env: Record<string, string | undefined>): SpawnResult {
+  const stdout = { buffer: '' };
+  const stderr = { buffer: '' };
+
+  // Strip keys whose value is `undefined` so they don't become the literal
+  // string "undefined" in the child env.
+  const mergedEnv: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (typeof v === 'string') mergedEnv[k] = v;
+  }
+  for (const [k, v] of Object.entries(env)) {
+    if (v === undefined) {
+      delete mergedEnv[k];
+    } else {
+      mergedEnv[k] = v;
+    }
+  }
+
+  const proc = spawn(BUN_PATH, [GENIE_ENTRY, 'serve', 'start', '--foreground', '--headless'], {
+    env: mergedEnv,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  proc.stdout?.on('data', (chunk: Buffer) => {
+    stdout.buffer += chunk.toString('utf-8');
+  });
+  proc.stderr?.on('data', (chunk: Buffer) => {
+    stderr.buffer += chunk.toString('utf-8');
+  });
+
+  const exit = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
+    proc.on('exit', (code, signal) => resolve({ code, signal }));
+  });
+
+  return { child: proc, stdout, stderr, exit };
+}
+
+beforeEach(() => {
+  testDir = join(tmpdir(), `genie-serve-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(testDir, { recursive: true });
+  genieHome = join(testDir, '.genie');
+  mkdirSync(genieHome, { recursive: true });
+  child = null;
+});
+
+afterEach(async () => {
+  if (child && isAlive(child.pid)) {
+    try {
+      child.kill('SIGKILL');
+    } catch {
+      // already dead
+    }
+    // Give the OS a moment to reap
+    await waitFor(100);
+  }
+  child = null;
+  try {
+    rmSync(testDir, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+});
+
+describe('serve lifecycle — bridge failure + shutdown', () => {
+  test('survives bridge failure when GENIE_OMNI_REQUIRED is unset', async () => {
+    const result = spawnServe({
+      GENIE_HOME: genieHome,
+      GENIE_NATS_URL: 'nats://127.0.0.1:1',
+      // Do NOT set GENIE_OMNI_REQUIRED — degraded mode should be the default.
+      GENIE_OMNI_REQUIRED: undefined,
+    });
+    child = result.child;
+
+    // Wait for the serve process to settle: PID file should exist and process
+    // should still be alive after 3 seconds despite the bridge failure.
+    const pidPath = join(genieHome, 'serve.pid');
+    const started = await waitUntil(() => existsSync(pidPath), 10_000);
+    expect(started).toBe(true);
+
+    // Hold for 3 seconds — if the bridge failure were fatal, the process
+    // would have exited long before this.
+    await waitFor(3_000);
+    expect(isAlive(result.child.pid)).toBe(true);
+
+    // stderr or stdout must mention degradation, not a FAILED hard error.
+    const combined = `${result.stdout.buffer}\n${result.stderr.buffer}`;
+    expect(combined).toContain('Omni bridge: degraded');
+    expect(combined).toContain('GENIE_OMNI_REQUIRED=1');
+
+    // Clean shutdown via SIGTERM: PID file should be removed and a
+    // daemon_stopped event should be flushed to scheduler.log.
+    result.child.kill('SIGTERM');
+    const exitInfo = await Promise.race([
+      result.exit,
+      waitFor(10_000).then(() => ({ code: null, signal: null as NodeJS.Signals | null })),
+    ]);
+    expect(exitInfo.code !== null || exitInfo.signal !== null).toBe(true);
+
+    // PID file gone after shutdown
+    expect(existsSync(pidPath)).toBe(false);
+
+    // Scheduler log must contain a daemon_stopped event.
+    const logPath = join(genieHome, 'logs', 'scheduler.log');
+    expect(existsSync(logPath)).toBe(true);
+    const logContents = readFileSync(logPath, 'utf-8');
+    expect(logContents).toContain('"event":"daemon_stopped"');
+  }, 30_000);
+
+  test('exits non-zero on bridge failure when GENIE_OMNI_REQUIRED=1', async () => {
+    const result = spawnServe({
+      GENIE_HOME: genieHome,
+      GENIE_NATS_URL: 'nats://127.0.0.1:1',
+      GENIE_OMNI_REQUIRED: '1',
+    });
+    child = result.child;
+
+    const exitInfo = await Promise.race([result.exit, waitFor(20_000).then(() => null)]);
+    expect(exitInfo).not.toBeNull();
+    if (!exitInfo) return; // satisfy TS narrowing
+    expect(exitInfo.code).not.toBe(0);
+
+    const combined = `${result.stdout.buffer}\n${result.stderr.buffer}`;
+    // Strict mode uses the old FAILED messaging
+    expect(combined).toContain('Omni bridge: FAILED');
+    expect(combined).not.toContain('Omni bridge: degraded');
+  }, 30_000);
 });

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -23,6 +23,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { Command } from 'commander';
 import { ensureTmux, tmuxBin } from '../lib/ensure-tmux.js';
+import { getProcessStartTime } from '../lib/process-identity.js';
 import { genieTmuxCmd } from '../lib/tmux-wrapper.js';
 
 // ============================================================================
@@ -43,27 +44,66 @@ function servePidPath(): string {
 // PID helpers
 // ============================================================================
 
-function readServePid(): number | null {
+/**
+ * Result of parsing `~/.genie/serve.pid`.
+ * `startTime === null` means the file is in the legacy single-PID format
+ * (treat as stale) or the kernel lookup failed at write time.
+ */
+interface ServePidEntry {
+  pid: number;
+  startTime: string | null;
+}
+
+/**
+ * Read `~/.genie/serve.pid`. Accepts both the new `{pid}:{startTime}` format
+ * and the legacy single-PID format (returned with `startTime: null` so
+ * callers treat it as stale — forces a one-time respawn on upgrade).
+ */
+function readServePid(): ServePidEntry | null {
   const path = servePidPath();
   if (!existsSync(path)) return null;
   const raw = readFileSync(path, 'utf-8').trim();
-  const pid = Number.parseInt(raw, 10);
+  if (raw === '') return null;
+
+  const sepIdx = raw.indexOf(':');
+  if (sepIdx < 0) {
+    // Legacy single-PID format from an older install.
+    const pid = Number.parseInt(raw, 10);
+    if (Number.isNaN(pid) || pid <= 0) return null;
+    return { pid, startTime: null };
+  }
+
+  const pidPart = raw.slice(0, sepIdx);
+  const startTimePart = raw.slice(sepIdx + 1).trim();
+  const pid = Number.parseInt(pidPart, 10);
   if (Number.isNaN(pid) || pid <= 0) return null;
-  return pid;
+  const startTime = startTimePart === '' || startTimePart === 'unknown' ? null : startTimePart;
+  return { pid, startTime };
 }
 
 function writeServePid(pid: number): void {
   mkdirSync(genieHome(), { recursive: true });
-  writeFileSync(servePidPath(), String(pid), 'utf-8');
+  const startTime = getProcessStartTime(pid) ?? 'unknown';
+  writeFileSync(servePidPath(), `${pid}:${startTime}`, 'utf-8');
 }
 
+/**
+ * Remove `~/.genie/serve.pid` — but only if it still belongs to us. A new
+ * serve may have raced in between our shutdown handler firing and this call;
+ * unlinking its file would orphan the new daemon from autoStartDaemon's
+ * identity check.
+ */
 function removeServePid(): void {
   const path = servePidPath();
-  if (existsSync(path)) {
-    try {
-      unlinkSync(path);
-    } catch {}
-  }
+  if (!existsSync(path)) return;
+  try {
+    const current = readServePid();
+    if (current && current.pid !== process.pid) {
+      // Another serve owns the file now — leave it alone.
+      return;
+    }
+    unlinkSync(path);
+  } catch {}
 }
 
 function isProcessAlive(pid: number): boolean {
@@ -288,8 +328,8 @@ function listAgentSessions(): string[] {
 
 /** Check if genie serve is currently running */
 export function isServeRunning(): boolean {
-  const pid = readServePid();
-  return pid !== null && isProcessAlive(pid);
+  const entry = readServePid();
+  return entry !== null && isProcessAlive(entry.pid);
 }
 
 /**
@@ -460,12 +500,16 @@ async function startScheduler(): Promise<void> {
  *  @param headless If true, skip TUI setup (services only: pgserve, scheduler, inbox-watcher).
  */
 async function startForeground(headless?: boolean): Promise<void> {
-  const existingPid = readServePid();
-  if (existingPid && isProcessAlive(existingPid)) {
-    console.log(`genie serve already running (PID ${existingPid})`);
+  const existingEntry = readServePid();
+  if (existingEntry && isProcessAlive(existingEntry.pid)) {
+    console.log(`genie serve already running (PID ${existingEntry.pid})`);
     process.exit(0);
   }
-  if (existingPid) removeServePid();
+  if (existingEntry) {
+    // Stale PID file — unlink it directly (removeServePid only removes files
+    // owned by process.pid, which wouldn't match here).
+    forceRemoveServePid();
+  }
 
   process.env.GENIE_IS_DAEMON = '1';
   writeServePid(process.pid);
@@ -608,7 +652,8 @@ async function startForeground(headless?: boolean): Promise<void> {
   }
 
   // 6. Start Omni bridge (NATS → agent session router).
-  // Bridge is mandatory: any failure here is fatal and exits non-zero.
+  // Bridge is optional by default: dev machines without NATS should not crash serve.
+  // Set GENIE_OMNI_REQUIRED=1 to make bridge startup fatal (strict/prod mode).
   // Executor type is resolved internally by the bridge.
   {
     const { OmniBridge } = await import('../services/omni-bridge.js');
@@ -619,13 +664,17 @@ async function startForeground(headless?: boolean): Promise<void> {
     });
     try {
       await bridge.start();
+      handles.omniBridge = bridge;
+      console.log('  Omni bridge started');
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      console.error(`  Omni bridge: FAILED — ${msg}`);
-      process.exit(1);
+      if (process.env.GENIE_OMNI_REQUIRED === '1') {
+        console.error(`  Omni bridge: FAILED — ${msg}`);
+        process.exit(1);
+      }
+      console.warn(`  Omni bridge: degraded — ${msg}; set GENIE_OMNI_REQUIRED=1 to make this fatal`);
+      // Continue without bridge — handles.omniBridge stays null so shutdown() skips it.
     }
-    handles.omniBridge = bridge;
-    console.log('  Omni bridge started');
   }
 
   const stopMsg = headless ? 'Send SIGTERM to stop.' : 'Press Ctrl+C to stop.';
@@ -633,7 +682,7 @@ async function startForeground(headless?: boolean): Promise<void> {
 
   // Signal handlers for graceful shutdown
   let shutdownStarted = false;
-  const shutdown = () => {
+  const shutdown = async (): Promise<void> => {
     if (shutdownStarted) return;
     shutdownStarted = true;
 
@@ -642,8 +691,18 @@ async function startForeground(headless?: boolean): Promise<void> {
     // 1. Stop agent watcher
     handles.agentWatcher?.close();
 
-    // 2. Stop scheduler (drains in-flight)
-    handles.schedulerHandle?.stop();
+    // 2. Stop scheduler (drains in-flight) and wait for its done promise so
+    // the final `daemon_stopped` log entry is flushed before we exit.
+    const schedulerHandle = handles.schedulerHandle;
+    if (schedulerHandle) {
+      schedulerHandle.stop();
+      try {
+        await schedulerHandle.done;
+      } catch {
+        // Best effort — we still need to finish the rest of shutdown
+      }
+      handles.schedulerHandle = null;
+    }
 
     // 2.1. Stop detector scheduler (self-healing B1 / Group 2)
     if (handles.detectorScheduler) {
@@ -653,13 +712,13 @@ async function startForeground(headless?: boolean): Promise<void> {
 
     // 2.5. Stop Omni approval handler
     if (handles.omniApprovalHandler) {
-      handles.omniApprovalHandler.stop().catch(() => {});
+      await handles.omniApprovalHandler.stop().catch(() => {});
       handles.omniApprovalHandler = null;
     }
 
     // 2.55. Stop Omni bridge (graceful: detach sessions, don't kill them)
     if (handles.omniBridge) {
-      handles.omniBridge.stop().catch(() => {});
+      await handles.omniBridge.stop().catch(() => {});
       handles.omniBridge = null;
     }
 
@@ -670,7 +729,7 @@ async function startForeground(headless?: boolean): Promise<void> {
     // immediately after shutdown(), so this is fire-and-forget like all other
     // services. The OS reclaims sockets/connections on process exit.)
     if (handles.brainHandle) {
-      handles.brainHandle.stop().catch(() => {});
+      await handles.brainHandle.stop().catch(() => {});
       handles.brainHandle = null;
     }
 
@@ -705,9 +764,13 @@ async function startForeground(headless?: boolean): Promise<void> {
     console.log('genie serve stopped.');
   };
 
-  // Set up force-kill timeout: if graceful shutdown takes > 10s, SIGKILL remaining
-  const forceKillShutdown = () => {
-    shutdown();
+  // Graceful shutdown wrapper: awaits shutdown() with a 10s force-kill fallback,
+  // then exits with the supplied code. Idempotent via the `shutdownStarted` guard.
+  const gracefulExit = (exitCode: number): void => {
+    // Guard against multiple concurrent signals
+    if (shutdownStarted) return;
+
+    // Set up force-kill timeout: if graceful shutdown takes > 10s, SIGKILL remaining
     const forceTimer = setTimeout(() => {
       console.error('Graceful shutdown timeout (10s). Force-killing remaining processes.');
       try {
@@ -722,18 +785,37 @@ async function startForeground(headless?: boolean): Promise<void> {
       } catch {
         // registry not available
       }
+      removeServePid();
       process.exit(1);
     }, 10_000);
     forceTimer.unref();
+
+    shutdown()
+      .catch(() => {
+        // Swallow — removeServePid below still runs
+      })
+      .finally(() => {
+        clearTimeout(forceTimer);
+        removeServePid();
+        process.exit(exitCode);
+      });
   };
 
-  process.on('SIGTERM', () => {
-    forceKillShutdown();
-    process.exit(143);
+  process.on('SIGTERM', () => gracefulExit(143));
+  process.on('SIGINT', () => gracefulExit(130));
+  process.on('SIGHUP', () => gracefulExit(129));
+
+  // `exit` handler can only run synchronous code — ensure the PID file is gone
+  // even if we reach process exit without going through gracefulExit (e.g. the
+  // scheduler's `done` promise resolved normally).
+  process.on('exit', () => {
+    removeServePid();
   });
-  process.on('SIGINT', () => {
-    forceKillShutdown();
-    process.exit(130);
+
+  // Last-resort handler: surface the error, attempt cleanup, then exit 1.
+  process.on('uncaughtException', (err) => {
+    console.error('Uncaught exception in genie serve:', err);
+    gracefulExit(1);
   });
 
   // Wait for scheduler to finish (blocks forever until signal)
@@ -751,12 +833,14 @@ async function startForeground(headless?: boolean): Promise<void> {
  *  @param headless If true, pass --headless to the foreground process.
  */
 async function startBackground(headless?: boolean): Promise<void> {
-  const existingPid = readServePid();
-  if (existingPid && isProcessAlive(existingPid)) {
-    console.log(`genie serve already running (PID ${existingPid})`);
+  const existingEntry = readServePid();
+  if (existingEntry && isProcessAlive(existingEntry.pid)) {
+    console.log(`genie serve already running (PID ${existingEntry.pid})`);
     process.exit(0);
   }
-  if (existingPid) removeServePid();
+  if (existingEntry) {
+    forceRemoveServePid();
+  }
 
   const bunPath = process.execPath ?? 'bun';
   const genieBin = process.argv[1] ?? 'genie';
@@ -786,18 +870,27 @@ async function startBackground(headless?: boolean): Promise<void> {
   }
 }
 
+/** Unlink serve.pid unconditionally, swallowing ENOENT and permission errors. */
+function forceRemoveServePid(): void {
+  try {
+    unlinkSync(servePidPath());
+  } catch {}
+}
+
 /** Stop genie serve and all child services */
 async function stopServe(): Promise<void> {
-  const pid = readServePid();
+  const entry = readServePid();
 
-  if (!pid) {
+  if (!entry) {
     console.log('genie serve is not running (no PID file).');
     return;
   }
 
+  const pid = entry.pid;
+
   if (!isProcessAlive(pid)) {
     console.log(`Stale PID file (PID ${pid} not running). Cleaning up.`);
-    removeServePid();
+    forceRemoveServePid();
     // Only kill TUI session — agent server is independent
     killTuiSession();
     return;
@@ -834,7 +927,9 @@ async function stopServe(): Promise<void> {
   // Only kill TUI session — agent tmux server is eternal
   killTuiSession();
 
-  removeServePid();
+  // Serve process is gone; unlink the file directly rather than through
+  // removeServePid (whose identity check would bail since pid !== process.pid).
+  forceRemoveServePid();
   console.log('genie serve stopped.');
 }
 
@@ -952,15 +1047,15 @@ async function printBridgeStatus(): Promise<void> {
 
 /** Show service health */
 async function statusServe(): Promise<void> {
-  const pid = readServePid();
-  const running = pid !== null && isProcessAlive(pid);
+  const entry = readServePid();
+  const running = entry !== null && isProcessAlive(entry.pid);
 
   console.log('\nGenie Serve');
   console.log('─'.repeat(50));
   console.log(`  Status:     ${running ? 'running' : 'stopped'}`);
 
-  if (running && pid) {
-    console.log(`  PID:        ${pid}`);
+  if (running && entry) {
+    console.log(`  PID:        ${entry.pid}`);
   }
 
   await printPgserveStatus();


### PR DESCRIPTION
## Summary

- `genie serve` exited with code 1 whenever the Omni bridge could not reach NATS (the default on any dev machine), which made every CLI command hang for 16s and blocked testing. The bridge is now optional: on start failure, serve logs `Omni bridge: degraded — <reason>` and continues. Set `GENIE_OMNI_REQUIRED=1` to restore strict (exit-1) behavior.
- Bundles the wider `genie-serve-stability` hardening: `{pid}:{startTime}` process identity for correct PID staleness checks (new `src/lib/process-identity.ts`), dead-socket reconciliation for stale workers, a zombie dead-pane pass for idle/working rows, and regression tests across `serve`, `db`, and `agent-registry`.
- Fixes two pre-existing gate blockers so `bun run check` and the pre-push hook go green:
  - Replace stale `genie reset` refs in `skills/pm/SKILL.md` and `skills/genie-hacks/SKILL.md` with `genie task unblock` (the current command).
  - Realpath `tmpdir()` in `src/__tests__/migrate.test.ts` so the macOS `/var` → `/private/var` symlink doesn't break path assertions.

Root cause of the original report: the fix existed only in the working tree — the globally installed `~/.bun/bin/genie` was a stale published build that still had `process.exit(1)` on bridge failure. Landing and publishing this PR ensures users who run `genie serve` pick up the optional bridge.

Wish: `.genie/wishes/genie-serve-stability/WISH.md`

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — only pre-existing complexity warnings in `agents.ts` (not touched by this PR)
- [x] `bun run skills:lint` — OK (0 missing)
- [x] `bun test` — 2493/2493 pass (previously 4 pre-existing macOS failures in `migrate.test.ts` — fixed here)
- [x] Manual: `genie serve` with no NATS running — prints `Omni bridge: degraded — CONNECTION_REFUSED`, continues, PID file present, SIGTERM shuts down cleanly
- [ ] Reviewer to verify: `GENIE_OMNI_REQUIRED=1 genie serve start --foreground` with no NATS still exits 1 (strict-mode regression check)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Serve process now validates process identity using PID and start-time to prevent stale daemon conflicts.
  * Omni bridge startup is now optional by default; specify `GENIE_OMNI_REQUIRED=1` to make it mandatory.
  * Improved timeout error messages that identify specific failure modes (stale PID, daemon not running, etc.).

* **Bug Fixes**
  * Enhanced tmux-based worker reconciliation to detect and recover from dead zombie processes.
  * Strengthened PID file cleanup logic to prevent serve shutdown races.
  * Improved serve graceful shutdown with signal handling and proper event emission.

* **Documentation**
  * Updated CLI guidance for task unblocking workflows.
  * Added serve stability specification with bug fix and validation criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->