### PR TITLE
fix(dir): roles field survives yaml → sync → PG round-trip

### DIFF
--- a/src/lib/agent-directory.ts
+++ b/src/lib/agent-directory.ts
@@ -510,7 +510,7 @@ function roleToEntry(
     dir: (metadata?.dir as string) || '',
     promptMode: (metadata?.promptMode as PromptMode) || 'append',
     model: metadata?.model as string | undefined,
-    roles: [],
+    roles: Array.isArray(metadata?.roles) ? (metadata.roles as string[]) : [],
     registeredAt,
     description: metadata?.description as string | undefined,
     color: metadata?.color as string | undefined,
@@ -535,6 +535,7 @@ function buildMetadata(entry: DirectoryEntry): Record<string, unknown> {
   if (entry.description) meta.description = entry.description;
   if (entry.color) meta.color = entry.color;
   if (entry.provider) meta.provider = entry.provider;
+  if (entry.roles && entry.roles.length > 0) meta.roles = entry.roles;
   if (entry.permissions) meta.permissions = entry.permissions;
   if (entry.disallowedTools) meta.disallowedTools = entry.disallowedTools;
   if (entry.omniScopes) meta.omniScopes = entry.omniScopes;

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -431,6 +431,7 @@ async function syncSingleAgent(agent: AgentInfo, result: SyncResult, workspaceRo
       description: configFields.description,
       color: configFields.color,
       provider: configFields.provider,
+      roles: configFields.roles,
       permissions: configFields.permissions,
       disallowedTools: configFields.disallowedTools,
       omniScopes: configFields.omniScopes,
@@ -452,6 +453,7 @@ async function syncSingleAgent(agent: AgentInfo, result: SyncResult, workspaceRo
     description: configFields.description,
     color: configFields.color,
     provider: configFields.provider,
+    roles: configFields.roles,
     permissions: configFields.permissions,
     disallowedTools: configFields.disallowedTools,
     omniScopes: configFields.omniScopes,
@@ -469,6 +471,7 @@ interface ConfigFields {
   description?: string;
   color?: string;
   provider?: string;
+  roles?: string[];
   permissions?: { allow?: string[]; deny?: string[]; preset?: string; bashAllowPatterns?: string[] };
   disallowedTools?: string[];
   omniScopes?: string[];
@@ -488,6 +491,7 @@ async function readYamlAsConfigFields(yamlPath: string): Promise<ConfigFields> {
     description: cfg.description,
     color: cfg.color,
     provider: cfg.provider,
+    roles: cfg.roles,
     permissions: cfg.permissions,
     disallowedTools: cfg.disallowedTools,
     omniScopes: cfg.omniScopes,
@@ -508,6 +512,7 @@ function readFrontmatterAsConfigFields(agentsMdPath: string): ConfigFields {
     description: fm.description as string | undefined,
     color: fm.color as string | undefined,
     provider: fm.provider as string | undefined,
+    roles: (fm as Record<string, unknown>).roles as string[] | undefined,
     permissions: fm.permissions as ConfigFields['permissions'],
     disallowedTools: fm.disallowedTools as string[] | undefined,
     omniScopes: fm.omniScopes as string[] | undefined,

--- a/src/term-commands/dir-edit.test.ts
+++ b/src/term-commands/dir-edit.test.ts
@@ -115,6 +115,24 @@ describe.skipIf(!DB_AVAILABLE)('dir edit — agent.yaml-first flow (wish dir-syn
     expect(parsed.sdk?.permissionMode).toBe('auto');
   });
 
+  test('--roles [...] → roles survive yaml + sync into PG metadata', async () => {
+    // Regression pin: `dir edit --roles` silently accepted the flag but the
+    // sync layer dropped roles on the way from yaml → PG, and `roleToEntry`
+    // hardcoded `roles: []` on read. Roles must now round-trip through the
+    // full yaml-first flow and be visible via `directory.get()`.
+    const agentDir = seedAgent('roles-agent', '---\npromptMode: append\n---');
+
+    await editAgentYaml('roles-agent', agentDir, {
+      roles: ['team-lead', 'engineer', 'reviewer', 'qa'],
+    });
+
+    const parsed = await parseAgentYaml(join(agentDir, 'agent.yaml'));
+    expect(parsed.roles).toEqual(['team-lead', 'engineer', 'reviewer', 'qa']);
+
+    const entry = await directory.get('roles-agent');
+    expect(entry!.roles).toEqual(['team-lead', 'engineer', 'reviewer', 'qa']);
+  });
+
   test('yaml write happens BEFORE db write — file wins if sync skipped', async () => {
     // Assertion: if we write the yaml but skip the sync step, the file on
     // disk reflects the edit immediately. This pins the "file is source of


### PR DESCRIPTION
## Summary

`genie dir edit --roles ...` silently accepts the flag but the value is dropped three different places on the round trip to PG, so `dir ls --json` always returns `roles: []` regardless of what you edited. Fix wires `roles` through the missing links in the sync path + metadata serializer + read-time entry builder.

## What was broken

1. `agent-sync.ts:ConfigFields` did not declare `roles`, so both `readYamlAsConfigFields` and `readFrontmatterAsConfigFields` silently dropped it before handing the config to `directory.add()` / `directory.edit()`.
2. `agent-directory.ts:buildMetadata()` omitted `roles` from the JSONB metadata patch, so even direct (pre-refactor) edits that called `directory.edit` with `roles` in the update lost them on the PG write.
3. `agent-directory.ts:roleToEntry()` hardcoded `roles: []` at read time, so consumers always saw an empty array even when storage was correct.

Net effect: `--roles` was a no-op end-to-end.

## Fix

- `ConfigFields` now includes `roles?: string[]`.
- Both config-field extractors populate `roles`.
- Both add and edit paths in `syncSingleAgent` pass `roles` through.
- `buildMetadata` serializes `roles` when non-empty.
- `roleToEntry` reads `roles` from metadata.

## Test plan

- [x] New regression pin in `src/term-commands/dir-edit.test.ts` exercises the full yaml → sync → PG flow and asserts both the yaml file and `directory.get()` return the edited roles.
- [x] `bun run check` — typecheck + lint + dead-code + skills/wishes-lint + emit-discipline + tests.
- [x] 3465 tests pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)