### PR TITLE
feat(doctor): detect multi-installer @automagik/genie conflicts

### DIFF
--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -15,6 +15,7 @@ import { tmuxBin } from '../lib/ensure-tmux.js';
 import { genieConfigExists, getGenieConfigPath, isSetupComplete, loadGenieConfig } from '../lib/genie-config.js';
 import { checkCommand } from '../lib/system-detect.js';
 import { findWorkspace } from '../lib/workspace.js';
+import { collectInstallerResolution } from './installer-resolution.js';
 import { collectObservabilityHealth } from './observability-health.js';
 
 interface CheckResult {
@@ -516,6 +517,7 @@ export async function doctorCommand(options?: {
   const counts = { errors: false, warnings: false };
 
   runCheckSection('Prerequisites', await checkPrerequisites(), counts);
+  runCheckSection('Installer Resolution', await collectInstallerResolution(), counts);
   runCheckSection('Configuration', await checkConfiguration(), counts);
   runCheckSection('Tmux', await checkTmux(), counts);
   runCheckSection('Worker Profiles', await checkWorkerProfiles(), counts);

--- a/src/genie-commands/installer-resolution.test.ts
+++ b/src/genie-commands/installer-resolution.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Unit tests for `classifyInstallerResolution`.
+ *
+ * The I/O-heavy probes (`probeInstallers`, `probeResolvedBinary`) spawn
+ * subprocesses and walk the filesystem — covered by a single smoke test
+ * that just asserts the function returns without throwing on whatever
+ * this box happens to have installed. The real behavior under test is
+ * the classifier, which is pure and covers every status transition.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  type InstallerEntry,
+  type ResolvedBinary,
+  classifyInstallerResolution,
+  collectInstallerResolution,
+  compareVersions,
+} from './installer-resolution.js';
+
+function resolved(path: string, realPath = path): ResolvedBinary {
+  return { path, realPath };
+}
+
+function entry(installer: InstallerEntry['installer'], binPath: string, version: string): InstallerEntry {
+  return {
+    installer,
+    binPath,
+    packageJsonPath: `${binPath}/package.json`,
+    version,
+  };
+}
+
+describe('classifyInstallerResolution', () => {
+  test('warns when no binary resolves on PATH', () => {
+    const rows = classifyInstallerResolution({ resolved: null, installers: [] });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe('warn');
+    expect(rows[0].name).toBe('Resolved binary');
+    expect(rows[0].message).toContain('which genie');
+  });
+
+  test('passes when resolver matches the only detected installer', () => {
+    // The match is via real-path comparison. Test doubles live under
+    // /tmp which has no genie — but we can exercise the no-match branch
+    // by pointing both at the same literal string since `safeRealpath`
+    // falls through to the input on ENOENT.
+    const bin = '/virtual/bin/genie';
+    const rows = classifyInstallerResolution({
+      resolved: resolved(bin),
+      installers: [entry('npm', bin, '4.260421.17')],
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe('pass');
+    expect(rows[0].message).toContain('npm');
+    expect(rows[0].message).toContain('4.260421.17');
+  });
+
+  test('warns when resolver is on PATH but no installer owns it (dev checkout)', () => {
+    const rows = classifyInstallerResolution({
+      resolved: resolved('/opt/custom/genie'),
+      installers: [entry('npm', '/some/npm/bin/genie', '4.260421.17')],
+    });
+    expect(rows[0].status).toBe('warn');
+    expect(rows[0].message).toContain('not owned');
+    expect(rows[0].suggestion).toContain('dev checkout');
+    // Still lists the detected installer so the user sees the alternative.
+    expect(rows[1].status).toBe('warn');
+    expect(rows[1].name).toContain('npm');
+  });
+
+  test('warns on duplicate installs and labels the older one stale', () => {
+    const npmBin = '/virtual/npm/bin/genie';
+    const bunBin = '/virtual/bun/bin/genie';
+    const rows = classifyInstallerResolution({
+      resolved: resolved(npmBin),
+      installers: [entry('npm', npmBin, '4.260421.17'), entry('bun', bunBin, '4.260420.5')],
+    });
+    expect(rows[0].status).toBe('pass'); // resolver is fine
+    const alsoBun = rows.find((r) => r.name.includes('bun'));
+    expect(alsoBun?.status).toBe('warn');
+    expect(alsoBun?.message).toContain('stale');
+    expect(alsoBun?.suggestion).toContain('bun remove -g');
+  });
+
+  test('warns when resolver is the stale one shadowed by a newer install', () => {
+    const bunBin = '/virtual/bun/bin/genie';
+    const npmBin = '/virtual/npm/bin/genie';
+    const rows = classifyInstallerResolution({
+      resolved: resolved(bunBin),
+      installers: [entry('bun', bunBin, '4.260420.5'), entry('npm', npmBin, '4.260421.17')],
+    });
+    // Resolved binary row passes (we found the installer)
+    expect(rows[0].status).toBe('pass');
+    expect(rows[0].message).toContain('bun');
+    // Sibling installer row shows newer version without "stale" label
+    const alsoNpm = rows.find((r) => r.name.includes('npm'));
+    expect(alsoNpm?.status).toBe('warn');
+    expect(alsoNpm?.message).not.toContain('stale');
+    // Explicit update-path advisory fires
+    const updatePath = rows.find((r) => r.name === 'Update path');
+    expect(updatePath?.status).toBe('warn');
+    expect(updatePath?.message).toContain('stale');
+    expect(updatePath?.message).toContain('shadowed');
+  });
+
+  test('passes cleanly with a single bun install (common user setup)', () => {
+    const bunBin = '/virtual/bun/bin/genie';
+    const rows = classifyInstallerResolution({
+      resolved: resolved(bunBin),
+      installers: [entry('bun', bunBin, '4.260421.17')],
+    });
+    expect(rows.every((r) => r.status === 'pass')).toBe(true);
+  });
+
+  test('handles pnpm + yarn duplicates (four-installer matrix)', () => {
+    const rows = classifyInstallerResolution({
+      resolved: resolved('/virtual/npm/bin/genie'),
+      installers: [
+        entry('npm', '/virtual/npm/bin/genie', '4.260421.17'),
+        entry('bun', '/virtual/bun/bin/genie', '4.260420.5'),
+        entry('pnpm', '/virtual/pnpm/bin/genie', '4.260419.0'),
+        entry('yarn', '/virtual/yarn/bin/genie', '4.260418.2'),
+      ],
+    });
+    // Three sibling advisories, each with the right remove hint
+    expect(rows.find((r) => r.name.includes('bun'))?.suggestion).toContain('bun remove -g');
+    expect(rows.find((r) => r.name.includes('pnpm'))?.suggestion).toContain('pnpm remove -g');
+    expect(rows.find((r) => r.name.includes('yarn'))?.suggestion).toContain('yarn global remove');
+  });
+});
+
+describe('compareVersions', () => {
+  test('orders major.minor.patch correctly', () => {
+    expect(compareVersions('1.0.0', '1.0.1')).toBeLessThan(0);
+    expect(compareVersions('1.0.1', '1.0.0')).toBeGreaterThan(0);
+    expect(compareVersions('1.0.0', '1.0.0')).toBe(0);
+  });
+
+  test('handles calendar-versioned genie releases', () => {
+    expect(compareVersions('4.260421.17', '4.260421.5')).toBeGreaterThan(0);
+    expect(compareVersions('4.260420.99', '4.260421.0')).toBeLessThan(0);
+  });
+
+  test('treats missing segments as zero', () => {
+    expect(compareVersions('1.0', '1.0.0')).toBe(0);
+    expect(compareVersions('2', '1.999.999')).toBeGreaterThan(0);
+  });
+
+  test('does not crash on non-numeric segments (naive comparator)', () => {
+    // Prerelease labels aren't semver-aware here — genie ships
+    // calendar-versioned releases without prereleases. Just assert the
+    // comparator yields a finite number without throwing.
+    const n = compareVersions('1.0.0-rc.1', '1.0.0');
+    expect(Number.isFinite(n)).toBe(true);
+  });
+});
+
+describe('collectInstallerResolution (smoke)', () => {
+  test('returns at least one CheckResult row without throwing', async () => {
+    const rows = await collectInstallerResolution();
+    expect(Array.isArray(rows)).toBe(true);
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    for (const row of rows) {
+      expect(typeof row.name).toBe('string');
+      expect(['pass', 'warn', 'fail']).toContain(row.status);
+    }
+  });
+});

--- a/src/genie-commands/installer-resolution.ts
+++ b/src/genie-commands/installer-resolution.ts
@@ -1,0 +1,300 @@
+/**
+ * Installer resolution diagnostic for `genie doctor`.
+ *
+ * Detects which package manager's global install resolves first on PATH,
+ * surfaces stale-shadow scenarios (e.g. `bun remove -g @automagik/genie`
+ * wasn't run, npm-global now shadows it but bun still lives on PATH),
+ * and suggests concrete `<installer> remove -g` commands.
+ *
+ * Why this exists: `@automagik/genie` ships via multiple installers
+ * (bun, npm, pnpm, yarn). Users who `npm install -g @automagik/genie@next`
+ * but still have `~/.bun/bin` higher on PATH end up running a stale copy
+ * and the version tag looks frozen. `genie doctor` should flag the drift.
+ *
+ * Pure-function-friendly layout:
+ *   - `probeInstallers()` / `probeResolvedBinary()` do I/O.
+ *   - `classifyInstallerResolution()` is a pure state -> CheckResult[]
+ *     translator so behavior is unit-testable without spawning processes.
+ */
+
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const PKG_NAME = '@automagik/genie';
+
+export type InstallerId = 'npm' | 'bun' | 'pnpm' | 'yarn';
+
+export interface InstallerEntry {
+  /** Which package manager owns the global install. */
+  installer: InstallerId;
+  /** Absolute path to the global bin shim (`<bin-dir>/genie`). */
+  binPath: string;
+  /** Resolved `package.json` path for `@automagik/genie`. */
+  packageJsonPath: string;
+  /** Version string from the resolved `package.json`. */
+  version: string;
+}
+
+export interface ResolvedBinary {
+  /** Output of `which genie` (or equivalent). */
+  path: string;
+  /** Symlink-resolved real path, used to match against installer entries. */
+  realPath: string;
+}
+
+interface InstallerResolutionState {
+  resolved: ResolvedBinary | null;
+  installers: InstallerEntry[];
+}
+
+interface CheckResult {
+  name: string;
+  status: 'pass' | 'fail' | 'warn';
+  message?: string;
+  suggestion?: string;
+}
+
+/**
+ * Spawn a short-lived process and capture trimmed stdout. Returns `null`
+ * on non-zero exit or thrown errors so callers can treat "installer
+ * missing" and "installer present but errored" uniformly.
+ */
+async function runSilent(cmd: string, args: string[]): Promise<string | null> {
+  try {
+    const proc = Bun.spawn([cmd, ...args], {
+      stdout: 'pipe',
+      stderr: 'ignore',
+      stdin: 'ignore',
+    });
+    const text = await new Response(proc.stdout).text();
+    const code = await proc.exited;
+    if (code !== 0) return null;
+    const trimmed = text.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Walk up from the real bin target looking for a `package.json` whose
+ * `name` matches `@automagik/genie`. Bounded to 8 levels so broken
+ * symlinks pointing into shared trees can't cause runaway traversal.
+ */
+function findPackageJson(realBinPath: string): { path: string; version: string } | null {
+  let dir = dirname(realBinPath);
+  for (let i = 0; i < 8; i++) {
+    const candidate = join(dir, 'package.json');
+    if (existsSync(candidate)) {
+      try {
+        const parsed = JSON.parse(readFileSync(candidate, 'utf-8')) as {
+          name?: string;
+          version?: string;
+        };
+        if (parsed.name === PKG_NAME && typeof parsed.version === 'string') {
+          return { path: candidate, version: parsed.version };
+        }
+      } catch {
+        // malformed package.json — keep walking
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+function safeRealpath(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
+}
+
+async function probeOne(installer: InstallerId, binDir: string | null): Promise<InstallerEntry | null> {
+  if (!binDir) return null;
+  const binPath = join(binDir, 'genie');
+  if (!existsSync(binPath)) return null;
+  const real = safeRealpath(binPath);
+  const pkg = findPackageJson(real);
+  if (!pkg) return null;
+  return { installer, binPath, packageJsonPath: pkg.path, version: pkg.version };
+}
+
+/**
+ * Probe the four supported installers for a global `@automagik/genie`
+ * install. Each probe is best-effort — a missing installer, failed
+ * command, or absent bin all yield `null` and are filtered out.
+ */
+async function probeInstallers(): Promise<InstallerEntry[]> {
+  const entries: InstallerEntry[] = [];
+
+  // npm: `npm root -g` returns the global node_modules dir; the bin dir
+  // lives at `<prefix>/bin`, which is `<root>/../bin`.
+  const npmRoot = await runSilent('npm', ['root', '-g']);
+  const npmBin = npmRoot ? join(dirname(npmRoot), 'bin') : null;
+
+  // bun: `bun pm -g bin` returns the bin dir directly.
+  const bunBin = await runSilent('bun', ['pm', '-g', 'bin']);
+
+  // pnpm: `pnpm root -g` is a node_modules dir; pnpm's bin dir sits next
+  // to it. Users may set PNPM_HOME which short-circuits this, so we try
+  // the env var first then fall back.
+  const pnpmRoot = await runSilent('pnpm', ['root', '-g']);
+  const pnpmBin = process.env.PNPM_HOME ?? (pnpmRoot ? join(dirname(pnpmRoot), 'bin') : null);
+
+  // yarn v1: `yarn global bin` returns the bin dir. Yarn v2+ doesn't
+  // support global installs — probe fails cleanly there.
+  const yarnBin = await runSilent('yarn', ['global', 'bin']);
+
+  const probes: Array<[InstallerId, string | null]> = [
+    ['npm', npmBin],
+    ['bun', bunBin],
+    ['pnpm', pnpmBin],
+    ['yarn', yarnBin],
+  ];
+
+  for (const [id, dir] of probes) {
+    const entry = await probeOne(id, dir);
+    if (entry) entries.push(entry);
+  }
+  return entries;
+}
+
+/** Probe the binary that currently resolves on PATH. */
+async function probeResolvedBinary(): Promise<ResolvedBinary | null> {
+  const path = await runSilent('which', ['genie']);
+  if (!path) return null;
+  return { path, realPath: safeRealpath(path) };
+}
+
+/**
+ * Compare semver-ish numeric version strings. Returns negative when
+ * `a < b`, positive when `a > b`, zero otherwise. Non-numeric segments
+ * sort as zero — good enough for the calendar-versioned genie releases
+ * used here; callers aren't branching on prerelease labels.
+ */
+export function compareVersions(a: string, b: string): number {
+  const pa = a.split('.').map((s) => Number.parseInt(s, 10));
+  const pb = b.split('.').map((s) => Number.parseInt(s, 10));
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const na = Number.isFinite(pa[i]) ? (pa[i] as number) : 0;
+    const nb = Number.isFinite(pb[i]) ? (pb[i] as number) : 0;
+    if (na !== nb) return na - nb;
+  }
+  return 0;
+}
+
+function uninstallHint(installer: InstallerId): string {
+  switch (installer) {
+    case 'npm':
+      return `npm uninstall -g ${PKG_NAME}`;
+    case 'bun':
+      return `bun remove -g ${PKG_NAME}`;
+    case 'pnpm':
+      return `pnpm remove -g ${PKG_NAME}`;
+    case 'yarn':
+      return `yarn global remove ${PKG_NAME}`;
+  }
+}
+
+/**
+ * Map a probed state to a list of `CheckResult` rows suitable for
+ * `genie doctor`. Pure function — exposed for unit testing.
+ *
+ * Classification:
+ *   - No `which genie` hit  -> `warn` (not on PATH).
+ *   - Resolver hits but no installer owns the bin -> `warn` (likely dev
+ *     checkout / manual symlink; package-manager updates won't replace it).
+ *   - Resolver matches an installer entry; no duplicates -> `pass`.
+ *   - Resolver matches an installer; duplicates exist -> `warn`, prefer
+ *     the highest-version installer and suggest removing the others.
+ *   - Duplicates exist and resolver is stale relative to the highest
+ *     available version -> `warn`, suggest reinstall via the resolver's
+ *     installer (so it wins on PATH) OR removal of the stale one.
+ */
+export function classifyInstallerResolution(state: InstallerResolutionState): CheckResult[] {
+  const { resolved, installers } = state;
+
+  if (!resolved) {
+    return [
+      {
+        name: 'Resolved binary',
+        status: 'warn',
+        message: '`which genie` returned nothing',
+        suggestion: 'Add the installer bin dir to PATH, or reinstall with: npm install -g @automagik/genie',
+      },
+    ];
+  }
+
+  // Identify which installer (if any) owns the resolved binary by
+  // comparing real paths — symlink chains (bun's `<bin>/genie -> ../install/global/...`)
+  // otherwise won't match the listed bin dir string-equal.
+  const owner = installers.find((e) => safeRealpath(e.binPath) === resolved.realPath) ?? null;
+
+  const rows: CheckResult[] = [];
+
+  if (!owner) {
+    rows.push({
+      name: 'Resolved binary',
+      status: 'warn',
+      message: `${resolved.path} (not owned by a detected installer)`,
+      suggestion:
+        'Likely a dev checkout or manual symlink. Package-manager updates (`npm i -g`, `bun add -g`) will not replace this binary.',
+    });
+    for (const entry of installers) {
+      rows.push({
+        name: `Also installed via ${entry.installer}`,
+        status: 'warn',
+        message: `${entry.version} at ${entry.binPath}`,
+      });
+    }
+    return rows;
+  }
+
+  rows.push({
+    name: 'Resolved binary',
+    status: 'pass',
+    message: `${resolved.path} (${owner.installer} @ ${owner.version})`,
+  });
+
+  const others = installers.filter((e) => e.installer !== owner.installer);
+  if (others.length === 0) {
+    return rows;
+  }
+
+  // Duplicates exist — figure out whether the resolver is stale.
+  const sorted = [...installers].sort((a, b) => compareVersions(b.version, a.version));
+  const newest = sorted[0];
+  const resolverIsStale = compareVersions(owner.version, newest.version) < 0;
+
+  for (const entry of others) {
+    const stale = compareVersions(entry.version, owner.version) < 0;
+    rows.push({
+      name: `Also installed via ${entry.installer}`,
+      status: 'warn',
+      message: `${entry.version}${stale ? ' (stale)' : ''} at ${entry.binPath}`,
+      suggestion: `Remove with: ${uninstallHint(entry.installer)}`,
+    });
+  }
+
+  if (resolverIsStale) {
+    rows.push({
+      name: 'Update path',
+      status: 'warn',
+      message: `${owner.installer}@${owner.version} is stale; ${newest.installer}@${newest.version} is newer but shadowed`,
+      suggestion: `Either reinstall via the resolver (${uninstallHint(owner.installer).replace('uninstall', 'install').replace('remove', 'add')}) or remove the resolver so ${newest.installer} takes over.`,
+    });
+  }
+
+  return rows;
+}
+
+/** High-level entry point: probe + classify in one call for `doctor`. */
+export async function collectInstallerResolution(): Promise<CheckResult[]> {
+  const [resolved, installers] = await Promise.all([probeResolvedBinary(), probeInstallers()]);
+  return classifyInstallerResolution({ resolved, installers });
+}


### PR DESCRIPTION
## Summary

New \`Installer Resolution\` section in \`genie doctor\` that detects when multiple package managers have \`@automagik/genie\` globally installed, classifies which one actually resolves on PATH, and flags stale-shadow scenarios.

Addresses the PATH-priority surprise flagged in the 2026-04-21 agent reflection: a user runs \`npm install -g @automagik/genie@next\` but \`genie --version\` still shows the old version because \`~/.bun/bin\` resolves first on PATH. Until now \`genie doctor\` had no visibility into this.

## What runs

- \`which genie\` → resolved binary (real-path, symlinks followed)
- Probe npm (\`npm root -g\`), bun (\`bun pm -g bin\`), pnpm (\`PNPM_HOME\` / \`pnpm root -g\`), yarn v1 (\`yarn global bin\`) for \`@automagik/genie\` installs
- Skip installers that aren't present or error out (all probes are best-effort)
- Classify + emit \`CheckResult\` rows matching existing doctor sections

## Classification matrix

| Situation | Status | Message / suggestion |
|---|---|---|
| Single installer owns resolver | pass | \`Resolved binary /path/to/genie (bun @ 4.260421.17)\` |
| Duplicates, resolver is the newest | warn | \`Also installed via npm: 4.260420.5 (stale) at /path\` → \`Remove with: npm uninstall -g @automagik/genie\` |
| Duplicates, resolver shadows a newer install | warn | \`Update path: bun@old is stale; npm@new is newer but shadowed\` → reinstall-via-resolver or remove-the-resolver |
| Resolver on PATH, no installer owns it | warn | \`(not owned by a detected installer)\` — flags dev-checkouts / manual symlinks |
| No \`which genie\` hit | warn | \`Add the installer bin dir to PATH, or reinstall with: npm install -g @automagik/genie\` |

## Scope

Detection + advisory only. Sub-fix (a) — \`genie update\` auto-routing based on the detected installer — deserves its own wish and is NOT in this PR. Sub-fix (c) — \`genie claude\` wrapper or \`genie observe --install\` — is tracked on #1263 / future issue.

## Live verification on my box (bun-only install)

\`\`\`
Installer Resolution:
  ✓ Resolved binary /home/genie/.bun/bin/genie (bun @ 4.260421.14)
\`\`\`

## Test plan

- [x] \`bun test src/genie-commands/installer-resolution.test.ts\` — 12/12 pass
- [x] \`bun test src/genie-commands/installer-resolution.test.ts src/genie-commands/doctor.test.ts\` — 19/19 pass
- [x] \`bun run typecheck\` — clean
- [x] \`bun run dead-code\` (knip) — clean (no unused exports from my module)
- [x] \`bun x biome check\` on my files — clean (2 pre-existing complexity warnings in doctor.ts unrelated functions)
- [x] \`bun run check\` — typecheck + lint + knip clean; 3453 tests pass; single flaky test (different one per run: once \`omni-bridge\`, once \`TeamCreate Esc on step 2\`) unrelated to this change — both pass in isolation
- [ ] Manual: \`genie doctor\` on a box with both npm-global and bun-global installs of genie → section surfaces duplicate + stale hint
- [ ] Manual: \`genie doctor\` on a box with \`@automagik/genie\` installed via pnpm only → pass row with \`pnpm @ <version>\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)