### PR TITLE
fix(sessions): inherit parent metadata for orphaned subagents

### DIFF
--- a/src/lib/session-backfill.ts
+++ b/src/lib/session-backfill.ts
@@ -228,10 +228,13 @@ export async function startBackfill(sql: SqlClient): Promise<void> {
 
     // Reconcile any subagent rows whose parent was inserted after they were
     // (e.g. orphan subagents that got parent=NULL earlier but a main jsonl
-    // with the matching id has since appeared).
+    // with the matching id has since appeared). Also backfills missing
+    // metadata (agent_id/team/wish_slug/...) from the parent for rows that
+    // already have a parent link but were captured without worker context.
     try {
-      const fixed = await reconcileSubagentParents(sql);
-      if (fixed > 0) console.log(`[backfill] reconciled parent_session_id for ${fixed} subagent(s)`);
+      const { linked, metadataFilled } = await reconcileSubagentParents(sql);
+      if (linked > 0) console.log(`[backfill] reconciled parent_session_id for ${linked} subagent(s)`);
+      if (metadataFilled > 0) console.log(`[backfill] inherited parent metadata for ${metadataFilled} subagent(s)`);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       console.warn(`[backfill] parent reconcile skipped: ${message}`);

--- a/src/lib/session-capture.test.ts
+++ b/src/lib/session-capture.test.ts
@@ -193,10 +193,88 @@ describe.skipIf(!DB_AVAILABLE)('reconcileSubagentParents — metadata inheritanc
     `;
 
     // Should not throw even when both rows are metadata-free.
-    await expect(reconcileSubagentParents(sql)).resolves.toBeDefined();
+    const result = await reconcileSubagentParents(sql);
+    expect(result.linked).toBe(0);
+    expect(result.metadataFilled).toBe(0);
 
     const [row] = await sql`SELECT agent_id, team FROM sessions WHERE id = ${childId}`;
     expect(row.agent_id).toBeNull();
     expect(row.team).toBeNull();
+  });
+
+  test('does NOT inherit executor_id when child agent differs from parent (codex review)', async () => {
+    // Scenario: child has its own agent_id that differs from parent's.
+    // Naively inheriting executor_id would link the child to an executor
+    // row that belongs to a different agent, breaking the executor→agent
+    // identity invariant used by `sessions → executors → agents` joins.
+    const sql = await getConnection();
+    const parentId = 'parent-sess-4';
+    const childId = 'agent-child-4';
+
+    await sql`
+      INSERT INTO agents (id, role, started_at)
+      VALUES ('agent-parent-x', 'engineer', now())
+      ON CONFLICT DO NOTHING
+    `;
+    await sql`
+      INSERT INTO executors (id, agent_id, provider, transport)
+      VALUES ('exec-parent-x', 'agent-parent-x', 'claude', 'process')
+      ON CONFLICT DO NOTHING
+    `;
+    await sql`
+      INSERT INTO sessions (
+        id, agent_id, executor_id, team,
+        project_path, jsonl_path, status, is_subagent
+      ) VALUES (
+        ${parentId}, 'agent-parent-x', 'exec-parent-x', 'team-parent-x',
+        '/tmp/proj4', '/tmp/proj4/parent.jsonl', 'active', false
+      )
+    `;
+    // Child has a DIFFERENT agent_id but no executor_id.
+    await sql`
+      INSERT INTO sessions (
+        id, agent_id, executor_id, team,
+        project_path, jsonl_path, status, is_subagent, parent_session_id
+      ) VALUES (
+        ${childId}, 'agent-child-distinct', NULL, NULL,
+        '/tmp/proj4', ${`/tmp/proj4/${parentId}/subagents/${childId}.jsonl`},
+        'orphaned', true, ${parentId}
+      )
+    `;
+
+    await reconcileSubagentParents(sql);
+
+    const [row] = await sql`SELECT * FROM sessions WHERE id = ${childId}`;
+    // Child's own agent preserved (COALESCE).
+    expect(row.agent_id).toBe('agent-child-distinct');
+    // CRITICAL: executor NOT inherited — would have paired the child with
+    // an executor row pointing at 'agent-parent-x'.
+    expect(row.executor_id).toBeNull();
+    // Safe fields still inherited from parent.
+    expect(row.team).toBe('team-parent-x');
+  });
+
+  test('returns structured counts for linked and metadataFilled', async () => {
+    const sql = await getConnection();
+    const parentId = 'parent-sess-5';
+    const childId = 'agent-child-5';
+
+    await sql`
+      INSERT INTO sessions (id, agent_id, team, project_path, jsonl_path, status, is_subagent)
+      VALUES (${parentId}, 'agent-p5', 'team-5',
+              '/tmp/proj5', '/tmp/proj5/parent.jsonl', 'active', false)
+    `;
+    await sql`
+      INSERT INTO sessions (id, project_path, jsonl_path, status, is_subagent, parent_session_id)
+      VALUES (${childId}, '/tmp/proj5',
+              ${`/tmp/proj5/${parentId}/subagents/${childId}.jsonl`},
+              'orphaned', true, ${parentId})
+    `;
+
+    const result = await reconcileSubagentParents(sql);
+    // Parent link was already set, so linked=0 for this child.
+    // Metadata should have been filled for this one row.
+    expect(result.linked).toBeGreaterThanOrEqual(0);
+    expect(result.metadataFilled).toBeGreaterThanOrEqual(1);
   });
 });

--- a/src/lib/session-capture.test.ts
+++ b/src/lib/session-capture.test.ts
@@ -6,10 +6,15 @@
  *   2. ensureSession() — when parent session missing, insert with NULL rather
  *      than crashing on sessions_parent_session_id_fkey.
  *   3. reconcileSubagentParents() SQL — surface shape, no throw.
+ *   4. reconcileSubagentParents() metadata inheritance — subagent rows captured
+ *      before their parent worker registered should pick up agent_id/team/
+ *      wish_slug/task_id/role from their parent session.
  */
 
-import { describe, expect, test } from 'bun:test';
-import { extractSubTool } from './session-capture.js';
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { getConnection } from './db.js';
+import { extractSubTool, reconcileSubagentParents } from './session-capture.js';
+import { DB_AVAILABLE, setupTestSchema } from './test-db.js';
 
 describe('extractSubTool — truncation for btree row size', () => {
   test('Bash: first line of command, trimmed, capped at 2000 chars', () => {
@@ -60,5 +65,138 @@ describe('extractSubTool — truncation for btree row size', () => {
     expect(extractSubTool('Bash', { command: '' })).toBeNull();
     expect(extractSubTool('Bash', {})).toBeNull();
     expect(extractSubTool('Bash', null)).toBeNull();
+  });
+});
+
+describe.skipIf(!DB_AVAILABLE)('reconcileSubagentParents — metadata inheritance', () => {
+  let cleanup: () => Promise<void>;
+
+  beforeAll(async () => {
+    cleanup = await setupTestSchema();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  test('backfills agent_id/team/wish_slug/task_id/role/executor_id from parent', async () => {
+    const sql = await getConnection();
+    const parentId = 'parent-sess-1';
+    const childId = 'agent-child-1';
+
+    // Real executor row so the FK constraint holds when we inherit executor_id.
+    await sql`
+      INSERT INTO agents (id, role, started_at)
+      VALUES ('agent-foo', 'engineer', now())
+      ON CONFLICT DO NOTHING
+    `;
+    await sql`
+      INSERT INTO executors (id, agent_id, provider, transport)
+      VALUES ('exec-foo', 'agent-foo', 'claude', 'process')
+      ON CONFLICT DO NOTHING
+    `;
+
+    // Parent session — fully populated (simulates a real genie-spawned worker).
+    await sql`
+      INSERT INTO sessions (
+        id, agent_id, executor_id, team, wish_slug, task_id, role,
+        project_path, jsonl_path, status, is_subagent
+      ) VALUES (
+        ${parentId}, 'agent-foo', 'exec-foo', 'team-alpha',
+        'wish-x', 'task-42', 'engineer',
+        '/tmp/proj', '/tmp/proj/parent.jsonl', 'active', false
+      )
+    `;
+
+    // Subagent row — parent_session_id already set (captured after
+    // reconcileSubagentParents ran once to backfill the link) but
+    // metadata is NULL because no worker was registered for it.
+    await sql`
+      INSERT INTO sessions (
+        id, agent_id, executor_id, team, wish_slug, task_id, role,
+        project_path, jsonl_path, status, is_subagent, parent_session_id
+      ) VALUES (
+        ${childId}, NULL, NULL, NULL, NULL, NULL, NULL,
+        '/tmp/proj', ${`/tmp/proj/${parentId}/subagents/${childId}.jsonl`},
+        'orphaned', true, ${parentId}
+      )
+    `;
+
+    await reconcileSubagentParents(sql);
+
+    const [row] = await sql`SELECT * FROM sessions WHERE id = ${childId}`;
+    expect(row.agent_id).toBe('agent-foo');
+    expect(row.executor_id).toBe('exec-foo');
+    expect(row.team).toBe('team-alpha');
+    expect(row.wish_slug).toBe('wish-x');
+    expect(row.task_id).toBe('task-42');
+    expect(row.role).toBe('engineer');
+    // Status stays 'orphaned' — the subagent has no direct worker of its own.
+    // The inheritance is metadata-only; status transitions are out of scope.
+    expect(row.status).toBe('orphaned');
+  });
+
+  test('never overwrites existing non-null child values', async () => {
+    const sql = await getConnection();
+    const parentId = 'parent-sess-2';
+    const childId = 'agent-child-2';
+
+    await sql`
+      INSERT INTO sessions (
+        id, agent_id, team, wish_slug, task_id, role,
+        project_path, jsonl_path, status, is_subagent
+      ) VALUES (
+        ${parentId}, 'parent-agent', 'parent-team', 'parent-wish',
+        'parent-task', 'parent-role',
+        '/tmp/proj2', '/tmp/proj2/parent.jsonl', 'active', false
+      )
+    `;
+
+    // Child has its own agent_id + team already; other fields NULL.
+    await sql`
+      INSERT INTO sessions (
+        id, agent_id, team, wish_slug, task_id, role,
+        project_path, jsonl_path, status, is_subagent, parent_session_id
+      ) VALUES (
+        ${childId}, 'child-agent', 'child-team', NULL, NULL, NULL,
+        '/tmp/proj2', ${`/tmp/proj2/${parentId}/subagents/${childId}.jsonl`},
+        'orphaned', true, ${parentId}
+      )
+    `;
+
+    await reconcileSubagentParents(sql);
+
+    const [row] = await sql`SELECT * FROM sessions WHERE id = ${childId}`;
+    // Pre-existing values preserved (COALESCE takes the non-null child value).
+    expect(row.agent_id).toBe('child-agent');
+    expect(row.team).toBe('child-team');
+    // Previously-null fields filled from parent.
+    expect(row.wish_slug).toBe('parent-wish');
+    expect(row.task_id).toBe('parent-task');
+    expect(row.role).toBe('parent-role');
+  });
+
+  test('no-op when parent also has NULL fields', async () => {
+    const sql = await getConnection();
+    const parentId = 'parent-sess-3';
+    const childId = 'agent-child-3';
+
+    await sql`
+      INSERT INTO sessions (id, project_path, jsonl_path, status, is_subagent)
+      VALUES (${parentId}, '/tmp/proj3', '/tmp/proj3/parent.jsonl', 'orphaned', false)
+    `;
+    await sql`
+      INSERT INTO sessions (id, project_path, jsonl_path, status, is_subagent, parent_session_id)
+      VALUES (${childId}, '/tmp/proj3',
+              ${`/tmp/proj3/${parentId}/subagents/${childId}.jsonl`},
+              'orphaned', true, ${parentId})
+    `;
+
+    // Should not throw even when both rows are metadata-free.
+    await expect(reconcileSubagentParents(sql)).resolves.toBeDefined();
+
+    const [row] = await sql`SELECT agent_id, team FROM sessions WHERE id = ${childId}`;
+    expect(row.agent_id).toBeNull();
+    expect(row.team).toBeNull();
   });
 });

--- a/src/lib/session-capture.ts
+++ b/src/lib/session-capture.ts
@@ -382,12 +382,20 @@ async function ensureSession(
 // Reconcile parent_session_id for subagent rows that landed before their parent
 // ============================================================================
 
-export async function reconcileSubagentParents(sql: SqlClient): Promise<number> {
+interface ReconcileSubagentParentsResult {
+  /** Subagent rows whose `parent_session_id` was just linked from the path pattern. */
+  linked: number;
+  /** Subagent rows that inherited at least one missing metadata field from their parent. */
+  metadataFilled: number;
+}
+
+export async function reconcileSubagentParents(sql: SqlClient): Promise<ReconcileSubagentParentsResult> {
   // jsonl_path for a subagent is: <projectPath>/<parentUuid>/subagents/<child>.jsonl
   // Recover <parentUuid> from jsonl_path and link if a matching session now exists.
   const linkResult = await sql`
     UPDATE sessions s
-    SET parent_session_id = p.id
+    SET parent_session_id = p.id,
+        updated_at = now()
     FROM sessions p
     WHERE s.is_subagent = true
       AND s.parent_session_id IS NULL
@@ -410,11 +418,24 @@ export async function reconcileSubagentParents(sql: SqlClient): Promise<number> 
   // Status stays 'orphaned': these subagents have no direct worker of
   // their own, so they still don't belong in `--active`. This change is
   // purely metadata inheritance for observability.
-  await sql`
+  //
+  // Safety (codex review on PR #1270): executor_id is only inheritable when
+  // the identity pair stays consistent — if the child already has its own
+  // agent_id that disagrees with the parent's, we must NOT pull the parent's
+  // executor in, or the child ends up pointing at an executor row that
+  // belongs to a different agent. The CASE expression gates executor
+  // inheritance on "child has no agent" OR "child agent matches parent".
+  const metaResult = await sql`
     UPDATE sessions s
     SET
       agent_id    = COALESCE(s.agent_id,    p.agent_id),
-      executor_id = COALESCE(s.executor_id, p.executor_id),
+      executor_id = COALESCE(
+        s.executor_id,
+        CASE
+          WHEN s.agent_id IS NULL OR s.agent_id = p.agent_id THEN p.executor_id
+          ELSE NULL
+        END
+      ),
       team        = COALESCE(s.team,        p.team),
       wish_slug   = COALESCE(s.wish_slug,   p.wish_slug),
       task_id     = COALESCE(s.task_id,     p.task_id),
@@ -425,7 +446,8 @@ export async function reconcileSubagentParents(sql: SqlClient): Promise<number> 
       AND s.parent_session_id = p.id
       AND (
         (s.agent_id    IS NULL AND p.agent_id    IS NOT NULL) OR
-        (s.executor_id IS NULL AND p.executor_id IS NOT NULL) OR
+        (s.executor_id IS NULL AND p.executor_id IS NOT NULL
+          AND (s.agent_id IS NULL OR s.agent_id = p.agent_id)) OR
         (s.team        IS NULL AND p.team        IS NOT NULL) OR
         (s.wish_slug   IS NULL AND p.wish_slug   IS NOT NULL) OR
         (s.task_id     IS NULL AND p.task_id     IS NOT NULL) OR
@@ -433,7 +455,10 @@ export async function reconcileSubagentParents(sql: SqlClient): Promise<number> 
       )
   `;
 
-  return linkResult.count ?? 0;
+  return {
+    linked: linkResult.count ?? 0,
+    metadataFilled: metaResult.count ?? 0,
+  };
 }
 
 // ============================================================================

--- a/src/lib/session-capture.ts
+++ b/src/lib/session-capture.ts
@@ -385,7 +385,7 @@ async function ensureSession(
 export async function reconcileSubagentParents(sql: SqlClient): Promise<number> {
   // jsonl_path for a subagent is: <projectPath>/<parentUuid>/subagents/<child>.jsonl
   // Recover <parentUuid> from jsonl_path and link if a matching session now exists.
-  const result = await sql`
+  const linkResult = await sql`
     UPDATE sessions s
     SET parent_session_id = p.id
     FROM sessions p
@@ -398,7 +398,42 @@ export async function reconcileSubagentParents(sql: SqlClient): Promise<number> 
         ''
       )
   `;
-  return result.count ?? 0;
+
+  // Inherit metadata from the parent for subagent rows that have a parent
+  // but were captured before their worker was registered. Subagent JSONLs
+  // (Task-tool children) never get a direct worker, so their agent_id/team/
+  // wish_slug/task_id/role stay NULL and they land as status='orphaned'.
+  // Copy the parent's context so `genie sessions list --orphaned` shows
+  // proper lineage and downstream tool-usage queries can join on these
+  // rows. We only fill NULLs — never overwrite existing values.
+  //
+  // Status stays 'orphaned': these subagents have no direct worker of
+  // their own, so they still don't belong in `--active`. This change is
+  // purely metadata inheritance for observability.
+  await sql`
+    UPDATE sessions s
+    SET
+      agent_id    = COALESCE(s.agent_id,    p.agent_id),
+      executor_id = COALESCE(s.executor_id, p.executor_id),
+      team        = COALESCE(s.team,        p.team),
+      wish_slug   = COALESCE(s.wish_slug,   p.wish_slug),
+      task_id     = COALESCE(s.task_id,     p.task_id),
+      role        = COALESCE(s.role,        p.role),
+      updated_at  = now()
+    FROM sessions p
+    WHERE s.is_subagent = true
+      AND s.parent_session_id = p.id
+      AND (
+        (s.agent_id    IS NULL AND p.agent_id    IS NOT NULL) OR
+        (s.executor_id IS NULL AND p.executor_id IS NOT NULL) OR
+        (s.team        IS NULL AND p.team        IS NOT NULL) OR
+        (s.wish_slug   IS NULL AND p.wish_slug   IS NOT NULL) OR
+        (s.task_id     IS NULL AND p.task_id     IS NOT NULL) OR
+        (s.role        IS NULL AND p.role        IS NOT NULL)
+      )
+  `;
+
+  return linkResult.count ?? 0;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Subagent JSONLs (Task-tool children) never get a direct worker, so `sessions.agent_id/team/wish_slug/task_id/role/executor_id` stayed NULL and rows landed forever as `status='orphaned'` with no lineage.
- Extended `reconcileSubagentParents` to COALESCE-fill those fields from the parent session alongside the existing `parent_session_id` backfill.
- Status deliberately stays `'orphaned'`: these sessions have no direct worker of their own; this PR is metadata-only and widens observability, not status semantics.

## Why
On my dev DB, 85+ of the 500+ orphaned sessions are subagents with a known parent but null metadata. `genie sessions list --orphaned` shows bare UUIDs with no team/wish/agent context; downstream joins on `agent_id`/`team`/`wish_slug` silently drop their tool events. Backfilling the link we already have in `parent_session_id` is free value.

## Changes
- `src/lib/session-capture.ts` — add a second UPDATE inside `reconcileSubagentParents` that COALESCE-fills metadata from the parent. Existing non-null child values are preserved. No new FK requirements.
- `src/lib/session-capture.test.ts` — three DB-backed regression tests:
  1. Full inheritance when child is bare.
  2. COALESCE never overwrites pre-existing child values.
  3. No-op / no-throw when parent is also bare.

## Test plan
- [x] `bun test src/lib/session-capture.test.ts` — 11/11 pass
- [x] `bun run check` — 3419/3419 pass
- [ ] Dogfood on `@automagik/genie@next` after merge: re-run `genie sessions list --orphaned --limit 10 --json` and confirm subagent rows now carry agent_id/team/wish_slug from their parents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)