### PR TITLE
chore(lint): reduce complexity — batch G3 sweep (heavy term-commands)

### DIFF
--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -1151,38 +1151,61 @@ async function runSdkQuery(
   };
 
   // Process SDK messages — same logic for streaming and non-streaming
+  const recordToolUseBlock = async (block: unknown): Promise<void> => {
+    const b = block as Record<string, unknown>;
+    const name = String(b.name ?? '');
+    const id = String(b.id ?? '');
+    if (id) toolNameById.set(id, name);
+    await record('tool_input', JSON.stringify(b.input ?? {}).slice(0, 500), name);
+  };
+
+  const recordAssistantBlocks = async (
+    message: Extract<import('@anthropic-ai/claude-agent-sdk').SDKMessage, { type: 'assistant' }>,
+  ): Promise<void> => {
+    if (!message.message) return;
+    for (const block of message.message.content) {
+      if (block.type === 'tool_use') {
+        await recordToolUseBlock(block);
+      } else if (block.type === 'text' && block.text) {
+        await record('assistant', block.text);
+      }
+    }
+  };
+
+  const recordToolResultBlock = async (block: unknown): Promise<void> => {
+    const b = block as Record<string, unknown>;
+    if (b.type !== 'tool_result') return;
+    const toolId = String(b.tool_use_id ?? '');
+    const toolName = toolNameById.get(toolId) ?? '';
+    const output = typeof b.content === 'string' ? b.content.slice(0, 500) : '';
+    await record('tool_output', output, toolName);
+  };
+
+  const recordToolResults = async (
+    message: Extract<import('@anthropic-ai/claude-agent-sdk').SDKMessage, { type: 'user' }>,
+  ): Promise<void> => {
+    if (!message.message?.content || !Array.isArray(message.message.content)) return;
+    for (const block of message.message.content) {
+      await recordToolResultBlock(block);
+    }
+  };
+
   const processMessage = async (message: import('@anthropic-ai/claude-agent-sdk').SDKMessage) => {
-    if (message.type === 'system' && (message as Record<string, unknown>).session_id) {
-      claudeSessionId = (message as Record<string, unknown>).session_id as string;
+    if (message.type === 'system') {
+      const sid = (message as Record<string, unknown>).session_id;
+      if (sid) claudeSessionId = sid as string;
+      return;
     }
-    if (message.type === 'assistant' && message.message) {
-      for (const block of message.message.content) {
-        if (block.type === 'tool_use') {
-          const b = block as unknown as Record<string, unknown>;
-          const name = String(b.name ?? '');
-          const id = String(b.id ?? '');
-          if (id) toolNameById.set(id, name);
-          await record('tool_input', JSON.stringify(b.input ?? {}).slice(0, 500), name);
-        }
-        if (block.type === 'text' && block.text) {
-          await record('assistant', block.text);
-        }
-      }
+    if (message.type === 'assistant') {
+      await recordAssistantBlocks(message);
+      return;
     }
-    // Tool results come as user messages with tool_result content blocks
-    if (message.type === 'user' && message.message?.content && Array.isArray(message.message.content)) {
-      for (const block of message.message.content) {
-        const b = block as unknown as Record<string, unknown>;
-        if (b.type === 'tool_result') {
-          const toolId = String(b.tool_use_id ?? '');
-          const toolName = toolNameById.get(toolId) ?? '';
-          const output = typeof b.content === 'string' ? b.content.slice(0, 500) : '';
-          await record('tool_output', output, toolName);
-        }
-      }
+    if (message.type === 'user') {
+      await recordToolResults(message);
+      return;
     }
-    if (message.type === 'result' && message.subtype === 'success') {
-      if (message.session_id) claudeSessionId = message.session_id;
+    if (message.type === 'result' && message.subtype === 'success' && message.session_id) {
+      claudeSessionId = message.session_id;
     }
   };
 
@@ -2669,6 +2692,91 @@ function recordManualResumeTelemetry(
   }
 }
 
+function buildResumeSpawnCtx(args: {
+  agent: registry.Agent;
+  validated: ReturnType<typeof validateSpawnParams>;
+  launch: ReturnType<typeof buildLaunchCommand>;
+  fullCommand: string;
+  now: string;
+  template: Awaited<ReturnType<typeof registry.listTemplates>>[number] | undefined;
+  resumeSessionId: string | undefined;
+  teamName: string;
+  agentIdentityId: string;
+  executorId: string;
+}): SpawnCtx {
+  const {
+    agent,
+    validated,
+    launch,
+    fullCommand,
+    now,
+    template,
+    resumeSessionId,
+    teamName,
+    agentIdentityId,
+    executorId,
+  } = args;
+  return {
+    workerId: agent.id,
+    validated,
+    launch,
+    layoutMode: resolveLayoutMode(undefined),
+    fullCommand,
+    agentName: agent.role ?? agent.id,
+    spawnColor: agent.nativeColor ?? 'blue',
+    parentSessionId: agent.parentSessionId ?? `genie-${teamName}`,
+    // `resumeSessionId` is returned by `getResumeSessionId` inside
+    // `buildFullResumeParams` — the canonical source now that the agent row
+    // no longer carries a session (migration 047).
+    claudeSessionId: resumeSessionId,
+    otelRelayActive: false,
+    now,
+    transport: 'tmux',
+    extraArgs: template?.extraArgs,
+    cwd: template?.cwd ?? agent.repoPath,
+    spawnIntoCurrentWindow: false,
+    autoResume: agent.autoResume,
+    agentIdentityId,
+    executorId,
+  };
+}
+
+function createResumeTmuxPaneOrExit(
+  ctx: SpawnCtx,
+  teamWindow: TeamWindowInfo | null,
+  telemetry: { shouldEmit: boolean; entityId: string; attemptNumber: number; stateBefore: string },
+): string {
+  try {
+    return createTmuxPane(ctx, teamWindow);
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : 'unknown error';
+    recordManualResumeTelemetry(telemetry.shouldEmit, 'agent.resume.failed', {
+      entity_id: telemetry.entityId,
+      attempt_number: telemetry.attemptNumber,
+      state_before: telemetry.stateBefore,
+      state_after: telemetry.stateBefore,
+      last_error: `createTmuxPane: ${errorMessage}`,
+      exhausted: false,
+    });
+    console.error(`Failed to create tmux pane: ${errorMessage}`);
+    process.exit(1);
+  }
+}
+
+function logResumeSuccess(
+  agent: registry.Agent,
+  resumeSessionId: string | undefined,
+  paneId: string,
+  teamWindow: TeamWindowInfo | null,
+): void {
+  console.log(`Agent "${agent.id}" resumed.`);
+  console.log(`  Session:  ${resumeSessionId ?? '(none)'}`);
+  console.log(`  Pane:     ${paneId}`);
+  if (teamWindow) {
+    console.log(`  Window:   ${teamWindow.windowName} (${teamWindow.windowId})`);
+  }
+}
+
 async function resumeAgent(agent: registry.Agent, opts: { resetAttempts?: boolean } = {}): Promise<void> {
   const resetAttempts = opts.resetAttempts !== false;
   const template = (await registry.listTemplates()).find((t) => t.id === (agent.role ?? agent.id));
@@ -2699,9 +2807,7 @@ async function resumeAgent(agent: registry.Agent, opts: { resetAttempts?: boolea
   // Mint executor identity BEFORE buildLaunchCommand so GENIE_EXECUTOR_ID /
   // GENIE_AGENT_ID propagate into the resumed child env. The same executorId
   // is later reused when createResumeExecutor INSERTs the executor row.
-  const resumeAgentName = agent.role ?? agent.id;
-  const resumeTeam = agent.team ?? params.team;
-  const agentIdentity = await registry.findOrCreateAgent(resumeAgentName, resumeTeam, agent.role);
+  const agentIdentity = await registry.findOrCreateAgent(agent.role ?? agent.id, agent.team ?? params.team, agent.role);
   const executorId = crypto.randomUUID();
   params.agentId = agentIdentity.id;
   params.executorId = executorId;
@@ -2716,52 +2822,29 @@ async function resumeAgent(agent: registry.Agent, opts: { resetAttempts?: boolea
     process.exit(1);
   }
 
-  const ctx: SpawnCtx = {
-    workerId: agent.id,
+  const ctx = buildResumeSpawnCtx({
+    agent,
     validated,
     launch,
-    layoutMode: resolveLayoutMode(undefined),
     fullCommand,
-    agentName: agent.role ?? agent.id,
-    spawnColor: agent.nativeColor ?? 'blue',
-    parentSessionId: agent.parentSessionId ?? `genie-${params.team}`,
-    // `params.resume` is the session UUID returned by `getResumeSessionId`
-    // inside `buildFullResumeParams` — the canonical source now that the
-    // agent row no longer carries a session (migration 047).
-    claudeSessionId: params.resume,
-    otelRelayActive: false,
     now,
-    transport: 'tmux',
-    extraArgs: template?.extraArgs,
-    cwd: template?.cwd ?? agent.repoPath,
-    spawnIntoCurrentWindow: false,
-    autoResume: agent.autoResume,
+    template,
+    resumeSessionId: params.resume,
+    teamName: params.team,
     agentIdentityId: agentIdentity.id,
     executorId,
-  };
+  });
 
   const teamWindow = await resolveSpawnTeamWindow(validated.team, ctx.cwd);
-
-  let paneId: string;
-  try {
-    paneId = createTmuxPane(ctx, teamWindow);
-  } catch (err) {
-    const errorMessage = err instanceof Error ? err.message : 'unknown error';
-    recordManualResumeTelemetry(shouldEmitTelemetry, 'agent.resume.failed', {
-      entity_id: agent.id,
-      attempt_number: telemetryAttemptNumber,
-      state_before: telemetryStateBefore,
-      state_after: telemetryStateBefore,
-      last_error: `createTmuxPane: ${errorMessage}`,
-      exhausted: false,
-    });
-    console.error(`Failed to create tmux pane: ${errorMessage}`);
-    process.exit(1);
-  }
+  const paneId = createResumeTmuxPaneOrExit(ctx, teamWindow, {
+    shouldEmit: shouldEmitTelemetry,
+    entityId: agent.id,
+    attemptNumber: telemetryAttemptNumber,
+    stateBefore: telemetryStateBefore,
+  });
 
   // Executor model: create new executor for resumed session
   await createResumeExecutor(agent, validated, paneId, teamWindow, ctx.cwd, ctx.spawnColor);
-
   await applySpawnLayout(ctx, teamWindow);
 
   await registry.update(agent.id, {
@@ -2776,7 +2859,6 @@ async function resumeAgent(agent: registry.Agent, opts: { resetAttempts?: boolea
   });
 
   await notifySpawnJoin(ctx, paneId);
-
   // Inject resume context so the agent knows what wish/group it was working on
   await injectResumeContext(ctx.cwd ?? agent.repoPath ?? process.cwd(), agent.id, agent.role ?? agent.id, params.team);
 
@@ -2788,7 +2870,6 @@ async function resumeAgent(agent: registry.Agent, opts: { resetAttempts?: boolea
     claudeSessionId: params.resume,
     team: agent.team,
   }).catch(() => {});
-
   recordManualResumeTelemetry(shouldEmitTelemetry, 'agent.resume.succeeded', {
     entity_id: agent.id,
     attempt_number: telemetryAttemptNumber,
@@ -2796,12 +2877,7 @@ async function resumeAgent(agent: registry.Agent, opts: { resetAttempts?: boolea
     state_after: 'spawning',
   });
 
-  console.log(`Agent "${agent.id}" resumed.`);
-  console.log(`  Session:  ${params.resume}`);
-  console.log(`  Pane:     ${paneId}`);
-  if (teamWindow) {
-    console.log(`  Window:   ${teamWindow.windowName} (${teamWindow.windowId})`);
-  }
+  logResumeSuccess(agent, params.resume, paneId, teamWindow);
 }
 
 type WorkerStatus = {

--- a/src/term-commands/dir.ts
+++ b/src/term-commands/dir.ts
@@ -279,12 +279,7 @@ interface EditOptions extends SdkDirOptions {
   global?: boolean;
 }
 
-async function handleEdit(name: string, options: EditOptions): Promise<void> {
-  // dir-sync-frontmatter-refresh (Group 4): `dir edit` writes to agent.yaml
-  // FIRST, then triggers a single-agent sync so the PG row picks up the new
-  // values. No more direct PG writes — the yaml file is the source of truth
-  // and the sync path mirrors it into the DB.
-
+function collectAgentConfigUpdates(options: EditOptions): Partial<AgentConfig> {
   const updates: Partial<AgentConfig> = {};
   if (options.dir) updates.dir = resolvePath(options.dir);
   if (options.repo) updates.repo = resolvePath(options.repo);
@@ -300,6 +295,16 @@ async function handleEdit(name: string, options: EditOptions): Promise<void> {
 
   const sdk = buildSdkConfig(options);
   if (sdk) updates.sdk = sdk as AgentConfig['sdk'];
+  return updates;
+}
+
+async function handleEdit(name: string, options: EditOptions): Promise<void> {
+  // dir-sync-frontmatter-refresh (Group 4): `dir edit` writes to agent.yaml
+  // FIRST, then triggers a single-agent sync so the PG row picks up the new
+  // values. No more direct PG writes — the yaml file is the source of truth
+  // and the sync path mirrors it into the DB.
+
+  const updates = collectAgentConfigUpdates(options);
 
   if (Object.keys(updates).length === 0) {
     console.error(

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -508,7 +508,7 @@ async function startScheduler(): Promise<void> {
 /** Start all services in foreground mode.
  *  @param headless If true, skip TUI setup (services only: pgserve, scheduler, inbox-watcher).
  */
-async function startForeground(headless?: boolean): Promise<void> {
+function claimServePidOrExit(): void {
   const existingEntry = readServePid();
   if (existingEntry && isProcessAlive(existingEntry.pid)) {
     console.log(`genie serve already running (PID ${existingEntry.pid})`);
@@ -519,7 +519,9 @@ async function startForeground(headless?: boolean): Promise<void> {
     // owned by process.pid, which wouldn't match here).
     forceRemoveServePid();
   }
+}
 
+function resolveServeMode(headless?: boolean): { skipTui: boolean; mode: 'headless' | 'no-tui' | 'full' } {
   // Hotfix: treat GENIE_TUI_DISABLE / --no-tui like --headless for TUI setup
   // so `genie serve` starts pgserve + scheduler + bridge but never seeds the
   // OpenTUI launch pane. Agent sessions (on `-L genie`) are unaffected.
@@ -527,24 +529,26 @@ async function startForeground(headless?: boolean): Promise<void> {
   if (tuiDisabled && !headless) {
     noticeTuiSkipped('serve');
   }
-  const skipTui = headless || tuiDisabled;
+  const skipTui = Boolean(headless) || tuiDisabled;
+  const mode: 'headless' | 'no-tui' | 'full' = headless ? 'headless' : tuiDisabled ? 'no-tui' : 'full';
+  return { skipTui, mode };
+}
 
-  process.env.GENIE_IS_DAEMON = '1';
-  writeServePid(process.pid);
-
-  const mode = headless ? 'headless' : tuiDisabled ? 'no-tui' : 'full';
-  console.log(`genie serve starting (PID ${process.pid}, mode: ${mode})`);
-
-  // Ensure tmux is available (downloads static binary if missing)
-  if (!skipTui) {
-    await ensureTmux();
+function resolveBrainPathFromWorkspace(): string | undefined {
+  try {
+    const { findWorkspace } = require('../lib/workspace.js') as typeof import('../lib/workspace.js');
+    const ws = findWorkspace();
+    if (ws?.root) {
+      const bp = join(ws.root, 'brain');
+      if (existsSync(bp) && existsSync(join(bp, 'brain.json'))) return bp;
+    }
+  } catch {
+    // No workspace — skip
   }
+  return undefined;
+}
 
-  // 1. Start pgserve
-  await startPgserve();
-
-  // 1.5. Start brain server (if @automagik/genie-brain is installed)
-  //
+async function startBrainServerIfEnabled(): Promise<void> {
   // Gated by `brain.embedded` config (default: true). Set `brain.embedded=false`
   // in ~/.genie/config.json to opt out — power-users can then run `brain serve`
   // standalone with custom settings (port, brain-path, @next dev channel).
@@ -552,95 +556,62 @@ async function startForeground(headless?: boolean): Promise<void> {
   const brainEmbedded = loadGenieConfigSync().brain.embedded;
   if (!brainEmbedded) {
     console.log('  Brain server: skipped (brain.embedded=false — managed externally)');
+    return;
+  }
+  try {
+    // Dynamic import — brain is optional. Silently skip if not installed.
+    // @ts-expect-error — brain is enterprise-only, not in genie's deps
+    const brain = await import('@khal-os/brain');
+    if (!brain.startEmbeddedBrainServer) return;
+    const { getActivePort } = await import('../lib/db.js');
+    const pgPort = getActivePort();
+    if (!pgPort) {
+      console.log('  Brain server: pgserve not available (skipped)');
+      return;
+    }
+    console.log('  Starting brain server...');
+    const brainPath = resolveBrainPathFromWorkspace();
+    if (!brainPath) {
+      console.log('  Brain server: no brain/ found in workspace (skipped)');
+      return;
+    }
+    const handle = await brain.startEmbeddedBrainServer({ brainPath, geniePgPort: pgPort });
+    handles.brainHandle = { stop: handle.stop, port: handle.port };
+    console.log(`  Brain server ready on port ${handle.port}`);
+  } catch {
+    // Brain not installed — fine, skip silently
+  }
+}
+
+function logAgentSessionInfo(): void {
+  const sessions = listAgentSessions();
+  if (sessions.length > 0) {
+    console.log(`  Agent server (-L genie): ${sessions.length} sessions`);
   } else {
+    console.log('  Agent server (-L genie): no sessions yet (created on first spawn)');
+  }
+}
+
+function startTuiSessionIfEnabled(skipTui: boolean): void {
+  if (skipTui) return;
+  console.log('  Setting up TUI session...');
+  const { leftPane, rightPane } = startTuiTmuxServer();
+  const ws = (() => {
     try {
-      // Dynamic import — brain is optional. If not installed, this throws
-      // and we silently skip. Zero behavior change for users without brain.
-      // @ts-expect-error — brain is enterprise-only, not in genie's deps
-      const brain = await import('@khal-os/brain');
-      if (brain.startEmbeddedBrainServer) {
-        const { getActivePort } = await import('../lib/db.js');
-        const pgPort = getActivePort();
-        if (pgPort) {
-          console.log('  Starting brain server...');
-          // Find brain path — check workspace for a brain/ dir
-          let brainPath: string | undefined;
-          try {
-            const { findWorkspace } = require('../lib/workspace.js') as typeof import('../lib/workspace.js');
-            const ws = findWorkspace();
-            if (ws?.root) {
-              const bp = join(ws.root, 'brain');
-              if (existsSync(bp) && existsSync(join(bp, 'brain.json'))) {
-                brainPath = bp;
-              }
-            }
-          } catch {
-            // No workspace — skip
-          }
-
-          if (brainPath) {
-            const handle = await brain.startEmbeddedBrainServer({
-              brainPath,
-              geniePgPort: pgPort,
-            });
-            handles.brainHandle = { stop: handle.stop, port: handle.port };
-            console.log(`  Brain server ready on port ${handle.port}`);
-          } else {
-            console.log('  Brain server: no brain/ found in workspace (skipped)');
-          }
-        } else {
-          console.log('  Brain server: pgserve not available (skipped)');
-        }
-      }
+      const { findWorkspace } = require('../lib/workspace.js') as typeof import('../lib/workspace.js');
+      return findWorkspace();
     } catch {
-      // Brain not installed — fine, skip silently
+      return null;
     }
-  }
+  })();
+  sendTuiLaunchScript(leftPane, rightPane, ws?.root);
+  console.log('  TUI server ready (session: genie-tui)');
+}
 
-  // 2. Report agent tmux server state (don't create empty sessions —
-  // sessions are created on-demand by `genie spawn`).
-  if (!headless) {
-    const sessions = listAgentSessions();
-    if (sessions.length > 0) {
-      console.log(`  Agent server (-L genie): ${sessions.length} sessions`);
-    } else {
-      console.log('  Agent server (-L genie): no sessions yet (created on first spawn)');
-    }
-  }
-
-  // 2b. Sync agent directory + start watcher
-  handles.agentWatcher = await startAgentSync();
-
-  // 3. Start TUI session on default tmux server (skip in headless / no-tui mode)
-  if (!skipTui) {
-    console.log('  Setting up TUI session...');
-    const { leftPane, rightPane } = startTuiTmuxServer();
-
-    // Send launch script to left pane (discovers workspace from serve cwd)
-    const ws = (() => {
-      try {
-        const { findWorkspace } = require('../lib/workspace.js') as typeof import('../lib/workspace.js');
-        return findWorkspace();
-      } catch {
-        return null;
-      }
-    })();
-    sendTuiLaunchScript(leftPane, rightPane, ws?.root);
-    console.log('  TUI server ready (session: genie-tui)');
-  }
-
-  // 4. Start scheduler + event-router + inbox-watcher
-  await startScheduler();
-
-  // 4a. Start detector scheduler (self-healing B1 / Group 2 — measurement only).
+async function startDetectorSchedulerSafely(): Promise<void> {
   // Read-only sweep of registered DetectorModules every 60s ± 5s. No auto-fix,
-  // no state mutation. `detector_version` is threaded into every emitted row
-  // via the shared emit pipeline.
-  //
-  // All detectors self-register at module load — importing built-in.ts
-  // pulls every production pattern (1-8) into the registry before the
-  // scheduler's first tick. Each module's top-level call to
-  // `registerDetector(module)` runs once via ESM cache.
+  // no state mutation. Importing built-in.ts pulls every production pattern
+  // (1-8) into the registry before the scheduler's first tick.
   try {
     await import('../detectors/built-in.js');
     const { start: startDetectorScheduler } = await import('../serve/detector-scheduler.js');
@@ -654,8 +625,9 @@ async function startForeground(headless?: boolean): Promise<void> {
     const msg = err instanceof Error ? err.message : String(err);
     console.warn(`  Detector scheduler: failed — ${msg}`);
   }
+}
 
-  // 4b. Start executor-read endpoint (Group 6 of turn-session-contract).
+async function startExecutorReadEndpointSafely(): Promise<void> {
   // Non-fatal: if the port is busy or Bun.serve errors, the endpoint logs and
   // skips. Direct-SQL consumers fall back to `executors_reader` role.
   try {
@@ -666,8 +638,9 @@ async function startForeground(headless?: boolean): Promise<void> {
     const msg = err instanceof Error ? err.message : String(err);
     console.warn(`  Executor read endpoint: failed — ${msg}`);
   }
+}
 
-  // 5. Start Omni approval handler (if workspace has approval config)
+async function startOmniApprovalHandlerSafely(): Promise<void> {
   try {
     const { startOmniApprovalHandler } = await import('../lib/omni-approval-handler.js');
     const handler = await startOmniApprovalHandler();
@@ -678,141 +651,129 @@ async function startForeground(headless?: boolean): Promise<void> {
   } catch {
     // NATS or workspace not configured — non-fatal
   }
+}
 
-  // 6. Start Omni bridge (NATS → agent session router).
+async function startOmniBridgeSafely(): Promise<void> {
   // Bridge is optional by default: dev machines without NATS should not crash serve.
   // Set GENIE_OMNI_REQUIRED=1 to make bridge startup fatal (strict/prod mode).
-  // Executor type is resolved internally by the bridge.
-  {
-    const { OmniBridge } = await import('../services/omni-bridge.js');
-    const bridge = new OmniBridge({
-      natsUrl: process.env.GENIE_NATS_URL ?? 'localhost:4222',
-      maxConcurrent: Number(process.env.GENIE_MAX_CONCURRENT ?? '20'),
-      idleTimeoutMs: Number(process.env.GENIE_IDLE_TIMEOUT_MS ?? '900000'),
-    });
-    try {
-      await bridge.start();
-      handles.omniBridge = bridge;
-      console.log('  Omni bridge started');
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (process.env.GENIE_OMNI_REQUIRED === '1') {
-        console.error(`  Omni bridge: FAILED — ${msg}`);
-        process.exit(1);
-      }
-      console.warn(`  Omni bridge: degraded — ${msg}; set GENIE_OMNI_REQUIRED=1 to make this fatal`);
-      // Continue without bridge — handles.omniBridge stays null so shutdown() skips it.
+  const { OmniBridge } = await import('../services/omni-bridge.js');
+  const bridge = new OmniBridge({
+    natsUrl: process.env.GENIE_NATS_URL ?? 'localhost:4222',
+    maxConcurrent: Number(process.env.GENIE_MAX_CONCURRENT ?? '20'),
+    idleTimeoutMs: Number(process.env.GENIE_IDLE_TIMEOUT_MS ?? '900000'),
+  });
+  try {
+    await bridge.start();
+    handles.omniBridge = bridge;
+    console.log('  Omni bridge started');
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (process.env.GENIE_OMNI_REQUIRED === '1') {
+      console.error(`  Omni bridge: FAILED — ${msg}`);
+      process.exit(1);
     }
+    console.warn(`  Omni bridge: degraded — ${msg}; set GENIE_OMNI_REQUIRED=1 to make this fatal`);
+    // Continue without bridge — handles.omniBridge stays null so shutdown() skips it.
   }
+}
 
-  const stopMsg = headless ? 'Send SIGTERM to stop.' : 'Press Ctrl+C to stop.';
-  console.log(`\ngenie serve is running (${mode}). ${stopMsg}`);
+async function stopSchedulerHandles(): Promise<void> {
+  handles.agentWatcher?.close();
+  // Stop scheduler (drains in-flight) and wait for its done promise so the
+  // final `daemon_stopped` log entry is flushed before we exit.
+  const schedulerHandle = handles.schedulerHandle;
+  if (schedulerHandle) {
+    schedulerHandle.stop();
+    try {
+      await schedulerHandle.done;
+    } catch {
+      // Best effort — we still need to finish the rest of shutdown
+    }
+    handles.schedulerHandle = null;
+  }
+  if (handles.detectorScheduler) {
+    handles.detectorScheduler.stop();
+    handles.detectorScheduler = null;
+  }
+}
 
-  // Signal handlers for graceful shutdown
+async function stopOmniAndBrainServices(): Promise<void> {
+  if (handles.omniApprovalHandler) {
+    await handles.omniApprovalHandler.stop().catch(() => {});
+    handles.omniApprovalHandler = null;
+  }
+  if (handles.omniBridge) {
+    await handles.omniBridge.stop().catch(() => {});
+    handles.omniBridge = null;
+  }
+  void import('../lib/executor-read.js').then((m) => m.stopExecutorReadEndpoint().catch(() => {}));
+  // Brain server: best-effort; signal handlers call process.exit() immediately
+  // after shutdown(). The OS reclaims sockets/connections on process exit.
+  if (handles.brainHandle) {
+    await handles.brainHandle.stop().catch(() => {});
+    handles.brainHandle = null;
+  }
+}
+
+function killRegisteredServices(): void {
+  try {
+    const { killAllServices } = require('../lib/service-registry.js');
+    killAllServices();
+  } catch {
+    // Registry not available — best effort
+  }
+}
+
+function removePgservePortLockfile(): void {
+  try {
+    const lockfilePath = join(genieHome(), 'pgserve.port');
+    if (existsSync(lockfilePath)) unlinkSync(lockfilePath);
+  } catch {
+    // Best effort
+  }
+}
+
+function sigKillRegisteredServices(): void {
+  try {
+    const { getRegisteredServices } = require('../lib/service-registry.js');
+    for (const svc of getRegisteredServices()) {
+      try {
+        process.kill(svc.pid, 'SIGKILL');
+      } catch {
+        // already dead
+      }
+    }
+  } catch {
+    // registry not available
+  }
+}
+
+function buildShutdownFn(headless?: boolean): { shutdown: () => Promise<void>; hasStarted: () => boolean } {
   let shutdownStarted = false;
   const shutdown = async (): Promise<void> => {
     if (shutdownStarted) return;
     shutdownStarted = true;
-
     console.log('\nShutting down genie serve...');
-
-    // 1. Stop agent watcher
-    handles.agentWatcher?.close();
-
-    // 2. Stop scheduler (drains in-flight) and wait for its done promise so
-    // the final `daemon_stopped` log entry is flushed before we exit.
-    const schedulerHandle = handles.schedulerHandle;
-    if (schedulerHandle) {
-      schedulerHandle.stop();
-      try {
-        await schedulerHandle.done;
-      } catch {
-        // Best effort — we still need to finish the rest of shutdown
-      }
-      handles.schedulerHandle = null;
-    }
-
-    // 2.1. Stop detector scheduler (self-healing B1 / Group 2)
-    if (handles.detectorScheduler) {
-      handles.detectorScheduler.stop();
-      handles.detectorScheduler = null;
-    }
-
-    // 2.5. Stop Omni approval handler
-    if (handles.omniApprovalHandler) {
-      await handles.omniApprovalHandler.stop().catch(() => {});
-      handles.omniApprovalHandler = null;
-    }
-
-    // 2.55. Stop Omni bridge (graceful: detach sessions, don't kill them)
-    if (handles.omniBridge) {
-      await handles.omniBridge.stop().catch(() => {});
-      handles.omniBridge = null;
-    }
-
-    // 2.58. Stop executor-read endpoint
-    void import('../lib/executor-read.js').then((m) => m.stopExecutorReadEndpoint().catch(() => {}));
-
-    // 2.6. Stop brain server (best-effort — signal handlers call process.exit()
-    // immediately after shutdown(), so this is fire-and-forget like all other
-    // services. The OS reclaims sockets/connections on process exit.)
-    if (handles.brainHandle) {
-      await handles.brainHandle.stop().catch(() => {});
-      handles.brainHandle = null;
-    }
-
-    // 3. Kill registered services via registry
-    try {
-      const { killAllServices } = require('../lib/service-registry.js');
-      killAllServices();
-    } catch {
-      // Registry not available — best effort
-    }
-
-    // 4. Kill TUI session (skip in headless mode)
-    if (!headless) {
-      killTuiSession();
-    }
-
+    await stopSchedulerHandles();
+    await stopOmniAndBrainServices();
+    killRegisteredServices();
     // NEVER kill the agent tmux server — agent sessions are eternal and must
     // survive serve restarts. Only the TUI session is owned by serve.
-
-    // 5. Remove pgserve lockfile
-    try {
-      const lockfilePath = join(genieHome(), 'pgserve.port');
-      if (existsSync(lockfilePath)) {
-        unlinkSync(lockfilePath);
-      }
-    } catch {
-      // Best effort
-    }
-
-    // 6. Remove PID file
+    if (!headless) killTuiSession();
+    removePgservePortLockfile();
     removeServePid();
     console.log('genie serve stopped.');
   };
+  return { shutdown, hasStarted: () => shutdownStarted };
+}
 
-  // Graceful shutdown wrapper: awaits shutdown() with a 10s force-kill fallback,
-  // then exits with the supplied code. Idempotent via the `shutdownStarted` guard.
+function installGracefulExitHandlers(shutdown: () => Promise<void>, hasStarted: () => boolean): void {
   const gracefulExit = (exitCode: number): void => {
-    // Guard against multiple concurrent signals
-    if (shutdownStarted) return;
-
-    // Set up force-kill timeout: if graceful shutdown takes > 10s, SIGKILL remaining
+    if (hasStarted()) return;
+    // 10s force-kill fallback — if graceful shutdown doesn't complete, SIGKILL remaining.
     const forceTimer = setTimeout(() => {
       console.error('Graceful shutdown timeout (10s). Force-killing remaining processes.');
-      try {
-        const { getRegisteredServices } = require('../lib/service-registry.js');
-        for (const svc of getRegisteredServices()) {
-          try {
-            process.kill(svc.pid, 'SIGKILL');
-          } catch {
-            // already dead
-          }
-        }
-      } catch {
-        // registry not available
-      }
+      sigKillRegisteredServices();
       removeServePid();
       process.exit(1);
     }, 10_000);
@@ -832,25 +793,50 @@ async function startForeground(headless?: boolean): Promise<void> {
   process.on('SIGTERM', () => gracefulExit(143));
   process.on('SIGINT', () => gracefulExit(130));
   process.on('SIGHUP', () => gracefulExit(129));
-
   // `exit` handler can only run synchronous code — ensure the PID file is gone
   // even if we reach process exit without going through gracefulExit (e.g. the
   // scheduler's `done` promise resolved normally).
   process.on('exit', () => {
     removeServePid();
   });
-
-  // Last-resort handler: surface the error, attempt cleanup, then exit 1.
   process.on('uncaughtException', (err) => {
     console.error('Uncaught exception in genie serve:', err);
     gracefulExit(1);
   });
+}
+
+async function startForeground(headless?: boolean): Promise<void> {
+  claimServePidOrExit();
+  const { skipTui, mode } = resolveServeMode(headless);
+  process.env.GENIE_IS_DAEMON = '1';
+  writeServePid(process.pid);
+  console.log(`genie serve starting (PID ${process.pid}, mode: ${mode})`);
+
+  if (!skipTui) {
+    await ensureTmux();
+  }
+
+  await startPgserve();
+  await startBrainServerIfEnabled();
+  if (!headless) logAgentSessionInfo();
+  handles.agentWatcher = await startAgentSync();
+  startTuiSessionIfEnabled(skipTui);
+  await startScheduler();
+  await startDetectorSchedulerSafely();
+  await startExecutorReadEndpointSafely();
+  await startOmniApprovalHandlerSafely();
+  await startOmniBridgeSafely();
+
+  const stopMsg = headless ? 'Send SIGTERM to stop.' : 'Press Ctrl+C to stop.';
+  console.log(`\ngenie serve is running (${mode}). ${stopMsg}`);
+
+  const { shutdown, hasStarted } = buildShutdownFn(headless);
+  installGracefulExitHandlers(shutdown, hasStarted);
 
   // Wait for scheduler to finish (blocks forever until signal)
   if (handles.schedulerHandle) {
     await handles.schedulerHandle.done;
   } else {
-    // No scheduler — just keep alive
     await new Promise(() => {});
   }
 
@@ -962,7 +948,7 @@ async function stopServe(): Promise<void> {
 }
 
 /** Check pgserve health and print status */
-async function printPgserveStatus(): Promise<void> {
+async function printPgserveHealth(): Promise<void> {
   try {
     const { isAvailable, getActivePort } = await import('../lib/db.js');
     const dbOk = await isAvailable();
@@ -970,45 +956,55 @@ async function printPgserveStatus(): Promise<void> {
   } catch {
     console.log('  pgserve:    unavailable');
   }
+}
 
-  // Brain server status — probe via HTTP healthz (works cross-process)
+function resolveBrainPortFromWorkspace(brain: { readServerInfo?: (p: string) => { port?: number } | null }):
+  | number
+  | null {
+  try {
+    const { findWorkspace } = require('../lib/workspace.js') as typeof import('../lib/workspace.js');
+    const ws = findWorkspace();
+    if (ws?.root && brain.readServerInfo) {
+      const info = brain.readServerInfo(join(ws.root, 'brain'));
+      if (info?.port) return info.port;
+    }
+  } catch {
+    // No workspace — caller falls back to in-memory handle
+  }
+  return null;
+}
+
+async function probeBrainHealth(brainPort: number): Promise<void> {
+  try {
+    const resp = await fetch(`http://127.0.0.1:${brainPort}/healthz`);
+    console.log(
+      resp.ok
+        ? `  brain:      running (port ${brainPort})`
+        : `  brain:      unhealthy (port ${brainPort}, status ${resp.status})`,
+    );
+  } catch {
+    console.log(`  brain:      stopped (port ${brainPort} unreachable)`);
+  }
+}
+
+async function printBrainStatus(): Promise<void> {
   try {
     // @ts-expect-error — brain is enterprise-only, not in genie's deps
     const brain = await import('@khal-os/brain');
-    // Try readServerInfo first (reads .brain-server.json from workspace)
-    let brainPort: number | null = null;
-    try {
-      const { findWorkspace } = require('../lib/workspace.js') as typeof import('../lib/workspace.js');
-      const ws = findWorkspace();
-      if (ws?.root && brain.readServerInfo) {
-        const info = brain.readServerInfo(join(ws.root, 'brain'));
-        if (info?.port) brainPort = info.port;
-      }
-    } catch {
-      // No workspace — fall back to handle
-    }
-    // Fall back to in-memory handle (same process only)
-    if (!brainPort && handles.brainHandle) {
-      brainPort = handles.brainHandle.port;
-    }
+    const brainPort = resolveBrainPortFromWorkspace(brain) ?? handles.brainHandle?.port ?? null;
     if (brainPort) {
-      // Probe the actual port to verify it's alive
-      try {
-        const resp = await fetch(`http://127.0.0.1:${brainPort}/healthz`);
-        if (resp.ok) {
-          console.log(`  brain:      running (port ${brainPort})`);
-        } else {
-          console.log(`  brain:      unhealthy (port ${brainPort}, status ${resp.status})`);
-        }
-      } catch {
-        console.log(`  brain:      stopped (port ${brainPort} unreachable)`);
-      }
+      await probeBrainHealth(brainPort);
     } else {
       console.log('  brain:      stopped');
     }
   } catch {
     console.log('  brain:      not installed');
   }
+}
+
+async function printPgserveStatus(): Promise<void> {
+  await printPgserveHealth();
+  await printBrainStatus();
 }
 
 /** Print tmux server statuses */

--- a/src/term-commands/wish.ts
+++ b/src/term-commands/wish.ts
@@ -168,120 +168,153 @@ function renderDiff(before: string, after: string): string {
   return out.join('\n');
 }
 
-async function wishLintCommand(
-  slug: string,
-  options: { json?: boolean; fix?: boolean; dryRun?: boolean; allowTodoPlaceholders?: boolean },
-): Promise<void> {
-  const wishPath = join(process.cwd(), '.genie', 'wishes', slug, 'WISH.md');
-  if (!existsSync(wishPath)) {
-    if (options.json) {
-      console.log(
-        JSON.stringify({
-          error: `Wish file not found: ${wishPath}`,
-          rule: 'missing-title',
-          wish: slug,
-          file: wishPath,
-        }),
-      );
-    } else {
-      console.error(`❌ Wish file not found: ${wishPath}`);
-    }
-    process.exit(1);
-  }
+type LintReport = ReturnType<typeof lintWish>;
+type WishLintOptions = { json?: boolean; fix?: boolean; dryRun?: boolean; allowTodoPlaceholders?: boolean };
 
-  const markdown = await readFile(wishPath, 'utf-8');
-  const lintOpts = { allowTodoPlaceholders: options.allowTodoPlaceholders };
-
-  let docOrError: ReturnType<typeof parseWish> | WishParseError;
+function parseWishOrError(markdown: string): Parameters<typeof lintWish>[0] {
   try {
-    docOrError = parseWish(markdown);
+    return parseWish(markdown) as Parameters<typeof lintWish>[0];
   } catch (err) {
-    if (err instanceof WishParseError) docOrError = err;
-    else throw err;
+    if (err instanceof WishParseError) return err as Parameters<typeof lintWish>[0];
+    throw err;
   }
-  let report = lintWish(docOrError as Parameters<typeof lintWish>[0], markdown, lintOpts);
-  // Rewrite `wish` + `file` for CLI context — the pure `lintWish` only has the slug if parse succeeded.
-  report = { ...report, wish: slug, file: wishPath };
+}
 
-  if (options.fix) {
-    // Apply fixes; optionally don't write.
-    const { applyFixes } = await import('../services/wish-lint.js');
-    const fixed = applyFixes(markdown, report);
-    if (fixed === markdown) {
-      if (options.json) {
-        console.log(JSON.stringify({ ...report, fixedViolations: 0 }));
-      } else {
-        console.log(formatLintReport(report, { color: process.stdout.isTTY ?? false, path: wishPath }));
-        console.log('\nNo fixable violations to apply.');
-      }
-      process.exit(report.summary.total > 0 ? 1 : 0);
-    }
-
-    if (options.dryRun) {
-      if (options.json) {
-        console.log(JSON.stringify({ ...report, dryRun: true, diff: renderDiff(markdown, fixed) }));
-      } else {
-        console.log(formatLintReport(report, { color: process.stdout.isTTY ?? false, path: wishPath }));
-        console.log(`\n--- Dry-run diff (${wishPath}) ---`);
-        console.log(renderDiff(markdown, fixed));
-        console.log('\nFile not modified (--dry-run).');
-      }
-      process.exit(report.summary.total > 0 ? 1 : 0);
-    }
-
-    await writeFile(wishPath, fixed, 'utf-8');
-    // Re-lint the new content.
-    let docOrError2: ReturnType<typeof parseWish> | WishParseError;
-    try {
-      docOrError2 = parseWish(fixed);
-    } catch (err) {
-      if (err instanceof WishParseError) docOrError2 = err;
-      else throw err;
-    }
-    let report2 = lintWish(docOrError2 as Parameters<typeof lintWish>[0], fixed, lintOpts);
-    report2 = { ...report2, wish: slug, file: wishPath };
-    const fixedCount = report.summary.fixable;
-    if (options.json) {
-      console.log(JSON.stringify({ ...report2, fixedViolations: fixedCount }));
-    } else {
-      console.log(`✅ Applied ${fixedCount} fix(es) to ${wishPath}`);
-      console.log('');
-      console.log(formatLintReport(report2, { color: process.stdout.isTTY ?? false, path: wishPath }));
-    }
-    const remainingErrors = report2.violations.filter((v) => v.severity === 'error').length;
-    process.exit(remainingErrors > 0 ? 1 : 0);
+function reportWishFileMissing(slug: string, wishPath: string, jsonMode: boolean): never {
+  if (jsonMode) {
+    console.log(
+      JSON.stringify({ error: `Wish file not found: ${wishPath}`, rule: 'missing-title', wish: slug, file: wishPath }),
+    );
+  } else {
+    console.error(`❌ Wish file not found: ${wishPath}`);
   }
+  process.exit(1);
+}
 
-  if (options.json) {
+function emitLintReport(report: LintReport, wishPath: string, jsonMode: boolean): void {
+  if (jsonMode) {
     console.log(JSON.stringify(report));
   } else {
     console.log(formatLintReport(report, { color: process.stdout.isTTY ?? false, path: wishPath }));
   }
+}
+
+function exitWithErrorCount(report: LintReport): never {
   const errors = report.violations.filter((v) => v.severity === 'error').length;
   process.exit(errors > 0 ? 1 : 0);
+}
+
+function handleNoFixableViolations(report: LintReport, wishPath: string, jsonMode: boolean): never {
+  if (jsonMode) {
+    console.log(JSON.stringify({ ...report, fixedViolations: 0 }));
+  } else {
+    console.log(formatLintReport(report, { color: process.stdout.isTTY ?? false, path: wishPath }));
+    console.log('\nNo fixable violations to apply.');
+  }
+  process.exit(report.summary.total > 0 ? 1 : 0);
+}
+
+function handleDryRunFix(
+  report: LintReport,
+  markdown: string,
+  fixed: string,
+  wishPath: string,
+  jsonMode: boolean,
+): never {
+  if (jsonMode) {
+    console.log(JSON.stringify({ ...report, dryRun: true, diff: renderDiff(markdown, fixed) }));
+  } else {
+    console.log(formatLintReport(report, { color: process.stdout.isTTY ?? false, path: wishPath }));
+    console.log(`\n--- Dry-run diff (${wishPath}) ---`);
+    console.log(renderDiff(markdown, fixed));
+    console.log('\nFile not modified (--dry-run).');
+  }
+  process.exit(report.summary.total > 0 ? 1 : 0);
+}
+
+async function applyAndReportFix(
+  report: LintReport,
+  fixed: string,
+  wishPath: string,
+  slug: string,
+  lintOpts: { allowTodoPlaceholders?: boolean },
+  jsonMode: boolean,
+): Promise<never> {
+  await writeFile(wishPath, fixed, 'utf-8');
+  const docOrError2 = parseWishOrError(fixed);
+  const report2 = { ...lintWish(docOrError2, fixed, lintOpts), wish: slug, file: wishPath };
+  const fixedCount = report.summary.fixable;
+  if (jsonMode) {
+    console.log(JSON.stringify({ ...report2, fixedViolations: fixedCount }));
+  } else {
+    console.log(`✅ Applied ${fixedCount} fix(es) to ${wishPath}`);
+    console.log('');
+    console.log(formatLintReport(report2, { color: process.stdout.isTTY ?? false, path: wishPath }));
+  }
+  const remainingErrors = report2.violations.filter((v) => v.severity === 'error').length;
+  process.exit(remainingErrors > 0 ? 1 : 0);
+}
+
+async function runLintFix(
+  report: LintReport,
+  markdown: string,
+  wishPath: string,
+  slug: string,
+  lintOpts: { allowTodoPlaceholders?: boolean },
+  options: WishLintOptions,
+): Promise<never> {
+  const { applyFixes } = await import('../services/wish-lint.js');
+  const fixed = applyFixes(markdown, report);
+  const jsonMode = options.json ?? false;
+  if (fixed === markdown) handleNoFixableViolations(report, wishPath, jsonMode);
+  if (options.dryRun) handleDryRunFix(report, markdown, fixed, wishPath, jsonMode);
+  return applyAndReportFix(report, fixed, wishPath, slug, lintOpts, jsonMode);
+}
+
+async function wishLintCommand(slug: string, options: WishLintOptions): Promise<void> {
+  const wishPath = join(process.cwd(), '.genie', 'wishes', slug, 'WISH.md');
+  const jsonMode = options.json ?? false;
+  if (!existsSync(wishPath)) reportWishFileMissing(slug, wishPath, jsonMode);
+
+  const markdown = await readFile(wishPath, 'utf-8');
+  const lintOpts = { allowTodoPlaceholders: options.allowTodoPlaceholders };
+  const docOrError = parseWishOrError(markdown);
+  const report: LintReport = { ...lintWish(docOrError, markdown, lintOpts), wish: slug, file: wishPath };
+
+  if (options.fix) {
+    await runLintFix(report, markdown, wishPath, slug, lintOpts, options);
+    return;
+  }
+
+  emitLintReport(report, wishPath, jsonMode);
+  exitWithErrorCount(report);
+}
+
+function reportWishParseError(error: WishParseError, jsonMode: boolean): void {
+  const payload = {
+    error: error.message,
+    rule: error.rule,
+    line: error.line,
+    column: error.column ?? null,
+    file: error.file ?? null,
+  };
+  if (jsonMode) {
+    console.log(JSON.stringify(payload));
+    return;
+  }
+  console.error(`❌ Parse failed (${payload.rule}): ${payload.error}`);
+  if (payload.file) console.error(`   File: ${payload.file}`);
+  if (payload.line) console.error(`   Line: ${payload.line}`);
 }
 
 async function wishParseCommand(slug: string, options: { json?: boolean }): Promise<void> {
   try {
     const doc = parseWishFile(slug);
-    const json = options.json ? JSON.stringify(doc) : JSON.stringify(doc, null, 2);
-    console.log(json);
+    console.log(options.json ? JSON.stringify(doc) : JSON.stringify(doc, null, 2));
+    return;
   } catch (error) {
     if (error instanceof WishParseError) {
-      const payload = {
-        error: error.message,
-        rule: error.rule,
-        line: error.line,
-        column: error.column ?? null,
-        file: error.file ?? null,
-      };
-      if (options.json) {
-        console.log(JSON.stringify(payload));
-      } else {
-        console.error(`❌ Parse failed (${payload.rule}): ${payload.error}`);
-        if (payload.file) console.error(`   File: ${payload.file}`);
-        if (payload.line) console.error(`   Line: ${payload.line}`);
-      }
+      reportWishParseError(error, options.json ?? false);
       process.exit(1);
     }
     const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary

Final complexity-cleanup sweep (G3 residual batch). Four files, eight offending functions, all reduced to ≤15 via **pure helper extraction — no `biome-ignore` escape hatches needed**.

Closes the dev-branch complexity count: **8 → 0**.

## Per-function before / after

| File | Function | Before | After | Technique |
|------|----------|:------:|:-----:|-----------|
| `src/term-commands/serve.ts` | `startForeground` | **63** | ≤15 | 12 helpers: `claimServePidOrExit`, `resolveServeMode`, `startBrainServerIfEnabled`, `logAgentSessionInfo`, `startTuiSessionIfEnabled`, `startDetectorSchedulerSafely`, `startExecutorReadEndpointSafely`, `startOmniApprovalHandlerSafely`, `startOmniBridgeSafely`, `buildShutdownFn`, `installGracefulExitHandlers`, `resolveBrainPathFromWorkspace` |
| `src/term-commands/serve.ts` | `shutdown` (nested) | 23 | ≤15 | split via `buildShutdownFn` → `stopSchedulerHandles`, `stopOmniAndBrainServices`, `killRegisteredServices`, `removePgservePortLockfile`, `sigKillRegisteredServices` |
| `src/term-commands/serve.ts` | `printPgserveStatus` | 16 | ≤15 | `printPgserveHealth`, `resolveBrainPortFromWorkspace`, `probeBrainHealth`, `printBrainStatus` |
| `src/term-commands/agents.ts` | `processMessage` | **49** | ≤15 | `recordToolUseBlock`, `recordAssistantBlocks`, `recordToolResultBlock`, `recordToolResults` + type-dispatch |
| `src/term-commands/agents.ts` | `resumeAgent` | 16 | ≤15 | `buildResumeSpawnCtx`, `createResumeTmuxPaneOrExit`, `logResumeSuccess` |
| `src/term-commands/wish.ts` | `wishLintCommand` | 36 | ≤15 | `parseWishOrError`, `reportWishFileMissing`, `emitLintReport`, `exitWithErrorCount`, `handleNoFixableViolations`, `handleDryRunFix`, `applyAndReportFix`, `runLintFix` |
| `src/term-commands/wish.ts` | `wishParseCommand` | 19 | ≤15 | `reportWishParseError` |
| `src/term-commands/dir.ts` | `handleEdit` | 18 | ≤15 | `collectAgentConfigUpdates` |

**Public signatures unchanged. No behavior changes.**

## Deferred issues (escape-hatch suppressions)

**None.** Decision #6 was evaluated for `startForeground` (63) and `processMessage` (49) but proved unnecessary — sequential orchestration + message-type dispatch reduced both cleanly.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bunx biome check src/term-commands/{agents,serve,wish,dir}.ts` — 0 complexity errors
- [x] `bun run build` — succeeds
- [x] `bun test src/term-commands/agents.test.ts src/term-commands/dir-edit.test.ts src/term-commands/__tests__/agents-resume.test.ts` — **54 pass / 0 fail**
- [x] `bunx biome check . | grep -c noExcessiveCognitiveComplexity` = **0** (dev-wide)

## Notes

- Pre-push hook ran cleanly on this branch — no `HUSKY=0` bypass needed (G2b/G2c deadlock did not reproduce).
- No changes to `src/lib/*` or `src/services/*` (respected G2a/b/c shared-import constraint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)