### PR TITLE
fix(codex): Group 1 — pane-content state detection (was hardcoded 'working')

### DIFF
--- a/src/lib/orchestrator/codex-state.test.ts
+++ b/src/lib/orchestrator/codex-state.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Codex state detector — pattern matching unit tests.
+ *
+ * Group 1 of codex-provider-parity wish.
+ *
+ * Run with: bun test src/lib/orchestrator/codex-state.test.ts
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { detectCodexState, mapCodexToExecutorState } from './codex-state.js';
+
+describe('detectCodexState', () => {
+  describe('permission states', () => {
+    test('matches "Press enter to confirm or esc to cancel"', () => {
+      const tail = `
+some output
+
+Press enter to confirm or esc to cancel
+`;
+      const result = detectCodexState(tail);
+      expect(result.type).toBe('permission');
+      expect(result.detail).toContain('enter-or-esc');
+    });
+
+    test('matches "Would you like to run"', () => {
+      const tail = `
+• exec
+Would you like to run this command?
+`;
+      const result = detectCodexState(tail);
+      expect(result.type).toBe('permission');
+    });
+  });
+
+  describe('working states', () => {
+    test('matches spinner glyph ⠋', () => {
+      const tail = '⠋ thinking...';
+      const result = detectCodexState(tail);
+      expect(result.type).toBe('working');
+      expect(result.detail).toContain('spinner');
+    });
+
+    test('matches spinner glyph ◐', () => {
+      const result = detectCodexState('processing ◐ stand by');
+      expect(result.type).toBe('working');
+    });
+
+    test('matches "esc to interrupt" affordance', () => {
+      const result = detectCodexState('working on response (esc to interrupt)');
+      expect(result.type).toBe('working');
+      expect(result.detail).toContain('esc-to-interrupt');
+    });
+
+    test('falls through to working when tail is non-empty but no recognizable signal', () => {
+      const result = detectCodexState('plain text output with no markers');
+      expect(result.type).toBe('working');
+      expect(result.detail).toContain('between-turns');
+    });
+
+    test('working takes precedence over the prompt glyph', () => {
+      // The `›` prompt placeholder can be visible WHILE codex is processing.
+      // Spinner / esc-to-interrupt must win.
+      const tail = `
+› user input here
+⠋ processing
+`;
+      const result = detectCodexState(tail);
+      expect(result.type).toBe('working');
+    });
+  });
+
+  describe('idle states', () => {
+    test('matches `›` prompt at start of a line', () => {
+      const tail = `
+some response
+›
+gpt-5.3-codex · ~/path
+`;
+      const result = detectCodexState(tail);
+      expect(result.type).toBe('idle');
+      expect(result.detail).toContain('prompt');
+    });
+
+    test('matches `>` prompt at start of a line (ASCII fallback)', () => {
+      const result = detectCodexState('output\n> \n');
+      expect(result.type).toBe('idle');
+    });
+
+    test('idle requires the prompt at line start, not mid-content', () => {
+      // A `›` mid-text shouldn't trigger idle.
+      const result = detectCodexState('some text › with arrow inline');
+      expect(result.type).toBe('working');
+    });
+  });
+
+  describe('edge cases', () => {
+    test('empty input returns unknown', () => {
+      const result = detectCodexState('');
+      expect(result.type).toBe('unknown');
+    });
+
+    test('whitespace-only input returns unknown', () => {
+      const result = detectCodexState('   \n\n  \t  ');
+      expect(result.type).toBe('unknown');
+    });
+  });
+});
+
+describe('mapCodexToExecutorState', () => {
+  test('working -> working', () => {
+    expect(mapCodexToExecutorState('working')).toBe('working');
+  });
+  test('idle -> idle', () => {
+    expect(mapCodexToExecutorState('idle')).toBe('idle');
+  });
+  test('permission -> permission', () => {
+    expect(mapCodexToExecutorState('permission')).toBe('permission');
+  });
+  test('unknown -> idle (graceful fallback)', () => {
+    expect(mapCodexToExecutorState('unknown')).toBe('idle');
+  });
+});

