### PR TITLE
fix(emit): latch shuttingDown across setupTestDatabase — close CONNECTION_ENDED gate

### DIFF
--- a/src/lib/emit.ts
+++ b/src/lib/emit.ts
@@ -558,6 +558,12 @@ function enqueueTyped(
 }
 
 function admitToQueue(row: QueuedRow): void {
+  // Drop admits while the test harness is swapping DBs. `enqueueTyped()` has
+  // a top-level shuttingDown check, but backpressure paths
+  // (`handleInfoBackpressure`, `handleSpillPath`) re-invoke `admitToQueue`
+  // after a bounded wait — this guard ensures those deferred paths also
+  // no-op during the quiesce window.
+  if (shuttingDown) return;
   queue.push(row);
   stats.enqueued++;
   stats.queue_depth = queue.length;
@@ -725,7 +731,11 @@ function newId(): string {
 // ---------------------------------------------------------------------------
 
 function ensureFlusher(): void {
-  if (flushTimer) return;
+  // Also gate on `shuttingDown` so leaked background pollers from prior test
+  // files can't re-arm the timer during the quiesce window while
+  // `setupTestDatabase()` is swapping DBs between `resetConnection()` and
+  // `createTestDatabase()`.
+  if (flushTimer || shuttingDown) return;
   flushTimer = setInterval(() => {
     void triggerFlush();
   }, FLUSH_INTERVAL_MS);
@@ -795,6 +805,15 @@ async function doFlush(): Promise<void> {
       void drainSpillJournal();
     }
   } catch (err) {
+    // If the test harness is quiescing, drop the batch rather than requeue
+    // against a sqlClient that's about to be reset. Requeueing here would
+    // repopulate the queue that shutdownEmitter() just cleared, and the next
+    // flush tick would hit the about-to-be-dropped DB and cascade into
+    // CONNECTION_ENDED on the next test's first await.
+    if (shuttingDown) {
+      stats.queue_depth = queue.length;
+      return;
+    }
     // Push back to the head so we don't lose events when PG blips. Cap the
     // re-inject so a permanently-broken PG can't pathologically grow memory.
     const reinjectCap = Math.max(0, QUEUE_CAP - queue.length);
@@ -837,6 +856,17 @@ export async function drainSpillJournalNow(): Promise<number> {
  *   4. Attempt ONE bounded final drain. If it fails, we do NOT loop — a dead
  *      PG would otherwise requeue forever. The queue is then reset explicitly
  *      so the test's next cycle starts from a clean slate.
+ *
+ * IMPORTANT: On return, `shuttingDown` STAYS LATCHED TRUE. Admits remain
+ * blocked until the caller explicitly invokes `resumeEmitter()`. This prevents
+ * leaked background pollers from prior test files (e.g. `audit.ts` setInterval,
+ * `runtime-events.ts` subscribe+poll) from re-arming the flusher against a
+ * stale `sqlClient` mid-swap while `setupTestDatabase()` is between
+ * `resetConnection()` and `createTestDatabase()`. If such a poller fires an
+ * `emitEvent()` in the quiesce window, it would hit `admitToQueue()` →
+ * `ensureFlusher()` → rearm the flush timer → flush against the about-to-be-
+ * dropped DB → `pg_terminate_backend` kills the backend mid-query →
+ * `CONNECTION_ENDED` propagates to the next test's first await.
  */
 export async function shutdownEmitter(): Promise<void> {
   shuttingDown = true;
@@ -851,8 +881,9 @@ export async function shutdownEmitter(): Promise<void> {
     }
   }
 
-  // Step 2: tear down all timers. The flusher's re-arm check (`if (flushTimer)
-  // return`) guarantees ensureFlusher() re-arms cleanly next call.
+  // Step 2: tear down all timers. The flusher's re-arm check (`if (flushTimer
+  // || shuttingDown) return`) guarantees ensureFlusher() stays quiesced until
+  // resumeEmitter() is called.
   if (flushTimer) {
     clearInterval(flushTimer);
     flushTimer = null;
@@ -884,6 +915,20 @@ export async function shutdownEmitter(): Promise<void> {
   // flushes use `flushNow()` before calling shutdown.
   queue.length = 0;
   stats.queue_depth = 0;
+  // Intentional: `shuttingDown` stays true until `resumeEmitter()` is called.
+  // See block comment above for the CONNECTION_ENDED race this prevents.
+  // `flushTimer` is already null — `ensureFlusher()` gates re-arm on both
+  // `flushTimer` and `shuttingDown`, so the quiesce window is honoured.
+}
+
+/**
+ * Re-open admits after a `shutdownEmitter()` quiesce.
+ *
+ * Must be called by the test harness AFTER `resetConnection()` +
+ * `createTestDatabase()` succeed, so fresh emits land in the new DB's pool
+ * rather than racing the swap.
+ */
+export function resumeEmitter(): void {
   shuttingDown = false;
 }
 

--- a/src/lib/test-db.ts
+++ b/src/lib/test-db.ts
@@ -17,7 +17,7 @@
  */
 
 import { ensurePgserve, resetConnection } from './db.js';
-import { shutdownEmitter } from './emit.js';
+import { resumeEmitter, shutdownEmitter } from './emit.js';
 import { createTestDatabase, dropTestDatabase } from './test-setup.js';
 
 /**
@@ -90,12 +90,24 @@ export async function setupTestDatabase(): Promise<() => Promise<void>> {
   try {
     await createTestDatabase(dbName);
   } catch {
+    // createTestDatabase failed (e.g. pgserve died, template DB missing).
+    // shutdownEmitter() already latched `shuttingDown = true`; if we return
+    // without resumeEmitter() the emitter stays quiesced for the remainder
+    // of this process, silently dropping every emit from every subsequent
+    // test file. Re-open admits before bailing so fallback no-op cleanup is
+    // truly side-effect free.
+    resumeEmitter();
     return async () => {};
   }
 
   // Point db.ts at the new database and force a rebuild.
   process.env.GENIE_TEST_DB_NAME = dbName;
   await resetConnection();
+  // Re-open admits now that the new DB is bound. shutdownEmitter() latched
+  // `shuttingDown = true` so leaked background pollers from prior test files
+  // couldn't re-arm the flusher mid-swap; with the new sqlClient in place,
+  // it's safe to accept new events again.
+  resumeEmitter();
 
   return async () => {
     // Quiesce the emit flusher BEFORE closing the pool. Same rationale as
@@ -111,6 +123,10 @@ export async function setupTestDatabase(): Promise<() => Promise<void>> {
     if (process.env.GENIE_TEST_DB_NAME === dbName) {
       process.env.GENIE_TEST_DB_NAME = undefined;
     }
+    // Re-open admits so subsequent test files (or the next setupTestDatabase
+    // cycle in this process) aren't locked out. Without this, admits stay
+    // latched-off indefinitely after the last cleanup runs.
+    resumeEmitter();
   };
 }
 


### PR DESCRIPTION
## Summary

Closes the residual CONNECTION_ENDED flake on PR #1341 that returned after merging #1344. Tracer `a8f4cd11` diagnosed the exact gap in the prior `shutdownEmitter()` — between it resetting `shuttingDown=false` and `test-db.ts` calling `resetConnection()`, leaked background pollers (`audit.ts:193`, `runtime-events.ts:343`) can fire `emitEvent → admitToQueue → ensureFlusher` → re-arm the flush timer → flush against the stale `sqlClient` pointing at the about-to-be-dropped DB → `pg_terminate_backend` kills the socket mid-query → CONNECTION_ENDED propagates to the next test's first await.

## Fix

- **`src/lib/emit.ts`**
  - `shutdownEmitter()` now keeps `shuttingDown=true` latched on return
  - `resumeEmitter()` new export — the explicit re-open
  - `ensureFlusher()` gates on `shuttingDown` (prevents leaked-poller rearm)
  - `admitToQueue()` early-returns when `shuttingDown` (including backpressure re-admits)
  - `doFlush()` catch returns early instead of requeueing when `shuttingDown` (prevents queue repopulation after `shutdownEmitter` clears it)
- **`src/lib/test-db.ts`**
  - Calls `resumeEmitter()` after `resetConnection` succeeds (setup path)
  - Calls `resumeEmitter()` after `createTestDatabase` catches (error path — otherwise `shuttingDown` stays latched for the whole process and drops every subsequent emit)
  - Calls `resumeEmitter()` at end of the cleanup closure (so subsequent `setupTestDatabase` cycles aren't locked out)

## Production-caller inventory

`grep -rn "shutdownEmitter\|shuttingDown" src/` — only `emit.ts` + `test-db.ts` touch these. No signal handlers, no `process.on('exit')` callers, no SIGINT/SIGTERM callers invoke `shutdownEmitter`. `db.ts` has pgserve child handlers but they don't touch the emitter. `__resetEmitForTests` at `emit.ts:1073` still correctly sets `shuttingDown=false` directly. **The stay-latched semantics are test-only safe.**

## Verification

| Gate | Result |
|------|--------|
| `bun run typecheck` | ✅ clean |
| `bun run lint` (biome, 665 files) | ✅ clean |
| Local `bun run check` | Blocked by orphan pgserve squatting port 20900 on my box — reproduces on untouched baseline, **not caused by this patch**. CI validates on clean runners. |

## Residual — Symptom 2 (manual)

PR #1341 also fails the **GitGuardian dashboard check**: 12 findings all in `src/lib/test-setup.ts` and `src/lib/test-setup.test.ts` — files ALREADY covered by `.gitguardian.yml:4-5,9` ignored-paths. The dashboard scanner does NOT read `.gitguardian.yml` (that file is CLI-only for `ggshield`); dashboard incidents are tracked server-side and require UI dismissal.

**Action required:** Visit https://dashboard.gitguardian.com/workspace/731580/incidents/18760271 and mark all 12 occurrences as Ignored / False Positive. Precedent: commit `50c8d0c4 ci: bounce to re-trigger GitGuardian dashboard check (incident resolved)` confirms the project's accepted workflow (manual UI resolution + CI rebounce). No YAML change closes this path.

## Test plan
- [ ] This branch's CI goes green (Unit, PG, Quality Gate, Commitlint, Secrets Scan)
- [ ] Merge triggers checks on PR #1341 and turns PG/Quality-Gate green
- [ ] You dismiss GG incident 18760271 in dashboard, then re-trigger PR #1341 GG check (push empty commit or re-run)

🔗 Trace diagnosis: agent `a8f4cd11` (HIGH confidence, structural-gap traced end-to-end)
🔗 Fix execution: agent `a7355a7b` (2 files, +65/-4)