### PR TITLE
ci(version): drop post-publish deprecate step — finalize npm independence

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -177,17 +177,19 @@ jobs:
         # On dev context: publish the version we just bumped to as @next.
         run: npm publish --access public --tag ${{ steps.context.outputs.npm_tag }}
 
-      - name: Mark published version as deprecated (npm-distribution sunset)
-        # The npm distribution channel is being soft-deprecated in favor of
-        # the cosign + SLSA verified installer at get.automagik.dev/genie.
-        # Every published version carries an `npm warn deprecated` notice
-        # pointing operators at the canonical install path. Existing pinned
-        # versions continue to install (the postinstall shim handles the
-        # delegation in the next umbrella PR); this step just makes the
-        # sunset visible in npm's own UX.
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          version="$(node -p 'require("./package.json").version')"
-          npm deprecate "@automagik/genie@${version}" \
-            "@automagik/genie via npm is soft-deprecated. Canonical install: curl -fsSL https://get.automagik.dev/genie | bash (cosign + SLSA verified). See https://automagik.dev/genie/security/distribution-sovereignty for the threat model and verification flow."
+      # The post-publish `npm deprecate` step lived here through
+      # 4.260428.8 and was retired on 2026-04-28 — it depended on a
+      # classic NPM_TOKEN secret (OIDC trusted-publisher tokens are
+      # publish-only, can't deprecate), and even with valid auth it
+      # raced the registry's <1s post-publish indexing window. Both
+      # failure modes are documented at:
+      #   automagik.dev/genie/security/distribution-sovereignty
+      #
+      # The npm soft-deprecation message moves to the postinstall
+      # shim per the umbrella sovereignty plan: every install via
+      # npm prints the canonical-install redirect at install time,
+      # which is closer to the user (lives in the package, not the
+      # registry config) and works without long-lived secrets.
+      #
+      # NPM_TOKEN secret is no longer used anywhere in this repo.
+      # Safe to delete from automagik-dev/genie repo + org settings.


### PR DESCRIPTION
## Why

Every release since OIDC migration has failed at the post-publish \`npm deprecate\` step (latest: 4.260428.8 — actually published, but workflow exits 1 because deprecate 404s).

## Two root causes

1. **Auth scope mismatch**: OIDC trusted-publisher tokens are publish-only — they cannot call \`npm deprecate\`. The step fell back to \`\${{ secrets.NPM_TOKEN }}\`, but that secret was either rotated, removed during OIDC migration, or never had \`deprecate\` scope. npm returns 404 for permission denied on deprecate (same misleading-404 trick as publish).

2. **Race condition**: Even with valid auth, deprecate fires <1s after publish. npm registry needs time to index the new version across replicas. Run logs show **680ms gap** between \`+ @automagik/genie@4.260428.5\` and \`404 Not Found PUT @automagik%2fgenie\`.

## What changed

- Removed the deprecate step entirely.
- Replaced with a tombstone comment block documenting why it was retired and where the soft-deprecation message will live (postinstall shim — umbrella sovereignty plan).

## What this enables

- **Zero long-lived npm secrets**. OIDC trusted-publisher handles publish; nothing else hits npm's API.
- **NPM_TOKEN secret can be deleted** from \`automagik-dev/genie\` repo + org settings.
- **Soft-deprecation message moves closer to the user**: postinstall shim prints the canonical-install redirect at install time. Works without secrets, doesn't depend on registry indexing timing, survives registry policy changes.

## Verified by

Reading failed run [25034889981](https://github.com/automagik-dev/genie/actions/runs/25034889981):
- \`05:03:12.77  Publish to npm via OIDC  + @automagik/genie@4.260428.5\` — **SUCCESS**
- \`05:03:13.45  Mark deprecated          404 Not Found PUT @automagik%2fgenie\` — **FAIL** (680ms after publish)

## Test plan

- [ ] Merge to dev → version.yml fires → publishes \`4.260428.9\` (or whatever) as @next via OIDC → workflow ends green (no deprecate step to fail on).
- [ ] Merge dev → main → publishes same version as @latest → workflow ends green.
- [ ] Confirm \`NPM_TOKEN\` no longer needed; delete from secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)