### PR TITLE
fix: auto-register workspace agents on spawn

### DIFF
--- a/src/genie.ts
+++ b/src/genie.ts
@@ -428,6 +428,7 @@ program
   .option('--new-window', 'Create a new tmux window instead of splitting')
   .option('--window <target>', 'Tmux window to split into (e.g., genie:3)')
   .option('--no-auto-resume', 'Disable auto-resume on pane death')
+  .option('--no-auto-sync', 'Disable auto-registration from workspace agents directory')
   .option('--stream', 'Stream SDK messages to stdout in real-time (claude-sdk provider)')
   .option('--stream-format <format>', 'Streaming output format: text, json, ndjson (default: text)', 'text')
   .option('--sdk-max-turns <n>', 'SDK: max conversation turns', parseNumericFlag('--sdk-max-turns'))
@@ -446,6 +447,7 @@ Examples:
   genie spawn council--questioner --provider codex  # Use Codex provider`,
   )
   .action(async (name: string, options: SpawnOptions) => {
+    if (options.autoSync === false) options.noAutoSync = true;
     try {
       await handleWorkerSpawn(name, options);
     } catch (error) {

--- a/src/lib/agent-identity-sync.test.ts
+++ b/src/lib/agent-identity-sync.test.ts
@@ -202,6 +202,23 @@ description: Wisdom agent
     expect(entry!.description).toBeUndefined();
   });
 
+  test('dir sync still registers frontmatter name mismatches by directory name', async () => {
+    createWorkspace(
+      'dir-sync-name-mismatch',
+      `---
+name: different-agent
+description: Directory sync remains permissive
+---`,
+    );
+
+    const result = await syncAgentDirectory(workspaceRoot);
+    expect(result.registered).toContain('dir-sync-name-mismatch');
+
+    const entry = await directory.get('dir-sync-name-mismatch');
+    expect(entry).not.toBeNull();
+    expect(entry!.description).toBe('Directory sync remains permissive');
+  });
+
   // ============================================================================
   // Sync unchanged — idempotent
   // ============================================================================

--- a/src/term-commands/agent/spawn.ts
+++ b/src/term-commands/agent/spawn.ts
@@ -34,6 +34,7 @@ export function registerAgentSpawn(parent: Command): void {
     .option('--new-window', 'Create a new tmux window instead of splitting')
     .option('--window <target>', 'Tmux window to split into (e.g., genie:3)')
     .option('--no-auto-resume', 'Disable auto-resume on pane death')
+    .option('--no-auto-sync', 'Disable auto-registration from workspace agents directory')
     .option('--prompt <prompt>', 'Initial prompt (first user message)')
     .option('--sdk-max-turns <n>', 'SDK: max conversation turns', parseNumericFlag('--sdk-max-turns'))
     .option('--sdk-max-budget <usd>', 'SDK: max budget in USD', parseNumericFlag('--sdk-max-budget'))
@@ -42,6 +43,7 @@ export function registerAgentSpawn(parent: Command): void {
     .option('--sdk-resume <session-id>', 'SDK: resume a previous session by ID')
     .action(async (name: string, options: SpawnOptions) => {
       if (options.prompt) options.initialPrompt = options.prompt;
+      if (options.autoSync === false) options.noAutoSync = true;
       try {
         await handleWorkerSpawn(name, options);
       } catch (error) {

--- a/src/term-commands/agents.spawn-autosync.test.ts
+++ b/src/term-commands/agents.spawn-autosync.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Spawn auto-sync tests for resolveAgentForSpawn.
+ *
+ * Run with: bun test src/term-commands/agents.spawn-autosync.test.ts
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, spyOn, test } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DirectoryEntry } from '../lib/agent-directory.js';
+import { parseFrontmatter } from '../lib/frontmatter.js';
+import type { SpawnOptions } from './agents.js';
+
+type AgentsModule = typeof import('./agents.js');
+type ResolvedAgent = { entry: DirectoryEntry; builtin: boolean };
+
+const directoryRows = new Map<string, DirectoryEntry>();
+const syncCalls: Array<{ root: string; name: string }> = [];
+
+describe('spawn auto-sync', () => {
+  let agents: AgentsModule;
+  let originalDeps: AgentsModule['_spawnAutoSyncDeps'];
+  let originalCwd: string;
+  let originalGenieHome: string | undefined;
+  let originalDisableAutoSync: string | undefined;
+  let tempRoots: string[] = [];
+
+  beforeAll(async () => {
+    agents = await import('./agents.js');
+    originalDeps = { ...agents._spawnAutoSyncDeps };
+  });
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    originalGenieHome = process.env.GENIE_HOME;
+    originalDisableAutoSync = process.env.GENIE_DISABLE_AUTO_SYNC;
+    tempRoots = [];
+    directoryRows.clear();
+    syncCalls.length = 0;
+    Object.assign(agents._spawnAutoSyncDeps, {
+      resolveAgent: fakeResolveAgent,
+      loadIdentity: fakeLoadIdentity,
+      syncSingleAgentByName: fakeSyncSingleAgentByName,
+    });
+
+    const genieHome = mkdtempSync(join(tmpdir(), 'genie-spawn-autosync-home-'));
+    tempRoots.push(genieHome);
+    process.env.GENIE_HOME = genieHome;
+    Reflect.deleteProperty(process.env, 'GENIE_DISABLE_AUTO_SYNC');
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    Object.assign(agents._spawnAutoSyncDeps, originalDeps);
+    restoreEnv('GENIE_HOME', originalGenieHome);
+    restoreEnv('GENIE_DISABLE_AUTO_SYNC', originalDisableAutoSync);
+
+    for (const root of tempRoots) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('auto-registers a valid unsynced on-disk agent on first spawn resolution', async () => {
+    const name = 'autosync-happy';
+    const { agentDir, workspaceRoot } = createWorkspaceAgent(name, validFrontmatter(name));
+
+    const { result, errors } = await captureConsoleError(() => agents.resolveAgentForSpawn(name, {}));
+
+    expect(result.entry.name).toBe(name);
+    expect(result.entry.dir).toBe(agentDir);
+    expect(result.identityPath).toBe(join(agentDir, 'AGENTS.md'));
+    expect(errors).toEqual([`Auto-registered agent '${name}' from ${agentDir}`]);
+    expect([...directoryRows.keys()]).toEqual([name]);
+    expect(directoryRows.get(name)?.description).toBe('Spawnable test agent');
+    expect(syncCalls).toEqual([{ root: workspaceRoot, name }]);
+  });
+
+  test('second spawn resolution is idempotent and does not log auto-register again', async () => {
+    const name = 'autosync-repeat';
+    const { agentDir, workspaceRoot } = createWorkspaceAgent(name, validFrontmatter(name));
+
+    const first = await captureConsoleError(() => agents.resolveAgentForSpawn(name, {}));
+    expect(first.errors).toEqual([`Auto-registered agent '${name}' from ${agentDir}`]);
+
+    const second = await captureConsoleError(() => agents.resolveAgentForSpawn(name, {}));
+    expect(second.result.entry.name).toBe(name);
+    expect(second.errors).toEqual([]);
+    expect([...directoryRows.keys()]).toEqual([name]);
+    expect(syncCalls).toEqual([{ root: workspaceRoot, name }]);
+  });
+
+  test('missing workspace preserves not-found behavior and creates no row', async () => {
+    const name = 'autosync-no-workspace';
+    createAgentWithoutWorkspace(name, validFrontmatter(name));
+
+    await expectResolveNotFound(name, {});
+
+    expect([...directoryRows.keys()]).toEqual([]);
+    expect(syncCalls).toEqual([]);
+  });
+
+  test('invalid frontmatter preserves not-found behavior and creates no row', async () => {
+    const mismatch = 'autosync-name-mismatch';
+    createWorkspaceAgent(
+      mismatch,
+      `---
+name: different-agent
+description: Spawnable test agent
+---`,
+    );
+
+    await expectResolveNotFound(mismatch, {});
+    expect([...directoryRows.keys()]).toEqual([]);
+    expect(syncCalls).toEqual([]);
+
+    const emptyDescription = 'autosync-empty-description';
+    createWorkspaceAgent(
+      emptyDescription,
+      `---
+name: ${emptyDescription}
+description: "   "
+---`,
+    );
+
+    await expectResolveNotFound(emptyDescription, {});
+    expect([...directoryRows.keys()]).toEqual([]);
+    expect(syncCalls).toEqual([]);
+  });
+
+  test('GENIE_DISABLE_AUTO_SYNC=1 prevents auto-register', async () => {
+    const name = 'autosync-env-disabled';
+    createWorkspaceAgent(name, validFrontmatter(name));
+    process.env.GENIE_DISABLE_AUTO_SYNC = '1';
+
+    await expectResolveNotFound(name, {});
+
+    expect([...directoryRows.keys()]).toEqual([]);
+    expect(syncCalls).toEqual([]);
+  });
+
+  test('--no-auto-sync prevents auto-register', async () => {
+    const name = 'autosync-flag-disabled';
+    createWorkspaceAgent(name, validFrontmatter(name));
+
+    await expectResolveNotFound(name, { noAutoSync: true });
+
+    expect([...directoryRows.keys()]).toEqual([]);
+    expect(syncCalls).toEqual([]);
+  });
+
+  function createWorkspaceAgent(name: string, frontmatter: string): { workspaceRoot: string; agentDir: string } {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'genie-spawn-autosync-workspace-'));
+    tempRoots.push(workspaceRoot);
+
+    mkdirSync(join(workspaceRoot, '.genie'), { recursive: true });
+    writeFileSync(join(workspaceRoot, '.genie', 'workspace.json'), JSON.stringify({ name: 'autosync-test' }));
+
+    const agentDir = join(workspaceRoot, 'agents', name);
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'AGENTS.md'), `${frontmatter}\n# ${name}\n`, 'utf-8');
+
+    process.chdir(workspaceRoot);
+    return { workspaceRoot, agentDir };
+  }
+
+  function createAgentWithoutWorkspace(name: string, frontmatter: string): string {
+    const root = mkdtempSync(join(tmpdir(), 'genie-spawn-autosync-no-workspace-'));
+    tempRoots.push(root);
+
+    const agentDir = join(root, 'agents', name);
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'AGENTS.md'), `${frontmatter}\n# ${name}\n`, 'utf-8');
+
+    process.chdir(root);
+    return agentDir;
+  }
+
+  function validFrontmatter(name: string): string {
+    return `---
+name: ${name}
+description: Spawnable test agent
+---`;
+  }
+
+  async function fakeResolveAgent(name: string): Promise<ResolvedAgent | null> {
+    const entry = directoryRows.get(name);
+    return entry ? { entry, builtin: false } : null;
+  }
+
+  function fakeLoadIdentity(entry: DirectoryEntry): string | null {
+    const agentsMd = join(entry.dir, 'AGENTS.md');
+    return existsSync(agentsMd) ? agentsMd : null;
+  }
+
+  async function fakeSyncSingleAgentByName(root: string, name: string): Promise<string> {
+    syncCalls.push({ root, name });
+
+    const agentDir = join(root, 'agents', name);
+    const agentsMd = join(agentDir, 'AGENTS.md');
+    if (!existsSync(agentsMd)) return 'not-found';
+
+    const existed = directoryRows.has(name);
+    const frontmatter = parseFrontmatter(readFileSync(agentsMd, 'utf-8'));
+    directoryRows.set(name, {
+      name,
+      dir: agentDir,
+      promptMode: 'append',
+      registeredAt: 'test',
+      description: frontmatter.description,
+    });
+    return existed ? 'updated' : 'registered';
+  }
+
+  async function captureConsoleError<T>(fn: () => Promise<T>): Promise<{ result: T; errors: string[] }> {
+    const errors: string[] = [];
+    const errorSpy = spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      errors.push(args.map(String).join(' '));
+    });
+
+    try {
+      const result = await fn();
+      return { result, errors };
+    } finally {
+      errorSpy.mockRestore();
+    }
+  }
+
+  async function expectResolveNotFound(name: string, options: SpawnOptions): Promise<void> {
+    const errors: string[] = [];
+    const errorSpy = spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      errors.push(args.map(String).join(' '));
+    });
+    const exitSpy = spyOn(process, 'exit').mockImplementation((code?: number | string | null) => {
+      throw new Error(`process.exit:${code}`);
+    });
+
+    try {
+      try {
+        await agents.resolveAgentForSpawn(name, options);
+        expect.unreachable('resolveAgentForSpawn should exit for an unknown agent');
+      } catch (err) {
+        expect((err as Error).message).toBe('process.exit:1');
+      }
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(errors).toEqual([
+        `Error: Agent "${name}" not found in directory or built-ins.`,
+        `  Register with: genie dir add ${name} --dir <path>`,
+        '  Or use a built-in: engineer, reviewer, qa, fix, ...',
+      ]);
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  }
+
+  function restoreEnv(name: string, value: string | undefined): void {
+    if (value === undefined) {
+      Reflect.deleteProperty(process.env, name);
+    } else {
+      process.env[name] = value;
+    }
+  }
+});

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -9,8 +9,11 @@
  *   handleLsCommand    - genie ls
  */
 
