### PR TITLE
feat(inbox-watcher): emit rot.inbox-watcher-spawn-loop on silent-skip

### DIFF
--- a/src/lib/events/registry.ts
+++ b/src/lib/events/registry.ts
@@ -38,6 +38,7 @@ import * as permissionsGrant from './schemas/permissions.grant.js';
 import * as resumeAttempt from './schemas/resume.attempt.js';
 import * as rotDetected from './schemas/rot.detected.js';
 import * as rotExecutorGhostDetected from './schemas/rot.executor-ghost.detected.js';
+import * as rotInboxWatcherSpawnLoopDetected from './schemas/rot.inbox-watcher-spawn-loop.detected.js';
 import * as rotTeamLsDriftDetected from './schemas/rot.team-ls-drift.detected.js';
 import * as runbookTriggered from './schemas/runbook.triggered.js';
 import * as schemaViolation from './schemas/schema.violation.js';
@@ -133,6 +134,12 @@ export const EventRegistry = {
   // emit this when GENIE_EXECUTOR_ID fails to resolve but agent_id lookup
   // succeeds. See `turn-close.ts#turnClose` and the boot reconciler (F).
   [rotExecutorGhostDetected.TYPE]: entry(rotExecutorGhostDetected),
+
+  // BUGLESS-GENIE Pattern 9 — inbox-watcher silent-skip after
+  // MAX_SPAWN_FAILURES consecutive spawn failures. Fired exactly once on
+  // the transition from recoverable to dead-inbox. See
+  // `brain/memory/reference_pattern9_inbox_watcher_spawn_loop.md`.
+  [rotInboxWatcherSpawnLoopDetected.TYPE]: entry(rotInboxWatcherSpawnLoopDetected),
 } as const satisfies Record<string, RegistryEntry>;
 
 export type EventType = keyof typeof EventRegistry;

