### PR TITLE
ci(publish-next): remove redundant publish job from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,74 +175,8 @@ jobs:
           echo "One or more sub-jobs did not succeed" >&2
           exit 1
 
-  publish-next:
-    name: Publish @next
-    needs: [quality-gate]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 10
-    # OIDC trusted publishing — mirrors version.yml (commit f807b3a8).
-    # `id-token: write` is required for npm to exchange the GitHub OIDC token
-    # for a short-lived publish credential. `contents: read` is the default
-    # needed for checkout.
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.11"
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Build
-        run: bun run build
-
-      - name: Setup Node (for npm OIDC publish)
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
-
-      # Node 22 bundles npm 10.x; npm Trusted Publishing (automatic OIDC
-      # token exchange) requires npm >= 11.5.1. Without this upgrade,
-      # `npm publish` sends the empty `XXXXX-...-XXXXX` placeholder token
-      # and the registry returns a misleading 404 instead of the real
-      # 401/403 auth failure. See: https://docs.npmjs.com/trusted-publishers
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
-
-      - name: Publish to npm @next via OIDC
-        env:
-          HUSKY: "0"
-          # npm auto-enables provenance in any CI env with `id-token: write`,
-          # regardless of the --provenance CLI flag. Self-hosted Blacksmith
-          # runners fail the server-side sigstore check with 422. Disable
-          # auto-provenance explicitly; OIDC token exchange still happens.
-          NPM_CONFIG_PROVENANCE: "false"
-        run: |
-          LOCAL=$(jq -r '.version' package.json)
-          # Check whether the exact version exists in the registry under ANY
-          # tag, not just @next. After a dev→main merge, version.yml bumps dev
-          # to a new version, publishes it as @latest, and commits the bump
-          # back to dev. The next dev push then reads that already-published
-          # version from package.json. Querying only the @next tag misses this
-          # cross-tag collision and causes a 403 when npm publish runs.
-          # Query by exact version so collisions from any tag short-circuit
-          # this step; version.yml will derive a fresh version and publish it.
-          if [ -n "$(npm view "@automagik/genie@${LOCAL}" version 2>/dev/null)" ]; then
-            echo "Version ${LOCAL} already published to npm — skipping @next publish"
-            echo "(version.yml will bump to a new version and publish it as @next)"
-            exit 0
-          fi
-          # `--provenance` would emit a sigstore attestation, but npm's
-          # provenance verification rejects self-hosted runners (Blacksmith
-          # is `blacksmith-Nvcpu-ubuntu-*`, not github-hosted). Trusted
-          # Publishing via OIDC token exchange still works without it —
-          # the publish is authenticated, just without the green provenance
-          # badge. To re-enable provenance, move this step to a
-          # `runs-on: ubuntu-latest` job.
-          npm publish --access public --tag next
+  # Publishing moved out of this workflow. `version.yml` triggers via
+  # workflow_run when CI completes on dev, derives the next version,
+  # bumps + tags, and publishes via OIDC. Keeping a second publish
+  # path here required a second npm Trusted Publisher entry for
+  # `ci.yml` and kept tripping 404s. One publish pipeline is simpler.


### PR DESCRIPTION
## Summary

After Version workflow run 24852034764 proved OIDC publish works end-to-end via `version.yml` (package `4.260423.5` landed on npm), the parallel `publish-next` job in `ci.yml` is redundant. It also kept failing with 404 because your npm Trusted Publisher config only lists `version.yml` — not `ci.yml`.

Rather than ask you to add a second Trusted Publisher entry, delete the duplicate job. One pipeline, one Trusted Publisher, one red-check surface.

## What this removes

The `publish-next` job (lines 178–248 of ci.yml, ~70 lines) including:
- `permissions.id-token: write` scoped to that job
- `actions/setup-node@v4` + `npm install -g npm@latest`
- The version-collision short-circuit (`npm view ... skip if already published`)
- `npm publish --access public --tag next`

## What still publishes

| Path | Trigger | Tag |
|------|---------|-----|
| `version.yml` | any dev push via `workflow_run` on CI completion (or `workflow_dispatch`) | `@next` |
| `release.yml` | push to `main` (or `workflow_dispatch`) | `@latest` |

Both go through OIDC with `NPM_CONFIG_PROVENANCE=false` (Blacksmith is self-hosted).

## Unblocks

- PR #1341 — the final red check on the rolling release was this vestigial job
- Once this merges, the next dev push triggers Version, publishes `4.260423.<N+1>` as `@next`, and the PR #1341 check rollup goes fully green

## Test plan
- [ ] Merge this
- [ ] Watch PR #1341's check rollup — `Publish @next` disappears as a check
- [ ] Watch next dev push triggers `version.yml` → publish lands
- [ ] PR #1341 ready to merge to main

## Related
- #1353 (disable auto-provenance + OIDC-enable release.yml) — merged
- #1352 (drop --provenance CLI flag) — merged
- #1351 (npm 11.5 upgrade) — merged
- #1349 (introduced the publish-next OIDC switch this PR reverses) — merged
- PR #1341 — blocked on this