### PR TITLE
fix(chokepoint): replace UUID/timestamp tiebreaker with BIGSERIAL seq

### DIFF
--- a/src/db/migrations/051_assignments_seq.sql
+++ b/src/db/migrations/051_assignments_seq.sql
@@ -1,0 +1,30 @@
+-- 051_assignments_seq.sql
+--
+-- Hotfix follow-up to a049e0c7 ("chokepoint tiebreaker + dispatch PG marker").
+-- That commit added `ORDER BY asg.started_at DESC, asg.id DESC` to the
+-- single-reader chokepoint and claimed BIGSERIAL guaranteed insertion-order
+-- ties. The claim was wrong: `assignments.id` is `TEXT DEFAULT
+-- gen_random_uuid()::text`, so `id DESC` is a coin flip on the equality
+-- case. The shared-pgserve test "most-recent assignment is the one
+-- consulted (older completed, newer open)" continued to flake because
+-- `started_at` is supplied by the JS caller from `new Date().toISOString()`
+-- (millisecond precision) and CI fits both INSERTs inside the same ms.
+--
+-- Real fix: give the table the monotonic insertion-order column the prior
+-- comment assumed already existed. BIGSERIAL fills existing rows in physical
+-- (ctid) order on column add, then increments deterministically for every
+-- subsequent INSERT. The chokepoint reader switches to `ORDER BY asg.seq
+-- DESC LIMIT 1` and the equality case disappears entirely — no timestamps,
+-- no UUIDs, just the sequence.
+--
+-- Backwards compatibility: existing readers that order by `started_at` are
+-- unaffected; nothing drops `started_at`. Only the chokepoint subquery in
+-- src/lib/should-resume.ts switches to the seq column.
+
+ALTER TABLE assignments
+  ADD COLUMN IF NOT EXISTS seq BIGSERIAL;
+
+-- Cover the chokepoint subquery's executor-scoped most-recent lookup.
+-- (executor_id ASC just narrows the scan; seq DESC is what matters.)
+CREATE INDEX IF NOT EXISTS idx_assignments_executor_seq
+  ON assignments (executor_id, seq DESC);

--- a/src/lib/should-resume.ts
+++ b/src/lib/should-resume.ts
@@ -104,13 +104,13 @@ async function readAgentResumeRow(agentId: string): Promise<AgentResumeRow | nul
         FROM assignments asg
         JOIN executors e2 ON e2.id = asg.executor_id
         WHERE e2.agent_id = a.id
-        -- id DESC is the tiebreaker: BIGSERIAL guarantees newer rows
-        -- have larger ids, so when two assignments share a started_at
-        -- (CI shared-pgserve frequently hits sub-millisecond collisions),
-        -- insertion order still wins. Without this, ORDER BY started_at
-        -- DESC alone is non-deterministic on the equality case and the
-        -- test "most-recent assignment is the one consulted" flakes.
-        ORDER BY asg.started_at DESC, asg.id DESC
+        -- seq is BIGSERIAL (migration 051): monotonically incremented on
+        -- every INSERT, independent of clock precision. The previous
+        -- ORDER BY started_at DESC, id DESC was non-deterministic because
+        -- (a) started_at is JS millisecond precision and (b) id is a
+        -- UUID, not BIGSERIAL — so ties on the same ms resolved by random
+        -- UUID order. seq DESC eliminates both axes of flakiness.
+        ORDER BY asg.seq DESC
         LIMIT 1
       ) AS latest_assignment_outcome
     FROM agents a


### PR DESCRIPTION
## Summary

CI on the #1401 invincible-genie merge has been failing the
`should-resume chokepoint > most-recent assignment is the one consulted
(older completed, newer open)` test on shared-pgserve. Two reruns
already burned. This PR closes the flake at the source.

## Root cause

`a049e0c7` added `ORDER BY started_at DESC, id DESC` to the chokepoint
subquery and the commit message claimed BIGSERIAL guaranteed
insertion-order ties. The schema disagrees:

```sql
id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text
```

UUIDs, not BIGSERIAL. So when CI's shared-pgserve fits two `INSERT`s
inside the same JS millisecond (`new Date().toISOString()`), the
`started_at` ties and the random UUID coin flip wins ~half the time.
The test is genuinely non-deterministic until we give the table a real
monotonic column.

## Fix

- Migration `051_assignments_seq.sql` adds `seq BIGSERIAL` to
  `assignments` plus an `(executor_id, seq DESC)` covering index for the
  chokepoint scan.
- `src/lib/should-resume.ts` chokepoint subquery switches to `ORDER BY
  asg.seq DESC LIMIT 1`. No more clock-precision dependency, no more
  UUID lex-order. Tied inserts are impossible by construction.
- Comment block updated to describe the new contract correctly.

## Validation

```
bun run typecheck            # clean
bun run lint                 # clean (only pre-existing symlink-cycle warning)
bun test src/lib/should-resume.test.ts
  17 pass / 0 fail
bun test src/lib/{should-resume,assignment-registry,agent-registry,executor-registry,scheduler-daemon.boot-pass,pane-trap}.test.ts
  244 pass / 0 fail
```

## Test plan

- [x] Local typecheck + lint
- [x] Local PG-backed tests for the chokepoint and adjacent surfaces
- [ ] CI Quality Gate green on this PR
- [ ] Merge to `dev` and confirm CI on the merge commit greens (unblocks dev → main release)

## Why now

The release pipeline is currently blocked on this single flaky test. With this fix landed, the dev → main rolling PR can merge and trigger `release.yml` + `version.yml` to ship `4.260426.x` to npm `@latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)