### PR TITLE
fix(events): warn when telemetry only covers genie-spawned agents (#1263)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh
 
 **Postgres-backed.** All state lives in PostgreSQL — agents, tasks, events, messages. Queryable. Durable. Real-time via LISTEN/NOTIFY.
 
-**Full observability.** Events, metrics, session replay, cost tracking. See everything your agents do.
+**Full observability.** Events, metrics, session replay, cost tracking. See everything your genie-spawned agents do — OTel-derived tool, cost, and API-request rows only cover sessions launched via `genie spawn` / `genie team create`; user-initiated Claude Code sessions are captured only when they export the OTLP env themselves.
 
 **Portable context.** Identity, skills, memory — all markdown files in your repo, git-versioned. You own everything.
 

--- a/src/term-commands/audit-events.test.ts
+++ b/src/term-commands/audit-events.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for the OTel scope-warning helpers exported by audit-events.ts.
+ *
+ * Issue #1263 Sub-fix 1 — the roll-ups (`events tools`, `events summary`,
+ * `events costs`) and the filtered list surfaces (`events list --type
+ * otel_*`, `events list --v2 --kind tool`) must surface the capture
+ * scope so empty output isn't read as "observability is broken." These
+ * tests pin down the helper behavior the command wrappers rely on.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { isOtelKindFilter, isOtelTypeFilter, printOtelScopeWarning } from './audit-events.js';
+
+describe('isOtelTypeFilter', () => {
+  test('matches otel_* prefixes', () => {
+    expect(isOtelTypeFilter('otel_tool_call')).toBe(true);
+    expect(isOtelTypeFilter('otel_api_request')).toBe(true);
+  });
+
+  test('does not match non-otel types', () => {
+    expect(isOtelTypeFilter('agent_spawn')).toBe(false);
+    expect(isOtelTypeFilter('task_moved')).toBe(false);
+    expect(isOtelTypeFilter('')).toBe(false);
+  });
+
+  test('handles undefined/nullish inputs', () => {
+    expect(isOtelTypeFilter(undefined)).toBe(false);
+  });
+});
+
+describe('isOtelKindFilter', () => {
+  test('matches tool / tool_call / tool_result prefixes', () => {
+    expect(isOtelKindFilter('tool')).toBe(true);
+    expect(isOtelKindFilter('tool_call')).toBe(true);
+    expect(isOtelKindFilter('tool_result')).toBe(true);
+  });
+
+  test('does not match non-tool kinds', () => {
+    expect(isOtelKindFilter('mailbox')).toBe(false);
+    expect(isOtelKindFilter('agent.lifecycle')).toBe(false);
+    expect(isOtelKindFilter('message')).toBe(false);
+    expect(isOtelKindFilter('')).toBe(false);
+  });
+
+  test('handles undefined inputs', () => {
+    expect(isOtelKindFilter(undefined)).toBe(false);
+  });
+});
+
+describe('printOtelScopeWarning', () => {
+  const originalLog = console.log;
+  let captured: string[] = [];
+
+  beforeEach(() => {
+    captured = [];
+    console.log = (...args: unknown[]) => {
+      captured.push(args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '));
+    };
+  });
+
+  afterEach(() => {
+    console.log = originalLog;
+  });
+
+  test('always emits the genie-spawned scope note', () => {
+    printOtelScopeWarning({ empty: false });
+    expect(captured.some((l) => l.includes('OTel-derived events only cover genie-spawned sessions'))).toBe(true);
+  });
+
+  test('non-empty case does NOT print the remediation hint', () => {
+    printOtelScopeWarning({ empty: false });
+    const joined = captured.join('\n');
+    expect(joined).not.toContain('OTEL_EXPORTER_OTLP_ENDPOINT');
+    expect(joined).toContain('not captured unless they export OTLP');
+  });
+
+  test('empty case prints the remediation hint with a concrete endpoint', () => {
+    printOtelScopeWarning({ empty: true });
+    const joined = captured.join('\n');
+    expect(joined).toContain('OTEL_EXPORTER_OTLP_ENDPOINT');
+    // Either a live port resolved from getOtelPort() or the fallback placeholder
+    expect(/http:\/\/127\.0\.0\.1:(\d+|<otel-port>)/.test(joined)).toBe(true);
+    expect(joined).toContain('CLAUDE_CODE_ENABLE_TELEMETRY=1');
+    expect(joined).toContain('restart your Claude Code session');
+  });
+});

--- a/src/term-commands/audit-events.ts
+++ b/src/term-commands/audit-events.ts
@@ -115,7 +115,7 @@ function summarizeDetails(details: Record<string, unknown> | string): string {
  * concrete remediation hint with the live receiver port; otherwise print
  * the scope note alone.
  */
-function printOtelScopeWarning(opts: { empty: boolean }): void {
+export function printOtelScopeWarning(opts: { empty: boolean }): void {
   console.log('\n⚠  OTel-derived events only cover genie-spawned sessions.');
   if (opts.empty) {
     let port: number | null = null;
@@ -135,8 +135,17 @@ function printOtelScopeWarning(opts: { empty: boolean }): void {
 }
 
 /** Returns true when a `--type` filter targets an OTel-sourced event stream. */
-function isOtelTypeFilter(type: string | undefined): boolean {
+export function isOtelTypeFilter(type: string | undefined): boolean {
   return typeof type === 'string' && type.startsWith('otel_');
+}
+
+/**
+ * Returns true when a v2 `--kind` filter targets kinds that only populate
+ * from the OTel exporter (e.g. `tool`, `tool_call`, `tool_result`). Those
+ * rows only land in `genie_runtime_events` for genie-spawned sessions.
+ */
+export function isOtelKindFilter(kind: string | undefined): boolean {
+  return typeof kind === 'string' && kind.startsWith('tool');
 }
 
 function printErrorsTable(patterns: ErrorPattern[]): void {
@@ -235,6 +244,12 @@ async function eventsListV2Command(options: ListOptions): Promise<void> {
       console.log(JSON.stringify(rows, null, 2));
     } else {
       printV2EventsTable(rows);
+      // v2 kinds like `tool` / `tool_call` / `tool_result` only populate
+      // from the OTLP exporter — mirror the same scope note the roll-ups
+      // surface so an empty result isn't read as "observability broke."
+      if (isOtelKindFilter(options.kind)) {
+        printOtelScopeWarning({ empty: rows.length === 0 });
+      }
     }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -678,7 +693,11 @@ async function eventsScanCommand(options: { since?: string; json?: boolean; brea
 // ============================================================================
 
 export function registerEventsCommands(program: Command): void {
-  const events = program.command('events').description('Audit event log from PG');
+  const events = program
+    .command('events')
+    .description(
+      'Audit event log from PG. OTel-derived data (tools/summary/costs and otel_* list rows) is scoped to genie-spawned agents — user-initiated Claude Code sessions are not captured unless they export OTLP env vars.',
+    );
 
   events
     .command('list', { isDefault: true })


### PR DESCRIPTION
## Summary

Closes #1263.

The OTel-derived surfaces (`events tools`, `events summary`, `events costs`, `events list --type otel_*`) already surface a capture-scope warning after PR #1276. This PR completes Sub-fix 1 by covering the remaining gaps:

- `events list --v2 --kind tool` / `tool_call` / `tool_result` now print the same `printOtelScopeWarning` note. Empty → concrete `OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:<getOtelPort()>` + `CLAUDE_CODE_ENABLE_TELEMETRY=1` remediation. Non-empty → scope note only.
- `genie events --help` description now states the OTel-derived rows are scoped to genie-spawned agents, so the boundary is discoverable without running a roll-up.
- README "Full observability" bullet calls out the spawned-agent scope and points user-initiated Claude Code sessions at the OTLP env they must export themselves.
- Colocated `audit-events.test.ts` pins down `isOtelTypeFilter`, `isOtelKindFilter`, and `printOtelScopeWarning` (always-on note + port-aware empty hint) so future refactors can't silently drop the warning.

Pure additive — JSON output paths untouched, no behavior change in data retrieval.

## Test plan

- [x] `bun run build` — clean (~305KB bundle)
- [x] `bunx biome check .` — no errors in changed files (46 pre-existing warnings elsewhere, unrelated)
- [x] `bun test src/term-commands/audit-events.test.ts` — 9 pass / 0 fail
- [x] `bun test src/term-commands/` — 369 pass / 0 fail
- [x] `make check` — 3473 pass / 0 fail across 199 files
- [x] `bun test src/lib/team-manager.test.ts` — 43 pass (confirmed unrelated flaky failure in one earlier parallel run; passes in isolation and in final `make check`)