### PR TITLE
fix: reduce macOS TUI renderer load

### DIFF
--- a/src/tui/render.test.ts
+++ b/src/tui/render.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test';
+import { resolveTuiRendererConfig } from './render.js';
+
+describe('resolveTuiRendererConfig', () => {
+  test('uses conservative renderer defaults on macOS', () => {
+    const config = resolveTuiRendererConfig({}, 'darwin');
+
+    expect(config.exitOnCtrlC).toBe(false);
+    expect(config.useThread).toBe(false);
+    expect(config.targetFps).toBe(8);
+    expect(config.maxFps).toBe(12);
+    expect(config.useMouse).toBe(false);
+    expect(config.enableMouseMovement).toBe(false);
+    expect(config.useKittyKeyboard).toBe(null);
+    expect(config.consoleMode).toBe('disabled');
+    expect(config.openConsoleOnError).toBe(false);
+  });
+
+  test('allows explicit macOS mouse and FPS overrides', () => {
+    const config = resolveTuiRendererConfig(
+      {
+        GENIE_TUI_MOUSE: '1',
+        GENIE_TUI_MOUSE_MOVEMENT: '1',
+        GENIE_TUI_TARGET_FPS: '20',
+        GENIE_TUI_MAX_FPS: '30',
+      },
+      'darwin',
+    );
+
+    expect(config.useMouse).toBe(true);
+    expect(config.enableMouseMovement).toBe(true);
+    expect(config.targetFps).toBe(20);
+    expect(config.maxFps).toBe(30);
+  });
+
+  test('keeps the old renderer defaults outside macOS', () => {
+    const config = resolveTuiRendererConfig({}, 'linux');
+
+    expect(config.useThread).toBe(true);
+    expect(config.targetFps).toBe(30);
+    expect(config.maxFps).toBe(60);
+    expect(config.useMouse).toBe(true);
+    expect(config.enableMouseMovement).toBe(true);
+    expect(config.useKittyKeyboard).toBeUndefined();
+    expect(config.consoleMode).toBeUndefined();
+    expect(config.openConsoleOnError).toBe(true);
+  });
+
+  test('keeps max FPS at least as high as target FPS', () => {
+    const config = resolveTuiRendererConfig(
+      {
+        GENIE_TUI_TARGET_FPS: '15',
+        GENIE_TUI_MAX_FPS: '4',
+      },
+      'darwin',
+    );
+
+    expect(config.targetFps).toBe(15);
+    expect(config.maxFps).toBe(15);
+  });
+});

--- a/src/tui/render.tsx
+++ b/src/tui/render.tsx
@@ -1,9 +1,54 @@
 /** @jsxImportSource @opentui/react */
 /** OpenTUI React renderer — separated from index.ts to isolate JSX */
 
-import { createCliRenderer } from '@opentui/core';
+import { type CliRendererConfig, createCliRenderer } from '@opentui/core';
 import { createRoot } from '@opentui/react';
 import { App } from './app.js';
+
+const TRUTHY = new Set(['1', 'true', 'yes', 'on']);
+const FALSY = new Set(['0', 'false', 'no', 'off']);
+
+type TuiRendererEnv = Record<string, string | undefined>;
+
+function readBool(env: TuiRendererEnv, name: string, fallback: boolean): boolean {
+  const raw = env[name];
+  if (!raw) return fallback;
+  const normalized = raw.trim().toLowerCase();
+  if (TRUTHY.has(normalized)) return true;
+  if (FALSY.has(normalized)) return false;
+  return fallback;
+}
+
+function readPositiveInt(env: TuiRendererEnv, name: string): number | undefined {
+  const raw = env[name];
+  if (!raw) return undefined;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+export function resolveTuiRendererConfig(
+  env: TuiRendererEnv = process.env,
+  platform: NodeJS.Platform | string = process.platform,
+): CliRendererConfig {
+  const isDarwin = platform === 'darwin';
+  const targetFps = readPositiveInt(env, 'GENIE_TUI_TARGET_FPS') ?? (isDarwin ? 8 : 30);
+  const configuredMaxFps = readPositiveInt(env, 'GENIE_TUI_MAX_FPS') ?? (isDarwin ? 12 : 60);
+  const maxFps = Math.max(configuredMaxFps, targetFps);
+  const useMouse = readBool(env, 'GENIE_TUI_MOUSE', !isDarwin);
+  const enableMouseMovement = useMouse && readBool(env, 'GENIE_TUI_MOUSE_MOVEMENT', !isDarwin);
+
+  return {
+    exitOnCtrlC: false, // We handle Ctrl+C ourselves via useKeyboard
+    useThread: !isDarwin,
+    targetFps,
+    maxFps,
+    useMouse,
+    enableMouseMovement,
+    useKittyKeyboard: isDarwin ? null : undefined,
+    consoleMode: isDarwin ? 'disabled' : undefined,
+    openConsoleOnError: !isDarwin,
+  };
+}
 
 export async function renderNav(): Promise<void> {
   const rightPane = process.env.GENIE_TUI_RIGHT || undefined;
@@ -11,14 +56,9 @@ export async function renderNav(): Promise<void> {
   const initialAgent = process.env.GENIE_TUI_AGENT || undefined;
 
   // OpenTUI handles SIGTERM/SIGHUP/SIGINT cleanup automatically.
-  // useThread:false on darwin — the native render pthread's __ulock_wait2 predicate
-  // doesn't settle on local Warp ptys (spins at ~101% CPU; SIGTERM ignored because
-  // the JS thread is blocked on the FFI lock). Linux already defaults to false.
-  const renderer = await createCliRenderer({
-    exitOnCtrlC: false, // We handle Ctrl+C ourselves via useKeyboard
-    useMouse: true,
-    useThread: process.platform !== 'darwin',
-  });
+  // macOS local ptys have repeatedly hit OpenTUI native hot loops. Keep the TUI
+  // usable there, but default to a conservative renderer and allow env opt-ins.
+  const renderer = await createCliRenderer(resolveTuiRendererConfig());
 
   createRoot(renderer).render(<App rightPane={rightPane} workspaceRoot={workspaceRoot} initialAgent={initialAgent} />);
 


### PR DESCRIPTION
## Summary
- keep the TUI enabled on macOS but switch OpenTUI to conservative renderer defaults
- disable mouse tracking, Kitty keyboard negotiation, and the console overlay on macOS by default
- add env overrides and tests for renderer config

## Verification
- bun test src/tui/render.test.ts
- bunx biome check src/tui/render.tsx src/tui/render.test.ts
- bun run typecheck
- bun run build
- bounded TUI smoke run with GENIE_TUI_DISABLE removed: renderer process reported ~0.5% CPU after 5 seconds, then cleaned up

## Note
Local pre-push hook currently fails on existing dev skills-lint issue: skills/omni/SKILL.md references missing omni connect. This branch does not touch that file.