+import { existsSync, readFileSync } from 'node:fs';
+import { isAbsolute, join, relative, resolve as resolvePath } from 'node:path';
 import * as directory from '../lib/agent-directory.js';
 import * as registry from '../lib/agent-registry.js';
+import { syncSingleAgentByName } from '../lib/agent-sync.js';
 import { getActor, recordAuditEvent } from '../lib/audit.js';
 import { resolveBuiltinAgentPath } from '../lib/builtin-agents.js';
 import * as nativeTeams from '../lib/claude-native-teams.js';
@@ -20,6 +23,7 @@ import { emitEvent } from '../lib/emit.js';
 import { tmuxBin } from '../lib/ensure-tmux.js';
 import * as executorRegistry from '../lib/executor-registry.js';
 import type { TransportType as ExecutorTransport } from '../lib/executor-types.js';
+import { parseFrontmatter } from '../lib/frontmatter.js';
 import { buildLayoutCommand, resolveLayoutMode } from '../lib/mosaic-layout.js';
 import { getOtelPort, startOtelReceiver } from '../lib/otel-receiver.js';
 import { injectResumeContext } from '../lib/protocol-router-spawn.js';
@@ -1691,10 +1695,81 @@ export interface SpawnOptions {
   sdkEffort?: string;
   /** SDK: resume a previous session by ID (--sdk-resume). */
   sdkResume?: string;
+  /** Disable spawn-time auto-registration from <workspace>/agents/<name>. */
+  noAutoSync?: boolean;
+  /** Commander backing field for --no-auto-sync. */
+  autoSync?: boolean;
+}
+
+export const _spawnAutoSyncDeps = {
+  resolveAgent: directory.resolve,
+  loadIdentity: directory.loadIdentity,
+  syncSingleAgentByName,
+  findWorkspace,
+  parseFrontmatter,
+  existsSync,
+  readFileSync,
+  stderr: (line: string) => console.error(line),
+};
+
+function autoSyncDisabled(options: Pick<SpawnOptions, 'autoSync' | 'noAutoSync'>): boolean {
+  return options.noAutoSync === true || options.autoSync === false || process.env.GENIE_DISABLE_AUTO_SYNC === '1';
+}
+
+function isWithinAgentsRoot(agentsRoot: string, agentDir: string): boolean {
+  const rel = relative(agentsRoot, agentDir);
+  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
+}
+
+/**
+ * On first spawn, register a valid workspace agent directory on demand.
+ *
+ * This intentionally does not scan, watch, prune, or reconcile the directory.
+ * It only checks the exact requested <workspace>/agents/<name>/AGENTS.md and
+ * delegates the real upsert to syncSingleAgentByName.
+ */
+export async function tryAutoRegisterAgent(
+  name: string,
+  options: Pick<SpawnOptions, 'autoSync' | 'noAutoSync'>,
+): Promise<{ entry: directory.DirectoryEntry; builtin: boolean } | null> {
+  if (autoSyncDisabled(options)) return null;
+
+  const workspace = _spawnAutoSyncDeps.findWorkspace();
+  if (!workspace) return null;
+
+  const agentsRoot = join(workspace.root, 'agents');
+  const agentDir = resolvePath(agentsRoot, name);
+  if (!isWithinAgentsRoot(agentsRoot, agentDir)) return null;
+
+  const agentsMdPath = join(agentDir, 'AGENTS.md');
+  if (!_spawnAutoSyncDeps.existsSync(agentsMdPath)) return null;
+
+  let frontmatter: ReturnType<typeof parseFrontmatter>;
+  try {
+    frontmatter = _spawnAutoSyncDeps.parseFrontmatter(_spawnAutoSyncDeps.readFileSync(agentsMdPath, 'utf-8'));
+  } catch {
+    return null;
+  }
+
+  if (frontmatter.name !== name) return null;
+  if (typeof frontmatter.description !== 'string' || frontmatter.description.trim().length === 0) return null;
+
+  try {
+    const action = await _spawnAutoSyncDeps.syncSingleAgentByName(workspace.root, name);
+    if (action === 'not-found') return null;
+  } catch {
+    return null;
+  }
+
+  const resolved = await _spawnAutoSyncDeps.resolveAgent(name);
+  if (!resolved) return null;
+
+  _spawnAutoSyncDeps.stderr(`Auto-registered agent '${name}' from ${agentDir}`);
+  return resolved;
 }
 
 /** Resolve agent from directory, returning entry + derived CWD/identity/model/systemPromptFile. */
