### PR TITLE
feat(task): add --wish <slug> flag to genie task create (Group 2 of #1300)

### DIFF
--- a/.genie/wishes/task-create-wish-flag/WISH.md
+++ b/.genie/wishes/task-create-wish-flag/WISH.md
@@ -1,0 +1,64 @@
+# Wish: Add `--wish <slug>` flag to `genie task create`
+
+**Issue:** #1300 (Group 2 of the broader wish-task-tree unification — scoped here as a single shippable unit.)
+**Status:** Implemented; ready for review.
+
+## Background
+
+`#1300` (wish-task-tree unification) splits into four groups:
+
+| Group | Scope | Status |
+|---|---|---|
+| G1 | Parser captures group titles | shipped via #1472 |
+| **G2** | **CLI flag: `genie task create --wish <slug>` populates `wish_file`** | **this PR** |
+| G3 | `wish-state` adopts existing parent task by title (fallback) + `genie.task.adopted` runtime event | future PR |
+| G4 | `/wish` SKILL.md docs updated to teach the flag | future PR |
+
+This wish covers G2 only — the rest stay on the parent issue. Splitting keeps the diff reviewable and unblocks operators who need to wire a manually-created task to a wish before G3 lands.
+
+## Goal
+
+Make `genie task create` wish-aware so manually created parent tasks land on the same `wish_file = .genie/wishes/<slug>/WISH.md` value that `genie work <slug>` later resolves. Without this flag, an operator who runs `genie task create "title" --type software` then `genie work my-wish` ends up with two parent tasks (one without `wish_file`, one with) — the duplication that G3 will then reconcile via adopt-by-title.
+
+## Deliverables
+
+1. **`CreateOptions.wish?: string`** added to `src/term-commands/task.ts`.
+2. **`--wish <slug>` commander flag** wired between `--external-url` and `.action(...)` in the `task create` registration (`src/term-commands/task.ts`).
+3. **`validateWishSlug(slug: string): string`** exported helper. Validates against `/^[a-z0-9][a-z0-9-]*$/`. Throws on invalid (rejects spaces, uppercase, leading hyphens, path traversal `..`, absolute paths, backslash separators, and any other non-slug shape). Returns the slug on success.
+4. **`wishFileFromSlug(slug: string): string`** exported helper. Returns `.genie/wishes/<slug>/WISH.md`.
+5. **Wired into `handleTaskCreate`**: when `options.wish` is set, the helper output is passed through the existing `wishFile` field on `taskService.createTask` (already accepted; no changes needed in `task-service.ts`).
+6. **Tests** in `src/term-commands/task.test.ts` (new file) covering all five hardening cases plus happy paths and `wishFileFromSlug` formatting.
+
+## Acceptance Criteria
+
+- [x] `genie task create "title" --type software --wish my-wish` succeeds and the resulting task row has `wish_file = '.genie/wishes/my-wish/WISH.md'`.
+- [x] `genie task create "title" --wish ../oops` fails with a clear error message that names the invalid input.
+- [x] All five hardening cases reject with named-input errors: spaces, uppercase, leading hyphen, `..` path traversal, absolute path, backslash separators.
+- [x] Existing `task create` invocations without `--wish` are unchanged (regression-safe — `wishFile` remains `undefined` when the flag is absent).
+- [x] `bun test src/term-commands/task.test.ts` passes (11 tests).
+- [x] `bun run typecheck` clean.
+- [x] `bunx biome check src/term-commands/task.ts src/term-commands/task.test.ts` clean.
+- [x] CLI smoke: `bun dist/genie.js task create --help` shows the new flag in the help output.
+
+## Validation
+
+```bash
+bun test src/term-commands/task.test.ts
+bun run typecheck
+bunx @biomejs/biome check src/term-commands/task.ts src/term-commands/task.test.ts
+bun run build
+bun dist/genie.js task create --help | grep -A1 -- '--wish'
+bun dist/genie.js task create "smoke-bad-slug" --type software --wish "../oops"   # must reject
+```
+
+## Out of Scope
+
+- Adopt-by-title fallback in `wish-state` (G3 — separate PR).
+- `genie.task.adopted` runtime event (G3 — separate PR).
+- `/wish` SKILL.md docs update (G4 — separate PR).
+- Reconciliation of pre-existing children of an adopted parent (G3 — separate PR).
+
+## Notes
+
+- `validateWishSlug` is exported from `task.ts` for unit-test isolation; commander's action wrapper already catches thrown errors and prints them via `console.error` + `exit(1)`. No `process.exit` lives inside the validator itself.
+- The slug pattern matches the canonical wish-dir naming convention used everywhere else in `.genie/wishes/`. No `i` flag — uppercase is intentionally rejected to keep wish dirs case-deterministic.

--- a/src/term-commands/task.test.ts
+++ b/src/term-commands/task.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'bun:test';
+import { validateWishSlug, wishFileFromSlug } from './task.js';
+
+describe('validateWishSlug', () => {
+  it('accepts a simple lowercase slug', () => {
+    expect(validateWishSlug('my-wish')).toBe('my-wish');
+  });
+
+  it('accepts a single-character slug', () => {
+    expect(validateWishSlug('a')).toBe('a');
+  });
+
+  it('accepts digits', () => {
+    expect(validateWishSlug('fix-1300')).toBe('fix-1300');
+  });
+
+  it('rejects spaces', () => {
+    expect(() => validateWishSlug('My Wish')).toThrow(/My Wish/);
+  });
+
+  it('rejects uppercase', () => {
+    expect(() => validateWishSlug('UPPER')).toThrow(/UPPER/);
+  });
+
+  it('rejects leading hyphen', () => {
+    expect(() => validateWishSlug('-leading')).toThrow(/-leading/);
+  });
+
+  it('rejects path traversal', () => {
+    expect(() => validateWishSlug('../oops')).toThrow(/\.\.\/oops/);
+  });
+
+  it('rejects absolute path', () => {
+    expect(() => validateWishSlug('/abs/path')).toThrow(/\/abs\/path/);
+  });
+
+  it('rejects empty string', () => {
+    expect(() => validateWishSlug('')).toThrow();
+  });
+
+  it('rejects backslash separators', () => {
+    expect(() => validateWishSlug('foo\\bar')).toThrow();
+  });
+});
+
+describe('wishFileFromSlug', () => {
+  it('builds the canonical wish file path', () => {
+    expect(wishFileFromSlug('my-wish')).toBe('.genie/wishes/my-wish/WISH.md');
+  });
+});

--- a/src/term-commands/task.ts
+++ b/src/term-commands/task.ts
@@ -321,6 +321,28 @@ interface CreateOptions {
   gh?: string;
   externalId?: string;
   externalUrl?: string;
+  wish?: string;
+}
+
+const WISH_SLUG_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+
+/**
+ * Validate a wish slug from `--wish <slug>`. Rejects spaces, uppercase, leading
+ * hyphens, path traversal (`..`), absolute paths, and any other non-slug input.
+ * Throws on invalid; returns the slug on success.
+ */
+export function validateWishSlug(slug: string): string {
+  if (!WISH_SLUG_PATTERN.test(slug)) {
+    throw new Error(
+      `Invalid --wish slug: "${slug}". Slug must match /^[a-z0-9][a-z0-9-]*$/ (lowercase letters, digits, hyphens; no leading hyphen, no spaces, no path separators).`,
+    );
+  }
+  return slug;
+}
+
+/** Compute the wish-file path for a validated slug. */
+export function wishFileFromSlug(slug: string): string {
+  return `.genie/wishes/${slug}/WISH.md`;
 }
 
 /** Parse --gh owner/repo#N into { externalId, externalUrl }. */
@@ -375,6 +397,8 @@ async function handleTaskCreate(title: string, options: CreateOptions): Promise<
     externalUrl = parsed.externalUrl;
   }
 
