### PR TITLE
fix(inbox-watcher): fallback to team.workingDir when lead not in members[]

### DIFF
--- a/src/lib/claude-native-teams.test.ts
+++ b/src/lib/claude-native-teams.test.ts
@@ -20,6 +20,7 @@ import {
   discoverTeamName,
   ensureNativeTeamWithSessionId,
   findTeamsContainingAgent,
+  listTeamsWithUnreadInbox,
   loadConfig,
   resolveNativeMemberName,
   resolveOrMintLeadSessionId,
@@ -719,5 +720,138 @@ describe('findTeamsContainingAgent', () => {
     // no team config has ever been written.
     const result = await findTeamsContainingAgent('khal-os');
     expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listTeamsWithUnreadInbox — workingDir resolution
+//
+// Regression coverage for the inbox-watcher spawn-blocker where
+// council/solo teams that leave members[] empty (or without a distinct
+// lead entry) emitted:
+//   [inbox-watcher] Cannot spawn team-lead for "council-…" — no workingDir in config
+// because `scanTeamInbox` only looked at `members[<lead>].cwd`. Fallback
+// order is now: leadMember.cwd → config.worktreePath → config.repo.
+// ---------------------------------------------------------------------------
+
+/**
+ * Write a team config with the exact fields we need to exercise the
+ * workingDir-fallback chain in `scanTeamInbox`. The existing
+ * `createTestTeamConfig` helper always populates members[] with a matching
+ * lead — the bug we're guarding against requires the opposite.
+ */
+async function createRawTeamConfig(
+  teamName: string,
+  config: {
+    leadAgentId?: string;
+    members?: { agentId: string; name: string; cwd?: string }[];
+    worktreePath?: string;
+    repo?: string;
+  },
+  unreadMessage = 'hello lead',
+): Promise<void> {
+  const sanitized = sanitizeTeamName(teamName);
+  const teamDir = join(tempDir, 'teams', sanitized);
+  const inboxDir = join(teamDir, 'inboxes');
+  await mkdir(inboxDir, { recursive: true });
+
+  const leadAgentId = config.leadAgentId ?? `team-lead@${sanitized}`;
+  const leadInboxName = leadAgentId.split('@')[0] ?? 'team-lead';
+
+  await writeFile(
+    join(teamDir, 'config.json'),
+    JSON.stringify({
+      name: sanitized,
+      description: `Test team: ${teamName}`,
+      createdAt: Date.now(),
+      leadAgentId,
+      leadSessionId: 'test-session-id',
+      members: (config.members ?? []).map((m) => ({
+        agentId: m.agentId,
+        name: m.name,
+        agentType: 'general-purpose',
+        joinedAt: Date.now(),
+        cwd: m.cwd,
+        backendType: 'tmux',
+        color: 'blue',
+        planModeRequired: false,
+        isActive: true,
+      })),
+      worktreePath: config.worktreePath,
+      repo: config.repo,
+    }),
+  );
+
+  const msg: NativeInboxMessage = {
+    from: 'someone',
+    text: unreadMessage,
+    summary: 'test',
+    timestamp: new Date().toISOString(),
+    color: 'blue',
+    read: false,
+  };
+  await writeFile(join(inboxDir, `${leadInboxName}.json`), JSON.stringify([msg]));
+}
+
+describe('listTeamsWithUnreadInbox workingDir fallback', () => {
+  test('uses leadMember.cwd when the lead is in members[]', async () => {
+    await createRawTeamConfig('team-alpha', {
+      leadAgentId: 'team-lead@team-alpha',
+      members: [{ agentId: 'team-lead@team-alpha', name: 'team-lead', cwd: '/tmp/alpha-cwd' }],
+      worktreePath: '/tmp/alpha-worktree',
+    });
+    const rows = await listTeamsWithUnreadInbox();
+    const row = rows.find((r) => r.teamName === 'team-alpha');
+    expect(row?.workingDir).toBe('/tmp/alpha-cwd');
+  });
+
+  test('falls back to config.worktreePath when lead is not in members[]', async () => {
+    // Ghost-lead scenario: the lead is the team itself (councils, solo
+    // agents), so members[] is empty. Pre-fix this returned workingDir:null
+    // and the inbox-watcher logged "no workingDir in config" + refused to
+    // spawn. Post-fix we trust the team's own worktreePath.
+    await createRawTeamConfig('council-1775707451', {
+      leadAgentId: 'team-lead@council-1775707451',
+      members: [],
+      worktreePath: '/tmp/council-worktree',
+    });
+    const rows = await listTeamsWithUnreadInbox();
+    const row = rows.find((r) => r.teamName === 'council-1775707451');
+    expect(row?.workingDir).toBe('/tmp/council-worktree');
+  });
+
+  test('falls back to config.repo when both leadMember.cwd and worktreePath are absent', async () => {
+    await createRawTeamConfig('team-bare', {
+      leadAgentId: 'team-lead@team-bare',
+      members: [],
+      repo: '/tmp/bare-repo',
+    });
+    const rows = await listTeamsWithUnreadInbox();
+    const row = rows.find((r) => r.teamName === 'team-bare');
+    expect(row?.workingDir).toBe('/tmp/bare-repo');
+  });
+
+  test('returns null when no fallback source is available', async () => {
+    // Exercised explicitly so the inbox-watcher's "no workingDir in config"
+    // rate-limited warning still fires for configs that have no usable path.
+    await createRawTeamConfig('team-blank', {
+      leadAgentId: 'team-lead@team-blank',
+      members: [],
+    });
+    const rows = await listTeamsWithUnreadInbox();
+    const row = rows.find((r) => r.teamName === 'team-blank');
+    expect(row?.workingDir).toBeNull();
+  });
+
+  test('prefers leadMember.cwd over worktreePath when both are present', async () => {
+    await createRawTeamConfig('team-priority', {
+      leadAgentId: 'team-lead@team-priority',
+      members: [{ agentId: 'team-lead@team-priority', name: 'team-lead', cwd: '/tmp/priority-cwd' }],
+      worktreePath: '/tmp/priority-worktree',
+      repo: '/tmp/priority-repo',
+    });
+    const rows = await listTeamsWithUnreadInbox();
+    const row = rows.find((r) => r.teamName === 'team-priority');
+    expect(row?.workingDir).toBe('/tmp/priority-cwd');
   });
 });

--- a/src/lib/claude-native-teams.ts
+++ b/src/lib/claude-native-teams.ts
@@ -654,8 +654,21 @@ async function scanTeamInbox(
 
   let workingDir: string | null = null;
   if (config) {
+    // Prefer the lead's own cwd from members[] when present.
     const leadMember = config.members.find((m) => m.agentId === config?.leadAgentId || m.name === leaderInboxName);
-    if (leadMember?.cwd) workingDir = leadMember.cwd;
+    if (leadMember?.cwd) {
+      workingDir = leadMember.cwd;
+    } else if (config.worktreePath) {
+      // Fallback: council/solo teams where the lead is the team itself often
+      // leave members[] empty (or without a matching lead entry). Use the
+      // team's own worktreePath instead of failing with "no workingDir in
+      // config". See inbox-watcher spawn-blocker reported against
+      // council-* sessions.
+      workingDir = config.worktreePath;
+    } else if (config.repo) {
+      // Final fallback: the repo root when no worktree is provisioned.
+      workingDir = config.repo;
+    }
   }
 
   return { teamName: name, unreadCount: unread.length, workingDir, firstUnreadText: unread[0]?.text ?? null };


### PR DESCRIPTION
## Summary

`scanTeamInbox` resolved the lead's `workingDir` only via `members[<lead>].cwd`. Councils and solo-lead teams (e.g. `council-1775707451`, `brainstorm-*`, single-agent teams) frequently have empty `members[]` (or no matching lead entry), so `workingDir` came back `null` and the inbox-watcher emitted:

```
[inbox-watcher] Cannot spawn team-lead for "council-1775707451" — no workingDir in config
```

...silently refusing to spawn the lead despite unread inbox messages. Felipe hit this live tonight.

## Fix

Adds a fallback chain identical to the PG teams mirror already used in `team-manager.ts`:

```
leadMember.cwd  →  config.worktreePath  →  config.repo  →  null
```

The terminal `null` case is preserved so the rate-limited "no workingDir in config" warning still fires when the config genuinely has no usable path — no new silent failure modes.

## Changes

- `src/lib/claude-native-teams.ts` — fallback chain in `scanTeamInbox` (lines 655-674)
- `src/lib/claude-native-teams.test.ts` — 5 new regression cases covering:
  - leadMember.cwd happy path
  - ghost-lead scenario (members: [], worktreePath set) — the exact `council-*` bug
  - bare-repo scenario (no worktree, only repo)
  - no-source-at-all → still null
  - precedence ordering (cwd wins over worktreePath)

## Test plan

- [x] `bun test src/lib/claude-native-teams.test.ts -t "workingDir fallback"` → 5/5 pass
- [x] `bun run check` → typecheck + lint + dead-code + 3485 tests pass
- [ ] Manual: open an existing council team whose config has `members: []` and confirm the inbox-watcher now spawns the lead on the next poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)