### PR TITLE
fix(spawn): Group 21 phantom-spawn — separate agent template from role

### DIFF
--- a/src/lib/provider-adapters.test.ts
+++ b/src/lib/provider-adapters.test.ts
@@ -87,6 +87,34 @@ describe('buildClaudeCommand', () => {
     expect(result.command).not.toContain('--agent');
   });
 
+  // Group 21 regression: --agent must use the resolved template name,
+  // NOT the operator's --role override. Prevents phantom-spawn cascade
+  // (custom name reaching Claude's template lookup → exit on missing
+  // template → 14M watchdog `resume.missing_session` events / 7d).
+  it('uses agentTemplate (not role) for --agent flag when both differ', () => {
+    const result = buildClaudeCommand({
+      provider: 'claude',
+      team: 'work',
+      role: 'custom-identity', // operator's --role override (registration name)
+      agentTemplate: 'engineer', // resolved template (verified on disk)
+    });
+    expect(result.command).toContain("--agent 'engineer'");
+    expect(result.command).not.toContain("--agent 'custom-identity'");
+    // Identity-shaped fields preserve the role override
+    expect(result.meta.role).toBe('custom-identity');
+  });
+
+  it('falls back to role for --agent when agentTemplate is unset', () => {
+    // Backward compatibility: callers that bypass buildSpawnParams (legacy
+    // paths) only set role. Behavior should match pre-Group-21 semantics.
+    const result = buildClaudeCommand({
+      provider: 'claude',
+      team: 'work',
+      role: 'engineer',
+    });
+    expect(result.command).toContain("--agent 'engineer'");
+  });
+
   it('does not include hidden teammate flags', () => {
     const result = buildClaudeCommand({ provider: 'claude', team: 'work', role: 'implementor' });
     expect(result.command).not.toContain('--teammate');

--- a/src/lib/provider-adapters.ts
+++ b/src/lib/provider-adapters.ts
@@ -65,6 +65,23 @@ export interface SpawnParams {
   provider: ProviderName;
   team: string;
   role?: string;
+  /**
+   * Resolved agent template name (the `<name>` positional arg that
+   * resolves via `directory.resolve` to a built-in or user-registered
+   * agent definition). Used as Claude's `--agent <template>` flag —
+   * Claude looks up the agent definition by this name.
+   *
+   * Distinct from `role`, which is the IDENTITY override (operator's
+   * `--role <custom>` flag). When operator passes `--role custom-id`
+   * with a template `engineer`, the spawn must build:
+   *   --agent 'engineer'         (template — for definition lookup)
+   *   --agent-name 'custom-id'   (identity — for inbox/registry)
+   *
+   * Group 21 fix: previously `--agent` was sourced from `role`, which
+   * cascaded the custom identity into Claude's template lookup,
+   * producing phantom rows and 14M `resume.missing_session` events.
+   */
+  agentTemplate?: string;
   skill?: string;
   /** Agent ID this executor belongs to. Used by executor model (Groups 3+). */
   agentId?: string;
@@ -131,6 +148,7 @@ const spawnParamsSchema = z.object({
   provider: z.enum(['claude', 'codex', 'claude-sdk', 'app-pty']),
   team: z.string().min(1, 'Team name is required'),
   role: z.string().optional(),
+  agentTemplate: z.string().optional(),
   skill: z.string().optional(),
   agentId: z.string().optional(),
   executorId: z.string().uuid().optional(),
@@ -360,7 +378,16 @@ function appendSessionFlags(parts: string[], params: SpawnParams): void {
   } else if (params.sessionId) {
     parts.push('--session-id', escapeShellArg(params.sessionId));
   }
-  if (params.role) parts.push('--agent', escapeShellArg(params.role));
+  // Group 21 fix: --agent flag uses the resolved template (agentTemplate),
+  // NOT the identity override (role). Falls back to role only when no
+  // template field is set (legacy callers / built-in spawn paths that
+  // bypass buildSpawnParams). When role is custom AND no template is
+  // resolved, we still emit --agent <role> to preserve prior behavior;
+  // the agents.ts:buildSpawnParams call site is now responsible for
+  // setting agentTemplate to the verified template name so the right
+  // value reaches Claude's template lookup.
+  const claudeAgentFlag = params.agentTemplate ?? params.role;
+  if (claudeAgentFlag) parts.push('--agent', escapeShellArg(claudeAgentFlag));
   if (params.model) parts.push('--model', escapeShellArg(params.model));
   if (params.name) parts.push('--name', escapeShellArg(params.name));
 }

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -1710,6 +1710,7 @@ async function buildSpawnParams(
   options: SpawnOptions,
   agent: Awaited<ReturnType<typeof resolveAgentForSpawn>>,
   preassignedSessionId?: string,
+  agentTemplate?: string,
 ): Promise<{ params: SpawnParams; parentSessionId: string; spawnColor: ClaudeTeamColor }> {
   // Provider resolution chain: CLI --provider > directory entry > default 'claude'
   const resolvedProvider = (options.provider ?? agent.entry.provider ?? 'claude') as ProviderName;
@@ -1718,6 +1719,11 @@ async function buildSpawnParams(
     provider: resolvedProvider,
     team,
     role: name,
+    // Group 21: pin the verified template separately from role/identity.
+    // The caller passes agentTemplate = the original `<name>` positional
+    // (the template that resolved via directory.resolve, guaranteed to
+    // exist on disk). Falls back to `name` itself for non-overridden spawns.
+    agentTemplate: agentTemplate ?? name,
     skill: options.skill,
     extraArgs: options.extraArgs,
     model: agent.model,
@@ -2147,12 +2153,16 @@ export async function handleWorkerSpawn(name: string, options: SpawnOptions): Pr
 
   // 3. Build params (pre-mint session UUID for state-machine paths so the row
   // id and the Claude session UUID stay in lockstep).
+  // Group 21: pass the ORIGINAL `name` as agentTemplate so Claude's `--agent`
+  // flag uses the resolved template (directory.resolve verified it exists),
+  // even when --role overrides the identity for registration.
   const { params, parentSessionId, spawnColor } = await buildSpawnParams(
     effectiveRole,
     team,
     options,
     agent,
     identity?.sessionUuid,
+    name,
   );
 
   // Set CC session display name if not already set


### PR DESCRIPTION
## Summary

P0 phantom-spawn fix (Group 21 in master-aware-spawn wish). When operator passes `genie spawn engineer --role custom-id`, the spawn-script generator emitted `--agent 'custom-id'` to Claude — but Claude looks up the agent definition by that name. `custom-id` is not a template on disk, Claude exits within ~1s, no executor row is ever live, watchdog spins on `resume.missing_session` forever.

**Empirical impact** (last 7 days, this server):
- **14,117,727 `resume.missing_session` events** — dominant orchestration failure mode by 4 orders of magnitude
- Live retry-loop reproduction earlier today: `genie-claude-resume` × 4 attempts × 30s = 2 minutes wasted

## Fix

Surgical separation of template (definition lookup) from role (identity):

1. New `SpawnParams.agentTemplate?: string` field — the resolved template name (the `<name>` positional that resolved via `directory.resolve`).
2. `provider-adapters.ts:appendSessionFlags` uses `params.agentTemplate ?? params.role` for `--agent` flag.
3. `agents.ts:buildSpawnParams` accepts `agentTemplate` argument; `handleWorkerSpawn` passes the original `name`.

**Result**: `--agent` always carries a template that exists on disk; identity flags keep the operator's `--role` override.

## Test plan

- [x] 2 new regression tests in `provider-adapters.test.ts` (uses agentTemplate over role; backward-compat fallback)
- [x] All 50 tests pass (+2 from baseline 48)
- [x] `bun run typecheck` clean
- [ ] CI runs full `bun run check` in isolation

## Related

- Wish: **Group 21 in `.genie/wishes/master-aware-spawn/WISH.md`**
- Sibling: Group 22 (send-path shadow dedup) merged in 4.260427.6 (PR #1416)
- Reproducer: `~/.genie/spawn-scripts/genie-genie-claude-resume-*.sh` × 3 retry scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)