### PR TITLE
fix(turn-close): resolver fallback by agent_id when env UUID is a ghost

### DIFF
--- a/src/lib/events/registry.ts
+++ b/src/lib/events/registry.ts
@@ -37,6 +37,7 @@ import * as permissionsDeny from './schemas/permissions.deny.js';
 import * as permissionsGrant from './schemas/permissions.grant.js';
 import * as resumeAttempt from './schemas/resume.attempt.js';
 import * as rotDetected from './schemas/rot.detected.js';
+import * as rotExecutorGhostDetected from './schemas/rot.executor-ghost.detected.js';
 import * as rotTeamLsDriftDetected from './schemas/rot.team-ls-drift.detected.js';
 import * as runbookTriggered from './schemas/runbook.triggered.js';
 import * as schemaViolation from './schemas/schema.violation.js';
@@ -127,6 +128,11 @@ export const EventRegistry = {
 
   // Self-healing B1 Group 3b — team-ls vs team-disband drift detector.
   [rotTeamLsDriftDetected.TYPE]: entry(rotTeamLsDriftDetected),
+
+  // fix-executor-ghost-on-reinstall — resolver fallback + boot reconciler
+  // emit this when GENIE_EXECUTOR_ID fails to resolve but agent_id lookup
+  // succeeds. See `turn-close.ts#turnClose` and the boot reconciler (F).
+  [rotExecutorGhostDetected.TYPE]: entry(rotExecutorGhostDetected),
 } as const satisfies Record<string, RegistryEntry>;
 
 export type EventType = keyof typeof EventRegistry;

--- a/src/lib/events/schemas/rot.executor-ghost.detected.ts
+++ b/src/lib/events/schemas/rot.executor-ghost.detected.ts
@@ -1,0 +1,77 @@
+/**
+ * Event: rot.executor-ghost.detected — the turn-close resolver or the boot
+ * reconciler observed a worker session whose `GENIE_EXECUTOR_ID` env var
+ * points to a row that does not exist in the `executors` table.
+ *
+ * Root cause: pgserve reset / reinstall / schema reboot wipes the
+ * `executors` table, but live worker panes retain the env var they were
+ * spawned with. The CLI-side has no on-disk source to rehydrate executors
+ * from (unlike teams; see `rot.team-ls-drift.detected` and PR #1249), so
+ * recovery happens either lazily (resolver fallback at turn-close) or
+ * eagerly (boot reconciler). Both paths emit this event with
+ * `resolution_source` set so operators can tell them apart.
+ *
+ * Behavior on a well-formed env pair (`GENIE_EXECUTOR_ID` + `GENIE_AGENT_NAME`):
+ *   - Resolver finds no row by id, looks up by agent_id, updates the session
+ *     to use the latest executor for that agent, and emits this event.
+ *   - Boot reconciler finds no row by id, checks whether an `agents` row
+ *     exists for the name, and either resurrects the executor row or marks
+ *     it unrecoverable — emitting this event either way.
+ *
+ * Wish: `fix-executor-ghost-on-reinstall` (planning PR #1252, merged).
+ */
+
+import { z } from 'zod';
+import { tagTier } from '../tier.js';
+
+export const SCHEMA_VERSION = 1;
+export const TYPE = 'rot.executor-ghost.detected' as const;
+export const KIND = 'event' as const;
+
+/**
+ * Which code path discovered the ghost. Closed enum — adding a new source
+ * is an explicit schema bump.
+ *   - `resolver`:   lazy fallback inside `turnClose` when the env UUID
+ *                   returns 0 rows; a matching `agent_id` row rescued the
+ *                   close.
+ *   - `reconciler`: eager boot-time pass in `genie serve` start that
+ *                   resurrects (or flags) executor rows for live panes.
+ */
+const ResolutionSourceSchema = tagTier(z.enum(['resolver', 'reconciler']), 'C');
+
+/** The env UUID that failed to resolve. Tokenized — no PII risk. */
+const EnvIdSchema = tagTier(z.string().uuid(), 'C');
+
+/**
+ * The executor id that was substituted (resolver) or INSERTed (reconciler).
+ * May equal `env_id` in the reconciler case when we resurrect with the same
+ * id; otherwise a freshly-looked-up UUID from the agents' most-recent row.
+ */
+const ResolvedIdSchema = tagTier(z.string().uuid(), 'C');
+
+/**
+ * Agent name used for the fallback lookup (`GENIE_AGENT_NAME`). A
+ * tokenized identifier (role/custom-name) — redaction belt-and-braces is
+ * unnecessary here as the name space is closed.
+ */
+const AgentNameSchema = tagTier(z.string().min(1).max(256), 'C');
+
+/**
+ * Whether the ghost was recoverable. For the reconciler, this is false when
+ * no matching `agents.id` row exists (the worker is orphaned at BOTH levels).
+ * For the resolver, this is always true — the event only fires on successful
+ * fallback.
+ */
+const RecoveredSchema = tagTier(z.boolean(), 'C');
+
+export const schema = z
+  .object({
+    resolution_source: ResolutionSourceSchema,
+    env_id: EnvIdSchema,
+    resolved_id: ResolvedIdSchema,
+    agent_name: AgentNameSchema,
+    recovered: RecoveredSchema,
+  })
+  .strict();
+
+export type RotExecutorGhostDetectedPayload = z.infer<typeof schema>;

