### PR TITLE
chore(council): default council member model to opus (#1310)

### DIFF
--- a/plugins/genie/agents/council--architect/AGENTS.md
+++ b/plugins/genie/agents/council--architect/AGENTS.md
@@ -1,7 +1,7 @@
 ---
 name: council--architect
 description: Systems thinking, backwards compatibility, and long-term stability review (Linus Torvalds inspiration)
-model: haiku
+model: opus
 provider: claude
 color: blue
 promptMode: append

--- a/plugins/genie/agents/council--benchmarker/AGENTS.md
+++ b/plugins/genie/agents/council--benchmarker/AGENTS.md
@@ -1,7 +1,7 @@
 ---
 name: council--benchmarker
 description: Performance-obsessed, benchmark-driven analysis demanding measured evidence (Matteo Collina inspiration)
-model: haiku
+model: opus
 provider: claude
 color: orange
 promptMode: append

--- a/plugins/genie/agents/council--deployer/AGENTS.md
+++ b/plugins/genie/agents/council--deployer/AGENTS.md
@@ -1,7 +1,7 @@
 ---
 name: council--deployer
 description: Zero-config deployment, CI/CD optimization, and preview environment review (Guillermo Rauch inspiration)
-model: haiku
+model: opus
 provider: claude
 color: green
 promptMode: append

--- a/plugins/genie/agents/council--ergonomist/AGENTS.md
+++ b/plugins/genie/agents/council--ergonomist/AGENTS.md
@@ -1,7 +1,7 @@
 ---
 name: council--ergonomist
 description: Developer experience, API usability, and error clarity review (Sindre Sorhus inspiration)
-model: haiku
+model: opus
 provider: claude
 color: cyan
 promptMode: append

--- a/plugins/genie/agents/council--measurer/AGENTS.md
+++ b/plugins/genie/agents/council--measurer/AGENTS.md
@@ -1,7 +1,7 @@
 ---
 name: council--measurer
 description: Observability, profiling, and metrics philosophy demanding measurement over guessing (Bryan Cantrill inspiration)
-model: haiku
+model: opus
 provider: claude
 color: yellow
 promptMode: append

--- a/plugins/genie/agents/council--operator/AGENTS.md
+++ b/plugins/genie/agents/council--operator/AGENTS.md
@@ -1,7 +1,7 @@
 ---
 name: council--operator
 description: Operations reality, infrastructure readiness, and on-call sanity review (Kelsey Hightower inspiration)
-model: haiku
+model: opus
 provider: claude
 color: red
 promptMode: append

--- a/plugins/genie/agents/council--questioner/AGENTS.md
+++ b/plugins/genie/agents/council--questioner/AGENTS.md
@@ -1,7 +1,7 @@
 ---
 name: council--questioner
 description: Challenge assumptions, seek foundational simplicity, question necessity (Ryan Dahl inspiration)
-model: haiku
+model: opus
 provider: claude
 color: magenta
 promptMode: append

--- a/plugins/genie/agents/council--sentinel/AGENTS.md
+++ b/plugins/genie/agents/council--sentinel/AGENTS.md
@@ -1,7 +1,7 @@
 ---
 name: council--sentinel
 description: Security oversight, blast radius assessment, and secrets management review (Troy Hunt inspiration)
-model: haiku
+model: opus
 provider: claude
 color: red
 promptMode: append

--- a/plugins/genie/agents/council--simplifier/AGENTS.md
+++ b/plugins/genie/agents/council--simplifier/AGENTS.md
@@ -1,7 +1,7 @@
 ---
 name: council--simplifier
 description: Complexity reduction and minimalist philosophy demanding deletion over addition (TJ Holowaychuk inspiration)
-model: haiku
+model: opus
 provider: claude
 color: green
 promptMode: append

--- a/plugins/genie/agents/council--tracer/AGENTS.md
+++ b/plugins/genie/agents/council--tracer/AGENTS.md
@@ -1,7 +1,7 @@
 ---
 name: council--tracer
 description: Production debugging, high-cardinality observability, and instrumentation review (Charity Majors inspiration)
-model: haiku
+model: opus
 provider: claude
 color: cyan
 promptMode: append

--- a/plugins/genie/agents/council/AGENTS.md
+++ b/plugins/genie/agents/council/AGENTS.md
@@ -1,7 +1,7 @@
 ---
 name: council
 description: Multi-perspective architectural review with 10 specialized perspectives via real multi-agent deliberation.
-model: haiku
+model: opus
 provider: claude
 color: purple
 promptMode: append

--- a/skills/council/members/config.md
+++ b/skills/council/members/config.md
@@ -39,6 +39,6 @@ council-dispatch.sh --topic "..." --members "questioner,architect" --model haiku
 
 ## Notes
 
-- `inherit` means the member uses whatever model is set in its agent definition frontmatter (currently `haiku` for all members)
+- `inherit` means the member uses whatever model is set in its agent definition frontmatter (currently `opus` for all members)
 - Provider/model overrides at spawn time take precedence over these defaults
 - Mixed-LLM councils (e.g., architect on codex/o3, questioner on claude/opus) are supported but require per-member spawn commands

--- a/src/lib/builtin-agents.test.ts
+++ b/src/lib/builtin-agents.test.ts
@@ -96,9 +96,9 @@ describe('BUILTIN_COUNCIL_MEMBERS', () => {
     expect(names).toContain('council--tracer');
   });
 
-  test('council members have haiku model', () => {
+  test('council members have opus model', () => {
     for (const member of BUILTIN_COUNCIL_MEMBERS) {
-      expect(member.model).toBe('haiku');
+      expect(member.model).toBe('opus');
     }
   });
 });


### PR DESCRIPTION
## Summary

- Changes the default model on all 11 council agents (`council` + 10 member specialists) from `haiku` to `opus` so `/council` spawns deliver architect-grade reasoning out of the box.
- Updates the explanatory note in `skills/council/members/config.md` to reflect the new default.
- Updates the `builtin-agents.test.ts` assertion to match (`council members have opus model`).

Sonnet/haiku remain available via explicit `--model` overrides, as documented in `skills/council/members/config.md`.

## Test plan

- [x] `bun run build` — bundled cleanly (519 modules)
- [x] `bunx biome check .` — exit 0 (46 pre-existing warnings, none new)
- [x] `bun run typecheck` — clean
- [x] `bun test src/lib/builtin-agents.test.ts` — 18/18 pass (new opus assertion)
- [x] `bun test` — 3463/3464 pass; 1 flake in `events-stream` DB-cursor test, passes in isolation, unrelated to council

Closes #1310