### PR TITLE
ci(publish): disable auto-provenance + OIDC-enable release.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,11 @@ jobs:
       - name: Publish to npm @next via OIDC
         env:
           HUSKY: "0"
+          # npm auto-enables provenance in any CI env with `id-token: write`,
+          # regardless of the --provenance CLI flag. Self-hosted Blacksmith
+          # runners fail the server-side sigstore check with 422. Disable
+          # auto-provenance explicitly; OIDC token exchange still happens.
+          NPM_CONFIG_PROVENANCE: "false"
         run: |
           LOCAL=$(jq -r '.version' package.json)
           # Check whether the exact version exists in the registry under ANY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
 
 permissions:
   contents: write
+  # Required for npm OIDC Trusted Publishing — exchange the GitHub OIDC
+  # token for a short-lived npm publish credential. Matches ci.yml +
+  # version.yml. See npmjs.com package Settings → Trusted Publishers.
+  id-token: write
 
 jobs:
   release:
@@ -108,20 +112,33 @@ jobs:
       - name: Build CLI
         run: bun run build
 
-      - name: Publish to npm
+      - name: Setup Node (for npm OIDC publish)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      # Node 22 bundles npm 10.x; npm Trusted Publishing (automatic OIDC
+      # token exchange) requires npm >= 11.5.1. Without this upgrade,
+      # `npm publish` + `npm dist-tag` send the empty placeholder token
+      # and the registry returns a misleading 404.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Publish to npm (latest) via OIDC
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
           HUSKY: "0"
+          # npm auto-enables provenance in any CI env with `id-token: write`,
+          # regardless of the --provenance CLI flag. Self-hosted Blacksmith
+          # runners fail the server-side sigstore check with 422. Disable
+          # auto-provenance explicitly; OIDC token exchange still happens.
+          NPM_CONFIG_PROVENANCE: "false"
         run: |
-          if [ -z "$NPM_TOKEN" ]; then
-            echo "ERROR: NPM_TOKEN secret is not set. Cannot publish to npm." >&2
-            exit 1
-          fi
           VERSION="${{ steps.ver.outputs.version }}"
-          # Try publish; if version exists (from @next), just retag as latest
-          if ! bun publish --access public 2>&1; then
+          # Try publish; if version exists (from @next), just retag as latest.
+          # npm dist-tag add also authenticates via the OIDC-exchanged token
+          # since both commands read from the same setup-node .npmrc.
+          if ! npm publish --access public 2>&1; then
             echo "Publish failed — version may already exist from @next. Retagging as latest..."
-            echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
             npm dist-tag add "@automagik/genie@${VERSION}" latest
           fi

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -122,11 +122,9 @@ jobs:
       - name: Publish to npm via OIDC
         env:
           HUSKY: "0"
-        # `--provenance` would emit a sigstore attestation, but npm's
-        # provenance verification rejects self-hosted runners (Blacksmith
-        # is `blacksmith-Nvcpu-ubuntu-*`, not github-hosted). Trusted
-        # Publishing via OIDC token exchange still works without it —
-        # the publish is authenticated, just without the green provenance
-        # badge. To re-enable provenance, move this step to a
-        # `runs-on: ubuntu-latest` job.
+          # npm auto-enables provenance in any CI env with `id-token: write`,
+          # regardless of the --provenance CLI flag. Self-hosted Blacksmith
+          # runners fail the server-side sigstore check with 422. Disable
+          # auto-provenance explicitly; OIDC token exchange still happens.
+          NPM_CONFIG_PROVENANCE: "false"
         run: npm publish --access public --tag ${{ steps.context.outputs.npm_tag }}


### PR DESCRIPTION
## Summary

Two fixes rolled together to fully unblock the `@automagik/genie` publish pipeline:

### 1. Disable auto-provenance (ci.yml + version.yml)

Version workflow run 24851473409 (post-#1352) proved that npm 11.5 **auto-enables provenance** whenever `id-token: write` is set — regardless of the `--provenance` CLI flag. The prior drop-flag commit (`ce81170a`) didn't help; npm still attempted to sign and the registry still returned:

```
422 Unprocessable Entity — Error verifying sigstore provenance bundle:
Unsupported GitHub Actions runner environment: "self-hosted".
Only "github-hosted" runners are supported when publishing with provenance.
```

Fix: add `NPM_CONFIG_PROVENANCE: "false"` to the publish `env:` block in both `ci.yml` (publish-next) and `version.yml` (auto-version). OIDC token exchange still fires — only the sigstore signing step is suppressed.

### 2. OIDC-enable release.yml (release.yml was still on bun publish + NPM_TOKEN)

`release.yml` runs on push to main + `workflow_dispatch`. It was still using `bun publish` with `NPM_TOKEN`, so the first dev→main merge would hit the same 404 as before. Applied the full OIDC treatment:

- `permissions.id-token: write`
- `actions/setup-node@v4` with `registry-url: https://registry.npmjs.org`
- `npm install -g npm@latest` (Trusted Publishing needs ≥11.5.1)
- `npm publish --access public` replaces `bun publish`
- The dist-tag retag fallback (for "version already on @next, promote to @latest") uses `npm dist-tag add` through the same setup-node `.npmrc` — no manual `NPM_TOKEN` wiring needed
- `NPM_CONFIG_PROVENANCE: "false"` for the same self-hosted reason

## Why not provenance?

`--provenance` would emit a sigstore attestation (green badge on npmjs.com), but npm's verification rejects self-hosted runners. To re-enable later:

```yaml
publish-job:
  runs-on: ubuntu-latest   # github-hosted, not blacksmith-*
  # remove NPM_CONFIG_PROVENANCE: "false"
```

Splitting the publish step into a dedicated github-hosted job stays out of this PR for scope — the immediate priority is a working publish.

## Test plan
- [ ] Merge this
- [ ] I re-dispatch `Version` workflow → package publishes to `@next`
- [ ] `npm view @automagik/genie@<new-version>` returns the version
- [ ] First dev→main merge (PR #1341) triggers `release.yml` → publishes `@latest` via the same OIDC path

## Related
- #1352 (drop `--provenance` CLI flag — insufficient, npm auto-enables)
- #1351 (npm 11.5 upgrade for OIDC)
- #1349 (ci.yml OIDC switch)
- `f807b3a8` (version.yml OIDC switch)
- PR #1341 — release, waiting on this