### PR TITLE
feat(hooks): codex UserPromptSubmit handler reads PG mailbox (PR B)

### DIFF
--- a/src/hooks/__tests__/dispatch.test.ts
+++ b/src/hooks/__tests__/dispatch.test.ts
@@ -181,6 +181,82 @@ describe('handler chain behavior', () => {
   });
 });
 
+describe('UserPromptSubmit dispatch flow', () => {
+  const originalEnv = { ...process.env };
+  let originalDeps: { findCodexAgent: unknown; fetchUnread: unknown; markReadBatch: unknown };
+
+  beforeEach(async () => {
+    process.env.GENIE_AGENT_NAME = 'codex-eng';
+    process.env.GENIE_TEAM = 'test-team';
+    process.env.NODE_ENV = undefined;
+    process.env.BUN_ENV = undefined;
+    const mod = await import('../handlers/codex-inbox-deliver.js');
+    originalDeps = { ...mod._deps };
+  });
+
+  afterEach(async () => {
+    process.env = { ...originalEnv };
+    const mod = await import('../handlers/codex-inbox-deliver.js');
+    mod._deps.findCodexAgent = originalDeps.findCodexAgent as typeof mod._deps.findCodexAgent;
+    mod._deps.fetchUnread = originalDeps.fetchUnread as typeof mod._deps.fetchUnread;
+    mod._deps.markReadBatch = originalDeps.markReadBatch as typeof mod._deps.markReadBatch;
+  });
+
+  test('codex inbox deliver additionalContext surfaces as hookSpecificOutput', async () => {
+    const mod = await import('../handlers/codex-inbox-deliver.js');
+    mod._deps.findCodexAgent = async () => ({
+      id: 'agent-uuid',
+      role: 'codex-eng',
+      customName: 'codex-eng',
+      repoPath: '/repo',
+      provider: 'codex',
+    });
+    mod._deps.fetchUnread = async () => [
+      {
+        id: 'msg-1',
+        from: 'operator',
+        to: 'codex-eng',
+        body: 'pong test',
+        createdAt: '2026-04-28T00:00:00Z',
+        read: false,
+        deliveredAt: null,
+        source: 'agent',
+        meta: {},
+      },
+    ];
+    mod._deps.markReadBatch = async () => 1;
+
+    const payload = {
+      hook_event_name: 'UserPromptSubmit',
+      session_id: 'session-1',
+      cwd: '/repo',
+      prompt: 'hi',
+    };
+    const raw = await dispatch(JSON.stringify(payload));
+    expect(raw).not.toBe('');
+    const parsed = JSON.parse(raw);
+    expect(parsed.hookSpecificOutput).toBeDefined();
+    expect(parsed.hookSpecificOutput.hookEventName).toBe('UserPromptSubmit');
+    expect(parsed.hookSpecificOutput.additionalContext).toBe('pong test');
+  });
+
+  test('UserPromptSubmit returns empty when no codex agent matches (no hookSpecificOutput)', async () => {
+    const mod = await import('../handlers/codex-inbox-deliver.js');
+    mod._deps.findCodexAgent = async () => null;
+    mod._deps.fetchUnread = async () => [];
+    mod._deps.markReadBatch = async () => 0;
+
+    const payload = {
+      hook_event_name: 'UserPromptSubmit',
+      session_id: 'session-1',
+      cwd: '/repo',
+      prompt: 'hi',
+    };
+    const raw = await dispatch(JSON.stringify(payload));
+    expect(raw).toBe('');
+  });
+});
+
 describe('runHandler crash behavior', () => {
   const crashingHandler: Handler = {
     name: 'crashing-handler',

--- a/src/hooks/handlers/__tests__/codex-inbox-deliver.test.ts
+++ b/src/hooks/handlers/__tests__/codex-inbox-deliver.test.ts
@@ -1,0 +1,244 @@
+/**
+ * codex-inbox-deliver handler — unit tests (mocked deps; no PG, no codex).
+ *
+ * Run with: bun test src/hooks/handlers/__tests__/codex-inbox-deliver.test.ts
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { MailboxMessage } from '../../../lib/mailbox.js';
+import type { HookPayload } from '../../types.js';
+import { type CodexAgentRef, _deps, codexInboxDeliver } from '../codex-inbox-deliver.js';
+
+const ENV_KEYS = ['GENIE_AGENT_NAME', 'GENIE_TEAM', 'NODE_ENV', 'BUN_ENV'] as const;
+
+function snapshotEnv(): Record<string, string | undefined> {
+  const out: Record<string, string | undefined> = {};
+  for (const k of ENV_KEYS) out[k] = process.env[k];
+  return out;
+}
+
+function restoreEnv(snap: Record<string, string | undefined>): void {
+  for (const k of ENV_KEYS) {
+    if (snap[k] === undefined) delete process.env[k];
+    else process.env[k] = snap[k];
+  }
+}
+
+function resetDeps(): void {
+  _deps.findCodexAgent = null;
+  _deps.fetchUnread = null;
+  _deps.markReadBatch = null;
+}
+
+function makeAgent(over: Partial<CodexAgentRef> = {}): CodexAgentRef {
+  return {
+    id: 'agent-uuid-1',
+    role: 'codex-eng',
+    customName: 'codex-eng',
+    repoPath: '/repo',
+    provider: 'codex',
+    ...over,
+  };
+}
+
+function makeMsg(over: Partial<MailboxMessage> = {}): MailboxMessage {
+  return {
+    id: `msg-${Math.random().toString(36).slice(2)}`,
+    from: 'operator',
+    to: 'codex-eng',
+    body: 'hello codex',
+    createdAt: new Date().toISOString(),
+    read: false,
+    deliveredAt: null,
+    source: 'agent',
+    meta: {},
+    ...over,
+  };
+}
+
+function basePayload(): HookPayload {
+  return {
+    hook_event_name: 'UserPromptSubmit',
+    session_id: 'session-1',
+    cwd: '/repo',
+    prompt: 'do the thing',
+  };
+}
+
+describe('codex-inbox-deliver handler', () => {
+  let envSnapshot: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    envSnapshot = snapshotEnv();
+    // Tests bypass the test-env short-circuit by installing dep overrides;
+    // clear the literal vars so resolveContext doesn't return null on
+    // missing GENIE_AGENT_NAME.
+    process.env.GENIE_AGENT_NAME = 'codex-eng';
+    process.env.GENIE_TEAM = 'genie';
+    process.env.NODE_ENV = undefined;
+    process.env.BUN_ENV = undefined;
+    resetDeps();
+  });
+
+  afterEach(() => {
+    resetDeps();
+    restoreEnv(envSnapshot);
+  });
+
+  test('returns undefined when no agent name is resolvable', async () => {
+    process.env.GENIE_AGENT_NAME = undefined;
+    _deps.findCodexAgent = async () => makeAgent();
+    _deps.fetchUnread = async () => [makeMsg()];
+    _deps.markReadBatch = async () => 1;
+
+    const result = await codexInboxDeliver(basePayload());
+    expect(result).toBeUndefined();
+  });
+
+  test('returns undefined when matched agent is not codex provider', async () => {
+    _deps.findCodexAgent = async () => makeAgent({ provider: 'claude' });
+    _deps.fetchUnread = async () => [makeMsg()];
+    _deps.markReadBatch = async () => 1;
+
+    const result = await codexInboxDeliver(basePayload());
+    expect(result).toBeUndefined();
+  });
+
+  test('returns undefined when no codex agent matches', async () => {
+    _deps.findCodexAgent = async () => null;
+    _deps.fetchUnread = async () => [makeMsg()];
+    _deps.markReadBatch = async () => 1;
+
+    const result = await codexInboxDeliver(basePayload());
+    expect(result).toBeUndefined();
+  });
+
+  test('returns undefined when mailbox is empty', async () => {
+    let fetched = false;
+    _deps.findCodexAgent = async () => makeAgent();
+    _deps.fetchUnread = async (_repo, _keys) => {
+      fetched = true;
+      return [];
+    };
+    _deps.markReadBatch = async () => 0;
+
+    const result = await codexInboxDeliver(basePayload());
+    expect(result).toBeUndefined();
+    expect(fetched).toBe(true);
+  });
+
+  test('renders N pending messages as newline-joined envelopes in fetch order', async () => {
+    const agent = makeAgent();
+    const msgs = [
+      makeMsg({ id: 'msg-a', from: 'operator', body: 'first', createdAt: '2026-04-28T00:00:00Z' }),
+      makeMsg({
+        id: 'msg-b',
+        from: '+5511999999999',
+        body: 'second',
+        createdAt: '2026-04-28T00:00:01Z',
+        source: 'whatsapp',
+        meta: { phone: '+5511999999999', conversationId: 'wa-1' },
+      }),
+      makeMsg({ id: 'msg-c', from: 'system', body: 'third', createdAt: '2026-04-28T00:00:02Z', source: 'system' }),
+    ];
+
+    _deps.findCodexAgent = async () => agent;
+    _deps.fetchUnread = async () => msgs;
+    _deps.markReadBatch = async () => msgs.length;
+
+    const result = await codexInboxDeliver(basePayload());
+    expect(result).toBeDefined();
+    expect(result?.hookSpecificOutput?.hookEventName).toBe('UserPromptSubmit');
+    const ctx = result?.hookSpecificOutput?.additionalContext ?? '';
+    const lines = ctx.split('\n');
+    expect(lines).toHaveLength(3);
+    // Default-source body passes through verbatim; non-default wraps as <channel ...>.
+    expect(lines[0]).toBe('first');
+    expect(lines[1]).toMatch(/^<channel source="whatsapp"/);
+    expect(lines[1]).toContain('phone="+5511999999999"');
+    expect(lines[1]).toContain('>second</channel>');
+    expect(lines[2]).toBe('<channel source="system" from="system">third</channel>');
+  });
+
+  test('marks delivered rows read with the exact id batch', async () => {
+    const agent = makeAgent();
+    const msgs = [makeMsg({ id: 'msg-1' }), makeMsg({ id: 'msg-2' })];
+    const captured: { ids: string[] } = { ids: [] };
+
+    _deps.findCodexAgent = async () => agent;
+    _deps.fetchUnread = async () => msgs;
+    _deps.markReadBatch = async (ids) => {
+      captured.ids = ids.slice();
+      return ids.length;
+    };
+
+    await codexInboxDeliver(basePayload());
+    expect(captured.ids).toEqual(['msg-1', 'msg-2']);
+  });
+
+  test('skips delivery when mark-read returns 0 (atomic guard against double-injection)', async () => {
+    const agent = makeAgent();
+    _deps.findCodexAgent = async () => agent;
+    _deps.fetchUnread = async () => [makeMsg(), makeMsg()];
+    _deps.markReadBatch = async () => 0; // PG transient or row vanished
+
+    const result = await codexInboxDeliver(basePayload());
+    expect(result).toBeUndefined();
+  });
+
+  test('queries mailbox using all keys the agent may be addressed by', async () => {
+    const agent = makeAgent({ id: 'uuid-x', role: 'codex-eng', customName: 'pr-b-codex' });
+    const captured: { keys: string[] } = { keys: [] };
+    _deps.findCodexAgent = async () => agent;
+    _deps.fetchUnread = async (_repo, keys) => {
+      captured.keys = keys.slice();
+      return [];
+    };
+    _deps.markReadBatch = async () => 0;
+
+    await codexInboxDeliver(basePayload());
+    const set = new Set(captured.keys);
+    // Includes id, role, customName, AND the GENIE_AGENT_NAME fallback.
+    expect(set.has('uuid-x')).toBe(true);
+    expect(set.has('codex-eng')).toBe(true);
+    expect(set.has('pr-b-codex')).toBe(true);
+  });
+
+  test('returns empty additionalContext (undefined) when fetch exceeds 500ms timeout', async () => {
+    _deps.findCodexAgent = async () => makeAgent();
+    _deps.fetchUnread = () => new Promise((resolve) => setTimeout(() => resolve([makeMsg()]), 5_000));
+    _deps.markReadBatch = async () => 1;
+
+    const start = Date.now();
+    const result = await codexInboxDeliver(basePayload());
+    const elapsed = Date.now() - start;
+    expect(result).toBeUndefined();
+    // Timeout budget is 500ms — give a generous CI fudge factor.
+    expect(elapsed).toBeLessThan(2_000);
+  });
+
+  test('swallows fetch errors and returns undefined (never crashes the dispatcher)', async () => {
+    _deps.findCodexAgent = async () => makeAgent();
+    _deps.fetchUnread = async () => {
+      throw new Error('PG unreachable');
+    };
+    _deps.markReadBatch = async () => 0;
+
+    const result = await codexInboxDeliver(basePayload());
+    expect(result).toBeUndefined();
+  });
+
+  test('respects team scoping when GENIE_TEAM is set', async () => {
+    let observedTeam: string | undefined;
+    _deps.findCodexAgent = async (_name, team) => {
+      observedTeam = team;
+      return makeAgent();
+    };
+    _deps.fetchUnread = async () => [];
+    _deps.markReadBatch = async () => 0;
+
+    process.env.GENIE_TEAM = 'sprint-team';
+    await codexInboxDeliver(basePayload());
+    expect(observedTeam).toBe('sprint-team');
+  });
+});

--- a/src/hooks/handlers/codex-inbox-deliver.ts
+++ b/src/hooks/handlers/codex-inbox-deliver.ts
@@ -1,0 +1,205 @@
+/**
+ * Codex Inbox Deliver Handler — UserPromptSubmit (codex provider only)
+ *
+ * When a codex agent starts a turn, codex fires `UserPromptSubmit` through
+ * the genie hook bridge (configured per-host by `injectCodexHooks` in
+ * src/hooks/codex-inject.ts). This handler reads the agent's pending mailbox
+ * rows from PostgreSQL, marks them read, and returns the rendered channel
+ * envelopes as `additionalContext` so codex injects them into the model
+ * input for that turn.
+ *
+ * This replaces tmux send-keys for engineer-driven codex sends — the hook
+ * fires before every turn, so any message persisted to the mailbox between
+ * turns surfaces on the next turn without polling, file watchers, or pane
+ * injection (the equivalent of native-team inbox JSON files for claude).
+ *
+ * Resolution:
+ *   - agent name from `GENIE_AGENT_NAME` (set by spawn) or payload.teammate_name
+ *   - team from `GENIE_TEAM` or payload.team_name
+ *   - lookup in `agents` table with provider === 'codex'; non-codex agents skip
+ *   - mailbox query uses every key the agent might be addressed by (id, role,
+ *     custom_name) to match how `mailbox.send` writes `to_worker` (varies by
+ *     delivery path — see `src/lib/protocol-router.ts`).
+ *
+ * Timeout: 500ms hard cap on the PG round-trip. Codex's hook timeout is 15s,
+ * but we want sub-second so a slow DB never stalls a turn — bail with empty
+ * additionalContext on timeout (no delivery this turn, message stays unread,
+ * next turn retries).
+ *
+ * Mark-read semantics: marked read BEFORE returning. If the mark fails, we
+ * bail with no delivery (better to miss a turn than double-inject after a
+ * partial PG failure). The same row never delivers twice because the next
+ * `UserPromptSubmit` reads `read = false` only.
+ *
+ * Priority: 25 — runs after `runtime-emit-user-prompt` (30) and before
+ * `session-sync-prompt` (35). Ordering is cosmetic for additionalContext
+ * (handlers are independent), but earlier priorities should not depend on
+ * the mailbox state.
+ */
+
+import { formatEnvelope } from '../../lib/channel-envelope.js';
+import type { MailboxMessage } from '../../lib/mailbox.js';
+import type { HandlerResult, HookPayload } from '../types.js';
+
+/** Hard timeout for the PG query — codex hook budget is 15s; we want sub-second. */
+const QUERY_TIMEOUT_MS = 500;
+
+/**
+ * Minimal agent shape required for routing — keeps the dep contract narrow
+ * so tests can inject plain objects without faking the full Agent type.
+ */
+export interface CodexAgentRef {
+  id: string;
+  role?: string;
+  customName?: string;
+  repoPath: string;
+  provider?: string;
+}
+
+type FindCodexAgentFn = (name: string, team?: string) => Promise<CodexAgentRef | null>;
+type FetchUnreadFn = (repoPath: string, workerKeys: string[]) => Promise<MailboxMessage[]>;
+type MarkReadBatchFn = (messageIds: string[]) => Promise<number>;
+
+/**
+ * Overridable deps for testing (mirrors the session-sync pattern). When left
+ * null, the handler lazy-imports the real modules at call time.
+ */
+export const _deps: {
+  findCodexAgent: FindCodexAgentFn | null;
+  fetchUnread: FetchUnreadFn | null;
+  markReadBatch: MarkReadBatchFn | null;
+} = {
+  findCodexAgent: null,
+  fetchUnread: null,
+  markReadBatch: null,
+};
+
+async function resolveDeps(): Promise<{
+  findCodexAgent: FindCodexAgentFn;
+  fetchUnread: FetchUnreadFn;
+  markReadBatch: MarkReadBatchFn;
+}> {
+  return {
+    findCodexAgent: _deps.findCodexAgent ?? defaultFindCodexAgent,
+    fetchUnread: _deps.fetchUnread ?? defaultFetchUnread,
+    markReadBatch: _deps.markReadBatch ?? defaultMarkReadBatch,
+  };
+}
+
+async function defaultFindCodexAgent(name: string, team?: string): Promise<CodexAgentRef | null> {
+  const registry = await import('../../lib/agent-registry.js');
+  const agents = await registry.list();
+  const candidates = agents.filter((a) => a.provider === 'codex');
+  const matched = candidates.find((a) => {
+    if (team && a.team && a.team !== team) return false;
+    return a.id === name || a.role === name || a.customName === name;
+  });
+  if (!matched) return null;
+  return {
+    id: matched.id,
+    role: matched.role,
+    customName: matched.customName,
+    repoPath: matched.repoPath,
+    provider: matched.provider,
+  };
+}
+
+async function defaultFetchUnread(repoPath: string, workerKeys: string[]): Promise<MailboxMessage[]> {
+  const mailbox = await import('../../lib/mailbox.js');
+  return mailbox.getUnread(repoPath, workerKeys);
+}
+
+async function defaultMarkReadBatch(messageIds: string[]): Promise<number> {
+  if (messageIds.length === 0) return 0;
+  const { getConnection } = await import('../../lib/db.js');
+  const sql = await getConnection();
+  const result = await sql`UPDATE mailbox SET read = true WHERE id = ANY(${messageIds}) RETURNING id`;
+  return result.length;
+}
+
+/** Race a promise against a timer; resolves to `fallback` if the promise loses. */
+async function withTimeout<T>(p: Promise<T>, ms: number, fallback: T): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<T>((resolve) => {
+    timer = setTimeout(() => resolve(fallback), ms);
+  });
+  try {
+    return await Promise.race([p, timeoutPromise]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+/** Build the union of identifiers a codex worker may be addressed by in mailbox. */
+function workerKeysFor(agent: CodexAgentRef, fallback: string): string[] {
+  const keys = new Set<string>();
+  keys.add(agent.id);
+  if (agent.role) keys.add(agent.role);
+  if (agent.customName) keys.add(agent.customName);
+  // Fallback covers the case where GENIE_AGENT_NAME was used to address the
+  // worker but doesn't match any registry field (e.g., legacy bare-name rows
+  // that the mailbox sender still references verbatim).
+  keys.add(fallback);
+  return [...keys].filter((k) => typeof k === 'string' && k.length > 0);
+}
+
+function resolveContext(payload: HookPayload): { agentName: string; teamName?: string } | null {
+  const hasOverrides = Object.values(_deps).some((v) => v !== null);
+  // In test envs (without explicit deps) the dispatcher must not block on PG.
+  if (!hasOverrides && (process.env.NODE_ENV === 'test' || process.env.BUN_ENV === 'test')) return null;
+
+  const agentName = process.env.GENIE_AGENT_NAME ?? (payload.teammate_name as string | undefined);
+  if (!agentName) return null;
+  const teamName = process.env.GENIE_TEAM ?? (payload.team_name as string | undefined);
+  return { agentName, teamName };
+}
+
+/**
+ * Render pending mailbox messages into a single newline-joined block of
+ * channel envelopes. Returns `null` when there is nothing to deliver (no
+ * codex agent matched, no pending rows, mark-read failed, or query timed
+ * out) — the dispatcher then emits no additionalContext for this turn.
+ */
+async function deliverPendingMessages(agentName: string, teamName?: string): Promise<string | null> {
+  const deps = await resolveDeps();
+  const agent = await deps.findCodexAgent(agentName, teamName);
+  if (!agent || agent.provider !== 'codex') return null;
+
+  const keys = workerKeysFor(agent, agentName);
+  const unread = await deps.fetchUnread(agent.repoPath, keys);
+  if (unread.length === 0) return null;
+
+  // Atomic batch mark-read BEFORE returning the body. Failure here means we
+  // skip delivery this turn rather than risk double-injection on the next.
+  const ids = unread.map((m) => m.id);
+  const updated = await deps.markReadBatch(ids);
+  if (updated === 0) return null;
+
+  const envelopes = unread.map((m) => formatEnvelope({ source: m.source, from: m.from, meta: m.meta, body: m.body }));
+  return envelopes.join('\n');
+}
+
+export async function codexInboxDeliver(payload: HookPayload): Promise<HandlerResult> {
+  const ctx = resolveContext(payload);
+  if (!ctx) return;
+
+  try {
+    const additionalContext = await withTimeout(
+      deliverPendingMessages(ctx.agentName, ctx.teamName),
+      QUERY_TIMEOUT_MS,
+      null,
+    );
+    if (!additionalContext) return;
+
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'UserPromptSubmit',
+        additionalContext,
+      },
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[codex-inbox-deliver] ${msg}`);
+    return;
+  }
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -28,6 +28,7 @@ import { auditContext } from './handlers/audit-context.js';
 import { autoSpawn } from './handlers/auto-spawn.js';
 import { brainInject } from './handlers/brain-inject.js';
 import { branchGuard } from './handlers/branch-guard.js';
+import { codexInboxDeliver } from './handlers/codex-inbox-deliver.js';
 import { freshness } from './handlers/freshness.js';
 import { identityInject } from './handlers/identity-inject.js';
 import { orchestrationGuard } from './handlers/orchestration-guard.js';
@@ -108,6 +109,12 @@ const handlers: Handler[] = [
     matcher: /^SendMessage$/,
     priority: 30,
     fn: emitMessageEvent,
+  },
+  {
+    name: 'codex-inbox-deliver',
+    event: 'UserPromptSubmit',
+    priority: 25,
+    fn: codexInboxDeliver,
   },
   {
     name: 'runtime-emit-user-prompt',
@@ -250,6 +257,17 @@ function buildBlockingResponse(
       output.updatedInput = currentInput;
     }
     response.hookSpecificOutput = output;
+  }
+
+  // UserPromptSubmit (claude + codex) accepts hookSpecificOutput.additionalContext
+  // to inject context into the model input for the upcoming turn. Pre-PR-B the
+  // dispatcher dropped this for non-PreToolUse blocking events; the codex
+  // inbox-deliver handler depends on it (see src/hooks/handlers/codex-inbox-deliver.ts).
+  if (hookEventName === 'UserPromptSubmit' && hasContext) {
+    response.hookSpecificOutput = {
+      hookEventName: 'UserPromptSubmit',
+      additionalContext: contextMessages.join('\n'),
+    };
   }
 
   return response;


### PR DESCRIPTION
## Summary

Codex hook handler for \`UserPromptSubmit\` that drains the PG mailbox into the model's \`additionalContext\` and atomically marks delivered rows read. Builds on PR A (#1432 channel-envelope foundation).

**This PR also bundles a generic dispatcher fix** (see "Bundled dispatcher fix" below) that the new handler depends on — pre-PR-B, \`UserPromptSubmit\` handlers' \`additionalContext\` was silently dropped before reaching stdout.

## What lands

- \`src/hooks/handlers/codex-inbox-deliver.ts\` (new, 205 lines) — the handler itself
- \`src/hooks/handlers/__tests__/codex-inbox-deliver.test.ts\` (new, 244 lines) — unit coverage
- \`src/hooks/index.ts\` (+18) — handler registration + **generic \`buildBlockingResponse\` fix** (see below)
- \`src/hooks/__tests__/dispatch.test.ts\` (+76) — e2e UserPromptSubmit dispatch tests

Total: 4 files, +543 / -0. Rebased onto current dev (was \`.10\`, now on \`.13\`+).

## Behaviors (handler)

- **500ms hard PG timeout** with fail-open (empty \`additionalContext\` → message stays unread → next turn retries). Boot/render path stays sub-second under PG hiccups.
- **Atomic mark-read** via \`UPDATE … WHERE id = ANY(\$ids)\` BEFORE returning. 0-row update skips delivery to prevent double-injection across racing turns.
- **Recipient match unions every key** (id, role, custom_name, GENIE_AGENT_NAME) to mirror how \`mailbox.send\` writes \`to_worker\` across delivery paths.
- **Envelope wrapping** — empty-source peer messages pass verbatim; sourced messages wrap as \`<channel source="…" …>body</channel>\` per PR A's \`formatEnvelope\`.

## Bundled dispatcher fix

Pre-PR-B, \`buildBlockingResponse\` in \`src/hooks/index.ts\` only emitted \`hookSpecificOutput\` for \`PreToolUse\`. Any \`UserPromptSubmit\` handler returning \`additionalContext\` had its output silently dropped before reaching stdout — the new codex handler would be dead-on-arrival without this fix.

The fix is **generic** (not codex-specific), but is bundled here because PR B is the first user of that path. If reviewers prefer strict separation, we can split into a precursor PR. The commit message documents both behaviors.

## Pre-existing baseline failures (informational)

Engineer baselined \`bun run check\` against a fresh \`origin/dev\` clone in \`/tmp/genie-base-check\` to prove the gate's failure surface is unrelated to PR B. Five pre-existing failures on plain dev, none in PR B's diff:

| Failure | Cause |
|---------|-------|
| \`executor-read\` HTTP listener flake | port-bind / pgserve race |
| \`buildTeamLeadCommand\` + \`session.ts buildClaudeCommand\` | folder-name detection fails when cwd basename ≠ project root (worktrees expose this) |
| \`doc/code coupling > docs/_internal/state-machine.mdx\` | \`docs/\` is a symlink to \`.docs-vendor/genie/\`; submodule unpopulated in fresh worktrees |
| \`pg > recordAuditEvent\` | pgserve flake under parallel load |
| visual snapshot drift on SystemStatsView/Nav | env-drift (already quarantined in #1448) |

PR B's CI surface is a strict superset of dev's only by these known flakes. Nothing in this diff regresses the gate.

## Test plan

- [x] All 156 hook tests pass locally
- [x] Baselined dev's \`bun run check\` to confirm all failures are pre-existing
- [ ] CI green (modulo known flakes above)
- [ ] **Manual empirical post-merge** — engineer couldn't spawn a live codex agent on the host; verify in 5 minutes:
  1. \`genie spawn codex-eng --provider codex --team genie\`
  2. From another agent: \`genie send 'pong test' --to codex-eng\`
  3. Check codex's next turn for the envelope in \`additionalContext\`
  4. \`genie send 'second' --to codex-eng\` — verify only "second" shows (mark-read prevents replay)

## Stack

PR A (#1432 channel-envelope foundation) → **PR B (this)** → PR C (omni native migration) → PR D (system-nudge migration) → PR E (protocol-router removal) → PR F (external adapters).