### PR TITLE
fix(events): --type filter matches entity_type too (#1259 bug 1)

### DIFF
--- a/src/lib/audit.test.ts
+++ b/src/lib/audit.test.ts
@@ -84,6 +84,30 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
       }
     });
 
+    test('matches entity_type on --type (regression: #1259 bug 1)', async () => {
+      // OTel-sourced rows set `entity_type='otel_tool'` but carry a
+      // generic `event_type` like `otel_event`. Before the fix, `--type
+      // otel_tool` returned [] because the filter only matched
+      // `event_type`. Now both columns are matched — the row flows
+      // through `events list --type otel_tool` as the user expects.
+      await recordAuditEvent('otel_tool', 'Bash-123', 'otel_event', 'test', { tool_name: 'Bash' });
+
+      const events = await queryAuditEvents({ type: 'otel_tool', since: '1h' });
+      const hit = events.find((e) => e.entity_type === 'otel_tool' && e.entity_id === 'Bash-123');
+      expect(hit).toBeDefined();
+      expect(hit?.event_type).toBe('otel_event');
+    });
+
+    test('--type still matches event_type (no regression)', async () => {
+      // Explicit assertion that the widening didn't break the original
+      // semantics — a caller filtering `--type command_start` still
+      // gets event_type='command_start' rows.
+      await recordAuditEvent('command', 'sanity', 'command_start', 'test');
+      const events = await queryAuditEvents({ type: 'command_start', since: '1h' });
+      const hit = events.find((e) => e.entity_id === 'sanity' && e.event_type === 'command_start');
+      expect(hit).toBeDefined();
+    });
+
     test('filters by entity', async () => {
       const events = await queryAuditEvents({ entity: 'command', since: '1h' });
       for (const e of events) {

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -82,7 +82,14 @@ export async function queryAuditEvents(options: AuditQueryOptions = {}): Promise
   let paramIdx = 1;
 
   if (options.type) {
-    conditions.push(`event_type = $${paramIdx++}`);
+    // Historically `--type` only matched `event_type`, which silently
+    // dropped OTel-sourced rows (they set `entity_type='otel_tool'` etc.
+    // but carry a generic `event_type` like `otel_event`). Widen to
+    // match either column so `--type otel_tool` does the obvious thing.
+    // Closes #1259 bug 1. Strictly non-regressive — every prior match
+    // still matches; the filter just returns a superset.
+    conditions.push(`(event_type = $${paramIdx} OR entity_type = $${paramIdx})`);
+    paramIdx++;
     values.push(options.type);
   }
   if (options.entity) {
@@ -140,7 +147,11 @@ export async function followAuditEvents(
     let paramIdx = 2;
 
     if (options.type) {
-      conditions.push(`event_type = $${paramIdx++}`);
+      // Match the widened semantics from queryAuditEvents — `--type`
+      // hits both `event_type` and `entity_type` so OTel-sourced rows
+      // flow through the follow path too. Closes #1259 bug 1.
+      conditions.push(`(event_type = $${paramIdx} OR entity_type = $${paramIdx})`);
+      paramIdx++;
       values.push(options.type);
     }
     if (options.entity) {


### PR DESCRIPTION
## Summary
- `genie events list --type otel_tool --since 24h` returned `[]` — filter only matched `event_type`, but OTel-sourced rows store the classification in `entity_type` with a generic `event_type='otel_event'`
- Widen the filter to `(event_type = \$X OR entity_type = \$X)` in both `queryAuditEvents` and the `followAuditEvents` drain path
- Strictly non-regressive — every prior match still matches; the filter returns a superset

## Repro (before)
```
$ genie events list --type otel_tool --since 24h --json
[]
```
(`otel_tool` rows exist in `audit_events`, but `--type` never hits them)

## After
`--type otel_tool` now routes correctly. `--type command_start` (and every other `event_type`) keeps working unchanged.

## Test plan
- [x] Added positive regression test: inserts row with `entity_type='otel_tool' event_type='otel_event'`, asserts `--type otel_tool` returns it
- [x] Added no-regression test: `--type command_start` still matches `event_type='command_start'` rows
- [x] `bun test src/lib/audit.test.ts` — 27/27 pass
- [x] `bun run check` — 3460/3460 pass locally

Closes bug 1 of #1259. Bugs 2 (`--kind` prefix semantics) and 3 (`events tools --json` drops `tool_input`) remain queued for follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)