--- a/src/lib/events/schemas/rot.inbox-watcher-spawn-loop.detected.ts
+++ b/src/lib/events/schemas/rot.inbox-watcher-spawn-loop.detected.ts
@@ -1,0 +1,111 @@
+/**
+ * Event: rot.inbox-watcher-spawn-loop.detected — the inbox-watcher daemon
+ * observed that a team-lead spawn has failed `MAX_SPAWN_FAILURES` (3)
+ * consecutive times and will silently skip future polls for this session
+ * key until the daemon restarts or `resetSpawnFailures()` is called.
+ *
+ * Root cause family:
+ *   - Team-lead spawn throws (tmux failure, missing workingDir validation at
+ *     deeper layer, stale team row, etc.) and the watcher increments an
+ *     in-memory failure counter.
+ *   - At `failures === MAX_SPAWN_FAILURES`, the watcher flips into silent-
+ *     skip mode. No PG event was emitted prior to this schema (canonical
+ *     blind spot). Messages addressed to the team keep arriving on disk
+ *     but are never picked up, so they are effectively lost until manual
+ *     intervention.
+ *
+ * Blast radius (observed 2026-04-20, `reference_pattern9_inbox_watcher_spawn_loop.md`):
+ *   215+ messages silently dropped across two ghost teams
+ *   (`wish-state-invalidation`, `omni-channels-pivot`) before the behavior
+ *   was noticed manually via a `/trace` pass.
+ *
+ * Emit site:
+ *   `src/lib/inbox-watcher.ts::attemptSpawn()` — fired exactly once on the
+ *   transition from `failures === MAX_SPAWN_FAILURES - 1` to `failures ===
+ *   MAX_SPAWN_FAILURES`. Subsequent skips are NOT re-emitted (prevents
+ *   polling-cadence flooding of the event substrate). A follow-up
+ *   `rot.inbox-watcher-spawn-loop.resolved` is a stretch event (not in
+ *   this schema) for when the team recovers and the counter resets.
+ *
+ * Consumer guidance:
+ *   - Runbook `rot.inbox-watcher-spawn-loop` (future B detector) can
+ *     archive the inbox dir, delete the team row (if truly dead), or
+ *     re-home the orphan tasks blocking spawn.
+ *   - False-positive check: confirm the team is NOT in mid-teardown via
+ *     `genie team ls --json` before any mutating action.
+ *
+ * Wish: genie-bugless-self-healing (sub-project B, brainstorm in flight).
+ * Pattern: Pattern 9 in the BUGLESS-GENIE 11-pathology roster.
+ */
+
+import { z } from 'zod';
+import { redactFreeText } from '../redactors.js';
+import { tagTier } from '../tier.js';
+
+export const SCHEMA_VERSION = 1;
+export const TYPE = 'rot.inbox-watcher-spawn-loop.detected' as const;
+export const KIND = 'event' as const;
+
+/**
+ * The team name whose inbox watcher is now in silent-skip mode.
+ * Tokenized identifier — no PII expected, but belt-and-braces redaction
+ * via `redactFreeText` guards against a future team-naming scheme leaking
+ * raw paths or user handles.
+ */
+const TeamNameSchema = tagTier(
+  z
+    .string()
+    .min(1)
+    .max(256)
+    .transform((v) => redactFreeText(v)),
+  'C',
+);
+
+/**
+ * The session key derived from the first unread message's routing header
+ * (or equal to `team_name` when the header is absent). Present so consumers
+ * can disambiguate when a single team has multiple session scopes spawning
+ * in parallel.
+ */
+const SessionKeySchema = tagTier(
+  z
+    .string()
+    .min(1)
+    .max(256)
+    .transform((v) => redactFreeText(v)),
+  'C',
+);
+
+/**
+ * The failure count at emit time. Always equals `MAX_SPAWN_FAILURES` (3) by
+ * design — this event only fires on the transition. Encoded as int rather
+ * than hard-coded so a future config bump to `MAX_SPAWN_FAILURES` surfaces
+ * in the event payload without a schema bump.
+ */
+const FailureCountSchema = tagTier(z.number().int().min(1).max(100), 'C');
+
+/**
+ * The most recent spawn-error message, redacted. Bounded at 2 KiB so a
+ * pathological stack trace can't balloon the events table — the emit site
+ * trims before serialization.
+ */
+const LastErrorMessageSchema = tagTier(
+  z
+    .string()
+    .min(1)
+    .max(2048)
+    .transform((v) => redactFreeText(v)),
+  'B',
+  'redacted error message from the final failed ensureTeamLead() call',
+);
+
+export const schema = z
+  .object({
+    team_name: TeamNameSchema,
+    session_key: SessionKeySchema,
+    failure_count: FailureCountSchema,
+    last_error_message: LastErrorMessageSchema,
+  })
+  .strict();
+
+export type RotInboxWatcherSpawnLoopDetectedPayload = z.infer<typeof schema>;

--- a/src/lib/events/schemas/schemas.test.ts
+++ b/src/lib/events/schemas/schemas.test.ts
@@ -286,6 +286,15 @@ const fixtures: Record<EventType, Record<string, unknown>> = {
     agent_name: 'genie-configure',
     recovered: true,
   },
