### PR TITLE
fix: preserve built-in agent identity on respawn

### DIFF
--- a/src/genie-commands/__tests__/session.test.ts
+++ b/src/genie-commands/__tests__/session.test.ts
@@ -51,10 +51,9 @@ describe('buildClaudeCommand', () => {
     expect(cmd).toContain('claude');
   });
 
-  test('sets GENIE_AGENT_NAME env var to folder name', () => {
+  test('sets GENIE_AGENT_NAME env var to leader name', () => {
     const cmd = buildClaudeCommand('genie');
-    const folderName = basename(process.cwd());
-    expect(cmd).toContain(`GENIE_AGENT_NAME='${folderName}'`);
+    expect(cmd).toContain("GENIE_AGENT_NAME='genie'");
   });
 
   test('sets GENIE_TEAM env var', () => {

--- a/src/lib/agent-directory.test.ts
+++ b/src/lib/agent-directory.test.ts
@@ -67,13 +67,31 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
       expect(resolved!.builtin).toBe(true);
     });
 
-    test('PG agent overrides built-in', async () => {
+    test('PG runtime row with empty dir for a built-in resolves as built-in', async () => {
       const sql = await getConnection();
-      await sql`INSERT INTO agents (id, pane_id, session, repo_path, state, role, started_at, last_state_change) VALUES ('eng1', '%1', 's', '/tmp', 'working', 'engineer', now(), now())`;
+      await sql`INSERT INTO agents (id, pane_id, session, repo_path, state, role, started_at, last_state_change, metadata) VALUES ('runtime-qa', '%1', 's', '/tmp', 'working', 'qa', now(), now(), '{}')`;
 
-      const resolved = await directory.resolve('engineer');
+      const resolved = await directory.resolve('qa');
+      expect(resolved).not.toBeNull();
+      expect(resolved!.builtin).toBe(true);
+      expect(resolved!.entry.dir).toBe('');
+    });
+
+    test('PG directory agent sharing a built-in name is not classified as built-in', async () => {
+      const sql = await getConnection();
+      await sql`
+        INSERT INTO agents (id, role, custom_name, repo_path, state, started_at, metadata)
+        VALUES ('dir:qa', 'qa', 'qa', ${agentDir}, NULL, now(), ${sql.json({
+          dir: agentDir,
+          registeredAt: 'test',
+          promptMode: 'append',
+        })})
+      `;
+
+      const resolved = await directory.resolve('qa');
       expect(resolved).not.toBeNull();
       expect(resolved!.builtin).toBe(false);
+      expect(resolved!.entry.dir).toBe(agentDir);
     });
 
     test('returns null for unknown name', async () => {

--- a/src/lib/agent-directory.ts
+++ b/src/lib/agent-directory.ts
@@ -346,6 +346,9 @@ export async function resolve(name: string): Promise<ResolvedAgent | null> {
           : (rows[0].created_at as string | undefined);
       const entry = roleToEntry(name, undefined, meta, createdAt);
       if (templateTeam) entry.team = templateTeam;
+      if (isKnownBuiltinName(name) && entry.dir.trim() === '') {
+        return { entry, builtin: true };
+      }
       return { entry, builtin: false };
     }
   } catch {
@@ -570,6 +573,10 @@ function builtinToEntry(agent: BuiltinAgent): DirectoryEntry {
     roles: [],
     registeredAt: '(built-in)',
   };
+}
+
+function isKnownBuiltinName(name: string): boolean {
+  return [...BUILTIN_ROLES, ...BUILTIN_COUNCIL_MEMBERS].some((agent) => agent.name === name);
 }
 
 /** Convert a PG agent role to a synthetic DirectoryEntry, enriched with metadata.

--- a/src/lib/provider-adapters.test.ts
+++ b/src/lib/provider-adapters.test.ts
@@ -127,6 +127,7 @@ describe('buildClaudeCommand', () => {
       team: 'work',
       role: 'custom-identity', // operator's --role override (registration name)
       agentTemplate: 'engineer', // resolved template (verified on disk)
+      systemPromptFile: '/path/to/AGENTS.md',
     });
     expect(result.command).toContain("--agent 'engineer'");
     expect(result.command).not.toContain("--agent 'custom-identity'");
@@ -141,6 +142,7 @@ describe('buildClaudeCommand', () => {
       provider: 'claude',
       team: 'work',
       role: 'engineer',
+      systemPromptFile: '/path/to/AGENTS.md',
     });
     expect(result.command).toContain("--agent 'engineer'");
   });
@@ -211,6 +213,27 @@ describe('buildClaudeCommand', () => {
     });
     expect(result.command).not.toContain('--system-prompt-file');
     expect(result.command).not.toContain('--append-system-prompt-file');
+  });
+
+  it('throws when a known built-in would launch without any prompt identity', () => {
+    expect(() =>
+      buildClaudeCommand({
+        provider: 'claude',
+        team: 'work',
+        role: 'qa',
+      }),
+    ).toThrow('Refusing to launch built-in agent "qa" without AGENTS.md identity');
+  });
+
+  it('allows a non-built-in agent to launch without prompt identity', () => {
+    const result = buildClaudeCommand({
+      provider: 'claude',
+      team: 'work',
+      role: 'implementor',
+    });
+    expect(result.command).toContain("--agent 'implementor'");
+    expect(result.command).not.toContain('--append-system-prompt-file');
+    expect(result.command).not.toContain('--system-prompt-file');
   });
 
   it('writes systemPrompt to temp file and uses --append-system-prompt-file', () => {
@@ -605,7 +628,7 @@ describe('OTel env injection in buildClaudeCommand', () => {
     const result = buildClaudeCommand({
       provider: 'claude',
       team: 'test-team',
-      role: 'engineer',
+      role: 'implementor',
       otelPort: 19643,
     });
     expect(result.env).toBeDefined();
@@ -622,22 +645,22 @@ describe('OTel env injection in buildClaudeCommand', () => {
     const result = buildClaudeCommand({
       provider: 'claude',
       team: 'test-team',
-      role: 'engineer',
+      role: 'implementor',
       otelPort: 19643,
       otelWishSlug: 'my-wish',
     });
     const attrs = result.env?.OTEL_RESOURCE_ATTRIBUTES ?? '';
-    expect(attrs).toContain('agent.name=engineer');
+    expect(attrs).toContain('agent.name=implementor');
     expect(attrs).toContain('team.name=test-team');
     expect(attrs).toContain('wish.slug=my-wish');
-    expect(attrs).toContain('agent.role=engineer');
+    expect(attrs).toContain('agent.role=implementor');
   });
 
   it('does not inject OTel env vars when otelPort is not set', () => {
     const result = buildClaudeCommand({
       provider: 'claude',
       team: 'test-team',
-      role: 'engineer',
+      role: 'implementor',
     });
     expect(result.env?.CLAUDE_CODE_ENABLE_TELEMETRY).toBeUndefined();
     expect(result.env?.OTEL_LOGS_EXPORTER).toBeUndefined();
@@ -647,7 +670,7 @@ describe('OTel env injection in buildClaudeCommand', () => {
     const result = buildClaudeCommand({
       provider: 'claude',
       team: 'test-team',
-      role: 'engineer',
+      role: 'implementor',
       otelPort: 19643,
       otelLogPrompts: false,
     });
@@ -661,7 +684,7 @@ describe('OTel env injection in buildClaudeCommand', () => {
       const result = buildClaudeCommand({
         provider: 'claude',
         team: 'test-team',
-        role: 'engineer',
+        role: 'implementor',
         otelPort: 19643,
       });
       // Should not override user's existing OTEL_EXPORTER_OTLP_ENDPOINT
@@ -698,7 +721,7 @@ describe('executor env propagation', () => {
     const result = buildClaudeCommand({
       provider: 'claude',
       team: 'work',
-      role: 'engineer',
+      role: 'implementor',
       executorId: execId,
       agentId,
     });
@@ -707,7 +730,7 @@ describe('executor env propagation', () => {
   });
 
   it('buildClaudeCommand omits GENIE_EXECUTOR_ID when not passed', () => {
-    const result = buildClaudeCommand({ provider: 'claude', team: 'work', role: 'engineer' });
+    const result = buildClaudeCommand({ provider: 'claude', team: 'work', role: 'implementor' });
     expect(result.env?.GENIE_EXECUTOR_ID).toBeUndefined();
     expect(result.env?.GENIE_AGENT_ID).toBeUndefined();
   });
@@ -749,7 +772,7 @@ describe('executor env propagation', () => {
     const launch = buildLaunchCommand({
       provider: 'claude',
       team: 'work',
-      role: 'engineer',
+      role: 'implementor',
       executorId: execId,
       agentId,
     });

--- a/src/lib/provider-adapters.ts
+++ b/src/lib/provider-adapters.ts
@@ -13,6 +13,7 @@
 
 import { z } from 'zod';
 import { buildDispatchCommand } from '../hooks/inject.js';
+import { resolveBuiltinAgentPath } from './builtin-agents.js';
 import {
   TRACE_ENV_VAR,
   TRACE_ID_ENV_VAR,
@@ -427,7 +428,22 @@ function appendDisallowedAndExtraArgs(parts: string[], params: SpawnParams): voi
   }
 }
 
+function assertClaudeBuiltinHasIdentity(params: SpawnParams): void {
+  const templateName = params.agentTemplate ?? params.role;
+  if (!templateName) return;
+  // Resumes attach to an existing Claude conversation whose identity was set
+  // at session creation; ResumeContext does not carry prompt fields.
+  if (params.resume) return;
+  if (!resolveBuiltinAgentPath(templateName)) return;
+  if (params.systemPromptFile || params.systemPrompt) return;
+
+  throw new Error(
+    `Refusing to launch built-in agent "${templateName}" without AGENTS.md identity. Resolve systemPromptFile or systemPrompt before building the Claude command.`,
+  );
+}
+
 export function buildClaudeCommand(params: SpawnParams): LaunchCommand {
+  assertClaudeBuiltinHasIdentity(params);
   preflightCheck('claude');
 
   const claudeBinary = resolveShellBinary('claude') ?? 'claude';

--- a/src/lib/providers/claude-code.test.ts
+++ b/src/lib/providers/claude-code.test.ts
@@ -46,6 +46,7 @@ function makeSpawnContext(overrides: Partial<SpawnContext> = {}): SpawnContext {
     team: 'test-team',
     role: 'engineer',
     cwd: '/home/genie/project',
+    systemPromptFile: '/path/to/AGENTS.md',
     ...overrides,
   };
 }
@@ -119,6 +120,7 @@ describe('ClaudeCodeProvider', () => {
         team: ctx.team,
         role: ctx.role,
         model: ctx.model,
+        systemPromptFile: ctx.systemPromptFile,
       });
       // Both should contain the same key components
       expect(providerResult.command).toContain("--agent 'reviewer'");

--- a/src/term-commands/agents.test.ts
+++ b/src/term-commands/agents.test.ts
@@ -10,6 +10,7 @@ import * as directory from '../lib/agent-directory.js';
 import type { DirectoryEntry } from '../lib/agent-directory.js';
 import type { Agent } from '../lib/agent-registry.js';
 import * as registry from '../lib/agent-registry.js';
+import { resolveBuiltinAgentPath } from '../lib/builtin-agents.js';
 import * as executorRegistry from '../lib/executor-registry.js';
 import { DB_AVAILABLE, setupTestDatabase } from '../lib/test-db.js';
 import * as wishState from '../lib/wish-state.js';
@@ -23,6 +24,7 @@ import {
   pickParallelShortId,
   recoverSurgery,
   rejectDuplicateRole,
+  resolveAgentForSpawn,
   resolveAgentWorkingDir,
   resolveSpawnIdentity,
   resolveTeamName,
@@ -190,6 +192,24 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
 
       // No wish state found, but has team — falls through to simple message
       expect(context).toBe("You were resumed. Check your team's current state with `genie status`.");
+    });
+  });
+
+  describe('resolveAgentForSpawn', () => {
+    test('uses built-in AGENTS.md identity when PG has a runtime row for the built-in role', async () => {
+      const { getConnection } = await import('../lib/db.js');
+      const sql = await getConnection();
+      await sql`
+        INSERT INTO agents (id, pane_id, session, repo_path, state, role, started_at, last_state_change, metadata)
+        VALUES ('runtime-qa', '%1', 's', '/tmp', 'working', 'qa', now(), now(), '{}')
+      `;
+
+      const expectedIdentityPath = resolveBuiltinAgentPath('qa');
+      const agent = await resolveAgentForSpawn('qa', {});
+
+      expect(expectedIdentityPath).not.toBeNull();
+      expect(agent.identityPath).toBe(expectedIdentityPath);
+      expect(agent.identityPath).toContain('/plugins/genie/agents/qa/AGENTS.md');
     });
   });
 });

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -1694,7 +1694,7 @@ export interface SpawnOptions {
 }
 
 /** Resolve agent from directory, returning entry + derived CWD/identity/model/systemPromptFile. */
-async function resolveAgentForSpawn(
+export async function resolveAgentForSpawn(
   name: string,
   options: SpawnOptions,
 ): Promise<{
@@ -1719,6 +1719,9 @@ async function resolveAgentForSpawn(
     identityPath = resolveBuiltinAgentPath(name);
   } else if (entry.dir) {
     identityPath = directory.loadIdentity(entry);
+  }
+  if (!identityPath) {
+    identityPath = resolveBuiltinAgentPath(name);
   }
 
   const repoPath = resolveAgentWorkingDir(entry, options.cwd);

--- a/src/term-commands/msg.test.ts
+++ b/src/term-commands/msg.test.ts
@@ -622,12 +622,10 @@ describe.skipIf(!DB_AVAILABLE)('printBridgeSuggestion', () => {
 // ---------------------------------------------------------------------------
 
 describe.skipIf(!DB_AVAILABLE)('buildTeamLeadCommand (shared module)', () => {
-  test('sets GENIE_AGENT_NAME to folder name', async () => {
-    const { basename } = await import('node:path');
+  test('sets GENIE_AGENT_NAME to leader name', async () => {
     const { buildTeamLeadCommand } = await import('../lib/team-lead-command.js');
     const cmd = buildTeamLeadCommand('genie');
-    const folderName = basename(process.cwd());
-    expect(cmd).toContain(`GENIE_AGENT_NAME='${folderName}'`);
+    expect(cmd).toContain("GENIE_AGENT_NAME='genie'");
   });
 
   test('sets all required CC native team flags', async () => {
@@ -675,12 +673,10 @@ describe.skipIf(!DB_AVAILABLE)('buildTeamLeadCommand (shared module)', () => {
 // ---------------------------------------------------------------------------
 
 describe.skipIf(!DB_AVAILABLE)('session.ts: delegates to shared buildTeamLeadCommand', () => {
-  test('session buildClaudeCommand sets GENIE_AGENT_NAME to folder name', async () => {
-    const { basename } = await import('node:path');
+  test('session buildClaudeCommand sets GENIE_AGENT_NAME to leader name', async () => {
     const { buildClaudeCommand } = await import('../genie-commands/session.js');
     const cmd = buildClaudeCommand('genie');
-    const folderName = basename(process.cwd());
-    expect(cmd).toContain(`GENIE_AGENT_NAME='${folderName}'`);
+    expect(cmd).toContain("GENIE_AGENT_NAME='genie'");
   });
 });
 


### PR DESCRIPTION
## Summary
- Preserve built-in agent identity after PG runtime rows exist for built-in roles.
- Add spawn resolver fallback to built-in AGENTS.md and loud guard for identity-less built-in launches.
- Cover built-in PG rows, user-agent name collision, spawn identity fallback, and guard behavior.

Fixes #1405
Wish: fix-builtin-agent-respawn-identity

## Validation
- bun run typecheck: PASS
- bun run lint: PASS (existing warnings only)
- bun test src/lib/agent-directory.test.ts src/term-commands/agents.test.ts src/lib/provider-adapters.test.ts: PASS (162 tests)
- GENIE_TEST_PG_NO_REUSE=1 bun run check: PASS (4137 pass, 11 skip, 0 fail)
- Independent execution review: SHIP
- Pre-push gate: PASS (existing warnings only)

## Residual Risk
- Initial full check needed PG reuse disabled due stale shared test PG lock/port. Isolated full check passed.
