### PR TITLE
docs(sec): apply reviewer round-2 fixes — deprecation mechanism + ack boundary + cadence SLA

### DIFF
--- a/.genie/wishes/sec-scan-av-ui/WISH.md
+++ b/.genie/wishes/sec-scan-av-ui/WISH.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | DRAFT (reviewer FIX-FIRST round 1 applied 2026-04-24) |
+| **Status** | DRAFT (reviewer round-1 FIX-FIRST + round-2 MEDIUM-gap fix applied 2026-04-24) |
 | **Slug** | `sec-scan-av-ui` |
 | **Date** | 2026-04-24 |
 | **Author** | Genie + Felipe (post-hotfix observation) |
@@ -92,7 +92,7 @@ This wish fixes both: ships a **real-time AV-grade progress UI** (sticky one-lin
 
 - **Deployment strategy (back-compat for band shift)** — The new bands (`CLEAN<20`, `OBSERVED 20-49`, `AFFECTED 50-79`, `COMPROMISED≥80`) change the user-facing verdict for hosts that previously scored 20-79 under the old bands (`CLEAN<50`, `AFFECTED 50-79`, `COMPROMISED≥80`). Automation keying off `summary.status == "CLEAN"` or `suspicionScore < 50` WILL start reporting differently. Three-release deprecation plan:
   1. **Release N (this wish):** JSON envelope emits BOTH `summary.status_v1` (old band) and `summary.status_v2` (new band). `summary.status` alias defaults to v2. Document the v1 alias in the runbook + release notes. Operators using old thresholds read `status_v1` during transition. Bump `reportVersion` to `1.1` (minor — additive).
-  2. **Release N+1 (1 minor later):** deprecation warning on stderr when any consumer reads `status_v1` via the `summary.status_v1_reads` counter (scanner emits on JSON stringify when the key is accessed through a documented `GENIE_SEC_V1_READ` sentinel).
+  2. **Release N+1 (1 minor later):** deprecation warning on stderr — fires AT MOST ONCE per scan invocation when `summary.status_v1` has been read. Implementation: the scanner constructs the JSON envelope with `summary` as a tracked object — a thin `Object.defineProperty(summary, 'status_v1', { get })` that, on first access, flips a `v1_was_read` flag (no re-fire on subsequent reads of the same scan). At end-of-scan, if `v1_was_read`, write a single line to stderr: `⚠ summary.status_v1 is deprecated (will be removed in release N+2 = <version>). Switch automation to summary.status (v2) or summary.status_v2. See docs/sec-scan/verdict-bands-migration.md.` Operators see the warning once per scan, not per access. Snapshot test locks the warning text + single-emit behaviour.
   3. **Release N+2 (2 minors later):** drop `status_v1` from JSON output. Bump `reportVersion` to `2`.
   - Snapshot tests lock both `status_v1` and `status_v2` output for every verdict fixture for Release N.
   - Documented in `docs/sec-scan/verdict-bands-migration.md` (created in this wish).

--- a/.genie/wishes/sec-signature-registry/WISH.md
+++ b/.genie/wishes/sec-signature-registry/WISH.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | DRAFT (reviewer FIX-FIRST round 1 applied 2026-04-24) |
+| **Status** | DRAFT (reviewer round-1 FIX-FIRST + round-2 MEDIUM/HIGH-gap fixes applied 2026-04-24) |
 | **Slug** | `sec-signature-registry` |
 | **Date** | 2026-04-24 |
 | **Author** | Felipe + Genie (product-vision distillation) |
@@ -193,10 +193,26 @@ Pack validation: JSON Schema file `.genie/schemas/signature-pack-v1.schema.json`
 - Bundled-inside pack is updated via `renovate` / manual PR when a new incident crystallizes; emergency updates bump patch version of `@automagik/genie-signatures` and operators get them via `genie sec signatures update`.
 - `npm install @automagik/genie` NEVER fails because of a signatures-package issue — bundled pack guarantees scanner is operational at install time.
 
+**Operational cadence contract (explicit):**
+- **Bundled pack is a FALLBACK FLOOR, not the primary delivery channel.** It updates only when `@automagik/genie` itself releases (cadence: weekly-to-monthly). For minute-to-hour incident response, operators MUST run `genie sec signatures update` on a regular schedule.
+- **Recommended SLA for `signatures update`:**
+  - Production / CI runners: cron every hour
+  - Development workstations: cron daily OR on-shell-startup
+  - Air-gapped environments: pull tarball + `signatures add --from-tarball` on the air-gap network's sync cadence
+- **Stale-pack banner** — scanner emits a loud stderr banner on every scan when any loaded pack's `reported` date is > 90 days old AND a newer version of `@automagik/genie-signatures` is available via `npm view`:
+  ```
+  ⚠ Signature packs are stale — oldest is <date> (<N> days). Run `genie sec signatures update`.
+  ⚠ Newer @automagik/genie-signatures@<version> is available (installed: <current>).
+  ```
+  The banner is suppressible via `GENIE_SEC_SCAN_SUPPRESS_STALE_BANNER=1` for CI / read-only environments; suppression logged to audit.
+- **Release coordination:** when a critical incident requires urgent signature delivery, Namastex security team publishes `@automagik/genie-signatures@<patch>` within 1 hour of signature approval; operators on the recommended update cadence receive it within their next scheduled run; operators on a looser cadence get the stale-pack banner.
+- Runbook (`docs/incident-response/canisterworm.md`, owned by `sec-incident-runbook` wish — already merged) MUST add a "signature update cadence" section referencing this contract. That update is in scope for this wish (modifies the existing runbook, not creates a new one).
+
 **G. Community contribution pathway (hardened trust model)**
 
 - **Reserved pack IDs** — canonical Namastex pack IDs (`canisterworm-*`, `teampcp-*`, `shai-hulud-*`, and any future namespace prefix matching the pattern `<incident-name>-<YYYY>-<MM>`) are RESERVED. Community packs must use a distinct namespace (e.g. `community-<contributor-handle>-<description>-<YYYY>-<MM>`). Loader refuses to register a community pack that collides with a reserved ID AND emits a loud error pointing to the documented reserved-ID list at `docs/sec-signatures/reserved-ids.md`.
-- **Per-install ack (never cached)** — `genie sec signatures add https://example.com/my-incident.yaml` prompts typed ack `I_ACKNOWLEDGE_UNVERIFIED_SIGNATURE_PACK_<random-6-hex>`. The hex suffix is fresh per invocation and logged to audit. Operators CANNOT save a blanket "trust unverified packs" preference; the ack prompt fires on every `add` call. Design decision: prevents muscle-memory drift where the typed ack becomes reflex.
+- **Per-install ack (never cached)** — `genie sec signatures add https://example.com/my-incident.yaml` prompts typed ack `I_ACKNOWLEDGE_UNVERIFIED_SIGNATURE_PACK_<random-6-hex>`. The hex suffix is fresh per invocation and logged to audit. Operators CANNOT save a blanket "trust unverified packs" preference; the ack prompt fires on every `add` call.
+  - **Threat-model boundary (explicit):** this mechanism prevents *reflexive* trust — an operator muscle-memorizing a fixed ack string and typing it without thinking. It does NOT prevent a determined adversary who scripts the ack (`echo "I_ACKNOWLEDGE_..._$(hex-gen)" | genie sec signatures add`). For determined-adversary threat models you need rate limiting, TOTP-style challenges, or an out-of-band approval channel — all explicitly out of scope for this wish. The contract we provide: a forced pause + fresh-hex prompt that breaks the muscle-memory loop of "type the same string you typed last time". Operators who bypass this with a shell alias have affirmatively decided to trust their automation.
 - **Verified-vs-unverified flag** — `genie sec signatures list` shows a `verified: true|false` column per pack, with "verified" meaning cosign-verified against the pinned Namastex identity. Unverified packs get a prominent `⚠ unverified — community pack, not reviewed by Namastex` banner in scan output whenever they produce a finding.
 - **Namastex review gate for upstream contributions** — community members wanting their pack canonicalized open a PR against `automagik-dev/genie-signatures`. PR review MUST check every item in CONTRIBUTING.md (see Group 7). Namastex security team approval required to merge; CI alone cannot self-merge community signature PRs.
 - **Community pack removal path** — if a community pack produces widespread false positives, operators can `genie sec signatures remove <id>` to drop it; `genie sec signatures blocklist add <id>` pins an anti-entry so subsequent `signatures add` of the same pack-id requires a fresh double typed ack.


### PR DESCRIPTION
Round-2 review verified all 10 round-1 gaps fixed; 3 new specification gaps surfaced and applied here.

## sec-scan-av-ui (1 MEDIUM)
- [M] status_v1_reads sentinel mechanism → replaced vague text with concrete Object.defineProperty getter + v1_was_read flag + single stderr warning at end-of-scan (not per-access). Snapshot test locks warning text + single-emit.

## sec-signature-registry (1 MEDIUM + 1 HIGH)
- [M] Ack threat-model boundary → documented boundary explicitly: prevents reflexive trust (muscle memory) NOT determined adversaries (who can script the ack). Honest about what the mechanism does and doesn't provide.
- [H] Bundled-pack cadence risk → added 'Operational cadence contract' section: bundled pack is FALLBACK FLOOR; recommended update SLA (cron hourly prod / daily workstation); stale-pack banner + GENIE_SEC_SCAN_SUPPRESS_STALE_BANNER escape hatch; Namastex 1-hour release SLA for critical incidents; runbook update in scope.

## Status
Both wishes now at 'DRAFT (reviewer round-1 FIX-FIRST + round-2 gap fixes applied 2026-04-24)'. Round 3 review recommended before promotion to APPROVED.

🤖 Generated with Claude Code