### PR TITLE
fix(sec-scan): eliminate self-detection false positives

### DIFF
--- a/scripts/sec-scan.cjs
+++ b/scripts/sec-scan.cjs
@@ -1496,6 +1496,28 @@ function searchBufferForIocs(buffer) {
   return uniq(hits);
 }
 
+// An install finding is "hard evidence" only when the version matches the
+// compromised list OR a file hash matches a known malware hash. IOC-string
+// matches in file content are NOT hard evidence on their own — the scanner's
+// own source literally contains every IOC string as a detection pattern, so
+// scanning `@automagik/genie@<clean-version>` would always match itself
+// (the self-detection false positive fixed here).
+function hasHardInfectionEvidence(inspection) {
+  if (inspection.compromisedVersion) return true;
+  if (inspection.iocFileHashes.some((entry) => entry.knownMalwareHash === true)) return true;
+  return false;
+}
+
+// `@automagik/genie` is the scanner package itself. On CLEAN versions its
+// source files contain IOC strings as detection patterns — scanning its own
+// bytes therefore produces thousands of spurious `iocStrings` hits. Skip the
+// content walk entirely for clean versions of the scanner package.
+function shouldSkipContentWalk(packageName, version) {
+  if (packageName !== '@automagik/genie') return false;
+  if (!version) return false;
+  return !isTrackedCompromisedVersion(packageName, version);
+}
+
 function inspectPackageDirectory(packageDir) {
   const result = {
     path: packageDir,
@@ -1506,6 +1528,7 @@ function inspectPackageDirectory(packageDir) {
     iocFiles: [],
     iocFileHashes: [],
     iocStrings: [],
+    contentWalkSkipped: false,
   };
 
   const packageJsonPath = join(packageDir, 'package.json');
@@ -1538,6 +1561,11 @@ function inspectPackageDirectory(packageDir) {
       knownMalwareHash:
         typeof MALWARE_FILE_HASHES[relativeSuffix] === 'string' && MALWARE_FILE_HASHES[relativeSuffix] === fileHash,
     });
+  }
+
+  if (shouldSkipContentWalk(result.packageName, result.version)) {
+    result.contentWalkSkipped = true;
+    return result;
   }
 
   const stack = [packageDir];
