### PR TITLE
fix(tui): detect Claude panes by process command

### DIFF
--- a/src/tui/diagnostics.ts
+++ b/src/tui/diagnostics.ts
@@ -21,9 +21,23 @@ export interface TmuxPane {
   paneId: string;
   pid: number;
   command: string;
+  processCommand: string;
   title: string;
   size: string;
   isDead: boolean;
+}
+
+function getProcessCommandByPid(pids: number[]): Map<number, string> {
+  const uniquePids = [...new Set(pids.filter((pid) => Number.isFinite(pid) && pid > 0))];
+  if (uniquePids.length === 0) return new Map();
+  const output = execQuiet(`ps -p ${uniquePids.join(',')} -o pid=,command=`);
+  const commands = new Map<number, string>();
+  for (const line of output.split('\n')) {
+    const match = line.trim().match(/^(\d+)\s+(.+)$/);
+    if (!match) continue;
+    commands.set(Number.parseInt(match[1], 10), match[2]);
+  }
+  return commands;
 }
 
 export interface TmuxWindow {
@@ -87,7 +101,10 @@ function execQuiet(cmd: string): string {
   }
 }
 
-function parsePaneLine(parts: string[]): {
+function parsePaneLine(
+  parts: string[],
+  processCommandByPid: Map<number, string>,
+): {
   sessionName: string;
   winIdxStr: string;
   session: Omit<TmuxSession, 'windows'>;
@@ -134,6 +151,7 @@ function parsePaneLine(parts: string[]): {
       paneId,
       pid: Number.parseInt(panePidStr, 10) || 0,
       command: paneCmd,
+      processCommand: processCommandByPid.get(Number.parseInt(panePidStr, 10) || 0) ?? '',
       title: paneTitle,
       size: paneSize,
       isDead: paneDead === '1',
@@ -149,15 +167,19 @@ function getTmuxInventory(): TmuxSession[] {
 
   if (!paneOutput) return [];
 
+  const paneLines = paneOutput.split('\n').filter(Boolean);
+  const panePids = paneLines
+    .map((line) => Number.parseInt(line.split('|')[7] ?? '', 10))
+    .filter((pid) => Number.isFinite(pid) && pid > 0);
+  const processCommandByPid = getProcessCommandByPid(panePids);
   const sessionMap = new Map<string, TmuxSession>();
   const windowMap = new Map<string, TmuxWindow>();
 
-  for (const line of paneOutput.split('\n')) {
-    if (!line) continue;
+  for (const line of paneLines) {
     const parts = line.split('|');
     if (parts.length < 15) continue;
 
-    const parsed = parsePaneLine(parts);
+    const parsed = parsePaneLine(parts, processCommandByPid);
 
     if (!sessionMap.has(parsed.sessionName)) {
       sessionMap.set(parsed.sessionName, { ...parsed.session, windows: [] });

--- a/src/tui/pane-detection.test.ts
+++ b/src/tui/pane-detection.test.ts
@@ -2,11 +2,17 @@ import { describe, expect, test } from 'bun:test';
 import { CLAUDE_CODE_ACTIVE_TITLE_PREFIX, isClaudeLikeCommandTitle } from './pane-detection.js';
 
 describe('isClaudeLikeCommandTitle', () => {
-  test('recognizes Claude Code v2 tmux panes by version command and active title prefix', () => {
-    expect(isClaudeLikeCommandTitle('2.1.123', `${CLAUDE_CODE_ACTIVE_TITLE_PREFIX}genie-genie`)).toBe(true);
+  test('recognizes Claude Code panes by the actual process command line', () => {
+    expect(
+      isClaudeLikeCommandTitle(
+        'opaque-runtime-title',
+        `${CLAUDE_CODE_ACTIVE_TITLE_PREFIX}genie-genie`,
+        '/Users/example/.local/bin/claude --agent-id genie@genie',
+      ),
+    ).toBe(true);
   });
 
   test('does not treat every active-looking tmux title as Claude Code', () => {
-    expect(isClaudeLikeCommandTitle('zsh', `${CLAUDE_CODE_ACTIVE_TITLE_PREFIX}genie-genie`)).toBe(false);
+    expect(isClaudeLikeCommandTitle('zsh', `${CLAUDE_CODE_ACTIVE_TITLE_PREFIX}genie-genie`, '/bin/zsh')).toBe(false);
   });
 });

--- a/src/tui/pane-detection.ts
+++ b/src/tui/pane-detection.ts
@@ -1,21 +1,23 @@
 import type { TmuxPane } from './diagnostics.js';
 
 export const CLAUDE_CODE_ACTIVE_TITLE_PREFIX = '\u2733 ';
-const SEMVER_COMMAND = /^\d+\.\d+\.\d+(?:[-+][\w.-]+)?$/;
+const CLAUDE_EXECUTABLE = /(^|[/\s])claude(\s|$)/i;
 
-/**
- * Claude Code v2 can report the pane command as its version string (for
- * example `2.1.123`) while setting the tmux title to `\u2733 agent-name`.
- */
-export function isClaudeLikeCommandTitle(command: string | undefined, title: string | undefined): boolean {
+export function isClaudeLikeCommandTitle(
+  command: string | undefined,
+  title: string | undefined,
+  processCommand: string | undefined,
+): boolean {
   const cmd = (command ?? '').toLowerCase();
-  const paneTitle = title ?? '';
-  const lowerTitle = paneTitle.toLowerCase();
-  const isClaudeCodeV2Title =
-    SEMVER_COMMAND.test(command ?? '') && paneTitle.startsWith(CLAUDE_CODE_ACTIVE_TITLE_PREFIX);
-  return cmd === 'claude' || cmd.includes('claude') || lowerTitle.includes('claude') || isClaudeCodeV2Title;
+  const lowerTitle = (title ?? '').toLowerCase();
+  return (
+    CLAUDE_EXECUTABLE.test(processCommand ?? '') ||
+    cmd === 'claude' ||
+    cmd.includes('claude') ||
+    lowerTitle.includes('claude')
+  );
 }
 
 export function isClaudeLikePane(pane: TmuxPane): boolean {
-  return !pane.isDead && isClaudeLikeCommandTitle(pane.command, pane.title);
+  return !pane.isDead && isClaudeLikeCommandTitle(pane.command, pane.title, pane.processCommand);
 }

--- a/src/tui/session-tree.test.ts
+++ b/src/tui/session-tree.test.ts
@@ -4,7 +4,8 @@ import { CLAUDE_CODE_ACTIVE_TITLE_PREFIX } from './pane-detection.js';
 import { buildSessionTree, buildWorkspaceTree, getSessionTarget, resolvePreferredWindowIndex } from './session-tree.js';
 import type { TreeNode, TuiExecutor } from './types.js';
 
-const CLAUDE_CODE_V2_TMUX_COMMAND = '2.1.123';
+const CLAUDE_CODE_V2_TMUX_COMMAND = 'opaque-runtime-title';
+const CLAUDE_CODE_V2_PROCESS_COMMAND = '/Users/example/.local/bin/claude --agent-id genie@genie';
 const CLAUDE_CODE_V2_TMUX_TITLE = `${CLAUDE_CODE_ACTIVE_TITLE_PREFIX}genie-genie`;
 
 function flattenTree(nodes: TreeNode[]): TreeNode[] {
@@ -27,6 +28,7 @@ function makePane(overrides: Partial<TmuxPane> = {}): TmuxPane {
     paneId: '%0',
     pid: 1000,
     command: 'bash',
+    processCommand: '/bin/bash',
     title: 'bash',
     size: '80x24',
     isDead: false,
@@ -268,8 +270,8 @@ describe('buildWorkspaceTree', () => {
   });
 
   test('Claude Code v2 pane title counts as a live agent pane', () => {
-    // Reproduces tmux output from Claude Code v2 on macOS:
-    // pane_current_command is the CLI version, while pane_title carries the agent name.
+    // Reproduces Claude Code v2 on macOS: tmux may report a non-claude
+    // pane_current_command, while ps still shows the stable claude executable.
     const win0 = makeWindow({ sessionName: 'genie', index: 0, name: 'zsh' });
     const win1 = makeWindow({
       sessionName: 'genie',
@@ -282,6 +284,7 @@ describe('buildWorkspaceTree', () => {
           windowIndex: 1,
           paneId: '%3',
           command: CLAUDE_CODE_V2_TMUX_COMMAND,
+          processCommand: CLAUDE_CODE_V2_PROCESS_COMMAND,
           title: CLAUDE_CODE_V2_TMUX_TITLE,
         }),
       ],

--- a/src/tui/session-tree.ts
+++ b/src/tui/session-tree.ts
@@ -304,6 +304,7 @@ function paneToNode(
     children: [],
     data: {
       command: pane.command,
+      processCommand: pane.processCommand,
       title: pane.title,
       isClaudeLike: isClaude,
       isDead: pane.isDead,


### PR DESCRIPTION
## Summary
- Remove version/semver-based Claude pane detection from the TUI runtime path.
- Enrich tmux pane diagnostics with the actual pane PID command line from ps and detect Claude by the executable path instead.
- Update the regression fixtures so they no longer hardcode a Claude version; the test now uses an opaque tmux command plus a stable claude process command.

## Verification
- bun test src/tui/pane-detection.test.ts src/tui/session-tree.test.ts src/tui/db.test.ts src/tui/components/Nav.test.tsx src/tui/render.test.ts
- bun run typecheck
- bunx biome check src/tui/pane-detection.ts src/tui/pane-detection.test.ts src/tui/session-tree.test.ts src/tui/db.test.ts src/tui/db.ts src/tui/diagnostics.ts src/tui/session-tree.ts src/tui/components/TreeNode.tsx src/tui/tmux.ts