### PR TITLE
fix(events): surface real error messages in `genie events errors`

### DIFF
--- a/src/lib/audit.test.ts
+++ b/src/lib/audit.test.ts
@@ -115,6 +115,53 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
         expect(deployTimeout.count).toBeGreaterThanOrEqual(2);
       }
     });
+
+    test('surfaces state_changed->error via reason field (regression: empty-message bug)', async () => {
+      // Before fix: state_changed matched via substring filter but COALESCE
+      // only looked at details.error/message → result was '(no message)'.
+      const entityId = `worker-stale-${Date.now()}`;
+      await recordAuditEvent('worker', entityId, 'state_changed', 'cli', {
+        state: 'error',
+        reason: 'stale_spawn',
+      });
+      await recordAuditEvent('worker', entityId, 'state_changed', 'cli', {
+        state: 'error',
+        reason: 'stale_spawn',
+      });
+
+      const patterns = await queryErrorPatterns('1h');
+      const staleSpawn = patterns.find((p) => p.entity_id === entityId && p.error_message === 'stale_spawn');
+      expect(staleSpawn).toBeDefined();
+      expect(staleSpawn?.error_message).toBe('stale_spawn');
+      expect(staleSpawn?.count).toBeGreaterThanOrEqual(2);
+      expect(staleSpawn?.error_message).not.toBe('(no message)');
+    });
+
+    test('excludes state_changed to non-error states (regression: over-broad filter)', async () => {
+      // Before fix: filter `details::text LIKE '%"error"%'` could match any
+      // event whose details serialization contained the substring "error".
+      // A clean transition to 'idle' must NOT appear as an error pattern.
+      const entityId = `worker-idle-${Date.now()}`;
+      await recordAuditEvent('worker', entityId, 'state_changed', 'cli', {
+        state: 'idle',
+        previous_state: 'running',
+      });
+
+      const patterns = await queryErrorPatterns('1h');
+      const noise = patterns.find((p) => p.entity_id === entityId);
+      expect(noise).toBeUndefined();
+    });
+
+    test('extracts error_type when primary error key is absent', async () => {
+      const entityId = `task-typed-${Date.now()}`;
+      await recordAuditEvent('task', entityId, 'task_failed', 'cli', {
+        error_type: 'DependencyMissing',
+      });
+
+      const patterns = await queryErrorPatterns('1h');
+      const row = patterns.find((p) => p.entity_id === entityId);
+      expect(row?.error_message).toBe('DependencyMissing');
+    });
   });
 
   describe('getActor', () => {

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -209,17 +209,40 @@ export async function queryErrorPatterns(since?: string): Promise<ErrorPattern[]
   const sql = await getConnection();
   const sinceTs = since ? parseSince(since) : new Date(Date.now() - 86_400_000).toISOString();
 
+  // Filter on structural signals, not substring matches:
+  // - event_type names that denote failure (error / failed / rot.*)
+  // - JSONB key 'error' present on details (explicit error payload)
+  // - state_changed where the new state value is literally 'error'
+  //
+  // Extract the human message from whichever key the producer used: error,
+  // message, error_type, reason (state_changed carries this), or stderr.
+  // NOTE: keep the COALESCE expression in SELECT and GROUP BY identical.
+  const messageExpr = `COALESCE(
+       NULLIF(details->>'error', ''),
+       NULLIF(details->>'message', ''),
+       NULLIF(details->>'error_type', ''),
+       NULLIF(details->>'reason', ''),
+       NULLIF(details->>'stderr', ''),
+       '(no message)'
+     )`;
+
   const rows = await sql.unsafe(
     `SELECT
        event_type,
        entity_id,
-       COALESCE(details->>'error', details->>'message', '(no message)') as error_message,
-       COUNT(*)::int as count,
-       MAX(created_at) as last_seen
+       ${messageExpr} AS error_message,
+       COUNT(*)::int AS count,
+       MAX(created_at) AS last_seen
      FROM audit_events
-     WHERE (event_type LIKE '%error%' OR details::text LIKE '%"error"%')
+     WHERE (
+         event_type LIKE '%error%'
+         OR event_type LIKE '%failed%'
+         OR event_type LIKE 'rot.%'
+         OR details ? 'error'
+         OR (event_type = 'state_changed' AND details->>'state' = 'error')
+       )
        AND created_at >= $1::timestamptz
-     GROUP BY event_type, entity_id, COALESCE(details->>'error', details->>'message', '(no message)')
+     GROUP BY event_type, entity_id, ${messageExpr}
      ORDER BY count DESC
      LIMIT 50`,
     [sinceTs],


### PR DESCRIPTION
## Summary

`genie events errors` was printing `(no message)` for every row — making the new observability surface useless. Two root causes:

- **Over-broad filter.** `details::text LIKE '%"error"%'` matches any event whose JSON serialization contains the substring `"error"`, including legitimate `state_changed` transitions like `{"state": "error", "reason": "stale_spawn"}` that carry real signal but also `{"previous_state": "error"}` which doesn't.
- **Narrow extraction.** The SELECT only looked at `details->>'error'` and `details->>'message'`, so producers that stored the signal under `reason`, `error_type`, or `stderr` all fell through to the `(no message)` fallback.

## Fix

- Replace substring filter with structural predicates: event_type contains `error`/`failed` or starts with `rot.`, OR `details ? 'error'` (explicit JSONB key present), OR `state_changed` where `state = 'error'`.
- Expand the message COALESCE chain to `error → message → error_type → reason → stderr → '(no message)'`, with `NULLIF(x, '')` so empty strings don't shadow later fallbacks.
- Lift the expression into a shared constant so SELECT and GROUP BY stay in sync.

## Before / After

Against the local DB (24h window, pre-fix):

```
2 | state_changed | dir:genie-docs/link-tracer | (no message) | 3h ago
2 | state_changed | dir:genie-docs/nav-inspector | (no message) | 3h ago
...
```

Post-fix the same rows surface their reason (`stale_spawn`, `dead_pane_zombie`, …) and benign `{state: "idle"}` transitions are filtered out.

## Test plan

- [x] 3 regression tests added in `src/lib/audit.test.ts`:
  - `state_changed → error` with `reason` surfaces correctly (not `(no message)`)
  - `state_changed → idle` is excluded (over-broad-filter regression)
  - `error_type` is extracted when `error`/`message` are absent
- [x] `bun test src/lib/audit.test.ts` — 24 pass
- [x] `bun run check` — 3400 tests pass; no new lint diagnostics (the 46 pre-existing warnings are unrelated)

## Notes

- Behaviour is strictly narrower on noise and strictly wider on signal. Any row that was previously extracted with a real message still extracts the same message.
- Found by dogfooding `@automagik/genie@next` on first spawn after the observability drop. First of a tiny-PR series — see `brain/reflections/2026-04-21.md` on the workspace side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)