### PR TITLE
fix(spawn): inline --settings hooks must use DISPATCHED_EVENT_MATCHERS too (Fix D completion)

### DIFF
--- a/src/hooks/codex-inject.test.ts
+++ b/src/hooks/codex-inject.test.ts
@@ -119,15 +119,20 @@ timeout = 15
     expect(await codexHooksInjected()).toBe(true);
   });
 
-  test('all six DISPATCHED_EVENTS are wired', () => {
-    // Sanity: the list matches what codex-rs/hooks/src/events/*.rs exposes
-    expect(CODEX_DISPATCHED_EVENTS).toEqual([
-      'PreToolUse',
-      'PostToolUse',
-      'UserPromptSubmit',
-      'SessionStart',
-      'Stop',
-      'PermissionRequest',
-    ]);
+  test('CODEX_DISPATCHED_EVENTS matches the handler-backed set (Fix D extension)', () => {
+    // Mac-CPU Fix D extension (#1513 follow-up): codex-side narrow now
+    // mirrors claude-side. SessionStart and PermissionRequest dropped
+    // because no handlers exist for them — wiring them with matcher='*'
+    // produced wasted bun cold-starts on every fire.
+    // dog-fooder-da66 verdict 2026-04-29 surfaced the codex-side leak.
+    const sorted = [...CODEX_DISPATCHED_EVENTS].sort();
+    expect(sorted as string[]).toEqual(['PostToolUse', 'PreToolUse', 'Stop', 'UserPromptSubmit']);
+  });
+
+  test('PostToolUse is wired with SendMessage matcher (not "*")', async () => {
+    await injectCodexHooks();
+    const config = readFileSync(join(tmp, 'config.toml'), 'utf-8');
+    const postSection = config.split('[[hooks.PostToolUse]]')[1] ?? '';
+    expect(postSection).toMatch(/matcher\s*=\s*"SendMessage"/);
   });
 });

--- a/src/hooks/codex-inject.ts
+++ b/src/hooks/codex-inject.ts
@@ -39,20 +39,22 @@ import { buildDispatchCommand } from './inject.js';
 const DISPATCH_TIMEOUT = 15;
 
 /**
- * Codex hook events we route through the dispatcher. Same events claude
- * uses, minus claude-specific ones (TeammateIdle, TaskCompleted, etc.).
+ * Codex hook events we route through the dispatcher.
  *
- * Source: codex-rs/hooks/src/events/*.rs (PreToolUse, PostToolUse,
- * UserPromptSubmit, SessionStart, Stop, PermissionRequest).
+ * Mac-CPU fix D extension (#1513 follow-up): narrowed to events that
+ * actually have handlers. Previously wired SessionStart and PermissionRequest
+ * with matcher='*' even though zero handlers exist for those events on the
+ * codex side — every fire was a wasted bun cold-start. dog-fooder-da66
+ * verdict 2026-04-29 surfaced this codex-side leak after Fix D #1479
+ * closed only the claude side.
+ *
+ * Derived from CODEX_DISPATCHED_EVENT_MATCHERS so the array and the
+ * matcher map can never drift.
  */
