### PR TITLE
fix(turn-close): flip both identity+legacy rows; skip boot-resume of terminal executors

### DIFF
--- a/src/lib/__tests__/auto-resume-zombie-cap.test.ts
+++ b/src/lib/__tests__/auto-resume-zombie-cap.test.ts
@@ -372,3 +372,95 @@ describe('Change #3: reconcileStaleSpawns GCs dead-pane zombies in active states
     expect(source).toContain('WHERE id = ${row.id} AND state = ${prevState}');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Gap #2 regression — boot-mode terminal-executor check (turn-session-contract)
+// ---------------------------------------------------------------------------
+
+/**
+ * Mock SQL that returns a closed executor for the isLegitimatelyClosed helper
+ * lookup (agent_id → executor with closed_at set).
+ */
+function createMockSqlWithTerminalExecutor(currentExecutorId: string) {
+  const sql: any = (strings: TemplateStringsArray, ..._values: unknown[]) => {
+    const query = strings.join(' ');
+    if (query.includes('current_executor_id') && query.includes('FROM agents')) {
+      return [{ current_executor_id: currentExecutorId }];
+    }
+    if (query.includes('FROM executors') && query.includes('closed_at')) {
+      return [{ closed_at: new Date(), outcome: 'done' }];
+    }
+    return [];
+  };
+  sql.begin = async (fn: (tx: typeof sql) => Promise<unknown>) => fn(sql);
+  sql.listen = async () => {};
+  sql.end = async () => {};
+  return sql;
+}
+
+describe('Gap #2 regression — boot-mode terminal-executor check (turn-session-contract)', () => {
+  test('boot mode skips resume when current executor is already terminal', async () => {
+    // Live-instance regression (2026-04-21): agent called `genie done`, executor
+    // was marked terminal, daemon restarted, boot-mode reconciler resurrected the
+    // agent anyway because D1/D3 rules were bypassed. Fix: check executor terminal
+    // state before resuming in boot mode.
+    const worker = makeWorker({
+      id: 'dead-closed',
+      paneId: '%50',
+      state: 'spawning',
+      claudeSessionId: 'sess-closed',
+    });
+    const { deps, resumedIds, logs } = createMockDeps({
+      listWorkers: async () => [worker],
+      isPaneAlive: async () => false,
+      getConnection: async () => createMockSqlWithTerminalExecutor('exec-closed-1'),
+    });
+
+    await runAgentRecoveryPass(deps, 'daemon-boot-test', defaultConfig, 'boot');
+
+    expect(resumedIds).not.toContain('dead-closed');
+    const skipLog = logs.find((l) => l.event === 'agent_resume_skipped_boot_terminal');
+    expect(skipLog).toBeDefined();
+  });
+
+  test('boot mode still resumes when executor is open (legitimate mid-turn crash recovery)', async () => {
+    // No regression to the legitimate recovery path — if the executor is still
+    // open (closed_at IS NULL AND outcome IS NULL), boot-mode resume fires as
+    // before. Default mock SQL returns empty rows → isLegitimatelyClosed=false.
+    const worker = makeWorker({
+      id: 'dead-open',
+      paneId: '%51',
+      state: 'spawning',
+      claudeSessionId: 'sess-open',
+    });
+    const { deps, resumedIds } = createMockDeps({
+      listWorkers: async () => [worker],
+      isPaneAlive: async () => false,
+    });
+
+    await runAgentRecoveryPass(deps, 'daemon-boot-test', defaultConfig, 'boot');
+
+    expect(resumedIds).toContain('dead-open');
+  });
+
+  test('sweep mode D1/D3 rules remain intact — state="spawning" + dead pane is skipped (no regression)', async () => {
+    // Separate assertion: the Gap #2 fix only touches boot mode. In sweep mode,
+    // state='spawning' falls through to the state-not-in-D3 skip at line 888 —
+    // unchanged. This guards against accidental bleed between boot and sweep
+    // branches during the fix.
+    const worker = makeWorker({
+      id: 'sweep-spawning',
+      paneId: '%52',
+      state: 'spawning',
+      claudeSessionId: 'sess-sweep',
+    });
+    const { deps, resumedIds } = createMockDeps({
+      listWorkers: async () => [worker],
+      isPaneAlive: async () => false,
+    });
+
+    await runAgentRecoveryPass(deps, 'daemon-sweep-test', defaultConfig, 'sweep');
+
+    expect(resumedIds).not.toContain('sweep-spawning');
+  });
+});

--- a/src/lib/scheduler-daemon.ts
+++ b/src/lib/scheduler-daemon.ts
@@ -857,6 +857,34 @@ type RecoveryMode = 'boot' | 'sweep';
  * preserved across reboot). The turn-aware rules exist for periodic
  * sweeps, where "idle + dead" is a ghost-loop precursor.
  */
