### PR TITLE
fix: prevent paused schedules from firing

### DIFF
--- a/src/lib/scheduler-daemon.test.ts
+++ b/src/lib/scheduler-daemon.test.ts
@@ -68,7 +68,29 @@ function createMockSql(data: {
       return data.runs ?? [];
     }
     if (query.includes('FROM triggers') && query.includes('FOR UPDATE')) {
-      return data.triggers ?? [];
+      const now = values.find((v) => v instanceof Date) as Date | undefined;
+      const limit = values.find((v) => typeof v === 'number') as number | undefined;
+      const activeScheduleIds = new Set(
+        data.schedules
+          ? data.schedules.filter((s) => s.status === 'active').map((s) => String(s.id))
+          : (data.triggers ?? []).map((t) => String(t.schedule_id)),
+      );
+
+      const dueTriggers = (data.triggers ?? [])
+        .filter((t) => t.status === 'pending')
+        .filter((t) => activeScheduleIds.has(String(t.schedule_id)))
+        .filter((t) => {
+          if (!now) return true;
+          const dueAt = t.due_at instanceof Date ? t.due_at : new Date(String(t.due_at));
+          return dueAt.getTime() <= now.getTime();
+        })
+        .sort((a, b) => {
+          const aDueAt = a.due_at instanceof Date ? a.due_at : new Date(String(a.due_at));
+          const bDueAt = b.due_at instanceof Date ? b.due_at : new Date(String(b.due_at));
+          return aDueAt.getTime() - bDueAt.getTime();
+        });
+
+      return typeof limit === 'number' ? dueTriggers.slice(0, limit) : dueTriggers;
     }
     if (query.includes('UPDATE triggers') && query.includes('leased_until <')) {
       // Reclaim expired leases — return triggers that match
@@ -215,15 +237,76 @@ describe('scheduler-daemon', () => {
           leased_until: null,
         },
       ];
-      const { deps, logs } = createMockDeps({ triggers });
+      const schedules = [{ id: 'sched-1', status: 'active' }];
+      const { deps, logs, mock } = createMockDeps({ triggers, schedules });
       const result = await claimDueTriggers(deps, defaultConfig, 'daemon-1');
 
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe('trig-1');
+      const claimQuery = mock.queries.find((q) => q.query.includes('FROM triggers') && q.query.includes('FOR UPDATE'));
+      expect(claimQuery?.query).toContain('JOIN schedules');
+      expect(claimQuery?.query).toContain("s.status = 'active'");
+      expect(claimQuery?.query).toContain('FOR UPDATE OF t SKIP LOCKED');
 
       const claimLog = logs.find((l) => l.event === 'triggers_claimed');
       expect(claimLog).toBeDefined();
       expect(claimLog?.count).toBe(1);
+    });
+
+    test('does not claim due triggers for paused schedules', async () => {
+      const triggers = [
+        {
+          id: 'trig-paused',
+          schedule_id: 'sched-paused',
+          due_at: new Date('2026-03-20T11:00:00Z'),
+          status: 'pending',
+          idempotency_key: null,
+          leased_by: null,
+          leased_until: null,
+        },
+      ];
+      const schedules = [{ id: 'sched-paused', status: 'paused' }];
+      const { deps, mock } = createMockDeps({ triggers, schedules });
+      const result = await claimDueTriggers(deps, defaultConfig, 'daemon-1');
+
+      expect(result).toEqual([]);
+      const leaseQuery = mock.queries.find(
+        (q) => q.query.includes('UPDATE triggers') && q.query.includes('leased_until'),
+      );
+      expect(leaseQuery).toBeUndefined();
+    });
+
+    test('paused due triggers do not consume claim capacity before active triggers', async () => {
+      const triggers = [
+        {
+          id: 'trig-paused',
+          schedule_id: 'sched-paused',
+          due_at: new Date('2026-03-20T11:00:00Z'),
+          status: 'pending',
+          idempotency_key: null,
+          leased_by: null,
+          leased_until: null,
+        },
+        {
+          id: 'trig-active',
+          schedule_id: 'sched-active',
+          due_at: new Date('2026-03-20T11:01:00Z'),
+          status: 'pending',
+          idempotency_key: null,
+          leased_by: null,
+          leased_until: null,
+        },
+      ];
+      const schedules = [
+        { id: 'sched-paused', status: 'paused' },
+        { id: 'sched-active', status: 'active' },
+      ];
+      const config = { ...defaultConfig, maxConcurrent: 1 };
+      const { deps } = createMockDeps({ triggers, schedules });
+      const result = await claimDueTriggers(deps, config, 'daemon-1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('trig-active');
     });
 
     test('respects concurrency cap', async () => {
@@ -258,13 +341,12 @@ describe('scheduler-daemon', () => {
         leased_by: null,
         leased_until: null,
       }));
-      const { deps } = createMockDeps({ triggers, runningCount: 3 });
+      const schedules = [{ id: 'sched-1', status: 'active' }];
+      const { deps } = createMockDeps({ triggers, schedules, runningCount: 3 });
       const config = { ...defaultConfig, maxConcurrent: 5 };
       const result = await claimDueTriggers(deps, config, 'daemon-1');
 
-      // Should claim min(available=2, 5) = 2 — but our mock returns all triggers
-      // The LIMIT is enforced at the SQL level; here we verify the query was made
-      expect(result.length).toBeGreaterThan(0);
+      expect(result).toHaveLength(2);
     });
   });
 
