### PR TITLE
feat(omni): sign genie→omni requests with the per-host ed25519 keypair (D5 Group 3)

### DIFF
--- a/src/lib/omni-registration.ts
+++ b/src/lib/omni-registration.ts
@@ -10,6 +10,7 @@
 
 import { generateTraceId, getActor, recordAuditEvent } from './audit.js';
 import { loadGenieConfig } from './genie-config.js';
+import { signOmniRequest } from './omni-signature.js';
 
 // ============================================================================
 // Types
@@ -115,10 +116,19 @@ export async function registerAgentInOmni(
       headers.Authorization = `Bearer ${apiKey}`;
     }
 
+    // Per omni-host-fingerprint-trust wish (Group 3): if this host has
+    // registered via `genie omni handshake`, attach the ed25519 signature
+    // headers so omni can verify the request came from a known host. Bearer
+    // stays as the auth source until Group 6's --require-genie-signature
+    // flag is on; the signature is informational/audit until then.
+    const bodyJson = JSON.stringify(body);
+    const sig = signOmniRequest('POST', '/api/v2/agents', bodyJson);
+    if (sig) Object.assign(headers, sig);
+
     const response = await fetch(`${apiUrl}/api/v2/agents`, {
       method: 'POST',
       headers,
-      body: JSON.stringify(body),
+      body: bodyJson,
       signal: AbortSignal.timeout(10000),
     });
 
@@ -171,7 +181,13 @@ export async function findOmniAgent(agentName: string): Promise<string | null> {
       headers.Authorization = `Bearer ${apiKey}`;
     }
 
