### PR TITLE
fix(events): widen queryErrorPatterns filter to catch error_type-only events

### DIFF
--- a/src/lib/audit.test.ts
+++ b/src/lib/audit.test.ts
@@ -162,6 +162,21 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
       const row = patterns.find((p) => p.entity_id === entityId);
       expect(row?.error_message).toBe('DependencyMissing');
     });
+
+    test('matches events whose only failure signal is the error_type key (gemini review)', async () => {
+      // Reviewer concern on PR #1267: the filter matched on `details ? 'error'`
+      // but not `details ? 'error_type'`. A producer emitting `error_type`
+      // with a neutral event_type (e.g. "resource_check") would slip through.
+      const entityId = `resource-${Date.now()}`;
+      await recordAuditEvent('resource', entityId, 'resource_check', 'cli', {
+        error_type: 'QuotaExceeded',
+      });
+
+      const patterns = await queryErrorPatterns('1h');
+      const row = patterns.find((p) => p.entity_id === entityId);
+      expect(row).toBeDefined();
+      expect(row?.error_message).toBe('QuotaExceeded');
+    });
   });
 
   describe('getActor', () => {

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -211,8 +211,14 @@ export async function queryErrorPatterns(since?: string): Promise<ErrorPattern[]
 
   // Filter on structural signals, not substring matches:
   // - event_type names that denote failure (error / failed / rot.*)
-  // - JSONB key 'error' present on details (explicit error payload)
+  // - JSONB key 'error' or 'error_type' present on details (explicit error payload)
   // - state_changed where the new state value is literally 'error'
+  //
+  // Note: `reason` / `stderr` intentionally do NOT widen the filter. They're
+  // extracted from details (see COALESCE below) but only when the event has
+  // ALREADY qualified as an error via another predicate — otherwise benign
+  // events like `turn_close.done` (which carries `reason: "user_requested"`)
+  // would pollute the result set.
   //
   // Extract the human message from whichever key the producer used: error,
   // message, error_type, reason (state_changed carries this), or stderr.
@@ -239,6 +245,7 @@ export async function queryErrorPatterns(since?: string): Promise<ErrorPattern[]
          OR event_type LIKE '%failed%'
          OR event_type LIKE 'rot.%'
          OR details ? 'error'
+         OR details ? 'error_type'
          OR (event_type = 'state_changed' AND details->>'state' = 'error')
        )
        AND created_at >= $1::timestamptz


### PR DESCRIPTION
## Summary

Follow-up to #1267 addressing [gemini-code-assist's review comment](https://github.com/automagik-dev/genie/pull/1267). The merged filter extracts `error_type` from the COALESCE chain, but the WHERE clause only matched on `details ? 'error'`. Result: an event whose **only** failure signal is the `error_type` JSONB key — and whose `event_type` does not contain `error`/`failed`/`rot.*` — slipped through the filter entirely.

## Fix

Add `OR details ? 'error_type'` to the WHERE clause. Three lines, one new predicate.

Also documents the deliberate asymmetry between extraction and filtering: `reason` and `stderr` appear in the COALESCE chain but **not** in the filter, because `reason` is a very general field (e.g. `turn_close.done` carries `reason: "user_requested"`, which is not an error). Pulling `reason` into the filter would pollute the result set; leaving it in the COALESCE is free because it only fires when the row has already qualified.

## Test plan

- [x] New regression test in `src/lib/audit.test.ts`: emits `recordAuditEvent('resource', id, 'resource_check', 'cli', { error_type: 'QuotaExceeded' })` — a neutral event_type with only `error_type` as the failure signal — and asserts the row surfaces in `queryErrorPatterns` with `error_message === 'QuotaExceeded'`.
- [x] `bun test src/lib/audit.test.ts` → 25 pass (was 24 before this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)