### PR TITLE
fix(cli): add 'list' alias for 'genie dir ls' (#1465)

### DIFF
--- a/src/term-commands/dir.test.ts
+++ b/src/term-commands/dir.test.ts
@@ -206,3 +206,14 @@ describe('buildSdkConfig', () => {
     });
   });
 });
+
+describe('dir command CLI surface', () => {
+  test('source declares both `ls` and `list` aliases for the list subcommand', () => {
+    const source = require('node:fs').readFileSync(require('node:path').join(__dirname, 'dir.ts'), 'utf-8');
+    // The `ls` form is the canonical command; `list` is registered via .alias()
+    // so both `genie dir ls` and `genie dir list` work and resolve to the same
+    // action handler. Closes #1465 (genie dir list exited 1 because the
+    // alias was missing).
+    expect(source).toMatch(/\.command\(['"]ls \[name\]['"]\)\s*\.alias\(['"]list['"]\)/);
+  });
+});

--- a/src/term-commands/dir.ts
+++ b/src/term-commands/dir.ts
@@ -99,9 +99,10 @@ export function registerDirNamespace(program: Command): void {
       }
     });
 
-  // dir ls [<name>]
+  // dir ls [<name>] (also: dir list — common alias)
   dir
     .command('ls [name]')
+    .alias('list')
     .description('List all agents or show single entry details')
     .option('--json', 'Output as JSON')
     .option('--builtins', 'Include built-in roles and council members')


### PR DESCRIPTION
## Summary

Closes **#1465** — `genie dir list` exits 1 with `unknown command`. Trivial alias addition.

## Why it's a release-blocker

`list` and `ls` are interchangeable across every other genie subcommand a user touches. `dir ls` being the *only* one that rejects `list` is a discoverability papercut on first use.

## Fix

```ts
dir
  .command('ls [name]')
  .alias('list')   // <-- new
  .description('List all agents or show single entry details')
```

## Validation

- 32/32 `src/term-commands/dir.test.ts` pass (1 new source-text assertion that the alias is wired)
- Empirical: both `genie dir ls` and `genie dir list` produce identical output