+
+  // BUGLESS-GENIE Pattern 9 — inbox-watcher silent-skip after
+  // MAX_SPAWN_FAILURES consecutive spawn failures.
+  'rot.inbox-watcher-spawn-loop.detected': {
+    team_name: 'wish-state-invalidation',
+    session_key: 'wish-state-invalidation',
+    failure_count: 3,
+    last_error_message: 'ensureTeamLead failed: tmux session not found',
+  },
 };
 
 describe('schema roundtrips — 15 new + 5 exemplars', () => {

--- a/src/lib/inbox-watcher.test.ts
+++ b/src/lib/inbox-watcher.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import type { InboxWatcherDeps } from './inbox-watcher.js';
+import type { DeadInboxEventPayload, InboxWatcherDeps } from './inbox-watcher.js';
 import { checkInboxes, resetNoWorkingDirWarned, resetSpawnFailures } from './inbox-watcher.js';
 
 // ============================================================================
@@ -23,6 +23,7 @@ function makeDeps(overrides: Partial<InboxWatcherDeps> = {}): InboxWatcherDeps {
     isAgentAlive: async () => false,
     ensureTeamLead: async () => ({ created: true }),
     warn: () => {},
+    emitDeadInbox: () => {},
     ...overrides,
   } as InboxWatcherDeps;
 }
@@ -274,5 +275,136 @@ describe('checkInboxes', () => {
     const result = await checkInboxes(deps);
     expect(result).toEqual(['plain-team']);
     expect(spawnedTeam).toBe('plain-team');
+  });
+
+  // ==========================================================================
+  // Pattern 9 — rot.inbox-watcher-spawn-loop.detected emission
+  //
+  // Covers the BUGLESS-GENIE Pattern 9 regression. Previously, the watcher
+  // hit `MAX_SPAWN_FAILURES = 3` and flipped into silent-skip mode without
+  // emitting any observable signal. `reference_pattern9_inbox_watcher_spawn_loop.md`
+  // documented 215+ silently-dropped messages before manual detection. The
+  // fix emits `rot.inbox-watcher-spawn-loop.detected` exactly once on the
+  // transition to `failure_count === MAX_SPAWN_FAILURES`.
+  // ==========================================================================
+
+  test('emits dead-inbox event exactly once on transition to MAX_SPAWN_FAILURES', async () => {
+    const emittedPayloads: DeadInboxEventPayload[] = [];
+    const deps = makeDeps({
+      listTeamsWithUnreadInbox: async () => [
+        {
+          teamName: 'dying-team',
+          unreadCount: 7,
+          workingDir: '/tmp/dying',
+          firstUnreadText: null,
+        },
+      ],
+      isTeamActive: async () => false,
+      ensureTeamLead: async () => {
+        throw new Error('ensureTeamLead: tmux spawn failed');
+      },
+      emitDeadInbox: (payload) => emittedPayloads.push(payload),
+    });
+
+    // 3 consecutive poll cycles, each fails the spawn.
+    await checkInboxes(deps); // failures: 1 (not yet emit)
+    expect(emittedPayloads.length).toBe(0);
+    await checkInboxes(deps); // failures: 2 (not yet emit)
+    expect(emittedPayloads.length).toBe(0);
+    await checkInboxes(deps); // failures: 3 (TRANSITION — emit)
+    expect(emittedPayloads.length).toBe(1);
+
+    const [event] = emittedPayloads;
+    expect(event.team_name).toBe('dying-team');
+    expect(event.session_key).toBe('dying-team');
+    expect(event.failure_count).toBe(3);
+    expect(event.last_error_message).toContain('tmux spawn failed');
+  });
+
+  test('subsequent polls after MAX_SPAWN_FAILURES do NOT re-emit', async () => {
+    const emittedPayloads: DeadInboxEventPayload[] = [];
+    const deps = makeDeps({
+      listTeamsWithUnreadInbox: async () => [
+        {
+          teamName: 'post-threshold-team',
+          unreadCount: 3,
+          workingDir: '/tmp/post-threshold',
+          firstUnreadText: null,
+        },
+      ],
+      isTeamActive: async () => false,
+      ensureTeamLead: async () => {
+        throw new Error('still broken');
+      },
+      emitDeadInbox: (payload) => emittedPayloads.push(payload),
+    });
+
+    // Drive to threshold.
+    await checkInboxes(deps);
+    await checkInboxes(deps);
+    await checkInboxes(deps);
+    expect(emittedPayloads.length).toBe(1);
+
+    // 5 more polls — each will hit the silent-skip branch. No re-emit.
+    for (let i = 0; i < 5; i++) {
+      await checkInboxes(deps);
+    }
+    expect(emittedPayloads.length).toBe(1);
+  });
+
+  test('successful spawn after partial failures does NOT emit', async () => {
+    const emittedPayloads: DeadInboxEventPayload[] = [];
+    let attempt = 0;
+    const deps = makeDeps({
+      listTeamsWithUnreadInbox: async () => [
+        {
+          teamName: 'recovering-team',
+          unreadCount: 1,
+          workingDir: '/tmp/recovering',
+          firstUnreadText: null,
+        },
+      ],
+      isTeamActive: async () => false,
+      ensureTeamLead: async () => {
+        attempt++;
+        if (attempt < 3) throw new Error('flaky spawn');
+        return { created: true };
+      },
+      emitDeadInbox: (payload) => emittedPayloads.push(payload),
+    });
+
+    await checkInboxes(deps); // fail 1
+    await checkInboxes(deps); // fail 2
+    await checkInboxes(deps); // success — resets counter, no emit
+    expect(emittedPayloads.length).toBe(0);
+    expect(attempt).toBe(3);
+  });
+
+  test('schema-bound error message is truncated at 2 KiB', async () => {
+    const emittedPayloads: DeadInboxEventPayload[] = [];
+    const hugeMessage = 'x'.repeat(5000);
+    const deps = makeDeps({
+      listTeamsWithUnreadInbox: async () => [
+        {
+          teamName: 'verbose-error-team',
+          unreadCount: 1,
+          workingDir: '/tmp/verbose',
+          firstUnreadText: null,
+        },
+      ],
+      isTeamActive: async () => false,
+      ensureTeamLead: async () => {
+        throw new Error(hugeMessage);
+      },
+      emitDeadInbox: (payload) => emittedPayloads.push(payload),
+    });
+
+    await checkInboxes(deps);
+    await checkInboxes(deps);
+    await checkInboxes(deps);
+    expect(emittedPayloads.length).toBe(1);
+    // Allow ellipsis — schema cap is 2048, truncation logic slices to 2045 + '...'.
+    expect(emittedPayloads[0].last_error_message.length).toBeLessThanOrEqual(2048);
+    expect(emittedPayloads[0].last_error_message.endsWith('...')).toBe(true);
   });
 });

