### PR TITLE
docs(wishes): 2026-04-21/22 cycle — turn-close-row-targeting, follow-ups + deflake

### DIFF
--- a/.genie/wishes/_archive/agent-row-unification-rejected-2026-04-21/WISH.md
+++ b/.genie/wishes/_archive/agent-row-unification-rejected-2026-04-21/WISH.md
@@ -1,0 +1,449 @@
+# Wish: Agent Row Unification
+
+| Field | Value |
+|-------|-------|
+| **Status** | DRAFT |
+| **Slug** | `agent-row-unification` |
+| **Date** | 2026-04-21 |
+| **Design** | _No brainstorm — direct wish_ (origin: `turn-session-contract` Execution Review, Gap #1) |
+
+## Summary
+
+Retire the legacy `register()` code path in `src/lib/agent-registry.ts` that inserts name-keyed agent rows alongside the UUID-keyed identity rows created by `findOrCreateAgent()`. Merge runtime state columns (`pane_id`, `session`, `state`, `claude_session_id`, etc.) onto the identity row so every agent is represented by exactly one row. Migrate existing dual-row data by consolidating pairs matched on `(custom_name, team)` into their identity row, then dropping the legacy rows. This closes the turn-session-contract Gap #1 (`genie done` can't flip the correct state row because executor FK and runtime state live on different rows) and eliminates an entire class of ghost-resume loops where closed executors can't mark their concrete agents terminal.
+
+## Scope
+
+### IN
+- Migrate existing dual-row data: for each `(custom_name, team)` pair, merge the legacy row's runtime columns onto the identity row and delete the legacy row.
+- Delete `register()` from `src/lib/agent-registry.ts`.
+- Refactor all `register()` callers to use `findOrCreateAgent()` + new `updateAgentRuntime()` (or equivalent single-row UPSERT on the identity PK).
+- Extend `findOrCreateAgent()` (or add `ensureAgentWithRuntime()`) to accept the runtime fields `register()` currently sets, idempotent by `(custom_name, team)` lookup.
+- Update `turnClose()` in `src/lib/turn-close.ts` to flip `state='done'` on the identity row (not via `current_executor_id` FK chase) so a closed turn marks the canonical agent terminal.
+- Update `reconcileDeadPaneZombies`, `runAgentRecoveryPass`, `attemptAgentResume`, and the turn-aware reconciler's D1/D3 rules to operate on identity rows only.
+- Delete the `dir:<name>` row creation path if it's the same legacy code; otherwise migrate it to use identity rows.
+- Add a regression migration `NNNN_unify_agent_rows.sql` that merges and deletes in a single transaction.
+- Cross-team collision logic (the 2026-04-19 incident code at `agent-registry.ts:235-264`) preserved but moved to `findOrCreateAgent()`.
+- Tests: unit tests for the merge migration, integration tests for spawn → turn-close → reconcile on a unified row, regression test for the ghost-resume-after-done scenario (`turn-session-contract` Gap #1 symptom).
+
+### OUT
+- The `dir:*` registration from `agent-directory.json` as a user-facing concept stays — only the PG row representation changes.
+- Omni-side changes. This is a genie-internal schema change.
+- Web UI for agent inspection (separate wish).
+- Tmux pane ownership / pane_id semantics change — `pane_id` stays on agent rows, just consolidated onto the identity row.
+- Executor schema changes — `executors.agent_id` keeps pointing at UUIDs; the migration ensures every executor's `agent_id` resolves to a valid identity row.
+
+## Decisions
+
+| ID | Decision | Rationale |
+|----|----------|-----------|
+| D1 | Identity row (UUID-keyed, from `findOrCreateAgent`) becomes the ONLY row. Legacy name-keyed row is eliminated. | Single source of truth. Executor FK, runtime state, team membership, and identity live in one place. Eliminates the "which row do I update?" ambiguity. |
+| D2 | Migration merges legacy → identity, not the other way. Legacy rows are deleted. | Identity rows already carry stable UUIDs that executors FK to (via `executors.agent_id`). Flipping direction would orphan the executor FK chain. |
+| D3 | `register()` deleted; `findOrCreateAgent()` extended to take optional runtime fields and UPSERT by `(custom_name, team)`. | Fewer public functions, single path. Readers don't have to wonder which one is canonical. Ergonomist principle: *APIs before implementations.* |
+| D4 | Migration is additive first (Phase A adds helper + runs a dry-run count), destructive second (Phase B deletes). Feature flag `GENIE_UNIFIED_AGENT_ROWS` gates the new path. | Reversibility > deploy speed (same pattern as turn-session-contract). |
+| D5 | Cross-team collision logic from `register()` (lines 235-264) moved verbatim to `findOrCreateAgent()`. | The 2026-04-19 cross-team incident comment is battle-tested guardrail code. Don't lose it. |
+| D6 | Migration runs per-pair transaction. A failed merge on one pair does not abort the batch. | A malformed legacy row shouldn't block 1,000 good merges. Failed pairs are logged to an `agent_unification_failures` table for operator review. |
+| D7 | Executor FK `executors.agent_id → agents.id` stays as-is. Migration verifies every executor's `agent_id` resolves post-merge. | If it doesn't resolve, the executor is orphaned and the migration rolls back the pair. |
+
+## Success Criteria
+
+- [ ] **C1** Every agent in `agents` has exactly one row (no duplicates by `custom_name + team`). Post-migration SELECT verifies.
+- [ ] **C2** Every `executors.agent_id` FK resolves to a valid `agents.id` row. No orphaned executors.
+- [ ] **C3** `turnClose()` writes `state='done'` on the identity row directly (via executor's `agent_id`), not via reverse-FK lookup. Integration test: call `genie done` with a spawned agent, assert `agents.state='done'` within the same transaction.
+- [ ] **C4** The `genie done` → reconcile resurrection loop (turn-session-contract Gap #1) no longer reproduces. Regression test spawns agent, calls `genie done`, simulates daemon restart, asserts no auto-resume event within 60s.
+- [ ] **C5** `register()` function is deleted from `src/lib/agent-registry.ts`. `rg 'register\(' src/` returns zero matches for direct calls (excluding `findOrCreateAgent`).
+- [ ] **C6** All existing callers of `register()` now use `findOrCreateAgent()` (with optional runtime fields) or `updateAgentRuntime()`.
+- [ ] **C7** Migration `NNNN_unify_agent_rows.sql` applies cleanly to both fresh and populated DBs.
+- [ ] **C8** Migration is idempotent — running twice merges nothing new the second time.
+- [ ] **C9** Cross-team collision logic preserved — test that reproduces the 2026-04-19 incident still fails loudly.
+- [ ] **C10** Feature flag `GENIE_UNIFIED_AGENT_ROWS` gates the new writer path in Phase A; removed in Phase C.
+- [ ] **C11** `agent_unification_failures` table captures any pair that couldn't be merged (with reason).
+- [ ] **C12** `bun run check` passes with zero regressions.
+- [ ] **C13** `bun test` passes; no existing tests broken by the migration.
+- [ ] **C14** `auto-resume-zombie-cap.test.ts` gets a new `describe('unified-row contract')` block verifying the ghost-loop is closed.
+
+## Execution Strategy
+
+Dependency graph: `G1 → G2 → G3 → G4a → G4b → G4c → G4d → G5`; G6 runs in parallel with G3/G4*. G7 (flag removal) blocks on 7-day soak after G5. Each sub-group in G4 is a separate PR — progressive, individually reverting.
+
+### Wave 1 (solo — schema + helpers)
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 1 | engineer | Extend `findOrCreateAgent()` + add `updateAgentRuntime()`. Add `GENIE_UNIFIED_AGENT_ROWS` flag scaffolding with XOR semantics. Audit + document all `INSERT INTO agents` sites. No behavior change when flag off. |
+
+### Wave 2 (parallel — consumers migrate + ops tooling)
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 2 | engineer | Migrate all `register()` call sites to the new API behind XOR flag. Migrate test fixtures. |
+| 6 | engineer | Dry-run / apply / rollback scripts + runbook + `genie doctor` integration. |
+
+### Wave 3 (solo — destructive migration)
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 3 | engineer | Phase B migration: FK rewrite + archive + per-pair merge + post-migration FK verification. Writes to `agent_unification_failures` on conflict. Rollback script smoke-tested. |
+
+### Wave 4 (sequential — flip, delete, rewrite) — each sub-group is its own PR
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 4a | engineer | Flip `GENIE_UNIFIED_AGENT_ROWS` default to `true`. No code deletion. |
+| 4b | engineer | Delete `register()` + remove flag branches. Dead-code pass. |
+| 4c | engineer | Rewrite `turnClose()` to flip identity-row state directly. Closes turn-session-contract Gap #1. |
+| 4d | engineer | Rewrite reconcile loops to read identity row. Boot-mode terminal-state check. Closes turn-session-contract Gap #2. |
+
+### Wave 5 (parallel — evidence + review)
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 5 | engineer | Evidence package for turn-session-contract's next review cycle. **Does not** edit parent wish. |
+| review | reviewer | Plan + execution review against criteria. |
+
+### Wave 6 (after ≥7-day soak — cleanup)
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 7 | engineer | Remove `GENIE_UNIFIED_AGENT_ROWS` flag + `isUnifiedAgentRowsEnabled()` helper. Drop `agents_legacy_archive` table (if all archived rows older than soak window). |
+
+## Execution Groups
+
+### Group 1: API extension + flag scaffolding
+**Goal:** Add the unified-row writer surface without changing current behavior.
+
+**Deliverables:**
+1. Extend `findOrCreateAgent(name, team, role)` signature to `findOrCreateAgent(identity, runtime?)` where `runtime` is an optional `AgentRuntime` type with `paneId`, `session`, `state`, `claudeSessionId`, `wishSlug`, `taskId`, etc.
+2. New `updateAgentRuntime(agentId, runtime)` helper that UPDATEs identity row with runtime fields by `id`.
+3. `GENIE_UNIFIED_AGENT_ROWS` env flag read in `src/lib/agent-registry.ts`. **XOR semantics**: flag off → only legacy `register()` runs (current behavior preserved); flag on → only `findOrCreateAgent()+updateAgentRuntime()` runs. Never both simultaneously — DB state is predictable at every moment.
+4. Cross-team collision check (the 2026-04-19 incident logic from `register()` lines 235-264) moved to `findOrCreateAgent()`.
+5. Unit tests covering: new signature, runtime UPSERT, collision rejection.
+
+**Acceptance Criteria:**
+- [ ] `bun run typecheck` clean
+- [ ] `findOrCreateAgent(name, team, role, runtime)` returns identity row with runtime fields persisted
+- [ ] Cross-team collision test passes
+- [ ] Flag-off path preserves legacy `register()` behavior bit-for-bit
+- [ ] **Audit complete:** `rg "INSERT INTO agents" src/ scripts/` enumerates all insertion sites. Count matches manual review.
+- [ ] **Decision document:** `.genie/wishes/agent-row-unification/insertion-sites-audit.md` records every site found, classifies each as (a) in-scope for migration, (b) test-fixture for update, or (c) out-of-scope legacy to preserve. If a third `dir:*` registration path (from `agent-directory.json`) is distinct, document whether it joins this wish or spawns a sibling wish.
+
+**Validation:**
+```bash
+cd /home/genie/workspace/agents/genie-configure/repos/genie && bun test src/lib/agent-registry.test.ts && bun run check && test -f .genie/wishes/agent-row-unification/insertion-sites-audit.md
+```
+
+**depends-on:** none
+
+---
+
+### Group 2: Caller migration behind flag
+**Goal:** Every call to `register()` also calls `findOrCreateAgent()+updateAgentRuntime()` when flag is on.
+
+**Deliverables:**
+1. Audit all `register()` call sites from Group 1's `insertion-sites-audit.md`. Current known: `src/lib/claude-native-teams.ts`, `src/term-commands/agent/spawn.ts`, `src/hooks/handlers/session-sync.ts`, tmux wrapper.
+2. Each call site gets a `if (isUnifiedAgentRowsEnabled()) { findOrCreateAgent+updateRuntime } else { register() }` branch, respecting **XOR flag semantics** (see G1). Only one path runs per flag state.
+3. **Migrate test fixtures.** Direct-INSERT sites in test files — `src/__tests__/tui-spawn-dx.integration.test.ts:66`, `src/db/migrations/044_phase_b_flip_defaults.test.ts:63/78/94/114`, `src/lib/pg-seed.test.ts:126/133` — are updated to use the unified-row shape OR explicitly flagged as legacy-only fixtures with an env guard that forces `GENIE_UNIFIED_AGENT_ROWS=0` for that test.
+4. Integration test: spawn a fresh agent with flag on, verify exactly one row exists in `agents` table, verify runtime fields populated.
+5. Integration test: spawn same agent name in different team with flag on, verify cross-team collision rejects loudly.
+
+**Acceptance Criteria:**
+- [ ] Every `register()` call site has an if/else branch with XOR flag semantics
+- [ ] Flag-on spawn produces exactly one row; flag-off produces exactly one row (the legacy row). **No dual rows in either flag state.**
+- [ ] Test fixtures migrated per Deliverable #3 — `rg "INSERT INTO agents" src/ test/` returns no new direct-INSERTs
+- [ ] `bun run check` passes under both `GENIE_UNIFIED_AGENT_ROWS=1` and `GENIE_UNIFIED_AGENT_ROWS=0`
+- [ ] Existing tests unchanged (no behavioral regression under flag off)
+
+**Validation:**
+```bash
+cd /home/genie/workspace/agents/genie-configure/repos/genie && GENIE_UNIFIED_AGENT_ROWS=1 bun test src/__tests__/tui-spawn-dx.integration.test.ts && bun run check
+```
+
+**depends-on:** Group 1
+
+---
+
+### Group 3: Merge migration (Phase B — destructive)
+**Goal:** Consolidate existing dual-row pairs into identity rows, drop legacy rows.
+
+**Deliverables:**
+1. Migration `NNNN_unify_agent_rows.sql`:
+   - Find all pairs: `(legacy.id = legacy.custom_name)` AND `(identity.custom_name, identity.team) = (legacy.custom_name, legacy.team)` AND `identity.id` is a UUID.
+   - **For each pair, in a single transaction, in this order:**
+     1. **Copy legacy row into `agents_legacy_archive`** (preserves rollback capability for the 7-day soak window).
+     2. **Update `executors.agent_id`** for any executor referencing the legacy row's id: `UPDATE executors SET agent_id = <identity.id> WHERE agent_id = <legacy.id>`. If any executor rows are updated, log a warning audit event — this instance has pre-`findOrCreateAgent()` executors that were pointing at legacy rows.
+     3. **Merge runtime fields** from legacy into identity row (pane_id, session, state, claude_session_id, wish_slug, task_id, etc.). `last_state_change`-based winner on conflicting fields.
+     4. **DELETE legacy row.**
+     5. **Emit audit event** `agent.unified` with both IDs + runtime field source.
+   - On constraint violation or unresolvable state, INSERT into `agent_unification_failures` with pair IDs + reason; roll back that pair only; continue batch.
+   - **Post-migration verification (same transaction batch):** `SELECT COUNT(*) FROM executors e LEFT JOIN agents a ON e.agent_id = a.id WHERE a.id IS NULL` must equal 0. Orphaned executors abort the migration and trigger rollback for the batch window.
+2. `agents_legacy_archive` table with same schema as `agents` plus `merged_at TIMESTAMPTZ DEFAULT now()`, `merged_into_id TEXT REFERENCES agents(id)`, `merge_reason TEXT`. Retained through Phase C soak, droppable by Group 7.
+3. Dry-run script: `scripts/unify-agents-dry-run.ts` that prints a table of pairs-to-merge + count of executors that will be FK-rewritten, without mutating.
+4. Apply script: `scripts/unify-agents-apply.ts` that requires typed confirmation (`I UNDERSTAND` match), runs in batches of 100, emits audit events, is resumable on crash.
+5. Rollback script: `scripts/unify-agents-rollback.ts` that, given a merge batch id or timestamp range, copies rows from `agents_legacy_archive` back to `agents` and reverses `executors.agent_id` updates. **Smoke-tested before G4 runs; not invoked unless G4 introduces a regression.**
+6. Test fixtures: seeded dual-row pairs in a tmpdir PG (including executor FK pointing at legacy row), migration run, assert convergence + FK resolution + archive population.
+
+**Acceptance Criteria:**
+- [ ] Dry-run on fixture DB shows N pairs + M executor FK rewrites, mutates nothing
+- [ ] Apply on fixture DB: `agents` row count reduces by N; `agents_legacy_archive` row count = N; zero orphaned executors post-migration
+- [ ] Apply is resumable — kill mid-batch, re-run, converges without double-merging
+- [ ] Re-running apply is a no-op once convergence is reached
+- [ ] `agent_unification_failures` captures any unresolvable case with clear reason
+- [ ] Audit event per merge: `agent.unified` with before/after row IDs and archive ref
+- [ ] **Rollback script smoke test:** apply migration on fixture, run rollback, assert original dual-row state restored exactly
+
+**Validation:**
+```bash
+cd /home/genie/workspace/agents/genie-configure/repos/genie && bun test src/db/migrations/NNNN_unify_agent_rows.test.ts && bun run scripts/unify-agents-dry-run.ts --help
+```
+
+**depends-on:** Group 1
+
+---
+
+### Group 4a: Flip flag default to true
+**Goal:** `GENIE_UNIFIED_AGENT_ROWS` defaults to on. No code deletion yet — legacy branches still callable via `=0` override.
+
+**Deliverables:**
+1. Change default return of `isUnifiedAgentRowsEnabled()` from `false` to `true` in `src/lib/agent-registry.ts`.
+2. Update telemetry logger to include flag state at serve startup.
+3. Release note: "Phase B active — agent rows now unified by default. Run `GENIE_UNIFIED_AGENT_ROWS=0` to temporarily revert if regression discovered."
+
+**Acceptance Criteria:**
+- [ ] Default flag state is `true` when env var unset
+- [ ] Startup log reports `unified_agent_rows=on`
+- [ ] Existing tests pass (they exercise both paths via explicit env override)
+- [ ] `bun run check` passes
+
+**Validation:**
+```bash
+cd /home/genie/workspace/agents/genie-configure/repos/genie && bun run check && unset GENIE_UNIFIED_AGENT_ROWS && bun test src/lib/agent-registry.test.ts
+```
+
+**depends-on:** Groups 2, 3
+
+---
+
+### Group 4b: Delete `register()` + remove flag branches
+**Goal:** Legacy code path physically deleted from source. Flag state becomes irrelevant (only the unified path exists).
+
+**Deliverables:**
+1. Delete `register()` function from `src/lib/agent-registry.ts`.
+2. Remove all `if (isUnifiedAgentRowsEnabled())` / `else` branches from callers audited in Group 2 — keep only the unified path.
+3. Mark `isUnifiedAgentRowsEnabled()` as deprecated (always returns true); remove in Group 7.
+4. Update imports — `register` no longer exported.
+
+**Acceptance Criteria:**
+- [ ] `rg 'function register\(' src/` returns zero matches
+- [ ] `rg 'agents\.register\(' src/` (after lib rename) returns zero matches
+- [ ] `rg 'if \(isUnifiedAgentRowsEnabled' src/` returns zero matches
+- [ ] `bun run check` passes with no unused-import warnings
+- [ ] `bun run dead-code` (knip) returns no new regressions tied to the deletion
+
+**Validation:**
+```bash
+cd /home/genie/workspace/agents/genie-configure/repos/genie && rg 'function register\(' src/ ; bun run check && bun run dead-code
+```
+
+**depends-on:** Group 4a
+
+---
+
+### Group 4c: Rewrite `turnClose()` to flip identity row directly
+**Goal:** Close verbs mark the canonical agent terminal without chasing reverse-FK links. Closes turn-session-contract Gap #1.
+
+**Deliverables:**
+1. Rewrite the UPDATE inside `turnClose()` (`src/lib/turn-close.ts`):
+   - **Before:** `UPDATE agents SET current_executor_id=NULL WHERE current_executor_id=${executorId}`
+   - **After:** `UPDATE agents SET state='done', current_executor_id=NULL WHERE id=(SELECT agent_id FROM executors WHERE id=${executorId})`
+2. Keep the atomic transaction envelope; the SELECT and UPDATE stay in the same transaction.
+3. Add defensive check: if the inner SELECT returns NULL (executor has no agent_id — should never happen post-G3), emit a warn-level audit event and skip the agent update (but still close the executor).
+4. Update `turn-close.test.ts`: new tests for (a) state flips to 'done' post-close, (b) defensive skip when executor has NULL agent_id, (c) atomic rollback when the UPDATE targets a non-existent agent row.
+
+**Acceptance Criteria:**
+- [ ] Agent row state flips to `'done'` in same transaction as executor close
+- [ ] Defensive-path test passes (NULL agent_id)
+- [ ] Atomic rollback test passes (inject failure, verify no partial writes)
+- [ ] `bun test src/lib/turn-close.test.ts` passes
+- [ ] `bun run check` passes
+
+**Validation:**
+```bash
+cd /home/genie/workspace/agents/genie-configure/repos/genie && bun test src/lib/turn-close.test.ts && bun run check
+```
+
+**depends-on:** Group 4b
+
+---
+
+### Group 4d: Reconcile loop reads identity row + boot-mode terminal check
+**Goal:** Reconciler + auto-resume consistently treat the identity row as canonical. Closes turn-session-contract Gap #2 (boot-mode bypass).
+
+**Deliverables:**
+1. Update `reconcileDeadPaneZombies`, `runAgentRecoveryPass`, `handleDeadPane`, `attemptAgentResume` in `src/lib/scheduler-daemon.ts` and `src/lib/agent-registry.ts` to read identity row state directly (no more legacy-row fallbacks).
+2. **Boot-mode terminal-state check** (closes turn-session-contract Gap #2): before running `attemptAgentResume()` in `mode === 'boot'`, query the agent's `current_executor_id` — if that executor has `closed_at IS NOT NULL` OR `outcome IS NOT NULL`, skip resume (agent was legitimately closed pre-restart).
+3. New helper `isLegitimatelyClosed(agent, deps)` that encapsulates the check for reuse across sweep + boot.
+4. Update `scheduler-daemon.test.ts`: new tests for (a) boot-mode on properly-closed agent does not resume, (b) boot-mode on mid-turn agent does resume, (c) sweep-mode unchanged.
+
+**Acceptance Criteria:**
+- [ ] Boot-mode test: spawn agent → `genie done` → restart daemon → no resume event within 60s
+- [ ] Boot-mode test: spawn agent → simulate mid-turn crash (state='working', no close verb) → restart daemon → resume fires
+- [ ] Sweep-mode tests unchanged
+- [ ] `isLegitimatelyClosed()` unit test covers: closed executor, open executor, NULL executor_id, missing executor row
+- [ ] `bun run check` passes
+
+**Validation:**
+```bash
+cd /home/genie/workspace/agents/genie-configure/repos/genie && bun test src/lib/scheduler-daemon.test.ts src/lib/__tests__/auto-resume-zombie-cap.test.ts && bun run check
+```
+
+**depends-on:** Group 4c
+
+---
+
+### Group 5: Evidence package for turn-session-contract Review Results
+**Goal:** Produce the evidence package that turn-session-contract's next `/review` cycle will consume to close Gaps #1, #3, #4. **This group does not edit the parent wish's Review Results section** — avoids circular ownership. The parent wish's reviewer owns that edit.
+
+**Deliverables:**
+1. Evidence doc: `.genie/wishes/agent-row-unification/turn-session-contract-evidence.md` that enumerates, for each parent-wish gap (#1, #3, #4):
+   - Which Group here (G4c, G4d, etc.) closes it.
+   - Proof command + expected output (e.g., `bun test src/lib/__tests__/auto-resume-zombie-cap.test.ts -t "boot-mode bypass"` → pass).
+   - Live-instance verification steps an operator can run post-deploy.
+2. Extend `src/lib/__tests__/auto-resume-zombie-cap.test.ts` with a `describe('unified-row contract — turn-session-contract Gap #1/#2/#4 coverage')` block.
+3. Live-instance reproduction script: `scripts/ghost-resurrection-repro.ts` that seeds a dual-row state, walks through `spawn → done → restart → assert no resume`, emits PASS/FAIL for Gap #1.
+4. Cross-reference: add a bidirectional link in both wishes' `Dependencies` sections pointing at this evidence doc.
+
+**Acceptance Criteria:**
+- [ ] Evidence doc exists and enumerates every parent-wish Gap explicitly
+- [ ] New `describe` block in zombie-cap tests passes under unified-row flag on
+- [ ] Repro script runs green on a freshly-unified instance
+- [ ] No write to `turn-session-contract/WISH.md` from this wish's branches (verified by git log)
+
+**Validation:**
+```bash
+cd /home/genie/workspace/agents/genie-configure/repos/genie && bun test src/lib/__tests__/auto-resume-zombie-cap.test.ts && bun run check
+```
+
+**depends-on:** Group 4
+
+---
+
+### Group 6: Dry-run and operational runbook
+**Goal:** Operators can run the migration confidently.
+
+**Deliverables:**
+1. `scripts/unify-agents-dry-run.ts` CLI: reads pairs, prints a table with counts and sample rows.
+2. `scripts/unify-agents-apply.ts` CLI: typed-confirmation apply + resumable (checkpoint per 100 pairs).
+3. Operational runbook in `docs/runbooks/agent-row-unification.md`: pre-check list, rollback, failure-table triage.
+4. `genie doctor` extended to report dual-row count with remediation link.
+
+**Acceptance Criteria:**
+- [ ] Dry-run runs against local PG and prints sensible output
+- [ ] Apply script is idempotent and resumable
+- [ ] `docs/runbooks/agent-row-unification.md` exists with worked example
+- [ ] `genie doctor` reports dual-row count when flag is on
+
+**Validation:**
+```bash
+cd /home/genie/workspace/agents/genie-configure/repos/genie && bun run scripts/unify-agents-dry-run.ts --help && genie doctor
+```
+
+**depends-on:** Group 3 (parallel with Groups 4/5)
+
+---
+
+### Group 7: Phase C — flag removal + cleanup
+**Goal:** Retire `GENIE_UNIFIED_AGENT_ROWS` after ≥7-day soak.
+
+**Deliverables:**
+1. Remove `GENIE_UNIFIED_AGENT_ROWS` flag read.
+2. Migrate `agent_unification_failures` to permanent observability (or drop if empty).
+3. Delete runbook's rollback section; keep the success path.
+4. Release notes.
+
+**Acceptance Criteria:**
+- [ ] `rg GENIE_UNIFIED_AGENT_ROWS src/` returns zero
+- [ ] `bun run check` passes
+- [ ] Release notes merged
+
+**Validation:**
+```bash
+cd /home/genie/workspace/agents/genie-configure/repos/genie && rg GENIE_UNIFIED_AGENT_ROWS src/ && bun run check
+```
+
+**depends-on:** Group 5 + 7-day soak
+
+---
+
+## Dependencies
+
+- **depends-on:** `turn-session-contract` — this wish consumes the `executors.agent_id` FK that turn-session-contract established. Must merge on top of a working turn-session-contract branch.
+- **depends-on:** `unified-executor-layer` (already merged, per turn-session-contract's reference).
+- **blocks:** nothing directly, but **unblocks** turn-session-contract's SHIP — without this, Gap #1 cannot close cleanly.
+
+### Boundary Contracts
+
+The only cross-repo contract exposed by this wish: `agents.id` remains a string (UUID after migration, but the column type doesn't change). External consumers (omni, tools) that query `agents` by `id` are unaffected as long as they accept any string ID.
+
+---
+
+## QA Criteria
+
+_Verified on dev after merge. QA agent tests each criterion._
+
+- [ ] Spawn a fresh agent, verify exactly one row exists in `agents`
+- [ ] Call `genie done` on that agent, verify `agents.state='done'` within 1s
+- [ ] `tmux kill-pane` without `genie done`, verify pane-trap writes `clean_exit_unverified` to the same identity row
+- [ ] Daemon restart (serve kill + restart) on a properly-closed agent → agent stays `state='done'`, no resume event
+- [ ] Daemon restart on a mid-turn agent (state='working') → agent resumes correctly
+- [ ] Cross-team collision test (2026-04-19 scenario) still rejects loudly
+- [ ] Apply migration on a populated fixture DB — no orphaned executors, `agent_unification_failures` empty (or accounted for)
+- [ ] `genie ls` shows unified rows with correct state/pane/session
+- [ ] `executors.agent_id` is never NULL for non-skeleton executors
+- [ ] No regression in turn-session-contract's existing QA criteria
+
+---
+
+## Assumptions / Risks
+
+| ID | Risk | Severity | Mitigation |
+|----|------|----------|------------|
+| R1 | Live instances may have dual-row pairs where legacy runtime state is NEWER than identity row's metadata (e.g., identity row created stale, legacy row updated on resume) | HIGH | Migration copies legacy → identity; preserves the newer runtime state. `last_state_change` determines winner on conflict. |
+| R2 | `register()` may have callers outside the obvious ones (hooks, tests, scripts) | HIGH | Group 2 does exhaustive grep + CI test run. `knip` configured to flag unused imports after deletion. |
+| R3 | Some legacy rows may be orphaned (no matching identity row) | MEDIUM | Migration creates identity row from legacy data if missing, then merges. Logs to failures table. |
+| R4 | Executor FK may point at legacy row (not identity row) in some edge cases | MEDIUM | Migration's FK-resolution verification catches this. Rollback pair + log. |
+| R5 | tmux pane ownership changes during migration window | MEDIUM | Migration runs under `serve` lock or during planned maintenance. Dry-run first. |
+| R6 | Code outside `src/lib/agent-registry.ts` may directly INSERT into `agents` with a name-keyed `id` | HIGH | Group 2 audit must grep for `INSERT INTO agents` across all of `src/`. Tests use the helper, not raw INSERT. |
+| R7 | Phase C cleanup removes `agent_unification_failures` before operators review | LOW | 7-day soak + runbook step requires triage confirmation before Group 7 runs. |
+| R8 | The `dir:<name>` registration pattern (from `agent-directory.json`) may be a third distinct code path | MEDIUM | Group 1 audit (`insertion-sites-audit.md`) must include this. If it's a third path, G1 decision doc records in-scope vs sibling-wish resolution. |
+| R9 | Destructive merge in G3 has no natural rollback window — Phase C runs 7 days after. | MEDIUM (mitigated) | `agents_legacy_archive` table retains pre-merge rows for the entire soak. Rollback script restores them + reverses executor FK updates. Drop only after G7 runs post-soak. |
+| R10 | Splitting G4 into 4 PRs multiplies merge conflicts if other work touches `agent-registry.ts` / `turn-close.ts` / `scheduler-daemon.ts` during the window | MEDIUM | Sequence G4a→G4b→G4c→G4d as a single-engineer serialized effort; coordinate with turn-session-contract merges; target all four PRs within 48h. |
+
+---
+
+## Review Results
+
+_Populated by `/review` after execution completes._
+
+---
+
+## Files to Create/Modify
+
+```
+Created:
+  src/db/migrations/NNNN_unify_agent_rows.sql
+  src/db/migrations/NNNN_unify_agent_rows.test.ts
+  scripts/unify-agents-dry-run.ts
+  scripts/unify-agents-dry-run.test.ts
+  scripts/unify-agents-apply.ts
+  scripts/unify-agents-apply.test.ts
+  docs/runbooks/agent-row-unification.md
+
+Modified:
+  src/lib/agent-registry.ts            (delete register(); extend findOrCreateAgent + new updateAgentRuntime)
+  src/lib/agent-registry.test.ts
+  src/lib/turn-close.ts                 (flip state='done' on identity row directly)
+  src/lib/turn-close.test.ts
+  src/lib/scheduler-daemon.ts           (reconcile reads identity row; boot-mode respects executor terminal state)
+  src/lib/scheduler-daemon.test.ts
+  src/lib/__tests__/auto-resume-zombie-cap.test.ts  (new describe: unified-row contract)
+  src/lib/claude-native-teams.ts        (caller migration)
+  src/term-commands/agent/spawn.ts      (caller migration)
+  src/hooks/handlers/session-sync.ts    (caller migration)
+  src/__tests__/tui-spawn-dx.integration.test.ts (fixture update)
+  .genie/wishes/turn-session-contract/WISH.md  (Review Results — close Gaps #1, #3, #4)
+  README.md                             (release notes)
+  CHANGELOG.md
+```

--- a/.genie/wishes/_archive/agent-row-unification-rejected-2026-04-21/council-report.md
+++ b/.genie/wishes/_archive/agent-row-unification-rejected-2026-04-21/council-report.md
@@ -1,0 +1,108 @@
+# Council Report: agent-row-unification
+
+**Session:** `council-1776750580` | **Members:** 5 | **Round 1:** 5/5 | **Round 2:** 5/5
+**Date:** 2026-04-21
+
+## Executive Summary
+
+The council was convened to review the `agent-row-unification` wish, which proposes eliminating the dual-row pattern in the `agents` PG table via a flagged staged migration (Phase A/B/C, 7 groups, rollback archive). **Four of five members independently concluded the wish is over-engineered for a problem whose magnitude is unmeasured and whose runtime regression is unobservable** — a rare consensus arrived at from distinct rubrics (challenge-assumptions, simplicity, operations reality, measurement). The single most important insight came from cross-pollination in Round 2: **questioner's one-line predicate fix (`turn-close.ts:122` → `WHERE id = ${row.agent_id}`) is necessary but not sufficient** (architect verified via executor FK analysis), and the real architectural debt is not dual-row but runtime state still living on `agents` instead of `executors` where migration `012_executor_model.sql` intended. The emerging recommendation is to surgically fix turn-session-contract's Gap #1 + Gap #2 in ≤50 lines, file a sibling wish `agents-runtime-extraction` for the deeper cleanup, and defer or delete the dual-row migration pending measurement of its actual blast radius.
+
+## Council Composition
+
+| Member | Lens | Provider | Model |
+|--------|------|----------|-------|
+| architect | Systems thinking, backwards compat (Linus) | claude | haiku (registry default overrode `--model opus` request) |
+| questioner | Challenge assumptions, foundational simplicity (Dahl) | claude | haiku |
+| operator | Ops reality, on-call ergonomics (Hightower) | claude | haiku |
+| simplifier | Complexity reduction, delete code (Holowaychuk) | claude | haiku |
+| measurer | Observability, measure-don't-guess (Cantrill) | claude | haiku |
+
+**Note on models:** Orchestrator requested `--model opus` per user directive; the agent registry default (`haiku`) overrode. Council output quality nevertheless exceeded expectations — substantive, specific, file/line-cited. Worth flagging as a separate tooling gap: `genie spawn --model` should either win or emit a warning when overridden by registry defaults.
+
+## Situation Analysis
+
+### architect (Linus — Systems Thinking)
+
+**Initial perspective (Round 1):**
+"The wish fixes the wrong layer." Diagnosed that the real architectural problem is `agents` table carrying 46 columns of runtime state (`005_pg_state.sql:10-47`) that `012_executor_model.sql:3` explicitly promised to move ("Slims: agents to durable identity only") — and never did. Dual-row collapse closes Gap #1 but cements the agents↔executors duplication for another 2 years. Proposed D8: deprecate runtime columns on agents post-G4; file follow-on wish `agents-runtime-extraction` now to prevent burial. *"One wish per abstraction. Ship this one clean; file the follow-on before you forget."*
+
+**After deliberation (Round 2):**
+Strongest point conceded: questioner's predicate-bug diagnosis at `turn-close.ts:90-94` vs `:119-123`. But proved questioner's fix is **incomplete** — executor FKs point at the UUID skeleton row, not the concrete name-keyed row, so `UPDATE ... WHERE id = ${row.agent_id}` terminalizes the wrong row while the name-keyed zombie stays in `state='spawning'`. This strengthens the "wrong layer" argument: moving runtime to executors makes the concrete row addressable by schema construction, not WHERE-clause vigilance. Converges with simplifier on "kill the flag" but diverges on G6 — keeps `genie doctor` observability as the tripwire for destructive migration.
+
+### questioner (Dahl — Challenge Assumptions)
+
+**Initial perspective (Round 1):**
+"Not convinced we are solving the right problem, or that a migration is the solution." Gap #1 is a one-line predicate bug at `turn-close.ts:119-123` — the `agent_id` is already SELECTed at lines 90-94, so the fix is `WHERE id = ${row.agent_id}` + add `state='done'`. Gap #2 is independent — `isLegitimatelyClosed(executor)` checking `closed_at IS NOT NULL`. Neither requires row unification. Proposed "zero-dependency version": delete the word "migration" from the wish. Keep G4c + G4d. ~40 lines of diff, zero schema change, zero flag, zero soak. *"Could we delete code instead of adding 7 execution groups?"*
+
+**After deliberation (Round 2):**
+Position refined (not changed). Concedes to architect that the sibling `agents-runtime-extraction` wish should be filed now. Hardens the skip-migration position: "If runtime should live only on executors, then G1–G3's collapse is work against the follow-on. Doing the collapse first pays for state that will be torn out." Notes four council lenses converging: "this wish is scaffolding for a change no one has measured, justified, or observed."
+
+### operator (Hightower — Ops Reality)
+
+**Initial perspective (Round 1):**
+Rollback skeleton is good, but serve behavior during G3 is unspecified (R5 at WISH.md:407 waves at "serve lock or planned maintenance" — pick one). The single biggest gap: **WHAT METRIC TRIGGERS ROLLBACK** — nowhere in the wish does anyone name a concrete observable threshold. Runbook G6 as "docs/runbooks/...md exists" is bureaucracy; real runbook answers who-gets-paged, decision-in-<5min, command-to-run. Demanded live-fire drill before G4a merge, 24h dev canary with `genie doctor` dual-row count convergence as merge gate. *"Without this, at 3am somebody is guessing."*
+
+**After deliberation (Round 2):**
+Position changed twice. (1) Adopts measurer's `genie_agents_dual_row_count` gauge as THE primary rollback signal. One dashboard, three tripwires. (2) Retracts G4a 24h-dev-canary IF flag is deleted. But holds firm: outage posture during G3 must be pinned ("serve drains to zero active spawns → migration runs → serve resumes; expected duration ≤N minutes at p99"); runbook must name a human owner, not a file. Pushes back on simplifier/questioner: can't go flagless until G1's insertion-sites audit proves no external callers exist; if audit shows unknowns, flag stays as circuit breaker. Endorses architect's sibling-wish filing now.
+
+### simplifier (Holowaychuk — Delete Code)
+
+**Initial perspective (Round 1):**
+"Delete the flag. The flag IS the complexity you claim to be fixing." Trading dual-row for dual-PATH — +500 LoC of bifurcation tax. Three concrete cuts: G6 entirely (migrations ARE the apply script), G5 evidence package (test file IS the evidence), G4a + G7 + flag + archive table + failures table (all ceremony). Success criteria: 16 items is theater; reduce to 6. G4a→G4d sequencing "multiplies merge conflicts" (R10 admits this) — one PR, revertible as unit. *"The wish's goal is deleting `register()`. Every other thing is surrounding ritual."*
+
+**After deliberation (Round 2):**
+Position **changed**. Adopts questioner's deeper position: "Delete the migration. Keep the 40-line diff." Operator's demands are an inadvertent proof the migration isn't worth doing — stacking outage SLO + primary metric + live-fire drill + canary gate + named owner next to questioner's 40-line patch shows the migration costs more to OPERATE than dual-row costs to LIVE WITH. Concedes one measurer demand: `genie_agents_dual_row_count` gauge as forever-canary (alerts if anyone accidentally writes a name-keyed row in future). Final recommendation: "Kill Groups 1, 2, 3, 4a, 4b, 5, 6, 7. Ship G4c's predicate + G4d's boot-mode check + Architect's sibling wish filed. Six success criteria become three."
+
+### measurer (Cantrill — Observability)
+
+**Initial perspective (Round 1):**
+"The wish is instrumentation-thin." Only `agent.unified` audit event is specified — a point event with no dimensions. No `agent.unification.started`, no `_batch_complete`, no `_rollback_triggered`. Failed merges get a row in `agent_unification_failures` but no event emission — operators are expected to poll SQL. No golden signal defined. 7-day soak measured in calendar days, not signals. Demanded minimum 5 signals: (1) `migration.batch` span with dimensions, (2) `genie_agents_dual_row_count` gauge + 2 siblings, (3) p50/p95/p99 histogram, (4) `baseline.json` artifact, (5) alert rule spec in runbook.
+
+**After deliberation (Round 2):**
+Position partially changed. Cantrill discipline self-applied: adopted questioner's "data should justify the operation" — `baseline.json` must exist BEFORE G3 is approved (not after), must include live dual-row pair count as a gate. If N<10 and half are stale test fixtures, migration is over-engineered. Dropped runbook-as-artifact demand (simplifier + operator converged). Three signals survive: gauge, span, baseline. Endorsed operator's "ghost-resume events within 60s of `genie done` > 0" as the single golden signal for rollback trigger.
+
+## Key Findings
+
+1. **The wish addresses a symptom, not the root cause** — architect's diagnosis that `agents` table carries runtime state that `012_executor_model.sql` promised to extract (but didn't) is the deepest finding. Dual-row collapse cements duplicated runtime columns across `agents` and `executors` for another 2 years. Questioner independently reached the same conclusion from the other direction: "doing the collapse first pays for state that will be torn out." **Consensus: file sibling wish `agents-runtime-extraction` before proceeding.**
+
+2. **Gap #1's in-flight fix is smaller than the wish suggests, but not as small as it first appears** — questioner's one-line predicate fix (`turn-close.ts:122` change `WHERE current_executor_id = ${executorId}` to `WHERE id = ${row.agent_id}` + add `state='done'` to SET clause) is NECESSARY but INSUFFICIENT on this instance's data. Architect's Round 2 verification: executor FKs point at UUID skeletons, so the proposed UPDATE terminalizes the skeleton while the name-keyed concrete row stays `state='spawning'` → auto-resume continues. **Requires either (a) move runtime to executors (architect's proposal), or (b) dual-row collapse (the current wish), or (c) turnClose updates rows by `role` not just `id`.**
+
+3. **The wish cannot observe its own success or failure in production** — measurer + operator converged independently: no named tripwire, no gauge, no baseline, no steady-state metric. "A migration whose success signal nobody can name in the wish should not run" (questioner's Round 2). The `agent.unified` audit event is a point event with no dimensions — proves a write happened, not that it merged correctly.
+
+4. **XOR flag semantics create dual-PATH complexity equal to the dual-row complexity being fixed** — simplifier's R1 + R2: +500 LoC of bifurcation tax across test matrix (WISH.md:146), every caller site (WISH.md:137), plus G4a + G7 + archive + failures tables. Operator pushes back partially: flag is defensible as a circuit breaker IF G1's audit shows external/unknown `register()` callers; otherwise delete it. Architect concurs with simplifier on flag deletion but keeps `genie doctor` observability.
+
+5. **Group 4's 4-way split is aspirational, not operational** — operator's R1 + R2: R10 (WISH.md:412) admits "multiplies merge conflicts"; "target all four PRs within 48h" is unverifiable; G4a flips default to TRUE while G4b/c/d legacy branches still callable, creating a window where production runs new default with escape hatch still present. Either collapse G4 back to a single atomic PR (simplifier) or pin an explicit rollback SLA at each sub-group boundary (operator).
+
+6. **Four independent perspectives converged on "this is premature"** — questioner (no measured motivation), simplifier (more complexity than it removes), measurer (can't observe its own success), operator (no named tripwire). Only architect defended migration as potentially necessary, and even that was conditional on filing the sibling runtime-extraction wish to make the deeper fix visible.
+
+## Recommendations
+
+| Priority | Recommendation | Rationale | Risk if Ignored |
+|----------|---------------|-----------|-----------------|
+| **P0** | Ship the minimalist fix first: G4c predicate fix (`turn-close.ts:122` → `WHERE id = ${row.agent_id}` + `state='done'`) + G4d boot-mode `isLegitimatelyClosed(executor)` check + a dual-row-aware fallback UPDATE for the name-keyed row. Target: ≤50 LoC, one PR, no flag, no migration, no archive. | questioner + simplifier converged on this; architect's Round 2 proved the naive 40-line version is insufficient but the ≤50 LoC version with dual-row-aware fallback closes Gap #1 + Gap #2. Observable via existing `auto-resume-zombie-cap.test.ts` regression. | Shipping the full wish as drafted: 7 groups, 2-3 week cycle, +500 LoC bifurcation tax, ambiguous ops posture during G3, destructive migration for unmeasured blast radius. |
+| **P0** | File sibling wish `agents-runtime-extraction` NOW, linked from both `turn-session-contract` and `agent-row-unification` dependencies. Scope: move `pane_id`, `session`, `state`, `claude_session_id`, `resume_attempts`, `window_id`, etc. off `agents` onto `executors`. | architect's strongest finding; questioner endorsed in R2; simplifier endorsed in R2; measurer noted metrics simplify under this abstraction. Filed-now prevents burial of the real architectural debt. | The 46-column `agents` row writing on every state tick becomes DB pressure at scale; future incident will surface the debt at the worst time. `012_executor_model.sql:3` promise stays unfulfilled indefinitely. |
+| **P0** | Run a `scripts/count-dual-rows.ts` baseline capture BEFORE deciding whether to ship the full `agent-row-unification` wish or defer it. If N<10 pairs and most are stale test fixtures, DEFER the migration indefinitely. If N≥100 with divergent runtime state, re-evaluate with measured motivation. | measurer + questioner converged in R2: the wish asserts dual-row is a problem but produces zero cardinality data. "Data should justify the operation." | Running a 7-group migration for 8 stale rows is the textbook over-engineering failure mode. Without baseline, ship-or-defer decision is on vibes. |
+| **P1** | IF the migration does ship (post-baseline justification), adopt measurer's minimum instrumentation (non-negotiable): `genie_agents_dual_row_count` gauge (golden signal, also acts as forever-canary post-migration), `migration.batch` span with dimensions (batch_id, pairs_count, duration_ms, fk_rewrites, failures, rolled_back), `baseline.json` artifact at wish root. Wire dual_row_count into `genie doctor`. | operator + measurer convergence on single-dashboard, three-tripwire minimum. Without these, on-call at 3am is guessing. | Migration ships blind — success/failure discovered via user reports, not metrics. |
+| **P1** | IF migration ships, pin outage posture explicitly: "serve drains to zero active spawns → migration runs → serve resumes; expected duration ≤N min at p99". Name a human owner for the 7-day soak. Replace prose runbook with: tripwire alert IDs + one rollback command + `genie doctor` remediation hint + 30-min dev drill gate. | operator's non-negotiable; simplifier partially agrees (runbook as prose is theater, as doctrine+automation survives). | Unpinned outage posture means concurrent writers during migration — row-level lock contention or partial-merge data corruption. |
+| **P2** | IF migration ships, delete the `GENIE_UNIFIED_AGENT_ROWS` flag per simplifier. Make `register()` internally call `findOrCreateAgent()` with runtime fields; ship flagless atomic migration in one PR. G1 insertion-sites audit proves no external callers exist as precondition. | simplifier R1+R2 + operator R2 conditional approval + architect R2 endorsement. "Dual-PATH" is genuine complexity, not risk mitigation. | Two code paths coexist for 7+ days, every caller site gates on flag — future engineers have to reason about which path is live. |
+| **P2** | Collapse Group 4 sub-split (G4a/b/c/d → single G4). | simplifier + architect convergence; R10 (WISH.md:412) admits merge conflict cost of the split. | Four PRs × review cycles × merge conflict resolution > one PR with one revert button. |
+
+## Next Steps
+
+- [ ] **(Orchestrator, next `/review` cycle)** Read this council report + apply-layer changes, produce new `/review` verdict on the updated wish. Specifically reconcile: should the wish be DRASTICALLY scoped down per P0 #1, fully rejected in favor of the minimalist fix + sibling wish, or retained with P1/P2 hardening?
+- [ ] **(User decision)** Between three paths: (a) **KILL** this wish, ship the ≤50 LoC minimalist fix as a standalone change, file `agents-runtime-extraction` for the deeper cleanup; (b) **DEFER** this wish pending baseline dual-row count measurement; (c) **HARDEN** this wish with the P1 + P2 changes (instrumentation, outage posture, flag deletion, G4 collapse).
+- [ ] **(If path (a) or (b))** Draft `agents-runtime-extraction/WISH.md` covering the `012_executor_model.sql` follow-through. File before any further work on row-unification.
+- [ ] **(Always)** Run `scripts/count-dual-rows.ts` (or equivalent inline query) against live instances + dev + CI fixtures. Capture to `baseline.json` regardless of which path is taken.
+- [ ] **(If path (c))** Wire measurer's gauge + span + baseline into G1; delete G6 runbook prose; name human soak owner; pin outage posture.
+
+## Dissent
+
+**architect** held the minority position that the migration IS worth shipping — but conditional on the sibling wish being filed now. Quoting: *"Keep THIS wish as the tactical dual-row collapse (it unblocks turn-session-contract Gap #1 this sprint), BUT add an explicit Decision D8."* (Round 1). In Round 2, architect tempered this after verifying questioner's evidence: *"The questioner's evidence actually strengthens this: the concrete row is unaddressable by any executor FK because executor FKs point at skeletons."* Architect's position collapses to: either unify rows (this wish) OR move runtime to executors (follow-on wish) — you cannot close Gap #1 with a predicate fix alone. Therefore the minimalist P0 #1 above must include a dual-row-aware turnClose fallback (UPDATE by `role` across all rows sharing the identity's role), which is halfway to the full migration.
+
+**operator** held a secondary minority: the `agents_legacy_archive` table (WISH.md:172) is necessary IF destructive merge ships, because `git revert` cannot undo DELETE rows. Simplifier's claim that revert + PG backup is equivalent depends on a pg_dump taken at the exact moment of migration, which is itself operational complexity the wish hasn't specified. Preserved: **if path (c) is chosen, the archive table is non-negotiable.**
+
+**All five members converged on filing the sibling `agents-runtime-extraction` wish before or alongside any further work here.** That is the only unanimous finding.
+
+---
+
+*Council session: `council-1776750580` | Members: 5 | Round 1: 5/5 | Round 2: 5/5*

--- a/.genie/wishes/agents-runtime-extraction/WISH.md
+++ b/.genie/wishes/agents-runtime-extraction/WISH.md
@@ -1,0 +1,164 @@
+# Wish: Agents Runtime Extraction
+
+| Field | Value |
+|-------|-------|
+| **Status** | DRAFT |
+| **Slug** | `agents-runtime-extraction` |
+| **Date** | 2026-04-21 |
+| **Design** | _No brainstorm — direct wish_ (origin: `agent-row-unification` council deliberation 2026-04-21; see `_archive/agent-row-unification-rejected-2026-04-21/council-report.md` Finding #1 and architect's Round 1 + Round 2 positions) |
+
+## Summary
+
+Move runtime state columns (`pane_id`, `session`, `state`, `claude_session_id`, `window_id`, `window_name`, `sub_panes`, `suspended_at`, `resume_attempts`, `last_resume_attempt`, `pane_color`, `transport`, `current_executor_id`) off the `agents` table onto `executors`, completing what `src/db/migrations/012_executor_model.sql:3` explicitly promised but never delivered ("Slims: agents (to durable identity only)"). After this wish, `agents` is a cold identity table (write once at spawn, read for display); `executors` is the single source of truth for runtime state; turnClose and reconcile loops target a schema where "which row carries state?" is unambiguous by construction.
+
+## Context
+
+The `agent-row-unification` council (2026-04-21, full report preserved at `_archive/agent-row-unification-rejected-2026-04-21/council-report.md`) unanimously concluded that dual-row collapse addresses a symptom, not the root cause. The root cause is that `005_pg_state.sql:10-47` put 46 runtime columns on `agents`, and `012_executor_model.sql:11-33` later duplicated them onto `executors` with the stated intent of slimming `agents` — a slimming that never happened. Every subsequent wish (turn-session-contract, agent-row-unification) has been patching over this duplication. This wish is the actual fix.
+
+This wish is the sequel to the minimalist predicate fix for turn-session-contract Gap #1 + Gap #2 (filed separately at `.genie/wishes/fix-turn-close-row-targeting/`) — that fix closes the immediate ghost-resume regression; this wish removes the architectural debt that made the regression possible.
+
+## Scope
+
+### IN
+- Extract 13 runtime columns from `agents` onto `executors`, consolidating all current duplication
+- Migration strategy: measurement-first. Baseline captured before any schema change. No code written until data justifies it.
+- New helper `getAgentRuntime(agentId)` that reads from `executors` via `agents.current_executor_id` join
+- Rewire reconcile loops (`scheduler-daemon.ts`, `agent-registry.ts`) to read runtime state from the executor, not the agent row
+- Rewire spawn paths to write runtime state only to executors (`agents` row is identity-only post-spawn)
+- Migration drops the now-unused runtime columns from `agents` in a final phase gated on soak
+- Backwards compat contract: `agents.id` remains string (stable), all external consumers unaffected
+
+### OUT
+- The minimalist turn-close predicate fix (filed at `fix-turn-close-row-targeting/`) is prerequisite, not in scope
+- Any dual-row collapse work (deferred indefinitely — council determined it may become unnecessary post-extraction)
+- Web UI changes
+- Executor schema changes beyond adding columns to receive the extracted state
+
+## Decisions (placeholder — requires baseline data)
+
+| ID | Decision | Rationale |
+|----|----------|-----------|
+| D1 | Baseline measurement precedes any code change | Council P0: "Data should justify the operation." Rejected wish failed because it asserted problems without cardinality data. |
+| D2 | If baseline shows zero readers of `agents.state` outside the reconcile loops, extraction is a simple INSERT-shadow + DROP pattern, no flag required | Council P0: dual-PATH is worse than dual-row when the scope is small |
+| D3 | `executors.agent_id` FK remains authoritative direction; `agents.current_executor_id` stays as reverse pointer for convenience | Preserves existing consumer expectations |
+
+## Success Criteria (placeholder — finalized post-baseline)
+
+Six core criteria, expandable to nine post-baseline:
+
+- [ ] **C1** Baseline captured: for each runtime column, count of readers (grep `agents\.\<col\>` in `src/`), count of writers, avg writes/hour on production fixture
+- [ ] **C2** Runtime columns present on `executors` with types matching current `agents` columns
+- [ ] **C3** Every reader of `agents.<runtime_col>` rewritten to read from `executors` via join helper (grep returns zero matches post-change)
+- [ ] **C4** Every writer of `agents.<runtime_col>` rewritten to write to `executors` instead
+- [ ] **C5** Reconcile loops (`scheduler-daemon.ts:runAgentRecoveryPass`, `handleDeadPane`, `reconcileDeadPaneZombies`) read state from executor row
+- [ ] **C6** Drop column migration: `agents` loses the 13 runtime columns; remaining columns are identity-only
+- [ ] **C7** (conditional — only if baseline shows cross-team consumers) Stable read-helper exposed at `src/lib/agent-runtime.ts` and documented for external callers
+- [ ] **C8** (conditional — only if baseline shows >100 live agents touched by reconcile/tick) Performance baseline shows equal or faster `agents` read latency post-extraction
+- [ ] **C9** (conditional — only if council P1 observability minimums weren't merged separately) Golden signal `agents_runtime_column_read_count` gauge at zero post-migration (regression canary)
+
+## Execution Strategy
+
+**Wave 0 (before anything else):** Baseline. Zero code changes. Output: `.genie/wishes/agents-runtime-extraction/baseline.md` with column-reader/writer inventory, row count, peak write rate.
+
+**Wave 1+:** populated after baseline. Council's warning: do not write execution groups before measurement.
+
+## Execution Groups
+
+### Group 0: Baseline measurement
+
+**Goal:** Answer two questions with data before any code change: (1) where are the runtime columns read/written, (2) what's the production volume.
+
+**Deliverables:**
+1. `scripts/baseline-agents-runtime.ts` that greps source + queries live PG + produces a markdown inventory
+2. `.genie/wishes/agents-runtime-extraction/baseline.md` committed with the output
+
+**Acceptance Criteria:**
+- [ ] Inventory lists every file:line that reads any of the 13 runtime columns
+- [ ] Inventory lists every file:line that writes them
+- [ ] Inventory records per-column row count and age distribution on dev + (if accessible) prod PG
+- [ ] Output is committed to the wish dir
+
+**Validation:**
+```bash
+cd /home/genie/workspace/agents/genie-configure/repos/genie && bun run scripts/baseline-agents-runtime.ts && test -f .genie/wishes/agents-runtime-extraction/baseline.md
+```
+
+**depends-on:** none
+
+---
+
+### Groups 1–N: TBD
+
+Populated after Group 0. Council's discipline: one wish per abstraction change; do not write execution groups before evidence.
+
+Expected shape (provisional, to be validated against baseline):
+
+- **Group 1** — schema migration: add 13 columns to `executors` (nullable, additive only)
+- **Group 2** — dual-write (writes go to both agents + executors); measure read-match rate
+- **Group 3** — flip readers to executors one at a time, with metrics per swap
+- **Group 4** — stop writing to agents runtime columns; drop columns migration
+- **Group 5** — cleanup: remove dual-write code, remove compat shims
+- **Group 6** — soak + observability steady-state verification
+
+Each group is a separate PR, revertible independently. No feature flag unless baseline shows external/unknown writers (council's rule from rejected wish).
+
+## Dependencies
+
+- **depends-on:** `fix-turn-close-row-targeting` — the minimalist fix that closes turn-session-contract Gap #1+#2. Ships BEFORE this wish begins.
+- **depends-on:** `unified-executor-layer` (already merged) — established the `executors` table.
+- **blocks:** follow-on wishes that would otherwise add more runtime columns to `agents`.
+
+## QA Criteria
+
+_Verified on dev after each group merges._
+
+- [ ] No reader of `agents.<runtime_col>` remains in `src/` post-extraction (grep returns zero)
+- [ ] Reconcile correctly identifies live/dead agents using only `executors.state`
+- [ ] turnClose atomically flips `executors.state='done'` + `agents.current_executor_id=NULL`
+- [ ] Spawn creates one identity row + one executor row; no runtime state written to agents row after spawn
+- [ ] Column drop migration applies cleanly to fresh and populated DBs
+- [ ] `bun run check` passes at every group boundary
+
+## Assumptions / Risks
+
+| ID | Risk | Severity | Mitigation |
+|----|------|----------|------------|
+| R1 | Baseline shows the runtime columns are read from many external/unknown callers (plugins, other repos) | MEDIUM | Group 0 output decides; if true, add compat shim + flag. If false, delete flag from scope. |
+| R2 | Moving `current_executor_id` is more invasive than other fields (it's a FK) | MEDIUM | Keep `current_executor_id` on `agents` as reverse pointer; only move the true-runtime fields. Refine decision post-baseline. |
+| R3 | Existing `agents.state` history is implicitly an audit trail for some observers | LOW-MEDIUM | Baseline surfaces this; if true, preserve via `audit_events` mirror before drop. |
+| R4 | Migration runtime on DBs with many historic agent rows | LOW | Drop column is O(rows) but background-runnable; not online-blocking. |
+| R5 | Council-identified over-engineering pattern recurs | HIGH | Explicit discipline: this wish's Group 1+ are unwritten until baseline (Group 0) produces data. No ceremony pre-planned. |
+
+## Review Results
+
+_Populated by `/review` after execution completes. First review is a plan-review after Group 0 completes — NOT before._
+
+## Files to Create/Modify (provisional)
+
+```
+Will create:
+  scripts/baseline-agents-runtime.ts
+  .genie/wishes/agents-runtime-extraction/baseline.md
+  src/db/migrations/NNNN_executors_add_runtime_cols.sql       (Group 1)
+  src/db/migrations/NNNN_agents_drop_runtime_cols.sql         (Group 4)
+  src/lib/agent-runtime.ts                                    (Group 3)
+
+Will modify (partial, refined post-baseline):
+  src/lib/agent-registry.ts            (reconcile reads from executors)
+  src/lib/scheduler-daemon.ts          (reconcile + auto-resume read executors)
+  src/lib/turn-close.ts                (already fixed by prerequisite wish; may need minor alignment)
+  src/term-commands/agent/spawn.ts     (write runtime only to executors)
+  src/__tests__/*                      (fixtures updated per Group 3)
+```
+
+## Council Acknowledgement
+
+This wish owes its existence to the `agent-row-unification` council (preserved at `_archive/agent-row-unification-rejected-2026-04-21/council-report.md`). Specifically:
+
+- **architect's** "wrong layer" diagnosis (Round 1 + Round 2)
+- **questioner's** "data before migration" discipline applied via Group 0
+- **measurer's** "baseline-before-approval" principle hardened into Decision D1
+- **simplifier's** "delete the flag unless justified" applied via Decision D2
+- **operator's** "name the tripwire" preserved via Success Criterion C9
+
+If any decision here diverges from the council's converged recommendation, the divergence must be explicit in a Decision table row with rationale.

--- a/.genie/wishes/fix-turn-close-row-targeting/PLAN.md
+++ b/.genie/wishes/fix-turn-close-row-targeting/PLAN.md
@@ -1,0 +1,244 @@
+# Fix Plan: Turn-Close Row Targeting + Boot-Mode Terminal Check
+
+**Type:** Fix (not a wish — ~30 LoC single-PR scope)
+**Origin:** Closes `turn-session-contract` WISH.md Gap #1 + Gap #2 (Review Results section)
+**Replaces:** `agent-row-unification` wish (rejected 2026-04-21 per council; archived at `_archive/agent-row-unification-rejected-2026-04-21/`)
+**Date:** 2026-04-21
+
+## Problem
+
+Two in-flight regressions in the turn-session-contract feature on live instances:
+
+**Gap #1 — `genie done` flips wrong agent row.** `src/lib/turn-close.ts:119-123` updates `agents SET current_executor_id=NULL WHERE current_executor_id=${executorId}`. This sweeps the UUID identity row (which holds the executor FK) but leaves the legacy name-keyed row in `state='spawning'`. Reconcile sees the live `spawning` row and auto-resumes the agent. Result: calling `genie done` does not actually terminate the agent; it resurrects on next daemon restart.
+
+**Gap #2 — boot-mode reconcile bypasses executor-terminal check.** `src/lib/scheduler-daemon.ts:868-871` unconditionally delegates to `attemptAgentResume` in boot mode. The D1/D3 turn-aware rules are skipped. Any agent with `auto_resume=true` + valid `claudeSessionId` gets resumed regardless of whether its last executor is already closed. Result: properly-closed agents (ones that called `genie done` before daemon restart) are resurrected on every restart.
+
+Both gaps are traced in detail at `.genie/wishes/turn-session-contract/WISH.md` Review Results section (lines 380-470). Live reproduction evidence is in PG audit log on the test team `turn-session-contract-genie` (this agent resumed 2x in a single night despite clean closes).
+
+## Fix
+
+Two edits in `src/lib/`, two matching test additions. Total: ~30 LoC + ~40 LoC of tests.
+
+### Change 1 — `src/lib/turn-close.ts:119-123`
+
+**Before:**
+```typescript
+await tx`
+  UPDATE agents
+  SET current_executor_id = NULL
+  WHERE current_executor_id = ${executorId}
+`;
+```
+
+**After:**
+```typescript
+// Flip the identity row's state directly via executor.agent_id — not the
+// reverse-FK sweep used previously (which missed dual-row legacy pairs).
+// Also defensively sweeps any legacy name-keyed row sharing (custom_name, team)
+// to close out the dual-row pattern on pre-unification instances. Becomes a
+// no-op when `agents-runtime-extraction` lands and dual rows no longer exist.
+const [ident] = await tx<{ custom_name: string | null; team: string | null }[]>`
+  UPDATE agents
+  SET state = 'done', current_executor_id = NULL
+  WHERE id = ${row.agent_id}
+  RETURNING custom_name, team
+`;
+if (ident?.custom_name && ident?.team) {
+  await tx`
+    UPDATE agents
+    SET state = 'done', current_executor_id = NULL
+    WHERE custom_name = ${ident.custom_name}
+      AND team = ${ident.team}
+      AND id != ${row.agent_id}
+  `;
+}
+```
+
+### Change 2 — `src/lib/scheduler-daemon.ts`
+
+**Add helper (place near `terminalizeCleanExitUnverified`, ~line 998):**
+```typescript
+/**
+ * Gap #2 (turn-session-contract): boot-mode reconciler's D1/D3 bypass resurrects
+ * properly-closed agents across daemon restart. Check returns true when the agent's
+ * current executor is already terminal (closed_at set OR outcome set), meaning an
+ * explicit close verb OR pane-exit trap already fired. Caller should skip resume.
+ */
+async function isLegitimatelyClosed(deps: SchedulerDeps, worker: WorkerInfo): Promise<boolean> {
+  const executorId = worker.currentExecutorId;
+  if (!executorId) return false;
+  try {
+    const sql = await deps.getConnection();
+    const rows = await sql<{ closed_at: Date | null; outcome: string | null }[]>`
+      SELECT closed_at, outcome FROM executors WHERE id = ${executorId}
+    `;
+    if (rows.length === 0) return false;
+    return rows[0].closed_at !== null || rows[0].outcome !== null;
+  } catch {
+    // DB blip — err on the side of attempting resume (legacy behavior).
+    return false;
+  }
+}
+```
+
+**Change `handleDeadPane` boot-mode branch (lines 868-871):**
+
+**Before:**
+```typescript
+if (mode === 'boot') {
+  const result = await attemptAgentResume(deps, config, worker);
+  return result === 'resumed' ? 'resumed' : 'skipped';
+}
+```
+
+**After:**
+```typescript
+if (mode === 'boot') {
+  // Gap #2 fix: before resuming, check if the agent's executor is already
+  // terminal. Otherwise we resurrect agents that called `genie done` before
+  // the daemon restarted (2026-04-21 live regression).
+  if (await isLegitimatelyClosed(deps, worker)) {
+    deps.log({
+      timestamp: deps.now().toISOString(),
+      level: 'debug',
+      event: 'agent_resume_skipped_boot_terminal',
+      daemon_id: daemonId,
+      agent_id: worker.id,
+      reason: 'executor_already_closed',
+    });
+    return 'skipped';
+  }
+  const result = await attemptAgentResume(deps, config, worker);
+  return result === 'resumed' ? 'resumed' : 'skipped';
+}
+```
+
+### Test 1 — add to `src/lib/turn-close.test.ts`
+
+```typescript
+describe('Gap #1 regression — dual-row state flip', () => {
+  it('flips both identity row and legacy name-keyed row to state=done', async () => {
+    // Seed dual-row pair
+    const teamName = 'gap1-test';
+    const customName = 'gap1-agent';
+    await sql`INSERT INTO agents (id, custom_name, team, state) VALUES (${customName}, ${customName}, ${teamName}, 'spawning')`;
+    const [identity] = await sql`INSERT INTO agents (id, custom_name, team, state) VALUES (${randomUUID()}, ${customName}, ${teamName}, NULL) RETURNING id`;
+    const [executor] = await sql`INSERT INTO executors (id, agent_id, state) VALUES (${randomUUID()}, ${identity.id}, 'running') RETURNING id`;
+    await sql`UPDATE agents SET current_executor_id = ${executor.id} WHERE id = ${identity.id}`;
+
+    await turnClose({ outcome: 'done', executorId: executor.id });
+
+    const [identityAfter] = await sql`SELECT state FROM agents WHERE id = ${identity.id}`;
+    const [legacyAfter]   = await sql`SELECT state FROM agents WHERE id = ${customName}`;
+    expect(identityAfter.state).toBe('done');
+    expect(legacyAfter.state).toBe('done');
+  });
+});
+```
+
+### Test 2 — add to `src/lib/__tests__/auto-resume-zombie-cap.test.ts`
+
+```typescript
+describe('Gap #2 regression — boot-mode terminal check', () => {
+  it('skips resume for agent whose current executor is already terminal', async () => {
+    const worker: WorkerInfo = makeTestWorker({ autoResume: true, claudeSessionId: 'sess-xyz', currentExecutorId: 'exec-done-1' });
+    const deps: SchedulerDeps = makeTestDeps({
+      getConnection: async () => sqlWithFixture({ executors: [{ id: 'exec-done-1', closed_at: new Date(), outcome: 'done' }] }),
+    });
+
+    const outcome = await handleDeadPane(deps, testConfig, 'daemon-1', worker, /* turnAware */ true, 'boot');
+    expect(outcome).toBe('skipped');
+    expect(deps.log).toHaveBeenCalledWith(expect.objectContaining({ event: 'agent_resume_skipped_boot_terminal' }));
+  });
+
+  it('still resumes for agent with open executor in boot mode (no regression)', async () => {
+    const worker: WorkerInfo = makeTestWorker({ autoResume: true, claudeSessionId: 'sess-xyz', currentExecutorId: 'exec-open-1' });
+    const deps: SchedulerDeps = makeTestDeps({
+      getConnection: async () => sqlWithFixture({ executors: [{ id: 'exec-open-1', closed_at: null, outcome: null }] }),
+      resumeAgent: mock(async () => true),
+    });
+
+    const outcome = await handleDeadPane(deps, testConfig, 'daemon-1', worker, /* turnAware */ true, 'boot');
+    expect(outcome).toBe('resumed');
+  });
+});
+```
+
+## Acceptance Criteria
+
+- [ ] Agent in dual-row state calls `genie done` → both rows flip to `state='done'` in one transaction
+- [ ] Agent with terminal executor does NOT resume on daemon boot
+- [ ] Agent with open executor (mid-turn crash) STILL resumes on daemon boot (no regression)
+- [ ] `bun run check` passes
+- [ ] turn-session-contract WISH.md Review Results Gap #1 + Gap #2 can be marked resolved
+
+## Validation
+
+```bash
+cd /home/genie/workspace/agents/genie-configure/repos/genie
+bun test src/lib/turn-close.test.ts
+bun test src/lib/__tests__/auto-resume-zombie-cap.test.ts
+bun run check
+```
+
+## Branch + commit
+
+**Branch name:** `fix/turn-close-row-targeting` (from `dev`)
+
+**Commit message (conventional commits):**
+```
+fix(turn-close): flip both identity + legacy rows; skip boot-resume of terminal executors
+
+Closes turn-session-contract Gap #1 and Gap #2.
+
+Gap #1: turnClose() was sweeping `agents.current_executor_id=NULL WHERE current_executor_id=...` which only flipped identity rows and left legacy name-keyed dual-row zombies in state='spawning'. Reconcile then auto-resumed them. Now updates identity row by executor's agent_id FK (direct key) and defensively sweeps any legacy row sharing (custom_name, team).
+
+Gap #2: scheduler-daemon boot-mode bypassed the D1/D3 turn-aware rules, delegating unconditionally to attemptAgentResume. This resurrected properly-closed agents on every daemon restart. Now checks executor terminal state (closed_at IS NOT NULL OR outcome IS NOT NULL) before resume.
+
+Architectural debt (runtime state still on agents table instead of executors) deferred to wish agents-runtime-extraction.
+
+Refs: turn-session-contract/WISH.md Review Results (Gaps #1, #2, #4)
+Refs: _archive/agent-row-unification-rejected-2026-04-21/council-report.md (why this path was chosen over full migration)
+```
+
+## PR description template
+
+```markdown
+## Summary
+
+Close two live regressions in turn-session-contract:
+- **Gap #1**: `genie done` leaves legacy name-keyed rows in `state='spawning'` → reconcile resurrects them
+- **Gap #2**: daemon boot-mode unconditionally resumes agents with valid `claudeSessionId`, bypassing the turn-aware D1/D3 terminal check
+
+30 LoC of source changes + 40 LoC of tests. No schema change. No flag. No migration.
+
+## Context
+
+This replaces the rejected `agent-row-unification` wish (archived at `.genie/wishes/_archive/agent-row-unification-rejected-2026-04-21/`). The council deliberation (preserved in that directory's `council-report.md`) concluded the full migration was over-engineered for the actual blast radius; the minimalist fix here closes the observed regressions with the minimum necessary code.
+
+The architectural debt flagged by the council (runtime state living on `agents` instead of `executors`) is tracked in the sibling wish `agents-runtime-extraction`. This PR does not touch that layer.
+
+## Test plan
+
+- [ ] `bun test src/lib/turn-close.test.ts` — Gap #1 regression test passes
+- [ ] `bun test src/lib/__tests__/auto-resume-zombie-cap.test.ts` — Gap #2 tests pass (terminal skip + open-executor resume preserved)
+- [ ] `bun run check` — typecheck + lint + dead-code + existing tests pass
+- [ ] Manual live-instance check: spawn agent, call `genie done`, restart daemon, verify no resume event within 60s
+- [ ] Turn-session-contract WISH.md Review Results section can be updated to close Gap #1 + Gap #2
+
+## Does not fix
+
+- **Gap #3** (`GENIE_EXECUTOR_ID` env verification) — deferred; needs live-instance instrumentation to confirm, not a code change
+- **Gap #5** (native-teams config schema: missing `workingDir`, auto-resume-appends-member) — separate wish needed (`native-teams-config-hardening`)
+- Architectural cleanup (runtime columns on `agents`) — tracked in `agents-runtime-extraction` wish
+```
+
+## Ready to execute?
+
+This plan is complete and ready. Two paths forward:
+
+**Self-execute:** I apply the edits, create `fix/turn-close-row-targeting` branch from `dev`, commit with the message above, open PR against `dev`. Requires explicit user authorization per agent-bible (destructive branch op + commit).
+
+**Engineer handoff:** User or a dispatched engineer picks up this PLAN.md, executes the same steps. Zero additional context needed — this doc is self-contained.
+
+My default is the second path unless user explicitly says "execute" or "commit it now" — PLAN.md is non-destructive artifact, commits are not.

--- a/.genie/wishes/test-suite-deflake/WISH.md
+++ b/.genie/wishes/test-suite-deflake/WISH.md
@@ -1,0 +1,235 @@
+# Wish: Test Suite Deflake
+
+| Field | Value |
+|-------|-------|
+| **Status** | DRAFT |
+| **Slug** | `test-suite-deflake` |
+| **Date** | 2026-04-22 |
+| **Design** | _No brainstorm — direct wish_ (origin: live observation across 5 consecutive `bun test` runs 2026-04-21/22 on `fix/turn-close-row-targeting`; documented failure rate fluctuation 0/1/2/3 failures per run with identical code + machine) |
+
+## Summary
+
+Eliminate the structural flakiness in `bun run check` that produces 0–3 non-deterministic failures per full-suite run. Root cause is **concurrent test-file setup saturating the shared `--ram` pgserve**: 48 test files call `setupTestSchema()`, bun runs 20 concurrently by default, and `src/lib/test-db.ts` silently absorbs setup failures via `return async () => {};` catches — tests then run against uninitialized PG state and fail non-deterministically. Fix by (a) surfacing setup failures as explicit skips instead of silent garbage runs, (b) capping test concurrency for DB-backed suites, (c) serializing `setupTestSchema` via in-process mutex so only one file at a time runs the `CREATE SCHEMA + runMigrations` critical section. P0 (listen-bomb timeout) was already shipped in commit `a1555b97 test(pentest): bump listen-bomb flood-spill timeout to 15s` — this wish covers the remaining residual Classes B and C.
+
+## Scope
+
+### IN
+- Replace silent catches in `src/lib/test-db.ts` with explicit `DB_SETUP_FAILED` flag + `describe.skipIf(DB_SETUP_FAILED)` pattern callers can consume
+- Serialize `setupTestSchema` via in-process mutex so `CREATE SCHEMA + runMigrations + dropNotifyTriggers` run one-at-a-time
+- Tune `bunfig.toml` test concurrency cap (propose 8, measure; target zero flakes on full-suite x20 consecutive runs)
+- Raise `postgres` client `connect_timeout` from 5s to 15s; raise `idle_timeout` from 1s to 30s; raise `max` from 1 to 2 on the admin connection (to survive transient connection close during retry)
+- Measurement: baseline pass/fail rate across 20 consecutive `bun test` runs on `origin/dev` before changes; same measurement after changes; proof is <=1 flake per 20 runs sustained
+- Documentation note in CLAUDE.md Testing section naming the concurrency cap + mutex pattern so future contributors don't silently re-introduce it
+
+### OUT
+- P0 listen-bomb timeout fix — already shipped in `a1555b97`
+- Rewriting any test that uses `setupTestSchema` — the fix is at the helper layer
+- Changing pgserve itself (capacity tuning, connection limits) — addressed separately if P1 cap + P2 mutex don't converge
+- Individual test-specific timeouts (those are Class A, one-offs — handle ad hoc as observed)
+- Moving tests off PG entirely (out of scope — genie tests validate real SQL behavior)
+
+## Decisions
+
+| ID | Decision | Rationale |
+|----|----------|-----------|
+| D1 | Silent catches become loud skips, not loud failures | Failing a whole suite on a transient pgserve blip is worse than skipping the DB tests that round. Skips ARE the correct signal — they tell operators "PG was unavailable" without masking the event. |
+| D2 | In-process mutex for `setupTestSchema`, not a distributed lock | Bun runs tests in one process with worker threads; a simple `async-mutex` or hand-rolled semaphore suffices. Cross-process is irrelevant because bun doesn't do multi-process test execution by default. |
+| D3 | Test concurrency cap at 8, not 4 or 1 | 4 is conservative and will noticeably slow the suite. 8 balances DB pressure vs runtime. Measure both values against the 20-consecutive-runs gate before committing to a number. |
+| D4 | Do not touch individual test files' hooks | Per-test timeout misconfigurations (Class A, e.g. listen-bomb) are individual bugs, not infrastructure bugs. Fix them one at a time as observed, not as a bulk change. |
+| D5 | Measurement-gated approval — no merge until 20 consecutive runs on the fixed branch hit zero flakes | Council discipline from `agent-row-unification` rejection: "data should justify the operation." Same discipline applies in reverse — data must justify that the fix actually works. |
+
+## Success Criteria
+
+- [ ] **C1** `src/lib/test-db.ts` `setupTestSchema` no longer returns no-op cleanup silently. Failure path sets module-level `DB_SETUP_FAILED` flag, logs `[test-db] pgserve unreachable — DB-backed tests will skip`, and returns a skip-marker.
+- [ ] **C2** `describe.skipIf(DB_SETUP_FAILED)` pattern documented as the canonical guard for DB-backed test blocks; audit confirms all 48 callers use it.
+- [ ] **C3** `setupTestSchema` acquires an in-process mutex before `CREATE SCHEMA`, releases after `dropNotifyTriggers` completes. Only one file at a time executes the critical section.
+- [ ] **C4** `bunfig.toml` sets test concurrency to 8; `[test]` section documented.
+- [ ] **C5** `postgres` client config in `setupTestSchema` + `cleanupSql`: `connect_timeout: 15`, `idle_timeout: 30`, `max: 2`.
+- [ ] **C6** Baseline measurement captured: 20 consecutive `bun test` runs on `origin/dev` at a named commit SHA recorded in `baseline.md`. Target: document current pass-rate distribution.
+- [ ] **C7** Post-fix measurement: 20 consecutive `bun test` runs on the fix branch. SHIP gate: ≤1 flake across 20 runs (95% pass).
+- [ ] **C8** CLAUDE.md Testing section updated with concurrency-cap + mutex notes.
+
+## Execution Strategy
+
+Dependency graph: `G1 → G2 → G3 → G4`. Each group is a separate PR, revertible independently. No flag — this is a test-infra change, not a behavior change; flags add cost without reversibility benefit.
+
+### Wave 1 (solo — measurement baseline)
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 1 | qa | 20× `bun test` runs on `origin/dev` at a pinned SHA; record pass/fail/timing into `baseline.md`. Establishes the "before" distribution. |
+
+### Wave 2 (parallel — three independent fixes, each its own PR)
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 2 | engineer | Loud-skip instead of silent-catch in `setupTestSchema`. Audit + migrate callers to `describe.skipIf(DB_SETUP_FAILED)`. |
+| 3 | engineer | In-process mutex around `CREATE SCHEMA + runMigrations + dropNotifyTriggers`. Use `async-mutex` package or hand-rolled promise chain; benchmark choice. |
+| 4 | engineer | `bunfig.toml` concurrency cap + `postgres` client timeout tuning. Single two-line PR. |
+
+### Wave 3 (solo — measurement + gate)
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 5 | qa | 20× `bun test` runs on the combined fix branch. SHIP gate = ≤1 flake. If fails, iterate on cap value (8 → 6 → 4) until gate passes. Record into `after.md`. |
+
+## Execution Groups
+
+### Group 1: Baseline measurement
+**Goal:** Quantify the "before" flake rate so we can prove the fix actually worked.
+
+**Deliverables:**
+1. `scripts/deflake-measure.sh` — runs `bun test` N times, records exit code + test-count summary per run to `.genie/wishes/test-suite-deflake/measurement-YYYYMMDD.log`
+2. Execute 20 runs on `origin/dev` at a pinned SHA. Commit log output.
+3. `.genie/wishes/test-suite-deflake/baseline.md` — summary: N pass, mean fail count, most common failing test
+
+**Acceptance Criteria:**
+- [ ] Script runs 20 iterations cleanly
+- [ ] Baseline doc present, cites commit SHA + bun version + machine
+- [ ] Summary table lists each run's pass/fail count
+
+**Validation:**
+```bash
+cd /home/genie/workspace/agents/genie-configure/repos/genie && bash scripts/deflake-measure.sh 20 origin/dev && test -f .genie/wishes/test-suite-deflake/baseline.md
+```
+
+**depends-on:** none
+
+---
+
+### Group 2: Loud-skip setup failures
+**Goal:** Silent PG-unavailable catches become explicit skips that test files can observe.
+
+**Deliverables:**
+1. Refactor `src/lib/test-db.ts`: module-level `DB_SETUP_FAILED` boolean, set true when `ensurePgserve` or `CREATE SCHEMA` throws; `setupTestSchema` logs the reason and returns a marker cleanup. Callers consume `describe.skipIf(DB_SETUP_FAILED)` or the existing `DB_AVAILABLE` flag (extended to reflect setup success, not just pgserve presence).
+2. Audit all 48 callers (`rg "setupTestSchema" src/ test/`); convert silent-test-runs-against-bad-state patterns to explicit skip guards.
+3. Tests: unit-test the skipIf flow with injected pgserve failure mock.
+
+**Acceptance Criteria:**
+- [ ] `setupTestSchema` never returns silent no-op cleanup without logging
+- [ ] All 48 callers use explicit `skipIf` guard; grep confirms zero unguarded usages
+- [ ] Simulated pgserve failure produces "skipped" status in bun output, not "fail"
+- [ ] `bun run check` passes on a machine with pgserve deliberately disabled (suite skips DB tests, doesn't fail)
+
+**Validation:**
+```bash
+cd /home/genie/workspace/agents/genie-configure/repos/genie && bun test src/lib/test-db.test.ts && bun run check
+```
+
+**depends-on:** Group 1 (baseline established first)
+
+---
+
+### Group 3: Serialize setup via mutex
+**Goal:** Only one test file at a time executes `CREATE SCHEMA + runMigrations + dropNotifyTriggers`. Parallelism preserved at the test-function level.
+
+**Deliverables:**
+1. Add a simple mutex to `src/lib/test-db.ts` — `await setupMutex.acquire()` at the top of `setupTestSchema`, `release` in a `finally` after cleanup registration.
+2. Benchmark: if using `async-mutex` package, document it; if hand-rolled, include unit test that verifies serialization.
+3. Ensure mutex does NOT block test-function execution — only the setup critical section.
+
+**Acceptance Criteria:**
+- [ ] Two concurrent `setupTestSchema` calls serialize (observable via timing + log interleaving)
+- [ ] Test-function execution still parallel after setup completes
+- [ ] `bun run check` runtime does not regress >20% vs baseline (mutex overhead tolerable)
+- [ ] Unit test for mutex serialization passes
+
+**Validation:**
+```bash
+cd /home/genie/workspace/agents/genie-configure/repos/genie && bun test src/lib/test-db.test.ts
+```
+
+**depends-on:** Group 2 (skipIf infrastructure lands first so mutex timeouts become visible skips, not hidden stalls)
+
+---
+
+### Group 4: Concurrency cap + pool timeouts
+**Goal:** Reduce raw concurrency pressure on pgserve. Complements mutex.
+
+**Deliverables:**
+1. `bunfig.toml` `[test]` section: `concurrency = 8` (initial value — tune in Group 5).
+2. `src/lib/test-db.ts` postgres client config: `connect_timeout: 15`, `idle_timeout: 30`, `max: 2` on admin connection.
+3. Same tuning on `cleanupSql` connection in the cleanup closure.
+4. CLAUDE.md Testing section: add note about concurrency cap and mutex, pointing at this wish's runbook.
+
+**Acceptance Criteria:**
+- [ ] `bunfig.toml` concurrency cap present
+- [ ] postgres client configs tuned per spec
+- [ ] CLAUDE.md updated
+- [ ] `bun run check` passes with new cap + tuning
+
+**Validation:**
+```bash
+cd /home/genie/workspace/agents/genie-configure/repos/genie && cat bunfig.toml && bun run check
+```
+
+**depends-on:** Group 3
+
+---
+
+### Group 5: Post-fix measurement + SHIP gate
+**Goal:** Prove the fix actually eliminated flakes at the measurement level, not just "it feels better."
+
+**Deliverables:**
+1. Re-run `scripts/deflake-measure.sh 20 <fix-branch>` on the combined fix branch (G2+G3+G4 merged).
+2. `.genie/wishes/test-suite-deflake/after.md` — same schema as baseline.md.
+3. SHIP gate: ≤1 flake across 20 runs AND runtime regression <20% vs baseline.
+4. If gate fails, iterate: drop concurrency cap from 8 → 6 → 4 until gate passes.
+
+**Acceptance Criteria:**
+- [ ] After-measurement doc present
+- [ ] ≤1 flake across 20 runs (95% green rate)
+- [ ] Runtime regression <20% vs baseline
+- [ ] Final concurrency value documented in bunfig.toml comment
+
+**Validation:**
+```bash
+cd /home/genie/workspace/agents/genie-configure/repos/genie && bash scripts/deflake-measure.sh 20 HEAD && cat .genie/wishes/test-suite-deflake/after.md
+```
+
+**depends-on:** Groups 2, 3, 4
+
+---
+
+## Dependencies
+
+- **depends-on:** none (standalone test-infra work)
+- **blocks:** smoother `genie-configure` developer experience; smoother PR-review flow (no more `--no-verify` bypass narrative on flaky test pushes)
+- **related:** `test-pg-ram-isolation` (prior wish that introduced the --ram pgserve pattern; this wish completes that work by addressing the residual concurrency pressure)
+
+## QA Criteria
+
+_Verified on the combined fix branch before merge._
+
+- [ ] 20× consecutive `bun test` runs on fix branch: ≥19/20 pass (≤1 flake)
+- [ ] 3× consecutive `bun run check` runs: 3/3 pass (integration smoke test)
+- [ ] Deliberate `pgserve` stop mid-suite: suite gracefully skips DB tests with loud logs, does not hang
+- [ ] Deliberate `pgserve` crash during setup: `setupTestSchema` times out loudly (not silently), tests skip with reason
+- [ ] CI flake rate on dev merges to main: ≥14 days observation window with ≤1 flake per 20 pushes
+
+## Assumptions / Risks
+
+| ID | Risk | Severity | Mitigation |
+|----|------|----------|------------|
+| R1 | The mutex adds contention that outweighs the flake reduction | MEDIUM | Group 3 benchmark; if >20% regression, fall back to Group 4 cap-only approach |
+| R2 | Concurrency cap at 8 is too low; suite becomes painfully slow | LOW-MEDIUM | Group 5 iterates; final value tuned against SHIP gate |
+| R3 | Class B root cause is actually somewhere else (e.g., filewatch preloading, NATS mock setup) not covered by this wish | MEDIUM | Group 1 baseline captures failure distribution; if most failures are NOT in DB-backed tests, re-scope wish |
+| R4 | Fresh `setupTestSchema` design reveals existing tests were passing *because* of the silent fallback (relying on uninitialized state) | LOW | Group 2 audit catches this before merge; any tests "passing by accident" become visible skips and can be fixed properly |
+| R5 | `--ram` pgserve has a hard connection limit that even cap+mutex can't solve | LOW | Would require pgserve-side fix; this wish's Group 5 measurement surfaces it if true |
+
+## Review Results
+
+_Populated by `/review` after execution completes. First plan-review can run immediately; execution-review after Group 5._
+
+## Files to Create/Modify (provisional)
+
+```
+Created:
+  scripts/deflake-measure.sh
+  .genie/wishes/test-suite-deflake/baseline.md            (Group 1 output)
+  .genie/wishes/test-suite-deflake/after.md               (Group 5 output)
+  src/lib/test-db.test.ts                                 (Groups 2, 3 unit tests)
+
+Modified:
+  src/lib/test-db.ts                  (skipIf flag + mutex + pool timeouts)
+  bunfig.toml                         (test concurrency cap)
+  CLAUDE.md                           (Testing section note)
+  ~48 test files                      (Group 2 — replace silent-skip usages with `describe.skipIf(DB_SETUP_FAILED)`)
+```

--- a/.genie/wishes/turn-session-contract/WISH.md
+++ b/.genie/wishes/turn-session-contract/WISH.md
@@ -373,7 +373,162 @@ Any change to these three surfaces after merge is a coordinated breaking change 
 
 ## Review Results
 
-_Populated by `/review` after execution completes._
+**Reviewed:** 2026-04-21 by `genie-configure` (Execution Review)
+**Branch under test:** `fix/tmux-unreachable-crashes-spawn` @ `940b3b9b`
+**Instance:** live genie serve on test team `turn-session-contract-genie` (the test team created exactly for validating this wish)
+**Evidence source:** PG state + audit events from live reproduction, source code read at cited line numbers.
+
+### Verdict: **FIX-FIRST**
+
+Four CRITICAL/HIGH gaps prevent SHIP. Groups 1-8 have shipped code artifacts, but the acceptance criteria fail at runtime on a canonical test instance. Gap list below is ordered by severity and has executable next-step guidance.
+
+### Checklist
+
+| Criterion | Result | Evidence |
+|-----------|:------:|----------|
+| **C1** `genie done/blocked/failed` verbs with context-dispatch | ✅ PASS | `src/term-commands/{done,blocked,failed}.ts` all exist; audit log shows `turn_close.done` events firing correctly from CLI invocations at 02:16:09 and 02:16:21. |
+| **C2** Atomic close transaction across executors + agents + audit_events | ⚠️ **PARTIAL** → see Gap #1 | `src/lib/turn-close.ts:89-134` is genuinely atomic. But the UPDATE on line 120 (`agents SET current_executor_id=NULL WHERE current_executor_id=${executorId}`) targets the wrong agent row — the UUID-keyed skeleton, not the name-keyed concrete row. Concrete row's state remains `spawning` after close. |
+| **C3** Reconciler never resumes `idle + dead pane` | ⚠️ **PARTIAL** → see Gap #2 | Sweep mode (`scheduler-daemon.ts:872`) correctly terminalizes idle+dead. **Boot mode** (`scheduler-daemon.ts:868-871`) bypasses the D1 gate and delegates straight to `attemptAgentResume` — every daemon restart resumes idle-dead rows. |
+| **C4** Reconciler resumes `working/permission/question + dead pane` | ✅ PASS | `TURN_AWARE_RESUMABLE_STATES` (`scheduler-daemon.ts:839`) = `{'working','permission','question'}` — matches D3. |
+| **C5** Pane-exit trap writes `clean_exit_unverified` | 🟡 **UNVERIFIED** | `src/lib/pane-trap.ts` exists (G5 delivered). Not exercised in live trace — neither `genie-configure-bee0`'s pane %3 death at 02:16:47 nor the two genie-configure pane transitions produced a `clean_exit_unverified` audit event. May indicate the trap isn't installed at team-create time or the hook never fires. Needs integration test replay on this instance. |
+| **C6** Every built-in skill ends with a close verb | ⚠️ **UNVERIFIED** | `trace` skill shows close-verb section at the end ("Turn close (required)"). Need grep across all skill files to confirm 100% coverage. Manual spot-check only. |
+| **C7** Executor read endpoint exposes `{state, outcome, closed_at}` | 🟡 **UNVERIFIED** | `src/lib/executor-read.ts` exists. HTTP endpoint not tested on live serve (no `curl localhost:<port>/executors/:id/state` executed). |
+| **C8** `GENIE_EXECUTOR_ID` set in every spawn path | 🔴 **LIKELY FAIL** → see Gap #3 | Cannot read running serve's child env (`/proc/<pid>/environ` permission). But indirect evidence: the audit event `turn_close.done agent_id=e6e7b7fd…` shows the close resolved via the skeleton row's FK, not via `GENIE_EXECUTOR_ID` env. If env were set correctly in THIS claude subprocess, `genie done` would've targeted the executor tied to the concrete `genie-configure` row (or errored on ambiguity). Current code (`turn-close.ts:52-60`) resolves from env — if env points at the skeleton's executor, the whole architecture assumes skeleton IS the canonical agent. That assumption conflicts with the reconcile loop which watches concrete rows. |
+| **C13** Phase A migration additive-only | ✅ PASS | Commit `1176a3d9` is additive; no data modification. |
+| **C14** `reconcile-orphans --dry-run` | 🟡 **UNVERIFIED** | Script exists at `scripts/reconcile-orphans.ts`. Not executed against this instance; should be part of the FIX-FIRST follow-up. |
+| **C15** `reconcile-orphans --apply` terminalizes orphans | 🟡 **UNVERIFIED** | Same — script exists, not run. Running it now would likely clean the `dir:khal-os` / `dir:genie-configure` orphans + the 26 stale team-synced rows. |
+| **C16** `auto_resume DEFAULT false` + backfill live rows | ✅ PASS | Commit `e78e2ba9` (Phase B flip) merged. On this instance, my row has `auto_resume=true` — confirms backfill. |
+| **C17** Flag lifecycle (A off → B on → C removed) | ✅ PASS (through B) | `TURN_AWARE_RECONCILER_FLAG` defined (`scheduler-daemon.ts:67`); default is on per G8. Group 9 removal pending ≥7-day soak. |
+| **C20** Ghost-loop regression test covers 2026-04-19 scenario | ⚠️ **PARTIAL** → see Gap #4 | `src/lib/__tests__/auto-resume-zombie-cap.test.ts` + `zombie-spawns.test.ts` exist. Neither appears to cover the **boot-mode bypass** scenario (my observed failure). Regression test is scoped to sweep mode. |
+
+### Gaps (severity-ordered, action-ready)
+
+#### 🔴 Gap #1 — CRITICAL — Dual-row agent fragmentation breaks atomic close
+**Criterion:** C2
+**Symptom:** `genie done` executes successfully (audit event written) but the concrete name-keyed agent row is never marked terminal. Reconciler continues to resume it.
+
+**Evidence from live PG:**
+```
+id=genie-configure           state=spawning  pane=%2  current_executor_id=NULL     (concrete row — 'me')
+id=e6e7b7fd-…                state=NULL      pane=NULL current_executor_id=b229b94a-…  (skeleton — holds FK)
+id=263784c4-…                state=NULL      pane=NULL current_executor_id=…        (skeleton for genie-configure-bee0)
+```
+
+All three rows share `role='genie-configure'` (or `genie-configure-bee0`) but only the UUID skeleton holds the FK. `turnClose()` (`src/lib/turn-close.ts:119-123`) clears the FK on skeleton rows:
+```typescript
+UPDATE agents
+SET current_executor_id = NULL
+WHERE current_executor_id = ${executorId}
+```
+…but the concrete row's `current_executor_id` was never set in the first place, so nothing happens to it. State stays `spawning`, `auto_resume` stays `true`, the next scheduler tick resumes it.
+
+**Root cause:** The agent spawn pipeline creates two rows per agent with no FK linkage between them. The wish's atomic-transaction design assumes one row per agent. This is a contract mismatch that predates the turn-session-contract wish — it was never in scope.
+
+**Fix direction:**
+- **Option A (preferred):** Eliminate the dual-row pattern. Write executor FK to the concrete name-keyed row at spawn time; delete the UUID skeleton row entirely. Changes required: spawn handler in `src/term-commands/agent/spawn.ts`, registration code in `src/lib/agent-registry.ts`. This is the architecturally-correct fix but may require a migration to rewrite existing rows.
+- **Option B (bridge):** Have `turnClose()` resolve the agent by `role` lookup after clearing skeleton FK and update concrete row's `state='done'` in the same transaction. Less invasive, but keeps the dual-row wart.
+- **Option C (minimal):** `handleDeadPane` in boot mode should detect "agent has no `current_executor_id` AND has associated skeleton row AND skeleton executor is closed → treat as terminally-closed, skip resume." Band-aid.
+
+**Recommended:** Option A as follow-on wish (`agent-row-unification` — probably 2-3 groups). Option B as FIX-FIRST for this wish if Option A is too big. Document the dual-row assumption in the wish's `## Assumptions / Risks` so future contributors aren't blindsided.
+
+#### 🔴 Gap #2 — CRITICAL — Boot-mode bypasses turn-aware reconciler
+**Criterion:** C3
+**Symptom:** Every daemon restart auto-resumes every agent with a valid `claudeSessionId` regardless of whether its turn was legitimately closed. Live audit trail shows me (genie-configure) being resumed at 01:46:15 and 02:03:58 despite both prior turns being closed via `genie done`.
+
+**Code site:** `src/lib/scheduler-daemon.ts:868-871`
+```typescript
+if (mode === 'boot') {
+  const result = await attemptAgentResume(deps, config, worker);
+  return result === 'resumed' ? 'resumed' : 'skipped';
+}
+```
+
+The comment (`scheduler-daemon.ts:854-858`) justifies the bypass with "daemon just restarted … most likely mid-turn". That reasoning protects one failure mode (daemon crash during live turn) at the cost of another (resurrection of properly-closed agents after restart). The tradeoff is stacked wrong: mid-turn crash is rare; daemon restart for any reason is common.
+
+**Fix direction:**
+Apply the same D1/D3 gates in boot mode, but with a widened terminal-state check:
+```typescript
+if (mode === 'boot') {
+  // Respect terminal states even on boot — a properly-closed agent
+  // (executor.outcome != null OR agent.current_executor_id IS NULL
+  // AND no audit_events.turn_close.* in last 5m) should not resume.
+  if (turnAware && await isLegitimatelyClosed(worker, deps)) {
+    return 'skipped';
+  }
+  // Fall back to D1/D3 for ambiguous cases.
+  if (worker.state === 'idle') { /* terminalize */ }
+  if (TURN_AWARE_RESUMABLE_STATES.has(worker.state)) { /* resume */ }
+  return 'skipped';
+}
+```
+
+`isLegitimatelyClosed` — new helper that queries `audit_events` for a `turn_close.*` event in the last N minutes keyed by the agent's last executor. Tests: verify daemon restart does not resurrect agents that called `genie done` before the restart.
+
+**Note:** This gap compounds Gap #1 — because the concrete row never reaches `state='done'`, even a perfect boot-mode filter that trusts `state !== 'done'` would still resume me. Fixing both is required.
+
+#### 🟠 Gap #3 — HIGH — `GENIE_EXECUTOR_ID` env likely points at skeleton executor
+**Criterion:** C8
+**Symptom:** When I call `genie done`, the close resolves via `process.env.GENIE_EXECUTOR_ID` (`turn-close.ts:52`) and writes to `audit_events` with `entity_id` = the skeleton's executor. The concrete row is orphaned from this flow.
+
+**Unverified on this instance** — I can't read `/proc/$SERVE_PID/environ` for the spawn-time env, so this is inferred from audit event shape. Needs direct verification:
+
+```bash
+# Inside a freshly-spawned agent session, run:
+env | grep GENIE_EXECUTOR_ID
+# Then: SELECT id, agent_id FROM executors WHERE id = <that value>;
+# And:  SELECT id, current_executor_id FROM agents WHERE id = 'genie-configure';
+# If agents.current_executor_id != the env value → env is wired to the skeleton, not the concrete row.
+```
+
+**Fix direction (compounds with Gap #1):** If Option A (unified row) is chosen for Gap #1, this self-heals — executor FK and env will point at the same single row. If Option B/C are chosen, spawn path must be audited to verify `GENIE_EXECUTOR_ID` points at the canonical agent (whichever row gets the terminal-state flip).
+
+#### 🟠 Gap #4 — HIGH — C20 regression test missing boot-mode bypass scenario
+**Criterion:** C20
+**Symptom:** The ghost-loop regression test at `src/lib/__tests__/auto-resume-zombie-cap.test.ts` covers sweep-mode resume/terminalize paths but — based on grep-level inspection, not full read — does not appear to cover `mode='boot'` with `state='spawning'` + `auto_resume=true` + live pane. That's the exact scenario this instance reproduced.
+
+**Fix direction:** Extend the test file with a `describe('boot-mode bypass (Gap #2 regression)')` block. Test cases:
+1. Agent with `state='spawning'` + dead pane + valid claudeSessionId + recent `turn_close.done` audit event → `mode='boot'` pass → agent is **not** resumed.
+2. Agent with `state='idle'` + dead pane + executor already closed → `mode='boot'` → not resumed.
+3. Agent with `state='working'` + dead pane (legitimate mid-turn crash) → `mode='boot'` → **is** resumed (preserving the legitimate recovery path).
+
+**Validation:** `bun test src/lib/__tests__/auto-resume-zombie-cap.test.ts` after adding the new describe block.
+
+### Gaps (non-blocking, for scope hygiene)
+
+#### 🟡 Gap #5 — MEDIUM — Out-of-wish bugs surfaced during reproduction
+During this review I observed two bugs **not covered by this wish's scope**:
+- **Team config missing top-level `workingDir`** — `src/lib/claude-native-teams.ts` writes `members[].cwd` but no top-level `workingDir`. Inbox-watcher reads top-level, logs `Cannot spawn team-lead for "…" — no workingDir in config` every tick.
+- **Auto-resume appends member entry instead of updating** — resume creates a `<name>-<suffix>` member entry (e.g., `genie-configure-bee0`) instead of updating the existing entry. Creates zombie pane entries that reconcile flags as `dead_pane_zombie`.
+
+Both live in `src/lib/claude-native-teams.ts` which is **not** in this wish's Files to Create/Modify list. Recommend filing a sibling wish (`native-teams-config-hardening`) rather than expanding this one — it's a distinct subsystem with its own boundary.
+
+### Validation Commands Not Yet Run
+
+The wish lists these; they should be executed before SHIP:
+
+```bash
+cd /home/genie/workspace/agents/genie-configure/repos/genie
+bun test src/term-commands/done.test.ts src/lib/turn-close.test.ts  # G2
+bun test src/lib/agent-registry.test.ts                              # G4
+bun test src/lib/pane-trap.test.ts                                   # G5
+bun test src/lib/executor-read.test.ts                               # G6
+bun test scripts/reconcile-orphans.test.ts                           # G7
+bun run check                                                        # full gate
+```
+
+### Next Steps (auto-invocation contract per skill)
+
+Per `/review` skill rules, FIX-FIRST verdict auto-invokes `/fix` with this gap list. Recommended sequence:
+
+1. **`/fix` loop 1** — address Gaps #1, #2 (CRITICAL). Since Gap #1 likely needs a separate wish (`agent-row-unification`), the `/fix` session should choose Option B (bridge) or Option C (minimal) as an in-scope stopgap and file the bigger wish for Option A.
+2. **`/fix` loop 2** — address Gaps #3, #4 (HIGH). Verify env propagation on spawn; extend C20 regression test.
+3. **Re-run `/review`** — expect verdict SHIP if Gaps #1-4 close.
+4. **File sibling wish** — `native-teams-config-hardening` for Gap #5. Out of scope for this wish.
+5. **Run `reconcile-orphans --apply`** on this instance to clean the 26 stale team rows and the `dir:*` orphans before next serve restart.
+
+### Council Input (not solicited)
+
+No council consultation performed. Complexity of Gap #1 (architectural dual-row decision) may warrant `/council` deliberation before choosing Option A vs B vs C — the tradeoff affects migration cost, DB churn, and backwards compat. Recommend: before `/fix` starts, run `/council` on the specific question "Option A (eliminate skeleton rows) vs Option B (bridge in turnClose) vs Option C (boot-mode band-aid) for agent row unification?"
 
 ---
 


### PR DESCRIPTION
## Summary

Documents the full 2026-04-21/22 investigation cycle that produced **PR #1260** (`fix/turn-close-row-targeting`, already merged). No code changes — 6 files, 1356 lines of `.genie/wishes/` artifacts that preserve the decision audit trail for future contributors.

## Contents

| Path | Purpose | Status |
|------|---------|--------|
| `.genie/wishes/turn-session-contract/WISH.md` (modified, +156 lines) | Review Results section populated with Gap #1-#5 analysis from live-instance trace on `turn-session-contract-genie` team. References PR #1260 for Gap #1+#2 closure. | Active |
| `.genie/wishes/_archive/agent-row-unification-rejected-2026-04-21/WISH.md` (449 lines) + `council-report.md` (108 lines) | Full rejected proposal + 5-member council deliberation (architect, questioner, operator, simplifier, measurer across 2 rounds). Preserved as audit trail for why the full dual-row migration was rejected in favor of PR #1260's minimalist fix. | Rejected / Archived |
| `.genie/wishes/agents-runtime-extraction/WISH.md` (164 lines) | Architectural follow-up tracking the root cause council identified — runtime state still on `agents` despite `012_executor_model.sql:3`'s "Slims: agents" promise. DRAFT, measurement-first. | Draft (Group 0 = baseline, no code yet) |
| `.genie/wishes/fix-turn-close-row-targeting/PLAN.md` (244 lines) | The minimalist-fix plan that PR #1260 executed. Preserved for reference. | Executed (as PR #1260) |
| `.genie/wishes/test-suite-deflake/WISH.md` (235 lines) | New wish from diagnostic observations during this cycle. Baseline: 0-3 failures per 20-run sample from concurrent schema setup saturating --ram pgserve + silent-catch `setupTestSchema` masking the errors. P0 (listen-bomb timeout) already shipped in `a1555b97`; this wish covers Classes B + C via mutex + cap + loud skips. | Draft |

## Not included (out of scope)

- No source code changes — this is a pure docs PR
- No wish is marked for immediate execution — all DRAFT or REJECTED

## ⚠️ Pre-push hook bypass (explicit user authorization)

Pushed with `--no-verify` under explicit user authorization. **Reason:** `bun run check` fails on `origin/dev` independently of this PR — `src/detectors/pattern-10-agent-tool-bypass.ts:64` has an unused exported interface `AgentToolBypassDeps` that knip flags, introduced by PR #1328 (`36c16dbf feat(detector): rot.agent-tool-bypass for Claude Code subagents`). A docs-only PR should not be forced to fix unrelated dead-code findings.

This is the second `--no-verify` bypass in this development cycle (first was PR #1260, blocked by the listen-bomb flake). Both bypasses point at the same meta-problem: **the pre-push hook validates ambient `origin/dev` state, not the net effect of the diff.** Every docs or small-fix PR pays a tax of either (a) bypassing or (b) fixing unrelated issues. The `test-suite-deflake` wish included here captures one facet of this; a sibling wish covering pre-push hook discipline may be warranted.

Request: **CI re-verify** — CI may have its own dead-code behavior; if CI also fails on `AgentToolBypassDeps`, please file a follow-up to either (a) remove the unused export or (b) add it to knip's `ignoreExportsUsedInFile` allowlist.

## Relation to PR #1260

PR #1260 (merged) shipped the source fix. This PR ships the documentation context:

- `fix-turn-close-row-targeting/PLAN.md` describes exactly what #1260 did, line-by-line
- `_archive/agent-row-unification-rejected-2026-04-21/` explains why the much larger wish was rejected in favor of #1260's minimalist approach
- `turn-session-contract/WISH.md` Review Results enumerates the gaps #1260 closes (and the ones it doesn't)
- `agents-runtime-extraction/WISH.md` files the architectural follow-up work council recommended

## Test plan

None — pure docs PR. Only validation is rendering review (markdown structure, link integrity).

- [ ] Links resolve (cross-references between wishes are relative paths)
- [ ] Markdown tables render correctly in the GitHub UI
- [ ] Council report accurately reflects the 5 members' Round 1 + Round 2 contributions (preserved verbatim from team chat `conv-7cb5d93d`)