### PR TITLE
fix(dispatch): expose invoker identity in cli-bypass sender

### DIFF
--- a/src/term-commands/agent/send.ts
+++ b/src/term-commands/agent/send.ts
@@ -13,7 +13,7 @@
  */
 
 import type { Command } from 'commander';
-import { detectSenderIdentity } from '../msg.js';
+import { detectSenderIdentity, isCliSender } from '../msg.js';
 
 export function registerAgentSend(parent: Command): void {
   parent
@@ -57,13 +57,13 @@ async function isTeamLeader(agentName: string, teamName: string): Promise<boolea
 
 /**
  * Check hierarchy: sender can reach recipient if:
- * 1. sender is 'cli' (bypass)
+ * 1. sender is the CLI bypass marker — `'cli'` or `'cli:<origin>'` (see `isCliSender`)
  * 2. recipient reports_to sender (direct report)
  * 3. sender reports_to recipient (manager)
  * 4. they share the same manager (siblings — allowed for team coordination)
  */
 async function checkHierarchy(from: string, to: string): Promise<{ allowed: boolean; reason?: string }> {
-  if (from === 'cli') return { allowed: true };
+  if (isCliSender(from)) return { allowed: true };
   if (from === to) return { allowed: true };
 
   try {

--- a/src/term-commands/dispatch.ts
+++ b/src/term-commands/dispatch.ts
@@ -28,6 +28,29 @@ import { isWideEmitEnabled } from '../lib/observability-flag.js';
 import * as protocolRouter from '../lib/protocol-router.js';
 import { getAmbient as getTraceContext } from '../lib/trace-context.js';
 import { parseWishRef, resolveWish } from '../lib/wish-resolve.js';
+import { detectSenderIdentity } from './msg.js';
+
+/**
+ * Build the sender identity for protocol-router messages emitted by dispatch
+ * commands (`genie brainstorm`, `wish`, `work`, `review`).
+ *
+ * These commands need to bypass hierarchy checks (the dispatcher is acting on
+ * behalf of the user/orchestrator, not as a peer of the recipient) — historically
+ * that bypass was implemented by hard-coding the literal sender `'cli'`. The
+ * downside: every dispatched message surfaces with sender `cli`, hiding the
+ * actual invoker (the human user, or — when `genie work` is fired from inside
+ * a team-lead session — the team-lead agent).
+ *
+ * The fix: prefix the bypass marker with the resolved invoker identity.
+ *   - From a true CLI invocation (no agent context):  `'cli'` (unchanged)
+ *   - From inside an agent session:                    `'cli:<agent-name>'`
+ *
+ * Bypass logic in `send.ts` / `msg.ts` matches both forms via prefix check.
+ */
+async function cliSender(): Promise<string> {
+  const origin = await detectSenderIdentity();
+  return origin === 'cli' ? 'cli' : `cli:${origin}`;
+}
 import type { GroupDefinition } from '../lib/wish-state.js';
 import * as wishState from '../lib/wish-state.js';
 import { handleWorkerSpawn } from './agents.js';
@@ -515,7 +538,7 @@ export async function brainstormCommand(agentName: string, slug: string): Promis
 
   // Deliver work prompt via mailbox as backup (durable, queued to disk)
   const repoPath = process.cwd();
-  const result = await protocolRouter.sendMessage(repoPath, 'cli', agentName, brainstormPrompt);
+  const result = await protocolRouter.sendMessage(repoPath, await cliSender(), agentName, brainstormPrompt);
   if (!result.delivered) {
     console.warn(`⚠ Backup delivery to ${agentName} failed: ${result.reason ?? 'unknown'}`);
   }
@@ -555,7 +578,7 @@ export async function wishCommand(agentName: string, slug: string): Promise<void
 
   // Deliver work prompt via mailbox as backup (durable, queued to disk)
   const repoPath = process.cwd();
-  const result = await protocolRouter.sendMessage(repoPath, 'cli', agentName, wishPrompt);
+  const result = await protocolRouter.sendMessage(repoPath, await cliSender(), agentName, wishPrompt);
   if (!result.delivered) {
     console.warn(`⚠ Backup delivery to ${agentName} failed: ${result.reason ?? 'unknown'}`);
   }
@@ -684,7 +707,7 @@ async function runWorkDispatch(
 
   // Deliver work prompt via mailbox as backup (durable, queued to disk)
   const repoPath = process.cwd();
-  const result = await protocolRouter.sendMessage(repoPath, 'cli', effectiveRole, workPrompt);
+  const result = await protocolRouter.sendMessage(repoPath, await cliSender(), effectiveRole, workPrompt);
   if (!result.delivered) {
     console.warn(`⚠ Backup delivery to ${effectiveRole} failed: ${result.reason ?? 'unknown'}`);
   }
@@ -763,7 +786,7 @@ export async function reviewCommand(agentName: string, ref: string): Promise<voi
 
   // Deliver work prompt via mailbox as backup (durable, queued to disk)
   const repoPath = process.cwd();
-  const result = await protocolRouter.sendMessage(repoPath, 'cli', agentName, reviewPrompt);
+  const result = await protocolRouter.sendMessage(repoPath, await cliSender(), agentName, reviewPrompt);
   if (!result.delivered) {
     console.warn(`⚠ Backup delivery to ${agentName} failed: ${result.reason ?? 'unknown'}`);
   }

--- a/src/term-commands/msg.test.ts
+++ b/src/term-commands/msg.test.ts
@@ -21,6 +21,7 @@ import { DB_AVAILABLE, setupTestDatabase } from '../lib/test-db.js';
 import {
   checkSendScope,
   detectSenderIdentity,
+  isCliSender,
   printBridgeSuggestion,
   registerSendInboxCommands,
   resolveSenderTeams,
@@ -79,6 +80,35 @@ afterEach(() => {
       process.env[k] = v;
     }
   }
+});
+
+// ---------------------------------------------------------------------------
+// isCliSender — CLI dispatch-bypass marker recognition
+// ---------------------------------------------------------------------------
+
+describe('isCliSender', () => {
+  test('returns true for plain "cli" sender (true CLI invocation)', () => {
+    expect(isCliSender('cli')).toBe(true);
+  });
+
+  test('returns true for "cli:<origin>" prefixed sender (agent-context invocation)', () => {
+    expect(isCliSender('cli:tui-sidebar')).toBe(true);
+    expect(isCliSender('cli:felipe')).toBe(true);
+    expect(isCliSender('cli:team-lead@my-team')).toBe(true);
+  });
+
+  test('returns false for non-cli senders', () => {
+    expect(isCliSender('felipe')).toBe(false);
+    expect(isCliSender('engineer')).toBe(false);
+    expect(isCliSender('team-lead')).toBe(false);
+  });
+
+  test('returns false for tricky names that resemble but do not equal the marker', () => {
+    expect(isCliSender('clip')).toBe(false);
+    expect(isCliSender('CLI')).toBe(false); // case-sensitive
+    expect(isCliSender('')).toBe(false);
+    expect(isCliSender(':cli')).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -171,6 +201,11 @@ describe.skipIf(!DB_AVAILABLE)('checkSendScope', () => {
 
   test('cli sender has no scope restriction', async () => {
     const error = await checkSendScope(tempDir, 'cli', 'anyone');
+    expect(error).toBeNull();
+  });
+
+  test('cli:<origin> sender has no scope restriction (preserves bypass)', async () => {
+    const error = await checkSendScope(tempDir, 'cli:tui-sidebar', 'anyone');
     expect(error).toBeNull();
   });
 
@@ -474,6 +509,11 @@ describe.skipIf(!DB_AVAILABLE)('suggestRelayLeader', () => {
 
   test('returns null for cli sender', async () => {
     const result = await suggestRelayLeader('cli');
+    expect(result).toBeNull();
+  });
+
+  test('returns null for cli:<origin> prefixed sender', async () => {
+    const result = await suggestRelayLeader('cli:felipe');
     expect(result).toBeNull();
   });
 

--- a/src/term-commands/msg.ts
+++ b/src/term-commands/msg.ts
@@ -56,6 +56,22 @@ async function getMailbox(): Promise<typeof import('../lib/mailbox.js')> {
 // ============================================================================
 
 /**
+ * True when `sender` is the CLI dispatch-bypass marker.
+ *
+ * Two surface forms exist:
+ *   - `'cli'`              — true CLI invocation, no agent context
+ *   - `'cli:<origin>'`     — invoker had agent context (e.g. team-lead running
+ *                            `genie work`); origin is the agent name
+ *
+ * Both forms bypass hierarchy + scope checks. The prefixed form preserves the
+ * actual invoker so downstream consumers (inboxes, audit logs, native team UI)
+ * can attribute the message to a real source instead of an opaque `cli`.
+ */
+export function isCliSender(sender: string): boolean {
+  return sender === 'cli' || sender.startsWith('cli:');
+}
+
+/**
  * Auto-detect the sender identity based on execution context.
  *
  * Detection cascade:
@@ -145,7 +161,7 @@ const DEFAULT_REACHBACK_PREFIXES = ['council-'];
  * Returns an error message if scope is violated, null if OK.
  */
 export async function checkSendScope(_repoPath: string, sender: string, recipient: string): Promise<string | null> {
-  if (sender === 'cli') return null;
+  if (isCliSender(sender)) return null;
 
   const teamManager = await getTeamManager();
   const teams = await teamManager.listTeams();
@@ -287,7 +303,7 @@ export function resolveSenderTeams(
  * ancestor in the chain. Returns null when the sender belongs to no team.
  */
 export async function suggestRelayLeader(sender: string): Promise<{ leader: string; team: string } | null> {
-  if (sender === 'cli') return null;
+  if (isCliSender(sender)) return null;
   const teamManager = await getTeamManager();
   const teams = await teamManager.listTeams();
   const reachable = resolveSenderTeams(teams, sender);


### PR DESCRIPTION
## Summary

- Dispatch commands (`brainstorm`, `wish`, `work`, `review`) hard-coded sender as `'cli'` to bypass hierarchy/scope checks, hiding the actual invoker in every dispatched message
- Replace with `cli:<origin>` where origin is resolved via `detectSenderIdentity` (env → tmux → registry); plain `'cli'` retained when no agent context exists
- Bypass checks in `send.ts` / `msg.ts` now accept both forms via new `isCliSender()` helper

## Why

Caught while debugging a teammate-message that arrived with `teammate_id="cli"` after `genie work` advanced a wave. Without the prefix it's impossible to attribute the message to a real source — was it the human user? a team-lead inside its own session? — without grep'ing `dispatch.ts:518/558/687/766`.

After this change, the same message would arrive as `from: cli:tui-sidebar` (or whatever agent fired the command), preserving attribution while keeping the dispatch-bypass mechanism intact.

## Changes

| File | Change |
|------|--------|
| `src/term-commands/dispatch.ts` | New `cliSender()` helper; 4 hardcoded `'cli'` sites replaced |
| `src/term-commands/msg.ts` | New exported `isCliSender()`; `checkSendScope` + `suggestRelayLeader` use it |
| `src/term-commands/agent/send.ts` | `checkHierarchy` uses `isCliSender()` |
| `src/term-commands/msg.test.ts` | New `isCliSender` describe (4 tests); extended scope + relay coverage |

## Test plan

- [x] `bun test src/term-commands/msg.test.ts src/term-commands/agent/send.test.ts` → 57 pass / 0 fail (6 new)
- [x] `bun run typecheck` → clean
- [ ] Smoke: spawn a team, fire `genie work` from team-lead, verify inbox shows `cli:<team-lead-name>` instead of `cli`

## Backwards compatibility

- True CLI invocations (no GENIE_AGENT_NAME) still emit plain `'cli'` — existing tests for that path unchanged
- `isCliSender` is the only new export; existing `cli`-equality checks were converted, no signature changes
- No data model / DB migration required