### PR TITLE
fix(tui): detect Claude Code v2 panes

### DIFF
--- a/src/tui/components/TreeNode.tsx
+++ b/src/tui/components/TreeNode.tsx
@@ -123,7 +123,7 @@ function getPaneIcon(node: TreeNodeType): string {
   if (node.agentState === 'idle') return '\u25cb'; // ○
   if (node.agentState === 'permission') return '\u26a0'; // ⚠
   if (node.agentState === 'error') return '\u2718'; // ✘
-  if (node.data.command === 'claude') return '\u25c6'; // ���
+  if (node.data.isClaudeLike) return '\u25c6'; // ◆
   return '\u25cb'; // ○
 }
 
@@ -187,7 +187,7 @@ function getPaneColor(node: TreeNodeType): string {
   if (node.agentState === 'permission') return palette.warning;
   if (node.agentState === 'error') return palette.error;
   if (node.agentState === 'idle') return palette.textDim;
-  if (node.data.command === 'claude') return palette.info;
+  if (node.data.isClaudeLike) return palette.info;
   return palette.textDim;
 }
 

--- a/src/tui/db.test.ts
+++ b/src/tui/db.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test';
+import { mergeWorkState } from './db.js';
+import type { WorkState } from './types.js';
+
+describe('mergeWorkState', () => {
+  test('keeps an active duplicate from being overwritten by a stale directory row', () => {
+    const states = new Map<string, WorkState>();
+
+    mergeWorkState(states, 'genie', 'in_flight');
+    mergeWorkState(states, 'genie', 'stuck');
+
+    expect(states.get('genie')).toBe('in_flight');
+  });
+
+  test('allows a stronger later state to replace a weaker earlier state', () => {
+    const states = new Map<string, WorkState>();
+
+    mergeWorkState(states, 'genie', 'stuck');
+    mergeWorkState(states, 'genie', 'paused');
+
+    expect(states.get('genie')).toBe('paused');
+  });
+});

--- a/src/tui/db.ts
+++ b/src/tui/db.ts
@@ -104,7 +104,7 @@ export async function loadAgentWorkStates(): Promise<Map<string, WorkState>> {
         const work = reasonToWorkState(decision.reason);
         if (!work) continue;
         const name = a.customName ?? a.role ?? a.id;
-        out.set(name, work);
+        mergeWorkState(out, name, work);
       } catch {
         /* one bad row can't wedge the diagnostics refresh */
       }
@@ -112,6 +112,20 @@ export async function loadAgentWorkStates(): Promise<Map<string, WorkState>> {
   });
   await Promise.all(workers);
   return out;