--- a/src/lib/inbox-watcher.ts
+++ b/src/lib/inbox-watcher.ts
@@ -7,12 +7,26 @@
  */
 
 import { listTeamsWithUnreadInbox } from './claude-native-teams.js';
+import { emitEvent } from './emit.js';
 import { parseRoutingHeader, resolveSessionKey } from './routing-header.js';
 import { ensureTeamLead, isAgentAlive, isTeamActive } from './team-auto-spawn.js';
 
 // ============================================================================
 // Dependency injection (testability without real filesystem/tmux)
 // ============================================================================
+
+/**
+ * Payload emitted when a session crosses the `MAX_SPAWN_FAILURES` threshold
+ * and the watcher flips into silent-skip mode. See
+ * `src/lib/events/schemas/rot.inbox-watcher-spawn-loop.detected.ts` for the
+ * full Zod schema (Pattern 9 of the BUGLESS-GENIE roster).
+ */
+export interface DeadInboxEventPayload {
+  team_name: string;
+  session_key: string;
+  failure_count: number;
+  last_error_message: string;
+}
 
 /** Dependencies used by inbox-watcher functions. */
 export interface InboxWatcherDeps {
@@ -21,6 +35,14 @@ export interface InboxWatcherDeps {
   isAgentAlive: (agentName: string) => Promise<boolean>;
   ensureTeamLead: (teamName: string, workingDir: string) => Promise<{ created: boolean }>;
   warn: (msg: string) => void;
+  /**
+   * Emits `rot.inbox-watcher-spawn-loop.detected` on the transition from
+   * `failures === MAX_SPAWN_FAILURES - 1` to `failures === MAX_SPAWN_FAILURES`.
+   * Called exactly once per session key per daemon lifetime (until
+   * `resetSpawnFailures()` clears the counter). Fire-and-forget — errors
+   * must not bubble into the watcher loop.
+   */
+  emitDeadInbox: (payload: DeadInboxEventPayload) => void;
 }
 
 /** Default production dependencies. */
@@ -30,6 +52,15 @@ const defaultDeps: InboxWatcherDeps = {
   isAgentAlive: (agentName) => isAgentAlive(agentName),
   ensureTeamLead: (teamName, workingDir) => ensureTeamLead(teamName, workingDir),
   warn: (msg) => console.warn(msg),
+  emitDeadInbox: (payload) => {
+    // Fire-and-forget per emit.ts contract; swallow any synchronous error so
+    // the watcher poll loop never crashes on an emit glitch.
+    try {
+      emitEvent('rot.inbox-watcher-spawn-loop.detected', payload);
+    } catch {
+      // intentionally swallowed — emit path is best-effort
+    }
+  },
 };
 
 // ============================================================================
@@ -115,6 +146,14 @@ function shouldWarnMissingWorkingDir(teamName: string): boolean {
 /**
  * Attempt to spawn a team-lead; track failures in `spawnFailures`.
  * Returns true on success (caller adds team to `spawned` list).
+ *
+ * On the exact transition to `MAX_SPAWN_FAILURES`, fires a
+ * `rot.inbox-watcher-spawn-loop.detected` event via `deps.emitDeadInbox`
+ * so downstream consumers (B-project detectors, operator runbooks) can
+ * observe the silent-skip state without polling the in-memory counter.
+ * Subsequent failures at or above the threshold do NOT re-emit (prevents
+ * polling-cadence flooding of the event substrate). The counter is reset
+ * on a successful spawn.
  */
 async function attemptSpawn(
   deps: InboxWatcherDeps,
@@ -134,6 +173,18 @@ async function attemptSpawn(
     deps.warn(
       `[inbox-watcher] Failed to spawn team-lead for "${teamName}" (attempt ${newCount}/${MAX_SPAWN_FAILURES}): ${message}`,
     );
+    // Pattern 9 — fire dead-inbox event exactly on the transition to the
+    // silent-skip state. The watcher has already tracked the failure; now
+    // the rest of the system learns about it.
+    if (newCount === MAX_SPAWN_FAILURES) {
+      deps.emitDeadInbox({
+        team_name: teamName,
+        session_key: sessionKey,
+        failure_count: newCount,
+        // Bound the message length to match the schema cap (2 KiB).
+        last_error_message: message.length > 2048 ? `${message.slice(0, 2045)}...` : message,
+      });
+    }
     return false;
   }
 }

--- a/src/lib/inbox-watcher.ts
+++ b/src/lib/inbox-watcher.ts
@@ -54,9 +54,12 @@ const defaultDeps: InboxWatcherDeps = {
   warn: (msg) => console.warn(msg),
   emitDeadInbox: (payload) => {
     // Fire-and-forget per emit.ts contract; swallow any synchronous error so
-    // the watcher poll loop never crashes on an emit glitch.
+    // the watcher poll loop never crashes on an emit glitch. The cast widens
+    // our strictly-typed payload to `Record<string, unknown>` at the emit
+    // boundary only — internal callers keep the full DeadInboxEventPayload
+    // signature for compile-time correctness.
     try {
-      emitEvent('rot.inbox-watcher-spawn-loop.detected', payload);
+      emitEvent('rot.inbox-watcher-spawn-loop.detected', payload as unknown as Record<string, unknown>);
     } catch {
       // intentionally swallowed — emit path is best-effort
     }

--- a/src/term-commands/agent/inbox.ts
+++ b/src/term-commands/agent/inbox.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Command } from 'commander';
+import { emitEvent } from '../../lib/emit.js';
 import type * as taskServiceTypes from '../../lib/task-service.js';
 import { formatTime, padRight, truncate } from '../../lib/term-format.js';
 import { detectSenderIdentity } from '../msg.js';
@@ -111,6 +112,15 @@ export function registerAgentInbox(parent: Command): void {
           return result;
         },
         warn: (msg) => console.log(msg),
+        // Pattern 9 — emit on silent-skip transition. Fire-and-forget; errors
+        // swallowed so the poll loop never crashes on an emit glitch.
+        emitDeadInbox: (payload) => {
+          try {
+            emitEvent('rot.inbox-watcher-spawn-loop.detected', payload as unknown as Record<string, unknown>);
+          } catch {
+            // best-effort
+          }
+        },
       });
 
       const shutdown = () => {

--- a/src/term-commands/msg.ts
+++ b/src/term-commands/msg.ts
@@ -18,6 +18,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { Command } from 'commander';
 import type * as registryTypes from '../lib/agent-registry.js';
+import { emitEvent } from '../lib/emit.js';
 import type * as taskServiceTypes from '../lib/task-service.js';
 import type * as teamManagerTypes from '../lib/team-manager.js';
 import { formatTime, padRight, truncate } from '../lib/term-format.js';
@@ -779,6 +780,15 @@ Examples:
           return result;
         },
         warn: (msg) => console.log(msg),
+        // Pattern 9 — emit on silent-skip transition. Fire-and-forget; errors
+        // swallowed so the poll loop never crashes on an emit glitch.
+        emitDeadInbox: (payload) => {
+          try {
+            emitEvent('rot.inbox-watcher-spawn-loop.detected', payload as unknown as Record<string, unknown>);
+          } catch {
+            // best-effort
+          }
+        },
       });
 
       const shutdown = () => {

--- a/test/pentest/observability/listen-bomb.test.ts
+++ b/test/pentest/observability/listen-bomb.test.ts
@@ -167,12 +167,24 @@ describe('pen-test: listen-bomb — NOTIFY flood back-pressure response', () => 
     __setSpillPathForTests(spillPath);
   });
 
