### PR TITLE
feat(task): add `genie task priority <id> <level>` subcommand (#1473)

### DIFF
--- a/src/lib/task-service.test.ts
+++ b/src/lib/task-service.test.ts
@@ -181,12 +181,7 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
 
       // Mirror the CLI handler: updateTask with priority + comment {actor, body}.
       const commentBody = 'elevating per quarterly recalibration';
-      const updated = await updateTask(
-        task.id,
-        { priority: 'urgent' },
-        REPO,
-        { actor, body: commentBody },
-      );
+      const updated = await updateTask(task.id, { priority: 'urgent' }, REPO, { actor, body: commentBody });
       expect(updated).not.toBeNull();
       expect(updated!.priority).toBe('urgent');
 

--- a/src/lib/task-service.test.ts
+++ b/src/lib/task-service.test.ts
@@ -172,6 +172,45 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
       expect(updated!.priority).toBe('high');
     });
 
+    // #1473 — priority subcommand wires through updateTask + optional comment.
+    // CLI surface: `genie task priority <id> <level> [--comment <msg>]`.
+    // This test exercises the exact path the CLI handler takes.
+    it('should set priority on existing task with optional comment (#1473)', async () => {
+      const task = await createTask({ title: 'Priority change target', priority: 'normal' }, REPO);
+      expect(task.priority).toBe('normal');
+
+      // Mirror the CLI handler: updateTask with priority + comment {actor, body}.
+      const commentBody = 'elevating per quarterly recalibration';
+      const updated = await updateTask(
+        task.id,
+        { priority: 'urgent' },
+        REPO,
+        { actor, body: commentBody },
+      );
+      expect(updated).not.toBeNull();
+      expect(updated!.priority).toBe('urgent');
+
+      // Verify the audit comment landed in the task's conversation.
+      const conv = await findOrCreateConversation({
+        linkedEntity: 'task',
+        linkedEntityId: task.id,
+        name: `Task ${task.id}`,
+        createdBy: actor,
+        members: [actor],
+      });
+      const messages = await getMessages(conv.id);
+      const lastMsg = messages[messages.length - 1];
+      expect(lastMsg?.body).toBe(commentBody);
+    });
+
+    it('should accept all four priority levels via updateTask (#1473)', async () => {
+      const task = await createTask({ title: 'Priority cycle' }, REPO);
+      for (const level of ['urgent', 'high', 'normal', 'low'] as const) {
+        const updated = await updateTask(task.id, { priority: level }, REPO);
+        expect(updated!.priority).toBe(level);
+      }
+    });
+
     it('should block and unblock task', async () => {
       const task = await createTask({ title: 'Blockable' }, REPO);
       const blocked = await blockTask(task.id, 'waiting on API', actor, undefined, REPO);

--- a/src/term-commands/task.ts
+++ b/src/term-commands/task.ts
@@ -752,6 +752,39 @@ export function registerTaskCommands(program: Command): void {
       }
     });
 
+  // ── task priority ──
+  // Closes #1473 — priority was settable on `task create` but not editable
+  // afterward. PMs curating large boards (47+ high-priority cards) had no
+  // way to recalibrate without recreating cards (loses comments + history).
+  task
+    .command('priority <id> <level>')
+    .description('Set the priority of an existing task (urgent|high|normal|low)')
+    .option('--comment <msg>', 'Audit comment for the priority change')
+    .action(async (id: string, level: string, options: { comment?: string }) => {
+      try {
+        type PriorityLevel = 'urgent' | 'high' | 'normal' | 'low';
+        const validLevels: PriorityLevel[] = ['urgent', 'high', 'normal', 'low'];
+        if (!validLevels.includes(level as PriorityLevel)) {
+          console.error(`Error: invalid priority "${level}". Valid: ${validLevels.join(', ')}`);
+          process.exit(1);
+        }
+        const priority = level as PriorityLevel;
+        const ts = await getTaskService();
+        const actor = currentActor();
+        const comment = options.comment ? { actor, body: options.comment } : undefined;
+        const t = await ts.updateTask(id, { priority }, undefined, comment);
+        if (!t) {
+          console.error(`Error: Task not found: ${id}`);
+          process.exit(1);
+        }
+        const colorCode = PRIORITY_COLORS[level] ?? '';
+        console.log(`Task #${t.seq} priority set to ${colorCode}${level}${RESET}.`);
+      } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+      }
+    });
+
   // ── task done ──
   task
     .command('done <id>')


### PR DESCRIPTION
## Summary

Adds the missing CLI surface for editing task priority post-creation. Closes #1473 from the W3 triage batch.

Priority was settable on `task create` but not editable afterward. PMs curating large boards (47+ high-priority cards) had no way to recalibrate without recreating cards (which loses comments + history).

## What changed

- `src/term-commands/task.ts` — adds `task priority <id> <level>` subcommand
- `src/lib/task-service.test.ts` — 2 new tests covering the exact CLI handler flow

## Surface

```bash
genie task priority <#seq|task-id> <urgent|high|normal|low> [--comment <msg>]
```

The implementation is a thin wire — `updateTask(id, { priority }, repoPath, comment?)` already existed; the gap was just the CLI surface. Mirrors the shape of `task move`, `task block`, `task assign`.

## Validation

- Rejects invalid priority levels with a clear error + valid list
- Returns "Task not found" if id doesn't resolve
- Comment, if provided, lands in the task's conversation as an audit message

## Tests

- 2 new tests, all 88 existing task-service tests still pass (90 total)
- `bun run typecheck` clean

## Closes

- Closes #1473

🤖 Generated with [Claude Code](https://claude.com/claude-code)