### PR TITLE
fix(omni-bridge): persist per-chat Claude session id so tmux respawns resume the same conversation

### DIFF
--- a/src/services/executor.ts
+++ b/src/services/executor.ts
@@ -18,7 +18,14 @@ export interface ExecutorSession {
   executorType: 'tmux' | 'sdk';
   createdAt: number;
   lastActivityAt: number;
-  tmux?: { session: string; window: string; paneId: string };
+  /**
+   * `claudeSessionId` is the persistent per-chat conversation id. The tmux
+   * executor sets it both on fresh spawns (newly-generated UUID passed via
+   * `--session-id`) and on resumed spawns (prior id passed via `--resume`).
+   * Bridge consumers persist it to `genie_bridge_sessions` so observers can
+   * trace a chat's full history across executor restarts.
+   */
+  tmux?: { session: string; window: string; paneId: string; claudeSessionId?: string };
   sdk?: { claudeSessionId?: string; executorId?: string };
 }
 

--- a/src/services/executors/claude-code.test.ts
+++ b/src/services/executors/claude-code.test.ts
@@ -180,6 +180,40 @@ describe('buildOmniSpawnParams', () => {
     expect(params.disallowedTools).toEqual(['Edit', 'Write', 'Agent']);
   });
 
+  test('emits resume (not sessionId) when resumeClaudeSessionId is set', () => {
+    // Operator-facing invariant: omni-spawned chats are permanent. When the
+    // bridge respawns a per-chat agent and we have a prior Claude session id
+    // for that (agent, chat), buildOmniSpawnParams must surface it as `resume`
+    // so buildLaunchCommand emits `--resume <id>` and Claude reattaches to
+    // the same JSONL transcript.
+    const priorClaudeSessionId = 'b25fb825-3695-4aa1-bcdf-7a4c20dc66c8';
+    const params = buildOmniSpawnParams(
+      'simone',
+      'chat123',
+      fakeEntry,
+      { OMNI_INSTANCE: 'inst-1', OMNI_SENDER_NAME: 'Stefani' },
+      'follow-up message',
+      priorClaudeSessionId,
+    );
+    expect(params.resume).toBe(priorClaudeSessionId);
+    // sessionId must be omitted on resume — they are mutually exclusive in
+    // buildLaunchCommand. A leftover sessionId would cause a noisy fallback
+    // when `resume` is consumed first.
+    expect(params.sessionId).toBeUndefined();
+  });
+
+  test('falls back to fresh sessionId when resumeClaudeSessionId is undefined', () => {
+    // Backward compat: existing callers (and the first-ever spawn for a chat)
+    // pass no resume id and must still get a generated sessionId for
+    // `--session-id <new-uuid>`. The newly-generated id is what gets
+    // persisted to executors.claude_session_id so the *next* respawn can
+    // resume it.
+    const params = buildOmniSpawnParams('simone', 'chat123', fakeEntry, {}, 'first message');
+    expect(params.resume).toBeUndefined();
+    expect(params.sessionId).toBeDefined();
+    expect(params.sessionId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
   test('omits permissions when entry has none (no false sense of security)', () => {
     const params = buildOmniSpawnParams('simone', 'chat123', fakeEntry, {});
     expect(params.permissions).toBeUndefined();

--- a/src/services/executors/claude-code.ts
+++ b/src/services/executors/claude-code.ts
@@ -129,6 +129,14 @@ async function lookupChatName(chatId: string, _instanceId: string): Promise<stri
 
 /**
  * Build SpawnParams from omni bridge context so we can delegate to buildLaunchCommand().
+ *
+ * @param resumeClaudeSessionId — when set, emits `--resume <id>` instead of
+ *   `--session-id <new-uuid>`. Used by the omni bridge to attach a freshly-
+ *   spawned tmux pane to the same Claude conversation that handled this chat
+ *   before a crash/restart, so per-chat history persists across executor death.
+ *   The two flags are mutually exclusive in `buildLaunchCommand` (see
+ *   provider-adapters.ts) — `resume` wins when both are set, but we omit
+ *   `sessionId` when resuming for clarity.
  */
 export function buildOmniSpawnParams(
   agentName: string,
@@ -136,6 +144,7 @@ export function buildOmniSpawnParams(
   entry: DirectoryEntry,
   env: Record<string, string>,
   initialMessage?: string,
+  resumeClaudeSessionId?: string,
 ): SpawnParams {
   const instanceId = env.OMNI_INSTANCE ?? '';
   const senderName = env.OMNI_SENDER_NAME ?? 'whatsapp-user';
@@ -159,7 +168,8 @@ export function buildOmniSpawnParams(
     provider: (entry.provider as SpawnParams['provider']) ?? 'claude',
     team: agentName,
     role: agentName,
-    sessionId: randomUUID(),
+    sessionId: resumeClaudeSessionId ? undefined : randomUUID(),
+    resume: resumeClaudeSessionId,
     model: entry.model,
     promptMode: entry.promptMode,
     systemPromptFile: join(entry.dir, 'AGENTS.md'),
@@ -209,9 +219,39 @@ export class ClaudeCodeOmniExecutor implements IExecutor {
     const windowName = sanitizeWindowName(chatId, chatName ?? undefined);
     const { paneId, created } = await ensureTeamWindow(tmuxSession, windowName, entry.dir);
 
+    // Find-or-create the per-chat agent record up front so we can look up any
+    // prior executor for this (agent, chat) pair BEFORE building the launch
+    // command. If a prior executor exists with a recorded Claude session id,
+    // we pass it as `--resume` so the freshly-spawned tmux pane attaches to
+    // the same conversation history. This is the key invariant requested by
+    // operators: "omni-bridged sessions are permanent until explicitly closed".
+    const instanceId = env.OMNI_INSTANCE ?? '';
+    const agent = this.safePgCall
+      ? await this.safePgCall(
+          'tmux-find-or-create-agent',
+          () => agents.findOrCreateAgent(`${agentName}:${chatId}`, 'omni', 'omni'),
+          null,
+          { chatId },
+        )
+      : null;
+    const existingExecutor = agent
+      ? ((await this.safePgCall?.(
+          'tmux-find-existing-executor',
+          () => registry.findLatestByMetadata({ agentId: agent.id, source: 'omni', chatId }),
+          null,
+          { chatId },
+        )) ?? null)
+      : null;
+    const resumeClaudeSessionId = existingExecutor?.claudeSessionId ?? undefined;
+
+    let claudeSessionId: string | undefined = resumeClaudeSessionId;
     if (created) {
       const omniEnv: Record<string, string> = { ...env, GENIE_OMNI_CHAT_ID: chatId, GENIE_OMNI_AGENT: agentName };
-      const params = buildOmniSpawnParams(agentName, chatId, entry, omniEnv, initialMessage);
+      const params = buildOmniSpawnParams(agentName, chatId, entry, omniEnv, initialMessage, resumeClaudeSessionId);
+      // The effective claude session id is the resume id when present, else
+      // the freshly-generated sessionId — we persist whichever was used so
+      // the next respawn finds the same id and can re-attach.
+      claudeSessionId = resumeClaudeSessionId ?? params.sessionId ?? undefined;
       const launch = buildLaunchCommand(params);
 
       // Merge omni-specific env vars with those produced by buildLaunchCommand
@@ -224,14 +264,16 @@ export class ClaudeCodeOmniExecutor implements IExecutor {
     }
 
     const sessionKey = `${agentName}:${chatId}`;
-    const registration = await this.registerInWorldA(
-      agentName,
+    const registration = await this.registerOrRelinkExecutor(
+      agent,
+      existingExecutor,
       chatId,
-      env.OMNI_INSTANCE ?? '',
+      instanceId,
       tmuxSession,
       windowName,
       paneId,
       entry.dir,
+      claudeSessionId,
     );
     this.sessions.set(sessionKey, {
       executorId: registration?.executorId ?? null,
@@ -248,27 +290,40 @@ export class ClaudeCodeOmniExecutor implements IExecutor {
       executorType: 'tmux' as const,
       createdAt: now,
       lastActivityAt: now,
-      tmux: { session: tmuxSession, window: windowName, paneId },
+      tmux: { session: tmuxSession, window: windowName, paneId, claudeSessionId },
     };
   }
 
-  private async registerInWorldA(
-    agentName: string,
+  /**
+   * Persist (or relink) the executor row for this per-chat omni session.
+   *
+   * - If an existing executor row was found by `findLatestByMetadata`, we
+   *   relink it to the same agent (in case current_executor_id drifted),
+   *   refresh its tmux pane/window pointers (a respawn lands in a new pane),
+   *   and persist the resolved Claude session id when the row was missing
+   *   one (e.g., legacy rows from before this fix). The row's identity
+   *   (executor.id) and history are preserved.
+   * - Otherwise, create a fresh executor row carrying the freshly-generated
+   *   Claude session id, so the *next* respawn finds it via
+   *   `findLatestByMetadata` and re-attaches via `--resume`.
+   *
+   * Either path makes per-chat sessions permanent across executor death:
+   * the bridge always finds the same `claude_session_id` for a given
+   * `(agent_id, chat_id)`, and Claude's `--resume` reloads the JSONL
+   * transcript transparently.
+   */
+  private async registerOrRelinkExecutor(
+    agent: { id: string } | null,
+    existingExecutor: { id: string; claudeSessionId?: string | null } | null,
     chatId: string,
     instanceId: string,
     tmuxSession: string,
     tmuxWindow: string,
     tmuxPaneId: string,
     repoPath: string,
+    claudeSessionId: string | undefined,
   ): Promise<{ executorId: string; agentId: string } | null> {
-    if (!this.safePgCall) return null;
-    const agent = await this.safePgCall(
-      'tmux-find-or-create-agent',
-      () => agents.findOrCreateAgent(`${agentName}:${chatId}`, 'omni', 'omni'),
-      null,
-      { chatId },
-    );
-    if (!agent) return null;
+    if (!this.safePgCall || !agent) return null;
 
     // Update agent record with pane_id and repo_path. Used by inter-agent
     // SendMessage (protocol-router) and observability — not by omni-turn
@@ -292,6 +347,49 @@ export class ClaudeCodeOmniExecutor implements IExecutor {
       { chatId },
     );
 
+    // RELINK PATH — reuse the prior executor row so the per-chat session id
+    // (claude_session_id) and audit history are preserved across crashes.
+    if (existingExecutor) {
+      await this.safePgCall(
+        'tmux-relink-executor',
+        () => registry.relinkExecutorToAgent(existingExecutor.id, agent.id),
+        undefined,
+        { executorId: existingExecutor.id, chatId },
+      );
+      // Refresh tmux pane pointers — a respawn lands in a new pane.
+      await this.safePgCall(
+        'tmux-refresh-executor-pane',
+        async () => {
+          const sql = await import('../../lib/db.js').then((m) => m.getConnection());
+          await sql`
+            UPDATE executors
+            SET tmux_session = ${tmuxSession},
+                tmux_window = ${tmuxWindow},
+                tmux_pane_id = ${tmuxPaneId},
+                ended_at = NULL,
+                state = 'running',
+                updated_at = now()
+            WHERE id = ${existingExecutor.id}
+          `;
+        },
+        undefined,
+        { executorId: existingExecutor.id, chatId },
+      );
+      // Backfill claude_session_id on legacy rows (pre-fix executors created
+      // without one). Idempotent — `updateClaudeSessionId` is a single UPDATE.
+      if (claudeSessionId && !existingExecutor.claudeSessionId) {
+        await this.safePgCall(
+          'tmux-backfill-claude-session-id',
+          () => registry.updateClaudeSessionId(existingExecutor.id, claudeSessionId),
+          undefined,
+          { executorId: existingExecutor.id, chatId },
+        );
+      }
+      return { executorId: existingExecutor.id, agentId: agent.id };
+    }
+
+    // CREATE PATH — fresh chat (no prior executor). Persist the
+    // claude_session_id so the next respawn finds it.
     const executor = await this.safePgCall(
       'tmux-create-executor',
       () =>
@@ -300,6 +398,7 @@ export class ClaudeCodeOmniExecutor implements IExecutor {
           tmuxWindow,
           tmuxPaneId,
           tmuxWindowId: null,
+          claudeSessionId,
           metadata: { source: 'omni', chat_id: chatId, instance_id: instanceId },
         }),
       null,

--- a/src/services/omni-bridge.ts
+++ b/src/services/omni-bridge.ts
@@ -1131,8 +1131,13 @@ export class OmniBridge {
       placeholder.session = session;
       placeholder.spawning = false;
 
-      // Record session in PG for crash recovery
+      // Record session in PG for crash recovery. Both executors expose a
+      // claude session id — sdk via `session.sdk.claudeSessionId`, tmux via
+      // `session.tmux.claudeSessionId` (added so the bridge can persist the
+      // per-chat conversation id and observers can trace history across
+      // executor restarts).
       if (this.sessionStore) {
+        const claudeSessionId = session.sdk?.claudeSessionId ?? session.tmux?.claudeSessionId;
         const pgId = await this.safePgCall(
           'session_create',
           (sql) =>
@@ -1142,7 +1147,7 @@ export class OmniBridge {
               agentName: message.agent,
               executorId: session.sdk?.executorId,
               tmuxPaneId: session.tmux?.paneId,
-              claudeSessionId: session.sdk?.claudeSessionId,
+              claudeSessionId,
             }),
           undefined,
           { chatId: message.chatId },


### PR DESCRIPTION
## Problem

Per-chat agents spawned by the omni bridge are supposed to be **permanent** — the same WhatsApp/Telegram thread should resume the same Claude conversation across executor death (tmux pane closed, claude crashed, host restarted), unless the chat is explicitly closed.

In production this isn't what happens for `tmux`-transport bridges: every executor crash starts a brand-new Claude conversation in a fresh transcript file, and the prior history is orphaned on disk. Operators discover this only when their chat partner sends "did you forget what we were just talking about?".

## Root cause

The SDK executor already does the right thing — `claude-sdk.ts` looks up the prior executor via `registry.findLatestByMetadata` and threads its `claudeSessionId` into `extraOptions.resume` (lines 367, 480).

The **tmux executor** (`claude-code.ts`) doesn't:

- `buildOmniSpawnParams` always generates a fresh `randomUUID()` for `--session-id` — no resume hook.
- `registerInWorldA` calls `createAndLinkExecutor` on every spawn without `claudeSessionId`, so `executors.claude_session_id` is always NULL for tmux rows.
- `ExecutorSession.tmux` had no `claudeSessionId` field, so even if we wanted the bridge to persist it via `BridgeSessionStore.create`, there was nowhere to read it from.

Net result: respawn → fresh uuid → fresh transcript → conversation history lost.

## Fix (this PR)

End-to-end plumbing of the per-chat Claude session id through the tmux path:

1. **`buildOmniSpawnParams`** accepts an optional `resumeClaudeSessionId`. When set, it emits `params.resume` (mapped to `--resume <id>` by `buildLaunchCommand`) instead of `params.sessionId`.
2. **`ClaudeCodeOmniExecutor.spawn`** looks up an existing executor for `(agent_id, source='omni', chat_id)` via `findLatestByMetadata` _before_ building the launch command. If found, its `claudeSessionId` is passed as resume; otherwise a fresh uuid is generated and persisted.
3. **`registerInWorldA` becomes `registerOrRelinkExecutor`**, which:
   - relinks an existing executor to the same agent (preserving its id and `claude_session_id`), refreshes its tmux pane/window pointers (a respawn lands in a new pane), and backfills `claude_session_id` on legacy rows that lack one;
   - or creates a fresh executor row carrying the new `claudeSessionId`, so the _next_ respawn finds it.
4. **`ExecutorSession.tmux`** gains a `claudeSessionId` field so consumers (omni-bridge → `BridgeSessionStore.create`) can persist the per-chat id for both executor types.
5. **`omni-bridge.ts`** reads `session.tmux?.claudeSessionId` as a fallback so `genie_bridge_sessions.claude_session_id` is populated for tmux spawns too — observers can now trace a chat's full Claude history across executor restarts.

## Verification

- `bun test src/services/executors/claude-code.test.ts` → **42 pass** (+2 new tests covering resume + fresh paths)
- `bun test src/services/__tests__/omni-bridge.test.ts` → **27 pass** (existing behavior unchanged)
- `bun run typecheck` → clean
- `bunx biome check` on touched files → clean

The new tests pin both directions of the contract:

- `emits resume (not sessionId) when resumeClaudeSessionId is set` — proves `params.resume` is wired and `params.sessionId` is omitted (mutual exclusion)
- `falls back to fresh sessionId when resumeClaudeSessionId is undefined` — proves the existing first-spawn path is preserved

## Test plan

- [x] Unit tests cover both code paths (resume + fresh) in `buildOmniSpawnParams`
- [x] Existing 27 `omni-bridge.test.ts` tests still pass
- [x] Existing 40 `claude-code.test.ts` tests still pass
- [ ] Manual test on a live omni-bridge: send WhatsApp message → kill executor pane → send another message → verify same `claude_session_id` reused, transcript history continued
- [ ] Confirm SDK executor path unchanged (it already worked)

## Backward compatibility

- `buildOmniSpawnParams` keeps its existing 5-argument contract; new param is optional and last.
- Existing executor rows without `claude_session_id` are backfilled on next spawn (the relink path detects `!existingExecutor.claudeSessionId` and calls `updateClaudeSessionId`). No migration needed.
- `ExecutorSession.tmux.claudeSessionId` is optional — sdk-only callers continue to work.

## Related

Hit in production while triaging a live KHAL-V1-LAUNCH WhatsApp bridge crash — operator's 210-turn `khal-os-3` conversation was preserved on disk but couldn't be re-attached to the bridge after the executor died, because the bridge had no record of the Claude session id and would have respawned with a fresh one anyway. This change fixes the underlying gap.