### PR TITLE
fix(brain): exit non-zero when @khal-os/brain package is not installed

### DIFF
--- a/src/term-commands/brain.ts
+++ b/src/term-commands/brain.ts
@@ -558,13 +558,16 @@ async function executeBrainCommand(args: string[]): Promise<void> {
     } else {
       console.error('Brain module loaded but execute() not found.');
       console.error('Update: genie brain install');
+      process.exit(1);
     }
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     if (isModuleNotFound(msg)) {
       printNotInstalledMessage();
+      process.exit(1);
     } else {
       console.error(`Brain error: ${msg}`);
+      process.exit(1);
     }
   }
 }


### PR DESCRIPTION
## Summary

Resolves #1151. Adds `process.exit(1)` at each of the three catch-paths in `executeBrainCommand` so `genie brain <subcommand>` exits non-zero whenever the `@khal-os/brain` module is missing or fails to load.

## Problem

Before this change, write subcommands (`brain learn ingest`, `brain decisions create`, etc.) printed the install instructions and silently exited 0 on a host without the brain package installed. Scripts that only check the exit code could not detect that writes were dropped. The issue reports a production sync reporting ~400 ingest + ~100 decisions-create calls as successful against a host with no brain installed — all silently discarded.

## Fix

`src/term-commands/brain.ts` — one `process.exit(1)` added at each of the three failure paths in `executeBrainCommand`:

1. Module loaded but `execute()` export not found
2. Module-not-found on import (the printed install-message path)
3. Other errors during execution

Picks option A of the issue's acceptance criteria: ALL subcommands exit non-zero on missing install. Read-only subcommands also exit 1 — this trades minor exit-code noise on read paths for the large correctness win on writes.

## Test plan

- [x] `bun test src/__tests__/resume.test.ts` — passes isolated (10/10, captured in commit body)
- [x] `bun run check` — 3442 pass / 0 fail / 126.24s on this host (Task #32 `resume.test.ts` PG-pollution flake did not reproduce here)
- [x] Pre-push hook — passed on attempt 3 after two hits of the known events-stream persisted-cursor flake (Task #28, ~80% rate on loaded hosts); no hook bypass, standard retry
- [x] Flake confirmed orthogonal: `bun test src/term-commands/events-stream.test.ts` passes 5/5 in isolation (9.80s); diff touches only `brain.ts`, so the flake cannot be regression
- [x] Single-axis change — 1 file, +3 lines

## Compliance

- [x] Targets `dev` (§19 v2)
- [x] No `--no-verify`, no hook bypass
- [x] Rebased onto latest `origin/dev` before push

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
