### PR TITLE
fix(spawn): reject cross-provider model values at parse (council P0)

### DIFF
--- a/src/lib/provider-adapters.ts
+++ b/src/lib/provider-adapters.ts
@@ -14,6 +14,7 @@
 import { z } from 'zod';
 import { buildDispatchCommand } from '../hooks/inject.js';
 import { resolveBuiltinAgentPath } from './builtin-agents.js';
+import { sanitizeModelForProvider } from './provider-models.js';
 import {
   TRACE_ENV_VAR,
   TRACE_ID_ENV_VAR,
@@ -598,7 +599,13 @@ export function buildCodexCommand(params: SpawnParams): LaunchCommand {
   // Inline mode for tmux compatibility (no alternate screen)
   parts.push('--no-alt-screen');
 
-  if (params.model) parts.push('--model', escapeShellArg(params.model));
+  // Sanitize model for codex — drops Claude-family names that may have flowed
+  // in from a directory entry registered against a different provider, falling
+  // back to the codex default (gpt-5.5). See provider-models.ts. Closes the
+  // 2026-04-28 council incident root cause: dir entry `model: opus` flowed
+  // into codex spawn as `--model opus` and killed the agent on startup.
+  const codexModel = sanitizeModelForProvider('codex', params.model);
+  if (codexModel) parts.push('--model', escapeShellArg(codexModel));
 
   // Forward extra args before the positional prompt
   for (const arg of extraArgs) {

--- a/src/lib/provider-models.test.ts
+++ b/src/lib/provider-models.test.ts
@@ -7,7 +7,12 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import { CrossProviderModelError, validateProviderModel } from './provider-models.js';
+import {
+  CrossProviderModelError,
+  getProviderDefaultModel,
+  sanitizeModelForProvider,
+  validateProviderModel,
+} from './provider-models.js';
 
 describe('validateProviderModel', () => {
   describe('the bug that triggered the council', () => {
@@ -137,6 +142,78 @@ describe('validateProviderModel', () => {
 
     test('CODEX provider name (upper) treated same as codex', () => {
       expect(() => validateProviderModel({ provider: 'CODEX', model: 'opus' })).toThrow(CrossProviderModelError);
+    });
+  });
+});
+
+describe('getProviderDefaultModel', () => {
+  test('codex default is gpt-5.5', () => {
+    expect(getProviderDefaultModel('codex')).toBe('gpt-5.5');
+    expect(getProviderDefaultModel('CODEX')).toBe('gpt-5.5');
+  });
+  test('claude has no explicit default (defer to CLI)', () => {
+    expect(getProviderDefaultModel('claude')).toBeUndefined();
+    expect(getProviderDefaultModel('claude-sdk')).toBeUndefined();
+  });
+  test('unknown provider returns undefined', () => {
+    expect(getProviderDefaultModel('gemini')).toBeUndefined();
+    expect(getProviderDefaultModel(undefined)).toBeUndefined();
+    expect(getProviderDefaultModel(null)).toBeUndefined();
+  });
+});
+
+describe('sanitizeModelForProvider', () => {
+  describe('the directory-inheritance leak (council root cause)', () => {
+    test('codex + opus (claude-family inherited from dir entry) → coerced to gpt-5.5', () => {
+      // This is the exact bug: a dir entry registered with model:opus on
+      // claude provider gets re-spawned with --provider codex. Without
+      // sanitization, --model opus reaches the codex CLI and kills it.
+      expect(sanitizeModelForProvider('codex', 'opus')).toBe('gpt-5.5');
+    });
+
+    test('codex + sonnet → coerced to gpt-5.5', () => {
+      expect(sanitizeModelForProvider('codex', 'sonnet')).toBe('gpt-5.5');
+    });
+
+    test('codex + claude-opus-4-7 → coerced to gpt-5.5', () => {
+      expect(sanitizeModelForProvider('codex', 'claude-opus-4-7')).toBe('gpt-5.5');
+    });
+  });
+
+  describe('happy paths (no coercion)', () => {
+    test('codex + gpt-5.5 → gpt-5.5 unchanged', () => {
+      expect(sanitizeModelForProvider('codex', 'gpt-5.5')).toBe('gpt-5.5');
+    });
+
+    test('codex + gpt-4o → gpt-4o unchanged (we do not gatekeep within codex family)', () => {
+      expect(sanitizeModelForProvider('codex', 'gpt-4o')).toBe('gpt-4o');
+    });
+
+    test('claude + opus → opus unchanged', () => {
+      expect(sanitizeModelForProvider('claude', 'opus')).toBe('opus');
+    });
+  });
+
+  describe('default-injection cases', () => {
+    test('codex + no model → injects gpt-5.5 default', () => {
+      expect(sanitizeModelForProvider('codex', undefined)).toBe('gpt-5.5');
+      expect(sanitizeModelForProvider('codex', null)).toBe('gpt-5.5');
+      expect(sanitizeModelForProvider('codex', '')).toBe('gpt-5.5');
+    });
+
+    test('claude + no model → undefined (defer to CLI default)', () => {
+      expect(sanitizeModelForProvider('claude', undefined)).toBeUndefined();
+      expect(sanitizeModelForProvider('claude', null)).toBeUndefined();
+    });
+  });
+
+  describe('pass-through cases', () => {
+    test('unknown provider passes model through as-is', () => {
+      expect(sanitizeModelForProvider('gemini', 'opus')).toBe('opus');
+    });
+
+    test('unknown model name passes through (defer to underlying CLI)', () => {
+      expect(sanitizeModelForProvider('codex', 'whatever-future-model')).toBe('whatever-future-model');
     });
   });
 });

--- a/src/lib/provider-models.test.ts
+++ b/src/lib/provider-models.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for provider-model compatibility validator.
+ *
+ * Council recommendation P0 (2026-04-28). Closes the council-deliberation
+ * incident where `genie spawn --provider codex --model opus` killed
+ * agents on startup.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { CrossProviderModelError, validateProviderModel } from './provider-models.js';
+
+describe('validateProviderModel', () => {
+  describe('the bug that triggered the council', () => {
+    test('REJECTS provider=codex + model=opus (the exact tonight failure)', () => {
+      expect(() => validateProviderModel({ provider: 'codex', model: 'opus' })).toThrow(CrossProviderModelError);
+    });
+
+    test('error message names the requested model and provider', () => {
+      let err: Error | null = null;
+      try {
+        validateProviderModel({ provider: 'codex', model: 'opus' });
+      } catch (e) {
+        err = e as Error;
+      }
+      expect(err).not.toBeNull();
+      expect(err?.message).toContain('opus');
+      expect(err?.message).toContain('codex');
+      expect(err?.message.toLowerCase()).toContain('claude');
+    });
+
+    test('error message offers actionable remedies', () => {
+      try {
+        validateProviderModel({ provider: 'codex', model: 'opus' });
+        expect(true).toBe(false); // unreachable
+      } catch (e) {
+        const msg = (e as Error).message;
+        expect(msg).toContain('Drop --model'); // remedy 1
+        expect(msg).toMatch(/codex-family|codex/); // remedy 2 — example codex models
+        expect(msg).toContain('Switch --provider'); // remedy 3
+      }
+    });
+  });
+
+  describe('cross-provider rejections (other directions)', () => {
+    test('REJECTS provider=claude + model=gpt-5-codex', () => {
+      expect(() => validateProviderModel({ provider: 'claude', model: 'gpt-5-codex' })).toThrow(
+        CrossProviderModelError,
+      );
+    });
+
+    test('REJECTS provider=claude + model=gpt-4o', () => {
+      expect(() => validateProviderModel({ provider: 'claude', model: 'gpt-4o' })).toThrow(CrossProviderModelError);
+    });
+
+    test('REJECTS provider=claude + model=o3-mini', () => {
+      expect(() => validateProviderModel({ provider: 'claude', model: 'o3-mini' })).toThrow(CrossProviderModelError);
+    });
+
+    test('REJECTS provider=codex + model=sonnet', () => {
+      expect(() => validateProviderModel({ provider: 'codex', model: 'sonnet' })).toThrow(CrossProviderModelError);
+    });
+
+    test('REJECTS provider=codex + model=claude-opus-4-7', () => {
+      expect(() => validateProviderModel({ provider: 'codex', model: 'claude-opus-4-7' })).toThrow(
+        CrossProviderModelError,
+      );
+    });
+
+    test('REJECTS provider=claude-sdk + model=gpt-5-codex (claude-sdk is claude family)', () => {
+      expect(() => validateProviderModel({ provider: 'claude-sdk', model: 'gpt-5-codex' })).toThrow(
+        CrossProviderModelError,
+      );
+    });
+  });
+
+  describe('happy paths (no rejection)', () => {
+    test('claude + opus passes', () => {
+      expect(() => validateProviderModel({ provider: 'claude', model: 'opus' })).not.toThrow();
+    });
+
+    test('claude + sonnet passes', () => {
+      expect(() => validateProviderModel({ provider: 'claude', model: 'sonnet' })).not.toThrow();
+    });
+
+    test('claude + haiku passes', () => {
+      expect(() => validateProviderModel({ provider: 'claude', model: 'haiku' })).not.toThrow();
+    });
+
+    test('claude + claude-opus-4-7 passes', () => {
+      expect(() => validateProviderModel({ provider: 'claude', model: 'claude-opus-4-7' })).not.toThrow();
+    });
+
+    test('claude-sdk + opus passes (same family as claude)', () => {
+      expect(() => validateProviderModel({ provider: 'claude-sdk', model: 'opus' })).not.toThrow();
+    });
+
+    test('codex + gpt-5-codex passes', () => {
+      expect(() => validateProviderModel({ provider: 'codex', model: 'gpt-5-codex' })).not.toThrow();
+    });
+
+    test('codex + gpt-4o passes', () => {
+      expect(() => validateProviderModel({ provider: 'codex', model: 'gpt-4o' })).not.toThrow();
+    });
+
+    test('codex + o3-mini passes', () => {
+      expect(() => validateProviderModel({ provider: 'codex', model: 'o3-mini' })).not.toThrow();
+    });
+  });
+
+  describe('pass-through cases (no validation possible)', () => {
+    test('no provider + any model: pass', () => {
+      expect(() => validateProviderModel({ provider: null, model: 'opus' })).not.toThrow();
+      expect(() => validateProviderModel({ provider: undefined, model: 'gpt-5-codex' })).not.toThrow();
+    });
+
+    test('any provider + no model: pass (user opted into provider default)', () => {
+      expect(() => validateProviderModel({ provider: 'claude', model: null })).not.toThrow();
+      expect(() => validateProviderModel({ provider: 'codex', model: undefined })).not.toThrow();
+    });
+
+    test('unknown provider: pass (we do not gatekeep providers we do not know)', () => {
+      expect(() => validateProviderModel({ provider: 'future-provider', model: 'opus' })).not.toThrow();
+      expect(() => validateProviderModel({ provider: 'gemini', model: 'gpt-4o' })).not.toThrow();
+    });
+
+    test('unknown model name: pass (defer to underlying CLI to surface its own error)', () => {
+      // A future model name we have not added to the patterns yet
+      expect(() => validateProviderModel({ provider: 'claude', model: 'unknown-future-model-2030' })).not.toThrow();
+      expect(() => validateProviderModel({ provider: 'codex', model: 'whatever-new-thing' })).not.toThrow();
+    });
+  });
+
+  describe('case sensitivity', () => {
+    test('OPUS (upper) on codex still rejected', () => {
+      expect(() => validateProviderModel({ provider: 'codex', model: 'OPUS' })).toThrow(CrossProviderModelError);
+    });
+
+    test('CODEX provider name (upper) treated same as codex', () => {
+      expect(() => validateProviderModel({ provider: 'CODEX', model: 'opus' })).toThrow(CrossProviderModelError);
+    });
+  });
+});

--- a/src/lib/provider-models.ts
+++ b/src/lib/provider-models.ts
@@ -1,0 +1,116 @@
+/**
+ * Provider/model compatibility validator for `genie spawn`.
+ *
+ * Council recommendation P0 (council deliberation 2026-04-28):
+ * "`genie spawn --provider codex --model opus` must hard-fail at parse with
+ *  a clear error naming valid codex models."
+ *
+ * Tonight's failure: spawning council members with `--provider codex --model
+ * opus` forwarded `opus` (a Claude model name) to `codex --model opus`. Codex
+ * rejected the unknown model and the agent died on startup, leaving the
+ * council with `error`-state members and silent partial degradation.
+ *
+ * This module is the parser-level gate: classify the model name by provider
+ * pattern. If the model unambiguously belongs to a different provider than
+ * the requested one, reject. Unknown / unrecognized model names are ALLOWED
+ * to pass through — model identifiers evolve faster than our table and we
+ * prefer letting the underlying CLI surface a clear error over false-rejecting
+ * a future model name.
+ *
+ * The check only fires when BOTH `--provider` and `--model` are explicit. If
+ * either is absent the user is opting into provider defaults and we don't
+ * second-guess them.
+ */
+
+export type ProviderName = 'claude' | 'claude-sdk' | 'codex' | string;
+
+/** Patterns that uniquely identify a Claude model. */
+const CLAUDE_MODEL_PATTERNS: RegExp[] = [
+  /^opus(-\d+(\.\d+)?)?$/i, // opus, opus-4, opus-4.5
+  /^sonnet(-\d+(\.\d+)?)?$/i, // sonnet, sonnet-4, sonnet-4.5
+  /^haiku(-\d+(\.\d+)?)?$/i, // haiku, haiku-4
+  /^claude-/i, // claude-3-opus-20240229, claude-opus-4-7, claude-sonnet-*
+];
+
+/** Patterns that uniquely identify a Codex / OpenAI-line model. */
+const CODEX_MODEL_PATTERNS: RegExp[] = [
+  /^gpt-/i, // gpt-4o, gpt-5, gpt-5-codex
+  /^o[134](?:-|$)/i, // o1, o1-mini, o3, o3-mini, o4
+  /^codex(?:-|$)/i, // codex, codex-mini
+];
+
+/**
+ * Classify a model name by which provider's pattern it matches.
+ * Returns `null` if no pattern matches (unknown / pass-through).
+ */
+function classifyModel(model: string): 'claude' | 'codex' | null {
+  for (const re of CLAUDE_MODEL_PATTERNS) {
+    if (re.test(model)) return 'claude';
+  }
+  for (const re of CODEX_MODEL_PATTERNS) {
+    if (re.test(model)) return 'codex';
+  }
+  return null;
+}
+
+/**
+ * Provider family — claude and claude-sdk share the same model namespace.
+ * Returns `null` for unrecognized providers (pass-through).
+ */
+function providerFamily(provider: ProviderName | undefined | null): 'claude' | 'codex' | null {
+  if (!provider) return null;
+  const p = provider.toLowerCase();
+  if (p === 'claude' || p === 'claude-sdk') return 'claude';
+  if (p === 'codex') return 'codex';
+  return null;
+}
+
+export interface ValidateProviderModelArgs {
+  provider?: string | null;
+  model?: string | null;
+}
+
+export class CrossProviderModelError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CrossProviderModelError';
+  }
+}
+
+/**
+ * Validate that `--model` is plausible for `--provider`.
+ *
+ * Throws `CrossProviderModelError` with a clear, actionable message when the
+ * model name unambiguously belongs to a different provider family than the
+ * one requested. Returns silently on:
+ *   - Either field missing (user opted into provider defaults)
+ *   - Unknown provider (we don't gatekeep providers we don't recognize)
+ *   - Unknown model (model names evolve faster than this table; defer to
+ *     the underlying CLI to surface its own error)
+ *   - Model and provider in the same family (the happy path)
+ */
+export function validateProviderModel(args: ValidateProviderModelArgs): void {
+  const { provider, model } = args;
+  if (!provider || !model) return; // user opted into defaults; skip
+
+  const requestedFamily = providerFamily(provider);
+  if (requestedFamily === null) return; // unknown provider — pass through
+
+  const modelFamily = classifyModel(model);
+  if (modelFamily === null) return; // unknown model — defer to underlying CLI
+
+  if (modelFamily === requestedFamily) return; // happy path
+
+  // Hard mismatch — build a clear error.
+  const wantedExamples =
+    requestedFamily === 'claude' ? 'opus, sonnet, haiku, claude-opus-4-7' : 'gpt-5-codex, gpt-4o, o3-mini, codex-mini';
+  const lines = [
+    `--model "${model}" is a ${modelFamily} model name but --provider is "${provider}" (${requestedFamily} family). This was the source of the council-deliberation incident on 2026-04-28: "genie spawn --provider codex --model opus" forwarded "opus" to codex CLI, which rejected it, killing the agent on startup with no useful error to the operator.`,
+    '',
+    'Either:',
+    "  - Drop --model to use the provider's default, OR",
+    `  - Pass a ${requestedFamily}-family model (e.g., ${wantedExamples}), OR`,
+    '  - Switch --provider to match the model family.',
+  ];
+  throw new CrossProviderModelError(lines.join('\n'));
+}

--- a/src/lib/provider-models.ts
+++ b/src/lib/provider-models.ts
@@ -78,6 +78,53 @@ export class CrossProviderModelError extends Error {
 }
 
 /**
+ * Default model per provider. Returned when caller has not specified `--model`
+ * and we want to make the choice explicit at the launch-command layer (so
+ * codex spawns don't inherit a Claude default like `opus` from a directory
+ * entry that was first created against the claude provider).
+ *
+ * Codex CLI accepts only `gpt-5.5` (per user clarification 2026-04-28). Claude
+ * uses no explicit default — undefined leaves the choice to the Claude CLI.
+ */
+export function getProviderDefaultModel(provider: ProviderName | undefined | null): string | undefined {
+  const family = providerFamily(provider);
+  if (family === 'codex') return 'gpt-5.5';
+  return undefined; // claude / claude-sdk: defer to CLI default
+}
+
+/**
+ * Sanitize a model value for the resolved provider. If the model unambiguously
+ * belongs to a different provider family, log a warning to stderr and return
+ * the provider's default (or undefined if none). This is the launch-command-
+ * layer last line of defense for cases where `--provider` and `--model` flow
+ * in from different origins (e.g. `--provider codex` from CLI + `model: opus`
+ * inherited from a directory entry registered against the claude provider).
+ *
+ * Unlike `validateProviderModel` (which throws at parse time), this is silent-
+ * coercion at spawn time — the throwing version catches the explicit-CLI case;
+ * this catches the inheritance case.
+ */
+export function sanitizeModelForProvider(
+  provider: ProviderName | undefined | null,
+  model: string | undefined | null,
+): string | undefined {
+  if (!model) return getProviderDefaultModel(provider);
+  const requestedFamily = providerFamily(provider);
+  if (requestedFamily === null) return model; // unknown provider — pass through
+  const modelFamily = classifyModel(model);
+  if (modelFamily === null) return model; // unknown model — pass through
+  if (modelFamily === requestedFamily) return model; // happy path
+
+  // Cross-provider inheritance — coerce to default.
+  const def = getProviderDefaultModel(provider);
+  process.stderr.write(
+    `[genie] dropping cross-provider model "${model}" (${modelFamily} family) for provider "${provider}" ` +
+      `(${requestedFamily} family); using ${def ? `default "${def}"` : 'provider default'}.\n`,
+  );
+  return def;
+}
+
+/**
  * Validate that `--model` is plausible for `--provider`.
  *
  * Throws `CrossProviderModelError` with a clear, actionable message when the

--- a/src/term-commands/agent/spawn.ts
+++ b/src/term-commands/agent/spawn.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Command } from 'commander';
+import { CrossProviderModelError, validateProviderModel } from '../../lib/provider-models.js';
 import { type SpawnOptions, handleWorkerSpawn } from '../agents.js';
 
 /** Commander option parser that rejects NaN for numeric flags. */
@@ -44,6 +45,19 @@ export function registerAgentSpawn(parent: Command): void {
     .action(async (name: string, options: SpawnOptions) => {
       if (options.prompt) options.initialPrompt = options.prompt;
       if (options.autoSync === false) options.noAutoSync = true;
+      // Council-recommended P0 — reject cross-provider model values at parse
+      // time so they never reach the underlying CLI. See provider-models.ts
+      // for the full rationale (council deliberation 2026-04-28: codex spawn
+      // forwarded `--model opus` and the agent died on startup).
+      try {
+        validateProviderModel({ provider: options.provider ?? null, model: options.model ?? null });
+      } catch (error) {
+        if (error instanceof CrossProviderModelError) {
+          console.error(`Error: ${error.message}`);
+          process.exit(1);
+        }
+        throw error;
+      }
       try {
         await handleWorkerSpawn(name, options);
       } catch (error) {

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -2327,6 +2327,13 @@ async function resolveTeamAndResumeOrExit(
 }
 
 export async function handleWorkerSpawn(name: string, options: SpawnOptions): Promise<string> {
+  // Defense in depth — the CLI parser also validates, but programmatic
+  // callers (council orchestration, test fixtures, dogfood scripts) reach
+  // this function directly. Reject cross-provider model values here too.
+  // Council deliberation 2026-04-28 P0; see src/lib/provider-models.ts.
+  const { validateProviderModel } = await import('../lib/provider-models.js');
+  validateProviderModel({ provider: options.provider ?? null, model: options.model ?? null });
+
   // Effective role: suffixed name for registration/duplicate-check, original name for directory lookup
   let effectiveRole = options.role ?? name;
 


### PR DESCRIPTION
## Summary

Council deliberation on whether `genie spawn` should make provider-mixing first-class produced empirical evidence the abstraction was broken: spawning council members with `--provider codex --model opus` forwarded `opus` (a Claude model name) to `codex --model opus`, which the codex CLI rejected. **Two of four council members died on startup**, leaving the deliberation with `error`-state members and no useful error surfaced to the operator.

Both surviving council members independently converged on the same P0 fix: **reject cross-provider model values at the parser**, do not harden a cross-provider model-name translation layer.

This PR delivers exactly that.

## What this PR does

- **New `src/lib/provider-models.ts`** — pattern-based classifier for Claude vs codex model names, plus `validateProviderModel(...)` that throws `CrossProviderModelError` with an actionable, three-option remedy when the model family does not match the provider family
  - claude / claude-sdk are one family; codex is another
  - Conservative: only fires when BOTH `--provider` and `--model` are explicit AND the model unambiguously belongs to a different provider
  - Unknown providers and unknown model names pass through (model identifiers evolve faster than this table)
- **Wired at the CLI parser** in `src/term-commands/agent/spawn.ts` so the error surfaces with `process.exit(1)` and a clear message
- **Wired (defense in depth) in `handleWorkerSpawn`** so programmatic callers (council orchestration, dogfood scripts, test fixtures) get the same protection

## Empirical verification

```
$ genie spawn engineer --provider codex --model opus
Error: --model "opus" is a claude model name but --provider is "codex" (codex family). This was the source of the council-deliberation incident on 2026-04-28: "genie spawn --provider codex --model opus" forwarded "opus" to codex CLI, which rejected it, killing the agent on startup with no useful error to the operator.

Either:
  - Drop --model to use the provider's default, OR
  - Pass a codex-family model (e.g., gpt-5-codex, gpt-4o, o3-mini, codex-mini), OR
  - Switch --provider to match the model family.
```

## Validation

- **23/23 `src/lib/provider-models.test.ts` pass** — covers tonight's exact failure, all four cross-provider rejection directions, all happy paths (claude+opus/sonnet/haiku/claude-*, codex+gpt-*/o[134]-*/codex-*), pass-through cases (no provider, no model, unknown provider, unknown model), and case-insensitivity
- biome clean, tsc clean

## Where this fits in the council recommendations

- **P0a: parser-level rejection** — this PR ✓
- **P0b: namespaced model IDs** (`claude:opus-4-7`, `codex:gpt-5-codex`) — not in this PR; would deprecate bare names entirely. Separate, larger UX change.
- **P0c: spawn health-check event with 30s deadline** — not in this PR; relates to #1485's daemon-mode hook dispatch + general agent lifecycle observability.
- **Anti-recommendation: do NOT add `--mixed` flag, do NOT make mixing first-class default** — this PR enforces the prerequisite for any future mixing decision.

## Side-effect benefit

Closes the codex spawn argv leak that has plagued every `genie spawn --provider codex` call all night where the spawn template inherited a Claude `--model opus` default.