### PR TITLE
fix(partition): drain DEFAULT before creating dated partitions

### DIFF
--- a/src/db/migrations/055_runtime_events_partition_drain.sql
+++ b/src/db/migrations/055_runtime_events_partition_drain.sql
@@ -1,0 +1,138 @@
+-- 055_runtime_events_partition_drain.sql
+-- Bug: genie_runtime_events_maintain_partitions never drained the DEFAULT
+-- partition. Rows that landed in genie_runtime_events_default (e.g. inserts
+-- after UTC midnight before the next maintenance call ran) permanently
+-- blocked creation of new dated partitions, because PG validates that no
+-- existing default-partition row would belong to the new partition. Symptom:
+-- SQLSTATE 23514 "updated partition constraint for default partition
+-- genie_runtime_events_default would be violated by some row" on every
+-- subsequent `genie serve start`. Migration 038's docstring claimed the
+-- nightly scheduler converted DEFAULT rows into named partitions; no such
+-- code ever existed.
+--
+-- Fix:
+--   1. New helper genie_runtime_events_drain_default() detaches DEFAULT,
+--      ensures dated partitions exist for every day represented by its rows,
+--      re-inserts the rows (parent-routing them to the correct dated
+--      partition) with notify-trigger suppression, truncates the now-empty
+--      detached default, and re-attaches it as DEFAULT.
+--   2. genie_runtime_events_maintain_partitions calls drain_default() before
+--      creating today..today+forward_days, so a stuck DEFAULT can no longer
+--      poison subsequent partition creation.
+--   3. One-shot drain at migration time so existing installs unstick on the
+--      first post-upgrade `genie serve start`.
+
+CREATE OR REPLACE FUNCTION genie_runtime_events_drain_default()
+RETURNS INTEGER AS $$
+DECLARE
+  drained   INTEGER := 0;
+  d_rec     RECORD;
+  prev_role TEXT;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE c.relname = 'genie_runtime_events_default'
+       AND n.nspname = current_schema()
+  ) THEN
+    RETURN 0;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM genie_runtime_events_default LIMIT 1) THEN
+    RETURN 0;
+  END IF;
+
+  -- Detach so the re-insert below routes to dated partitions instead of
+  -- looping back into DEFAULT. Non-CONCURRENTLY form is transaction-safe.
+  EXECUTE 'ALTER TABLE genie_runtime_events DETACH PARTITION genie_runtime_events_default';
+
+  -- Ensure a dated partition exists for every day represented in the
+  -- detached default. create_partition is CREATE TABLE IF NOT EXISTS, so
+  -- pre-existing partitions are fine.
+  FOR d_rec IN
+    SELECT DISTINCT date_trunc('day', created_at)::DATE AS d
+      FROM genie_runtime_events_default
+  LOOP
+    PERFORM genie_runtime_events_create_partition(d_rec.d);
+  END LOOP;
+
+  -- Suppress AFTER INSERT triggers (notify_runtime_event_split, audit chain
+  -- triggers, etc.) for the drain. These rows already fired their notifies
+  -- on their original insert; re-firing would broadcast duplicates to every
+  -- LISTEN'er.
+  prev_role := current_setting('session_replication_role');
+  PERFORM set_config('session_replication_role', 'replica', true);
+
+  EXECUTE $sql$
+    INSERT INTO genie_runtime_events (
+      id, repo_path, subject, kind, source, agent, team, direction, peer,
+      text, data, thread_id, trace_id, parent_event_id, span_id, parent_span_id,
+      severity, schema_version, duration_ms, dedup_key, source_subsystem, created_at
+    )
+    OVERRIDING SYSTEM VALUE
+    SELECT id, repo_path, subject, kind, source, agent, team, direction, peer,
+           text, data, thread_id, trace_id, parent_event_id, span_id, parent_span_id,
+           severity, schema_version, duration_ms, dedup_key, source_subsystem, created_at
+      FROM genie_runtime_events_default
+  $sql$;
+
+  GET DIAGNOSTICS drained = ROW_COUNT;
+
+  PERFORM set_config('session_replication_role', prev_role, true);
+
+  EXECUTE 'TRUNCATE genie_runtime_events_default';
+  EXECUTE 'ALTER TABLE genie_runtime_events ATTACH PARTITION genie_runtime_events_default DEFAULT';
+
+  RETURN drained;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION genie_runtime_events_maintain_partitions(
+  forward_days   INTEGER DEFAULT 2,
+  retention_days INTEGER DEFAULT 30
+)
+RETURNS JSONB AS $$
+DECLARE
+  drained INTEGER;
+  created INTEGER := 0;
+  dropped INTEGER := 0;
+  i       INTEGER;
+BEGIN
+  -- Drain DEFAULT first so any rows that accumulated there (UTC-midnight
+  -- rollover between maintenance calls) get routed to their proper dated
+  -- partitions before we try to CREATE the new ones.
+  drained := genie_runtime_events_drain_default();
+
+  FOR i IN 0..forward_days LOOP
+    PERFORM genie_runtime_events_create_partition((CURRENT_DATE + i)::DATE);
+    created := created + 1;
+  END LOOP;
+  SELECT genie_runtime_events_drop_old_partitions(retention_days) INTO dropped;
+  RETURN jsonb_build_object(
+    'created_or_present',  created,
+    'dropped',             dropped,
+    'drained_from_default', drained,
+    'next_rotation_at',    (CURRENT_DATE + 1)::TIMESTAMPTZ
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+-- Mirror the role grants from migration 041 for the new helper. Conditional
+-- so this works on installs that ran 041 before events_admin existed.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'events_admin') THEN
+    EXECUTE 'GRANT EXECUTE ON FUNCTION genie_runtime_events_drain_default() TO events_admin';
+  END IF;
+END$$;
+
+DO $$
+DECLARE
+  drained INTEGER;
+BEGIN
+  drained := genie_runtime_events_drain_default();
+  IF drained > 0 THEN
+    RAISE NOTICE 'genie_runtime_events_default: drained % stuck row(s) into dated partitions', drained;
+  END IF;
+END$$;

