### PR TITLE
fix(inbox-watcher): member-cwd fallback for councils with null worktreePath/repo

### DIFF
--- a/src/lib/claude-native-teams.test.ts
+++ b/src/lib/claude-native-teams.test.ts
@@ -831,9 +831,53 @@ describe('listTeamsWithUnreadInbox workingDir fallback', () => {
     expect(row?.workingDir).toBe('/tmp/bare-repo');
   });
 
+  test('falls back to any member.cwd when lead not in members[] and no worktreePath/repo', async () => {
+    // Real-world council config (e.g. council-1775707451) observed with:
+    //   - leadAgentId pointing at the council itself
+    //   - members[] containing only worker council agents (architect, sentinel, …)
+    //     with a matching cwd on the shared council worktree
+    //   - worktreePath: null, repo: null
+    // Before this tier the inbox-watcher silently refused to spawn the lead
+    // despite unread messages. Any member.cwd recovers the intended path.
+    await createRawTeamConfig('council-1775707451', {
+      leadAgentId: 'council-1775707451@council-1775707451',
+      members: [
+        {
+          agentId: 'council--questioner@council-1775707451',
+          name: 'council--questioner',
+          cwd: '/tmp/shared-council-worktree',
+        },
+        {
+          agentId: 'council--sentinel@council-1775707451',
+          name: 'council--sentinel',
+          cwd: '/tmp/shared-council-worktree',
+        },
+      ],
+    });
+    const rows = await listTeamsWithUnreadInbox();
+    const row = rows.find((r) => r.teamName === 'council-1775707451');
+    expect(row?.workingDir).toBe('/tmp/shared-council-worktree');
+  });
+
+  test('member.cwd fallback skips entries with no cwd and picks the first populated one', async () => {
+    await createRawTeamConfig('team-mixed-cwd', {
+      leadAgentId: 'lead@team-mixed-cwd',
+      members: [
+        { agentId: 'worker-a@team-mixed-cwd', name: 'worker-a' },
+        { agentId: 'worker-b@team-mixed-cwd', name: 'worker-b', cwd: '/tmp/first-populated' },
+        { agentId: 'worker-c@team-mixed-cwd', name: 'worker-c', cwd: '/tmp/also-populated' },
+      ],
+    });
+    const rows = await listTeamsWithUnreadInbox();
+    const row = rows.find((r) => r.teamName === 'team-mixed-cwd');
+    expect(row?.workingDir).toBe('/tmp/first-populated');
+  });
+
   test('returns null when no fallback source is available', async () => {
     // Exercised explicitly so the inbox-watcher's "no workingDir in config"
-    // rate-limited warning still fires for configs that have no usable path.
+    // rate-limited warning still fires for configs that have no usable path
+    // — e.g. malformed configs whose members[] is empty AND lack
+    // worktreePath/repo.
     await createRawTeamConfig('team-blank', {
       leadAgentId: 'team-lead@team-blank',
       members: [],
@@ -841,6 +885,17 @@ describe('listTeamsWithUnreadInbox workingDir fallback', () => {
     const rows = await listTeamsWithUnreadInbox();
     const row = rows.find((r) => r.teamName === 'team-blank');
     expect(row?.workingDir).toBeNull();
+  });
+
+  test('worktreePath still beats member.cwd when both are present (ordering invariant)', async () => {
+    await createRawTeamConfig('team-order-invariant', {
+      leadAgentId: 'lead@team-order-invariant',
+      members: [{ agentId: 'worker@team-order-invariant', name: 'worker', cwd: '/tmp/worker-cwd' }],
+      worktreePath: '/tmp/team-worktree',
+    });
+    const rows = await listTeamsWithUnreadInbox();
+    const row = rows.find((r) => r.teamName === 'team-order-invariant');
+    expect(row?.workingDir).toBe('/tmp/team-worktree');
   });
 
   test('prefers leadMember.cwd over worktreePath when both are present', async () => {

--- a/src/lib/claude-native-teams.ts
+++ b/src/lib/claude-native-teams.ts
@@ -619,6 +619,27 @@ function extractLeaderInboxName(config: NativeTeamConfig | null, teamName?: stri
   return atIdx > 0 ? config.leadAgentId.slice(0, atIdx) : (teamName ?? 'unknown');
 }
 
+/**
+ * Resolve the working directory for a team's lead, for inbox-watcher spawn.
+ *
+ * Fallback order, matching the PG teams mirror in team-manager.ts:
+ *   1. leadMember.cwd            — the lead's own cwd when present in members[]
+ *   2. config.worktreePath       — team-level worktree when lead isn't a distinct member
+ *   3. config.repo               — repo root when no worktree provisioned
+ *   4. any member.cwd            — real councils seen with both worktreePath/repo
+ *                                  null but workers on the shared council worktree
+ *   5. null                      — preserved so the inbox-watcher's rate-limited
+ *                                  "no workingDir in config" warning still fires
+ *                                  for configs that genuinely have no usable path
+ */
+function resolveLeadWorkingDir(config: NativeTeamConfig, leaderInboxName: string): string | null {
+  const leadMember = config.members.find((m) => m.agentId === config.leadAgentId || m.name === leaderInboxName);
+  if (leadMember?.cwd) return leadMember.cwd;
+  if (config.worktreePath) return config.worktreePath;
+  if (config.repo) return config.repo;
+  return config.members.find((m) => m.cwd)?.cwd ?? null;
+}
+
 /** Scan a single team directory for unread leader inbox messages. */
 async function scanTeamInbox(
   base: string,
@@ -652,24 +673,7 @@ async function scanTeamInbox(
   const unread = messages.filter((m) => m.read === false);
   if (unread.length === 0) return null;
 
-  let workingDir: string | null = null;
-  if (config) {
-    // Prefer the lead's own cwd from members[] when present.
-    const leadMember = config.members.find((m) => m.agentId === config?.leadAgentId || m.name === leaderInboxName);
-    if (leadMember?.cwd) {
-      workingDir = leadMember.cwd;
-    } else if (config.worktreePath) {
-      // Fallback: council/solo teams where the lead is the team itself often
-      // leave members[] empty (or without a matching lead entry). Use the
-      // team's own worktreePath instead of failing with "no workingDir in
-      // config". See inbox-watcher spawn-blocker reported against
-      // council-* sessions.
-      workingDir = config.worktreePath;
-    } else if (config.repo) {
-      // Final fallback: the repo root when no worktree is provisioned.
-      workingDir = config.repo;
-    }
-  }
+  const workingDir = config ? resolveLeadWorkingDir(config, leaderInboxName) : null;
 
   return { teamName: name, unreadCount: unread.length, workingDir, firstUnreadText: unread[0]?.text ?? null };
 }


### PR DESCRIPTION
## Summary

Follow-up to #1286. That PR fixed the common council shape (lead absent from `members[]`, team-level `worktreePath`/`repo` populated) but left a residual gap for real-world configs like `council-1775707451` where **both** `worktreePath` and `repo` are `null` yet workers in `members[]` carry the correct shared-worktree `cwd`.

Without this tier, `scanTeamInbox` drops through to `null` and the inbox-watcher logs `Cannot spawn team-lead for "council-1775707451" — no workingDir in config` despite a perfectly usable path sitting one level down.

## Change

- Add `config.members.find((m) => m.cwd)?.cwd` as the **final** fallback before returning `null`.
- Extract `resolveLeadWorkingDir()` helper — keeps `scanTeamInbox` under the biome 15-complexity ceiling.
- `null` is preserved for configs that have no usable path at all, so the watcher's rate-limited `no workingDir` warning still fires on genuine misses.

## Fallback chain

```
1. leadMember.cwd       — lead present in members[]
2. config.worktreePath  — team-level worktree (#1286)
3. config.repo          — repo root (#1286)
4. any member.cwd       — shared worktree via workers (this PR)
5. null                 — genuine blanks still warn
```

## Test plan

- [x] 3 new fallback tests added (total 8 in `listTeamsWithUnreadInbox workingDir fallback`):
  - council-1775707451 shape (lead absent + null worktreePath/repo + worker cwds)
  - member-cwd fallback skips entries with no cwd, picks first populated
  - ordering invariant: `worktreePath` still beats `member.cwd` when both present
- [x] `bun run check` — 3489 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)