### PR TITLE
fix(test): point acid-test at vendored docs/_internal path

### DIFF
--- a/test/observability/acid-test.test.ts
+++ b/test/observability/acid-test.test.ts
@@ -28,7 +28,18 @@ import { getConnection } from '../../src/lib/db.js';
 import { DB_AVAILABLE, setupTestDatabase } from '../../src/lib/test-db.js';
 import { ALL_SEEDERS, type FixtureResult, type Seeder } from './replay-dataset/index.js';
 
-const SQL_FILE = join(import.meta.dir, '..', '..', 'docs', 'observability-acid-tests.sql');
+// Path migrated from `docs/observability-acid-tests.sql` to
+// `docs/_internal/observability-acid-tests.sql` when docs/ became a symlink
+// into the automagik-dev/docs submodule (#1426). Mirrors the precedent set
+// by c0ea815a for state-machine.invariants.test.ts.
+const SQL_FILE = join(
+  import.meta.dir,
+  '..',
+  '..',
+  'docs',
+  '_internal',
+  'observability-acid-tests.sql',
+);
 
 // ---------------------------------------------------------------------------
 // SQL extraction — strip psql-specific syntax so postgres.js accepts the body.


### PR DESCRIPTION
## Summary

Fixes the PG-tests CI red on \`dev\` since the docs-vendoring merge (#1426).

\`test/observability/acid-test.test.ts:31\` resolved to \`docs/observability-acid-tests.sql\` — a dangling symlink target after the docs/ → submodule migration. Upstream docs commit \`5dedf60\` placed the file at \`genie/_internal/\`, one level deeper than the symlink lands. \`extractQueries()\` threw ENOENT at module load, bun reported \`1 error\` (separate counter from \`0 fail\`), CI exit 1 deterministically, branch protection blocked merges.

## Root cause

Mirrors precedent \`c0ea815a fix(test): point state-machine.invariants test at vendored docs path\` — same shape change applied to a sibling test, missed for this one.

\`unit-tests\` job's file-list builder (\`scripts/list-tests.ts\`) only walks \`src/\` and \`scripts/\` so this file was invisible there. The PG job runs bare \`bun test\` with no filter, discovers \`test/observability/\`, hits the load-time throw.

## Fix

Single-line: add \`'_internal'\` segment to the \`join()\` args, plus brief breadcrumb comment.

```diff
-const SQL_FILE = join(import.meta.dir, '..', '..', 'docs', 'observability-acid-tests.sql');
+// Path migrated from \`docs/observability-acid-tests.sql\` to
+// \`docs/_internal/observability-acid-tests.sql\` when docs/ became a symlink
+// into the automagik-dev/docs submodule (#1426). Mirrors precedent c0ea815a.
+const SQL_FILE = join(import.meta.dir, '..', '..', 'docs', '_internal', 'observability-acid-tests.sql');
```

## Validation

- \`bun test test/observability/acid-test.test.ts\` ✅ **12/12 pass**
- File path resolves: \`.docs-vendor/genie/_internal/observability-acid-tests.sql\` (13791 bytes)
- No infra change needed — \`actions/checkout@v4 submodules: recursive\` already initializes \`.docs-vendor\`

## Trace report

Diagnosis was end-to-end via /trace + genie observability. Key lines from CI run 25030596941, job 73311257574:

\`\`\`
test/observability/acid-test.test.ts:38:16
error: ENOENT: no such file or directory, open '/home/runner/_work/genie/genie/docs/observability-acid-tests.sql'
4046 pass / 0 fail / 1 error
\`\`\`

**Confidence: high.** Three independent evidence lines converge: bun stack trace, git history of the symlink commit, sibling commit \`c0ea815a\` establishing the canonical migration pattern.

PRs #1434 and #1436 are NOT in the regression range. They touch only \`team-lead-command.ts\`, \`team-lead-command.test.ts\`, \`knip.json\` — none of which is loaded by \`acid-test.test.ts\`.

## Out of scope

- Doc-comment references to \`docs/observability-acid-tests.sql\` on lines 8, 67 of the same file and 6, 30 of \`test/observability/replay-dataset/index.ts\` are JSDoc only — runtime unaffected; left alone to keep the diff minimal.
- The \`[filewatch] failed to start\` and \`[claude-native-teams] Failed to load config for "bad-team"\` log noise observed in the same CI log are intentional fixture-driven negatives or non-fatal warnings — not blocking PG tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)