### PR TITLE
fix: fan out broadcasts to native inboxes

### DIFF
--- a/src/detectors/__tests__/pattern-7-dispatch-silent-drop.broadcast-fanout.test.ts
+++ b/src/detectors/__tests__/pattern-7-dispatch-silent-drop.broadcast-fanout.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { start as startScheduler } from '../../serve/detector-scheduler.js';
+import { type DetectorModule, __clearDetectorsForTests } from '../index.js';
+import {
+  type DispatchSilentDropRow,
+  type DispatchSilentDropState,
+  extractDeliveredBroadcastRecipients,
+  makeDispatchSilentDropDetector,
+} from '../pattern-7-dispatch-silent-drop.js';
+
+interface CapturedEmit {
+  type: string;
+  payload: Record<string, unknown>;
+}
+
+function drop(overrides: Partial<DispatchSilentDropRow> = {}): DispatchSilentDropRow {
+  return {
+    team: 'fix-team',
+    broadcast_id: '12345',
+    broadcast_at: '2026-04-28T12:00:00.000Z',
+    idle_member_ids: ['engineer'],
+    expected_prompt_count: 1,
+    actual_prompt_count: 0,
+    ...overrides,
+  };
+}
+
+async function runDetector(state: DispatchSilentDropState): Promise<CapturedEmit[]> {
+  const captured: CapturedEmit[] = [];
+  const detector = makeDispatchSilentDropDetector({ loadState: async () => state });
+  const scheduler = startScheduler({
+    tickIntervalMs: 1_000_000,
+    jitterMs: 0,
+    now: () => Date.UTC(2026, 3, 28, 12, 2, 0),
+    detectorSource: () => [detector as DetectorModule<unknown>],
+    emitFn: (type, payload) => captured.push({ type, payload }),
+    setTimeoutFn: () => ({ id: Symbol('test') }),
+    clearTimeoutFn: () => {},
+  });
+  await scheduler.tickNow();
+  scheduler.stop();
+  return captured;
+}
+
+describe('rot.dispatch-silent-drop broadcast fan-out audit', () => {
+  afterEach(() => {
+    __clearDetectorsForTests();
+  });
+
+  test('pre-fix broadcast shape has no recipient audit and still fires via roster fallback', async () => {
+    expect(extractDeliveredBroadcastRecipients({ messageId: 1, team: 'fix-team' })).toBeNull();
+
+    const captured = await runDetector({ drops: [drop()] });
+
+    const fires = captured.filter((event) => event.type === 'rot.detected');
+    expect(fires.length).toBe(1);
+    expect(fires[0].payload.pattern_id).toBe('pattern-7-dispatch-silent-drop');
+  });
+
+  test('post-fix broadcast shape with delivered recipients and prompt evidence stays silent', async () => {
+    const delivered = extractDeliveredBroadcastRecipients({
+      messageId: 1,
+      team: 'fix-team',
+      recipients: [
+        { agent: 'engineer', delivered: true },
+        { agent: 'reviewer', delivered: true },
+        { agent: 'offline-worker', delivered: false, reason: 'offline' },
+      ],
+    });
+    const prompted = new Set(['engineer', 'reviewer']);
+
+    expect(delivered).toEqual(['engineer', 'reviewer']);
+    expect(delivered?.filter((agent) => !prompted.has(agent))).toEqual([]);
+
+    const captured = await runDetector({ drops: [] });
+    expect(captured.filter((event) => event.type === 'rot.detected')).toEqual([]);
+  });
+
+  test('self-broadcast recipient audit is a clean no-op snapshot', () => {
+    expect(extractDeliveredBroadcastRecipients({ recipients: [] })).toEqual([]);
+  });
+});

--- a/src/detectors/pattern-7-dispatch-silent-drop.ts
+++ b/src/detectors/pattern-7-dispatch-silent-drop.ts
@@ -68,6 +68,41 @@ export interface DispatchSilentDropState {
   readonly drops: ReadonlyArray<DispatchSilentDropRow>;
 }
 
