### PR TITLE
fix(db): guard pgserve against uid=0 with actionable error (#1226)

### DIFF
--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -471,6 +471,67 @@ describe('parallel dispatch race (issue #1207)', () => {
   });
 });
 
+describe('root guard (issue #1226)', () => {
+  let origGetuid: (() => number) | undefined;
+  let origAllowRoot: string | undefined;
+
+  beforeEach(() => {
+    origGetuid = process.getuid;
+    origAllowRoot = process.env.GENIE_ALLOW_ROOT;
+  });
+
+  afterEach(() => {
+    // Restore original getuid
+    if (origGetuid) {
+      Object.defineProperty(process, 'getuid', { value: origGetuid, configurable: true });
+    }
+    if (origAllowRoot !== undefined) {
+      process.env.GENIE_ALLOW_ROOT = origAllowRoot;
+    } else {
+      process.env.GENIE_ALLOW_ROOT = undefined;
+    }
+  });
+
+  test('returns null when uid is non-zero', async () => {
+    Object.defineProperty(process, 'getuid', { value: () => 1000, configurable: true });
+    const { checkRootGuard } = await import('./db.js');
+    expect(checkRootGuard()).toBeNull();
+  });
+
+  test('returns actionable error when running as root', async () => {
+    Object.defineProperty(process, 'getuid', { value: () => 0, configurable: true });
+    process.env.GENIE_ALLOW_ROOT = undefined;
+    const { checkRootGuard } = await import('./db.js');
+    const msg = checkRootGuard();
+    expect(msg).not.toBeNull();
+    // Must name the real cause
+    expect(msg).toContain('uid 0');
+    expect(msg).toContain('root');
+    // Must offer the escape hatch
+    expect(msg).toContain('GENIE_ALLOW_ROOT=1');
+    // Must link the issue for more context
+    expect(msg).toContain('1226');
+  });
+
+  test('GENIE_ALLOW_ROOT=1 bypasses the guard', async () => {
+    Object.defineProperty(process, 'getuid', { value: () => 0, configurable: true });
+    process.env.GENIE_ALLOW_ROOT = '1';
+    const { checkRootGuard } = await import('./db.js');
+    expect(checkRootGuard()).toBeNull();
+  });
+
+  test('_ensurePgserve invokes checkRootGuard before spawn paths', () => {
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    // The guard call must live inside _ensurePgserve, before the GENIE_IS_DAEMON branch
+    const fnStart = source.indexOf('async function _ensurePgserve');
+    expect(fnStart).toBeGreaterThan(-1);
+    const daemonBranch = source.indexOf("GENIE_IS_DAEMON === '1'", fnStart);
+    const guardCall = source.indexOf('checkRootGuard()', fnStart);
+    expect(guardCall).toBeGreaterThan(-1);
+    expect(guardCall).toBeLessThan(daemonBranch);
+  });
+});
+
 describe('migration directory resolution', () => {
   test('does not use process.cwd() for migration lookup', () => {
     const source = readFileSync(join(__dirname, 'db-migrations.ts'), 'utf-8');

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -35,6 +35,30 @@ function maskCredentials(url: string): string {
 }
 
 /**
+ * Detect whether pgserve would refuse to start because the current process
+ * is running as uid 0 (root). PostgreSQL aborts with
+ *   "root" execution of the PostgreSQL server is not permitted
+ * at the binary level, which surfaces in the CLI as a misleading 16s timeout
+ * with tmux/scheduler cascade errors (issue #1226). Failing fast up front
+ * gives the user the real reason.
+ *
+ * Returns a user-facing error message if the guard should fire, or null if
+ * startup should proceed. `GENIE_ALLOW_ROOT=1` bypasses the guard (pgserve
+ * will still fail at the postgres binary level, but the real error is then
+ * surfaced immediately from the child process).
+ */
+export function checkRootGuard(): string | null {
+  const uid = process.getuid?.();
+  if (uid !== 0) return null;
+  if (process.env.GENIE_ALLOW_ROOT === '1') return null;
+  return (
+    'pgserve cannot start under uid 0 (root) — PostgreSQL refuses to run as root for security reasons. ' +
+    'Run genie as a non-root user, or set GENIE_ALLOW_ROOT=1 to attempt anyway. ' +
+    'See: https://github.com/automagik-dev/genie/issues/1226'
+  );
+}
+
+/**
  * Self-heal: kill stale postgres processes, clean shared memory, remove stale PID files.
  * Handles zombies (which can't be killed) by cleaning their artifacts instead.
  */
@@ -414,6 +438,15 @@ async function _ensurePgserve(): Promise<number> {
   if (process.env.CI === 'true') {
     process.env.GENIE_PG_AVAILABLE = 'false';
     throw new Error('pgserve not available in CI');
+  }
+
+  // 3b. Root guard — pgserve would otherwise time out with a misleading
+  //     16s error because postgres refuses uid 0 at the binary level. See
+  //     checkRootGuard() and issue #1226.
+  const rootErr = checkRootGuard();
+  if (rootErr !== null) {
+    process.env.GENIE_PG_AVAILABLE = 'false';
+    throw new Error(rootErr);
   }
 
   // 4a. If we ARE the daemon (genie serve) — spawn pgserve directly.


### PR DESCRIPTION
## Summary

Running `genie` as root caused pgserve to silently refuse startup — postgres aborts under uid 0 at the binary level (\`\"root\" execution of the PostgreSQL server is not permitted\`). The failure surfaced as a generic 16s timeout with misleading cascades: \`Bridge stale: pid N not running\`, \`error connecting to /tmp/tmux-65534/genie\`, and orphaned \`/tmp/pgserve-sock-*\` dirs accumulating on every CLI call.

This PR adds a fail-fast guard at the \`_ensurePgserve\` entry point so the user sees the real cause immediately instead of the 16s timeout.

## Changes

- \`src/lib/db.ts\`
  - New \`checkRootGuard()\` — returns an actionable error string when \`process.getuid?.() === 0\`, honoring \`GENIE_ALLOW_ROOT=1\` as escape hatch.
  - Guard call inserted between the CI short-circuit and the daemon/CLI spawn branches, so both \`GENIE_IS_DAEMON=1\` direct-spawn and CLI \`autoStartDaemon()\` paths benefit from the same check.
- \`src/lib/db.test.ts\` — 4 regression tests covering: non-root no-op, root error shape (uid 0 / GENIE_ALLOW_ROOT=1 / issue link), escape hatch bypass, static assertion that the guard runs before the daemon spawn branch.

## Error shape

\`\`\`
pgserve cannot start under uid 0 (root) — PostgreSQL refuses to run as root for security reasons.
Run genie as a non-root user, or set GENIE_ALLOW_ROOT=1 to attempt anyway.
See: https://github.com/automagik-dev/genie/issues/1226
\`\`\`

## Test plan

- [x] \`bun run check\` — typecheck + lint + dead-code + 3468 tests pass
- [x] \`bun test src/lib/db.test.ts -t \"root guard\"\` — 4/4 pass
- [ ] Manual: run \`genie ls\` as root → expect the new error instead of the 16s timeout

Resolves #1226

🤖 Generated with [Claude Code](https://claude.com/claude-code)