### PR TITLE
fix(detectors): team-lead predicate uses reports_to parentage (#1296 #1298)

### DIFF
--- a/src/detectors/pattern-5-zombie-team-lead.ts
+++ b/src/detectors/pattern-5-zombie-team-lead.ts
@@ -24,6 +24,7 @@
 
 import { getConnection } from '../lib/db.js';
 import { type DetectorEvent, type DetectorModule, registerDetector } from './index.js';
+import { teamLeadPredicate } from './shared/team-leads.js';
 
 /** Agent states that count as "alive and polling". Matches the PG CHECK constraint. */
 const ALIVE_STATES = ['spawning', 'working', 'idle', 'permission', 'question'] as const;
@@ -76,7 +77,7 @@ export function createZombieTeamLeadDetector(opts?: {
       WITH active_leads AS (
         SELECT id, team, state
           FROM agents
-         WHERE role = 'team-lead'
+         WHERE ${teamLeadPredicate(sql)}
            AND team IS NOT NULL
            AND state = ANY(${sql.array([...ALIVE_STATES])})
       ),

--- a/src/detectors/pattern-9-team-unpushed-orphaned-worktree.ts
+++ b/src/detectors/pattern-9-team-unpushed-orphaned-worktree.ts
@@ -45,6 +45,7 @@ import { execFile } from 'node:child_process';
 import { statSync } from 'node:fs';
 import { getConnection } from '../lib/db.js';
 import { type DetectorEvent, type DetectorModule, registerDetector } from './index.js';
+import { teamLeadPredicate } from './shared/team-leads.js';
 
 /** Executor states that count as "alive and making progress". Matches migration 012 CHECK. */
 const LIVE_EXECUTOR_STATES = ['running', 'spawning'] as const;
@@ -214,7 +215,7 @@ export function createTeamUnpushedOrphanedWorktreeDetector(opts?: {
       team_leads AS (
         SELECT DISTINCT ON (team) team, id AS lead_agent_id, state AS lead_state
           FROM agents
-         WHERE role = 'team-lead'
+         WHERE ${teamLeadPredicate(sql)}
            AND team IS NOT NULL
          ORDER BY team, created_at DESC
       )

--- a/src/detectors/shared/__tests__/team-leads.test.ts
+++ b/src/detectors/shared/__tests__/team-leads.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Regression tests for the shared team-lead predicate (issues #1296 / #1298).
+ *
+ * Both detectors historically used `WHERE role = 'team-lead'` which matched
+ * zero rows because `agents.role` stores the agent's identity (e.g.,
+ * `'brain'`, `'engineer'`) rather than a role-type. The fix moves the
+ * signal onto the `reports_to` parentage FK.
+ *
+ * These tests seed real PG rows (via `setupTestSchema`) with roles that
+ * are NOT the literal string `'team-lead'`, and assert the detectors
+ * still classify them correctly based on parentage — proving the broken
+ * role-based predicate is gone and the parentage-based one is in place.
+ *
+ * The tests run the detectors' default (non-injected) queries so the
+ * assertions exercise the actual SQL that ships in production, not a
+ * stub.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { getConnection } from '../../../lib/db.js';
+import { DB_AVAILABLE, setupTestSchema } from '../../../lib/test-db.js';
+import { createZombieTeamLeadDetector } from '../../pattern-5-zombie-team-lead.js';
+import { createTeamUnpushedOrphanedWorktreeDetector } from '../../pattern-9-team-unpushed-orphaned-worktree.js';
+
+describe.skipIf(!DB_AVAILABLE)('shared team-lead predicate (#1296, #1298)', () => {
+  let cleanup: () => Promise<void>;
+
+  beforeAll(async () => {
+    cleanup = await setupTestSchema();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  beforeEach(async () => {
+    const sql = await getConnection();
+    await sql`DELETE FROM executors`;
+    await sql`DELETE FROM agents`;
+    await sql`DELETE FROM teams`;
+  });
+
+  async function seedTeamWithLead(params: {
+    leadId: string;
+    childId: string;
+    team: string;
+    leadRole?: string;
+    leadState?: string;
+  }): Promise<void> {
+    const sql = await getConnection();
+    const leadRole = params.leadRole ?? 'brain';
+    const leadState = params.leadState ?? 'idle';
+    // `role` is seeded with a realistic identity (NOT the literal
+    // 'team-lead') so the assertion demonstrates the predicate does
+    // not look at this column.
+    await sql`
+      INSERT INTO agents (id, pane_id, session, state, repo_path, started_at, team, role)
+      VALUES (${params.leadId}, '%1', 'sess', ${leadState}, '/tmp/test', now(), ${params.team}, ${leadRole})
+    `;
+    await sql`
+      INSERT INTO agents (id, pane_id, session, state, repo_path, started_at, team, role, reports_to)
+      VALUES (${params.childId}, '%2', 'sess', 'working', '/tmp/test', now(), ${params.team}, 'engineer', ${params.leadId})
+    `;
+  }
+
+  test('pattern-5 fires on lead identified via reports_to parentage (role="brain", not "team-lead")', async () => {
+    await seedTeamWithLead({
+      leadId: 'lead-p5',
+      childId: 'child-p5',
+      team: 'team-p5',
+      leadRole: 'brain',
+      leadState: 'idle',
+    });
+
+    // Default query path — no override. The shared predicate must classify
+    // the seeded row as a team-lead via the `reports_to` FK despite
+    // `role != 'team-lead'`. No runtime events means last_activity_ms is
+    // null, which pattern-5 treats as zombie.
+    const detector = createZombieTeamLeadDetector({ idleMinutes: 5 });
+    const state = await detector.query();
+
+    expect(state.zombies.length).toBe(1);
+    expect(state.zombies[0].lead_agent_id).toBe('lead-p5');
+    expect(state.zombies[0].team).toBe('team-p5');
+    expect(state.zombies[0].lead_state).toBe('idle');
+  });
+
+  test('pattern-5 ignores a lone agent with role="team-lead" but no children via reports_to', async () => {
+    const sql = await getConnection();
+    // Seed the exact shape the broken predicate used to match: an agent
+    // whose `role` column literally equals 'team-lead' but has no
+    // children pointing at it via `reports_to`. The fix must exclude it.
+    await sql`
+      INSERT INTO agents (id, pane_id, session, state, repo_path, started_at, team, role)
+      VALUES ('solo-lead', '%3', 'sess', 'idle', '/tmp/test', now(), 'solo-team', 'team-lead')
+    `;
+
+    const detector = createZombieTeamLeadDetector({ idleMinutes: 5 });
+    const state = await detector.query();
+
+    expect(state.zombies.length).toBe(0);
+  });
+
+  test('pattern-9 emits non-null lead_agent_id/lead_state via reports_to parentage', async () => {
+    const sql = await getConnection();
+    await seedTeamWithLead({
+      leadId: 'lead-p9',
+      childId: 'child-p9',
+      team: 'team-p9',
+      leadRole: 'felipe-alpha',
+      leadState: 'working',
+    });
+    await sql`
+      INSERT INTO teams (name, repo, base_branch, worktree_path, status)
+      VALUES ('team-p9', '/tmp/repo', 'dev', '/tmp/worktree-p9', 'in_progress')
+    `;
+
+    // No executor row → last_executor_active_ms is null → treated as idle
+    // past threshold. Stub git probe so the detector classifies the row
+    // as stalled and we can observe the joined lead_agent_id/lead_state.
+    const detector = createTeamUnpushedOrphanedWorktreeDetector({
+      idleMinutes: 10,
+      gitProbe: async () => ({ ok: true, branch_ahead_count: 3, last_commit_ms: Date.now() - 60_000 }),
+    });
+    const state = await detector.query();
+
+    expect(state.stalled.length).toBe(1);
+    expect(state.stalled[0].row.team_name).toBe('team-p9');
+    expect(state.stalled[0].row.lead_agent_id).toBe('lead-p9');
+    expect(state.stalled[0].row.lead_state).toBe('working');
+  });
+});

--- a/src/detectors/shared/team-leads.ts
+++ b/src/detectors/shared/team-leads.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared team-lead identification primitives for rot detectors.
+ *
+ * Both the Pattern 5 (rot.zombie-team-lead) and Pattern 9
+ * (rot.team-unpushed-orphaned-worktree) detectors need to identify which
+ * rows in the `agents` table are team-leads. The historical predicate
+ * `WHERE role = 'team-lead'` matched zero rows in production: the
+ * `agents.role` column stores the agent's identity (e.g., `'brain'`,
+ * `'engineer'`, `'felipe-alpha'`), not a role-type. Both detectors
+ * shipped "dead" — Pattern 5 never fired, Pattern 9 emitted
+ * `lead_agent_id=null` / `lead_state=null` in 100% of its events
+ * (issues #1296 and #1298).
+ *
+ * The correct signal is parentage: the `reports_to` FK on `agents` is
+ * set on child agents whose parent spawned them, so an agent `a` is a
+ * team-lead when at least one other row has `reports_to = a.id`. The
+ * column was added in migration `012_executor_model.sql` specifically
+ * to encode this relationship. This predicate is the single source of
+ * truth for "is this agent a team-lead?" and any future detector that
+ * needs the same classification should import from here.
+ */
+
+import type { Sql } from '../../lib/db.js';
+
+/**
+ * SQL fragment: "this row in `agents` is a team-lead".
+ *
+ * Returns a postgres.js fragment compatible with tagged-template
+ * interpolation — embed as `${teamLeadPredicate(sql)}` inside a
+ * larger `sql\`\`` query. The fragment has no dynamic bindings, so the
+ * cost of building it is negligible and the call is pure.
+ *
+ * Naming note: the fragment uses the unaliased column `id`, so the
+ * caller's `FROM agents` (or a CTE with `agents` as the root table)
+ * must not shadow that column. Every existing caller — Patterns 5
+ * and 9 — already does `FROM agents` without aliasing, so this is a
+ * drop-in replacement for the dead `role = 'team-lead'` predicate.
+ */
+export function teamLeadPredicate(sql: Sql) {
+  return sql`id IN (SELECT DISTINCT reports_to FROM agents WHERE reports_to IS NOT NULL)`;
+}


### PR DESCRIPTION
## Summary

Fixes **both** [#1296](https://github.com/namastexlabs/automagik-genie/issues/1296) and [#1298](https://github.com/namastexlabs/automagik-genie/issues/1298) in one commit — they share a root cause.

Both pattern-5 (`rot.zombie-team-lead`) and pattern-9 (`rot.team-unpushed-orphaned-worktree`) shipped dead against production data. Their SQL filtered on `agents.role = 'team-lead'`, but `agents.role` stores the agent's **identity** (e.g., `'brain'`, `'engineer'`, `'felipe-alpha'`) — never the literal string `'team-lead'`.

- Pattern 5 never fired at all.
- Pattern 9 fired but emitted `lead_agent_id=null` / `lead_state=null` in 100% of its events because the `LEFT JOIN team_leads` never matched.

## Root cause

`agents.role` is the identity, not a role-type. The real signal for "is this row a team-lead?" is **parentage**: the `reports_to` FK (added in migration `012_executor_model.sql`) points each child agent at its spawning parent. An agent `a` is a team-lead iff at least one other row has `reports_to = a.id`.

## Fix

Extracted the predicate into a shared `teamLeadPredicate(sql)` fragment at `src/detectors/shared/team-leads.ts`. Both detectors import and interpolate it in place of the dead `role = 'team-lead'` filter. A single source of truth means any future detector that needs the same classification imports from one place — no more drift.

## Regression coverage

New tests at `src/detectors/shared/__tests__/team-leads.test.ts` seed real PG rows (via `setupTestSchema`) and exercise each detector's **default SQL** — not a stubbed query — proving:

1. **pattern-5 fires on correct parentage** — lead row with `role='brain'` (NOT `'team-lead'`) and a child via `reports_to` is classified as a zombie. This was the historical false negative.
2. **pattern-5 ignores fake role-match** — a lone agent with `role='team-lead'` but no children is NOT classified as a zombie. This was the historical false positive the broken predicate would have matched.
3. **pattern-9 joins non-null lead fields** — the `team_leads` CTE returns the lead's `id` and `state` when identified via parentage.

Verified via stash-and-replay: all three tests **fail** against the previous predicate and **pass** against the new one.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run dead-code` — no new findings
- [x] `bun test src/detectors/` — 79/79 pass (13 files)
- [x] `bun test src/detectors/shared/__tests__/team-leads.test.ts` — 3/3 pass
- [x] Regression harness: confirmed 3/3 tests fail on pre-fix predicate, pass on new predicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)