### PR TITLE
chore(lint): reduce complexity — batch G2a (services)

### DIFF
--- a/src/services/__tests__/wish-lint.test.ts
+++ b/src/services/__tests__/wish-lint.test.ts
@@ -178,6 +178,30 @@ function wishWithGroupBody(groupBody: string[]): string {
   ].join('\n');
 }
 
+type LintReport = ReturnType<typeof lintWish>;
+type Violation = LintReport['violations'][number];
+
+function lintMarkdownSafe(md: string): LintReport {
+  try {
+    return lintWish(parseWish(md), md);
+  } catch (err) {
+    if (err instanceof WishParseError) return lintWish(err, md);
+    throw err;
+  }
+}
+
+function expectViolationOrdered(prev: Violation, cur: Violation): void {
+  if (prev.line === cur.line && prev.column === cur.column) {
+    expect(prev.rule.localeCompare(cur.rule)).toBeLessThanOrEqual(0);
+    return;
+  }
+  if (prev.line === cur.line) {
+    expect(prev.column).toBeLessThanOrEqual(cur.column);
+    return;
+  }
+  expect(prev.line).toBeLessThanOrEqual(cur.line);
+}
+
 // ============================================================================
 // Shape / export contract
 // ============================================================================
@@ -209,26 +233,13 @@ describe('lintWish — shape contract', () => {
     const md = cleanMultiGroupWish()
       .replace('### Group 2: Second', '### Grupo 2 — Second')
       .replace('**depends-on:** none', '**depends-on:** Groups 1 and 2');
-    let report: ReturnType<typeof lintWish>;
-    try {
-      const parsed = parseWish(md);
-      report = lintWish(parsed, md);
-    } catch (err) {
-      if (err instanceof WishParseError) report = lintWish(err, md);
-      else throw err;
-    }
+    const report = lintMarkdownSafe(md);
     expect(report.violations.length).toBeGreaterThan(1);
     for (let i = 1; i < report.violations.length; i++) {
       const prev = report.violations[i - 1];
       const cur = report.violations[i];
       if (!prev || !cur) continue;
-      if (prev.line === cur.line && prev.column === cur.column) {
-        expect(prev.rule.localeCompare(cur.rule)).toBeLessThanOrEqual(0);
-      } else if (prev.line === cur.line) {
-        expect(prev.column).toBeLessThanOrEqual(cur.column);
-      } else {
-        expect(prev.line).toBeLessThanOrEqual(cur.line);
-      }
+      expectViolationOrdered(prev, cur);
     }
   });
 

--- a/src/services/omni-bridge.ts
+++ b/src/services/omni-bridge.ts
@@ -248,73 +248,78 @@ export class OmniBridge {
     }
 
     console.log(`[omni-bridge] Connecting to NATS at ${this.natsUrl}...`);
-
     this.nc = await this.natsConnectFn({
       servers: this.natsUrl,
       name: 'genie-omni-bridge',
       reconnect: true,
-      maxReconnectAttempts: -1, // Unlimited reconnects
+      maxReconnectAttempts: -1,
       reconnectTimeWait: 2000,
     });
-
     console.log('[omni-bridge] Connected to NATS');
 
-    // PG probe: graceful degradation on failure — never block startup.
-    // Group 3 scaffolding; Group 4 consumers (SDK + tmux executors) receive a
-    // bound `safePgCall` reference below.
-    await this.probePg();
+    await this.setupPg();
+    this.wireExecutorHooks();
+    this.subscribeOmniChannels();
 
-    // Initialize PG-backed session store and recover surviving sessions.
+    this.startedAtMs = Date.now();
+    this.subscribePingChannel();
+
+    await this.claimPidfile();
+    this.armSignalCleanup();
+
+    // Arm the idle session checker LAST — after the pidfile write has
+    // succeeded and all prior rollback paths are past. See issue #1137.
+    this.idleCheckTimer = setInterval(() => this.checkIdleSessions(), IDLE_CHECK_INTERVAL_MS);
+
+    console.log(
+      `[omni-bridge] Listening on omni.message.> (max_concurrent=${this.maxConcurrent}, idle_timeout=${this.idleTimeoutMs}ms)`,
+    );
+  }
+
+  /** PG probe + session store + queue initialization. */
+  private async setupPg(): Promise<void> {
+    await this.probePg();
     if (this.pgAvailable && this.sql) {
       this.sessionStore = new BridgeSessionStore(this.sql);
       await this.recoverSessions();
     }
-
-    // Initialize PG-backed queue for SDK executor when PG is available.
     if (this.executorType === 'sdk' && this.pgAvailable && this.sql) {
       this.queue = new OmniQueue(this.sql, (_req, msg) => this.routeMessage(msg), this.queueConfig);
       await this.queue.recoverStale();
       this.queue.start();
     }
+  }
 
-    // Inject the bridge's safePgCall into the executor so its World A registry
-    // writes are guarded by the same pgAvailable / connection-loss logic as
-    // the rest of the bridge. Both executors expose `setSafePgCall` (Group 4,
-    // Decision 2 in WISH Post-Audit).
+  /** Inject safePgCall + NATS publish into the executor. */
+  private wireExecutorHooks(): void {
     this.executor.setSafePgCall(this.safePgCall.bind(this));
-
-    // Inject NATS publish for in-process reply delivery (replaces subprocess fork).
     const sc = this.sc;
     const nc = this.nc;
+    if (!nc) return;
     this.executor.setNatsPublish((topic: string, payload: string) => {
       nc.publish(topic, sc.encode(payload));
     });
+  }
 
-    // Subscribe to all omni messages
+  /** Subscribe to omni.message.>, omni.turn.*.>, omni.session.reset.>. */
+  private subscribeOmniChannels(): void {
+    if (!this.nc) return;
     this.sub = this.nc.subscribe('omni.message.>', { queue: 'genie-bridge' });
     this.processSubscription();
 
-    // Turn lifecycle events from Omni
     const turnSubs = ['omni.turn.open.>', 'omni.turn.done.>', 'omni.turn.nudge.>', 'omni.turn.timeout.>'];
     for (const topic of turnSubs) {
       const sub = this.nc.subscribe(topic, { queue: 'genie-bridge' });
       this.processTurnEvents(sub);
     }
 
-    // Session reset events from Omni — kill the agent's executor session when the user
-    // sends a reset token (e.g. 🗑️). Paired with omni-side publisher in
-    // automagik-dev/omni#361. Subject hierarchy: omni.session.reset.{instance}.{chat}
-    // (recursive `>` because WhatsApp chat ids contain dots).
     const sessionResetSub = this.nc.subscribe('omni.session.reset.>', { queue: 'genie-bridge' });
     this.processSessionResetEvents(sessionResetSub);
+  }
 
-    // Set uptime anchor before subscribing the ping handler so the first pong
-    // reports a non-negative value.
-    this.startedAtMs = Date.now();
-
-    // Subscribe to the omni.bridge.ping IPC channel used by `genie doctor`.
-    // Handler replies with {ok,pid,uptimeMs,subjects} so out-of-process
-    // callers can prove the bridge is actually responsive, not just alive.
+  /** Subscribe to the omni.bridge.ping IPC channel and start the responder loop. */
+  private subscribePingChannel(): void {
+    if (!this.nc) return;
     this.pingSub = this.nc.subscribe(BRIDGE_PING_SUBJECT);
     const pingSub = this.pingSub;
     const pingSc = this.sc;
@@ -336,49 +341,14 @@ export class OmniBridge {
     })().catch(() => {
       // subscription closed on shutdown — fine
     });
+  }
 
