### PR TITLE
ci(publish): drop --provenance — incompatible with self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,11 @@ jobs:
             echo "(version.yml will bump to a new version and publish it as @next)"
             exit 0
           fi
-          # --provenance is implied by Trusted Publishing but pass it
-          # explicitly so a misconfigured publisher fails loudly instead
-          # of silently falling back to token-based auth.
-          npm publish --access public --tag next --provenance
+          # `--provenance` would emit a sigstore attestation, but npm's
+          # provenance verification rejects self-hosted runners (Blacksmith
+          # is `blacksmith-Nvcpu-ubuntu-*`, not github-hosted). Trusted
+          # Publishing via OIDC token exchange still works without it —
+          # the publish is authenticated, just without the green provenance
+          # badge. To re-enable provenance, move this step to a
+          # `runs-on: ubuntu-latest` job.
+          npm publish --access public --tag next

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -122,4 +122,11 @@ jobs:
       - name: Publish to npm via OIDC
         env:
           HUSKY: "0"
-        run: npm publish --access public --tag ${{ steps.context.outputs.npm_tag }} --provenance
+        # `--provenance` would emit a sigstore attestation, but npm's
+        # provenance verification rejects self-hosted runners (Blacksmith
+        # is `blacksmith-Nvcpu-ubuntu-*`, not github-hosted). Trusted
+        # Publishing via OIDC token exchange still works without it —
+        # the publish is authenticated, just without the green provenance
+        # badge. To re-enable provenance, move this step to a
+        # `runs-on: ubuntu-latest` job.
+        run: npm publish --access public --tag ${{ steps.context.outputs.npm_tag }}


### PR DESCRIPTION
## Summary

Follow-up to #1351 (`9111afaf`). The OIDC token exchange worked perfectly on Version run 24850939081 — my npm-11.5 upgrade step ran clean, npm auto-authenticated via Trusted Publishing. Publish failed **only** at provenance verification:

```
npm error 422 Unprocessable Entity
Error verifying sigstore provenance bundle: Unsupported GitHub Actions
runner environment: "self-hosted". Only "github-hosted" runners are
supported when publishing with provenance.
```

Blacksmith runners (`blacksmith-Nvcpu-ubuntu-*`) are not GitHub-hosted; npm's sigstore verifier rejects their attestation signatures by design.

## Fix

Drop `--provenance` from both publish invocations:
- `.github/workflows/ci.yml` — `Publish to npm @next via OIDC`
- `.github/workflows/version.yml` — `Publish to npm via OIDC`

Trusted Publishing via OIDC token exchange is independent of provenance — the publish stays authenticated, just without the sigstore badge. To re-enable provenance later, split the publish step into a `runs-on: ubuntu-latest` job.

## Test plan
- [ ] Merge this
- [ ] Re-dispatch `Version` workflow manually (or wait for next dev push)
- [ ] Verify `@automagik/genie@<version>` lands on npm tagged `next`

## Related
- #1351 (npm 11.5 upgrade for OIDC)
- #1349 (ci.yml OIDC switch)
- `f807b3a8` (version.yml OIDC switch)
- PR #1341 — unblocked once this publishes