### PR TITLE
feat(observability): auto-resume event emission (#1304)

### DIFF
--- a/src/lib/__tests__/auto-resume-telemetry.test.ts
+++ b/src/lib/__tests__/auto-resume-telemetry.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Issue #1304 — auto-resume telemetry emission shape contract.
+ *
+ * Verifies that the exact payload shapes the scheduler and the manual CLI
+ * resume path emit via `emitEvent` parse cleanly against the registered Zod
+ * schemas. Schema violations in production would fire silently as
+ * `schema.violation` meta events, leaving the telemetry gap unclosed — this
+ * test traps that regression at build time.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { getEntry } from '../events/registry.js';
+
+type AttemptedPayload = {
+  entity_id: string;
+  attempt_number: number;
+  state_before: string;
+  state_after: string;
+  trigger: 'scheduler' | 'manual' | 'boot';
+  last_error?: string;
+};
+
+type FailedPayload = AttemptedPayload & { exhausted: boolean };
+
+describe('agent.resume.* schema contract (issue #1304)', () => {
+  test('scheduler-triggered attempted payload parses', () => {
+    const payload: AttemptedPayload = {
+      entity_id: 'engineer-alpha',
+      attempt_number: 2,
+      state_before: 'error',
+      state_after: 'error',
+      trigger: 'scheduler',
+    };
+    const entry = getEntry('agent.resume.attempted')!;
+    expect(entry.kind).toBe('event');
+    expect(entry.schema.safeParse(payload).success).toBe(true);
+  });
+
+  test('manual-triggered attempted payload parses', () => {
+    const payload: AttemptedPayload = {
+      entity_id: 'qa-bravo',
+      attempt_number: 1,
+      state_before: 'suspended',
+      state_after: 'suspended',
+      trigger: 'manual',
+    };
+    expect(getEntry('agent.resume.attempted')!.schema.safeParse(payload).success).toBe(true);
+  });
+
+  test('succeeded payload records the spawning transition', () => {
+    const payload: AttemptedPayload = {
+      entity_id: 'engineer-alpha',
+      attempt_number: 1,
+      state_before: 'error',
+      state_after: 'spawning',
+      trigger: 'scheduler',
+    };
+    expect(getEntry('agent.resume.succeeded')!.schema.safeParse(payload).success).toBe(true);
+  });
+
+  test('failed payload requires the exhausted flag', () => {
+    const entry = getEntry('agent.resume.failed')!;
+    const withoutExhausted = {
+      entity_id: 'engineer-alpha',
+      attempt_number: 3,
+      state_before: 'error',
+      state_after: 'error',
+      trigger: 'scheduler' as const,
+      last_error: 'spawn failed: tmux session not found',
+    };
+    expect(entry.schema.safeParse(withoutExhausted).success).toBe(false);
+
+    const complete: FailedPayload = { ...withoutExhausted, exhausted: true };
+    expect(entry.schema.safeParse(complete).success).toBe(true);
+  });
+
+  test('last_error longer than 500 chars is rejected (caller must truncate)', () => {
+    const long = 'x'.repeat(501);
+    const entry = getEntry('agent.resume.failed')!;
+    const result = entry.schema.safeParse({
+      entity_id: 'engineer-alpha',
+      attempt_number: 1,
+      state_before: 'error',
+      state_after: 'error',
+      trigger: 'scheduler',
+      last_error: long,
+      exhausted: false,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('entity_id is hashed at parse time (tier-A PII protection)', () => {
+    const entry = getEntry('agent.resume.attempted')!;
+    const parsed = entry.schema.parse({
+      entity_id: 'engineer-alpha',
+      attempt_number: 1,
+      state_before: 'error',
+      state_after: 'error',
+      trigger: 'scheduler',
+    }) as Record<string, unknown>;
+    expect(parsed.entity_id).not.toBe('engineer-alpha');
+    expect(String(parsed.entity_id)).toContain('tier-a:agent:');
+  });
+
+  test('unknown AgentState values are not allowed — caller must map to "unknown"', () => {
+    const entry = getEntry('agent.resume.attempted')!;
+    const result = entry.schema.safeParse({
+      entity_id: 'engineer-alpha',
+      attempt_number: 1,
+      state_before: 'nonexistent-state',
+      state_after: 'error',
+      trigger: 'scheduler',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('"unknown" is an allowed state fallback', () => {
+    const entry = getEntry('agent.resume.attempted')!;
+    const result = entry.schema.safeParse({
+      entity_id: 'engineer-alpha',
+      attempt_number: 1,
+      state_before: 'unknown',
+      state_after: 'unknown',
+      trigger: 'scheduler',
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/lib/events/registry.ts
+++ b/src/lib/events/registry.ts
@@ -13,6 +13,9 @@
 import type { z } from 'zod';
 
 import * as agentLifecycle from './schemas/agent.lifecycle.js';
+import * as agentResumeAttempted from './schemas/agent.resume.attempted.js';
+import * as agentResumeFailed from './schemas/agent.resume.failed.js';
+import * as agentResumeSucceeded from './schemas/agent.resume.succeeded.js';
 import * as auditExport from './schemas/audit.export.js';
 import * as auditUnHash from './schemas/audit.un_hash.js';
 import * as cacheHit from './schemas/cache.hit.js';
@@ -140,6 +143,15 @@ export const EventRegistry = {
   // the transition from recoverable to dead-inbox. See
   // `brain/memory/reference_pattern9_inbox_watcher_spawn_loop.md`.
   [rotInboxWatcherSpawnLoopDetected.TYPE]: entry(rotInboxWatcherSpawnLoopDetected),
+
+  // Issue #1304 — auto-resume telemetry. Every attempt to resume an agent
+  // emits an `attempted` event up-front, then one of `succeeded` / `failed`
+  // once the strategy returns. Pair with existing `resume.attempt` span for
+  // end-to-end latency; these point events expose the attempt/result ratio
+  // that thrash detectors consume.
+  [agentResumeAttempted.TYPE]: entry(agentResumeAttempted),
+  [agentResumeSucceeded.TYPE]: entry(agentResumeSucceeded),
+  [agentResumeFailed.TYPE]: entry(agentResumeFailed),
 } as const satisfies Record<string, RegistryEntry>;
 
 export type EventType = keyof typeof EventRegistry;

--- a/src/lib/events/schemas/agent.resume.attempted.ts
+++ b/src/lib/events/schemas/agent.resume.attempted.ts
@@ -1,0 +1,65 @@
+/**
+ * Event: agent.resume.attempted — fired when the scheduler or the manual
+ * `genie resume` CLI enters the resume path for an agent. Emitted BEFORE the
+ * spawn call so the substrate records every attempt even if the spawn itself
+ * crashes (the failure-silence that drove #1304).
+ *
+ * Pair this with `agent.resume.succeeded` / `agent.resume.failed` to close the
+ * loop; thrash detectors watch the ratio between `attempted` and
+ * `succeeded` over a rolling window.
+ */
+
+import { z } from 'zod';
+import { hashEntity, redactFreeText } from '../redactors.js';
+import { tagTier } from '../tier.js';
+
+export const SCHEMA_VERSION = 1;
+export const TYPE = 'agent.resume.attempted' as const;
+export const KIND = 'event' as const;
+
+const AGENT_STATES = [
+  'spawning',
+  'working',
+  'idle',
+  'permission',
+  'question',
+  'done',
+  'error',
+  'suspended',
+  'unknown',
+] as const;
+
+const EntityIdSchema = tagTier(
+  z
+    .string()
+    .min(1)
+    .max(256)
+    .transform((v) => hashEntity('agent', v)),
+  'A',
+  'agent id hashed',
+);
+const AttemptNumberSchema = tagTier(z.number().int().min(1).max(64), 'C');
+const StateSchema = tagTier(z.enum(AGENT_STATES), 'C');
+const LastErrorSchema = tagTier(
+  z
+    .string()
+    .max(500)
+    .transform((v) => redactFreeText(v))
+    .optional(),
+  'B',
+  'truncated to 500 chars',
+);
+const TriggerSchema = tagTier(z.enum(['scheduler', 'manual', 'boot']), 'C');
+
+export const schema = z
+  .object({
+    entity_id: EntityIdSchema,
+    attempt_number: AttemptNumberSchema,
+    state_before: StateSchema,
+    state_after: StateSchema,
+    last_error: LastErrorSchema,
+    trigger: TriggerSchema,
+  })
+  .strict();
+
+export type AgentResumeAttemptedPayload = z.infer<typeof schema>;

--- a/src/lib/events/schemas/agent.resume.failed.ts
+++ b/src/lib/events/schemas/agent.resume.failed.ts
@@ -1,0 +1,68 @@
+/**
+ * Event: agent.resume.failed — fired when a resume attempt exits without
+ * succeeding (spawn returned false, pane refused to take over, or the CLI
+ * handler threw). `state_after` typically equals `state_before` — the thrash
+ * detector signal — unless the scheduler moved the row to `error` after the
+ * retry budget is exhausted.
+ *
+ * `last_error` carries a truncated (<=500 chars) operator-readable excerpt of
+ * the failure reason so a forensic query can surface the root cause without
+ * chasing log files.
+ */
+
+import { z } from 'zod';
+import { hashEntity, redactFreeText } from '../redactors.js';
+import { tagTier } from '../tier.js';
+
+export const SCHEMA_VERSION = 1;
+export const TYPE = 'agent.resume.failed' as const;
+export const KIND = 'event' as const;
+
+const AGENT_STATES = [
+  'spawning',
+  'working',
+  'idle',
+  'permission',
+  'question',
+  'done',
+  'error',
+  'suspended',
+  'unknown',
+] as const;
+
+const EntityIdSchema = tagTier(
+  z
+    .string()
+    .min(1)
+    .max(256)
+    .transform((v) => hashEntity('agent', v)),
+  'A',
+  'agent id hashed',
+);
+const AttemptNumberSchema = tagTier(z.number().int().min(1).max(64), 'C');
+const StateSchema = tagTier(z.enum(AGENT_STATES), 'C');
+const LastErrorSchema = tagTier(
+  z
+    .string()
+    .max(500)
+    .transform((v) => redactFreeText(v))
+    .optional(),
+  'B',
+  'truncated to 500 chars',
+);
+const TriggerSchema = tagTier(z.enum(['scheduler', 'manual', 'boot']), 'C');
+const ExhaustedSchema = tagTier(z.boolean(), 'C');
+
+export const schema = z
+  .object({
+    entity_id: EntityIdSchema,
+    attempt_number: AttemptNumberSchema,
+    state_before: StateSchema,
+    state_after: StateSchema,
+    last_error: LastErrorSchema,
+    trigger: TriggerSchema,
+    exhausted: ExhaustedSchema,
+  })
+  .strict();
+
+export type AgentResumeFailedPayload = z.infer<typeof schema>;

--- a/src/lib/events/schemas/agent.resume.succeeded.ts
+++ b/src/lib/events/schemas/agent.resume.succeeded.ts
@@ -1,0 +1,63 @@
+/**
+ * Event: agent.resume.succeeded — fired after `deps.resumeAgent` returns true
+ * (a successful respawn + pane takeover) and the `resumeAttempts` counter
+ * has been reset.
+ *
+ * Carries the same shape as `agent.resume.attempted` so consumers can join
+ * attempts to outcomes without branching on event type.
+ */
+
+import { z } from 'zod';
+import { hashEntity, redactFreeText } from '../redactors.js';
+import { tagTier } from '../tier.js';
+
+export const SCHEMA_VERSION = 1;
+export const TYPE = 'agent.resume.succeeded' as const;
+export const KIND = 'event' as const;
+
+const AGENT_STATES = [
+  'spawning',
+  'working',
+  'idle',
+  'permission',
+  'question',
+  'done',
+  'error',
+  'suspended',
+  'unknown',
+] as const;
+
+const EntityIdSchema = tagTier(
+  z
+    .string()
+    .min(1)
+    .max(256)
+    .transform((v) => hashEntity('agent', v)),
+  'A',
+  'agent id hashed',
+);
+const AttemptNumberSchema = tagTier(z.number().int().min(1).max(64), 'C');
+const StateSchema = tagTier(z.enum(AGENT_STATES), 'C');
+const LastErrorSchema = tagTier(
+  z
+    .string()
+    .max(500)
+    .transform((v) => redactFreeText(v))
+    .optional(),
+  'B',
+  'truncated to 500 chars',
+);
+const TriggerSchema = tagTier(z.enum(['scheduler', 'manual', 'boot']), 'C');
+
+export const schema = z
+  .object({
+    entity_id: EntityIdSchema,
+    attempt_number: AttemptNumberSchema,
+    state_before: StateSchema,
+    state_after: StateSchema,
+    last_error: LastErrorSchema,
+    trigger: TriggerSchema,
+  })
+  .strict();
+
+export type AgentResumeSucceededPayload = z.infer<typeof schema>;

--- a/src/lib/events/schemas/schemas.test.ts
+++ b/src/lib/events/schemas/schemas.test.ts
@@ -14,9 +14,15 @@ import { EventRegistry, type EventType, getEntry, isRegistered, listTypes } from
 import { readTier } from '../tier.js';
 
 describe('event registry — closed world', () => {
-  test('all registered types are non-empty (G2 exemplars + G3 + G5 audit + G6 watcher)', () => {
+  test('all registered types are non-empty (G2 exemplars + G3 + G5 audit + G6 watcher + #1304 auto-resume)', () => {
     const types = listTypes();
     expect(types.length).toBeGreaterThanOrEqual(22);
+  });
+
+  test('auto-resume triplet is registered (#1304)', () => {
+    expect(isRegistered('agent.resume.attempted')).toBe(true);
+    expect(isRegistered('agent.resume.succeeded')).toBe(true);
+    expect(isRegistered('agent.resume.failed')).toBe(true);
   });
 
   test('getEntry resolves for every registered type', () => {
@@ -294,6 +300,31 @@ const fixtures: Record<EventType, Record<string, unknown>> = {
     session_key: 'wish-state-invalidation',
     failure_count: 3,
     last_error_message: 'ensureTeamLead failed: tmux session not found',
+  },
+
+  // Issue #1304 — auto-resume telemetry triplet.
+  'agent.resume.attempted': {
+    entity_id: 'engineer-alpha',
+    attempt_number: 1,
+    state_before: 'error',
+    state_after: 'error',
+    trigger: 'scheduler',
+  },
+  'agent.resume.succeeded': {
+    entity_id: 'engineer-alpha',
+    attempt_number: 1,
+    state_before: 'error',
+    state_after: 'spawning',
+    trigger: 'scheduler',
+  },
+  'agent.resume.failed': {
+    entity_id: 'engineer-alpha',
+    attempt_number: 3,
+    state_before: 'error',
+    state_after: 'error',
+    last_error: 'spawn failed: tmux session not found',
+    trigger: 'scheduler',
+    exhausted: true,
   },
 };
 

--- a/src/lib/scheduler-daemon.ts
+++ b/src/lib/scheduler-daemon.ts
@@ -21,7 +21,9 @@ import { appendFileSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { Agent, AgentState } from './agent-registry.js';
+import { recordAuditEvent } from './audit.js';
 import { computeNextCronDue, parseDuration } from './cron.js';
+import { emitEvent } from './emit.js';
 import { type EventRouterHandle, startEventRouter } from './event-router.js';
 import { getInboxPollIntervalMs, startInboxWatcher, stopInboxWatcher } from './inbox-watcher.js';
 import { type MailboxMessage, getRetryable, markEscalated, subscribeDelivery } from './mailbox.js';
@@ -1241,6 +1243,79 @@ type ResumeResult = 'resumed' | 'exhausted' | 'skipped';
  * Checks eligibility (autoResume flag, retry budget, cooldown, concurrency cap),
  * then delegates to `deps.resumeAgent` to actually respawn the agent.
  */
+/**
+ * Known `AgentState` values we expose on the auto-resume telemetry events.
+ * Any unrecognized value (e.g., a schema migration landed a new state we
+ * haven't registered yet) degrades to `'unknown'` so emission never throws
+ * on a Zod enum mismatch. Keep in sync with `src/lib/events/schemas/agent.resume.*.ts`.
+ */
+const TELEMETRY_STATES = new Set<AgentState>([
+  'spawning',
+  'working',
+  'idle',
+  'permission',
+  'question',
+  'done',
+  'error',
+  'suspended',
+]);
+
+function telemetryState(raw: AgentState | null | undefined): string {
+  return raw && TELEMETRY_STATES.has(raw) ? raw : 'unknown';
+}
+
+/**
+ * Emit the auto-resume telemetry triplet (`agent.resume.attempted|succeeded|failed`)
+ * to both sinks:
+ *   - `audit_events` (via `recordAuditEvent`) so `genie events list --type
+ *      agent.resume.*` surfaces rows immediately. Issue #1304.
+ *   - v2 runtime events (via `emitEvent`) for detector consumers.
+ *
+ * Both calls are best-effort — `recordAuditEvent` swallows DB errors, and
+ * `emitEvent` is fire-and-forget. Failure here MUST NOT break the resume path.
+ */
+function recordResumeTelemetry(
+  eventType: 'agent.resume.attempted' | 'agent.resume.succeeded' | 'agent.resume.failed',
+  payload: {
+    entity_id: string;
+    attempt_number: number;
+    state_before: string;
+    state_after: string;
+    last_error?: string;
+    trigger: 'scheduler' | 'manual' | 'boot';
+    exhausted?: boolean;
+  },
+  actor: string,
+): void {
+  // audit_events (default `genie events list` target)
+  void recordAuditEvent('agent.resume', payload.entity_id, eventType, actor, payload).catch(() => {
+    /* best-effort — swallowed inside recordAuditEvent too */
+  });
+
+  // v2 runtime events (detector target)
+  try {
+    const v2Payload: Record<string, unknown> = {
+      entity_id: payload.entity_id,
+      attempt_number: payload.attempt_number,
+      state_before: payload.state_before,
+      state_after: payload.state_after,
+      trigger: payload.trigger,
+    };
+    if (payload.last_error) {
+      v2Payload.last_error = payload.last_error.slice(0, 500);
+    }
+    if (eventType === 'agent.resume.failed') {
+      v2Payload.exhausted = payload.exhausted ?? false;
+    }
+    emitEvent(eventType, v2Payload, {
+      severity: eventType === 'agent.resume.failed' ? 'warn' : 'info',
+      source_subsystem: 'scheduler.auto-resume',
+    });
+  } catch {
+    /* emit is best-effort — observability must never break the path it observes */
+  }
+}
+
 export async function attemptAgentResume(
   deps: SchedulerDeps,
   config: SchedulerConfig,
@@ -1348,6 +1423,19 @@ export async function attemptAgentResume(
     max_resume_attempts: maxAttempts,
   });
 
+  const stateBefore = telemetryState(agent.state);
+  recordResumeTelemetry(
+    'agent.resume.attempted',
+    {
+      entity_id: agentId,
+      attempt_number: newAttempts,
+      state_before: stateBefore,
+      state_after: stateBefore,
+      trigger: 'scheduler',
+    },
+    'scheduler',
+  );
+
   // Attempt the resume
   const success = await deps.resumeAgent(agentId);
 
@@ -1363,6 +1451,22 @@ export async function attemptAgentResume(
       agent_id: agentId,
       resume_attempts: newAttempts,
     });
+    recordResumeTelemetry(
+      'agent.resume.succeeded',
+      {
+        entity_id: agentId,
+        attempt_number: newAttempts,
+        state_before: stateBefore,
+        // A successful resume re-spawns the agent; the registry row is about
+        // to transition to 'spawning' as `defaultSpawnCommand` fires. Emitting
+        // 'spawning' here gives detectors the state_before != state_after
+        // signal they need to distinguish thrashing (where state never moves)
+        // from healthy resumes (where it does).
+        state_after: 'spawning',
+        trigger: 'scheduler',
+      },
+      'scheduler',
+    );
     return 'resumed';
   }
 
@@ -1374,6 +1478,23 @@ export async function attemptAgentResume(
     resume_attempts: newAttempts,
     max_resume_attempts: maxAttempts,
   });
+
+  const willExhaust = newAttempts >= maxAttempts;
+  recordResumeTelemetry(
+    'agent.resume.failed',
+    {
+      entity_id: agentId,
+      attempt_number: newAttempts,
+      state_before: stateBefore,
+      // On failure the state does NOT move (this is the thrash signal). When
+      // exhaustion trips immediately after, the reconciler flips the row to
+      // `error` — captured on the next scheduler tick, not here.
+      state_after: stateBefore,
+      trigger: 'scheduler',
+      exhausted: willExhaust,
+    },
+    'scheduler',
+  );
 
   // If this was the last attempt, mark exhausted AND persist
   // `auto_resume=false` so the next scheduler tick's resumable filter excludes

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -16,6 +16,7 @@ import { resolveBuiltinAgentPath } from '../lib/builtin-agents.js';
 import * as nativeTeams from '../lib/claude-native-teams.js';
 import { OTEL_RELAY_PORT, ensureCodexOtelConfig } from '../lib/codex-config.js';
 import { type ResolveContext, resolveField } from '../lib/defaults.js';
+import { emitEvent } from '../lib/emit.js';
 import { tmuxBin } from '../lib/ensure-tmux.js';
 import * as executorRegistry from '../lib/executor-registry.js';
 import type { TransportType as ExecutorTransport } from '../lib/executor-types.js';
@@ -2511,13 +2512,97 @@ async function createResumeExecutor(
  *     increment and prevent the exhaustion check from ever firing. See
  *     fix/auto-resume-counter-persistence.
  */
+const TELEMETRY_KNOWN_STATES = new Set([
+  'spawning',
+  'working',
+  'idle',
+  'permission',
+  'question',
+  'done',
+  'error',
+  'suspended',
+]);
+
+function resumeTelemetryState(raw: registry.AgentState | null | undefined): string {
+  return raw && TELEMETRY_KNOWN_STATES.has(raw) ? raw : 'unknown';
+}
+
+/**
+ * Emit the auto-resume telemetry triplet for the MANUAL CLI path. Pass
+ * `shouldEmit=false` on scheduler-triggered invocations (`--no-reset-attempts`)
+ * — the scheduler's own `attemptAgentResume` is already instrumented in
+ * `scheduler-daemon.ts`, so emitting here would double-count every thrash
+ * detector rate. Issue #1304.
+ *
+ * Both sinks (audit_events + v2 runtime events) are best-effort — never let
+ * observability break the resume path it observes.
+ */
+function recordManualResumeTelemetry(
+  shouldEmit: boolean,
+  eventType: 'agent.resume.attempted' | 'agent.resume.succeeded' | 'agent.resume.failed',
+  payload: {
+    entity_id: string;
+    attempt_number: number;
+    state_before: string;
+    state_after: string;
+    last_error?: string;
+    exhausted?: boolean;
+  },
+): void {
+  if (!shouldEmit) return;
+
+  void recordAuditEvent('agent.resume', payload.entity_id, eventType, getActor(), {
+    ...payload,
+    trigger: 'manual',
+  }).catch(() => {});
+
+  try {
+    const v2: Record<string, unknown> = {
+      entity_id: payload.entity_id,
+      attempt_number: payload.attempt_number,
+      state_before: payload.state_before,
+      state_after: payload.state_after,
+      trigger: 'manual',
+    };
+    if (payload.last_error) {
+      v2.last_error = payload.last_error.slice(0, 500);
+    }
+    if (eventType === 'agent.resume.failed') {
+      v2.exhausted = payload.exhausted ?? false;
+    }
+    emitEvent(eventType, v2, {
+      severity: eventType === 'agent.resume.failed' ? 'warn' : 'info',
+      source_subsystem: 'cli.resume',
+    });
+  } catch {
+    /* best-effort */
+  }
+}
+
 async function resumeAgent(agent: registry.Agent, opts: { resetAttempts?: boolean } = {}): Promise<void> {
   const resetAttempts = opts.resetAttempts !== false;
   const template = (await registry.listTemplates()).find((t) => t.id === (agent.role ?? agent.id));
+  // Only emit from the manual path. The scheduler path invokes us via
+  // `genie agent resume <id> --no-reset-attempts` and is already instrumented
+  // by `attemptAgentResume` — double-emission here would inflate every
+  // thrash-detector rate by 2x.
+  const shouldEmitTelemetry = resetAttempts;
+  const telemetryStateBefore = resumeTelemetryState(agent.state);
+  // When manual, `registry.update` below resets the counter to 0, so the
+  // in-flight attempt is #1. When scheduler-triggered, the counter has
+  // already been incremented by `attemptAgentResume` — we don't emit there.
+  const telemetryAttemptNumber = 1;
 
   if (resetAttempts) {
     await registry.update(agent.id, { resumeAttempts: 0 });
   }
+
+  recordManualResumeTelemetry(shouldEmitTelemetry, 'agent.resume.attempted', {
+    entity_id: agent.id,
+    attempt_number: telemetryAttemptNumber,
+    state_before: telemetryStateBefore,
+    state_after: telemetryStateBefore,
+  });
 
   const params = await buildFullResumeParams(agent, template);
 
@@ -2568,7 +2653,16 @@ async function resumeAgent(agent: registry.Agent, opts: { resetAttempts?: boolea
   try {
     paneId = createTmuxPane(ctx, teamWindow);
   } catch (err) {
-    console.error(`Failed to create tmux pane: ${err instanceof Error ? err.message : 'unknown error'}`);
+    const errorMessage = err instanceof Error ? err.message : 'unknown error';
+    recordManualResumeTelemetry(shouldEmitTelemetry, 'agent.resume.failed', {
+      entity_id: agent.id,
+      attempt_number: telemetryAttemptNumber,
+      state_before: telemetryStateBefore,
+      state_after: telemetryStateBefore,
+      last_error: `createTmuxPane: ${errorMessage}`,
+      exhausted: false,
+    });
+    console.error(`Failed to create tmux pane: ${errorMessage}`);
     process.exit(1);
   }
 
@@ -2601,6 +2695,13 @@ async function resumeAgent(agent: registry.Agent, opts: { resetAttempts?: boolea
     claudeSessionId: agent.claudeSessionId,
     team: agent.team,
   }).catch(() => {});
+
+  recordManualResumeTelemetry(shouldEmitTelemetry, 'agent.resume.succeeded', {
+    entity_id: agent.id,
+    attempt_number: telemetryAttemptNumber,
+    state_before: telemetryStateBefore,
+    state_after: 'spawning',
+  });
 
   console.log(`Agent "${agent.id}" resumed.`);
   console.log(`  Session:  ${agent.claudeSessionId}`);


### PR DESCRIPTION
Closes #1304 — Part 1 (MANDATORY).

## Summary

Auto-resume thrashing was invisible to the event substrate. `genie events list --type agent.resume` returned nothing because the auto-resume path (scheduler + manual `genie resume`) only wrote plain log lines via `deps.log(...)` — never a structured row that operators or detectors could query. This PR wires three new point events on the attempt/succeed/fail lifecycle.

## What ships

Three new v2 schemas (`kind: 'event'`), registered in the closed registry:

- `agent.resume.attempted` — fired before the spawn call so the telemetry lands even if the spawn itself crashes
- `agent.resume.succeeded` — fired after a successful respawn (`state_after: 'spawning'`)
- `agent.resume.failed`    — fired on spawn failure, carries `exhausted: boolean`

Each payload carries: `entity_id` (tier-A hashed agent id), `attempt_number`, `state_before`, `state_after`, optional `last_error` (truncated to 500 chars, tier-B redacted), and `trigger` ∈ {`scheduler`, `manual`, `boot`}.

Emission sites:

- `src/lib/scheduler-daemon.ts#attemptAgentResume` — instrumented next to the existing ` deps.log(...)` lines. Scheduler-triggered attempts emit with `trigger='scheduler'`.
- `src/term-commands/agents.ts#resumeAgent` — instrumented for the manual CLI path (`resetAttempts !== false`). The scheduler calls into this function via `--no-reset-attempts`, and we deliberately **skip emission** in that branch to avoid double-counting thrash-detector rates.

Each call writes to both sinks:

- `audit_events` (default target of `genie events list --type <X>`) via `recordAuditEvent('agent.resume', agentId, '<attempted|succeeded|failed>', actor, details)`. Because `queryAuditEvents` widens the `--type` filter to match on `entity_type` as well as `event_type`, both `--type agent.resume` and `--type agent.resume.attempted` surface rows.
- `genie_runtime_events` v2 via `emitEvent(...)` with Zod schema validation — the structured feed detectors (and the forthcoming thrash detector) consume.

Both sinks are best-effort — observability never breaks the resume path it observes.

## Part 2 — intentionally deferred

The brief made `rot.auto-resume-thrashing` optional: *ship Part 1 alone if Part 2 requires deep architectural changes*. I shipped Part 1 alone. The detector lands in a follow-up once these events have soaked long enough in production to tune the `>= 3 in 10 min with no state transition` threshold with real data instead of a guess.

## Test plan

- [x] `bun run build` — bundles cleanly (522 modules, 4.96 MB)
- [x] `bunx biome check .` — exit 0, warnings only (one complexity warning at 16 vs max 15 on `resumeAgent` after the emission additions; all other warnings are pre-existing)
- [x] `bun run typecheck` — exit 0
- [x] `bun test` (focused: schemas + scheduler + resume + zombie-cap) — 116 pass / 0 fail / 352 expect() calls
- [x] Schema contract test (`auto-resume-telemetry.test.ts`) — asserts the exact payload shapes the two emitters build parse cleanly; traps silent `schema.violation` regressions at build time
- [x] Happy-path + strict-mode fixtures added to `schemas.test.ts` for all three new event types
- [ ] Manual smoke: `genie resume <name>` + `genie events list --type agent.resume` to confirm rows surface (verification on reviewer's machine — the emission is fire-and-forget and requires a live PG)

## Footprint

Within the brief's footprint (`src/lib/events/schemas/*.ts`, `schemas.test.ts`, auto-resume call sites, colocated tests). No touches to `genie ls`, the audit query layer, or the reconciler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)