-    // Write the pidfile AFTER NATS is live and the ping handler is armed so
-    // any reader who sees the file can trust the IPC channel to answer.
-    // Uses O_EXCL so two concurrent `genie serve` starts cannot both claim it.
+  /** Write the pidfile, rolling back NATS on collision. Uses O_EXCL to arbitrate races. */
+  private async claimPidfile(): Promise<void> {
     this.pidfilePath = getBridgePidfilePath();
     try {
       mkdirSync(dirname(this.pidfilePath), { recursive: true });
-      // Stale-pidfile recovery: if a pidfile exists whose owning process is
-      // gone, the previous holder crashed. Unlink it and retake. If the PID
-      // is alive, fail fast — another bridge is legitimately holding the lock.
-      if (existsSync(this.pidfilePath)) {
-        let stalePid: number | null = null;
-        try {
-          const raw = readFileSync(this.pidfilePath, 'utf8');
-          const parsed = JSON.parse(raw) as { pid?: unknown };
-          if (typeof parsed.pid === 'number' && Number.isFinite(parsed.pid)) {
-            stalePid = parsed.pid;
-          }
-        } catch {
-          // Unreadable/corrupt pidfile — treat as stale and unlink below.
-        }
-        if (stalePid !== null) {
-          let alive = false;
-          try {
-            process.kill(stalePid, 0);
-            alive = true;
-          } catch (probeErr) {
-            // ESRCH = no such process → stale. Any other errno (e.g. EPERM)
-            // means the process exists and we must not steal the lock.
-            const code = (probeErr as NodeJS.ErrnoException).code;
-            alive = code !== 'ESRCH';
-          }
-          if (alive) {
-            throw new Error(`pidfile locked by PID ${stalePid}`);
-          }
-        }
-        try {
-          unlinkSync(this.pidfilePath);
-        } catch {
-          // Another process may have cleaned it up already — openSync wx below
-          // will still arbitrate the race atomically.
-        }
-      }
+      this.evictStalePidfile(this.pidfilePath);
       const fd = openSync(this.pidfilePath, 'wx');
       const payload = JSON.stringify({
         pid: process.pid,
@@ -389,28 +359,72 @@ export class OmniBridge {
       writeSync(fd, payload);
       closeSync(fd);
     } catch (err) {
-      // Roll back the NATS connection so a locked pidfile causes a clean,
-      // non-zero exit in serve instead of a half-initialized bridge.
-      this.pidfilePath = null;
-      const detail = err instanceof Error ? err.message : String(err);
-      try {
-        if (this.pingSub) this.pingSub.unsubscribe();
-      } catch {
-        // ignore
-      }
-      this.pingSub = null;
-      try {
-        await this.nc?.drain();
-      } catch {
-        // ignore
-      }
-      this.nc = null;
-      throw new Error(`[omni-bridge] pidfile locked at ${getBridgePidfilePath()}: ${detail}`);
+      await this.rollbackStartOnPidfileError(err);
     }
+  }
 
-    // Best-effort pidfile cleanup on fatal signals. stop() removes it on
-    // graceful shutdown; these handlers cover SIGTERM/SIGINT paths where
-    // stop() may race the process exit.
+  /**
+   * Stale-pidfile recovery: if a pidfile exists whose owning process is
+   * gone, the previous holder crashed. Unlink it and retake. If the PID
+   * is alive, fail fast — another bridge is legitimately holding the lock.
+   */
+  private evictStalePidfile(path: string): void {
+    if (!existsSync(path)) return;
+    let stalePid: number | null = null;
+    try {
+      const raw = readFileSync(path, 'utf8');
+      const parsed = JSON.parse(raw) as { pid?: unknown };
+      if (typeof parsed.pid === 'number' && Number.isFinite(parsed.pid)) {
+        stalePid = parsed.pid;
+      }
+    } catch {
+      // Unreadable/corrupt pidfile — treat as stale and unlink below.
+    }
+    if (stalePid !== null && this.isPidAlive(stalePid)) {
+      throw new Error(`pidfile locked by PID ${stalePid}`);
+    }
+    try {
+      unlinkSync(path);
+    } catch {
+      // Another process may have cleaned it up already — openSync wx will still arbitrate atomically.
+    }
+  }
+
+  private isPidAlive(pid: number): boolean {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (probeErr) {
+      // ESRCH = no such process → stale. Any other errno (e.g. EPERM)
+      // means the process exists and we must not steal the lock.
+      return (probeErr as NodeJS.ErrnoException).code !== 'ESRCH';
+    }
+  }
+
+  private async rollbackStartOnPidfileError(err: unknown): Promise<never> {
+    this.pidfilePath = null;
+    const detail = err instanceof Error ? err.message : String(err);
+    try {
+      if (this.pingSub) this.pingSub.unsubscribe();
+    } catch {
+      // ignore
+    }
+    this.pingSub = null;
+    try {
+      await this.nc?.drain();
+    } catch {
+      // ignore
+    }
+    this.nc = null;
+    throw new Error(`[omni-bridge] pidfile locked at ${getBridgePidfilePath()}: ${detail}`);
+  }
+
+  /**
+   * Best-effort pidfile cleanup on fatal signals. stop() removes it on
+   * graceful shutdown; these handlers cover SIGTERM/SIGINT paths where
+   * stop() may race the process exit.
+   */
+  private armSignalCleanup(): void {
     const onSignal = () => {
       if (this.pidfilePath) {
         try {
@@ -427,17 +441,6 @@ export class OmniBridge {
       process.removeListener('SIGTERM', onSignal);
       process.removeListener('SIGINT', onSignal);
     };
-
-    // Arm the idle session checker LAST — after the pidfile write has
-    // succeeded and all prior rollback paths are past. This guarantees
-    // that if any earlier step throws, no timer handle has been created
-    // and there is nothing for the caller (or test harness) to leak.
-    // See issue #1137 for the bun-test-hang this ordering prevents.
-    this.idleCheckTimer = setInterval(() => this.checkIdleSessions(), IDLE_CHECK_INTERVAL_MS);
-
-    console.log(
-      `[omni-bridge] Listening on omni.message.> (max_concurrent=${this.maxConcurrent}, idle_timeout=${this.idleTimeoutMs}ms)`,
-    );
   }
 
   /**
@@ -455,75 +458,23 @@ export class OmniBridge {
 
     console.log('[omni-bridge] Shutting down...');
 
-    // Stop queue worker
     if (this.queue) {
       this.queue.stop();
       this.queue = null;
     }
-
-    // Stop idle checker
     if (this.idleCheckTimer) {
       clearInterval(this.idleCheckTimer);
       this.idleCheckTimer = null;
     }
 
-    // Clear idle timers and shut down non-tmux sessions.
-    // Tmux sessions are left running — their PG rows stay 'active' so
-    // recoverSessions() can re-attach after restart.
-    for (const [key, entry] of this.sessions) {
-      if (entry.idleTimer) clearTimeout(entry.idleTimer);
-      if (!entry.spawning && entry.session) {
-        if (entry.session.executorType === 'tmux') {
-          console.log(`[omni-bridge] Detaching from tmux session ${key} (pane stays alive)`);
-        } else {
-          try {
-            await this.executor.shutdown(entry.session);
-          } catch (err) {
-            console.warn(`[omni-bridge] Error shutting down session ${key}:`, err);
-          }
-          // Close SDK sessions in PG since they can't survive restart
-          const closeId = entry.pgBridgeSessionId;
-          if (closeId && this.sessionStore) {
-            await this.safePgCall('session_close_sdk', (sql) => new BridgeSessionStore(sql).close(closeId), undefined);
-          }
-        }
-      }
-    }
-    this.sessions.clear();
-
-    // Unsubscribe
-    if (this.sub) {
-      this.sub.unsubscribe();
-      this.sub = null;
-    }
-
-    // Tear down the ping IPC channel.
-    if (this.pingSub) {
-      try {
-        this.pingSub.unsubscribe();
-      } catch {
-        // ignore
-      }
-      this.pingSub = null;
-    }
-
-    // Remove the pidfile deterministically on clean stop.
-    if (this.pidfilePath) {
-      try {
-        unlinkSync(this.pidfilePath);
-      } catch {
-        // already gone — fine
-      }
-      this.pidfilePath = null;
-    }
-
-    // Remove signal handlers so tests can start/stop repeatedly without leaks.
+    await this.shutdownActiveSessions();
+    this.unsubscribeChannels();
+    this.clearPidfileOnStop();
     if (this.signalCleanup) {
       this.signalCleanup();
       this.signalCleanup = null;
     }
 
-    // Drain and close
     try {
       await this.nc.drain();
     } catch {
@@ -538,6 +489,57 @@ export class OmniBridge {
     this.sessionStore = null;
 
     console.log('[omni-bridge] Stopped');
+  }
+
+  /**
+   * Clear idle timers and shut down non-tmux sessions.
+   * Tmux sessions are left running — their PG rows stay 'active' so
+   * recoverSessions() can re-attach after restart.
+   */
+  private async shutdownActiveSessions(): Promise<void> {
+    for (const [key, entry] of this.sessions) {
+      if (entry.idleTimer) clearTimeout(entry.idleTimer);
+      if (entry.spawning || !entry.session) continue;
+      if (entry.session.executorType === 'tmux') {
+        console.log(`[omni-bridge] Detaching from tmux session ${key} (pane stays alive)`);
+        continue;
+      }
+      try {
+        await this.executor.shutdown(entry.session);
+      } catch (err) {
+        console.warn(`[omni-bridge] Error shutting down session ${key}:`, err);
+      }
+      const closeId = entry.pgBridgeSessionId;
+      if (closeId && this.sessionStore) {
+        await this.safePgCall('session_close_sdk', (sql) => new BridgeSessionStore(sql).close(closeId), undefined);
+      }
+    }
+    this.sessions.clear();
+  }
+
+  private unsubscribeChannels(): void {
+    if (this.sub) {
+      this.sub.unsubscribe();
+      this.sub = null;
+    }
+    if (this.pingSub) {
+      try {
+        this.pingSub.unsubscribe();
+      } catch {
+        // ignore
+      }
+      this.pingSub = null;
+    }
+  }
+
+  private clearPidfileOnStop(): void {
+    if (!this.pidfilePath) return;
+    try {
+      unlinkSync(this.pidfilePath);
+    } catch {
+      // already gone — fine
+    }
+    this.pidfilePath = null;
   }
 
   /**
@@ -715,6 +717,48 @@ export class OmniBridge {
   // Internal
   // ==========================================================================
 
+  /** Fill instanceId/chatId from the NATS subject when the payload omits them. */
+  private fillSubjectMetadata(parsed: OmniMessage, subject: string): void {
+    const parts = subject.split('.');
+    if (parts.length < 4) return;
+    parsed.instanceId = parsed.instanceId || (parts[2] as string);
+    parsed.chatId = parsed.chatId || (parts[3] as string);
+  }
+
+  /** Track a recently-seen message id, returning true if it is a duplicate. */
+  private isDuplicateMessage(messageId: string | undefined): boolean {
+    if (!messageId) return false;
+    if (this.recentMessageIds.has(messageId)) return true;
+    this.recentMessageIds.set(messageId, Date.now());
+    // Prune stale entries when cache grows large (TTL 60s)
+    if (this.recentMessageIds.size > 1000) {
+      const cutoff = Date.now() - 60_000;
+      for (const [id, ts] of this.recentMessageIds) {
+        if (ts < cutoff) this.recentMessageIds.delete(id);
+      }
+    }
+    return false;
+  }
+
+  /**
+   * SDK executor with PG queue: persist to queue for durable processing.
+   * Tmux executor or degraded mode: route directly (fire-and-forget).
+   */
+  private async dispatchMessage(parsed: OmniMessage): Promise<void> {
+    if (this.queue) {
+      // biome-ignore lint/suspicious/noExplicitAny: NATS payload may have extra fields
+      const raw = parsed as any;
+      const env = (raw.env as Record<string, string>) ?? {};
+      await this.queue.enqueue(parsed, env);
+      return;
+    }
+    const key = `${parsed.agent}:${parsed.chatId}`;
+    const hasSession = this.sessions.has(key);
+    console.log(`[omni-bridge] Routing message for ${key} (hasSession=${hasSession}, queue=${!!this.queue})`);
+    await this.routeMessage(parsed);
+    console.log(`[omni-bridge] routeMessage done for ${key}`);
+  }
+
   /**
    * Process incoming NATS messages from the subscription.
    */
@@ -725,32 +769,15 @@ export class OmniBridge {
       try {
         const data = this.sc.decode(msg.data);
         const parsed: OmniMessage = JSON.parse(data);
-
-        // Extract instance_id and chat_id from subject: omni.message.{instance}.{chat_id}
-        const parts = msg.subject.split('.');
-        if (parts.length >= 4) {
-          parsed.instanceId = parsed.instanceId || parts[2];
-          parsed.chatId = parsed.chatId || parts[3];
-        }
+        this.fillSubjectMetadata(parsed, msg.subject);
 
         console.log(`[omni-bridge] NATS message received: ${msg.subject} agent=${parsed.agent} chat=${parsed.chatId}`);
 
-        // Dedup: skip messages already processed (JetStream redelivery protection)
         // biome-ignore lint/suspicious/noExplicitAny: NATS payload has extra fields beyond OmniMessage
         const messageId = (parsed as any).messageId as string | undefined;
-        if (messageId && this.recentMessageIds.has(messageId)) {
+        if (this.isDuplicateMessage(messageId)) {
           console.log(`[omni-bridge] Dedup: skipping duplicate messageId=${messageId}`);
           continue;
-        }
-        if (messageId) {
-          this.recentMessageIds.set(messageId, Date.now());
-          // Prune stale entries when cache grows large (TTL 60s)
-          if (this.recentMessageIds.size > 1000) {
-            const cutoff = Date.now() - 60_000;
-            for (const [id, ts] of this.recentMessageIds) {
-              if (ts < cutoff) this.recentMessageIds.delete(id);
-            }
-          }
         }
 
         if (!parsed.chatId || !parsed.agent) {
@@ -758,20 +785,7 @@ export class OmniBridge {
           continue;
         }
 
-        // SDK executor with PG queue: persist to queue for durable processing.
-        // Tmux executor or degraded mode: route directly (fire-and-forget).
-        if (this.queue) {
-          // biome-ignore lint/suspicious/noExplicitAny: NATS payload may have extra fields
-          const raw = parsed as any;
-          const env = (raw.env as Record<string, string>) ?? {};
-          await this.queue.enqueue(parsed, env);
-        } else {
-          const key = `${parsed.agent}:${parsed.chatId}`;
-          const hasSession = this.sessions.has(key);
-          console.log(`[omni-bridge] Routing message for ${key} (hasSession=${hasSession}, queue=${!!this.queue})`);
-          await this.routeMessage(parsed);
-          console.log(`[omni-bridge] routeMessage done for ${key}`);
-        }
+        await this.dispatchMessage(parsed);
       } catch (err) {
         console.error('[omni-bridge] Error processing message:', err);
       }

--- a/src/services/wish-lint.ts
+++ b/src/services/wish-lint.ts
@@ -290,101 +290,106 @@ function findValidationFenceInfo(
   return { labelLine, fenceLine, fenceTag, fenceClose };
 }
 
-function scanValidation(doc: WishDocument, lines: string[]): Violation[] {
+const FIELD_BOUNDARY_REGEX = /^\*\*(Goal|Deliverables|Acceptance Criteria|depends-on)\s*:\*\*/i;
+
+function collectValidationProse(lines: string[], start: number, end: number): string[] {
+  let stop = end;
+  for (let j = start; j < end; j++) {
+    if (FIELD_BOUNDARY_REGEX.test(lines[j] as string)) {
+      stop = j;
+      break;
+    }
+  }
+  const collected: string[] = [];
+  for (let j = start; j < stop; j++) collected.push(lines[j] as string);
+  while (collected.length > 0 && (collected[collected.length - 1] as string).trim() === '') {
+    collected.pop();
+  }
+  return collected;
+}
+
+function violationForMissingFence(info: { labelLine: number; fenceLine: number }, contentLines: string[]): Violation {
+  if (!contentLines.some((l) => l.trim() !== '')) {
+    return {
+      rule: 'missing-validation-command',
+      severity: 'error',
+      line: info.labelLine + 1,
+      column: 1,
+      message: 'Validation block is empty — add a fenced `bash` block with the verification command',
+      fixable: false,
+      fix: null,
+    };
+  }
+  return {
+    rule: 'validation-not-fenced-bash',
+    severity: 'error',
+    line: info.labelLine + 1,
+    column: 1,
+    message: 'Validation block is not wrapped in a ```bash fenced code block',
+    fixable: true,
+    fix: {
+      kind: 'rewrite',
+      at: { line: info.labelLine + 2 },
+      content: ['```bash', ...contentLines, '```'].join('\n'),
+      range: { endLine: info.labelLine + 1 + contentLines.length, endColumn: 1 },
+    },
+  };
+}
+
+function violationsForFencedBlock(
+  lines: string[],
+  info: { fenceLine: number; fenceTag: string | null; fenceClose: number | null },
+): Violation[] {
   const out: Violation[] = [];
-  for (const group of doc.executionGroups) {
-    const info = findValidationFenceInfo(lines, group);
-    if (!info) continue; // missing-validation-field already handled
-    if (info.fenceLine < 0) {
-      // Validation label present but no fenced block at all → fixable: wrap content in bash fence.
-      const start = info.labelLine + 1;
-      // Find content range — up to next field label or group end.
-      let end = group.endLine;
-      for (let j = start; j < end; j++) {
-        if (/^\*\*(Goal|Deliverables|Acceptance Criteria|depends-on)\s*:\*\*/i.test(lines[j] as string)) {
-          end = j;
-          break;
-        }
-      }
-      const contentLines: string[] = [];
-      for (let j = start; j < end; j++) {
-        contentLines.push(lines[j] as string);
-      }
-      while (contentLines.length > 0 && (contentLines[contentLines.length - 1] as string).trim() === '') {
-        contentLines.pop();
-      }
-      const nonEmpty = contentLines.some((l) => l.trim() !== '');
-      if (!nonEmpty) {
-        out.push({
-          rule: 'missing-validation-command',
-          severity: 'error',
-          line: info.labelLine + 1,
-          column: 1,
-          message: 'Validation block is empty — add a fenced `bash` block with the verification command',
-          fixable: false,
-          fix: null,
-        });
-        continue;
-      }
-      // Fixable: wrap existing prose in a bash fence.
-      out.push({
-        rule: 'validation-not-fenced-bash',
-        severity: 'error',
-        line: info.labelLine + 1,
-        column: 1,
-        message: 'Validation block is not wrapped in a ```bash fenced code block',
-        fixable: true,
-        fix: {
-          kind: 'rewrite',
-          at: { line: info.labelLine + 2 },
-          content: ['```bash', ...contentLines, '```'].join('\n'),
-          range: { endLine: info.labelLine + 1 + contentLines.length, endColumn: 1 },
-        },
-      });
-      continue;
-    }
-    // Fence found — check the tag.
-    if (info.fenceTag !== 'bash') {
-      // Known-safe rewrite: change just the fence tag to `bash`.
-      out.push({
-        rule: 'validation-not-fenced-bash',
-        severity: 'error',
-        line: info.fenceLine + 1,
-        column: 1,
-        message: `Validation fence has tag "${info.fenceTag ?? '<none>'}" — expected \`bash\``,
-        fixable: true,
-        fix: {
-          kind: 'rewrite',
-          at: { line: info.fenceLine + 1 },
-          content: '```bash',
-          range: { endLine: info.fenceLine + 1, endColumn: ((lines[info.fenceLine] as string).length || 1) + 1 },
-        },
-      });
-    }
-    // Check for empty body inside the fence.
-    if (info.fenceClose !== null) {
-      const body: string[] = [];
-      for (let j = info.fenceLine + 1; j < info.fenceClose; j++) body.push(lines[j] as string);
-      const nonEmpty = body.some((l) => l.trim() !== '');
-      if (!nonEmpty) {
-        out.push({
-          rule: 'missing-validation-command',
-          severity: 'error',
-          line: info.fenceLine + 1,
-          column: 1,
-          message: 'Validation bash block is empty — add a command that verifies this group',
-          fixable: false,
-          fix: null,
-        });
-      }
-    }
+  if (info.fenceTag !== 'bash') {
+    out.push({
+      rule: 'validation-not-fenced-bash',
+      severity: 'error',
+      line: info.fenceLine + 1,
+      column: 1,
+      message: `Validation fence has tag "${info.fenceTag ?? '<none>'}" — expected \`bash\``,
+      fixable: true,
+      fix: {
+        kind: 'rewrite',
+        at: { line: info.fenceLine + 1 },
+        content: '```bash',
+        range: { endLine: info.fenceLine + 1, endColumn: ((lines[info.fenceLine] as string).length || 1) + 1 },
+      },
+    });
+  }
+  if (info.fenceClose === null) return out;
+  const body: string[] = [];
+  for (let j = info.fenceLine + 1; j < info.fenceClose; j++) body.push(lines[j] as string);
+  if (!body.some((l) => l.trim() !== '')) {
+    out.push({
+      rule: 'missing-validation-command',
+      severity: 'error',
+      line: info.fenceLine + 1,
+      column: 1,
+      message: 'Validation bash block is empty — add a command that verifies this group',
+      fixable: false,
+      fix: null,
+    });
   }
   return out;
 }
 
-function scanScope(doc: WishDocument, lines: string[]): Violation[] {
+function scanValidation(doc: WishDocument, lines: string[]): Violation[] {
   const out: Violation[] = [];
-  let scopeHeaderLine = -1;
+  for (const group of doc.executionGroups) {
+    const info = findValidationFenceInfo(lines, group);
+    if (!info) continue;
+    if (info.fenceLine < 0) {
+      const contentLines = collectValidationProse(lines, info.labelLine + 1, group.endLine);
+      out.push(violationForMissingFence(info, contentLines));
+      continue;
+    }
+    out.push(...violationsForFencedBlock(lines, info));
+  }
+  return out;
+}
+
+function findScopeHeaderLine(lines: string[]): number {
   let inFence = false;
   for (let i = 0; i < lines.length; i++) {
     const raw = lines[i] as string;
@@ -393,46 +398,45 @@ function scanScope(doc: WishDocument, lines: string[]): Violation[] {
       continue;
     }
     if (inFence) continue;
-    if (/^##\s+Scope\s*$/i.test(raw)) {
-      scopeHeaderLine = i;
-      break;
-    }
+    if (/^##\s+Scope\s*$/i.test(raw)) return i;
   }
+  return -1;
+}
+
+function findScopeEndIdx(lines: string[], scopeHeaderLine: number): number {
+  for (let i = scopeHeaderLine + 1; i < lines.length; i++) {
+    if (/^##\s+/.test(lines[i] as string)) return i;
+  }
+  return lines.length;
+}
+
+function findOutLine(lines: string[], start: number, end: number): number {
+  for (let i = start; i < end; i++) {
+    if (/^###\s+OUT\b/i.test(lines[i] as string)) return i;
+  }
+  return -1;
+}
+
+function scopeMissingViolation(line: number, message: string): Violation {
+  return { rule: 'scope-section-missing', severity: 'error', line, column: 1, message, fixable: false, fix: null };
+}
+
+function scanScope(doc: WishDocument, lines: string[]): Violation[] {
+  const out: Violation[] = [];
+  const scopeHeaderLine = findScopeHeaderLine(lines);
   if (scopeHeaderLine < 0) {
-    out.push({
-      rule: 'scope-section-missing',
-      severity: 'error',
-      line: 1,
-      column: 1,
-      message: 'Wish is missing the `## Scope` section',
-      fixable: false,
-      fix: null,
-    });
+    out.push(scopeMissingViolation(1, 'Wish is missing the `## Scope` section'));
     return out;
   }
-  // Detect IN / OUT presence by scanning H3 under scope up to next H2.
-  const endIdx = (() => {
-    for (let i = scopeHeaderLine + 1; i < lines.length; i++) {
-      if (/^##\s+/.test(lines[i] as string)) return i;
-    }
-    return lines.length;
-  })();
-  const hasIn = lines.slice(scopeHeaderLine + 1, endIdx).some((l) => /^###\s+IN\b/i.test(l));
-  const hasOut = lines.slice(scopeHeaderLine + 1, endIdx).some((l) => /^###\s+OUT\b/i.test(l));
+  const endIdx = findScopeEndIdx(lines, scopeHeaderLine);
+  const slice = lines.slice(scopeHeaderLine + 1, endIdx);
+  const hasIn = slice.some((l) => /^###\s+IN\b/i.test(l));
+  const hasOut = slice.some((l) => /^###\s+OUT\b/i.test(l));
   if (!hasIn && !hasOut) {
-    out.push({
-      rule: 'scope-section-missing',
-      severity: 'error',
-      line: scopeHeaderLine + 1,
-      column: 1,
-      message: '`## Scope` section has no `### IN` or `### OUT` subsections',
-      fixable: false,
-      fix: null,
-    });
+    out.push(scopeMissingViolation(scopeHeaderLine + 1, '`## Scope` section has no `### IN` or `### OUT` subsections'));
     return out;
   }
   if (!hasOut) {
-    // Insert an OUT stub at the end of the scope section.
     out.push({
       rule: 'scope-section-missing',
       severity: 'error',
@@ -440,11 +444,7 @@ function scanScope(doc: WishDocument, lines: string[]): Violation[] {
       column: 1,
       message: '`## Scope` is missing the `### OUT` subsection',
       fixable: true,
-      fix: {
-        kind: 'insert',
-        at: { line: endIdx + 1 },
-        content: '### OUT\n\n- <TODO>\n\n',
-      },
+      fix: { kind: 'insert', at: { line: endIdx + 1 }, content: '### OUT\n\n- <TODO>\n\n' },
     });
   }
   if (!hasIn) {
@@ -455,22 +455,11 @@ function scanScope(doc: WishDocument, lines: string[]): Violation[] {
       column: 1,
       message: '`## Scope` is missing the `### IN` subsection',
       fixable: true,
-      fix: {
-        kind: 'insert',
-        at: { line: scopeHeaderLine + 2 },
-        content: '\n### IN\n\n- <TODO>\n',
-      },
+      fix: { kind: 'insert', at: { line: scopeHeaderLine + 2 }, content: '\n### IN\n\n- <TODO>\n' },
     });
   }
   if (hasOut && doc.scope.out.length === 0) {
-    // Find OUT line for a more precise location.
-    let outLine = -1;
-    for (let i = scopeHeaderLine + 1; i < endIdx; i++) {
-      if (/^###\s+OUT\b/i.test(lines[i] as string)) {
-        outLine = i;
-        break;
-      }
-    }
+    const outLine = findOutLine(lines, scopeHeaderLine + 1, endIdx);
     out.push({
       rule: 'empty-out-scope',
       severity: 'error',
@@ -484,117 +473,136 @@ function scanScope(doc: WishDocument, lines: string[]): Violation[] {
   return out;
 }
 
+const DEPENDS_REF_PATTERN =
+  /^(?:Group\s+\d+|[A-Za-z][A-Za-z0-9_-]*(?:\/(?:Group\s+\d+|[A-Za-z][A-Za-z0-9_-]*))*|[A-Za-z][A-Za-z0-9_-]*#\d+)$/i;
+
+function findDependsLine(lines: string[], group: { startLine: number; endLine: number }): number {
+  const start = Math.max(0, group.startLine);
+  const end = Math.min(lines.length, group.endLine);
+  for (let i = start; i < end; i++) {
+    if (/^\*\*depends-on\s*:\*\*/i.test(lines[i] as string)) return i;
+  }
+  return -1;
+}
+
+function splitDependsParts(rawValue: string): string[] {
+  return rawValue
+    .replace(/\.$/, '')
+    .split(/\s*,\s*/)
+    .map((p) =>
+      p
+        .trim()
+        .replace(/\s*\(.*$/, '')
+        .trim(),
+    )
+    .filter(Boolean);
+}
+
+function canonicalizeDependsRefs(parts: string[]): { canonical: string[]; malformed: boolean } {
+  const canonical: string[] = [];
+  let malformed = false;
+  for (const raw of parts) {
+    if (DEPENDS_REF_PATTERN.test(raw)) {
+      canonical.push(raw.replace(/^group\s+/i, 'Group '));
+      continue;
+    }
+    const numbers = [...raw.matchAll(/(\d+)/g)].map((m) => Number.parseInt(m[1] as string, 10));
+    if (numbers.length > 0) {
+      for (const n of numbers) canonical.push(`Group ${n}`);
+      malformed = true;
+      continue;
+    }
+    canonical.push(raw);
+    malformed = true;
+  }
+  return { canonical, malformed };
+}
+
+function allRefsResolvable(canonical: string[], validNumbers: Set<number>): boolean {
+  const refs = canonical.filter((p) => /^Group\s+\d+$/i.test(p));
+  if (refs.length === 0) return false;
+  return refs.every((r) => {
+    const m = /^Group\s+(\d+)$/i.exec(r);
+    if (!m) return false;
+    return validNumbers.has(Number.parseInt(m[1] as string, 10));
+  });
+}
+
+function buildMalformedViolation(
+  canonical: string[],
+  rawValue: string,
+  labelLine: string,
+  dependsLine: number,
+  validNumbers: Set<number>,
+): Violation {
+  if (allRefsResolvable(canonical, validNumbers)) {
+    return {
+      rule: 'depends-on-malformed',
+      severity: 'error',
+      line: dependsLine + 1,
+      column: 1,
+      message: `depends-on value "${rawValue}" is not in canonical "Group N, Group M" form`,
+      fixable: true,
+      fix: {
+        kind: 'rewrite',
+        at: { line: dependsLine + 1 },
+        content: `**depends-on:** ${canonical.join(', ')}`,
+        range: { endLine: dependsLine + 1, endColumn: (labelLine.length || 1) + 1 },
+      },
+    };
+  }
+  return {
+    rule: 'depends-on-malformed',
+    severity: 'error',
+    line: dependsLine + 1,
+    column: 1,
+    message: `depends-on value "${rawValue}" cannot be parsed — expected "none", "Group N", a descriptive name, or a slug/group reference`,
+    fixable: false,
+    fix: null,
+  };
+}
+
+function collectDanglingViolations(
+  canonical: string[],
+  groupNumber: number,
+  dependsLine: number,
+  validNumbers: Set<number>,
+): Violation[] {
+  const out: Violation[] = [];
+  for (const ref of canonical) {
+    const m = /^Group\s+(\d+)$/i.exec(ref);
+    if (!m) continue;
+    const n = Number.parseInt(m[1] as string, 10);
+    if (validNumbers.has(n)) continue;
+    out.push({
+      rule: 'depends-on-dangling',
+      severity: 'error',
+      line: dependsLine + 1,
+      column: 1,
+      message: `Group ${groupNumber} depends-on references non-existent Group ${n}`,
+      fixable: false,
+      fix: null,
+    });
+  }
+  return out;
+}
+
 function scanDependsOn(doc: WishDocument, lines: string[]): Violation[] {
   const out: Violation[] = [];
   const validNumbers = new Set(doc.executionGroups.map((g) => g.number));
   for (const group of doc.executionGroups) {
-    // Find raw depends-on line within the group.
-    const start = Math.max(0, group.startLine);
-    const end = Math.min(lines.length, group.endLine);
-    let dependsLine = -1;
-    for (let i = start; i < end; i++) {
-      if (/^\*\*depends-on\s*:\*\*/i.test(lines[i] as string)) {
-        dependsLine = i;
-        break;
-      }
-    }
+    const dependsLine = findDependsLine(lines, group);
     if (dependsLine < 0) continue;
     const labelLine = lines[dependsLine] as string;
     const rawValue = labelLine.replace(/^\*\*depends-on\s*:\*\*/i, '').trim();
     if (!rawValue) continue;
     if (/^none$/i.test(rawValue.replace(/\.$/, ''))) continue;
-    // Strip trailing parenthetical commentary on each ref (e.g., "Group 2 (replaces stub)" → "Group 2").
-    const parts = rawValue
-      .replace(/\.$/, '')
-      .split(/\s*,\s*/)
-      .map((p) =>
-        p
-          .trim()
-          .replace(/\s*\(.*$/, '')
-          .trim(),
-      )
-      .filter(Boolean);
-    // Accepted ref shapes:
-    //   * `Group N`                       — canonical numeric within current wish
-    //   * `Foundation` / `migration-2`    — descriptive identifier (in-wish or cross-wish slug)
-    //   * `wish-slug/group-1`             — same-wish or cross-wish slash form
-    //   * `repo/wish-slug/group-N`        — fully qualified cross-repo reference (any depth)
-    //   * `slug#3`                        — legacy hash form
-    // Reject only truly malformed shapes (empty, bad punctuation, free-form prose).
-    const refPattern =
-      /^(?:Group\s+\d+|[A-Za-z][A-Za-z0-9_-]*(?:\/(?:Group\s+\d+|[A-Za-z][A-Za-z0-9_-]*))*|[A-Za-z][A-Za-z0-9_-]*#\d+)$/i;
-    const canonicalParts: string[] = [];
-    let anyMalformed = false;
-    for (const raw of parts) {
-      if (refPattern.test(raw)) {
-        canonicalParts.push(raw.replace(/^group\s+/i, 'Group '));
-        continue;
-      }
-      // Try to recover "Group N and Group M" or "Groups 1 and 2".
-      const numbers = [...raw.matchAll(/(\d+)/g)].map((m) => Number.parseInt(m[1] as string, 10));
-      if (numbers.length > 0) {
-        for (const n of numbers) canonicalParts.push(`Group ${n}`);
-        anyMalformed = true;
-        continue;
-      }
-      canonicalParts.push(raw);
-      anyMalformed = true;
+    const parts = splitDependsParts(rawValue);
+    const { canonical, malformed } = canonicalizeDependsRefs(parts);
+    if (malformed) {
+      out.push(buildMalformedViolation(canonical, rawValue, labelLine, dependsLine, validNumbers));
     }
-    if (anyMalformed) {
-      // Are all recovered refs resolvable?
-      const refs = canonicalParts.filter((p) => /^Group\s+\d+$/i.test(p));
-      const allResolvable =
-        refs.length > 0 &&
-        refs.every((r) => {
-          const m = /^Group\s+(\d+)$/i.exec(r);
-          if (!m) return false;
-          return validNumbers.has(Number.parseInt(m[1] as string, 10));
-        });
-      if (allResolvable) {
-        const fixed = `**depends-on:** ${canonicalParts.join(', ')}`;
-        out.push({
-          rule: 'depends-on-malformed',
-          severity: 'error',
-          line: dependsLine + 1,
-          column: 1,
-          message: `depends-on value "${rawValue}" is not in canonical "Group N, Group M" form`,
-          fixable: true,
-          fix: {
-            kind: 'rewrite',
-            at: { line: dependsLine + 1 },
-            content: fixed,
-            range: { endLine: dependsLine + 1, endColumn: (labelLine.length || 1) + 1 },
-          },
-        });
-      } else {
-        out.push({
-          rule: 'depends-on-malformed',
-          severity: 'error',
-          line: dependsLine + 1,
-          column: 1,
-          message: `depends-on value "${rawValue}" cannot be parsed — expected "none", "Group N", a descriptive name, or a slug/group reference`,
-          fixable: false,
-          fix: null,
-        });
-      }
-    }
-    // Dangling references — emit here with precise line (schema superRefine covers this too but without line).
-    for (const ref of canonicalParts) {
-      const m = /^Group\s+(\d+)$/i.exec(ref);
-      if (!m) continue;
-      const n = Number.parseInt(m[1] as string, 10);
-      if (!validNumbers.has(n)) {
-        out.push({
-          rule: 'depends-on-dangling',
-          severity: 'error',
-          line: dependsLine + 1,
-          column: 1,
-          message: `Group ${group.number} depends-on references non-existent Group ${n}`,
-          fixable: false,
-          fix: null,
-        });
-      }
-    }
+    out.push(...collectDanglingViolations(canonical, group.number, dependsLine, validNumbers));
   }
   return out;
 }
@@ -631,6 +639,39 @@ function scanTodoPlaceholders(lines: string[]): Violation[] {
   return out;
 }
 
+function collectParseErrorViolations(err: WishParseError, lines: string[]): Violation[] {
+  const violations: Violation[] = [detectParseErrorViolation(err)];
+  if (err.rule !== 'missing-execution-groups-header') return violations;
+  const firstGroup = findFirstGroupHeaderLine(lines);
+  if (firstGroup >= 0) {
+    (violations[0] as Violation).fix = {
+      kind: 'insert',
+      at: { line: firstGroup + 1 },
+      content: '## Execution Groups\n\n',
+    };
+  }
+  violations.push(...scanStrayGroupHeaders(lines, null));
+  return violations;
+}
+
+function collectPostParseViolations(doc: WishDocument, lines: string[], options: LintOptions): Violation[] {
+  const violations: Violation[] = [];
+  const execRange = findExecGroupsRange(lines);
+  violations.push(...scanStrayGroupHeaders(lines, execRange));
+  violations.push(...scanGroupFieldLabels(doc, lines));
+  violations.push(...scanEmptyFieldContent(doc, lines));
+  violations.push(...scanValidation(doc, lines));
+  violations.push(...scanScope(doc, lines));
+  violations.push(...scanDependsOn(doc, lines));
+  if (!options.allowTodoPlaceholders) {
+    violations.push(...scanTodoPlaceholders(lines));
+  }
+  // Run schema as a catch-all; currently no additional violations are surfaced because
+  // richer per-line rules cover each case, but the call remains for future-proofing.
+  WishDocumentSchema.safeParse(doc);
+  return violations;
+}
+
 /**
  * Lint a wish. Accepts either a parsed `WishDocument` or a `WishParseError`
  * (so callers can wrap `parseWish` in a try/catch and hand the error here
@@ -643,72 +684,10 @@ export function lintWish(
 ): LintReport {
   const normalized = markdown.replace(/\r\n/g, '\n');
   const lines = normalized.split('\n');
-  const violations: Violation[] = [];
-
   if (docOrError instanceof WishParseError) {
-    violations.push(detectParseErrorViolation(docOrError));
-    // For `missing-execution-groups-header`, also enumerate stray group headers so
-    // `--fix` can repair both the missing parent and every non-canonical child at once.
-    if (docOrError.rule === 'missing-execution-groups-header') {
-      const firstGroup = findFirstGroupHeaderLine(lines);
-      if (firstGroup >= 0) {
-        // Give the parse-error violation a concrete fix now that we know where to insert.
-        const pv = violations[0] as Violation;
-        pv.fix = {
-          kind: 'insert',
-          at: { line: firstGroup + 1 },
-          content: '## Execution Groups\n\n',
-        };
-      }
-      // Also emit group-header-format violations for stray Portuguese/dash headers.
-      violations.push(...scanStrayGroupHeaders(lines, null));
-    }
-    return finalize(violations, docOrError, options);
+    return finalize(collectParseErrorViolations(docOrError, lines), docOrError, options);
   }
-
-  // Parse succeeded — run the full rule battery.
-  const doc = docOrError;
-
-  // 1. Stray group headers under `## Execution Groups`.
-  const execRange = findExecGroupsRange(lines);
-  violations.push(...scanStrayGroupHeaders(lines, execRange));
-
-  // 2. Per-group field-label scan.
-  violations.push(...scanGroupFieldLabels(doc, lines));
-
-  // 3. Empty field content (label present, value empty).
-  violations.push(...scanEmptyFieldContent(doc, lines));
-
-  // 4. Validation fence checks.
-  violations.push(...scanValidation(doc, lines));
-
-  // 5. Scope section.
-  violations.push(...scanScope(doc, lines));
-
-  // 6. depends-on malformed / dangling.
-  violations.push(...scanDependsOn(doc, lines));
-
-  // 7. TODO placeholders (unless bypassed for scaffolds).
-  if (!options.allowTodoPlaceholders) {
-    violations.push(...scanTodoPlaceholders(lines));
-  }
-
-  // 8. Catch-all: run schema and surface any issue we didn't already emit.
-  const schemaResult = WishDocumentSchema.safeParse(doc);
-  if (!schemaResult.success) {
-    for (const issue of schemaResult.error.issues) {
-      // Skip issues we already emitted via richer per-line rules.
-      const path = issue.path.join('.');
-      const isHandled =
-        (path.startsWith('scope.out') && violations.some((v) => v.rule === 'empty-out-scope')) ||
-        (path.startsWith('executionGroups') && /Group \d+ depends-on references/.test(issue.message)) ||
-        (/min|minimum/i.test(issue.message) &&
-          violations.some((v) => v.rule.startsWith('missing-') || v.rule === 'empty-out-scope'));
-      if (isHandled) continue;
-    }
-  }
-
-  return finalize(violations, doc, options);
+  return finalize(collectPostParseViolations(docOrError, lines, options), docOrError, options);
 }
 
 function finalize(

--- a/src/services/wish-parser.ts
+++ b/src/services/wish-parser.ts
@@ -125,12 +125,11 @@ function sliceContent(lines: string[], span: SectionSpan): string[] {
   return lines.slice(start, end);
 }
 
-function parseMetadataTable(lines: string[], startLine: number): WishMetadata {
+function extractMetadataFromRows(lines: string[]): { metadata: Partial<WishMetadata>; sawHeader: boolean } {
   const metadata: Partial<WishMetadata> = {};
   let sawHeader = false;
   let sawDivider = false;
-  for (let i = 0; i < lines.length; i++) {
-    const raw = lines[i] as string;
+  for (const raw of lines) {
     const line = raw.trim();
     if (!line.startsWith('|')) {
       if (sawHeader) break;
@@ -150,12 +149,16 @@ function parseMetadataTable(lines: string[], startLine: number): WishMetadata {
       .map((c) => c.trim());
     if (cells.length < 2) continue;
     const keyRaw = stripBold(cells[0] as string).toLowerCase();
-    const value = stripBackticks(cells[1] as string);
     const mapped = METADATA_KEY_MAP[keyRaw];
     if (mapped) {
-      (metadata as Record<string, string>)[mapped] = value;
+      (metadata as Record<string, string>)[mapped] = stripBackticks(cells[1] as string);
     }
   }
+  return { metadata, sawHeader };
+}
+
+function parseMetadataTable(lines: string[], startLine: number): WishMetadata {
+  const { metadata, sawHeader } = extractMetadataFromRows(lines);
   if (!sawHeader) {
     throw new WishParseError({
       rule: 'metadata-table-missing-field',
@@ -314,8 +317,28 @@ function extractLabeledField(
   };
 }
 
+function extractValidationBody(rawValue: string): string {
+  const vLines = rawValue.split('\n');
+  let inFence = false;
+  const collected: string[] = [];
+  for (const l of vLines) {
+    const fenceOpen = /^\s*```(\S*)\s*$/.exec(l);
+    if (fenceOpen) {
+      if (!inFence) {
+        inFence = true;
+        continue;
+      }
+      inFence = false;
+      break;
+    }
+    if (inFence) collected.push(l);
+  }
+  // If no fence present, keep raw content (the linter rule `validation-not-fenced-bash` handles this).
+  return collected.length > 0 ? collected.join('\n') : rawValue;
+}
+
 function parseExecutionGroup(
-  allLines: string[],
+  _allLines: string[],
   headerLine: string,
   headerLineNumber: number,
   bodyLines: string[],
@@ -342,40 +365,11 @@ function parseExecutionGroup(
   const validationField = extractLabeledField(bodyLines, bodyStartLine, /^\*\*Validation:\*\*/i, stopRegex);
   const dependsOnField = extractLabeledField(bodyLines, bodyStartLine, /^\*\*depends-on:\*\*/i, stopRegex);
 
-  // Acceptance checklist extraction.
   const acceptanceItems = acceptanceField.found ? parseChecklist(acceptanceField.value.split('\n')) : [];
-
-  // Validation fenced block extraction: first ```bash (or ``` ) block after the label.
-  let validationBody = '';
-  if (validationField.found) {
-    const vLines = validationField.value.split('\n');
-    let inFence = false;
-    let fenceTag: string | null = null;
-    const collected: string[] = [];
-    for (const l of vLines) {
-      const fenceOpen = /^\s*```(\S*)\s*$/.exec(l);
-      if (fenceOpen) {
-        if (!inFence) {
-          inFence = true;
-          fenceTag = (fenceOpen[1] as string) || '';
-          continue;
-        }
-        inFence = false;
-        break;
-      }
-      if (inFence) collected.push(l);
-    }
-    // If no fence present, keep raw content (the linter rule `validation-not-fenced-bash` handles this).
-    validationBody = collected.length > 0 ? collected.join('\n') : validationField.value;
-    // Suppress unused fence-tag warning; parser does not branch on it yet (linter does).
-    void fenceTag;
-  }
-
+  const validationBody = validationField.found ? extractValidationBody(validationField.value) : '';
   const { value: dependsOnValue } = dependsOnField.found
     ? parseDependsOnValue(dependsOnField.value)
     : { value: [] as string[] };
-
-  void allLines; // retained for future line-range utilities
 
   return {
     name: `Group ${number}: ${title}`,
@@ -444,12 +438,10 @@ function extractFencedBlock(content: string): string {
   return m ? (m[1] as string) : '';
 }
 
-export function parseWish(markdown: string): WishDocument {
-  const normalized = markdown.replace(/\r\n/g, '\n');
-  const lines = normalized.split('\n');
-  const spans = detectHeadings(lines);
-
-  // Title (H1).
+function parseTitleAndMetadata(
+  lines: string[],
+  spans: SectionSpan[],
+): { title: string; metadata: WishMetadata; titleSpan: SectionSpan; firstH2: SectionSpan | undefined } {
   const titleSpan = spans.find((s) => s.level === 1);
   if (!titleSpan || !/^Wish:\s*/i.test(titleSpan.title)) {
     throw new WishParseError({
@@ -459,55 +451,33 @@ export function parseWish(markdown: string): WishDocument {
     });
   }
   const title = titleSpan.title.replace(/^Wish:\s*/i, '').trim();
-
-  // Metadata table lives between the title and the first H2.
   const firstH2 = spans.find((s) => s.level === 2);
   const metaLines = lines.slice(titleSpan.start, firstH2 ? firstH2.start - 1 : lines.length);
   const metadata = parseMetadataTable(metaLines, titleSpan.start + 1);
+  return { title, metadata, titleSpan, firstH2 };
+}
 
-  // Summary.
-  const summarySpan = spans.find((s) => s.level === 2 && /^summary$/i.test(s.title));
-  if (!summarySpan) {
-    throw new WishParseError({
-      rule: 'missing-summary',
-      line: firstH2?.start ?? titleSpan.start,
-      message: 'Wish is missing the `## Summary` section',
-    });
-  }
-  const summary = sliceContent(lines, summarySpan).join('\n').trim();
-
-  // Scope.
+function parseScopeSection(lines: string[], spans: SectionSpan[]): { in: string[]; out: string[] } {
   const scopeSpan = spans.find((s) => s.level === 2 && /^scope$/i.test(s.title));
   const scopeIn: string[] = [];
   const scopeOut: string[] = [];
-  if (scopeSpan) {
-    const scopeSubs = spans.filter((s) => s.level === 3 && s.start > scopeSpan.start && s.start <= scopeSpan.end);
-    for (const sub of scopeSubs) {
-      const content = sliceContent(lines, sub);
-      if (/^in\b/i.test(sub.title)) scopeIn.push(...parseBullets(content));
-      else if (/^out\b/i.test(sub.title)) scopeOut.push(...parseBullets(content));
-    }
+  if (!scopeSpan) return { in: scopeIn, out: scopeOut };
+  const scopeSubs = spans.filter((s) => s.level === 3 && s.start > scopeSpan.start && s.start <= scopeSpan.end);
+  for (const sub of scopeSubs) {
+    const content = sliceContent(lines, sub);
+    if (/^in\b/i.test(sub.title)) scopeIn.push(...parseBullets(content));
+    else if (/^out\b/i.test(sub.title)) scopeOut.push(...parseBullets(content));
   }
+  return { in: scopeIn, out: scopeOut };
+}
 
-  // Decisions.
-  const decisionsSpan = spans.find((s) => s.level === 2 && /^decisions$/i.test(s.title));
-  const decisions = decisionsSpan ? parseDecisions(sliceContent(lines, decisionsSpan)) : [];
-
-  // Success Criteria.
-  const successSpan = spans.find((s) => s.level === 2 && /^success criteria$/i.test(s.title));
-  const successCriteria = successSpan ? parseChecklist(sliceContent(lines, successSpan)) : [];
-
-  // Execution Strategy.
-  const strategySpan = spans.find((s) => s.level === 2 && /^execution strategy$/i.test(s.title));
-  const executionStrategy = strategySpan ? parseExecutionStrategy(lines, strategySpan, spans) : [];
-
-  // Execution Groups — hard-required section.
+function parseExecutionGroupsSection(lines: string[], spans: SectionSpan[], fallbackLine: number): ExecutionGroup[] {
   const execGroupsSpan = spans.find((s) => s.level === 2 && /^execution groups$/i.test(s.title));
   if (!execGroupsSpan) {
     const stray = detectStrayGroupHeaders(lines);
     throw new WishParseError({
       rule: 'missing-execution-groups-header',
-      line: stray?.line ?? firstH2?.start ?? titleSpan.start,
+      line: stray?.line ?? fallbackLine,
       message: stray
         ? `Wish contains a "${stray.text}" header but the parent "## Execution Groups" header is missing`
         : 'Wish is missing the `## Execution Groups` section',
@@ -521,20 +491,50 @@ export function parseWish(markdown: string): WishDocument {
       message: 'Wish contains `## Execution Groups` but no `### Group N: …` subsections',
     });
   }
+  return executionGroups;
+}
 
-  // QA Criteria.
+function requireSummary(lines: string[], spans: SectionSpan[], fallbackLine: number): string {
+  const summarySpan = spans.find((s) => s.level === 2 && /^summary$/i.test(s.title));
+  if (!summarySpan) {
+    throw new WishParseError({
+      rule: 'missing-summary',
+      line: fallbackLine,
+      message: 'Wish is missing the `## Summary` section',
+    });
+  }
+  return sliceContent(lines, summarySpan).join('\n').trim();
+}
+
+export function parseWish(markdown: string): WishDocument {
+  const normalized = markdown.replace(/\r\n/g, '\n');
+  const lines = normalized.split('\n');
+  const spans = detectHeadings(lines);
+
+  const { title, metadata, titleSpan, firstH2 } = parseTitleAndMetadata(lines, spans);
+  const summary = requireSummary(lines, spans, firstH2?.start ?? titleSpan.start);
+  const scope = parseScopeSection(lines, spans);
+
+  const decisionsSpan = spans.find((s) => s.level === 2 && /^decisions$/i.test(s.title));
+  const decisions = decisionsSpan ? parseDecisions(sliceContent(lines, decisionsSpan)) : [];
+
+  const successSpan = spans.find((s) => s.level === 2 && /^success criteria$/i.test(s.title));
+  const successCriteria = successSpan ? parseChecklist(sliceContent(lines, successSpan)) : [];
+
+  const strategySpan = spans.find((s) => s.level === 2 && /^execution strategy$/i.test(s.title));
+  const executionStrategy = strategySpan ? parseExecutionStrategy(lines, strategySpan, spans) : [];
+
+  const executionGroups = parseExecutionGroupsSection(lines, spans, firstH2?.start ?? titleSpan.start);
+
   const qaSpan = spans.find((s) => s.level === 2 && /^qa criteria$/i.test(s.title));
   const qaCriteria = qaSpan ? parseChecklist(sliceContent(lines, qaSpan)) : [];
 
-  // Assumptions / Risks.
   const risksSpan = spans.find((s) => s.level === 2 && /^assumptions\s*\/\s*risks$/i.test(s.title));
   const assumptionsRisks = risksSpan ? parseRisks(sliceContent(lines, risksSpan)) : [];
 
-  // Review Results.
   const reviewSpan = spans.find((s) => s.level === 2 && /^review results$/i.test(s.title));
   const reviewResults = reviewSpan ? stripHorizontalRules(sliceContent(lines, reviewSpan).join('\n')) : '';
 
-  // Files to Create/Modify.
   const filesSpan = spans.find((s) => s.level === 2 && /^files to create(\/modify)?$/i.test(s.title));
   const filesToCreate = filesSpan ? extractFencedBlock(sliceContent(lines, filesSpan).join('\n')) : '';
 
@@ -542,7 +542,7 @@ export function parseWish(markdown: string): WishDocument {
     title,
     metadata,
     summary,
-    scope: { in: scopeIn, out: scopeOut },
+    scope,
     decisions,
     successCriteria,
     executionStrategy,


### PR DESCRIPTION
## Summary

Reduce cognitive complexity in 4 `src/services/` files to ≤15 via helper extraction + early-return flattening. Public signatures unchanged. Part of the complexity-cleanup-phase-2 wish; meta-blocker clears only when G2a + G2b + G2c all merge.

## Before / After (biome complexity scores)

### `src/services/wish-lint.ts`
| Function | Before | After | Strategy |
|---|---|---|---|
| `scanValidation` | 34 | <15 | extract `collectValidationProse`, `violationForMissingFence`, `violationsForFencedBlock` |
| `scanScope` | 21 | <15 | extract `findScopeHeaderLine`, `findScopeEndIdx`, `findOutLine`, `scopeMissingViolation` |
| `scanDependsOn` | 37 | <15 | extract `findDependsLine`, `splitDependsParts`, `canonicalizeDependsRefs`, `allRefsResolvable`, `buildMalformedViolation`, `collectDanglingViolations` |
| `lintWish` | 17 | <15 | split into `collectParseErrorViolations` + `collectPostParseViolations`; retained unused `WishDocumentSchema.safeParse` call as future-proofing hook |

### `src/services/wish-parser.ts`
| Function | Before | After | Strategy |
|---|---|---|---|
| `parseMetadataTable` | 18 | <15 | extract `extractMetadataFromRows` |
| `parseExecutionGroup` | 19 | <15 | extract `extractValidationBody`; drop unused `void allLines` retention |
| `parseWish` | 27 | <15 | extract `parseTitleAndMetadata`, `requireSummary`, `parseScopeSection`, `parseExecutionGroupsSection` |

### `src/services/omni-bridge.ts`
| Function | Before | After | Strategy |
|---|---|---|---|
| `start` | 31 | <15 | extract `setupPg`, `wireExecutorHooks`, `subscribeOmniChannels`, `subscribePingChannel`, `claimPidfile`, `evictStalePidfile`, `isPidAlive`, `rollbackStartOnPidfileError`, `armSignalCleanup` |
| `stop` | 31 | <15 | extract `shutdownActiveSessions`, `unsubscribeChannels`, `clearPidfileOnStop` |
| `processSubscription` | 31 | <15 | extract `fillSubjectMetadata`, `isDuplicateMessage`, `dispatchMessage` |

### `src/services/__tests__/wish-lint.test.ts`
| Function | Before | After | Strategy |
|---|---|---|---|
| sort-order test (line 207) | 16 | <15 | extract `lintMarkdownSafe`, `expectViolationOrdered` helpers |

## Decision #6 escape hatch

Not used. `scanValidation` (34) and `scanDependsOn` (37) both landed below 15 via helper extraction alone — diagnostic ordering is preserved because extracted helpers return `Violation[]` spread back into the same push sequence as the original.

## Validation

- `bun run typecheck` ✅
- `bunx biome check` on all 4 files ✅ (0 complexity errors)
- `bun run build` ✅ (dist/genie.js produced)
- `bun test src/services` ✅ **292 pass / 0 fail / 809 expects** across 12 files

## Notes for reviewer

- Public signatures unchanged on all exports (`lintWish`, `parseWish`, `OmniBridge.start/stop`, etc.).
- `parseExecutionGroup` sheds an unused `void allLines` retention comment — the param is now prefixed `_allLines` to keep the call sites stable.
- The `lintWish` catch-all schema block previously had a dead loop (`isHandled` computed but never acted on); reduced to a single `WishDocumentSchema.safeParse(doc)` call retained as a future-proofing hook, per the code comment.
- Biome formatter re-flowed two multi-line function signatures during `biome check --write`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)