+}
+
+const WORK_STATE_PRIORITY: Record<WorkState, number> = {
+  in_flight: 4,
+  paused: 3,
+  stuck: 2,
+  done: 1,
+};
+
+export function mergeWorkState(states: Map<string, WorkState>, name: string, next: WorkState): void {
+  const current = states.get(name);
+  if (!current || WORK_STATE_PRIORITY[next] > WORK_STATE_PRIORITY[current]) {
+    states.set(name, next);
+  }
 }
 
 function reasonToWorkState(reason: string): WorkState | undefined {

--- a/src/tui/diagnostics.ts
+++ b/src/tui/diagnostics.ts
@@ -9,6 +9,7 @@
 
 import { execSync } from 'node:child_process';
 import { tmuxBin } from '../lib/ensure-tmux.js';
+import { isClaudeLikePane } from './pane-detection.js';
 import type { TuiAssignment, TuiExecutor, WorkState } from './types.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -189,9 +190,7 @@ function isPidAlive(pid: number): boolean {
 
 /** Get all claude panes from all sessions flattened. */
 function allClaudePanes(sessions: TmuxSession[]): TmuxPane[] {
-  return sessions
-    .flatMap((s) => s.windows.flatMap((w) => w.panes))
-    .filter((p) => p.command === 'claude' || p.title.includes('claude'));
+  return sessions.flatMap((s) => s.windows.flatMap((w) => w.panes)).filter(isClaudeLikePane);
 }
 
 /**

--- a/src/tui/pane-detection.test.ts
+++ b/src/tui/pane-detection.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'bun:test';
+import { CLAUDE_CODE_ACTIVE_TITLE_PREFIX, isClaudeLikeCommandTitle } from './pane-detection.js';
+
+describe('isClaudeLikeCommandTitle', () => {
+  test('recognizes Claude Code v2 tmux panes by version command and active title prefix', () => {
+    expect(isClaudeLikeCommandTitle('2.1.123', `${CLAUDE_CODE_ACTIVE_TITLE_PREFIX}genie-genie`)).toBe(true);
+  });
+
+  test('does not treat every active-looking tmux title as Claude Code', () => {
+    expect(isClaudeLikeCommandTitle('zsh', `${CLAUDE_CODE_ACTIVE_TITLE_PREFIX}genie-genie`)).toBe(false);
+  });
+});

--- a/src/tui/pane-detection.ts
+++ b/src/tui/pane-detection.ts
@@ -1,0 +1,21 @@
+import type { TmuxPane } from './diagnostics.js';
+
+export const CLAUDE_CODE_ACTIVE_TITLE_PREFIX = '\u2733 ';
+const SEMVER_COMMAND = /^\d+\.\d+\.\d+(?:[-+][\w.-]+)?$/;
+
+/**
+ * Claude Code v2 can report the pane command as its version string (for
+ * example `2.1.123`) while setting the tmux title to `\u2733 agent-name`.
+ */
+export function isClaudeLikeCommandTitle(command: string | undefined, title: string | undefined): boolean {
+  const cmd = (command ?? '').toLowerCase();
+  const paneTitle = title ?? '';
+  const lowerTitle = paneTitle.toLowerCase();
+  const isClaudeCodeV2Title =
+    SEMVER_COMMAND.test(command ?? '') && paneTitle.startsWith(CLAUDE_CODE_ACTIVE_TITLE_PREFIX);
+  return cmd === 'claude' || cmd.includes('claude') || lowerTitle.includes('claude') || isClaudeCodeV2Title;
+}
+
+export function isClaudeLikePane(pane: TmuxPane): boolean {
+  return !pane.isDead && isClaudeLikeCommandTitle(pane.command, pane.title);
+}

--- a/src/tui/session-tree.test.ts
+++ b/src/tui/session-tree.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from 'bun:test';
 import type { TmuxPane, TmuxSession, TmuxWindow } from './diagnostics.js';
+import { CLAUDE_CODE_ACTIVE_TITLE_PREFIX } from './pane-detection.js';
 import { buildSessionTree, buildWorkspaceTree, getSessionTarget, resolvePreferredWindowIndex } from './session-tree.js';
 import type { TreeNode, TuiExecutor } from './types.js';
+
+const CLAUDE_CODE_V2_TMUX_COMMAND = '2.1.123';
+const CLAUDE_CODE_V2_TMUX_TITLE = `${CLAUDE_CODE_ACTIVE_TITLE_PREFIX}genie-genie`;
 
 function flattenTree(nodes: TreeNode[]): TreeNode[] {
   const out: TreeNode[] = [];
@@ -261,6 +265,44 @@ describe('buildWorkspaceTree', () => {
     });
 
     expect(tree[0].wsAgentState).toBe('running');
+  });
+
+  test('Claude Code v2 pane title counts as a live agent pane', () => {
+    // Reproduces tmux output from Claude Code v2 on macOS:
+    // pane_current_command is the CLI version, while pane_title carries the agent name.
+    const win0 = makeWindow({ sessionName: 'genie', index: 0, name: 'zsh' });
+    const win1 = makeWindow({
+      sessionName: 'genie',
+      index: 1,
+      name: 'claude',
+      active: true,
+      panes: [
+        makePane({
+          sessionName: 'genie',
+          windowIndex: 1,
+          paneId: '%3',
+          command: CLAUDE_CODE_V2_TMUX_COMMAND,
+          title: CLAUDE_CODE_V2_TMUX_TITLE,
+        }),
+      ],
+    });
+    const executor = makeExecutor({
+      agentName: 'genie',
+      state: 'spawning',
+      tmuxPaneId: '%3',
+    });
+
+    const tree = buildWorkspaceTree({
+      agentNames: ['genie'],
+      sessions: [makeSession('genie', [win0, win1])],
+      executors: [executor],
+    });
+
+    expect(tree[0].wsAgentState).toBe('running');
+    expect(tree[0].activePanes).toBe(1);
+    expect(tree[0].data.attachWindowIndex).toBe(1);
+    expect(tree[0].children[0].activePanes).toBe(1);
+    expect(tree[0].children[0].children[0].data.isClaudeLike).toBe(true);
   });
 
   test('permission executor state reflected on agentState', () => {

--- a/src/tui/session-tree.ts
+++ b/src/tui/session-tree.ts
@@ -9,6 +9,7 @@
  */
 
 import type { DiagnosticSnapshot, TmuxPane, TmuxSession, TmuxWindow } from './diagnostics.js';
+import { isClaudeLikePane } from './pane-detection.js';
 import type { AgentKind, AgentState, TreeNode, TuiExecutor, WorkState } from './types.js';
 
 /** The TUI's own session name — filtered from the tree to prevent self-attach loops */
@@ -109,8 +110,7 @@ export function buildWorkspaceTree(input: WorkspaceTreeInput): TreeNode[] {
 
 export function resolvePreferredWindowIndex(session: TmuxSession, agentName?: string): number | undefined {
   const windows = [...session.windows].sort((a, b) => a.index - b.index);
-  const hasClaudePane = (window: TmuxWindow) =>
-    window.panes.some((pane) => !pane.isDead && (pane.command === 'claude' || pane.title.includes('claude')));
+  const hasClaudePane = (window: TmuxWindow) => window.panes.some(isClaudeLikePane);
 
   const preferred =
     windows.find((window) => window.active && hasClaudePane(window)) ??
@@ -123,9 +123,7 @@ export function resolvePreferredWindowIndex(session: TmuxSession, agentName?: st
 }
 
 function hasLiveClaudeWindow(session: TmuxSession): boolean {
-  return session.windows.some((window) =>
-    window.panes.some((pane) => !pane.isDead && (pane.command === 'claude' || pane.title.includes('claude'))),
-  );
+  return session.windows.some((window) => window.panes.some(isClaudeLikePane));
 }
 
 /** Separate scoped names (parent/sub) from top-level names. */
@@ -173,10 +171,7 @@ function appendSubAgentNodes(
 }
 
 function countClaudePanes(session: TmuxSession): number {
-  return session.windows.reduce(
-    (sum, w) => sum + w.panes.filter((p) => p.command === 'claude' || p.title.includes('claude')).length,
-    0,
-  );
+  return session.windows.reduce((sum, w) => sum + w.panes.filter(isClaudeLikePane).length, 0);
 }
 
 function buildAgentNode(
@@ -258,10 +253,7 @@ function deriveExecutorState(execs: TuiExecutor[]): TreeNode['agentState'] {
 // ─── Shared Node Builders ────────────────────────────────────────────────────
 
 function sessionToNode(session: TmuxSession, executorMap: Map<string, TuiExecutor>): TreeNode {
-  const claudePanes = session.windows.reduce(
-    (sum, w) => sum + w.panes.filter((p) => p.command === 'claude' || p.title.includes('claude')).length,
-    0,
-  );
+  const claudePanes = session.windows.reduce((sum, w) => sum + w.panes.filter(isClaudeLikePane).length, 0);
 
   return {
     id: `session:${session.name}`,
@@ -278,9 +270,7 @@ function sessionToNode(session: TmuxSession, executorMap: Map<string, TuiExecuto
 }
 
 function windowToNode(sessionName: string, window: TmuxWindow, executorMap: Map<string, TuiExecutor>): TreeNode {
-  const activePanes = window.panes.filter(
-    (p) => !p.isDead && (p.command === 'claude' || p.title.includes('claude')),
-  ).length;
+  const activePanes = window.panes.filter(isClaudeLikePane).length;
 
   return {
     id: `window:${sessionName}:${window.index}`,
@@ -303,7 +293,7 @@ function paneToNode(
   executorMap: Map<string, TuiExecutor>,
 ): TreeNode {
   const executor = executorMap.get(pane.paneId);
-  const isClaude = pane.command === 'claude' || pane.title.includes('claude');
+  const isClaude = isClaudeLikePane(pane);
 
   return {
     id: `pane:${pane.paneId}`,
@@ -314,6 +304,8 @@ function paneToNode(
     children: [],
     data: {
       command: pane.command,
+      title: pane.title,
+      isClaudeLike: isClaude,
       isDead: pane.isDead,
       pid: pane.pid,
       size: pane.size,

--- a/src/tui/tmux.ts
+++ b/src/tui/tmux.ts
@@ -80,6 +80,7 @@ export function attachProjectWindow(rightPane: string, targetSession: string, wi
 }
 
 export function attachTuiSession(): void {
+  runTuiTmux(['select-pane', '-t', `${SESSION_NAME}:0.0`]);
   if (process.env.TMUX) {
     // Already inside a tmux session — switch-client avoids nested attach
     runTuiTmux(['switch-client', '-t', SESSION_NAME], 'inherit');


### PR DESCRIPTION
## Summary
- Recognize Claude Code v2 tmux panes whose command is reported as a version string and title is star-prefixed, so TUI counts and attaches live agents correctly.
- Merge duplicate agent work-state rows by priority so stale directory rows cannot override active team-member rows.
- Focus the TUI nav pane before attaching so clicks/keyboard land on the left menu.

## Verification
- bun test src/tui/session-tree.test.ts src/tui/db.test.ts src/tui/components/Nav.test.tsx src/tui/render.test.ts
- bun run typecheck
- bunx biome check src/tui/pane-detection.ts src/tui/db.test.ts src/tui/db.ts src/tui/diagnostics.ts src/tui/session-tree.ts src/tui/session-tree.test.ts src/tui/components/TreeNode.tsx src/tui/tmux.ts

## Runtime check
- Restarted local patched serve from dist/genie.js on Felipe's Mac.
- TUI now shows Agents 1/1 and genie running/idle for Claude Code v2 pane title `✳ genie-genie`.