### PR TITLE
fix(workspace): skip $HOME from findWorkspace walk-up + saved-root fallback

### DIFF
--- a/src/lib/workspace.test.ts
+++ b/src/lib/workspace.test.ts
@@ -96,6 +96,67 @@ describe('findWorkspace', () => {
     const result = findWorkspace(testDir);
     expect(result!.agent).toBeUndefined();
   });
+
+  // Regression: a stray `~/.genie/workspace.json` (from a misfired `genie init`
+  // run from $HOME, or carried over during ops) used to hijack walk-up — every
+  // cwd that traverses HOME would resolve as a workspace rooted at HOME, then
+  // scanAgents would look for `$HOME/agents/` (which does not exist) and the
+  // TUI sidebar would silently surface "Agents 0/0". Observed and fixed
+  // 2026-04-29 — this test pins the behavior so the bug cannot reappear.
+  test('skips $HOME as workspace root even when $HOME/.genie/workspace.json exists', () => {
+    const fakeHome = join(testDir, 'fake-home');
+    mkdirSync(fakeHome, { recursive: true });
+    // Plant the rogue workspace.json directly inside fake $HOME — the exact
+    // file shape that hijacked production on 2026-04-29.
+    makeWorkspace(fakeHome, { name: 'rogue-from-home' });
+
+    // Walk up from a child of fake $HOME — without the fix, findWorkspace
+    // would return `{root: fakeHome, ...}` because it found the marker at
+    // `fakeHome/.genie/workspace.json`. With the fix, that candidate is
+    // skipped at HOME and walk-up continues past it.
+    const childOfHome = join(fakeHome, 'somewhere');
+    mkdirSync(childOfHome, { recursive: true });
+    const result = findWorkspace(childOfHome, { userHome: fakeHome });
+
+    // Either null (no real workspace anywhere up the chain) or — if walk-up
+    // bubbles into the test's ancestor tmp dirs and finds another marker —
+    // a root that is NOT $HOME. The contract this test pins: $HOME is never
+    // returned as a workspace root via walk-up.
+    if (result !== null) {
+      expect(result.root).not.toBe(fakeHome);
+    }
+  });
+
+  // Belt-and-suspenders: even if a previous (pre-fix) run persisted $HOME as
+  // workspaceRoot in the global config, the fallback path must not honor it.
+  test('refuses saved root that points to $HOME', () => {
+    const fakeHome = join(testDir, 'fake-home-saved');
+    mkdirSync(fakeHome, { recursive: true });
+    makeWorkspace(fakeHome, { name: 'rogue-from-home-saved' });
+
+    // Persist the rogue saved root in the isolated genie home's config.json.
+    const config = { workspaceRoot: fakeHome };
+    writeFileSync(join(fakeGenieHome, 'config.json'), JSON.stringify(config));
+
+    // Walk-up from a path that is NOT under any real workspace.
+    const cwd = join(testDir, 'unrelated');
+    mkdirSync(cwd, { recursive: true });
+    const result = findWorkspace(cwd, { userHome: fakeHome });
+
+    if (result !== null) {
+      expect(result.root).not.toBe(fakeHome);
+    }
+  });
+
+  // Sanity: a legitimate workspace at a normal path still resolves correctly
+  // when an unrelated $HOME is supplied. Guards against an over-zealous fix
+  // that accidentally drops valid markers.
+  test('does NOT skip legitimate non-$HOME workspace markers', () => {
+    makeWorkspace(testDir);
+    const result = findWorkspace(testDir, { userHome: '/non-existent-home' });
+    expect(result).not.toBeNull();
+    expect(result!.root).toBe(testDir);
+  });
 });
 
 describe('getWorkspaceConfig', () => {

--- a/src/lib/workspace.ts
+++ b/src/lib/workspace.ts
@@ -79,18 +79,35 @@ const WORKSPACE_MARKER = '.genie/workspace.json';
  * Falls back to the registered workspace root from ~/.genie/config.json.
  * Returns workspace root + optional agent name, or null if not in a workspace.
  */
-export function findWorkspace(cwd?: string): WorkspaceInfo | null {
+export function findWorkspace(cwd?: string, opts?: { userHome?: string }): WorkspaceInfo | null {
   const startDir = resolve(cwd ?? process.cwd());
   let current = startDir;
+  // `userHome` is injectable for tests — `homedir()` in some Bun builds caches
+  // its return value at process start and ignores subsequent `process.env.HOME`
+  // changes, which makes the regression test for the rogue-`~/.genie/workspace.json`
+  // hijack hard to express through env mutation alone.
 
   // 1. Walk-up from cwd
+  const userHome = opts?.userHome ?? homedir();
   while (true) {
-    const candidate = join(current, WORKSPACE_MARKER);
-    if (existsSync(candidate)) {
-      // Persist workspace root for global access
-      saveWorkspaceRoot(current);
-      const agent = detectAgent(startDir, current);
-      return { root: current, agent: agent ?? undefined };
+    // Skip the user's home directory — `~/.genie/` is genie's GLOBAL config
+    // dir (daemon socket, logs, saved workspace root, version files), NOT a
+    // workspace marker. A stray `~/.genie/workspace.json` (legacy from a
+    // misfired `genie init` run from $HOME, or carried over during an ops
+    // sync) would otherwise hijack walk-up: every cwd that traverses HOME
+    // resolves as a workspace rooted at HOME, then scanAgents looks for
+    // `$HOME/agents/` (which does not exist) and the TUI sidebar surfaces
+    // the silent "Agents 0/0" / "no agents in left menu" bug — observed on
+    // 2026-04-29 (issue #<TODO> — root-caused via /proc env inspection;
+    // user's TUI showed empty sidebar despite 10 canonical agents on disk).
+    if (current !== userHome) {
+      const candidate = join(current, WORKSPACE_MARKER);
+      if (existsSync(candidate)) {
+        // Persist workspace root for global access
+        saveWorkspaceRoot(current);
+        const agent = detectAgent(startDir, current);
+        return { root: current, agent: agent ?? undefined };
+      }
     }
     const parent = dirname(current);
     if (parent === current) break; // reached filesystem root
@@ -99,7 +116,10 @@ export function findWorkspace(cwd?: string): WorkspaceInfo | null {
 
   // 2. Fall back to registered workspace root
   const savedRoot = loadWorkspaceRoot();
-  if (savedRoot && existsSync(join(savedRoot, WORKSPACE_MARKER))) {
+  // Same guard: the saved root must not be $HOME — if a previous buggy walk-up
+  // persisted `$HOME` (pre-this-fix), refuse to honor it. Self-heal will clear
+  // it from config on the first call that misses the marker check.
+  if (savedRoot && savedRoot !== userHome && existsSync(join(savedRoot, WORKSPACE_MARKER))) {
     const agent = detectAgent(startDir, savedRoot);
     return { root: savedRoot, agent: agent ?? undefined };
   }


### PR DESCRIPTION
## Summary

A stray \`~/.genie/workspace.json\` hijacks workspace detection: every cwd whose walk-up traverses \$HOME resolves as a workspace rooted at \$HOME, \`scanAgents\` then looks for \`\$HOME/agents/\` (which doesn't exist), and the TUI sidebar silently shows **Agents 0/0** — no error, no log, the operator's left menu is just empty.

\`~/.genie/\` is genie's GLOBAL config dir (daemon socket, logs, saved workspace root, version files), **never** a workspace. \`findWorkspace\` should refuse to honor it.

## Repro (without this fix)

\`\`\`bash
echo '{"name":"oops"}' > ~/.genie/workspace.json
cd /home/me  # or any path whose walk-up traverses \$HOME
genie  # TUI sidebar shows "Agents 0/0", no canonical agents listed
\`\`\`

## Root-causing this took a day

Observed in production 2026-04-29. The phantom symptom (\`Agents 0/0\` after PR #1447 landed the \`kind\` discriminator) was attributed to a regression in the new TUI render path. Multiple investigation cycles, version bumps (.12 → .29), an attempted dispatch of a fix-engineer team — all chasing the wrong tree.

The actual culprit (\`~/.genie/workspace.json\` planted months ago, forgotten) was identified by inspecting the live TUI process's \`/proc/<pid>/environ\` and finding \`GENIE_TUI_WORKSPACE=/home/genie\` (instead of \`/home/genie/workspace\`). Walk-up could not distinguish a real workspace marker from a stale config-dir file.

## Fix

In both branches of \`findWorkspace\`:

1. **Walk-up** — when \`current === userHome\`, skip the marker check and continue to the parent. \`~/.genie/workspace.json\` is no longer a valid hit.
2. **Saved-root fallback** — refuse to honor a saved \`workspaceRoot\` that points at \$HOME. Any pre-fix run that persisted \$HOME (via the now-removed walk-up bug) self-heals: the saved root is rejected, returning \`null\`, and \`saveWorkspaceRoot\` will write a real root the next time walk-up succeeds.

\`findWorkspace\` accepts an optional \`{ userHome }\` opts arg for testability — \`homedir()\` in Bun caches at process start and does not respond to \`process.env.HOME\` mutation, which makes the regression test impossible via env alone. Public API unchanged; \`userHome\` defaults to \`homedir()\`.

## Test plan

- [x] \`bun test src/lib/workspace.test.ts\` → 17 pass / 0 fail (3 new tests)
- [x] \`bun run typecheck\` → clean
- [ ] CI green
- [ ] Smoke: drop a rogue \`~/.genie/workspace.json\`, run \`genie\` from \`/home/genie\`, confirm sidebar populates from saved real workspace root instead of resolving to \$HOME

## Files

- \`src/lib/workspace.ts\` — fix (+27 -9)
- \`src/lib/workspace.test.ts\` — regression coverage (+61)

No \`.docs-vendor\` or other unrelated changes.