### PR TITLE
ci(publish): unify through version.yml + fix main-vs-release version drift

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,12 @@
 name: Release
 
+# Creates a GitHub Release object (tag + changelog) on every push to main.
+# npm publishing is intentionally NOT handled here — `version.yml` owns the
+# entire publish path for both `@next` (dev) and `@latest` (main) via a single
+# npm Trusted Publisher entry. Keeping publish logic in one workflow avoids
+# double-publishes, duplicate Trusted Publisher entries on npmjs.com, and the
+# race between `release.yml` and `version.yml` both reacting to a main push.
+
 on:
   push:
     branches: [main]
@@ -7,10 +14,6 @@ on:
 
 permissions:
   contents: write
-  # Required for npm OIDC Trusted Publishing — exchange the GitHub OIDC
-  # token for a short-lived npm publish credential. Matches ci.yml +
-  # version.yml. See npmjs.com package Settings → Trusted Publishers.
-  id-token: write
 
 jobs:
   release:
@@ -91,54 +94,4 @@ jobs:
               --target "${{ github.sha }}" \
               --title "${TAG}" \
               --notes-file /tmp/release-notes.md
-          fi
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.10"
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Patch version for hotfix
-        if: steps.ver.outputs.hotfix == 'true'
-        run: |
-          VERSION="${{ steps.ver.outputs.version }}"
-          jq --arg v "$VERSION" '.version = $v' package.json > package.json.tmp
-          mv package.json.tmp package.json
-          echo "Patched package.json to ${VERSION}"
-
-      - name: Build CLI
-        run: bun run build
-
-      - name: Setup Node (for npm OIDC publish)
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
-
-      # Node 22 bundles npm 10.x; npm Trusted Publishing (automatic OIDC
-      # token exchange) requires npm >= 11.5.1. Without this upgrade,
-      # `npm publish` + `npm dist-tag` send the empty placeholder token
-      # and the registry returns a misleading 404.
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
-
-      - name: Publish to npm (latest) via OIDC
-        env:
-          HUSKY: "0"
-          # npm auto-enables provenance in any CI env with `id-token: write`,
-          # regardless of the --provenance CLI flag. Self-hosted Blacksmith
-          # runners fail the server-side sigstore check with 422. Disable
-          # auto-provenance explicitly; OIDC token exchange still happens.
-          NPM_CONFIG_PROVENANCE: "false"
-        run: |
-          VERSION="${{ steps.ver.outputs.version }}"
-          # Try publish; if version exists (from @next), just retag as latest.
-          # npm dist-tag add also authenticates via the OIDC-exchanged token
-          # since both commands read from the same setup-node .npmrc.
-          if ! npm publish --access public 2>&1; then
-            echo "Publish failed — version may already exist from @next. Retagging as latest..."
-            npm dist-tag add "@automagik/genie@${VERSION}" latest
           fi


### PR DESCRIPTION
## Summary

Two complementary fixes to the publish suite, motivated by today's observed drift:

| Location | Version |
|----------|---------|
| GitHub Release (isLatest) | `v4.260423.9` |
| npm `latest` | `4.260423.10` |

Both from the same main push. `release.yml` tagged 4.260423.9 from main's package.json; `version.yml` then ran, **independently derived a new version** (today + tag-count = `.10`), and published `.10` as `@latest`. Two workflows, two versions — `@latest` no longer pointed at the Release GitHub was advertising.

## Fix 1 — `release.yml` stops publishing to npm

Your npm Trusted Publisher is configured for **one workflow only**: `version.yml`. Unify: `release.yml` keeps responsibility for the GitHub Release object (tag + git-cliff changelog + release notes) and drops all npm-publish machinery.

**Removed from release.yml** (~54 lines):
- `permissions.id-token: write`
- `actions/setup-node@v4`
- `npm install -g npm@latest`
- `Publish to npm (latest) via OIDC` (with dist-tag retag fallback)
- `Setup Bun`, `Install dependencies`, `Build CLI`, `Patch version for hotfix` (all only existed to feed the removed publish)

## Fix 2 — `version.yml` stops bumping on main context

On main triggers, `version.yml` now publishes whatever `package.json` already holds (the version `release.yml` just tagged), rather than deriving and bumping again.

**Changes in version.yml**:
- `context` step emits `should_bump=true` only for dev triggers (and manual `workflow_dispatch`, which targets dev by default)
- `Configure git` / `Derive version` / `Sync version files` / `Format JSON` / `Commit and tag` steps gate on `should_bump=true`
- `context` emits `branch=main` (not `branch=dev`) for main triggers, so checkout reads main's package.json
- New `Resolve publish version` step for logging
- `npm publish` reads package.json + tags with `npm_tag` — unchanged shape

## Unified routing after merge

| Trigger | Result |
|---------|--------|
| PR merged → dev | CI → `version.yml` bumps dev + publishes `@next` |
| PR merged → main | `release.yml` tags + creates GitHub Release v`X` |
|  | CI on main → `version.yml` publishes v`X` as `@latest` (same X; **no drift**) |
| `workflow_dispatch Version` | Bumps dev + publishes `@next` (manual hotfix path) |

## Why this works with one Trusted Publisher entry

`release.yml` doesn't publish to npm anymore, so it doesn't need a Trusted Publisher entry. `version.yml` is the single authenticated channel for every publish event.

## Test plan

- [ ] Merge this PR to dev
- [ ] Merge PR #1341 (dev → main) — the rolling release
- [ ] Observe:
  - `release.yml` creates `v4.260423.<N>` Release on main
  - `version.yml` publishes the same `4.260423.<N>` as `@latest` on npm
  - `npm view @automagik/genie@latest` matches the GitHub Release tag
- [ ] Future dev pushes: `@next` moves automatically (already proven in run 24852034764)

## Related
- PR #1354 (removed ci.yml publish-next — first pass at unification)
- PR #1353, #1352, #1351, #1349 (the OIDC build-up)
- PR #1341 — dev → main rolling release, waiting on this