+/**
+ * Gap #2 (turn-session-contract): boot-mode reconciler's D1/D3 bypass resurrects
+ * properly-closed agents across daemon restart. Returns true when the agent's
+ * current executor is already terminal (closed_at set OR outcome set), meaning an
+ * explicit close verb OR pane-exit trap already fired. Caller should skip resume.
+ *
+ * Never throws — a transient PG error returns false so the worker falls back to
+ * legacy resume behavior. Errs on the side of attempting resume (mirrors the
+ * pre-fix default) rather than silently dropping a legitimate mid-turn crash.
+ */
+async function isLegitimatelyClosed(deps: SchedulerDeps, worker: WorkerInfo): Promise<boolean> {
+  try {
+    const sql = await deps.getConnection();
+    const agentRows = await sql<{ current_executor_id: string | null }[]>`
+      SELECT current_executor_id FROM agents WHERE id = ${worker.id}
+    `;
+    const executorId = agentRows[0]?.current_executor_id;
+    if (!executorId) return false;
+    const execRows = await sql<{ closed_at: Date | null; outcome: string | null }[]>`
+      SELECT closed_at, outcome FROM executors WHERE id = ${executorId}
+    `;
+    if (execRows.length === 0) return false;
+    return execRows[0].closed_at !== null || execRows[0].outcome !== null;
+  } catch {
+    return false;
+  }
+}
+
 async function handleDeadPane(
   deps: SchedulerDeps,
   config: SchedulerConfig,
@@ -866,6 +894,20 @@ async function handleDeadPane(
   mode: RecoveryMode,
 ): Promise<RecoveryOutcome> {
   if (mode === 'boot') {
+    // Gap #2 fix: before resuming, check if the agent's executor is already
+    // terminal. Otherwise we resurrect agents that called `genie done` before
+    // the daemon restarted (2026-04-21 live regression in turn-session-contract-genie team).
+    if (turnAware && (await isLegitimatelyClosed(deps, worker))) {
+      deps.log({
+        timestamp: deps.now().toISOString(),
+        level: 'debug',
+        event: 'agent_resume_skipped_boot_terminal',
+        daemon_id: daemonId,
+        agent_id: worker.id,
+        reason: 'executor_already_closed',
+      });
+      return 'skipped';
+    }
     const result = await attemptAgentResume(deps, config, worker);
     return result === 'resumed' ? 'resumed' : 'skipped';
   }

--- a/src/lib/turn-close.test.ts
+++ b/src/lib/turn-close.test.ts
@@ -257,4 +257,63 @@ describe.skipIf(!DB_AVAILABLE)('turn-close', () => {
     const fallbackWarns = warns.filter((w) => w.includes('falling back'));
     expect(fallbackWarns).toHaveLength(0);
   });
+
+  test('Gap #1 regression — dual-row state flip: both identity and legacy name-keyed rows marked done', async () => {
+    // Reproduce the turn-session-contract dual-row pattern observed live on
+    // 2026-04-21 (test team `turn-session-contract-genie`):
+    //   - Identity row: id=UUID, custom_name='genie-configure', team=...
+    //     (created by findOrCreateAgent, carries the executor FK)
+    //   - Legacy row:   id='genie-configure', custom_name=NULL, team=...
+    //     (created by legacy register() path; custom_name=NULL because partial
+    //     unique index `idx_agents_custom_name_team` blocks a second row from
+    //     sharing non-null custom_name)
+    // Before this fix, turnClose only swept by current_executor_id — legacy
+    // row stayed state='spawning' and reconcile resurrected the agent on next
+    // daemon restart.
+    const sql = await getConnection();
+    const teamName = 'dual-row-test';
+    const customName = 'dual-row-agent';
+
+    // Identity row (UUID-keyed) — carries the executor FK
+    const identity = await findOrCreateAgent(customName, teamName, 'engineer');
+    const exec = await createExecutor(identity.id, 'claude', 'tmux', { state: 'working' });
+    await setCurrentExecutor(identity.id, exec.id);
+
+    // Legacy name-keyed row — id = customName, custom_name=NULL (matches live pattern)
+    await sql`
+      INSERT INTO agents (id, custom_name, team, role, state, started_at, last_state_change, repo_path)
+      VALUES (${customName}, NULL, ${teamName}, 'engineer', 'spawning', now(), now(), '/tmp/test')
+    `;
+
+    const result = await turnClose({ outcome: 'done', executorId: exec.id });
+    expect(result.noop).toBe(false);
+
+    // Both rows must be flipped to state='done'
+    const rows = await sql<{ id: string; state: string | null; current_executor_id: string | null }[]>`
+      SELECT id, state, current_executor_id FROM agents
+      WHERE (id = ${customName} OR id = ${identity.id}) AND team = ${teamName}
+      ORDER BY id
+    `;
+    expect(rows.length).toBe(2);
+    for (const row of rows) {
+      expect(row.state).toBe('done');
+      expect(row.current_executor_id).toBeNull();
+    }
+  });
+
+  test('Gap #1 regression — single-row (post-unification) path: identity-only flip still works', async () => {
+    // When only the identity row exists (no legacy dual-row pair), the
+    // defensive sweep is a no-op and the identity row is flipped correctly.
+    const { agentId, executorId } = await seed();
+
+    const result = await turnClose({ outcome: 'done', executorId });
+    expect(result.noop).toBe(false);
+
+    const sql = await getConnection();
+    const [row] = await sql<{ state: string | null; current_executor_id: string | null }[]>`
+      SELECT state, current_executor_id FROM agents WHERE id = ${agentId}
+    `;
+    expect(row.state).toBe('done');
+    expect(row.current_executor_id).toBeNull();
+  });
 });

