### PR TITLE
fix(spawn): refuse owner-spawn parallel when canonical alive

### DIFF
--- a/src/term-commands/agents.test.ts
+++ b/src/term-commands/agents.test.ts
@@ -14,6 +14,7 @@ import * as executorRegistry from '../lib/executor-registry.js';
 import { DB_AVAILABLE, setupTestDatabase } from '../lib/test-db.js';
 import * as wishState from '../lib/wish-state.js';
 import {
+  OwnerSpawnCollisionError,
   RecoverAgentNotFoundError,
   buildInitialSplitWindowCommand,
   buildResumeContext,
@@ -870,6 +871,117 @@ describe.skipIf(!DB_AVAILABLE)('spawn state machine', () => {
       const a = await registry.get('engineer-2');
       expect(a?.team).toBe(teamA);
       expect(a?.paneId).toBe('%67');
+    });
+  });
+
+  // Regression for owner-spawn identity collision (2026-04-28 04:05):
+  // `genie spawn genie --team genie` cloned the orchestrator-genie's identity
+  // because findDeadResumable's alive-pane branch silently returned null →
+  // resolveSpawnIdentity created a parallel that ended up duplicating the
+  // owner's name. The contract below pins findDeadResumable's owner-aware
+  // throw on alive + kind='permanent'.
+  describe('findDeadResumable: owner-collision throw', () => {
+    const alwaysAlive = async () => true;
+    const alwaysDead = async () => false;
+
+    /** Mark an existing canonical row as a task spawn (kind='task') by
+     * pointing reports_to at a parent. The kind column is GENERATED, so
+     * this is the only path to flip it. */
+    async function makeTaskKind(id: string, parentId: string): Promise<void> {
+      const { getConnection } = await import('../lib/db.js');
+      const sql = await getConnection();
+      await sql`UPDATE agents SET reports_to = ${parentId} WHERE id = ${id}`;
+    }
+
+    test('throws OwnerSpawnCollisionError when alive canonical has kind=permanent', async () => {
+      const team = `team-owner-throw-${Date.now()}`;
+      await seedCanonical('genie', team, {
+        paneId: '%66',
+        state: 'idle',
+        role: 'genie',
+        provider: 'claude',
+        transport: 'tmux',
+        claudeSessionId: 'orch-session-aaaa-bbbb-cccc-dddddddddddd',
+      });
+
+      let caught: unknown = null;
+      try {
+        await findDeadResumable(team, 'genie', alwaysAlive);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(OwnerSpawnCollisionError);
+      const err = caught as OwnerSpawnCollisionError;
+      expect(err.ownerName).toBe('genie');
+      expect(err.team).toBe(team);
+      expect(err.conflictId).toBe('genie');
+      expect(err.conflictPaneId).toBe('%66');
+      expect(err.conflictState).toBe('idle');
+    });
+
+    test('does NOT throw when canonical pane is dead — returns it for resume', async () => {
+      const team = `team-owner-dead-${Date.now()}`;
+      await seedCanonical('genie', team, {
+        paneId: '%67',
+        state: 'error',
+        role: 'genie',
+        provider: 'claude',
+        transport: 'tmux',
+        claudeSessionId: 'orch-session-dead-bbbb-cccc-dddddddddddd',
+      });
+
+      // Dead pane → returns the candidate so the caller can resume it.
+      // No throw, no parallel-creation path needed.
+      const found = await findDeadResumable(team, 'genie', alwaysDead);
+      expect(found).not.toBeNull();
+      expect(found?.id).toBe('genie');
+    });
+
+    test('does NOT throw when alive candidate has kind=task (non-owner)', async () => {
+      const team = `team-owner-task-${Date.now()}`;
+      // Seed a parent owner so the child has a valid reports_to FK target.
+      await seedCanonical('lead', team, { paneId: '%50', state: 'idle', role: 'lead' });
+      await seedCanonical('engineer', team, {
+        paneId: '%51',
+        state: 'idle',
+        role: 'engineer',
+        provider: 'claude',
+        transport: 'tmux',
+        claudeSessionId: 'engineer-session-eeee-ffff-0000-111111111111',
+      });
+      await makeTaskKind('engineer', 'lead');
+
+      // Alive engineer with kind='task' → owner-collision branch skipped,
+      // alive-pane fallback returns null (caller falls through to spawn
+      // state machine, which handles the kind='task' duplicate via
+      // findOrCreateAgent ON CONFLICT).
+      const found = await findDeadResumable(team, 'engineer', alwaysAlive);
+      expect(found).toBeNull();
+    });
+
+    test('does NOT throw when --role override drops owner out of prefilter', async () => {
+      // `genie spawn genie --role genie-clone --team genie` is the canonical
+      // escape hatch. handleWorkerSpawn passes effectiveRole='genie-clone'
+      // here, so the owner row (role='genie') drops out of the prefilter and
+      // findDeadResumable returns null — no collision check, no throw.
+      const team = `team-owner-role-bypass-${Date.now()}`;
+      await seedCanonical('genie', team, {
+        paneId: '%66',
+        state: 'idle',
+        role: 'genie',
+        provider: 'claude',
+        transport: 'tmux',
+        claudeSessionId: 'orch-session-bypass-aaaa-bbbb-cccccccccccc',
+      });
+
+      const found = await findDeadResumable(team, 'genie-clone', alwaysAlive);
+      expect(found).toBeNull();
+    });
+
+    test('does NOT throw on fresh spawn — no candidate to compare', async () => {
+      const team = `team-owner-fresh-${Date.now()}`;
+      const found = await findDeadResumable(team, 'genie', alwaysAlive);
+      expect(found).toBeNull();
     });
   });
 });

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -1428,6 +1428,30 @@ async function launchInlineSpawn(ctx: SpawnCtx): Promise<string> {
 }
 
 /**
+ * Typed error thrown by `findDeadResumable` when a fresh `<name>` spawn would
+ * clone an alive owner agent's identity (`kind = 'permanent'`). Caller
+ * (`handleWorkerSpawn`) catches this and prints a helpful error directing
+ * the user to use `--role` to carve out a separate identity.
+ *
+ * Empirical incident 2026-04-28 04:05: `genie spawn genie --team genie`
+ * cloned the orchestrator-genie's identity because the alive-pane branch in
+ * `findDeadResumable` returned `null` (silently fell through to parallel
+ * creation), instead of refusing the collision.
+ */
+export class OwnerSpawnCollisionError extends Error {
+  override readonly name = 'OwnerSpawnCollisionError';
+  constructor(
+    readonly ownerName: string,
+    readonly team: string,
+    readonly conflictId: string,
+    readonly conflictPaneId: string,
+    readonly conflictState: string,
+  ) {
+    super(`owner agent "${ownerName}" already alive in team "${team}"`);
+  }
+}
+
+/**
  * Find a dead worker with a resumable Claude session for the given role/team.
  * Must run BEFORE rejectDuplicateRole which would unregister the dead worker
  * and lose the claudeSessionId needed for resume.
@@ -1436,9 +1460,25 @@ async function launchInlineSpawn(ctx: SpawnCtx): Promise<string> {
  * their id), so `findDeadResumable(team, name)` filters them out — parallels
  * are resumable only by their full id (`genie spawn <name>-<sN>`).
  *
- * Exported for unit testing the "parallels off auto-resume path" invariant.
+ * Owner-collision contract: when the resumable candidate's pane is alive AND
+ * `kind = 'permanent'`, throw `OwnerSpawnCollisionError` instead of silently
+ * returning null. Owner identities are exclusive — the alive orchestrator
+ * holds the name; a fresh spawn would clone its identity. The caller refuses
+ * the spawn and surfaces the error message. An explicit `--role <other>`
+ * bypasses naturally because `effectiveRole` no longer matches the owner's
+ * `role`, dropping it out of the prefilter.
+ *
+ * `isAliveFn` is injected so unit tests can exercise alive/dead branches
+ * without real tmux — same pattern as `resolveSpawnIdentity`.
+ *
+ * Exported for unit testing the "parallels off auto-resume path" invariant
+ * and the owner-collision throw.
  */
