### PR TITLE
fix(sec-scan): distinguish exfil-path curl from bare-domain probe

### DIFF
--- a/scripts/sec-scan.cjs
+++ b/scripts/sec-scan.cjs
@@ -364,9 +364,24 @@ const TEXT_MATCHERS = [
     regex: /\b(?:node|bun|bash|sh)\b[^\n]{0,200}env-compat\.(?:cjs|js)\b/i,
   },
   {
-    label: 'network:curl-wget IOC',
+    // Hard evidence: curl/wget/fetch to the exact exfil endpoint path.
+    // This is what the CanisterWorm payload uses to upload stolen data
+    // (POST /v1/telemetry and POST /v1/drop). Matching these = compromise.
+    label: 'network:curl-wget IOC-exfil',
     category: 'network',
-    regex: /\b(?:curl|wget|fetch|Invoke-WebRequest)\b[^\n]{0,200}(?:telemetry\.api-monitor\.com|raw\.icp0\.io\/drop)/i,
+    regex:
+      /\b(?:curl|wget|fetch|Invoke-WebRequest)\b[^\n]{0,200}(?:telemetry\.api-monitor\.com\/v1\/(?:telemetry|drop)|raw\.icp0\.io\/drop)/i,
+  },
+  {
+    // Soft evidence: bare-host mention of the exfil domain WITHOUT the
+    // /v1/ path. Almost always an incident responder (or documentation)
+    // probing the host, not the payload itself — the payload never runs
+    // a bare `curl <host>` because there's no endpoint that would accept
+    // the uploaded payload. Classify as 'probe' so it shows in the
+    // report but doesn't elevate the suspicion score.
+    label: 'network:exfil-host-probe',
+    category: 'probe',
+    regex: /\b(?:curl|wget|fetch|Invoke-WebRequest)\b[^\n]{0,200}telemetry\.api-monitor\.com(?!\/v1\/)/i,
   },
 ];
 
@@ -1415,6 +1430,7 @@ function collectTextIndicators(text) {
     installCommands: [],
     executionCommands: [],
     networkCommands: [],
+    probeMatches: [],
     allMatches: [],
   };
 
@@ -1427,6 +1443,11 @@ function collectTextIndicators(text) {
     if (matcher.category === 'install') indicators.installCommands.push(matcher.label);
     if (matcher.category === 'execution') indicators.executionCommands.push(matcher.label);
     if (matcher.category === 'network') indicators.networkCommands.push(matcher.label);
+    // `probe` is informational-only: it means the text references an
+    // exfil host but WITHOUT the attacker's uploading path. Almost
+    // always a responder probing or documentation. Never elevates
+    // compromise severity.
+    if (matcher.category === 'probe') indicators.probeMatches.push(matcher.label);
   }
 
   for (const trackedPackage of TRACKED_PACKAGES) {


### PR DESCRIPTION
## Observed on Felipe's host

Post-\`sec fix\` run showed residual \`LIKELY COMPROMISED 20/100\` with zero install/cache/tarball findings. The single source of the 20 points:

\`\`\`
~/.zsh_history:
  curl telemetry.api-monitor.com
\`\`\`

That line is Felipe hand-probing the IOC host during investigation, not the payload. Attacker exfil uses **POST to /v1/telemetry and /v1/drop** with AES-256-CBC-encrypted bodies + X-Session-ID/X-Request-Signature headers. A bare \`curl <host>\` has no endpoint that accepts an upload.

## Fix

Split the one network-IOC regex into two matchers:

| Category | Regex | Weight |
|---|---|---|
| \`network\` (compromise, +20 each) | matches exact exfil path \`/v1/telemetry\`, \`/v1/drop\`, \`raw.icp0.io/drop\` | unchanged |
| \`probe\` (informational, 0 weight) | matches bare \`telemetry.api-monitor.com\` without \`/v1/\` | **new** |

\`probeMatches\` is recorded as a separate field so the line is still visible in the scan output (transparency) but never feeds compromise severity or suspicion score.

## Effect

Felipe's curl-telemetry line drops +20 → 0. After \`sec fix\` on a clean-but-previously-compromised host:

\`\`\`
Before: Status: LIKELY COMPROMISED  score: 20/100
After:  Status: NO FINDINGS          score: 0/100   (or OBSERVED ONLY for historical cache residue)
\`\`\`

## Tests

56/56 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)