### PR TITLE
fix(sec-scan): weak temp findings no longer elevate status

### DIFF
--- a/scripts/sec-scan.cjs
+++ b/scripts/sec-scan.cjs
@@ -3023,9 +3023,14 @@ function summarize(report) {
   if (installHistoryEvidence > 0) {
     affectedReasons.push('shell history shows package installation commands');
   }
-  if (report.tempArtifactFindings.length > 0 && strongTempEvidence === 0) {
-    affectedReasons.push('temp or cache directories retain suspicious tarball or package references');
-  }
+  // Weak temp findings (name-only matches on /tmp text files like Claude
+  // session logs and bun task-output dumps) are NOT affected-grade evidence
+  // — they're just text files that happen to contain the string "pgserve"
+  // or "@automagik/genie". They still appear in the report for transparency
+  // but must not elevate status from OBSERVED ONLY to LIKELY AFFECTED.
+  // Only `strongTempEvidence` (IOC string, malware hash, env-compat name)
+  // pushes a compromise/affected reason, via the `compromiseReasons` branch
+  // above.
 
   const likelyCompromised = compromiseReasons.length > 0;
   const likelyAffected =


### PR DESCRIPTION
## Observed on Hapvida VPS scan

Felipe ran \`genie sec scan --all-homes --redact\` on Hapvida VPS with \`@automagik/genie@next\` 4.260424.12. Result:

\`\`\`
Status: LIKELY AFFECTED
Suspicion score: 2/100

Affected reasons:
- temp or cache directories retain suspicious tarball or package references

temp and cache artifact findings:
- /tmp/r_session.jsonl                              ← Claude Code session JSONL
  matches: package=package:pgserve
- /tmp/claude-1000/.../bgqq4016b.output             ← bun task-output log
  matches: package=package:pgserve
  snippets: "Starting pgserve...", "pgserve failed to start"
\`\`\`

Both temp findings are **text files with the literal string 'pgserve'** in their content. No IOC, no malware hash, no env-compat nameMatch. Pure noise from Felipe's own dev tooling.

Real evidence on the VPS lives in \`lockfileFindings\` + \`npmLogHits\` which ALONE should classify as \`OBSERVED ONLY\`. But a single \`affectedReasons\` push — from weak temp findings — was elevating status to \`LIKELY AFFECTED\`.

## Root cause

\`scripts/sec-scan.cjs:3026\`:

\`\`\`js
if (report.tempArtifactFindings.length > 0 && strongTempEvidence === 0) {
    affectedReasons.push('temp or cache directories retain suspicious tarball or package references');
}
\`\`\`

This predicate fires **specifically when there are weak temp findings** (no IOC/hash/env-compat match). Since #1378 already demoted these from the scoring predicate via \`countStrongTempEvidence\`, this remaining \`affectedReasons\` push was inconsistent — the score treats them as noise, but status band treats them as evidence.

## Fix

Drop the weak-evidence \`affectedReasons.push\`. Weak temp findings still appear in the report output (transparency), but they no longer promote status classification. Strong temp evidence (\`strongTempEvidence > 0\`) continues to push \`compromiseReasons\` as before.

**Net effect:** hosts whose only \"affected\" signal was weak temp findings correctly drop from \`LIKELY AFFECTED\` → \`OBSERVED ONLY\`. Real affected-grade evidence (installFindings, npmTarballFetches, bunCacheFindings, install-history with versions) continues to classify as LIKELY AFFECTED.

## Verification

- \`bun test scripts/sec-scan.test.ts\`: **56/56 pass**
- Real-machine scan with genuine compromise evidence in /tmp still reports LIKELY COMPROMISED (strong temp evidence path still works)

## Expected Hapvida re-scan result after merge

\`\`\`
Status: OBSERVED ONLY           ← was LIKELY AFFECTED
Suspicion score: 2/100

Observed reasons (driven by real evidence):
- lockfile references compromised versions (omni-ui/bun.lock)
- npm log shows compromised version install from today

temp and cache artifact findings (informational):
- /tmp/r_session.jsonl
- /tmp/claude-1000/.../bgqq4016b.output
\`\`\`

Partners can now trust the status band: \`OBSERVED ONLY\` means "historical contamination, regenerate affected lockfiles + purge caches" not "act immediately".

🤖 Generated with [Claude Code](https://claude.com/claude-code)