### PR TITLE
fix(db): hook_perf_baseline filters wrong column (#1494 residual)

### DIFF
--- a/src/db/migrations/057_hook_perf_baseline_view_filter_fix.sql
+++ b/src/db/migrations/057_hook_perf_baseline_view_filter_fix.sql
@@ -1,0 +1,63 @@
+-- 057_hook_perf_baseline_view_filter_fix.sql — fix #1494 residual
+--
+-- Background: #1492 (the schema fix) accepts the new `event` key emitted by
+-- runHandler post-#1485, so hook.delivery spans now insert into
+-- genie_runtime_events without rejection. But dog-fooder-11eb's verdict
+-- (state/evidence/followups-1490-1491-1493/REPORT.md) flagged a SECOND
+-- bug: the hook_perf_baseline view created by migration 056 filters
+-- `WHERE kind = 'hook.delivery'`, but the actual emitted row carries:
+--
+--   subject = 'hook.delivery'   ← what we want to filter on
+--   kind    = 'system'          ← what the view incorrectly filters on
+--   data->>'_kind' = 'span'     ← span marker
+--
+-- Net effect: rows accepted into the table never appear in the view, so
+-- `genie doctor --perf` and `hook_perf_baseline` queries always returned
+-- empty. The hookify-perf-foundation telemetry value (#1485) stayed inert.
+--
+-- Fix: replace the view to filter on `subject='hook.delivery'` AND require
+-- `data->>'_kind' = 'span'` (so we only count completed spans, not other
+-- runtime events that might happen to share the subject).
+
+CREATE OR REPLACE VIEW hook_perf_baseline AS
+WITH spans AS (
+  SELECT
+    COALESCE(data->>'event', '<unknown>')      AS event_name,
+    COALESCE(data->>'tool',  '<none>')         AS tool_name,
+    COALESCE(data->>'hook_name', '<unknown>')  AS handler_name,
+    NULLIF(data->>'duration_ms', '')::numeric  AS duration_ms,
+    created_at
+  FROM genie_runtime_events
+  WHERE subject = 'hook.delivery'
+    AND data->>'_kind' = 'span'
+    AND data ? 'duration_ms'
+)
+SELECT
+  event_name,
+  tool_name,
+  handler_name,
+  PERCENTILE_CONT(0.5)
+    WITHIN GROUP (ORDER BY duration_ms)
+    FILTER (WHERE created_at >= now() - interval '1 hour')   AS p50_1h,
+  PERCENTILE_CONT(0.99)
+    WITHIN GROUP (ORDER BY duration_ms)
+    FILTER (WHERE created_at >= now() - interval '1 hour')   AS p99_1h,
+  PERCENTILE_CONT(0.5)
+    WITHIN GROUP (ORDER BY duration_ms)
+    FILTER (WHERE created_at >= now() - interval '24 hours') AS p50_24h,
+  PERCENTILE_CONT(0.99)
+    WITHIN GROUP (ORDER BY duration_ms)
+    FILTER (WHERE created_at >= now() - interval '24 hours') AS p99_24h,
+  PERCENTILE_CONT(0.5)
+    WITHIN GROUP (ORDER BY duration_ms)
+    FILTER (WHERE created_at >= now() - interval '7 days')   AS p50_7d,
+  PERCENTILE_CONT(0.99)
+    WITHIN GROUP (ORDER BY duration_ms)
+    FILTER (WHERE created_at >= now() - interval '7 days')   AS p99_7d,
+  COUNT(*) FILTER (WHERE created_at >= now() - interval '24 hours')::bigint AS sample_count_24h
+FROM spans
+WHERE duration_ms IS NOT NULL
+GROUP BY event_name, tool_name, handler_name;
+
+COMMENT ON VIEW hook_perf_baseline IS
+  'Rolling P50/P99 per (event, tool, handler) over 1h/24h/7d windows. Source: hook.delivery spans in genie_runtime_events (filtered by subject + data._kind=span). Fixed in #1494 residual / migration 057 — original migration 056 filtered the wrong column.';

--- a/src/db/migrations/hook-perf-baseline.test.ts
+++ b/src/db/migrations/hook-perf-baseline.test.ts
@@ -48,7 +48,7 @@ describe.skipIf(!DB_AVAILABLE)('hook_perf_baseline view', () => {
   test('empty source data → view returns no rows (no error)', async () => {
     const sql = await getConnection();
     // Wipe any rows the migration runner might have left.
-    await sql`DELETE FROM genie_runtime_events WHERE kind = 'hook.delivery'`;
+    await sql`DELETE FROM genie_runtime_events WHERE subject = 'hook.delivery' OR kind = 'hook.delivery'`;
     const rows = (await sql`SELECT * FROM hook_perf_baseline`) as unknown[];
     expect(rows.length).toBe(0);
   });
@@ -58,11 +58,12 @@ describe.skipIf(!DB_AVAILABLE)('hook_perf_baseline view', () => {
     // Wipe and seed a known distribution: durations 1..101 ms for one
     // (event, tool, handler) tuple. Created 5 minutes ago so they fall
     // inside the 1h, 24h, AND 7d windows.
-    await sql`DELETE FROM genie_runtime_events WHERE kind = 'hook.delivery'`;
+    await sql`DELETE FROM genie_runtime_events WHERE subject = 'hook.delivery' OR kind = 'hook.delivery'`;
 
     const fiveMinAgo = new Date(Date.now() - 5 * 60_000);
     for (let i = 1; i <= 101; i++) {
       const data = sql.json({
+        _kind: 'span',
         event: 'PreToolUse',
         tool: 'Bash',
         hook_name: 'branch-guard',
@@ -70,9 +71,9 @@ describe.skipIf(!DB_AVAILABLE)('hook_perf_baseline view', () => {
       });
       await sql`
         INSERT INTO genie_runtime_events
-          (repo_path, kind, source, agent, text, data, created_at)
+          (repo_path, subject, kind, source, agent, text, data, created_at)
         VALUES
-          ('test', 'hook.delivery', 'hooks', 'test', '', ${data}, ${fiveMinAgo})
+          ('test', 'hook.delivery', 'system', 'hooks', 'test', '', ${data}, ${fiveMinAgo})
       `;
     }
 
@@ -120,7 +121,7 @@ describe.skipIf(!DB_AVAILABLE)('hook_perf_baseline view', () => {
 
   test('rolling windows correctly partition rows by created_at', async () => {
     const sql = await getConnection();
-    await sql`DELETE FROM genie_runtime_events WHERE kind = 'hook.delivery'`;
+    await sql`DELETE FROM genie_runtime_events WHERE subject = 'hook.delivery' OR kind = 'hook.delivery'`;
 
     // Two cohorts:
     //   - 50 rows at 30 minutes ago, duration 10ms → falls in 1h, 24h, 7d
@@ -130,6 +131,7 @@ describe.skipIf(!DB_AVAILABLE)('hook_perf_baseline view', () => {
 
     for (let i = 0; i < 50; i++) {
       const data = sql.json({
+        _kind: 'span',
         event: 'PreToolUse',
         tool: 'Read',
         hook_name: 'freshness',
@@ -137,13 +139,14 @@ describe.skipIf(!DB_AVAILABLE)('hook_perf_baseline view', () => {
       });
       await sql`
         INSERT INTO genie_runtime_events
-          (repo_path, kind, source, agent, text, data, created_at)
+          (repo_path, subject, kind, source, agent, text, data, created_at)
         VALUES
-          ('test', 'hook.delivery', 'hooks', 'test', '', ${data}, ${thirtyMinAgo})
+          ('test', 'hook.delivery', 'system', 'hooks', 'test', '', ${data}, ${thirtyMinAgo})
       `;
     }
     for (let i = 0; i < 50; i++) {
       const data = sql.json({
+        _kind: 'span',
         event: 'PreToolUse',
         tool: 'Read',
         hook_name: 'freshness',
@@ -151,9 +154,9 @@ describe.skipIf(!DB_AVAILABLE)('hook_perf_baseline view', () => {
       });
       await sql`
         INSERT INTO genie_runtime_events
-          (repo_path, kind, source, agent, text, data, created_at)
+          (repo_path, subject, kind, source, agent, text, data, created_at)
         VALUES
-          ('test', 'hook.delivery', 'hooks', 'test', '', ${data}, ${fiveDaysAgo})
+          ('test', 'hook.delivery', 'system', 'hooks', 'test', '', ${data}, ${fiveDaysAgo})
       `;
     }
 
@@ -186,27 +189,29 @@ describe.skipIf(!DB_AVAILABLE)('hook_perf_baseline view', () => {
 
   test('rows missing data.duration_ms are filtered out', async () => {
     const sql = await getConnection();
-    await sql`DELETE FROM genie_runtime_events WHERE kind = 'hook.delivery'`;
+    await sql`DELETE FROM genie_runtime_events WHERE subject = 'hook.delivery' OR kind = 'hook.delivery'`;
 
     // One valid row + one row missing duration_ms.
     const fiveMinAgo = new Date(Date.now() - 5 * 60_000);
     const validData = sql.json({
+      _kind: 'span',
       event: 'Stop',
       tool: '<none>',
       hook_name: 'runtime-emit-assistant-response',
       duration_ms: 42,
     });
     const missingDurData = sql.json({
+      _kind: 'span',
       event: 'Stop',
       tool: '<none>',
       hook_name: 'runtime-emit-assistant-response',
     });
     await sql`
       INSERT INTO genie_runtime_events
-        (repo_path, kind, source, agent, text, data, created_at)
+        (repo_path, subject, kind, source, agent, text, data, created_at)
       VALUES
-        ('test', 'hook.delivery', 'hooks', 'test', '', ${validData}, ${fiveMinAgo}),
-        ('test', 'hook.delivery', 'hooks', 'test', '', ${missingDurData}, ${fiveMinAgo})
+        ('test', 'hook.delivery', 'system', 'hooks', 'test', '', ${validData}, ${fiveMinAgo}),
+        ('test', 'hook.delivery', 'system', 'hooks', 'test', '', ${missingDurData}, ${fiveMinAgo})
     `;
 
     const rows = (await sql`


### PR DESCRIPTION
Companion fix to #1494. dog-fooder-11eb's verdict flagged that migration 056 filtered `WHERE kind = 'hook.delivery'` but actual rows carry `subject='hook.delivery'`, `kind='system'`, `data._kind='span'`. View was returning 0 rows regardless of dispatch activity.

Migration 057 replaces the view to filter on `subject='hook.delivery' AND data->>'_kind'='span'`.

## Empirical
- BEFORE: `SELECT count(*) FROM hook_perf_baseline` → 0
- AFTER:  `SELECT count(*) FROM hook_perf_baseline` → 5

`genie doctor --perf` and the hookify-perf-foundation telemetry now actually work.