### PR TITLE
feat(sessions): reconcile subagent parents on every daemon start

### DIFF
--- a/src/lib/scheduler-daemon.ts
+++ b/src/lib/scheduler-daemon.ts
@@ -2175,6 +2175,42 @@ export function startDaemon(
       const captureSql = await d.getConnection();
       const { startFilewatch } = await import('./session-filewatch.js');
       const { startBackfill } = await import('./session-backfill.js');
+      const { reconcileSubagentParents } = await import('./session-capture.js');
+
+      // Retroactive reconcile — runs once per daemon start, independent of
+      // backfill. The backfill-tail reconcile only fires when backfill
+      // actually runs (i.e., `session_sync.status != 'complete'`). Post-
+      // v1 deployments leave backfill done, so subagents captured by
+      // filewatch BEFORE their parent session row was enriched (async
+      // worker-map lookup miss, filewatch ordering race, or parent
+      // inserted from a later jsonl batch) stay metadata-free forever.
+      //
+      // Running the same idempotent UPDATEs here catches those rows on
+      // the next restart. Zero rows is the happy case; a non-zero count
+      // is diagnostic gold — it says "the filewatch ordering skipped
+      // metadata for N subagents and we just fixed them."
+      reconcileSubagentParents(captureSql)
+        .then(({ linked, metadataFilled }) => {
+          if (linked > 0 || metadataFilled > 0) {
+            d.log({
+              timestamp: d.now().toISOString(),
+              level: 'info',
+              event: 'subagent_reconcile_on_start',
+              linked,
+              metadata_filled: metadataFilled,
+            });
+          }
+        })
+        .catch((err) => {
+          const msg = err instanceof Error ? err.message : String(err);
+          d.log({
+            timestamp: d.now().toISOString(),
+            level: 'warn',
+            event: 'subagent_reconcile_on_start_failed',
+            error: msg,
+          });
+        });
+
       const filewatchOk = await startFilewatch(captureSql);
       if (!filewatchOk) {
         const { ingestFileFull, discoverAllJsonlFiles, buildWorkerMap } = await import('./session-capture.js');


### PR DESCRIPTION
## Summary
- \`reconcileSubagentParents\` previously only ran at the tail of backfill; once \`session_sync.status='complete'\` it never fires again, so subagents captured by filewatch before their parent session row was enriched stay metadata-free across restarts
- call it once on daemon startup alongside \`startBackfill\` — idempotent UPDATEs only touch rows that still need filling
- fire-and-forget: logs \`subagent_reconcile_on_start\` with \`linked\`/\`metadata_filled\` counts when non-zero; errors surface as a \`warn\` and do not block daemon bringup

## Why now
PR #1270 shipped the inheritance fix but only wired it into the backfill path. Post-v1 users have completed backfills, so the fix went dormant for them. This slot re-activates it retroactively on the next daemon boot and guarantees forward-healing from any future filewatch ordering drift.

## Test plan
- [x] \`bun test src/lib/scheduler-daemon.test.ts\` — 95/95 pass with change applied
- [x] \`bun run check\` — 3442/3442 pass
- [ ] Post-merge: restart daemon on a host with known metadata-free subagents-with-parent-metadata and confirm a \`subagent_reconcile_on_start\` log with non-zero counts