### PR TITLE
fix: start all resolved brain vaults

### DIFF
--- a/src/lib/brain-vaults.test.ts
+++ b/src/lib/brain-vaults.test.ts
@@ -1,0 +1,324 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  type BrainServerApi,
+  type BrainVaultResolution,
+  findBrainVault,
+  resolveBrainVaults,
+  startResolvedBrainVaults,
+} from './brain-vaults.js';
+
+let testDir: string;
+let homeDir: string;
+let warn: ReturnType<typeof mock>;
+let log: ReturnType<typeof mock>;
+
+function makeVault(name: string, brainJson = '{}'): string {
+  const path = join(testDir, name);
+  mkdirSync(path, { recursive: true });
+  writeFileSync(join(path, 'brain.json'), brainJson, 'utf-8');
+  return path;
+}
+
+function makeDir(name: string): string {
+  const path = join(testDir, name);
+  mkdirSync(path, { recursive: true });
+  return path;
+}
+
+function deps(overrides: Parameters<typeof resolveBrainVaults>[0] = {}): Parameters<typeof resolveBrainVaults>[0] {
+  return {
+    cwd: testDir,
+    homeDir,
+    workspaceRoot: null,
+    warn,
+    log,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  testDir = join(tmpdir(), `genie-brain-vaults-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  homeDir = join(testDir, 'home');
+  mkdirSync(homeDir, { recursive: true });
+  warn = mock(() => {});
+  log = mock(() => {});
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+describe('resolveBrainVaults', () => {
+  test('uses explicit brain.paths and does not consult registry', async () => {
+    const first = makeVault('first');
+    const second = makeVault('second');
+    const listBrains = mock(async () => [{ homePath: makeVault('registered') }]);
+
+    const result = await resolveBrainVaults(
+      deps({
+        config: { brain: { embedded: true, paths: [first, second] } },
+        brain: { listBrains },
+      }),
+    );
+
+    expect(result).toEqual({ source: 'config', paths: [first, second] });
+    expect(listBrains.mock.calls.length).toBe(0);
+    expect(warn.mock.calls.length).toBe(0);
+  });
+
+  test('warns and filters configured vaults missing brain.json without consulting registry', async () => {
+    const missingBrainJson = makeDir('configured-missing');
+    const listBrains = mock(async () => [{ homePath: makeVault('registered') }]);
+
+    const result = await resolveBrainVaults(
+      deps({
+        config: { brain: { embedded: true, paths: [missingBrainJson] } },
+        brain: { listBrains },
+      }),
+    );
+
+    expect(result).toEqual({ source: 'config', paths: [] });
+    expect(listBrains.mock.calls.length).toBe(0);
+    expect(warn.mock.calls.length).toBe(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain(`skipped configured vault ${missingBrainJson}`);
+    expect(String(warn.mock.calls[0]?.[0])).toContain('missing brain.json');
+  });
+
+  test('treats brain.paths: [] as registry discovery mode', async () => {
+    const registered = makeVault('registered');
+    const workspaceRoot = makeDir('workspace');
+    mkdirSync(join(workspaceRoot, 'brain'), { recursive: true });
+    writeFileSync(join(workspaceRoot, 'brain', 'brain.json'), '{}', 'utf-8');
+
+    const result = await resolveBrainVaults(
+      deps({
+        config: { brain: { embedded: true, paths: [] } },
+        workspaceRoot,
+        brain: { listBrains: mock(async () => [{ homePath: registered }]) },
+      }),
+    );
+
+    expect(result).toEqual({ source: 'registry', paths: [registered], registryCount: 1 });
+  });
+
+  test('discovers multiple registered brain vaults', async () => {
+    const first = makeVault('registered-a');
+    const second = makeVault('registered-b');
+
+    const result = await resolveBrainVaults(
+      deps({
+        config: { brain: { embedded: true } },
+        brain: {
+          listBrains: mock(async () => [
+            { id: 'a', homePath: first },
+            { id: 'b', brainPath: second },
+          ]),
+        },
+      }),
+    );
+
+    expect(result).toEqual({ source: 'registry', paths: [first, second], registryCount: 2 });
+  });
+
+  test('falls back to the legacy workspace brain when registry is empty', async () => {
+    const workspaceRoot = makeDir('workspace');
+    const legacy = join(workspaceRoot, 'brain');
+    mkdirSync(legacy, { recursive: true });
+    writeFileSync(join(legacy, 'brain.json'), '{}', 'utf-8');
+
+    const result = await resolveBrainVaults(
+      deps({
+        config: { brain: { embedded: true } },
+        workspaceRoot,
+        brain: { listBrains: mock(async () => []) },
+      }),
+    );
+
+    expect(result).toEqual({ source: 'legacy', paths: [legacy] });
+  });
+
+  test('warns and filters registered vaults missing brain.json', async () => {
+    const valid = makeVault('valid');
+    const missingBrainJson = makeDir('missing');
+
+    const result = await resolveBrainVaults(
+      deps({
+        config: { brain: { embedded: true } },
+        brain: {
+          listBrains: mock(async () => [
+            { id: 'valid', homePath: valid },
+            { id: 'missing', homePath: missingBrainJson },
+          ]),
+        },
+      }),
+    );
+
+    expect(result).toEqual({ source: 'registry', paths: [valid], registryCount: 2 });
+    expect(warn.mock.calls.length).toBe(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain(`skipped registered vault ${missingBrainJson}`);
+    expect(String(warn.mock.calls[0]?.[0])).toContain('missing brain.json');
+  });
+});
+
+describe('findBrainVault', () => {
+  test('returns the first configured valid vault without consulting registry', async () => {
+    const first = makeVault('configured-a');
+    const second = makeVault('configured-b');
+    const listBrains = mock(async () => [{ homePath: makeVault('registered') }]);
+
+    const result = await findBrainVault(
+      deps({
+        config: { brain: { embedded: true, paths: [first, second] } },
+        brain: { listBrains },
+      }),
+    );
+
+    expect(result).toBe(first);
+    expect(listBrains.mock.calls.length).toBe(0);
+  });
+
+  test('returns a registered vault before legacy fallback candidates', async () => {
+    const registered = makeVault('registered');
+    const workspaceRoot = makeDir('workspace');
+    const legacy = join(workspaceRoot, 'brain');
+    mkdirSync(legacy, { recursive: true });
+    writeFileSync(join(legacy, 'brain.json'), '{}', 'utf-8');
+
+    const result = await findBrainVault(
+      deps({
+        config: { brain: { embedded: true } },
+        workspaceRoot,
+        brain: { listBrains: mock(async () => [{ homePath: registered }]) },
+      }),
+    );
+
+    expect(result).toBe(registered);
+  });
+
+  test('falls back to the legacy workspace brain when registry is empty', async () => {
+    const workspaceRoot = makeDir('workspace');
+    const legacy = join(workspaceRoot, 'brain');
+    mkdirSync(legacy, { recursive: true });
+    writeFileSync(join(legacy, 'brain.json'), '{}', 'utf-8');
+
+    const result = await findBrainVault(
+      deps({
+        config: { brain: { embedded: true } },
+        workspaceRoot,
+        brain: { listBrains: mock(async () => []) },
+      }),
+    );
+
+    expect(result).toBe(legacy);
+  });
+});
+
+describe('startResolvedBrainVaults', () => {
+  test('continues starting valid configured vaults after one brain.json is invalid', async () => {
+    const corrupt = makeVault('corrupt', '{not-json');
+    const valid = makeVault('valid');
+    const stop = mock(async () => {});
+    const startEmbeddedBrainServer = mock(async ({ brainPath }: { brainPath: string }) => {
+      if (brainPath === corrupt) throw new Error('invalid brain.json');
+      return { port: 4401, stop };
+    });
+    const brain: BrainServerApi = {
+      startEmbeddedBrainServer,
+    };
+
+    const result = await startResolvedBrainVaults({ source: 'config', paths: [corrupt, valid] }, brain, 19642, deps());
+
+    expect(startEmbeddedBrainServer.mock.calls.length).toBe(2);
+    expect(result.map((handle) => handle.brainPath)).toEqual([valid]);
+    expect(warn.mock.calls.length).toBe(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain('invalid brain.json');
+  });
+
+  test('starts every unique resolved vault once for multi-vault autostart', async () => {
+    const first = makeVault('first');
+    const second = makeVault('second');
+    const stop = mock(async () => {});
+    const started: string[] = [];
+    const startEmbeddedBrainServer = mock(async ({ brainPath }: { brainPath: string }) => {
+      started.push(brainPath);
+      return { port: 4500 + started.length, stop };
+    });
+    const brain: BrainServerApi = {
+      startEmbeddedBrainServer,
+    };
+    const resolution: BrainVaultResolution = { source: 'registry', paths: [first, second, first] };
+
+    const result = await startResolvedBrainVaults(resolution, brain, 19642, deps());
+
+    expect(started).toEqual([first, second]);
+    expect(result.map((handle) => handle.brainPath)).toEqual([first, second]);
+    expect(startEmbeddedBrainServer.mock.calls.length).toBe(2);
+  });
+
+  test('starts resolved vaults with bounded parallelism when an earlier vault is pending', async () => {
+    const first = makeVault('first');
+    const second = makeVault('second');
+    const third = makeVault('third');
+    const stop = mock(async () => {});
+    const started: string[] = [];
+    const release = new Map<string, () => void>();
+    const ports = new Map([
+      [first, 4601],
+      [second, 4602],
+      [third, 4603],
+    ]);
+    const startEmbeddedBrainServer = mock(({ brainPath }: { brainPath: string }) => {
+      started.push(brainPath);
+      if (brainPath === third) {
+        return Promise.resolve({ port: ports.get(brainPath) ?? 4603, stop });
+      }
+      return new Promise<{ port: number; stop: () => Promise<void> }>((resolve) => {
+        release.set(brainPath, () => resolve({ port: ports.get(brainPath) ?? 4600, stop }));
+      });
+    });
+    const brain: BrainServerApi = {
+      startEmbeddedBrainServer,
+    };
+
+    const pending = startResolvedBrainVaults(
+      { source: 'config', paths: [first, second, third] },
+      brain,
+      19642,
+      deps({ startupConcurrency: 2 }),
+    );
+
+    await Promise.resolve();
+    expect(started).toEqual([first, second]);
+    expect(startEmbeddedBrainServer.mock.calls.length).toBe(2);
+
+    release.get(second)?.();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(started).toEqual([first, second, third]);
+
+    release.get(first)?.();
+    const result = await pending;
+    expect(result.map((handle) => handle.brainPath)).toEqual([first, second, third]);
+  });
+
+  test('warns when registry starts fewer vaults than the registry reports', async () => {
+    const valid = makeVault('valid');
+    const stop = mock(async () => {});
+    const startEmbeddedBrainServer = mock(async () => ({ port: 4701, stop }));
+    const brain: BrainServerApi = {
+      startEmbeddedBrainServer,
+    };
+
+    const result = await startResolvedBrainVaults(
+      { source: 'registry', paths: [valid], registryCount: 2 },
+      brain,
+      19642,
+      deps(),
+    );
+
+    expect(result.map((handle) => handle.brainPath)).toEqual([valid]);
+    expect(warn.mock.calls.some((call) => String(call[0]).includes('registry drift: started 1/2'))).toBe(true);
+  });
+});

--- a/src/lib/brain-vaults.ts
+++ b/src/lib/brain-vaults.ts
@@ -1,0 +1,360 @@
+import { existsSync, realpathSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { loadGenieConfigSync } from './genie-config.js';
+import { findWorkspace } from './workspace.js';
+
+export type BrainVaultResolutionSource = 'config' | 'registry' | 'legacy';
+
+export interface BrainVaultResolution {
+  source: BrainVaultResolutionSource;
+  paths: string[];
+  registryCount?: number;
+}
+
+export interface StartedBrainVault {
+  brainPath: string;
+  port: number;
+  stop: () => Promise<void>;
+}
+
+interface BrainConfigLike {
+  brain?: {
+    embedded?: boolean;
+    paths?: string[];
+  };
+}
+
+export interface BrainRegistryApi {
+  listBrains?: () => unknown | Promise<unknown>;
+  listBrainVaults?: () => unknown | Promise<unknown>;
+  listVaults?: () => unknown | Promise<unknown>;
+  listRegisteredBrains?: () => unknown | Promise<unknown>;
+  listRegisteredBrainVaults?: () => unknown | Promise<unknown>;
+  getBrainRegistry?: () => unknown | Promise<unknown>;
+  readBrainRegistry?: () => unknown | Promise<unknown>;
+}
+
+export interface BrainServerApi extends BrainRegistryApi {
+  startEmbeddedBrainServer?: (options: {
+    brainPath: string;
+    geniePgPort: number;
+  }) => Promise<{ stop: () => Promise<void>; port: number }>;
+}
+
+interface BrainVaultDeps {
+  brain?: BrainRegistryApi | null;
+  config?: BrainConfigLike;
+  cwd?: string;
+  homeDir?: string;
+  workspaceRoot?: string | null;
+  startupConcurrency?: number;
+  warn?: (message: string) => void;
+  log?: (message: string) => void;
+  exists?: (path: string) => boolean;
+  realpath?: (path: string) => string;
+}
+
+const REGISTRY_PATH_FIELDS = ['homePath', 'brainPath', 'vaultPath', 'path', 'root', 'dir'] as const;
+const REGISTRY_COLLECTION_FIELDS = ['paths', 'brains', 'vaults', 'entries', 'items', 'registered'] as const;
+const DEFAULT_BRAIN_START_CONCURRENCY = 4;
+
+interface RegisteredBrainVaultDiscovery {
+  paths: string[];
+  registryCount: number;
+}
+
+function getCwd(deps: BrainVaultDeps): string {
+  return deps.cwd ?? process.cwd();
+}
+
+function getHomeDir(deps: BrainVaultDeps): string {
+  return deps.homeDir ?? homedir();
+}
+
+function getWorkspaceRoot(deps: BrainVaultDeps): string | null {
+  if ('workspaceRoot' in deps) return deps.workspaceRoot ?? null;
+  return findWorkspace()?.root ?? null;
+}
+
+function getConfig(deps: BrainVaultDeps): BrainConfigLike {
+  return deps.config ?? loadGenieConfigSync();
+}
+
+function expandHome(path: string, homeDir: string): string {
+  if (path === '~') return homeDir;
+  if (path.startsWith('~/')) return join(homeDir, path.slice(2));
+  return path;
+}
+
+function normalizeBrainVaultPath(path: string, deps: BrainVaultDeps): string {
+  return resolve(getCwd(deps), expandHome(path, getHomeDir(deps)));
+}
+
+function canonicalBrainVaultPath(path: string, deps: BrainVaultDeps): string {
+  const realpath = deps.realpath ?? realpathSync;
+  try {
+    return realpath(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
+export function dedupeBrainVaultPaths(paths: string[], deps: BrainVaultDeps = {}): string[] {
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+  for (const path of paths) {
+    const canonical = canonicalBrainVaultPath(path, deps);
+    if (seen.has(canonical)) continue;
+    seen.add(canonical);
+    deduped.push(canonical);
+  }
+  return deduped;
+}
+
+function hasBrainJson(path: string, deps: BrainVaultDeps): boolean {
+  const exists = deps.exists ?? existsSync;
+  return exists(join(path, 'brain.json'));
+}
+
+function filterVaultsWithBrainJson(
+  paths: string[],
+  source: BrainVaultResolutionSource,
+  deps: BrainVaultDeps,
+): string[] {
+  const warn = deps.warn ?? console.warn;
+  const label = source === 'config' ? 'configured' : source === 'registry' ? 'registered' : 'legacy';
+  const valid: string[] = [];
+  for (const path of paths) {
+    if (hasBrainJson(path, deps)) {
+      valid.push(path);
+      continue;
+    }
+    warn(`  Brain server: skipped ${label} vault ${path} (missing brain.json)`);
+  }
+  return valid;
+}
+
+function normalizeAndDedupe(paths: string[], deps: BrainVaultDeps): string[] {
+  return dedupeBrainVaultPaths(
+    paths.map((path) => normalizeBrainVaultPath(path, deps)),
+    deps,
+  );
+}
+
+function pushPathFromEntry(entry: Record<string, unknown>, paths: string[]): boolean {
+  let found = false;
+  for (const field of REGISTRY_PATH_FIELDS) {
+    const value = entry[field];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      paths.push(value);
+      found = true;
+    }
+  }
+  return found;
+}
+
+function isRegistryRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function collectRegistryArray(values: unknown[], paths: string[]): void {
+  for (const item of values) collectRegistryPaths(item, paths);
+}
+
+function collectRegistryObject(entry: Record<string, unknown>, paths: string[]): void {
+  const foundPath = pushPathFromEntry(entry, paths);
+
+  for (const field of REGISTRY_COLLECTION_FIELDS) {
+    if (field in entry) collectRegistryPaths(entry[field], paths);
+  }
+
+  if (!foundPath) {
+    for (const item of Object.values(entry)) {
+      if (item && typeof item === 'object') collectRegistryPaths(item, paths);
+    }
+  }
+}
+
+function collectRegistryPaths(value: unknown, paths: string[]): void {
+  if (typeof value === 'string') {
+    if (value.trim().length > 0) paths.push(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    collectRegistryArray(value, paths);
+    return;
+  }
+  if (isRegistryRecord(value)) collectRegistryObject(value, paths);
+}
+
+function countRegistryItems(value: unknown, fallback: number): number {
+  if (Array.isArray(value)) return value.length;
+  if (!isRegistryRecord(value)) return fallback;
+
+  for (const field of REGISTRY_COLLECTION_FIELDS) {
+    const collection = value[field];
+    if (Array.isArray(collection)) return collection.length;
+    if (isRegistryRecord(collection)) return Object.keys(collection).length;
+  }
+
+  return fallback;
+}
+
+async function discoverRegisteredBrainVaultPaths(deps: BrainVaultDeps): Promise<RegisteredBrainVaultDiscovery> {
+  const brain = deps.brain;
+  if (!brain) return { paths: [], registryCount: 0 };
+
+  const registryCalls = [
+    'listBrains',
+    'listBrainVaults',
+    'listVaults',
+    'listRegisteredBrains',
+    'listRegisteredBrainVaults',
+    'getBrainRegistry',
+    'readBrainRegistry',
+  ] as const;
+
+  for (const name of registryCalls) {
+    const read = brain[name];
+    if (typeof read !== 'function') continue;
+    try {
+      const result = await read.call(brain);
+      const paths: string[] = [];
+      collectRegistryPaths(result, paths);
+      if (paths.length > 0) {
+        return {
+          paths,
+          registryCount: countRegistryItems(result, paths.length),
+        };
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      (deps.warn ?? console.warn)(`  Brain registry: ${name} failed: ${msg}`);
+    }
+  }
+
+  return { paths: [], registryCount: 0 };
+}
+
+async function findLegacyBrainVault(deps: BrainVaultDeps = {}): Promise<string | null> {
+  const cwd = getCwd(deps);
+  const homeDir = getHomeDir(deps);
+  const workspaceRoot = getWorkspaceRoot(deps);
+  const candidates = [
+    workspaceRoot ? join(workspaceRoot, 'brain') : undefined,
+    cwd,
+    join(cwd, 'brain'),
+    join(homeDir, 'brain'),
+  ].filter((path): path is string => typeof path === 'string');
+
+  for (const path of normalizeAndDedupe(candidates, deps)) {
+    if (hasBrainJson(path, deps)) return path;
+  }
+  return null;
+}
+
+export async function findBrainVault(deps: BrainVaultDeps = {}): Promise<string | null> {
+  const resolution = await resolveBrainVaults(deps);
+  return resolution.paths[0] ?? null;
+}
+
+export async function resolveBrainVaults(deps: BrainVaultDeps = {}): Promise<BrainVaultResolution> {
+  const configuredPaths = getConfig(deps).brain?.paths;
+  if (Array.isArray(configuredPaths) && configuredPaths.length > 0) {
+    const paths = filterVaultsWithBrainJson(normalizeAndDedupe(configuredPaths, deps), 'config', deps);
+    return { source: 'config', paths };
+  }
+
+  const registered = await discoverRegisteredBrainVaultPaths(deps);
+  if (registered.paths.length > 0) {
+    const paths = filterVaultsWithBrainJson(normalizeAndDedupe(registered.paths, deps), 'registry', deps);
+    return { source: 'registry', paths, registryCount: registered.registryCount };
+  }
+
+  const legacyPath = await findLegacyBrainVault(deps);
+  return { source: 'legacy', paths: legacyPath ? [legacyPath] : [] };
+}
+
+function normalizeStartupConcurrency(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return DEFAULT_BRAIN_START_CONCURRENCY;
+  return Math.max(1, Math.floor(value));
+}
+
+async function allSettledBounded<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+  const results: PromiseSettledResult<R>[] = new Array(items.length);
+  let nextIndex = 0;
+
+  async function runWorker(): Promise<void> {
+    while (true) {
+      const index = nextIndex++;
+      if (index >= items.length) return;
+
+      try {
+        results[index] = { status: 'fulfilled', value: await worker(items[index], index) };
+      } catch (reason) {
+        results[index] = { status: 'rejected', reason };
+      }
+    }
+  }
+
+  await Promise.allSettled(Array.from({ length: Math.min(concurrency, items.length) }, () => runWorker()));
+  return results;
+}
+
+function warnRegistryDrift(
+  resolution: BrainVaultResolution,
+  startedCount: number,
+  resolvedCount: number,
+  deps: BrainVaultDeps,
+): void {
+  if (resolution.source !== 'registry') return;
+
+  const expectedCount = resolution.registryCount ?? resolvedCount;
+  if (startedCount === expectedCount) return;
+
+  const warn = deps.warn ?? console.warn;
+  warn(
+    `  Brain server: registry drift: started ${startedCount}/${expectedCount} registered vault(s) ` +
+      `(${resolvedCount} resolved valid path(s))`,
+  );
+}
+
+export async function startResolvedBrainVaults(
+  resolution: BrainVaultResolution,
+  brain: BrainServerApi,
+  geniePgPort: number,
+  deps: BrainVaultDeps = {},
+): Promise<StartedBrainVault[]> {
+  const startEmbeddedBrainServer = brain.startEmbeddedBrainServer;
+  if (!startEmbeddedBrainServer) return [];
+
+  const warn = deps.warn ?? console.warn;
+  const log = deps.log ?? console.log;
+  const handles: StartedBrainVault[] = [];
+  const paths = dedupeBrainVaultPaths(resolution.paths, deps);
+  const concurrency = normalizeStartupConcurrency(deps.startupConcurrency);
+
+  const results = await allSettledBounded(paths, concurrency, async (brainPath) => {
+    const handle = await startEmbeddedBrainServer.call(brain, { brainPath, geniePgPort });
+    log(`  Brain server ready on port ${handle.port} (${brainPath})`);
+    return { brainPath, port: handle.port, stop: handle.stop };
+  });
+
+  for (let index = 0; index < results.length; index++) {
+    const result = results[index];
+    if (result.status === 'fulfilled') {
+      handles.push(result.value);
+    } else {
+      const msg = result.reason instanceof Error ? result.reason.message : String(result.reason);
+      warn(`  Brain server: failed for ${paths[index]}: ${msg}`);
+    }
+  }
+
+  warnRegistryDrift(resolution, handles.length, paths.length, deps);
+  return handles;
+}

--- a/src/term-commands/brain.test.ts
+++ b/src/term-commands/brain.test.ts
@@ -142,4 +142,14 @@ describe('installBrain → brain install wizard chain', () => {
     expect(src).toMatch(/Install wizard skipped/);
     expect(src).toMatch(/brain install --apply --yes/);
   });
+
+  test('install autostart resolves configured and registered vaults', () => {
+    const { readFileSync } = require('node:fs') as typeof import('node:fs');
+    const { dirname, join } = require('node:path') as typeof import('node:path');
+    const src = readFileSync(join(dirname(import.meta.path), 'brain.ts'), 'utf-8');
+
+    expect(src).toContain('let installedBrain: BrainRegistryApi | null = null;');
+    expect(src).toContain('installedBrain = brain as BrainRegistryApi;');
+    expect(src).toContain('await findBrainVault({ brain: installedBrain });');
+  });
 });

--- a/src/term-commands/brain.ts
+++ b/src/term-commands/brain.ts
@@ -14,6 +14,7 @@ import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import type { Command } from 'commander';
+import { type BrainRegistryApi, findBrainVault } from '../lib/brain-vaults.js';
 
 const BRAIN_PKG = '@khal-os/brain';
 const BRAIN_REPO = 'khal-os/brain';
@@ -71,15 +72,6 @@ function resolveBrainBin(): string | undefined {
     if (existsSync(c)) return c;
   }
   return undefined;
-}
-
-/** Search for a brain vault (brain.json) in common locations. Returns path or null. */
-function findBrainVault(): string | null {
-  const candidates = [process.cwd(), join(process.cwd(), 'brain'), join(homedir(), 'brain')];
-  for (const dir of candidates) {
-    if (existsSync(join(dir, 'brain.json'))) return dir;
-  }
-  return null;
 }
 
 interface ActiveBrainConfig {
@@ -431,8 +423,10 @@ async function installBrain(): Promise<boolean> {
     console.log('');
 
     // Auto-run migrations
+    let installedBrain: BrainRegistryApi | null = null;
     try {
       const brain = await import(BRAIN_PKG);
+      installedBrain = brain as BrainRegistryApi;
       if (brain.runAllMigrations) {
         console.log('  Running brain migrations...');
         await brain.runAllMigrations();
@@ -445,7 +439,7 @@ async function installBrain(): Promise<boolean> {
     await runBrainInstallWizard();
 
     // Auto-start daemon if a vault is found
-    const vaultPath = findBrainVault();
+    const vaultPath = await findBrainVault({ brain: installedBrain });
     if (vaultPath) {
       startBrainDaemon(vaultPath);
     } else {

--- a/src/term-commands/serve.test.ts
+++ b/src/term-commands/serve.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { type ChildProcess, spawn } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -9,6 +9,7 @@ import {
   getTuiKeybindings,
   getTuiQuitBindingArgs,
   isStoppingLockActive,
+  startBrainServerIfEnabled,
   writeStoppingLockSync,
 } from './serve.js';
 
@@ -42,6 +43,127 @@ describe('getTuiKeybindings', () => {
       'genie-tui:0.0',
       'C-q',
     ]);
+  });
+});
+
+describe('brain startup integration', () => {
+  function makeVault(root: string, name: string): string {
+    const path = join(root, name);
+    mkdirSync(path, { recursive: true });
+    writeFileSync(join(path, 'brain.json'), '{}', 'utf-8');
+    return path;
+  }
+
+  function makeDir(root: string, name: string): string {
+    const path = join(root, name);
+    mkdirSync(path, { recursive: true });
+    return path;
+  }
+
+  async function eventually(predicate: () => boolean): Promise<void> {
+    for (let attempt = 0; attempt < 20; attempt++) {
+      if (predicate()) return;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  }
+
+  test('skips brain import and startup when brain.embedded=false', async () => {
+    const importBrain = mock(async () => {
+      throw new Error('brain should not be imported');
+    });
+    const logs: string[] = [];
+    const warnings: string[] = [];
+    const log = mock((message: string) => logs.push(message));
+    const warn = mock((message: string) => warnings.push(message));
+    const setBrainHandles = mock(() => {});
+
+    const result = await startBrainServerIfEnabled({
+      loadConfig: () => ({ brain: { embedded: false } }),
+      importBrain,
+      getActivePort: () => 19642,
+      log,
+      warn,
+      setBrainHandles,
+    });
+
+    expect(result).toEqual([]);
+    expect(importBrain.mock.calls.length).toBe(0);
+    expect(setBrainHandles.mock.calls.length).toBe(0);
+    expect(logs[0]).toContain('brain.embedded=false');
+    expect(warnings.length).toBe(0);
+  });
+
+  test('warns when registry reports more brains than were started', async () => {
+    const root = join(tmpdir(), `genie-serve-brain-drift-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const valid = makeVault(root, 'valid');
+    const missing = makeDir(root, 'missing');
+    const stop = mock(async () => {});
+    const startEmbeddedBrainServer = mock(async () => ({ port: 4801, stop }));
+    const warnings: string[] = [];
+    const warn = mock((message: string) => warnings.push(message));
+
+    try {
+      const result = await startBrainServerIfEnabled({
+        loadConfig: () => ({ brain: { embedded: true } }),
+        importBrain: async () => ({
+          listBrains: mock(async () => [{ homePath: valid }, { homePath: missing }]),
+          startEmbeddedBrainServer,
+        }),
+        getActivePort: () => 19642,
+        log: mock(() => {}),
+        warn,
+        setBrainHandles: mock(() => {}),
+      });
+
+      expect(result.map((handle) => handle.brainPath)).toEqual([valid]);
+      expect(startEmbeddedBrainServer.mock.calls.length).toBe(1);
+      expect(warnings.some((message) => message.includes(`skipped registered vault ${missing}`))).toBe(true);
+      expect(warnings.some((message) => message.includes('registry drift: started 1/2'))).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('schedules a later brain vault while an earlier start is pending', async () => {
+    const root = join(tmpdir(), `genie-serve-brain-parallel-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const first = makeVault(root, 'first');
+    const second = makeVault(root, 'second');
+    const stop = mock(async () => {});
+    const started: string[] = [];
+    let releaseFirst: (() => void) | undefined;
+    const startEmbeddedBrainServer = mock(({ brainPath }: { brainPath: string }) => {
+      started.push(brainPath);
+      if (brainPath === first) {
+        return new Promise<{ port: number; stop: () => Promise<void> }>((resolve) => {
+          releaseFirst = () => resolve({ port: 4901, stop });
+        });
+      }
+      return Promise.resolve({ port: 4902, stop });
+    });
+
+    try {
+      const pending = startBrainServerIfEnabled({
+        loadConfig: () => ({ brain: { embedded: true } }),
+        importBrain: async () => ({
+          listBrains: mock(async () => [{ homePath: first }, { homePath: second }]),
+          startEmbeddedBrainServer,
+        }),
+        getActivePort: () => 19642,
+        log: mock(() => {}),
+        warn: mock(() => {}),
+        setBrainHandles: mock(() => {}),
+      });
+
+      await eventually(() => startEmbeddedBrainServer.mock.calls.length >= 2);
+      expect(started).toEqual([first, second]);
+
+      releaseFirst?.();
+      const result = await pending;
+      expect(result.map((handle) => handle.brainPath)).toEqual([first, second]);
+    } finally {
+      releaseFirst?.();
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -32,6 +32,12 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { Command } from 'commander';
 import { palette } from '../../packages/genie-tokens';
+import {
+  type BrainServerApi,
+  type StartedBrainVault,
+  resolveBrainVaults,
+  startResolvedBrainVaults,
+} from '../lib/brain-vaults.js';
 import { ensureTmux, tmuxBin } from '../lib/ensure-tmux.js';
 import { getProcessStartTime } from '../lib/process-identity.js';
 import { genieTmuxCmd } from '../lib/tmux-wrapper.js';
@@ -209,6 +215,26 @@ const TUI_STYLE = {
   activeBorder: palette.borderActive,
   inactiveBorder: palette.border,
 };
+
+interface BrainStartupConfig {
+  brain?: {
+    embedded?: boolean;
+    paths?: string[];
+  };
+}
+
+interface StartBrainServerDeps {
+  loadConfig?: () => BrainStartupConfig;
+  importBrain?: () => Promise<BrainServerApi>;
+  getActivePort?: () => number | undefined;
+  resolveVaults?: typeof resolveBrainVaults;
+  startVaults?: typeof startResolvedBrainVaults;
+  setBrainHandles?: (brainHandles: StartedBrainVault[]) => void;
+  log?: (message: string) => void;
+  warn?: (message: string) => void;
+}
+
+type BrainStartupLogger = (message: string) => void;
 
 export function getTuiKeybindings(sessionName = TUI_SESSION): string[] {
   return [
@@ -487,7 +513,7 @@ export function ensureTuiSession(workspaceRoot?: string): void {
 interface DaemonHandles {
   schedulerHandle: { stop: () => void; done: Promise<void> } | null;
   agentWatcher: { close: () => void } | null;
-  brainHandle: { stop: () => Promise<void>; port: number } | null;
+  brainHandles: StartedBrainVault[];
   omniApprovalHandler: { stop: () => Promise<void> } | null;
   omniBridge: { stop: () => Promise<void> } | null;
   detectorScheduler: { stop: () => void } | null;
@@ -498,7 +524,7 @@ interface DaemonHandles {
 const handles: DaemonHandles = {
   schedulerHandle: null,
   agentWatcher: null,
-  brainHandle: null,
+  brainHandles: [],
   omniApprovalHandler: null,
   omniBridge: null,
   detectorScheduler: null,
@@ -672,52 +698,85 @@ function resolveServeMode(headless?: boolean): { skipTui: boolean; mode: 'headle
   return { skipTui, mode };
 }
 
-function resolveBrainPathFromWorkspace(): string | undefined {
-  try {
-    const { findWorkspace } = require('../lib/workspace.js') as typeof import('../lib/workspace.js');
-    const ws = findWorkspace();
-    if (ws?.root) {
-      const bp = join(ws.root, 'brain');
-      if (existsSync(bp) && existsSync(join(bp, 'brain.json'))) return bp;
-    }
-  } catch {
-    // No workspace — skip
-  }
-  return undefined;
+async function loadBrainStartupConfig(deps: StartBrainServerDeps): Promise<BrainStartupConfig> {
+  return deps.loadConfig?.() ?? (await import('../lib/genie-config.js')).loadGenieConfigSync();
 }
 
-async function startBrainServerIfEnabled(): Promise<void> {
+async function importBrainForStartup(deps: StartBrainServerDeps): Promise<BrainServerApi> {
+  if (deps.importBrain) return deps.importBrain();
+  // Dynamic import — brain is optional. Silently skip if not installed.
+  // @ts-expect-error — brain is enterprise-only, not in genie's deps
+  return import('@khal-os/brain');
+}
+
+async function getBrainStartupPgPort(deps: StartBrainServerDeps): Promise<number | undefined> {
+  return deps.getActivePort?.() ?? (await import('../lib/db.js')).getActivePort();
+}
+
+function assignBrainHandles(deps: StartBrainServerDeps, brainHandles: StartedBrainVault[]): void {
+  if (deps.setBrainHandles) {
+    deps.setBrainHandles(brainHandles);
+    return;
+  }
+  handles.brainHandles = brainHandles;
+}
+
+function isMissingBrainModule(message: string): boolean {
+  return message.includes('Cannot find') || message.includes('not found') || message.includes('MODULE_NOT_FOUND');
+}
+
+async function startBrainServer(
+  deps: StartBrainServerDeps,
+  config: BrainStartupConfig,
+  log: BrainStartupLogger,
+  warn: BrainStartupLogger,
+): Promise<StartedBrainVault[]> {
+  const brain = await importBrainForStartup(deps);
+  if (!brain.startEmbeddedBrainServer) return [];
+
+  const pgPort = await getBrainStartupPgPort(deps);
+  if (!pgPort) {
+    log('  Brain server: pgserve not available (skipped)');
+    return [];
+  }
+
+  const resolveVaults = deps.resolveVaults ?? resolveBrainVaults;
+  const startVaults = deps.startVaults ?? startResolvedBrainVaults;
+  const resolution = await resolveVaults({ brain, config, warn });
+  if (resolution.paths.length === 0) {
+    log(`  Brain server: no ${resolution.source} brain vaults found (skipped)`);
+    return [];
+  }
+
+  log(`  Starting brain server (${resolution.paths.length} ${resolution.source} vault(s))...`);
+  const brainHandles = await startVaults(resolution, brain, pgPort, { warn, log });
+  assignBrainHandles(deps, brainHandles);
+  if (brainHandles.length === 0) {
+    log('  Brain server: no vaults started');
+  }
+  return brainHandles;
+}
+
+export async function startBrainServerIfEnabled(deps: StartBrainServerDeps = {}): Promise<StartedBrainVault[]> {
   // Gated by `brain.embedded` config (default: true). Set `brain.embedded=false`
   // in ~/.genie/config.json to opt out — power-users can then run `brain serve`
   // standalone with custom settings (port, brain-path, @next dev channel).
-  const { loadGenieConfigSync } = await import('../lib/genie-config.js');
-  const brainEmbedded = loadGenieConfigSync().brain.embedded;
+  const config = await loadBrainStartupConfig(deps);
+  const brainEmbedded = config.brain?.embedded !== false;
+  const log = deps.log ?? console.log;
+  const warn = deps.warn ?? console.warn;
   if (!brainEmbedded) {
-    console.log('  Brain server: skipped (brain.embedded=false — managed externally)');
-    return;
+    log('  Brain server: skipped (brain.embedded=false — managed externally)');
+    return [];
   }
   try {
-    // Dynamic import — brain is optional. Silently skip if not installed.
-    // @ts-expect-error — brain is enterprise-only, not in genie's deps
-    const brain = await import('@khal-os/brain');
-    if (!brain.startEmbeddedBrainServer) return;
-    const { getActivePort } = await import('../lib/db.js');
-    const pgPort = getActivePort();
-    if (!pgPort) {
-      console.log('  Brain server: pgserve not available (skipped)');
-      return;
-    }
-    console.log('  Starting brain server...');
-    const brainPath = resolveBrainPathFromWorkspace();
-    if (!brainPath) {
-      console.log('  Brain server: no brain/ found in workspace (skipped)');
-      return;
-    }
-    const handle = await brain.startEmbeddedBrainServer({ brainPath, geniePgPort: pgPort });
-    handles.brainHandle = { stop: handle.stop, port: handle.port };
-    console.log(`  Brain server ready on port ${handle.port}`);
-  } catch {
+    return await startBrainServer(deps, config, log, warn);
+  } catch (err) {
     // Brain not installed — fine, skip silently
+    const msg = err instanceof Error ? err.message : String(err);
+    if (isMissingBrainModule(msg)) return [];
+    warn(`  Brain server: failed: ${msg}`);
+    return [];
   }
 }
 
@@ -851,9 +910,11 @@ async function stopOmniAndBrainServices(): Promise<void> {
   void import('../lib/executor-read.js').then((m) => m.stopExecutorReadEndpoint().catch(() => {}));
   // Brain server: best-effort; signal handlers call process.exit() immediately
   // after shutdown(). The OS reclaims sockets/connections on process exit.
-  if (handles.brainHandle) {
-    await handles.brainHandle.stop().catch(() => {});
-    handles.brainHandle = null;
+  if (handles.brainHandles.length > 0) {
+    for (const handle of handles.brainHandles) {
+      await handle.stop().catch(() => {});
+    }
+    handles.brainHandles = [];
   }
 }
 
@@ -1146,7 +1207,13 @@ async function printBrainStatus(): Promise<void> {
   try {
     // @ts-expect-error — brain is enterprise-only, not in genie's deps
     const brain = await import('@khal-os/brain');
-    const brainPort = resolveBrainPortFromWorkspace(brain) ?? handles.brainHandle?.port ?? null;
+    if (handles.brainHandles.length > 0) {
+      for (const handle of handles.brainHandles) {
+        await probeBrainHealth(handle.port);
+      }
+      return;
+    }
+    const brainPort = resolveBrainPortFromWorkspace(brain);
     if (brainPort) {
       await probeBrainHealth(brainPort);
     } else {

--- a/src/types/genie-config.ts
+++ b/src/types/genie-config.ts
@@ -89,6 +89,15 @@ const BrainConfigSchema = z.object({
    *   `genie brain install` becomes a no-op that points at the manual install command.
    */
   embedded: z.boolean().default(true),
+  /**
+   * Explicit brain vault paths to start with `genie serve`.
+   *
+   * - omitted - discover registered brains, then fall back to the legacy
+   *   workspace/root brain vault if the registry is empty.
+   * - non-empty array - start only these paths and do not consult the registry.
+   * - empty array - force registry discovery (with legacy fallback if empty).
+   */
+  paths: z.array(z.string()).optional(),
 });
 
 // Council preset configuration


### PR DESCRIPTION
## Summary
- Resolve configured, registered, and legacy brain vaults with source-gated behavior.
- Start all valid brain vaults concurrently with allSettled-style isolation and drift warnings.
- Update brain install/serve paths and tests for explicit paths, registry mode, missing/corrupt vaults, and embedded=false behavior.

Fixes #1150
Wish: fix-brain-multi-vault-autostart

## Validation
- bun test src/lib/brain*.test.ts src/term-commands/brain.test.ts src/term-commands/serve*.test.ts: PASS (40 tests)
- bun run typecheck: PASS
- bun run lint: PASS (existing warnings only)
- Independent execution review after two fix loops: SHIP
- Pre-push gate: PASS (existing warnings only)

## Residual Risk
- Full check in worker hit unrelated GENIE_AGENT_NAME basename-sensitive tests before the fix loop; focused validation is green. Real-world concurrent behavior still depends on @khal-os/brain embedded server behavior.