@@ -1968,7 +1996,7 @@ function scanBunCache(homePath, report) {
     if (!safeExists(bunGlobal)) continue;
 
     const inspection = inspectPackageDirectory(bunGlobal);
-    if (inspection.compromisedVersion || inspection.iocFiles.length > 0 || inspection.iocStrings.length > 0) {
+    if (hasHardInfectionEvidence(inspection)) {
       const finding = {
         kind: 'bun-global',
         home: homePath,
@@ -2017,9 +2045,7 @@ function scanGlobalInstallCandidates(homes, report) {
 
     for (const candidate of findTrackedPackageDirs(nodeModulesPath)) {
       const inspection = inspectPackageDirectory(candidate);
-      if (!inspection.compromisedVersion && inspection.iocFiles.length === 0 && inspection.iocStrings.length === 0) {
-        continue;
-      }
+      if (!hasHardInfectionEvidence(inspection)) continue;
 
       const finding = {
         kind: 'global-install',
@@ -2178,9 +2204,7 @@ function scanProjectRoots(roots, report, runtime) {
     (nodeModulesPath) => {
       for (const packageDir of findTrackedPackageDirs(nodeModulesPath)) {
         const inspection = inspectPackageDirectory(packageDir);
-        if (!inspection.compromisedVersion && inspection.iocFiles.length === 0 && inspection.iocStrings.length === 0) {
-          continue;
-        }
+        if (!hasHardInfectionEvidence(inspection)) continue;
 
         const finding = {
           kind: 'local-install',
@@ -2825,19 +2849,27 @@ function scanLiveProcesses(report) {
     if (!match) continue;
 
     const [, pid, ppid, user, elapsed, command] = match;
+
+    // Self-exclusion: the running scanner process itself always matches
+    // `exec:@automagik/genie` in its own cmdline. Ignore it.
+    if (command.includes('sec-scan.cjs') || command.includes('/sec-scan ')) continue;
+
     const indicators = collectTextIndicators(command);
     const namedHits = collectNamedArtifactHits(command);
     const matchedInstallPaths = suspectPaths.filter((path) => command.includes(path));
 
-    const isStrongHit =
+    // Hard evidence requires either an actual compromised version token in
+    // the cmdline OR an IOC string hit OR a network-IOC command. Pure name
+    // matches (e.g. `pgserve@1.1.10` where 1.1.10 is CLEAN) are NOT compromise
+    // evidence — they only tell us the package is running, which is normal.
+    const hasHardEvidence =
       indicators.iocMatches.length > 0 ||
-      indicators.executionCommands.length > 0 ||
       indicators.networkCommands.length > 0 ||
       indicators.versions.length > 0 ||
-      namedHits.length > 0 ||
       matchedInstallPaths.length > 0;
 
-    if (!isStrongHit) continue;
+    const hasWeakHit = hasHardEvidence || indicators.executionCommands.length > 0 || namedHits.length > 0;
+    if (!hasWeakHit) continue;
 
     report.liveProcessFindings.push({
       pid: Number(pid),
@@ -2851,13 +2883,16 @@ function scanLiveProcesses(report) {
       executionCommands: indicators.executionCommands,
       networkCommands: indicators.networkCommands,
       nameMatches: namedHits,
+      hardEvidence: hasHardEvidence,
     });
 
     addTimeline(report, {
       time: null,
       category: 'live-process',
-      severity: 'compromised',
-      summary: `live process ${pid} matches suspicious package execution indicators`,
+      severity: hasHardEvidence ? 'compromised' : 'observed',
+      summary: hasHardEvidence
+        ? `live process ${pid} matches suspicious package execution indicators`
+        : `live process ${pid} running tracked package name (clean or unversioned) — informational`,
       path: command,
     });
   }
@@ -2943,7 +2978,8 @@ function summarize(report) {
   if (strongTempEvidence > 0) {
     compromiseReasons.push('temp or cache directories retain dropped env-compat artifacts or IOC strings');
   }
-  if (report.liveProcessFindings.length > 0) {
+  const hardEvidenceProcesses = report.liveProcessFindings.filter((entry) => entry.hardEvidence);
+  if (hardEvidenceProcesses.length > 0) {
     compromiseReasons.push('live processes match suspicious package execution indicators');
   }
   if (report.pythonPthFindings.length > 0) {
@@ -2983,7 +3019,7 @@ function summarize(report) {
   suspicionScore += Math.min(strongProfileEvidence * 20, 40);
   suspicionScore += Math.min(executionHistoryEvidence * 20, 40);
   suspicionScore += Math.min(strongTempEvidence * 20, 40);
-  suspicionScore += Math.min(report.liveProcessFindings.length * 25, 50);
+  suspicionScore += Math.min(hardEvidenceProcesses.length * 25, 50);
   suspicionScore += Math.min(report.pythonPthFindings.length * 25, 50);
   suspicionScore += Math.min(report.installFindings.length * 12, 24);
   suspicionScore += Math.min(report.npmTarballFetches.length * 8, 24);


### PR DESCRIPTION
## Problem — reported by Felipe from real partner scan output

End-user scan output from a CLEAN Mac:

\`\`\`
Status: LIKELY COMPROMISED
Suspicion score: 100/100

install findings:
- bun-global at ~/.bun/install/global/node_modules/@automagik/genie
  version: 4.260423.10    ← CLEAN (not in compromised list 4.260421.33-40)
  IOC strings: telemetry.api-monitor.com, env-compat.cjs, X-Session-ID, ...

live process findings:
- pid 17173 command: bun .../genie/dist/genie.js    ← clean genie running
- pid 14380 command: bun .../sec-scan.cjs --all-homes --redact    ← the scan itself!
- pid 11766 command: ...pgserve@1.1.10/...    ← CLEAN pgserve (compromised is 1.1.11-13)
\`\`\`

Every partner running a clean, current \`@automagik/genie\` install would see this → can't distinguish real infection from noise.

## Root cause

Three self-detection bugs:

1. \`inspectPackageDirectory\` walks the installed scanner's own source files and finds every IOC string as \"evidence\" — but those strings are the scanner's *detection patterns*, not malware payload. Same class of bug as an antivirus flagging its own signature database.

2. \`scanLiveProcesses\` matches the running scanner's own cmdline because it contains \`@automagik/genie\` (via \`exec:node_modules/@automagik/genie\` regex).

3. Live-process name-match against CLEAN package versions (e.g. \`pgserve@1.1.10\`) triggers \`severity: 'compromised'\` — running a clean version of a tracked package is not compromise.

## Fix

- **\`hasHardInfectionEvidence(inspection)\`** — new gate helper. An install finding requires \`compromisedVersion === true\` OR a \`knownMalwareHash === true\` file. IOC strings in content are NOT hard evidence. Applied to all three install-finding sites (bun-global, global-install, local-install).

- **\`shouldSkipContentWalk(name, version)\`** — on CLEAN versions of \`@automagik/genie\` itself, skip the per-file content walk entirely. Scanner source files never get searched against IOC patterns they themselves contain.

- **\`scanLiveProcesses\` self-exclusion** — skip processes whose cmdline contains \`sec-scan.cjs\` or \`/sec-scan \`. The running scan process no longer flags itself.

- **Live-process severity gating** — new \`hardEvidence: boolean\` on each live-process entry. Hard evidence = compromised-version-in-cmdline OR IOC string match OR network-IOC command OR install-path match. Weak hits (name-only) still reported, but with \`severity: 'observed'\` (informational) rather than \`'compromised'\`. Suspicion score and compromise-reasons derivation now use hard-evidence-filtered list.

## Verification

Scan run against a clean host with \`@automagik/genie@4.260423.10\` installed globally:
- Before fix: LIKELY COMPROMISED, score 100/100, 2 install findings, 5+ live-process findings (self-flags + clean pgserve)
- After fix: \`installFindings: 0\`, \`liveProcessFindings\` contains only real evidence entries

Real infection evidence still surfaces correctly:
- Lockfiles referencing compromised versions → \`lockfileFindings\`
- Shell history with \`curl telemetry.api-monitor.com\` → \`shellHistoryFindings\`
- npm log hits for compromised \`pgserve\` installs → \`npmLogHits\`

## Tests

\`bun test scripts/sec-scan.test.ts\`: **56/56 pass**.

## Follow-ups (separate wishes)

- Deep-scan mode (\`--sudo\` variant): system-wide roots, /etc/crontab, /var/spool/cron, /var/log/ufw.log, macOS Little Snitch logs for historical outbound to IOC hosts
- Fix command with per-action confirmation UI
- Network-level analysis: DNS + netstat + firewall-log retrospective
- AI firewall brainstorm: pre-install / pre-exec allowlist + egress-domain filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)