### PR TITLE
[codex] align sec docs with sec scan

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ Send private reports to one of the following channels:
 | Channel | Address | Best for |
 |---------|---------|----------|
 | Security email | `privacidade@namastex.ai` | Anything security-related, including coordinated disclosure |
-| DPO (privacy + security officer) | `dpo@khal.ai` | Privacy, LGPD, data protection concerns |
+| DPO (privacy + security officer) | `dpo@namastex.ai` | Privacy, LGPD, data protection concerns |
 | Private GitHub advisory | [Report via GitHub](https://github.com/automagik-dev/genie/security/advisories/new) | Preferred for CVE assignment and coordinated release |
 
 **PGP** available on request.
@@ -44,6 +44,33 @@ Always install from the current stable line. Pin explicit versions in your `pack
 
 ---
 
+## Self-Service Host Triage
+
+If you installed a compromised version or need to assess a workstation, developer VM, CI runner, or WSL environment, start with:
+
+```bash
+genie sec scan --all-homes --root "$PWD"
+```
+
+Add one `--root` per repository or application directory you want scanned. Use `--json` for machine-readable output.
+
+Interpretation:
+
+- `LIKELY COMPROMISED` — execution, persistence, `.pth`, dropped payload, or live-process evidence exists.
+- `LIKELY AFFECTED` — compromised versions were installed or fetched and the host should be treated as exposed.
+- `OBSERVED ONLY` — logs, caches, or lockfiles reference the malicious versions, but stronger execution evidence was not found.
+- `NO FINDINGS` — no incident-specific evidence was found in the scanned scope.
+
+The scanner inventories:
+
+- compromised versions in npm and bun caches plus installed package directories
+- shell history, shell startup files, persistence locations, Python `.pth` injection paths, temp drops, and suspicious live processes
+- `at-risk local material present on host` so operators can see which secret stores, browser profiles, wallets, and local app files were present and should be considered during rotation
+
+If `genie` is not available, use the manual procedure in the incident response guide below.
+
+---
+
 ## Past Incidents
 
 ### 2026-04 — CanisterWorm supply-chain compromise
@@ -55,10 +82,10 @@ Between 2026-04-21 (~22:14 UTC) and 2026-04-22 (~14:00 UTC), versions `4.260421.
 - **Estimated base affected:** ≤ 2% of weekly download volume
 - **Current status:** malicious versions `npm unpublish`-ed and no longer installable
 
-**If you installed any version in that range between April 21–22, 2026, assume your machine is compromised.** Follow the remediation guide linked below.
+**If you installed any version in that range between April 21–22, 2026, run `genie sec scan --all-homes --root "$PWD"` immediately.** If the host shows `LIKELY COMPROMISED` or `LIKELY AFFECTED`, follow the remediation guide linked below.
 
 **Resources:**
-- 📖 [Full incident response manual](https://github.com/namastexlabs/genie-dpo/blob/main/knowledge/canisterworm-incident-response.md)
+- 📖 [Incident response manual](./docs/incident-response/canisterworm.md)
 - 🌐 [Public advisory (English)](https://automagik.dev/security)
 - 🌐 [Aviso público (Português)](https://automagik.dev/seguranca)
 - 🛡️ [GitHub Security Advisories](https://github.com/automagik-dev/genie/security/advisories) for this repository
@@ -104,7 +131,7 @@ Effective 2026-04-23, all `@automagik/genie` releases are governed by:
 ## Contact
 
 - **Security & incidents:** `privacidade@namastex.ai`
-- **Data Protection Officer (DPO):** Cezar Vasconcelos — `dpo@khal.ai`
+- **Data Protection Officer (DPO):** Cezar Vasconcelos — `dpo@namastex.ai`
 - **Security disclosure page:** [automagik.dev/security](https://automagik.dev/security)
 
 Namastex Labs Serviços em Tecnologia Ltda · CNPJ 46.156.854/0001-62

--- a/docs/incident-response/canisterworm.md
+++ b/docs/incident-response/canisterworm.md
@@ -14,6 +14,8 @@ Entre 21 e 22 de abril de 2026, versões maliciosas dos pacotes npm `@automagik/
 
 Se você instalou qualquer versão listada abaixo entre **2026-04-21 e 2026-04-22**, leia este documento do início ao fim antes de executar qualquer comando.
 
+O caminho preferencial agora é começar com `genie sec scan`. Os checks manuais abaixo continuam válidos como confirmação adicional, fallback, ou triagem em hosts onde o CLI não está disponível.
+
 ---
 
 ## 1. O que aconteceu
@@ -62,11 +64,51 @@ Se qualquer versão maliciosa foi instalada na sua máquina, os itens abaixo for
 
 > ⚠️ **Leitura crítica:** o roubo aconteceu no momento da instalação. Rotacionar chaves no GitHub **não desfaz** o que já foi exfiltrado — você precisa rotacionar **todos** os itens listados acima.
 
+Sempre que possível, use também a saída do `genie sec scan` para confirmar quais tipos de material estavam presentes no host. A seção `at-risk local material present on host` não mostra segredos, mas lista os caminhos e artefatos locais que o malware provavelmente teria tentado ler.
+
 ---
 
 ## 2. Passo 1 — Identificar se você foi afetado
 
 Execute todos os checks abaixo. Anote resultados antes de seguir para o Passo 2.
+
+### Usando `genie sec scan` (recomendado)
+
+Rode primeiro:
+
+```bash
+genie sec scan --all-homes --root "$PWD"
+```
+
+Se precisar cobrir múltiplos repositórios ou serviços:
+
+```bash
+genie sec scan --all-homes --root /srv/app --root /opt/service --root "$PWD"
+```
+
+Use `--json` quando quiser arquivar ou automatizar a triagem:
+
+```bash
+genie sec scan --json --all-homes --root "$PWD"
+```
+
+Como interpretar:
+
+- `LIKELY COMPROMISED` — há sinais de execução, persistência, `.pth`, artefatos de drop, ou processo ativo. Vá direto para o Passo 3.
+- `LIKELY AFFECTED` — há versões comprometidas instaladas ou em cache. Trate o host como exposto e siga para o Passo 3.
+- `OBSERVED ONLY` — só foram encontradas referências em cache, lockfile, ou log. Ainda assim revise os checks manuais abaixo antes de declarar o host limpo.
+- `NO FINDINGS` — não houve evidência específica do incidente dentro do escopo escaneado.
+
+O scanner cobre os mesmos sinais principais deste manual:
+
+- caches npm e bun
+- instalações locais e globais
+- históricos de shell e arquivos de inicialização
+- persistência `systemd`, `cron`, `launchd`, `.pth`
+- artefatos temporários e processos vivos
+- material local em risco para priorizar rotação
+
+Se o scanner acusar `LIKELY COMPROMISED` ou `LIKELY AFFECTED`, continue com os passos manuais abaixo apenas para coleta complementar e preservação de evidência.
 
 ### 2.1 Versão instalada globalmente (bun)
 
@@ -159,6 +201,10 @@ ss -tnp 2>/dev/null | grep -iE "api-monitor|icp0|tdtqy|cjn37|143\.198\.237\.25"
 
 | Situação | Veredicto | Ação |
 |----------|-----------|------|
+| `genie sec scan` retorna `LIKELY COMPROMISED` | **INFECTADO** | Desconecte da rede se possível e execute o Passo 3 completo |
+| `genie sec scan` retorna `LIKELY AFFECTED` | **INFECTADO** | Execute o Passo 3 completo |
+| `genie sec scan` retorna `OBSERVED ONLY` | **OBSERVADO** | Continue nos checks manuais; se houver dúvida operacional, trate como infectado |
+| `genie sec scan` retorna `NO FINDINGS` | **CLEAN provisório** | Se o escopo cobriu todos os homes e roots relevantes, siga para o Passo 4 |
 | Nenhuma versão maliciosa no cache, nenhum IoC | **CLEAN** | Vá direto para o Passo 4 (prevenção) |
 | Versão maliciosa no cache, mas `env-compat.cjs`/`check-env.js` ausentes | **OBSERVADO** | Cache presente mas postinstall pode não ter rodado — trate como **INFECTADO** por precaução (Passo 3) |
 | `env-compat.cjs`, `public.pem` ou `check-env.js` presentes | **INFECTADO** | Execute o Passo 3 completo |
@@ -218,6 +264,8 @@ bun install -g pgserve@1.1.10
 ### 4.4 Rotacionar TODAS as credenciais
 
 > 🔥 **Este é o passo mais importante.** Qualquer credencial presente na máquina no momento da instalação foi exfiltrada. Rotacionar = revogar a existente e emitir uma nova.
+
+Se você executou `genie sec scan`, use a seção `at-risk local material present on host` como checklist para não esquecer nenhuma classe de credencial, carteira, perfil de navegador, ou `.env` local presente no host comprometido.
 
 **npm**
 ```bash
@@ -428,6 +476,8 @@ Em Sophos, OPNsense, pfSense ou similares, crie um grupo `CanisterWorm-C2` com o
 ## 7. Checklist de um olhar (imprima e cole no monitor)
 
 - [ ] Verifiquei cache bun e npm — nenhuma versão da tabela 1.2 presente
+- [ ] Rodei `genie sec scan --all-homes --root <repo>` e revisei o veredicto
+- [ ] Revisei `at-risk local material present on host` para priorizar rotação
 - [ ] Verifiquei `env-compat.cjs`, `public.pem`, `check-env.js` — ausentes
 - [ ] Verifiquei `pgmon.service` e `/tmp/pglog` — ausentes
 - [ ] Verifiquei `.pth` Python — apenas legítimos


### PR DESCRIPTION
## What changed
- updates `SECURITY.md` to add the `genie sec scan` self-service triage flow
- updates the CanisterWorm incident response manual to use `genie sec scan` as the recommended first step before the manual fallback checks
- replaces the remaining `khal.ai` contact references with `namastex.ai`

## Why
These security docs were written before the `sec scan` toolset existed, so they still pushed users into a fully manual workflow. They also still had outdated `khal.ai` contact details.

## Impact
- users get a clear scanner-first path for incident triage on Linux, macOS, and WSL
- remediation guidance now points operators at the scan sections that show what local material was at risk
- contact details are consistent with current Namastex branding

## Validation
- docs-only change
- verified updated content in `SECURITY.md` and `docs/incident-response/canisterworm.md`
