### PR TITLE
fix(team-auto-spawn): prefer team's own session over caller's

### DIFF
--- a/src/lib/team-auto-spawn.ts
+++ b/src/lib/team-auto-spawn.ts
@@ -47,27 +47,42 @@ function getSystemPromptFile(workingDir: string): string | null {
 /**
  * Ensure a tmux session exists for the given team.
  *
- * Resolution order:
- *   1. Current tmux session (caller is inside tmux)
- *   2. Team config `tmuxSessionName` (stored during team create)
- *   3. Create/find session named after team (last resort)
+ * Resolution order (TEAM CONFIG FIRST — never the caller's session):
+ *   1. Team config `tmuxSessionName` (authoritative, stored during team create)
+ *   2. Caller's current tmux session (legacy fallback for human-interactive
+ *      callers without team config)
+ *   3. Create/find a session named after the team (last resort)
+ *
+ * Why team config first: when a background daemon (inbox-watcher, scheduler)
+ * processes work for team X while running INSIDE the tmux session of team Y,
+ * the legacy "current session first" rule would route team X operations into
+ * team Y's session — producing ghost team-leads in the wrong place. The team's
+ * own configured session is the only correct target for cross-team automation.
  */
 async function ensureSession(teamName: string): Promise<string> {
-  // If inside tmux, reuse the current session
-  const current = await tmux.getCurrentSessionName();
-  if (current) return current;
-
-  // Check team config for stored session name
   const { getTeam } = await import('./team-manager.js');
   const teamConfig = await getTeam(teamName);
+
+  // 1. Team's own configured session (cross-team safe).
   if (teamConfig?.tmuxSessionName) {
     const existing = await tmux.findSessionByName(teamConfig.tmuxSessionName);
     if (existing) return teamConfig.tmuxSessionName;
+    // Team config knows the session name but it doesn't exist on disk yet —
+    // fall through to creation below using that name.
   }
 
-  // Fallback: atomically create session named after the team.
-  // Uses new-session directly and catches "duplicate session" to eliminate TOCTOU race.
-  const sessionName = sanitizeTeamName(teamName);
+  // 2. Legacy fallback: only when no team config exists (human-interactive
+  // CLI invocations without an established team). Background daemons should
+  // never reach this branch because team configs are persisted at create time.
+  if (!teamConfig) {
+    const current = await tmux.getCurrentSessionName();
+    if (current) return current;
+  }
+
+  // 3. Atomically create a session named after the team (or its configured
+  // name if known). Uses new-session directly and catches "duplicate session"
+  // to eliminate TOCTOU race.
+  const sessionName = teamConfig?.tmuxSessionName ?? sanitizeTeamName(teamName);
   try {
     await tmux.createSession(sessionName);
   } catch (error) {
@@ -85,14 +100,21 @@ async function ensureSession(teamName: string): Promise<string> {
  *
  * A team is considered "active" if:
  * 1. Its native config.json exists, AND
- * 2. A tmux window with the team name exists in any session
+ * 2. A tmux window matching the team name exists in the team's own session
+ *
+ * Session resolution prefers the team's configured `tmuxSessionName` over the
+ * caller's current session — see `ensureSession` above for rationale. Without
+ * this, an inbox-watcher running inside team Y's session would always report
+ * team X as inactive (looking in the wrong session) and trigger ghost spawns.
  */
 export async function isTeamActive(teamName: string): Promise<boolean> {
   const config = await loadConfig(teamName);
   if (!config) return false;
 
-  // Check current session first, then try team name as session
-  const sessionName = (await tmux.getCurrentSessionName()) ?? sanitizeTeamName(teamName);
+  const { getTeam } = await import('./team-manager.js');
+  const teamConfig = await getTeam(teamName);
+  const sessionName = teamConfig?.tmuxSessionName ?? (await tmux.getCurrentSessionName()) ?? sanitizeTeamName(teamName);
+
   const session = await tmux.findSessionByName(sessionName);
   if (!session) return false;
 
@@ -139,10 +161,17 @@ export async function isAgentAlive(agentName: string): Promise<boolean> {
  * @returns Result indicating whether the team was created or already existed
  */
 export async function ensureTeamLead(teamName: string, workingDir: string): Promise<EnsureTeamLeadResult> {
+  // Resolve target session FROM TEAM CONFIG, never from the caller's session.
+  // See `ensureSession` rationale: caller-session fallback is wrong for any
+  // background daemon (inbox-watcher, scheduler) processing cross-team work.
+  const { getTeam } = await import('./team-manager.js');
+  const teamConfig = await getTeam(teamName);
+  const targetSession =
+    teamConfig?.tmuxSessionName ?? (await tmux.getCurrentSessionName()) ?? sanitizeTeamName(teamName);
+
   // Fast path: team already active
-  const currentSession = (await tmux.getCurrentSessionName()) ?? sanitizeTeamName(teamName);
   if (await isTeamActive(teamName)) {
-    return { created: false, session: currentSession, window: sanitizeWindowName(teamName) };
+    return { created: false, session: targetSession, window: sanitizeWindowName(teamName) };
   }
 
   // Resolve the actual leader name from team config (never returns 'team-lead')


### PR DESCRIPTION
## Summary

Fixes the ghost-team-lead respawn loop where a background daemon (e.g. `inbox-watcher` running inside the genie session) keeps spawning a `simone@simone` team-lead inside the WRONG tmux session, because the previous heuristic preferred the caller's current session over the team's configured one.

## Root cause

`isTeamActive`, `ensureSession`, and `ensureTeamLead` all consulted `getCurrentSessionName()` first. For a daemon processing cross-team work, "current session" is the daemon's own session — never the target team's. The team's `tmuxSessionName` (stored at team-create time) is the only correct authority.

## Symptom

```
PID 2018973  etime 32:18  simone:1 pane %1   ← real simone team-lead
PID 2031802  etime 00:03  genie:2  pane %8   ← ghost spawned by daemon
Both: claude --agent-id simone@simone --resume da6ceb34-...

Killing 2031802 → reconciler/inbox-watcher respawns within ~3s.
```

Two `simone@simone` claude processes fighting for the same Claude Code session UUID, in different tmux sessions, in an endless loop the reconciler can't break.

## Fix

Three call sites in `src/lib/team-auto-spawn.ts`:

1. `ensureSession` — team config first, caller's session only as legacy human-interactive fallback.
2. `isTeamActive` — same priority.
3. `ensureTeamLead` — derives `targetSession` from team config before any current-session probe.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test src/lib/inbox-watcher.test.ts src/lib/team-manager.test.ts` → 54/54 pass
- [x] `bun run build` clean
- [ ] Manual: deploy + verify ghost respawn stops in production tmux topology

## Companion PR

Pairs with #1248 (tmux `=` literal-name prefix). #1248 fixed the lookup mechanism (don't let tmux misparse `@N` as window-id syntax). This PR fixes the upstream decision of WHICH session to look in.

## Out of scope

Two related issues not addressed here, tracked separately:

1. **Spawn coordination** between reconciler and inbox-watcher (no lock — they can both fire `ensureTeamLead` concurrently). This fix removes the FALSE NEGATIVE that triggered duplicate spawns; coordination would prevent any concurrent races still possible in race-prone callers.
2. **Agent registry GC** for orphan worktree entries (e.g. `council-1776713669` with missing `workingDir`). Tracked in earlier `/trace` report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)