### PR TITLE
fix: address review findings for inbox seed and serve

### DIFF
--- a/src/hooks/handlers/__tests__/codex-inbox-deliver.test.ts
+++ b/src/hooks/handlers/__tests__/codex-inbox-deliver.test.ts
@@ -217,6 +217,22 @@ describe('codex-inbox-deliver handler', () => {
     expect(elapsed).toBeLessThan(2_000);
   });
 
+  test('does not mark rows read when a timed-out fetch resolves later', async () => {
+    let markReadCalls = 0;
+    _deps.findCodexAgent = async () => makeAgent();
+    _deps.fetchUnread = () => new Promise((resolve) => setTimeout(() => resolve([makeMsg({ id: 'late-msg' })]), 650));
+    _deps.markReadBatch = async () => {
+      markReadCalls += 1;
+      return 1;
+    };
+
+    const result = await codexInboxDeliver(basePayload());
+    expect(result).toBeUndefined();
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(markReadCalls).toBe(0);
+  });
+
   test('swallows fetch errors and returns undefined (never crashes the dispatcher)', async () => {
     _deps.findCodexAgent = async () => makeAgent();
     _deps.fetchUnread = async () => {

--- a/src/hooks/handlers/codex-inbox-deliver.ts
+++ b/src/hooks/handlers/codex-inbox-deliver.ts
@@ -21,10 +21,12 @@
  *     custom_name) to match how `mailbox.send` writes `to_worker` (varies by
  *     delivery path — see `src/lib/protocol-router.ts`).
  *
- * Timeout: 500ms hard cap on the PG round-trip. Codex's hook timeout is 15s,
- * but we want sub-second so a slow DB never stalls a turn — bail with empty
- * additionalContext on timeout (no delivery this turn, message stays unread,
- * next turn retries).
+ * Timeout: 500ms hard cap on the read-only PG lookup. Codex's hook timeout is
+ * 15s, but we want sub-second so a slow DB never stalls a turn — bail with
+ * empty additionalContext on timeout (no delivery this turn, message stays
+ * unread, next turn retries). The timeout never races the mark-read write; once
+ * we start mutating mailbox rows we wait for the result and return the context
+ * in the same turn.
  *
  * Mark-read semantics: marked read BEFORE returning. If the mark fails, we
  * bail with no delivery (better to miss a turn than double-inject after a
@@ -59,6 +61,11 @@ export interface CodexAgentRef {
 type FindCodexAgentFn = (name: string, team?: string) => Promise<CodexAgentRef | null>;
 type FetchUnreadFn = (repoPath: string, workerKeys: string[]) => Promise<MailboxMessage[]>;
 type MarkReadBatchFn = (messageIds: string[]) => Promise<number>;
+
+interface PendingDelivery {
+  unread: MailboxMessage[];
+  markReadBatch: MarkReadBatchFn;
+}
 
 /**
  * Overridable deps for testing (mirrors the session-sync pattern). When left
@@ -155,12 +162,10 @@ function resolveContext(payload: HookPayload): { agentName: string; teamName?: s
 }
 
 /**
- * Render pending mailbox messages into a single newline-joined block of
- * channel envelopes. Returns `null` when there is nothing to deliver (no
- * codex agent matched, no pending rows, mark-read failed, or query timed
- * out) — the dispatcher then emits no additionalContext for this turn.
+ * Read pending mailbox messages without mutating state. This promise may still
+ * complete after `withTimeout` returns, so it must stay read-only.
  */
-async function deliverPendingMessages(agentName: string, teamName?: string): Promise<string | null> {
+async function loadPendingMessages(agentName: string, teamName?: string): Promise<PendingDelivery | null> {
   const deps = await resolveDeps();
   const agent = await deps.findCodexAgent(agentName, teamName);
   if (!agent || agent.provider !== 'codex') return null;
@@ -169,13 +174,23 @@ async function deliverPendingMessages(agentName: string, teamName?: string): Pro
   const unread = await deps.fetchUnread(agent.repoPath, keys);
   if (unread.length === 0) return null;
 
+  return { unread, markReadBatch: deps.markReadBatch };
+}
+
+/**
+ * Mark the loaded rows read and render them into a single newline-joined block
+ * of channel envelopes. Returns `null` when the mark-read guard fails.
+ */
+async function deliverPendingMessages(pending: PendingDelivery): Promise<string | null> {
   // Atomic batch mark-read BEFORE returning the body. Failure here means we
   // skip delivery this turn rather than risk double-injection on the next.
-  const ids = unread.map((m) => m.id);
-  const updated = await deps.markReadBatch(ids);
+  const ids = pending.unread.map((m) => m.id);
+  const updated = await pending.markReadBatch(ids);
   if (updated === 0) return null;
 
-  const envelopes = unread.map((m) => formatEnvelope({ source: m.source, from: m.from, meta: m.meta, body: m.body }));
+  const envelopes = pending.unread.map((m) =>
+    formatEnvelope({ source: m.source, from: m.from, meta: m.meta, body: m.body }),
+  );
   return envelopes.join('\n');
 }
 
@@ -184,11 +199,10 @@ export async function codexInboxDeliver(payload: HookPayload): Promise<HandlerRe
   if (!ctx) return;
 
   try {
-    const additionalContext = await withTimeout(
-      deliverPendingMessages(ctx.agentName, ctx.teamName),
-      QUERY_TIMEOUT_MS,
-      null,
-    );
+    const pending = await withTimeout(loadPendingMessages(ctx.agentName, ctx.teamName), QUERY_TIMEOUT_MS, null);
+    if (!pending) return;
+
+    const additionalContext = await deliverPendingMessages(pending);
     if (!additionalContext) return;
 
     return {

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -411,7 +411,8 @@ describe('GENIE_SKIP_DB_BOOT (Mac CPU fix C — hook-dispatch coldstart)', () =>
     expect(source).toMatch(/skipBoot\s*=\s*isTestMode\s*\|\|\s*process\.env\.GENIE_SKIP_DB_BOOT/);
     // Both migrations and seed gated by skipBoot
     expect(source).toMatch(/if \(!skipBoot\) await runMigrations/);
-    expect(source).toMatch(/if \(!skipBoot && needsSeed\(\)\) await runSeed/);
+    expect(source).toMatch(/if \(!skipBoot && \(needsSeed\(\) \|\| \(await needsSeededTeams\(client\)\)\)\) \{/);
+    expect(source).toContain('await runSeed(client);');
   });
 
   test('hook dispatch entrypoint sets GENIE_SKIP_DB_BOOT before invoking dispatch()', () => {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -12,7 +12,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type postgres from 'postgres';
 import { runMigrations } from './db-migrations.js';
-import { needsSeed, runSeed } from './pg-seed.js';
+import { needsSeed, needsSeededTeams, runSeed } from './pg-seed.js';
 import { getProcessStartTime } from './process-identity.js';
 
 /**
@@ -683,7 +683,9 @@ async function runPostConnectSetup(client: postgres.Sql, isTestMode: boolean, ti
   if (!skipBoot) await runMigrations(client);
   const _t3 = Date.now();
 
-  if (!skipBoot && needsSeed()) await runSeed(client);
+  if (!skipBoot && (needsSeed() || (await needsSeededTeams(client)))) {
+    await runSeed(client);
+  }
   const _t4 = Date.now();
 
   // Retention is no longer run from getConnection — it now lives on a

--- a/src/lib/pg-seed.test.ts
+++ b/src/lib/pg-seed.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { getConnection } from './db.js';
-import { needsSeed, runSeed } from './pg-seed.js';
+import { needsSeed, needsSeededTeams, runSeed } from './pg-seed.js';
 import { DB_AVAILABLE, setupTestDatabase } from './test-db.js';
 
 describe.skipIf(!DB_AVAILABLE)('pg', () => {
@@ -352,6 +352,7 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
       expect(marker).toEqual({
         teamsDir: join(testClaudeDir, 'teams'),
         mtimeMs: String(statSync(join(testClaudeDir, 'teams')).mtimeMs),
+        teamNames: ['seed-team-beta'],
       });
     });
 
@@ -507,7 +508,11 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
       mkdirSync(stateDir, { recursive: true });
       writeFileSync(
         join(stateDir, 'teams-seed-marker'),
-        `${JSON.stringify({ teamsDir, mtimeMs: String(statSync(teamsDir).mtimeMs) })}\n`,
+        `${JSON.stringify({
+          teamsDir,
+          mtimeMs: String(statSync(teamsDir).mtimeMs),
+          teamNames: ['seed-team-cache'],
+        })}\n`,
       );
 
       const originalReaddirSync = fs.readdirSync;
@@ -525,6 +530,34 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
       } finally {
         fs.readdirSync = originalReaddirSync;
       }
+    });
+
+    test('needsSeededTeams detects fresh marker rows missing after pgserve reset', async () => {
+      const sql = await getConnection();
+      const teamName = 'seed-team-reset-marker';
+      const teamsDir = join(testClaudeDir, 'teams');
+      const stateDir = join(testHome, 'state');
+      mkdirSync(join(teamsDir, teamName), { recursive: true });
+      mkdirSync(stateDir, { recursive: true });
+      writeFileSync(join(teamsDir, teamName, 'config.json'), JSON.stringify({ name: teamName }));
+      writeFileSync(
+        join(stateDir, 'teams-seed-marker'),
+        `${JSON.stringify({
+          teamsDir,
+          mtimeMs: String(statSync(teamsDir).mtimeMs),
+          teamNames: [teamName],
+        })}\n`,
+      );
+
+      await sql`DELETE FROM teams WHERE name = ${teamName}`;
+      expect(await needsSeededTeams(sql)).toBe(true);
+
+      await sql`
+        INSERT INTO teams (name, repo, base_branch, worktree_path, members)
+        VALUES (${teamName}, '/tmp/repo', 'dev', '/tmp/repo', ${sql.json([])})
+      `;
+      expect(await needsSeededTeams(sql)).toBe(false);
+      await sql`DELETE FROM teams WHERE name = ${teamName}`;
     });
 
     test('needsSeed returns false after migration (no workers.json, no claude teams)', () => {

--- a/src/lib/pg-seed.ts
+++ b/src/lib/pg-seed.ts
@@ -18,6 +18,18 @@ import { type NativeTeamConfig, loadAllNativeTeamConfigs } from './claude-native
 
 type Sql = postgres.Sql;
 
+interface TeamsSeedMarker {
+  teamsDir: string;
+  mtimeMs: string;
+  teamNames: string[];
+}
+
+interface SeedTeamsResult {
+  count: number;
+  teamNames: string[];
+  hadFailures: boolean;
+}
+
 // ============================================================================
 // Path helpers
 // ============================================================================
@@ -46,27 +58,44 @@ function teamsDirMtime(claudeTeamsDir: string): string | null {
   }
 }
 
-function hasFreshTeamsSeedMarker(claudeTeamsDir: string): boolean {
+function readFreshTeamsSeedMarker(claudeTeamsDir: string): TeamsSeedMarker | null {
   const mtimeMs = teamsDirMtime(claudeTeamsDir);
-  if (!mtimeMs) return false;
+  if (!mtimeMs) return null;
   try {
     const marker = JSON.parse(readFileSync(teamsSeedMarkerPath(), 'utf-8')) as {
       teamsDir?: string;
       mtimeMs?: string;
+      teamNames?: unknown;
     };
-    return marker.teamsDir === claudeTeamsDir && marker.mtimeMs === mtimeMs;
+    if (marker.teamsDir !== claudeTeamsDir || marker.mtimeMs !== mtimeMs || !Array.isArray(marker.teamNames)) {
+      return null;
+    }
+    return {
+      teamsDir: marker.teamsDir,
+      mtimeMs: marker.mtimeMs,
+      teamNames: marker.teamNames.filter((name): name is string => typeof name === 'string' && name.length > 0),
+    };
   } catch {
-    return false;
+    return null;
   }
 }
 
-async function writeTeamsSeedMarker(): Promise<void> {
+function hasFreshTeamsSeedMarker(claudeTeamsDir: string): boolean {
+  return readFreshTeamsSeedMarker(claudeTeamsDir) !== null;
+}
+
+async function writeTeamsSeedMarker(teamNames: string[]): Promise<void> {
   const claudeTeamsDir = claudeTeamsDirPath();
   const mtimeMs = teamsDirMtime(claudeTeamsDir);
   if (!mtimeMs) return;
   const markerPath = teamsSeedMarkerPath();
+  const marker: TeamsSeedMarker = {
+    teamsDir: claudeTeamsDir,
+    mtimeMs,
+    teamNames: [...new Set(teamNames)].sort(),
+  };
   await mkdir(join(getGenieHome(), 'state'), { recursive: true });
-  await writeFile(markerPath, `${JSON.stringify({ teamsDir: claudeTeamsDir, mtimeMs })}\n`, 'utf-8');
+  await writeFile(markerPath, `${JSON.stringify(marker)}\n`, 'utf-8');
 }
 
 /** Check if a source file needs migration (exists and not yet migrated). */
@@ -132,6 +161,24 @@ export function needsSeed(): boolean {
     return entries.some((e) => !e.startsWith('.'));
   } catch {
     return false;
+  }
+}
+
+/**
+ * Check whether the current database is missing team rows represented by a
+ * fresh disk seed marker. This catches pgserve data-dir resets, where the
+ * marker in GENIE_HOME survives but the `teams` table has been rebuilt empty.
+ */
+export async function needsSeededTeams(sql: Sql): Promise<boolean> {
+  const marker = readFreshTeamsSeedMarker(claudeTeamsDirPath());
+  if (!marker || marker.teamNames.length === 0) return false;
+  try {
+    const rows = await sql<Array<{ name: string }>>`
+      SELECT name FROM teams WHERE name = ANY(${marker.teamNames})
+    `;
+    return rows.length < marker.teamNames.length;
+  } catch {
+    return true;
   }
 }
 
@@ -334,20 +381,24 @@ async function upsertNativeTeam(sql: Sql, c: NativeTeamConfig): Promise<void> {
   `;
 }
 
-async function seedTeams(sql: Sql): Promise<number> {
+async function seedTeams(sql: Sql): Promise<SeedTeamsResult> {
   const configs = await loadAllNativeTeamConfigs();
+  const teamNames: string[] = [];
   let count = 0;
+  let hadFailures = false;
   for (const cfg of configs) {
     if (!cfg?.name) continue;
+    teamNames.push(cfg.name);
     try {
       await upsertNativeTeam(sql, cfg);
       count++;
     } catch (err) {
+      hadFailures = true;
       const msg = err instanceof Error ? err.message : String(err);
       console.warn(`[pg-seed] Failed to seed team "${cfg.name}": ${msg}`);
     }
   }
-  return count;
+  return { count, teamNames, hadFailures };
 }
 
 // ============================================================================
@@ -519,7 +570,8 @@ export async function runSeed(sql: Sql, repoPath?: string): Promise<SeedResult> 
   result.agents = workers.agents;
   result.templates = workers.templates;
 
-  result.teams = await seedTeams(sql);
+  const teams = await seedTeams(sql);
+  result.teams = teams.count;
 
   if (repoPath) {
     result.mailboxMessages = await seedMailbox(sql, repoPath);
@@ -528,7 +580,7 @@ export async function runSeed(sql: Sql, repoPath?: string): Promise<SeedResult> 
 
   // Phase 2: Mark source files as migrated (only after all UPSERTs succeed)
   await markMigrated(repoPath);
-  await writeTeamsSeedMarker();
+  if (!teams.hadFailures) await writeTeamsSeedMarker(teams.teamNames);
 
   return result;
 }

--- a/src/term-commands/serve.test.ts
+++ b/src/term-commands/serve.test.ts
@@ -433,11 +433,23 @@ describe('serve boot precondition ordering', () => {
     const startForegroundSource = source.slice(startIdx, endIdx);
 
     const daemonMarkerIdx = startForegroundSource.indexOf("process.env.GENIE_IS_DAEMON = '1'");
-    const preconditionsIdx = startForegroundSource.indexOf('await runStartPreconditions(autoFix)');
+    const preconditionsIdx = startForegroundSource.indexOf('await runStartPreconditions(autoFix');
 
     expect(daemonMarkerIdx).toBeGreaterThanOrEqual(0);
     expect(preconditionsIdx).toBeGreaterThanOrEqual(0);
     expect(daemonMarkerIdx).toBeLessThan(preconditionsIdx);
+  });
+
+  test('daemon no-fix waits for child startup status before reporting success', () => {
+    const source = readFileSync(resolve(__dirname, 'serve.ts'), 'utf-8');
+    const startIdx = source.indexOf('async function startBackground');
+    const endIdx = source.indexOf('/** Unlink serve.pid', startIdx);
+    const startBackgroundSource = source.slice(startIdx, endIdx);
+
+    expect(startBackgroundSource).toContain('GENIE_SERVE_STARTUP_STATUS');
+    expect(startBackgroundSource).toContain('await confirmBackgroundStarted');
+    expect(source).toContain('await waitForStartupStatus');
+    expect(source).toContain('status?.ok === false');
   });
 });
 

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -29,7 +29,7 @@ import {
   writeSync,
 } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import type { Command } from 'commander';
 import { palette } from '../../packages/genie-tokens';
 import {
@@ -53,6 +53,10 @@ function genieHome(): string {
 
 function servePidPath(): string {
   return join(genieHome(), 'serve.pid');
+}
+
+function serveStartupStatusPath(): string {
+  return join(genieHome(), 'state', `serve-startup-${process.pid}-${Date.now()}.json`);
 }
 
 // TUI uses default tmux server (no separate socket or config)
@@ -533,6 +537,12 @@ const handles: DaemonHandles = {
   derivedSignals: null,
   hookSocket: null,
 };
+
+interface ServeStartupStatus {
+  ok: boolean;
+  code?: number;
+  lines?: string[];
+}
 
 /** Sync agent directory from workspace and start file watcher. */
 async function startAgentSync(): Promise<{ close: () => void } | null> {
@@ -1040,6 +1050,84 @@ function installGracefulExitHandlers(shutdown: () => Promise<void>, hasStarted: 
   });
 }
 
+function writeStartupStatus(status: ServeStartupStatus): void {
+  const statusPath = process.env.GENIE_SERVE_STARTUP_STATUS;
+  if (!statusPath) return;
+  try {
+    mkdirSync(dirname(statusPath), { recursive: true });
+    writeFileSync(statusPath, `${JSON.stringify(status)}\n`, 'utf-8');
+  } catch {
+    // Best effort; the parent still falls back to liveness checks.
+  }
+}
+
+function readStartupStatus(statusPath: string): ServeStartupStatus | null {
+  try {
+    const parsed = JSON.parse(readFileSync(statusPath, 'utf-8')) as Partial<ServeStartupStatus>;
+    if (typeof parsed.ok !== 'boolean') return null;
+    return {
+      ok: parsed.ok,
+      code: typeof parsed.code === 'number' ? parsed.code : undefined,
+      lines: Array.isArray(parsed.lines)
+        ? parsed.lines.filter((line): line is string => typeof line === 'string')
+        : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function waitForStartupStatus(
+  statusPath: string,
+  childPid: number,
+  timeoutMs: number,
+): Promise<ServeStartupStatus | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const status = readStartupStatus(statusPath);
+    if (status) return status;
+    if (!isProcessAlive(childPid)) return { ok: false, code: 1 };
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return null;
+}
+
+function exitBackgroundStartFailed(): never {
+  console.error('Error: genie serve exited immediately.');
+  process.exit(1);
+}
+
+function exitStartupStatusFailure(status: ServeStartupStatus): never {
+  for (const line of status.lines ?? []) console.error(line);
+  process.exit(status.code ?? 1);
+}
+
+function exitStartupStatusMissing(childPid: number): never {
+  console.error('Error: genie serve did not report startup precondition status within 16s.');
+  try {
+    process.kill(childPid, 'SIGTERM');
+  } catch {
+    // Already gone.
+  }
+  process.exit(1);
+}
+
+async function confirmBackgroundStarted(childPid: number, startupStatusPath?: string): Promise<void> {
+  if (startupStatusPath) {
+    const status = await waitForStartupStatus(startupStatusPath, childPid, 16_000);
+    forceRemovePath(startupStatusPath);
+    if (status?.ok === false) exitStartupStatusFailure(status);
+    if (status?.ok !== true) exitStartupStatusMissing(childPid);
+    if (!isProcessAlive(childPid)) exitBackgroundStartFailed();
+    console.log(`genie serve started (PID ${childPid})`);
+    return;
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  if (!isProcessAlive(childPid)) exitBackgroundStartFailed();
+  console.log(`genie serve started (PID ${childPid})`);
+}
+
 async function startForeground(headless?: boolean, autoFix = true): Promise<void> {
   claimServePidOrExit();
   // Invalidate any stale port lockfile from an unclean prior shutdown — the
@@ -1054,18 +1142,32 @@ async function startForeground(headless?: boolean, autoFix = true): Promise<void
 
   // Preconditions call getConnection(); the daemon marker must already be set
   // so pgserve starts in this process instead of recursively auto-spawning serve.
+  const preconditionLines: string[] = [];
+  const preconditionLog = process.env.GENIE_SERVE_STARTUP_STATUS
+    ? (line: string): void => {
+        preconditionLines.push(line);
+        console.log(line);
+      }
+    : undefined;
   try {
-    const preconditionsOk = await runStartPreconditions(autoFix);
+    const preconditionsOk = await runStartPreconditions(autoFix, preconditionLog);
     if (!preconditionsOk) {
+      writeStartupStatus({ ok: false, code: 2, lines: preconditionLines });
       removeServePid();
       process.exit(2);
     }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`genie serve start preconditions failed: ${msg}`);
+    writeStartupStatus({
+      ok: false,
+      code: 1,
+      lines: [...preconditionLines, `genie serve start preconditions failed: ${msg}`],
+    });
     removeServePid();
     process.exit(1);
   }
+  writeStartupStatus({ ok: true });
 
   if (!skipTui) {
     await ensureTmux();
@@ -1114,6 +1216,7 @@ async function startBackground(headless?: boolean, autoFix = true): Promise<void
 
   const bunPath = process.execPath ?? 'bun';
   const genieBin = process.argv[1] ?? 'genie';
+  const startupStatusPath = autoFix ? undefined : serveStartupStatusPath();
 
   const args = [genieBin, 'serve', '--foreground'];
   if (headless) args.push('--headless');
@@ -1122,19 +1225,17 @@ async function startBackground(headless?: boolean, autoFix = true): Promise<void
   const child = spawn(bunPath, args, {
     detached: true,
     stdio: 'ignore',
-    env: { ...process.env, GENIE_IS_DAEMON: '1' },
+    env: {
+      ...process.env,
+      GENIE_IS_DAEMON: '1',
+      ...(startupStatusPath ? { GENIE_SERVE_STARTUP_STATUS: startupStatusPath } : {}),
+    },
   });
 
   child.unref();
 
   if (child.pid) {
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    if (isProcessAlive(child.pid)) {
-      console.log(`genie serve started (PID ${child.pid})`);
-    } else {
-      console.error('Error: genie serve exited immediately.');
-      process.exit(1);
-    }
+    await confirmBackgroundStarted(child.pid, startupStatusPath);
   } else {
     console.error('Error: failed to spawn genie serve');
     process.exit(1);
@@ -1143,8 +1244,12 @@ async function startBackground(headless?: boolean, autoFix = true): Promise<void
 
 /** Unlink serve.pid unconditionally, swallowing ENOENT and permission errors. */
 function forceRemoveServePid(): void {
+  forceRemovePath(servePidPath());
+}
+
+function forceRemovePath(path: string): void {
   try {
-    unlinkSync(servePidPath());
+    unlinkSync(path);
   } catch {}
 }
 
@@ -1429,13 +1534,15 @@ interface ServeStartOptions {
  * (e.g. bridge-failure assertions) within a tight timing envelope. Production
  * code paths must never set this — `--no-fix` is the operator-facing escape.
  */
-async function runStartPreconditions(autoFix: boolean): Promise<boolean> {
+async function runStartPreconditions(autoFix: boolean, log?: (line: string) => void): Promise<boolean> {
   if (process.env.GENIE_SKIP_PRECONDITIONS === '1') return true;
   const { ensureServeReady } = await import('./serve/ensure-ready.js');
-  const report = await ensureServeReady({ autoFix });
+  const report = await ensureServeReady({ autoFix, deps: log ? { log } : undefined });
   if (autoFix) return true;
   if (!report.ok) {
-    console.error('genie serve start refused: one or more preconditions are not ok (--no-fix mode).');
+    const message = 'genie serve start refused: one or more preconditions are not ok (--no-fix mode).';
+    if (log) log(message);
+    else console.error(message);
     return false;
   }
   return true;


### PR DESCRIPTION
## Summary
- keep Codex inbox timeout on the read-only lookup so late fetches cannot mark messages read without delivery
- rehydrate team rows after pgserve resets by validating seeded team marker rows against PG
- make daemon --no-fix startup wait for child precondition status before reporting success

## Verification
- bun run typecheck
- bun run lint
- bun test src/hooks/handlers/__tests__/codex-inbox-deliver.test.ts
- bun test src/lib/pg-seed.test.ts
- bun test src/term-commands/serve.test.ts -t "daemon no-fix waits"