### PR TITLE
chore(npm): mark @automagik/genie as soft-deprecated; canonical install moves to get.automagik.dev

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -176,3 +176,18 @@ jobs:
         # (no bump, matches the GitHub Release tag exactly).
         # On dev context: publish the version we just bumped to as @next.
         run: npm publish --access public --tag ${{ steps.context.outputs.npm_tag }}
+
+      - name: Mark published version as deprecated (npm-distribution sunset)
+        # The npm distribution channel is being soft-deprecated in favor of
+        # the cosign + SLSA verified installer at get.automagik.dev/genie.
+        # Every published version carries an `npm warn deprecated` notice
+        # pointing operators at the canonical install path. Existing pinned
+        # versions continue to install (the postinstall shim handles the
+        # delegation in the next umbrella PR); this step just makes the
+        # sunset visible in npm's own UX.
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          version="$(node -p 'require("./package.json").version')"
+          npm deprecate "@automagik/genie@${version}" \
+            "@automagik/genie via npm is soft-deprecated. Canonical install: curl -fsSL https://get.automagik.dev/genie | bash (cosign + SLSA verified). See https://automagik.dev/genie/security/distribution-sovereignty for the threat model and verification flow."

--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@
 
 <br />
 
+> [!IMPORTANT]
+> **Genie's npm distribution is being soft-deprecated** in favor of a cosign + SLSA-verified install through our own CDN.
+>
+> The canonical install going forward is:
+>
+> ```bash
+> curl -fsSL https://get.automagik.dev/genie | bash
+> ```
+>
+> Existing operators on `npm install -g @automagik/genie` continue to work — the npm package will become a thin postinstall shim that downloads and runs the verified installer. See [Security & Trust → Distribution Sovereignty](https://automagik.dev/genie/security/distribution-sovereignty) for the threat model and verification flow.
+
+<br />
+
 <!-- TODO: Record a 30s terminal demo with vhs/asciinema and uncomment:
 <p align="center">
   <img src=".github/assets/genie-demo.gif" alt="Genie demo" width="720" />

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@automagik/genie",
   "version": "4.260427.10",
-  "description": "Collaborative terminal toolkit for human + AI workflows",
+  "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: the npm distribution is being soft-deprecated — the canonical install is `curl -fsSL https://get.automagik.dev/genie | bash` (cosign + SLSA verified). See https://automagik.dev/genie/security/distribution-sovereignty",
   "type": "module",
   "bin": {
     "genie": "./dist/genie.js"


### PR DESCRIPTION
## Summary

Operator-visible signaling that the npm distribution channel is being soft-deprecated in favor of the cosign + SLSA verified installer at `get.automagik.dev/genie`. Three small changes; **no install behavior changes** in this PR — the binary still installs as before. Only the deprecation message changes.

## Changes

| File | Change |
|------|--------|
| `package.json` | Description rewritten to lead with the deprecation notice + canonical install command + docs link. `npm view @automagik/genie` and the npmjs.com listing now show this immediately. |
| `README.md` | Top-of-page `> [!IMPORTANT]` callout explaining the soft-deprecate posture and pointing at the docs. |
| `.github/workflows/version.yml` | Every `npm publish` step is now followed by `npm deprecate <version> "<message>"`. Operators running `npm install -g @automagik/genie` see npm's own warn-deprecated notice immediately. |

## What does NOT change

- Install path still works: `npm install -g @automagik/genie` still produces a working binary
- No behavior change in `dist/genie.js`, the postinstall scripts, or any downstream tooling
- Zero risk to existing operators on `npm update -g`

## Sequencing

This is **PR-A3** in the security-roadmap mini-PR sequence:
- ✅ A0: docs submodule (docs#66 + genie#1426)
- ✅ A1: Security & Trust nav + 3 MDX (docs#67)
- 🚧 A2: fingerprint pinning prepared for install.sh (sibling PR, parallel)
- 🚧 **A3: this PR** — npm sunset metadata + signaling
- 🟡 A4 onwards: build pipeline + install.sh + cosign + binary install + npm shim

The hard install-flow change (50-LOC postinstall shim that delegates to install.sh, hard sunset 90 days post-v1 GA) ships in PR-A10 — that's the actual cutover. This PR is signaling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)