### PR TITLE
fix(bridge): address PR #1271 review feedback on tmux session resolver

### DIFF
--- a/src/lib/agent-directory.ts
+++ b/src/lib/agent-directory.ts
@@ -540,7 +540,11 @@ function buildMetadata(entry: DirectoryEntry): Record<string, unknown> {
   if (entry.omniScopes) meta.omniScopes = entry.omniScopes;
   if (entry.hooks) meta.hooks = entry.hooks;
   if (entry.sdk) meta.sdk = entry.sdk;
-  if (entry.bridgeTmuxSession) meta.bridgeTmuxSession = entry.bridgeTmuxSession;
+  // Always emit bridgeTmuxSession (as null when unset) so the JSONB merge in
+  // edit() can overwrite a stale persisted value. Other optional fields above
+  // share the same "truthy-only" pattern as a pre-existing (separate) concern;
+  // we only fix this field here because it's the one flagged by the review.
+  meta.bridgeTmuxSession = entry.bridgeTmuxSession ?? null;
   return meta;
 }
 

--- a/src/services/executors/claude-code.test.ts
+++ b/src/services/executors/claude-code.test.ts
@@ -241,13 +241,35 @@ describe('resolveBridgeTmuxSession', () => {
     expect(resolveBridgeTmuxSession('agent', 'yaml-default', '')).toBe('yaml-default');
   });
 
+  test('empty-string yaml default is treated as absent (falls through to agentName)', () => {
+    // Regression for Gemini review on PR #1271: a yaml file with
+    // `bridgeTmuxSession: ''` previously short-circuited to "" (nameless
+    // session, rejected by tmux). `||` semantics now fall through.
+    expect(resolveBridgeTmuxSession('agent-name', '', undefined)).toBe('agent-name');
+  });
+
   test('empty-string env override falls through to agentName when yaml also empty', () => {
     expect(resolveBridgeTmuxSession('fallback', undefined, '')).toBe('fallback');
   });
 
-  test('preserves non-slash special chars (tmux already rejects them downstream)', () => {
-    // We only sanitize `/` because tmux treats it as a target separator.
-    // Other characters are the caller's responsibility.
+  test('empty-string env and empty-string yaml both fall through to agentName', () => {
+    expect(resolveBridgeTmuxSession('fallback-both', '', '')).toBe('fallback-both');
+  });
+
+  test('sanitizes `:` to `-` (tmux reserves `:` as session:window separator)', () => {
+    // Regression for Gemini review on PR #1271.
+    expect(resolveBridgeTmuxSession('agent', 'team:window', undefined)).toBe('team-window');
+    expect(resolveBridgeTmuxSession('agent', 'yaml', 'whatsapp:12')).toBe('whatsapp-12');
+    expect(resolveBridgeTmuxSession('agent:role', undefined, undefined)).toBe('agent-role');
+  });
+
+  test('sanitizes mixed `/` and `:` in a single value', () => {
+    expect(resolveBridgeTmuxSession('agent', 'team:sub/window', undefined)).toBe('team-sub-window');
+  });
+
+  test('preserves benign special chars (., _, non-reserved)', () => {
+    // Sanitization targets only `/` and `:`; other chars are the caller's
+    // concern. Dots and underscores are legal in tmux session names.
     expect(resolveBridgeTmuxSession('agent', 'with_underscore-and.dot', undefined)).toBe('with_underscore-and.dot');
   });
 });

--- a/src/services/executors/claude-code.ts
+++ b/src/services/executors/claude-code.ts
@@ -80,18 +80,21 @@ export function sanitizeWindowName(chatId: string, chatName?: string): string {
  *      Enables hierarchical co-location ("felipe/scout lands in felipe session").
  *   3. `agentName` — backward-compatible fallback (legacy behavior).
  *
- * Tmux rejects `/` in session names, so the resolved value is sanitized
- * regardless of source. Empty strings are treated as absent (fall through
- * to the next layer) so a caller passing `env.GENIE_TMUX_SESSION = ''`
- * does not accidentally short-circuit to a nameless session.
+ * Uses `||` (not `??`) so any falsy value — including the empty string —
+ * falls through to the next layer. Empty strings in either source would
+ * produce a nameless session, which tmux rejects with a cryptic error.
+ *
+ * Tmux also reserves `/` (used in some window addressing) and `:` (session
+ * vs window separator, e.g. `session:window.pane`), so both are sanitized
+ * to `-` regardless of source.
  */
 export function resolveBridgeTmuxSession(
   agentName: string,
   entryBridgeTmuxSession: string | undefined,
   envOverride: string | undefined,
 ): string {
-  const raw = (envOverride && envOverride.length > 0 ? envOverride : undefined) ?? entryBridgeTmuxSession ?? agentName;
-  return raw.replace(/\//g, '-');
+  const raw = envOverride || entryBridgeTmuxSession || agentName;
+  return raw.replace(/[\/:]/g, '-');
 }
 
 /**


### PR DESCRIPTION
## Summary
Addresses three reviewer comments on PR #1271 (merged):

| # | Reviewer | Severity | Issue |
|---|---|---|---|
| 1 | Gemini | MEDIUM | Resolver used `??` → empty string in yaml would produce a nameless tmux session; should use `\|\|` |
| 2 | Gemini | MEDIUM | Only `/` was sanitized; tmux also rejects `:` (session:window separator) |
| 3 | Codex | P2 | `buildMetadata` only emits `bridgeTmuxSession` when truthy → JSONB-merge `edit()` keeps stale value forever when yaml removes the field |

## Changes

**`src/services/executors/claude-code.ts`**
- `resolveBridgeTmuxSession` now uses `||` for all three layers → any falsy value (empty string, undefined, null) falls through
- Sanitizer extended to `[\/:]` → both tmux reserved separators are normalized to `-`

**`src/lib/agent-directory.ts`**
- `buildMetadata` always emits `bridgeTmuxSession` (as `null` when unset) so the JSONB merge in `edit()` clears stale values on the next sync
- Reader (`roleToEntry`) unchanged — runtime already treats `null` as falsy via the `||` chain

**`src/services/executors/claude-code.test.ts`** — +4 new regression cases:
- Empty-string yaml falls through to agentName
- Empty-string yaml + empty-string env both fall through
- `:` sanitization across all three layers (env, yaml, agentName)
- Mixed `/` + `:` in the same value

## Test Evidence
```
$ bun test src/services/executors/claude-code.test.ts
40 pass, 0 fail (4 new)

$ bun run typecheck
clean
```

## Out of Scope
- Other optional fields (`hooks`, `omniScopes`, `disallowedTools`) have the same "truthy-only emit" pattern in `buildMetadata` — not fixed here since this PR is scoped to the tmux-session wish's review feedback. Filed as pre-existing for a separate cleanup.
- `resolveBridgeTmuxSession` stays purely character-level; stricter validation (alphanumeric-only) would reject legitimate names like `felipe-whatsapp` and is the instance/provider layer's job.

## Refs
- Parent wish: `.genie/wishes/bridge-tmux-session-config/WISH.md`
- Original PR: #1271 (merged)
- Sibling omni PR under review: automagik-dev/omni#471

🤖 Generated with [Claude Code](https://claude.com/claude-code)