### PR TITLE
fix(test-runbook): delete scan-1 output + scope scan-2 out-of-/tmp

### DIFF
--- a/scripts/test-runbook.sh
+++ b/scripts/test-runbook.sh
@@ -436,7 +436,7 @@ fi
 # Step 1: scan — expect findings (the cache entries match compromised versions).
 scan_out="${TMP_DIR}/scan-1.json"
 set +e
-timeout 600 "${BUN_BIN}" "${SCAN_SCRIPT}" --json --home "${SANDBOX_HOME}" --root "${SANDBOX_HOME}" > "${scan_out}" 2>&1
+timeout 600 "${BUN_BIN}" "${SCAN_SCRIPT}" --json --no-progress --home "${SANDBOX_HOME}" --root "${SANDBOX_HOME}" > "${scan_out}" 2>"${scan_out}.stderr.log"
 scan_exit=$?
 set -e
 if [ ! -s "${scan_out}" ]; then
@@ -475,11 +475,26 @@ for v in 11 12 13 14; do
 done
 ok "purged compromised cache entries"
 
+# Step 2b: remove every intermediate scan JSON under TMP_DIR. TMP_DIR lives
+# at /tmp/runbook-test.XXX (via mktemp), and the scanner walks /tmp as a
+# hardcoded temp root. scan-1.json AND scan-1-findings.json (the jq slice
+# from step 1) both contain compromised version strings inside their
+# findings arrays — if we leave them on disk, the re-scan walks them and
+# pushes their contents back into tempArtifactFindings, causing a
+# scan-of-its-own-prior-output loop.
+rm -f "${scan_out}" "${findings_slice_initial}"
+
+# Redirect scan-2 output into the sandbox (not /tmp) so the re-scan doesn't
+# walk itself either. Belt-and-suspenders in case someone wraps the test to
+# re-run Phase 4.
+SCAN2_DIR="${SANDBOX_HOME}/.runbook-test-scratch"
+mkdir -p "${SCAN2_DIR}"
+
 # Step 3: re-scan — should now show no compromised-version references within the
 # sandbox scope.
-scan2_out="${TMP_DIR}/scan-2.json"
+scan2_out="${SCAN2_DIR}/scan-2.json"
 set +e
-timeout 600 "${BUN_BIN}" "${SCAN_SCRIPT}" --json --home "${SANDBOX_HOME}" --root "${SANDBOX_HOME}" > "${scan2_out}" 2>&1
+timeout 600 "${BUN_BIN}" "${SCAN_SCRIPT}" --json --no-progress --home "${SANDBOX_HOME}" --root "${SANDBOX_HOME}" > "${scan2_out}" 2>"${scan2_out}.stderr.log"
 set -e
 if [ ! -s "${scan2_out}" ]; then
   err "re-scan produced no output"
@@ -524,6 +539,13 @@ fi
 
 if grep -qE '4\.260421\.(3[3-9]|40)|pgserve@1\.1\.1[1-4]' "${findings_slice}"; then
   err "re-scan still references compromised versions — purge did not cover the sandbox layout"
+  # Emit debug context so CI logs show WHERE the leak is.
+  log "debug: first 5 matches from findings slice:"
+  grep -E --color=never -B1 -A2 '4\.260421\.(3[3-9]|40)|pgserve@1\.1\.1[1-4]' "${findings_slice}" | head -40 >&2 || true
+  log "debug: listing of SANDBOX_HOME (top 40 entries):"
+  find "${SANDBOX_HOME}" -maxdepth 4 -printf '%p\n' 2>/dev/null | head -40 >&2 || true
+  log "debug: listing of /tmp (top 20 entries):"
+  find /tmp -maxdepth 2 -printf '%p\n' 2>/dev/null | head -20 >&2 || true
   exit 2
 fi
 ok "re-scan shows no residual compromised-version references"


### PR DESCRIPTION
## Why PR #1379's slice fix alone wasn't enough

PR #1379 correctly scoped the grep to the scan output's findings arrays only, skipping the envelope's \`trackedPackages\` header. But CI still failed.

**Root cause I missed:** \`scan_out = \${TMP_DIR}/scan-1.json\` where \`TMP_DIR = mktemp -d -t runbook-test.XXX\` → that's under \`/tmp\`. The scanner walks \`/tmp\` as a hardcoded temp root. So the RE-SCAN walks \`scan-1.json\`, reads its JSON body (which **does** contain compromised version strings inside the findings arrays from the initial scan), and pushes them into \`scan-2.json\`'s \`tempArtifactFindings\`. The grep on \`scan-2\`'s findings slice then hits those strings.

It's a scan-of-its-own-output loop.

## Fix

Two-part:

1. **\`rm -f \$scan_out\`** after the purge step, before re-scanning. The LIKELY AFFECTED recipe is \"purge compromised cache entries\" — the scanner's own intermediate JSON isn't a cache entry the recipe is responsible for. Removing it lets the re-scan see a clean filesystem.

2. **Redirect \`scan2_out\` into \`\$SANDBOX_HOME/.runbook-test-scratch\`** instead of \`\$TMP_DIR\`. Belt-and-suspenders so even if the test gets wrapped and re-executes Phase 4, the scan output files never pollute the scanner's walk roots.

## Expected

CI's Cold-runbook replay goes green for the first time since the test shipped. Once merged, #1380 and #1381 can re-run against the fixed dev and both should pass cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)