-export const CODEX_DISPATCHED_EVENTS = [
-  'PreToolUse',
-  'PostToolUse',
-  'UserPromptSubmit',
-  'SessionStart',
-  'Stop',
-  'PermissionRequest',
-] as const;
+import { CODEX_DISPATCHED_EVENT_MATCHERS } from './types.js';
+export const CODEX_DISPATCHED_EVENTS = Object.keys(CODEX_DISPATCHED_EVENT_MATCHERS) as ReadonlyArray<
+  keyof typeof CODEX_DISPATCHED_EVENT_MATCHERS
+>;
 
 function codexHomeDir(): string {
   return process.env.CODEX_HOME ?? join(homedir(), '.codex');
@@ -83,9 +85,9 @@ function buildCodexHookFragment(): string {
   lines.push('[hooks]');
   lines.push('feature_enabled = true');
   lines.push('');
-  for (const event of CODEX_DISPATCHED_EVENTS) {
+  for (const [event, matcher] of Object.entries(CODEX_DISPATCHED_EVENT_MATCHERS)) {
     lines.push(`[[hooks.${event}]]`);
-    lines.push('matcher = "*"');
+    lines.push(`matcher = ${escapeTomlString(matcher)}`);
     lines.push('');
     lines.push(`[[hooks.${event}.hooks]]`);
     lines.push('type = "command"');

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -105,6 +105,33 @@ export const DISPATCHED_EVENT_MATCHERS: Partial<Record<HookEventName, string>> =
 };
 
 /**
+ * Codex-side counterpart to DISPATCHED_EVENT_MATCHERS — wider because codex
+ * has additional handlers that don't exist on claude:
+ *   - codex-inbox-deliver runs on UserPromptSubmit
+ *   - runtime-emit-assistant-response runs on Stop
+ *
+ * Like DISPATCHED_EVENT_MATCHERS, only events that actually have a handler
+ * are wired. Pre-fix, codex-inject.ts wired 6 events (PreToolUse, PostToolUse,
+ * UserPromptSubmit, SessionStart, Stop, PermissionRequest) all with matcher='*'
+ * — including SessionStart and PermissionRequest which have no handlers,
+ * causing wasted bun cold-starts on every codex hook fire.
+ *
+ * dog-fooder-da66 verdict 2026-04-29 surfaced the codex-side leak after
+ * Fix D #1479 closed only the claude side.
+ */
+export const CODEX_DISPATCHED_EVENT_MATCHERS: Partial<Record<HookEventName, string>> = {
+  PreToolUse: '*',
+  // Same as claude — only runtime-emit-msg matches SendMessage.
+  PostToolUse: 'SendMessage',
+  // codex-inbox-deliver + runtime-emit-user-prompt + session-sync-prompt all run here.
+  UserPromptSubmit: '*',
+  // runtime-emit-assistant-response runs here.
+  Stop: '*',
+  // SessionStart, PermissionRequest dropped — no handlers (verified against
+  // src/hooks/index.ts handler registry as of 2026-04-29).
+};
+
+/**
  * Convenience array — derived from DISPATCHED_EVENT_MATCHERS.
  * Kept so callers that need the event list (without matcher) are unchanged.
  */

--- a/src/lib/provider-adapters.ts
+++ b/src/lib/provider-adapters.ts
@@ -409,12 +409,20 @@ function buildSettingsObject(params: SpawnParams): Record<string, unknown> {
   if (!params.skipHooks) {
     const dispatchCmd = buildDispatchCommand();
     const hookEntry = { type: 'command', command: dispatchCmd, timeout: 15 };
-    settingsObj.hooks = {
-      PreToolUse: [{ matcher: '*', hooks: [hookEntry] }],
-      PostToolUse: [{ matcher: '*', hooks: [hookEntry] }],
-      UserPromptSubmit: [{ hooks: [hookEntry] }],
-      Stop: [{ hooks: [hookEntry] }],
-    };
+    // Mac-CPU fix D, **completion** — Fix D #1479 narrowed the team-level
+    // settings.json matchers via DISPATCHED_EVENT_MATCHERS in `inject.ts`.
+    // This inline `--settings` codepath (passed directly to the claude CLI
+    // command at spawn time) was a SECOND injection layer that was missed
+    // and still hardcoded the wide matchers. dog-fooder-da66 verdict
+    // 2026-04-29 surfaced the discrepancy in
+    // state/phaseb-413-20260429T143731Z/. Source the matcher map so both
+    // layers stay aligned.
+    const { DISPATCHED_EVENT_MATCHERS } = require('../hooks/types.js') as typeof import('../hooks/types.js');
+    const hooks: Record<string, Array<{ matcher?: string; hooks: (typeof hookEntry)[] }>> = {};
+    for (const [event, matcher] of Object.entries(DISPATCHED_EVENT_MATCHERS)) {
+      hooks[event] = [{ matcher, hooks: [hookEntry] }];
+    }
+    settingsObj.hooks = hooks;
   }
   if (params.permissions) {
     const perms: Record<string, string[]> = {};


### PR DESCRIPTION
Surfaced by dog-fooder-da66 in 4.260429.13 Phase B verification — #1479 (Fix D narrow matchers) only landed in ONE of TWO injection layers.

## Two-layer injection problem

1. **`inject.ts:injectIntoFile`** — writes `~/.claude/teams/<team>/settings.json` for native teams. Already narrowed via DISPATCHED_EVENT_MATCHERS in #1479 ✓
2. **`provider-adapters.ts:buildSettingsObject`** — emits **inline `--settings` JSON** to the claude CLI at spawn time. **Still hardcoded the wide matchers** ❌

Every spawn was still wiring `PostToolUse:*`, `UserPromptSubmit`, and `Stop` for inline-settings-driven sessions, defeating Fix D for the spawn-time path.

## Fix

`buildSettingsObject` now sources `DISPATCHED_EVENT_MATCHERS` from `hooks/types.js` and iterates it. Both layers stay aligned when the matcher map is updated.

## Empirical

```
$ bun run src/genie.ts spawn engineer --provider claude --model opus --no-interactive
... --settings ...PostToolUse:[{matcher:"SendMessage"}]...
```
(was `PostToolUse:[{matcher:"*"}]` + extra UserPromptSubmit/Stop entries before)

## Evidence
dog-fooder-da66 verdict 2026-04-29 — `state/phaseb-413-20260429T143731Z/`