### PR TITLE
fix(ci): route team-auto-spawn.test.ts to PG classifier

### DIFF
--- a/src/lib/team-auto-spawn.test.ts
+++ b/src/lib/team-auto-spawn.test.ts
@@ -3,6 +3,13 @@
  *
  * Tests the core logic of ensureTeamLead without requiring actual tmux sessions.
  * Run with: bun test src/lib/team-auto-spawn.test.ts
+ *
+ * Classifier marker: this file calls registry.findOrCreateAgent /
+ * executorRegistry.createAndLinkExecutor which transitively open PG via
+ * getConnection(). Without this marker, scripts/list-tests.ts would land
+ * it on the unit-tests (no-pgserve) runner and the tests would fast-fail.
+ * See #1335 and .genie/wishes/pg-test-perf/WISH.md Group 9.
+ * @requires GENIE_TEST_PG
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';


### PR DESCRIPTION
## Summary

Follow-up to #1317 (pg-test-perf wish). `src/lib/team-auto-spawn.test.ts` uses `agent-registry` + `executor-registry` which transitively call `getConnection()`, but the classifier regex in `scripts/list-tests.ts` only matches literal `test-db` / `test-setup` / `getConnection` / `GENIE_TEST_PG`. Without a marker, the file was routed to `unit-tests` (which sets `GENIE_TEST_SKIP_PGSERVE=1`) and fast-failed on post-merge dev CI.

Adds a `@requires GENIE_TEST_PG` marker comment so the classifier correctly routes it to the PG Tests job.

## Test plan

- [x] \`bun run scripts/list-tests.ts --pg\` includes \`team-auto-spawn.test.ts\`
- [x] \`bun run scripts/list-tests.ts --non-pg\` does NOT
- [ ] CI unit-tests job green
- [ ] CI pg-tests job green (or retry-once masked flake)

Related: #1335 (flake tracker), #1317 (merged wish).