### PR TITLE
fix(detector): truncate team-ls-drift payload before emit (#1291)

### DIFF
--- a/src/detectors/__tests__/pattern-2-team-ls-drift.test.ts
+++ b/src/detectors/__tests__/pattern-2-team-ls-drift.test.ts
@@ -257,4 +257,68 @@ describe('pattern-2 team-ls-drift detector', () => {
     expect(ids).toContain(DETECTOR_ID);
     expect(DETECTOR_ID).toBe('rot.team-ls-drift');
   });
+
+  test('#1291 — pathological drift (1000 ghosts) stays under schema cap and flags truncation', async () => {
+    // Before #1291: the detector's per-list caps (200 snapshots + 100 divergent
+    // entries) were individually small but compounded past the schema's
+    // 16_384-char `observed_state_json` limit — every emit was rejected by
+    // Zod and 100 % of the rot.team-ls-drift signal was lost. This fixture
+    // reproduces the overflow and proves the fallback-summary path lands a
+    // valid event with `observed_state_json_truncated: true`.
+    const ghostCount = 1000;
+    const lsRows: LsSnapshotEntry[] = Array.from({ length: ghostCount }, (_, i) => ({
+      name: `ghost-team-with-a-reasonably-long-name-${i}`,
+      status: 'in_progress',
+      worktreePath: `/tmp/fake-worktree-${i}`,
+    }));
+    // Zero overlap with disband dirs → every PG row is `missing_in_disband`.
+    const disbandDirs: DisbandSnapshotEntry[] = [];
+    const existingPaths = new Set<string>(lsRows.map((r) => r.worktreePath));
+
+    const detector = makeTeamLsDriftDetector(makeSources(lsRows, disbandDirs, existingPaths));
+    const { captured } = await driveOneTick(detector);
+
+    const rotFires = captured.filter((c) => c.type === 'rot.team-ls-drift.detected');
+    expect(rotFires.length).toBe(1);
+
+    const evt = rotFires[0];
+    expect(evt.payload.divergent_count).toBe(ghostCount);
+    expect(evt.payload.observed_state_json_truncated).toBe(true);
+
+    // Emitted string must fit under the schema cap so Zod parse succeeds.
+    const observedJson = String(evt.payload.observed_state_json);
+    expect(observedJson.length).toBeLessThanOrEqual(16_384);
+
+    // Summary JSON round-trips and preserves totals for downstream triage.
+    const observed = JSON.parse(observedJson);
+    expect(observed.divergent_total).toBe(ghostCount);
+    expect(observed.ls_total).toBe(ghostCount);
+    expect(observed.disband_total).toBe(0);
+    expect(observed.divergence_kind).toBe('missing_in_disband');
+    expect(Array.isArray(observed.divergent_ids)).toBe(true);
+    expect(observed.divergent_ids.length).toBeGreaterThan(0);
+    expect(typeof observed.truncation_reason).toBe('string');
+
+    // Schema parse must succeed — this is the regression assertion that
+    // ties the fix to the 100 %-signal-loss bug.
+    const { getEntry } = await import('../../lib/events/registry.js');
+    const entry = getEntry('rot.team-ls-drift.detected');
+    expect(entry).not.toBeNull();
+    const result = entry!.schema.safeParse(evt.payload);
+    if (!result.success) {
+      console.error('schema parse failed', result.error.issues);
+    }
+    expect(result.success).toBe(true);
+  });
+
+  test('#1291 — normal drift emits without truncation flag', async () => {
+    // Belt-and-braces: confirm the flag is strictly present-on-truncate so
+    // consumers can use `if (payload.observed_state_json_truncated)` without
+    // worrying about accidental `false` values being emitted.
+    const lsRows: LsSnapshotEntry[] = [{ name: 'ghost', status: 'in_progress', worktreePath: '/tmp/ghost' }];
+    const detector = makeTeamLsDriftDetector(makeSources(lsRows, [], new Set(['/tmp/ghost'])));
+    const { captured } = await driveOneTick(detector);
+
+    expect(captured[0].payload.observed_state_json_truncated).toBeUndefined();
+  });
 });

--- a/src/detectors/pattern-2-team-ls-drift.ts
+++ b/src/detectors/pattern-2-team-ls-drift.ts
@@ -103,6 +103,17 @@ const DETECTOR_VERSION = '0.1.0';
 const MAX_DIVERGENT_IN_EVENT = 100;
 /** Hard cap on snapshot length emitted — detector trims before serialization. */
 const MAX_SNAPSHOT_IN_EVENT = 200;
+/**
+ * Mirror of the schema's `observed_state_json.max(16_384)` — the detector
+ * self-enforces *before* emit so a pathological input falls back to a
+ * compact summary instead of tripping Zod validation and dumping the event
+ * into `schema.violation`. Bug #1291: the per-entry caps above don't
+ * compound-cap, so 100 × (180-char reason) + 200 × {name,status} + 200 × dir
+ * routinely overflows 16 KiB even though each individual slice looks small.
+ */
+const MAX_OBSERVED_STATE_JSON_CHARS = 16_384;
+/** Ids kept in the summary fallback — large enough to triage, small enough to fit. */
+const SUMMARY_DIVERGENT_ID_CAP = 20;
 
 // ---------------------------------------------------------------------------
 // Query + comparison logic
