### PR TITLE
ci(publish): upgrade npm to 11.5+ for OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,14 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
+      # Node 22 bundles npm 10.x; npm Trusted Publishing (automatic OIDC
+      # token exchange) requires npm >= 11.5.1. Without this upgrade,
+      # `npm publish` sends the empty `XXXXX-...-XXXXX` placeholder token
+      # and the registry returns a misleading 404 instead of the real
+      # 401/403 auth failure. See: https://docs.npmjs.com/trusted-publishers
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: Publish to npm @next via OIDC
         env:
           HUSKY: "0"
@@ -225,4 +233,7 @@ jobs:
             echo "(version.yml will bump to a new version and publish it as @next)"
             exit 0
           fi
-          npm publish --access public --tag next
+          # --provenance is implied by Trusted Publishing but pass it
+          # explicitly so a misconfigured publisher fails loudly instead
+          # of silently falling back to token-based auth.
+          npm publish --access public --tag next --provenance

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -112,7 +112,14 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
+      # Node 22 bundles npm 10.x; npm Trusted Publishing (automatic OIDC
+      # token exchange) requires npm >= 11.5.1. Without this upgrade,
+      # `npm publish` sends the empty placeholder token and the registry
+      # returns a misleading 404 instead of the real 401/403 auth failure.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: Publish to npm via OIDC
         env:
           HUSKY: "0"
-        run: npm publish --access public --tag ${{ steps.context.outputs.npm_tag }}
+        run: npm publish --access public --tag ${{ steps.context.outputs.npm_tag }} --provenance


### PR DESCRIPTION
## Summary

Fixes the misleading 404 failure on both publish workflows after the OIDC switch (#1349 for ci.yml, f807b3a8 for version.yml).

## Root cause

npm Trusted Publishing — the mechanism that exchanges a GitHub OIDC token for a short-lived publish credential — landed in **npm 11.5.1** (Sep 2025). Node 22 LTS bundles **npm 10.x**, which does NOT perform the exchange.

`actions/setup-node@v4` with `registry-url` writes an `.npmrc` containing a placeholder `${NODE_AUTH_TOKEN}` (`XXXXX-XXXXX-...`). When Trusted Publishing can't auto-exchange on an older npm, `npm publish` sends that placeholder; the registry masks the 401/403 as a 404 to avoid leaking scope existence.

Evidence from CI run 24848087469 (post-#1349-merge):

```
NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
npm error 404 Not Found - PUT https://registry.npmjs.org/@automagik%2fgenie
npm error 404  '@automagik/genie@4.260422.5' is not in this registry.
```

Trusted Publisher is already wired up on the npm side (confirmed by the user) for both `ci.yml` and `version.yml`. The only missing piece is a recent npm CLI on the runner.

## Changes

- `.github/workflows/ci.yml` (publish-next job) — add `npm install -g npm@latest` before publish
- `.github/workflows/version.yml` (auto-version job) — same upgrade step
- Both: add `--provenance` to the publish command. It's implicit under Trusted Publishing, but passing it explicitly makes a misconfigured publisher fail loudly ("unable to generate provenance statement") instead of silently falling back to token auth.

## Test plan
- [ ] This PR's CI passes (publish-next only runs on push-to-dev, won't run here)
- [ ] Merge to dev → push-event triggers publish-next → npm upgrade runs → `npm publish --provenance` succeeds and package appears at https://www.npmjs.com/package/@automagik/genie with a green **Provenance** badge
- [ ] PR #1341's check rollup flips to all-green (assuming you merge this before merging #1341)

## Notes

- The `--provenance` flag produces an attestation visible on npmjs.com and verifiable via `npm audit signatures`. This is the "green provenance badge" that SLSA tooling expects.
- After this lands and you verify one successful publish, you can delete the legacy `NPM_TOKEN` GitHub secret — OIDC fully replaces it.

## Related
- #1349 (ci.yml OIDC switch) — merged
- `f807b3a8` (version.yml OIDC switch) — user-authored
- PR #1341 — rolling release, blocked by this