### PR TITLE
fix(dir-edit): support --dir relocation without yaml-anchor chicken-and-egg (D4)

### DIFF
--- a/src/lib/agent-directory.test.ts
+++ b/src/lib/agent-directory.test.ts
@@ -556,6 +556,28 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
       await expect(directory.edit('editable', { dir: '/nonexistent/path' })).rejects.toThrow('does not exist');
     });
 
+    test('edit relocates agent to new dir even when old dir is unreadable (fixes D4 chicken-and-egg)', async () => {
+      // Operator scenario: agent was registered with --dir pointing at a
+      // wrong folder. Now they want to fix it. The OLD dir's AGENTS.md may
+      // not even exist anymore — `directory.edit` must validate the NEW
+      // dir without needing the OLD dir to be readable.
+      const sql = await getConnection();
+      await sql`INSERT INTO agents (id, role, custom_name, started_at, metadata) VALUES ('dir:relocatable', 'relocatable', 'relocatable', now(), '{"dir":"/tmp/old-broken-dir","model":"opus"}')`;
+
+      // The OLD dir is not on disk at all. The NEW dir exists with a real AGENTS.md.
+      const newHome = join(testDir, 'new-home');
+      mkdirSync(newHome, { recursive: true });
+      writeFileSync(join(newHome, 'AGENTS.md'), '# relocated agent\n');
+
+      const updated = await directory.edit('relocatable', { dir: newHome });
+      expect(updated.dir).toBe(newHome);
+
+      // Verify PG metadata.dir was updated
+      const rows = await sql`SELECT metadata FROM agents WHERE id = 'dir:relocatable'`;
+      const metadata = rows[0].metadata as Record<string, unknown>;
+      expect(metadata.dir).toBe(newHome);
+    });
+
     test('edit persists model to PG metadata', async () => {
       const sql = await getConnection();
       await sql`INSERT INTO agents (id, role, custom_name, started_at, metadata) VALUES ('dir:meta-agent', 'meta-agent', 'meta-agent', now(), '{}')`;

--- a/src/term-commands/dir.ts
+++ b/src/term-commands/dir.ts
@@ -136,7 +136,11 @@ export function registerDirNamespace(program: Command): void {
     .option('--permission-preset <preset>', 'Permission preset: full, read-only, chat-only')
     .option('--allow <tools>', 'Comma-separated tool allow list (e.g. "Read,Glob,Grep,Bash")')
     .option('--bash-allow <patterns>', 'Comma-separated regex patterns for allowed bash commands')
-    .option('--global', 'Edit in global directory instead of project');
+    .option('--global', 'Edit in global directory instead of project')
+    .option(
+      '--allow-symlink',
+      'Accept a symlinked AGENTS.md at the new --dir (default: rejected — usually indicates --dir was pointed at the wrong folder)',
+    );
   registerSdkFlags(editCmd);
   editCmd.action(async (name: string, options: EditOptions) => {
     try {
@@ -286,6 +290,7 @@ interface EditOptions extends SdkDirOptions {
   allow?: string;
   bashAllow?: string;
   global?: boolean;
+  allowSymlink?: boolean;
 }
 
 function collectAgentConfigUpdates(options: EditOptions): Partial<AgentConfig> {
@@ -331,6 +336,42 @@ async function handleEdit(name: string, options: EditOptions): Promise<void> {
     process.exit(1);
   }
   const agentDir = resolved.entry.dir;
+
+  // Relocation case: `--dir` is being changed. The yaml-first flow below
+  // anchors on the CURRENT entry.dir, which is exactly the field we're
+  // moving — reading agent.yaml from the OLD dir before the relocation
+  // applies makes no sense, and on a wrong-dir registration (where the OLD
+  // dir was the operator's mistake we're trying to fix), the chicken-and-egg
+  // makes recovery impossible without raw SQL.
+  //
+  // For relocation, skip the yaml-anchor migration and write the metadata
+  // patch directly to PG via `directory.edit`. `directory.edit` already
+  // validates the NEW dir's AGENTS.md (incl. symlink-safety per #1514) before
+  // persisting. The agent.yaml at the OLD dir is left in place — operators
+  // can delete it after verifying the move; future non-relocation `dir edit`
+  // calls will write fresh yaml at the NEW dir on the next yaml-anchored edit.
+  if (updates.dir) {
+    const newDir = resolvePath(updates.dir);
+    const updated = await directory.edit(
+      name,
+      { ...updates, dir: newDir },
+      { global: options.global, allowSymlink: options.allowSymlink },
+    );
+    recordAuditEvent('item', name, 'item_updated', getActor(), {
+      type: 'agent',
+      source: 'dir_edit',
+      relocation: { from: agentDir, to: newDir },
+    }).catch(() => {});
+    const scope = options.global ? 'global' : 'project';
+    console.log(`Agent "${name}" relocated to ${contractPath(newDir)} (${scope}).`);
+    if (existsSync(join(agentDir, 'agent.yaml'))) {
+      console.warn(
+        `Note: agent.yaml at ${contractPath(agentDir)} is now orphaned. Remove it after verifying the new home is correct.`,
+      );
+    }
+    printEntry(updated);
+    return;
+  }
 
   // If the agent hasn't been migrated yet, migrate first. After this the
   // canonical source is agents/<name>/agent.yaml and AGENTS.md loses its


### PR DESCRIPTION
## Problem

\`genie dir edit <name> --dir <new-path>\` failed with:

\`\`\`
Failed to read agent.yaml at <OLD-dir>/agent.yaml: ENOENT
\`\`\`

…even when the operator's whole reason for running the command was to fix a wrong \`--dir\` registration. The yaml-first flow added by the \`dir-sync-frontmatter-refresh\` wish anchors on \`resolved.entry.dir\` (the **current** dir) and tries to read/migrate \`agent.yaml\` from it **before** applying the update. When the old dir was the operator's mistake (e.g. registered against a workspace root that lacked a real \`agent.yaml\`), the chicken-and-egg blocked recovery — the only fix available was raw SQL on the \`agents\` table's \`metadata->>'dir'\` field.

This was a contributing factor in a recent KHAL-V1-LAUNCH bridge incident triage where recovery had to bypass the CLI entirely.

## Fix

When \`--dir\` is in updates, treat it as a **relocation**:

- Skip the yaml-anchor migration (which assumes the old dir is valid).
- Call \`directory.edit(name, { ...updates, dir: newDir }, options)\` directly. This goes through the PG metadata patch path which already validates the **new** dir's AGENTS.md (incl. symlink-safety per #1514) before persisting.
- Print a warning if an \`agent.yaml\` survives at the old dir, so operators can clean it up after verifying the move.
- Record an audit event noting the relocation (from/to paths) so the operation is traceable.

Non-relocation edits (model, color, permissions, etc. without a \`--dir\` change) continue to use the yaml-first flow unchanged.

## What changed

| File | Change |
|---|---|
| \`src/term-commands/dir.ts\` | Relocation branch in \`handleEdit\` — bypasses yaml read, writes via \`directory.edit\`, logs orphan warning, records audit event with from/to paths. New \`--allow-symlink\` CLI flag (forwards to \`directory.edit\`). \`EditOptions\` gains \`allowSymlink?\`. |
| \`src/lib/agent-directory.test.ts\` | New test: relocation succeeds when old dir is unreadable but new dir has a real AGENTS.md; verifies \`metadata.dir\` is updated in PG. |

## Test plan

- [x] \`bun test src/lib/agent-directory.test.ts\` → **49/49 pass** (+1 new for the chicken-and-egg fix)
- [x] \`bun run typecheck\` → green
- [x] \`bunx biome check\` on touched files → clean
- [x] Pre-push gate (typecheck + lint + dead-code + skills/wishes-lint + emit-discipline) → all green

## Manual smoke (post-merge)

\`\`\`bash
# Reproduce the old failure path (would have errored before this PR):
genie agent register foo --dir /tmp/wrong-dir --skip-omni    # fails per #1514's symlink check OR succeeds with wrong dir
# (assume foo got registered with a wrong dir somehow)

# Fix it via dir edit — this PR makes this work without raw SQL:
genie dir edit foo --dir /home/me/agents/foo

# Output:
#   Agent "foo" relocated to ~/agents/foo (project).
#   Note: agent.yaml at /tmp/wrong-dir is now orphaned. Remove it after verifying the new home is correct.
\`\`\`

## Context

Tracked under the \`canonical-genie-omni-wiring\` wish (deferred follow-up to Wave 1 / Group 1 — defect D4 specifically). Companion symlink hardening that this fix builds on landed at #1514. ADR is at namastexlabs/genie-configure#10.

| # | Repo | PR | Status |
|---|---|---|---|
| 1 | \`namastexlabs/genie-configure\` | [#10](https://github.com/namastexlabs/genie-configure/pull/10) | merged |
| 2 | \`automagik-dev/omni\` | [#552](https://github.com/automagik-dev/omni/pull/552) | merged |
| 3 | \`automagik-dev/omni\` | [#553](https://github.com/automagik-dev/omni/pull/553) | merged |
| 4 | \`automagik-dev/genie\` | [#1514](https://github.com/automagik-dev/genie/pull/1514) | merged |
| 5 | \`automagik-dev/genie\` | [#1516](https://github.com/automagik-dev/genie/pull/1516) | open — \`/genie:omni\` skill |
| **6** | \`automagik-dev/genie\` | **this PR** | D4 \`dir edit --dir\` relocation |