--- a/src/lib/events/schemas/schemas.test.ts
+++ b/src/lib/events/schemas/schemas.test.ts
@@ -277,6 +277,15 @@ const fixtures: Record<EventType, Record<string, unknown>> = {
       divergence_kind: 'missing_in_disband',
     }),
   },
+
+  // fix-executor-ghost-on-reinstall — resolver fallback + boot reconciler.
+  'rot.executor-ghost.detected': {
+    resolution_source: 'resolver',
+    env_id: '49483b1e-ebd6-4d7a-b824-fffa945ec052',
+    resolved_id: 'aabbccdd-0000-4000-8000-00ff00ff00ff',
+    agent_name: 'genie-configure',
+    recovered: true,
+  },
 };
 
 describe('schema roundtrips — 15 new + 5 exemplars', () => {

--- a/src/lib/turn-close.test.ts
+++ b/src/lib/turn-close.test.ts
@@ -175,4 +175,86 @@ describe.skipIf(!DB_AVAILABLE)('turn-close', () => {
     process.env.GENIE_EXECUTOR_ID = undefined;
     await expect(turnClose({ outcome: 'done' })).rejects.toThrow(/GENIE_EXECUTOR_ID/);
   });
+
+  // --------------------------------------------------------------------------
+  // Bug E — resolver fallback for ghost executors.
+  //
+  // Scenario: pgserve reset wipes the `executors` row but the live worker
+  // pane retains `GENIE_EXECUTOR_ID` in env. `turnClose` must fall back to
+  // `agent_id = GENIE_AGENT_NAME` and close successfully with a warning +
+  // `rot.executor-ghost.detected` event, rather than throwing.
+  // --------------------------------------------------------------------------
+
+  test('fallback: env id ghost → resolves by GENIE_AGENT_NAME, closes cleanly', async () => {
+    const { agentId, executorId } = await seed();
+    // Simulate the ghost: env points to a UUID that does not exist in PG.
+    const ghostId = '00000000-dead-4000-8000-000000000001';
+    process.env.GENIE_EXECUTOR_ID = ghostId;
+    process.env.GENIE_AGENT_NAME = agentId;
+
+    const result = await turnClose({ outcome: 'done', actor: agentId });
+
+    expect(result.noop).toBe(false);
+    // Fallback resolved to the real executor for this agent.
+    expect(result.executorId).toBe(executorId);
+    expect(result.outcome).toBe('done');
+
+    // The real executor row got closed, not the ghost UUID.
+    const exec = await getExecutor(executorId);
+    expect(exec!.outcome).toBe('done');
+    expect(exec!.state).toBe('done');
+
+    // Ghost UUID still has no row (we didn't invent one).
+    const sql = await getConnection();
+    const [ghostRow] = await sql<{ id: string }[]>`SELECT id FROM executors WHERE id = ${ghostId}`;
+    expect(ghostRow).toBeUndefined();
+  });
+
+  test('fallback: picks most recent executor when agent has multiple', async () => {
+    const { agentId } = await seed();
+    // Second executor for the same agent — this should win the fallback.
+    const newer = await createExecutor(agentId, 'claude', 'tmux', { state: 'working' });
+
+    process.env.GENIE_EXECUTOR_ID = '00000000-dead-4000-8000-000000000002';
+    process.env.GENIE_AGENT_NAME = agentId;
+
+    const result = await turnClose({ outcome: 'done', actor: agentId });
+    expect(result.executorId).toBe(newer.id);
+  });
+
+  test('fallback: no agent name env → throws (no silent pick)', async () => {
+    await seed();
+    process.env.GENIE_EXECUTOR_ID = '00000000-dead-4000-8000-000000000003';
+    process.env.GENIE_AGENT_NAME = undefined;
+
+    await expect(turnClose({ outcome: 'done' })).rejects.toThrow(/not found/);
+  });
+
+  test('fallback: agent name with zero executor rows → throws', async () => {
+    process.env.GENIE_EXECUTOR_ID = '00000000-dead-4000-8000-000000000004';
+    process.env.GENIE_AGENT_NAME = 'nonexistent-agent-xyz';
+    // No seed — truly nothing exists for this agent.
+
+    await expect(turnClose({ outcome: 'done' })).rejects.toThrow(/not found/);
+  });
+
+  test('happy path unchanged: env id resolves directly, no fallback warning', async () => {
+    const { executorId, agentId } = await seed();
+    process.env.GENIE_EXECUTOR_ID = executorId;
+    process.env.GENIE_AGENT_NAME = agentId;
+
+    // Capture stderr warnings — happy path must NOT emit the fallback warn.
+    const originalWarn = console.warn;
+    const warns: string[] = [];
+    console.warn = (...args: unknown[]) => warns.push(args.join(' '));
+    try {
+      const result = await turnClose({ outcome: 'done', actor: agentId });
+      expect(result.executorId).toBe(executorId);
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    const fallbackWarns = warns.filter((w) => w.includes('falling back'));
+    expect(fallbackWarns).toHaveLength(0);
+  });
 });

--- a/src/lib/turn-close.ts
+++ b/src/lib/turn-close.ts
@@ -16,6 +16,7 @@
  */
 
 import { type Sql, getConnection } from './db.js';
+import { emitEvent } from './emit.js';
 import type { TurnOutcome } from './executor-types.js';
 
 interface TurnCloseOpts {
@@ -87,19 +88,66 @@ export async function turnClose(opts: TurnCloseOpts): Promise<TurnCloseResult> {
   const sql = await getConnection();
 
   return sql.begin(async (tx: Sql) => {
-    const rows = await tx<{ state: string; outcome: string | null; agent_id: string }[]>`
+    let effectiveId = executorId;
+    let rows = await tx<{ state: string; outcome: string | null; agent_id: string }[]>`
       SELECT state, outcome, agent_id FROM executors
       WHERE id = ${executorId}
       FOR UPDATE
     `;
     if (rows.length === 0) {
-      throw new Error(`turnClose: executor ${executorId} not found`);
+      // Bug E — executor row is a ghost (e.g. env UUID survived a pgserve
+      // reset that wiped the row). Attempt fallback: resolve by the worker's
+      // GENIE_AGENT_NAME env var, taking the most-recent live executor for
+      // that agent. Emits `rot.executor-ghost.detected` on successful
+      // fallback so operators can watch ghost-rate trends.
+      // Use GENIE_AGENT_NAME (not opts.actor) — the env var is set by the
+      // spawn path and is the canonical agent identity for fallback
+      // resolution. `opts.actor` can override just the audit actor.
+      const agentName = process.env.GENIE_AGENT_NAME;
+      if (agentName) {
+        const fallback = await tx<{ id: string }[]>`
+          SELECT id FROM executors
+          WHERE agent_id = ${agentName}
+          ORDER BY started_at DESC
+          LIMIT 1
+          FOR UPDATE
+        `;
+        if (fallback.length > 0) {
+          effectiveId = fallback[0].id;
+          rows = await tx<{ state: string; outcome: string | null; agent_id: string }[]>`
+            SELECT state, outcome, agent_id FROM executors
+            WHERE id = ${effectiveId}
+            FOR UPDATE
+          `;
+          console.warn(
+            `[turn-close] executor ${executorId} not found, falling back to agent_id='${agentName}' → ${effectiveId}`,
+          );
+          try {
+            emitEvent(
+              'rot.executor-ghost.detected',
+              {
+                resolution_source: 'resolver',
+                env_id: executorId,
+                resolved_id: effectiveId,
+                agent_name: agentName,
+                recovered: true,
+              },
+              { severity: 'warn', source_subsystem: 'turn-close' },
+            );
+          } catch {
+            // emit is best-effort — never block turn-close on observability.
+          }
+        }
+      }
+      if (rows.length === 0) {
+        throw new Error(`turnClose: executor ${executorId} not found (no fallback by agent_id='${agentName ?? ''}')`);
+      }
     }
     const row = rows[0];
     if (row.outcome !== null || TERMINAL_STATES.has(row.state)) {
       return {
         noop: true,
-        executorId,
+        executorId: effectiveId,
         outcome: (row.outcome as TurnOutcome | null) ?? opts.outcome,
         closedAt: null,
       };
@@ -113,23 +161,23 @@ export async function turnClose(opts: TurnCloseOpts): Promise<TurnCloseResult> {
           close_reason = ${reason},
           state = 'done',
           ended_at = ${now}
-      WHERE id = ${executorId}
+      WHERE id = ${effectiveId}
     `;
 
     await tx`
       UPDATE agents
       SET current_executor_id = NULL
-      WHERE current_executor_id = ${executorId}
+      WHERE current_executor_id = ${effectiveId}
     `;
 
     await auditInsert(tx, {
-      executorId,
+      executorId: effectiveId,
       agentId: row.agent_id,
       outcome: opts.outcome,
       reason,
       actor,
     });
 
-    return { noop: false, executorId, outcome: opts.outcome, closedAt: now };
+    return { noop: false, executorId: effectiveId, outcome: opts.outcome, closedAt: now };
   });
 }


### PR DESCRIPTION
## Summary

Implements **Bug E** of the `fix-executor-ghost-on-reinstall` wish (planning PR #1252, merged). After a `pgserve` reset, live worker panes retain `GENIE_EXECUTOR_ID` in env but the matching row in `executors` is gone. `turnClose` used to throw `executor not found` with no fallback — leaving workers unable to signal completion until an operator ran raw SQL.

This PR adds a name-based fallback: when the env UUID returns zero rows, `turnClose` looks up `WHERE agent_id = GENIE_AGENT_NAME ORDER BY started_at DESC LIMIT 1` and closes that executor instead, with a visible warning and a new `rot.executor-ghost.detected` audit event.

**Scope note:** Bug F (boot reconciler that proactively iterates live tmux panes and resurrects missing executor rows) and Group 3 (end-to-end repro script) are deferred to a follow-up PR. The resolver fallback alone self-heals in-session, which is the hot path operators actually hit. The follow-up adds tmux introspection + eager resurrection.

## Behavior

**Happy path (unchanged):** env UUID + row present → single `SELECT ... FOR UPDATE` → close as before. No extra query, no warning.

**Ghost path (new):** env UUID missing from PG:
1. Look up the most-recent executor for `GENIE_AGENT_NAME`.
2. If found: re-fetch the row, close it, emit `[turn-close] executor <env-id> not found, falling back to agent_id='<name>' → <resolved-id>` to stderr, emit `rot.executor-ghost.detected` event with `resolution_source='resolver'`.
3. If no agent env or zero-match: throw a clear error naming both the env UUID and the attempted agent name.

## Live incident reference

Reproduced today (2026-04-21 ~04:30 UTC) on `genie-stefani` after `genie update` (4.260421.3): a worker session had `GENIE_EXECUTOR_ID=49483b1e-...` but zero rows in `executors`. Every `genie done`/`blocked`/`failed` threw. Manual recovery required raw SQL — documented in the sibling wish.

With this change, the same scenario resolves automatically: the fallback finds the agent's most-recent executor row (if the `agents.id = GENIE_AGENT_NAME` row still exists) and closes it, logging the ghost event.

## Why name-based fallback + most-recent, not smarter heuristics

- **Exact match by `agent_id`** (not `LIKE`) — partial matches could resolve to a different worker's executor.
- **`ORDER BY started_at DESC LIMIT 1`** — long-running agents accumulate multiple executor rows over time (one per `agent resume`); most-recent is the live one.
- **Throws when agent env missing** — no silent no-op close; the error message names both the env UUID and the (empty) attempted fallback, preserving debuggability.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (46 pre-existing warnings, 0 errors)
- [x] `bun test src/lib/turn-close.test.ts` — **15 pass / 0 fail** (10 existing + 5 new)
- [x] `bun test src/lib/turn-close.test.ts src/lib/events/schemas/schemas.test.ts src/lib/__tests__/emit-integrity.test.ts src/lib/executor-registry.test.ts` — **178 pass / 0 fail**
- [x] Pre-push hook full project suite — green

### New test cases

1. `fallback: env id ghost → resolves by GENIE_AGENT_NAME, closes cleanly`
2. `fallback: picks most recent executor when agent has multiple`
3. `fallback: no agent name env → throws (no silent pick)`
4. `fallback: agent name with zero executor rows → throws`
5. `happy path unchanged: env id resolves directly, no fallback warning` (regression guard on happy-path side effects)

## Files

```
Modify:
  src/lib/turn-close.ts                            # Bug E — fallback inside turnClose
  src/lib/turn-close.test.ts                       # 5 new tests
  src/lib/events/registry.ts                       # register the new event
  src/lib/events/schemas/schemas.test.ts           # roundtrip fixture

Create:
  src/lib/events/schemas/rot.executor-ghost.detected.ts
```

## Wish

Ref: `.genie/wishes/fix-executor-ghost-on-reinstall/WISH.md` (PR #1252, merged)
Sibling: `.genie/wishes/fix-pg-disk-rehydration/WISH.md` (PR #1249, merged)