### PR TITLE
fix(hooks): skip db boot for dispatch — Mac CPU fix C

### DIFF
--- a/src/hooks/dispatch-command.ts
+++ b/src/hooks/dispatch-command.ts
@@ -18,6 +18,24 @@ async function readStdin(): Promise<string> {
 }
 
 async function dispatchAction(): Promise<void> {
+  // Mac-CPU fix C — short-circuit DB boot for hook dispatch forks.
+  //
+  // The long-lived `genie serve` daemon owns migrations + seed (it ran
+  // them at startup). Each `genie hook dispatch` fork (hundreds/min on a
+  // busy Mac dev machine) is short-lived; making each fork re-run
+  // `runMigrations` + `needsSeed` (which loops all 92 ~/.claude/teams
+  // entries on every call) is the second-largest contributor to the
+  // .18 100%-CPU regression on Mac.
+  //
+  // Setting this env BEFORE `dispatch(stdin)` ensures the first
+  // `getConnection()` inside any handler skips migrations + seed.
+  // Handlers that need DB still get a working connection — they just
+  // skip the boot-time setup that the daemon already handled.
+  //
+  // Set unconditionally for the dispatch entrypoint; daemon and CLI
+  // code paths never enter this function.
+  process.env.GENIE_SKIP_DB_BOOT = '1';
+
   const stdin = await readStdin();
   if (!stdin.trim()) {
     process.exit(0);

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -402,6 +402,34 @@ describe('retention cleanup', () => {
   });
 });
 
+describe('GENIE_SKIP_DB_BOOT (Mac CPU fix C — hook-dispatch coldstart)', () => {
+  test('runPostConnectSetup honors GENIE_SKIP_DB_BOOT alongside isTestMode', () => {
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    // The skipBoot guard must combine isTestMode + the env var so the
+    // hook-dispatch entrypoint can short-circuit migrations + seed
+    expect(source).toContain("process.env.GENIE_SKIP_DB_BOOT === '1'");
+    expect(source).toMatch(/skipBoot\s*=\s*isTestMode\s*\|\|\s*process\.env\.GENIE_SKIP_DB_BOOT/);
+    // Both migrations and seed gated by skipBoot
+    expect(source).toMatch(/if \(!skipBoot\) await runMigrations/);
+    expect(source).toMatch(/if \(!skipBoot && needsSeed\(\)\) await runSeed/);
+  });
+
+  test('hook dispatch entrypoint sets GENIE_SKIP_DB_BOOT before invoking dispatch()', () => {
+    const dispatchSource = readFileSync(join(__dirname, '..', 'hooks', 'dispatch-command.ts'), 'utf-8');
+    // Env must be set inside dispatchAction (not at module load — that would
+    // affect the entire genie binary including the daemon path)
+    const dispatchActionIdx = dispatchSource.indexOf('async function dispatchAction');
+    expect(dispatchActionIdx).toBeGreaterThan(-1);
+    const fnBody = dispatchSource.slice(dispatchActionIdx, dispatchSource.indexOf('}', dispatchActionIdx + 100));
+    expect(fnBody).toContain("process.env.GENIE_SKIP_DB_BOOT = '1'");
+    // Must be set BEFORE dispatch(stdin) so the first getConnection() inside
+    // any handler skips migrations + seed
+    const envSetIdx = dispatchSource.indexOf("GENIE_SKIP_DB_BOOT = '1'");
+    const dispatchCallIdx = dispatchSource.indexOf('await dispatch(stdin)');
+    expect(envSetIdx).toBeLessThan(dispatchCallIdx);
+  });
+});
+
 describe('pool error recovery', () => {
   test('migration failure resets both sqlClient and activePort', () => {
     const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -663,13 +663,27 @@ async function healthCheckCachedClient() {
   }
 }
 
-/** Run post-connect setup (migrations, seed, retention). Skipped in test mode. */
+/**
+ * Run post-connect setup (migrations, seed, retention).
+ *
+ * Skipped when:
+ *   - `isTestMode` (test DB has its own setup path)
+ *   - `GENIE_SKIP_DB_BOOT=1` (set by `genie hook dispatch` — Mac CPU fix C)
+ *
+ * The `genie serve` daemon owns migrations + seed at startup; short-lived
+ * forks (especially hook dispatch, hundreds/minute on a busy Mac) must not
+ * re-run them. Doing so means every PreToolUse / UserPromptSubmit /
+ * PostToolUse cold-start re-issues the migration check + loops all 92
+ * `~/.claude/teams` entries via `needsSeed()`. That was the second-largest
+ * contributor to the .18 100%-CPU Mac regression.
+ */
 async function runPostConnectSetup(client: postgres.Sql, isTestMode: boolean, timings: { t0: number; t1: number }) {
   const _t2 = Date.now();
-  if (!isTestMode) await runMigrations(client);
+  const skipBoot = isTestMode || process.env.GENIE_SKIP_DB_BOOT === '1';
+  if (!skipBoot) await runMigrations(client);
   const _t3 = Date.now();
 
-  if (!isTestMode && needsSeed()) await runSeed(client);
+  if (!skipBoot && needsSeed()) await runSeed(client);
   const _t4 = Date.now();
 
   // Retention is no longer run from getConnection — it now lives on a


### PR DESCRIPTION
## Summary

**Fix C** of the 5-step .19 Mac-CPU root-cause plan. Second-largest single CPU win after fix A.

Every `genie hook dispatch` bun fork was running `runMigrations()` + `needsSeed()`+`runSeed()` on first PG connect. `needsSeed()` loops all 92 `~/.claude/teams` entries on every call. With hundreds of hook forks per minute on a busy Mac dev machine, this was the second-largest contributor to the .18 100%-CPU regression (after fix A which dropped retention DELETEs from the same path).

## Fix

- `src/hooks/dispatch-command.ts:dispatchAction()` sets `GENIE_SKIP_DB_BOOT=1` **before** calling `dispatch(stdin)`, so the first `getConnection()` inside any handler skips migrations + seed
- `src/lib/db.ts:runPostConnectSetup()` honors `GENIE_SKIP_DB_BOOT` alongside `isTestMode` via a unified `skipBoot` guard

## Correctness

- The long-lived `genie serve` daemon owns migrations + seed at startup — short-lived hook forks must not re-run them. The schema is already there.
- Handlers that need DB (e.g., `codex-inbox-deliver`) still get a working connection — they just skip the boot-time setup the daemon already handled.
- Daemon and CLI code paths never enter `dispatchAction()`, so the env-flag scope is correctly hook-only (no risk of leaking to other genie binary subcommands).

## Validation

- `bun test src/lib/db.test.ts` — **45/45 pass** (43 prior + 2 new contract tests)
- `bun x tsc --noEmit` clean

## Where this fits in the .19 Mac-CPU sprint

- **A** ✓ #1475 — drop runRetention from getConnection
- **filewatch** ✓ #1474 — chokidar replacement
- **C** — this PR
- **B** queued — cache `needsSeed` via teams-mtime marker (orthogonal speedup; this PR makes it lower priority since hooks now skip seed entirely)
- **D** queued — narrow hook matchers (`PostToolUse=SendMessage` only, drop empty events) — eliminates wasted bun cold-starts
- **E** queued — persist session-sync cache file