### PR TITLE
fix(broadcast): fire UserPromptSubmit on every idle team member (#1218)

### DIFF
--- a/src/term-commands/agent/send.test.ts
+++ b/src/term-commands/agent/send.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Broadcast fan-out regression tests (#1218).
+ *
+ * Before this fix, `genie broadcast --team <name>` wrote only to the team's
+ * group conversation. Idle members received no pane-side prompt, so at most
+ * one of N members would wake. `deliverBroadcastToMembers` fans the broadcast
+ * out through protocolRouter.sendMessage — the same delivery primitive DMs
+ * use — so every team member's pane gets the UserPromptSubmit.
+ *
+ * Tests inject stubs rather than exercising real protocol-router / team
+ * manager (those have their own test suites) so this file stays deterministic
+ * and free of tmux/PG dependencies.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { type BroadcastFanoutDeps, type BroadcastFanoutResult, deliverBroadcastToMembers } from './send.js';
+
+type SendCall = {
+  repo: string;
+  from: string;
+  to: string;
+  body: string;
+  teamName?: string;
+};
+
+function buildDeps(opts: {
+  members: string[] | null;
+  onSend?: (call: SendCall) => { delivered: boolean; reason?: string };
+}): { deps: BroadcastFanoutDeps; calls: SendCall[] } {
+  const calls: SendCall[] = [];
+  const deps: BroadcastFanoutDeps = {
+    listMembers: async (_teamName) => opts.members,
+    sendMessage: async (repo, from, to, body, teamName) => {
+      const call = { repo, from, to, body, teamName };
+      calls.push(call);
+      const outcome = opts.onSend?.(call) ?? { delivered: true };
+      return {
+        messageId: `msg-${to}`,
+        workerId: to,
+        delivered: outcome.delivered,
+        reason: outcome.reason,
+      };
+    },
+  };
+  return { deps, calls };
+}
+
+describe('deliverBroadcastToMembers (#1218)', () => {
+  test('fires sendMessage for every team member — regression for 4-member council', async () => {
+    const { deps, calls } = buildDeps({
+      members: ['council--questioner', 'council--simplifier', 'council--architect', 'council--measurer'],
+    });
+    const results: BroadcastFanoutResult[] = await deliverBroadcastToMembers(
+      deps,
+      '/repo',
+      'cli',
+      'council-1218',
+      'ROUND 1 — topic ...',
+    );
+
+    expect(results).toHaveLength(4);
+    expect(results.every((r) => r.delivered)).toBe(true);
+    expect(calls.map((c) => c.to).sort()).toEqual([
+      'council--architect',
+      'council--measurer',
+      'council--questioner',
+      'council--simplifier',
+    ]);
+    expect(calls.every((c) => c.body === 'ROUND 1 — topic ...')).toBe(true);
+    expect(calls.every((c) => c.from === 'cli')).toBe(true);
+    expect(calls.every((c) => c.teamName === 'council-1218')).toBe(true);
+  });
+
+  test('elides the sender when the sender is a member of the team', async () => {
+    const { deps, calls } = buildDeps({ members: ['alpha', 'beta', 'gamma'] });
+    await deliverBroadcastToMembers(deps, '/repo', 'beta', 'team', 'msg');
+
+    expect(calls.map((c) => c.to)).toEqual(['alpha', 'gamma']);
+  });
+
+  test('records reason when a single recipient is not delivered', async () => {
+    const { deps } = buildDeps({
+      members: ['live', 'dead'],
+      onSend: ({ to }) => (to === 'dead' ? { delivered: false, reason: 'pane died' } : { delivered: true }),
+    });
+
+    const results = await deliverBroadcastToMembers(deps, '/repo', 'cli', 'team', 'x');
+
+    expect(results).toEqual([
+      { member: 'live', delivered: true, reason: undefined },
+      { member: 'dead', delivered: false, reason: 'pane died' },
+    ]);
+  });
+
+  test('returns empty array when listMembers returns null (team not found)', async () => {
+    const { deps, calls } = buildDeps({ members: null });
+    const results = await deliverBroadcastToMembers(deps, '/repo', 'cli', 'ghost', 'x');
+
+    expect(results).toEqual([]);
+    expect(calls).toEqual([]);
+  });
+
+  test('catches thrown errors from sendMessage and continues fan-out', async () => {
+    // One recipient throws; the rest still receive the broadcast. Guard
+    // against the obvious failure mode where a single crashed pane aborts
+    // delivery for every subsequent member.
+    const { deps, calls } = buildDeps({
+      members: ['a', 'b', 'c'],
+      onSend: ({ to }) => {
+        if (to === 'b') throw new Error('boom');
+        return { delivered: true };
+      },
+    });
+
+    const results = await deliverBroadcastToMembers(deps, '/repo', 'cli', 'team', 'x');
+
+    expect(calls.map((c) => c.to)).toEqual(['a', 'b', 'c']);
+    expect(results).toHaveLength(3);
+    expect(results[0]).toEqual({ member: 'a', delivered: true, reason: undefined });
+    expect(results[1]).toEqual({ member: 'b', delivered: false, reason: 'boom' });
+    expect(results[2]).toEqual({ member: 'c', delivered: true, reason: undefined });
+  });
+
+  test('preserves member order (important for deterministic CLI output)', async () => {
+    const { deps, calls } = buildDeps({ members: ['zeta', 'alpha', 'beta'] });
+    const results = await deliverBroadcastToMembers(deps, '/repo', 'cli', 'team', 'x');
+
+    expect(results.map((r) => r.member)).toEqual(['zeta', 'alpha', 'beta']);
+    expect(calls.map((c) => c.to)).toEqual(['zeta', 'alpha', 'beta']);
+  });
+});

--- a/src/term-commands/agent/send.ts
+++ b/src/term-commands/agent/send.ts
@@ -187,6 +187,74 @@ async function handleDirectMessage(from: string, to: string, body: string, team?
 // Broadcast (--broadcast)
 // ============================================================================
 
+/**
+ * Per-member fan-out result for a broadcast. Surfaced to the caller so the
+ * CLI can report which recipients woke and which did not (#1218).
+ */
+export interface BroadcastFanoutResult {
+  member: string;
+  delivered: boolean;
+  reason?: string;
+}
+
+/**
+ * Injectable dependencies for `deliverBroadcastToMembers`. Matches the
+ * `_deps` pattern used in `src/lib/protocol-router.ts` — avoids `mock.module`
+ * in tests (which leaks across bun:test files) while still letting callers
+ * inject stubs for listMembers / sendMessage.
+ */
+export interface BroadcastFanoutDeps {
+  listMembers: (teamName: string) => Promise<string[] | null>;
+  sendMessage: (
+    repoPath: string,
+    from: string,
+    to: string,
+    body: string,
+    teamName?: string,
+  ) => Promise<{ messageId: string; workerId: string; delivered: boolean; reason?: string }>;
+}
+
+/**
+ * Fan out a broadcast to every team member via `protocolRouter.sendMessage`
+ * so each idle recipient gets pane-injected (fires UserPromptSubmit) the
+ * same way a DM does. The previous broadcast implementation only wrote a
+ * group conversation row, which meant at most one member (the one whose
+ * native-team client happened to observe the team conversation log) would
+ * wake — the other N-1 stayed idle indefinitely. Bug #1218.
+ *
+ * Delivery to each member is best-effort and independent: a pane death or
+ * thrown exception on one recipient never aborts the fan-out. Per-member
+ * outcomes are returned so callers can surface them to the operator.
+ *
+ * Self-delivery is elided at the fan-out layer (earlier than protocol-router's
+ * own `from === to` guard) so the results array doesn't include a no-op entry
+ * for the sender.
+ */
+export async function deliverBroadcastToMembers(
+  deps: BroadcastFanoutDeps,
+  repoPath: string,
+  from: string,
+  teamName: string,
+  body: string,
+): Promise<BroadcastFanoutResult[]> {
+  const members = (await deps.listMembers(teamName)) ?? [];
+  const results: BroadcastFanoutResult[] = [];
+  for (const member of members) {
+    if (member === from) continue;
+    try {
+      const r = await deps.sendMessage(repoPath, from, member, body, teamName);
+      results.push({ member, delivered: r.delivered, reason: r.reason });
+    } catch (err) {
+      results.push({
+        member,
+        delivered: false,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return results;
+}
+
 async function handleBroadcast(from: string, body: string, team?: string): Promise<void> {
   const taskService = await import('../../lib/task-service.js');
   const repoPath = process.cwd();
@@ -227,7 +295,26 @@ async function handleBroadcast(from: string, body: string, team?: string): Promi
     // Silent degradation
   }
 
+  // Fan out UserPromptSubmit to every team member (#1218).
+  const { listMembers } = await import('../../lib/team-manager.js');
+  const protocolRouter = await import('../../lib/protocol-router.js');
+  const fanoutResults = await deliverBroadcastToMembers(
+    { listMembers, sendMessage: protocolRouter.sendMessage },
+    repoPath,
+    from,
+    teamName,
+    body,
+  );
+
   console.log(`Broadcast sent to team "${teamName}".`);
   console.log(`  Message ID: ${msg.id}`);
   console.log(`  Conversation: ${conv.id}`);
+
+  const deliveredCount = fanoutResults.filter((r) => r.delivered).length;
+  console.log(`  Fan-out: ${deliveredCount}/${fanoutResults.length} members reached`);
+  for (const r of fanoutResults) {
+    if (!r.delivered) {
+      console.log(`    ⚠ ${r.member}: ${r.reason ?? 'delivery failed'}`);
+    }
+  }
 }


### PR DESCRIPTION
## Summary

`genie broadcast <msg> --team <team>` previously wrote only to the team's group conversation row via `taskService.sendMessage`. Idle members had **no pane-side prompt injected** — at most one member (the one whose native-team UI happened to surface the team chat) would wake. In Felipe's 4-member council repro, only 1 of 4 members transitioned `idle → running`; the other 3 stayed silent and never fired `UserPromptSubmit`. The `/council` skill (and any future broadcast-as-prompt-fanout flow) silently broke on 75%+ of recipients.

## Fix

After writing the group conversation row, fan the broadcast out across `listMembers(teamName)` via `protocolRouter.sendMessage` — the same delivery primitive a DM uses. Each member's pane gets the same UserPromptSubmit-triggering injection (mailbox → native inbox → pane send-keys) that the DM path already runs.

## Design

- Extracted `deliverBroadcastToMembers(deps, repoPath, from, teamName, body)` as an injectable, testable helper. `deps = { listMembers, sendMessage }` matches the `_deps` pattern in `protocol-router.ts`, avoiding `mock.module` (which leaks across `bun:test` files).
- **Self-delivery is elided at the fan-out layer** so the sender doesn't appear as a no-op entry in the results array. (protocol-router's own `from === to` guard would have suppressed it too, but excluding early keeps the CLI output clean.)
- **Per-recipient independence**: thrown exceptions and pane-death outcomes are captured per-member. One dead pane never aborts the fan-out for the rest.
- CLI output now shows `Fan-out: N/M members reached` with per-failure reasons — operator sees immediate signal when delivery degrades.

## Test plan

- [x] 6 regression tests in `src/term-commands/agent/send.test.ts`:
  1. 4-member council repro — all 4 members receive `sendMessage`, not just 1
  2. Self-elision — sender excluded when in `members[]`
  3. Per-recipient `delivered:false` reason propagates
  4. `listMembers → null` returns empty array cleanly (team not found)
  5. Thrown exceptions caught per-recipient, fan-out continues
  6. Member order preserved (deterministic CLI output)
- [x] `bun run check` — 3494 pass / 0 fail / 8547 expect calls across 201 files

## Scope

Minimal. Does not alter DM path, hierarchy ACL, or scope enforcement. Does not introduce the "fan-out only to idle members" filter the issue body mentions — it's unnecessary (writing to a running member's inbox is harmless, gets picked up on their next turn) and would add fragile registry-state dependencies.

Fixes #1218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)