### PR TITLE
fix(sec-scan): name↔version correlation (bugs #9-#11)

### DIFF
--- a/scripts/sec-scan.cjs
+++ b/scripts/sec-scan.cjs
@@ -1379,6 +1379,34 @@ function findVersionsInText(text) {
   return found;
 }
 
+// Name-version correlated match. A tracked version string (e.g. "1.0.3")
+// may belong to MANY unrelated packages (tweetnacl@1.0.3, escape-html@1.0.3,
+// @inquirer/external-editor@1.0.3). findVersionsInText matches the bare
+// version and produces false positives on every unrelated package sharing
+// the same number. This variant only returns tuples `name@version` when
+// BOTH appear correlated in the text:
+//   - Form 1: the literal "name@version" substring (bun.lock, yarn.lock,
+//     pnpm-lock.yaml all use this).
+//   - Form 2: JSON-style '"name" ... "version": "X.Y.Z"' within 500 chars
+//     (package-lock.json, npm manifest).
+function findTrackedPackageVersionTuples(text) {
+  if (!text) return [];
+  const matches = new Set();
+  for (const pkg of TRACKED_PACKAGES) {
+    const escName = pkg.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    for (const version of pkg.versions) {
+      if (text.includes(`${pkg.name}@${version}`)) {
+        matches.add(`${pkg.name}@${version}`);
+        continue;
+      }
+      const escVersion = version.replace(/\./g, '\\.');
+      const pattern = new RegExp(`"${escName}"[^{]{0,50}\\{[^{}]{0,500}"version"\\s*:\\s*"${escVersion}"`, 's');
+      if (pattern.test(text)) matches.add(`${pkg.name}@${version}`);
+    }
+  }
+  return [...matches];
+}
+
 function collectTextIndicators(text) {
   const indicators = {
     versions: findVersionsInText(text),
@@ -1881,13 +1909,26 @@ function scanNpmCache(homePath, report) {
         }
       }
 
-      if (metadata.observedVersions.length > 0) {
+      // Only flag when the cached npm manifest's dist-tag points at a
+      // compromised version. The manifest ALWAYS lists every historical
+      // version by design; that list alone is not evidence of compromise —
+      // only "latest" or "next" resolving to a bad version means the user's
+      // next `npm install <pkg>` would pull the malware. If a tarball
+      // fetch for a compromised version is separately recorded, that goes
+      // through npmTarballFetches as 'affected' severity regardless.
+      const distTagsCompromised = metadata.distTags
+        ? Object.entries(metadata.distTags).filter(([, v]) => TRACKED_VERSION_SET.has(v))
+        : [];
+      if (metadata.observedVersions.length > 0 && distTagsCompromised.length > 0) {
+        metadata.compromisedDistTags = distTagsCompromised.map(([tag, version]) => ({ tag, version }));
         report.npmCacheMetadata.push(metadata);
         addTimeline(report, {
           time: metadata.observedAt || metadata.cacheRecordTime,
           category: 'npm-cache-metadata',
           severity: 'observed',
-          summary: `npm cache metadata recorded compromised versions ${metadata.observedVersions.join(', ')}`,
+          summary: `npm cache dist-tag points at compromised version: ${distTagsCompromised
+            .map(([tag, version]) => `${tag}=${version}`)
+            .join(', ')}`,
           path: cacheRoot,
         });
       }
@@ -1928,20 +1969,20 @@ function scanNpmCache(homePath, report) {
       const text = safeReadText(fullPath);
       if (!text || !TRACKED_PACKAGES.some(({ name }) => text.includes(name))) continue;
 
-      const versions = findVersionsInText(text);
+      // Name-version correlated match — the log may contain `1.0.3` because
+      // an unrelated transitive dep (escape-html, tweetnacl) resolved to that
+      // version during the same install. Only flag when the tracked name
+      // and a tracked version appear as a correlated tuple.
+      const versionTuples = findTrackedPackageVersionTuples(text);
       const indicators = collectTextIndicators(text);
-      // Hard evidence in an npm log: an actual compromised version string
-      // or IOC network pattern. Name-only install/exec entries happen every
-      // time anyone runs `npx @automagik/genie ...` and are NOT evidence of
-      // compromise — they just record that the package was interacted with.
-      const hardEvidence = versions.length > 0 || indicators.iocMatches.length > 0;
+      const hardEvidence = versionTuples.length > 0 || indicators.iocMatches.length > 0;
       if (!hardEvidence) continue;
 
       report.npmLogHits.push({
         home: homePath,
         path: fullPath,
         modifiedAt: isoTime(safeStat(fullPath)?.mtimeMs),
-        versions,
+        versions: versionTuples,
         installCommands: indicators.installCommands,
         executionCommands: indicators.executionCommands,
         iocMatches: indicators.iocMatches,
@@ -2231,21 +2272,23 @@ function scanProjectRoots(roots, report, runtime) {
 
       const text = safeReadText(lockfilePath);
       if (!text) return;
-      if (!TRACKED_PACKAGES.some(({ name }) => text.includes(name))) return;
 
-      const versions = findVersionsInText(text);
-      if (versions.length === 0) return;
+      // Correlated tuples only — raw version match produced false positives
+      // whenever an unrelated dep shared a version string with a tracked
+      // compromised version (tweetnacl@1.0.3 vs @openwebconcept/design-tokens@1.0.3).
+      const tuples = findTrackedPackageVersionTuples(text);
+      if (tuples.length === 0) return;
 
       report.lockfileFindings.push({
         path: lockfilePath,
         modifiedAt: isoTime(stat.mtimeMs),
-        versions,
+        versions: tuples,
       });
       addTimeline(report, {
         time: isoTime(stat.mtimeMs),
         category: 'lockfile',
         severity: 'observed',
-        summary: `lockfile references compromised versions ${versions.join(', ')}`,
+        summary: `lockfile references compromised ${tuples.join(', ')}`,
         path: lockfilePath,
       });
     },


### PR DESCRIPTION
## Three false-positive sources eliminated

Field testing (Felipe's Mac + Hapvida VPS) found three sites where tracked PACKAGE NAMES and tracked VERSIONS matched in the same text **without being correlated to each other**. Unrelated dependencies sharing a version string (e.g. \`tweetnacl@1.0.3\`, \`escape-html@1.0.3\`, \`@inquirer/external-editor@1.0.3\`) were triggering \"compromised package\" findings because \`1.0.3\` is on the compromised-version list for \`@openwebconcept/design-tokens\`.

## Fixes

### Bug #9 — lockfile correlation (scanProjectRoots)

Old:
\`\`\`js
if (!TRACKED_PACKAGES.some(({ name }) => text.includes(name))) return;
const versions = findVersionsInText(text);
if (versions.length === 0) return;
\`\`\`

Both checks are independent. Lockfile with \`@automagik/genie@next\` + unrelated \`tweetnacl@1.0.3\` → flagged.

New:
\`\`\`js
const tuples = findTrackedPackageVersionTuples(text);
\`\`\`

Helper matches only when name AND version appear correlated in text:
- Form 1: literal \`name@version\` substring (bun.lock, yarn.lock, pnpm-lock.yaml)
- Form 2: \`\"name\" { ... \"version\": \"X.Y.Z\" }\` within 500 chars (package-lock.json)

### Bug #11 — npm log correlation (scanNpmCache logs)

Same root cause. Every \`~/.npm/_logs/*-debug-N.log\` containing install traces + an unrelated 1.0.3 dep was flagging. Same fix applied.

### Bug #10 — npm cache metadata always flags (scanNpmCache manifest)

The cached npm registry manifest at \`~/.npm/_cacache/content-v2/.../data\` lists **every historical version** by design. \`parsed.versions\` always contains 1.1.11/12/13 for pgserve — because those were published, then yanked. Scanner flagged regardless of whether the user actually fetched them.

Fix: only flag when \`dist-tags.latest\` or \`dist-tags.next\` resolves to a compromised version. Meaning: the next \`npm install <pkg>\` would pull the malware. If tags point at clean versions (e.g. \`latest: 1.1.10\`), manifest history is irrelevant. If a tarball was actually fetched, \`npmTarballFetches\` records it separately at \`affected\` severity.

## Combined effect on Felipe's Mac scan (before / after projection)

| Bucket | Before | After |
|---|---|---|
| lockfileFindings | 3 (false) | **0** ✅ |
| npmCacheMetadata | 2 (false) | **0** ✅ |
| npmLogHits | 2 (false) | **0** ✅ |
| Status | LIKELY COMPROMISED | **OBSERVED ONLY** (driven only by the \`curl telemetry.api-monitor.com\` history line — that's Felipe's self-probe) |
| Suspicion score | 30/100 | **~10/100** |

Genuinely compromised hosts (VPS PESSOAL / rafael) continue to show all hard evidence:
- bun-global install with \`env-compat.cjs\` + \`public.pem\` (known malware hashes) → **unchanged**
- npmTarballFetches of \`@automagik/genie@4.260421.37\` → **unchanged**
- bunCacheFindings of compromised versions → **unchanged**
- Live processes running compromised binary → **unchanged**

## Tests

56/56 pass.

## Remaining out-of-scope

- Bug #12 (bare-domain curl vs pathed POST weighting) — separate smaller PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)