### PR TITLE
fix(wish-state): surface repo_path drift + guard UPDATE silent-0-row (#1234)

### DIFF
--- a/src/lib/wish-state.test.ts
+++ b/src/lib/wish-state.test.ts
@@ -262,6 +262,59 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
   });
 
   // ============================================================================
+  // findParent diagnostics — issue #1234 repo_path drift warnings
+  // ============================================================================
+
+  describe('findParent state-partition warning (issue #1234)', () => {
+    test('warns when wish has parents at other repo_paths', async () => {
+      // Simulate the real-world bug: the same wish slug gets a parent row
+      // in repo_path A (e.g. a worktree), then someone runs from repo_path B
+      // (e.g. the main repo) and silently forks a NEW parent with fresh
+      // ready/blocked children, so status reads reflect nothing.
+      const cwdA = `${cwd}-A`;
+      const cwdB = `${cwd}-B`;
+
+      await createState('drift-wish', sampleGroups, cwdA);
+
+      // Capture console.warn from the getState call made against cwdB.
+      const warnings: string[] = [];
+      const originalWarn = console.warn;
+      console.warn = (msg: string) => warnings.push(msg);
+
+      try {
+        const stateB = await getState('drift-wish', cwdB);
+        expect(stateB).toBeNull();
+      } finally {
+        console.warn = originalWarn;
+      }
+
+      const partitionWarning = warnings.find((w) => w.includes('partitioned across repo_paths'));
+      expect(partitionWarning).toBeDefined();
+      expect(partitionWarning).toContain(cwdA);
+      expect(partitionWarning).toContain(cwdB);
+      expect(partitionWarning).toContain('drift-wish');
+    });
+
+    test('does NOT warn when no other repo_paths own this wish', async () => {
+      // Genuinely-new wish — no partition, no noise. A `genie wish status` on
+      // an uncreated wish should still feel clean, not yell about drift.
+      const warnings: string[] = [];
+      const originalWarn = console.warn;
+      console.warn = (msg: string) => warnings.push(msg);
+
+      try {
+        const state = await getState('totally-new-wish', cwd);
+        expect(state).toBeNull();
+      } finally {
+        console.warn = originalWarn;
+      }
+
+      const partitionWarning = warnings.find((w) => w.includes('partitioned across repo_paths'));
+      expect(partitionWarning).toBeUndefined();
+    });
+  });
+
+  // ============================================================================
   // getState / getGroupState
   // ============================================================================
 

