### PR TITLE
fix(wish): honor shipped status in status command

### DIFF
--- a/src/term-commands/state.test.ts
+++ b/src/term-commands/state.test.ts
@@ -8,7 +8,15 @@ import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { DB_AVAILABLE, setupTestDatabase } from '../lib/test-db.js';
 import * as wishState from '../lib/wish-state.js';
-import { archiveWishNamedAgents, detectWaveCompletion, ensureWorkPushed, parseRef, resolveWishPath } from './state.js';
+import {
+  archiveWishNamedAgents,
+  detectWaveCompletion,
+  ensureWorkPushed,
+  parseRef,
+  parseWishLifecycleStatus,
+  resolveWishPath,
+  statusCommand,
+} from './state.js';
 
 // ============================================================================
 // Sample WISH.md with Execution Strategy for wave detection tests
@@ -81,6 +89,63 @@ describe('parseRef()', () => {
 
   it('should throw on missing hash', () => {
     expect(() => parseRef('nohash')).toThrow('Invalid reference');
+  });
+});
+
+describe('parseWishLifecycleStatus()', () => {
+  it('parses table and bold status markers', () => {
+    expect(parseWishLifecycleStatus('| **Status** | SHIPPED |')).toBe('SHIPPED');
+    expect(parseWishLifecycleStatus('**Status:** SHIPPED — 2026-04-29')).toBe('SHIPPED');
+  });
+});
+
+async function captureConsoleLog(fn: () => Promise<void>): Promise<string> {
+  const original = console.log;
+  const lines: string[] = [];
+  console.log = (...args: unknown[]) => {
+    lines.push(args.join(' '));
+  };
+  try {
+    await fn();
+  } finally {
+    console.log = original;
+  }
+  return lines.join('\n');
+}
+
+describe('statusCommand()', () => {
+  it('prints terminal WISH.md status instead of auto-initializing shipped wishes', async () => {
+    const cwd = join('/tmp', `wish-status-shipped-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const wishDir = join(cwd, '.genie', 'wishes', 'shipped-wish');
+    await mkdir(wishDir, { recursive: true });
+    await writeFile(
+      join(wishDir, 'WISH.md'),
+      `# Wish: Shipped
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+## Execution Groups
+
+### Group 1: Done work
+
+**depends-on:** none
+`,
+    );
+
+    const previous = process.cwd();
+    process.chdir(cwd);
+    try {
+      const output = await captureConsoleLog(() => statusCommand('shipped-wish'));
+      expect(output).toContain('Status: SHIPPED');
+      expect(output).toContain('No active execution state initialized');
+      expect(output).not.toContain('Auto-initialized');
+      expect(output).not.toContain('ready');
+    } finally {
+      process.chdir(previous);
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/term-commands/state.ts
+++ b/src/term-commands/state.ts
@@ -468,6 +468,47 @@ async function autoInitWishState(slug: string): Promise<Awaited<ReturnType<typeo
   return state;
 }
 
+const TERMINAL_WISH_STATUSES = new Set(['shipped', 'done', 'complete', 'completed', 'archived']);
+
+export interface TerminalWishLifecycleStatus {
+  status: string;
+  wishPath: string;
+}
+
+export function parseWishLifecycleStatus(content: string): string | null {
+  const patterns = [
+    /^\|\s*\*\*Status\*\*\s*\|\s*([^|]+?)\s*\|/im,
+    /^\*\*Status:\*\*\s*([A-Za-z][A-Za-z_-]*)/im,
+    /^Status:\s*([A-Za-z][A-Za-z_-]*)/im,
+  ];
+  for (const pattern of patterns) {
+    const match = content.match(pattern);
+    const token = match?.[1]?.trim().match(/^[A-Za-z][A-Za-z_-]*/)?.[0];
+    if (token) return token.toUpperCase();
+  }
+  return null;
+}
+
+export async function getTerminalWishLifecycleStatus(slug: string): Promise<TerminalWishLifecycleStatus | null> {
+  const wishPath = resolveWishPath(slug);
+  if (!wishPath) return null;
+
+  const content = await readFile(wishPath, 'utf-8');
+  const status = parseWishLifecycleStatus(content);
+  if (!status || !TERMINAL_WISH_STATUSES.has(status.toLowerCase())) return null;
+  return { status, wishPath };
+}
+
+export function printTerminalWishLifecycleStatus(slug: string, terminal: TerminalWishLifecycleStatus): void {
+  console.log(`\nWish: ${slug}`);
+  console.log('─'.repeat(60));
+  console.log(`  Status: ${terminal.status}`);
+  console.log(`  Source: ${terminal.wishPath}`);
+  console.log('');
+  console.log('  No active execution state initialized for terminal wish status.');
+  console.log('');
+}
+
 async function printWishExecutors(slug: string): Promise<void> {
   try {
     const { registry, executorRegistry, assignmentRegistry } = await loadExecutorInfo();
@@ -502,6 +543,12 @@ async function printWishExecutors(slug: string): Promise<void> {
 
 export async function statusCommand(slug: string): Promise<void> {
   try {
+    const terminal = await getTerminalWishLifecycleStatus(slug);
+    if (terminal) {
+      printTerminalWishLifecycleStatus(slug, terminal);
+      return;
+    }
+
     const state = (await wishState.getState(slug)) ?? (await autoInitWishState(slug));
 
     console.log(`\nWish: ${state.wish}`);

--- a/src/term-commands/task/status.ts
+++ b/src/term-commands/task/status.ts
@@ -8,7 +8,7 @@ import type { Command } from 'commander';
 import { formatTimestamp, padRight } from '../../lib/term-format.js';
 import * as wishState from '../../lib/wish-state.js';
 import { parseWishGroups } from '../dispatch.js';
-import { resolveWishPath } from '../state.js';
+import { getTerminalWishLifecycleStatus, printTerminalWishLifecycleStatus, resolveWishPath } from '../state.js';
 
 const STATUS_ICONS: Record<string, string> = {
   blocked: '🔒',
@@ -60,6 +60,12 @@ async function printActiveExecutors(slug: string): Promise<void> {
 }
 
 async function statusCommand(slug: string): Promise<void> {
+  const terminal = await getTerminalWishLifecycleStatus(slug);
+  if (terminal) {
+    printTerminalWishLifecycleStatus(slug, terminal);
+    return;
+  }
+
   let state = await wishState.getState(slug);
   if (!state) {
     const wishPath = resolveWishPath(slug);


### PR DESCRIPTION
## Summary
- Makes `genie wish status <slug>` honor terminal lifecycle status from `WISH.md` before auto-initializing execution state.
- Handles table status (`| **Status** | SHIPPED |`) and bold status (`**Status:** SHIPPED — date`) markers.
- Applies the same guard to `genie task status`.
- Adds regression coverage for shipped wishes and lifecycle marker parsing.

## Dogfood repro
- Issue: #1523
- Evidence dir: `/home/genie/workspace/agents/genie/.genie/agents/dog-fooder/state/evidence/round-20260429-pr1517-refine/repro-wish-status-shipped/`
- Repro showed `canonical-genie-omni-wiring` declared `SHIPPED` while `genie wish status` rendered `0/5 done` with ready/blocked groups.

## Validation
- `bun test src/term-commands/state.test.ts` — 21 pass
- `bun run build` — pass
- `bun src/genie.ts --no-tui wish status canonical-genie-omni-wiring` — prints `Status: SHIPPED`

Fixes #1523.
