### PR TITLE
fix(events): --kind bare-word matches namespace segments too (#1259 bug 2)

### DIFF
--- a/src/lib/events/v2-query.test.ts
+++ b/src/lib/events/v2-query.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import { kindFilterToLike } from './v2-query.js';
+import { kindFilterToLike, kindFilterToLikePatterns } from './v2-query.js';
 
 describe('kindFilterToLike — predicate translator', () => {
   test('bare prefix preserves historic LIKE-prefix contract', () => {
@@ -36,6 +36,42 @@ describe('kindFilterToLike — predicate translator', () => {
     // (or maliciously) widen the predicate by typing them in --kind.
     expect(kindFilterToLike('mail%box')).toBe('mail\\%box%');
     expect(kindFilterToLike('agent_lifecycle')).toBe('agent\\_lifecycle%');
+  });
+});
+
+describe('kindFilterToLikePatterns — bare-word segment matching (#1259 bug 2)', () => {
+  test('bare word returns prefix plus namespace-segment patterns', () => {
+    // `agent` should match `genie.agent.*` / `rot.agent.*` subjects, not
+    // just literal-prefix `agent*`. Patterns are OR'd in SQL so the
+    // historic prefix case (`mailbox%`) is still reachable.
+    const patterns = kindFilterToLikePatterns('agent');
+    expect(patterns).toEqual(['agent%', '%.agent.%', '%.agent']);
+
+    expect(patterns.some((p) => matchesLike('genie.agent.dir:X.spawned', p))).toBe(true);
+    expect(patterns.some((p) => matchesLike('genie.agent.lifecycle', p))).toBe(true);
+    expect(patterns.some((p) => matchesLike('rot.agent.detected', p))).toBe(true);
+    expect(patterns.some((p) => matchesLike('agent.lifecycle', p))).toBe(true); // prefix path
+    // Negative controls: namespaces that don't contain `agent` as a segment.
+    expect(patterns.some((p) => matchesLike('command.success', p))).toBe(false);
+    expect(patterns.some((p) => matchesLike('genie.tool.call', p))).toBe(false);
+  });
+
+  test('dotted input keeps the prefix-only pattern (no regression)', () => {
+    // `agent.lifecycle` was already working as a dotted prefix — widening
+    // it would surprise users who picked the dotted form intentionally.
+    expect(kindFilterToLikePatterns('agent.lifecycle')).toEqual(['agent.lifecycle%']);
+  });
+
+  test('glob input keeps the single translated pattern (no regression)', () => {
+    expect(kindFilterToLikePatterns('detector.*')).toEqual(['detector.%']);
+    expect(kindFilterToLikePatterns('rot.*.detected')).toEqual(['rot.%.detected']);
+  });
+
+  test('kindFilterToLike alias still returns the headline prefix pattern', () => {
+    // Back-compat: callers that only take the first pattern still see the
+    // historic behavior. `mailbox` → `mailbox%`.
+    expect(kindFilterToLike('mailbox')).toBe('mailbox%');
+    expect(kindFilterToLike('detector.*')).toBe('detector.%');
   });
 });
 

--- a/src/lib/events/v2-query.ts
+++ b/src/lib/events/v2-query.ts
@@ -61,17 +61,44 @@ export const V2_SELECT = `
 /**
  * Translate a user-supplied kind filter into a SQL LIKE pattern.
  *
- * Backwards compatible with the historic prefix contract: bare strings like
- * `mailbox` continue to match `mailbox%`. Additionally accepts simple `*`
- * globs so operators can write `detector.*` per the runbook UX (and matches
- * `detector.fired`, `detector.disabled`, but not `command.success`). SQL
- * wildcards (`%`, `_`) inside the input are escaped so they cannot leak into
- * the predicate.
+ * Preserved as a thin alias over `kindFilterToLikePatterns(...)[0]` for
+ * callers that only need the headline prefix pattern (e.g. `mailbox` →
+ * `mailbox%`). New call sites should prefer the `Patterns` variant so bare
+ * words also hit namespace-prefixed segments (`agent` → `genie.agent.*`).
+ *
+ * SQL wildcards (`%`, `_`) inside the input are escaped so they cannot
+ * leak into the predicate.
  */
 export function kindFilterToLike(input: string): string {
+  return kindFilterToLikePatterns(input)[0];
+}
+
+/**
+ * Translate a user-supplied kind filter into one or more SQL LIKE patterns.
+ * The caller OR-combines them against `subject`/`kind`.
+ *
+ * Historical contract (prefix LIKE) is a strict subset of the output:
+ *   - Bare word `mailbox`      -> `['mailbox%', '%.mailbox.%', '%.mailbox']`
+ *   - Dotted    `agent.lifecycle` -> `['agent.lifecycle%']` (unchanged)
+ *   - Glob      `detector.*`   -> `['detector.%']` (unchanged)
+ *
+ * Why bare words get the wider pattern set: subjects emitted by v2 follow
+ * a `<namespace>.<kind>.<...>` shape (`genie.agent.dir:Y.spawned`,
+ * `rot.team-ls-drift.detected`). Users arriving from the audit_events surface
+ * type `--kind agent` expecting to hit `genie.agent.*`; under the old prefix
+ * rule this returned `[]` because the namespace (`genie.`) sat in front.
+ * Widening bare words to also match `%.<word>.%` / `%.<word>` fixes the
+ * intuitive case without changing what already-correct queries (dotted or
+ * globbed) return. Closes #1259 bug 2.
+ *
+ * Any `%` or `_` in the input is still escaped.
+ */
+export function kindFilterToLikePatterns(input: string): string[] {
   const escaped = input.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
-  if (escaped.includes('*')) return escaped.replace(/\*/g, '%');
-  return `${escaped}%`;
+  if (escaped.includes('*')) return [escaped.replace(/\*/g, '%')];
+  if (escaped.includes('.')) return [`${escaped}%`];
+  // Bare word: historic prefix plus namespace-segment matches.
+  return [`${escaped}%`, `%.${escaped}.%`, `%.${escaped}`];
 }
 
 /**
@@ -110,8 +137,15 @@ export async function queryV2Batch(filter: V2StreamFilter): Promise<V2EventRow[]
 
   if (filter.afterId != null) clauses.push(`id > ${param(filter.afterId)}`);
   if (filter.kindPrefix) {
-    const pattern = kindFilterToLike(filter.kindPrefix);
-    clauses.push(`(subject LIKE ${param(pattern)} ESCAPE '\\' OR kind LIKE ${param(pattern)} ESCAPE '\\')`);
+    // Bare words expand to multiple patterns (prefix + namespace-segment)
+    // per `kindFilterToLikePatterns`. OR them all against both `subject`
+    // and `kind` so `--kind agent` hits `genie.agent.*` subjects too.
+    const patterns = kindFilterToLikePatterns(filter.kindPrefix);
+    const ors = patterns.flatMap((p) => {
+      const placeholder = param(p);
+      return [`subject LIKE ${placeholder} ESCAPE '\\'`, `kind LIKE ${placeholder} ESCAPE '\\'`];
+    });
+    clauses.push(`(${ors.join(' OR ')})`);
   }
   if (filter.severity) {
     clauses.push(`(COALESCE(severity, data->>'_severity') = ${param(filter.severity)})`);


### PR DESCRIPTION
## Summary
- `genie events list --v2 --kind agent` returned `[]` even though `genie.agent.*` subjects existed — `--kind` was a literal prefix match, and the namespace prefix (`genie.`) was in the way
- Introduce `kindFilterToLikePatterns()`: for bare words, returns the historic prefix pattern **plus** `%.<word>.%` and `%.<word>` so subjects where `<word>` sits in the kind segment also match
- Dotted (`agent.lifecycle`) and glob (`detector.*`) inputs are unchanged — every query that worked before still works
- `kindFilterToLike` kept as a thin alias over `kindFilterToLikePatterns(...)[0]` for callers that only took the headline pattern

## Repro (before)
```
$ genie events list --v2 --since 24h --kind agent
No events found.
$ genie events list --v2 --since 24h --kind tool
# (matched — `tool` happened to live at the subject prefix)
```

## After
`--kind agent` matches `genie.agent.*`, `rot.agent.*`, etc. Plain-prefix bare words (`mailbox`) still match their top-level subjects. Dotted/globbed inputs take the same path as before.

## Test plan
- [x] Added 4 regression tests in `v2-query.test.ts`:
  - Bare-word returns 3 patterns; verify SQL LIKE matches against sample subjects
  - Dotted input returns single prefix pattern (no regression)
  - Glob input returns single translated pattern (no regression)
  - `kindFilterToLike` alias still returns historic prefix pattern
- [x] `bun test src/lib/events/v2-query.test.ts` — 8/8 pass
- [x] `bunx biome check` on changed files — clean

Closes bug 2 of #1259. Bug 3 (`events tools --json` drops `tool_input`) remains queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)