### PR TITLE
fix(spawn): owner-vs-meeseeks gate — don't leak team-lead session into identity spawns

### DIFF
--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -1574,16 +1574,41 @@ async function getPaneSession(paneId: string): Promise<string | null> {
 async function resolveNativeTeam(
   team: string,
   _repoPath: string,
-  options: { provider: string; role?: string; color?: string; planMode?: boolean; permissionMode?: string },
+  options: {
+    provider: string;
+    role?: string;
+    color?: string;
+    planMode?: boolean;
+    permissionMode?: string;
+    /**
+     * When true, the spawn is identity-bearing (the caller passed
+     * `--role <custom>` AND it differs from the agent template). Identity
+     * spawns MUST NOT inherit `parent-session-id` from the team-lead, because
+     * Claude Code seeds the child session from the parent's jsonl — leaking
+     * the spawner's full conversation history into a worker that should have
+     * its own clean context. See `owner-vs-meeseeks-spawn` brainstorm
+     * (`.genie/brainstorms/owner-vs-meeseeks-spawn/DESIGN.md`).
+     */
+    isIdentitySpawn?: boolean;
+  },
 ): Promise<{ parentSessionId: string; spawnColor: ClaudeTeamColor; nativeTeam?: SpawnParams['nativeTeam'] }> {
   // Team parent session collapses into the team-lead agent's current executor
   // session (claude-resume-by-session-id wish, Group 5). The legacy
   // `teams.native_team_parent_session_id` column is no longer read here.
+  //
+  // owner-vs-meeseeks gate (2026-04-28): when the spawn is identity-bearing
+  // (`isIdentitySpawn === true`), skip the leader-session lookup so the new
+  // worker gets a fresh-context parent id (the `genie-${team}` fallback) and
+  // Claude Code does NOT seed it from the team-lead's jsonl. Empirical proof:
+  // `genie spawn genie --role genie-0ca8` (2026-04-27 23:45) produced a spawn
+  // script with `--parent-session-id <orchestrator-uuid>` and the new claude
+  // process inherited the orchestrator's full conversation (~2035 entries)
+  // until an explicit `/clear` reset it.
   const leaderName = await teamManager.resolveLeaderName(team);
   const sanitizedTeam = nativeTeams.sanitizeTeamName(team);
   const leaderAgent = await registry.getAgentByName(leaderName, sanitizedTeam).catch(() => null);
   let parentSessionId: string | undefined;
-  if (leaderAgent) {
+  if (leaderAgent && !options.isIdentitySpawn) {
     // Route through the canonical chokepoint. We want the leader's session
     // UUID for use as a parent_session_id — `shouldResume` exposes it
     // regardless of the resume verdict (a paused or assignment-closed leader
@@ -1780,10 +1805,16 @@ async function buildSpawnParams(
     windowTarget: options.window,
   };
 
+  // owner-vs-meeseeks gate: propagate the identity-spawn signal so
+  // resolveNativeTeam can skip leader-session inheritance for spawns that
+  // override `--role` (those carve out a new identity and must not seed
+  // their conversation from the team-lead's jsonl).
+  const isIdentitySpawn = options.role !== undefined && options.role !== name;
   const { parentSessionId, spawnColor, nativeTeam } = await resolveNativeTeam(team, agent.repoPath, {
     ...options,
     provider: resolvedProvider,
     role: name,
+    isIdentitySpawn,
   });
   if (nativeTeam) params.nativeTeam = nativeTeam;
 


### PR DESCRIPTION
## Summary

Closes the empirical leak from 2026-04-27 23:45: `genie spawn genie --role genie-0ca8` produced a spawn script with `--parent-session-id <orchestrator-uuid>`, causing the new claude process to inherit the orchestrator's full conversation (~2035 entries) until an explicit `/clear` reset it.

## Root cause

`resolveNativeTeam` in `src/term-commands/agents.ts` unconditionally seeded `parentSessionId` from the team-lead's session UUID via `shouldResume(leaderAgent.id)`. Claude Code uses `--parent-session-id` to seed the child session from the parent's jsonl — appropriate for ephemeral sub-agents (Task tool semantics), but catastrophic for identity-bearing spawns where the caller explicitly carved out a new role with `--role <custom>`.

## Fix

Gate the leader-session lookup on `!isIdentitySpawn`. The signal uses the existing discriminator from `handleWorkerSpawn:2149`: `options.role !== undefined && options.role !== name`. When true, the spawn falls through to the `genie-${team}` fallback (a non-UUID sentinel), so Claude Code can't seed context from a non-existent session — the new worker gets a clean start.

Sub-agent semantics preserved: spawns without `--role` (or with `--role <name>` matching the positional template) keep the existing context-inheritance behavior.

## Touch points

- `resolveNativeTeam`: new optional `isIdentitySpawn?: boolean` in options + gate `if (leaderAgent && !options.isIdentitySpawn)` before `shouldResume` lookup.
- `buildSpawnParams`: compute `isIdentitySpawn` from `options.role !== name` and propagate.
- Resume path (`buildFullResumeParams`) untouched — agents being resumed already have their own `--resume <session-id>` which takes precedence over parent-session-id seeding.

## Test plan

- [x] `bun run typecheck` clean
- [x] Pre-push hook (`bun run check`) passed — push succeeded without --no-verify

## Brainstorm reference

`.genie/brainstorms/owner-vs-meeseeks-spawn/DESIGN.md`. Wave 1 Item 1 (`resolveResumeSessionId` dir-fallback) was already shipped. Wave 1 owner identity contract (collision check) shipped via `67a3883f`. This patch closes the remaining context-leak vector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)