### PR TITLE
fix(release): resolve pgserve sibling before version publish

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -100,6 +100,14 @@ jobs:
         with:
           bun-version: "1.3.10"
 
+      # package.json pins `pgserve: file:../pgserve` until pgserve@2.0.0 is
+      # published to npm. Version publishes run outside CI's test jobs, so they
+      # need the same sibling checkout before `bun install` can resolve deps.
+      - name: Checkout pgserve v2 sibling
+        run: |
+          git clone --depth 1 --branch wish/pgserve-v2 https://github.com/namastexlabs/pgserve.git ../pgserve
+          (cd ../pgserve && bun install --no-save)
+
       - name: Install dependencies
         run: bun install
 


### PR DESCRIPTION
## Summary
- unblock the Version workflow after pgserve moved to a temporary file:../pgserve dependency
- mirror CI's pgserve v2 sibling checkout before the version publish job runs bun install
- keeps @next publishing working until pgserve@2.0.0 is available on npm

## Validation
- git diff --check