### PR TITLE
fix(serve): contain failed pgserve startup

### DIFF
--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -788,3 +788,22 @@ describe('autoStartDaemon branched timeout messages', () => {
     expect(source).toContain('Stale ~/.genie/serve.pid');
   });
 });
+
+describe('pgserve failure containment', () => {
+  test('timeout cleanup targets the detached pgserve process group', () => {
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    expect(source).toContain('async function terminatePgserveTree');
+    expect(source).toContain('process.kill(-pid, signal)');
+
+    const fnStart = source.indexOf('async function startPgserveOnPort');
+    expect(fnStart).toBeGreaterThan(-1);
+    const terminateCall = source.indexOf('await terminatePgserveTree(child)', fnStart);
+    const selfHealCall = source.indexOf('selfHealPostgres(DATA_DIR)', fnStart);
+    const timeoutThrow = source.indexOf('pgserve failed to start on port', fnStart);
+    expect(terminateCall).toBeGreaterThan(-1);
+    expect(selfHealCall).toBeGreaterThan(-1);
+    expect(timeoutThrow).toBeGreaterThan(-1);
+    expect(terminateCall).toBeLessThan(timeoutThrow);
+    expect(selfHealCall).toBeLessThan(timeoutThrow);
+  });
+});

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -106,6 +106,53 @@ function selfHealPostgres(dataDir: string): void {
   }
 }
 
+function signalPgserveTree(child: ChildProcess, signal: NodeJS.Signals): void {
+  const pid = child.pid;
+  if (pid === undefined) {
+    try {
+      child.kill(signal);
+    } catch {
+      /* already dead */
+    }
+    return;
+  }
+
+  try {
+    if (process.platform === 'win32') {
+      child.kill(signal);
+    } else {
+      process.kill(-pid, signal);
+    }
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      /* already dead */
+    }
+  }
+}
+
+async function terminatePgserveTree(child: ChildProcess): Promise<void> {
+  signalPgserveTree(child, 'SIGTERM');
+
+  const exited = await new Promise<boolean>((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolve(true);
+      return;
+    }
+    const timer = setTimeout(() => resolve(false), 1000);
+    timer.unref();
+    child.once('exit', () => {
+      clearTimeout(timer);
+      resolve(true);
+    });
+  });
+
+  if (!exited) {
+    signalPgserveTree(child, 'SIGKILL');
+  }
+}
+
 /** Resolved port from env or default */
 function getPort(): number {
   const envPort = process.env.GENIE_PG_PORT;
@@ -590,11 +637,9 @@ async function startPgserveOnPort(port: number): Promise<number> {
     await new Promise((r) => setTimeout(r, 500));
   }
 
-  try {
-    child.kill('SIGTERM');
-  } catch {
-    /* dead */
-  }
+  await terminatePgserveTree(child);
+  if (pgserveChild === child) pgserveChild = null;
+  selfHealPostgres(DATA_DIR);
   throw new Error(`pgserve failed to start on port ${port} (timeout after ${timeout / 1000}s)`);
 }
 
@@ -605,11 +650,7 @@ function registerExitHandler(): void {
 
   const cleanup = () => {
     if (pgserveChild) {
-      try {
-        pgserveChild.kill('SIGTERM');
-      } catch {
-        /* dead */
-      }
+      signalPgserveTree(pgserveChild, 'SIGTERM');
       pgserveChild = null;
     }
     if (ownsLockfile) {

--- a/src/term-commands/serve.test.ts
+++ b/src/term-commands/serve.test.ts
@@ -46,6 +46,18 @@ describe('getTuiKeybindings', () => {
   });
 });
 
+describe('pgserve failure containment', () => {
+  test('serve disables in-process pgserve retries after startup failure', () => {
+    const source = readFileSync(join(__dirname, 'serve.ts'), 'utf-8');
+    const fnStart = source.indexOf('async function startPgserve');
+    expect(fnStart).toBeGreaterThan(-1);
+    const catchStart = source.indexOf('} catch (err) {', fnStart);
+    const retryGuard = source.indexOf("process.env.GENIE_PG_NO_AUTOSTART = '1'", catchStart);
+    expect(catchStart).toBeGreaterThan(-1);
+    expect(retryGuard).toBeGreaterThan(-1);
+  });
+});
+
 describe('brain startup integration', () => {
   function makeVault(root: string, name: string): string {
     const path = join(root, name);

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -610,6 +610,8 @@ async function startPgserve(): Promise<void> {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`  pgserve failed: ${msg}`);
+    process.env.GENIE_PG_NO_AUTOSTART = '1';
+    console.error('  pgserve retries disabled for this serve process; fix pgserve and restart `genie serve`.');
   }
 }
 


### PR DESCRIPTION
## Summary
- kill the whole detached pgserve process group when startup times out
- run stale pgserve cleanup after timeout so orphaned Postgres children do not survive
- disable further in-process pgserve retries after initial serve startup failure; restart serve after fixing pgserve

## Verification
- bun test src/lib/db.test.ts -t "pgserve failure containment"
- bun test src/term-commands/serve.test.ts -t "pgserve failure containment"
- bun run typecheck
- bunx biome check src/lib/db.ts src/lib/db.test.ts src/term-commands/serve.ts src/term-commands/serve.test.ts (passes with pre-existing retentionRan warning)

Note: full `bun test src/lib/db.test.ts src/term-commands/serve.test.ts` still hits existing macOS /var vs /private/var path assertions in serve.test brain startup cases.