### PR TITLE
fix(hooks): forward --repo flag to branch-guard PR base lookup

### DIFF
--- a/src/hooks/__tests__/branch-guard.test.ts
+++ b/src/hooks/__tests__/branch-guard.test.ts
@@ -189,6 +189,83 @@ describe('branch-guard', () => {
     }
   });
 
+  // Regression: multi-repo workstation — the hook's `gh pr view` subprocess
+  // inherits a cwd whose git remote points at a different fork/clone than
+  // the PR being merged, so default gh resolution lands on the wrong repo
+  // and GraphQL returns "no such PR". Fix: forward `--repo OWNER/NAME` (or
+  // `-R OWNER/NAME`, with or without `=`) from the agent command to the
+  // lookup subprocess so both sides target the same repo.
+  describe('forwards --repo flag from gh pr merge to resolvePrBase', () => {
+    type ResolveCall = { prNum: string; repo: string | undefined };
+    function spyDeps(base: string): { deps: BranchGuardDeps; calls: ResolveCall[] } {
+      const calls: ResolveCall[] = [];
+      return {
+        calls,
+        deps: {
+          resolvePrBase: async (prNum, repo) => {
+            calls.push({ prNum, repo });
+            return { base };
+          },
+        },
+      };
+    }
+
+    const variants: Array<[string, string]> = [
+      ['long flag, space-separated', 'gh pr merge 1270 --squash --repo automagik-dev/genie'],
+      ['long flag, equals-separated', 'gh pr merge 1270 --repo=automagik-dev/genie --squash'],
+      ['short flag, space-separated', 'gh pr merge 1270 --squash -R automagik-dev/genie'],
+      ['short flag, equals-separated', 'gh pr merge 1270 -R=automagik-dev/genie'],
+      ['repo before pr num still parsed', 'gh pr merge 1270 --repo automagik-dev/genie --auto --delete-branch'],
+      ['slug with dots and hyphens', 'gh pr merge 42 --repo my-org/my.repo-name'],
+      ['slug with underscores', 'gh pr merge 7 --repo owner_x/name_y'],
+    ];
+    for (const [label, cmd] of variants) {
+      test(`${label}: "${cmd}"`, async () => {
+        const { deps, calls } = spyDeps('dev');
+        const result = await branchGuard(makePayload(cmd), deps);
+        expect(result).toBeUndefined();
+        expect(calls).toHaveLength(1);
+        expect(calls[0].prNum).toBe(cmd.match(/gh\s+pr\s+merge\s+(\d+)/)![1]);
+        // The repo slug must round-trip verbatim so subprocess targets the
+        // same repo the merge will hit.
+        expect(calls[0].repo).toBe(cmd.match(/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+/)![0]);
+      });
+    }
+
+    test('absent --repo leaves repo param undefined (backward compat — fall back to cwd resolution)', async () => {
+      const { deps, calls } = spyDeps('dev');
+      const result = await branchGuard(makePayload('gh pr merge 1270 --squash'), deps);
+      expect(result).toBeUndefined();
+      expect(calls).toHaveLength(1);
+      expect(calls[0].repo).toBeUndefined();
+    });
+
+    test('malformed repo arg (no slash) is ignored — repo stays undefined', async () => {
+      const { deps, calls } = spyDeps('dev');
+      await branchGuard(makePayload('gh pr merge 1270 --repo justowner'), deps);
+      expect(calls[0].repo).toBeUndefined();
+    });
+
+    test('--repo inside a quoted body is stripped before extraction (no accidental forwarding)', async () => {
+      const { deps, calls } = spyDeps('dev');
+      // The body text describes `--repo X/Y`; the actual merge command has
+      // no real --repo flag. The hook must NOT pull the slug out of the body.
+      await branchGuard(
+        makePayload('gh pr merge 1270 --squash --body "see --repo namastexlabs/genie for context"'),
+        deps,
+      );
+      expect(calls[0].repo).toBeUndefined();
+    });
+
+    test('still denies when --repo is present but PR targets main', async () => {
+      const { deps } = spyDeps('main');
+      const result = await branchGuard(makePayload('gh pr merge 1270 --repo automagik-dev/genie'), deps);
+      expect(result).toBeDefined();
+      expect(result!.decision).toBe('deny');
+      expect(result!.reason).toContain('main');
+    });
+  });
+
   describe('allows legitimate commands', () => {
     const allowed = [
       // Push to feature branches

--- a/src/hooks/handlers/branch-guard.ts
+++ b/src/hooks/handlers/branch-guard.ts
@@ -71,8 +71,16 @@ export interface BranchGuardDeps {
   /**
    * Resolve the base branch of a GitHub PR. Callers fall-closed on any
    * failure shape (`reason` present) — that's the §19 v2 safety contract.
+   *
+   * `repo` (when provided) pins the lookup to that `OWNER/NAME` slug. Needed
+   * on multi-repo workstations where the hook's subprocess cwd may resolve
+   * to a different git remote than the PR being merged — e.g. agents running
+   * from a workspace dir whose git remote points at a fork while the PR
+   * lives on the upstream. Without pinning, `gh pr view <num>` hits the
+   * wrong repo and returns GraphQL "no such PR" → fall-closed deny on a
+   * perfectly legitimate merge.
    */
-  resolvePrBase: (prNum: string) => Promise<ResolvePrBaseResult>;
+  resolvePrBase: (prNum: string, repo?: string) => Promise<ResolvePrBaseResult>;
 }
 
 /** Maximum stderr bytes we surface in a deny reason. Protects against gh
@@ -80,14 +88,22 @@ export interface BranchGuardDeps {
 const STDERR_SURFACE_CAP = 500;
 
 const defaultDeps: BranchGuardDeps = {
-  async resolvePrBase(prNum) {
+  async resolvePrBase(prNum, repo) {
     // spawnSync (not execSync) so we can inspect exit code AND stderr
     // independently. The previous `stdio: ['ignore','pipe','ignore']` routed
     // stderr to /dev/null, making every fall-closed deny undiagnosable.
     // Timeout bumped 5s→10s for headroom during `gh auth` token refreshes.
+    //
+    // When the agent's `gh pr merge` command carried `--repo OWNER/NAME` we
+    // forward the same flag to our verification lookup. That keeps the hook
+    // pointing at the same PR the merge will hit — otherwise gh's default
+    // resolution (from the subprocess cwd's git remote) can drift to a
+    // different repo on multi-repo workstations.
+    const args = ['pr', 'view', prNum, '--json', 'baseRefName', '-q', '.baseRefName'];
+    if (repo) args.push('--repo', repo);
     let result: ReturnType<typeof spawnSync>;
     try {
-      result = spawnSync('gh', ['pr', 'view', prNum, '--json', 'baseRefName', '-q', '.baseRefName'], {
+      result = spawnSync('gh', args, {
         encoding: 'utf8',
         timeout: 10_000,
         stdio: ['ignore', 'pipe', 'pipe'],
@@ -120,6 +136,24 @@ const defaultDeps: BranchGuardDeps = {
  */
 function extractPrNumber(cmd: string): string | null {
   const match = cmd.match(/gh\s+pr\s+merge\s+(\d+)\b/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Extract an explicit `--repo OWNER/NAME` (or `-R OWNER/NAME`) arg from the
+ * command so the hook's verification `gh pr view` can target the same repo
+ * as the merge. Both the short form and the long form, with or without `=`,
+ * are accepted so the hook matches gh's own tolerance.
+ *
+ * Constrains the slug to `[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+` — loose enough
+ * to cover every real GitHub owner/repo, tight enough to refuse an attacker
+ * trying to smuggle shell metachars into our subsequent `spawnSync` args.
+ *
+ * Returns `null` when no explicit repo is present; callers fall back to the
+ * subprocess's default resolution (git remote of cwd).
+ */
+function extractRepoFlag(cmd: string): string | null {
+  const match = cmd.match(/(?:--repo|-R)(?:\s+|=)([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)\b/);
   return match ? match[1] : null;
 }
 
@@ -219,7 +253,8 @@ export async function branchGuard(payload: HookPayload, deps: BranchGuardDeps = 
           'BLOCKED: `gh pr merge` requires an explicit PR number so the target base branch can be verified. §19 (v2): agents merge PRs targeting `dev` only; main/master is humans-only via GitHub UI.',
       };
     }
-    const resolved = await deps.resolvePrBase(prNum);
+    const repo = extractRepoFlag(matchTarget) ?? undefined;
+    const resolved = await deps.resolvePrBase(prNum, repo);
     if ('reason' in resolved) {
       return {
         decision: 'deny',


### PR DESCRIPTION
## Summary
- branch-guard's \`gh pr view\` verification defaulted to the subprocess cwd's git remote, so merges run from a workspace whose remote points at a fork / different clone got denied with GraphQL "no such PR" on the fall-closed branch
- extract \`--repo OWNER/NAME\` / \`-R\` (space- or equals-separated) from the agent command and forward the same flag into the lookup subprocess; slug regex refuses shell metachars
- 9 new tests cover both flag forms, positioning, slug characters, quoted-body isolation, backward compat, and main-deny still firing when repo is forwarded

## Live repro
Merging PR #1270 from the \`agents/genie\` workspace (remote = \`namastexlabs/genie\`) was denied because \`gh pr view 1270\` resolved against the wrong repo. Workaround required manually adding an \`automagik\` remote + \`gh repo set-default\`. This fix removes the workstation prerequisite.

## Test plan
- [x] \`bun test src/hooks/__tests__/branch-guard.test.ts\` — 83 pass
- [x] \`bun run check\` — 3442/3442 pass
- [ ] Post-merge: try \`gh pr merge <num> --repo automagik-dev/genie\` from \`agents/genie\` (no git-remote setup) — should succeed