### PR TITLE
fix: forward Claude agent permissions

### DIFF
--- a/src/lib/agent-directory.ts
+++ b/src/lib/agent-directory.ts
@@ -47,7 +47,7 @@ export interface DirectoryEntry {
   color?: string;
   /** AI provider: 'claude' | 'codex' | 'claude-sdk'. Resolved at spawn time. */
   provider?: string;
-  /** Permission config for SDK provider (allowlist-only). */
+  /** Claude permission config honored by SDK and canonical tmux spawn paths. */
   permissions?: {
     preset?: string;
     allow?: string[];

--- a/src/lib/provider-adapters.test.ts
+++ b/src/lib/provider-adapters.test.ts
@@ -2,7 +2,7 @@
  * Provider Adapters — Unit Tests
  */
 
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import {
   type SpawnParams,
   buildClaudeCommand,
@@ -39,6 +39,39 @@ function codexPromptPathFromCommand(command: string): string {
 function codexPromptContentFromCommand(command: string): string {
   const { readFileSync } = require('node:fs') as typeof import('node:fs');
   return readFileSync(codexPromptPathFromCommand(command), 'utf-8');
+}
+
+function extractShellFlagValue(command: string, flag: string): string | undefined {
+  const flagIndex = command.indexOf(flag);
+  if (flagIndex === -1) return undefined;
+
+  let index = flagIndex + flag.length;
+  while (command[index] === ' ') index++;
+
+  if (command[index] !== "'") {
+    const end = command.indexOf(' ', index);
+    return command.slice(index, end === -1 ? undefined : end);
+  }
+
+  index++;
+  let value = '';
+  while (index < command.length) {
+    if (command.slice(index, index + 4) === "'\\''") {
+      value += "'";
+      index += 4;
+      continue;
+    }
+    if (command[index] === "'") return value;
+    value += command[index];
+    index++;
+  }
+  return undefined;
+}
+
+function extractClaudeSettings(command: string): Record<string, unknown> {
+  const rawSettings = extractShellFlagValue(command, '--settings');
+  if (!rawSettings) throw new Error(`Missing --settings in command: ${command}`);
+  return JSON.parse(rawSettings) as Record<string, unknown>;
 }
 
 // ============================================================================
@@ -78,6 +111,18 @@ describe('validateSpawnParams', () => {
     const params: SpawnParams = { provider: 'claude', team: 'work' };
     const result = validateSpawnParams(params);
     expect(result.provider).toBe('claude');
+  });
+
+  it('preserves Claude permission fields through validation', () => {
+    const result = validateSpawnParams({
+      provider: 'claude',
+      team: 'work',
+      permissions: { allow: ['Read', 'Glob'], deny: ['Bash(rm *)'] },
+      disallowedTools: ['Edit', 'Write'],
+    });
+
+    expect(result.permissions).toEqual({ allow: ['Read', 'Glob'], deny: ['Bash(rm *)'] });
+    expect(result.disallowedTools).toEqual(['Edit', 'Write']);
   });
 });
 
@@ -159,6 +204,124 @@ describe('buildClaudeCommand', () => {
       extraArgs: ['--dangerously-skip-permissions'],
     });
     expect(result.command).toContain('--dangerously-skip-permissions');
+  });
+
+  describe('permissions forwarding', () => {
+    it('includes permissions.allow in --settings JSON', () => {
+      const result = buildClaudeCommand({
+        provider: 'claude',
+        team: 'work',
+        role: 'sandboxed',
+        permissions: { allow: ['Read', 'Glob'] },
+      });
+
+      const permissions = extractClaudeSettings(result.command).permissions as Record<string, unknown>;
+      expect(permissions.allow).toEqual(['Read', 'Glob']);
+      expect(permissions.deny).toBeUndefined();
+    });
+
+    it('includes permissions.allow and permissions.deny in --settings JSON', () => {
+      const result = buildClaudeCommand({
+        provider: 'claude',
+        team: 'work',
+        role: 'sandboxed',
+        permissions: { allow: ['Read', 'Glob'], deny: ['Bash(rm *)'] },
+      });
+
+      const permissions = extractClaudeSettings(result.command).permissions as Record<string, unknown>;
+      expect(permissions.allow).toEqual(['Read', 'Glob']);
+      expect(permissions.deny).toEqual(['Bash(rm *)']);
+    });
+
+    it('preserves permissions through buildLaunchCommand validation', () => {
+      const result = buildLaunchCommand({
+        provider: 'claude',
+        team: 'work',
+        role: 'sandboxed',
+        permissions: { allow: ['Read'], deny: ['Write'] },
+      });
+
+      const permissions = extractClaudeSettings(result.command).permissions as Record<string, unknown>;
+      expect(permissions).toEqual({ allow: ['Read'], deny: ['Write'] });
+    });
+
+    it('emits one --disallowedTools flag per input tool in order', () => {
+      const result = buildClaudeCommand({
+        provider: 'claude',
+        team: 'work',
+        role: 'sandboxed',
+        disallowedTools: ['Edit', 'Write', 'Agent'],
+      });
+
+      expect(result.command).toContain("--disallowedTools 'Edit' --disallowedTools 'Write' --disallowedTools 'Agent'");
+    });
+
+    it('omits permissions from --settings JSON when allow and deny are empty', () => {
+      const result = buildClaudeCommand({
+        provider: 'claude',
+        team: 'work',
+        role: 'sandboxed',
+        permissions: { allow: [], deny: [] },
+      });
+
+      expect(extractClaudeSettings(result.command).permissions).toBeUndefined();
+    });
+
+    it('does not hardcode forbidden permission bypass flag literals', () => {
+      const { readFileSync } = require('node:fs') as typeof import('node:fs');
+      const { fileURLToPath } = require('node:url') as typeof import('node:url');
+      const { dirname, join } = require('node:path') as typeof import('node:path');
+      const sourcePath = join(dirname(fileURLToPath(import.meta.url)), 'provider-adapters.ts');
+      const source = readFileSync(sourcePath, 'utf-8');
+
+      expect(source).not.toMatch(/['"]--dangerously-skip-permissions['"]/);
+      expect(source).not.toMatch(/['"]--permission-mode['"],\s*['"]bypassPermissions['"]/);
+    });
+
+    it('warns once when permissions.allow is paired with explicit bypassPermissions', () => {
+      const stderrWrite = spyOn(process.stderr, 'write').mockImplementation(() => true);
+      try {
+        buildClaudeCommand({
+          provider: 'claude',
+          team: 'work',
+          role: 'sandboxed',
+          permissions: { allow: ['Read'] },
+          nativeTeam: {
+            enabled: true,
+            agentName: 'sandboxed',
+            permissionMode: 'bypassPermissions',
+          },
+        });
+
+        expect(stderrWrite).toHaveBeenCalledTimes(1);
+        expect(stderrWrite.mock.calls[0][0]).toBe(
+          'Warning: agent sandboxed declares permissions.allow but permissionMode is bypassPermissions — allow rules are advisory under bypass (deny still enforced).\n',
+        );
+      } finally {
+        stderrWrite.mockRestore();
+      }
+    });
+
+    it('does not warn when bypassPermissions has no allow rules to bypass', () => {
+      const stderrWrite = spyOn(process.stderr, 'write').mockImplementation(() => true);
+      try {
+        buildClaudeCommand({
+          provider: 'claude',
+          team: 'work',
+          role: 'deny-only',
+          permissions: { deny: ['Write'] },
+          nativeTeam: {
+            enabled: true,
+            agentName: 'deny-only',
+            permissionMode: 'bypassPermissions',
+          },
+        });
+
+        expect(stderrWrite).not.toHaveBeenCalled();
+      } finally {
+        stderrWrite.mockRestore();
+      }
+    });
   });
 
   it('includes --model flag when model is set', () => {

--- a/src/lib/provider-adapters.ts
+++ b/src/lib/provider-adapters.ts
@@ -172,6 +172,13 @@ const spawnParamsSchema = z.object({
   model: z.string().optional(),
   initialPrompt: z.string().optional(),
   name: z.string().optional(),
+  permissions: z
+    .object({
+      allow: z.array(z.string()).optional(),
+      deny: z.array(z.string()).optional(),
+    })
+    .optional(),
+  disallowedTools: z.array(z.string()).optional(),
   otelPort: z.number().optional(),
   otelLogPrompts: z.boolean().optional(),
   otelWishSlug: z.string().optional(),
@@ -416,6 +423,16 @@ function buildSettingsObject(params: SpawnParams): Record<string, unknown> {
   return settingsObj;
 }
 
+function warnIfAllowRulesAreBypassed(params: SpawnParams): void {
+  if (!params.permissions?.allow?.length) return;
+  if (params.nativeTeam?.permissionMode !== 'bypassPermissions') return;
+
+  const agentName = params.nativeTeam.agentName ?? params.role ?? params.name ?? 'unknown';
+  process.stderr.write(
+    `Warning: agent ${agentName} declares permissions.allow but permissionMode is bypassPermissions — allow rules are advisory under bypass (deny still enforced).\n`,
+  );
+}
+
 function appendDisallowedAndExtraArgs(parts: string[], params: SpawnParams): void {
   if (params.disallowedTools?.length) {
     for (const tool of params.disallowedTools) {
@@ -442,6 +459,8 @@ export function buildClaudeCommand(params: SpawnParams): LaunchCommand {
 
   appendSessionFlags(parts, params);
   appendSystemPromptFlags(parts, params);
+
+  warnIfAllowRulesAreBypassed(params);
 
   const settingsObj = buildSettingsObject(params);
   if (Object.keys(settingsObj).length > 0) {

--- a/src/term-commands/agents.test.ts
+++ b/src/term-commands/agents.test.ts
@@ -16,6 +16,7 @@ import * as wishState from '../lib/wish-state.js';
 import {
   OwnerSpawnCollisionError,
   RecoverAgentNotFoundError,
+  buildDirectoryPermissionSpawnParams,
   buildInitialSplitWindowCommand,
   buildResumeContext,
   buildWorkerStatusMap,
@@ -238,6 +239,61 @@ describe('resolveAgentWorkingDir', () => {
     };
 
     expect(resolveAgentWorkingDir(entry)).toBe('/tmp/agents/genie');
+  });
+});
+
+describe('buildDirectoryPermissionSpawnParams', () => {
+  function makeEntry(overrides: Partial<DirectoryEntry> = {}): DirectoryEntry {
+    return {
+      name: 'restricted',
+      dir: '/tmp/agents/restricted',
+      promptMode: 'append',
+      registeredAt: new Date().toISOString(),
+      ...overrides,
+    };
+  }
+
+  test('forwards non-empty permissions.allow and permissions.deny', () => {
+    const params = buildDirectoryPermissionSpawnParams(
+      makeEntry({
+        permissions: {
+          allow: ['Read', 'Glob'],
+          deny: ['Bash(rm *)'],
+        },
+      }),
+    );
+
+    expect(params.permissions).toEqual({ allow: ['Read', 'Glob'], deny: ['Bash(rm *)'] });
+  });
+
+  test('omits permissions when allow and deny are empty', () => {
+    const params = buildDirectoryPermissionSpawnParams(
+      makeEntry({
+        permissions: {
+          allow: [],
+          deny: [],
+        },
+      }),
+    );
+
+    expect(params.permissions).toBeUndefined();
+  });
+
+  test('forwards disallowedTools when configured', () => {
+    const params = buildDirectoryPermissionSpawnParams(
+      makeEntry({
+        disallowedTools: ['Edit', 'Write', 'Agent'],
+      }),
+    );
+
+    expect(params.disallowedTools).toEqual(['Edit', 'Write', 'Agent']);
+  });
+
+  test('leaves fields undefined when no permission config is present', () => {
+    const params = buildDirectoryPermissionSpawnParams(makeEntry());
+
+    expect(params.permissions).toBeUndefined();
+    expect(params.disallowedTools).toBeUndefined();
   });
 });
 

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -1789,6 +1789,20 @@ export function resolveAgentWorkingDir(entry: directory.DirectoryEntry, explicit
   return process.cwd();
 }
 
+export function buildDirectoryPermissionSpawnParams(
+  entry: directory.DirectoryEntry,
+): Pick<SpawnParams, 'permissions' | 'disallowedTools'> {
+  const permissions =
+    entry.permissions?.allow?.length || entry.permissions?.deny?.length
+      ? { allow: entry.permissions.allow, deny: entry.permissions.deny }
+      : undefined;
+
+  return {
+    ...(permissions ? { permissions } : {}),
+    ...(entry.disallowedTools ? { disallowedTools: entry.disallowedTools } : {}),
+  };
+}
+
 /** Build SpawnParams from resolved agent + options. */
 async function buildSpawnParams(
   name: string,
@@ -1818,6 +1832,9 @@ async function buildSpawnParams(
     initialPrompt: options.prompt ?? options.initialPrompt,
     newWindow: options.newWindow,
     windowTarget: options.window,
+    // #1449: keep canonical tmux spawn aligned with buildOmniSpawnParams()
+    // so agent.yaml allow/deny rules reach Claude's --settings payload.
+    ...buildDirectoryPermissionSpawnParams(agent.entry),
   };
 
   // owner-vs-meeseeks gate: propagate the identity-spawn signal so


### PR DESCRIPTION
## Summary
- Forward agent.yaml permissions allow/deny into Claude settings JSON.
- Remove hardcoded bypass behavior from the allow/deny path and add bypass-vs-allow warning coverage.
- Add provider/spawn tests and forbidden-literal guard.

Fixes #1449
Wish: fix-agent-permissions-spawn-forwarding

## Validation
- bun run typecheck: PASS
- bun run lint: PASS (existing warnings only)
- bun test src/term-commands/agents.test.ts src/lib/provider-adapters.test.ts: PASS (126 tests)
- Forbidden-literal grep: PASS
- Independent execution review: SHIP
- Pre-push gate: PASS (existing warnings only)

## Residual Risk
- Full bun run check failed only on existing cwd-sensitive tests expecting the checkout basename to be genie; scoped validation is green.