-async function resolveAgentForSpawn(
+export async function resolveAgentForSpawn(
   name: string,
   options: SpawnOptions,
 ): Promise<{
@@ -1703,7 +1778,7 @@ async function resolveAgentForSpawn(
   identityPath: string | null;
   model: string | undefined;
 }> {
-  const resolved = await directory.resolve(name);
+  const resolved = (await _spawnAutoSyncDeps.resolveAgent(name)) ?? (await tryAutoRegisterAgent(name, options));
   if (!resolved) {
     console.error(`Error: Agent "${name}" not found in directory or built-ins.`);
     console.error(`  Register with: genie dir add ${name} --dir <path>`);
@@ -1718,7 +1793,7 @@ async function resolveAgentForSpawn(
   if (resolved.builtin) {
     identityPath = resolveBuiltinAgentPath(name);
   } else if (entry.dir) {
-    identityPath = directory.loadIdentity(entry);
+    identityPath = _spawnAutoSyncDeps.loadIdentity(entry);
   }
 
   const repoPath = resolveAgentWorkingDir(entry, options.cwd);


### PR DESCRIPTION
## Summary
- Auto-register a valid on-disk workspace agent on first spawn miss, then retry resolution once.
- Add --no-auto-sync to both spawn command surfaces and support GENIE_DISABLE_AUTO_SYNC=1.
- Add autosync coverage for happy path, idempotency, invalid frontmatter, missing agents, and opt-outs.

Fixes #1261
Wish: fix-agent-dir-autosync

## Validation
- bun run build: PASS
- ./dist/genie.js spawn --help | grep -q -- --no-auto-sync: PASS
- ./dist/genie.js agent spawn --help | grep -q -- --no-auto-sync: PASS
- bun test src/term-commands/agents.spawn-autosync.test.ts: PASS (6 tests)
- bun test src/lib/agent-identity-sync.test.ts -t "dir sync still registers frontmatter name mismatches by directory name": PASS
- bun run typecheck: PASS
- bun run lint: PASS (existing warnings only)
- Independent execution review: SHIP
- Pre-push gate: PASS (existing warnings only)

## Residual Risk
- Full bun run check completed but failed on unrelated existing docs/session test issues: missing docs/_internal files and GENIE_AGENT_NAME expectation failures.
