### PR TITLE
fix(trace-context): make parseToken tamper test deterministic (#1314)

### DIFF
--- a/src/lib/trace-context.test.ts
+++ b/src/lib/trace-context.test.ts
@@ -44,7 +44,12 @@ describe('trace-context — mint/parse', () => {
     const ctx = { trace_id: newTraceId() };
     const token = mintToken(ctx);
     const [payload, sig] = token.split('.');
-    const tampered = `${payload}.${sig.slice(0, -2)}AA`;
+    // Guarantee the replacement differs from the original: HMAC-SHA256 → 43
+    // base64url chars where the last 2 chars equal "AA" ~1/1024 runs; without
+    // this guard, the "tampered" signature is byte-identical to the original
+    // and the assertion fails (#1314).
+    const replacement = sig.endsWith('AA') ? 'BB' : 'AA';
+    const tampered = `${payload}.${sig.slice(0, -2)}${replacement}`;
     const parsed = parseToken(tampered);
     expect(parsed.ok).toBe(false);
     expect(parsed.reason).toBe('signature');


### PR DESCRIPTION
## Summary

- Fixes a real ~1/1024 flake in `parseToken rejects tampered signatures`.
- Root cause is in the **test**, not in `parseToken` — no source patch.
- The tamper step `sig.slice(0, -2) + 'AA'` produced an unchanged signature when the original already ended in `"AA"`, and `parseToken` correctly returned `ok: true`, failing the assertion.

## Root cause

HMAC-SHA256 → 43 base64url chars (no padding). The last char encodes only 4 info bits (16 possible values); the second-to-last encodes 6 bits (64 values). So `P(sig ends in "AA") = 1/(16·64) = 1/1024`. Whenever that happened, the "tampered" token was byte-identical to the original.

**Deterministic repro (worktree):**
```
attempts_until_AA: 1264
tampered_equals_original: true
parseToken_result: { ok: true, sig_end: "R7AA" }
```

**Statistical pre-fix:** 6 accepted out of 5000 iterations (expected ≈ 4.88 by math, matches).

## Fix

If the original signature already ends in `"AA"`, replace with `"BB"` instead — the tampered signature is now guaranteed to differ from the original. The assertion semantics are unchanged.

## Validation

- `bun test src/lib/trace-context.test.ts --rerun-each=20` → 300 pass / 0 fail.
- Post-fix hot loop: **0 accepted / 10,000 iterations** (with 11 runs hitting the `"AA"` branch → proves the fallback triggers and still rejects).
- `bun run build` → ok
- `bun run typecheck` → ok
- `bunx biome check .` → no new diagnostics
- `make check` → 3464 pass / 0 fail (198 files, 145s)

## Test plan

- [x] Tamper test passes deterministically over 20x rerun
- [x] 10k-iteration hot loop: 0 false positives
- [x] Full suite green (`make check`)
- [x] No source-code changes to `trace-context.ts`

Closes #1314

🤖 Generated with [Claude Code](https://claude.com/claude-code)