### PR TITLE
fix(codex): Group 11 — honor initialPrompt as codex worker's first message

### DIFF
--- a/src/lib/provider-adapters.test.ts
+++ b/src/lib/provider-adapters.test.ts
@@ -316,6 +316,36 @@ describe('buildCodexCommand', () => {
     expect(result.command).toContain('Role: tester');
   });
 
+  // Group 11 (codex-provider-parity): codex spawn must honor --prompt
+  // (params.initialPrompt) as the worker's first user message, not
+  // override it with the auto-generated "Genie worker. Team: X." string.
+  it('honors initialPrompt verbatim when provided (Group 11)', () => {
+    const customPrompt = 'Implement Group 7 of security-install-download-guard wish';
+    const result = buildCodexCommand({
+      provider: 'codex',
+      team: 'work',
+      role: 'sec-install-guard-codex',
+      initialPrompt: customPrompt,
+    });
+    // Custom prompt is used verbatim
+    expect(result.command).toContain(customPrompt);
+    // Auto-generated prompt is NOT used when initialPrompt is supplied
+    expect(result.command).not.toContain('Genie worker. Team: work');
+  });
+
+  it('falls back to auto-prompt when initialPrompt is empty/absent', () => {
+    // Backward compat: spawn-without-prompt produces the same auto-string
+    // as before the Group 11 change.
+    const result = buildCodexCommand({
+      provider: 'codex',
+      team: 'work',
+      role: 'tester',
+      skill: 'work',
+    });
+    expect(result.command).toContain('Genie worker. Team: work.');
+    expect(result.command).toContain('Role: tester.');
+  });
+
   it('does not depend on agent-name routing', () => {
     const result = buildCodexCommand({ provider: 'codex', team: 'work', skill: 'work' });
     expect(result.command).not.toContain('--agent');

--- a/src/lib/provider-adapters.ts
+++ b/src/lib/provider-adapters.ts
@@ -442,6 +442,14 @@ export function buildClaudeCommand(params: SpawnParams): LaunchCommand {
  * Uses `codex` with `--instructions` to inject skill-based task
  * instructions. Role is advisory metadata only (DEC-4).
  */
+/** Build the auto-generated codex prompt when no initialPrompt is supplied. */
+function buildCodexAutoPrompt(params: SpawnParams): string {
+  const promptParts = [`Genie worker. Team: ${params.team}.`];
+  if (params.role) promptParts.push(`Role: ${params.role}.`);
+  if (params.skill) promptParts.push(`Execute the ${params.skill} skill instructions.`);
+  return promptParts.join(' ');
+}
+
 export function buildCodexCommand(params: SpawnParams): LaunchCommand {
   preflightCheck('codex');
 
@@ -465,11 +473,16 @@ export function buildCodexCommand(params: SpawnParams): LaunchCommand {
     }
   }
 
-  // Build prompt from available context (skill + role are both optional)
-  const promptParts = [`Genie worker. Team: ${params.team}.`];
-  if (params.role) promptParts.push(`Role: ${params.role}.`);
-  if (params.skill) promptParts.push(`Execute the ${params.skill} skill instructions.`);
-  const prompt = promptParts.join(' ');
+  // Group 11 (codex-provider-parity): honor params.initialPrompt as the
+  // codex worker's first user message. Pre-fix, codex spawn ignored
+  // --prompt entirely — operators were stuck either editing --extra-args
+  // by hand or sending a follow-up via genie send (which until Group 3
+  // landed today, silently failed the native bridge for codex agents).
+  //
+  // When initialPrompt is provided, use it verbatim. When absent, fall
+  // back to the auto-generated "Genie worker. Team: X. Role: Y." string
+  // so spawn-without-prompt behavior is unchanged.
+  const prompt = params.initialPrompt ?? buildCodexAutoPrompt(params);
   parts.push(escapeShellArg(prompt));
 
   return {


### PR DESCRIPTION
## Summary

P2 fix in codex-provider-parity wish (Group 11). \`buildCodexCommand\` hardcoded the prompt as \`Genie worker. Team: X. Role: Y. Execute the Z skill instructions.\` regardless of whether the operator passed \`--prompt\` to \`genie spawn\`. Custom prompts had to be smuggled through \`--extra-args\` or sent as a follow-up via \`genie send\` (which until Group 3 landed today, silently failed the native bridge for codex agents).

## Fix

When \`params.initialPrompt\` is set, use it verbatim as the codex worker's positional prompt argument. Falls back to the auto-generated string when absent — spawn-without-prompt behavior is unchanged.

Refactor: extract \`buildCodexAutoPrompt\` as a small helper for the fallback path so the main flow stays linear.

## Test plan

- [x] 2 new regression cases:
  - \`honors initialPrompt verbatim when provided\`
  - \`falls back to auto-prompt when initialPrompt is empty/absent\`
- [x] All 50 tests in \`provider-adapters.test.ts\` pass (+2 from baseline 48)
- [x] \`bun run typecheck\` clean

## Related

- Wish: **Group 11 in \`.genie/wishes/codex-provider-parity/WISH.md\`**
- Sibling: Group 3 (codex native inbox bridge — PR #1420) which made \`genie send\` to codex agents resolve natively, complementing this prompt-injection path
- Together with Group 9 (auto-brief on codex spawn — coming later), this enables operators to load codex workers with full task context at spawn time

🤖 Generated with [Claude Code](https://claude.com/claude-code)