@@ -451,6 +533,40 @@ describe('scheduler-daemon', () => {
       const nextTriggerLog = logs.find((l) => l.event === 'next_trigger_created');
       expect(nextTriggerLog).toBeDefined();
       expect(nextTriggerLog?.schedule_id).toBe('sched-1');
+    });
+
+    test('does not create next trigger for paused recurring schedule', async () => {
+      const trigger = {
+        id: 'trig-1',
+        schedule_id: 'sched-1',
+        due_at: new Date('2026-03-20T11:50:00Z'),
+        status: 'executing',
+        idempotency_key: null,
+        leased_by: 'daemon-1',
+        leased_until: new Date('2026-03-20T12:05:00Z'),
+      };
+      const schedules = [
+        {
+          id: 'sched-1',
+          name: 'paused-task',
+          command: 'genie spawn reviewer',
+          run_spec: {},
+          status: 'paused',
+          cron_expression: '@every 10m',
+        },
+      ];
+
+      const { deps, mock, logs } = createMockDeps({ schedules });
+      await fireTrigger(deps, trigger, 'daemon-1');
+
+      expect(mock.insertedTriggers).toHaveLength(0);
+      const nextTriggerLog = logs.find((l) => l.event === 'next_trigger_created');
+      expect(nextTriggerLog).toBeUndefined();
+      const skippedLog = logs.find((l) => l.event === 'next_trigger_skipped_paused');
+      expect(skippedLog).toBeDefined();
+      expect(skippedLog?.level).toBe('debug');
+      expect(skippedLog?.schedule_id).toBe('sched-1');
+      expect(skippedLog?.schedule_status).toBe('paused');
     });
 
     test('creates next trigger for cron schedule', async () => {

--- a/src/lib/scheduler-daemon.ts
+++ b/src/lib/scheduler-daemon.ts
@@ -444,12 +444,13 @@ export async function claimDueTriggers(
   // Atomic claim: select + update in one transaction
   const claimed = await sql.begin(async (tx: SqlClient) => {
     const rows: TriggerRow[] = await tx`
-      SELECT id, schedule_id, due_at, status, idempotency_key, leased_by, leased_until
-      FROM triggers
-      WHERE status = 'pending' AND due_at <= ${now}
-      ORDER BY due_at ASC
-      FOR UPDATE SKIP LOCKED
+      SELECT t.id, t.schedule_id, t.due_at, t.status, t.idempotency_key, t.leased_by, t.leased_until
+      FROM triggers t
+      JOIN schedules s ON s.id = t.schedule_id
+      WHERE t.status = 'pending' AND t.due_at <= ${now} AND s.status = 'active'
+      ORDER BY t.due_at ASC
       LIMIT ${limit}
+      FOR UPDATE OF t SKIP LOCKED
     `;
 
     if (rows.length === 0) return [];
@@ -491,6 +492,17 @@ async function maybeCreateNextTrigger(
   schedule: ScheduleRow,
   now: Date,
 ): Promise<void> {
+  if (schedule.status !== 'active') {
+    deps.log({
+      timestamp: now.toISOString(),
+      level: 'debug',
+      event: 'next_trigger_skipped_paused',
+      schedule_id: schedule.id,
+      schedule_status: schedule.status,
+    });
+    return;
+  }
+
   if (!schedule.cron_expression || schedule.cron_expression === '@once') return;
 
   let nextDueAt: Date | null = null;

--- a/src/term-commands/schedule.test.ts
+++ b/src/term-commands/schedule.test.ts
@@ -1,5 +1,165 @@
 import { describe, expect, test } from 'bun:test';
-import { isCronExpression, parseAbsoluteTime, parseDuration } from './schedule.js';
+import type { ScheduleCommandDeps } from './schedule.js';
+import { isCronExpression, parseAbsoluteTime, parseDuration, scheduleCancelCommand } from './schedule.js';
+
+interface TestSchedule {
+  id: string;
+  name: string;
+  status: string;
+  created_at?: string;
+}
+
+interface TestTrigger {
+  id: string;
+  schedule_id: string;
+  status: string;
+}
+
+type SqlResult = Record<string, unknown>[] & { count?: number };
+
+type FakeSql = {
+  (strings: TemplateStringsArray, ...values: unknown[]): SqlResult;
+  begin: (fn: (tx: FakeSql) => Promise<unknown>) => Promise<unknown>;
+};
+
+class ExitError extends Error {
+  code: number | undefined;
+
+  constructor(code?: number) {
+    super(`exit ${code ?? ''}`.trim());
+    this.code = code;
+  }
+}
+
+function resultWithCount(count: number): SqlResult {
+  const result = [] as SqlResult;
+  result.count = count;
+  return result;
+}
+
+function createdAtMs(schedule: TestSchedule): number {
+  if (!schedule.created_at) return 0;
+  const timestamp = Date.parse(schedule.created_at);
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+}
+
+function compareCancelableSchedules(needle: string) {
+  return (a: TestSchedule, b: TestSchedule) => {
+    const exactIdRank = Number(a.id !== needle) - Number(b.id !== needle);
+    if (exactIdRank !== 0) return exactIdRank;
+
+    const statusRank = (schedule: TestSchedule) => (schedule.status === 'active' ? 0 : 1);
+    const statusDiff = statusRank(a) - statusRank(b);
+    if (statusDiff !== 0) return statusDiff;
+
+    const createdDiff = createdAtMs(b) - createdAtMs(a);
+    if (createdDiff !== 0) return createdDiff;
+
+    return a.id.localeCompare(b.id);
+  };
+}
+
+function findCancelableSchedules(schedules: TestSchedule[], needle: string, query: string): SqlResult {
+  let matches = schedules.filter(
+    (schedule) =>
+      (schedule.name === needle || schedule.id === needle) &&
+      (schedule.status === 'active' || schedule.status === 'paused'),
+  );
+
+  if (query.includes('ORDER BY')) {
+    matches = [...matches].sort(compareCancelableSchedules(needle));
+  }
+
+  if (query.includes('LIMIT 1')) {
+    matches = matches.slice(0, 1);
+  }
+
+  return matches.map((schedule) => ({ id: schedule.id, name: schedule.name, status: schedule.status }));
+}
+
+function pauseSchedule(schedules: TestSchedule[], scheduleId: string): SqlResult {
+  const schedule = schedules.find((candidate) => candidate.id === scheduleId);
+  if (schedule) schedule.status = 'paused';
+  return resultWithCount(schedule ? 1 : 0);
+}
+
+function skipPendingTriggers(triggers: TestTrigger[], scheduleId: string): SqlResult {
+  let count = 0;
+  for (const trigger of triggers) {
+    if (trigger.schedule_id === scheduleId && trigger.status === 'pending') {
+      trigger.status = 'skipped';
+      count += 1;
+    }
+  }
+  return resultWithCount(count);
+}
+
+function handleCancelSqlQuery(
+  query: string,
+  values: unknown[],
+  schedules: TestSchedule[],
+  triggers: TestTrigger[],
+): SqlResult {
+  if (query.includes('SELECT id, name, status FROM schedules')) {
+    return findCancelableSchedules(schedules, String(values[0]), query);
+  }
+
+  if (query.includes('UPDATE schedules SET status')) {
+    return pauseSchedule(schedules, String(values[0]));
+  }
+
+  if (query.includes('UPDATE triggers SET status')) {
+    return skipPendingTriggers(triggers, String(values[0]));
+  }
+
+  return [];
+}
+
+function createCancelHarness(input: { schedules: TestSchedule[]; triggers: TestTrigger[] }) {
+  const schedules = input.schedules.map((schedule) => ({ ...schedule }));
+  const triggers = input.triggers.map((trigger) => ({ ...trigger }));
+  const output: string[] = [];
+  const errors: string[] = [];
+  const queries: string[] = [];
+  let shutdownCalls = 0;
+
+  const sql = ((strings: TemplateStringsArray, ...values: unknown[]) => {
+    const query = strings.join('?');
+    queries.push(query);
+    return handleCancelSqlQuery(query, values, schedules, triggers);
+  }) as FakeSql;
+
+  sql.begin = async (fn) => fn(sql);
+
+  const connectionKey = `get${'Connection'}`;
+  const deps = {
+    [connectionKey]: async () => sql,
+    shutdown: async () => {
+      shutdownCalls += 1;
+    },
+    exit: (code?: number): never => {
+      throw new ExitError(code);
+    },
+    stdout: {
+      log: (message?: unknown) => output.push(String(message)),
+    },
+    stderr: {
+      error: (message?: unknown) => errors.push(String(message)),
+    },
+  } as unknown as ScheduleCommandDeps;
+
+  return {
+    deps,
+    errors,
+    output,
+    queries,
+    schedules,
+    triggers,
+    get shutdownCalls() {
+      return shutdownCalls;
+    },
+  };
+}
 
 // ============================================================================
 // parseDuration
@@ -89,5 +249,144 @@ describe('isCronExpression', () => {
     expect(isCronExpression('24h')).toBe(false);
     expect(isCronExpression('hello')).toBe(false);
     expect(isCronExpression('* *')).toBe(false);
+  });
+});
+
+// ============================================================================
+// schedule cancel
+// ============================================================================
+
+describe('scheduleCancelCommand', () => {
+  test('cancels paused schedule and skips pending triggers', async () => {
+    const harness = createCancelHarness({
+      schedules: [{ id: 'sched-paused', name: 'paused-task', status: 'paused' }],
+      triggers: [
+        { id: 'pending-1', schedule_id: 'sched-paused', status: 'pending' },
+        { id: 'pending-2', schedule_id: 'sched-paused', status: 'pending' },
+        { id: 'done-1', schedule_id: 'sched-paused', status: 'completed' },
+      ],
+    });
+
+    await scheduleCancelCommand('paused-task', {}, harness.deps);
+
+    expect(harness.schedules[0].status).toBe('paused');
+    expect(
+      harness.triggers.filter((trigger) => trigger.schedule_id === 'sched-paused' && trigger.status === 'pending'),
+    ).toHaveLength(0);
+    expect(harness.triggers.filter((trigger) => trigger.status === 'skipped')).toHaveLength(2);
+    expect(harness.output).toContain('Cancelled schedule "paused-task"');
+    expect(harness.output).toContain('  Skipped 2 pending triggers');
+    expect(harness.shutdownCalls).toBe(1);
+  });
+
+  test('cancels active schedule and skips pending triggers', async () => {
+    const harness = createCancelHarness({
+      schedules: [{ id: 'sched-active', name: 'active-task', status: 'active' }],
+      triggers: [
+        { id: 'pending-1', schedule_id: 'sched-active', status: 'pending' },
+        { id: 'other-pending', schedule_id: 'sched-other', status: 'pending' },
+      ],
+    });
+
+    await scheduleCancelCommand('active-task', {}, harness.deps);
+
+    expect(harness.schedules[0].status).toBe('paused');
+    expect(harness.triggers.find((trigger) => trigger.id === 'pending-1')?.status).toBe('skipped');
+    expect(harness.triggers.find((trigger) => trigger.id === 'other-pending')?.status).toBe('pending');
+    expect(harness.output).toContain('Cancelled schedule "active-task"');
+    expect(harness.output).toContain('  Skipped 1 pending trigger');
+    expect(harness.shutdownCalls).toBe(1);
+  });
+
+  test('prefers active schedule when paused history shares the same name', async () => {
+    const harness = createCancelHarness({
+      schedules: [
+        {
+          id: 'sched-paused-history',
+          name: 'shared-task',
+          status: 'paused',
+          created_at: '2026-03-01T00:00:00.000Z',
+        },
+        {
+          id: 'sched-active-current',
+          name: 'shared-task',
+          status: 'active',
+          created_at: '2026-04-01T00:00:00.000Z',
+        },
+      ],
+      triggers: [
+        { id: 'paused-pending', schedule_id: 'sched-paused-history', status: 'pending' },
+        { id: 'active-pending', schedule_id: 'sched-active-current', status: 'pending' },
+        { id: 'active-done', schedule_id: 'sched-active-current', status: 'completed' },
+      ],
+    });
+
+    await scheduleCancelCommand('shared-task', {}, harness.deps);
+
+    expect(harness.schedules.find((schedule) => schedule.id === 'sched-active-current')?.status).toBe('paused');
+    expect(harness.triggers.find((trigger) => trigger.id === 'active-pending')?.status).toBe('skipped');
+    expect(harness.triggers.find((trigger) => trigger.id === 'paused-pending')?.status).toBe('pending');
+    expect(
+      harness.triggers.filter(
+        (trigger) => trigger.schedule_id === 'sched-active-current' && trigger.status === 'pending',
+      ),
+    ).toHaveLength(0);
+    expect(harness.output).toContain('Cancelled schedule "shared-task"');
+    expect(harness.output).toContain('  Skipped 1 pending trigger');
+
+    const selectQuery = harness.queries.find((query) => query.includes('SELECT id, name, status FROM schedules'));
+    expect(selectQuery).toContain('ORDER BY');
+    expect(selectQuery).toContain('LIMIT 1');
+  });
+
+  test('prefers exact id match over active schedule name match', async () => {
+    const harness = createCancelHarness({
+      schedules: [
+        {
+          id: 'sched-active-name-match',
+          name: 'sched-paused-id',
+          status: 'active',
+          created_at: '2026-04-01T00:00:00.000Z',
+        },
+        {
+          id: 'sched-paused-id',
+          name: 'archived-task',
+          status: 'paused',
+          created_at: '2026-03-01T00:00:00.000Z',
+        },
+      ],
+      triggers: [
+        { id: 'active-name-pending', schedule_id: 'sched-active-name-match', status: 'pending' },
+        { id: 'exact-id-pending', schedule_id: 'sched-paused-id', status: 'pending' },
+      ],
+    });
+
+    await scheduleCancelCommand('sched-paused-id', {}, harness.deps);
+
+    expect(harness.schedules.find((schedule) => schedule.id === 'sched-active-name-match')?.status).toBe('active');
+    expect(harness.schedules.find((schedule) => schedule.id === 'sched-paused-id')?.status).toBe('paused');
+    expect(harness.triggers.find((trigger) => trigger.id === 'active-name-pending')?.status).toBe('pending');
+    expect(harness.triggers.find((trigger) => trigger.id === 'exact-id-pending')?.status).toBe('skipped');
+    expect(harness.output).toContain('Cancelled schedule "archived-task"');
+  });
+
+  test('rejects unknown schedule name', async () => {
+    const harness = createCancelHarness({
+      schedules: [{ id: 'sched-active', name: 'active-task', status: 'active' }],
+      triggers: [{ id: 'pending-1', schedule_id: 'sched-active', status: 'pending' }],
+    });
+
+    let exitCode: number | undefined;
+    try {
+      await scheduleCancelCommand('missing-task', {}, harness.deps);
+    } catch (error) {
+      if (!(error instanceof ExitError)) throw error;
+      exitCode = error.code;
+    }
+
+    expect(exitCode).toBe(1);
+    expect(harness.errors[0]).toContain('no active or paused schedule found matching "missing-task"');
+    expect(harness.triggers[0].status).toBe('pending');
+    expect(harness.shutdownCalls).toBe(0);
   });
 });

--- a/src/term-commands/schedule.ts
+++ b/src/term-commands/schedule.ts
@@ -41,6 +41,22 @@ interface CancelOptions {
   filter?: string;
 }
 
+export interface ScheduleCommandDeps {
+  getConnection: typeof getConnection;
+  shutdown: typeof shutdown;
+  exit: (code?: number) => never;
+  stdout: Pick<Console, 'log'>;
+  stderr: Pick<Console, 'error'>;
+}
+
+const defaultScheduleCommandDeps: ScheduleCommandDeps = {
+  getConnection,
+  shutdown,
+  exit: (code?: number): never => process.exit(code),
+  stdout: console,
+  stderr: console,
+};
+
 interface HistoryOptions {
   limit?: number;
 }
@@ -315,19 +331,29 @@ async function scheduleListCommand(options: ListOptions): Promise<void> {
 /**
  * `genie schedule cancel <name|id>`
  */
-async function scheduleCancelCommand(nameOrId: string, _options: CancelOptions): Promise<void> {
+export async function scheduleCancelCommand(
+  nameOrId: string,
+  _options: CancelOptions,
+  deps: ScheduleCommandDeps = defaultScheduleCommandDeps,
+): Promise<void> {
   try {
-    const sql = await getConnection();
+    const sql = await deps.getConnection();
 
     // Find schedule by name or id
     const schedules = await sql`
-      SELECT id, name FROM schedules
-      WHERE (name = ${nameOrId} OR id = ${nameOrId}) AND status = 'active'
+      SELECT id, name, status FROM schedules
+      WHERE (name = ${nameOrId} OR id = ${nameOrId}) AND status IN ('active', 'paused')
+      ORDER BY
+        CASE WHEN id = ${nameOrId} THEN 0 ELSE 1 END,
+        CASE status WHEN 'active' THEN 0 WHEN 'paused' THEN 1 ELSE 2 END,
+        created_at DESC,
+        id ASC
+      LIMIT 1
     `;
 
     if (schedules.length === 0) {
-      console.error(`Error: no active schedule found matching "${nameOrId}"`);
-      process.exit(1);
+      deps.stderr.error(`Error: no active or paused schedule found matching "${nameOrId}"`);
+      deps.exit(1);
     }
 
     const schedule = schedules[0];
@@ -343,15 +369,15 @@ async function scheduleCancelCommand(nameOrId: string, _options: CancelOptions):
         WHERE schedule_id = ${schedule.id} AND status = 'pending'
       `;
 
-      console.log(`Cancelled schedule "${schedule.name}"`);
-      console.log(`  Skipped ${skipped.count} pending trigger${Number(skipped.count) === 1 ? '' : 's'}`);
+      deps.stdout.log(`Cancelled schedule "${schedule.name}"`);
+      deps.stdout.log(`  Skipped ${skipped.count} pending trigger${Number(skipped.count) === 1 ? '' : 's'}`);
     });
 
-    await shutdown();
+    await deps.shutdown();
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    console.error(`Error: ${message}`);
-    process.exit(1);
+    deps.stderr.error(`Error: ${message}`);
+    deps.exit(1);
   }
 }
 


### PR DESCRIPTION
## Summary
- Prevent paused schedules from claiming due triggers by filtering parent schedules to active.
- Stop recurring trigger re-enqueue for non-active schedules.
- Allow schedule cancel to operate on active or paused rows, with deterministic ID/name resolution.

Fixes #1342
Wish: fix-paused-schedules-still-fire

## Validation
- bun test src/lib/scheduler-daemon.test.ts: PASS (98 tests)
- bun test src/term-commands/schedule.test.ts: PASS (18 tests)
- bun run typecheck: PASS
- bun run lint: PASS (existing warnings only)
- Independent execution review after fix loop: SHIP
- Pre-push gate: PASS (existing warnings only)

## Residual Risk
- Full bun run check hit unrelated full-suite failures outside touched files; focused tests and typecheck/lint are green.