--- a/src/lib/turn-close.ts
+++ b/src/lib/turn-close.ts
@@ -76,6 +76,38 @@ async function defaultAuditInsert(tx: Sql, p: AuditPayload): Promise<void> {
   `;
 }
 
+/**
+ * Close out an agent's rows in the turn-close transaction.
+ *
+ * Flips the identity row's state to 'done' directly via the executor's
+ * agent_id FK (not the reverse-FK sweep used pre-2026-04-21, which missed
+ * dual-row legacy pairs and left name-keyed rows in state='spawning' that
+ * reconcile then resurrected — see turn-session-contract Review Results
+ * Gap #1).
+ *
+ * Also defensively sweeps any legacy name-keyed row sharing (custom_name, team)
+ * so the dual-row pattern on pre-unification instances closes cleanly. Legacy
+ * rows have `id = custom_name` and `custom_name IS NULL` (the partial unique
+ * index `idx_agents_custom_name_team` blocks two rows from sharing non-null
+ * custom_name), so the legacy row is addressable by id=${ident.custom_name}.
+ * Becomes a no-op when `agents-runtime-extraction` lands.
+ */
+async function terminalizeAgentRows(tx: Sql, agentId: string): Promise<void> {
+  const identRows = await tx<{ custom_name: string | null; team: string | null }[]>`
+    UPDATE agents
+    SET state = 'done', current_executor_id = NULL
+    WHERE id = ${agentId}
+    RETURNING custom_name, team
+  `;
+  const ident = identRows[0];
+  if (!ident?.custom_name || !ident?.team || ident.custom_name === agentId) return;
+  await tx`
+    UPDATE agents
+    SET state = 'done', current_executor_id = NULL
+    WHERE id = ${ident.custom_name} AND team = ${ident.team}
+  `;
+}
+
 export async function turnClose(opts: TurnCloseOpts): Promise<TurnCloseResult> {
   if ((opts.outcome === 'blocked' || opts.outcome === 'failed') && !opts.reason?.trim()) {
     throw new Error(`turnClose: --reason is required for outcome '${opts.outcome}'`);
@@ -170,11 +202,7 @@ export async function turnClose(opts: TurnCloseOpts): Promise<TurnCloseResult> {
       WHERE id = ${effectiveId}
     `;
 
-    await tx`
-      UPDATE agents
-      SET current_executor_id = NULL
-      WHERE current_executor_id = ${effectiveId}
-    `;
+    await terminalizeAgentRows(tx, row.agent_id);
 
     await auditInsert(tx, {
       executorId: effectiveId,


### PR DESCRIPTION
## Summary

Close two live regressions in `turn-session-contract`:

- **Gap #1** — `genie done` left legacy name-keyed rows in `state='spawning'` → reconcile resurrected them on next daemon restart
- **Gap #2** — `scheduler-daemon` boot-mode unconditionally resumed agents with valid `claudeSessionId`, bypassing the turn-aware D1/D3 terminal check

69 LoC of source changes + 148 LoC of tests (5 new regression tests). No schema change. No flag. No migration.

## Context

This minimalist fix replaces a rejected full-migration wish (`agent-row-unification`) that was convened to a 5-member council and unanimously deferred in favor of this patch. Preserved at `.genie/wishes/_archive/agent-row-unification-rejected-2026-04-21/` with the full `council-report.md`.

Root cause of Gap #1: the UPDATE at `src/lib/turn-close.ts:173-177` was doing a reverse-FK sweep (`WHERE current_executor_id = ${executorId}`) which only touched the identity row that holds the FK — the legacy name-keyed dual-row zombie retained `state='spawning'`. Fix flips state directly by `id = ${row.agent_id}` (the executor's `agent_id` FK was already SELECTed at line 92 — no extra query), then defensively sweeps any legacy row addressable by `id = identity.custom_name`. Extracted to `terminalizeAgentRows()` helper for complexity hygiene.

Root cause of Gap #2: `scheduler-daemon.ts:868-871` bypassed the D1/D3 gates in boot mode, per the comment "most likely mid-turn when the daemon itself died." That rationale protected one rare failure mode (mid-turn crash) at the cost of another common one (restart after clean close). Fix adds `isLegitimatelyClosed(deps, worker)` — a read-only pair of SELECTs that returns true when the executor has `closed_at IS NOT NULL OR outcome IS NOT NULL`. Legitimate mid-turn crashes (executor still open) still resume as before.

The architectural debt the council flagged (runtime state still lives on `agents` instead of `executors`, despite `012_executor_model.sql:3`'s promise to slim agents) is tracked in sibling wish `agents-runtime-extraction` (pending separate PR).

## Files changed

```
src/lib/turn-close.ts                              (+34, -4)   helper + simplified call
src/lib/scheduler-daemon.ts                        (+42)       isLegitimatelyClosed + boot-mode check
src/lib/turn-close.test.ts                         (+59)       Gap #1 regression tests
src/lib/__tests__/auto-resume-zombie-cap.test.ts   (+92)       Gap #2 regression tests
```

## Test plan

- [x] `bun test src/lib/turn-close.test.ts` — 17/17 pass (2 new Gap #1 tests green)
- [x] `bun test src/lib/__tests__/auto-resume-zombie-cap.test.ts` — 15/15 pass (3 new Gap #2 tests green)
- [x] Targeted runs: 32 tests, 91 expect calls, zero fails in isolation
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean on my files (46 pre-existing warnings in other files unchanged)
- [x] `bun run dead-code`, `bun run skills:lint`, `bun run wishes:lint`, `bun run lint:emit` — all pass
- [ ] CI re-run — see note below on pre-push bypass
- [ ] Manual live-instance: spawn agent, `genie done`, restart daemon, assert no resume within 60s
- [ ] turn-session-contract WISH.md Review Results — Gaps #1, #2, #4 marked resolved after merge

## ⚠️ Pre-push hook bypass (explicit user authorization)

This PR was pushed with `--no-verify` under explicit user authorization, because the local pre-push hook (husky `bun run check` full test suite) has 1-3 pre-existing flaky tests per run — not caused by this change.

**Evidence the flakes pre-date this PR:**

- 4 consecutive `bun run check` runs on this branch yielded 3388, 3389, 3390 passes (fluctuating) — classic flake symptom
- Only consistently-visible failure is `test/pentest/observability/listen-bomb.test.ts > NOTIFY flood back-pressure response` with `beforeEach/afterEach hook timed out`
- Commit `d801890d test(pentest): give listen-bomb saturation test explicit 15s timeout` shows this test was already being patched pre-existing to my changes
- My targeted test files pass 32/32 consistently across every run

Request: **CI re-verify this PR** — CI environment may have different flake rates than local dev. If CI also flakes, please file a follow-up to deflake listen-bomb rather than blocking this PR.

## Does not fix (scope)

- **Gap #3** (`GENIE_EXECUTOR_ID` env verification) — deferred; needs live-instance instrumentation, not a code change
- **Gap #5** (native-teams config: missing `workingDir`, auto-resume appends member) — separate wish needed (`native-teams-config-hardening`)
- Architectural runtime-columns-on-agents debt — tracked in `agents-runtime-extraction` wish (separate PR coming)

## Related

- Closes gaps from: `.genie/wishes/turn-session-contract/WISH.md` Review Results
- Council deliberation (5 members, 2 rounds): `.genie/wishes/_archive/agent-row-unification-rejected-2026-04-21/council-report.md` (will land in separate docs PR)
- Follow-up wish: `.genie/wishes/agents-runtime-extraction/WISH.md` (pending separate PR)