### PR TITLE
fix(session-backfill): sort parents before subagents to satisfy FK ordering

### DIFF
--- a/src/lib/__tests__/session-backfill-sort.test.ts
+++ b/src/lib/__tests__/session-backfill-sort.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Regression tests for `compareBackfillFiles` — the sort comparator that
+ * controls backfill insert order.
+ *
+ * Context: the `sessions.parent_session_id` FK (migration 010) is not
+ * DEFERRABLE. If a subagent row gets inserted before its parent row, the
+ * insert fails with `sessions_parent_session_id_fkey` and the backfill
+ * silently drops that file's data. Historically the sort was
+ * `(a, b) => b.mtime - a.mtime`, which mixes parents and subagents — and
+ * subagents tend to be newer than their parents, so they lose the race.
+ *
+ * These tests lock in the parent-first ordering so nobody reverts to a
+ * pure-mtime comparator without failing CI first.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { compareBackfillFiles } from '../session-backfill.js';
+
+interface TestFile {
+  id: string;
+  isSubagent: boolean;
+  mtime: number;
+}
+
+function sorted(files: TestFile[]): string[] {
+  return [...files].sort(compareBackfillFiles).map((f) => f.id);
+}
+
+describe('compareBackfillFiles', () => {
+  test('parents come before subagents regardless of mtime', () => {
+    // Subagent is newer than parent — naive mtime sort would put it first.
+    const files: TestFile[] = [
+      { id: 'subagent-new', isSubagent: true, mtime: 2000 },
+      { id: 'parent-old', isSubagent: false, mtime: 1000 },
+    ];
+    expect(sorted(files)).toEqual(['parent-old', 'subagent-new']);
+  });
+
+  test('within parents, newest first', () => {
+    const files: TestFile[] = [
+      { id: 'parent-old', isSubagent: false, mtime: 1000 },
+      { id: 'parent-new', isSubagent: false, mtime: 3000 },
+      { id: 'parent-mid', isSubagent: false, mtime: 2000 },
+    ];
+    expect(sorted(files)).toEqual(['parent-new', 'parent-mid', 'parent-old']);
+  });
+
+  test('within subagents, newest first', () => {
+    const files: TestFile[] = [
+      { id: 'sub-old', isSubagent: true, mtime: 1000 },
+      { id: 'sub-new', isSubagent: true, mtime: 3000 },
+      { id: 'sub-mid', isSubagent: true, mtime: 2000 },
+    ];
+    expect(sorted(files)).toEqual(['sub-new', 'sub-mid', 'sub-old']);
+  });
+
+  test('mixed set — all parents (newest first), then all subagents (newest first)', () => {
+    const files: TestFile[] = [
+      { id: 'sub-new', isSubagent: true, mtime: 4000 },
+      { id: 'parent-old', isSubagent: false, mtime: 1000 },
+      { id: 'sub-old', isSubagent: true, mtime: 2000 },
+      { id: 'parent-new', isSubagent: false, mtime: 3000 },
+    ];
+    expect(sorted(files)).toEqual(['parent-new', 'parent-old', 'sub-new', 'sub-old']);
+  });
+
+  test('reproduces the original FK-violation scenario from prod logs', () => {
+    // Simulate the real pattern: many subagents with recent mtimes and a
+    // small number of parent sessions. Under the old sort they'd interleave;
+    // under the new sort every parent lands before any subagent.
+    const parents: TestFile[] = Array.from({ length: 4 }, (_, i) => ({
+      id: `parent-${i}`,
+      isSubagent: false,
+      mtime: 1000 + i * 10,
+    }));
+    const subagents: TestFile[] = Array.from({ length: 20 }, (_, i) => ({
+      id: `sub-${i}`,
+      isSubagent: true,
+      mtime: 5000 + i, // strictly newer than any parent
+    }));
+    const sortedIds = sorted([...subagents, ...parents]);
+
+    // Assert: every parent appears before every subagent.
+    const firstSubagentIdx = sortedIds.findIndex((id) => id.startsWith('sub-'));
+    const lastParentIdx = sortedIds.map((id) => id.startsWith('parent-')).lastIndexOf(true);
+    expect(lastParentIdx).toBeLessThan(firstSubagentIdx);
+    expect(sortedIds.slice(0, 4).every((id) => id.startsWith('parent-'))).toBe(true);
+    expect(sortedIds.slice(4).every((id) => id.startsWith('sub-'))).toBe(true);
+  });
+
+  test('stable on empty input', () => {
+    expect(sorted([])).toEqual([]);
+  });
+
+  test('equal-mtime parents preserve relative order (comparator returns 0)', () => {
+    const files: TestFile[] = [
+      { id: 'a', isSubagent: false, mtime: 1000 },
+      { id: 'b', isSubagent: false, mtime: 1000 },
+    ];
+    // Bun's sort is not guaranteed stable across implementations, but the
+    // comparator MUST return 0 for equal mtimes in the same tier — verify that.
+    expect(compareBackfillFiles(files[0], files[1])).toBe(0);
+  });
+});

