### PR TITLE
[codex] fix sec scan test exit handling after early merge

### DIFF
--- a/src/term-commands/sec.test.ts
+++ b/src/term-commands/sec.test.ts
@@ -3,16 +3,19 @@ import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'nod
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Command } from 'commander';
-import { type SecScanDeps, buildSecScanArgv, registerSecCommands, resolveSecScanScript } from './sec.js';
+import {
+  type SecScanDeps,
+  applySecScanExitCode,
+  buildSecScanArgv,
+  registerSecCommands,
+  resolveSecScanScript,
+} from './sec.js';
 
 describe('sec scan command', () => {
   let originalArgv1: string | undefined;
-  let originalExitCode: typeof process.exitCode;
 
   beforeEach(() => {
     originalArgv1 = process.argv[1];
-    originalExitCode = process.exitCode;
-    process.exitCode = undefined;
   });
 
   afterEach(() => {
@@ -21,7 +24,6 @@ describe('sec scan command', () => {
     } else {
       process.argv[1] = originalArgv1;
     }
-    process.exitCode = originalExitCode;
   });
 
   test('buildSecScanArgv preserves repeated homes and roots', () => {
@@ -64,10 +66,12 @@ describe('sec scan command', () => {
 
   test('registered command forwards options to the scanner payload and preserves exit code', async () => {
     const spawnMock = mock<SecScanDeps['spawnSync']>(() => ({ status: 2 }));
+    const setExitCodeMock = mock<SecScanDeps['setExitCode']>(() => {});
     const deps: SecScanDeps = {
       existsSync: (path) => path === '/repo/package.json' || path === '/repo/scripts/sec-scan.cjs',
       realpathSync: (path) => path,
       spawnSync: spawnMock,
+      setExitCode: setExitCodeMock,
     };
 
     process.argv[1] = '/repo/dist/genie.js';
@@ -106,6 +110,15 @@ describe('sec scan command', () => {
       ],
       { stdio: 'inherit' },
     );
-    expect(process.exitCode).toBe(2);
+    expect(setExitCodeMock).toHaveBeenCalledTimes(1);
+    expect(setExitCodeMock).toHaveBeenCalledWith(2);
+  });
+
+  test('applySecScanExitCode is a no-op for successful scans', () => {
+    const setExitCodeMock = mock<SecScanDeps['setExitCode']>(() => {});
+
+    applySecScanExitCode(0, { setExitCode: setExitCodeMock });
+
+    expect(setExitCodeMock).not.toHaveBeenCalled();
   });
 });

--- a/src/term-commands/sec.ts
+++ b/src/term-commands/sec.ts
@@ -19,12 +19,16 @@ export interface SecScanDeps {
   existsSync: (path: string) => boolean;
   realpathSync: (path: string) => string;
   spawnSync: (command: string, args: string[], options: { stdio: 'inherit' }) => SecScanSpawnResult;
+  setExitCode: (exitCode: number) => void;
 }
 
 const defaultDeps: SecScanDeps = {
   existsSync,
   realpathSync,
   spawnSync,
+  setExitCode: (exitCode) => {
+    process.exitCode = exitCode;
+  },
 };
 
 function collectRepeatedOption(value: string, previous: string[]): string[] {
@@ -89,6 +93,10 @@ export function runSecScan(options: SecScanCommandOptions, deps: SecScanDeps = d
   return result.status ?? 1;
 }
 
+export function applySecScanExitCode(exitCode: number, deps: Pick<SecScanDeps, 'setExitCode'> = defaultDeps): void {
+  if (exitCode !== 0) deps.setExitCode(exitCode);
+}
+
 export function registerSecCommands(program: Command, deps: SecScanDeps = defaultDeps): void {
   const sec = program.command('sec').description('Security tooling — host compromise triage and IOC hunts');
 
@@ -101,6 +109,6 @@ export function registerSecCommands(program: Command, deps: SecScanDeps = defaul
     .option('--root <path>', 'Add an application root to scan for project evidence', collectRepeatedOption, [])
     .action((options: SecScanCommandOptions) => {
       const exitCode = runSecScan(options, deps);
-      if (exitCode !== 0) process.exitCode = exitCode;
+      applySecScanExitCode(exitCode, deps);
     });
 }


### PR DESCRIPTION
## What changed
- isolates `genie sec scan` exit-code handling behind an injected setter in `src/term-commands/sec.ts`
- updates `src/term-commands/sec.test.ts` to assert the injected setter instead of mutating the real process exit state
- adds a no-op success-path assertion for the new helper

## Why
PR #1348 merged before commit `dc003a33` landed. Without this follow-up, `src/term-commands/sec.test.ts` can leave a non-zero `process.exitCode` behind, which makes Bun exit non-zero even though the test file itself passes.

## Impact
- keeps the new `genie sec scan` command coverage intact
- removes the false-red failure mode from local runs and CI non-PG test execution
- complements merged PR #1348 without changing scanner behavior

## Root cause
The test was asserting against the real `process.exitCode` set by the command action. Bun honors that exit code for the whole test process, so the run could report success in-file but still exit with status `2`.

## Validation
- `bun test src/term-commands/sec.test.ts`
- `bun run typecheck`
- `GENIE_TEST_SKIP_PGSERVE=1 bun test \"${files[@]}\"` using `scripts/list-tests.ts --non-pg` output
