### PR TITLE
fix(version): walk up to find @automagik/genie package.json (#1464)

### DIFF
--- a/src/lib/version.test.ts
+++ b/src/lib/version.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for the runtime version resolver — closes #1464.
+ *
+ * The resolver must be worktree-aware: when the binary lives in
+ * `<repo>/.worktrees/<name>/dist/`, it must find
+ * `<repo>/.worktrees/<name>/package.json` (the binary's own package), NOT
+ * `<repo>/package.json` (the parent repo).
+ *
+ * These tests verify the source contract via static-text assertions plus a
+ * live runtime check that the currently-loaded VERSION matches the closest
+ * `@automagik/genie` package.json walking up from this test file.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { VERSION } from './version.js';
+
+describe('version resolver — Mac CPU sprint sibling fix #1464', () => {
+  const versionSource = readFileSync(resolve(__dirname, 'version.ts'), 'utf-8');
+
+  test('VERSION is a non-empty string', () => {
+    expect(typeof VERSION).toBe('string');
+    expect(VERSION.length).toBeGreaterThan(0);
+    expect(VERSION).not.toBe('0.0.0-unknown');
+  });
+
+  test('VERSION matches the closest @automagik/genie package.json walking up from this file', () => {
+    const ourPackageName = '@automagik/genie';
+    let dir = dirname(resolve(__dirname));
+    let walked = 0;
+    let found: { name?: string; version?: string } | null = null;
+    while (walked < 10) {
+      const pkgPath = resolve(dir, 'package.json');
+      if (existsSync(pkgPath)) {
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+        if (pkg.name === ourPackageName) {
+          found = pkg;
+          break;
+        }
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+      walked++;
+    }
+    expect(found).not.toBeNull();
+    expect(found?.version).toBeDefined();
+    expect(VERSION).toBe(found?.version as string);
+  });
+
+  test('source identifies @automagik/genie as the package name to match', () => {
+    expect(versionSource).toContain("PACKAGE_NAME = '@automagik/genie'");
+  });
+
+  test('source bounds the walk depth (no runaway scans)', () => {
+    expect(versionSource).toContain('MAX_WALK_DEPTH');
+  });
+
+  test('source matches by package name FIRST, then falls back to any version', () => {
+    // Two-pass walk: name-matched, then any-package-with-version
+    const namePassIdx = versionSource.indexOf('pkg?.name === PACKAGE_NAME');
+    const fallbackPassIdx = versionSource.indexOf('Fallback');
+    expect(namePassIdx).toBeGreaterThan(0);
+    expect(fallbackPassIdx).toBeGreaterThan(namePassIdx);
+  });
+
+  test('source explicitly stops at filesystem root', () => {
+    expect(versionSource).toMatch(/parent === current/);
+  });
+});

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,37 +1,78 @@
 /**
- * Version — reads from package.json at runtime so `genie update` reflects the new version.
+ * Version — reads from package.json at runtime so `genie update` reflects the
+ * new version.
  *
- * Resolution order:
- *   1. package.json relative to this file (dev / bun run)
- *   2. package.json in the project root (compiled dist)
- *   3. Hardcoded fallback
+ * Closes #1464.
+ *
+ * Previous resolver tried fixed `..` / `../..` relative paths from
+ * `import.meta.dir` and used the FIRST package.json that existed. That broke
+ * in worktree contexts: when the binary runs from
+ * `<repo>/.worktrees/<name>/dist/genie.js`, the `../..` candidate resolves to
+ * `<repo>/package.json` (the *parent* repo, often a different version) before
+ * the `..` candidate would have found `<repo>/.worktrees/<name>/package.json`
+ * (the actual binary's package). On a dogfood box this surfaced as
+ * `genie --version` reporting 4.260428.16 while the worktree itself was
+ * 4.260428.19.
+ *
+ * Fix: walk UP from the binary's location and return the version of the
+ * FIRST package.json whose `name === "@automagik/genie"`. This guarantees
+ * we identify our own package no matter how deep the binary lives.
  */
 
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
 const FALLBACK_VERSION = '0.0.0-unknown';
+const PACKAGE_NAME = '@automagik/genie';
+/** Hard cap on how many parent dirs we walk before giving up. Bounded
+ *  to prevent runaway scans on filesystems with no genie root reachable. */
+const MAX_WALK_DEPTH = 10;
+
+interface PackageJson {
+  name?: string;
+  version?: string;
+}
+
+function readPackageJson(path: string): PackageJson | null {
+  try {
+    if (!existsSync(path)) return null;
+    return JSON.parse(readFileSync(path, 'utf-8')) as PackageJson;
+  } catch {
+    return null;
+  }
+}
 
 function readVersionFromPackageJson(): string {
-  // Try paths relative to this module
-  const candidates = [
-    // From src/lib/version.ts → ../../package.json
-    resolve(dirname(import.meta.dir ?? __dirname), '..', '..', 'package.json'),
-    // From dist/genie.js → ../package.json
-    resolve(dirname(import.meta.dir ?? __dirname), '..', 'package.json'),
-    // From dist/genie.js → ./package.json (if placed alongside)
-    resolve(dirname(import.meta.dir ?? __dirname), 'package.json'),
-  ];
+  const startDir = dirname(import.meta.dir ?? __dirname);
 
-  for (const candidate of candidates) {
-    try {
-      if (existsSync(candidate)) {
-        const pkg = JSON.parse(readFileSync(candidate, 'utf-8'));
-        if (pkg.version) return pkg.version;
-      }
-    } catch {
-      // Try next candidate
+  // Walk up from the binary's location, return the first package.json whose
+  // `name` matches ours. This is worktree-aware: a binary in
+  // <repo>/.worktrees/<name>/dist will find <repo>/.worktrees/<name>/package.json
+  // (1 level up) before continuing to <repo>/package.json (3 levels up) —
+  // and only the first one whose name matches counts as ours.
+  let current = startDir;
+  for (let depth = 0; depth < MAX_WALK_DEPTH; depth++) {
+    const candidate = resolve(current, 'package.json');
+    const pkg = readPackageJson(candidate);
+    if (pkg?.name === PACKAGE_NAME && pkg.version) {
+      return pkg.version;
     }
+    const parent = dirname(current);
+    if (parent === current) break; // reached filesystem root
+    current = parent;
+  }
+
+  // Fallback: same walk but accept ANY package.json with a version field.
+  // This catches edge cases like running directly from a tarball where
+  // `name` may be unset, and preserves the prior resolver's lenience.
+  current = startDir;
+  for (let depth = 0; depth < MAX_WALK_DEPTH; depth++) {
+    const candidate = resolve(current, 'package.json');
+    const pkg = readPackageJson(candidate);
+    if (pkg?.version) return pkg.version;
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
   }
 
   return FALLBACK_VERSION;


### PR DESCRIPTION
## Summary

Closes **#1464** — `genie --version` reported a stale version on dogfood boxes where the binary lived inside a worktree:
- worktree `package.json`: 4.260428.19
- `genie --version`: 4.260428.16

## Root cause (dog-fooder analysis)

Per evidence in `state/evidence/1474-d3976b96-20260428T235714Z/1464`:

The previous resolver tried fixed `..` and `../..` paths from `import.meta.dir` and accepted the FIRST `package.json` that existed. For a binary at `<repo>/.worktrees/<name>/dist/genie.js`:
- `../..` candidate → `<repo>/package.json` (parent repo — wrong)
- `..` candidate → `<repo>/.worktrees/<name>/package.json` (our own — right)

The `../..` candidate is checked first and wins, returning the parent repo's version.

## Fix

Walk UP from the binary's location and return the version of the FIRST `package.json` whose `name === "@automagik/genie"`. The parent-repo `package.json` is correctly skipped because the worktree's own `package.json` (with matching name) is hit first on the way up.

Two-pass strategy:
1. Walk up looking for `name === '@automagik/genie'` (primary, worktree-aware)
2. Walk up again accepting any `package.json` with a `version` field (fallback for tarballs / detached envs where `name` is missing)

Bounded by `MAX_WALK_DEPTH=10` + filesystem-root stop.

## Empirical verification

```bash
# In worktree (.worktrees/fix-version-resolver/, package.json says 4.260428.19)
$ bun -e "import('./src/lib/version.js').then(m => console.log(m.VERSION))"
4.260428.19   ✓

# In parent repo (package.json says 4.260428.16)
$ bun -e "import('./src/lib/version.ts').then(m => console.log(m.VERSION))"
4.260428.16   ✓
```

## Validation

- **6/6 `src/lib/version.test.ts` pass** (new file): VERSION non-empty + non-fallback, matches closest `@automagik/genie` package.json, source contract assertions for PACKAGE_NAME / MAX_WALK_DEPTH / two-pass order / root-stop
- biome clean
- tsc clean

## Evidence credit

dog-fooder (the bare `genie/dog-fooder` instance) pinned the smoking gun in `src/lib/version.ts` with full file path enumeration. Full audit trail in evidence dir cited above.