### PR TITLE
fix(sec-scan): eliminate scan-self-reference noise (bugs #4-#7)

### DIFF
--- a/scripts/sec-scan.cjs
+++ b/scripts/sec-scan.cjs
@@ -1930,14 +1930,12 @@ function scanNpmCache(homePath, report) {
 
       const versions = findVersionsInText(text);
       const indicators = collectTextIndicators(text);
-      if (
-        versions.length === 0 &&
-        indicators.installCommands.length === 0 &&
-        indicators.executionCommands.length === 0 &&
-        indicators.iocMatches.length === 0
-      ) {
-        continue;
-      }
+      // Hard evidence in an npm log: an actual compromised version string
+      // or IOC network pattern. Name-only install/exec entries happen every
+      // time anyone runs `npx @automagik/genie ...` and are NOT evidence of
+      // compromise — they just record that the package was interacted with.
+      const hardEvidence = versions.length > 0 || indicators.iocMatches.length > 0;
+      if (!hardEvidence) continue;
 
       report.npmLogHits.push({
         home: homePath,
@@ -2333,25 +2331,36 @@ function scanShellHistories(homes, report) {
       const finding = inspectTextEvidenceFile(fullPath);
       if (!finding) continue;
 
-      const exposure =
-        finding.executionCommands.length > 0 || finding.networkCommands.length > 0
-          ? 'execution'
-          : finding.installCommands.length > 0
-            ? 'install'
-            : 'reference';
+      // Hard evidence: network-IOC pattern (curl/wget to exfil host),
+      // raw IOC string match, or explicit compromised-version string in
+      // history. Pure `executionCommands`/`installCommands` name-match is
+      // ambient noise (triggered every time the user runs the scanner).
+      const hasHardEvidence =
+        finding.networkCommands.length > 0 ||
+        finding.iocMatches.length > 0 ||
+        finding.versions.length > 0;
+
+      const exposure = hasHardEvidence
+        ? 'execution'
+        : finding.executionCommands.length > 0 || finding.installCommands.length > 0
+          ? 'reference'
+          : 'reference';
 
       report.shellHistoryFindings.push({
         kind: 'shell-history',
         home: homePath,
         exposure,
+        hardEvidence: hasHardEvidence,
         ...finding,
       });
 
       addTimeline(report, {
         time: finding.modifiedAt,
         category: 'shell-history',
-        severity: exposure === 'execution' ? 'compromised' : 'affected',
-        summary: `shell history shows ${exposure} evidence for suspicious package activity`,
+        severity: hasHardEvidence ? 'compromised' : 'observed',
+        summary: hasHardEvidence
+          ? `shell history shows execution evidence for suspicious package activity`
+          : `shell history references tracked package name (clean or unversioned) — informational`,
         path: finding.path,
       });
     }
@@ -2850,9 +2859,15 @@ function scanLiveProcesses(report) {
 
     const [, pid, ppid, user, elapsed, command] = match;
 
-    // Self-exclusion: the running scanner process itself always matches
-    // `exec:@automagik/genie` in its own cmdline. Ignore it.
+    // Self-exclusion: the running scanner + any wrapping shell that invoked
+    // it (e.g. `bash -c "npx @automagik/genie sec scan …"`) will always
+    // match the tracked-package regexes in their own cmdline. Ignore both.
+    if (String(pid) === String(process.pid)) continue;
+    if (String(pid) === String(process.ppid)) continue;
     if (command.includes('sec-scan.cjs') || command.includes('/sec-scan ')) continue;
+    if (/\bgenie\s+sec\s+(scan|remediate|restore|rollback|verify-install|quarantine|print-cleanup-commands)\b/.test(command)) {
+      continue;
+    }
 
     const indicators = collectTextIndicators(command);
     const namedHits = collectNamedArtifactHits(command);
@@ -2908,22 +2923,38 @@ function countStrongProfileEvidence(report) {
   ).length;
 }
 
+// Hard execution evidence in shell history = actual network-IOC (curl/wget
+// to exfil host) or raw IOC string or explicit compromised version. Pure
+// `executionCommands` matches (exec:@automagik/genie, exec:npx @automagik/genie)
+// fire every time the user runs the scanner itself or any other genie command
+// and are NOT compromise evidence. Same for `installCommands` — cleanup
+// activity (`npm uninstall -g @automagik/genie`) triggers them.
 function countExecutionHistoryEvidence(report) {
   return report.shellHistoryFindings.filter(
     (finding) =>
-      finding.executionCommands.length > 0 || finding.networkCommands.length > 0 || finding.iocMatches.length > 0,
+      finding.networkCommands.length > 0 ||
+      finding.iocMatches.length > 0 ||
+      finding.versions.length > 0,
   ).length;
 }
 
 function countInstallHistoryEvidence(report) {
-  return report.shellHistoryFindings.filter((finding) => finding.installCommands.length > 0).length;
+  // Same logic: only count install lines that explicitly reference a
+  // compromised version OR carry an IOC pattern. Bare install/uninstall
+  // commands on tracked package names are ambient noise.
+  return report.shellHistoryFindings.filter(
+    (finding) => finding.versions.length > 0 || finding.iocMatches.length > 0,
+  ).length;
 }
 
+// Strong temp-artifact evidence = actual malware bytes / IOC strings /
+// env-compat artifact. Pure `executionCommands` (package-name execute
+// pattern) in a text file (log, audit json, registry) is NOT compromise —
+// dev tooling routinely writes package names into /tmp during tests.
 function countStrongTempEvidence(report) {
   return report.tempArtifactFindings.filter(
     (finding) =>
       finding.iocMatches.length > 0 ||
-      finding.executionCommands.length > 0 ||
       finding.knownMalwareHash ||
       finding.nameMatches.some((value) => /env-compat\.(?:cjs|js)/i.test(value)),
   ).length;

--- a/scripts/sec-scan.cjs
+++ b/scripts/sec-scan.cjs
@@ -2336,15 +2336,9 @@ function scanShellHistories(homes, report) {
       // history. Pure `executionCommands`/`installCommands` name-match is
       // ambient noise (triggered every time the user runs the scanner).
       const hasHardEvidence =
-        finding.networkCommands.length > 0 ||
-        finding.iocMatches.length > 0 ||
-        finding.versions.length > 0;
+        finding.networkCommands.length > 0 || finding.iocMatches.length > 0 || finding.versions.length > 0;
 
-      const exposure = hasHardEvidence
-        ? 'execution'
-        : finding.executionCommands.length > 0 || finding.installCommands.length > 0
-          ? 'reference'
-          : 'reference';
+      const exposure = hasHardEvidence ? 'execution' : 'reference';
 
       report.shellHistoryFindings.push({
         kind: 'shell-history',
@@ -2359,8 +2353,8 @@ function scanShellHistories(homes, report) {
         category: 'shell-history',
         severity: hasHardEvidence ? 'compromised' : 'observed',
         summary: hasHardEvidence
-          ? `shell history shows execution evidence for suspicious package activity`
-          : `shell history references tracked package name (clean or unversioned) — informational`,
+          ? 'shell history shows execution evidence for suspicious package activity'
+          : 'shell history references tracked package name (clean or unversioned) — informational',
         path: finding.path,
       });
     }
@@ -2865,7 +2859,11 @@ function scanLiveProcesses(report) {
     if (String(pid) === String(process.pid)) continue;
     if (String(pid) === String(process.ppid)) continue;
     if (command.includes('sec-scan.cjs') || command.includes('/sec-scan ')) continue;
-    if (/\bgenie\s+sec\s+(scan|remediate|restore|rollback|verify-install|quarantine|print-cleanup-commands)\b/.test(command)) {
+    if (
+      /\bgenie\s+sec\s+(scan|remediate|restore|rollback|verify-install|quarantine|print-cleanup-commands)\b/.test(
+        command,
+      )
+    ) {
       continue;
     }
 
@@ -2931,10 +2929,7 @@ function countStrongProfileEvidence(report) {
 // activity (`npm uninstall -g @automagik/genie`) triggers them.
 function countExecutionHistoryEvidence(report) {
   return report.shellHistoryFindings.filter(
-    (finding) =>
-      finding.networkCommands.length > 0 ||
-      finding.iocMatches.length > 0 ||
-      finding.versions.length > 0,
+    (finding) => finding.networkCommands.length > 0 || finding.iocMatches.length > 0 || finding.versions.length > 0,
   ).length;
 }
 
@@ -2942,9 +2937,8 @@ function countInstallHistoryEvidence(report) {
   // Same logic: only count install lines that explicitly reference a
   // compromised version OR carry an IOC pattern. Bare install/uninstall
   // commands on tracked package names are ambient noise.
-  return report.shellHistoryFindings.filter(
-    (finding) => finding.versions.length > 0 || finding.iocMatches.length > 0,
-  ).length;
+  return report.shellHistoryFindings.filter((finding) => finding.versions.length > 0 || finding.iocMatches.length > 0)
+    .length;
 }
 
 // Strong temp-artifact evidence = actual malware bytes / IOC strings /


### PR DESCRIPTION
## Problem — 4 self-reference loops inflate suspicion on clean hosts

Follow-up to #1376. After eliminating the install-findings + live-process self-detection, Felipe's re-scan on a clean Mac still showed \`LIKELY COMPROMISED 30/100\`. Tracing the remaining score to source:

| Bug | Source | Scale on Felipe's Mac |
|---|---|---|
| **#4** shell-history exec/install match | Every \`npx @automagik/genie\` run writes to .zsh_history → matches \`exec:@automagik/genie\` / \`install:@automagik/genie\` regex | 1 finding, \`exposure='execution'\` → compromise severity |
| **#5** npm log hits | Every \`npx\` invocation creates \`~/.npm/_logs/*-debug-N.log\` → matches \`install:@automagik/genie\` | 6 findings on his Mac, all from today's scans |
| **#6** live-process bash wrapper | \`bash -c "… npx genie sec scan …"\` has \`exec:@automagik/genie\` in its own cmdline | 1 finding (wrapping shell) |
| **#7** temp-artifact name-match | Dev tooling writes package names into \`/tmp\` (test logs, audit JSON, registry dumps) → \`executionCommands\` match on plain text files | 4 findings on this host |

All four are the same class of bug: the scanner's IOC regex patterns match legitimate ambient text that exists precisely because the user just ran the scanner.

## Fix

### Bug #4 — `countExecutionHistoryEvidence` / `countInstallHistoryEvidence`
Hard evidence in shell history now requires \`networkCommands\` (curl/wget to exfil host), \`iocMatches\` (raw IOC string), or \`versions\` (explicit compromised-version string). Bare name-matches (\`exec:@automagik/genie\`, \`install:@automagik/genie\`) downgrade to \`exposure: 'reference'\` + \`severity: 'observed'\`, no suspicion contribution.

### Bug #5 — `scanNpmLogs`
Push to \`npmLogHits\` now requires \`versions.length > 0\` (actual compromised-version string in log body) OR \`iocMatches.length > 0\` (IOC network pattern). Name-only install/exec entries dropped entirely.

### Bug #6 — `scanLiveProcesses`
Self-exclusion expanded: skip \`pid === process.pid || pid === process.ppid\`, AND skip any cmdline matching \`/\\bgenie\\s+sec\\s+(scan|remediate|restore|rollback|verify-install|quarantine|print-cleanup-commands)\\b/\`. Catches the bash wrapper around \`npx\`.

### Bug #7 — \`countStrongTempEvidence\`
Predicate now requires \`iocMatches\` OR \`knownMalwareHash\` OR \`env-compat\` nameMatch. Bare \`executionCommands\` on \`.log\` / \`.json\` / \`.err\` files in /tmp no longer triggers 'strong' evidence.

## Verification

Run on this host (/home/genie with clean 4.260423.10 genie installed + running):

| Stage | Score | Status | Noise sources |
|---|---|---|---|
| Before #1376 | 100/100 | LIKELY COMPROMISED | installFindings self-flagged + live-procs self-flagged + shell history + npm logs |
| After #1376 | 48/100 | LIKELY COMPROMISED | shell history + npm logs + bash wrapper |
| **After this PR** | **28/100** | LIKELY COMPROMISED\* | \*only driven by real historical evidence: \`/tmp/automagik-genie-registry.json\` has env-compat IOC + compromised versions listed |

Counts before/after:
- \`shellHistoryFindings\`: 1 execution → 1 reference (no longer counts)
- \`npmLogHits\`: 8 → 2 (both have real compromised version in log body)
- \`liveProcessFindings\`: 6+ (all flagging self) → 3 \`[observed]\` (no compromise severity)
- \`tempArtifactFindings\`: 4 (all counted) → 4 reported, 1 counts (the one with real IOC)

On a TRULY clean host (no genie history, no compromised lockfiles), this should produce \`0 findings\` / \`NO FINDINGS\` status.

## Tests

\`bun test scripts/sec-scan.test.ts\`: **56/56 pass**.

## Remaining noise (for future wish)

Lockfiles referencing compromised versions (\`lockfileFindings: 28\` on dev machines) are real historical signal but create a cluttered report. Consider grouping lockfile findings by repo with a per-repo \"resolved\" marker when the user regenerates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)