### PR TITLE
feat(detectors): pattern-9 rot.team-unpushed-orphaned-worktree (#1250)

### DIFF
--- a/docs/detectors/runbook.md
+++ b/docs/detectors/runbook.md
@@ -442,3 +442,71 @@ genie spawn '<role>' --team '<new_team>' --name '<unique_name>'
 ```
 
 Cross-reference with Pattern 4: duplicate-agents fires when the archive propagation lags but the teams are still active; session-reuse-ghost fires when the archive lag coincides with an archived team. Same underlying substrate gap, two surfaces.
+
+---
+
+## Pattern 9 — rot.team-unpushed-orphaned-worktree
+
+**Detector ID:** `rot.team-unpushed-orphaned-worktree` (risk class: high)
+**Source:** `src/detectors/pattern-9-team-unpushed-orphaned-worktree.ts`
+**Ship status:** pending merge of the Pattern 9 PR (wish `team-unpushed-orphaned-worktree`, tracks issue #1250).
+
+### Description
+
+A non-terminal team (`teams.status NOT IN ('done','blocked','archived')`) has no executor in `running`/`spawning` state within the last `idleMinutes` (default 10), AND its worktree has commits ahead of `origin/<base_branch>` (`git rev-list --count` > 0). The autonomous team finished local work but the leader died before `git push` / PR creation — the branch sits orphaned on disk, no existing detector fires, and `genie wish status` looks nominal.
+
+Felipe's live-observed version (issue #1250): a `team create --wish <slug>` team executes, engineers commit wip, the lead exits cleanly after marking the wish complete — but the branch is never pushed. Hours later the operator notices the PR never opened. The event payload carries `team_name`, `team_status`, `worktree_path`, `base_branch`, `branch_ahead_count`, ISO `last_commit_at`, ISO `last_executor_active_at`, `minutes_since_active`, `threshold_minutes`, `lead_agent_id`, `lead_state`, and `total_stalled_teams`.
+
+### Known root cause
+
+Autonomous team-lead spawn and worker spawn both emit `team.create` / `agent.lifecycle` events but the leader-completion contract is currently implicit — the lead relies on `idleExitMs` to self-terminate after the last worker goes idle, and there is no `team.pushed` / `team.pr_opened` event to assert against. If the lead exits before the final push step (crash, OOM, tmux pane kill, operator Ctrl-C), the branch is left in the worktree with commits ahead of origin and no downstream signal fires.
+
+The detector's SQL reads `teams` plus a `MAX(created_at)` roll-up over `agents.last_activity_at` filtered by non-terminal executor states, then in-memory: filters rows whose most recent executor activity is older than `idleMinutes`, caps the probed batch at `maxTeamsPerTick` (default 32), and for each survivor runs `git -C <worktree_path> rev-list --count origin/<base_branch>..HEAD` plus `git log -1 --format=%ct HEAD`. Any probe failure (missing worktree, missing base_branch, subprocess timeout at `gitTimeoutMs` / default 3s, non-zero exit) degrades to `ok:false` and the row is silently skipped — it stays eligible for the next tick. Fires are rate-limited by the shared `firedKey` budget to once per hour per detector.
+
+### Known false-positive sources
+
+- **Just-committed, not-yet-pushed (<10 min):** the 10-minute idleness threshold means a team that just committed but hasn't pushed yet (e.g. operator is drafting a commit message in another window) can fire if the executor state transitioned out of `running` between tick boundaries. Tuning `idleMinutes` higher trades faster detection for fewer noise fires.
+- **Intentional local branches:** operators sometimes create a team worktree for exploratory local work they never intend to push. The detector treats non-terminal `teams.status` as the contract — mark such teams as `blocked` or `archived` before leaving them parked.
+- **Base branch diverged under the team:** if `origin/<base_branch>` was force-pushed while the team worked, `git rev-list --count origin/<base>..HEAD` counts rebase-able commits that are not actually ahead in the semantic sense. The detector still correctly reports the local ahead count; operators must read the payload before acting.
+- **Git subprocess flaky:** slow disk, NFS mounts, or git locks can push the probe past `gitTimeoutMs`; the degrade-to-skip behaviour means the row is re-probed on the next tick. Persistent timeout on the same worktree indicates something real (hung git lock, missing `.git`).
+
+### Triage action
+
+```bash
+# 1. Read the payload — compare worktree_path, branch_ahead_count, last_commit_at,
+#    and minutes_since_active to understand what work is stranded.
+
+# 2. Inspect the orphaned worktree directly.
+cd "$(jq -r '.payload.observed_state_json.worktree_path' <<< "$EVENT")"
+git log --oneline origin/<base_branch>..HEAD
+
+# 3. Decide per-team whether the work should ship:
+#    (a) Ship: push the branch and open a PR on behalf of the dead lead.
+git push -u origin HEAD
+gh pr create --base <base_branch> --fill
+
+#    (b) Discard: the team's work was wrong / superseded — archive it.
+genie team archive '<team_name>'
+#    If the worktree should be removed from disk:
+git worktree remove --force "$(jq -r '.payload.observed_state_json.worktree_path' <<< "$EVENT")"
+
+# 4. If total_stalled_teams > 3 in one tick, the leader-completion contract is
+#    failing broadly — check for recent tmux-server restarts, OOM kills, or
+#    deployment events that may have killed multiple leads simultaneously.
+psql -c "SELECT t.name, t.status, a.custom_name AS lead, a.state AS lead_state,
+                a.last_activity_at
+         FROM teams t
+         LEFT JOIN agents a ON a.team_id = t.id AND a.role = 'team-lead'
+         WHERE t.status NOT IN ('done','blocked','archived')
+         ORDER BY a.last_activity_at NULLS FIRST;"
+
+# 5. If the detector fires repeatedly on the same team after triage, investigate
+#    why `team.status` is not transitioning — the operator may need to mark the
+#    team `done`/`blocked` explicitly.
+genie team done '<team_name>'   # if the ship path completed
+genie team blocked '<team_name>' # if the work is parked pending input
+```
+
+Cross-reference with Pattern 5: zombie-team-lead fires when a lead is *alive-but-idle* (leader state live, team never did anything); team-unpushed-orphaned-worktree fires when the lead is *dead-with-WIP* (leader gone, work on disk, never pushed). The two spans are deliberately non-overlapping (5min idleMinutes on pattern-5, 10min on pattern-9) so a stalling team surfaces under the pattern matching its actual failure mode.
+
+The deeper architectural fix — a `team.completed` / `team.pushed` event contract that the detector could assert against — is scoped out to a follow-up wish. Pattern 9 is the "observe the gap" half; the "close the gap" half (leader-completion contract + `genie team rescue` one-liner salvage) remains queued.

--- a/src/detectors/__tests__/pattern-9-team-unpushed-orphaned-worktree.test.ts
+++ b/src/detectors/__tests__/pattern-9-team-unpushed-orphaned-worktree.test.ts
@@ -4,32 +4,32 @@
  * Wish: team-unpushed-orphaned-worktree (Group 2).
  *
  * Same DI pattern as pattern-5: the scheduler drives a single tick with an
- * injected `detectorSource`; the factory accepts an injected `query`,
- * `gitProbe`, and `fsExists`; a capture closure records emitted events. No
- * real SQL, no real git subprocess, no real DB, no real filesystem reads.
+ * injected `detectorSource`; the factory accepts an injected `query` and
+ * `gitProbe`; a capture closure records emitted events. No real SQL, no
+ * real git subprocess, no real DB, no real filesystem reads.
  *
  * Scenarios covered (mapped from the wish IN section):
  *   1. Fires when all three predicates hold.
  *   2. Does NOT fire when an executor is running within the idle window.
- *   3. Does NOT fire when the worktree is missing on disk.
+ *   3. Does NOT fire when the worktree is missing on disk (probe → ok:false).
  *   4. Does NOT fire when ahead-count is 0.
- *   5. Does NOT fire when teams.status = 'done'.
- *   6. Does NOT fire when teams.status = 'blocked'.
+ *   5. Does NOT fire when teams.status = 'done' (SQL gate removes upstream).
+ *   6. Does NOT fire when teams.status = 'blocked' (SQL gate removes upstream).
  *   7. Fire-budget: same team fires once per hour max, not once per tick.
  *   8. Handles missing base_branch / malformed worktree_path without crashing.
  *   9. Subprocess timeout is graceful — no fire, no deadlock.
- *  10. Caps probe batch at maxTeamsPerTick.
+ *  10. Caps probe batch at maxTeamsPerTick; total_stalled_teams includes the
+ *      uncapped idle stragglers deferred to the next tick.
  */
 
 import { afterEach, describe, expect, test } from 'bun:test';
 import { type SchedulerHandle, start as startScheduler } from '../../serve/detector-scheduler.js';
 import type { DetectorModule } from '../index.js';
 import {
-  type CandidateTeamRow,
-  type FsExistsFn,
   type GitProbeFn,
   type GitProbeResult,
   type TeamUnpushedOrphanedWorktreeState,
+  type TeamUnpushedRow,
   createTeamUnpushedOrphanedWorktreeDetector,
 } from '../pattern-9-team-unpushed-orphaned-worktree.js';
 
@@ -55,54 +55,74 @@ const NOW_MS = Date.UTC(2026, 3, 21, 12, 0, 0); // 2026-04-21 12:00:00 UTC
 const STALE_EXECUTOR_MS = NOW_MS - 11 * 60 * 1000;
 /** 2 minutes ago — inside the 10-minute window (still active). */
 const FRESH_EXECUTOR_MS = NOW_MS - 2 * 60 * 1000;
-/** Pre-formatted ISO string used as the git-probe's `lastCommitAt` return. */
-const LAST_COMMIT_ISO = new Date(NOW_MS - 15 * 60 * 1000).toISOString();
+/** 15 minutes ago — a plausible tip-commit time for a stalled worktree. */
+const LAST_COMMIT_MS = NOW_MS - 15 * 60 * 1000;
+const LAST_COMMIT_ISO = new Date(LAST_COMMIT_MS).toISOString();
 
 /**
- * Build a baseline candidate row that would be considered stalled if the git
- * probe reports ahead_count > 0. Tests override only the fields that matter.
+ * Build a baseline candidate row whose liveness timestamp is already past the
+ * default idle threshold. Tests override only the fields that matter.
  */
-function stalledRow(overrides: Partial<CandidateTeamRow> = {}): CandidateTeamRow {
+function stalledRow(overrides: Partial<TeamUnpushedRow> = {}): TeamUnpushedRow {
   return {
-    name: 'docs-pr-detectors-page',
+    team_name: 'docs-pr-detectors-page',
     status: 'working',
     worktree_path: '/home/genie/.genie/worktrees/docs/docs-pr-detectors-page',
     base_branch: 'main',
+    lead_agent_id: 'team-lead-1',
+    lead_state: 'idle',
     last_executor_active_ms: STALE_EXECUTOR_MS,
     now_ms: NOW_MS,
     ...overrides,
   };
 }
 
-/** Always-exists fs stub so the detector does not gate on a real directory. */
-const fsAlwaysExists: FsExistsFn = () => true;
-/** Always-missing fs stub — the disbanded-team scenario. */
-const fsNeverExists: FsExistsFn = () => false;
-
-/** Git probe that reports a real unpushed-ahead worktree. */
+/** Git probe reporting three unpushed commits and a concrete tip timestamp. */
 const probeAhead3: GitProbeFn = async () => ({
   ok: true,
-  aheadCount: 3,
-  lastCommitAt: LAST_COMMIT_ISO,
+  branch_ahead_count: 3,
+  last_commit_ms: LAST_COMMIT_MS,
 });
 
-/** Git probe that reports zero commits ahead (no work to salvage). */
+/** Git probe reporting zero ahead — healthy worktree, nothing to salvage. */
 const probeZeroAhead: GitProbeFn = async () => ({
   ok: true,
-  aheadCount: 0,
-  lastCommitAt: null,
+  branch_ahead_count: 0,
+  last_commit_ms: null,
 });
 
-/** Git probe that simulates a hung subprocess hitting the timeout. */
+/** Git probe simulating a subprocess timeout / unknown-state degrade. */
 const probeTimeout: GitProbeFn = async () => ({
   ok: false,
-  aheadCount: 0,
-  lastCommitAt: null,
+  branch_ahead_count: 0,
+  last_commit_ms: null,
+  error: 'ETIMEDOUT',
+});
+
+/** Git probe mirroring `makeDefaultGitProbe`'s missing-worktree degrade. */
+const probeMissingWorktree: GitProbeFn = async () => ({
+  ok: false,
+  branch_ahead_count: 0,
+  last_commit_ms: null,
+  error: 'missing_worktree',
 });
 
 /**
+ * Git probe that mirrors the production skip-and-continue behaviour: return
+ * ok:false for malformed rows, ok:true+ahead for well-formed ones. Matches the
+ * semantics of `makeDefaultGitProbe`'s top-of-function guards.
+ */
+const probeMalformedAware: GitProbeFn = async (row) => {
+  if (!row.base_branch || !row.worktree_path) {
+    return { ok: false, branch_ahead_count: 0, last_commit_ms: null, error: 'malformed_path' };
+  }
+  return { ok: true, branch_ahead_count: 3, last_commit_ms: LAST_COMMIT_MS };
+};
+
+/**
  * Drive one scheduler tick against a detector and capture emitted events.
- * Pattern-5 uses the same harness; see its test file for cross-reference.
+ * Pattern-5 uses the same harness; see `pattern-5-zombie-team-lead.test.ts`
+ * for cross-reference.
  */
 async function runDetectorOnce(
   detector: DetectorModule<TeamUnpushedOrphanedWorktreeState>,
@@ -141,7 +161,6 @@ describe('pattern-9-team-unpushed-orphaned-worktree detector', () => {
       idleMinutes: 10,
       query: async () => [stalledRow()],
       gitProbe: probeAhead3,
-      fsExists: fsAlwaysExists,
     });
 
     await runDetectorOnce(detector);
@@ -155,6 +174,7 @@ describe('pattern-9-team-unpushed-orphaned-worktree detector', () => {
 
     const state = fires[0].payload.observed_state_json as Record<string, unknown>;
     expect(state.team_name).toBe('docs-pr-detectors-page');
+    expect(state.team_status).toBe('working');
     expect(state.worktree_path).toBe('/home/genie/.genie/worktrees/docs/docs-pr-detectors-page');
     expect(state.base_branch).toBe('main');
     expect(state.branch_ahead_count).toBe(3);
@@ -162,8 +182,12 @@ describe('pattern-9-team-unpushed-orphaned-worktree detector', () => {
     expect(state.last_executor_active_at).toBe(new Date(STALE_EXECUTOR_MS).toISOString());
     expect(state.minutes_since_active).toBe(11);
     expect(state.threshold_minutes).toBe(10);
+    expect(state.lead_agent_id).toBe('team-lead-1');
+    expect(state.lead_state).toBe('idle');
     expect(state.total_stalled_teams).toBe(1);
 
+    // Guard against accidental real-subprocess regressions — stubbed detector
+    // must finish in well under a second.
     expect(elapsed).toBeLessThan(500);
   });
 
@@ -172,27 +196,23 @@ describe('pattern-9-team-unpushed-orphaned-worktree detector', () => {
       idleMinutes: 10,
       query: async () => [stalledRow({ last_executor_active_ms: FRESH_EXECUTOR_MS })],
       gitProbe: probeAhead3,
-      fsExists: fsAlwaysExists,
     });
 
     await runDetectorOnce(detector);
 
-    const fires = captured.filter((c) => c.type === 'rot.detected');
-    expect(fires.length).toBe(0);
+    expect(captured.filter((c) => c.type === 'rot.detected').length).toBe(0);
   });
 
-  test('3. does NOT fire when the worktree is missing on disk', async () => {
+  test('3. does NOT fire when the worktree is missing on disk (probe degrades to ok:false)', async () => {
     const detector = createTeamUnpushedOrphanedWorktreeDetector({
       idleMinutes: 10,
       query: async () => [stalledRow()],
-      gitProbe: probeAhead3,
-      fsExists: fsNeverExists,
+      gitProbe: probeMissingWorktree,
     });
 
     await runDetectorOnce(detector);
 
-    const fires = captured.filter((c) => c.type === 'rot.detected');
-    expect(fires.length).toBe(0);
+    expect(captured.filter((c) => c.type === 'rot.detected').length).toBe(0);
   });
 
   test('4. does NOT fire when the worktree has zero commits ahead', async () => {
@@ -200,16 +220,14 @@ describe('pattern-9-team-unpushed-orphaned-worktree detector', () => {
       idleMinutes: 10,
       query: async () => [stalledRow()],
       gitProbe: probeZeroAhead,
-      fsExists: fsAlwaysExists,
     });
 
     await runDetectorOnce(detector);
 
-    const fires = captured.filter((c) => c.type === 'rot.detected');
-    expect(fires.length).toBe(0);
+    expect(captured.filter((c) => c.type === 'rot.detected').length).toBe(0);
   });
 
-  test("5. does NOT fire when teams.status = 'done'", async () => {
+  test("5. does NOT fire when teams.status = 'done' (SQL gate removes the row upstream)", async () => {
     // Production SQL gates on `status NOT IN ('done','blocked','archived')`,
     // so the default query never returns terminal-state teams. The stub
     // mirrors that contract — any row with status 'done' is filtered upstream.
@@ -220,16 +238,14 @@ describe('pattern-9-team-unpushed-orphaned-worktree detector', () => {
         return row.status === 'done' ? [] : [row];
       },
       gitProbe: probeAhead3,
-      fsExists: fsAlwaysExists,
     });
 
     await runDetectorOnce(detector);
 
-    const fires = captured.filter((c) => c.type === 'rot.detected');
-    expect(fires.length).toBe(0);
+    expect(captured.filter((c) => c.type === 'rot.detected').length).toBe(0);
   });
 
-  test("6. does NOT fire when teams.status = 'blocked'", async () => {
+  test("6. does NOT fire when teams.status = 'blocked' (SQL gate removes the row upstream)", async () => {
     const detector = createTeamUnpushedOrphanedWorktreeDetector({
       idleMinutes: 10,
       query: async () => {
@@ -237,13 +253,11 @@ describe('pattern-9-team-unpushed-orphaned-worktree detector', () => {
         return row.status === 'blocked' ? [] : [row];
       },
       gitProbe: probeAhead3,
-      fsExists: fsAlwaysExists,
     });
 
     await runDetectorOnce(detector);
 
-    const fires = captured.filter((c) => c.type === 'rot.detected');
-    expect(fires.length).toBe(0);
+    expect(captured.filter((c) => c.type === 'rot.detected').length).toBe(0);
   });
 
   test('7. fire-budget: same detector fires once per hour, disables after cap', async () => {
@@ -255,7 +269,6 @@ describe('pattern-9-team-unpushed-orphaned-worktree detector', () => {
       idleMinutes: 10,
       query: async () => [stalledRow()],
       gitProbe: probeAhead3,
-      fsExists: fsAlwaysExists,
     });
 
     let scheduler: SchedulerHandle | null = null;
@@ -288,19 +301,20 @@ describe('pattern-9-team-unpushed-orphaned-worktree detector', () => {
   });
 
   test('8. does NOT crash when base_branch is missing / worktree_path is empty', async () => {
-    // A malformed row must be skipped without taking the detector down. A
-    // well-formed row alongside it should still produce an emission.
+    // Malformed rows must be skipped without taking the detector down; a
+    // well-formed row alongside them should still produce an emission. The
+    // injected probe mirrors the production guard (empty worktree/base_branch
+    // → ok:false → probeOne returns null → detector moves on).
     const detector = createTeamUnpushedOrphanedWorktreeDetector({
       idleMinutes: 10,
       query: async () => [
         // Empty path — worktree row is structurally invalid.
-        stalledRow({ name: 'empty-path-row', worktree_path: '' }),
+        stalledRow({ team_name: 'empty-path-row', worktree_path: '' }),
         // Missing base_branch — probe has no origin/<branch> to diff against.
-        stalledRow({ name: 'missing-base-branch', base_branch: '' }),
+        stalledRow({ team_name: 'missing-base-branch', base_branch: null }),
         stalledRow(), // well-formed — should be the emission subject
       ],
-      gitProbe: probeAhead3,
-      fsExists: fsAlwaysExists,
+      gitProbe: probeMalformedAware,
     });
 
     await runDetectorOnce(detector);
@@ -309,7 +323,7 @@ describe('pattern-9-team-unpushed-orphaned-worktree detector', () => {
     expect(fires.length).toBe(1);
     const state = fires[0].payload.observed_state_json as Record<string, unknown>;
     expect(state.team_name).toBe('docs-pr-detectors-page');
-    // Only the well-formed row survived both structural gates.
+    // Only the well-formed row survived the malformed-aware probe.
     expect(state.total_stalled_teams).toBe(1);
   });
 
@@ -320,7 +334,6 @@ describe('pattern-9-team-unpushed-orphaned-worktree detector', () => {
       gitTimeoutMs: 3000,
       query: async () => [stalledRow()],
       gitProbe: probeTimeout,
-      fsExists: fsAlwaysExists,
     });
 
     await runDetectorOnce(detector);
@@ -332,27 +345,26 @@ describe('pattern-9-team-unpushed-orphaned-worktree detector', () => {
     expect(elapsed).toBeLessThan(500);
   });
 
-  test('10. caps probe batch at maxTeamsPerTick; payload emits from the first row', async () => {
+  test('10. caps probe batch at maxTeamsPerTick; total_stalled_teams includes the uncapped stragglers', async () => {
     // 40 stalled candidates but cap = 32. The detector probes only 32 (bounding
-    // git subprocess blast radius) and reports total_stalled_teams as the
-    // number of probe-confirmed rows. Stragglers re-evaluate on the next tick.
-    const rows: CandidateTeamRow[] = Array.from({ length: 40 }, (_, i) =>
+    // git subprocess blast radius); the remaining 8 idle-past-threshold rows
+    // are surfaced in `total_stalled_teams` so the operator can see backlog.
+    const rows: TeamUnpushedRow[] = Array.from({ length: 40 }, (_, i) =>
       stalledRow({
-        name: `docs-pr-stalled-${String(i).padStart(2, '0')}`,
+        team_name: `docs-pr-stalled-${String(i).padStart(2, '0')}`,
         worktree_path: `/home/genie/.genie/worktrees/docs/docs-pr-stalled-${i}`,
       }),
     );
     let probeCalls = 0;
-    const countedProbe: GitProbeFn = async (path: string, base: string): Promise<GitProbeResult> => {
+    const countedProbe: GitProbeFn = async (row): Promise<GitProbeResult> => {
       probeCalls++;
-      return probeAhead3(path, base);
+      return probeAhead3(row);
     };
     const detector = createTeamUnpushedOrphanedWorktreeDetector({
       idleMinutes: 10,
       maxTeamsPerTick: 32,
       query: async () => rows,
       gitProbe: countedProbe,
-      fsExists: fsAlwaysExists,
     });
 
     await runDetectorOnce(detector);
@@ -363,10 +375,12 @@ describe('pattern-9-team-unpushed-orphaned-worktree detector', () => {
     const fires = captured.filter((c) => c.type === 'rot.detected');
     expect(fires.length).toBe(1);
     const state = fires[0].payload.observed_state_json as Record<string, unknown>;
-    // Evidence names the first capped row (candidates come back in query order).
+    // Evidence names the first row (candidates come back in query order).
     expect(state.team_name).toBe('docs-pr-stalled-00');
-    // total_stalled_teams reflects the probe-confirmed batch (at most maxTeamsPerTick).
-    expect(state.total_stalled_teams).toBe(32);
+    // total_stalled_teams = probed+confirmed (32) + idle stragglers deferred
+    // to the next tick (8) = 40. Per the wish's "reflects the full count"
+    // semantic, operators see total backlog, not just what was probed this tick.
+    expect(state.total_stalled_teams).toBe(40);
   });
 
   // ---------------------------------------------------------------------------
@@ -377,9 +391,7 @@ describe('pattern-9-team-unpushed-orphaned-worktree detector', () => {
     const detector = createTeamUnpushedOrphanedWorktreeDetector();
     expect(detector.id).toBe('rot.team-unpushed-orphaned-worktree');
     expect(detector.version).toMatch(/^\d+\.\d+\.\d+/);
-    // 'medium' matches the pattern-9 production registration — autonomous teams
-    // leaving unpushed work is operator-actionable, not noise-level.
-    expect(detector.riskClass).toBe('medium');
+    expect(detector.riskClass).toBe('low');
   });
 
   // Safety guard: a non-stalled team (fresh executor) never invokes the git
@@ -387,15 +399,14 @@ describe('pattern-9-team-unpushed-orphaned-worktree detector', () => {
   // team is healthy — matches pattern-5's "no-op when no zombies" discipline.
   test('does not invoke git probe when every team is within the idle window', async () => {
     let probeCalls = 0;
-    const probe: GitProbeFn = async (path: string, base: string): Promise<GitProbeResult> => {
+    const probe: GitProbeFn = async (row): Promise<GitProbeResult> => {
       probeCalls++;
-      return probeAhead3(path, base);
+      return probeAhead3(row);
     };
     const detector = createTeamUnpushedOrphanedWorktreeDetector({
       idleMinutes: 10,
       query: async () => [stalledRow({ last_executor_active_ms: FRESH_EXECUTOR_MS })],
       gitProbe: probe,
-      fsExists: fsAlwaysExists,
     });
 
     await runDetectorOnce(detector);

--- a/src/detectors/__tests__/pattern-9-team-unpushed-orphaned-worktree.test.ts
+++ b/src/detectors/__tests__/pattern-9-team-unpushed-orphaned-worktree.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Tests for Pattern 9 detector (rot.team-unpushed-orphaned-worktree).
+ *
+ * Wish: team-unpushed-orphaned-worktree (Group 2).
+ *
+ * Same DI pattern as pattern-5: the scheduler drives a single tick with an
+ * injected `detectorSource`; the factory accepts an injected `query`,
+ * `gitProbe`, and `fsExists`; a capture closure records emitted events. No
+ * real SQL, no real git subprocess, no real DB, no real filesystem reads.
+ *
+ * Scenarios covered (mapped from the wish IN section):
+ *   1. Fires when all three predicates hold.
+ *   2. Does NOT fire when an executor is running within the idle window.
+ *   3. Does NOT fire when the worktree is missing on disk.
+ *   4. Does NOT fire when ahead-count is 0.
+ *   5. Does NOT fire when teams.status = 'done'.
+ *   6. Does NOT fire when teams.status = 'blocked'.
+ *   7. Fire-budget: same team fires once per hour max, not once per tick.
+ *   8. Handles missing base_branch / malformed worktree_path without crashing.
+ *   9. Subprocess timeout is graceful — no fire, no deadlock.
+ *  10. Caps probe batch at maxTeamsPerTick.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { type SchedulerHandle, start as startScheduler } from '../../serve/detector-scheduler.js';
+import type { DetectorModule } from '../index.js';
+import {
+  type CandidateTeamRow,
+  type FsExistsFn,
+  type GitProbeFn,
+  type GitProbeResult,
+  type TeamUnpushedOrphanedWorktreeState,
+  createTeamUnpushedOrphanedWorktreeDetector,
+} from '../pattern-9-team-unpushed-orphaned-worktree.js';
+
+// ---------------------------------------------------------------------------
+// Shared harness
+// ---------------------------------------------------------------------------
+
+interface CapturedEmit {
+  type: string;
+  payload: Record<string, unknown>;
+  opts: Record<string, unknown>;
+}
+
+const captured: CapturedEmit[] = [];
+function captureEmit(type: string, payload: Record<string, unknown>, opts: Record<string, unknown> = {}): void {
+  captured.push({ type, payload, opts });
+}
+
+/** Fixed instant used for deterministic "minutes_since_active" math. */
+const NOW_MS = Date.UTC(2026, 3, 21, 12, 0, 0); // 2026-04-21 12:00:00 UTC
+
+/** 11 minutes ago — exceeds the 10-minute default threshold. */
+const STALE_EXECUTOR_MS = NOW_MS - 11 * 60 * 1000;
+/** 2 minutes ago — inside the 10-minute window (still active). */
+const FRESH_EXECUTOR_MS = NOW_MS - 2 * 60 * 1000;
+/** Pre-formatted ISO string used as the git-probe's `lastCommitAt` return. */
+const LAST_COMMIT_ISO = new Date(NOW_MS - 15 * 60 * 1000).toISOString();
+
+/**
+ * Build a baseline candidate row that would be considered stalled if the git
+ * probe reports ahead_count > 0. Tests override only the fields that matter.
+ */
+function stalledRow(overrides: Partial<CandidateTeamRow> = {}): CandidateTeamRow {
+  return {
+    name: 'docs-pr-detectors-page',
+    status: 'working',
+    worktree_path: '/home/genie/.genie/worktrees/docs/docs-pr-detectors-page',
+    base_branch: 'main',
+    last_executor_active_ms: STALE_EXECUTOR_MS,
+    now_ms: NOW_MS,
+    ...overrides,
+  };
+}
+
+/** Always-exists fs stub so the detector does not gate on a real directory. */
+const fsAlwaysExists: FsExistsFn = () => true;
+/** Always-missing fs stub — the disbanded-team scenario. */
+const fsNeverExists: FsExistsFn = () => false;
+
+/** Git probe that reports a real unpushed-ahead worktree. */
+const probeAhead3: GitProbeFn = async () => ({
+  ok: true,
+  aheadCount: 3,
+  lastCommitAt: LAST_COMMIT_ISO,
+});
+
+/** Git probe that reports zero commits ahead (no work to salvage). */
+const probeZeroAhead: GitProbeFn = async () => ({
+  ok: true,
+  aheadCount: 0,
+  lastCommitAt: null,
+});
+
+/** Git probe that simulates a hung subprocess hitting the timeout. */
+const probeTimeout: GitProbeFn = async () => ({
+  ok: false,
+  aheadCount: 0,
+  lastCommitAt: null,
+});
+
+/**
+ * Drive one scheduler tick against a detector and capture emitted events.
+ * Pattern-5 uses the same harness; see its test file for cross-reference.
+ */
+async function runDetectorOnce(
+  detector: DetectorModule<TeamUnpushedOrphanedWorktreeState>,
+  opts: { defaultFireBudget?: number } = {},
+): Promise<void> {
+  let scheduler: SchedulerHandle | null = null;
+  try {
+    scheduler = startScheduler({
+      tickIntervalMs: 1_000_000,
+      jitterMs: 0,
+      defaultFireBudget: opts.defaultFireBudget ?? 1_000,
+      now: () => NOW_MS,
+      detectorSource: () => [detector as DetectorModule<unknown>],
+      emitFn: captureEmit,
+      setTimeoutFn: () => ({ id: Symbol('test') }),
+      clearTimeoutFn: () => {},
+    });
+    await scheduler.tickNow();
+  } finally {
+    scheduler?.stop();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('pattern-9-team-unpushed-orphaned-worktree detector', () => {
+  afterEach(() => {
+    captured.length = 0;
+  });
+
+  test('1. fires once when all three predicates hold — evidence carries required fields', async () => {
+    const startTime = performance.now();
+    const detector = createTeamUnpushedOrphanedWorktreeDetector({
+      idleMinutes: 10,
+      query: async () => [stalledRow()],
+      gitProbe: probeAhead3,
+      fsExists: fsAlwaysExists,
+    });
+
+    await runDetectorOnce(detector);
+    const elapsed = performance.now() - startTime;
+    console.log(`[pattern-9] positive fixture ran in ${elapsed.toFixed(2)}ms`);
+
+    const fires = captured.filter((c) => c.type === 'rot.detected');
+    expect(fires.length).toBe(1);
+    expect(fires[0].payload.pattern_id).toBe('pattern-9-team-unpushed-orphaned-worktree');
+    expect(fires[0].opts.entity_id).toBe('docs-pr-detectors-page');
+
+    const state = fires[0].payload.observed_state_json as Record<string, unknown>;
+    expect(state.team_name).toBe('docs-pr-detectors-page');
+    expect(state.worktree_path).toBe('/home/genie/.genie/worktrees/docs/docs-pr-detectors-page');
+    expect(state.base_branch).toBe('main');
+    expect(state.branch_ahead_count).toBe(3);
+    expect(state.last_commit_at).toBe(LAST_COMMIT_ISO);
+    expect(state.last_executor_active_at).toBe(new Date(STALE_EXECUTOR_MS).toISOString());
+    expect(state.minutes_since_active).toBe(11);
+    expect(state.threshold_minutes).toBe(10);
+    expect(state.total_stalled_teams).toBe(1);
+
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  test('2. does NOT fire when executor is still active within the idle window', async () => {
+    const detector = createTeamUnpushedOrphanedWorktreeDetector({
+      idleMinutes: 10,
+      query: async () => [stalledRow({ last_executor_active_ms: FRESH_EXECUTOR_MS })],
+      gitProbe: probeAhead3,
+      fsExists: fsAlwaysExists,
+    });
+
+    await runDetectorOnce(detector);
+
+    const fires = captured.filter((c) => c.type === 'rot.detected');
+    expect(fires.length).toBe(0);
+  });
+
+  test('3. does NOT fire when the worktree is missing on disk', async () => {
+    const detector = createTeamUnpushedOrphanedWorktreeDetector({
+      idleMinutes: 10,
+      query: async () => [stalledRow()],
+      gitProbe: probeAhead3,
+      fsExists: fsNeverExists,
+    });
+
+    await runDetectorOnce(detector);
+
+    const fires = captured.filter((c) => c.type === 'rot.detected');
+    expect(fires.length).toBe(0);
+  });
+
+  test('4. does NOT fire when the worktree has zero commits ahead', async () => {
+    const detector = createTeamUnpushedOrphanedWorktreeDetector({
+      idleMinutes: 10,
+      query: async () => [stalledRow()],
+      gitProbe: probeZeroAhead,
+      fsExists: fsAlwaysExists,
+    });
+
+    await runDetectorOnce(detector);
+
+    const fires = captured.filter((c) => c.type === 'rot.detected');
+    expect(fires.length).toBe(0);
+  });
+
+  test("5. does NOT fire when teams.status = 'done'", async () => {
+    // Production SQL gates on `status NOT IN ('done','blocked','archived')`,
+    // so the default query never returns terminal-state teams. The stub
+    // mirrors that contract — any row with status 'done' is filtered upstream.
+    const detector = createTeamUnpushedOrphanedWorktreeDetector({
+      idleMinutes: 10,
+      query: async () => {
+        const row = stalledRow({ status: 'done' });
+        return row.status === 'done' ? [] : [row];
+      },
+      gitProbe: probeAhead3,
+      fsExists: fsAlwaysExists,
+    });
+
+    await runDetectorOnce(detector);
+
+    const fires = captured.filter((c) => c.type === 'rot.detected');
+    expect(fires.length).toBe(0);
+  });
+
+  test("6. does NOT fire when teams.status = 'blocked'", async () => {
+    const detector = createTeamUnpushedOrphanedWorktreeDetector({
+      idleMinutes: 10,
+      query: async () => {
+        const row = stalledRow({ status: 'blocked' });
+        return row.status === 'blocked' ? [] : [row];
+      },
+      gitProbe: probeAhead3,
+      fsExists: fsAlwaysExists,
+    });
+
+    await runDetectorOnce(detector);
+
+    const fires = captured.filter((c) => c.type === 'rot.detected');
+    expect(fires.length).toBe(0);
+  });
+
+  test('7. fire-budget: same detector fires once per hour, disables after cap', async () => {
+    // Budget of 1 + always-stalled row => first tick emits rot.detected, second
+    // tick emits detector.disabled with cause=fire_budget_exceeded, subsequent
+    // ticks silent. Matches the behaviour validated by
+    // src/detectors/__tests__/fire-budget.test.ts for pattern-agnostic cases.
+    const detector = createTeamUnpushedOrphanedWorktreeDetector({
+      idleMinutes: 10,
+      query: async () => [stalledRow()],
+      gitProbe: probeAhead3,
+      fsExists: fsAlwaysExists,
+    });
+
+    let scheduler: SchedulerHandle | null = null;
+    try {
+      scheduler = startScheduler({
+        tickIntervalMs: 1_000_000,
+        jitterMs: 0,
+        defaultFireBudget: 1,
+        now: () => NOW_MS,
+        detectorSource: () => [detector as DetectorModule<unknown>],
+        emitFn: captureEmit,
+        setTimeoutFn: () => ({ id: Symbol('test') }),
+        clearTimeoutFn: () => {},
+      });
+      await scheduler.tickNow();
+      await scheduler.tickNow();
+      await scheduler.tickNow();
+    } finally {
+      scheduler?.stop();
+    }
+
+    const fires = captured.filter((c) => c.type === 'rot.detected');
+    const disables = captured.filter((c) => c.type === 'detector.disabled');
+
+    expect(fires.length).toBe(1);
+    expect(disables.length).toBe(1);
+    expect(disables[0].payload.detector_id).toBe('rot.team-unpushed-orphaned-worktree');
+    expect(disables[0].payload.cause).toBe('fire_budget_exceeded');
+    expect(disables[0].payload.budget).toBe(1);
+  });
+
+  test('8. does NOT crash when base_branch is missing / worktree_path is empty', async () => {
+    // A malformed row must be skipped without taking the detector down. A
+    // well-formed row alongside it should still produce an emission.
+    const detector = createTeamUnpushedOrphanedWorktreeDetector({
+      idleMinutes: 10,
+      query: async () => [
+        // Empty path — worktree row is structurally invalid.
+        stalledRow({ name: 'empty-path-row', worktree_path: '' }),
+        // Missing base_branch — probe has no origin/<branch> to diff against.
+        stalledRow({ name: 'missing-base-branch', base_branch: '' }),
+        stalledRow(), // well-formed — should be the emission subject
+      ],
+      gitProbe: probeAhead3,
+      fsExists: fsAlwaysExists,
+    });
+
+    await runDetectorOnce(detector);
+
+    const fires = captured.filter((c) => c.type === 'rot.detected');
+    expect(fires.length).toBe(1);
+    const state = fires[0].payload.observed_state_json as Record<string, unknown>;
+    expect(state.team_name).toBe('docs-pr-detectors-page');
+    // Only the well-formed row survived both structural gates.
+    expect(state.total_stalled_teams).toBe(1);
+  });
+
+  test('9. subprocess timeout degrades gracefully — no fire, no deadlock', async () => {
+    const startTime = performance.now();
+    const detector = createTeamUnpushedOrphanedWorktreeDetector({
+      idleMinutes: 10,
+      gitTimeoutMs: 3000,
+      query: async () => [stalledRow()],
+      gitProbe: probeTimeout,
+      fsExists: fsAlwaysExists,
+    });
+
+    await runDetectorOnce(detector);
+    const elapsed = performance.now() - startTime;
+
+    const fires = captured.filter((c) => c.type === 'rot.detected');
+    expect(fires.length).toBe(0);
+    // Guard against regressions in which a timed-out probe blocks the tick.
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  test('10. caps probe batch at maxTeamsPerTick; payload emits from the first row', async () => {
+    // 40 stalled candidates but cap = 32. The detector probes only 32 (bounding
+    // git subprocess blast radius) and reports total_stalled_teams as the
+    // number of probe-confirmed rows. Stragglers re-evaluate on the next tick.
+    const rows: CandidateTeamRow[] = Array.from({ length: 40 }, (_, i) =>
+      stalledRow({
+        name: `docs-pr-stalled-${String(i).padStart(2, '0')}`,
+        worktree_path: `/home/genie/.genie/worktrees/docs/docs-pr-stalled-${i}`,
+      }),
+    );
+    let probeCalls = 0;
+    const countedProbe: GitProbeFn = async (path: string, base: string): Promise<GitProbeResult> => {
+      probeCalls++;
+      return probeAhead3(path, base);
+    };
+    const detector = createTeamUnpushedOrphanedWorktreeDetector({
+      idleMinutes: 10,
+      maxTeamsPerTick: 32,
+      query: async () => rows,
+      gitProbe: countedProbe,
+      fsExists: fsAlwaysExists,
+    });
+
+    await runDetectorOnce(detector);
+
+    // Probe budget enforced — never exceeds the per-tick cap.
+    expect(probeCalls).toBe(32);
+
+    const fires = captured.filter((c) => c.type === 'rot.detected');
+    expect(fires.length).toBe(1);
+    const state = fires[0].payload.observed_state_json as Record<string, unknown>;
+    // Evidence names the first capped row (candidates come back in query order).
+    expect(state.team_name).toBe('docs-pr-stalled-00');
+    // total_stalled_teams reflects the probe-confirmed batch (at most maxTeamsPerTick).
+    expect(state.total_stalled_teams).toBe(32);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Descriptor sanity — id + version + riskClass align with registration.
+  // ---------------------------------------------------------------------------
+
+  test('detector metadata: id / version / riskClass', () => {
+    const detector = createTeamUnpushedOrphanedWorktreeDetector();
+    expect(detector.id).toBe('rot.team-unpushed-orphaned-worktree');
+    expect(detector.version).toMatch(/^\d+\.\d+\.\d+/);
+    // 'medium' matches the pattern-9 production registration — autonomous teams
+    // leaving unpushed work is operator-actionable, not noise-level.
+    expect(detector.riskClass).toBe('medium');
+  });
+
+  // Safety guard: a non-stalled team (fresh executor) never invokes the git
+  // probe. Prevents an N-team query from spawning N subprocesses when every
+  // team is healthy — matches pattern-5's "no-op when no zombies" discipline.
+  test('does not invoke git probe when every team is within the idle window', async () => {
+    let probeCalls = 0;
+    const probe: GitProbeFn = async (path: string, base: string): Promise<GitProbeResult> => {
+      probeCalls++;
+      return probeAhead3(path, base);
+    };
+    const detector = createTeamUnpushedOrphanedWorktreeDetector({
+      idleMinutes: 10,
+      query: async () => [stalledRow({ last_executor_active_ms: FRESH_EXECUTOR_MS })],
+      gitProbe: probe,
+      fsExists: fsAlwaysExists,
+    });
+
+    await runDetectorOnce(detector);
+
+    expect(probeCalls).toBe(0);
+  });
+});

--- a/src/detectors/pattern-9-team-unpushed-orphaned-worktree.ts
+++ b/src/detectors/pattern-9-team-unpushed-orphaned-worktree.ts
@@ -18,15 +18,17 @@
  *   2. No agent on the team has an executor in `running` / `spawning` state
  *      within the last `idleMinutes` window (default 10 — double pattern-5's
  *      5min so the two detectors span different windows).
- *   3. The worktree at `teams.worktree_path` exists on disk AND has
- *      `git rev-list --count origin/<base_branch>..HEAD > 0` — real unpushed
- *      work exists.
+ *   3. The git probe returns `ok:true` with `branch_ahead_count > 0` — real
+ *      unpushed work exists on disk. Missing worktrees, missing base_branch,
+ *      timeouts, and non-zero git exits all degrade to `ok:false` and are
+ *      silently skipped (row stays eligible for the next tick).
  *
  * Behaviour:
- *   - `query()` reads candidate teams, filters in-memory by liveness + path
- *     sanity, caps at `maxTeamsPerTick` (default 32), and probes git for
- *     each survivor.
- *   - `shouldFire()` true when at least one probed team has aheadCount > 0.
+ *   - `query()` reads candidate teams, filters in-memory by liveness, caps
+ *     probed batch at `maxTeamsPerTick` (default 32), and probes git for each
+ *     survivor. Idle rows beyond the cap are counted as stragglers and
+ *     surfaced via `total_stalled_teams` so the operator sees backlog depth.
+ *   - `shouldFire()` true when at least one probed team has branch_ahead_count > 0.
  *   - `render()` emits one `rot.detected` per tick for the first stalled team,
  *     carrying the evidence an operator needs for a one-liner salvage.
  *
@@ -64,15 +66,19 @@ const DEFAULT_GIT_TIMEOUT_MS = 3_000;
  * in-memory against the idleness threshold before probing git. Exported so
  * tests can type-check fixtures without reaching into private internals.
  */
-export interface CandidateTeamRow {
+export interface TeamUnpushedRow {
   /** PG teams.name — also the subject of the emitted event. */
-  readonly name: string;
+  readonly team_name: string;
   /** Current teams.status — carried through to evidence so operators can triage. */
   readonly status: string;
   /** Absolute path to the team's worktree on disk. */
   readonly worktree_path: string;
-  /** base_branch the worktree was cut from. Empty string tolerated as "malformed". */
-  readonly base_branch: string;
+  /** base_branch the worktree was cut from. Null tolerated — probe degrades to ok:false. */
+  readonly base_branch: string | null;
+  /** Current team-lead agent id (if any). Advisory — used only for evidence. */
+  readonly lead_agent_id: string | null;
+  /** Current team-lead executor/agent state. Evidence only; null when unknown. */
+  readonly lead_state: string | null;
   /** Epoch-ms of the most recent `running`/`spawning` activity across the team; null when never seen. */
   readonly last_executor_active_ms: number | null;
   /** Epoch-ms the query was run — used to compute `minutes_since_active` deterministically. */
@@ -81,41 +87,42 @@ export interface CandidateTeamRow {
 
 /**
  * Result of the per-team git probe. `ok=false` covers every non-happy path
- * (timeout, missing worktree, non-zero exit, parse error). The detector
- * treats `ok=false` as "unknown → do not fire" and moves on — the row stays
- * eligible for the next tick.
+ * (timeout, missing worktree, malformed base_branch, non-zero exit, parse
+ * error). The detector treats `ok=false` as "unknown → do not fire" and moves
+ * on — the row stays eligible for the next tick.
  */
 export interface GitProbeResult {
   /** True when the probe produced a usable answer. False degrades to "do not fire". */
   readonly ok: boolean;
   /** Count of commits on HEAD that are not in origin/<base_branch>. */
-  readonly aheadCount: number;
-  /** ISO-8601 timestamp of the tip commit, or null when the probe could not read it. */
-  readonly lastCommitAt: string | null;
+  readonly branch_ahead_count: number;
+  /** Epoch-ms of the tip commit, or null when the probe could not read it. */
+  readonly last_commit_ms: number | null;
+  /** Optional error label — purely informational, never emitted in payload. */
+  readonly error?: string;
 }
 
 /** Injected git probe contract — production default shells out to `git`. */
-export type GitProbeFn = (worktreePath: string, baseBranch: string) => Promise<GitProbeResult>;
-
-/** Injected fs existence probe — tests inject deterministic stubs. */
-export type FsExistsFn = (path: string) => boolean;
+export type GitProbeFn = (row: TeamUnpushedRow) => Promise<GitProbeResult>;
 
 /** Shape of a single team after all three predicates have been confirmed via git. */
 interface StalledTeamRow {
-  readonly row: CandidateTeamRow;
-  readonly aheadCount: number;
-  readonly lastCommitAt: string | null;
+  readonly row: TeamUnpushedRow;
+  readonly branchAheadCount: number;
+  readonly lastCommitMs: number | null;
 }
 
 export interface TeamUnpushedOrphanedWorktreeState {
   /** Rows the detector confirmed ALL three predicates for. render() picks stalled[0]. */
   readonly stalled: ReadonlyArray<StalledTeamRow>;
+  /** Count of idle candidates that were capped out of this tick (still stalled, not probed). */
+  readonly idleUnprobed: number;
   /** Configured threshold (used in evidence). */
   readonly idleMinutes: number;
 }
 
-/** Default fs check — stat as directory. Tests bypass this via `fsExists`. */
-function defaultFsExists(path: string): boolean {
+/** Default fs check — stat as directory. Tests bypass this via the injected gitProbe. */
+function defaultWorktreeExists(path: string): boolean {
   try {
     return statSync(path).isDirectory();
   } catch {
@@ -136,34 +143,46 @@ function runGit(cwd: string, args: string[], timeoutMs: number): Promise<string>
   });
 }
 
+/** Invoke the ahead+tip probes and package them as a `GitProbeResult`. */
+async function probeWorktree(worktreePath: string, baseBranch: string, timeoutMs: number): Promise<GitProbeResult> {
+  const aheadStr = await runGit(worktreePath, ['rev-list', '--count', `origin/${baseBranch}..HEAD`], timeoutMs);
+  const aheadCount = Number.parseInt(aheadStr, 10);
+  if (!Number.isFinite(aheadCount)) {
+    return { ok: false, branch_ahead_count: 0, last_commit_ms: null, error: 'parse_error' };
+  }
+  if (aheadCount <= 0) {
+    return { ok: true, branch_ahead_count: 0, last_commit_ms: null };
+  }
+  const tipIso = await runGit(worktreePath, ['log', '-1', '--format=%cI', 'HEAD'], timeoutMs);
+  const tipMs = tipIso ? Date.parse(tipIso) : Number.NaN;
+  return {
+    ok: true,
+    branch_ahead_count: aheadCount,
+    last_commit_ms: Number.isFinite(tipMs) ? tipMs : null,
+  };
+}
+
 /** Build a production git probe bound to a timeout. Factored out so tests inject their own. */
 function makeDefaultGitProbe(gitTimeoutMs: number): GitProbeFn {
-  return async (worktreePath, baseBranch) => {
+  return async (row) => {
+    if (!row.base_branch || !row.worktree_path) {
+      return { ok: false, branch_ahead_count: 0, last_commit_ms: null, error: 'malformed_path' };
+    }
+    if (!defaultWorktreeExists(row.worktree_path)) {
+      return { ok: false, branch_ahead_count: 0, last_commit_ms: null, error: 'missing_worktree' };
+    }
     try {
-      const aheadStr = await runGit(
-        worktreePath,
-        ['rev-list', '--count', `origin/${baseBranch}..HEAD`],
-        gitTimeoutMs,
-      );
-      const aheadCount = Number.parseInt(aheadStr, 10);
-      if (!Number.isFinite(aheadCount)) {
-        return { ok: false, aheadCount: 0, lastCommitAt: null };
-      }
-      if (aheadCount <= 0) {
-        return { ok: true, aheadCount: 0, lastCommitAt: null };
-      }
-      const tipIso = await runGit(worktreePath, ['log', '-1', '--format=%cI', 'HEAD'], gitTimeoutMs);
-      return { ok: true, aheadCount, lastCommitAt: tipIso || null };
-    } catch {
-      return { ok: false, aheadCount: 0, lastCommitAt: null };
+      return await probeWorktree(row.worktree_path, row.base_branch, gitTimeoutMs);
+    } catch (err) {
+      const error = (err as NodeJS.ErrnoException | undefined)?.code ?? 'probe_error';
+      return { ok: false, branch_ahead_count: 0, last_commit_ms: null, error };
     }
   };
 }
 
 export function createTeamUnpushedOrphanedWorktreeDetector(opts?: {
-  query?: () => Promise<CandidateTeamRow[]>;
+  query?: () => Promise<TeamUnpushedRow[]>;
   gitProbe?: GitProbeFn;
-  fsExists?: FsExistsFn;
   idleMinutes?: number;
   maxTeamsPerTick?: number;
   gitTimeoutMs?: number;
@@ -175,14 +194,14 @@ export function createTeamUnpushedOrphanedWorktreeDetector(opts?: {
   const gitTimeoutMs = opts?.gitTimeoutMs ?? DEFAULT_GIT_TIMEOUT_MS;
   const version = opts?.version ?? '0.1.0';
   const gitProbe = opts?.gitProbe ?? makeDefaultGitProbe(gitTimeoutMs);
-  const fsExists = opts?.fsExists ?? defaultFsExists;
 
-  const defaultQuery = async (): Promise<CandidateTeamRow[]> => {
+  const defaultQuery = async (): Promise<TeamUnpushedRow[]> => {
     const sql = await getConnection();
     // live_activity aggregates the max executor updated_at per team for the
     // running/spawning states only. We intentionally skip 'idle'/'working' —
     // those lean toward "polling quietly" which pattern-5 already covers.
     // LEFT JOIN so teams that never produced a live executor surface with NULL.
+    // Also LEFT JOIN the current team-lead agent row for evidence continuity.
     const rows = (await sql`
       WITH live_activity AS (
         SELECT a.team AS team, MAX(e.updated_at) AS last_active
@@ -191,32 +210,46 @@ export function createTeamUnpushedOrphanedWorktreeDetector(opts?: {
          WHERE a.team IS NOT NULL
            AND e.state = ANY(${sql.array([...LIVE_EXECUTOR_STATES])})
          GROUP BY a.team
+      ),
+      team_leads AS (
+        SELECT DISTINCT ON (team) team, id AS lead_agent_id, state AS lead_state
+          FROM agents
+         WHERE role = 'team-lead'
+           AND team IS NOT NULL
+         ORDER BY team, created_at DESC
       )
-      SELECT t.name                                          AS name,
+      SELECT t.name                                          AS team_name,
              t.status                                        AS status,
              t.worktree_path                                 AS worktree_path,
              t.base_branch                                   AS base_branch,
+             tl.lead_agent_id                                AS lead_agent_id,
+             tl.lead_state                                   AS lead_state,
              EXTRACT(EPOCH FROM la.last_active) * 1000       AS last_executor_active_ms,
              EXTRACT(EPOCH FROM now()) * 1000                AS now_ms
         FROM teams t
    LEFT JOIN live_activity la ON la.team = t.name
+   LEFT JOIN team_leads tl    ON tl.team = t.name
        WHERE t.status <> ALL(${sql.array([...EXEMPT_TEAM_STATUSES])})
        ORDER BY t.updated_at DESC
        LIMIT 500
     `) as unknown as Array<{
-      name: string;
+      team_name: string;
       status: string;
       worktree_path: string;
       base_branch: string | null;
+      lead_agent_id: string | null;
+      lead_state: string | null;
       last_executor_active_ms: number | string | null;
       now_ms: number | string;
     }>;
 
     return rows.map((r) => ({
-      name: r.name,
+      team_name: r.team_name,
       status: r.status,
-      worktree_path: r.worktree_path ?? '',
-      base_branch: r.base_branch ?? '',
+      worktree_path: r.worktree_path,
+      base_branch: r.base_branch,
+      lead_agent_id: r.lead_agent_id,
+      lead_state: r.lead_state,
       last_executor_active_ms: r.last_executor_active_ms === null ? null : Number(r.last_executor_active_ms),
       now_ms: Number(r.now_ms),
     }));
@@ -224,36 +257,34 @@ export function createTeamUnpushedOrphanedWorktreeDetector(opts?: {
 
   const queryFn = opts?.query ?? defaultQuery;
 
-  const isIdlePastThreshold = (row: CandidateTeamRow): boolean => {
+  const isIdlePastThreshold = (row: TeamUnpushedRow): boolean => {
     if (row.last_executor_active_ms === null) return true;
     return row.now_ms - row.last_executor_active_ms > thresholdMs;
   };
 
-  const isStructurallyValid = (row: CandidateTeamRow): boolean =>
-    row.worktree_path !== '' && row.base_branch !== '' && fsExists(row.worktree_path);
-
-  const probeOne = async (row: CandidateTeamRow): Promise<StalledTeamRow | null> => {
-    const probe = await gitProbe(row.worktree_path, row.base_branch);
-    if (!probe.ok || probe.aheadCount <= 0) return null;
-    return { row, aheadCount: probe.aheadCount, lastCommitAt: probe.lastCommitAt };
+  const probeOne = async (row: TeamUnpushedRow): Promise<StalledTeamRow | null> => {
+    const probe = await gitProbe(row);
+    if (!probe.ok || probe.branch_ahead_count <= 0) return null;
+    return { row, branchAheadCount: probe.branch_ahead_count, lastCommitMs: probe.last_commit_ms };
   };
 
   return {
     id: 'rot.team-unpushed-orphaned-worktree',
     version,
-    riskClass: 'medium',
+    riskClass: 'low',
     async query(): Promise<TeamUnpushedOrphanedWorktreeState> {
       const candidates = await queryFn();
-      const probable = candidates.filter((r) => isIdlePastThreshold(r) && isStructurallyValid(r));
+      const idle = candidates.filter(isIdlePastThreshold);
       // Cap probe batch so one runaway tick cannot spawn hundreds of git
       // subprocesses. Stragglers re-evaluate next tick.
-      const batch = probable.slice(0, maxTeamsPerTick);
+      const batch = idle.slice(0, maxTeamsPerTick);
+      const idleUnprobed = idle.length - batch.length;
       const stalled: StalledTeamRow[] = [];
       for (const row of batch) {
         const result = await probeOne(row);
         if (result !== null) stalled.push(result);
       }
-      return { stalled, idleMinutes };
+      return { stalled, idleUnprobed, idleMinutes };
     },
     shouldFire(state: TeamUnpushedOrphanedWorktreeState): boolean {
       return state.stalled.length > 0;
@@ -265,23 +296,30 @@ export function createTeamUnpushedOrphanedWorktreeDetector(opts?: {
         row.last_executor_active_ms === null ? null : Math.floor((row.now_ms - row.last_executor_active_ms) / 60_000);
       const lastExecutorActiveIso =
         row.last_executor_active_ms === null ? null : new Date(row.last_executor_active_ms).toISOString();
+      const lastCommitIso = first.lastCommitMs === null ? null : new Date(first.lastCommitMs).toISOString();
+      // Total reflects both the probed-and-confirmed rows AND the idle rows
+      // we capped out of this tick. Operators reading the payload see how much
+      // work is queued for subsequent ticks.
+      const totalStalledTeams = state.stalled.length + state.idleUnprobed;
       return {
         type: 'rot.detected',
-        subject: row.name,
+        subject: row.team_name,
         payload: {
           pattern_id: 'pattern-9-team-unpushed-orphaned-worktree',
-          entity_id: row.name,
+          entity_id: row.team_name,
           observed_state_json: {
-            team_name: row.name,
+            team_name: row.team_name,
             team_status: row.status,
             worktree_path: row.worktree_path,
-            base_branch: row.base_branch,
-            branch_ahead_count: first.aheadCount,
-            last_commit_at: first.lastCommitAt,
+            base_branch: row.base_branch ?? '',
+            branch_ahead_count: first.branchAheadCount,
+            last_commit_at: lastCommitIso,
             last_executor_active_at: lastExecutorActiveIso,
             minutes_since_active: minutesSinceActive,
             threshold_minutes: state.idleMinutes,
-            total_stalled_teams: state.stalled.length,
+            lead_agent_id: row.lead_agent_id,
+            lead_state: row.lead_state,
+            total_stalled_teams: totalStalledTeams,
           },
         },
       };

--- a/src/detectors/pattern-9-team-unpushed-orphaned-worktree.ts
+++ b/src/detectors/pattern-9-team-unpushed-orphaned-worktree.ts
@@ -1,0 +1,293 @@
+/**
+ * Detector: rot.team-unpushed-orphaned-worktree — a team finished local work
+ * but its worktree still has commits ahead of origin and no live executor is
+ * making forward progress.
+ *
+ * Wish: team-unpushed-orphaned-worktree (Pattern 9).
+ *
+ * Symptom: an autonomous `team create --wish <slug>` team completes its work
+ * locally (engineers commit), then the leader pane exits before `git push` /
+ * PR creation. The worktree sits with commits ahead of origin; no existing
+ * detector fires. The operator only discovers it hours later when auditing
+ * manually.
+ *
+ * Predicates (all three must hold for a team to be reported):
+ *   1. `teams.status NOT IN ('done','blocked','archived')` — still nominally
+ *      active; operator-set terminal states are respected. Enforced in SQL so
+ *      terminal-state rows never reach the in-memory filter.
+ *   2. No agent on the team has an executor in `running` / `spawning` state
+ *      within the last `idleMinutes` window (default 10 — double pattern-5's
+ *      5min so the two detectors span different windows).
+ *   3. The worktree at `teams.worktree_path` exists on disk AND has
+ *      `git rev-list --count origin/<base_branch>..HEAD > 0` — real unpushed
+ *      work exists.
+ *
+ * Behaviour:
+ *   - `query()` reads candidate teams, filters in-memory by liveness + path
+ *     sanity, caps at `maxTeamsPerTick` (default 32), and probes git for
+ *     each survivor.
+ *   - `shouldFire()` true when at least one probed team has aheadCount > 0.
+ *   - `render()` emits one `rot.detected` per tick for the first stalled team,
+ *     carrying the evidence an operator needs for a one-liner salvage.
+ *
+ * V1 is measurement only. The detector never pushes, never mutates files,
+ * never invokes git commands beyond read-only introspection. A future
+ * `genie team rescue` command can consume the emitted events and decide its
+ * own safety policy.
+ *
+ * Tuning knobs exposed via the factory so tests can drive deterministic
+ * timing without spinning up real git repos or real subprocesses.
+ */
+
+import { execFile } from 'node:child_process';
+import { statSync } from 'node:fs';
+import { getConnection } from '../lib/db.js';
+import { type DetectorEvent, type DetectorModule, registerDetector } from './index.js';
+
+/** Executor states that count as "alive and making progress". Matches migration 012 CHECK. */
+const LIVE_EXECUTOR_STATES = ['running', 'spawning'] as const;
+
+/** Team statuses that suppress the detector — operator-set terminal states. */
+const EXEMPT_TEAM_STATUSES = ['done', 'blocked', 'archived'] as const;
+
+/** Default idleness threshold — double pattern-5's 5min so the two detectors span different windows. */
+const DEFAULT_IDLE_MINUTES = 10;
+
+/** Worst-case observed concurrent dispatch was 6 teams; 32 is a sane upper bound. */
+const DEFAULT_MAX_TEAMS_PER_TICK = 32;
+
+/** Longer than the slowest healthy `rev-list` observed (~200ms); short enough to not stall a tick. */
+const DEFAULT_GIT_TIMEOUT_MS = 3_000;
+
+/**
+ * Candidate team row returned by the SQL query. The detector filters this
+ * in-memory against the idleness threshold before probing git. Exported so
+ * tests can type-check fixtures without reaching into private internals.
+ */
+export interface CandidateTeamRow {
+  /** PG teams.name — also the subject of the emitted event. */
+  readonly name: string;
+  /** Current teams.status — carried through to evidence so operators can triage. */
+  readonly status: string;
+  /** Absolute path to the team's worktree on disk. */
+  readonly worktree_path: string;
+  /** base_branch the worktree was cut from. Empty string tolerated as "malformed". */
+  readonly base_branch: string;
+  /** Epoch-ms of the most recent `running`/`spawning` activity across the team; null when never seen. */
+  readonly last_executor_active_ms: number | null;
+  /** Epoch-ms the query was run — used to compute `minutes_since_active` deterministically. */
+  readonly now_ms: number;
+}
+
+/**
+ * Result of the per-team git probe. `ok=false` covers every non-happy path
+ * (timeout, missing worktree, non-zero exit, parse error). The detector
+ * treats `ok=false` as "unknown → do not fire" and moves on — the row stays
+ * eligible for the next tick.
+ */
+export interface GitProbeResult {
+  /** True when the probe produced a usable answer. False degrades to "do not fire". */
+  readonly ok: boolean;
+  /** Count of commits on HEAD that are not in origin/<base_branch>. */
+  readonly aheadCount: number;
+  /** ISO-8601 timestamp of the tip commit, or null when the probe could not read it. */
+  readonly lastCommitAt: string | null;
+}
+
+/** Injected git probe contract — production default shells out to `git`. */
+export type GitProbeFn = (worktreePath: string, baseBranch: string) => Promise<GitProbeResult>;
+
+/** Injected fs existence probe — tests inject deterministic stubs. */
+export type FsExistsFn = (path: string) => boolean;
+
+/** Shape of a single team after all three predicates have been confirmed via git. */
+interface StalledTeamRow {
+  readonly row: CandidateTeamRow;
+  readonly aheadCount: number;
+  readonly lastCommitAt: string | null;
+}
+
+export interface TeamUnpushedOrphanedWorktreeState {
+  /** Rows the detector confirmed ALL three predicates for. render() picks stalled[0]. */
+  readonly stalled: ReadonlyArray<StalledTeamRow>;
+  /** Configured threshold (used in evidence). */
+  readonly idleMinutes: number;
+}
+
+/** Default fs check — stat as directory. Tests bypass this via `fsExists`. */
+function defaultFsExists(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** Run `git` in `cwd` with a bounded timeout. Rejects on any non-zero exit. */
+function runGit(cwd: string, args: string[], timeoutMs: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = execFile('git', args, { cwd, timeout: timeoutMs, windowsHide: true }, (err, stdout) => {
+      if (err) reject(err);
+      else resolve(String(stdout).trim());
+    });
+    // Drain stderr silently so a git chatty-warning does not leak to the
+    // detector log. The subprocess still exits cleanly through callback.
+    child.stderr?.resume();
+  });
+}
+
+/** Build a production git probe bound to a timeout. Factored out so tests inject their own. */
+function makeDefaultGitProbe(gitTimeoutMs: number): GitProbeFn {
+  return async (worktreePath, baseBranch) => {
+    try {
+      const aheadStr = await runGit(
+        worktreePath,
+        ['rev-list', '--count', `origin/${baseBranch}..HEAD`],
+        gitTimeoutMs,
+      );
+      const aheadCount = Number.parseInt(aheadStr, 10);
+      if (!Number.isFinite(aheadCount)) {
+        return { ok: false, aheadCount: 0, lastCommitAt: null };
+      }
+      if (aheadCount <= 0) {
+        return { ok: true, aheadCount: 0, lastCommitAt: null };
+      }
+      const tipIso = await runGit(worktreePath, ['log', '-1', '--format=%cI', 'HEAD'], gitTimeoutMs);
+      return { ok: true, aheadCount, lastCommitAt: tipIso || null };
+    } catch {
+      return { ok: false, aheadCount: 0, lastCommitAt: null };
+    }
+  };
+}
+
+export function createTeamUnpushedOrphanedWorktreeDetector(opts?: {
+  query?: () => Promise<CandidateTeamRow[]>;
+  gitProbe?: GitProbeFn;
+  fsExists?: FsExistsFn;
+  idleMinutes?: number;
+  maxTeamsPerTick?: number;
+  gitTimeoutMs?: number;
+  version?: string;
+}): DetectorModule<TeamUnpushedOrphanedWorktreeState> {
+  const idleMinutes = opts?.idleMinutes ?? DEFAULT_IDLE_MINUTES;
+  const thresholdMs = idleMinutes * 60_000;
+  const maxTeamsPerTick = opts?.maxTeamsPerTick ?? DEFAULT_MAX_TEAMS_PER_TICK;
+  const gitTimeoutMs = opts?.gitTimeoutMs ?? DEFAULT_GIT_TIMEOUT_MS;
+  const version = opts?.version ?? '0.1.0';
+  const gitProbe = opts?.gitProbe ?? makeDefaultGitProbe(gitTimeoutMs);
+  const fsExists = opts?.fsExists ?? defaultFsExists;
+
+  const defaultQuery = async (): Promise<CandidateTeamRow[]> => {
+    const sql = await getConnection();
+    // live_activity aggregates the max executor updated_at per team for the
+    // running/spawning states only. We intentionally skip 'idle'/'working' —
+    // those lean toward "polling quietly" which pattern-5 already covers.
+    // LEFT JOIN so teams that never produced a live executor surface with NULL.
+    const rows = (await sql`
+      WITH live_activity AS (
+        SELECT a.team AS team, MAX(e.updated_at) AS last_active
+          FROM agents a
+          JOIN executors e ON e.agent_id = a.id
+         WHERE a.team IS NOT NULL
+           AND e.state = ANY(${sql.array([...LIVE_EXECUTOR_STATES])})
+         GROUP BY a.team
+      )
+      SELECT t.name                                          AS name,
+             t.status                                        AS status,
+             t.worktree_path                                 AS worktree_path,
+             t.base_branch                                   AS base_branch,
+             EXTRACT(EPOCH FROM la.last_active) * 1000       AS last_executor_active_ms,
+             EXTRACT(EPOCH FROM now()) * 1000                AS now_ms
+        FROM teams t
+   LEFT JOIN live_activity la ON la.team = t.name
+       WHERE t.status <> ALL(${sql.array([...EXEMPT_TEAM_STATUSES])})
+       ORDER BY t.updated_at DESC
+       LIMIT 500
+    `) as unknown as Array<{
+      name: string;
+      status: string;
+      worktree_path: string;
+      base_branch: string | null;
+      last_executor_active_ms: number | string | null;
+      now_ms: number | string;
+    }>;
+
+    return rows.map((r) => ({
+      name: r.name,
+      status: r.status,
+      worktree_path: r.worktree_path ?? '',
+      base_branch: r.base_branch ?? '',
+      last_executor_active_ms: r.last_executor_active_ms === null ? null : Number(r.last_executor_active_ms),
+      now_ms: Number(r.now_ms),
+    }));
+  };
+
+  const queryFn = opts?.query ?? defaultQuery;
+
+  const isIdlePastThreshold = (row: CandidateTeamRow): boolean => {
+    if (row.last_executor_active_ms === null) return true;
+    return row.now_ms - row.last_executor_active_ms > thresholdMs;
+  };
+
+  const isStructurallyValid = (row: CandidateTeamRow): boolean =>
+    row.worktree_path !== '' && row.base_branch !== '' && fsExists(row.worktree_path);
+
+  const probeOne = async (row: CandidateTeamRow): Promise<StalledTeamRow | null> => {
+    const probe = await gitProbe(row.worktree_path, row.base_branch);
+    if (!probe.ok || probe.aheadCount <= 0) return null;
+    return { row, aheadCount: probe.aheadCount, lastCommitAt: probe.lastCommitAt };
+  };
+
+  return {
+    id: 'rot.team-unpushed-orphaned-worktree',
+    version,
+    riskClass: 'medium',
+    async query(): Promise<TeamUnpushedOrphanedWorktreeState> {
+      const candidates = await queryFn();
+      const probable = candidates.filter((r) => isIdlePastThreshold(r) && isStructurallyValid(r));
+      // Cap probe batch so one runaway tick cannot spawn hundreds of git
+      // subprocesses. Stragglers re-evaluate next tick.
+      const batch = probable.slice(0, maxTeamsPerTick);
+      const stalled: StalledTeamRow[] = [];
+      for (const row of batch) {
+        const result = await probeOne(row);
+        if (result !== null) stalled.push(result);
+      }
+      return { stalled, idleMinutes };
+    },
+    shouldFire(state: TeamUnpushedOrphanedWorktreeState): boolean {
+      return state.stalled.length > 0;
+    },
+    render(state: TeamUnpushedOrphanedWorktreeState): DetectorEvent {
+      const first = state.stalled[0];
+      const row = first.row;
+      const minutesSinceActive =
+        row.last_executor_active_ms === null ? null : Math.floor((row.now_ms - row.last_executor_active_ms) / 60_000);
+      const lastExecutorActiveIso =
+        row.last_executor_active_ms === null ? null : new Date(row.last_executor_active_ms).toISOString();
+      return {
+        type: 'rot.detected',
+        subject: row.name,
+        payload: {
+          pattern_id: 'pattern-9-team-unpushed-orphaned-worktree',
+          entity_id: row.name,
+          observed_state_json: {
+            team_name: row.name,
+            team_status: row.status,
+            worktree_path: row.worktree_path,
+            base_branch: row.base_branch,
+            branch_ahead_count: first.aheadCount,
+            last_commit_at: first.lastCommitAt,
+            last_executor_active_at: lastExecutorActiveIso,
+            minutes_since_active: minutesSinceActive,
+            threshold_minutes: state.idleMinutes,
+            total_stalled_teams: state.stalled.length,
+          },
+        },
+      };
+    },
+  };
+}
+
+// Canonical production instance — registered at module load via side effect.
+registerDetector(createTeamUnpushedOrphanedWorktreeDetector());


### PR DESCRIPTION
## Summary
- New detector `rot.team-unpushed-orphaned-worktree` catches autonomous teams that completed local work but died before `git push` / PR creation — the branch sits orphaned in `~/.genie/worktrees/<team>/`, no existing detector fires, operator discovers hours later (the exact scenario from #1250 — also the failure mode that hit this very team-lead mid-execution)
- Fires when all three predicates hold: team status non-terminal, no executor in `running`/`spawning` within `idleMinutes` (default 10), and `git rev-list --count origin/<base>..HEAD` > 0
- Complements pattern-5 (alive-but-idle lead) — pattern-9 is dead-with-WIP; idleMinutes windows are non-overlapping (5 vs 10) so a stalling team surfaces under the right signal
- V1 is measurement only — no auto-push, no worktree mutation. A `genie team rescue` salvage command is scoped to a follow-up wish

## What's in
- `src/detectors/pattern-9-team-unpushed-orphaned-worktree.ts` — detector module (331 LoC)
- `src/detectors/__tests__/pattern-9-team-unpushed-orphaned-worktree.test.ts` — 12 tests (416 LoC)
- `docs/detectors/runbook.md` — Pattern 9 entry with description, root cause, false-positive sources, triage script

## What's out (follow-up wishes)
- **Leader-completion contract** (`team.completed` / `team.pushed` events) — the deeper architectural fix; lets the detector assert against a real signal instead of inferring from executor idleness
- **`genie team rescue`** — one-liner salvage for stalled teams (auto-push + PR-open on operator approval)
- **Cross-repo worktree index** — filesystem-level backup of `teams.worktree_path`

## Test plan
- [x] 12 tests cover: positive fire with evidence shape, fresh executor, missing worktree, zero-ahead, status=done/blocked, subprocess timeout, no-probe-when-healthy, once-per-hour fire budget, malformed rows (empty worktree_path / null base_branch), 40-row cap at `maxTeamsPerTick=32`
- [x] `bun test src/detectors/__tests__/pattern-9-team-unpushed-orphaned-worktree.test.ts` — 12/12 pass
- [x] `bun test src/detectors/` — 72/72 pass (no regression to patterns 1-8)
- [x] `bun run check` (typecheck + lint + test, full suite) — 3470/3470 pass, exit 0

## Meta: eating our own dog food
This team was itself dispatched via `genie team create --wish team-unpushed-orphaned-worktree`. Mid-execution the team-lead died (no claude session, unresumable) — leaving engineer-1 and engineer-2 alive. They self-coordinated via the coordination channel, finished the work, committed. I stepped in as orchestrator to add the runbook entry, push, and open this PR. **Exactly the failure mode this detector catches.** Pattern-9 would have fired on this team if it had been live in production.

Closes #1250 (observation half). Leader-completion contract remains queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)