### PR TITLE
feat(codex): hook bridge — codex events route through 'genie hook dispatch'

### DIFF
--- a/src/hooks/codex-inject.test.ts
+++ b/src/hooks/codex-inject.test.ts
@@ -23,7 +23,7 @@ describe('injectCodexHooks', () => {
 
   afterEach(() => {
     if (originalCodexHome === undefined) {
-      delete process.env.CODEX_HOME;
+      process.env.CODEX_HOME = undefined as unknown as string;
     } else {
       process.env.CODEX_HOME = originalCodexHome;
     }

--- a/src/hooks/codex-inject.test.ts
+++ b/src/hooks/codex-inject.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for codex hook config TOML injection.
+ *
+ * Run with: bun test src/hooks/codex-inject.test.ts
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { CODEX_DISPATCHED_EVENTS, codexHooksInjected, injectCodexHooks } from './codex-inject.js';
+
+describe('injectCodexHooks', () => {
+  let tmp: string;
+  let originalCodexHome: string | undefined;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'codex-inject-'));
+    originalCodexHome = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = tmp;
+  });
+
+  afterEach(() => {
+    if (originalCodexHome === undefined) {
+      delete process.env.CODEX_HOME;
+    } else {
+      process.env.CODEX_HOME = originalCodexHome;
+    }
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test('writes a fresh config.toml when none exists', async () => {
+    const modified = await injectCodexHooks();
+    expect(modified).toBe(true);
+
+    const written = readFileSync(join(tmp, 'config.toml'), 'utf-8');
+    expect(written).toContain('# === GENIE HOOK BRIDGE BEGIN ===');
+    expect(written).toContain('# === GENIE HOOK BRIDGE END ===');
+    expect(written).toContain('feature_enabled = true');
+
+    // Each dispatched event has a [[hooks.X]] section + nested .hooks entry
+    for (const event of CODEX_DISPATCHED_EVENTS) {
+      expect(written).toContain(`[[hooks.${event}]]`);
+      expect(written).toContain(`[[hooks.${event}.hooks]]`);
+    }
+    expect(written).toContain('type = "command"');
+    expect(written).toContain('hook dispatch');
+  });
+
+  test('preserves user-defined TOML content outside the genie block', async () => {
+    const userConfig = `
+model = "gpt-5.5"
+
+[mcp_servers.foo]
+command = "/usr/local/bin/foo-mcp"
+
+[sandbox]
+mode = "workspace-write"
+`;
+    writeFileSync(join(tmp, 'config.toml'), userConfig);
+
+    await injectCodexHooks();
+    const merged = readFileSync(join(tmp, 'config.toml'), 'utf-8');
+
+    expect(merged).toContain('model = "gpt-5.5"');
+    expect(merged).toContain('[mcp_servers.foo]');
+    expect(merged).toContain('command = "/usr/local/bin/foo-mcp"');
+    expect(merged).toContain('[sandbox]');
+    expect(merged).toContain('# === GENIE HOOK BRIDGE BEGIN ===');
+  });
+
+  test('is idempotent on repeated invocations with no change', async () => {
+    const first = await injectCodexHooks();
+    expect(first).toBe(true);
+
+    const beforeSecond = readFileSync(join(tmp, 'config.toml'), 'utf-8');
+    const second = await injectCodexHooks();
+    expect(second).toBe(false); // no change needed
+
+    const afterSecond = readFileSync(join(tmp, 'config.toml'), 'utf-8');
+    expect(afterSecond).toBe(beforeSecond);
+  });
+
+  test('replaces an old genie block when the dispatch command changes', async () => {
+    // Seed a stale block manually with a different (fake) command path
+    const stale = `
+model = "gpt-5.5"
+
+# === GENIE HOOK BRIDGE BEGIN ===
+[hooks]
+feature_enabled = true
+
+[[hooks.UserPromptSubmit]]
+matcher = "*"
+
+[[hooks.UserPromptSubmit.hooks]]
+type = "command"
+command = "/old/path/to/genie hook dispatch"
+timeout = 15
+# === GENIE HOOK BRIDGE END ===
+`;
+    writeFileSync(join(tmp, 'config.toml'), stale);
+
+    const modified = await injectCodexHooks();
+    expect(modified).toBe(true);
+
+    const written = readFileSync(join(tmp, 'config.toml'), 'utf-8');
+    expect(written).toContain('model = "gpt-5.5"'); // user content preserved
+    expect(written).not.toContain('/old/path/to/genie'); // stale command gone
+    // Only ONE block should exist now (no duplicates)
+    const beginCount = (written.match(/=== GENIE HOOK BRIDGE BEGIN ===/g) ?? []).length;
+    expect(beginCount).toBe(1);
+  });
+
+  test('codexHooksInjected reports presence', async () => {
+    expect(await codexHooksInjected()).toBe(false);
+    await injectCodexHooks();
+    expect(await codexHooksInjected()).toBe(true);
+  });
+
+  test('all six DISPATCHED_EVENTS are wired', () => {
+    // Sanity: the list matches what codex-rs/hooks/src/events/*.rs exposes
+    expect(CODEX_DISPATCHED_EVENTS).toEqual([
+      'PreToolUse',
+      'PostToolUse',
+      'UserPromptSubmit',
+      'SessionStart',
+      'Stop',
+      'PermissionRequest',
+    ]);
+  });
+});

--- a/src/hooks/codex-inject.ts
+++ b/src/hooks/codex-inject.ts
@@ -148,7 +148,10 @@ export async function injectCodexHooks(): Promise<boolean> {
 
   await mkdir(codexHomeDir(), { recursive: true });
   await writeFile(path, candidate);
-  return existed ? true : true; // semantics: "modified or freshly added"
+  // Semantics: "modified or freshly added"; existed is captured for any
+  // future caller that wants to distinguish "first install" from "update".
+  void existed;
+  return true;
 }
 
 /**

--- a/src/hooks/codex-inject.ts
+++ b/src/hooks/codex-inject.ts
@@ -1,0 +1,167 @@
+/**
+ * Codex hook injection — writes TOML hook config into ~/.codex/config.toml
+ * (or $CODEX_HOME/config.toml) so codex's hook system routes events through
+ * `genie hook dispatch`.
+ *
+ * Mirror of `src/hooks/inject.ts` (claude flavor). Codex hooks fire on the
+ * SAME events claude does (PreToolUse, PostToolUse, UserPromptSubmit,
+ * SessionStart, Stop) and use a near-identical TOML/JSON wire shape — see
+ * `~/workspace/repos/genie/.genie/brainstorms/codex-first-class-integration/DESIGN.md`
+ * for the codex schema survey.
+ *
+ * Codex hook config example (the format we generate here):
+ *
+ *   [hooks]
+ *   feature_enabled = true
+ *
+ *   [[hooks.UserPromptSubmit]]
+ *   matcher = "*"
+ *
+ *   [[hooks.UserPromptSubmit.hooks]]
+ *   type = "command"
+ *   command = "genie hook dispatch"
+ *   timeout = 15
+ *
+ * Once this is in place, codex agents become first-class:
+ *   - Hook events flow through `genie hook dispatch` (the same shim claude
+ *     uses) → runtime_events PG table → genie log/events surfaces light up
+ *   - UserPromptSubmit handlers can return additionalContext to inject
+ *     genie inbox messages into the codex turn (file-watcher equivalent —
+ *     replaces tmux send-keys for engineer-driven sends)
+ */
+
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { buildDispatchCommand } from './inject.js';
+
+const DISPATCH_TIMEOUT = 15;
+
+/**
+ * Codex hook events we route through the dispatcher. Same events claude
+ * uses, minus claude-specific ones (TeammateIdle, TaskCompleted, etc.).
+ *
+ * Source: codex-rs/hooks/src/events/*.rs (PreToolUse, PostToolUse,
+ * UserPromptSubmit, SessionStart, Stop, PermissionRequest).
+ */
+export const CODEX_DISPATCHED_EVENTS = [
+  'PreToolUse',
+  'PostToolUse',
+  'UserPromptSubmit',
+  'SessionStart',
+  'Stop',
+  'PermissionRequest',
+] as const;
+
+function codexHomeDir(): string {
+  return process.env.CODEX_HOME ?? join(homedir(), '.codex');
+}
+
+function codexConfigPath(): string {
+  return join(codexHomeDir(), 'config.toml');
+}
+
+function escapeTomlString(value: string): string {
+  // TOML basic-string escapes — codex uses these literal-style.
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * Build the TOML fragment that wires codex hooks into `genie hook dispatch`.
+ *
+ * Returns the complete fragment as a string; merge logic is in
+ * `injectCodexHooks` below so we can detect existing genie-injected entries
+ * and avoid duplicate writes.
+ */
+function buildCodexHookFragment(): string {
+  const cmd = buildDispatchCommand();
+  const lines: string[] = [];
+  lines.push('# === GENIE HOOK BRIDGE BEGIN ===');
+  lines.push('# Auto-injected by `genie spawn ... --provider codex`. Do not edit by hand.');
+  lines.push('# Removing this block disables codex → genie hook event delivery.');
+  lines.push('[hooks]');
+  lines.push('feature_enabled = true');
+  lines.push('');
+  for (const event of CODEX_DISPATCHED_EVENTS) {
+    lines.push(`[[hooks.${event}]]`);
+    lines.push('matcher = "*"');
+    lines.push('');
+    lines.push(`[[hooks.${event}.hooks]]`);
+    lines.push('type = "command"');
+    lines.push(`command = ${escapeTomlString(cmd)}`);
+    lines.push(`timeout = ${DISPATCH_TIMEOUT}`);
+    lines.push('');
+  }
+  lines.push('# === GENIE HOOK BRIDGE END ===');
+  return lines.join('\n');
+}
+
+const BEGIN_MARKER = '# === GENIE HOOK BRIDGE BEGIN ===';
+const END_MARKER = '# === GENIE HOOK BRIDGE END ===';
+
+/**
+ * Strip an existing GENIE HOOK BRIDGE block from a TOML config string.
+ * Preserves all other content. Returns the trimmed config + a flag
+ * indicating whether a block was found.
+ */
+function stripExistingBlock(content: string): { trimmed: string; existed: boolean } {
+  const beginIdx = content.indexOf(BEGIN_MARKER);
+  const endIdx = content.indexOf(END_MARKER);
+  if (beginIdx === -1 || endIdx === -1 || endIdx < beginIdx) {
+    return { trimmed: content, existed: false };
+  }
+  const before = content.slice(0, beginIdx).replace(/\s+$/, '');
+  const after = content.slice(endIdx + END_MARKER.length).replace(/^\s+/, '');
+  const joined = before && after ? `${before}\n\n${after}\n` : before ? `${before}\n` : after ? `${after}` : '';
+  return { trimmed: joined, existed: true };
+}
+
+/**
+ * Inject the genie hook bridge into the codex config TOML.
+ *
+ * - Idempotent: if the existing block matches what we'd write, no-op.
+ * - Preserves all other TOML content (model, sandbox, MCP config, etc.).
+ * - Atomically replaces an old block if the dispatch command changed
+ *   (e.g. `genie hook dispatch` path moved between bun and source installs).
+ *
+ * Returns `true` if the file was modified, `false` if no change needed.
+ */
+export async function injectCodexHooks(): Promise<boolean> {
+  const path = codexConfigPath();
+  let existing = '';
+  if (existsSync(path)) {
+    try {
+      existing = await readFile(path, 'utf-8');
+    } catch {
+      existing = '';
+    }
+  }
+
+  const desired = buildCodexHookFragment();
+  const { trimmed, existed } = stripExistingBlock(existing);
+
+  // If a block existed AND the rest of the file plus the same desired
+  // block reconstructs the original, no write is needed.
+  const candidate = trimmed ? `${trimmed.replace(/\s+$/, '')}\n\n${desired}\n` : `${desired}\n`;
+  if (existing.trim() === candidate.trim()) return false;
+
+  await mkdir(codexHomeDir(), { recursive: true });
+  await writeFile(path, candidate);
+  return existed ? true : true; // semantics: "modified or freshly added"
+}
+
+/**
+ * Check whether the genie hook bridge block is present in the codex config.
+ * Used by tests + diagnostics.
+ */
+export async function codexHooksInjected(): Promise<boolean> {
+  const path = codexConfigPath();
+  if (!existsSync(path)) return false;
+  try {
+    const content = await readFile(path, 'utf-8');
+    return content.includes(BEGIN_MARKER) && content.includes(END_MARKER);
+  } catch {
+    return false;
+  }
+}

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -1761,7 +1761,7 @@ async function buildSpawnParams(
     try {
       const { injectCodexHooks } = await import('../hooks/codex-inject.js');
       const codexInjected = await injectCodexHooks();
-      if (codexInjected) console.log(`  Hooks:    injected genie hook dispatch into ~/.codex/config.toml`);
+      if (codexInjected) console.log('  Hooks:    injected genie hook dispatch into ~/.codex/config.toml');
     } catch (err) {
       console.warn(`Warning: could not inject codex hooks: ${err instanceof Error ? err.message : err}`);
     }

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -1750,6 +1750,23 @@ async function buildSpawnParams(
     console.warn(`Warning: could not inject hooks for team "${team}": ${err instanceof Error ? err.message : err}`);
   }
 
+  // Codex hook bridge — write `~/.codex/config.toml` so codex agents fire
+  // PreToolUse / PostToolUse / UserPromptSubmit / SessionStart / Stop /
+  // PermissionRequest hooks through `genie hook dispatch`. Same dispatcher
+  // claude uses; closes the genie log/events blackout for codex AND enables
+  // file-watcher-equivalent message delivery (UserPromptSubmit handler can
+  // return additionalContext from genie's mailbox). Replaces tmux send-keys
+  // for engineer-driven sends.
+  if (params.provider === 'codex') {
+    try {
+      const { injectCodexHooks } = await import('../hooks/codex-inject.js');
+      const codexInjected = await injectCodexHooks();
+      if (codexInjected) console.log(`  Hooks:    injected genie hook dispatch into ~/.codex/config.toml`);
+    } catch (err) {
+      console.warn(`Warning: could not inject codex hooks: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+
   // Generate a session ID for Claude workers so we can resume by ID later.
   // Stored in the agent registry on spawn for --resume on respawn.
   // The state machine in handleWorkerSpawn pre-mints the UUID for parallels so


### PR DESCRIPTION
## Summary

Closes the genie observability + delivery gap for codex agents that required tmux send-keys until now. **Codex's hook system has identical shape to claude's** (PreToolUse / PostToolUse / UserPromptSubmit / SessionStart / Stop / PermissionRequest); we just need to write the TOML config that points codex at our existing \`genie hook dispatch\` shim.

## Empirical validation (today, evening session)

Spawned codex with this exact hook config in \`/tmp/codex-research/\`, pre-loaded a test message in a mock inbox, typed a prompt:

\`\`\`
$ echo "what time is it?" | CODEX_HOME=/tmp/codex-research/codex-home codex exec --experimental-json ...

# user typed: what time is it?
# codex responded:
"I'll check the PR/CI signal first as requested, then I'll answer the time question with the local clock."

# Then ran:
git rev-parse --abbrev-ref HEAD
date
gh pr checks 1417

# Final reply:
"PR #1417 CI is currently all passing. The local time is Mon Apr 27 07:50:07 PM -03 2026."
\`\`\`

Codex's UserPromptSubmit hook fired with the standard payload (\`session_id\` / \`turn_id\` / \`cwd\` / \`hook_event_name\` / \`prompt\`), our hook returned \`hookSpecificOutput.additionalContext\`, codex injected that context inline with the engineer's prompt, **and acted on BOTH the engineer's text AND the genie message in the same turn**. The file-watcher-equivalent pattern claude already uses via its SendMessage tool — now available for codex.

## Files

| File | Purpose |
|------|---------|
| \`src/hooks/codex-inject.ts\` | Writes/merges genie hook block into \`~/.codex/config.toml\` (or \`\$CODEX_HOME/config.toml\`) using BEGIN/END marker comments. Idempotent. Mirror of claude's existing \`src/hooks/inject.ts\`. |
| \`src/hooks/codex-inject.test.ts\` | 6 tests: fresh write, merge with existing user config, idempotence, stale-block replacement, presence detection, event-list sanity. |
| \`src/term-commands/agents.ts\` (\`buildSpawnParams\`) | When \`provider === 'codex'\`, call \`injectCodexHooks()\` alongside the existing claude-side \`injectTeamHooks\`. Best-effort with same warn-don't-block semantics. |

## What this unlocks

- **Codex observability**: hooks fire on every codex tool use, prompt submission, and session lifecycle event. \`genie events list/timeline/errors\` and \`genie log <codex-agent>\` light up uniformly with claude.
- **File-watcher-equivalent delivery**: a follow-up handler in \`src/hooks/handlers/\` can pull from PG mailbox on \`UserPromptSubmit\` and return \`additionalContext\` — message reaches codex on next engineer turn, no tmux send-keys needed.
- **Cognitive uniformity**: same hook dispatcher serves both providers; one mental model, one observability substrate.

## Out of scope (follow-up PRs)

- A genie hook handler that pulls from PG mailbox for codex agents on UserPromptSubmit. This PR establishes the PIPE; the handler is a small follow-up. Tracked in the codex-first-class-integration design.
- Removing \`src/lib/protocol-router.ts:injectToTmuxPane\` fallback once codex mailbox delivery via hook is wired.
- Codex SDK / app-server alternative drivers — separate larger track in \`.genie/brainstorms/codex-first-class-integration/DESIGN.md\`.

## Test plan

- [x] \`bun test src/hooks/codex-inject.test.ts\` — 6 pass, 0 fail
- [x] \`bun run typecheck\` clean
- [x] \`bunx biome check .\` clean (only pre-existing warnings)
- [x] Empirical end-to-end test in \`/tmp/codex-research/\` — codex hook injection + additionalContext round-trip works

## Related

- Design: \`.genie/brainstorms/codex-first-class-integration/DESIGN.md\`
- Sibling work: previously-merged \`#1417-#1423\` codex parity micro-fixes (Groups 1, 3, 6, 7, 11, 21 + Group 7 v2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)