+  const wishFile = options.wish ? wishFileFromSlug(validateWishSlug(options.wish)) : undefined;
+
   const task = await ts.createTask(
     {
       title,
@@ -389,6 +413,7 @@ async function handleTaskCreate(title: string, options: CreateOptions): Promise<
       boardId,
       externalId,
       externalUrl,
+      wishFile,
     },
     repoPath,
     projectId,
@@ -467,6 +492,7 @@ export function registerTaskCommands(program: Command): void {
     .option('--gh <owner/repo#N>', 'Link to GitHub issue (sets external_id + external_url)')
     .option('--external-id <id>', 'External tracker ID (e.g., JIRA-123)')
     .option('--external-url <url>', 'External tracker URL')
+    .option('--wish <slug>', 'Associate task with a wish (sets wish_file to .genie/wishes/<slug>/WISH.md)')
     .action(async (title: string, options: CreateOptions) => {
       try {
         await handleTaskCreate(title, options);


### PR DESCRIPTION
## Summary

- Adds `--wish <slug>` to `genie task create` so operators can wire a manually-created parent task to a wish from the CLI
- Slug validator rejects spaces, uppercase, leading hyphens, `../` traversal, absolute paths, backslash separators
- 11 new unit tests (5 hardening cases + happy paths)

This is **Group 2 of #1300** — split as a focused PR. G1 already shipped via #1472. G3 (adopt-by-title fallback + `genie.task.adopted` event) and G4 (docs) follow as separate PRs.

## Wish

`.genie/wishes/task-create-wish-flag/WISH.md`

## Test plan

- [x] `bun test src/term-commands/task.test.ts` — 11 pass
- [x] `bun run typecheck` clean
- [x] `bunx @biomejs/biome check src/term-commands/task.ts src/term-commands/task.test.ts` clean
- [x] `bun run skills:lint` OK
- [x] CLI smoke: `bun dist/genie.js task create --help` shows the flag
- [x] CLI smoke: `--wish "../oops"` rejects with named-input error

🤖 Generated with [Claude Code](https://claude.com/claude-code)