### PR TITLE
fix(detector): raise default fire budget and allow per-detector override (#1292)

### DIFF
--- a/src/detectors/__tests__/fire-budget.test.ts
+++ b/src/detectors/__tests__/fire-budget.test.ts
@@ -6,7 +6,12 @@
  */
 
 import { afterAll, afterEach, beforeAll, describe, expect, test } from 'bun:test';
-import { DEFAULT_FIRE_BUDGET, type SchedulerHandle, start as startScheduler } from '../../serve/detector-scheduler.js';
+import {
+  DEFAULT_DETECTOR_BUDGETS,
+  DEFAULT_FIRE_BUDGET,
+  type SchedulerHandle,
+  start as startScheduler,
+} from '../../serve/detector-scheduler.js';
 import { makeHelloDetector } from '../__fixtures__/hello.js';
 import type { DetectorModule } from '../index.js';
 
@@ -125,8 +130,96 @@ describe('fire_budget enforcement', () => {
     expect(captured.filter((c) => c.type === 'detector.disabled').length).toBe(2);
   });
 
-  test('default fire budget is 10', () => {
-    expect(DEFAULT_FIRE_BUDGET).toBe(10);
+  test('default fire budget is 100', () => {
+    // Raised from 10 → 100 in #1292 so well-behaved detectors never self-
+    // disable under the 60s scheduler cadence (≤60 fires/hr < 100 budget).
+    expect(DEFAULT_FIRE_BUDGET).toBe(100);
+  });
+
+  test('known-chatty detectors carry built-in budget overrides below the default', () => {
+    // #1292: these two detectors were exhausting the old 10/hr budget every
+    // bucket. The built-in overrides keep them below the raised default so
+    // operators still get a single `detector.disabled` signal per hour rather
+    // than continuous `runbook.triggered` noise.
+    expect(DEFAULT_DETECTOR_BUDGETS['rot.team-ls-drift']).toBeLessThan(DEFAULT_FIRE_BUDGET);
+    expect(DEFAULT_DETECTOR_BUDGETS['rot.backfill-no-worktree']).toBeLessThan(DEFAULT_FIRE_BUDGET);
+  });
+
+  test('built-in per-detector overrides apply without explicit fireBudgets', async () => {
+    // Simulate the three production shapes in one bucket:
+    //   - rot.team-ls-drift   → throttled by DEFAULT_DETECTOR_BUDGETS (20)
+    //   - rot.backfill-no-worktree → throttled by DEFAULT_DETECTOR_BUDGETS (40)
+    //   - rot.anchor-orphan   → falls through to DEFAULT_FIRE_BUDGET (100)
+    const teamLsDrift = makeHelloDetector({ id: 'rot.team-ls-drift', alwaysFire: true });
+    const backfill = makeHelloDetector({ id: 'rot.backfill-no-worktree', alwaysFire: true });
+    const other = makeHelloDetector({ id: 'rot.anchor-orphan', alwaysFire: true });
+    const frozenNow = Date.UTC(2026, 3, 20, 10, 30, 0);
+
+    scheduler = startScheduler({
+      tickIntervalMs: 1_000_000,
+      jitterMs: 0,
+      // No defaultFireBudget override, no fireBudgets — exercise the defaults.
+      now: () => frozenNow,
+      detectorSource: () => [teamLsDrift, backfill, other] as ReadonlyArray<DetectorModule<unknown>>,
+      emitFn: captureEmit,
+      setTimeoutFn: () => ({ id: Symbol('test') }),
+      clearTimeoutFn: () => {},
+    });
+
+    // Ticks chosen so we exceed the largest chatty override (40) without
+    // approaching the raised default (100) — `rot.anchor-orphan` must stay
+    // below its budget to prove the default still applies.
+    for (let i = 0; i < 45; i++) {
+      await scheduler.tickNow();
+    }
+
+    const teamLsFires = captured.filter(
+      (c) => c.type === 'runbook.triggered' && c.opts.entity_id === 'rot.team-ls-drift',
+    );
+    const backfillFires = captured.filter(
+      (c) => c.type === 'runbook.triggered' && c.opts.entity_id === 'rot.backfill-no-worktree',
+    );
+    const otherFires = captured.filter(
+      (c) => c.type === 'runbook.triggered' && c.opts.entity_id === 'rot.anchor-orphan',
+    );
+    const disabledIds = captured.filter((c) => c.type === 'detector.disabled').map((c) => c.payload.detector_id);
+
+    expect(teamLsFires.length).toBe(DEFAULT_DETECTOR_BUDGETS['rot.team-ls-drift']);
+    expect(backfillFires.length).toBe(DEFAULT_DETECTOR_BUDGETS['rot.backfill-no-worktree']);
+    expect(otherFires.length).toBe(45);
+    expect(disabledIds).toContain('rot.team-ls-drift');
+    expect(disabledIds).toContain('rot.backfill-no-worktree');
+    expect(disabledIds).not.toContain('rot.anchor-orphan');
+  });
+
+  test('caller-supplied fireBudgets override built-in defaults', async () => {
+    // Operators (or tests) must be able to loosen or tighten any built-in
+    // override by passing fireBudgets. Verify the caller's value for
+    // `rot.team-ls-drift` wins over DEFAULT_DETECTOR_BUDGETS['rot.team-ls-drift'].
+    const detector = makeHelloDetector({ id: 'rot.team-ls-drift', alwaysFire: true });
+    const frozenNow = Date.UTC(2026, 3, 20, 10, 30, 0);
+    const overrideBudget = 3;
+
+    scheduler = startScheduler({
+      tickIntervalMs: 1_000_000,
+      jitterMs: 0,
+      fireBudgets: { 'rot.team-ls-drift': overrideBudget },
+      now: () => frozenNow,
+      detectorSource: () => [detector as DetectorModule<unknown>],
+      emitFn: captureEmit,
+      setTimeoutFn: () => ({ id: Symbol('test') }),
+      clearTimeoutFn: () => {},
+    });
+
+    for (let i = 0; i < 10; i++) {
+      await scheduler.tickNow();
+    }
+
+    const fires = captured.filter((c) => c.type === 'runbook.triggered');
+    const disables = captured.filter((c) => c.type === 'detector.disabled');
+    expect(fires.length).toBe(overrideBudget);
+    expect(disables.length).toBe(1);
+    expect(disables[0].payload.budget).toBe(overrideBudget);
   });
 
   test('per-detector budget overrides default', async () => {

--- a/src/serve/detector-scheduler.ts
+++ b/src/serve/detector-scheduler.ts
@@ -59,8 +59,36 @@ type DetectorEventResult = DetectorEvent;
 export const DEFAULT_TICK_INTERVAL_MS = 60_000;
 /** Jitter window applied per-tick (±) to smear scheduler load. */
 export const DEFAULT_JITTER_MS = 5_000;
-/** Default hourly fire budget per detector. */
-export const DEFAULT_FIRE_BUDGET = 10;
+/**
+ * Default hourly fire budget per detector.
+ *
+ * Raised from 10 → 100 in #1292. At the old 10/hr cap, noisy-but-valid
+ * detectors (`rot.team-ls-drift`, `rot.backfill-no-worktree`) exhausted the
+ * budget within the first few minutes of every hour bucket and self-disabled
+ * for the remaining 55+ minutes, producing bursty `detector.disabled` traffic
+ * every hour rollover. 100 covers one fire every ~36s over the bucket — well
+ * above the scheduler's own 60s cadence — so well-behaved detectors never hit
+ * the ceiling under normal load.
+ */
+export const DEFAULT_FIRE_BUDGET = 100;
+/**
+ * Built-in per-detector budget overrides applied automatically for detectors
+ * known to emit at elevated rates. Callers that pass `fireBudgets` in
+ * `SchedulerOptions` can still override any entry here — the caller's map is
+ * layered on top of these defaults.
+ *
+ * - `rot.team-ls-drift`: throttled hard while #1291 is open. Every fire is
+ *   currently rejected by the event receiver schema, so fewer rows is strictly
+ *   better than more. One `detector.disabled` per bucket signals the condition
+ *   without drowning the receiver in events that will be dropped anyway.
+ * - `rot.backfill-no-worktree`: chatty when the observable worktree population
+ *   is large. Keeping it under the default gives operators a clear disable
+ *   signal instead of wall-to-wall `runbook.triggered` noise.
+ */
+export const DEFAULT_DETECTOR_BUDGETS: Readonly<Record<string, number>> = Object.freeze({
+  'rot.team-ls-drift': 20,
+  'rot.backfill-no-worktree': 40,
+});
 /** Hour bucket size in milliseconds. */
 const HOUR_MS = 60 * 60 * 1000;
 
@@ -140,7 +168,10 @@ export function start(options: SchedulerOptions = {}): SchedulerHandle {
   const tickIntervalMs = options.tickIntervalMs ?? DEFAULT_TICK_INTERVAL_MS;
   const jitterMs = options.jitterMs ?? DEFAULT_JITTER_MS;
   const defaultBudget = options.defaultFireBudget ?? DEFAULT_FIRE_BUDGET;
-  const budgets = options.fireBudgets ?? {};
+  // Layer built-in overrides (chatty production detectors) under caller-
+  // provided overrides so tests and future callers can bump any specific
+  // detector without having to remember the whole default set.
+  const budgets: Record<string, number> = { ...DEFAULT_DETECTOR_BUDGETS, ...(options.fireBudgets ?? {}) };
   const now = options.now ?? (() => Date.now());
   const setTimeoutFn = options.setTimeoutFn ?? ((fn: () => void, ms: number): TimerHandle => setTimeout(fn, ms));
   const clearTimeoutFn =


### PR DESCRIPTION
## Summary
- Raise `DEFAULT_FIRE_BUDGET` from 10/hr → 100/hr so scheduler-cadence detectors (~60 fires/hr) no longer exhaust the budget in the first few minutes of every hour bucket and self-disable for the rest of the hour.
- Add `DEFAULT_DETECTOR_BUDGETS` built-in overrides for the two named chatty detectors: `rot.team-ls-drift` = 20/hr (paired with #1291 — fires are schema-rejected), `rot.backfill-no-worktree` = 40/hr.
- Layer built-ins under caller-provided `SchedulerOptions.fireBudgets` so any entry remains override-able without re-declaring the whole map.

## Root cause
`DEFAULT_FIRE_BUDGET = 10` at `src/serve/detector-scheduler.ts:63` was below the natural fire rate of healthy detectors on the 60s ± 5s scheduler cadence, so each hour bucket burned through the cap in minutes and emitted one `detector.disabled` event — creating the bursts the issue called out.

## Test plan
- [x] `bun test src/detectors/__tests__/fire-budget.test.ts` — 7 pass (3 new, covering raised default, built-in overrides applied without explicit config, and caller override winning over built-in)
- [x] `bun test src/serve/__tests__/detector-scheduler.test.ts` — 6 pass (no regressions)
- [x] `bun test` — 3467 pass / 0 fail
- [x] `bun run build` — single-file bundle OK
- [x] `bunx biome check .` — no new errors (pre-existing 46 warnings untouched)
- [x] `bun run typecheck` — exit 0

Closes #1292

🤖 Generated with [Claude Code](https://claude.com/claude-code)