### PR TITLE
fix(tmux): force literal session-name match with `=` prefix

### DIFF
--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -218,7 +218,9 @@ async function checkTmux(): Promise<CheckResult[]> {
   const sessionName = config.session.name;
 
   try {
-    const sessionResult = await $`${tmuxBin()} -L genie has-session -t ${sessionName} 2>/dev/null`.quiet();
+    // `=` prefix forces literal session-name match — without it tmux parses
+    // values like `@46` as window-id syntax and fails lookup.
+    const sessionResult = await $`${tmuxBin()} -L genie has-session -t ${`=${sessionName}`} 2>/dev/null`.quiet();
     if (sessionResult.exitCode === 0) {
       results.push({
         name: `Session '${sessionName}' exists`,

--- a/src/genie.ts
+++ b/src/genie.ts
@@ -734,8 +734,10 @@ if (args.length === 0) {
   if (resolved.source !== 'default') {
     const { execSync } = await import('node:child_process');
     try {
-      // Check if agent has a running tmux session
-      execSync(`tmux has-session -t ${initialAgent} 2>/dev/null`, { stdio: 'pipe' });
+      // Check if agent has a running tmux session.
+      // `=` prefix forces literal session-name match — without it tmux parses
+      // values like `@46` as window-id syntax and fails lookup.
+      execSync(`tmux has-session -t =${initialAgent} 2>/dev/null`, { stdio: 'pipe' });
     } catch {
       // Agent session doesn't exist — spawn it
       console.log(`Spawning ${initialAgent}...`);

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -156,7 +156,11 @@ export async function killSession(sessionId: string): Promise<void> {
 export async function listWindows(sessionId: string): Promise<TmuxWindow[]> {
   try {
     const format = '#{window_id}:#{window_name}:#{window_index}:#{?window_active,1,0}';
-    const output = await executeTmux(`list-windows -t '${sessionId}' -F '${format}'`);
+    // Use `=` prefix to force literal session-name match. Without it, tmux
+    // interprets values like `@46` as window-id syntax (`@N`) instead of
+    // session names, causing "can't find window: @46" errors when looking up
+    // anonymously-named sessions created by `genie spawn --new-window`.
+    const output = await executeTmux(`list-windows -t '=${sessionId}' -F '${format}'`);
 
     if (!output) return [];
 

--- a/src/tui/tmux.ts
+++ b/src/tui/tmux.ts
@@ -91,9 +91,13 @@ export function attachTuiSession(): void {
 /** Find the next numeric suffix for a role name by listing tmux windows in the agent's session. */
 function nextRoleSuffix(baseName: string): number {
   const sessionName = baseName.replace(/\//g, '-');
+  // Use `=` prefix to force literal session-name match. Without it, tmux
+  // interprets values like `@46` as window-id syntax (`@N`) instead of
+  // session names, causing "can't find window" errors for anonymously-named
+  // sessions created by `genie spawn --new-window`.
   const output = spawnSync(
     TMUX_BIN,
-    ['-L', GENIE_AGENT_SOCKET, 'list-windows', '-t', sessionName, '-F', '#{window_name}'],
+    ['-L', GENIE_AGENT_SOCKET, 'list-windows', '-t', `=${sessionName}`, '-F', '#{window_name}'],
     {
       encoding: 'utf-8',
     },


### PR DESCRIPTION
## Summary

- 4 surgical patches at every `tmux ... -t <name>` call that targets a session by name.
- Without the `=` prefix, tmux interprets values like `@46` (auto-generated anonymous session names from `genie spawn --new-window`) as window-id syntax (`@N`) instead of session names → lookup fails with `can't find window: @46`.

## Reproduction (current `dev`)

In a workspace where any agent was spawned via `genie spawn --new-window --team <name>`, the team-named session ends up with an anonymous `@N` name registered for it. Then:

```bash
$ tmux list-sessions
@46: 1 windows (created Mon Apr 20 16:58:31 2026)

$ tmux list-windows -t @46
can't find window: @46
```

The reconciler / inbox-watcher loop then spams the `genie serve` log:

```
[reconcile] Reset stuck agent dir:genie from spawning → error
[inbox-watcher] Failed to spawn team-lead for "simone" (attempt 2/3): can't find window: @46
[inbox-watcher] Failed to spawn team-lead for "simone" (attempt 3/3): can't find window: @46
```

## Fix

Prefix the session name with `=` (tmux literal-name match operator) at four call sites:

| File | Line | Function |
|------|------|----------|
| `src/lib/tmux.ts` | 158 | `listWindows()` |
| `src/tui/tmux.ts` | 96 | `nextRoleSuffix()` |
| `src/genie-commands/doctor.ts` | 221 | `has-session` diagnostic |
| `src/genie.ts` | 738 | `initialAgent` `has-session` check |

`agents.ts:799` already uses the correct pattern (`=${session}`) — used as reference.

## Out of scope (separate PRs)

This PR is the immediate hotfix for the spam. Two underlying issues remain:

1. **Anonymous `@N` names should never be registered.** `genie spawn --team <name>` should resolve the existing team-named session and add a window to it, never create a brand-new anonymous session.
2. **`--new-window --team <name>` topology.** The original symptom that produces `@N` names in the first place.

Tracked separately when ready.

## Test plan

- [x] `bun test src/lib/tmux.test.ts` → 7/7 pass (existing tests, no behavioural regression on the mocked `list-windows` path)
- [x] `bun run typecheck` clean
- [x] `bun run build` clean
- [ ] Manual: in a workspace with anonymously-named sessions, verify `inbox-watcher` no longer spams "can't find window" after restart

## Affected scope

- inbox-watcher (stops spamming)
- reconciler (stops marking agents as stuck)
- auto-resume (now finds anonymous sessions correctly)
- `genie kill <name>` ambiguity issues might also relate
- Any code path that targets tmux by stored session-name

🤖 Generated with [Claude Code](https://claude.com/claude-code)