### PR TITLE
fix: probe OTel receiver ports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,8 @@ Worktrees share the main repo's `.genie/` via `git rev-parse --git-common-dir`. 
 | `CLAUDECODE=1` | Enables Claude Code features (set in team-lead command) |
 | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` | Enables native teammate UI |
 | `GENIE_IDLE_TIMEOUT_MS` | Auto-suspend idle workers after N ms |
+| `GENIE_OTEL_PORT` | Pins the Claude OTel receiver to one explicit port; if busy, genie skips telemetry injection instead of probing |
+| `GENIE_OTEL_PORT_PROBE_MAX` | Number of receiver ports to probe in default mode, starting at pgserve port + 1; defaults to 8 |
 
 `GENIE_AGENT_NAME` and the 5 native team CLI flags must stay in sync — if any are missing, Claude Code won't recognize the agent as a team member.
 

--- a/src/lib/otel-receiver.test.ts
+++ b/src/lib/otel-receiver.test.ts
@@ -1,45 +1,121 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { getOtelPort, isOtelReceiverRunning, startOtelReceiver, stopOtelReceiver } from './otel-receiver.js';
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test';
+import { getActivePort } from './db.js';
+import {
+  getOtelPort,
+  isOtelReceiverRunning,
+  isPortBusyError,
+  startOtelReceiver,
+  stopOtelReceiver,
+} from './otel-receiver.js';
+
+type TestServer = ReturnType<typeof Bun.serve>;
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+function startBusyServer(port: number): TestServer {
+  return Bun.serve({
+    hostname: '127.0.0.1',
+    port,
+    fetch: () => new Response('busy'),
+  });
+}
+
+async function stopBusyServer(server: TestServer): Promise<void> {
+  await server.stop(true);
+}
+
+async function stopBusyServers(servers: TestServer[]): Promise<void> {
+  await Promise.all(servers.map((server) => server.stop(true)));
+}
+
+async function startBusyServers(ports: number[]): Promise<TestServer[]> {
+  const servers: TestServer[] = [];
+  try {
+    for (const port of ports) {
+      servers.push(startBusyServer(port));
+    }
+    return servers;
+  } catch (err) {
+    await stopBusyServers(servers);
+    throw err;
+  }
+}
+
+function getServerPort(server: TestServer): number {
+  const port = server.port;
+  if (port === undefined) throw new Error('Test server did not expose a bound port');
+  return port;
+}
+
+async function reserveConsecutivePorts(count: number): Promise<TestServer[]> {
+  const minPort = 57000;
+  const maxBasePort = 64000 - count + 1;
+
+  for (let attempt = 0; attempt < 100; attempt++) {
+    const basePort = minPort + Math.floor(Math.random() * (maxBasePort - minPort + 1));
+    const servers: TestServer[] = [];
+    try {
+      for (let offset = 0; offset < count; offset++) {
+        servers.push(startBusyServer(basePort + offset));
+      }
+      return servers;
+    } catch (err) {
+      await stopBusyServers(servers);
+      if (!isPortBusyError(err)) throw err;
+    }
+  }
+
+  throw new Error(`Could not reserve ${count} consecutive test ports`);
+}
+
+async function useFreeExplicitOtelPort(): Promise<number> {
+  const [server] = await reserveConsecutivePorts(1);
+  const port = getServerPort(server);
+  await stopBusyServer(server);
+  process.env.GENIE_OTEL_PORT = String(port);
+  return port;
+}
+
+async function configureDefaultOtelPortWindow(count: number): Promise<number> {
+  const servers = await reserveConsecutivePorts(count);
+  const defaultPort = getServerPort(servers[0]);
+  await stopBusyServers(servers);
+  process.env.GENIE_PG_PORT = String(defaultPort - 1);
+  return getOtelPort();
+}
 
 describe('otel-receiver', () => {
   let origPort: string | undefined;
+  let origProbeMax: string | undefined;
+  let origPgPort: string | undefined;
 
   beforeEach(() => {
     origPort = process.env.GENIE_OTEL_PORT;
-    // Use a random high port to avoid conflicts with running pgserve or parallel tests
-    // Range 57000-63999 avoids typical pgserve ports (19643-19700) and ephemeral ports
-    process.env.GENIE_OTEL_PORT = String(57000 + Math.floor(Math.random() * 7000));
+    origProbeMax = process.env.GENIE_OTEL_PORT_PROBE_MAX;
+    origPgPort = process.env.GENIE_PG_PORT;
+    restoreEnv('GENIE_OTEL_PORT', undefined);
+    restoreEnv('GENIE_OTEL_PORT_PROBE_MAX', undefined);
+    restoreEnv('GENIE_PG_PORT', undefined);
   });
 
   afterEach(async () => {
     await stopOtelReceiver();
-    if (origPort !== undefined) process.env.GENIE_OTEL_PORT = origPort;
-    else process.env.GENIE_OTEL_PORT = undefined;
+    restoreEnv('GENIE_OTEL_PORT', origPort);
+    restoreEnv('GENIE_OTEL_PORT_PROBE_MAX', origProbeMax);
+    restoreEnv('GENIE_PG_PORT', origPgPort);
   });
 
-  // Parallel test workers can collide on the 7000-port window (57000-63999)
-  // because port selection is random, not coordinated. When they do,
-  // startOtelReceiver() returns false with EADDRINUSE and the test fails
-  // intermittently in CI. This helper re-rolls the port and retries up to
-  // maxAttempts. If the receiver fails for a non-port reason, all retries
-  // fail the same way and the test surfaces the real error instead of
-  // silently masking it. Source-level fix (#1148) would be ephemeral port
-  // binding (port: 0) in otel-receiver.ts itself — tracked separately.
-  async function startWithPortRetry(maxAttempts = 5): Promise<boolean> {
-    for (let i = 0; i < maxAttempts; i++) {
-      if (i > 0) {
-        // re-roll on retry so we don't keep hitting the same busy port
-        process.env.GENIE_OTEL_PORT = String(57000 + Math.floor(Math.random() * 7000));
-      }
-      const ok = await startOtelReceiver();
-      if (ok) return true;
-      // Ensure no leaked server between attempts
-      await stopOtelReceiver();
-    }
-    return false;
-  }
-
   test('getOtelPort returns pgserve port + 1 by default', () => {
+    expect(getOtelPort()).toBe(getActivePort() + 1);
+  });
+
+  test('getOtelPort returns a valid default without env overrides', () => {
     const port = getOtelPort();
     expect(port).toBeGreaterThan(0);
     expect(port).toBeLessThan(65536);
@@ -50,12 +126,106 @@ describe('otel-receiver', () => {
     expect(getOtelPort()).toBe(12345);
   });
 
+  test('isPortBusyError recognizes Node, legacy, and Bun busy-port shapes', () => {
+    expect(isPortBusyError(Object.assign(new Error('listen failed'), { code: 'EADDRINUSE' }))).toBe(true);
+    expect(isPortBusyError('EADDRINUSE')).toBe(true);
+    expect(isPortBusyError(new Error('address already in use'))).toBe(true);
+    expect(isPortBusyError(new Error('Failed to start server. Is port 4318 in use?'))).toBe(true);
+    expect(isPortBusyError(new Error('port 4318 is in use'))).toBe(true);
+    expect(isPortBusyError(new Error('permission denied'))).toBe(false);
+  });
+
+  test('default mode probes to a distinct free port and reports the bound port', async () => {
+    const defaultPort = await configureDefaultOtelPortWindow(2);
+    const [busyDefault, freeNext] = await startBusyServers([defaultPort, defaultPort + 1]);
+    const nextPort = defaultPort + 1;
+    await stopBusyServer(freeNext);
+    process.env.GENIE_OTEL_PORT_PROBE_MAX = '2';
+
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const started = await startOtelReceiver();
+      expect(started).toBe(true);
+      expect(isOtelReceiverRunning()).toBe(true);
+      expect(getOtelPort()).toBe(nextPort);
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      const res = await fetch(`http://127.0.0.1:${getOtelPort()}/health`);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { port: number };
+      expect(body.port).toBe(nextPort);
+    } finally {
+      warnSpy.mockRestore();
+      await stopBusyServer(busyDefault);
+    }
+  });
+
+  test('explicit GENIE_OTEL_PORT attempts one busy port and does not probe', async () => {
+    const [busyExplicit, freeNext] = await reserveConsecutivePorts(2);
+    await stopBusyServer(freeNext);
+    const busyPort = getServerPort(busyExplicit);
+    process.env.GENIE_OTEL_PORT = String(busyPort);
+    process.env.GENIE_OTEL_PORT_PROBE_MAX = '2';
+
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const started = await startOtelReceiver();
+      expect(started).toBe(false);
+      expect(isOtelReceiverRunning()).toBe(false);
+      expect(getOtelPort()).toBe(busyPort);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0]?.[0]).toContain(`port ${busyPort} already in use`);
+    } finally {
+      warnSpy.mockRestore();
+      await stopBusyServer(busyExplicit);
+    }
+  });
+
+  test('default mode warns once when all probed ports are busy', async () => {
+    const defaultPort = await configureDefaultOtelPortWindow(3);
+    const blockers = await startBusyServers([defaultPort, defaultPort + 1, defaultPort + 2]);
+    process.env.GENIE_OTEL_PORT_PROBE_MAX = '3';
+
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const started = await startOtelReceiver();
+      expect(started).toBe(false);
+      expect(isOtelReceiverRunning()).toBe(false);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0]?.[0]).toContain(`all probed ports busy (${defaultPort}-${defaultPort + 2})`);
+    } finally {
+      warnSpy.mockRestore();
+      await stopBusyServers(blockers);
+    }
+  });
+
+  test('stopOtelReceiver clears the bound port', async () => {
+    const defaultPort = await configureDefaultOtelPortWindow(2);
+    const [busyDefault, freeNext] = await startBusyServers([defaultPort, defaultPort + 1]);
+    await stopBusyServer(freeNext);
+    process.env.GENIE_OTEL_PORT_PROBE_MAX = '2';
+
+    try {
+      const started = await startOtelReceiver();
+      expect(started).toBe(true);
+      expect(getOtelPort()).toBe(defaultPort + 1);
+
+      await stopOtelReceiver();
+      expect(isOtelReceiverRunning()).toBe(false);
+      expect(getOtelPort()).toBe(defaultPort);
+    } finally {
+      await stopBusyServer(busyDefault);
+    }
+  });
+
   test('startOtelReceiver starts and is idempotent', async () => {
+    const port = await useFreeExplicitOtelPort();
     expect(isOtelReceiverRunning()).toBe(false);
 
-    const started = await startWithPortRetry();
+    const started = await startOtelReceiver();
     expect(started).toBe(true);
     expect(isOtelReceiverRunning()).toBe(true);
+    expect(getOtelPort()).toBe(port);
 
     // Second call is idempotent
     const started2 = await startOtelReceiver();
@@ -63,7 +233,8 @@ describe('otel-receiver', () => {
   });
 
   test('stopOtelReceiver stops the server', async () => {
-    const started = await startWithPortRetry();
+    await useFreeExplicitOtelPort();
+    const started = await startOtelReceiver();
     expect(started).toBe(true);
     expect(isOtelReceiverRunning()).toBe(true);
 
@@ -72,7 +243,8 @@ describe('otel-receiver', () => {
   });
 
   test('POST /v1/logs returns 200', async () => {
-    const started = await startWithPortRetry();
+    await useFreeExplicitOtelPort();
+    const started = await startOtelReceiver();
     expect(started).toBe(true);
     const port = getOtelPort();
 
@@ -107,7 +279,8 @@ describe('otel-receiver', () => {
   });
 
   test('POST /v1/metrics returns 200', async () => {
-    const started = await startWithPortRetry();
+    await useFreeExplicitOtelPort();
+    const started = await startOtelReceiver();
     expect(started).toBe(true);
     const port = getOtelPort();
 
@@ -141,7 +314,8 @@ describe('otel-receiver', () => {
   });
 
   test('POST /v1/logs handles empty payload', async () => {
-    const started = await startWithPortRetry();
+    await useFreeExplicitOtelPort();
+    const started = await startOtelReceiver();
     expect(started).toBe(true);
     const port = getOtelPort();
 
@@ -155,7 +329,8 @@ describe('otel-receiver', () => {
   });
 
   test('GET /health returns ok', async () => {
-    const started = await startWithPortRetry();
+    await useFreeExplicitOtelPort();
+    const started = await startOtelReceiver();
     expect(started).toBe(true);
     const port = getOtelPort();
 
@@ -166,7 +341,8 @@ describe('otel-receiver', () => {
   });
 
   test('unknown route returns 404', async () => {
-    const started = await startWithPortRetry();
+    await useFreeExplicitOtelPort();
+    const started = await startOtelReceiver();
     expect(started).toBe(true);
     const port = getOtelPort();
 

--- a/src/lib/otel-receiver.ts
+++ b/src/lib/otel-receiver.ts
@@ -80,6 +80,9 @@ interface OtlpMetricsPayload {
 // ============================================================================
 
 let server: ReturnType<typeof Bun.serve> | null = null;
+let boundOtelPort: number | null = null;
+
+const DEFAULT_OTEL_PORT_PROBE_MAX = 8;
 
 // ============================================================================
 // Helpers
@@ -139,6 +142,48 @@ function mapEventToEntityType(eventName: string): string {
   if (eventName.includes('user_prompt')) return 'otel_prompt';
   if (eventName.includes('tool_decision')) return 'otel_decision';
   return 'otel_event';
+}
+
+function parseValidPort(raw: string | undefined): number | null {
+  if (!raw) return null;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isNaN(parsed) && parsed > 0 && parsed < 65536) return parsed;
+  return null;
+}
+
+function parseProbeMax(): number {
+  const parsed = Number.parseInt(process.env.GENIE_OTEL_PORT_PROBE_MAX ?? '', 10);
+  if (!Number.isNaN(parsed) && parsed > 0) return parsed;
+  return DEFAULT_OTEL_PORT_PROBE_MAX;
+}
+
+function getConfiguredOtelPort(): { port: number; explicit: boolean } {
+  const envPort = parseValidPort(process.env.GENIE_OTEL_PORT);
+  if (envPort !== null) return { port: envPort, explicit: true };
+  return { port: getActivePort() + 1, explicit: false };
+}
+
+function getCandidatePorts(startPort: number, explicit: boolean): number[] {
+  if (explicit) return [startPort];
+  const probeCount = Math.min(parseProbeMax(), Math.max(1, 65535 - startPort + 1));
+  return Array.from({ length: probeCount }, (_, index) => startPort + index);
+}
+
+function formatPortList(ports: number[]): string {
+  if (ports.length === 1) return String(ports[0]);
+  return `${ports[0]}-${ports[ports.length - 1]}`;
+}
+
+export function isPortBusyError(err: unknown): boolean {
+  if (err && typeof err === 'object' && 'code' in err && err.code === 'EADDRINUSE') return true;
+
+  const message = err instanceof Error ? err.message : String(err);
+  return (
+    message.includes('EADDRINUSE') ||
+    message.includes('address already in use') ||
+    /Failed to start server\. Is port \d+ in use\?/i.test(message) ||
+    /\bis in use\b/i.test(message)
+  );
 }
 
 // ============================================================================
@@ -296,12 +341,47 @@ async function flushToPg(rows: AuditRow[]): Promise<void> {
  * Get the OTel receiver port. Default: pgserve port + 1.
  */
 export function getOtelPort(): number {
-  const envPort = process.env.GENIE_OTEL_PORT;
-  if (envPort) {
-    const parsed = Number.parseInt(envPort, 10);
-    if (!Number.isNaN(parsed) && parsed > 0 && parsed < 65536) return parsed;
-  }
-  return getActivePort() + 1;
+  return boundOtelPort ?? getConfiguredOtelPort().port;
+}
+
+function serveOtelReceiver(port: number): ReturnType<typeof Bun.serve> {
+  return Bun.serve({
+    port,
+    hostname: '127.0.0.1',
+    fetch: async (req) => {
+      const url = new URL(req.url);
+
+      if (req.method === 'POST' && url.pathname === '/v1/logs') {
+        try {
+          const payload = (await req.json()) as OtlpLogsPayload;
+          const rows = processLogs(payload);
+          // Fire-and-forget — don't block the HTTP response
+          flushToPg(rows).catch(() => {});
+        } catch {
+          // Malformed payload — ignore
+        }
+        return new Response('', { status: 200 });
+      }
+
+      if (req.method === 'POST' && url.pathname === '/v1/metrics') {
+        try {
+          const payload = (await req.json()) as OtlpMetricsPayload;
+          const rows = processMetrics(payload);
+          flushToPg(rows).catch(() => {});
+        } catch {
+          // Malformed payload — ignore
+        }
+        return new Response('', { status: 200 });
+      }
+
+      // Health check
+      if (req.method === 'GET' && url.pathname === '/health') {
+        return Response.json({ status: 'ok', port });
+      }
+
+      return new Response('Not Found', { status: 404 });
+    },
+  });
 }
 
 /**
@@ -314,75 +394,43 @@ export function getOtelPort(): number {
 export async function startOtelReceiver(): Promise<boolean> {
   if (server) return true;
 
-  const port = getOtelPort();
+  const { port: startPort, explicit } = getConfiguredOtelPort();
+  const candidatePorts = getCandidatePorts(startPort, explicit);
 
-  try {
-    server = Bun.serve({
-      port,
-      hostname: '127.0.0.1',
-      fetch: async (req) => {
-        const url = new URL(req.url);
+  for (const port of candidatePorts) {
+    try {
+      server = serveOtelReceiver(port);
+      boundOtelPort = server.port ?? port;
+      return true;
+    } catch (err) {
+      if (isPortBusyError(err)) continue;
 
-        if (req.method === 'POST' && url.pathname === '/v1/logs') {
-          try {
-            const payload = (await req.json()) as OtlpLogsPayload;
-            const rows = processLogs(payload);
-            // Fire-and-forget — don't block the HTTP response
-            flushToPg(rows).catch(() => {});
-          } catch {
-            // Malformed payload — ignore
-          }
-          return new Response('', { status: 200 });
-        }
-
-        if (req.method === 'POST' && url.pathname === '/v1/metrics') {
-          try {
-            const payload = (await req.json()) as OtlpMetricsPayload;
-            const rows = processMetrics(payload);
-            flushToPg(rows).catch(() => {});
-          } catch {
-            // Malformed payload — ignore
-          }
-          return new Response('', { status: 200 });
-        }
-
-        // Health check
-        if (req.method === 'GET' && url.pathname === '/health') {
-          return Response.json({ status: 'ok', port });
-        }
-
-        return new Response('Not Found', { status: 404 });
-      },
-    });
-
-    return true;
-  } catch (err) {
-    // Port busy or other error — non-fatal
-    const message = err instanceof Error ? err.message : String(err);
-    if (message.includes('EADDRINUSE') || message.includes('address already in use')) {
-      console.warn(`OTel receiver: port ${port} already in use — skipping (another instance may be running)`);
-    } else {
+      const message = err instanceof Error ? err.message : String(err);
       console.warn(`OTel receiver: failed to start on port ${port}: ${message}`);
+      return false;
     }
-    return false;
   }
+
+  if (explicit) {
+    console.warn(`OTel receiver: port ${startPort} already in use - skipping (another instance may be running)`);
+  } else {
+    console.warn(`OTel receiver: all probed ports busy (${formatPortList(candidatePorts)}) - skipping`);
+  }
+  return false;
 }
 
 /**
  * Stop the OTel receiver. Used in tests and graceful shutdown.
  *
  * Awaits `server.stop(true)` so the listening port is fully released before
- * the next start attempt. Without the await, back-to-back start/stop cycles
- * in tests (afterEach → next beforeEach) could race on the TCP port and
- * produce EADDRINUSE when parallel tests randomly collide within the
- * 7000-port window (57000-63999), which caused the intermittent push-event
- * CI failure on `POST /v1/logs handles empty payload`.
+ * the next start attempt. Also clears the remembered bound port so later
+ * callers fall back to the configured default or explicit override.
  */
 export async function stopOtelReceiver(): Promise<void> {
-  if (server) {
-    await server.stop(true);
-    server = null;
-  }
+  const activeServer = server;
+  server = null;
+  boundOtelPort = null;
+  if (activeServer) await activeServer.stop(true);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Probe OTel receiver ports when the default is busy and persist the actually-bound port for child env injection.
- Centralize busy-port error detection for Node/legacy/Bun error shapes.
- Document GENIE_OTEL_PORT and GENIE_OTEL_PORT_PROBE_MAX.

Fixes #1148
Wish: fix-otel-port-collision

## Validation
- bun test src/lib/otel-receiver.test.ts: PASS (15 tests)
- bun run typecheck: PASS
- bun run lint: PASS (existing warnings only)
- Independent execution review: SHIP
- Pre-push gate: PASS (existing warnings only)

## Residual Risk
- Full bun run check was attempted by the worker and failed due unrelated shared PG/test environment and docs/worktree issues, not this diff.