-    const response = await fetch(`${apiUrl}/api/v2/agents?name=${encodeURIComponent(agentName)}`, {
+    // Sign the GET as well — empty body, but the path includes the query
+    // string so the verifier sees the same canonical input we sign here.
+    const path = `/api/v2/agents?name=${encodeURIComponent(agentName)}`;
+    const sig = signOmniRequest('GET', path, '');
+    if (sig) Object.assign(headers, sig);
+
+    const response = await fetch(`${apiUrl}${path}`, {
       method: 'GET',
       headers,
       signal: AbortSignal.timeout(10000),

--- a/src/lib/omni-signature.test.ts
+++ b/src/lib/omni-signature.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for the genie→omni request signing helper (Group 3 of the
+ * omni-host-fingerprint-trust wish).
+ *
+ * Pinned contract:
+ *   - canonicalSigningInput is byte-stable for known inputs (golden vector).
+ *     Both sides of the wire (this module + omni's Group 4 verifier) must
+ *     produce identical bytes; any drift here breaks every signed request.
+ *   - signOmniRequest returns null + emits a one-time stderr warning when
+ *     the keypair is missing (bearer fallback path).
+ *   - signOmniRequest emits the three expected headers when keys exist,
+ *     and the signature verifies under the registered public key.
+ *   - The body hash is computed over the string the caller passed
+ *     (UTF-8 encoded), not over the parsed JSON.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { generateKeyPairSync, verify } from 'node:crypto';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { __test__, canonicalSigningInput, signOmniRequest } from './omni-signature';
+
+const ORIGINAL_GENIE_HOME = process.env.GENIE_HOME;
+let workDir: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'genie-omni-sig-test-'));
+  process.env.GENIE_HOME = workDir;
+  __test__.resetState();
+});
+
+afterEach(() => {
+  if (ORIGINAL_GENIE_HOME === undefined) {
+    process.env.GENIE_HOME = undefined;
+  } else {
+    process.env.GENIE_HOME = ORIGINAL_GENIE_HOME;
+  }
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe('canonicalSigningInput — golden vector', () => {
+  test('byte-stable for a known input', () => {
+    // If this test ever has to change, every signed request that's in
+    // flight at the time of the change will fail until the omni-side
+    // verifier (Group 4) is updated to match. Treat this as a wire
+    // protocol change.
+    const input = canonicalSigningInput(
+      '2026-04-29T18:00:00.000Z',
+      'POST',
+      '/api/v2/agents',
+      JSON.stringify({ name: 'foo', provider: 'claude' }),
+    );
+    const expected =
+      '2026-04-29T18:00:00.000Z\n' +
+      'POST\n' +
+      '/api/v2/agents\n' +
+      // sha256('{"name":"foo","provider":"claude"}') as hex
+      '22f73e1c7000ed8f1cb694d1b1019750c3e9ad05380832b114d6d17f1cefa38a';
+    // Sanity: do the actual hash to double-check the constant above stays
+    // accurate if the test author re-runs against fresh node:crypto.
+    const { createHash } = require('node:crypto') as typeof import('node:crypto');
+    const actualBodyHash = createHash('sha256').update('{"name":"foo","provider":"claude"}', 'utf-8').digest('hex');
+    expect(input.endsWith(`\n${actualBodyHash}`)).toBe(true);
+    expect(input.startsWith('2026-04-29T18:00:00.000Z\nPOST\n/api/v2/agents\n')).toBe(true);
+    // The full vector in code-comment form so reviewers can see it:
+    expect(input).toBe(`2026-04-29T18:00:00.000Z\nPOST\n/api/v2/agents\n${actualBodyHash}`);
+    // The hex literal above must match for omni's verifier; if your local
+    // crypto returns something different the verifier will reject.
+    const expectedHash = expected.split('\n').pop() ?? '';
+    expect(actualBodyHash).toBe(expectedHash);
+  });
+
+  test('lowercases method-only keeping path/body intact', () => {
+    const a = canonicalSigningInput('t', 'get', '/p', '');
+    const b = canonicalSigningInput('t', 'GET', '/p', '');
+    expect(a).toBe(b);
+  });
+
+  test('empty body produces the empty-string sha256', () => {
+    const input = canonicalSigningInput('t', 'GET', '/p', '');
+    // sha256('') = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    expect(input).toBe('t\nGET\n/p\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855');
+  });
+});
+
+describe('signOmniRequest — bearer fallback', () => {
+  test('returns null when host record is missing', () => {
+    const result = signOmniRequest('POST', '/api/v2/agents', '{}');
+    expect(result).toBeNull();
+  });
+
+  test('warns once on stderr (not on subsequent calls)', () => {
+    const captured: string[] = [];
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+      captured.push(typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      signOmniRequest('POST', '/x', '');
+      signOmniRequest('POST', '/x', '');
+      signOmniRequest('POST', '/x', '');
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+    const warnings = captured.filter((c) => c.includes('[omni-signature]'));
+    // 2 lines per warning emission (the "Falling back" + "Run handshake" lines
+    // are written together in one write call → 1 chunk).
+    expect(warnings.length).toBeGreaterThanOrEqual(1);
+    expect(warnings.length).toBeLessThanOrEqual(2);
+    expect(warnings[0]).toContain('genie omni handshake');
+  });
+});
+
+describe('signOmniRequest — keypair present', () => {
+  function setupKeyAndHost(): { pubkey: Buffer } {
+    const keysDir = join(workDir, 'keys');
+    mkdirSync(keysDir, { recursive: true });
+    const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+    writeFileSync(join(keysDir, 'genie-host.ed25519'), privateKey.export({ format: 'pem', type: 'pkcs8' }), {
+      mode: 0o600,
+    });
+    const rawPubDer = publicKey.export({ format: 'der', type: 'spki' });
+    const rawPub = rawPubDer.subarray(rawPubDer.length - 32);
+    const pubkeyB64Url = rawPub.toString('base64url');
+    writeFileSync(join(keysDir, 'genie-host.ed25519.pub'), pubkeyB64Url);
+    writeFileSync(
+      join(keysDir, 'host.json'),
+      JSON.stringify(
+        {
+          hostId: 'host-uuid-test',
+          pubkey: pubkeyB64Url,
+          hostname: 'genie.test',
+          registeredAt: new Date().toISOString(),
+        },
+        null,
+        2,
+      ),
+    );
+    return { pubkey: rawPub };
+  }
+
+  test('emits the 3 expected headers', () => {
+    setupKeyAndHost();
+    const sig = signOmniRequest('POST', '/api/v2/agents', '{"k":"v"}');
+    expect(sig).not.toBeNull();
+    expect(sig?.['X-Genie-Host-Id']).toBe('host-uuid-test');
+    expect(sig?.['X-Genie-Timestamp']).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    expect(sig?.['X-Genie-Signature']).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  test('signature verifies against the registered public key', () => {
+    const { pubkey } = setupKeyAndHost();
+    const body = '{"k":"v"}';
+    const sig = signOmniRequest('POST', '/api/v2/agents', body);
+    expect(sig).not.toBeNull();
+
+    // Reconstruct what omni's Group 4 verifier will produce and check the
+    // signature verifies — proves both sides will agree.
+    const { createPublicKey } = require('node:crypto') as typeof import('node:crypto');
+    // ed25519 SPKI prefix (DER): 0x302a300506032b6570032100 + 32 bytes
+    const spki = Buffer.concat([Buffer.from('302a300506032b6570032100', 'hex'), pubkey]);
+    const pubKeyObj = createPublicKey({ key: spki, format: 'der', type: 'spki' });
+
+    const canonical = canonicalSigningInput(sig?.['X-Genie-Timestamp'] ?? '', 'POST', '/api/v2/agents', body);
+    const sigBytes = Buffer.from(sig?.['X-Genie-Signature'] ?? '', 'base64url');
+    const ok = verify(null, Buffer.from(canonical, 'utf-8'), pubKeyObj, sigBytes);
+    expect(ok).toBe(true);
+  });
+
+  test('different body produces different signature (hash is part of canonical)', () => {
+    setupKeyAndHost();
+    const a = signOmniRequest('POST', '/api/v2/agents', '{"k":"v"}');
+    const b = signOmniRequest('POST', '/api/v2/agents', '{"k":"different"}');
+    expect(a?.['X-Genie-Signature']).not.toBe(b?.['X-Genie-Signature']);
+  });
+
+  test('does NOT warn when keypair is present', () => {
+    setupKeyAndHost();
+    const captured: string[] = [];
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+      captured.push(typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      signOmniRequest('POST', '/x', '{}');
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+    expect(captured.filter((c) => c.includes('[omni-signature]'))).toHaveLength(0);
+  });
+});

--- a/src/lib/omni-signature.ts
+++ b/src/lib/omni-signature.ts
@@ -1,0 +1,151 @@
+/**
+ * Omni Request Signing — attach `X-Genie-Signature` headers to every
+ * outgoing genie→omni write so omni can verify the request came from a
+ * registered host.
+ *
+ * Wish: omni-host-fingerprint-trust, Group 3.
+ *
+ * Reads the keypair that `genie omni handshake` (Group 2) drops at
+ * `~/.genie/keys/genie-host.ed25519` and `~/.genie/keys/host.json`.
+ *
+ * Signature scheme (matches the wish's Group 4 verifier on the omni side):
+ *   - Canonical input: `<iso8601-timestamp>\n<METHOD>\n<path>\n<sha256(body)>`
+ *   - Algorithm: ed25519 sign over the UTF-8 bytes of the canonical input
+ *   - Encoding: base64url (no padding) for the signature
+ *   - Body hash: empty string for body-less requests; sha256(body) otherwise
+ *
+ * Headers attached on success:
+ *   X-Genie-Host-Id    UUID from host.json
+ *   X-Genie-Timestamp  ISO 8601 UTC (e.g. 2026-04-29T18:00:00.000Z)
+ *   X-Genie-Signature  base64url(ed25519(canonical))
+ *
+ * Bearer-fallback semantics: if the keypair file is missing OR the host
+ * record is missing, `signOmniRequest` returns `null` and the caller
+ * falls back to bearer-token auth (the existing behavior). A one-time
+ * stderr warning is emitted per process so operators see the situation
+ * without being spammed on every call.
+ *
+ * IMPORTANT: this module does NOT decide whether the omni endpoint
+ * accepts the signature — that's Group 4's verifier. Group 3 just
+ * produces signed requests; the omni server still trusts the bearer
+ * token for now (backward-compat mode).
+ */
+
+import { type KeyObject, createHash, createPrivateKey, sign } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+interface KeyPaths {
+  privateKey: string;
+  hostJson: string;
+}
+
+interface HostRecord {
+  hostId: string;
+  pubkey: string;
+  hostname: string;
+}
+
+/** Headers attached to a signed request. */
+export interface OmniSignatureHeaders {
+  'X-Genie-Host-Id': string;
+  'X-Genie-Timestamp': string;
+  'X-Genie-Signature': string;
+}
+
+let warnedMissingKey = false;
+
+function keyPaths(): KeyPaths {
+  const home = process.env.GENIE_HOME ?? join(process.env.HOME ?? '/root', '.genie');
+  return {
+    privateKey: join(home, 'keys', 'genie-host.ed25519'),
+    hostJson: join(home, 'keys', 'host.json'),
+  };
+}
+
+function loadHostRecord(path: string): HostRecord | null {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as HostRecord;
+  } catch {
+    return null;
+  }
+}
+
+let cachedKey: KeyObject | null = null;
+let cachedKeyPath: string | null = null;
+function loadPrivateKey(path: string): KeyObject | null {
+  if (cachedKey && cachedKeyPath === path) return cachedKey;
+  if (!existsSync(path)) return null;
+  try {
+    const pem = readFileSync(path, 'utf-8');
+    const key = createPrivateKey(pem);
+    cachedKey = key;
+    cachedKeyPath = path;
+    return key;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build the canonical input the verifier on the omni side will reconstruct
+ * from the incoming request. Both sides must produce byte-identical input
+ * or the signature will fail. Keep this function tiny and obvious — every
+ * change here is a wire-protocol change.
+ */
+export function canonicalSigningInput(timestamp: string, method: string, path: string, body: string): string {
+  const bodyHash = createHash('sha256').update(body, 'utf-8').digest('hex');
+  return `${timestamp}\n${method.toUpperCase()}\n${path}\n${bodyHash}`;
+}
+
+/**
+ * Produce the signature header set for a single outgoing request.
+ *
+ * @param method  HTTP method (any case; canonicalized to upper).
+ * @param path    Request path INCLUDING query string. The omni verifier
+ *                reconstructs this from `req.url.pathname + req.url.search`.
+ * @param body    Stringified body. Empty string for body-less GETs.
+ * @returns Header set on success, `null` when the local keypair is missing.
+ */
+export function signOmniRequest(method: string, path: string, body: string): OmniSignatureHeaders | null {
+  const paths = keyPaths();
+  const host = loadHostRecord(paths.hostJson);
+  const key = loadPrivateKey(paths.privateKey);
+
+  if (!host || !key) {
+    if (!warnedMissingKey) {
+      warnedMissingKey = true;
+      // One-time warning per process. Stderr-only so JSON consumers stay clean.
+      // Note: this is informational, not an error — bearer fallback still
+      // works for hosts that haven't run `genie omni handshake` yet.
+      const reason = !host
+        ? 'host record at ~/.genie/keys/host.json'
+        : 'private key at ~/.genie/keys/genie-host.ed25519';
+      process.stderr.write(
+        `[omni-signature] Falling back to bearer auth — missing ${reason}.\n[omni-signature] Run \`genie omni handshake\` to register this host and enable signed requests.\n`,
+      );
+    }
+    return null;
+  }
+
+  const timestamp = new Date().toISOString();
+  const canonical = canonicalSigningInput(timestamp, method, path, body);
+  const signature = sign(null, Buffer.from(canonical, 'utf-8'), key).toString('base64url');
+
+  return {
+    'X-Genie-Host-Id': host.hostId,
+    'X-Genie-Timestamp': timestamp,
+    'X-Genie-Signature': signature,
+  };
+}
+
+/** Test-only: reset the one-shot warn flag and the cached key. */
+export const __test__ = {
+  resetState(): void {
+    warnedMissingKey = false;
+    cachedKey = null;
+    cachedKeyPath = null;
+  },
+  keyPaths,
+};


### PR DESCRIPTION
## Summary

Group 3 of the **omni-host-fingerprint-trust** wish (D5 follow-up). Reads the keypair that `genie omni handshake` (Group 2 / #1537) drops at `~/.genie/keys/genie-host.{ed25519,host.json}` and attaches signature headers to every outgoing genie→omni write.

**Bearer-token auth stays on as the primary credential** — the omni-side verification middleware (Group 4) doesn't enforce signatures yet, so this PR makes signed requests **additive** (informational / audit), backward-compatible during rollout.

## Wire protocol

```
Canonical input:  <iso8601-timestamp>\n<METHOD>\n<path>\n<sha256(body-utf8) hex>
Algorithm:        ed25519 sign over the UTF-8 bytes of the canonical input
Encoding:         base64url for the signature
Body hash:        sha256('') for body-less GETs; sha256(string) otherwise
```

Headers attached on success:

| Header | Value |
|---|---|
| `X-Genie-Host-Id` | UUID from `host.json` |
| `X-Genie-Timestamp` | ISO 8601 UTC (e.g. `2026-04-29T18:00:00.000Z`) |
| `X-Genie-Signature` | base64url(ed25519(canonical)) |

**The canonical input format is the WIRE PROTOCOL** — both sides (this module and Group 4's verifier) must produce byte-identical input or every signed request fails. The format is intentionally tiny and obvious; treat any change as a wire-protocol change.

## Bearer fallback semantics

If `host.json` is missing OR the private key file is missing, `signOmniRequest` returns `null` and callers fall back to bearer-token auth (the existing behavior). A one-time stderr warning is emitted per process so operators see the situation without being spammed:

```
[omni-signature] Falling back to bearer auth — missing host record at ~/.genie/keys/host.json.
[omni-signature] Run `genie omni handshake` to register this host and enable signed requests.
```

## What changed

| File | Change |
|---|---|
| `src/lib/omni-signature.ts` (new) | `canonicalSigningInput` pure helper + `signOmniRequest` with cached private key + one-time bearer-fallback warn. |
| `src/lib/omni-signature.test.ts` (new) | 9 tests — golden vector (sha256 hex pinned), method case-fold, empty-body sha256, bearer-fallback null + one-time warn, header shape, signature verifies under the registered pubkey, body-sensitive signature, no warn when keys present. |
| `src/lib/omni-registration.ts` | Wire `signOmniRequest` into both fetch sites (POST `/api/v2/agents` and GET `/api/v2/agents?name=…`). Bearer header stays first; signature headers added on top. |

## What's NOT in this PR

- **Wiring into the omni-bridge's outbound publish path**: the bridge publishes via NATS, not HTTP. Signing for NATS is a separate concern; deferred.
- **Verification on the omni side (Group 4)** — security-review gate: the request is signed, but omni doesn't enforce it yet.
- **Replay-window enforcement (±60s timestamp check)**: lives in Group 4's verifier.
- **Per-host scope enforcement (Group 5)**.

## Test plan

- [x] `bun test src/lib/omni-signature.test.ts` → **9/9 pass**
- [x] `bun run typecheck` → green (FULL TURBO)
- [x] `bunx biome check` → clean
- [x] Pre-push gate (typecheck + lint + dead-code + skills/wishes-lint + emit-discipline + 3815 tests) → all green

## Cross-PR coordination

| Group | Repo | PR | Status |
|---|---|---|---|
| 1.0 | omni | #555 | merged |
| 1.1 | omni | #556 | merged |
| 1.2 | omni | #558 | merged |
| 2 | genie | #1537 | merged |
| **3** | **genie** | **this PR** | open |
| 4 | omni | next | verification middleware **(security review gate)** |
| 5 | omni | next | scope enforcement |
| 6 | omni | next | `--require-genie-signature` opt-in |
| 7 | genie-configure | next | brain entries + ADR |

Wish: `<genie-repo>/.genie/wishes/omni-host-fingerprint-trust/WISH.md`.