+interface BroadcastRecipientAudit {
+  readonly agent?: unknown;
+  readonly delivered?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function sanitizeAgentName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9]/g, '-').toLowerCase();
+}
+
+/**
+ * Extract the broadcast-time delivered recipient snapshot.
+ *
+ * `null` means "pre-fix event shape, fall back to the live roster". `[]`
+ * means "post-fix event shape with no delivered recipients", which is a
+ * clean no-op for self-broadcasts or fully skipped/offline rosters.
+ */
+export function extractDeliveredBroadcastRecipients(data: unknown): string[] | null {
+  if (!isRecord(data)) return null;
+  const recipients = data.recipients;
+  if (!Array.isArray(recipients)) return null;
+
+  const delivered: string[] = [];
+  for (const recipient of recipients as BroadcastRecipientAudit[]) {
+    if (!isRecord(recipient)) continue;
+    if (recipient.delivered !== true) continue;
+    if (typeof recipient.agent !== 'string' || recipient.agent.length === 0) continue;
+    delivered.push(recipient.agent);
+  }
+  return [...new Set(delivered)];
+}
+
 interface DispatchSilentDropDeps {
   readonly loadState: () => Promise<DispatchSilentDropState>;
   /** Injected clock — tests freeze time; prod uses `Date.now`. */
@@ -85,13 +120,12 @@ interface DispatchSilentDropDeps {
  * with multiple broadcasts in flight.
  */
 /** Quick check: has the member's user.prompt subject fired since the broadcast? */
-async function memberHasRespondedSince(
+async function promptSubjectFiredSince(
   sql: Awaited<ReturnType<typeof getConnection>>,
-  member: { id: string; customName?: string; role?: string },
+  agentName: string,
   sinceIso: string,
 ): Promise<boolean> {
-  const name = member.customName ?? member.role ?? member.id;
-  const promptSubject = `genie.user.${name}.prompt`;
+  const promptSubject = `genie.user.${agentName}.prompt`;
   const rows = await sql<Array<{ id: number }>>`
     SELECT id FROM genie_runtime_events
     WHERE subject = ${promptSubject}
@@ -101,15 +135,38 @@ async function memberHasRespondedSince(
   return rows.length > 0;
 }
 
+/** Quick check: has the member's user.prompt subject fired since the broadcast? */
+async function memberHasRespondedSince(
+  sql: Awaited<ReturnType<typeof getConnection>>,
+  member: { id: string; customName?: string; role?: string },
+  sinceIso: string,
+): Promise<boolean> {
+  const name = member.customName ?? member.role ?? member.id;
+  return promptSubjectFiredSince(sql, name, sinceIso);
+}
+
+function memberMatchesRecipientSnapshot(
+  member: { id: string; customName?: string; role?: string },
+  recipients: ReadonlySet<string>,
+): boolean {
+  const candidates = [member.id, member.customName, member.role].filter((v): v is string => Boolean(v));
+  return candidates.some((candidate) => recipients.has(candidate) || recipients.has(sanitizeAgentName(candidate)));
+}
+
 /** Return the ids of running team members who didn't respond to the broadcast. */
 async function findIdleMembers(
   sql: Awaited<ReturnType<typeof getConnection>>,
   team: string,
   broadcastAt: string,
+  recipientSnapshot?: ReadonlyArray<string>,
 ): Promise<string[]> {
   const members = await listAgents({ team });
+  const recipientSet = recipientSnapshot
+    ? new Set(recipientSnapshot.flatMap((name) => [name, sanitizeAgentName(name)]))
+    : null;
   const idle: string[] = [];
   for (const member of members) {
+    if (recipientSet && !memberMatchesRecipientSnapshot(member, recipientSet)) continue;
     const exec = await getCurrentExecutor(member.id);
     if (exec?.state !== 'running') continue;
     const responded = await memberHasRespondedSince(sql, member, broadcastAt);
@@ -124,8 +181,8 @@ async function defaultLoadState(): Promise<DispatchSilentDropState> {
   const cutoffBroadcast = new Date(nowMs - MIN_SILENT_WINDOW_MS).toISOString();
   const cutoffLookback = new Date(nowMs - BROADCAST_LOOKBACK_MS).toISOString();
 
-  const broadcasts = await sql<Array<{ id: number; team: string | null; created_at: Date | string }>>`
-    SELECT id, team, created_at FROM genie_runtime_events
+  const broadcasts = await sql<Array<{ id: number; team: string | null; data: unknown; created_at: Date | string }>>`
+    SELECT id, team, data, created_at FROM genie_runtime_events
     WHERE subject = 'genie.msg.broadcast'
       AND created_at < ${cutoffBroadcast}
       AND created_at > ${cutoffLookback}
@@ -138,7 +195,9 @@ async function defaultLoadState(): Promise<DispatchSilentDropState> {
   for (const b of broadcasts) {
     if (b.team === null) continue;
     const broadcastAt = b.created_at instanceof Date ? b.created_at.toISOString() : String(b.created_at);
-    const idleMembers = await findIdleMembers(sql, b.team, broadcastAt);
+    const recipientSnapshot = extractDeliveredBroadcastRecipients(b.data);
+    if (recipientSnapshot && recipientSnapshot.length === 0) continue;
+    const idleMembers = await findIdleMembers(sql, b.team, broadcastAt, recipientSnapshot ?? undefined);
     if (idleMembers.length === 0) continue;
     drops.push({
       team: b.team,

--- a/src/term-commands/msg.broadcast.test.ts
+++ b/src/term-commands/msg.broadcast.test.ts
@@ -1,0 +1,312 @@
+import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import { Command } from 'commander';
+import type * as registryTypes from '../lib/agent-registry.js';
+import type { NativeInboxMessage, NativeTeamConfig } from '../lib/claude-native-teams.js';
+import * as nativeTeams from '../lib/claude-native-teams.js';
+import * as mailbox from '../lib/mailbox.js';
+import type { RuntimeEvent } from '../lib/runtime-events.js';
+import * as runtimeEvents from '../lib/runtime-events.js';
+import * as taskService from '../lib/task-service.js';
+import * as teamManager from '../lib/team-manager.js';
+import { handleBroadcast, registerSendInboxCommands } from './msg.js';
+
+type BroadcastDeps = NonNullable<Parameters<typeof handleBroadcast>[2]>;
+type AgentIdentity = Awaited<ReturnType<typeof registryTypes.listAgents>>[number];
+
+interface NativeWrite {
+  team: string;
+  agent: string;
+  message: NativeInboxMessage;
+}
+
+interface CapturedBroadcastEvent {
+  repoPath: string;
+  subject: string;
+  event: Parameters<NonNullable<BroadcastDeps['publishSubjectEvent']>>[2];
+}
+
+function sanitizeTeamName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9]/g, '-').toLowerCase();
+}
+
+function agent(name: string, stateId = name): AgentIdentity {
+  return {
+    id: stateId,
+    startedAt: '2026-04-28T00:00:00.000Z',
+    customName: name,
+    team: 'fix-team',
+    currentExecutorId: `exec-${stateId}`,
+  };
+}
+
+function nativeConfig(
+  team: string,
+  members: Array<{ name: string; isActive?: boolean; color?: string }>,
+): NativeTeamConfig {
+  return {
+    name: sanitizeTeamName(team),
+    createdAt: 1,
+    leadAgentId: `team-lead@${sanitizeTeamName(team)}`,
+    leadSessionId: 'session-1',
+    members: members.map((member) => ({
+      agentId: `${sanitizeTeamName(member.name)}@${sanitizeTeamName(team)}`,
+      name: sanitizeTeamName(member.name),
+      agentType: 'worker',
+      joinedAt: 1,
+      backendType: 'tmux' as const,
+      color: member.color ?? 'blue',
+      planModeRequired: false,
+      isActive: member.isActive ?? true,
+    })),
+  };
+}
+
+function conversationRow(id = 'conv-1'): Awaited<ReturnType<typeof taskService.findOrCreateConversation>> {
+  return {
+    id,
+    parentMessageId: null,
+    name: 'Team: fix-team',
+    type: 'group',
+    linkedEntity: 'team',
+    linkedEntityId: 'fix-team',
+    createdByType: 'local',
+    createdById: 'team-lead',
+    metadata: {},
+    createdAt: '2026-04-28T00:00:00.000Z',
+    updatedAt: '2026-04-28T00:00:00.000Z',
+  };
+}
+
+function messageRow(id = 101): Awaited<ReturnType<typeof taskService.sendMessage>> {
+  return {
+    id,
+    conversationId: 'conv-1',
+    replyToId: null,
+    senderType: 'local',
+    senderId: 'team-lead',
+    body: 'wake up',
+    metadata: {},
+    createdAt: '2026-04-28T00:00:00.000Z',
+    updatedAt: '2026-04-28T00:00:00.000Z',
+  };
+}
+
+function conversationMemberRow(
+  conversationId = 'conv-1',
+  actorId = 'team-lead',
+): Awaited<ReturnType<typeof taskService.addMember>> {
+  return {
+    conversationId,
+    actorType: 'local',
+    actorId,
+    role: 'member',
+    joinedAt: '2026-04-28T00:00:00.000Z',
+  };
+}
+
+function runtimeEvent(
+  repoPath: string,
+  subject: string,
+  event: Parameters<NonNullable<BroadcastDeps['publishSubjectEvent']>>[2],
+): RuntimeEvent {
+  return {
+    id: 1,
+    repoPath,
+    timestamp: '2026-04-28T00:00:00.000Z',
+    kind: event.kind,
+    agent: event.agent,
+    team: event.team,
+    direction: event.direction,
+    peer: event.peer,
+    text: event.text,
+    data: event.data,
+    source: event.source,
+    subject,
+  };
+}
+
+function makeBroadcastHarness(opts: {
+  agents: AgentIdentity[];
+  states?: Record<string, Awaited<ReturnType<typeof registryTypes.getAgentEffectiveState>>>;
+  config?: NativeTeamConfig | null;
+}): {
+  deps: BroadcastDeps;
+  writes: NativeWrite[];
+  events: CapturedBroadcastEvent[];
+} {
+  const writes: NativeWrite[] = [];
+  const events: CapturedBroadcastEvent[] = [];
+  const deps: BroadcastDeps = {
+    repoPath: '/tmp/repo',
+    now: () => new Date('2026-04-28T12:00:00.000Z'),
+    taskService: {
+      findOrCreateConversation: async () => conversationRow(),
+      addMember: async (_conversationId, actor) => conversationMemberRow('conv-1', actor.actorId),
+      sendMessage: async () => messageRow(),
+    },
+    registry: {
+      listAgents: async (filters) => opts.agents.filter((a) => a.team === filters?.team),
+      getAgentEffectiveState: async (agentId) => opts.states?.[agentId] ?? 'idle',
+    },
+    nativeTeams: {
+      loadConfig: async () => opts.config ?? null,
+      sanitizeTeamName,
+      writeNativeInbox: async (team, agentName, message) => {
+        writes.push({ team, agent: agentName, message });
+      },
+    },
+    publishSubjectEvent: async (repoPath, subject, event) => {
+      events.push({ repoPath, subject, event });
+      return runtimeEvent(repoPath, subject, event);
+    },
+  };
+  return { deps, writes, events };
+}
+
+function captureConsoleLogs(): string[] {
+  const lines: string[] = [];
+  spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    lines.push(args.map((arg) => String(arg)).join(' '));
+  });
+  return lines;
+}
+
+describe('genie broadcast native inbox fan-out', () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test('delivers to N-1 live members, unions native config fallback, and emits recipients audit', async () => {
+    const logs = captureConsoleLogs();
+    const { deps, writes, events } = makeBroadcastHarness({
+      agents: [agent('team-lead'), agent('engineer')],
+      config: nativeConfig('fix-team', [{ name: 'team-lead' }, { name: 'engineer' }, { name: 'reviewer' }]),
+    });
+
+    const result = await handleBroadcast('wake up', { from: 'team-lead', team: 'fix-team' }, deps);
+
+    expect(writes.map((w) => w.agent)).toEqual(['engineer', 'reviewer']);
+    expect(result.recipients).toEqual([
+      { agent: 'engineer', delivered: true },
+      { agent: 'reviewer', delivered: true },
+    ]);
+    expect(events.length).toBe(1);
+    expect(events[0].subject).toBe('genie.msg.broadcast');
+    expect(events[0].event.team).toBe('fix-team');
+    expect(events[0].event.data?.recipients).toEqual(result.recipients);
+    expect(logs[0]).toBe('Broadcast sent to team "fix-team" (delivered to 2 of 2 members).');
+  });
+
+  test('self-broadcast exits cleanly with no recipients', async () => {
+    const logs = captureConsoleLogs();
+    const { deps, writes, events } = makeBroadcastHarness({
+      agents: [agent('team-lead')],
+      config: nativeConfig('fix-team', [{ name: 'team-lead' }]),
+    });
+
+    const result = await handleBroadcast('note to self', { from: 'team-lead', team: 'fix-team' }, deps);
+
+    expect(writes).toEqual([]);
+    expect(result.recipients).toEqual([]);
+    expect(events[0].event.data?.recipients).toEqual([]);
+    expect(logs[0]).toBe('Broadcast sent to team "fix-team" (delivered to 0 of 0 members).');
+  });
+
+  test('skips terminated and offline members with audit reasons', async () => {
+    captureConsoleLogs();
+    const { deps, writes, events } = makeBroadcastHarness({
+      agents: [agent('team-lead'), agent('live'), agent('term'), agent('off')],
+      states: { live: 'idle', term: 'terminated', off: 'offline' },
+      config: nativeConfig('fix-team', [{ name: 'team-lead' }, { name: 'live' }, { name: 'term' }, { name: 'off' }]),
+    });
+
+    const result = await handleBroadcast('wake up', { from: 'team-lead', team: 'fix-team' }, deps);
+
+    expect(writes.map((w) => w.agent)).toEqual(['live']);
+    expect(result.recipients).toEqual([
+      { agent: 'live', delivered: true },
+      { agent: 'term', delivered: false, reason: 'terminated' },
+      { agent: 'off', delivered: false, reason: 'offline' },
+    ]);
+    expect(events[0].event.data?.recipients).toEqual(result.recipients);
+  });
+
+  test('audits native inbox write failures without aborting other recipients', async () => {
+    captureConsoleLogs();
+    const writes: NativeWrite[] = [];
+    const { deps } = makeBroadcastHarness({
+      agents: [agent('team-lead'), agent('engineer'), agent('reviewer')],
+      config: nativeConfig('fix-team', [{ name: 'team-lead' }, { name: 'engineer' }, { name: 'reviewer' }]),
+    });
+    deps.nativeTeams!.writeNativeInbox = async (team, agentName, message) => {
+      if (agentName === 'engineer') throw new Error('disk full');
+      writes.push({ team, agent: agentName, message });
+    };
+
+    const result = await handleBroadcast('wake up', { from: 'team-lead', team: 'fix-team' }, deps);
+
+    expect(writes.map((w) => w.agent)).toEqual(['reviewer']);
+    expect(result.recipients).toEqual([
+      { agent: 'engineer', delivered: false, reason: 'disk full' },
+      { agent: 'reviewer', delivered: true },
+    ]);
+  });
+});
+
+describe('genie send native inbox bridge regression', () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test('direct message still writes only the addressed local native surface', async () => {
+    const writes: NativeWrite[] = [];
+    spyOn(teamManager, 'listTeams').mockResolvedValue([]);
+    spyOn(taskService, 'findOrCreateConversation').mockResolvedValue(conversationRow('dm-1'));
+    spyOn(taskService, 'addMember').mockImplementation(async (conversationId, actor) =>
+      conversationMemberRow(conversationId, actor.actorId),
+    );
+    spyOn(taskService, 'sendMessage').mockResolvedValue({
+      ...messageRow(202),
+      conversationId: 'dm-1',
+      senderId: 'alice',
+    });
+    spyOn(mailbox, 'send').mockResolvedValue({
+      id: 'mail-1',
+      from: 'alice',
+      to: 'bob',
+      body: 'hello',
+      createdAt: '2026-04-28T00:00:00.000Z',
+      read: false,
+      deliveredAt: null,
+      source: 'agent',
+      meta: {},
+    });
+    spyOn(mailbox, 'markDelivered').mockResolvedValue(true);
+    spyOn(runtimeEvents, 'publishSubjectEvent').mockResolvedValue(
+      runtimeEvent('/tmp/repo', 'genie.msg.bob', {
+        kind: 'message',
+        agent: 'alice',
+        direction: 'out',
+        peer: 'bob',
+        text: 'hello',
+        data: {},
+        source: 'mailbox',
+      }),
+    );
+    spyOn(nativeTeams, 'resolveNativeMemberName').mockResolvedValue('bob');
+    spyOn(nativeTeams, 'writeNativeInbox').mockImplementation(async (team, agentName, message) => {
+      writes.push({ team, agent: agentName, message });
+    });
+
+    captureConsoleLogs();
+    const program = new Command();
+    registerSendInboxCommands(program);
+
+    await program.parseAsync(['send', 'hello', '--to', 'bob', '--from', 'alice', '--team', 'fix-team'], {
+      from: 'user',
+    });
+
+    expect(writes.map((w) => w.agent)).toEqual(['bob']);
+    expect(writes[0].team).toBe('fix-team');
+  });
+});

--- a/src/term-commands/msg.ts
+++ b/src/term-commands/msg.ts
@@ -643,6 +643,243 @@ export async function printBridgeSuggestion(
 // Send Handler
 // ============================================================================
 
+export interface BroadcastDeliveryAudit {
+  agent: string;
+  delivered: boolean;
+  reason?: string;
+}
+
+export interface BroadcastHandleResult {
+  messageId: number;
+  conversationId: string;
+  team: string;
+  recipients: BroadcastDeliveryAudit[];
+}
+
+type NativeTeamsModule = typeof import('../lib/claude-native-teams.js');
+type BroadcastAgent = Awaited<ReturnType<typeof registryTypes.listAgents>>[number];
+type BroadcastTaskService = Pick<typeof taskServiceTypes, 'findOrCreateConversation' | 'addMember' | 'sendMessage'>;
+type BroadcastRegistry = Pick<typeof registryTypes, 'listAgents' | 'getAgentEffectiveState'>;
+type BroadcastNativeTeams = Pick<NativeTeamsModule, 'loadConfig' | 'sanitizeTeamName' | 'writeNativeInbox'>;
+
+interface BroadcastRosterEntry {
+  agent: string;
+  sanitized: string;
+  inboxName: string;
+  agentId?: string;
+  nativeColor?: string;
+  nativeActive?: boolean;
+}
+
+interface BroadcastNativeFanoutDeps {
+  listAgents: BroadcastRegistry['listAgents'];
+  getAgentEffectiveState: BroadcastRegistry['getAgentEffectiveState'];
+  loadConfig: BroadcastNativeTeams['loadConfig'];
+  sanitizeTeamName: BroadcastNativeTeams['sanitizeTeamName'];
+  writeNativeInbox: BroadcastNativeTeams['writeNativeInbox'];
+  now?: () => Date;
+}
+
+interface BroadcastHandlerDeps {
+  taskService?: BroadcastTaskService;
+  registry?: BroadcastRegistry;
+  nativeTeams?: BroadcastNativeTeams;
+  publishSubjectEvent?: typeof import('../lib/runtime-events.js').publishSubjectEvent;
+  repoPath?: string;
+  now?: () => Date;
+}
+
+function broadcastAgentName(agent: BroadcastAgent): string {
+  return agent.customName ?? agent.role ?? agent.id;
+}
+
+function mergeBroadcastRosterEntry(
+  bySanitized: Map<string, BroadcastRosterEntry>,
+  sanitized: string,
+  patch: Omit<BroadcastRosterEntry, 'sanitized'>,
+): void {
+  if (!sanitized) return;
+  const existing = bySanitized.get(sanitized);
+  bySanitized.set(sanitized, {
+    agent: existing?.agent ?? patch.agent,
+    sanitized,
+    inboxName: patch.inboxName ?? existing?.inboxName ?? sanitized,
+    agentId: existing?.agentId ?? patch.agentId,
+    nativeColor: existing?.nativeColor ?? patch.nativeColor,
+    nativeActive: existing?.nativeActive ?? patch.nativeActive,
+  });
+}
+
+async function resolveBroadcastRoster(
+  teamName: string,
+  deps: BroadcastNativeFanoutDeps,
+): Promise<BroadcastRosterEntry[]> {
+  const [agents, nativeConfig] = await Promise.all([
+    deps.listAgents({ team: teamName }).catch(() => [] as BroadcastAgent[]),
+    deps.loadConfig(teamName).catch(() => null),
+  ]);
+
+  const bySanitized = new Map<string, BroadcastRosterEntry>();
+
+  for (const agent of agents) {
+    const name = broadcastAgentName(agent);
+    const sanitized = deps.sanitizeTeamName(name);
+    mergeBroadcastRosterEntry(bySanitized, sanitized, {
+      agent: name,
+      inboxName: sanitized,
+      agentId: agent.id,
+      nativeColor: agent.nativeColor,
+    });
+  }
+
+  for (const member of nativeConfig?.members ?? []) {
+    const sanitized = deps.sanitizeTeamName(member.name);
+    mergeBroadcastRosterEntry(bySanitized, sanitized, {
+      agent: member.name,
+      inboxName: member.name,
+      nativeColor: member.color,
+      nativeActive: member.isActive,
+    });
+  }
+
+  return [...bySanitized.values()];
+}
+
+function makeBroadcastNativeMessage(
+  from: string,
+  body: string,
+  timestamp: string,
+  color: string,
+): import('../lib/claude-native-teams.js').NativeInboxMessage {
+  return {
+    from,
+    text: body,
+    summary: body.length > 50 ? `${body.substring(0, 50)}...` : body,
+    timestamp,
+    color,
+    read: false,
+  };
+}
+
+async function broadcastSkipReason(
+  entry: BroadcastRosterEntry,
+  deps: BroadcastNativeFanoutDeps,
+): Promise<string | null> {
+  if (entry.nativeActive === false) return 'offline';
+  if (!entry.agentId) return null;
+
+  const state = await deps.getAgentEffectiveState(entry.agentId).catch(() => 'offline' as const);
+  if (state === 'offline') return 'offline';
+  if (state === 'terminated') return 'terminated';
+  if (state === 'error') return 'dead';
+  if (state === 'done') return 'done';
+  return null;
+}
+
+export async function fanoutBroadcastToNativeInboxes(
+  teamName: string,
+  from: string,
+  body: string,
+  deps: BroadcastNativeFanoutDeps,
+): Promise<BroadcastDeliveryAudit[]> {
+  const sender = deps.sanitizeTeamName(from);
+  const roster = await resolveBroadcastRoster(teamName, deps);
+  const timestamp = (deps.now ?? (() => new Date()))().toISOString();
+  const recipients: BroadcastDeliveryAudit[] = [];
+
+  for (const entry of roster) {
+    if (entry.sanitized === sender) continue;
+
+    const skipReason = await broadcastSkipReason(entry, deps);
+    if (skipReason) {
+      recipients.push({ agent: entry.agent, delivered: false, reason: skipReason });
+      continue;
+    }
+
+    try {
+      await deps.writeNativeInbox(
+        teamName,
+        entry.inboxName,
+        makeBroadcastNativeMessage(from, body, timestamp, entry.nativeColor ?? 'blue'),
+      );
+      recipients.push({ agent: entry.agent, delivered: true });
+    } catch (err) {
+      recipients.push({
+        agent: entry.agent,
+        delivered: false,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return recipients;
+}
+
+export async function handleBroadcast(
+  body: string,
+  options: { from?: string; team?: string },
+  deps: BroadcastHandlerDeps = {},
+): Promise<BroadcastHandleResult> {
+  const ts = deps.taskService ?? (await getTaskService());
+  const registry = deps.registry ?? (await getRegistry());
+  const nativeTeams = deps.nativeTeams ?? (await import('../lib/claude-native-teams.js'));
+  const repoPath = deps.repoPath ?? process.cwd();
+  const from = options.from ?? (await detectSenderIdentity(options.team));
+  const teamName = await resolveTeamName(options.team, repoPath, from);
+  const senderActor = localActor(from);
+
+  const conv = await ts.findOrCreateConversation({
+    type: 'group',
+    name: `Team: ${teamName}`,
+    linkedEntity: 'team',
+    linkedEntityId: teamName,
+    createdBy: senderActor,
+    members: [senderActor],
+  });
+
+  await ts.addMember(conv.id, senderActor);
+  const msg = await ts.sendMessage(conv.id, senderActor, body);
+
+  const recipients = await fanoutBroadcastToNativeInboxes(teamName, from, body, {
+    listAgents: registry.listAgents,
+    getAgentEffectiveState: registry.getAgentEffectiveState,
+    loadConfig: nativeTeams.loadConfig,
+    sanitizeTeamName: nativeTeams.sanitizeTeamName,
+    writeNativeInbox: nativeTeams.writeNativeInbox,
+    now: deps.now,
+  });
+
+  // Emit runtime event for real-time observability (fire-and-forget)
+  try {
+    const publishSubjectEvent =
+      deps.publishSubjectEvent ?? (await import('../lib/runtime-events.js')).publishSubjectEvent;
+    await publishSubjectEvent(repoPath, 'genie.msg.broadcast', {
+      kind: 'message',
+      agent: from,
+      team: teamName,
+      direction: 'out',
+      peer: teamName,
+      text: body,
+      data: { messageId: msg.id, conversationId: conv.id, from, team: teamName, recipients },
+      source: 'mailbox',
+    });
+  } catch {
+    // Event log unavailable — silent degradation
+  }
+
+  const deliveredCount = recipients.filter((r) => r.delivered).length;
+  console.log(`Broadcast sent to team "${teamName}" (delivered to ${deliveredCount} of ${recipients.length} members).`);
+  console.log(`  Message ID: ${msg.id}`);
+  console.log(`  Conversation: ${conv.id}`);
+  for (const recipient of recipients) {
+    if (!recipient.delivered) {
+      console.log(`  ${recipient.agent}: ${recipient.reason ?? 'delivery failed'}`);
+    }
+  }
+
+  return { messageId: msg.id, conversationId: conv.id, team: teamName, recipients };
+}
+
 async function handleSend(
   body: string,
   options: { to: string; from?: string; team?: string; bridge?: boolean },
@@ -750,47 +987,7 @@ Examples:
     .option('--team <name>', 'Team name (auto-detected from context)')
     .action(async (body: string, options: { from?: string; team?: string }) => {
       try {
-        const ts = await getTaskService();
-        const repoPath = process.cwd();
-        const from = options.from ?? (await detectSenderIdentity());
-        const teamName = await resolveTeamName(options.team, repoPath, from);
-
-        const senderActor = localActor(from);
-
-        // Find or create team conversation
-        const conv = await ts.findOrCreateConversation({
-          type: 'group',
-          name: `Team: ${teamName}`,
-          linkedEntity: 'team',
-          linkedEntityId: teamName,
-          createdBy: senderActor,
-          members: [senderActor],
-        });
-
-        // Ensure sender is member
-        await ts.addMember(conv.id, senderActor);
-
-        const msg = await ts.sendMessage(conv.id, senderActor, body);
-
-        // Emit runtime event for real-time observability (fire-and-forget)
-        try {
-          const { publishSubjectEvent } = await import('../lib/runtime-events.js');
-          await publishSubjectEvent(repoPath, 'genie.msg.broadcast', {
-            kind: 'message',
-            agent: from,
-            direction: 'out',
-            peer: teamName,
-            text: body,
-            data: { messageId: msg.id, conversationId: conv.id, from, team: teamName },
-            source: 'mailbox',
-          });
-        } catch {
-          // Event log unavailable — silent degradation
-        }
-
-        console.log(`Broadcast sent to team "${teamName}".`);
-        console.log(`  Message ID: ${msg.id}`);
-        console.log(`  Conversation: ${conv.id}`);
+        await handleBroadcast(body, options);
       } catch (error) {
         console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         process.exit(1);


### PR DESCRIPTION
## Summary
- Fan out team broadcasts to native inboxes for every live non-sender teammate.
- Add delivery audit recipients to genie.msg.broadcast events and operator delivered-count output.
- Add focused broadcast and Pattern 7 detector regression tests.

Fixes #1399
Wish: fix-broadcast-fanout-wake

## Validation
- bun run typecheck: PASS
- bun run lint: PASS (existing warnings only)
- bun test src/term-commands/msg.broadcast.test.ts: PASS (5 tests)
- bun test src/detectors/__tests__/pattern-7-dispatch-silent-drop.broadcast-fanout.test.ts: PASS (3 tests)
- Independent execution review: SHIP
- Pre-push gate: PASS (existing warnings only)

## Residual Risk
- Full bun run check failed only on unrelated docs/session/shared-PG issues outside this scope.
