### PR TITLE
fix(scheduler): W1 hotfix — move resume.missing_session emission from read path to scheduler

### DIFF
--- a/src/lib/__tests__/auto-resume-zombie-cap.test.ts
+++ b/src/lib/__tests__/auto-resume-zombie-cap.test.ts
@@ -555,3 +555,97 @@ describe('#1462: orphan agents (no currentSessionId) increment counter and exhau
     expect(agentUpdates.length).toBe(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// W1 hotfix — `resume.missing_session` emission contract
+//
+// PR #1528 emitted from the read path (getResumeSessionId) with in-process
+// dedupe; that didn't survive CLI process boundaries (each `genie ls` is a
+// fresh process). PR #1530 (this) moves emission to the scheduler's
+// attemptAgentResume no-session branch — bounded to ≤1 emit per orphan per
+// scheduler tick (60s) by the daemon's tick rate.
+//
+// These tests use a real pgserve so we can verify audit rows landed
+// (createMockSql() returns [] for every query so audit writes are no-ops
+// there). We dispatch the actual function and read audit_events.
+// ---------------------------------------------------------------------------
+
+import { afterAll, beforeAll, beforeEach } from 'bun:test';
+import { findOrCreateAgent } from '../agent-registry.js';
+import { getConnection } from '../db.js';
+import { DB_AVAILABLE, setupTestDatabase } from '../test-db.js';
+
+describe.skipIf(!DB_AVAILABLE)('W1 hotfix: scheduler emits resume.missing_session for orphan path', () => {
+  let cleanupDb: () => Promise<void>;
+
+  beforeAll(async () => {
+    cleanupDb = await setupTestDatabase();
+  });
+
+  afterAll(async () => {
+    await cleanupDb();
+  });
+
+  beforeEach(async () => {
+    const sql = await getConnection();
+    await sql`DELETE FROM audit_events WHERE event_type = 'resume.missing_session'`;
+    await sql`DELETE FROM agents WHERE id LIKE 'w1-hotfix-%'`;
+  });
+
+  async function countMissingSessionEvents(agentId: string): Promise<number> {
+    const sql = await getConnection();
+    const rows = await sql<{ count: number }[]>`
+      SELECT COUNT(*)::int AS count
+      FROM audit_events
+      WHERE entity_type = 'agent'
+        AND entity_id = ${agentId}
+        AND event_type = 'resume.missing_session'
+    `;
+    return rows[0].count;
+  }
+
+  test('attemptAgentResume on orphan with no session emits exactly one resume.missing_session per call', async () => {
+    const agent = await findOrCreateAgent('w1-hotfix-orphan-1', 'w1-hotfix-team', 'engineer');
+
+    const orphan = makeWorker({
+      id: agent.id,
+      currentSessionId: null,
+      resumeAttempts: 0,
+      maxResumeAttempts: 3,
+      autoResume: true,
+    });
+
+    const { deps } = createMockDeps({
+      getConnection: async () => await getConnection(),
+    });
+
+    expect(await countMissingSessionEvents(agent.id)).toBe(0);
+    await attemptAgentResume(deps, defaultConfig, orphan);
+    expect(await countMissingSessionEvents(agent.id)).toBe(1);
+  });
+
+  test('three sequential ticks produce three events (bounded by tick cadence, not unbounded)', async () => {
+    const agent = await findOrCreateAgent('w1-hotfix-orphan-3', 'w1-hotfix-team', 'engineer');
+    const { deps } = createMockDeps({
+      getConnection: async () => await getConnection(),
+    });
+
+    // Three scheduler ticks back-to-back. In production these are 60s apart
+    // by daemon cadence; the test compresses time. Each tick increments the
+    // counter and emits one event until exhaustion at attempt=3.
+    for (let attempts = 0; attempts < 3; attempts++) {
+      const orphan = makeWorker({
+        id: agent.id,
+        currentSessionId: null,
+        resumeAttempts: attempts,
+        maxResumeAttempts: 3,
+        autoResume: true,
+      });
+      await attemptAgentResume(deps, defaultConfig, orphan);
+    }
+
+    // Three ticks → three events. NOT 368 like the read-path storm da66
+    // measured pre-hotfix (PR #1528).
+    expect(await countMissingSessionEvents(agent.id)).toBe(3);
+  });
+});

--- a/src/lib/executor-registry.test.ts
+++ b/src/lib/executor-registry.test.ts
@@ -11,6 +11,7 @@ import { completeAssignment, createAssignment, getActiveAssignment } from './ass
 import { getConnection } from './db.js';
 import {
   type CreateExecutorOpts,
+  _resetMissingSessionDedupeForTests,
   _resumeJsonlScannerDeps,
   createAndLinkExecutor,
   createExecutor,
@@ -354,19 +355,22 @@ describe.skipIf(!DB_AVAILABLE)('executor-registry', () => {
       expect(event!.details.sessionId).toBe('sess-happy');
     });
 
-    test('no current executor: returns null and emits resume.missing_session (no_executor)', async () => {
+    test('no current executor: returns null SILENTLY (no audit event from read path — W1 hotfix)', async () => {
       const agentId = await seedAgent();
       // No executor assigned → current_executor_id is null
 
       const sessionId = await getResumeSessionId(agentId);
       expect(sessionId).toBeNull();
 
+      // W1 hotfix: read path no longer emits resume.missing_session. The
+      // scheduler's attemptAgentResume owns emission so it's bounded to ≤1
+      // per orphan per scheduler tick. See PR #1530 (this hotfix) for why
+      // PR #1528's in-process dedupe was insufficient.
       const event = await latestAuditForAgent(agentId, 'resume.missing_session');
-      expect(event).not.toBeNull();
-      expect(event!.details.reason).toBe('no_executor');
+      expect(event).toBeNull();
     });
 
-    test('executor without session: returns null and emits resume.missing_session (null_session)', async () => {
+    test('executor without session: returns null SILENTLY (no audit event from read path — W1 hotfix)', async () => {
       const agentId = await seedAgent();
       const exec = await createExecutor(agentId, 'claude', 'tmux'); // no claudeSessionId
       await setCurrentExecutor(agentId, exec.id);
@@ -375,9 +379,7 @@ describe.skipIf(!DB_AVAILABLE)('executor-registry', () => {
       expect(sessionId).toBeNull();
 
       const event = await latestAuditForAgent(agentId, 'resume.missing_session');
-      expect(event).not.toBeNull();
-      expect(event!.details.reason).toBe('null_session');
-      expect(event!.details.executorId).toBe(exec.id);
+      expect(event).toBeNull();
     });
 
     test('multiple prior executors: only the current executor counts', async () => {
@@ -403,13 +405,12 @@ describe.skipIf(!DB_AVAILABLE)('executor-registry', () => {
       expect(event!.details.sessionId).toBe('sess-current');
     });
 
-    test('returns null for unknown agent and emits resume.missing_session', async () => {
+    test('returns null for unknown agent SILENTLY (no audit event from read path — W1 hotfix)', async () => {
       const sessionId = await getResumeSessionId('00000000-0000-0000-0000-000000000000');
       expect(sessionId).toBeNull();
 
       const event = await latestAuditForAgent('00000000-0000-0000-0000-000000000000', 'resume.missing_session');
-      expect(event).not.toBeNull();
-      expect(event!.details.reason).toBe('no_executor');
+      expect(event).toBeNull();
     });
 
     test('picks up session written after executor creation via updateClaudeSessionId', async () => {
@@ -503,7 +504,7 @@ describe.skipIf(!DB_AVAILABLE)('executor-registry', () => {
         }
       });
 
-      test('no executor + no JSONL on disk: still emits resume.missing_session (no_executor)', async () => {
+      test('no executor + no JSONL on disk: returns null SILENTLY (W1 hotfix — no read-path emission)', async () => {
         const cwd = '/tmp/no-jsonl-fixture';
         _resumeJsonlScannerDeps.scanForSession = async () => null;
 
@@ -513,9 +514,10 @@ describe.skipIf(!DB_AVAILABLE)('executor-registry', () => {
           const sessionId = await getResumeSessionId(agentId);
           expect(sessionId).toBeNull();
 
+          // W1 hotfix: read path no longer emits resume.missing_session.
+          // Scheduler emits via attemptAgentResume (bounded to 1/tick).
           const event = await latestAuditForAgent(agentId, 'resume.missing_session');
-          expect(event).not.toBeNull();
-          expect(event!.details.reason).toBe('no_executor');
+          expect(event).toBeNull();
 
           const recovered = await latestAuditForAgent(agentId, 'resume.recovered_via_jsonl');
           expect(recovered).toBeNull();
@@ -524,7 +526,7 @@ describe.skipIf(!DB_AVAILABLE)('executor-registry', () => {
         }
       });
 
-      test('agent with no repo_path: skips JSONL scan entirely', async () => {
+      test('agent with no repo_path: skips JSONL scan entirely (W1 hotfix — still no read-path emission)', async () => {
         let scannerCalls = 0;
         _resumeJsonlScannerDeps.scanForSession = async () => {
           scannerCalls++;
@@ -540,19 +542,19 @@ describe.skipIf(!DB_AVAILABLE)('executor-registry', () => {
           expect(scannerCalls).toBe(0); // scanner never invoked when cwd is null
 
           const event = await latestAuditForAgent(agentId, 'resume.missing_session');
-          expect(event).not.toBeNull();
-          expect(event!.details.reason).toBe('no_executor');
+          expect(event).toBeNull();
         } finally {
           resetScanner();
         }
       });
 
-      test('agent with cwd but null custom_name: scanner refuses (identity unknown)', async () => {
+      test('agent with cwd but null custom_name: scanner refuses, returns null silently (W1 hotfix)', async () => {
         // Legacy rows / partially-seeded agents where custom_name is NULL.
         // Returning newest JSONL would attach this agent to whatever
         // happened to be most-recent in the project dir — cross-agent
         // context corruption. Strict refusal is the right behavior; the
-        // outer caller emits resume.missing_session.
+        // scheduler (not this read path) is responsible for surfacing the
+        // missing-session signal via audit emission.
         const cwd = '/tmp/null-customname-fixture';
         let scannerCalls = 0;
         _resumeJsonlScannerDeps.scanForSession = async () => {
@@ -570,7 +572,7 @@ describe.skipIf(!DB_AVAILABLE)('executor-registry', () => {
           expect(scannerCalls).toBe(0); // gate fired before reaching scanner
 
           const event = await latestAuditForAgent(agentId, 'resume.missing_session');
-          expect(event).not.toBeNull();
+          expect(event).toBeNull();
         } finally {
           resetScanner();
         }
@@ -1421,33 +1423,25 @@ describe.skipIf(!DB_AVAILABLE)('executor-registry', () => {
   });
 
   // ==========================================================================
-  // #1461 — `resume.missing_session` dedupe (60s window per agent+actor+reason)
+  // #1461 — `resume.missing_session` is NOT emitted from the read path
   //
-  // Pre-fix: every `getResumeSessionId()` call for an orphan agent emitted a
-  // fresh `resume.missing_session` audit row. Each TUI tick / `genie ls` /
-  // `genie agent show` for a missing-executor agent fired the event, producing
-  // 14M events / 7-day window on one observed machine.
+  // PR #1528 (Wave 1) attempted to dedupe at the source via an in-process
+  // Map keyed by (agentId, actor, reason) with a 60s window. dog-fooder-da66
+  // verdict 2026-04-29 verified this insufficient: each CLI invocation /
+  // TUI tick is a fresh process with no shared in-memory state, so a
+  // synthetic orphan still produced 368 cli + 66 genie events in 67s.
   //
-  // Fix: in-process dedupe map suppresses repeats within
-  // `MISSING_SESSION_DEDUPE_WINDOW_MS` (60s) keyed by
-  // `${agentId}:${actor}:${reason}`. Behavior is observability-only — the
-  // function still returns null and the operator still sees the row is broken.
+  // PR #1530 (this hotfix) takes the architecturally correct approach: the
+  // read path emits ZERO events. Emission moves to the scheduler's
+  // `attemptAgentResume`, where it's bounded to ≤1 emit per orphan per
+  // scheduler tick (default 60s) by the long-running daemon's tick cadence.
+  // The READ path is observability-of-state, the WRITE path is
+  // observability-of-action; emission belongs to the latter.
+  //
+  // Tests below verify this contract: any number of reads on an orphan
+  // agent must produce ZERO `resume.missing_session` events.
   // ==========================================================================
-  describe('#1461: resume.missing_session emission is deduped within a 60s window', () => {
-    let _resetMissingSessionDedupeForTests: () => void;
-    beforeAll(async () => {
-      const mod = (await import('./executor-registry.js')) as unknown as {
-        _resetMissingSessionDedupeForTests: () => void;
-      };
-      _resetMissingSessionDedupeForTests = mod._resetMissingSessionDedupeForTests;
-    });
-
-    beforeEach(() => {
-      // Each test starts with an empty dedupe cache so the assertion uses a
-      // single emission counter, not whatever drift the previous test left.
-      _resetMissingSessionDedupeForTests();
-    });
-
+  describe('#1461: resume.missing_session is not emitted from getResumeSessionId (W1 hotfix)', () => {
     async function countMissingSessionEvents(agentId: string): Promise<number> {
       const sql = await getConnection();
       const rows = await sql<{ count: number }[]>`
@@ -1460,61 +1454,55 @@ describe.skipIf(!DB_AVAILABLE)('executor-registry', () => {
       return rows[0].count;
     }
 
-    test('first call emits, subsequent calls within window do not', async () => {
+    test('many back-to-back reads on an orphan agent produce ZERO events', async () => {
       const agentId = await seedAgent();
 
-      // Five back-to-back reads (mimics TUI tick + status reads + scheduler).
-      for (let i = 0; i < 5; i++) {
+      // 50 reads — mimicking sustained TUI ticks + status reads on an orphan.
+      // Pre-W1: 50 events. Post-W1 (PR #1528 in-process dedupe): 1 event per
+      // process. Post-hotfix (this PR): 0 events (read path is silent).
+      for (let i = 0; i < 50; i++) {
         expect(await getResumeSessionId(agentId)).toBeNull();
       }
 
-      // Only the first emission landed.
-      expect(await countMissingSessionEvents(agentId)).toBe(1);
+      expect(await countMissingSessionEvents(agentId)).toBe(0);
     });
 
-    test('different agents do not dedupe against each other', async () => {
-      const agentA = await seedAgent('eng-a');
-      const agentB = await seedAgent('eng-b');
+    test('reads on no-session executor produce ZERO events', async () => {
+      const agentId = await seedAgent('null-sess');
+      const exec = await createExecutor(agentId, 'claude', 'tmux'); // no claudeSessionId
+      await setCurrentExecutor(agentId, exec.id);
 
-      await getResumeSessionId(agentA);
-      await getResumeSessionId(agentB);
-      await getResumeSessionId(agentA); // Within window — no second emission.
-      await getResumeSessionId(agentB); // Within window — no second emission.
+      for (let i = 0; i < 20; i++) {
+        expect(await getResumeSessionId(agentId)).toBeNull();
+      }
 
-      expect(await countMissingSessionEvents(agentA)).toBe(1);
-      expect(await countMissingSessionEvents(agentB)).toBe(1);
+      expect(await countMissingSessionEvents(agentId)).toBe(0);
     });
 
-    test('different reasons (no_executor vs null_session) dedupe independently', async () => {
-      // `null_session` reason: executor exists but has no claude_session_id.
-      const agentNullSess = await seedAgent('null-sess');
-      const exec = await createExecutor(agentNullSess, 'claude', 'tmux');
-      await setCurrentExecutor(agentNullSess, exec.id);
+    test('happy path (resume.found) is still emitted — only the missing_session emission was removed', async () => {
+      const agentId = await seedAgent('happy');
+      const exec = await createExecutor(agentId, 'claude', 'tmux', { claudeSessionId: 'sess-happy-1' });
+      await setCurrentExecutor(agentId, exec.id);
 
-      // `no_executor` reason: no executor at all.
-      const agentNoExec = await seedAgent('no-exec');
+      expect(await getResumeSessionId(agentId)).toBe('sess-happy-1');
 
-      await getResumeSessionId(agentNullSess);
-      await getResumeSessionId(agentNullSess); // dedupe
-      await getResumeSessionId(agentNoExec);
-      await getResumeSessionId(agentNoExec); // dedupe
-
-      expect(await countMissingSessionEvents(agentNullSess)).toBe(1);
-      expect(await countMissingSessionEvents(agentNoExec)).toBe(1);
+      // Confirm we didn't accidentally silence the success-path audit too.
+      const sql = await getConnection();
+      const found = await sql<{ count: number }[]>`
+        SELECT COUNT(*)::int AS count
+        FROM audit_events
+        WHERE entity_type = 'agent' AND entity_id = ${agentId} AND event_type = 'resume.found'
+      `;
+      expect(found[0].count).toBeGreaterThanOrEqual(1);
     });
 
-    test('reset (simulating window expiry) re-enables emission', async () => {
-      const agentId = await seedAgent();
-
-      await getResumeSessionId(agentId);
-      await getResumeSessionId(agentId); // deduped
-
-      // Simulate the 60s window passing — clear the cache.
+    test('reset helper is a no-op (kept for back-compat with PR #1528 tests)', () => {
+      // The dedupe map was removed entirely in this hotfix. The reset helper
+      // is kept as an exported no-op so any external/in-flight tests that
+      // imported it don't break their import resolution.
+      // biome-ignore lint/suspicious/noConsoleLog: explicit no-op verification
       _resetMissingSessionDedupeForTests();
-
-      await getResumeSessionId(agentId); // new window — emits
-
-      expect(await countMissingSessionEvents(agentId)).toBe(2);
+      expect(true).toBe(true);
     });
   });
 });

--- a/src/lib/executor-registry.ts
+++ b/src/lib/executor-registry.ts
@@ -500,65 +500,39 @@ async function tryJsonlFallback(agentId: string, row: ResumeRow | null, actor: s
 }
 
 /**
- * In-process dedupe cache for `resume.missing_session` emissions. Keyed by
- * `${agentId}:${actor}:${reason}`; value is the last emit timestamp (ms).
+ * Test-only: no-op kept for back-compat with tests that asserted on dedupe
+ * behavior in PR #1528 (Wave 1). The dedupe was removed in the W1 hotfix
+ * because in-process maps don't survive CLI process boundaries — every
+ * `genie ls` / TUI tick is a fresh process and each emitted a fresh event,
+ * which made the 60s dedupe window ineffective in the observed storm path.
  *
- * Why: every TUI tick / `genie ls` / `genie agent show` / status read calls
- * `getResumeSessionId()` for orphan agents, and each call emitted a fresh
- * audit row. On one observed machine this produced 14M `resume.missing_session`
- * events in 7 days (one orphan, one TUI, one observer — multiplied across
- * every reader). The events are observability, not behavior, so coalescing
- * within a 60s window keeps the signal (operator sees the row is broken)
- * without the noise (one event per reader-tick).
+ * The architectural fix instead removes emission from the read path
+ * (`getResumeSessionId`) entirely. Emission now happens only from the
+ * scheduler's `attemptAgentResume` no-session branch — bounded to one
+ * event per orphan per scheduler tick by the long-running daemon.
  *
- * Closes #1461 — `shouldResume` status reads emit unbounded audit events.
+ * See PR #1530 (this hotfix) and #1528 (the original Wave 1 attempt).
  */
-const MISSING_SESSION_DEDUPE_WINDOW_MS = 60_000;
-const missingSessionLastEmit = new Map<string, number>();
-/** Cap the dedupe map so a long-running daemon with many orphans doesn't grow forever. */
-const MISSING_SESSION_DEDUPE_MAX_KEYS = 4096;
-
-function shouldEmitMissingSession(agentId: string, actor: string, reason: string): boolean {
-  const key = `${agentId}:${actor}:${reason}`;
-  const now = Date.now();
-  const last = missingSessionLastEmit.get(key);
-  if (last !== undefined && now - last < MISSING_SESSION_DEDUPE_WINDOW_MS) {
-    return false;
-  }
-  // LRU-ish trim: when over cap, drop the oldest 25% in one pass.
-  if (missingSessionLastEmit.size >= MISSING_SESSION_DEDUPE_MAX_KEYS) {
-    const entries = Array.from(missingSessionLastEmit.entries()).sort((a, b) => a[1] - b[1]);
-    const drop = Math.floor(entries.length / 4);
-    for (let i = 0; i < drop; i++) missingSessionLastEmit.delete(entries[i][0]);
-  }
-  missingSessionLastEmit.set(key, now);
-  return true;
-}
-
-/** Test-only: clear the dedupe cache. */
 export function _resetMissingSessionDedupeForTests(): void {
-  missingSessionLastEmit.clear();
+  /* noop — dedupe map removed in W1 hotfix */
 }
 
 /**
- * Emit the appropriate `resume.missing_session` event when both DB and JSONL miss.
+ * Record a `resume.missing_session` audit event. **Caller is responsible for
+ * rate-limiting** — this writes one row unconditionally. Used by the
+ * scheduler from `attemptAgentResume` (bounded to ≤1 emit per orphan per
+ * 60s tick by the daemon's tick cadence).
  *
- * Coalesces successive emissions for the same `(agentId, actor, reason)` within
- * `MISSING_SESSION_DEDUPE_WINDOW_MS` (60s) — see {@link shouldEmitMissingSession}.
+ * The READ path (`getResumeSessionId`) deliberately does NOT call this:
+ * status reads / TUI ticks / `genie ls` would otherwise produce one event
+ * per reader-process, which 14M-events-in-7-days confirmed is unbounded.
  */
-async function emitMissingSession(agentId: string, row: ResumeRow | null, actor: string): Promise<void> {
-  if (row === null || row.executor_id === null) {
-    if (!shouldEmitMissingSession(agentId, actor, 'no_executor')) return;
-    await recordAuditEvent('agent', agentId, 'resume.missing_session', actor, {
-      reason: 'no_executor',
-    });
-    return;
-  }
-  if (!shouldEmitMissingSession(agentId, actor, 'null_session')) return;
-  await recordAuditEvent('agent', agentId, 'resume.missing_session', actor, {
-    reason: 'null_session',
-    executorId: row.executor_id,
-  });
+export async function recordResumeMissingSession(
+  agentId: string,
+  actor: string,
+  details: { reason: 'no_executor' | 'null_session' | 'no_session_id'; executorId?: string | null },
+): Promise<void> {
+  await recordAuditEvent('agent', agentId, 'resume.missing_session', actor, details);
 }
 
 export async function getResumeSessionId(agentId: string): Promise<string | null> {
@@ -593,8 +567,13 @@ export async function getResumeSessionId(agentId: string): Promise<string | null
   const recovered = await tryJsonlFallback(agentId, row, actor);
   if (recovered) return recovered;
 
-  // Final miss — no DB session, no JSONL on disk.
-  await emitMissingSession(agentId, row, actor);
+  // Final miss — no DB session, no JSONL on disk. Returns null SILENTLY.
+  // Emission of `resume.missing_session` is the scheduler's responsibility
+  // (see `attemptAgentResume`). Pre-hotfix, this read path emitted on every
+  // call; under load that was 14M events/7-day for one orphan because every
+  // CLI invocation / TUI tick is a fresh process with no in-memory dedupe.
+  // The architectural fix is that the actor-that-attempts-the-resume emits,
+  // not the actor-that-queries-state.
   return null;
 }
 

--- a/src/lib/scheduler-daemon.ts
+++ b/src/lib/scheduler-daemon.ts
@@ -1504,6 +1504,21 @@ export async function attemptAgentResume(
       resume_attempts: newAttempts,
       max_resume_attempts: maxAttempts,
     });
+    // W1 hotfix: emit `resume.missing_session` from the SCHEDULER (not from
+    // every read-path call to getResumeSessionId). The scheduler tick is
+    // bounded — at most one emission per orphan per cycle (60s by default),
+    // independent of how many CLI / TUI processes are reading status.
+    // Pre-hotfix: every read emitted; under load that hit 14M events / 7d
+    // because each `genie ls` is a fresh process with no in-memory dedupe.
+    try {
+      const { recordResumeMissingSession } = await import('./executor-registry.js');
+      const actor = process.env.GENIE_AGENT_NAME ?? 'scheduler';
+      await recordResumeMissingSession(agentId, actor, {
+        reason: 'no_session_id',
+      });
+    } catch {
+      /* observability is best-effort — never block the resume path on audit failure */
+    }
     if (newAttempts >= maxAttempts) {
       await deps.updateAgent(agentId, { autoResume: false });
       deps.log({


### PR DESCRIPTION
## Summary

**Hotfix for PR #1528.** dog-fooder-da66 verdict 2026-04-29 verified that PR #1528's in-process dedupe was insufficient for the production storm pattern: synthetic orphan still emitted **368 cli + 66 genie events in 67s** because each `genie ls` / TUI tick / status read is a fresh process with no shared in-memory state.

This PR takes the architecturally correct approach: emission belongs to the actor-that-attempts-the-action (scheduler), not the actor-that-queries-state (CLI/TUI/protocol-router). The read path now emits **zero** events; the scheduler emits one per orphan per tick (bounded by the 60s daemon cadence).

## What changed

### Read path (`src/lib/executor-registry.ts`)
- `getResumeSessionId` no longer emits `resume.missing_session`
- `emitMissingSession()` removed; replaced by exported `recordResumeMissingSession(agentId, actor, details)` that the scheduler calls explicitly
- In-process dedupe map removed (load-bearing was illusory)
- `_resetMissingSessionDedupeForTests()` retained as a no-op for back-compat

### Scheduler (`src/lib/scheduler-daemon.ts attemptAgentResume`)
- In the `!currentSessionId` branch, after counter increment, calls `recordResumeMissingSession()` to emit one event per scheduler tick
- Worst-case: 1 event / orphan / 60s regardless of CLI process count

## Tests

| File | Existing | Modified | Added | Total | Status |
|------|---------:|---------:|------:|------:|--------|
| `executor-registry.test.ts` | 92 | 4 | 0 | 96 | ✅ |
| `auto-resume-zombie-cap.test.ts` | 18 | 0 | 2 | 20 | ✅ |
| `scheduler-daemon.test.ts` | 113 | 0 | 0 | 113 | ✅ no regression |
| `should-resume.test.ts` | 109 | 0 | 0 | 109 | ✅ no regression |
| `agent-registry.test.ts` | 93 | 0 | 0 | 93 | ✅ no regression |

Modified tests flip from "asserts emission happens" to "asserts NO emission from read path" — that's the new contract.

The 2 new `auto-resume-zombie-cap.test.ts` tests use a real pgserve so we can verify the audit row landed:
- `attemptAgentResume on orphan with no session emits exactly one resume.missing_session per call`
- `three sequential ticks produce three events (bounded by tick cadence, not unbounded)`

## Why PR #1528's dedupe failed

PR #1528 added an in-process Map keyed by `(agentId, actor, reason)` with a 60s TTL. That works inside one process. But:

- `genie ls` / `genie agent show` / TUI ticks each spawn a **new process**
- Each process starts with an empty Map, emits its first event
- 5+ such processes per second = 300+ events / minute / orphan
- Daemon-side reads (genie serve) have their own Map but were correctly deduping → da66 saw 66 daemon events vs 368 cli events

This hotfix removes the question entirely by moving the emission point to a long-running process.

## Validation

- All affected test files pass in isolation
- `bun run typecheck` clean
- Awaiting da66's verification on this branch

## Closes (re-opens + actually closes)

- Closes #1461 (in addition to PR #1528 which was VERIFIED-BROKEN)

## Related

- Builds on #1528 (PR #1528 — the original W1 attempt that introduced #1461/#1462/#1463)

🤖 Generated with [Claude Code](https://claude.com/claude-code)