--- a/src/lib/session-backfill.ts
+++ b/src/lib/session-backfill.ts
@@ -25,6 +25,27 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Order backfill files so parent sessions ingest before their subagents.
+ *
+ * The `sessions.parent_session_id` FK (migration `010_session_capture_v2`) is
+ * not DEFERRABLE, so inserting a subagent row whose parent hasn't been
+ * inserted yet fails with `sessions_parent_session_id_fkey` and that file's
+ * data is silently dropped. Sorting by mtime alone mixes parents and
+ * subagents arbitrarily — subagents are usually newer than their parents,
+ * so they win the race and get inserted first.
+ *
+ * Fix: sort non-subagents before subagents, then preserve newest-first within
+ * each tier. Exported so the comparator can be unit-tested without a DB.
+ */
+export function compareBackfillFiles(
+  a: { isSubagent: boolean; mtime: number },
+  b: { isSubagent: boolean; mtime: number },
+): number {
+  if (a.isSubagent !== b.isSubagent) return a.isSubagent ? 1 : -1;
+  return b.mtime - a.mtime;
+}
+
 // ============================================================================
 // Progress state
 // ============================================================================
@@ -180,7 +201,7 @@ export async function startBackfill(sql: SqlClient): Promise<void> {
 
   try {
     const allFiles = await discoverAllJsonlFiles();
-    allFiles.sort((a, b) => b.mtime - a.mtime);
+    allFiles.sort(compareBackfillFiles);
 
     const totalBytes = allFiles.reduce((sum, f) => sum + f.fileSize, 0);
     const progress: BackfillProgress = {


### PR DESCRIPTION
## Summary

Backfill was inserting subagent session rows before their parent rows, triggering `sessions_parent_session_id_fkey` FK violations and silently dropping those files' data.

The `sessions.parent_session_id` FK (migration `010_session_capture_v2`) is not DEFERRABLE, so ordering matters on every INSERT. The previous sort was `(a, b) => b.mtime - a.mtime` — a pure mtime sort that mixes parents and subagents. Since subagents are usually newer than their parents, they won the race and got inserted first, then failed the FK check.

## Root cause (from /trace)

- **File:** `src/lib/session-backfill.ts:183`
- **Cause:** sort comparator ignored the parent/child relationship encoded in `isSubagent`
- **Effect:** FK violation → file skipped → silent data loss on backfill
- **Reproduced:** observed on a fresh-install server hitting `sessions_parent_session_id_fkey` repeatedly during initial ingest

## Fix

Extract the comparator as an exported, testable function `compareBackfillFiles`:

1. Non-subagents (parents) always sort before subagents.
2. Within each tier, preserve newest-first by `mtime`.

Result: every parent lands before any subagent, so the FK constraint always sees the parent row it needs.

## Test coverage

New file: `src/lib/__tests__/session-backfill-sort.test.ts` — 7 regression tests:

- parents come before subagents regardless of mtime
- within-parents newest-first
- within-subagents newest-first
- mixed set partitions cleanly into parent tier then subagent tier
- reproduces the original FK-violation scenario (4 parents + 20 strictly-newer subagents)
- stable on empty input
- equal-mtime returns 0

## Follow-up

Separate PR will add a stub-parent fallback in `session-capture.ts` for the edge case where the parent JSONL has been deleted but a subagent still references it. Out of scope here — this PR is the minimum fix for the ordering bug.

## Validation

- `bun test src/lib/__tests__/session-backfill-sort.test.ts` → 7/7 pass
- Full husky pre-push (`bun run check` + `bun test`) → 3357 pass / 0 fail