### PR TITLE
fix(wish-lint): accept descriptive and cross-wish depends-on (#1311)

### DIFF
--- a/src/services/__tests__/wish-lint.test.ts
+++ b/src/services/__tests__/wish-lint.test.ts
@@ -529,6 +529,80 @@ describe('lintWish — post-parse rules', () => {
     expect(v?.fixable).toBe(true);
   });
 
+  test('depends-on accepts canonical numeric form (regression)', () => {
+    const md = cleanMultiGroupWish(); // Group 2 already declares `**depends-on:** Group 1`
+    const doc = parseWish(md);
+    const report = lintWish(doc, md);
+    expect(report.violations.some((v) => v.rule === 'depends-on-malformed')).toBe(false);
+    expect(report.violations.some((v) => v.rule === 'depends-on-dangling')).toBe(false);
+  });
+
+  test('depends-on accepts descriptive in-wish names (Foundation, Migration)', () => {
+    const md = cleanMultiGroupWish().replace('**depends-on:** Group 1', '**depends-on:** Foundation, Migration');
+    const doc = parseWish(md);
+    const report = lintWish(doc, md);
+    expect(report.violations.some((v) => v.rule === 'depends-on-malformed')).toBe(false);
+    expect(report.violations.some((v) => v.rule === 'depends-on-dangling')).toBe(false);
+  });
+
+  test('depends-on accepts same-wish slash form (slug/group-1, slug/foundation)', () => {
+    const md = cleanMultiGroupWish().replace(
+      '**depends-on:** Group 1',
+      '**depends-on:** multi/group-1, multi/foundation',
+    );
+    const doc = parseWish(md);
+    const report = lintWish(doc, md);
+    expect(report.violations.some((v) => v.rule === 'depends-on-malformed')).toBe(false);
+    expect(report.violations.some((v) => v.rule === 'depends-on-dangling')).toBe(false);
+  });
+
+  test('depends-on accepts cross-wish bare slug', () => {
+    const md = cleanMultiGroupWish().replace('**depends-on:** Group 1', '**depends-on:** other-wish');
+    const doc = parseWish(md);
+    const report = lintWish(doc, md);
+    expect(report.violations.some((v) => v.rule === 'depends-on-malformed')).toBe(false);
+    expect(report.violations.some((v) => v.rule === 'depends-on-dangling')).toBe(false);
+  });
+
+  test('depends-on accepts cross-wish repo/slug form', () => {
+    const md = cleanMultiGroupWish().replace('**depends-on:** Group 1', '**depends-on:** automagik-dev/other-wish');
+    const doc = parseWish(md);
+    const report = lintWish(doc, md);
+    expect(report.violations.some((v) => v.rule === 'depends-on-malformed')).toBe(false);
+    expect(report.violations.some((v) => v.rule === 'depends-on-dangling')).toBe(false);
+  });
+
+  test('depends-on accepts fully qualified repo/slug/group-N form', () => {
+    const md = cleanMultiGroupWish().replace(
+      '**depends-on:** Group 1',
+      '**depends-on:** automagik-dev/rlmx/rlmx-sdk-upgrade/group-2',
+    );
+    const doc = parseWish(md);
+    const report = lintWish(doc, md);
+    expect(report.violations.some((v) => v.rule === 'depends-on-malformed')).toBe(false);
+    expect(report.violations.some((v) => v.rule === 'depends-on-dangling')).toBe(false);
+  });
+
+  test('depends-on accepts mixed numeric, cross-wish, and descriptive refs', () => {
+    const md = cleanMultiGroupWish().replace(
+      '**depends-on:** Group 1',
+      '**depends-on:** Group 1, other-wish/foundation, automagik-dev/genie/some-wish/group-5',
+    );
+    const doc = parseWish(md);
+    const report = lintWish(doc, md);
+    expect(report.violations.some((v) => v.rule === 'depends-on-malformed')).toBe(false);
+    expect(report.violations.some((v) => v.rule === 'depends-on-dangling')).toBe(false);
+  });
+
+  test('depends-on still rejects truly malformed punctuation', () => {
+    const md = cleanMultiGroupWish().replace('**depends-on:** Group 1', '**depends-on:** !@#$');
+    const doc = parseWish(md);
+    const report = lintWish(doc, md);
+    const v = report.violations.find((x) => x.rule === 'depends-on-malformed');
+    expect(v).toBeDefined();
+    expect(v?.fixable).toBe(false);
+  });
+
   test('todo-placeholder-remaining fires on `<TODO>` markers, bypassed by allowTodoPlaceholders', () => {
     const md = cleanMinimalWish().replace('widget.ts exists', '<TODO: real criterion>');
     const doc = parseWish(md);

--- a/src/services/wish-lint.ts
+++ b/src/services/wish-lint.ts
@@ -514,7 +514,15 @@ function scanDependsOn(doc: WishDocument, lines: string[]): Violation[] {
           .trim(),
       )
       .filter(Boolean);
-    const refPattern = /^(Group\s+\d+|[\w-]+#\d+)$/i;
+    // Accepted ref shapes:
+    //   * `Group N`                       — canonical numeric within current wish
+    //   * `Foundation` / `migration-2`    — descriptive identifier (in-wish or cross-wish slug)
+    //   * `wish-slug/group-1`             — same-wish or cross-wish slash form
+    //   * `repo/wish-slug/group-N`        — fully qualified cross-repo reference (any depth)
+    //   * `slug#3`                        — legacy hash form
+    // Reject only truly malformed shapes (empty, bad punctuation, free-form prose).
+    const refPattern =
+      /^(?:Group\s+\d+|[A-Za-z][A-Za-z0-9_-]*(?:\/(?:Group\s+\d+|[A-Za-z][A-Za-z0-9_-]*))*|[A-Za-z][A-Za-z0-9_-]*#\d+)$/i;
     const canonicalParts: string[] = [];
     let anyMalformed = false;
     for (const raw of parts) {
@@ -564,7 +572,7 @@ function scanDependsOn(doc: WishDocument, lines: string[]): Violation[] {
           severity: 'error',
           line: dependsLine + 1,
           column: 1,
-          message: `depends-on value "${rawValue}" cannot be parsed — expected "none" or "Group N[, Group M]"`,
+          message: `depends-on value "${rawValue}" cannot be parsed — expected "none", "Group N", a descriptive name, or a slug/group reference`,
           fixable: false,
           fix: null,
         });

--- a/src/services/wish-parser.ts
+++ b/src/services/wish-parser.ts
@@ -265,9 +265,10 @@ function parseDependsOnValue(raw: string): { value: DependsOn; malformed: boolea
   const trimmed = raw.trim().replace(/\.$/, '');
   if (!trimmed) return { value: [], malformed: true };
   if (/^none$/i.test(trimmed)) return { value: 'none', malformed: false };
-  // Accept `Group 1, Group 2` or `slug#1, slug#2`
+  // Accept `Group N`, `Foundation`, `wish-slug/group-1`, `repo/wish-slug/group-N`, or `slug#N`.
   const parts = trimmed.split(/\s*,\s*/).filter(Boolean);
-  const refPattern = /^(Group\s+\d+|[\w-]+#\d+)$/i;
+  const refPattern =
+    /^(?:Group\s+\d+|[A-Za-z][A-Za-z0-9_-]*(?:\/(?:Group\s+\d+|[A-Za-z][A-Za-z0-9_-]*))*|[A-Za-z][A-Za-z0-9_-]*#\d+)$/i;
   const malformed = parts.some((p) => !refPattern.test(p));
   return { value: parts, malformed };
 }


### PR DESCRIPTION
## Summary
- Broadens the `depends-on:` linter pattern in `src/services/wish-lint.ts` (and mirror in `src/services/wish-parser.ts`) to accept all shapes the `/wish` skill already documents.
- Newly accepted refs: descriptive identifiers (`Foundation`, `Migration`), same-wish slash form (`slug/group-1`, `slug/foundation`), bare cross-wish slugs (`other-wish`), and fully qualified cross-repo refs of any depth (`automagik-dev/rlmx/rlmx-sdk-upgrade/group-2`).
- Canonical `Group N, Group M` and the existing `Groups 1 and 2` -> `Group 1, Group 2` recovery fix continue to behave exactly as before; dangling-ref detection still applies to bare `Group N` only.

Closes #1311

## Test plan
- [x] `bun test src/services/__tests__/wish-lint.test.ts` — 38/38 pass (30 original + 8 new shape tests + 1 regression)
- [x] `bun test src/services/__tests__/` + wish-cli integration — 201/201 pass
- [x] `bun run build` — clean bundle (519 modules)
- [x] `bun run typecheck` — clean
- [x] `bunx biome check .` — 0 errors (only pre-existing complexity warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)