### PR TITLE
ci(publish-next): switch ci.yml Publish @next to npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,13 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
+    # OIDC trusted publishing — mirrors version.yml (commit f807b3a8).
+    # `id-token: write` is required for npm to exchange the GitHub OIDC token
+    # for a short-lived publish credential. `contents: read` is the default
+    # needed for checkout.
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -194,23 +201,23 @@ jobs:
       - name: Build
         run: bun run build
 
-      - name: Publish to npm @next
+      - name: Setup Node (for npm OIDC publish)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish to npm @next via OIDC
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
           HUSKY: "0"
         run: |
-          if [ -z "$NPM_TOKEN" ]; then
-            echo "NPM_TOKEN not set — skipping @next publish"
-            exit 0
-          fi
           LOCAL=$(jq -r '.version' package.json)
           # Check whether the exact version exists in the registry under ANY
           # tag, not just @next. After a dev→main merge, version.yml bumps dev
           # to a new version, publishes it as @latest, and commits the bump
           # back to dev. The next dev push then reads that already-published
           # version from package.json. Querying only the @next tag misses this
-          # cross-tag collision and causes a 403 when bun publish runs.
+          # cross-tag collision and causes a 403 when npm publish runs.
           # Query by exact version so collisions from any tag short-circuit
           # this step; version.yml will derive a fresh version and publish it.
           if [ -n "$(npm view "@automagik/genie@${LOCAL}" version 2>/dev/null)" ]; then
@@ -218,4 +225,4 @@ jobs:
             echo "(version.yml will bump to a new version and publish it as @next)"
             exit 0
           fi
-          bun publish --tag next --access public
+          npm publish --access public --tag next


### PR DESCRIPTION
## Summary

Switches `.github/workflows/ci.yml` Publish @next step from `bun publish` + NPM_TOKEN to `npm publish` via GitHub OIDC trusted publishing. Mirrors what `f807b3a8` did in `version.yml`.

Unblocks the last red check on PR #1341 (the dev→main release). The current failure on every dev push is:

```
Tag: next
404 Not Found: https://registry.npmjs.org/@automagik%2fgenie
 - '@automagik/genie@4.260422.5' does not exist in this registry
Access: public
Registry: https://registry.npmjs.org/
##[error]Process completed with exit code 1.
```

## Changes

- Added `permissions: { id-token: write, contents: read }` to the `publish-next` job — required for the OIDC token exchange.
- Added `actions/setup-node@v4` with `registry-url: https://registry.npmjs.org` so `npm` picks up the OIDC-negotiated credential.
- Swapped `bun publish --tag next --access public` for `npm publish --access public --tag next` (bun publish does not participate in npm OIDC).
- Dropped the `NPM_TOKEN` / `NPM_CONFIG_TOKEN` env wiring and the silent-skip guard — OIDC is mandatory now; a misconfigured trusted publisher surfaces as a real failure instead of being masked.
- Preserved the version-collision short-circuit (`npm view ... version` → `exit 0`) because `version.yml` still owns the canonical release and this step is purely the per-dev-push @next cut.

## Prerequisite (one-time)

Before this can publish successfully, npmjs.com needs a Trusted Publisher configuration for `@automagik/genie` pointing at:
- Owner: `automagik-dev`
- Repository: `genie`
- Workflow: `.github/workflows/ci.yml`
- Environment: (none)

If that's not configured, `npm publish` will fail with a permission error — a **real** failure surface we can act on, unlike the current silent 404.

## Test plan
- [ ] This branch's CI: all required checks pass (publish-next job only runs on push-to-dev, not on this PR)
- [ ] Merge to dev: push-event triggers publish-next; it either publishes (if trusted publisher is configured) or fails loudly with a clear OIDC error
- [ ] PR #1341 rolling release check rollup flips to all-green

## Related
- `f807b3a8` — version.yml OIDC switch (same pattern, different workflow)
- PR #1341 — rolling release blocked by this check