### PR TITLE
fix(detectors): register pattern-9 in built-in aggregator (#1288)

### DIFF
--- a/src/detectors/__tests__/built-in.test.ts
+++ b/src/detectors/__tests__/built-in.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Built-in aggregator wiring discipline (#1288).
+ *
+ * Every `pattern-N-<slug>.ts` source file in `src/detectors/` must have a
+ * matching `import './pattern-N-<slug>.js';` line in `built-in.ts`. Without
+ * that import, the module's `registerDetector(...)` side-effect never runs
+ * and the detector silently no-ops in production despite passing its own
+ * unit tests — the failure mode that shipped with #1283 and was fixed by
+ * this PR.
+ *
+ * Static scan rather than runtime: importing `built-in.ts` in a test would
+ * populate the shared detector registry with production detectors and leak
+ * cross-test state (see the top-of-file comment in `built-in.ts`). The
+ * source-text check catches the same regression class with zero registry
+ * mutation.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const DETECTORS_DIR = join(import.meta.dir, '..');
+const PATTERN_FILE_RE = /^pattern-\d+-.+\.ts$/;
+
+describe('built-in aggregator wiring (#1288)', () => {
+  test('every pattern-N-<slug>.ts source has a matching import in built-in.ts', () => {
+    const builtInSource = readFileSync(join(DETECTORS_DIR, 'built-in.ts'), 'utf8');
+    const patternFiles = readdirSync(DETECTORS_DIR).filter((f) => PATTERN_FILE_RE.test(f) && !f.endsWith('.test.ts'));
+
+    // Guard against a directory layout change that would silently pass the
+    // loop below with zero iterations.
+    expect(patternFiles.length).toBeGreaterThan(0);
+
+    for (const file of patternFiles) {
+      const expectedImport = `'./${file.replace(/\.ts$/, '.js')}'`;
+      expect(builtInSource).toContain(expectedImport);
+    }
+  });
+
+  test('pattern-9 specifically is wired (regression guard for #1288)', () => {
+    const builtInSource = readFileSync(join(DETECTORS_DIR, 'built-in.ts'), 'utf8');
+    expect(builtInSource).toContain("'./pattern-9-team-unpushed-orphaned-worktree.js'");
+  });
+});

--- a/src/detectors/built-in.ts
+++ b/src/detectors/built-in.ts
@@ -31,5 +31,9 @@ import './pattern-6-subagent-cascade.js';
 import './pattern-7-dispatch-silent-drop.js';
 import './pattern-8-session-reuse-ghost.js';
 
+// Group 3d — pattern-9 team-unpushed-orphaned-worktree (#1288 — registers
+// detector from #1283, which shipped the source without wiring the import).
+import './pattern-9-team-unpushed-orphaned-worktree.js';
+
 // Future detector groups append their imports above. Keep imports
 // alphabetical within each group for predictable registration order.


### PR DESCRIPTION
## Summary

PR #1283 shipped `src/detectors/pattern-9-team-unpushed-orphaned-worktree.ts` with its own `registerDetector(...)` side-effect but **never added the import** to `src/detectors/built-in.ts`. `serve.ts` only calls `await import('./built-in.js')` before polling `listDetectors()`, so the pattern-9 detector never wakes in production despite passing its own unit tests. #1283 was effectively a no-op.

## One-line fix

Add the import under a new "Group 3d" block in `built-in.ts`.

## Class fix (ship-but-not-wired smoke test)

Added `src/detectors/__tests__/built-in.test.ts` with a **static source-text check**: for every `pattern-N-<slug>.ts` file in `src/detectors/`, assert that `built-in.ts` contains a matching `import './pattern-N-<slug>.js';` line.

Static scan rather than runtime `import()` + `listDetectors()` because `built-in.ts` itself carries a "Never import this from test code" constraint — doing so pollutes the shared detector registry across the bun:test process. The source-text check catches the exact regression class with zero registry mutation.

**Locally verified** by reverting the `built-in.ts` import: test fails with the missing-import string. Restoring the import turns it green.

Future pattern-N detectors are automatically covered — the next ship-but-not-wired regression breaks CI, not prod.

## Test plan

- [x] `bun run check` → 3488 pass / 0 fail / 8530 expect calls
- [x] Reverse-verified: stashing the built-in.ts import makes the new smoke test fail loudly
- [x] Fixes #1288

🤖 Generated with [Claude Code](https://claude.com/claude-code)