### PR TITLE
fix(spawn): Group 3 — register all providers as native team members

### DIFF
--- a/src/lib/protocol-router-spawn.ts
+++ b/src/lib/protocol-router-spawn.ts
@@ -381,9 +381,22 @@ export async function spawnWorkerFromTemplate(
     /* best-effort: executor tracking is additive, don't block auto-spawn */
   }
 
-  if (isClaude) {
-    await registerNativeTeamMember(team, agentName, template, paneId, repoPath, spawnColor, resumeSessionId);
-  }
+  // Group 3 (codex-provider-parity): register ALL providers as native team
+  // members, not just claude. The native registry is what `genie send`'s
+  // bridge resolver (`resolveNativeMemberName`) queries to route messages
+  // through `~/.claude/teams/<team>/inboxes/<agent>.json`. Pre-fix, codex
+  // agents were never registered, so every `genie send --to <codex-agent>`
+  // emitted the warning `[genie send] Native inbox bridge: could not find
+  // native team member for "<name>"`. PG mailbox path worked as fallback,
+  // but native delivery silently failed.
+  //
+  // Note: `nativeTeamEnabled` on the agent registry row stays gated by
+  // isClaude — that flag controls claude-cli-specific protocol behaviors
+  // (--agent-id, --team-name, --agent-color flags) which codex's CLI
+  // doesn't understand. We register the codex agent in the native team
+  // namespace, but don't pretend it speaks the claude-cli teammate
+  // protocol.
+  await registerNativeTeamMember(team, agentName, template, paneId, repoPath, spawnColor, resumeSessionId);
 
   if (spawnColor) {
     await applyPaneColor(paneId, spawnColor, teamWindow?.windowId);


### PR DESCRIPTION
## Summary

P0 fix in codex-provider-parity wish (Group 3). `protocol-router-spawn` gated `registerNativeTeamMember` behind `if (isClaude)`, so codex spawns were never registered in `~/.claude/teams/<team>/inboxes/<agent>.json`.

**Symptom:** every `genie send --to <codex-agent>` emitted:
\`\`\`
[genie send] Native inbox bridge: could not find native team member for "<name>"
\`\`\`

The bridge's resolver `resolveNativeMemberName` queries the native registry and got null for unregistered codex agents. PG mailbox path worked as fallback (so messages still landed in `genie inbox list`), but native delivery silently failed.

**Live evidence captured today:** `genie-8b0e` (codex) + `sec-install-guard-codex` (codex) both consistently triggered the warning on every cross-agent message during the security-microPR work.

## Fix

Remove the `isClaude` gate around `registerNativeTeamMember`. Codex agents now get registered in the native team namespace alongside claude.

`nativeTeamEnabled` on the agent registry row stays gated by `isClaude` — that flag controls claude-cli-specific protocol behaviors (`--agent-id`, `--team-name`, `--agent-color` flags) which codex's CLI doesn't understand. We register codex agents in the native team namespace but don't pretend they speak the claude-cli teammate protocol.

## Test plan

- [x] All 28 tests in `protocol-router.test.ts` + `protocol-router-spawn.test.ts` continue to pass
- [x] `bun run typecheck` clean
- [ ] Acceptance criteria are integration-level — verify post-merge:
  - [ ] `genie spawn ... --provider codex` followed by `genie send --to <codex-agent>` does NOT print the bridge warning
  - [ ] `~/.claude/teams/<team>/inboxes/<codex-agent>.json` exists after codex spawn
  - [ ] PG mailbox path continues to work as fallback

## Related

- Wish: **Group 3 in `.genie/wishes/codex-provider-parity/WISH.md`**
- Sibling P0s: PR #1419 (Group 1 codex state detection), Group 2 (OTel→runtime_events bridge — coming next)
- Today's empirical evidence: `genie history genie-8b0e` shows the warning on every send attempt before this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)