--- a/src/lib/orchestrator/codex-state.ts
+++ b/src/lib/orchestrator/codex-state.ts
@@ -1,0 +1,97 @@
+/**
+ * Codex pane-content state detector.
+ *
+ * Mirrors the patterns Claude's `state-detector.ts` uses for claude-code,
+ * but tuned to codex's TUI shell:
+ *   - permission prompts: "Press enter to confirm or esc to cancel"
+ *   - active processing: spinner glyphs + "esc to interrupt" affordance
+ *   - idle: `›` prompt at start of a tail line (status bar below it)
+ *
+ * Also serves as the canonical source for the OTel relay's inline
+ * detector. The relay script in `agents.ts:ensureOtelRelay` carries a
+ * copy of these patterns; if you change them here, mirror them in the
+ * relay or extract patterns into a shared JSON.
+ *
+ * Group 1 of codex-provider-parity wish.
+ */
+
+import type { ExecutorState } from '../executor-types.js';
+
+/**
+ * Result type — broader than ExecutorState so callers can distinguish
+ * permission/question/idle/working without losing nuance. Map to
+ * ExecutorState via `mapToExecutorState` when the consumer expects
+ * that narrower set.
+ */
+export type CodexStateType = 'idle' | 'working' | 'permission' | 'unknown';
+
+export interface CodexStateResult {
+  type: CodexStateType;
+  /** Optional human-readable detail for logs/UI. */
+  detail?: string;
+}
+
+/**
+ * Detect codex state from pane scrollback / capture.
+ *
+ * Inputs the last N lines of the codex tmux pane (typically 50).
+ * Returns the most-specific recognized state; falls through to
+ * 'working' when nothing matches (codex's idle is a `›` prompt;
+ * no prompt + non-empty tail = still processing).
+ */
+export function detectCodexState(output: string): CodexStateResult {
+  if (!output || !output.trim()) {
+    return { type: 'unknown', detail: 'empty pane' };
+  }
+
+  const lines = output.split('\n').filter((l) => l.trim());
+  const tail = lines.slice(-8).join('\n');
+
+  // Permission prompts — codex is awaiting user approval. Highest priority.
+  if (/Press enter to confirm or esc to cancel/.test(tail)) {
+    return { type: 'permission', detail: 'enter-or-esc gate' };
+  }
+  if (/Would you like to run/.test(tail)) {
+    return { type: 'permission', detail: 'run-confirmation' };
+  }
+
+  // Working indicators MUST be checked BEFORE idle. Codex's `›` prompt
+  // placeholder is visible even while the agent is actively processing,
+  // so spinner glyphs / "esc to interrupt" hint take precedence.
+  if (/[◦◐◑◒◓⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/.test(tail)) {
+    return { type: 'working', detail: 'spinner glyph' };
+  }
+  if (/esc to interrupt/.test(tail)) {
+    return { type: 'working', detail: 'esc-to-interrupt affordance' };
+  }
+
+  // Idle — codex prompt waiting for input. The status bar
+  // (`gpt-5.3-codex · ~/path`) appears below the prompt.
+  if (/^\s*[>›]\s/m.test(tail)) {
+    return { type: 'idle', detail: 'prompt detected' };
+  }
+
+  // No prompt + non-empty tail + no spinner: codex is between turns,
+  // mid-render. Treat as working — when the next render lands either
+  // the prompt or the spinner will surface.
+  return { type: 'working', detail: 'between-turns render' };
+}
+
+/**
+ * Translate `CodexStateResult.type` into the narrower `ExecutorState`
+ * union the orchestrator's executor table uses. `permission` becomes
+ * `idle` (codex is waiting on the operator, just like a non-codex idle
+ * worker). `unknown` falls through to `idle` rather than blocking.
+ */
+export function mapCodexToExecutorState(state: CodexStateType): ExecutorState {
+  switch (state) {
+    case 'working':
+      return 'working';
+    case 'permission':
+      return 'permission';
+    case 'idle':
+      return 'idle';
+    default:
+      return 'idle';
+  }
+}

--- a/src/lib/providers/codex.ts
+++ b/src/lib/providers/codex.ts
@@ -11,7 +11,6 @@
  * Termination: best-effort SIGTERM when PID is available.
  */
 
-import { detectCodexState, mapCodexToExecutorState } from '../orchestrator/codex-state.js';
 import type {
   Executor,
   ExecutorProvider,
@@ -20,6 +19,7 @@ import type {
   SpawnContext,
   TransportType,
 } from '../executor-types.js';
+import { detectCodexState, mapCodexToExecutorState } from '../orchestrator/codex-state.js';
 import type { SpawnParams } from '../provider-adapters.js';
 import { buildCodexCommand } from '../provider-adapters.js';
 

--- a/src/lib/providers/codex.ts
+++ b/src/lib/providers/codex.ts
@@ -1,13 +1,17 @@
 /**
- * CodexProvider — Limited ExecutorProvider for Codex.
+ * CodexProvider — ExecutorProvider for Codex.
  *
- * Transport: api (fire-and-forget)
- * State detection: returns 'working' (API polling is future work)
- * Session extraction: not supported (no JSONL)
- * Resume: not supported
- * Termination: no-op (API cancel is future work)
+ * Transport: api (fire-and-forget) + tmux pane.
+ * State detection: pane-content based via `detectCodexState` (Group 1
+ *   of codex-provider-parity wish — was previously a hardcoded 'working'
+ *   stub, leaving genie ls/status blind to codex activity).
+ * Session extraction: not supported (no JSONL — `~/.codex/sessions/`
+ *   ingest tracked as Group 4 of codex-provider-parity).
+ * Resume: not supported (codex's --fork is the upstream-owned mechanic).
+ * Termination: best-effort SIGTERM when PID is available.
  */
 
+import { detectCodexState, mapCodexToExecutorState } from '../orchestrator/codex-state.js';
 import type {
   Executor,
   ExecutorProvider,
@@ -47,14 +51,36 @@ export class CodexProvider implements ExecutorProvider {
   }
 
   /**
-   * Detect the current state of an executor.
+   * Detect the current state of an executor via tmux pane capture +
+   * codex-specific pattern matching (`detectCodexState`).
    *
-   * Codex is fire-and-forget — returns 'working' for any non-terminated executor.
-   * API-based state polling is future work.
+   * Group 1 of codex-provider-parity wish: was a hardcoded 'working'
+   * stub. Now mirrors ClaudeCodeProvider's pane-capture flow but
+   * recognizes codex's prompt glyph (`›`), spinner glyphs, and
+   * permission affordances.
+   *
+   * Falls back to 'working' (the prior stub behavior) if pane capture
+   * fails — preserves "the worker is alive but state is uncertain"
+   * semantics rather than mis-marking as 'idle' or 'terminated'.
    */
   async detectState(executor: Executor): Promise<ExecutorState> {
     if (executor.state === 'terminated' || executor.endedAt) return 'terminated';
-    return 'working';
+
+    const paneId = executor.tmuxPaneId;
+    if (!paneId) return 'working'; // No pane to inspect — keep prior semantics.
+
+    try {
+      const { capturePaneContent } = await import('../tmux.js');
+      const content = await capturePaneContent(paneId, 50);
+      if (!content || !content.trim()) return 'working';
+      const result = detectCodexState(content);
+      return mapCodexToExecutorState(result.type);
+    } catch {
+      // Pane gone or tmux not running — caller will reconcile via
+      // pane-liveness probe; here we fall back to 'working' to avoid
+      // false-positive transitions to terminated/idle.
+      return 'working';
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

P0 fix in codex-provider-parity wish (Group 1). `CodexProvider.detectState` was a stub that returned `'working'` for any non-terminated executor, leaving `genie ls`, `genie status`, and `genie agent show` blind to actual codex worker state.

Today's session ran `genie-8b0e` + `sec-install-guard-codex` for 7+ hours; both showed `'working'` or `'running'` regardless of whether they were actively processing or sitting at the prompt.

## Fix

1. **New module** `src/lib/orchestrator/codex-state.ts`:
   - `detectCodexState(content): CodexStateResult` — recognizes permission gates, spinner glyphs / "esc to interrupt" working signals, prompt-glyph idle signals, between-turns rendering, and empty pane edge case
   - `mapCodexToExecutorState(type): ExecutorState` — translates to the executor table's narrower union
   - Working takes precedence over idle because codex's prompt placeholder can be visible WHILE actively processing

2. **`CodexProvider.detectState`** wired to `capturePaneContent` + `detectCodexState` (mirrors `ClaudeCodeProvider`'s flow). Falls back to `'working'` on pane-capture failure rather than mis-marking terminated/idle.

3. **OTel relay's inline detector** (in `agents.ts:164-183`) keeps its copy of these patterns — the relay script lives at `~/.genie/relay/otel-relay.mjs` at runtime and can't import TS modules. The new module's docs note this duplication; follow-up could extract patterns to a shared JSON.

## Test plan

- [x] 16 new test cases in `src/lib/orchestrator/codex-state.test.ts` covering each state, priority ordering, edge cases (empty, whitespace, mid-line prompt char)
- [x] All pass
- [x] `bun run typecheck` clean

## Related

- Wish: **Group 1 in `.genie/wishes/codex-provider-parity/WISH.md`**
- Sibling P0 in same wish: Group 2 (OTel→runtime_events bridge), Group 3 (native inbox bridge)
- Other parts of P0 wave still ahead in this round

🤖 Generated with [Claude Code](https://claude.com/claude-code)