### PR TITLE
fix(ci): knip ignores unblock version workflow + @next publish

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -54,7 +54,25 @@
     "test/observability/emit-bench.ts"
   ],
   "project": ["src/**/*.ts", "src/**/*.tsx"],
-  "ignoreBinaries": ["which"],
+  "ignoreBinaries": [
+    "which",
+    "init",
+    "config",
+    "add",
+    "commit",
+    "branch",
+    "worktree",
+    "team",
+    "fetch",
+    "rev-parse",
+    "diff",
+    "ls-files",
+    "origin/",
+    "tsc",
+    "biome",
+    "husky",
+    "scripts/verify-release.sh"
+  ],
   "ignoreExportsUsedInFile": true,
   "ignoreDependencies": [
     "@khal-os/brain",
@@ -64,6 +82,8 @@
     "@vitejs/plugin-react",
     "vite",
     "@types/react-dom",
-    "esbuild"
+    "@biomejs/biome",
+    "@commitlint/cli",
+    "husky"
   ]
 }


### PR DESCRIPTION
## Problem

After PR #1363 (signing) merged, CI started failing on dev HEAD. The failing check is Unit Tests / Quality Gate, but the actual failure is inside the \`dead-code\` step:

- knip flags \`@biomejs/biome\`, \`@commitlint/cli\`, \`husky\` as unused devDependencies (they're binary-only, invoked from npm scripts / git hooks)
- knip flags 14 git subcommands as \"Unlisted binaries\" (\`init\`, \`config\`, \`add\`, \`commit\`, \`branch\`, \`worktree\`, \`team\`, \`fetch\`, \`rev-parse\`, \`diff\`, \`ls-files\`, \`origin/\`) plus \`tsc\`, \`biome\`, \`husky\`, \`scripts/verify-release.sh\` (the latter new from #1363)
- \`esbuild\` is no longer unused (knip's own hint says \"Remove from ignoreDependencies\")

CI failure → version workflow requires \`workflow_run.conclusion == 'success'\` → workflow skipped → no auto-version bump on dev → **@next stuck at 4.260423.12, cannot publish the 100+ KB of new sec-remediate + signing code to users**.

## Fix

Update \`knip.json\`:
- Move \`@biomejs/biome\`, \`@commitlint/cli\`, \`husky\` into \`ignoreDependencies\`
- Add the flagged git subcommands + \`scripts/verify-release.sh\` into \`ignoreBinaries\`
- Remove \`esbuild\` from \`ignoreDependencies\` (per knip hint, now used directly)

Result: \`bun run dead-code\` exits 0. \"Configuration hints (18)\" remain as INFORMATIONAL but don't fail CI.

## Unblocks

Once this merges to dev:
1. Version workflow auto-fires
2. \`@automagik/genie@next\` publishes with sec-remediate (#1361) + signing (#1363) code
3. End users can run \`npx @automagik/genie@next sec remediate --dry-run\` and \`sec verify-install\`

## Test plan

- [x] \`bun run dead-code\` exits 0 locally
- [ ] CI Unit Tests + Quality Gate green
- [ ] Version workflow triggers on merge and bumps to 4.260423.13+
- [ ] \`npm view @automagik/genie@next version\` reflects the bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)