--- a/src/db/migrations/observability-migrations.test.ts
+++ b/src/db/migrations/observability-migrations.test.ts
@@ -196,6 +196,53 @@ describe.skipIf(!DB_AVAILABLE)('Group 1 observability migrations', () => {
     expect(deleteErr?.message).toMatch(/append-only/);
   });
 
+  test('maintain_partitions drains rows stuck in DEFAULT (regression: SQLSTATE 23514)', async () => {
+    const sql = await getConnection();
+
+    // Pick a far-future date that no rolling-window partition covers.
+    // create_partition uses session-TZ midnight, so the date string suffices.
+    const stuckDate = '2099-12-31';
+
+    // Pre-clean any leftovers from a previous test run.
+    await sql`DELETE FROM genie_runtime_events WHERE kind = 'partition.drain.test'`;
+
+    // Insert a row whose created_at falls outside every dated partition. It
+    // must route to genie_runtime_events_default.
+    await sql`
+      INSERT INTO genie_runtime_events (repo_path, kind, source, agent, text, created_at)
+      VALUES ('test', 'partition.drain.test', 'test', 'test', 'stuck', ${`${stuckDate} 12:00:00+00`}::TIMESTAMPTZ)
+    `;
+
+    const beforeDefault = await sql<{ n: number }[]>`
+      SELECT count(*)::INT AS n FROM genie_runtime_events_default
+       WHERE kind = 'partition.drain.test'
+    `;
+    expect(beforeDefault[0].n).toBe(1);
+
+    const result = await sql<
+      Array<{ r: { created_or_present: number; drained_from_default: number } }>
+    >`SELECT genie_runtime_events_maintain_partitions(2, 30)::jsonb AS r`;
+    expect(result[0].r.drained_from_default).toBeGreaterThanOrEqual(1);
+
+    const afterDefault = await sql<{ n: number }[]>`
+      SELECT count(*)::INT AS n FROM genie_runtime_events_default
+       WHERE kind = 'partition.drain.test'
+    `;
+    expect(afterDefault[0].n).toBe(0);
+
+    const inDated = await sql<{ relname: string }[]>`
+      SELECT tableoid::regclass::TEXT AS relname
+        FROM genie_runtime_events
+       WHERE kind = 'partition.drain.test'
+    `;
+    expect(inDated.length).toBe(1);
+    expect(inDated[0].relname).toMatch(/genie_runtime_events_p20991231$/);
+
+    // Cleanup so the dated partition created above doesn't haunt the rolling
+    // window or the retention sweep on subsequent runs.
+    await sql`DELETE FROM genie_runtime_events WHERE kind = 'partition.drain.test'`;
+  });
+
   test('Group 1 migrations are idempotent on re-apply', async () => {
     // Re-run each migration body against the already-migrated schema and
     // confirm the guarded statements are all no-ops.


### PR DESCRIPTION
## Summary
- `genie_runtime_events_maintain_partitions` never drained the DEFAULT partition. Rows that landed in `genie_runtime_events_default` (e.g. inserts after UTC midnight before the next maintenance call) blocked creation of new dated partitions because PG validates that no DEFAULT row would belong to the new partition (SQLSTATE 23514). Every subsequent `genie serve start` then failed at the partition precondition.
- Migration 038's docstring promised a "scheduler daemon nightly maintain_partitions" that converted DEFAULT rows into named partitions; that code never existed.
- New migration 051 adds a `drain_default()` helper, replaces `maintain_partitions` to drain first, and runs a one-shot drain at migration time so existing stuck installs unstick on the first post-upgrade `genie serve start`.

## Root cause
Reproduced on a live install:
```
PostgresError: updated partition constraint for default partition
"genie_runtime_events_default" would be violated by some row
  code: 23514, table_name: "genie_runtime_events_default"
  routine: "check_default_partition_contents"
```
Trigger sequence: UTC clock crosses midnight while genie is running → inserts route to DEFAULT (next dated partition not yet created) → next `serve` calls `maintain_partitions(2,30)` → `CREATE TABLE … PARTITION OF parent FOR VALUES FROM ('YYYY-MM-DD 00:00:00+00')` → PG scans DEFAULT, finds rows belonging to the new range, errors.

## What changed
- **`src/db/migrations/051_runtime_events_partition_drain.sql`** (new): `genie_runtime_events_drain_default()` detaches DEFAULT, ensures dated partitions exist for every day represented in its rows, re-inserts with `session_replication_role=replica` (suppresses notify-trigger fan-out — those rows already fired their notifies on original insert), truncates, re-attaches DEFAULT empty. `maintain_partitions` calls drain first. Mirrors 041's `events_admin` grant for the new helper.
- **`src/db/migrations/observability-migrations.test.ts`** (+47): regression test inserts a backdated row (2099-12-31) into DEFAULT, runs `maintain_partitions`, asserts row moved to its dated partition and DEFAULT is empty.

## Verification
Live-verified against the affected pgserve before opening this PR:
- Migration applied at 2026-04-28 01:53 UTC.
- `genie_runtime_events_default` row count post-drain: 0.
- `SELECT genie_runtime_events_maintain_partitions(2,30)::jsonb` returns `{"created_or_present":3,"dropped":0,"drained_from_default":0,"next_rotation_at":"2026-04-29T00:00:00+00:00"}`.
- `genie serve` partition precondition now passes on the same machine that was producing 23514 minutes earlier.

## Test plan
- [ ] `bun test src/db/migrations/observability-migrations.test.ts` (regression test exercises drain via `maintain_partitions`).
- [ ] `bun run check` (typecheck + lint + dead-code + test).
- [ ] Manual: insert a row into `genie_runtime_events_default` (any date outside the rolling window), run `maintain_partitions(2,30)`, observe `drained_from_default` ≥ 1 in the JSON return and 0 rows in DEFAULT after.
- [ ] Backwards compat: existing JSON-result consumer at `src/term-commands/serve/ensure-ready.ts:148-156` only destructures `created_or_present`, `dropped`, `next_rotation_at` — the new `drained_from_default` key is additive.

## Notes
- `maintain_partitions` is only invoked from `ensureServeReady` at serve startup. Any host that crosses UTC midnight while running will accumulate DEFAULT rows until the next start. A follow-up to schedule maintenance more frequently (hourly) is worth tracking separately — out of scope here, but the bug now self-heals on next start instead of permanently bricking serve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)