### PR TITLE
fix(resume): close 4 structural gaps from power-outage post-mortem

### DIFF
--- a/src/hooks/__tests__/session-sync.test.ts
+++ b/src/hooks/__tests__/session-sync.test.ts
@@ -84,13 +84,17 @@ describe('session-sync handler', () => {
     function installMocks(options: {
       executorId: string;
       currentSessionId: string | null;
+      executorState?: string | null;
       updates?: { id: string; sessionId: string }[];
       emissions?: Emission[];
     }) {
       const updates = options.updates ?? [];
       const emissions = options.emissions ?? [];
       _deps.getAgentByName = async () => ({ currentExecutorId: options.executorId });
-      _deps.getExecutor = async () => ({ claudeSessionId: options.currentSessionId });
+      _deps.getExecutor = async () => ({
+        claudeSessionId: options.currentSessionId,
+        state: options.executorState ?? 'running',
+      });
       _deps.updateClaudeSessionId = async (id, sid) => {
         updates.push({ id, sessionId: sid });
       };
@@ -163,6 +167,110 @@ describe('session-sync handler', () => {
 
       expect(updates).toHaveLength(0);
       expect(emissions).toHaveLength(0);
+    });
+
+    // ========================================================================
+    // Gap 5 (2026-04-25 power-outage post-mortem): when the executor is in a
+    // terminal state, its claude_session_id is a recovery anchor — overwriting
+    // it with a divergent live session destroys the only DB-side handle to
+    // the dormant session UUID. Regression tests below.
+    // ========================================================================
+
+    test('PRESERVES stored UUID when executor is terminated (recovery anchor)', async () => {
+      process.env.GENIE_AGENT_NAME = 'worker';
+      process.env.GENIE_TEAM = 'alpha';
+
+      const { updates, emissions } = installMocks({
+        executorId: 'exec-terminated',
+        currentSessionId: '9623de43-cf19-4350-a970-770ef6382e29', // dormant pre-crash session
+        executorState: 'terminated',
+      });
+
+      await sessionSync({
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        session_id: '8b9b674e-9063-4f84-aada-5925eb7db1f4', // live post-crash session
+      });
+
+      // The original session_id MUST survive untouched.
+      expect(updates).toHaveLength(0);
+      // session.divergence_preserved emitted instead of session.reconciled.
+      expect(emissions).toHaveLength(1);
+      expect(emissions[0]?.type).toBe('session.divergence_preserved');
+      expect(emissions[0]?.details.stored_session_id).toBe('9623de43-cf19-4350-a970-770ef6382e29');
+      expect(emissions[0]?.details.live_session_id).toBe('8b9b674e-9063-4f84-aada-5925eb7db1f4');
+      expect(emissions[0]?.details.executor_state).toBe('terminated');
+      expect(emissions[0]?.details.reason).toBe('terminal_executor_is_recovery_anchor');
+    });
+
+    test('PRESERVES stored UUID when executor is in error state', async () => {
+      process.env.GENIE_AGENT_NAME = 'worker';
+      process.env.GENIE_TEAM = 'alpha';
+
+      const { updates, emissions } = installMocks({
+        executorId: 'exec-error',
+        currentSessionId: 'dormant-uuid',
+        executorState: 'error',
+      });
+
+      await sessionSync({ hook_event_name: 'PreToolUse', tool_name: 'Bash', session_id: 'live-uuid' });
+
+      expect(updates).toHaveLength(0);
+      expect(emissions[0]?.type).toBe('session.divergence_preserved');
+      expect(emissions[0]?.details.executor_state).toBe('error');
+    });
+
+    test('PRESERVES stored UUID when executor is in done state', async () => {
+      process.env.GENIE_AGENT_NAME = 'worker';
+      process.env.GENIE_TEAM = 'alpha';
+
+      const { updates, emissions } = installMocks({
+        executorId: 'exec-done',
+        currentSessionId: 'dormant-uuid',
+        executorState: 'done',
+      });
+
+      await sessionSync({ hook_event_name: 'PreToolUse', tool_name: 'Bash', session_id: 'live-uuid' });
+
+      expect(updates).toHaveLength(0);
+      expect(emissions[0]?.type).toBe('session.divergence_preserved');
+    });
+
+    test('STILL overwrites when executor is in active state (UUID rotation, original purpose)', async () => {
+      process.env.GENIE_AGENT_NAME = 'worker';
+      process.env.GENIE_TEAM = 'alpha';
+
+      const { updates, emissions } = installMocks({
+        executorId: 'exec-running',
+        currentSessionId: 'pre-rotation-uuid',
+        executorState: 'running',
+      });
+
+      await sessionSync({ hook_event_name: 'PreToolUse', tool_name: 'Bash', session_id: 'post-rotation-uuid' });
+
+      // Active-state divergence is genuine UUID rotation — handler's original
+      // job. Overwrite + emit session.reconciled.
+      expect(updates).toEqual([{ id: 'exec-running', sessionId: 'post-rotation-uuid' }]);
+      expect(emissions[0]?.type).toBe('session.reconciled');
+    });
+
+    test('STILL writes on first capture when oldSessionId is null even if state is terminated', async () => {
+      // Edge case: terminal-state executor with no session yet (synthesized
+      // recovery row). First capture should still write — there's no
+      // pre-existing UUID to preserve, only NULL.
+      process.env.GENIE_AGENT_NAME = 'worker';
+      process.env.GENIE_TEAM = 'alpha';
+
+      const { updates, emissions } = installMocks({
+        executorId: 'exec-fresh-terminal',
+        currentSessionId: null,
+        executorState: 'terminated',
+      });
+
+      await sessionSync({ hook_event_name: 'PreToolUse', tool_name: 'Bash', session_id: 'first-uuid' });
+
+      expect(updates).toEqual([{ id: 'exec-fresh-terminal', sessionId: 'first-uuid' }]);
+      expect(emissions[0]?.type).toBe('session.reconciled');
     });
 
     test('does NOT re-emit on repeated invocations with the same UUID (process cache)', async () => {

--- a/src/hooks/handlers/session-sync.ts
+++ b/src/hooks/handlers/session-sync.ts
@@ -34,8 +34,11 @@ export function _resetSyncedSessions(): void {
   syncedSessions.clear();
 }
 
-type GetAgentByNameFn = (name: string, team: string) => Promise<{ currentExecutorId?: string | null } | null>;
-type GetExecutorFn = (id: string) => Promise<{ claudeSessionId?: string | null } | null>;
+type GetAgentByNameFn = (
+  name: string,
+  team: string,
+) => Promise<{ id?: string; currentExecutorId?: string | null } | null>;
+type GetExecutorFn = (id: string) => Promise<{ claudeSessionId?: string | null; state?: string | null } | null>;
 type UpdateClaudeSessionIdFn = (executorId: string, sessionId: string) => Promise<void>;
 type EmitAuditEventFn = (
   entityType: string,
@@ -92,6 +95,20 @@ function shouldSkipSync(payload: HookPayload): { sessionId: string; agentName: s
   return { sessionId, agentName, teamName };
 }
 
+/**
+ * Executor states that mean "this row is frozen" — reached the end of its
+ * lifecycle and is now a recovery anchor (the session UUID it stores is what
+ * `claude --resume <uuid>` will replay). When session-sync sees the current
+ * executor in one of these states AND the live `payload.session_id` differs
+ * from what the row already holds, it MUST NOT overwrite — that destroys the
+ * recovery anchor. This is the single bug that ate the genie/genie session
+ * during the 2026-04-25 power-outage recovery: a manual re-link to a
+ * terminated executor (holding the dormant UUID) was silently overwritten by
+ * the next session-sync fire in the live process, replacing the dormant UUID
+ * with the live one and orphaning the recovery anchor.
+ */
+const TERMINAL_EXECUTOR_STATES = new Set(['done', 'error', 'terminated']);
+
 export async function sessionSync(payload: HookPayload): Promise<HandlerResult> {
   try {
     const ctx = shouldSkipSync(payload);
@@ -107,14 +124,41 @@ export async function sessionSync(payload: HookPayload): Promise<HandlerResult> 
     if (!executor) return;
 
     const oldSessionId = executor.claudeSessionId ?? null;
-    if (oldSessionId !== ctx.sessionId) {
-      await deps.updateClaudeSessionId(executorId, ctx.sessionId);
-      await deps.emitAuditEvent('executor', executorId, 'session.reconciled', ctx.agentName, {
-        old_session_id: oldSessionId,
-        new_session_id: ctx.sessionId,
-        team: ctx.teamName,
-      });
+    if (oldSessionId === ctx.sessionId) {
+      syncedSessions.set(executorId, ctx.sessionId);
+      return;
     }
+
+    // Divergence detected. Two cases:
+    //   1. First capture (oldSessionId === null) → write live session_id.
+    //   2. Rotation while executor is still active (Claude Code rotates UUIDs
+    //      on resume / compaction) → overwrite is the original purpose of
+    //      this handler (`session.reconciled`).
+    //   3. Stored session != live session AND the executor row is in a
+    //      terminal state → the row is a frozen recovery anchor. Overwriting
+    //      it destroys recovery information. Skip the write, emit a
+    //      `session.divergence_preserved` audit event for visibility, and
+    //      cache to suppress audit-event spam on subsequent hook fires.
+    const isTerminal = TERMINAL_EXECUTOR_STATES.has(executor.state ?? '');
+    if (oldSessionId !== null && isTerminal) {
+      await deps.emitAuditEvent('executor', executorId, 'session.divergence_preserved', ctx.agentName, {
+        stored_session_id: oldSessionId,
+        live_session_id: ctx.sessionId,
+        executor_state: executor.state ?? null,
+        team: ctx.teamName,
+        reason: 'terminal_executor_is_recovery_anchor',
+      });
+      syncedSessions.set(executorId, ctx.sessionId);
+      return;
+    }
+
+    // First-capture or active-state rotation — safe to overwrite.
+    await deps.updateClaudeSessionId(executorId, ctx.sessionId);
+    await deps.emitAuditEvent('executor', executorId, 'session.reconciled', ctx.agentName, {
+      old_session_id: oldSessionId,
+      new_session_id: ctx.sessionId,
+      team: ctx.teamName,
+    });
     syncedSessions.set(executorId, ctx.sessionId);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/src/lib/agent-directory.test.ts
+++ b/src/lib/agent-directory.test.ts
@@ -197,6 +197,49 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
       expect(metadata.dir).toBe(agentDir);
     });
 
+    test('add writes team and repo_path to PG (Gap 1+3 fix, 2026-04-25 power-outage post-mortem)', async () => {
+      // Pre-fix bug: dir: agents inserted with team=NULL even when the entry
+      // had a known team. session-sync hook's `getAgentByName(name, team)`
+      // lookup then missed (WHERE custom_name=$1 AND team=$2 → NULL row),
+      // so the agent's claude_session_id was never persisted. Post-fix:
+      // team and dir are written to top-level columns, not just metadata.
+      await directory.add({
+        name: 'teamed-agent',
+        dir: agentDir,
+        promptMode: 'append',
+        team: 'genie',
+      });
+
+      const sql = await getConnection();
+      const rows = await sql<{ team: string | null; repo_path: string | null }[]>`
+        SELECT team, repo_path FROM agents WHERE id = 'dir:teamed-agent'
+      `;
+      expect(rows.length).toBe(1);
+      expect(rows[0].team).toBe('genie');
+      expect(rows[0].repo_path).toBe(agentDir);
+    });
+
+    test('add upserts team without overwriting an already-set team (Gap 3 idempotence)', async () => {
+      const sql = await getConnection();
+      // Pre-seed with team
+      await directory.add({ name: 'idempotent-team', dir: agentDir, promptMode: 'append', team: 'genie' });
+      // Re-add with no team — must not clobber
+      await sql`UPDATE agents SET team = 'genie' WHERE id = 'dir:idempotent-team'`;
+      // Calling add again with no team specified should not erase the existing one.
+      // (Note: add() throws on duplicate non-builtin, so test via raw INSERT path.)
+      await sql`
+        INSERT INTO agents (id, role, custom_name, team, repo_path, started_at, state, metadata)
+        VALUES ('dir:idempotent-team', 'idempotent-team', 'idempotent-team', NULL, ${agentDir}, now(), NULL, '{}'::jsonb)
+        ON CONFLICT (id) DO UPDATE SET
+          team = COALESCE(EXCLUDED.team, agents.team),
+          metadata = '{}'::jsonb
+      `;
+      const [row] = await sql<{ team: string | null }[]>`
+        SELECT team FROM agents WHERE id = 'dir:idempotent-team'
+      `;
+      expect(row.team).toBe('genie');
+    });
+
     test('rm returns removed=false with no message for truly non-existent', async () => {
       const result = await directory.rm('nonexistent');
       expect(result.removed).toBe(false);

--- a/src/lib/agent-directory.ts
+++ b/src/lib/agent-directory.ts
@@ -178,6 +178,17 @@ export async function add(
   // Build metadata JSONB from frontmatter fields
   const metadata = buildMetadata(full);
 
+  // Resolve canonical team — prefer the `team` field on the entry (template-
+  // pinned, per `lookupTemplateTeam` precedence), fall back to the entry's
+  // tmuxSession when set, else NULL. Without this, dir: rows historically
+  // landed with team=NULL and the session-sync hook's `getAgentByName(name,
+  // teamName)` lookup missed (the lookup is `WHERE custom_name=$1 AND
+  // team=$2`), so the agent's `claude_session_id` was never persisted —
+  // every native-team teammate (`dir:email` was the canonical victim)
+  // accumulated megabytes of JSONL on disk with zero DB rows. See the
+  // 2026-04-25 power-outage post-mortem.
+  const team = entry.team ?? entry.bridgeTmuxSession ?? null;
+
   // Store as a directory agent in PG with metadata.
   // state = NULL: directory records (id prefix `dir:`) are identity rows that
   // track state through their runtime/executor children, not the legacy `state`
@@ -187,9 +198,21 @@ export async function add(
   const { getConnection } = await import('./db.js');
   const sql = await getConnection();
   await sql`
-    INSERT INTO agents (id, role, custom_name, started_at, state, metadata)
-    VALUES (${`dir:${entry.name}`}, ${entry.name}, ${entry.name}, now(), ${null}, ${sql.json(metadata)})
-    ON CONFLICT (id) DO UPDATE SET metadata = ${sql.json(metadata)}
+    INSERT INTO agents (id, role, custom_name, team, repo_path, started_at, state, metadata)
+    VALUES (
+      ${`dir:${entry.name}`},
+      ${entry.name},
+      ${entry.name},
+      ${team},
+      ${entry.dir},
+      now(),
+      ${null},
+      ${sql.json(metadata)}
+    )
+    ON CONFLICT (id) DO UPDATE SET
+      team = COALESCE(EXCLUDED.team, agents.team),
+      repo_path = COALESCE(NULLIF(EXCLUDED.repo_path, ''), agents.repo_path),
+      metadata = ${sql.json(metadata)}
   `;
 
   return full;

--- a/src/lib/pane-trap.test.ts
+++ b/src/lib/pane-trap.test.ts
@@ -120,7 +120,14 @@ describe.skipIf(!DB_AVAILABLE)('trapPaneExit (integration)', () => {
     const [agentRow] = await sql<{ current_executor_id: string | null }[]>`
       SELECT current_executor_id FROM agents WHERE id = ${agentId}
     `;
-    expect(agentRow.current_executor_id).toBeNull();
+    // Post-2026-04-25 power-outage post-mortem: keep current_executor_id
+    // pointing at the just-terminated executor so its claude_session_id
+    // survives as the recovery anchor for getResumeSessionId. Prior contract
+    // (null FK on terminate) erased the link to the dormant session UUID.
+    // Liveness is gated by executor.state ∈ {error, terminated, done} via
+    // getCurrentExecutor / getLiveExecutorState, so the FK staying populated
+    // is safe.
+    expect(agentRow.current_executor_id).toBe(executorId);
 
     const audits = await sql<{ event_type: string; actor: string; details: unknown }[]>`
       SELECT event_type, actor, details FROM audit_events

--- a/src/lib/pane-trap.ts
+++ b/src/lib/pane-trap.ts
@@ -114,11 +114,15 @@ export async function trapPaneExit(opts: TrapPaneExitOpts): Promise<TrapPaneExit
         WHERE id = ${executorId}
       `;
 
-      await tx`
-        UPDATE agents
-        SET current_executor_id = NULL
-        WHERE current_executor_id = ${executorId}
-      `;
+      // Keep `current_executor_id` pointing at the just-terminated executor
+      // so its `claude_session_id` survives as the recovery anchor for
+      // `getResumeSessionId` (see executor-registry.ts and the 2026-04-25
+      // power-outage post-mortem). State filters in `getCurrentExecutor` /
+      // `getLiveExecutorState` already gate "alive" semantics on executor
+      // state, so leaving the FK populated is safe — and required for
+      // post-crash auto-resume to find the dormant session.
+      // (No agent UPDATE needed here — the executor row's state transition
+      // above is the source of truth for "this run is over.")
 
       await tx`
         INSERT INTO audit_events (entity_type, entity_id, event_type, actor, details)

--- a/src/lib/scheduler-daemon.test.ts
+++ b/src/lib/scheduler-daemon.test.ts
@@ -2382,7 +2382,13 @@ describe('terminalizeCleanExitUnverified (D1 write)', () => {
     expect(fake.executorRow.close_reason).toBe('reconciler_idle_dead_pane');
     expect(fake.executorRow.state).toBe('error');
     expect(fake.executorRow.closed_at).not.toBeNull();
-    expect(fake.agentRow.current_executor_id).toBeNull();
+    // Post-2026-04-25 power-outage post-mortem: keep current_executor_id
+    // pointing at the just-terminated executor so its claude_session_id
+    // survives as the recovery anchor for getResumeSessionId. Liveness is
+    // gated by executor.state via getCurrentExecutor / getLiveExecutorState,
+    // so the FK staying populated is safe — and required for post-crash
+    // auto-resume to find the dormant session.
+    expect(fake.agentRow.current_executor_id).toBe('exec-1');
     expect(fake.agentRow.state).toBe('error');
     expect(fake.audit).toHaveLength(1);
     expect(logs.find((l) => l.event === 'terminalize_clean_exit_unverified_failed')).toBeUndefined();
@@ -2400,7 +2406,9 @@ describe('terminalizeCleanExitUnverified (D1 write)', () => {
     expect(res).toEqual({ terminalized: false, executorId: 'exec-2' });
     expect(fake.executorRow.outcome).toBe('done'); // not overwritten
     expect(fake.executorRow.close_reason).toBeNull();
-    expect(fake.agentRow.current_executor_id).toBeNull(); // still cleared
+    // Recovery-anchor preservation: even on the idempotent branch the FK
+    // stays populated. See note above.
+    expect(fake.agentRow.current_executor_id).toBe('exec-2');
     expect(fake.agentRow.state).toBe('error');
     expect(fake.audit).toHaveLength(0);
   });

--- a/src/lib/scheduler-daemon.ts
+++ b/src/lib/scheduler-daemon.ts
@@ -1102,10 +1102,16 @@ export async function terminalizeCleanExitUnverified(
       `;
       const alreadyClosed = execRows.length > 0 && (execRows[0].closed_at !== null || execRows[0].outcome !== null);
       if (alreadyClosed) {
+        // Keep `current_executor_id` pointing at the terminated executor —
+        // its `claude_session_id` is the only durable handle to the dormant
+        // session UUID. Nulling it here erases the recovery anchor (see the
+        // `getResumeSessionId` contract in executor-registry.ts and the
+        // 2026-04-25 power-outage post-mortem). The state filter on
+        // `getCurrentExecutor` / `getLiveExecutorState` already encodes "is it
+        // alive"; the FK becomes a "what was the last session" pointer.
         await tx`
           UPDATE agents
-          SET current_executor_id = NULL,
-              state = 'error',
+          SET state = 'error',
               last_state_change = ${nowIso}
           WHERE id = ${worker.id}
         `;
@@ -1122,10 +1128,12 @@ export async function terminalizeCleanExitUnverified(
         WHERE id = ${executorId}
       `;
 
+      // See note above: keep `current_executor_id` pointing at the just-
+      // terminated executor so `getResumeSessionId` and the JSONL fallback
+      // can use its `claude_session_id` as the recovery anchor.
       await tx`
         UPDATE agents
-        SET current_executor_id = NULL,
-            state = 'error',
+        SET state = 'error',
             last_state_change = ${nowIso}
         WHERE id = ${worker.id}
       `;


### PR DESCRIPTION
## Summary

Power-outage post-mortem (2026-04-25). PR #1395 shipped a JSONL fallback in `getResumeSessionId` that's correct but **load-bearing only**. Four structural bugs upstream of it kept stranding teammate work on every reboot.

This PR closes the four gaps so a real power-outage recovery is automatic.

## The four gaps

### Gap 5 (HIGH) — session-sync silently overwrote recovery anchors
**Smoking gun**: during the live recovery, manually re-linking the genie agent's `current_executor_id` to a terminated executor holding the dormant session UUID worked for one tick — then the next `PreToolUse` hook in the live process saw the divergence (live UUID ≠ stored UUID), called them "out of sync" and **clobbered the stored UUID with the live one**. The dormant session reference vanished from the DB.

**Fix**: when the executor row is in `{done, error, terminated}` AND stored session_id ≠ live session_id AND stored is non-null, refuse the overwrite. Emit `session.divergence_preserved` for visibility. The original UUID-rotation purpose (active-state divergence = same logical session, new UUID) is unchanged.

### Gap 2 (HIGH) — reconciler/pane-trap nulled `current_executor_id` on terminate
Three sites in `scheduler-daemon.ts` (`terminalizeCleanExitUnverified` × 2) and `pane-trap.ts` (`trapPaneExit`) set the agent's FK to NULL on terminate. Every downstream consumer joins through that FK to find the session UUID. With the FK nulled, auto-resume skipped with `no_session_id` until the user manually noticed.

**Fix**: drop `current_executor_id = NULL` from the three UPDATEs. Liveness is gated by `executor.state` via `getCurrentExecutor` / `getLiveExecutorState` — the FK staying populated is safe and becomes a "what was the last session" pointer surviving termination.

### Gaps 1 + 3 (HIGH) — `dir:` agents inserted with `team=NULL` and no `repo_path`
`agent-directory.ts::add()` wrote only `(id, role, custom_name, started_at, state, metadata)`. The session-sync hook's `getAgentByName(name, team)` query is `WHERE custom_name=$1 AND team=$2`, so the lookup missed for every dir: row. **The genie/email agent accumulated 19.5 MB of JSONL on disk with zero DB rows for ~5 hours pre-crash.** Chronic, not crash-specific.

**Fix**: write `team` and `repo_path` to top-level columns at insert. Use `COALESCE` on conflict so re-`add` doesn't clobber an existing populated row with NULLs.

## Tests

- **5 new** session-sync tests covering terminal-state preservation for `{terminated, error, done}`, active-state rotation (still overwrites), first-capture edge case (still writes).
- **2 new** agent-directory tests asserting `team` + `repo_path` landing in PG, plus COALESCE idempotence.
- **2 existing** tests updated to the new contract: pane-trap and scheduler-daemon now assert `current_executor_id` stays populated.

**3807/3807 tests pass; full typecheck clean; biome clean.**

## Outstanding follow-up (out of scope this PR)

**Gap 4** — `scheduler-daemon.ts::defaultListWorkers` does a bare DB JOIN at boot instead of calling `getResumeSessionId`. That means auto-resume on pgserve restart still won't fire the JSONL fallback for orphaned agents. Tracking separately.

Plus the 7 `genie spawn` / `session.ts` paths that still mint fresh UUIDs without consulting the fallback (Wish Group 4/5 deferred work). Those can ride a separate sweep.

## Why this is reboot-safe

After this lands and you `npm install -g @automagik/genie@next`:
1. Pane dies (crash, OOM, kill) → `pane-trap` terminalizes the executor BUT keeps the agent FK pointing at it. Recovery anchor preserved.
2. Reconciler runs → same; FK stays.
3. Next spawn → `getResumeSessionId` joins through the FK, returns the dormant UUID via DB happy path.
4. Even if FK gets nulled by some other future code path → JSONL fallback (#1395) takes over.
5. Even if a re-link to a terminated executor happens manually → session-sync no longer overwrites the recovery anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)