### PR TITLE
fix: forward Codex spawn context

### DIFF
--- a/src/lib/provider-adapters.test.ts
+++ b/src/lib/provider-adapters.test.ts
@@ -2,7 +2,7 @@
  * Provider Adapters — Unit Tests
  */
 
-import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import {
   type SpawnParams,
   buildClaudeCommand,
@@ -10,6 +10,36 @@ import {
   buildLaunchCommand,
   validateSpawnParams,
 } from './provider-adapters.js';
+import { CodexProvider } from './providers/codex.js';
+
+const CODEX_PROMPT_TEST_DIR = '/tmp/genie-codex-prompts';
+const CODEX_SOURCE_PROMPT_TEST_DIR = '/tmp/genie-codex-source-prompts';
+
+function resetCodexPromptTestDirs(): void {
+  const { rmSync } = require('node:fs') as typeof import('node:fs');
+  rmSync(CODEX_PROMPT_TEST_DIR, { recursive: true, force: true });
+  rmSync(CODEX_SOURCE_PROMPT_TEST_DIR, { recursive: true, force: true });
+}
+
+function writeCodexSourcePromptFile(name: string, content: string): string {
+  const { mkdirSync, writeFileSync } = require('node:fs') as typeof import('node:fs');
+  const { join } = require('node:path') as typeof import('node:path');
+  mkdirSync(CODEX_SOURCE_PROMPT_TEST_DIR, { recursive: true });
+  const path = join(CODEX_SOURCE_PROMPT_TEST_DIR, name);
+  writeFileSync(path, content, 'utf-8');
+  return path;
+}
+
+function codexPromptPathFromCommand(command: string): string {
+  const match = command.match(/"\$\(cat '([^']+)'\)"/);
+  expect(match).toBeTruthy();
+  return match![1];
+}
+
+function codexPromptContentFromCommand(command: string): string {
+  const { readFileSync } = require('node:fs') as typeof import('node:fs');
+  return readFileSync(codexPromptPathFromCommand(command), 'utf-8');
+}
 
 // ============================================================================
 // Validation Tests (Group A)
@@ -308,8 +338,12 @@ describe('buildCodexCommand', () => {
     (Bun as Record<string, unknown>).which = (name: string) =>
       name === 'codex' ? '/usr/local/bin/codex' : typeof originalWhich === 'function' ? originalWhich(name) : null;
   });
+  beforeEach(() => {
+    resetCodexPromptTestDirs();
+  });
   afterAll(() => {
     (Bun as Record<string, unknown>).which = originalWhich;
+    resetCodexPromptTestDirs();
   });
 
   it('builds command with positional prompt for skill', () => {
@@ -344,10 +378,74 @@ describe('buildCodexCommand', () => {
     expect(result.command).toContain('Role: tester');
   });
 
+  it('includes --model flag when model is set', () => {
+    const result = buildCodexCommand({
+      provider: 'codex',
+      team: 'work',
+      skill: 'work',
+      model: 'gpt-5-codex',
+    });
+    expect(result.command).toContain("--model 'gpt-5-codex'");
+  });
+
+  it('writes systemPromptFile content to a temp prompt file referenced by command', () => {
+    const systemPromptFile = writeCodexSourcePromptFile('AGENTS.md', 'AGENTS instructions for Codex');
+    const result = buildCodexCommand({
+      provider: 'codex',
+      team: 'work',
+      executorId: '11111111-2222-3333-4444-555555555555',
+      systemPromptFile,
+    });
+
+    const promptPath = codexPromptPathFromCommand(result.command);
+    expect(promptPath).toBe(`${CODEX_PROMPT_TEST_DIR}/11111111-2222-3333-4444-555555555555.txt`);
+    expect(result.command).toContain(`"$(cat '${promptPath}')"`);
+    expect(result.command).not.toContain(systemPromptFile);
+    expect(codexPromptContentFromCommand(result.command)).toBe('AGENTS instructions for Codex');
+  });
+
+  it('writes inline systemPrompt to a temp prompt file', () => {
+    const result = buildCodexCommand({
+      provider: 'codex',
+      team: 'work',
+      executorId: '22222222-2222-3333-4444-555555555555',
+      systemPrompt: 'Inline system prompt for a built-in agent',
+    });
+
+    expect(codexPromptContentFromCommand(result.command)).toBe('Inline system prompt for a built-in agent');
+    expect(result.command).not.toContain('Inline system prompt for a built-in agent');
+  });
+
+  it('consumes prompt-file extraArgs and strips them from the codex command', () => {
+    const appendPromptFile = writeCodexSourcePromptFile('append.md', 'append prompt file');
+    const systemPromptFile = writeCodexSourcePromptFile('system.md', 'system prompt file');
+    const result = buildCodexCommand({
+      provider: 'codex',
+      team: 'work',
+      executorId: '33333333-2222-3333-4444-555555555555',
+      extraArgs: [
+        '--sandbox',
+        'workspace-write',
+        '--append-system-prompt-file',
+        appendPromptFile,
+        '--system-prompt-file',
+        systemPromptFile,
+      ],
+    });
+
+    expect(result.command).toContain('--sandbox');
+    expect(result.command).toContain('workspace-write');
+    expect(result.command).not.toContain('--append-system-prompt-file');
+    expect(result.command).not.toContain('--system-prompt-file');
+    expect(result.command).not.toContain(appendPromptFile);
+    expect(result.command).not.toContain(systemPromptFile);
+    expect(codexPromptContentFromCommand(result.command)).toBe('append prompt file\n\nsystem prompt file');
+  });
+
   // Group 11 (codex-provider-parity): codex spawn must honor --prompt
   // (params.initialPrompt) as the worker's first user message, not
   // override it with the auto-generated "Genie worker. Team: X." string.
-  it('honors initialPrompt verbatim when provided (Group 11)', () => {
+  it('honors initialPrompt via temp prompt file when provided (Group 11)', () => {
     const customPrompt = 'Implement Group 7 of security-install-download-guard wish';
     const result = buildCodexCommand({
       provider: 'codex',
@@ -355,13 +453,28 @@ describe('buildCodexCommand', () => {
       role: 'sec-install-guard-codex',
       initialPrompt: customPrompt,
     });
-    // Custom prompt is used verbatim
-    expect(result.command).toContain(customPrompt);
+    // Custom prompt is used verbatim via a temp file, not inline.
+    expect(codexPromptContentFromCommand(result.command)).toBe(customPrompt);
+    expect(result.command).not.toContain(customPrompt);
     // Auto-generated prompt is NOT used when initialPrompt is supplied
     expect(result.command).not.toContain('Genie worker. Team: work');
   });
 
-  it('falls back to auto-prompt when initialPrompt is empty/absent', () => {
+  it('preserves initialPrompt newlines, quotes, and backticks in a temp file without inlining it', () => {
+    const customPrompt =
+      'Line 1 "quoted"\nLine 2 with `backticks`\nLine 3: $(echo should-not-run)\nSingle quote: \'ok\'';
+    const result = buildCodexCommand({
+      provider: 'codex',
+      team: 'work',
+      executorId: '44444444-2222-3333-4444-555555555555',
+      initialPrompt: customPrompt,
+    });
+
+    expect(codexPromptContentFromCommand(result.command)).toBe(customPrompt);
+    expect(result.command).not.toContain(customPrompt);
+  });
+
+  it('falls back to auto-prompt when no prompt fields are set and writes no temp file', () => {
     // Backward compat: spawn-without-prompt produces the same auto-string
     // as before the Group 11 change.
     const result = buildCodexCommand({
@@ -372,6 +485,28 @@ describe('buildCodexCommand', () => {
     });
     expect(result.command).toContain('Genie worker. Team: work.');
     expect(result.command).toContain('Role: tester.');
+    expect(result.command).not.toContain(CODEX_PROMPT_TEST_DIR);
+    const { existsSync } = require('node:fs') as typeof import('node:fs');
+    expect(existsSync(CODEX_PROMPT_TEST_DIR)).toBe(false);
+  });
+
+  it('round-trips CodexProvider systemPromptFile and initialPrompt into the rendered command', () => {
+    const systemPromptFile = writeCodexSourcePromptFile('provider-AGENTS.md', 'provider AGENTS content');
+    const provider = new CodexProvider();
+    const result = provider.buildSpawnCommand({
+      agentId: 'agent-001',
+      executorId: 'codex-provider-roundtrip',
+      team: 'work',
+      role: 'engineer',
+      cwd: '/tmp',
+      systemPromptFile,
+      initialPrompt: 'Initial Omni turn prompt',
+    });
+
+    expect(result.command).toContain(`"$(cat '${CODEX_PROMPT_TEST_DIR}/codex-provider-roundtrip.txt')"`);
+    expect(result.command).not.toContain(systemPromptFile);
+    expect(result.command).not.toContain('Initial Omni turn prompt');
+    expect(codexPromptContentFromCommand(result.command)).toBe('provider AGENTS content\n\nInitial Omni turn prompt');
   });
 
   it('does not depend on agent-name routing', () => {

--- a/src/lib/provider-adapters.ts
+++ b/src/lib/provider-adapters.ts
@@ -466,15 +466,83 @@ export function buildClaudeCommand(params: SpawnParams): LaunchCommand {
 /**
  * Build the launch command for a Codex worker.
  *
- * Uses `codex` with `--instructions` to inject skill-based task
- * instructions. Role is advisory metadata only (DEC-4).
+ * Uses `codex` with a positional prompt. Role is advisory metadata
+ * only (DEC-4).
  */
-/** Build the auto-generated codex prompt when no initialPrompt is supplied. */
+/** Build the auto-generated codex prompt when no prompt-bearing fields are supplied. */
 function buildCodexAutoPrompt(params: SpawnParams): string {
   const promptParts = [`Genie worker. Team: ${params.team}.`];
   if (params.role) promptParts.push(`Role: ${params.role}.`);
   if (params.skill) promptParts.push(`Execute the ${params.skill} skill instructions.`);
   return promptParts.join(' ');
+}
+
+const CODEX_PROMPT_DIR = '/tmp/genie-codex-prompts';
+const CODEX_PROMPT_FILE_FLAGS = new Set(['--append-system-prompt-file', '--system-prompt-file']);
+
+function sanitizeCodexPromptFileStem(stem: string): string {
+  const safe = stem.replace(/[^a-zA-Z0-9._-]/g, '-');
+  return safe || Date.now().toString(36);
+}
+
+function splitCodexExtraArgs(extraArgs: string[] | undefined): { forwarded: string[]; promptFiles: string[] } {
+  const forwarded: string[] = [];
+  const promptFiles: string[] = [];
+  const args = extraArgs ?? [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const equalsFlag = [...CODEX_PROMPT_FILE_FLAGS].find((flag) => arg.startsWith(`${flag}=`));
+
+    if (equalsFlag) {
+      const path = arg.slice(equalsFlag.length + 1);
+      if (!path) throw new Error(`Missing path for ${equalsFlag}`);
+      promptFiles.push(path);
+      continue;
+    }
+
+    if (CODEX_PROMPT_FILE_FLAGS.has(arg)) {
+      const path = args[i + 1];
+      if (!path) throw new Error(`Missing path after ${arg}`);
+      promptFiles.push(path);
+      i++;
+      continue;
+    }
+
+    forwarded.push(arg);
+  }
+
+  return { forwarded, promptFiles };
+}
+
+function buildCodexMergedPrompt(params: SpawnParams, extraPromptFiles: string[]): string | null {
+  const { readFileSync } = require('node:fs') as typeof import('node:fs');
+  const sections: string[] = [];
+
+  if (params.systemPromptFile !== undefined) {
+    sections.push(readFileSync(params.systemPromptFile, 'utf-8'));
+  }
+  if (params.systemPrompt !== undefined) {
+    sections.push(params.systemPrompt);
+  }
+  for (const promptFile of extraPromptFiles) {
+    sections.push(readFileSync(promptFile, 'utf-8'));
+  }
+  if (params.initialPrompt !== undefined) {
+    sections.push(params.initialPrompt);
+  }
+
+  return sections.length > 0 ? sections.join('\n\n') : null;
+}
+
+function writeCodexPromptFile(params: SpawnParams, content: string): string {
+  const { mkdirSync, writeFileSync } = require('node:fs') as typeof import('node:fs');
+  const { join } = require('node:path') as typeof import('node:path');
+  mkdirSync(CODEX_PROMPT_DIR, { recursive: true });
+  const stem = sanitizeCodexPromptFileStem(params.executorId ?? Date.now().toString(36));
+  const promptFile = join(CODEX_PROMPT_DIR, `${stem}.txt`);
+  writeFileSync(promptFile, content, 'utf-8');
+  return promptFile;
 }
 
 export function buildCodexCommand(params: SpawnParams): LaunchCommand {
@@ -485,7 +553,9 @@ export function buildCodexCommand(params: SpawnParams): LaunchCommand {
   if (params.executorId) env.GENIE_EXECUTOR_ID = params.executorId;
   if (params.agentId) env.GENIE_AGENT_ID = params.agentId;
   if (params.role) env.GENIE_AGENT_NAME = params.role;
+  else if (params.name) env.GENIE_AGENT_NAME = params.name;
   if (params.team) env.GENIE_TEAM = params.team;
+  const { forwarded: extraArgs, promptFiles: extraPromptFiles } = splitCodexExtraArgs(params.extraArgs);
 
   // Full autonomous execution — no permission prompts
   parts.push('--yolo');
@@ -493,11 +563,11 @@ export function buildCodexCommand(params: SpawnParams): LaunchCommand {
   // Inline mode for tmux compatibility (no alternate screen)
   parts.push('--no-alt-screen');
 
+  if (params.model) parts.push('--model', escapeShellArg(params.model));
+
   // Forward extra args before the positional prompt
-  if (params.extraArgs) {
-    for (const arg of params.extraArgs) {
-      parts.push(escapeShellArg(arg));
-    }
+  for (const arg of extraArgs) {
+    parts.push(escapeShellArg(arg));
   }
 
   // Group 11 (codex-provider-parity): honor params.initialPrompt as the
@@ -506,11 +576,23 @@ export function buildCodexCommand(params: SpawnParams): LaunchCommand {
   // by hand or sending a follow-up via genie send (which until Group 3
   // landed today, silently failed the native bridge for codex agents).
   //
-  // When initialPrompt is provided, use it verbatim. When absent, fall
-  // back to the auto-generated "Genie worker. Team: X. Role: Y." string
-  // so spawn-without-prompt behavior is unchanged.
-  const prompt = params.initialPrompt ?? buildCodexAutoPrompt(params);
-  parts.push(escapeShellArg(prompt));
+  // Prompt-bearing fields are merged into a temp file and supplied through
+  // command substitution so AGENTS.md, inline system prompts, and first-turn
+  // prompts survive shell/tmux quoting. When none are supplied, keep the
+  // auto-generated "Genie worker. Team: X. Role: Y." fallback unchanged.
+  //
+  // Decision: prompt-bearing Codex spawns write the merged prompt file
+  // synchronously before returning this command. The file is named by
+  // executorId when available, otherwise by timestamp, and is left in /tmp
+  // for OS cleanup so tmux's later shell exec can `cat` it without a
+  // deletion race.
+  const mergedPrompt = buildCodexMergedPrompt(params, extraPromptFiles);
+  if (mergedPrompt !== null) {
+    const promptFile = writeCodexPromptFile(params, mergedPrompt);
+    parts.push(`"$(cat ${escapeShellArg(promptFile)})"`);
+  } else {
+    parts.push(escapeShellArg(buildCodexAutoPrompt(params)));
+  }
 
   return {
     command: parts.join(' '),

--- a/src/lib/providers/codex.ts
+++ b/src/lib/providers/codex.ts
@@ -131,5 +131,15 @@ function spawnContextToParams(ctx: SpawnContext): SpawnParams {
     agentId: ctx.agentId,
     executorId: ctx.executorId,
     extraArgs: ctx.extraArgs,
+    model: ctx.model,
+    systemPromptFile: ctx.systemPromptFile,
+    systemPrompt: ctx.systemPrompt,
+    promptMode: ctx.promptMode,
+    initialPrompt: ctx.initialPrompt,
+    name: ctx.name,
+    nativeTeam: ctx.nativeTeam,
+    otelPort: ctx.otelPort,
+    otelLogPrompts: ctx.otelLogPrompts,
+    otelWishSlug: ctx.otelWishSlug,
   };
 }


### PR DESCRIPTION
## Summary
- Forward Claude-equivalent spawn context fields through the Codex provider translator.
- Merge AGENTS.md/system prompt/initialPrompt/prompt-file extras into a synchronous temp prompt file for Codex.
- Strip supported Claude prompt-file flags from the final Codex command and preserve auto-prompt fallback.

Fixes #1316
Wish: fix-codex-spawn-context-forwarding

## Validation
- bun run typecheck: PASS
- bun run lint: PASS (existing warnings only)
- bun test src/lib/provider-adapters.test.ts: PASS (58 tests)
- bun test src/lib/providers/codex.test.ts: PASS (20 tests)
- Independent execution review: SHIP
- Pre-push gate: PASS (existing warnings only)

## Residual Risk
- Full bun run check was attempted and went red due unrelated shared PG/test service and unchanged msg test failures, not this diff.