+  // 15s afterEach budget: `shutdownEmitter()` drains the test queue which
+  // holds up to __TEST_QUEUE_CAP (10_000) events between runs. Under
+  // parallel load the drain occasionally exceeds the default 5000ms hook
+  // timeout. Matches the test-body budget bumped above.
   afterEach(async () => {
     await shutdownEmitter();
     __setSpillPathForTests(null);
     rmSync(spillDir, { recursive: true, force: true });
-  });
+  }, 15_000);
 
+  // This test asserts *functional correctness* only (spill file exists,
+  // backpressure flag set, spill lines >= 100) — NOT performance. The
+  // 10_000 info pre-fill + 1000 warn flood through the emit path can
+  // legitimately exceed the bun-test default 5000ms under parallel load;
+  // we've seen 5512ms locally. 15s is a generous ceiling matching the
+  // sibling `saturation finishes within one second` test and c5fc3db0's
+  // spill-drain fix. A real hang would still fail; we just stop the
+  // false-flake on saturated CI hosts.
   test('flood of warn events spills to disk and raises consumer.lagged', () => {
     // Pre-fill queue with info so any warn hits back-pressure immediately.
     const payload = {
@@ -201,7 +213,7 @@ describe('pen-test: listen-bomb — NOTIFY flood back-pressure response', () => 
       .split('\n')
       .filter((l) => l.length > 0);
     expect(lines.length).toBeGreaterThanOrEqual(100);
-  });
+  }, 15_000);
 
   test('saturation finishes within one second — no unbounded block on spill', async () => {
     // Back-pressure policy says warn+ bounded-wait-then-spill at 50ms. 1000


### PR DESCRIPTION
## Summary

- Fixes **Pattern 9** from the BUGLESS-GENIE pathology roster — the inbox-watcher silently dropped 215+ messages across two ghost teams (`wish-state-invalidation`, `omni-channels-pivot`) after 3 consecutive spawn failures (`MAX_SPAWN_FAILURES`), with zero PG event record. Manual `/trace` surfaced the behaviour; no automated signal existed.
- Introduces the Zod-validated event **`rot.inbox-watcher-spawn-loop.detected`** (SCHEMA_VERSION=1, KIND=event, strict, tier-tagged payload) and fires it **exactly once** on the transition `newCount === MAX_SPAWN_FAILURES`. Subsequent polls in the silent-skip state do NOT re-emit — this is a state-transition signal, not a polling-cadence flood.
- First pathology to ship through the **D7 four-artefact gate** declared by merged umbrella PR #1258. Event type in A (this PR) ✅ + detector in B (follow-up) + fix in consumer (this PR's emit + future runbook response) + regression tests (this PR, 4 new tests).

## What this PR ships

| File | Δ | Role |
|---|---|---|
| `src/lib/events/schemas/rot.inbox-watcher-spawn-loop.detected.ts` | +111 (new) | Zod schema. Payload: `team_name` (tier C), `session_key` (tier C), `failure_count` (tier C int, always === `MAX_SPAWN_FAILURES` at emit), `last_error_message` (tier B, 1–2048, emit-site truncated at 2 KiB) |
| `src/lib/events/registry.ts` | +7 | Register the new type next to existing `rot.*` detectors |
| `src/lib/events/schemas/schemas.test.ts` | +9 | Fixture for the closed `Record<EventType, ...>` (roundtrip tests) |
| `src/lib/inbox-watcher.ts` | +54 | Add `emitDeadInbox` to `InboxWatcherDeps` (fire-and-forget per `emit.ts` contract, sync errors swallowed so poll loop never crashes); fire exactly on the transition `newCount === MAX_SPAWN_FAILURES` in `attemptSpawn()` |
| `src/lib/inbox-watcher.test.ts` | +134 / -1 | 4 regression tests: emit-on-transition, no re-emit on subsequent polls, no emit on partial-then-success path, 2 KiB truncation |
| `src/term-commands/agent/inbox.ts` | +10 | Caller-side wiring of `emitDeadInbox` dep (production entry point for `genie agent inbox watch`) |
| `src/term-commands/msg.ts` | +10 | Caller-side wiring of `emitDeadInbox` dep (production entry point for `genie inbox watch`) |
| `test/pentest/observability/listen-bomb.test.ts` | +16 / -2 | Test stabilization — mirrors c5fc3db0 style for the existing baseline flake (listen-bomb flood-spill). Asserts functional correctness only; 15s budget stops false-flake on saturated CI |

**Total:** 8 files / +348 / -3. Pattern 9 axis: feature + schema + wiring + tests (single logical unit, split into 2 commits for caller-wiring hygiene). Separate 3rd commit for test-stabilization (single axis, documented precedent).

## Commits on this branch

1. `c90c155f` — `feat(inbox-watcher): emit rot.inbox-watcher-spawn-loop.detected on silent-skip (Pattern 9)`
2. `03155edb` — `fix(inbox-watcher): complete Pattern 9 wiring across callers + schemas test`
3. `a1555b97` — `test(pentest): bump listen-bomb flood-spill timeout to 15s`

## Design notes

### Emit semantics — exactly once per transition

The watcher enters silent-skip on `newCount === MAX_SPAWN_FAILURES` (by contract, `MAX_SPAWN_FAILURES === 3`). Before this PR, the transition logged a warning but produced no event. After this PR:

- **At transition** — `emitDeadInbox` fires once with the full payload.
- **Subsequent polls** — `newCount > MAX_SPAWN_FAILURES` is now unreachable via `attemptSpawn` because the watcher short-circuits before calling spawn again. No re-emit risk.
- **Partial-then-success** — if spawn succeeds on attempt 1 or 2, `failure_count` never reaches the threshold; no emit. Covered by regression test #3.

This matches the umbrella's R5 feedback-loop principle: single emission per observable state change, consumer handles the response one-shot.

### Error-message truncation

`last_error_message` is capped at 2048 bytes (2 KiB) to respect the schema cap. Emit-site truncates with a `"..."` ellipsis if the underlying exception exceeds the bound. Regression test #4 verifies the truncation path.

### Fire-and-forget contract

`emitDeadInbox` is a void-returning dep on `InboxWatcherDeps`. Per `src/lib/events/emit.ts` contract, sync errors are swallowed so the poll loop never crashes on a misconfigured transport. This preserves the invariant: **observability must not become a reliability regression**.

### Test stabilization (commit 3)

`test/pentest/observability/listen-bomb.test.ts` had a pre-existing baseline flake (`flood of warn events spills to disk`) where the 10_000 info pre-fill + 1000 warn flood through the emit path exceeded bun-test's default 5000ms under parallel load. Three observed fails at 5299ms / 5486ms / 5512ms across the BUGLESS-GENIE night session. Fix mirrors **c5fc3db0** (`test(backpressure): bump timeout on spill-drain test to 30s`) — the assertion body validates functional correctness (spill file exists, backpressure flag, spill lines >= 100), not performance. 15s budget is generous ceiling; a real hang would still fail.

## Test plan

- [x] `bun test src/lib/inbox-watcher.test.ts src/lib/events/schemas/schemas.test.ts` — 99/99 pass locally, 2.62s
- [x] `bun test src/lib/executor-read.test.ts` — 12/12 pass in isolation (port-race flake confirmed unrelated to this diff)
- [x] `bun test test/pentest/observability/listen-bomb.test.ts` — 9/9 pass post-stabilization, 11.9s
- [x] `bun run check` — 3397 pass / 0 fail / exit=0 locally (clean post-stabilization)
- [x] Schema `.strict()` rejects extra keys (closed-world registry invariant)
- [x] Payload field tier classifications match umbrella's redaction policy
- [ ] Live smoke post-merge — `genie events list --type rot.inbox-watcher-spawn-loop.detected --since 1h` returns empty on a healthy system, populated on reproduction

## Evidence chain

- **Blast radius trace:** `brain/memory/reference_pattern9_inbox_watcher_spawn_loop.md` (prior-session, alpha+beta co-authored) — 215+ messages silently dropped across 2 ghost teams
- **Night ship-cycle audit:** `brain/memory/reference_am_audit_close_2026_04_21.md`
- **Baseline-flake blocker context:** `brain/memory/reference_baseline_flakes_blocker_2026_04_21.md`
- **Detector card for sibling gate miscalibration:** `brain/memory/reference_detector_gate_miscalibration_docs_only_2026_04_21.md`
- **D7 gate:** `.genie/brainstorms/genie-self-healing-observability/DESIGN.md` → D7 row (merged via PR #1258)
- **Umbrella roadmap:** PR #1258 (merged as `018392ad`)

## Compliance checklist

- [x] Targets `dev` (not `main`) — branch-guard compliance, Tier-3 authority per §19 v2
- [x] No `--no-verify`, no hook bypass — final push went through full `bun run check` (3397 pass / 0 fail)
- [x] Single-axis commits — feature+schema / caller-wiring / test-stabilization kept separate
- [x] Schema follows convention — `.strict()`, SCHEMA_VERSION=1, KIND=event, tier tags, redactFreeText on all free-text fields
- [x] Tests present — 4 regression cases covering the named transitions
- [x] Fire-and-forget honored — consumer errors cannot crash the producer
- [x] Cross-reference to precedent memory and umbrella design preserved
- [x] Rebased on latest `origin/dev` (`4db3ccec`) before push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: felipe-alpha <noreply@anthropic.com>