### PR TITLE
fix(pg-seed): cache native team seed marker

### DIFF
--- a/src/lib/pg-seed.test.ts
+++ b/src/lib/pg-seed.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { getConnection } from './db.js';
@@ -347,6 +347,12 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
       // Claude-native configs must NOT be renamed to .migrated (authoritative).
       expect(existsSync(join(teamDir, 'config.json'))).toBe(true);
       expect(existsSync(join(teamDir, 'config.json.migrated'))).toBe(false);
+
+      const marker = JSON.parse(require('node:fs').readFileSync(join(testHome, 'state', 'teams-seed-marker'), 'utf-8'));
+      expect(marker).toEqual({
+        teamsDir: join(testClaudeDir, 'teams'),
+        mtimeMs: String(statSync(join(testClaudeDir, 'teams')).mtimeMs),
+      });
     });
 
     test('seed imports mailbox/*.json into mailbox table', async () => {
@@ -480,6 +486,45 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
 
       // Cleanup
       await sql`DELETE FROM agents WHERE id = 'seed-test-idempotent'`;
+    });
+
+    test('needsSeed uses fresh teams marker without scanning team entries', () => {
+      const fs = require('node:fs');
+      const workersPath = join(testHome, 'workers.json');
+      try {
+        fs.rmSync(workersPath, { force: true });
+      } catch {}
+      try {
+        fs.rmSync(`${workersPath}.migrated`, { force: true });
+      } catch {}
+
+      const teamsDir = join(testClaudeDir, 'teams');
+      fs.rmSync(teamsDir, { recursive: true, force: true });
+      mkdirSync(join(teamsDir, 'seed-team-cache'), { recursive: true });
+      writeFileSync(join(teamsDir, 'seed-team-cache', 'config.json'), JSON.stringify({ name: 'seed-team-cache' }));
+
+      const stateDir = join(testHome, 'state');
+      mkdirSync(stateDir, { recursive: true });
+      writeFileSync(
+        join(stateDir, 'teams-seed-marker'),
+        `${JSON.stringify({ teamsDir, mtimeMs: String(statSync(teamsDir).mtimeMs) })}\n`,
+      );
+
+      const originalReaddirSync = fs.readdirSync;
+      let readdirCalls = 0;
+      fs.readdirSync = (...args: unknown[]) => {
+        readdirCalls += 1;
+        return originalReaddirSync(...args);
+      };
+
+      try {
+        const start = performance.now();
+        expect(needsSeed()).toBe(false);
+        expect(performance.now() - start).toBeLessThan(1);
+        expect(readdirCalls).toBe(0);
+      } finally {
+        fs.readdirSync = originalReaddirSync;
+      }
     });
 
     test('needsSeed returns false after migration (no workers.json, no claude teams)', () => {

--- a/src/lib/pg-seed.ts
+++ b/src/lib/pg-seed.ts
@@ -9,8 +9,8 @@
  * Trigger: source `.json` exists AND `.json.migrated` does NOT.
  */
 
-import { existsSync } from 'node:fs';
-import { readFile, readdir, rename } from 'node:fs/promises';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { mkdir, readFile, readdir, rename, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type postgres from 'postgres';
@@ -28,6 +28,45 @@ function getGenieHome(): string {
 
 function workersJsonPath(): string {
   return join(getGenieHome(), 'workers.json');
+}
+
+function claudeTeamsDirPath(): string {
+  return join(process.env.CLAUDE_CONFIG_DIR ?? join(homedir(), '.claude'), 'teams');
+}
+
+function teamsSeedMarkerPath(): string {
+  return join(getGenieHome(), 'state', 'teams-seed-marker');
+}
+
+function teamsDirMtime(claudeTeamsDir: string): string | null {
+  try {
+    return String(statSync(claudeTeamsDir).mtimeMs);
+  } catch {
+    return null;
+  }
+}
+
+function hasFreshTeamsSeedMarker(claudeTeamsDir: string): boolean {
+  const mtimeMs = teamsDirMtime(claudeTeamsDir);
+  if (!mtimeMs) return false;
+  try {
+    const marker = JSON.parse(readFileSync(teamsSeedMarkerPath(), 'utf-8')) as {
+      teamsDir?: string;
+      mtimeMs?: string;
+    };
+    return marker.teamsDir === claudeTeamsDir && marker.mtimeMs === mtimeMs;
+  } catch {
+    return false;
+  }
+}
+
+async function writeTeamsSeedMarker(): Promise<void> {
+  const claudeTeamsDir = claudeTeamsDirPath();
+  const mtimeMs = teamsDirMtime(claudeTeamsDir);
+  if (!mtimeMs) return;
+  const markerPath = teamsSeedMarkerPath();
+  await mkdir(join(getGenieHome(), 'state'), { recursive: true });
+  await writeFile(markerPath, `${JSON.stringify({ teamsDir: claudeTeamsDir, mtimeMs })}\n`, 'utf-8');
 }
 
 /** Check if a source file needs migration (exists and not yet migrated). */
@@ -73,20 +112,21 @@ async function renameMatchingFiles(dir: string, filter: (filename: string) => bo
  *  - `~/.genie/workers.json` exists without a `.migrated` sibling (legacy
  *    one-time migration path — worker seed still uses markers), OR
  *  - Any Claude-native team config exists on disk at
- *    `~/.claude/teams/<name>/config.json`.
+ *    `~/.claude/teams/<name>/config.json` and the teams directory mtime differs
+ *    from the last successful seed marker.
  *
- * The Claude-native branch triggers on every boot when teams exist on disk.
- * That's intentional: `seedTeams` is idempotent (`ON CONFLICT DO NOTHING`) and
- * this is how we rehydrate PG after a `pgserve` reset. See Bug A in
- * `.genie/wishes/fix-pg-disk-rehydration/WISH.md`.
+ * The Claude-native branch is cached by `~/.genie/state/teams-seed-marker`.
+ * This avoids scanning every team directory on every daemon startup when the
+ * authoritative `~/.claude/teams` tree has not changed.
  */
 export function needsSeed(): boolean {
   if (needsMigration(workersJsonPath())) return true;
 
   // Claude-native team configs are authoritative — if any exist on disk,
   // run the seed so PG mirrors them. No `.migrated` markers here.
-  const claudeTeamsDir = join(process.env.CLAUDE_CONFIG_DIR ?? join(homedir(), '.claude'), 'teams');
+  const claudeTeamsDir = claudeTeamsDirPath();
   if (!existsSync(claudeTeamsDir)) return false;
+  if (hasFreshTeamsSeedMarker(claudeTeamsDir)) return false;
   try {
     const entries = require('node:fs').readdirSync(claudeTeamsDir) as string[];
     return entries.some((e) => !e.startsWith('.'));
@@ -488,6 +528,7 @@ export async function runSeed(sql: Sql, repoPath?: string): Promise<SeedResult> 
 
   // Phase 2: Mark source files as migrated (only after all UPSERTs succeed)
   await markMigrated(repoPath);
+  await writeTeamsSeedMarker();
 
   return result;
 }


### PR DESCRIPTION
## Summary
- Cache Claude-native team seed scans behind `~/.genie/state/teams-seed-marker`.
- `needsSeed()` now returns false without scanning `~/.claude/teams/*` when the parent teams directory mtime matches the marker from the last successful seed.
- `runSeed()` writes the marker only after seed + migration marking complete.

## Why
Fix B for the Mac CPU cold-start track. Fix C makes hook dispatch skip DB boot, but non-hook daemon startup and defensive DB boot paths still called `needsSeed()` and scanned every native team directory on each process boot.

## Validation
- `bun test src/lib/pg-seed.test.ts` — pass, 16/16.
- `bun run check:fast && bun test src/lib/pg-seed.test.ts` — pass.
- `bun run check` — rerun twice; both fail in existing `src/lib/executor-read.test.ts` endpoint tests with Bun server port/connection-refused behavior. This branch does not touch executor-read surfaces; pg-seed targeted coverage is green.

## Notes
- This uses the requested parent `~/.claude/teams` mtime marker, so cache invalidates on team directory add/remove/rename and avoids per-team `readdirSync` on the fresh-marker path.
