### PR TITLE
fix(ci): pin COLUMNS=80 to stabilize visual snapshot tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,20 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Pin terminal width for the test process. test/visual/tui-snapshot.test.tsx
+# (and any future visual regression test) renders OpenTUI components without
+# forcing an explicit width — OpenTUI auto-detects from $COLUMNS. Local
+# developer terminals default to 80 cols (snapshots were captured at 80);
+# Blacksmith CI runners default to ~100+ cols, which produces wider card
+# borders and breaks every visual snapshot.
+#
+# Pin COLUMNS=80 at the workflow level so every job/step inherits the same
+# render width as the snapshots. Both `unit-tests > Visual regression` and
+# `pg-tests > Test` run test/visual/* and need the same value, so a single
+# workflow-level env is the right scope.
+env:
+  COLUMNS: "80"
+
 jobs:
   secrets-scan:
     name: Secrets Scan (GitGuardian)


### PR DESCRIPTION
## Summary

- All 3 open PRs (#1432, #1435, #1440) fail CI with identical 5 visual snapshot diffs even though their code changes are unrelated to TUI rendering
- Root cause: `test/visual/tui-snapshot.test.tsx` lets OpenTUI auto-detect width from `$COLUMNS`. Local terminals default to 80 (snapshots captured here); Blacksmith CI runners default to ~100+, producing wider card borders
- Fix: pin `COLUMNS=80` at the workflow `env:` level in `.github/workflows/ci.yml` so every step in every job inherits the same render width

## Evidence

Failing test pattern across all 3 PRs:
```
visual: AgentPicker > empty directory          (fail)
visual: AgentPicker > populated                (fail)
visual: AgentPicker > filtered                 (fail)
visual: TeamCreate > step 1 (name)             (fail)
visual: ContextMenu > running agent menu       (fail)
```

Snapshot diff signature (same shape across all 5 tests):
```
-           ╭──── 80 chars ────╮          (expected: padded narrow)
+ ╭──── 100+ chars ────╮                  (actual: unpadded wide)
```

Local repro on dev (`bun test test/visual/tui-snapshot.test.tsx`):
```
17 pass, 0 fail, 17 snapshots, 18 expect() calls
```

Local passes, CI fails — pure terminal-width drift.

## Why workflow-level env

Both `unit-tests > Visual regression` (line 83-86) and `pg-tests > Test (serial)` (which runs the full suite, including `test/visual/`) need the same value. Workflow-level `env:` is the single source of truth and future-proofs new visual tests.

## Test plan

- [ ] CI re-runs on this PR — should pass since COLUMNS=80 matches snapshots
- [ ] After merge, rebase #1432, #1435, #1440 — they should auto-go-green
- [ ] No code changes outside `.github/workflows/ci.yml`; no risk to runtime behavior