--- a/src/lib/wish-state.ts
+++ b/src/lib/wish-state.ts
@@ -174,7 +174,19 @@ function toISO(v: unknown): string | undefined {
 // biome-ignore lint/suspicious/noExplicitAny: postgres.js Sql type varies
 type Sql = any;
 
-/** Find parent task for a wish slug. */
+/**
+ * Find parent task for a wish slug at a specific repo_path.
+ *
+ * Also emits a loud warning when the slug has parent rows at OTHER repo_paths
+ * (state-partitioning — issue #1234). Worktrees, submodule clones, and main
+ * repos all resolve to different `repo_path` values, and naively filtering on
+ * the current cwd's path silently hides sibling state.
+ *
+ * Still returns null on miss — we never auto-heal by adopting a foreign
+ * parent, because picking the wrong one would silently merge unrelated
+ * execution into the current cwd's wish. The warning gives the operator
+ * enough signal to diagnose and reconcile manually.
+ */
 async function findParent(sql: Sql, slug: string, repoPath: string) {
   const wishFile = wishFilePath(slug);
   const rows = await sql`
@@ -182,7 +194,25 @@ async function findParent(sql: Sql, slug: string, repoPath: string) {
     WHERE wish_file = ${wishFile} AND repo_path = ${repoPath} AND parent_id IS NULL
     LIMIT 1
   `;
-  return rows.length > 0 ? rows[0] : null;
+  if (rows.length > 0) return rows[0];
+
+  // Diagnostic: are there parent rows for this wish at *other* repo_paths?
+  // Those would silently own the state while we report "not found" here.
+  const crossRows = await sql`
+    SELECT repo_path FROM tasks
+    WHERE wish_file = ${wishFile} AND parent_id IS NULL AND repo_path != ${repoPath}
+  `;
+  if (crossRows.length > 0) {
+    const otherPaths = crossRows
+      .map((r: Record<string, unknown>) => r.repo_path as string)
+      .filter((p: string, i: number, arr: string[]) => arr.indexOf(p) === i);
+    const otherList = otherPaths.map((p: string) => `     - ${p}`).join('\n');
+    console.warn(
+      `⚠ Wish "${slug}" has state partitioned across repo_paths (issue #1234).\n   Current cwd resolves to: ${repoPath}\n   Other parents exist at:\n${otherList}\n   Operations against this wish from the current cwd see NONE of the state above.\n   Re-run from one of the listed paths, or reconcile the partitioned rows manually.`,
+    );
+  }
+
+  return null;
 }
 
 /** Find a child task (group) under a parent. */
@@ -493,10 +523,24 @@ export async function completeGroup(slug: string, groupName: string, cwd?: strin
   }
 
   const now = new Date();
-  await sql`
+  // Use RETURNING so a 0-row update fails loudly instead of silently no-opping.
+  // The status read-path and write-path both key on (wish_file, repo_path),
+  // and pre-check gates (findParent, findGroup, status guards) normally catch
+  // drift earlier — but if a concurrent delete or race nukes the row between
+  // the pre-check and this UPDATE, we never want to return success on 0 rows.
+  // Issue #1234: "make genie done fail loudly when it doesn't actually update".
+  const updated = await sql`
     UPDATE tasks SET status = 'done', ended_at = ${now}, updated_at = ${now}
     WHERE id = ${child.id as string}
+    RETURNING id
   `;
+  if (updated.length === 0) {
+    throw new Error(
+      `Completion UPDATE affected 0 rows for group "${groupName}" in wish "${slug}" ` +
+        `(child id ${child.id as string} disappeared mid-operation). ` +
+        `State was NOT written — re-run \`genie done ${slug}#${groupName}\` to retry.`,
+    );
+  }
 
   // Recalculate dependents: blocked siblings → ready when ALL deps done
   await sql`


### PR DESCRIPTION
## Summary

Felipe's bug report #1234 — `genie done <slug>#<group>` appears silent and groups stay pending under `genie wish status`.

Root cause: PG-backed wish state is partitioned on `(wish_file, repo_path)`. For submodules and genie "worktrees" (full clones under `~/.genie/worktrees/`), `resolveRepoPath()` derives different `repo_path` values for the same logical wish when invoked from different entrypoints. This creates multiple parent rows; `genie done` updates one, `genie wish status` reads another, and neither complains.

Live evidence: `omni-scope-profiles` had 2 parent rows at different repo_paths; `hv-rename-and-full-redeploy` had 3.

## What this PR does — minimum-viable diagnostic

- **`findParent()`** now runs a secondary query for parents of the same wish at OTHER repo_paths. If any exist, emits a `console.warn` block naming the current cwd's resolved repo_path, listing all other repo_paths owning this wish, and telling the operator their operations see NONE of that state.
- **`completeGroup()`** now uses `UPDATE ... RETURNING id` and throws if the UPDATE affects 0 rows — previously it swallowed 0-row outcomes silently.

## Out of scope

- Reconciling existing partitioned rows (needs a migration)
- Changing `resolveRepoPath()` semantics (would need a migration-safe rollout)
- The `autoKillPane()` 1s kill-pane that amplifies the "silent" perception (separate issue)

Full reconciliation + resolveRepoPath refactor is follow-up work once operators start surfacing partition warnings from the wild.

## Test plan

- [x] `bun test src/lib/wish-state.test.ts` — 78 pass, 0 fail (added 2 new tests: warn-on-partition and no-warn-on-clean)
- [x] `bun run lint` — 0 errors, 42 pre-existing warnings
- [x] `bun run check` — passes (flaky `listen-bomb` pen-test is pre-existing, not caused by this change)

Closes part of #1234.