### PR TITLE
fix(agent-directory): reject symlinked AGENTS.md + warn on --skip-omni (D1, D2)

### DIFF
--- a/src/lib/agent-directory.test.ts
+++ b/src/lib/agent-directory.test.ts
@@ -180,6 +180,40 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
       );
     });
 
+    test('add rejects symlinked AGENTS.md by default', async () => {
+      const { symlinkSync } = await import('node:fs');
+      // Real agent home with a real AGENTS.md
+      const realHome = join(testDir, 'real-home');
+      mkdirSync(realHome, { recursive: true });
+      writeFileSync(join(realHome, 'AGENTS.md'), '# real agent\n');
+      // Wrong home — operator points --dir at this; AGENTS.md is a symlink
+      // to the real home (mirrors the bug that caused the KHAL-V1-LAUNCH
+      // misregistration: /home/genie/workspace/AGENTS.md → agents/khal-os/AGENTS.md)
+      const wrongHome = join(testDir, 'wrong-home');
+      mkdirSync(wrongHome, { recursive: true });
+      symlinkSync(join(realHome, 'AGENTS.md'), join(wrongHome, 'AGENTS.md'));
+      await expect(directory.add({ name: 'symlink-bait', dir: wrongHome, promptMode: 'append' })).rejects.toThrow(
+        /symlink/i,
+      );
+    });
+
+    test('add accepts symlinked AGENTS.md when allowSymlink is set', async () => {
+      const { symlinkSync } = await import('node:fs');
+      const realHome2 = join(testDir, 'real-home-2');
+      mkdirSync(realHome2, { recursive: true });
+      writeFileSync(join(realHome2, 'AGENTS.md'), '# real agent 2\n');
+      const wrongHome2 = join(testDir, 'wrong-home-2');
+      mkdirSync(wrongHome2, { recursive: true });
+      symlinkSync(join(realHome2, 'AGENTS.md'), join(wrongHome2, 'AGENTS.md'));
+      // Power-user escape hatch: explicit opt-in via { allowSymlink: true }
+      const entry = await directory.add(
+        { name: 'symlink-allowed', dir: wrongHome2, promptMode: 'append' },
+        { allowSymlink: true },
+      );
+      expect(entry.name).toBe('symlink-allowed');
+      expect(entry.dir).toBe(wrongHome2);
+    });
+
     test('add rejects empty name', async () => {
       await expect(directory.add({ name: '', dir: agentDir, promptMode: 'append' })).rejects.toThrow(
         'name is required',

--- a/src/lib/agent-directory.ts
+++ b/src/lib/agent-directory.ts
@@ -6,10 +6,58 @@
  * Built-in agent definitions remain in code (builtin-agents.ts).
  */
 
-import { existsSync } from 'node:fs';
+import { existsSync, lstatSync } from 'node:fs';
 import { join } from 'node:path';
 import { BUILTIN_COUNCIL_MEMBERS, BUILTIN_ROLES, type BuiltinAgent } from './builtin-agents.js';
 import type { SdkDirectoryConfig } from './sdk-directory-types.js';
+
+/**
+ * Validate that `<dir>/AGENTS.md` is a real, regular file inside `<dir>` —
+ * NOT a symlink that points elsewhere.
+ *
+ * Why: `existsSync()` follows symlinks. A directory containing a symlinked
+ * `AGENTS.md` (e.g. `/home/genie/workspace/AGENTS.md → agents/khal-os/AGENTS.md`)
+ * passes the lazy check even though it isn't a real agent home — the cwd
+ * lacks the agent's brain, runbooks, init.sh, etc. Operators registering with
+ * `--dir <symlinked-parent>` end up with an agent that spawns in the wrong
+ * cwd and can't find its own resources.
+ *
+ * `lstatSync().isFile()` returns false for symlinks, so we reject them by
+ * default. Operators who *intentionally* symlink (e.g. shared template
+ * across multiple per-chat agent dirs) opt in via `allowSymlink: true`.
+ */
+function validateAgentsMd(dir: string, allowSymlink: boolean): void {
+  const agentsPath = join(dir, 'AGENTS.md');
+  if (!existsSync(agentsPath)) {
+    throw new Error(`AGENTS.md not found in ${dir}. Each agent directory must contain an AGENTS.md file.`);
+  }
+  if (allowSymlink) return;
+  // existsSync above guarantees the path resolves; lstatSync with the default
+  // throwIfNoEntry=true semantics never returns undefined here, but the TS
+  // overload includes that case. Guard explicitly so strict-null typecheck
+  // stays happy without a non-null assertion.
+  const stat = lstatSync(agentsPath);
+  if (!stat) {
+    throw new Error(`AGENTS.md in ${dir} disappeared between exists check and stat.`);
+  }
+  if (stat.isSymbolicLink()) {
+    throw new Error(
+      `AGENTS.md in ${dir} is a symlink. Refusing to register: a symlinked AGENTS.md usually means --dir was pointed at a containing folder rather than the agent's real home (the cwd will be wrong and the agent's brain/runbooks won't be visible). Pass --allow-symlink to override if this is intentional.`,
+    );
+  }
+  if (!stat.isFile()) {
+    throw new Error(`AGENTS.md in ${dir} is not a regular file (got ${describeFileType(stat)}).`);
+  }
+}
+
+function describeFileType(stat: import('node:fs').Stats): string {
+  if (stat.isDirectory()) return 'directory';
+  if (stat.isBlockDevice()) return 'block device';
+  if (stat.isCharacterDevice()) return 'character device';
+  if (stat.isFIFO()) return 'FIFO';
+  if (stat.isSocket()) return 'socket';
+  return 'unknown special file';
+}
 
 // ============================================================================
 // Types
@@ -81,6 +129,13 @@ export interface ScopedDirectoryEntry extends DirectoryEntry {
 
 interface ScopeOptions {
   global?: boolean;
+  /**
+   * When true, accept a symlinked `<dir>/AGENTS.md`. By default, registration
+   * rejects symlinks because they almost always indicate `--dir` was pointed
+   * at a containing folder instead of the agent's real home. Power users with
+   * an intentional symlink layout opt in explicitly.
+   */
+  allowSymlink?: boolean;
 }
 
 /**
@@ -153,7 +208,7 @@ export function getProjectRoot(): string {
  */
 export async function add(
   entry: Omit<DirectoryEntry, 'registeredAt'>,
-  _options?: ScopeOptions,
+  options?: ScopeOptions,
 ): Promise<DirectoryEntry> {
   if (!entry.name || entry.name.trim() === '') {
     throw new Error('Agent name is required.');
@@ -167,10 +222,7 @@ export async function add(
     throw new Error(`Directory does not exist: ${entry.dir}`);
   }
 
-  const agentsPath = join(entry.dir, 'AGENTS.md');
-  if (!existsSync(agentsPath)) {
-    throw new Error(`AGENTS.md not found in ${entry.dir}. Each agent directory must contain an AGENTS.md file.`);
-  }
+  validateAgentsMd(entry.dir, options?.allowSymlink ?? false);
 
   const full: DirectoryEntry = {
     ...entry,
@@ -500,16 +552,13 @@ export async function edit(
       | 'bridgeTmuxSession'
     >
   >,
-  _options?: ScopeOptions,
+  options?: ScopeOptions,
 ): Promise<DirectoryEntry> {
   if (updates.dir) {
     if (!existsSync(updates.dir)) {
       throw new Error(`Directory does not exist: ${updates.dir}`);
     }
-    const agentsPath = join(updates.dir, 'AGENTS.md');
-    if (!existsSync(agentsPath)) {
-      throw new Error(`AGENTS.md not found in ${updates.dir}.`);
-    }
+    validateAgentsMd(updates.dir, options?.allowSymlink ?? false);
   }
 
   const existing = await get(name);

--- a/src/term-commands/agent/register.ts
+++ b/src/term-commands/agent/register.ts
@@ -22,6 +22,7 @@ interface RegisterOptions {
   roles?: string[];
   global?: boolean;
   skipOmni?: boolean;
+  allowSymlink?: boolean;
 }
 
 function validatePromptMode(mode: string): 'system' | 'append' {
@@ -90,16 +91,24 @@ async function handleAgentRegister(name: string, options: RegisterOptions): Prom
       model: options.model,
       roles,
     },
-    { global: options.global },
+    { global: options.global, allowSymlink: options.allowSymlink },
   );
 
   const scope = options.global ? 'global' : 'project';
   console.log(`Agent "${entry.name}" registered (${scope}).`);
   printEntry(entry);
 
-  if (!options.skipOmni) {
-    await handleOmniRegistration(name, { ...options, roles });
+  if (options.skipOmni) {
+    // Operators using --skip-omni often forget to wire the omni side later,
+    // leading to a registered genie agent that's invisible to omni and a
+    // broken bridge when messages arrive. Make the cost of skipping explicit.
+    process.stderr.write(
+      `\n⚠ Skipped Omni auto-registration. The genie directory entry exists, but no Omni agent\n  record, no nats-genie provider, and no instance binding were created. Until you wire\n  the Omni side, this agent will not receive messages from any channel.\n\n  To complete the wire when ready:\n      omni connect <instance-id> ${entry.name}\n\n  Or run the canonical wizard from a Claude session:\n      /genie:omni\n\n`,
+    );
+    return;
   }
+
+  await handleOmniRegistration(name, { ...options, roles });
 }
 
 export function registerAgentRegister(parent: Command): void {
@@ -112,7 +121,11 @@ export function registerAgentRegister(parent: Command): void {
     .option('--model <model>', 'Default model (sonnet, opus, codex)')
     .option('--roles <roles...>', 'Built-in roles this agent can orchestrate')
     .option('--global', 'Write to global directory instead of project')
-    .option('--skip-omni', 'Skip Omni auto-registration')
+    .option('--skip-omni', 'Skip Omni auto-registration (prints a stderr warning explaining the cost)')
+    .option(
+      '--allow-symlink',
+      'Accept a symlinked AGENTS.md (default: rejected — usually indicates --dir was pointed at the wrong folder)',
+    )
     .action(async (name: string, options: RegisterOptions) => {
       try {
         await handleAgentRegister(name, options);


### PR DESCRIPTION
## Summary

Closes two correctness defects from the **canonical-genie-omni-wiring** wish that combined to silently produce wrong-cwd agent registrations.

| # | Defect | Evidence in the wild |
|---|---|---|
| **D1** | `agent-directory.add()` validated AGENTS.md with `existsSync()` — which follows symlinks. A directory containing a symlinked `AGENTS.md → ../real-agent/AGENTS.md` passed validation even though the cwd lacked the agent's real brain, runbooks, init.sh. | Yesterday: `genie agent register khal-os-3 --dir /home/genie/workspace` accepted because `/home/genie/workspace/AGENTS.md` was a symlink to `agents/khal-os/AGENTS.md`. The agent then spawned in the wrong cwd, lost access to its brain and tooling, and the WhatsApp bridge broke. |
| **D2** | `genie agent register --skip-omni` silently decoupled genie from omni with no hint that the omni side stayed unwired. Operators consistently forgot to run `omni connect` afterwards. | Same incident: `--skip-omni` was used to bypass a previous-session orphan; recovery later required raw SQL because the operator (and the agent) didn't realize the omni side was stale. |

## D1 — symlink-aware AGENTS.md validation

New helper `validateAgentsMd(dir, allowSymlink)` in `src/lib/agent-directory.ts`:

- Uses `lstatSync().isSymbolicLink()` (does NOT follow links) to detect symlinked AGENTS.md.
- Rejects symlinks **by default** with a clear error explaining the most likely operator mistake (`--dir` pointed at a containing folder).
- Power-user escape hatch: `{ allowSymlink: true }` on `add()`/`edit()`, surfaced as `--allow-symlink` on `genie agent register`.
- Same helper used in both `add()` (initial registration) and `edit()` (dir update), so symlinks are rejected consistently.

```
$ genie agent register foo --dir /home/genie/workspace   # symlinked AGENTS.md
Error: AGENTS.md in /home/genie/workspace is a symlink. Refusing to register: a
symlinked AGENTS.md usually means --dir was pointed at a containing folder rather
than the agent's real home (the cwd will be wrong and the agent's brain/runbooks
won't be visible). Pass --allow-symlink to override if this is intentional.
```

## D2 — `--skip-omni` warning block

When operators pass `--skip-omni`, `register.ts` now writes a stderr WARNING after the directory entry is created:

```
⚠ Skipped Omni auto-registration. The genie directory entry exists, but no Omni agent
  record, no nats-genie provider, and no instance binding were created. Until you wire
  the Omni side, this agent will not receive messages from any channel.

  To complete the wire when ready:
      omni connect <instance-id> <name>

  Or run the canonical wizard from a Claude session:
      /genie:omni
```

The legacy behavior is otherwise unchanged. `--skip-omni` still skips the omni POST.

## What changed

| File | Change |
|---|---|
| `src/lib/agent-directory.ts` | New `validateAgentsMd` + `describeFileType` helpers. `ScopeOptions` gains optional `allowSymlink`. `add()` and `edit()` route through the helper. |
| `src/term-commands/agent/register.ts` | New `--allow-symlink` flag. `RegisterOptions` gains `allowSymlink`. Stderr WARNING block on `--skip-omni`. |
| `src/lib/agent-directory.test.ts` | +2 tests: symlinked AGENTS.md rejected by default; `{ allowSymlink: true }` escape hatch accepted. |

## Test plan

- [x] `bun test src/lib/agent-directory.test.ts` → **48/48 pass** (+2 new)
- [x] `bun run typecheck` → green (strict null checks)
- [x] `bunx biome check` on touched files → clean (auto-fix applied for template-literal style)
- [x] Pre-push gate (full typecheck + lint + dead-code + skills/wishes lint + emit-discipline) → passed

## Scope (intentionally narrow)

Defect D4 (`genie dir edit --dir <new>` chicken-and-egg with the `agent.yaml` migration in `handleEdit`) needs a separate refactor — the `dir edit` flow runs a yaml migration off the OLD dir, not a relocation. Lands as its own focused micro-PR.

## Context

Tracked under the **canonical-genie-omni-wiring** wish (Wave 1 / Group 1, partial — D1 + D2). Wish lives at `.genie/wishes/canonical-genie-omni-wiring/WISH.md`. Companion artifacts:

- Brain map + runbook + ADR: namastexlabs/genie-configure#10
- Omni stale-hint fix: automagik-dev/omni#552
- Omni deprecation nudges (scaffolding): automagik-dev/omni#553
- Next: `/genie:omni` skill markdown (Group 4) — depends on this PR landing first.