### PR TITLE
test(serve): make bridge-lifecycle tests hermetic so CI passes + @next can publish

### DIFF
--- a/src/term-commands/serve.test.ts
+++ b/src/term-commands/serve.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { type ChildProcess, spawn } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { getTuiKeybindings, getTuiQuitBindingArgs } from './serve.js';
@@ -111,6 +111,7 @@ function spawnServe(env: Record<string, string | undefined>): SpawnResult {
 
   const proc = spawn(BUN_PATH, [GENIE_ENTRY, 'serve', 'start', '--foreground', '--headless'], {
     env: mergedEnv,
+    cwd: testDir,
     stdio: ['ignore', 'pipe', 'pipe'],
   });
   proc.stdout?.on('data', (chunk: Buffer) => {
@@ -132,6 +133,10 @@ beforeEach(() => {
   mkdirSync(testDir, { recursive: true });
   genieHome = join(testDir, '.genie');
   mkdirSync(genieHome, { recursive: true });
+  // Mark this tmp dir as a workspace so `ensureWorkspace()` doesn't abort
+  // with "No workspace found" in hermetic environments (CI) where no
+  // ancestor .genie/workspace.json exists.
+  writeFileSync(join(genieHome, 'workspace.json'), '{"name":"test","tmuxSocket":"genie"}');
   child = null;
 });
 


### PR DESCRIPTION
## Summary

- The two lifecycle tests added in #1239 (`survives bridge failure when GENIE_OMNI_REQUIRED is unset` and `exits non-zero on bridge failure when GENIE_OMNI_REQUIRED=1`) passed locally but failed in CI. `findWorkspace()` walked up from the developer's repo cwd and happily found an ancestor `.genie/workspace.json`; in CI the repo lives under `/home/runner/_work/...` with no ancestor workspace, so `ensureWorkspace()` exited the child with code 2 before the bridge code ever ran. Assertions then saw `"No workspace found. Run \`genie init\` to set up."` instead of any bridge output.
- Make the tests hermetic: write `<testDir>/.genie/workspace.json` in `beforeEach` and `spawn` the child with `cwd: testDir` so walk-up finds the test-owned workspace immediately. No production code changes.
- Unblocks the `Publish @next` CI step, which was SKIPPED after the Quality Gate failure on #1239's merge — so `bun add -g @automagik/genie@next` still ships the stale pre-fix binary on users' machines.

## Test plan

- [x] `bun test src/term-commands/serve.test.ts` — 5/5 pass
- [x] `bun test` — 3301/3301 pass (pre-push hook, full suite)
- [ ] Verify CI Quality Gate goes green on this PR so `Publish @next` runs and `@next` picks up the Omni-bridge-optional fix