-export async function findDeadResumable(team: string, role: string): Promise<registry.Agent | null> {
+export async function findDeadResumable(
+  team: string,
+  role: string,
+  isAliveFn: (paneId: string) => Promise<boolean> = isPaneAliveOrDead,
+): Promise<registry.Agent | null> {
   const existing = await registry.list();
   // Resume currently only supports tmux transport (resumeAgent hard-requires
   // process.env.TMUX + createTmuxPane). A stale `transport: 'inline'` row
@@ -1464,8 +1504,14 @@ export async function findDeadResumable(team: string, role: string): Promise<reg
   if (!candidate) return null;
   // `isPaneAliveOrDead` swallows TmuxUnreachableError → dead, so a zombie
   // tmux socket doesn't crash the spawn path.
-  const alive = await isPaneAliveOrDead(candidate.paneId);
-  return alive ? null : candidate;
+  const alive = await isAliveFn(candidate.paneId);
+  if (alive) {
+    if (candidate.kind === 'permanent') {
+      throw new OwnerSpawnCollisionError(role, team, candidate.id, candidate.paneId, candidate.state);
+    }
+    return null;
+  }
+  return candidate;
 }
 
 /**
@@ -2115,6 +2161,30 @@ async function resolveTeamAndResume(
   return { team, teamWasExplicit };
 }
 
+/**
+ * Wrap `resolveTeamAndResume` so the owner-collision throw from
+ * `findDeadResumable` becomes a clean error message + exit(1), not a CLI
+ * stack trace. Keeps `handleWorkerSpawn`'s cyclomatic complexity at the
+ * pre-existing budget — the catch lives here, not inline at the call site.
+ */
+async function resolveTeamAndResumeOrExit(
+  effectiveRole: string,
+  options: SpawnOptions,
+  agent: Awaited<ReturnType<typeof resolveAgentForSpawn>>,
+): Promise<{ team: string; teamWasExplicit: boolean; resumed?: string }> {
+  try {
+    return await resolveTeamAndResume(effectiveRole, options, agent);
+  } catch (err) {
+    if (err instanceof OwnerSpawnCollisionError) {
+      console.error(
+        `Error: owner agent "${err.ownerName}" already alive in team "${err.team}" (id: ${err.conflictId}, pane: ${err.conflictPaneId}, state: ${err.conflictState}).\nOwner identities are exclusive — to spawn a separate worker under the same template, use --role <custom-name>:\n  genie spawn ${err.ownerName} --role ${err.ownerName}-2 --team ${err.team}`,
+      );
+      return process.exit(1) as never;
+    }
+    throw err;
+  }
+}
+
 export async function handleWorkerSpawn(name: string, options: SpawnOptions): Promise<string> {
   // Effective role: suffixed name for registration/duplicate-check, original name for directory lookup
   let effectiveRole = options.role ?? name;
@@ -2126,7 +2196,15 @@ export async function handleWorkerSpawn(name: string, options: SpawnOptions): Pr
   // `agent` is passed through so template-pinned teams (agent.entry.team) take
   // precedence over GENIE_TEAM / discoverTeamName — preserves canonical-UUID invariant
   // when spawning from a tmux session that does not match the agent's home team.
-  const { team, teamWasExplicit, resumed } = await resolveTeamAndResume(effectiveRole, options, agent);
+  // Owner-collision guard lives inside `findDeadResumable` (called by
+  // `resolveTeamAndResume`): when the resumable candidate is alive AND
+  // `kind = 'permanent'`, it throws `OwnerSpawnCollisionError` instead of
+  // silently falling through to parallel creation. `resolveTeamAndResumeOrExit`
+  // catches + formats so the user sees a helpful message + clean exit (not a
+  // CLI stack trace). Explicit `--role <other>` bypasses naturally because
+  // the owner's role no longer matches `effectiveRole` and the candidate drops
+  // out of the findDeadResumable prefilter.
+  const { team, teamWasExplicit, resumed } = await resolveTeamAndResumeOrExit(effectiveRole, options, agent);
   if (resumed) return resumed;
 
   // 2b. Spawn state machine — branch on canonical liveness (authority: wish


### PR DESCRIPTION
## Summary

- `findDeadResumable` now throws `OwnerSpawnCollisionError` when its resumable candidate is alive AND `kind = 'permanent'` instead of silently falling through to parallel creation.
- `handleWorkerSpawn` (via `resolveTeamAndResumeOrExit` wrapper) catches the throw, prints a helpful error directing the user to `--role <custom>`, and exits 1.
- Owner identities (`kind = 'permanent'`) are now exclusive within a team — duplicate spawns are refused, not silently cloned.

## Why

Empirical incident **2026-04-28 04:05**: `genie spawn genie --team genie` cloned the orchestrator-genie's identity. PID 1824998, pane %166, fresh executor `7533bcc9-…`, while the orchestrator-genie (team-lead, owner identity) was alive. Result: TWO agents named `genie` in team `genie`, breaking every downstream resolver (`genie send`, `agent show`, idle-routing).

Root cause: `findDeadResumable`'s alive-pane branch returned `null` ("no resumable, caller proceed with fresh spawn"). For owner agents, that fell through to `resolveSpawnIdentity` → parallel creation, but the parallel ended up duplicating the owner's display name.

## What

**`findDeadResumable` contract change** — when candidate is alive AND `kind = 'permanent'`, throw `OwnerSpawnCollisionError` carrying ownerName / team / conflictId / paneId / state. Non-permanent (`kind = 'task'`) rows still return `null` at the alive-pane branch (zero behavior change). New optional `isAliveFn` injection point mirrors `resolveSpawnIdentity` for deterministic unit tests.

**`resolveTeamAndResumeOrExit`** is a thin wrapper around `resolveTeamAndResume` that catches `OwnerSpawnCollisionError` and surfaces it as a clean error message + `process.exit(1)` — no CLI stack trace. Keeps `handleWorkerSpawn`'s cyclomatic complexity at its pre-existing budget.

**Explicit `--role <other>` bypasses naturally** — when the user passes `--role genie-clone`, `effectiveRole='genie-clone'` no longer matches the owner's `role='genie'`, so the owner row drops out of `findDeadResumable`'s prefilter. No special-case logic in the throw site.

**Resume paths unaffected** — `genie agent resume <owner>` flows through `buildFullResumeParams`, not `handleWorkerSpawn`, so the new throw cannot interfere with resume. External `handleWorkerSpawn` callers verified to all be spawn paths (`team.ts:378` team-lead spawn, `dispatch.ts` work/review, `agent/spawn.ts` CLI).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bunx biome check src/term-commands/agents.{ts,test.ts}` — clean (sole warning is pre-existing `buildSpawnParams` complexity, untouched)
- [x] `bun test src/term-commands/agents.test.ts` — 54 pass / 0 fail / 135 expect calls / 2.78s
- [x] Owner-collision branch coverage (5 new tests under `findDeadResumable: owner-collision throw`):
  - [x] alive canonical kind=permanent → throws `OwnerSpawnCollisionError` with all fields populated
  - [x] dead pane → returns candidate (resume path), no throw
  - [x] alive kind=task → returns null at alive branch, no throw
  - [x] explicit `--role <other>` (`effectiveRole !== owner.role`) → owner drops out of prefilter, returns null, no throw
  - [x] no candidate (fresh spawn) → returns null, no throw

## Acceptance

- `genie spawn genie --team genie` while orchestrator-genie alive → exit 1 with `--role <custom>` suggestion
- `genie spawn genie --role genie-clone --team genie` → proceeds (parallel-clone path)
- `genie spawn genie --team genie` while orchestrator-genie pane is dead → resume path fires (recovery)
- `genie spawn engineer --team genie` with `engineer` kind=task → proceeds (state machine handles via `findOrCreateAgent` ON CONFLICT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)