### PR TITLE
fix(spawn): §19 v3 — block @N-named ghost sessions on --new-window path

### DIFF
--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -308,6 +308,18 @@ async function ensureMasterWindow(session: string, masterName: string): Promise<
  * eliminating the TOCTOU race of find-then-create.
  */
 async function ensureSessionExists(name: string): Promise<void> {
+  // §19 v3 belt-and-suspenders: refuse session names that mimic tmux ids.
+  // tmux uses `@N` for window-ids and `$N` for session-ids; allowing those
+  // shapes as session NAMES creates unsearchable ghost sessions (the `@60`
+  // trap that captured spawns all night on 2026-04-26 → 04-27). Even if a
+  // caller passes one of these by accident, refusing here short-circuits
+  // the cascade. Twin's evidence at
+  // `/tmp/genie-recover/twin-overnight/finding-001-ghost-session-at60.md`.
+  if (/^[@$]\d+$/.test(name)) {
+    throw new Error(
+      `Refused to create tmux session with id-shaped name "${name}". Names matching /^[@$]\\d+$/ collide with tmux's window-id (@N) and session-id ($N) notation, producing ghost sessions that cannot be safely targeted. Pass a human-readable session name (e.g. the team or agent name) instead.`,
+    );
+  }
   try {
     await executeTmux(`new-session -d -s "${name}" -e LC_ALL=C.UTF-8 -e LANG=C.UTF-8`);
   } catch (error) {
@@ -329,7 +341,7 @@ export async function ensureTeamWindow(
   session: string,
   teamName: string,
   workingDir?: string,
-): Promise<{ windowId: string; windowName: string; paneId: string; created: boolean }> {
+): Promise<{ windowId: string; windowName: string; sessionName: string; paneId: string; created: boolean }> {
   const maxRetries = 3;
   const baseDelayMs = 250;
 
@@ -367,7 +379,7 @@ async function ensureTeamWindowOnce(
   session: string,
   teamName: string,
   workingDir?: string,
-): Promise<{ windowId: string; windowName: string; paneId: string; created: boolean }> {
+): Promise<{ windowId: string; windowName: string; sessionName: string; paneId: string; created: boolean }> {
   // Atomic session creation — eliminates TOCTOU race
   await ensureSessionExists(session);
 
@@ -383,7 +395,7 @@ async function ensureTeamWindowOnce(
     await rehydratePaneColorHook(existing.id);
     const panes = await listPanes(existing.id);
     const paneId = panes.length > 0 ? panes[0].id : `${session}:${teamName}.0`;
-    return { windowId: existing.id, windowName: teamName, paneId, created: false };
+    return { windowId: existing.id, windowName: teamName, sessionName: session, paneId, created: false };
   }
 
   // Remember the current master window (lowest-index window) before creating
@@ -404,7 +416,7 @@ async function ensureTeamWindowOnce(
   await rehydratePaneColorHook(newWindow.id);
   const panes = await listPanes(newWindow.id);
   const paneId = panes.length > 0 ? panes[0].id : `${session}:${teamName}.0`;
-  return { windowId: newWindow.id, windowName: teamName, paneId, created: true };
+  return { windowId: newWindow.id, windowName: teamName, sessionName: session, paneId, created: true };
 }
 
 /**

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -666,7 +666,20 @@ function printSpawnInfo(ctx: SpawnCtx, paneId: string, workerEntry: registry.Age
   }
 }
 
-type TeamWindowInfo = { windowId: string; windowName: string; paneId: string; created: boolean };
+type TeamWindowInfo = {
+  windowId: string;
+  windowName: string;
+  /**
+   * Human-readable session name (e.g. `genie`, `felipe`). Distinct from
+   * `windowId` (which is `@N` per tmux's `#{window_id}`) and from the
+   * tmux session-id (which is `$N`). Used as the canonical session anchor
+   * when bootstrapping a new window — see §19 v3 / `agents.ts:newWindow`
+   * branch comment for the full bug story.
+   */
+  sessionName: string;
+  paneId: string;
+  created: boolean;
+};
 
 function shellQuote(arg: string): string {
   return `'${arg.replace(/'/g, "'\\''")}'`;
@@ -822,7 +835,19 @@ function createTmuxPane(ctx: SpawnCtx & { sessionOverride?: string }, teamWindow
   // The claude window is created with `-n claude`; navigation-wise `home` is
   // window 0 and `claude` is window 1, matching the multi-member team layout.
   if (ctx.validated.newWindow) {
-    const session = ctx.sessionOverride ?? teamWindow?.windowId?.split(':')[0] ?? ctx.validated.team;
+    // §19 v3 fix: prefer the human-readable session name (canonical 1:1 anchor)
+    // over `teamWindow.windowId.split(':')[0]`. The split was wrong in two ways:
+    // (a) `windowId` is ALWAYS in `@N` format from tmux's `#{window_id}`, never
+    //     `<session>:<window>` — the colon never appears, so split returns `@N`
+    //     verbatim and downstream `tmux new-session -d -s "@N"` creates a rogue
+    //     session NAMED literally `@N`. Twin's evidence at
+    //     `/tmp/genie-recover/twin-overnight/finding-001-ghost-session-at60.md`
+    //     traced this to PR #1413's incomplete §19 v2 — the fix only landed at
+    //     the protocol-router layer, this CLI spawn path remained broken.
+    // (b) Even if `@N` were a valid session id, tmux distinguishes `@`-prefix
+    //     (window-id) from `$`-prefix (session-id) — neither is a session NAME.
+    //     Routing them to `tmux new-session -s "${name}"` always corrupts.
+    const session = ctx.sessionOverride ?? teamWindow?.sessionName ?? ctx.validated.team;
     const cwdFlag = ctx.cwd ? ` -c ${shellQuote(ctx.cwd)}` : '';
     let sessionExists = false;
     try {


### PR DESCRIPTION
Closes the §19 v2 hole that PR #1413 didn't reach. Twin's overnight forensic pass (genie-twin-overnight, 2026-04-27 ~05:00 UTC) line-numbered the actual culprit: `src/term-commands/agents.ts:825`'s `--new-window` spawn path derived the session via:

```typescript
const session = ctx.sessionOverride
  ?? teamWindow?.windowId?.split(':')[0]
  ?? ctx.validated.team;
```

`teamWindow.windowId` is **always** in `@N` format (raw `#{window_id}` from `listWindows`), and `.split(':')[0]` returns that `@N` verbatim because the colon never appears. Then line 838's `tmux new-session -d -s "@N"` creates a session NAMED literally `@N` — a ghost that captures every subsequent spawn whose lookup happens to resolve through it.

**Birth-of-the-ghost timestamp** (twin's audit): `$13` created `Mon Apr 27 04:50:35` — exactly when master-aware-spawn Wave 2 engineers were respawned via `--new-window` in shared worktrees. PR #1413's §19 v2 fix only landed at the protocol-router layer; this CLI spawn path inherited the broken session derivation.

## Fix (3 surgical changes)

1. **`TeamWindowInfo` gains `sessionName: string`** — the canonical 1:1 anchor name (e.g. `genie`, `felipe`), distinct from `@N`-shaped `windowId` and `$N`-shaped session-id. Set in both branches of `ensureTeamWindowOnce` + propagated through `ensureTeamWindow`'s return type. Source-of-truth lives in `src/lib/tmux.ts`.
2. **`agents.ts:825` resolves session via `teamWindow?.sessionName`** instead of the busted `windowId.split(':')[0]`. Inline comment block documents the trap so future readers don't reintroduce the bug.
3. **Belt-and-suspenders in `ensureSessionExists`**: refuse names matching `/^[@$]\d+$/`. Even if some upstream caller ever passes a window-id (`@N`) or session-id (`$N`)-shaped string by accident, this gate short-circuits the cascade with an explicit error directing callers to use a human-readable name.

## Evidence (preserved on disk, not committed)

- `/tmp/genie-recover/twin-overnight/finding-001-ghost-session-at60.md` — full repro + line numbers + timestamps
- `/tmp/genie-recover/twin-overnight/finding-002-group-14d-customname-null.md` — tangential 14d clarification surfaced same surveillance pass

## Validation

- `bun run typecheck` clean
- `bun run lint` clean (only pre-existing symlink-cycle warning unrelated)
- `bun run check` failed on `executor-read > startExecutorReadEndpoint is idempotent` — port-collision env flake (4007 pass / 1 fail), same flake we've been hitting all night, unrelated to this diff. Pushed via retry-on-flake protocol (4 attempts).

## Wave 2 unblock

Wave 2 dispatch was paused tonight pending this fix. After this lands, re-spawning Group 4/7/14/etc. engineers via `--new-window` will route into the spawner's session correctly, no more `@N` orphans.

## Coordinated PR

Twin in parallel committed the orphan Group 14a+b work (engineer-w2g14's preserved-on-disk migration) on `wish/master-aware-spawn-w2`. That PR will follow once their retry clears the cross-worktree test-pgserve lockfile race (a separate finding twin caught while pushing — see Group 18 in `WISH.md`).

Co-Authored-By: genie-twin-overnight (root cause + line-level diagnosis) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)