### PR TITLE
fix(agent-directory): write state=NULL for dir: identity rows

### DIFF
--- a/src/db/migrations/046_dir_agents_state_null.sql
+++ b/src/db/migrations/046_dir_agents_state_null.sql
@@ -1,0 +1,19 @@
+-- Backfill: clear 'spawning'/'error' from directory-agent identity rows.
+--
+-- Directory rows (id prefix `dir:`) are identity records, not runtime spawns.
+-- They never have a pane or executor of their own — state is tracked via
+-- their runtime/executor children. Prior to this fix, directory.add()
+-- INSERTed without a `state` value and the column DEFAULT ('spawning')
+-- applied, causing reconcileStaleSpawns() to flip every dir row to
+-- 'error' ~60s after every `genie serve` boot.
+--
+-- The INSERT is now corrected in agent-directory.ts to pass NULL explicitly,
+-- and reconcileStaleSpawns() skips `dir:%` ids as belt-and-suspenders.
+-- This migration repairs rows already poisoned by the old behavior.
+UPDATE agents
+   SET state = NULL,
+       last_state_change = now()
+ WHERE id LIKE 'dir:%'
+   AND state IN ('spawning', 'error')
+   AND (pane_id IS NULL OR pane_id = '')
+   AND current_executor_id IS NULL;

--- a/src/lib/agent-directory.ts
+++ b/src/lib/agent-directory.ts
@@ -178,12 +178,17 @@ export async function add(
   // Build metadata JSONB from frontmatter fields
   const metadata = buildMetadata(full);
 
-  // Store as a directory agent in PG with metadata
+  // Store as a directory agent in PG with metadata.
+  // state = NULL: directory records (id prefix `dir:`) are identity rows that
+  // track state through their runtime/executor children, not the legacy `state`
+  // column. NULL prevents reconcileStaleSpawns() from false-positive sweeping
+  // them to 'error' ~60s after every `genie serve` boot (column DEFAULT is
+  // 'spawning'). Mirrors the defense in identityCreate() (agent-registry.ts).
   const { getConnection } = await import('./db.js');
   const sql = await getConnection();
   await sql`
-    INSERT INTO agents (id, role, custom_name, started_at, metadata)
-    VALUES (${`dir:${entry.name}`}, ${entry.name}, ${entry.name}, now(), ${sql.json(metadata)})
+    INSERT INTO agents (id, role, custom_name, started_at, state, metadata)
+    VALUES (${`dir:${entry.name}`}, ${entry.name}, ${entry.name}, now(), ${null}, ${sql.json(metadata)})
     ON CONFLICT (id) DO UPDATE SET metadata = ${sql.json(metadata)}
   `;
 

--- a/src/lib/agent-registry.test.ts
+++ b/src/lib/agent-registry.test.ts
@@ -429,6 +429,31 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
       expect(reset).not.toContain(agent.id);
     });
 
+    test('does not touch directory identity rows (dir:%)', async () => {
+      // Directory rows (id prefix `dir:`) are identity records inserted by
+      // directory.add(). Pre-fix, the INSERT omitted `state` so PG applied
+      // the column DEFAULT 'spawning' and the reconciler flipped every row
+      // to 'error' ~60s after every `genie serve` boot (first-pass match:
+      // spawning + no pane + no executor + old). The reconciler now skips
+      // `dir:%` ids unconditionally so legacy rows (and any forgetful
+      // future caller) are safe. This test guards that invariant.
+      const sql = await getConnection();
+      const oldStart = new Date(Date.now() - 10_000).toISOString();
+      await sql`
+        INSERT INTO agents (id, role, custom_name, started_at, state, pane_id, current_executor_id)
+        VALUES ('dir:legacy-poisoned', 'legacy-poisoned', 'legacy-poisoned', ${oldStart}, 'spawning', '', ${null})
+      `;
+
+      const reset = await reconcileStaleSpawns(2);
+      expect(reset).not.toContain('dir:legacy-poisoned');
+
+      // Row still exists, still `spawning` — reconciler ignored it.
+      const [row] = await sql<{ state: string | null }[]>`
+        SELECT state FROM agents WHERE id = 'dir:legacy-poisoned'
+      `;
+      expect(row?.state).toBe('spawning');
+    });
+
     test('flips idle+dead-pane rows to error (auto-resume-zombie-cap fix)', async () => {
       // This is Change #3 of the auto-resume-zombie-cap fix: idle/working
       // rows whose tmux pane is dead must be flipped to 'error' so they

--- a/src/lib/agent-registry.ts
+++ b/src/lib/agent-registry.ts
@@ -308,6 +308,7 @@ export async function reconcileStaleSpawns(thresholdSeconds = 60): Promise<strin
         AND (pane_id IS NULL OR pane_id = '')
         AND current_executor_id IS NULL
         AND started_at < now() - interval '1 second' * ${thresholdSeconds}
+        AND id NOT LIKE 'dir:%'
       RETURNING id
     `;
     for (const row of rows) {


### PR DESCRIPTION
## Summary
- `directory.add()` INSERTed `dir:<name>` identity rows without a `state` value → PG applied the column DEFAULT `'spawning'` (migration 012) → `reconcileStaleSpawns()` flipped every `dir:*` row to `'error'` ~60s after every `genie serve` boot, producing spurious log lines and false-positive errors in `genie ls`. 19 agents hit this on a fresh restart on Felipe's machine tonight.
- Primary fix: write `state=NULL` explicitly, mirroring the defense already present in `identityCreate()` at `agent-registry.ts:737-738`.
- Belt-and-suspenders: `reconcileStaleSpawns()` first-pass predicate now excludes `id LIKE 'dir:%'` so a future forgetful caller can't re-introduce the same symptom.
- Backfill migration `046_dir_agents_state_null.sql` repairs any live `dir:*` rows already poisoned by the old behavior (verified on one live DB: 19/19 rows cleared).
- Regression test locks the invariant: a legacy-shape `dir:` row with `state='spawning'`, empty `pane_id`, null `current_executor_id`, old `started_at` is NOT touched by the reconciler.

## Root cause chain
1. `genie serve` → `startAgentSync` → walks `agents/` → calls `directory.add()` per entry.
2. Pre-fix INSERT omits `state` → row lands as `state='spawning'`, `pane_id=NULL`, `current_executor_id=NULL`.
3. Scheduler-daemon's 60s reconcile tick runs `reconcileStaleSpawns()`.
4. First-pass UPDATE matches every `dir:*` row (>60s, spawning, no pane, no executor) → flips to `'error'`.
5. One `[reconcile] Reset stuck agent ... from spawning → error` log per row → noisy boot, polluted audit stream.

## Test plan
- [x] `bun test src/lib/agent-registry.test.ts` — 86/86 pass, incl. new regression `does not touch directory identity rows (dir:%)`.
- [x] `bun test src/term-commands/dir-add.test.ts src/term-commands/dir-edit.test.ts src/term-commands/agents.test.ts` — 54/54 pass.
- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — 47 pre-existing warnings, no new issues.
- [x] Live DB backfill on Felipe's machine: 19/19 `dir:*` rows cleared from `error`, `genie ls` shows zero rows in error state.

## Severity
Cosmetic / audit-noise. `genie serve` came up fine — the bug polluted state visibility, didn't break functionality. Still worth shipping because it (a) corrupts the audit stream on every boot and (b) makes `genie ls` unreliable for spotting real errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)