### PR TITLE
fix(reconciler): TTL-archive dead-pane zombies + genie prune --zombies (#1293)

### DIFF
--- a/src/genie.ts
+++ b/src/genie.ts
@@ -64,6 +64,7 @@ import { registerSendInboxCommands } from './term-commands/msg.js';
 import { registerNotifyCommands } from './term-commands/notify.js';
 import * as orchestrateCmd from './term-commands/orchestrate.js';
 import { registerProjectCommands } from './term-commands/project.js';
+import { registerPruneCommands } from './term-commands/prune.js';
 import {
   type QaCheckOptions,
   type QaOptions,
@@ -229,6 +230,7 @@ registerBoardCommands(program);
 registerTagCommands(program);
 registerReleaseCommands(program);
 registerProjectCommands(program);
+registerPruneCommands(program);
 registerNotifyCommands(program);
 registerEventsCommands(program);
 registerSessionsCommands(program);
@@ -613,7 +615,8 @@ program
   .description('List registered agents with runtime status')
   .option('--json', 'Output as JSON')
   .option('--source <name>', 'Filter by executor metadata source (e.g. omni)')
-  .action(async (options: { json?: boolean; source?: string }) => {
+  .option('--all', 'Include archived agents (hidden by default)')
+  .action(async (options: { json?: boolean; source?: string; all?: boolean }) => {
     try {
       await handleLsCommand(options);
     } catch (error) {

--- a/src/lib/agent-registry.ts
+++ b/src/lib/agent-registry.ts
@@ -477,9 +477,122 @@ export async function reconcileStaleSpawns(thresholdSeconds = 60): Promise<strin
       }
     }
 
+    // Fourth pass: TTL-archive exhausted dead-pane zombies.
+    // Once the reconciler flips a dead-pane zombie to state='error' and the
+    // scheduler exhausts its retry budget (auto_resume=false), the row is
+    // inert — it can't be resumed and clutters `genie ls` forever. After
+    // `DEAD_PANE_ZOMBIE_TTL_HOURS`, transition it to 'archived' so the
+    // default listing filter hides it (see listAgents includeArchived).
+    try {
+      const archived = await archiveExhaustedZombies();
+      if (archived.length > 0) {
+        resetIds.push(...archived);
+      }
+    } catch {
+      // Best-effort — TTL archive failure must not block reconciliation.
+    }
+
     return resetIds;
   } catch {
     return []; // Best-effort — don't block startup if DB is unavailable
+  }
+}
+
+/**
+ * Default TTL (hours) after which an exhausted dead-pane zombie is archived.
+ *
+ * A zombie is any agent whose reconciler audit trail shows
+ * `reason=dead_pane_zombie` AND whose `auto_resume` has been flipped to false
+ * by the scheduler's exhaustion branch. Without this TTL, such rows stayed
+ * visible in `genie ls` forever (#1293), holding registry slots and confusing
+ * users into thinking the agent is still recoverable.
+ */
+const DEAD_PANE_ZOMBIE_TTL_HOURS = 24;
+
+/**
+ * Archive exhausted dead-pane zombies older than the TTL.
+ *
+ * Targets agents that:
+ *   1. Are in terminal `state = 'error'`
+ *   2. Have `auto_resume = false` (retry budget exhausted)
+ *   3. Were last transitioned > `ttlHours` ago
+ *   4. Have at least one reconciler audit event tagged
+ *      `reason = 'dead_pane_zombie'` (distinguishes them from other error
+ *      causes the user might want to keep visible, e.g. manual error states).
+ *
+ * Transitions matching rows to `state = 'archived'` so the default listing
+ * filter hides them. An audit event is emitted per row for traceability.
+ *
+ * @param ttlHours - Minimum age in hours before archival (default: 24)
+ * @returns IDs of agents that were archived
+ */
+export async function archiveExhaustedZombies(ttlHours = DEAD_PANE_ZOMBIE_TTL_HOURS): Promise<string[]> {
+  try {
+    const sql = await getConnection();
+    const rows = await sql<{ id: string }[]>`
+      UPDATE agents a
+      SET state = 'archived', last_state_change = now()
+      WHERE a.state = 'error'
+        AND a.auto_resume = false
+        AND a.last_state_change < now() - make_interval(hours => ${ttlHours})
+        AND EXISTS (
+          SELECT 1 FROM audit_events e
+          WHERE e.entity_type = 'worker'
+            AND e.entity_id = a.id
+            AND e.event_type = 'state_changed'
+            AND e.details->>'reason' = 'dead_pane_zombie'
+        )
+      RETURNING id
+    `;
+    const auditPromises: Promise<void>[] = [];
+    for (const row of rows) {
+      console.error(`[reconcile] Archived exhausted zombie ${row.id} (TTL ${ttlHours}h)`);
+      auditPromises.push(
+        recordAuditEvent('worker', row.id, 'state_changed', 'reconciler', {
+          state: 'archived',
+          reason: 'dead_pane_zombie_ttl_exhausted',
+          ttl_hours: ttlHours,
+        }).catch(() => {}),
+      );
+    }
+    // Wait for audit writes to land so callers can immediately query the log.
+    // `recordAuditEvent` already swallows errors, so this never throws.
+    await Promise.allSettled(auditPromises);
+    return rows.map((r: { id: string }) => r.id);
+  } catch {
+    return []; // Best-effort — never block the reconciler
+  }
+}
+
+/**
+ * Count dead-pane zombies eligible for TTL archive without mutating them.
+ * Used by `genie prune --zombies --dry-run`.
+ */
+export async function listExhaustedZombies(
+  ttlHours = DEAD_PANE_ZOMBIE_TTL_HOURS,
+): Promise<Array<{ id: string; lastStateChange: string }>> {
+  try {
+    const sql = await getConnection();
+    const rows = await sql<{ id: string; last_state_change: string }[]>`
+      SELECT a.id, a.last_state_change FROM agents a
+      WHERE a.state = 'error'
+        AND a.auto_resume = false
+        AND a.last_state_change < now() - make_interval(hours => ${ttlHours})
+        AND EXISTS (
+          SELECT 1 FROM audit_events e
+          WHERE e.entity_type = 'worker'
+            AND e.entity_id = a.id
+            AND e.event_type = 'state_changed'
+            AND e.details->>'reason' = 'dead_pane_zombie'
+        )
+      ORDER BY a.last_state_change ASC
+    `;
+    return rows.map((r: { id: string; last_state_change: string }) => ({
+      id: r.id,
+      lastStateChange: r.last_state_change,
+    }));
+  } catch {
+    return [];
   }
 }
 

--- a/src/lib/archive-zombies.test.ts
+++ b/src/lib/archive-zombies.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Regression tests for TTL-archive of exhausted dead-pane zombies (issue #1293).
+ *
+ * Scenario:
+ *   1. Reconciler flips a dead-pane agent to `state='error'` with audit
+ *      `reason='dead_pane_zombie'`.
+ *   2. Scheduler exhausts the 3-retry budget → persists `auto_resume=false`.
+ *   3. The row is inert: it never resumes, but stays visible in `genie ls`
+ *      forever. Without TTL archival, they accumulate and clutter the list.
+ *
+ * This suite asserts:
+ *   - Rows younger than the TTL are NOT archived (false positive guard).
+ *   - Rows older than the TTL ARE archived.
+ *   - Rows without the `dead_pane_zombie` audit trail are NOT archived
+ *     (we don't touch manually-errored rows).
+ *   - Rows with `auto_resume=true` are NOT archived (still eligible).
+ *   - `listExhaustedZombies` (dry-run view) does not mutate state.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { archiveExhaustedZombies, listExhaustedZombies } from './agent-registry.js';
+import { getConnection } from './db.js';
+import { DB_AVAILABLE, setupTestSchema } from './test-db.js';
+
+describe.skipIf(!DB_AVAILABLE)('archiveExhaustedZombies (issue #1293)', () => {
+  let cleanup: () => Promise<void>;
+
+  beforeAll(async () => {
+    cleanup = await setupTestSchema();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  beforeEach(async () => {
+    const sql = await getConnection();
+    await sql`DELETE FROM audit_events`;
+    await sql`DELETE FROM agents`;
+  });
+
+  /**
+   * Helper: insert an agent row at a specific age (hours) with the requested
+   * state / auto_resume / audit trail.
+   */
+  async function seedZombie(opts: {
+    id: string;
+    ageHours: number;
+    state?: string;
+    autoResume?: boolean;
+    withDeadPaneAudit?: boolean;
+  }): Promise<void> {
+    const sql = await getConnection();
+    const state = opts.state ?? 'error';
+    const autoResume = opts.autoResume ?? false;
+    await sql`
+      INSERT INTO agents (id, pane_id, session, repo_path, started_at, state, last_state_change, auto_resume)
+      VALUES (
+        ${opts.id},
+        ${'%' + opts.id},
+        ${'genie'},
+        ${'/tmp/test'},
+        now() - make_interval(hours => ${opts.ageHours}),
+        ${state},
+        now() - make_interval(hours => ${opts.ageHours}),
+        ${autoResume}
+      )
+    `;
+    if (opts.withDeadPaneAudit ?? true) {
+      await sql`
+        INSERT INTO audit_events (entity_type, entity_id, event_type, actor, details, created_at)
+        VALUES (
+          'worker',
+          ${opts.id},
+          'state_changed',
+          'reconciler',
+          ${sql.json({ state: 'error', reason: 'dead_pane_zombie' })},
+          now() - make_interval(hours => ${opts.ageHours})
+        )
+      `;
+    }
+  }
+
+  async function getAgentState(id: string): Promise<string | null> {
+    const sql = await getConnection();
+    const rows = await sql<{ state: string }[]>`SELECT state FROM agents WHERE id = ${id}`;
+    return rows.length > 0 ? rows[0].state : null;
+  }
+
+  test('TTL not triggered at 23h (just under 24h default)', async () => {
+    await seedZombie({ id: 'young-zombie', ageHours: 23 });
+
+    const ids = await archiveExhaustedZombies();
+
+    expect(ids).not.toContain('young-zombie');
+    expect(await getAgentState('young-zombie')).toBe('error');
+  });
+
+  test('TTL triggered at 24h+1 (just over 24h default)', async () => {
+    await seedZombie({ id: 'old-zombie', ageHours: 25 });
+
+    const ids = await archiveExhaustedZombies();
+
+    expect(ids).toContain('old-zombie');
+    expect(await getAgentState('old-zombie')).toBe('archived');
+  });
+
+  test('custom ttlHours parameter is honoured', async () => {
+    await seedZombie({ id: 'edge-zombie', ageHours: 2 });
+
+    // Not archived with default 24h TTL
+    expect(await archiveExhaustedZombies(24)).not.toContain('edge-zombie');
+    expect(await getAgentState('edge-zombie')).toBe('error');
+
+    // Archived with 1h TTL override
+    expect(await archiveExhaustedZombies(1)).toContain('edge-zombie');
+    expect(await getAgentState('edge-zombie')).toBe('archived');
+  });
+
+  test('does not archive rows with auto_resume=true (still recoverable)', async () => {
+    await seedZombie({ id: 'recoverable', ageHours: 48, autoResume: true });
+
+    const ids = await archiveExhaustedZombies();
+
+    expect(ids).not.toContain('recoverable');
+    expect(await getAgentState('recoverable')).toBe('error');
+  });
+
+  test('does not archive rows without dead_pane_zombie audit trail', async () => {
+    // Manually-errored row: same state/auto_resume but no reconciler audit
+    await seedZombie({ id: 'manual-error', ageHours: 48, withDeadPaneAudit: false });
+
+    const ids = await archiveExhaustedZombies();
+
+    expect(ids).not.toContain('manual-error');
+    expect(await getAgentState('manual-error')).toBe('error');
+  });
+
+  test('does not touch rows already archived', async () => {
+    await seedZombie({ id: 'pre-archived', ageHours: 48, state: 'archived' });
+
+    const ids = await archiveExhaustedZombies();
+
+    expect(ids).not.toContain('pre-archived');
+    expect(await getAgentState('pre-archived')).toBe('archived');
+  });
+
+  test('archives many rows in a single pass', async () => {
+    await seedZombie({ id: 'z1', ageHours: 48 });
+    await seedZombie({ id: 'z2', ageHours: 48 });
+    await seedZombie({ id: 'z3', ageHours: 48 });
+    await seedZombie({ id: 'young', ageHours: 1 });
+
+    const ids = await archiveExhaustedZombies();
+
+    expect(ids.sort()).toEqual(['z1', 'z2', 'z3']);
+    expect(await getAgentState('young')).toBe('error');
+  });
+
+  test('emits a state_changed audit event for each archived row', async () => {
+    await seedZombie({ id: 'audit-me', ageHours: 48 });
+
+    await archiveExhaustedZombies();
+
+    const sql = await getConnection();
+    const rows = await sql<{ reason: string; state: string }[]>`
+      SELECT details->>'reason' AS reason, details->>'state' AS state
+      FROM audit_events
+      WHERE entity_type = 'worker'
+        AND entity_id = 'audit-me'
+        AND event_type = 'state_changed'
+        AND details->>'state' = 'archived'
+    `;
+    expect(rows.length).toBe(1);
+    expect(rows[0].reason).toBe('dead_pane_zombie_ttl_exhausted');
+  });
+});
+
+describe.skipIf(!DB_AVAILABLE)('listExhaustedZombies — dry-run view (issue #1293)', () => {
+  let cleanup: () => Promise<void>;
+
+  beforeAll(async () => {
+    cleanup = await setupTestSchema();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  beforeEach(async () => {
+    const sql = await getConnection();
+    await sql`DELETE FROM audit_events`;
+    await sql`DELETE FROM agents`;
+  });
+
+  async function seedOldZombie(id: string, ageHours = 48): Promise<void> {
+    const sql = await getConnection();
+    await sql`
+      INSERT INTO agents (id, pane_id, session, repo_path, started_at, state, last_state_change, auto_resume)
+      VALUES (${id}, ${'%' + id}, 'genie', '/tmp/test',
+              now() - make_interval(hours => ${ageHours}),
+              'error',
+              now() - make_interval(hours => ${ageHours}),
+              false)
+    `;
+    await sql`
+      INSERT INTO audit_events (entity_type, entity_id, event_type, actor, details)
+      VALUES ('worker', ${id}, 'state_changed', 'reconciler',
+              ${sql.json({ state: 'error', reason: 'dead_pane_zombie' })})
+    `;
+  }
+
+  test('dry-run returns candidates without mutating state', async () => {
+    await seedOldZombie('dry-1');
+    await seedOldZombie('dry-2');
+
+    const listed = await listExhaustedZombies();
+    expect(listed.map((z) => z.id).sort()).toEqual(['dry-1', 'dry-2']);
+
+    // State must still be 'error' — dry-run does not archive
+    const sql = await getConnection();
+    const rows = await sql<{ state: string }[]>`
+      SELECT state FROM agents WHERE id IN ('dry-1', 'dry-2')
+    `;
+    for (const r of rows) {
+      expect(r.state).toBe('error');
+    }
+  });
+
+  test('dry-run respects ttlHours threshold', async () => {
+    await seedOldZombie('old', 48);
+    await seedOldZombie('young', 1);
+
+    const withDefaultTtl = await listExhaustedZombies(24);
+    expect(withDefaultTtl.map((z) => z.id)).toEqual(['old']);
+
+    const withTightTtl = await listExhaustedZombies(0);
+    expect(withTightTtl.map((z) => z.id).sort()).toEqual(['old', 'young']);
+  });
+});

--- a/src/term-commands/agent/list.ts
+++ b/src/term-commands/agent/list.ts
@@ -13,7 +13,8 @@ export function registerAgentList(parent: Command): void {
     .description('List registered agents with runtime status')
     .option('--json', 'Output as JSON')
     .option('--source <name>', 'Filter by executor metadata source (e.g. omni)')
-    .action(async (options: { json?: boolean; source?: string }) => {
+    .option('--all', 'Include archived agents (hidden by default)')
+    .action(async (options: { json?: boolean; source?: string; all?: boolean }) => {
       try {
         await handleLsCommand(options);
       } catch (error) {

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -2673,7 +2673,11 @@ async function resolveAgentNamesBySource(source: string): Promise<Set<string>> {
 /**
  * genie ls — Smart view of registered agents with runtime status.
  */
-export async function handleLsCommand(options: { json?: boolean; source?: string }): Promise<void> {
+export async function handleLsCommand(options: {
+  json?: boolean;
+  source?: string;
+  all?: boolean;
+}): Promise<void> {
   const dirEntries = await directory.ls();
   const workers = await registry.list();
   const statusMap = await buildWorkerStatusMap(workers);
@@ -2724,6 +2728,12 @@ export async function handleLsCommand(options: { json?: boolean; source?: string
   // Apply source filter if provided
   if (sourceAgentNames) {
     entries = entries.filter((e) => sourceAgentNames.has(e.name));
+  }
+
+  // Hide archived agents by default (issue #1293 — TTL-archived dead-pane
+  // zombies pile up otherwise). `--all` opts back in for audit/debug.
+  if (!options.all) {
+    entries = entries.filter((e) => e.status !== 'archived');
   }
 
   if (options.json) {

--- a/src/term-commands/prune.ts
+++ b/src/term-commands/prune.ts
@@ -1,0 +1,93 @@
+/**
+ * genie prune — bulk cleanup of stale or exhausted registry entries.
+ *
+ * Subcommands/flags:
+ *   genie prune --zombies           Archive exhausted dead-pane zombies
+ *   genie prune --zombies --dry-run List zombies that would be archived
+ *   genie prune --ttl-hours <n>     Override the default 24h TTL
+ *
+ * A "dead-pane zombie" is an agent whose reconciler audit trail tagged
+ * it `reason=dead_pane_zombie` (tmux pane vanished mid-run) AND whose
+ * auto-resume budget was subsequently exhausted (auto_resume=false).
+ * Once that happens the row is inert: it never resumes and clutters
+ * `genie ls`. See issue #1293.
+ */
+
+import type { Command } from 'commander';
+import { archiveExhaustedZombies, listExhaustedZombies } from '../lib/agent-registry.js';
+import { isAvailable, shutdown } from '../lib/db.js';
+
+interface PruneOptions {
+  zombies?: boolean;
+  dryRun?: boolean;
+  ttlHours?: number;
+}
+
+function parsePositiveInt(value: string, name: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Invalid ${name}: ${value} (expected a positive integer)`);
+  }
+  return parsed;
+}
+
+async function pruneCommand(options: PruneOptions): Promise<void> {
+  if (!options.zombies) {
+    console.error('Error: no prune target specified. Use `--zombies`.');
+    console.error('See `genie prune --help` for available targets.');
+    process.exit(2);
+  }
+
+  const ttlHours = options.ttlHours ?? 24;
+
+  const available = await isAvailable();
+  if (!available) {
+    console.error('Database is not running. Start it with: genie db status');
+    process.exit(1);
+  }
+
+  try {
+    if (options.dryRun) {
+      const zombies = await listExhaustedZombies(ttlHours);
+      if (zombies.length === 0) {
+        console.log(`No exhausted zombies older than ${ttlHours}h.`);
+        return;
+      }
+      console.log(`Would archive ${zombies.length} zombie agent${zombies.length === 1 ? '' : 's'} older than ${ttlHours}h:`);
+      for (const z of zombies) {
+        console.log(`  ${z.id}  (last state change: ${z.lastStateChange})`);
+      }
+      return;
+    }
+
+    const ids = await archiveExhaustedZombies(ttlHours);
+    if (ids.length === 0) {
+      console.log(`No exhausted zombies older than ${ttlHours}h. Nothing to archive.`);
+      return;
+    }
+    console.log(`Archived ${ids.length} zombie agent${ids.length === 1 ? '' : 's'} older than ${ttlHours}h:`);
+    for (const id of ids) {
+      console.log(`  ${id}`);
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`Prune failed: ${message}`);
+    process.exit(1);
+  } finally {
+    await shutdown().catch(() => {});
+  }
+}
+
+export function registerPruneCommands(program: Command): void {
+  program
+    .command('prune')
+    .description('Bulk cleanup of stale or exhausted registry entries')
+    .option('--zombies', 'Archive dead-pane zombies whose auto-resume retries are exhausted')
+    .option('--dry-run', 'List targets that would be affected without mutating')
+    .option(
+      '--ttl-hours <hours>',
+      'Minimum age in hours before a zombie is eligible for archive (default: 24)',
+      (v) => parsePositiveInt(v, '--ttl-hours'),
+    )
+    .action(pruneCommand);
+}


### PR DESCRIPTION
## Summary

Closes #1293.

Dead-pane zombies (agents whose tmux pane died, flipped to `state=error` with audit `reason=dead_pane_zombie`, and subsequently exhausted their 3 auto-resume retries → `auto_resume=false`) accumulated forever. They cluttered `genie ls` and held registry slots with zero chance of recovery.

## Changes

- **TTL auto-archive in reconciler** (`src/lib/agent-registry.ts`)
  - New `archiveExhaustedZombies(ttlHours = 24)` transitions matching rows to `state='archived'`.
  - Matching criteria: `state='error'` + `auto_resume=false` + `last_state_change < now - TTL` + at least one reconciler audit event tagged `reason='dead_pane_zombie'` (manually-errored rows are left alone).
  - Called as a 4th pass from `reconcileStaleSpawns`, so it runs on the same scheduler cadence as existing passes.
  - Emits a `state_changed` audit event with `reason='dead_pane_zombie_ttl_exhausted'` per archived row.
- **`genie ls` / `genie agent list` hide archived by default**
  - `--all` opts back in for audit/debug.
- **New `genie prune --zombies` subcommand** (`src/term-commands/prune.ts`)
  - `--dry-run` lists candidates without mutating.
  - `--ttl-hours <n>` overrides the 24h default.
  - Exit 2 when no prune target is specified.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun run build` — bundles.
- [x] `bun test src/lib/archive-zombies.test.ts` — 10/10 pass.
- [x] `bun test src/lib/agent-registry.test.ts src/lib/__tests__/auto-resume-zombie-cap.test.ts src/lib/__tests__/zombie-spawns.test.ts` — 116/116 pass (no reconciler regressions).
- [x] `bun test src/lib/scheduler-daemon.test.ts` — 95/95 pass.
- [x] `bun dist/genie.js prune --help` — flags render correctly.
- [x] `bun dist/genie.js ls --help` — `--all` flag present on both `genie ls` and `genie agent list`.
- [x] `bunx biome check` on touched files — no new diagnostics (repo has 3 pre-existing complexity errors in `turn-close.ts`, `team-manager.ts`, and the existing `resumeAgent` function in `agents.ts` — none introduced by this PR).

## Test coverage

- TTL boundary: not triggered at 23h, triggered at 25h
- Custom TTL override respected
- `auto_resume=true` rows preserved (still recoverable)
- Rows without `dead_pane_zombie` audit trail preserved (manual errors)
- Already-archived rows untouched
- Multi-row pass archives all eligible rows
- Audit event emitted per archival
- Dry-run (`listExhaustedZombies`) does not mutate state