### PR TITLE
fix(hooks): bypass workspace guard on `genie hook dispatch` (#1295)

### DIFF
--- a/src/__tests__/interactivity.test.ts
+++ b/src/__tests__/interactivity.test.ts
@@ -189,6 +189,25 @@ describe('commandRequiresWorkspace()', () => {
     const create = team.command('create');
     expect(commandRequiresWorkspace(create)).toBe(false);
   });
+
+  test('#1295 — returns false for hook namespace (root command)', () => {
+    // Regression guard: CC calls `genie hook dispatch` on every PreToolUse /
+    // Stop / UserPromptSubmit event, from any cwd the editor happens to be
+    // in. A non-zero exit here blocks every tool call on the host.
+    const program = new Command();
+    const hook = program.command('hook');
+    expect(commandRequiresWorkspace(hook)).toBe(false);
+  });
+
+  test('#1295 — returns false for hook dispatch subcommand', () => {
+    // The actual invocation shape Claude Code uses — `hook dispatch` must
+    // bypass the workspace guard so a missing `.genie/` never bubbles up as
+    // exit 2.
+    const program = new Command();
+    const hook = program.command('hook');
+    const dispatch = hook.command('dispatch');
+    expect(commandRequiresWorkspace(dispatch)).toBe(false);
+  });
 });
 
 // ─── ensureWorkspace() ──────────────────────────────────────────────────────
@@ -345,5 +364,43 @@ describe('installWorkspaceCheck()', () => {
     expect(actionFn).toHaveBeenCalledTimes(1);
     // No prompt because workspace exists
     expect(mockConfirm).not.toHaveBeenCalled();
+  });
+
+  test('#1295 — hook dispatch runs to completion even when no workspace exists', async () => {
+    // Fleet-breaking regression in 4.260421.30: `genie hook dispatch` exited
+    // with code 2 whenever cwd lacked `.genie/`, because the pre-fix
+    // WORKSPACE_EXEMPT set didn't include `hook` and stdin was piped
+    // (non-interactive → exit 2 path). CC treated the non-zero as a blocking
+    // deny and every Bash/Read/Edit/etc. tool call died on the host.
+    //
+    // This test drives the real preAction hook with a null workspace and
+    // asserts the hook action runs without triggering the init prompt and
+    // without calling process.exit. If someone removes `'hook'` from the
+    // exempt set, this test fails the same way the live fleet did.
+    Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+    // biome-ignore lint/performance/noDelete: process.env requires delete
+    delete process.env.CI;
+    process.argv = ['node', 'genie', 'hook', 'dispatch'];
+    findWorkspaceSpy.mockReturnValue(null);
+
+    const actionFn = mock(async () => {});
+    const exitSpy = spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit should not be called for hook dispatch');
+    });
+
+    try {
+      const program = new Command();
+      const hook = program.command('hook');
+      hook.command('dispatch').action(actionFn);
+      installWorkspaceCheck(program);
+
+      await program.parseAsync(['node', 'genie', 'hook', 'dispatch']);
+
+      expect(actionFn).toHaveBeenCalledTimes(1);
+      expect(mockConfirm).not.toHaveBeenCalled();
+      expect(exitSpy).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+    }
   });
 });

--- a/src/lib/interactivity.ts
+++ b/src/lib/interactivity.ts
@@ -31,6 +31,16 @@ export function isInteractive(): boolean {
 /**
  * Commands that do NOT require a workspace.
  * These are matched against the root-level command name (first subcommand under `genie`).
+ *
+ * `hook` is exempt because Claude Code calls `genie hook dispatch` on every
+ * PreToolUse / Stop / UserPromptSubmit event from whatever cwd the user's
+ * editor or terminal happens to be in — often far outside any `.genie/`
+ * workspace. If the hook exits non-zero (which `ensureWorkspace` did for
+ * any missing-workspace cwd, because hook stdin is piped so `isInteractive`
+ * is always false), Claude Code treats it as a blocking deny and the tool
+ * call dies. That was the fleet-breaking P0 regression in #1295: one
+ * non-zero exit from a single hook invocation blocks every tool call on
+ * the host. Hooks must never gate on environmental state.
  */
 const WORKSPACE_EXEMPT = new Set([
   'init',
@@ -42,6 +52,7 @@ const WORKSPACE_EXEMPT = new Set([
   'team',
   'version',
   'help',
+  'hook',
 ]);
 
 /**


### PR DESCRIPTION
## Summary

P0 fleet-breaker in 4.260421.30: `genie hook dispatch` exited with code 2 whenever the invoking cwd lacked `.genie/`. Claude Code calls the dispatcher on every PreToolUse / Stop / UserPromptSubmit event — often from the editor's cwd or an arbitrary terminal — so a single missing-workspace exit was interpreted as a blocking deny and every Bash/Read/Edit/etc. tool call on the host died. Global binary was rolled back to 4.260421.28 at 20:43 UTC as temp mitigation.

## Root cause

`WORKSPACE_EXEMPT` in `src/lib/interactivity.ts` lists every command that should skip the workspace guard (init, setup, doctor, …) — but the `hook` namespace was missing. The `preAction` Commander hook therefore called `ensureWorkspace()`; hook stdin is always piped so `isInteractive()` returned false; that branch `process.exit(2)`s. Hooks must never gate on environmental state.

## Fix

- Add `'hook'` to `WORKSPACE_EXEMPT` with a commented rationale so a future exemption-list audit doesn't remove it.

## Test plan

- [x] `commandRequiresWorkspace(hook)` → false — regression guard for the root `hook` namespace.
- [x] `commandRequiresWorkspace(hook.dispatch)` → false — the actual invocation shape Claude Code uses.
- [x] End-to-end drive through `installWorkspaceCheck(program)` with a null workspace: action runs, no init prompt, `process.exit` never called — mirrors the live CC invocation path.
- [x] Verified regression behavior by stashing the fix — all three new tests fail exactly where the live fleet did, proving they guard the P0 class.
- [x] `bun run check` → 3499 pass, 0 fail.

## Unblocks

Global binary rollback from 4.260421.28 → latest resumes once this lands on dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)