### PR TITLE
feat(detector): rot.team-unpushed-orphaned-worktree (#1250)

### DIFF
--- a/.genie/wishes/team-unpushed-orphaned-worktree/WISH.md
+++ b/.genie/wishes/team-unpushed-orphaned-worktree/WISH.md
@@ -5,6 +5,9 @@
 | **Status** | DRAFT |
 | **Slug** | `team-unpushed-orphaned-worktree` |
 | **Date** | 2026-04-21 |
+| **Author** | felipe |
+| **Appetite** | medium |
+| **Branch** | `team-unpushed-orphaned-worktree` |
 | **Issue** | #1250 — team-create autonomous PR teams complete work but never push branches; no detector fires |
 | **Siblings** | `pattern-5-zombie-team-lead` (nearest neighbor; different failure mode — alive-but-idle vs dead-with-WIP) |
 
@@ -135,10 +138,18 @@ Two waves, parallel where possible.
   - `render()` emits `rot.detected` with `pattern_id: 'pattern-9-team-unpushed-orphaned-worktree'` and the documented evidence shape
   - Side-effect `registerDetector(createTeamUnpushedOrphanedWorktreeDetector())` at module tail
 
+**Acceptance Criteria:**
+- [ ] All three predicates enforced: non-terminal team status, no live executor within the idle window, `branch_ahead_count > 0`.
+- [ ] Probe degradation is total — every non-happy path returns `ok:false` and never throws up the stack.
+- [ ] Event payload carries the full evidence shape (team_name, status, worktree_path, base_branch, branch_ahead_count, last_commit_at, last_executor_active_at, minutes_since_active, threshold_minutes, lead_agent_id, lead_state, total_stalled_teams).
+- [ ] Factory exposes `query`, `gitProbe`, `idleMinutes`, `maxTeamsPerTick`, `gitTimeoutMs`, `version` knobs so tests can drive deterministic timing.
+
 **Validation:**
-- Typecheck clean
-- Lint clean (keep cognitive complexity ≤ 15)
-- Module loads without throwing when required at process start
+```bash
+bun run typecheck && bun run lint
+```
+
+**depends-on:** none
 
 ### Group 2: Tests — `pattern-9-team-unpushed-orphaned-worktree.test.ts`
 
@@ -148,9 +159,18 @@ Two waves, parallel where possible.
 - `src/detectors/__tests__/pattern-9-team-unpushed-orphaned-worktree.test.ts`
 - Reusable `__fixtures__/fake-git-probe.ts` if a factored helper makes the other pattern tests cleaner (optional — only if it reduces duplication)
 
+**Acceptance Criteria:**
+- [ ] Every scenario from the Success Criteria table has a matching test with the injected `query` + `gitProbe` fakes.
+- [ ] No test shells out to real `git`; no test talks to a real Postgres instance.
+- [ ] Negative paths covered: terminal-status exemption, live-executor bypass, `branch_ahead_count == 0`, probe `ok:false` degradation, `idleUnprobed` cap behaviour.
+- [ ] Full `bun test src/detectors/` suite stays green — no regression to patterns 1-8.
+
 **Validation:**
-- `bun test src/detectors/__tests__/pattern-9-team-unpushed-orphaned-worktree.test.ts` — all 9 pass
-- `bun test src/detectors/` — full suite still green (no regression)
+```bash
+bun test src/detectors/__tests__/pattern-9-team-unpushed-orphaned-worktree.test.ts && bun test src/detectors/
+```
+
+**depends-on:** Group 1
 
 ### Group 3: Docs — runbook entry
 
@@ -159,6 +179,18 @@ Two waves, parallel where possible.
 **Deliverables:**
 - New section in `docs/detectors/runbook.md` under the existing detector list
 - Shape: ID, trigger, evidence fields, operator action, severity, related events
+
+**Acceptance Criteria:**
+- [ ] Runbook section exists and is linked from the detector index.
+- [ ] Section documents: detector ID, the three firing predicates, every evidence field emitted, the suggested operator salvage command, severity (`low`), and related detectors (pattern-5 sibling).
+- [ ] Terminology matches the code: field names are identical (`branch_ahead_count`, `minutes_since_active`, `total_stalled_teams`, etc.).
+
+**Validation:**
+```bash
+test -f docs/detectors/runbook.md && grep -q 'pattern-9-team-unpushed-orphaned-worktree' docs/detectors/runbook.md
+```
+
+**depends-on:** Group 1
 
 ### Group 4: Review
 
@@ -169,6 +201,19 @@ Two waves, parallel where possible.
 - `bun run check` green
 - No cognitive-complexity regressions in `pattern-9-*.ts`
 - Docs entry renders correctly in Mintlify
+
+**Acceptance Criteria:**
+- [ ] Every Success Criteria item (SC 1-10) has an explicit pass/fail verdict from the reviewer.
+- [ ] `bun run check` completes without errors or new warnings.
+- [ ] Cognitive complexity of the detector module stays at or below the pre-existing ceiling (≤ 15 per function).
+- [ ] Mintlify preview renders the new runbook section without layout breakage.
+
+**Validation:**
+```bash
+bun run check
+```
+
+**depends-on:** Group 1, Group 2, Group 3
 
 ## Non-goals & follow-up wishes
 

--- a/docs/detectors/runbook.md
+++ b/docs/detectors/runbook.md
@@ -2,7 +2,7 @@
 
 **Audience:** operators tailing `genie events stream-follow --kind='rot.*'` (the live-stream verb that owns runtime event filtering — see PR #1244 for the `*`-glob predicate) who need a mid-incident reference for what a detector event means, why it fires, when it lies, and what to do next.
 
-**Scope:** one section per rot pattern (1–8) shipped under the wish `genie-self-healing-observability-b1-detectors`. Every detector listed here is **read-only** — it observes PG / tmux / filesystem state and emits a `rot.detected` (or `rot.team-ls-drift.detected` for Pattern 2) event. None of them mutate genie state. Remediation is still a human decision in B1; graduation to auto-fix happens per-detector in B2 once fire-rate and false-positive-rate evidence accumulates.
+**Scope:** one section per rot pattern (1–9). Patterns 1–8 shipped under the wish `genie-self-healing-observability-b1-detectors`; Pattern 9 (`rot.team-unpushed-orphaned-worktree`) follows under wish `team-unpushed-orphaned-worktree` (issue #1250). Every detector listed here is **read-only** — it observes PG / tmux / filesystem state and emits a `rot.detected` (or `rot.team-ls-drift.detected` for Pattern 2) event. None of them mutate genie state. Remediation is still a human decision in B1; graduation to auto-fix happens per-detector in B2 once fire-rate and false-positive-rate evidence accumulates.
 
 **Relationship to code:** each pattern lives in a dedicated source file under `src/detectors/`. The scheduler wiring is `src/serve/detector-scheduler.ts`; the plugin API is `src/detectors/index.ts`; the shared event substrate is PR #1213 (`genie_runtime_events`).
 
@@ -20,6 +20,7 @@
 - [Pattern 6 — rot.subagent-cascade](#pattern-6--rotsubagent-cascade)
 - [Pattern 7 — rot.dispatch-silent-drop](#pattern-7--rotdispatch-silent-drop)
 - [Pattern 8 — rot.session-reuse-ghost](#pattern-8--rotsession-reuse-ghost)
+- [Pattern 9 — rot.team-unpushed-orphaned-worktree](#pattern-9--rotteam-unpushed-orphaned-worktree)
 
 ---
 
@@ -447,7 +448,7 @@ Cross-reference with Pattern 4: duplicate-agents fires when the archive propagat
 
 ## Pattern 9 — rot.team-unpushed-orphaned-worktree
 
-**Detector ID:** `rot.team-unpushed-orphaned-worktree` (risk class: high)
+**Detector ID:** `rot.team-unpushed-orphaned-worktree` (risk class: low)
 **Source:** `src/detectors/pattern-9-team-unpushed-orphaned-worktree.ts`
 **Ship status:** pending merge of the Pattern 9 PR (wish `team-unpushed-orphaned-worktree`, tracks issue #1250).
 
@@ -455,7 +456,7 @@ Cross-reference with Pattern 4: duplicate-agents fires when the archive propagat
 
 A non-terminal team (`teams.status NOT IN ('done','blocked','archived')`) has no executor in `running`/`spawning` state within the last `idleMinutes` (default 10), AND its worktree has commits ahead of `origin/<base_branch>` (`git rev-list --count` > 0). The autonomous team finished local work but the leader died before `git push` / PR creation — the branch sits orphaned on disk, no existing detector fires, and `genie wish status` looks nominal.
 
-Felipe's live-observed version (issue #1250): a `team create --wish <slug>` team executes, engineers commit wip, the lead exits cleanly after marking the wish complete — but the branch is never pushed. Hours later the operator notices the PR never opened. The event payload carries `team_name`, `team_status`, `worktree_path`, `base_branch`, `branch_ahead_count`, ISO `last_commit_at`, ISO `last_executor_active_at`, `minutes_since_active`, `threshold_minutes`, `lead_agent_id`, `lead_state`, and `total_stalled_teams`.
+Reference incident (issue #1250, 2026-04-20T23 → 2026-04-21T01 UTC): 6 `docs-pr-*` teams were dispatched in parallel, only 1 opened a PR. The other 5 worktrees had committed-but-unpushed work that had to be salvaged by hand — ~30-45 min of recovery for work that should have been zero-touch. Pattern 9 is the signal that would have surfaced those 5 stalled teams within one tick after they crossed the 10-minute idleness threshold, instead of waiting for the operator to audit manually hours later. The event payload carries `team_name`, `team_status`, `worktree_path`, `base_branch`, `branch_ahead_count`, ISO `last_commit_at`, ISO `last_executor_active_at`, `minutes_since_active`, `threshold_minutes`, `lead_agent_id`, `lead_state`, and `total_stalled_teams`.
 
 ### Known root cause
 


### PR DESCRIPTION
## Summary

Adds **Pattern 9 — `rot.team-unpushed-orphaned-worktree`**: a detector that fires when an autonomous team finishes local work but the leader dies before `git push` / PR creation, leaving committed-but-unpushed work rotting in the worktree.

Predicates (all three must hold):
1. `teams.status NOT IN ('done','blocked','archived')`
2. No agent in the team has an executor in `running`/`spawning` within the last `idleMinutes` window (default 10)
3. Git probe returns `ok:true` with `branch_ahead_count > 0`

V1 is measurement-only — never pushes, never mutates. A future `genie team rescue` command can consume the emitted events.

## What's in this PR

- `src/detectors/pattern-9-team-unpushed-orphaned-worktree.ts` (+331) — SQL query + git probe + `render()` that emits `rot.detected` with the full evidence shape. Factory exposes `query`, `gitProbe`, `idleMinutes`, `maxTeamsPerTick`, `gitTimeoutMs`, `version` knobs.
- `src/detectors/__tests__/pattern-9-team-unpushed-orphaned-worktree.test.ts` (+416) — 12 tests covering every SC predicate + negative paths (exempt status, live-executor bypass, zero-ahead, probe degradation, fire-budget cap, `idleUnprobed` straggler count).
- `docs/detectors/runbook.md` (+71) — full runbook entry: ID, root cause, known false-positive sources, triage bash one-liners.
- `.genie/wishes/team-unpushed-orphaned-worktree/WISH.md` (+50/-5) — metadata completeness + execution-group labels so the wish passes `genie wish lint`.

Tracks issue **#1250**. Reference incident (2026-04-20T23 → 2026-04-21T01 UTC): 6 `docs-pr-*` teams dispatched in parallel, only 1 opened a PR — 5 required manual salvage. Pattern 9 surfaces those within one tick after the 10-minute idleness threshold.

## Test plan

- [x] `bun test src/detectors/__tests__/pattern-9-team-unpushed-orphaned-worktree.test.ts` — 12/12 pass
- [x] `bun run check` — typecheck + lint + dead-code + full test suite (3470 pass / 0 fail / 132s)
- [x] `genie wish lint team-unpushed-orphaned-worktree` — no violations
- [x] Self-review against SC 1-11 (SHIP with SC 8 flagged as post-merge operator smoke-test only)
- [ ] Manual end-to-end (post-merge): spawn team, kill leader, commit in worktree, wait one tick, confirm `rot.detected` fires via `genie events list --type rot.detected --since 5m`

🤖 Generated with [Claude Code](https://claude.com/claude-code)