### PR TITLE
fix(hooks/branch-guard): surface subprocess diagnostic in deny reason

### DIFF
--- a/src/hooks/__tests__/branch-guard.test.ts
+++ b/src/hooks/__tests__/branch-guard.test.ts
@@ -12,11 +12,22 @@ function makePayload(command: string): HookPayload {
 
 /**
  * Build a mock `BranchGuardDeps` that returns the supplied value from
- * `resolvePrBase`. Pass `null` to simulate a lookup failure.
+ * `resolvePrBase`. Pass `null` to simulate a generic lookup failure; pass
+ * a string to simulate a successful base-branch resolution.
  */
 function mockDeps(base: string | null): BranchGuardDeps {
   return {
-    resolvePrBase: async () => base,
+    resolvePrBase: async () => (base === null ? { reason: 'mock-null-failure' } : { base }),
+  };
+}
+
+/**
+ * Build a mock that fails `resolvePrBase` with a specific diagnostic
+ * reason — lets us assert that the diagnostic surfaces in the deny message.
+ */
+function mockDepsWithReason(reason: string): BranchGuardDeps {
+  return {
+    resolvePrBase: async () => ({ reason }),
   };
 }
 
@@ -91,11 +102,50 @@ describe('branch-guard', () => {
   });
 
   describe('blocks gh pr merge when base cannot be resolved', () => {
-    test('blocks when resolvePrBase returns null', async () => {
+    test('blocks when resolvePrBase returns null (generic failure)', async () => {
       const result = await branchGuard(makePayload('gh pr merge 123'), mockDeps(null));
       expect(result).toBeDefined();
       expect(result!.decision).toBe('deny');
       expect(result!.reason).toContain('could not resolve');
+    });
+
+    // Regression: Task #26 — the previous `execSync` with `stdio: ['ignore',
+    // 'pipe', 'ignore']` collapsed every failure mode into one opaque deny
+    // message ("gh view failed or returned empty"), making production
+    // fall-closed incidents undiagnosable. The new `spawnSync` + explicit
+    // `{ reason }` channel surfaces the subprocess diagnostic verbatim.
+    test('surfaces subprocess exit-code diagnostic in deny reason', async () => {
+      const result = await branchGuard(
+        makePayload('gh pr merge 1262'),
+        mockDepsWithReason('gh pr view exited 1: could not find pull request #1262'),
+      );
+      expect(result).toBeDefined();
+      expect(result!.decision).toBe('deny');
+      expect(result!.reason).toContain('#1262');
+      expect(result!.reason).toContain('gh pr view exited 1');
+      expect(result!.reason).toContain('could not find pull request');
+      expect(result!.reason).toContain('§19');
+    });
+
+    test('surfaces empty-stdout diagnostic when subprocess succeeded but produced nothing', async () => {
+      const result = await branchGuard(
+        makePayload('gh pr merge 1262'),
+        mockDepsWithReason('gh pr view exited 0 with empty stdout (stderr: none)'),
+      );
+      expect(result).toBeDefined();
+      expect(result!.decision).toBe('deny');
+      expect(result!.reason).toContain('exited 0 with empty stdout');
+    });
+
+    test('surfaces spawn exception diagnostic in deny reason', async () => {
+      const result = await branchGuard(
+        makePayload('gh pr merge 1262'),
+        mockDepsWithReason('spawnSync threw: ENOENT: no such file or directory, gh'),
+      );
+      expect(result).toBeDefined();
+      expect(result!.decision).toBe('deny');
+      expect(result!.reason).toContain('spawnSync threw');
+      expect(result!.reason).toContain('ENOENT');
     });
   });
 

--- a/src/hooks/handlers/branch-guard.ts
+++ b/src/hooks/handlers/branch-guard.ts
@@ -12,7 +12,7 @@
  * Priority: 1 (runs FIRST, before all other handlers)
  */
 
-import { execSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import type { HandlerResult, HookPayload } from '../types.js';
 
 /** Branches that agents are allowed to merge PRs into. */
@@ -52,31 +52,64 @@ const SYNC_DENY_PATTERNS: SyncDenyPattern[] = [
 ];
 
 /**
+ * Result of a PR base-branch resolution attempt.
+ * - `{ base: string }` — lookup succeeded; caller checks base against allowlist.
+ * - `{ reason: string }` — lookup failed for a reason the caller surfaces in
+ *   the deny message so humans can diagnose without re-running.
+ *
+ * The reason-channel replaces the older `null` sentinel (which collapsed
+ * "subprocess threw", "exit != 0", and "exit=0 but empty stdout" into one
+ * opaque deny — undiagnosable when it fires in production).
+ */
+export type ResolvePrBaseResult = { base: string } | { reason: string };
+
+/**
  * Dependencies injection surface — tests supply a mock `resolvePrBase` so
  * the hook can be exercised without a live GitHub call.
  */
 export interface BranchGuardDeps {
   /**
-   * Resolve the base branch of a GitHub PR. Return `null` when the lookup
-   * fails (network error, missing PR, auth failure). Callers treat `null`
-   * as a deny.
+   * Resolve the base branch of a GitHub PR. Callers fall-closed on any
+   * failure shape (`reason` present) — that's the §19 v2 safety contract.
    */
-  resolvePrBase: (prNum: string) => Promise<string | null>;
+  resolvePrBase: (prNum: string) => Promise<ResolvePrBaseResult>;
 }
+
+/** Maximum stderr bytes we surface in a deny reason. Protects against gh
+ *  emitting a wall of text and flooding the hook decision payload. */
+const STDERR_SURFACE_CAP = 500;
 
 const defaultDeps: BranchGuardDeps = {
   async resolvePrBase(prNum) {
+    // spawnSync (not execSync) so we can inspect exit code AND stderr
+    // independently. The previous `stdio: ['ignore','pipe','ignore']` routed
+    // stderr to /dev/null, making every fall-closed deny undiagnosable.
+    // Timeout bumped 5s→10s for headroom during `gh auth` token refreshes.
+    let result: ReturnType<typeof spawnSync>;
     try {
-      const out = execSync(`gh pr view ${prNum} --json baseRefName -q .baseRefName`, {
+      result = spawnSync('gh', ['pr', 'view', prNum, '--json', 'baseRefName', '-q', '.baseRefName'], {
         encoding: 'utf8',
-        timeout: 5000,
-        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 10_000,
+        stdio: ['ignore', 'pipe', 'pipe'],
       });
-      const base = out.trim();
-      return base || null;
-    } catch {
-      return null;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { reason: `spawnSync threw: ${message.slice(0, STDERR_SURFACE_CAP)}` };
     }
+    if (result.error) {
+      return { reason: `subprocess error: ${result.error.message.slice(0, STDERR_SURFACE_CAP)}` };
+    }
+    const stderr = typeof result.stderr === 'string' ? result.stderr.trim() : '';
+    if (result.status !== 0) {
+      const tail = stderr.slice(-STDERR_SURFACE_CAP) || 'no stderr captured';
+      return { reason: `gh pr view exited ${result.status}: ${tail}` };
+    }
+    const stdout = typeof result.stdout === 'string' ? result.stdout.trim() : '';
+    if (!stdout) {
+      const tail = stderr.slice(-STDERR_SURFACE_CAP) || 'none';
+      return { reason: `gh pr view exited 0 with empty stdout (stderr: ${tail})` };
+    }
+    return { base: stdout };
   },
 };
 
@@ -116,13 +149,14 @@ export async function branchGuard(payload: HookPayload, deps: BranchGuardDeps = 
           'BLOCKED: `gh pr merge` requires an explicit PR number so the target base branch can be verified. §19 (v2): agents merge PRs targeting `dev` only; main/master is humans-only via GitHub UI.',
       };
     }
-    const base = await deps.resolvePrBase(prNum);
-    if (!base) {
+    const resolved = await deps.resolvePrBase(prNum);
+    if ('reason' in resolved) {
       return {
         decision: 'deny',
-        reason: `BLOCKED: could not resolve base branch of PR #${prNum} (gh view failed or returned empty). §19 (v2): cannot merge without verifying base is \`dev\`. Check the PR exists and try again, or ask a human to merge via GitHub UI.`,
+        reason: `BLOCKED: could not resolve base branch of PR #${prNum} — ${resolved.reason}. §19 (v2): cannot merge without verifying base is \`dev\`. Check the PR exists and try again, or ask a human to merge via GitHub UI.`,
       };
     }
+    const base = resolved.base;
     if (!ALLOWED_MERGE_BASES.has(base)) {
       return {
         decision: 'deny',


### PR DESCRIPTION
## Summary

Makes fall-closed auto-merge denies diagnosable. The hook's subprocess previously swallowed stderr (`stdio: ['ignore', 'pipe', 'ignore']`), collapsing three distinct failure modes — *subprocess threw* / *exit != 0* / *exit=0 with empty stdout* — into one generic `"gh view failed or returned empty"` deny message.

**Live reproducer:** the Pattern 9 PR. Agent tried to auto-merge; hook denied; no diagnostic survived. Direct `gh pr view` of the same PR from the same host succeeded in 0.4s from three different cwds (inside the genie repo, outside it, and with explicit `-R`). The actual subprocess failure mode is **still unknown** — but with this fix, the NEXT occurrence will carry the subprocess's real exit code and stderr tail.

## Changes

- `src/hooks/handlers/branch-guard.ts`:
  - `execSync` → `spawnSync` (exit code + stderr inspectable independently).
  - `resolvePrBase` return type widened from `Promise<string | null>` to `Promise<{ base: string } | { reason: string }>`. The `reason` is surfaced verbatim in the deny message, truncated to 500 chars to bound hook payload size.
  - Three distinct reason strings for subprocess-threw / non-zero-exit / exit-0-empty-stdout.
  - Timeout 5s → 10s for gh-auth-refresh headroom.
  - **Fall-closed policy preserved:** any `reason` present → deny. §19 v2 contract intact.
- `src/hooks/__tests__/branch-guard.test.ts`:
  - `mockDeps(null)` still works (returns `{ reason: 'mock-null-failure' }`).
  - Added `mockDepsWithReason(reason)` helper.
  - **Three new regression tests** assert each diagnostic surfaces in the deny message (exit-code, empty-stdout, spawn-exception).

## Test plan

- [x] `bun test src/hooks/__tests__/branch-guard.test.ts` → **62 pass / 0 fail**
- [x] `bun run check` full suite — green on retry (baseline flake `events-stream — DB path > persisted cursor` fired 4× / 5 runs tonight, unrelated to this diff; backlog-tracked)
- [x] Pre-push hook passed on final push (3 attempts, same stochastic pattern as the Pattern 9 overnight cycle)
- [x] Fall-closed policy: all 7 push-to-main blocks, 3 pr-create-without-base blocks, 4 pr-to-main blocks, 5 pr-to-dev allows, 6 checkout-main-then-mutate blocks — **unchanged**

## Design notes

### Why widen the return type (vs. a side-channel)

Rejected options:
- **Module-level error var** — not thread-safe under concurrent hook invocations.
- **Logger injection** — emits to stderr but caller can't read it back to include in the deny message without rewiring.
- **Throw on failure** — forces caller into try/catch and breaks the deterministic "any failure → deny" contract.

The explicit union is the clearest fit — caller branches on the result shape, mocks return either variant, no hidden state.

### Why not also add `-R <slug>` or explicit `cwd`

Considered and rejected. Repro test from three different cwds all succeeded with the same command and args — so cwd is **not** the root cause. Adding `-R` would be speculation without evidence; with this PR's stderr capture, the next fall-closed incident will tell us the actual cause.

## Bonus: second-order bug discovered while opening this PR

The hook's PR-merge matcher regex over-matches when the merge command substring appears inside a quoted `--body` argument to a PR-create invocation. This PR's first create attempt was blocked by the regex matching the reproducer string inside the body itself. Logged as a separate backlog task — the fix is to shell-parse the command into argv and only match against argv[0..N], not the raw concatenated string. Not in scope for this PR.

## Compliance

- [x] Targets `dev` (§19 v2 compliance)
- [x] No `--no-verify`, no hook bypass
- [x] Single-axis change — diagnostic channel only, no policy or semantic change
- [x] Fall-closed policy preserved
- [x] Regression tests present — 3 new cases covering each diagnostic path

Closes internal task tracker #26.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
