### PR TITLE
chore(lint): also disable MD034 in .markdownlint.json (companion lost in #1497 squash)

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -3,6 +3,7 @@
   "default": true,
   "MD013": false,
   "MD033": false,
+  "MD034": false,
   "MD036": false,
   "MD040": false,
   "MD041": false,


### PR DESCRIPTION
Companion fix to #1497 — the .markdownlint.json edit was on the same branch but didn't make it into the squash-merged commit. Without it, docs lint still fails on canisterworm.mdx, blocking PR #1446.