### PR TITLE
fix(pgserve): prefer v2 daemon without disrupting v1

### DIFF
--- a/src/genie-commands/doctor.test.ts
+++ b/src/genie-commands/doctor.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { checkGenieAgentTemplate, checkLegacyAgentFrontmatter, findBundledTmuxConfigDir } from './doctor.js';
@@ -240,5 +240,33 @@ describe('findBundledTmuxConfigDir', () => {
     // relative to this module's URL.
     expect(dir).not.toBeNull();
     expect(dir).toMatch(/scripts[/\\]tmux$/);
+  });
+});
+
+describe('pgserve v1/v2 coexistence', () => {
+  test('doctor --fix does not broad-kill pgserve/postgres by default', () => {
+    const source = readFileSync(join(__dirname, 'doctor.ts'), 'utf-8');
+    const fnStart = source.indexOf('async function killStalePostgres');
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnEnd = source.indexOf('async function cleanSharedMemory', fnStart);
+    const body = source.slice(fnStart, fnEnd);
+
+    expect(body).toContain('legacyPgserveRepairEnabled()');
+    expect(body).toContain('Skipping legacy pgserve v1 process cleanup');
+    expect(body).not.toContain('pkill -9 -f "postgres.*pgserve"');
+    expect(body).toContain("join(genieHome, 'data', 'pgserve')");
+  });
+
+  test('doctor --fix leaves legacy port/data files untouched unless legacy repair is enabled', () => {
+    const source = readFileSync(join(__dirname, 'doctor.ts'), 'utf-8');
+    const fnStart = source.indexOf('function removeStaleFiles');
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnEnd = source.indexOf('async function restartDaemon', fnStart);
+    const body = source.slice(fnStart, fnEnd);
+
+    expect(body).toContain('legacyPgserveRepairEnabled()');
+    expect(body).toContain('Leaving legacy pgserve v1 port/data files untouched');
+    expect(body).toContain("join(genieHome, 'pgserve.port')");
+    expect(body).toContain("join(genieHome, 'data', 'pgserve', 'postmaster.pid')");
   });
 });

--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -836,18 +836,34 @@ function printDoctorSummary(counts: { errors: boolean; warnings: boolean }): voi
   console.log();
 }
 
+function legacyPgserveRepairEnabled(): boolean {
+  return process.env.GENIE_PG_FORCE_TCP === '1' || process.env.GENIE_DOCTOR_FIX_LEGACY_PGSERVE === '1';
+}
+
 /**
- * `genie doctor --fix` — automated recovery for stale PG state.
- * Kills zombie postgres, cleans shared memory, removes stale files, restarts daemon.
+ * `genie doctor --fix` — automated recovery for daemon state.
+ *
+ * pgserve v2 is portless and must coexist with pgserve v1 (latest v1:
+ * 1.2.0). Default doctor repair therefore avoids broad pgserve/postgres
+ * process kills. Legacy TCP cleanup is opt-in via GENIE_PG_FORCE_TCP=1 or
+ * GENIE_DOCTOR_FIX_LEGACY_PGSERVE=1 and is scoped to Genie's legacy data dir.
  */
