### PR TITLE
fix(dir): register explicit dir add paths

### DIFF
--- a/src/term-commands/dir-add.test.ts
+++ b/src/term-commands/dir-add.test.ts
@@ -8,15 +8,17 @@
  */
 
 import { afterAll, afterEach, beforeAll, describe, expect, test } from 'bun:test';
-import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { Command } from 'commander';
 import * as directory from '../lib/agent-directory.js';
 import { syncSingleAgentByName } from '../lib/agent-sync.js';
 import { type AgentConfig, parseAgentYaml, writeAgentYaml } from '../lib/agent-yaml.js';
 import { getConnection } from '../lib/db.js';
 import { DB_AVAILABLE, setupTestDatabase } from '../lib/test-db.js';
+import { registerDirNamespace } from './dir.js';
 
 describe.skipIf(!DB_AVAILABLE)(
   'dir add — scaffolds agent.yaml + body-only AGENTS.md (wish dir-sync-frontmatter-refresh group 5)',
@@ -114,6 +116,46 @@ TBD
       const entry = await directory.get('db-match-agent');
       expect(entry).not.toBeNull();
       expect(entry!.model).toBe('sonnet');
+    });
+
+    test('CLI registers explicit --dir outside workspace agents directory', async () => {
+      workspaceRoot = join(tmpdir(), `dir-add-cli-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+      const externalDir = join(tmpdir(), `dir-add-external-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+      const name = 'explicit-dir-agent';
+      mkdirSync(join(workspaceRoot, '.genie'), { recursive: true });
+      mkdirSync(externalDir, { recursive: true });
+      writeFileSync(join(workspaceRoot, '.genie', 'workspace.json'), JSON.stringify({ name: 'dir-add-test' }));
+      writeFileSync(join(externalDir, 'AGENTS.md'), 'Explicit --dir prompt.\n');
+
+      const previousCwd = process.cwd();
+      process.chdir(workspaceRoot);
+      try {
+        const program = new Command();
+        program.exitOverride();
+        program.configureOutput({ writeOut: () => {}, writeErr: () => {} });
+        registerDirNamespace(program);
+        await program.parseAsync([
+          'node',
+          'genie',
+          'dir',
+          'add',
+          name,
+          '--dir',
+          externalDir,
+          '--repo',
+          workspaceRoot,
+          '--model',
+          'codex',
+        ]);
+      } finally {
+        process.chdir(previousCwd);
+      }
+
+      const entry = await directory.get(name);
+      expect(entry).not.toBeNull();
+      expect(entry!.dir).toBe(externalDir);
+      expect(entry!.repo).toBe(workspaceRoot);
+      expect(entry!.model).toBe('codex');
     });
 
     test('permissions flags land in yaml + DB', async () => {

--- a/src/term-commands/dir.ts
+++ b/src/term-commands/dir.ts
@@ -232,27 +232,30 @@ async function handleDirAdd(name: string, options: DirAddOptions): Promise<void>
   // Write agent.yaml atomically (locked).
   await writeAgentYaml(join(resolvedDir, 'agent.yaml'), config);
 
-  // Propagate to the DB via the same single-agent sync path used by `dir edit`.
+  const directoryEntry = {
+    name,
+    dir: resolvedDir,
+    repo: options.repo ? resolvePath(options.repo) : undefined,
+    promptMode,
+    model: options.model,
+    roles: normalizeRoles(options.roles),
+    ...(permissions && { permissions }),
+    ...(sdk && { sdk }),
+  };
+
+  // Propagate to the DB via the same single-agent sync path used by `dir edit`
+  // when the requested name is discoverable at workspace/agents/<name>. For
+  // explicit --dir paths outside that convention, register the row directly
+  // using the same payload instead of reporting success with no resolvable row.
   const ws = findWorkspace();
-  if (ws) {
-    await syncSingleAgentByName(ws.root, name);
-  } else {
-    // Not in a workspace — register a stub in the directory table so the
-    // agent is reachable even before the user runs `genie init`.
-    await directory.add(
-      {
-        name,
-        dir: resolvedDir,
-        repo: options.repo ? resolvePath(options.repo) : undefined,
-        promptMode,
-        model: options.model,
-        roles: normalizeRoles(options.roles),
-        ...(permissions && { permissions }),
-        ...(sdk && { sdk }),
-      },
-      { global: options.global },
-    );
-    console.warn('Not in a genie workspace — directory row created; run `genie dir sync` in a workspace to re-sync.');
+  const syncAction = ws ? await syncSingleAgentByName(ws.root, name) : 'not-found';
+  if (syncAction === 'not-found') {
+    await directory.add(directoryEntry, { global: options.global });
+    if (!ws) {
+      // Not in a workspace — register a stub in the directory table so the
+      // agent is reachable even before the user runs `genie init`.
+      console.warn('Not in a genie workspace — directory row created; run `genie dir sync` in a workspace to re-sync.');
+    }
   }
 
   recordAuditEvent('item', name, 'item_registered', getActor(), { type: 'agent', source: 'dir_add' }).catch(() => {});


### PR DESCRIPTION
## Summary
- Fixes `genie dir add --dir <explicit-path>` inside a workspace when the path is outside `workspace/agents/<name>`.
- Preserves the existing yaml-first sync path for discoverable workspace agents.
- Falls back to direct directory registration when `syncSingleAgentByName` returns `not-found`.
- Adds a Commander-level regression test that exercises the actual `dir add` command.

## Dogfood repro
- Existing issue: #1315
- Fresh evidence comment: https://github.com/automagik-dev/genie/issues/1315#issuecomment-4346066428
- Evidence dir: `/home/genie/workspace/agents/genie/.genie/agents/dog-fooder/state/evidence/round-20260429-pr1517-refine/repro-dir-add-explicit-dir/`

## Validation
- `bun test src/term-commands/dir-add.test.ts` — 7 pass
- `bun run build` — pass

Refs #1315.
