### PR TITLE
fix(team): clean empty source branch on disband

### DIFF
--- a/src/lib/team-manager.test.ts
+++ b/src/lib/team-manager.test.ts
@@ -414,6 +414,11 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
     });
 
     describe('disbandTeam', () => {
+      async function sourceBranchExists(branchName: string): Promise<boolean> {
+        const result = await $`git -C ${TEST_REPO} rev-parse --verify ${branchName}`.quiet().nothrow();
+        return result.exitCode === 0;
+      }
+
       test('removes clone directory and config from PG', async () => {
         const config = await createTeam('feat/disband-test', TEST_REPO, 'dev');
         const worktreePath = config.worktreePath;
@@ -427,6 +432,38 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
         // Team config should be gone from PG
         const team = await getTeam('feat/disband-test');
         expect(team).toBeNull();
+      });
+
+      test('removes empty source branch on disband', async () => {
+        const teamName = 'feat/disband-empty-branch';
+        await createTeam(teamName, TEST_REPO, 'dev');
+
+        await $`git -C ${TEST_REPO} rev-parse --verify ${teamName}`.quiet();
+
+        const disbanded = await disbandTeam(teamName);
+        expect(disbanded).toBe(true);
+
+        expect(await sourceBranchExists(teamName)).toBe(false);
+      });
+
+      test('preserves source branch with commits on disband', async () => {
+        const teamName = 'feat/disband-committed-branch';
+        const config = await createTeam(teamName, TEST_REPO, 'dev');
+
+        await writeFile(join(config.worktreePath, 'team-work.txt'), 'preserve me');
+        await $`git -C ${config.worktreePath} add team-work.txt`.quiet();
+        await $`git -C ${config.worktreePath} commit -m "Team work"`.quiet();
+        await $`git -C ${config.worktreePath} push origin ${teamName}`.quiet();
+
+        const branchTip = (await $`git -C ${TEST_REPO} rev-parse ${teamName}`.quiet()).text().trim();
+        const baseTip = (await $`git -C ${TEST_REPO} rev-parse dev`.quiet()).text().trim();
+        expect(branchTip).not.toBe(baseTip);
+
+        const disbanded = await disbandTeam(teamName);
+        expect(disbanded).toBe(true);
+
+        const preservedTip = (await $`git -C ${TEST_REPO} rev-parse ${teamName}`.quiet()).text().trim();
+        expect(preservedTip).toBe(branchTip);
       });
 
       test('returns false for non-existent team', async () => {

--- a/src/lib/team-manager.ts
+++ b/src/lib/team-manager.ts
@@ -821,7 +821,7 @@ export async function disbandTeam(teamName: string): Promise<boolean> {
     }
   }
 
-  await removeWorktree(config.worktreePath);
+  await cleanupTeamGitArtifacts(config);
   await cleanupTeamTmuxSession(config.tmuxSessionName ?? teamName, teamName);
 
   // Atomically reset wish groups + archive team in a single transaction


### PR DESCRIPTION
## Summary
- Reuses `cleanupTeamGitArtifacts` from `disbandTeam` so empty team source branches are removed like archive/done cleanup.
- Adds regression coverage for empty branch removal.
- Adds safety coverage that source branches with pushed commits are preserved.
- Refines the branch-existence assertion after review to avoid manual try/catch while keeping Bun shell interpolation safe.

## Dogfood repro
- Issue: #1515
- Evidence dir: `/home/genie/workspace/agents/genie/.genie/agents/dog-fooder/state/evidence/round-20260429/`
- Repro showed `genie team disband <team>` removed the team row/worktree but left an empty source branch at the same SHA as `dev`.

## Validation
- `bun test src/lib/team-manager.test.ts` — 45 pass
- `bun run build` — pass

Fixes #1515.