-async function killStalePostgres(): Promise<void> {
-  console.log('  Killing stale postgres processes...');
+async function killStalePostgres(genieHome: string): Promise<void> {
+  if (!legacyPgserveRepairEnabled()) {
+    console.log('  Skipping legacy pgserve v1 process cleanup (v1/v2 coexistence)');
+    return;
+  }
+
+  console.log('  Killing stale Genie legacy pgserve processes...');
   try {
     const { execSync } = await import('node:child_process');
-    execSync('pkill -9 -f "postgres.*pgserve" 2>/dev/null || true', { stdio: 'ignore', timeout: 5000 });
-    console.log('  \x1b[32m\u2713\x1b[0m Stale postgres processes killed');
+    const legacyDataDir = join(genieHome, 'data', 'pgserve');
+    const escaped = legacyDataDir.replace(/\//g, '\\/');
+    execSync(`pkill -9 -f "postgres.*${escaped}" 2>/dev/null || true`, { stdio: 'ignore', timeout: 5000 });
+    execSync(`pkill -9 -f "pgserve.*${escaped}" 2>/dev/null || true`, { stdio: 'ignore', timeout: 5000 });
+    console.log('  \x1b[32m\u2713\x1b[0m Stale Genie legacy pgserve processes killed');
   } catch {
-    console.log('  \x1b[33m!\x1b[0m Could not kill stale postgres processes');
+    console.log('  \x1b[33m!\x1b[0m Could not kill stale Genie legacy pgserve processes');
   }
 }
 
@@ -900,10 +916,14 @@ async function stopExistingDaemon(pidFile: string): Promise<void> {
 }
 
 function removeStaleFiles(genieHome: string, pidFile: string): void {
-  const portFile = join(genieHome, 'pgserve.port');
-  const postmasterPid = join(genieHome, 'data', 'pgserve', 'postmaster.pid');
+  const files = [pidFile];
+  if (legacyPgserveRepairEnabled()) {
+    files.push(join(genieHome, 'pgserve.port'), join(genieHome, 'data', 'pgserve', 'postmaster.pid'));
+  } else {
+    console.log('  Leaving legacy pgserve v1 port/data files untouched (v1/v2 coexistence)');
+  }
 
-  for (const file of [portFile, pidFile, postmasterPid]) {
+  for (const file of files) {
     if (existsSync(file)) {
       try {
         unlinkSync(file);
@@ -1065,10 +1085,11 @@ async function doctorFix(): Promise<void> {
   console.log('\n\x1b[1mGenie Doctor \u2014 Auto Fix\x1b[0m');
   console.log(`\x1b[2m${'\u2500'.repeat(40)}\x1b[0m\n`);
 
-  await killStalePostgres();
+  const genieHome = process.env.GENIE_HOME ?? join(homedir(), '.genie');
+
+  await killStalePostgres(genieHome);
   await cleanSharedMemory();
 
-  const genieHome = process.env.GENIE_HOME ?? join(homedir(), '.genie');
   const pidFile = join(genieHome, 'scheduler.pid');
 
   await stopExistingDaemon(pidFile);

--- a/src/lib/brain-vaults.test.ts
+++ b/src/lib/brain-vaults.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -19,13 +19,13 @@ function makeVault(name: string, brainJson = '{}'): string {
   const path = join(testDir, name);
   mkdirSync(path, { recursive: true });
   writeFileSync(join(path, 'brain.json'), brainJson, 'utf-8');
-  return path;
+  return realpathSync(path);
 }
 
 function makeDir(name: string): string {
   const path = join(testDir, name);
   mkdirSync(path, { recursive: true });
-  return path;
+  return realpathSync(path);
 }
 
 function deps(overrides: Parameters<typeof resolveBrainVaults>[0] = {}): Parameters<typeof resolveBrainVaults>[0] {

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -534,6 +534,37 @@ describe('parallel dispatch race (issue #1207)', () => {
     expect(catchBody).not.toMatch(/await\s+\w+\.end\(/);
     expect(catchBody).toMatch(/\.end\([^)]*\)\.catch\(/);
   });
+
+  test('_buildConnection starts pgserve v2 daemon before socket connect', () => {
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    const fnStart = source.indexOf('async function _buildConnection');
+    expect(fnStart).toBeGreaterThan(-1);
+
+    const socketDecision = source.indexOf('const useSocket = shouldUseUnixSocket();', fnStart);
+    const daemonStart = source.indexOf('if (useSocket) await getOrStartDaemon();', fnStart);
+    const portDecision = source.indexOf('const port = useSocket ? 5432 : await ensurePgserve();', fnStart);
+
+    expect(socketDecision).toBeGreaterThan(-1);
+    expect(daemonStart).toBeGreaterThan(socketDecision);
+    expect(portDecision).toBeGreaterThan(daemonStart);
+  });
+
+  test('getOrStartDaemon does not kill a pid-file process when v2 socket is absent', () => {
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    const fnStart = source.indexOf('export async function getOrStartDaemon');
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnEnd = source.indexOf('/** Sanitize connection URLs', fnStart);
+    const body = source.slice(fnStart, fnEnd);
+
+    const partialState = body.indexOf("initial.reason === 'pid alive but no socket'");
+    const nextBranch = body.indexOf("initial.reason === 'socket present but pid stale'", partialState);
+    expect(partialState).toBeGreaterThan(-1);
+    expect(nextBranch).toBeGreaterThan(partialState);
+    const block = body.slice(partialState, nextBranch);
+
+    expect(block).toContain('unlinkSync(resolvePgserveDaemonPidPath())');
+    expect(block).not.toContain('process.kill(initial.pid');
+  });
 });
 
 describe('root guard (issue #1226)', () => {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -219,14 +219,15 @@ export async function getOrStartDaemon(): Promise<DaemonState> {
   }
 
   daemonStartPromise = (async () => {
-    // Clean up partial state before respawning.
+    // Clean up partial state before respawning. Do not signal a pid from the
+    // v2 pid file when the socket is absent: during migration that pid may be
+    // stale/recycled, and pgserve v1 TCP daemons must be allowed to coexist.
     if (initial.reason === 'pid alive but no socket' && initial.pid !== null) {
       try {
-        process.kill(initial.pid, 'SIGTERM');
+        unlinkSync(resolvePgserveDaemonPidPath());
       } catch {
-        /* already gone */
+        /* gone */
       }
-      await sleep(500);
     }
     if (initial.reason === 'socket present but pid stale') {
       try {
@@ -1064,6 +1065,7 @@ async function maybePrintBanner(client: postgres.Sql, isTestMode: boolean): Prom
 async function _buildConnection(): Promise<any> {
   const _t0 = Date.now();
   const useSocket = shouldUseUnixSocket();
+  if (useSocket) await getOrStartDaemon();
   const port = useSocket ? 5432 : await ensurePgserve();
   const _t1 = Date.now();
   const pgModule = (await import('postgres')).default;

--- a/src/term-commands/agents.spawn-autosync.test.ts
+++ b/src/term-commands/agents.spawn-autosync.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { afterEach, beforeAll, beforeEach, describe, expect, spyOn, test } from 'bun:test';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { DirectoryEntry } from '../lib/agent-directory.js';
@@ -150,7 +150,7 @@ description: "   "
   });
 
   function createWorkspaceAgent(name: string, frontmatter: string): { workspaceRoot: string; agentDir: string } {
-    const workspaceRoot = mkdtempSync(join(tmpdir(), 'genie-spawn-autosync-workspace-'));
+    const workspaceRoot = realpathSync(mkdtempSync(join(tmpdir(), 'genie-spawn-autosync-workspace-')));
     tempRoots.push(workspaceRoot);
 
     mkdirSync(join(workspaceRoot, '.genie'), { recursive: true });
@@ -165,7 +165,7 @@ description: "   "
   }
 
   function createAgentWithoutWorkspace(name: string, frontmatter: string): string {
-    const root = mkdtempSync(join(tmpdir(), 'genie-spawn-autosync-no-workspace-'));
+    const root = realpathSync(mkdtempSync(join(tmpdir(), 'genie-spawn-autosync-no-workspace-')));
     tempRoots.push(root);
 
     const agentDir = join(root, 'agents', name);

--- a/src/term-commands/serve.test.ts
+++ b/src/term-commands/serve.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { type ChildProcess, spawn } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import {
@@ -47,6 +47,21 @@ describe('getTuiKeybindings', () => {
 });
 
 describe('pgserve failure containment', () => {
+  test('serve startup uses the pgserve v2 daemon path', () => {
+    const source = readFileSync(join(__dirname, 'serve.ts'), 'utf-8');
+    const fnStart = source.indexOf('async function startPgserve');
+    const fnEnd = source.indexOf('/** Start the scheduler daemon', fnStart);
+    expect(fnStart).toBeGreaterThan(-1);
+    expect(fnEnd).toBeGreaterThan(fnStart);
+    const body = source.slice(fnStart, fnEnd);
+
+    expect(body).toContain('getOrStartDaemon');
+    expect(body).toContain('resolvePgserveLibpqSocketPath');
+    expect(body).not.toContain('ensurePgserve');
+    expect(body).not.toContain('registerService');
+    expect(body).not.toContain('pgserve ready on port');
+  });
+
   test('serve disables in-process pgserve retries after startup failure', () => {
     const source = readFileSync(join(__dirname, 'serve.ts'), 'utf-8');
     const fnStart = source.indexOf('async function startPgserve');
@@ -63,13 +78,13 @@ describe('brain startup integration', () => {
     const path = join(root, name);
     mkdirSync(path, { recursive: true });
     writeFileSync(join(path, 'brain.json'), '{}', 'utf-8');
-    return path;
+    return realpathSync(path);
   }
 
   function makeDir(root: string, name: string): string {
     const path = join(root, name);
     mkdirSync(path, { recursive: true });
-    return path;
+    return realpathSync(path);
   }
 
   async function eventually(predicate: () => boolean): Promise<void> {
@@ -524,37 +539,26 @@ describe('atomic PID claim', () => {
 });
 
 // ============================================================================
-// Stale pgserve.port invalidation — Defect 3
+// pgserve v1/v2 coexistence
 //
-// An unclean prior shutdown leaves ~/.genie/pgserve.port pointing at a dead
-// port. startForeground() must remove that lockfile before pgserve is
-// brought up, so cached callers don't ECONNREFUSED forever.
+// pgserve@1.2.0 is the final v1 line and uses TCP/port lockfiles. pgserve v2
+// is portless. New serve startup must not delete legacy v1 artifacts unless
+// the operator explicitly forces legacy TCP mode.
 // ============================================================================
 
-describe('pgserve port lockfile invalidation', () => {
-  test('startForeground removes a pre-existing pgserve.port at boot', async () => {
-    // Seed a stale lockfile pointing at an unused port.
-    const stalePortPath = join(genieHome, 'pgserve.port');
-    writeFileSync(stalePortPath, '19642', 'utf-8');
-    expect(readFileSync(stalePortPath, 'utf-8').trim()).toBe('19642');
+describe('pgserve v1/v2 coexistence', () => {
+  test('serve only removes the legacy pgserve.port file when legacy TCP is forced', () => {
+    const source = readFileSync(join(__dirname, 'serve.ts'), 'utf-8');
+    const helperStart = source.indexOf('function removeLegacyPgservePortLockfileIfForcedTcp');
+    expect(helperStart).toBeGreaterThan(-1);
+    const helperEnd = source.indexOf('\n}\n', helperStart);
+    const helperBody = source.slice(helperStart, helperEnd);
 
-    const result = spawnServe({
-      GENIE_HOME: genieHome,
-      GENIE_NATS_URL: 'nats://127.0.0.1:1',
-      GENIE_OMNI_REQUIRED: undefined,
-    });
-    child = result.child;
+    expect(helperBody).toContain("process.env.GENIE_PG_FORCE_TCP !== '1'");
+    expect(helperBody).toContain("join(genieHome(), 'pgserve.port')");
 
-    // Wait until the stale value is gone (either deleted or rewritten by
-    // ensurePgserve to the new live port).
-    const cleared = await waitUntil(() => {
-      if (!existsSync(stalePortPath)) return true;
-      const current = readFileSync(stalePortPath, 'utf-8').trim();
-      return current !== '19642' && current !== '';
-    }, 15_000);
-    expect(cleared).toBe(true);
-
-    result.child.kill('SIGKILL');
-    await Promise.race([result.exit, waitFor(5_000)]);
-  }, 30_000);
+    const startForeground = source.slice(source.indexOf('async function startForeground'));
+    expect(startForeground).toContain('removeLegacyPgservePortLockfileIfForcedTcp();');
+    expect(startForeground).not.toContain('removePgservePortLockfile();');
+  });
 });

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -598,15 +598,9 @@ async function startAgentSync(): Promise<{ close: () => void } | null> {
 async function startPgserve(): Promise<void> {
   console.log('  Starting pgserve...');
   try {
-    const { ensurePgserve } = await import('../lib/db.js');
-    const port = await ensurePgserve();
-    console.log(`  pgserve ready on port ${port}`);
-    try {
-      const { registerService } = await import('../lib/service-registry.js');
-      registerService('pgserve-owner', process.pid);
-    } catch {
-      // Registry not available — non-fatal
-    }
+    const { getOrStartDaemon, resolvePgserveLibpqSocketPath } = await import('../lib/db.js');
+    const daemon = await getOrStartDaemon();
+    console.log(`  pgserve ready at ${resolvePgserveLibpqSocketPath()}${daemon.pid ? ` (pid ${daemon.pid})` : ''}`);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`  pgserve failed: ${msg}`);
@@ -950,7 +944,8 @@ function killRegisteredServices(): void {
   }
 }
 
-function removePgservePortLockfile(): void {
+function removeLegacyPgservePortLockfileIfForcedTcp(): void {
+  if (process.env.GENIE_PG_FORCE_TCP !== '1') return;
   try {
     const lockfilePath = join(genieHome(), 'pgserve.port');
     if (existsSync(lockfilePath)) unlinkSync(lockfilePath);
@@ -1007,7 +1002,7 @@ function buildShutdownFn(headless?: boolean): { shutdown: () => Promise<void>; h
     // NEVER kill the agent tmux server — agent sessions are eternal and must
     // survive serve restarts. Only the TUI session is owned by serve.
     if (!headless) killTuiSession();
-    removePgservePortLockfile();
+    removeLegacyPgservePortLockfileIfForcedTcp();
     removeServePid();
     console.log('genie serve stopped.');
   };
@@ -1132,11 +1127,10 @@ async function confirmBackgroundStarted(childPid: number, startupStatusPath?: st
 
 async function startForeground(headless?: boolean, autoFix = true): Promise<void> {
   claimServePidOrExit();
-  // Invalidate any stale port lockfile from an unclean prior shutdown — the
-  // next ensurePgserve() call will rewrite it with the live port. Without
-  // this, callers (TUI, hooks) cache the dead port and hammer ECONNREFUSED
-  // until pgserve happens to reuse it.
-  removePgservePortLockfile();
+  // Default pgserve v2 uses a Unix socket and must coexist with legacy v1
+  // TCP daemons. Only touch ~/.genie/pgserve.port when the operator has
+  // explicitly forced the legacy TCP path.
+  removeLegacyPgservePortLockfileIfForcedTcp();
   const { skipTui, mode } = resolveServeMode(headless);
   process.env.GENIE_IS_DAEMON = '1';
   // claimServePidOrExit already wrote `${pid}:${startTime}` atomically.

--- a/test/hooks/daemon-outage.test.ts
+++ b/test/hooks/daemon-outage.test.ts
@@ -27,10 +27,10 @@ import { startHookSocket } from '../../src/serve/hook-socket.js';
 let socketPath: string;
 
 beforeEach(() => {
-  socketPath = join(
-    tmpdir(),
-    `genie-daemon-outage-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.sock`,
-  );
+  // macOS sockaddr_un is capped around 104 bytes; tmpdir() expands to a long
+  // /var/folders/... path, so keep the socket path intentionally short.
+  const socketRoot = process.platform === 'darwin' ? '/tmp' : tmpdir();
+  socketPath = join(socketRoot, `genie-do-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.sock`);
   process.env.GENIE_HOOK_SOCK = socketPath;
 });
 


### PR DESCRIPTION
## Summary
- start pgserve v2 daemon before socket-mode DB connects
- make `genie serve` use the v2 daemon/socket path instead of legacy TCP startup
- preserve pgserve v1/TCP coexistence by leaving `pgserve.port`, legacy data files, and broad pgserve/postgres processes alone by default
- tighten macOS path/socket regression tests that were failing locally

## Verification
- `bunx biome check src/lib/db.ts src/term-commands/serve.ts src/genie-commands/doctor.ts src/lib/db.test.ts src/term-commands/serve.test.ts src/genie-commands/doctor.test.ts src/lib/brain-vaults.test.ts src/term-commands/agents.spawn-autosync.test.ts test/hooks/daemon-outage.test.ts`
- `bun test src/lib/db.test.ts src/term-commands/serve.test.ts src/genie-commands/doctor.test.ts src/lib/brain-vaults.test.ts src/term-commands/agents.spawn-autosync.test.ts test/hooks/daemon-outage.test.ts --timeout 30000`
- `bun run typecheck`
- `GENIE_TEST_PG_NO_REUSE=1 bun run check` (4416 pass, 9 skip, 0 fail)
- pre-push hook: `bun run typecheck && bun run lint && bun run dead-code && bun run skills:lint && bun run wishes:lint && bun run lint:emit`
