### PR TITLE
fix(metrics): make event throughput actually observable from the CLI

### DIFF
--- a/src/lib/runtime-events.test.ts
+++ b/src/lib/runtime-events.test.ts
@@ -4,6 +4,7 @@ import {
   getLatestRuntimeEventId,
   listRuntimeEvents,
   publishRuntimeEvent,
+  queryRuntimeEventThroughput,
   waitForRuntimeEvent,
 } from './runtime-events.js';
 import { DB_AVAILABLE, setupTestSchema } from './test-db.js';
@@ -205,6 +206,37 @@ describe.skipIf(!DB_AVAILABLE)('runtime-events', () => {
     const event = await waitPromise;
     expect(event?.text).toBe('right-repo');
     expect(event?.data?.result).toBe('pass');
+  });
+
+  test('queryRuntimeEventThroughput counts recently-published events (regression: CLI reported 0)', async () => {
+    // Before C3 the metrics CLI read a module-level `eventsEmitted` counter
+    // from a fresh process → always 0. The fix reads this DB query instead.
+    const baseline = await queryRuntimeEventThroughput(60);
+
+    const marker = `throughput-${Date.now()}`;
+    await publishRuntimeEvent({
+      repoPath: `/tmp/${marker}-a`,
+      kind: 'message',
+      agent: 'agent-a',
+      text: 'hello',
+      source: 'mailbox',
+    });
+    await publishRuntimeEvent({
+      repoPath: `/tmp/${marker}-b`,
+      kind: 'message',
+      agent: 'agent-b',
+      text: 'world',
+      source: 'mailbox',
+    });
+
+    const after = await queryRuntimeEventThroughput(60);
+    expect(after.emitted).toBeGreaterThanOrEqual(baseline.emitted + 2);
+  });
+
+  test('queryRuntimeEventThroughput rejects non-positive windows', async () => {
+    await expect(queryRuntimeEventThroughput(0)).rejects.toThrow(/positive/);
+    await expect(queryRuntimeEventThroughput(-5)).rejects.toThrow(/positive/);
+    await expect(queryRuntimeEventThroughput(Number.NaN)).rejects.toThrow(/positive/);
   });
 
   test('latest event id advances monotonically', async () => {

--- a/src/lib/runtime-events.ts
+++ b/src/lib/runtime-events.ts
@@ -47,23 +47,6 @@ class EventCircuitBreaker {
 
 const circuitBreaker = new EventCircuitBreaker();
 
-// ---------------------------------------------------------------------------
-// Event throughput metrics (Group 3 — #858)
-// ---------------------------------------------------------------------------
-let eventsEmitted = 0;
-let eventsFailed = 0;
-let lastEmitDuration = 0;
-
-/** Returns in-process event throughput counters for the metrics CLI. */
-export function getEventMetrics(): {
-  eventsEmitted: number;
-  eventsFailed: number;
-  lastEmitDuration: number;
-  circuitState: string;
-} {
-  return { eventsEmitted, eventsFailed, lastEmitDuration, circuitState: circuitBreaker.state };
-}
-
 export type RuntimeEventKind =
   | 'user'
   | 'assistant'
@@ -236,11 +219,9 @@ function buildWhere(query: RuntimeEventQuery): { clause: string; values: unknown
 
 export async function publishRuntimeEvent(input: RuntimeEventInput): Promise<RuntimeEvent> {
   if (circuitBreaker.isOpen()) {
-    eventsFailed++;
     throw new Error('circuit breaker open — PG event write skipped');
   }
 
-  const start = Date.now();
   try {
     const sql = await getConnection();
     const threadId = input.threadId ?? `agent:${input.agent}`;
@@ -268,12 +249,9 @@ export async function publishRuntimeEvent(input: RuntimeEventInput): Promise<Run
     `;
 
     circuitBreaker.recordSuccess();
-    eventsEmitted++;
-    lastEmitDuration = Date.now() - start;
     return rowToRuntimeEvent(rows[0]);
   } catch (error) {
     circuitBreaker.recordFailure();
-    eventsFailed++;
     throw error;
   }
 }
@@ -284,6 +262,24 @@ export async function publishSubjectEvent(
   event: Omit<RuntimeEventInput, 'repoPath' | 'subject'>,
 ): Promise<RuntimeEvent> {
   return publishRuntimeEvent({ ...event, repoPath, subject });
+}
+
+/**
+ * Count runtime events emitted within the last `windowSeconds`. Backs
+ * `genie metrics` — a CLI-visible alternative to in-process counters, which
+ * are useless in a short-lived observer process.
+ */
+export async function queryRuntimeEventThroughput(windowSeconds = 60): Promise<{ emitted: number }> {
+  if (!Number.isFinite(windowSeconds) || windowSeconds <= 0) {
+    throw new Error(`windowSeconds must be a positive number, got ${windowSeconds}`);
+  }
+  const sql = await getConnection();
+  const rows = await sql<{ emitted: number }[]>`
+    SELECT COUNT(*)::int AS emitted
+    FROM genie_runtime_events
+    WHERE created_at > NOW() - make_interval(secs => ${windowSeconds})
+  `;
+  return { emitted: rows[0]?.emitted ?? 0 };
 }
 
 export async function listRuntimeEvents(query: RuntimeEventQuery = {}): Promise<RuntimeEvent[]> {

--- a/src/term-commands/metrics.ts
+++ b/src/term-commands/metrics.ts
@@ -9,7 +9,7 @@
 
 import type { Command } from 'commander';
 import { getConnection, isAvailable } from '../lib/db.js';
-import { getEventMetrics } from '../lib/runtime-events.js';
+import { queryRuntimeEventThroughput } from '../lib/runtime-events.js';
 import { formatRelativeTimestamp as formatTimestamp, padRight } from '../lib/term-format.js';
 
 function parseSince(since: string): string {
@@ -62,7 +62,12 @@ async function metricsNowCommand(options: { json?: boolean }): Promise<void> {
   const teamCount = await sql`SELECT count(*)::int as cnt FROM teams WHERE status = 'in_progress'`;
 
   const snapshot = snapshots[0] ?? {};
-  const eventMetrics = getEventMetrics();
+
+  // Event throughput: count runtime events emitted in the last 60s.
+  // Must be DB-backed — a CLI process can't observe the emitter's in-process
+  // counters, which used to show 0 even when the system was busy.
+  const throughput = await queryRuntimeEventThroughput(60);
+
   const data = {
     active_workers: snapshot.active_workers ?? agentCount[0]?.cnt ?? 0,
     active_teams: snapshot.active_teams ?? teamCount[0]?.cnt ?? 0,
@@ -70,10 +75,7 @@ async function metricsNowCommand(options: { json?: boolean }): Promise<void> {
     cpu_percent: snapshot.cpu_percent ?? null,
     memory_mb: snapshot.memory_mb ?? null,
     snapshot_at: snapshot.created_at ? new Date(snapshot.created_at).toISOString() : null,
-    events_emitted: eventMetrics.eventsEmitted,
-    events_failed: eventMetrics.eventsFailed,
-    last_emit_duration_ms: eventMetrics.lastEmitDuration,
-    circuit_state: eventMetrics.circuitState,
+    events_emitted_last_60s: throughput.emitted,
   };
 
   if (options.json) {
@@ -88,11 +90,8 @@ async function metricsNowCommand(options: { json?: boolean }): Promise<void> {
   if (data.cpu_percent !== null) console.log(`  CPU:      ${data.cpu_percent}%`);
   if (data.memory_mb !== null) console.log(`  Memory:   ${data.memory_mb} MB`);
   if (data.snapshot_at) console.log(`  As of:    ${formatTimestamp(data.snapshot_at)}`);
-  console.log('\nEvent Throughput:');
-  console.log(`  Emitted:  ${data.events_emitted}`);
-  console.log(`  Failed:   ${data.events_failed}`);
-  console.log(`  Last ms:  ${data.last_emit_duration_ms}`);
-  console.log(`  Circuit:  ${data.circuit_state}`);
+  console.log('\nEvent Throughput (last 60s):');
+  console.log(`  Emitted:  ${data.events_emitted_last_60s}`);
 }
 
 async function metricsHistoryCommand(options: { since?: string; json?: boolean }): Promise<void> {


### PR DESCRIPTION
## Summary

`genie metrics` reported `Emitted: 0 / Failed: 0 / Last ms: 0 / Circuit: closed` even while the system was busy — 2000+ events in the audit log over 24h, yet the CLI claimed nothing had happened.

**Root cause:** all four fields came from module-level `let` counters in `runtime-events.ts` (`eventsEmitted`, `eventsFailed`, `lastEmitDuration`) plus the process-local `circuitBreaker.state`. A CLI invocation is a fresh process — it hasn't emitted anything yet, so those counters are always 0/closed. They were per-emitter state, fundamentally unobservable from an outside process.

## Fix

- **New helper `queryRuntimeEventThroughput(windowSeconds)`** in `runtime-events.ts` — a DB-backed count of `genie_runtime_events` emitted inside the window. Validates input is a positive finite number.
- **`genie metrics now` uses the helper** and relabels the section `Event Throughput (last 60s):` so the semantics are explicit.
- **Dropped `Failed`, `Last ms`, `Circuit`** from the CLI output. They could only ever be meaningful inside the emitter process; showing them from a CLI observer was always a lie. JSON output keys realigned accordingly (`events_emitted_last_60s`).
- **Deleted `getEventMetrics` and its orphaned counter state.** Nothing else consumed it, and keeping dead state around invites confusion.

## Before / After

Before (reproducing on a live genie):

```
Event Throughput:
  Emitted:  0
  Failed:   0
  Last ms:  0
  Circuit:  closed
```

After, on the same machine with events flowing:

```
Event Throughput (last 60s):
  Emitted:  42
```

## Test plan

- [x] `queryRuntimeEventThroughput` returns ≥N after N `publishRuntimeEvent` calls (regression test that asserts the exact scenario the CLI was lying about).
- [x] Helper rejects `0`, negative, and `NaN` windows.
- [x] `bun test src/lib/runtime-events.test.ts` → 9 pass.
- [x] `bun run check` → 3402 tests pass, zero new lint diagnostics.

## Notes

- Second of a tiny-PR sequence. Sibling PR #1267 fixes `genie events errors` (empty-message bug). These are independent — different files, different surfaces.
- Breaking change for JSON consumers: the keys `events_emitted / events_failed / last_emit_duration_ms / circuit_state` are removed in favor of `events_emitted_last_60s`. The old keys were reporting unusable values, so no real consumer depends on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)