@@ -183,9 +194,11 @@ function primaryDivergenceKind(divergent: ReadonlyArray<DivergentTeam>): Diverge
 }
 
 /**
- * Build the event payload. We cap both snapshots and the divergent list so
- * the `observed_state_json` string honours the schema's 16 KiB limit even
- * when the detector sees a flood of ghost teams.
+ * Build the event payload. The per-list caps above trim individual slices,
+ * but their product can still overflow 16 KiB — so after serializing we
+ * measure and, if we're over, fall back to a compact summary that carries
+ * only totals + the top-N divergent ids. Downstream consumers see
+ * `observed_state_json_truncated: true` and know detail was dropped.
  */
 function renderPayload(state: TeamLsDriftState): Record<string, unknown> {
   const primary = primaryDivergenceKind(state.divergent);
@@ -207,10 +220,30 @@ function renderPayload(state: TeamLsDriftState): Record<string, unknown> {
     divergent_total: state.divergent.length,
   };
 
+  let observedJson = JSON.stringify(observed);
+  let truncated = false;
+
+  if (observedJson.length > MAX_OBSERVED_STATE_JSON_CHARS) {
+    truncated = true;
+    const summary = {
+      divergence_kind: primary,
+      divergent_ids: divergentTrimmed.slice(0, SUMMARY_DIVERGENT_ID_CAP).map((d) => d.team_id),
+      ls_total: state.ls_snapshot.length,
+      disband_total: state.disband_snapshot.length,
+      divergent_total: state.divergent.length,
+      truncation_reason: 'detail payload exceeded observed_state_json cap',
+    };
+    observedJson = JSON.stringify(summary);
+    if (observedJson.length > MAX_OBSERVED_STATE_JSON_CHARS) {
+      observedJson = observedJson.slice(0, MAX_OBSERVED_STATE_JSON_CHARS);
+    }
+  }
+
   return {
     divergence_kind: primary,
     divergent_count: state.divergent.length,
-    observed_state_json: JSON.stringify(observed),
+    observed_state_json: observedJson,
+    ...(truncated ? { observed_state_json_truncated: true as const } : {}),
   };
 }
 

--- a/src/lib/events/schemas/rot.team-ls-drift.detected.ts
+++ b/src/lib/events/schemas/rot.team-ls-drift.detected.ts
@@ -70,11 +70,25 @@ const ObservedStateJsonSchema = tagTier(
   'JSON-encoded snapshot of both data sources for triage',
 );
 
+/**
+ * Flag set by the detector when the natural payload would exceed
+ * `observed_state_json`'s 16 KiB cap, so it falls back to a compact summary.
+ * Absent when full detail fits. Literal-true shape (no `false` value) so
+ * consumers can use `if (payload.observed_state_json_truncated)` without
+ * a tri-state check.
+ */
+const ObservedStateJsonTruncatedSchema = tagTier(
+  z.literal(true).optional(),
+  'C',
+  'set when detail was dropped to honor the observed_state_json cap',
+);
+
 export const schema = z
   .object({
     divergence_kind: DivergenceKindSchema,
     divergent_count: DivergentCountSchema,
     observed_state_json: ObservedStateJsonSchema,
+    observed_state_json_truncated: ObservedStateJsonTruncatedSchema,
   })
   .strict();
 


### PR DESCRIPTION
## Summary

- **Bug (#1291, HIGH severity)**: `rot.team-ls-drift.detected` was emitting at ~2/min but 100% of events were rejected by Zod — `observed_state_json` routinely exceeded the schema's 16 KiB cap. The detector's per-list caps (200 snapshots + 100 divergent entries × ~180-char reason strings) compound well past the cap, but the code path never measured the serialized length before emit. Net: 100% signal loss on a real rot pattern + ~2/min wasted `schema.violation` bandwidth.
- **Fix**: After building the detail JSON, measure it. If it exceeds 16 KiB, fall back to a compact summary (totals + top-20 divergent ids + truncation_reason) and flag `observed_state_json_truncated: true` on the payload so downstream consumers know detail was dropped.
- **Schema**: Optional `observed_state_json_truncated` field added as `z.literal(true).optional()` — present-on-truncate only, so consumers use `if (payload.observed_state_json_truncated)` without a tri-state check.

## Why the caps were aspirational

The comment on `MAX_DIVERGENT_IN_EVENT = 100` and `MAX_SNAPSHOT_IN_EVENT = 200` claimed they "cap the per-event payload before serialization" — but that's per-list trimming, not byte-level. A single `divergent_detail` entry with the long `missing_in_disband` reason string is ~180 chars; 100 × 180 = 18 KiB before either snapshot array is added.

## Test plan

- [x] New regression test seeds 1000 ghost teams → asserts event fires, fits ≤16 KiB, carries `observed_state_json_truncated: true`, and `schema.safeParse` succeeds.
- [x] Second test guards that normal (non-pathological) drift omits the flag entirely, so literal-true discipline holds.
- [x] Verified regression catches the pre-fix bug: `git stash` on the detector/schema changes → new test fails with `Expected: true / Received: undefined`, exactly the shape of the live signal loss.
- [x] Full `bun run check` passes: 3496 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)