### PR TITLE
fix(pgserve): start v2 daemon from serve

### DIFF
--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -337,6 +337,29 @@ describe('daemon-owned pgserve', () => {
     // Self-heal function exists
     expect(source.includes('selfHealPostgres')).toBe(true);
   });
+
+  test('socket connections ensure the v2 daemon before dialing libpq path', () => {
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    const fnStart = source.indexOf('async function _buildConnection');
+    expect(fnStart).toBeGreaterThan(-1);
+    const body = source.slice(fnStart, source.indexOf('\n}\n', fnStart));
+
+    const useSocketIdx = body.indexOf('const useSocket = shouldUseUnixSocket()');
+    const ensureIdx = body.indexOf('if (useSocket) await getOrStartDaemon()');
+    const portIdx = body.indexOf('const port = useSocket ? 5432 : await ensurePgserve()');
+
+    expect(useSocketIdx).toBeGreaterThan(-1);
+    expect(ensureIdx).toBeGreaterThan(useSocketIdx);
+    expect(portIdx).toBeGreaterThan(ensureIdx);
+  });
+
+  test('v2 daemon autostart uses persistent Genie data dir', () => {
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    const fnStart = source.indexOf('export async function getOrStartDaemon');
+    expect(fnStart).toBeGreaterThan(-1);
+    const body = source.slice(fnStart, source.indexOf('\nfunction maskCredentials', fnStart));
+    expect(body).toContain("['daemon', '--data', DATA_DIR, '--log', 'warn']");
+  });
 });
 
 describe('retention cleanup', () => {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -112,6 +112,23 @@ interface DaemonState {
   reason?: string;
 }
 
+interface PgserveSdkDaemonState {
+  running: boolean;
+  pid: number | null;
+  libpqSocketPresent?: boolean;
+  socketPresent?: boolean;
+  reason?: string | null;
+}
+
+interface PgserveSdk {
+  ensureDaemon?: (options?: {
+    dataDir?: string;
+    logLevel?: string;
+    timeoutMs?: number;
+    controlSocketDir?: string;
+  }) => Promise<PgserveSdkDaemonState>;
+}
+
 /**
  * Probe the v2 daemon. Returns running=true only when both the libpq socket
  * file exists AND the recorded pid is alive. A pid file with no socket (or
@@ -119,28 +136,8 @@ interface DaemonState {
  * whether to clean up and respawn.
  */
 export function probePgserveDaemon(): DaemonState {
-  const socketPath = resolvePgserveLibpqSocketPath();
-  const pidPath = resolvePgserveDaemonPidPath();
-  const socketPresent = existsSync(socketPath);
-  let pid: number | null = null;
-  if (existsSync(pidPath)) {
-    try {
-      const raw = readFileSync(pidPath, 'utf-8').trim();
-      const parsed = Number.parseInt(raw, 10);
-      if (Number.isInteger(parsed) && parsed > 0) pid = parsed;
-    } catch {
-      /* unreadable */
-    }
-  }
-  if (pid !== null) {
-    try {
-      process.kill(pid, 0);
-    } catch (err) {
-      const e = err as NodeJS.ErrnoException;
-      // EPERM means the process exists but we don't own it — still alive.
-      if (e.code !== 'EPERM') pid = null;
-    }
-  }
+  const socketPresent = existsSync(resolvePgserveLibpqSocketPath());
+  const pid = liveDaemonPid(readDaemonPid(resolvePgserveDaemonPidPath()));
   if (socketPresent && pid !== null) return { running: true, pid, socketPresent: true };
   if (!socketPresent && pid === null) {
     return { running: false, pid: null, socketPresent: false, reason: 'no daemon' };
@@ -151,6 +148,29 @@ export function probePgserveDaemon(): DaemonState {
     socketPresent,
     reason: socketPresent ? 'socket present but pid stale' : 'pid alive but no socket',
   };
+}
+
+function readDaemonPid(pidPath: string): number | null {
+  if (!existsSync(pidPath)) return null;
+  try {
+    const raw = readFileSync(pidPath, 'utf-8').trim();
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function liveDaemonPid(pid: number | null): number | null {
+  if (pid === null) return null;
+  try {
+    process.kill(pid, 0);
+    return pid;
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    // EPERM means the process exists but we don't own it — still alive.
+    return e.code === 'EPERM' ? pid : null;
+  }
 }
 
 /** Resolve the v2 daemon binary path — local node_modules → global → PATH. */
@@ -197,8 +217,10 @@ let daemonStartPromise: Promise<void> | null = null;
  * downstream commits; exported here so those call-sites land cleanly.
  */
 export async function getOrStartDaemon(): Promise<DaemonState> {
-  if (process.env.GENIE_PG_DISABLE_AUTOSTART === '1') {
-    return probePgserveDaemon();
+  if (process.env.GENIE_PG_DISABLE_AUTOSTART === '1' || isPgAutostartDisabled()) {
+    const state = probePgserveDaemon();
+    if (state.running) return state;
+    throw new Error('pgserve daemon unavailable and PG autostart is disabled');
   }
   const initial = probePgserveDaemon();
   if (initial.running) return initial;
@@ -218,51 +240,7 @@ export async function getOrStartDaemon(): Promise<DaemonState> {
     return probePgserveDaemon();
   }
 
-  daemonStartPromise = (async () => {
-    // Clean up partial state before respawning.
-    if (initial.reason === 'pid alive but no socket' && initial.pid !== null) {
-      try {
-        process.kill(initial.pid, 'SIGTERM');
-      } catch {
-        /* already gone */
-      }
-      await sleep(500);
-    }
-    if (initial.reason === 'socket present but pid stale') {
-      try {
-        unlinkSync(resolvePgserveDaemonPidPath());
-      } catch {
-        /* gone */
-      }
-    }
-
-    const bin = findPgserveDaemonBin();
-    if (bin === null) {
-      throw new Error(
-        'pgserve binary not found. Install with `bun add pgserve@^2.0.0` (or `npm i pgserve@^2.0.0`), or start `pgserve daemon` manually before running genie.',
-      );
-    }
-
-    mkdirSync(resolvePgserveSocketDir(), { recursive: true, mode: 0o700 });
-
-    const child = spawn(bin, ['daemon'], {
-      detached: true,
-      stdio: 'ignore',
-      env: { ...process.env },
-    });
-    child.unref();
-
-    const socketPath = resolvePgserveLibpqSocketPath();
-    const timeout = Number(process.env.GENIE_PGSERVE_TIMEOUT) || 16000;
-    const deadline = Date.now() + timeout;
-    while (Date.now() < deadline) {
-      if (existsSync(socketPath)) return;
-      await sleep(250);
-    }
-    throw new Error(
-      `pgserve v2 daemon did not bind ${socketPath} within ${Math.round(timeout / 1000)}s. Try starting it manually: ${bin} daemon`,
-    );
-  })();
+  daemonStartPromise = startPgserveDaemonOnce(initial);
 
   try {
     await daemonStartPromise;
@@ -270,6 +248,79 @@ export async function getOrStartDaemon(): Promise<DaemonState> {
     daemonStartPromise = null;
   }
   return probePgserveDaemon();
+}
+
+async function startPgserveDaemonOnce(initial: DaemonState): Promise<void> {
+  if (await tryEnsureDaemonWithSdk()) return;
+  await cleanPartialDaemonState(initial);
+  const bin = requirePgserveDaemonBin();
+  mkdirSync(resolvePgserveSocketDir(), { recursive: true, mode: 0o700 });
+
+  const child = spawn(bin, ['daemon', '--data', DATA_DIR, '--log', 'warn'], {
+    detached: true,
+    stdio: 'ignore',
+    env: { ...process.env },
+  });
+  child.unref();
+  await waitForDaemonSocket(bin);
+}
+
+function requirePgserveDaemonBin(): string {
+  const bin = findPgserveDaemonBin();
+  if (bin !== null) return bin;
+  throw new Error(
+    'pgserve binary not found. Install with `bun add pgserve@^2.0.0` (or `npm i pgserve@^2.0.0`), or start `pgserve daemon` manually before running genie.',
+  );
+}
+
+async function cleanPartialDaemonState(initial: DaemonState): Promise<void> {
+  if (initial.reason === 'pid alive but no socket' && initial.pid !== null) {
+    try {
+      process.kill(initial.pid, 'SIGTERM');
+    } catch {
+      /* already gone */
+    }
+    await sleep(500);
+  }
+  if (initial.reason === 'socket present but pid stale') {
+    try {
+      unlinkSync(resolvePgserveDaemonPidPath());
+    } catch {
+      /* gone */
+    }
+  }
+}
+
+async function waitForDaemonSocket(bin: string): Promise<void> {
+  const socketPath = resolvePgserveLibpqSocketPath();
+  const timeout = Number(process.env.GENIE_PGSERVE_TIMEOUT) || 16000;
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if (existsSync(socketPath)) return;
+    await sleep(250);
+  }
+  throw new Error(
+    `pgserve v2 daemon did not bind ${socketPath} within ${Math.round(timeout / 1000)}s. Try starting it manually: ${bin} daemon`,
+  );
+}
+
+async function tryEnsureDaemonWithSdk(): Promise<boolean> {
+  let sdk: PgserveSdk;
+  try {
+    sdk = (await import('pgserve')) as PgserveSdk;
+  } catch {
+    return false;
+  }
+  if (typeof sdk.ensureDaemon !== 'function') return false;
+
+  const timeoutMs = Number(process.env.GENIE_PGSERVE_TIMEOUT) || 16000;
+  const state = await sdk.ensureDaemon({
+    dataDir: DATA_DIR,
+    logLevel: 'warn',
+    timeoutMs,
+    controlSocketDir: resolvePgserveSocketDir(),
+  });
+  return Boolean(state.running && (state.libpqSocketPresent ?? state.socketPresent ?? true));
 }
 
 /** Sanitize connection URLs for logging — never expose credentials */
@@ -1064,6 +1115,7 @@ async function maybePrintBanner(client: postgres.Sql, isTestMode: boolean): Prom
 async function _buildConnection(): Promise<any> {
   const _t0 = Date.now();
   const useSocket = shouldUseUnixSocket();
+  if (useSocket) await getOrStartDaemon();
   const port = useSocket ? 5432 : await ensurePgserve();
   const _t1 = Date.now();
   const pgModule = (await import('postgres')).default;

--- a/src/term-commands/serve.test.ts
+++ b/src/term-commands/serve.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { type ChildProcess, spawn } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import {
@@ -55,6 +55,19 @@ describe('pgserve failure containment', () => {
     const retryGuard = source.indexOf("process.env.GENIE_PG_NO_AUTOSTART = '1'", catchStart);
     expect(catchStart).toBeGreaterThan(-1);
     expect(retryGuard).toBeGreaterThan(-1);
+  });
+
+  test('serve starts pgserve daemon instead of legacy TCP router', () => {
+    const source = readFileSync(join(__dirname, 'serve.ts'), 'utf-8');
+    const fnStart = source.indexOf('async function startPgserve');
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnEnd = source.indexOf('/** Start the scheduler daemon', fnStart);
+    const body = source.slice(fnStart, fnEnd);
+
+    expect(body).toContain('getOrStartDaemon');
+    expect(body).toContain('pgserve daemon ready');
+    expect(body).not.toContain('ensurePgserve');
+    expect(body).not.toContain('pgserve ready on port');
   });
 });
 
@@ -127,9 +140,11 @@ describe('brain startup integration', () => {
         setBrainHandles: mock(() => {}),
       });
 
-      expect(result.map((handle) => handle.brainPath)).toEqual([valid]);
+      expect(result.map((handle) => handle.brainPath)).toEqual([realpathSync(valid)]);
       expect(startEmbeddedBrainServer.mock.calls.length).toBe(1);
-      expect(warnings.some((message) => message.includes(`skipped registered vault ${missing}`))).toBe(true);
+      expect(warnings.some((message) => message.includes(`skipped registered vault ${realpathSync(missing)}`))).toBe(
+        true,
+      );
       expect(warnings.some((message) => message.includes('registry drift: started 1/2'))).toBe(true);
     } finally {
       rmSync(root, { recursive: true, force: true });
@@ -167,11 +182,11 @@ describe('brain startup integration', () => {
       });
 
       await eventually(() => startEmbeddedBrainServer.mock.calls.length >= 2);
-      expect(started).toEqual([first, second]);
+      expect(started).toEqual([realpathSync(first), realpathSync(second)]);
 
       releaseFirst?.();
       const result = await pending;
-      expect(result.map((handle) => handle.brainPath)).toEqual([first, second]);
+      expect(result.map((handle) => handle.brainPath)).toEqual([realpathSync(first), realpathSync(second)]);
     } finally {
       releaseFirst?.();
       rmSync(root, { recursive: true, force: true });

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -596,11 +596,12 @@ async function startAgentSync(): Promise<{ close: () => void } | null> {
 
 /** Start pgserve and register it in the service registry. */
 async function startPgserve(): Promise<void> {
-  console.log('  Starting pgserve...');
+  console.log('  Starting pgserve daemon...');
   try {
-    const { ensurePgserve } = await import('../lib/db.js');
-    const port = await ensurePgserve();
-    console.log(`  pgserve ready on port ${port}`);
+    const { getDataDir, getOrStartDaemon, resolvePgserveSocketDir } = await import('../lib/db.js');
+    const state = await getOrStartDaemon();
+    const pid = state.pid ? `, pid ${state.pid}` : '';
+    console.log(`  pgserve daemon ready on ${resolvePgserveSocketDir()} (data: ${getDataDir()}${pid})`);
     try {
       const { registerService } = await import('../lib/service-registry.js');
       registerService('pgserve-owner', process.pid);
@@ -611,6 +612,7 @@ async function startPgserve(): Promise<void> {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`  pgserve failed: ${msg}`);
     process.env.GENIE_PG_NO_AUTOSTART = '1';
+    process.env.GENIE_PG_DISABLE_AUTOSTART = '1';
     console.error('  pgserve retries disabled for this serve process; fix pgserve and restart `genie serve`.');
   }
 }
@@ -1322,9 +1324,10 @@ async function stopServe(): Promise<void> {
 /** Check pgserve health and print status */
 async function printPgserveHealth(): Promise<void> {
   try {
-    const { isAvailable, getActivePort } = await import('../lib/db.js');
+    const { isAvailable, getActivePort, isSocketMode, resolvePgserveSocketDir } = await import('../lib/db.js');
     const dbOk = await isAvailable();
-    console.log(`  pgserve:    ${dbOk ? `healthy (port ${getActivePort()})` : 'unreachable'}`);
+    const where = isSocketMode() ? `socket ${resolvePgserveSocketDir()}` : `port ${getActivePort()}`;
+    console.log(`  pgserve:    ${dbOk ? `healthy (${where})` : 'unreachable'}`);
   } catch {
     console.log('  pgserve:    unavailable');
   }

--- a/src/types/pgserve.d.ts
+++ b/src/types/pgserve.d.ts
@@ -1,0 +1,16 @@
+declare module 'pgserve' {
+  export interface PgserveDaemonState {
+    running: boolean;
+    pid: number | null;
+    libpqSocketPresent?: boolean;
+    socketPresent?: boolean;
+    reason?: string | null;
+  }
+
+  export function ensureDaemon(options?: {
+    dataDir?: string;
+    logLevel?: string;
+    timeoutMs?: number;
+    controlSocketDir?: string;
+  }): Promise<PgserveDaemonState>;
+}


### PR DESCRIPTION
## Summary
- make socket-mode getConnection ensure pgserve daemon exists before dialing /tmp/pgserve
- make genie serve start the v2 daemon instead of legacy --port 19642 TCP pgserve
- keep Genie data at the existing ~/.genie/data/pgserve path and print it in startup output
- consume pgserve SDK when available, with CLI fallback for pgserve@2.0.0

## Tests
- bun test src/lib/db.test.ts src/term-commands/serve.test.ts
- bun test src/term-commands/serve.test.ts
- bun run typecheck
- bun run build
- bunx biome check src/lib/db.ts src/lib/db.test.ts src/term-commands/serve.ts src/term-commands/serve.test.ts src/types/pgserve.d.ts
- bun run lint (repo warnings only; command exits 0)
- pre-push gate ran during git push