### PR TITLE
fix(update): Group 7 — realpath symlink chain in detectFromBinaryPath

### DIFF
--- a/src/genie-commands/__tests__/update.test.ts
+++ b/src/genie-commands/__tests__/update.test.ts
@@ -4,8 +4,11 @@
  * Run with: bun test src/genie-commands/__tests__/update.test.ts
  */
 
+import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, test } from 'bun:test';
-import { detectGlobalInstalls } from '../update.js';
+import { detectFromBinaryPath, detectGlobalInstalls } from '../update.js';
 
 // We can't easily mock runCommandSilent inside the module, so we test
 // detectGlobalInstalls by actually running the detection commands.
@@ -26,6 +29,79 @@ describe('detectGlobalInstalls', () => {
     // and returns a valid (possibly empty) Set
     const result = await detectGlobalInstalls();
     expect(result.size).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// Group 7 regression: detectFromBinaryPath must follow symlinks before
+// pattern-matching. The standard install symlinks
+// `~/.local/bin/genie → ~/.bun/bin/genie → ~/.bun/install/global/.../dist/genie.js`
+// produce a literal LOCAL_BIN path; pre-fix, that mis-detected as 'source'
+// and ran `git fetch` against a non-existent ~/.genie/src, causing
+// `ENOENT: posix_spawn 'git'` for bun-installed users.
+describe('detectFromBinaryPath symlink resolution (Group 7)', () => {
+  test('follows symlink chain to detect bun install via node_modules in target', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'genie-update-detect-'));
+    try {
+      // Simulate: ~/.bun/install/global/node_modules/@automagik/genie/dist/genie.js
+      const realDir = join(tmp, '.bun/install/global/node_modules/@automagik/genie/dist');
+      mkdirSync(realDir, { recursive: true });
+      const realBin = join(realDir, 'genie.js');
+      writeFileSync(realBin, '#!/usr/bin/env bun\n', { mode: 0o755 });
+
+      // Simulate: ~/.local/bin/genie -> ~/.bun/bin/genie -> realBin (two-hop chain)
+      const bunBinDir = join(tmp, '.bun/bin');
+      mkdirSync(bunBinDir, { recursive: true });
+      const bunSymlink = join(bunBinDir, 'genie');
+      symlinkSync(realBin, bunSymlink);
+
+      const localBinDir = join(tmp, '.local/bin');
+      mkdirSync(localBinDir, { recursive: true });
+      const localSymlink = join(localBinDir, 'genie');
+      symlinkSync(bunSymlink, localSymlink);
+
+      // Pre-fix this returned 'source' (mismatch on literal path); post-fix
+      // returns 'bun' (resolved target contains '.bun/').
+      const result = detectFromBinaryPath(localSymlink);
+      expect(result).toBe('bun');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('resolves npm install via node_modules path', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'genie-update-detect-'));
+    try {
+      // ~/.npm/.../node_modules/@automagik/genie/dist/genie.js (no .bun in path)
+      const realDir = join(tmp, '.npm/lib/node_modules/@automagik/genie/dist');
+      mkdirSync(realDir, { recursive: true });
+      const realBin = join(realDir, 'genie.js');
+      writeFileSync(realBin, '#!/usr/bin/env node\n', { mode: 0o755 });
+
+      const localBinDir = join(tmp, '.local/bin');
+      mkdirSync(localBinDir, { recursive: true });
+      const localSymlink = join(localBinDir, 'genie');
+      symlinkSync(realBin, localSymlink);
+
+      const result = detectFromBinaryPath(localSymlink);
+      expect(result).toBe('npm');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('falls back to original path on broken symlink (graceful)', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'genie-update-detect-'));
+    try {
+      const broken = join(tmp, 'broken-genie');
+      symlinkSync('/nonexistent/path/genie', broken);
+
+      // realpathSync throws; we fall back to the original path which has
+      // neither '.bun' nor 'node_modules', so result is null.
+      const result = detectFromBinaryPath(broken);
+      expect(result).toBeNull();
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/genie-commands/__tests__/update.test.ts
+++ b/src/genie-commands/__tests__/update.test.ts
@@ -4,10 +4,10 @@
  * Run with: bun test src/genie-commands/__tests__/update.test.ts
  */
 
-import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync, rmSync } from 'node:fs';
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, test } from 'bun:test';
 import { detectFromBinaryPath, detectGlobalInstalls } from '../update.js';
 
 // We can't easily mock runCommandSilent inside the module, so we test

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -135,10 +135,32 @@ async function runCommandSilent(
 
 type InstallationType = 'source' | 'npm' | 'bun' | 'unknown';
 
-function detectFromBinaryPath(path: string): InstallationType | null {
-  if (path.includes('.bun')) return 'bun';
-  if (path.includes('node_modules')) return 'npm';
-  if (path === join(LOCAL_BIN, 'genie') || path.startsWith(GENIE_BIN)) return 'source';
+/**
+ * Detect installation type from the binary path returned by `which genie`.
+ *
+ * Group 7 fix: realpath the input first. The standard CLI install symlinks
+ * `~/.local/bin/genie → ~/.bun/bin/genie → ~/.bun/install/global/.../dist/genie.js`
+ * mean the literal `which` output is the symlink path, not the resolved target.
+ * Pre-fix, `~/.local/bin/genie` matched the `LOCAL_BIN` source-install branch
+ * even when the actual binary lived in `node_modules`, breaking
+ * `genie update --next` for bun-installed users with `ENOENT: posix_spawn 'git'`
+ * because the source-install path then tried to `git fetch` against a
+ * non-existent `~/.genie/src/` directory.
+ */
+export function detectFromBinaryPath(path: string): InstallationType | null {
+  // Resolve symlink chain so node_modules / .bun checks see the real target.
+  let resolved = path;
+  try {
+    resolved = require('node:fs').realpathSync(path);
+  } catch {
+    // Broken symlink or permission error — fall back to the literal path.
+  }
+
+  if (resolved.includes('.bun')) return 'bun';
+  if (resolved.includes('node_modules')) return 'npm';
+  // Source install: literal LOCAL_BIN path with no node_modules in resolved
+  // target, OR the binary lives under ~/.genie/bin/ directly.
+  if (path === join(LOCAL_BIN, 'genie') || resolved.startsWith(GENIE_BIN)) return 'source';
   return null;
 }
 


### PR DESCRIPTION
## Summary

P1 fix (codex-provider-parity wish, Group 7). `genie update --next` mis-classified bun-installed binaries as `'source'` because `detectFromBinaryPath` checked the literal path returned by `which genie` without resolving the symlink chain.

Standard install layout:
\`\`\`
~/.local/bin/genie → ~/.bun/bin/genie → ~/.bun/install/global/.../dist/genie.js
\`\`\`

Pre-fix, the literal `~/.local/bin/genie` matched the `LOCAL_BIN` source-install branch. Update then tried `git fetch origin` inside `~/.genie/src/` — but that directory doesn't exist for bun installs, and where `git` was missing from the non-interactive PATH it failed with `ENOENT: no such file or directory, posix_spawn 'git'`.

**Felipe hit this today** after upgrading to 4.260427.6 via `bun add -g @automagik/genie@next`.

## Fix

`realpathSync` the binary path first; pattern-match the resolved target. Source install detection still works via the LOCAL_BIN literal-path fallback and the `GENIE_BIN` prefix check for `~/.genie/bin/` direct installs.

## Test plan

- [x] 3 new regression tests covering (1) bun symlink chain → `'bun'`, (2) npm direct-symlink → `'npm'`, (3) broken symlink → graceful fallback to `null`
- [x] All 7 update tests pass (+3 from baseline 4)
- [x] `bun run typecheck` clean

## Related

- Wish: **Group 7 in `.genie/wishes/codex-provider-parity/WISH.md`**
- Sibling Group 21 (phantom-spawn template separation): PR #1417

🤖 Generated with [Claude Code](https://claude.com/claude-code)