### PR TITLE
feat(migration): 14a+b master backfill + bare-name shadow archive

### DIFF
--- a/src/__tests__/state-machine.invariants.test.ts
+++ b/src/__tests__/state-machine.invariants.test.ts
@@ -148,6 +148,7 @@ describe('invariant 2: no ad-hoc permanence inference', () => {
       `--glob '!src/db/migrations/046_dir_agents_state_null.sql'`,
       `--glob '!src/db/migrations/049_agents_kind_generated.sql'`,
       `--glob '!src/db/migrations/agents-kind.test.ts'`,
+      `--glob '!src/db/migrations/master-backfill-and-shadow-cleanup.test.ts'`,
       `--glob '!src/__tests__/state-machine.invariants.test.ts'`,
     );
     // Strip comment lines (SQL `--`, TS `//`, JSDoc `*`) — references inside

--- a/src/db/migrations/053_master_backfill_and_shadow_cleanup.sql
+++ b/src/db/migrations/053_master_backfill_and_shadow_cleanup.sql
@@ -1,0 +1,161 @@
+-- 053_master_backfill_and_shadow_cleanup.sql
+--
+-- master-aware-spawn wish, Wave 2, Group 14 (sub-deliverables 14a + 14b).
+--
+-- The 2026-04-25 power-outage post-mortem surfaced that masters today fall
+-- into two shadow patterns in PG (twin's analysis at
+-- /tmp/genie-recover/group-1-shadow-analysis.json):
+--
+--   Type A — `dir:<name>` + bare-name pair (only `email` today). Both rows
+--           exist; `findLiveWorkerFuzzy(name)` returns the bare row first,
+--           so Group 1's `worker?.id ?? \`dir:\${recipientId}\`` chokepoint
+--           fallback never fires. Result: master `email` re-spawns fresh
+--           every time the live worker dies.
+--
+--   Type B — UUID + bare-name pair, NO `dir:<name>` row (`felipe`, `genie`,
+--           `genie-pgserve`). The bare row's `custom_name=''` blocks the
+--           jsonl-scan fallback (Group 7), and there is no `dir:` row for
+--           Group 1's chokepoint to anchor on. Result: post-`unregister`
+--           recovery is impossible without manual surgery.
+--
+-- This migration closes both gaps in two passes:
+--
+--   1. **14b — master backfill:** for every agent row with
+--      `kind='permanent' AND repo_path != ''` whose canonical name (custom_name
+--      or role fallback) lacks a `dir:<name>` peer, create the missing
+--      directory row using the bare row's identity columns. Brings
+--      `dir:felipe`, `dir:genie`, `dir:genie-pgserve` into existence.
+--
+--   2. **14a — bare-name shadow cleanup:** for every `dir:<name>` row that
+--      pairs with a non-UUID, non-dir bare-name row whose
+--      `current_executor_id IS NULL`, archive (state='archived',
+--      auto_resume=false) the bare row. **Heal-not-wipe** — never DELETE.
+--      The Group 3 guardrail in `src/lib/agent-directory.ts:rm()` blocks
+--      DELETE on `kind='permanent' AND repo_path != ''` regardless, but
+--      a SQL-side UPDATE bypasses that lock by design.
+--
+-- 14b runs before 14a so the dir-rows we just created can pair with their
+-- bare shadows in the same migration. After this migration runs:
+--
+--   - `dir:email`, `dir:felipe`, `dir:genie`, `dir:genie-pgserve` all exist
+--     and carry `repo_path`. Group 1's chokepoint extension covers all four.
+--   - bare `email`, `felipe`, `genie`, `genie-pgserve` rows with
+--     `current_executor_id IS NULL` are archived. registry.get(name) now
+--     returns either nothing (so worker is null → Group 1 fallback fires) or
+--     the dir:<name> row directly.
+--
+-- Idempotent: each pass gates on a NOT-EXISTS / DISTINCT-FROM-archived
+-- predicate. Re-running the migration affects zero additional rows.
+--
+-- Audit: every backfilled row emits `directory.master_backfilled`; every
+-- archived bare shadow emits `state_changed` with reason
+-- `bare_name_shadow_archived`.
+
+-- ---------------------------------------------------------------------------
+-- Pass 1 (14b): backfill dir:<name> rows for masters that lack one.
+-- ---------------------------------------------------------------------------
+WITH
+  -- Pick one canonical source row per "name" equivalence class. The bare
+  -- row of a Type-B pair (custom_name='' but role + repo_path set) is the
+  -- only source carrying repo_path, so we filter on repo_path-non-empty
+  -- candidates here. Prefer rows with non-empty custom_name when both
+  -- candidates exist (NULLIF + ORDER BY in DISTINCT ON).
+  backfill_targets AS (
+    SELECT DISTINCT ON (COALESCE(NULLIF(a.custom_name, ''), a.role))
+      COALESCE(NULLIF(a.custom_name, ''), a.role) AS name,
+      a.role,
+      a.team,
+      a.repo_path
+    FROM agents a
+    WHERE a.kind = 'permanent'
+      AND a.id NOT LIKE 'dir:%'
+      AND a.repo_path IS NOT NULL AND a.repo_path <> ''
+      AND COALESCE(NULLIF(a.custom_name, ''), a.role) IS NOT NULL
+      AND a.auto_resume = true
+      AND a.state IS DISTINCT FROM 'archived'
+      AND NOT EXISTS (
+        SELECT 1 FROM agents d
+        WHERE d.id = 'dir:' || COALESCE(NULLIF(a.custom_name, ''), a.role)
+      )
+    ORDER BY
+      COALESCE(NULLIF(a.custom_name, ''), a.role),
+      -- Prefer rows that already populate custom_name (UUID peer in Type B),
+      -- so role/team fields come from the canonical identity row.
+      (CASE WHEN a.custom_name IS NOT NULL AND a.custom_name <> '' THEN 0 ELSE 1 END),
+      a.id
+  ),
+  inserted AS (
+    INSERT INTO agents (id, role, custom_name, team, repo_path, started_at, state, metadata)
+    SELECT
+      'dir:' || c.name,
+      c.role,
+      -- The unique partial index `idx_agents_custom_name_team` requires
+      -- (custom_name, team) to be unique when both are non-null. If a peer
+      -- already owns that slot (Type B production: UUID peer with
+      -- custom_name=name, team=team), set custom_name=NULL on the dir row
+      -- so the new row sits outside the unique index. Session-sync's
+      -- `getAgentByName(name, team)` lookup will route to the UUID peer
+      -- while it lives; once the peer is unregistered, an UPDATE
+      -- backfill (separate migration if the slot ever frees) can repopulate.
+      CASE
+        WHEN c.team IS NOT NULL AND EXISTS (
+          SELECT 1 FROM agents x
+          WHERE x.custom_name = c.name AND x.team = c.team
+            AND x.id <> 'dir:' || c.name
+        ) THEN NULL
+        ELSE c.name
+      END,
+      c.team,
+      c.repo_path,
+      now(),
+      NULL,
+      '{}'::jsonb
+    FROM backfill_targets c
+    ON CONFLICT (id) DO NOTHING
+    RETURNING id
+  )
+INSERT INTO audit_events (entity_type, entity_id, event_type, actor, details)
+SELECT 'agent', i.id, 'directory.master_backfilled',
+       'migration:053_master_backfill_and_shadow_cleanup',
+       jsonb_build_object('reason', 'master_backfill',
+                          'wish', 'master-aware-spawn',
+                          'group', '14b')
+FROM inserted i;
+
+-- ---------------------------------------------------------------------------
+-- Pass 2 (14a): archive bare-name shadows whose dir:<name> peer now exists.
+-- Heal-not-wipe — never DELETE. Idempotent via state IS DISTINCT FROM.
+-- ---------------------------------------------------------------------------
+WITH archived AS (
+  UPDATE agents bare
+  SET state = 'archived',
+      auto_resume = false,
+      last_state_change = now()
+  FROM agents dir
+  WHERE dir.id = 'dir:' || bare.id
+    AND bare.id NOT LIKE 'dir:%'
+    -- Exclude UUID-shaped ids (4 hyphens). Same heuristic as migration 050.
+    AND bare.id NOT LIKE '%-%-%-%-%'
+    AND bare.current_executor_id IS NULL
+    AND bare.state IS DISTINCT FROM 'archived'
+    AND bare.repo_path IS NOT NULL
+    AND bare.repo_path <> ''
+    -- Belt-and-suspenders identity match: the bare row's role or id must
+    -- agree with the dir's custom_name. Prevents archiving an unrelated
+    -- bare row whose id happens to suffix a dir: id.
+    AND (
+      bare.role = dir.custom_name
+      OR bare.id = dir.custom_name
+      OR bare.custom_name = dir.custom_name
+    )
+  RETURNING bare.id
+)
+INSERT INTO audit_events (entity_type, entity_id, event_type, actor, details)
+SELECT 'worker', a.id, 'state_changed',
+       'migration:053_master_backfill_and_shadow_cleanup',
+       jsonb_build_object('reason', 'bare_name_shadow_archived',
+                          'state', 'archived',
+                          'auto_resume', false,
+                          'wish', 'master-aware-spawn',
+                          'group', '14a')
+FROM archived a;

--- a/src/db/migrations/agents-kind.test.ts
+++ b/src/db/migrations/agents-kind.test.ts
@@ -187,6 +187,11 @@ describe.skipIf(!DB_AVAILABLE)('migration 049 — agents.kind GENERATED column',
           `--glob '!src/db/migrations/049_agents_kind_generated.sql' ` +
           `--glob '!src/db/migrations/046_dir_agents_state_null.sql' ` +
           `--glob '!src/db/migrations/agents-kind.test.ts' ` +
+          // Migration 053's test file (master-aware-spawn Group 14a+b)
+          // legitimately queries `id LIKE 'dir:%'` to verify dir-row
+          // backfill + bare-shadow archive shape post-migration. Distinguishing
+          // dir-shape vs bare-shape is the whole point — not permanence inference.
+          `--glob '!src/db/migrations/master-backfill-and-shadow-cleanup.test.ts' ` +
           // The state-machine invariants test file legitimately references
           // the pattern in test descriptions, comments, and the rg pattern
           // it itself constructs.

--- a/src/db/migrations/master-backfill-and-shadow-cleanup.test.ts
+++ b/src/db/migrations/master-backfill-and-shadow-cleanup.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Integration tests for migration 053 — master_backfill_and_shadow_cleanup.
+ *
+ * Covers Group 14 sub-deliverables 14a (bare-name shadow archival) and 14b
+ * (master backfill of dir:<name> rows).
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { getConnection } from '../../lib/db.js';
+import { DB_AVAILABLE, setupTestDatabase } from '../../lib/test-db.js';
+
+const MIGRATION_PATH = join(import.meta.dir, '053_master_backfill_and_shadow_cleanup.sql');
+
+async function applyMigrationManually(): Promise<void> {
+  const sql = await getConnection();
+  const body = await readFile(MIGRATION_PATH, 'utf-8');
+  await sql.unsafe(body);
+}
+
+describe.skipIf(!DB_AVAILABLE)('migration 053 — master_backfill_and_shadow_cleanup', () => {
+  let cleanup: () => Promise<void>;
+
+  beforeAll(async () => {
+    cleanup = await setupTestDatabase();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  beforeEach(async () => {
+    const sql = await getConnection();
+    await sql`DELETE FROM audit_events WHERE actor = 'migration:053_master_backfill_and_shadow_cleanup'`;
+    await sql`DELETE FROM assignments`;
+    await sql`DELETE FROM executors`;
+    await sql`DELETE FROM agents`;
+  });
+
+  // ==========================================================================
+  // 14b — master backfill: dir:<name> created from existing canonical fields
+  // ==========================================================================
+
+  test('14b: backfills dir:felipe from a bare felipe row (Type-B shape)', async () => {
+    const sql = await getConnection();
+    // Twin's analysis: the bare row is the only candidate carrying
+    // repo_path. `custom_name` is empty/null in production (the partial
+    // unique index `idx_agents_custom_name_team` requires it to be unique
+    // when populated alongside team — bare rows skirt that by leaving it
+    // null); role is the canonical identity.
+    await sql`
+      INSERT INTO agents (id, role, custom_name, team, repo_path, started_at, state, auto_resume, reports_to)
+      VALUES ('felipe', 'felipe', NULL, 'felipe', '/home/genie/workspace/agents/felipe', now(), NULL, true, NULL)
+    `;
+
+    await applyMigrationManually();
+
+    const dirRow = await sql<
+      { id: string; role: string; custom_name: string | null; team: string; repo_path: string }[]
+    >`
+      SELECT id, role, custom_name, team, repo_path
+      FROM agents WHERE id = 'dir:felipe'
+    `;
+    expect(dirRow.length).toBe(1);
+    expect(dirRow[0].role).toBe('felipe');
+    expect(dirRow[0].custom_name).toBe('felipe');
+    expect(dirRow[0].team).toBe('felipe');
+    expect(dirRow[0].repo_path).toBe('/home/genie/workspace/agents/felipe');
+
+    const audit = await sql<{ details: { reason: string; group: string } }[]>`
+      SELECT details FROM audit_events
+       WHERE actor = 'migration:053_master_backfill_and_shadow_cleanup'
+         AND entity_id = 'dir:felipe'
+         AND event_type = 'directory.master_backfilled'
+    `;
+    expect(audit.length).toBe(1);
+    expect(audit[0].details.reason).toBe('master_backfill');
+    expect(audit[0].details.group).toBe('14b');
+  });
+
+  test('14b: backfills dir:genie and dir:genie-pgserve from twin-shape masters', async () => {
+    const sql = await getConnection();
+    await sql`
+      INSERT INTO agents (id, role, custom_name, team, repo_path, started_at, state, auto_resume, reports_to)
+      VALUES
+        ('genie', 'genie', NULL, 'genie', '/home/genie/workspace/agents/genie', now(), 'idle', true, NULL),
+        ('genie-pgserve', 'genie-pgserve', NULL, 'genie', '/home/genie/workspace/agents/genie-pgserve', now(), NULL, true, NULL)
+    `;
+
+    await applyMigrationManually();
+
+    const created = await sql<{ id: string }[]>`
+      SELECT id FROM agents WHERE id LIKE 'dir:%' ORDER BY id
+    `;
+    expect(created.map((r: { id: string }) => r.id)).toEqual(['dir:genie', 'dir:genie-pgserve']);
+
+    const repoPaths = await sql<{ id: string; repo_path: string }[]>`
+      SELECT id, repo_path FROM agents WHERE id LIKE 'dir:%' ORDER BY id
+    `;
+    const byId = new Map(repoPaths.map((r: { id: string; repo_path: string }) => [r.id, r.repo_path]));
+    expect(byId.get('dir:genie')).toBe('/home/genie/workspace/agents/genie');
+    expect(byId.get('dir:genie-pgserve')).toBe('/home/genie/workspace/agents/genie-pgserve');
+  });
+
+  test('14b: NULLs custom_name when (name, team) slot is held by another live peer', async () => {
+    const sql = await getConnection();
+    // Production Type-B: UUID peer holds (custom_name='felipe', team='felipe')
+    // in the unique partial index. The bare row lacks dir:<name>. Backfilling
+    // dir:felipe with custom_name='felipe' team='felipe' would conflict with
+    // the index, so the migration must NULL custom_name on the new row.
+    await sql`
+      INSERT INTO agents (id, role, custom_name, team, repo_path, started_at, state, auto_resume, reports_to)
+      VALUES
+        ('00000000-0000-0000-0000-feedfacefeed', 'felipe', 'felipe', 'felipe', '/some/uuid/path', now(), 'idle', true, NULL),
+        ('felipe', 'felipe', NULL, 'felipe', '/home/genie/workspace/agents/felipe', now(), 'idle', true, NULL)
+    `;
+
+    await applyMigrationManually();
+
+    const dirRow = await sql<{ custom_name: string | null }[]>`
+      SELECT custom_name FROM agents WHERE id = 'dir:felipe'
+    `;
+    expect(dirRow.length).toBe(1);
+    expect(dirRow[0].custom_name).toBeNull();
+  });
+
+  test('14b: skips agents that already have a dir:<name> peer (no duplicate insert)', async () => {
+    const sql = await getConnection();
+    await sql`
+      INSERT INTO agents (id, role, custom_name, team, repo_path, started_at, state, auto_resume, reports_to)
+      VALUES ('dir:email', 'email', 'email', 'felipe', '/home/genie/workspace/agents/email', now(), NULL, true, NULL)
+    `;
+    await sql`
+      INSERT INTO agents (id, role, custom_name, team, repo_path, started_at, state, auto_resume, reports_to)
+      VALUES ('email', 'email', NULL, 'felipe', '/home/genie/workspace/agents/email', now(), NULL, true, NULL)
+    `;
+
+    await applyMigrationManually();
+
+    const dirRows = await sql<{ id: string }[]>`
+      SELECT id FROM agents WHERE id LIKE 'dir:%' ORDER BY id
+    `;
+    expect(dirRows.length).toBe(1);
+    expect(dirRows[0].id).toBe('dir:email');
+  });
+
+  test('14b: skips bare task-shaped rows (kind=task / archived / no repo_path)', async () => {
+    const sql = await getConnection();
+    await sql`
+      INSERT INTO agents (id, role, custom_name, team, repo_path, started_at, state, auto_resume, reports_to)
+      VALUES
+        ('engineer-w2g3', 'engineer', 'engineer', 'master-aware-spawn', '/some/path', now(), 'idle', true, 'team-lead-uuid'),
+        ('archived-master', 'archived', '', 'archived', '/some/path', now(), 'archived', true, NULL),
+        ('no-repo-master', 'foo', '', 'foo', NULL, now(), NULL, true, NULL)
+    `;
+
+    await applyMigrationManually();
+
+    const dirRows = await sql<{ id: string }[]>`SELECT id FROM agents WHERE id LIKE 'dir:%'`;
+    expect(dirRows.length).toBe(0);
+  });
+
+  // ==========================================================================
+  // 14a — bare-name shadow cleanup (heal-not-wipe)
+  // ==========================================================================
+
+  test('14a: archives bare-name shadow when dir:<name> peer exists (no executor)', async () => {
+    const sql = await getConnection();
+    await sql`
+      INSERT INTO agents (id, role, custom_name, team, repo_path, started_at, state, auto_resume, reports_to)
+      VALUES
+        ('dir:email', 'email', 'email', 'felipe', '/home/genie/workspace/agents/email', now(), NULL, false, NULL),
+        ('email', 'email', NULL, 'felipe', '/home/genie/workspace/agents/email', now(), NULL, true, NULL)
+    `;
+
+    await applyMigrationManually();
+
+    const bare = await sql<{ state: string | null; auto_resume: boolean }[]>`
+      SELECT state, auto_resume FROM agents WHERE id = 'email'
+    `;
+    expect(bare[0].state).toBe('archived');
+    expect(bare[0].auto_resume).toBe(false);
+
+    // dir: row left intact.
+    const dir = await sql<{ state: string | null; repo_path: string }[]>`
+      SELECT state, repo_path FROM agents WHERE id = 'dir:email'
+    `;
+    expect(dir[0].state).toBeNull();
+    expect(dir[0].repo_path).toBe('/home/genie/workspace/agents/email');
+
+    const audit = await sql<{ details: { reason: string; group: string } }[]>`
+      SELECT details FROM audit_events
+       WHERE actor = 'migration:053_master_backfill_and_shadow_cleanup'
+         AND entity_id = 'email'
+         AND event_type = 'state_changed'
+    `;
+    expect(audit.length).toBe(1);
+    expect(audit[0].details.reason).toBe('bare_name_shadow_archived');
+    expect(audit[0].details.group).toBe('14a');
+  });
+
+  test('14a: NEVER deletes bare-name shadow rows (heal-not-wipe contract)', async () => {
+    const sql = await getConnection();
+    await sql`
+      INSERT INTO agents (id, role, custom_name, team, repo_path, started_at, state, auto_resume, reports_to)
+      VALUES
+        ('dir:email', 'email', 'email', 'felipe', '/home/genie/workspace/agents/email', now(), NULL, false, NULL),
+        ('email', 'email', NULL, 'felipe', '/home/genie/workspace/agents/email', now(), NULL, true, NULL)
+    `;
+
+    await applyMigrationManually();
+
+    // Row still exists (just archived). Wholesale deletion is the failure
+    // mode the master-aware-spawn wish was born from.
+    const stillThere = await sql<{ id: string; state: string | null }[]>`
+      SELECT id, state FROM agents WHERE id = 'email'
+    `;
+    expect(stillThere.length).toBe(1);
+    expect(stillThere[0].state).toBe('archived');
+  });
+
+  test('14a: leaves bare-name shadow alone when current_executor_id is set (live peer)', async () => {
+    const sql = await getConnection();
+    await sql`
+      INSERT INTO agents (id, role, custom_name, team, repo_path, started_at, state, auto_resume, reports_to)
+      VALUES
+        ('dir:email', 'email', 'email', 'felipe', '/some/path', now(), NULL, false, NULL),
+        ('email', 'email', NULL, 'felipe', '/some/path', now(), 'idle', true, NULL)
+    `;
+    // Attach a live executor to the bare row.
+    await sql`
+      INSERT INTO executors (id, agent_id, provider, transport, state)
+      VALUES ('exec-live', 'email', 'claude', 'tmux', 'running')
+    `;
+    await sql`UPDATE agents SET current_executor_id = 'exec-live' WHERE id = 'email'`;
+
+    await applyMigrationManually();
+
+    const bare = await sql<{ state: string | null }[]>`
+      SELECT state FROM agents WHERE id = 'email'
+    `;
+    expect(bare[0].state).toBe('idle');
+  });
+
+  test('14a: never archives UUID-shaped rows even if dir:<uuid> exists', async () => {
+    const sql = await getConnection();
+    const uuid = '11111111-2222-3333-4444-555555555555';
+    await sql`
+      INSERT INTO agents (id, role, custom_name, team, repo_path, started_at, state, auto_resume, reports_to)
+      VALUES
+        (${`dir:${uuid}`}, 'weird', 'weird', 'team-dir', '/p', now(), NULL, false, NULL),
+        (${uuid}, 'weird', 'weird', 'team-uuid', '/p', now(), 'idle', true, NULL)
+    `;
+
+    await applyMigrationManually();
+
+    const uuidRow = await sql<{ state: string | null }[]>`
+      SELECT state FROM agents WHERE id = ${uuid}
+    `;
+    expect(uuidRow[0].state).toBe('idle');
+  });
+
+  // ==========================================================================
+  // Composite + idempotency
+  // ==========================================================================
+
+  test('14a + 14b run in one pass: bare felipe gets archived AFTER dir:felipe is backfilled', async () => {
+    const sql = await getConnection();
+    // Only the bare row exists; the migration must first create dir:felipe
+    // (14b) and only THEN archive the bare felipe shadow (14a).
+    await sql`
+      INSERT INTO agents (id, role, custom_name, team, repo_path, started_at, state, auto_resume, reports_to)
+      VALUES ('felipe', 'felipe', NULL, 'felipe', '/home/genie/workspace/agents/felipe', now(), 'idle', true, NULL)
+    `;
+
+    await applyMigrationManually();
+
+    const dir = await sql<{ id: string }[]>`SELECT id FROM agents WHERE id = 'dir:felipe'`;
+    expect(dir.length).toBe(1);
+
+    const bare = await sql<{ state: string | null; auto_resume: boolean }[]>`
+      SELECT state, auto_resume FROM agents WHERE id = 'felipe'
+    `;
+    expect(bare[0].state).toBe('archived');
+    expect(bare[0].auto_resume).toBe(false);
+  });
+
+  test('idempotent: re-running the migration touches zero new rows', async () => {
+    const sql = await getConnection();
+    await sql`
+      INSERT INTO agents (id, role, custom_name, team, repo_path, started_at, state, auto_resume, reports_to)
+      VALUES ('felipe', 'felipe', NULL, 'felipe', '/home/genie/workspace/agents/felipe', now(), 'idle', true, NULL)
+    `;
+
+    await applyMigrationManually();
+    const firstAuditCount = await sql<{ cnt: number }[]>`
+      SELECT count(*)::int AS cnt FROM audit_events
+       WHERE actor = 'migration:053_master_backfill_and_shadow_cleanup'
+    `;
+
+    await applyMigrationManually();
+    const secondAuditCount = await sql<{ cnt: number }[]>`
+      SELECT count(*)::int AS cnt FROM audit_events
+       WHERE actor = 'migration:053_master_backfill_and_shadow_cleanup'
+    `;
+
+    expect(secondAuditCount[0].cnt).toBe(firstAuditCount[0].cnt);
+  });
+});


### PR DESCRIPTION
Closes Wave 2 sub-deliverables 14a + 14b of the **master-aware-spawn** wish.

## Summary

Two-pass migration that brings all four masters (`felipe`, `genie`, `genie-pgserve`, `email`) under Group 1's `dir:<name>` chokepoint coverage and cleans up the bare-name shadow rows that were blocking session resume.

- **14a — bare-name shadow cleanup.** Archives bare-name rows (`state='archived'`, `auto_resume=false`, NEVER DELETE) when a `dir:<name>` peer exists, the bare row's `current_executor_id IS NULL`, and the bare row identifies as the same agent (role/id/custom_name match dir.custom_name). Heal-not-wipe contract per Group 3 — no row is destroyed; archive is the safe terminal state. Audit event `state_changed` with reason `bare_name_shadow_archived`.
- **14b — master backfill.** For every `kind='permanent' AND repo_path != ''` row that lacks a `dir:<name>` peer, INSERTs the missing `dir:<name>` row using the bare row's identity columns. Brings `dir:felipe`, `dir:genie`, `dir:genie-pgserve` into existence (only `dir:email` existed before). Audit event `directory.master_backfilled`.

## NULL-vs-empty custom_name (twin's finding-002)

Production PG has `custom_name IS NULL` (not `''`) for 3 of 4 masters. The migration uses `COALESCE(NULLIF(custom_name, ''), role)` to handle both shapes — NULLIF turns `''` into NULL, COALESCE picks the first non-null. Test fixtures explicitly seed with `NULL` to exercise the production shape.

## Smart unique-index handling

The partial unique index `idx_agents_custom_name_team` requires `(custom_name, team)` to be unique when both non-null. If a live UUID peer already owns that slot (Type B production: UUID with `custom_name=name, team=team`), 14b's INSERT sets `dir.custom_name=NULL` so the new row sits outside the unique index. Session-sync's `getAgentByName(name, team)` lookup routes to the UUID peer while it lives; once the peer is unregistered, a future migration can repopulate `custom_name` via UPDATE.

## Validation

```
$ bun test src/db/migrations/master-backfill-and-shadow-cleanup.test.ts
[test-setup] reusing pgserve on port 20900 (pid 3973216)
 11 pass
 0 fail
 31 expect() calls
Ran 11 tests across 1 file. [1241.00ms]
```

Test coverage:
- 14b backfill: felipe (Type B), twin-shape masters, slot-conflict (NULL custom_name), idempotency, type filtering
- 14a archive: peer-exists path, heal-not-wipe contract, live-peer protection, UUID-shape exclusion (`NOT LIKE '%-%-%-%-%'`)
- Combined-pass: bare felipe archived AFTER dir:felipe is backfilled
- Idempotency: re-running affects zero rows

## Forensic-recovery note

Authoring engineer was `engineer-w2g14@genie`. Original session UUID lost in the §19v3 ghost-session collapse around 2026-04-27 ~04:50 UTC: spawn machinery passed `teamWindow.windowId` (raw `@N` format) as a tmux session-name, creating rogue session `$13` literally named `"@60"`. Engineer process landed in the orphan and died before commit. Work preserved on disk via twin overnight forensic pass; recommitted by `genie-twin-overnight` after §19v3 root-cause identification (see PR #1414, this PR's sibling).

## Evidence files (preserved on disk)

- `/tmp/genie-recover/twin-overnight/finding-002-group-14d-customname-null.md` — NULL custom_name production proof, `dir:email` had 10 jsonl recoveries in 24h while the 4 NULL-customName masters had 0
- `/tmp/genie-recover/twin-overnight/SUMMARY-hour-1.md` — full overnight surveillance report

## Test plan

- [x] `bun test src/db/migrations/master-backfill-and-shadow-cleanup.test.ts` — 11 pass / 0 fail (locally)
- [x] `bun run typecheck` — clean
- [x] `bunx biome check` on the test file — clean
- [ ] Confirm CI Quality Gate green before merge
- [ ] Manual post-merge: query `SELECT id, custom_name FROM agents WHERE id LIKE 'dir:%' AND id IN ('dir:felipe', 'dir:genie', 'dir:genie-pgserve');` — confirm 3 new dir-rows exist
- [ ] Manual post-merge: query `SELECT id, state FROM agents WHERE id IN ('felipe','genie','genie-pgserve','email') AND current_executor_id IS NULL;` — confirm bare rows transitioned to archived (or remained alive if executor still set)

## Coordinated landing

Pairs with PR #1414 (§19v3 ghost-session fix). Together: §19v3 stops new ghosts from forming; this PR fixes the directory shape so future master recoveries succeed across all four masters.

Co-Authored-By: engineer-w2g14 (orphan-session victim) <noreply@anthropic.com>
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)