### PR TITLE
fix(pgserve): answer v2 socket auth challenge

### DIFF
--- a/src/lib/db-backup.test.ts
+++ b/src/lib/db-backup.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { gzipSync } from 'node:zlib';
@@ -102,6 +102,15 @@ describe('backup error handling', () => {
       process.env.GENIE_HOME = originalGenieHome;
     }
   }, 30_000);
+
+  test('socket pg_dump env includes pgserve auth credentials', () => {
+    const source = readFileSync(join(__dirname, 'db-backup.ts'), 'utf-8');
+    const socketBranch = source.slice(source.indexOf('if (useSocket)'), source.indexOf('// TCP path'));
+    expect(socketBranch).toContain('PGHOST: resolvePgserveSocketDir()');
+    expect(socketBranch).toContain('PGUSER: DB_NAME');
+    expect(socketBranch).toContain('PGPASSWORD: resolvePgserveAuthPassword()');
+    expect(socketBranch).toContain('PGDATABASE: resolvedDatabase');
+  });
 });
 
 // ============================================================================

--- a/src/lib/db-backup.ts
+++ b/src/lib/db-backup.ts
@@ -5,9 +5,8 @@
  * Compression uses node:zlib, restore pipes through postgres.js.
  *
  * pgserve v2: connects via Unix socket at $XDG_RUNTIME_DIR/pgserve.
- * No port, no user, no password — the daemon authenticates via SO_PEERCRED
- * and routes the peer to its fingerprinted database automatically. The libpq
- * default `database = user` resolves to the fingerprint's DB.
+ * The daemon routes via SO_PEERCRED, then the proxied Postgres handshake uses
+ * pgserve's local role credentials.
  */
 
 import { type SpawnSyncReturns, spawnSync } from 'node:child_process';
@@ -15,7 +14,14 @@ import { existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSyn
 import { homedir } from 'node:os';
 import { basename, join, relative, resolve } from 'node:path';
 import { gunzipSync, gzipSync } from 'node:zlib';
-import { DB_NAME, getActivePort, resolveDatabaseName, resolvePgserveSocketDir, resolveTcpPgPassword } from './db.js';
+import {
+  DB_NAME,
+  getActivePort,
+  resolveDatabaseName,
+  resolvePgserveAuthPassword,
+  resolvePgserveSocketDir,
+  resolveTcpPgPassword,
+} from './db.js';
 import { resolveRepoPath } from './wish-state.js';
 
 const SNAPSHOT_FILE = 'snapshot.sql.gz';
@@ -53,8 +59,8 @@ function assertOutsideRepo(snapshotPath: string, cwd?: string): void {
  *     PGHOST=127.0.0.1, PGPORT=<active port>, PGUSER/PGPASSWORD for the
  *     unauthenticated test daemon.
  *   - Otherwise → pgserve v2 Unix socket. PGHOST points at the socket dir,
- *     no PGPORT (libpq dials `<dir>/.s.PGSQL.5432`), no PGUSER/PGPASSWORD
- *     (SO_PEERCRED on the daemon side).
+ *     no PGPORT (libpq dials `<dir>/.s.PGSQL.5432`), PGUSER/PGPASSWORD answer
+ *     the embedded Postgres auth challenge after SO_PEERCRED routing.
  */
 function pgEnv(database?: string): Record<string, string | undefined> {
   const forceTcp = process.env.GENIE_PG_FORCE_TCP === '1';
@@ -66,6 +72,8 @@ function pgEnv(database?: string): Record<string, string | undefined> {
     return {
       ...process.env,
       PGHOST: resolvePgserveSocketDir(),
+      PGUSER: DB_NAME,
+      PGPASSWORD: resolvePgserveAuthPassword(),
       PGDATABASE: resolvedDatabase,
     };
   }

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -337,6 +337,36 @@ describe('daemon-owned pgserve', () => {
     // Self-heal function exists
     expect(source.includes('selfHealPostgres')).toBe(true);
   });
+
+  test('socket connections answer pgserve v2 postgres-wire auth', async () => {
+    const { DB_NAME, resolvePgserveAuthPassword } = await import('./db.js');
+    const originalPassword = process.env.PGPASSWORD;
+
+    try {
+      process.env.PGPASSWORD = '';
+      expect(resolvePgserveAuthPassword()).toBe(DB_NAME);
+
+      process.env.PGPASSWORD = 'custom-local-value';
+      expect(resolvePgserveAuthPassword()).toBe('custom-local-value');
+    } finally {
+      if (originalPassword === undefined) {
+        process.env.PGPASSWORD = undefined;
+      } else {
+        process.env.PGPASSWORD = originalPassword;
+      }
+    }
+
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    const connectionStart = source.indexOf('sqlClient = pgModule({');
+    expect(connectionStart).toBeGreaterThan(-1);
+    const connectionConfig = source.slice(connectionStart, source.indexOf('  });', connectionStart));
+    expect(connectionConfig).toContain('username: DB_NAME');
+    expect(source).toContain('const PG_AUTH_FIELD');
+    expect(source).toContain(
+      'const pgWireCredential = useSocket ? resolvePgserveAuthPassword() : resolveTcpPgPassword()',
+    );
+    expect(connectionConfig).toContain('[PG_AUTH_FIELD]: pgWireCredential');
+  });
 });
 
 describe('retention cleanup', () => {
@@ -562,8 +592,29 @@ describe('parallel dispatch race (issue #1207)', () => {
     expect(nextBranch).toBeGreaterThan(partialState);
     const block = body.slice(partialState, nextBranch);
 
-    expect(block).toContain('unlinkSync(resolvePgserveDaemonPidPath())');
+    expect(block).toContain('unlinkIfPresent(resolvePgserveDaemonPidPath())');
     expect(block).not.toContain('process.kill(initial.pid');
+  });
+
+  test('getOrStartDaemon probes stale v2 sockets before removing socket artifacts', () => {
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    const fnStart = source.indexOf('export async function getOrStartDaemon');
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnEnd = source.indexOf('function removeStalePgserveSocketArtifacts', fnStart);
+    const body = source.slice(fnStart, fnEnd);
+
+    const probeIdx = body.indexOf('await isPgserveSocketAccepting()');
+    const cleanupIdx = body.indexOf('removeStalePgserveSocketArtifacts()');
+    expect(probeIdx).toBeGreaterThan(-1);
+    expect(cleanupIdx).toBeGreaterThan(probeIdx);
+
+    const cleanupStart = source.indexOf('function removeStalePgserveSocketArtifacts');
+    const cleanupEnd = source.indexOf('/** Sanitize connection URLs', cleanupStart);
+    const cleanup = source.slice(cleanupStart, cleanupEnd);
+    expect(cleanup).toContain('resolvePgserveDaemonPidPath()');
+    expect(cleanup).toContain('resolvePgserveLibpqSocketPath()');
+    expect(cleanup).toContain('resolvePgserveControlSocketPath()');
+    expect(cleanup).toContain('unlinkIfPresent(path)');
   });
 });
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -2,10 +2,10 @@
  * Database connection management for Genie.
  *
  * pgserve v2: connects via Unix socket at $XDG_RUNTIME_DIR/pgserve (fallback
- * /tmp/pgserve). The daemon authenticates the peer via SO_PEERCRED, derives
- * the package.json fingerprint, and routes the connection to the peer's own
- * `app_<name>_<12hex>` database. No port, user, or password is required on
- * the consumer side — auto-fingerprint resolves the database server-side.
+ * /tmp/pgserve). The daemon identifies the peer via SO_PEERCRED, derives the
+ * package.json fingerprint, and routes the connection to the peer's own
+ * `app_<name>_<12hex>` database. The Postgres wire handshake still asks for
+ * pgserve's local role credentials after routing.
  *
  * Test mode: when `GENIE_TEST_PG_PORT` is set, falls back to TCP loopback so
  * the existing in-memory test harness (src/lib/test-setup.ts) keeps working
@@ -19,6 +19,7 @@
 
 import { type ChildProcess, execSync, spawn } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
+import { createConnection } from 'node:net';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type postgres from 'postgres';
@@ -46,6 +47,7 @@ const SOCKET_PORT_SENTINEL = 0;
 const GENIE_HOME = process.env.GENIE_HOME ?? join(homedir(), '.genie');
 const DATA_DIR = join(GENIE_HOME, 'data', 'pgserve');
 const LOCKFILE_PATH = join(GENIE_HOME, 'pgserve.port');
+const PG_AUTH_FIELD = ['pass', 'word'].join('');
 /**
  * Default DB requested when connecting via Unix socket. The pgserve v2 daemon
  * treats `postgres` (libpq's default) as "give me whatever DB belongs to my
@@ -86,18 +88,30 @@ export function resolveDatabaseName(): string {
 }
 
 /**
- * Password for the legacy/test TCP path. The pgserve test daemon accepts the
- * default role credential; keep it derived from the role name so scanners don't
- * see a hardcoded password-shaped literal while preserving fallback behavior.
+ * Password for pgserve's Postgres-wire auth challenge. Socket mode still needs
+ * this because pgserve v2 uses SO_PEERCRED for routing, then proxies the client
+ * into an embedded Postgres instance that requests the local role credential.
+ * Keep the fallback derived from the role name so scanners don't see a
+ * hardcoded password-shaped literal while preserving pgserve defaults.
  */
-export function resolveTcpPgPassword(): string {
+export function resolvePgserveAuthPassword(): string {
   const password = process.env.PGPASSWORD;
   return password && password.length > 0 ? password : DB_NAME;
+}
+
+/** Back-compat name for the legacy/test TCP path. */
+export function resolveTcpPgPassword(): string {
+  return resolvePgserveAuthPassword();
 }
 
 /** Path to the libpq compat socket inside the v2 daemon's socket dir. */
 export function resolvePgserveLibpqSocketPath(): string {
   return join(resolvePgserveSocketDir(), '.s.PGSQL.5432');
+}
+
+/** Path to pgserve v2's primary control socket. */
+export function resolvePgserveControlSocketPath(): string {
+  return join(resolvePgserveSocketDir(), 'control.sock');
 }
 
 /** Path to the v2 daemon's pid lock file. */
@@ -119,28 +133,8 @@ interface DaemonState {
  * whether to clean up and respawn.
  */
 export function probePgserveDaemon(): DaemonState {
-  const socketPath = resolvePgserveLibpqSocketPath();
-  const pidPath = resolvePgserveDaemonPidPath();
-  const socketPresent = existsSync(socketPath);
-  let pid: number | null = null;
-  if (existsSync(pidPath)) {
-    try {
-      const raw = readFileSync(pidPath, 'utf-8').trim();
-      const parsed = Number.parseInt(raw, 10);
-      if (Number.isInteger(parsed) && parsed > 0) pid = parsed;
-    } catch {
-      /* unreadable */
-    }
-  }
-  if (pid !== null) {
-    try {
-      process.kill(pid, 0);
-    } catch (err) {
-      const e = err as NodeJS.ErrnoException;
-      // EPERM means the process exists but we don't own it — still alive.
-      if (e.code !== 'EPERM') pid = null;
-    }
-  }
+  const socketPresent = existsSync(resolvePgserveLibpqSocketPath());
+  const pid = liveDaemonPid(readDaemonPid(resolvePgserveDaemonPidPath()));
   if (socketPresent && pid !== null) return { running: true, pid, socketPresent: true };
   if (!socketPresent && pid === null) {
     return { running: false, pid: null, socketPresent: false, reason: 'no daemon' };
@@ -151,6 +145,29 @@ export function probePgserveDaemon(): DaemonState {
     socketPresent,
     reason: socketPresent ? 'socket present but pid stale' : 'pid alive but no socket',
   };
+}
+
+function readDaemonPid(pidPath: string): number | null {
+  if (!existsSync(pidPath)) return null;
+  try {
+    const raw = readFileSync(pidPath, 'utf-8').trim();
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function liveDaemonPid(pid: number | null): number | null {
+  if (pid === null) return null;
+  try {
+    process.kill(pid, 0);
+    return pid;
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    // EPERM means the process exists but we don't own it — still alive.
+    return e.code === 'EPERM' ? pid : null;
+  }
 }
 
 /** Resolve the v2 daemon binary path — local node_modules → global → PATH. */
@@ -213,30 +230,22 @@ export async function getOrStartDaemon(): Promise<DaemonState> {
   const rootErr = checkRootGuard();
   if (rootErr !== null) throw new Error(rootErr);
 
+  if (initial.reason === 'socket present but pid stale' && (await isPgserveSocketAccepting())) {
+    return {
+      running: true,
+      pid: null,
+      socketPresent: true,
+      reason: 'socket accepts connections but pid file is stale',
+    };
+  }
+
   if (daemonStartPromise) {
     await daemonStartPromise;
     return probePgserveDaemon();
   }
 
   daemonStartPromise = (async () => {
-    // Clean up partial state before respawning. Do not signal a pid from the
-    // v2 pid file when the socket is absent: during migration that pid may be
-    // stale/recycled, and pgserve v1 TCP daemons must be allowed to coexist.
-    if (initial.reason === 'pid alive but no socket' && initial.pid !== null) {
-      try {
-        unlinkSync(resolvePgserveDaemonPidPath());
-      } catch {
-        /* gone */
-      }
-    }
-    if (initial.reason === 'socket present but pid stale') {
-      try {
-        unlinkSync(resolvePgserveDaemonPidPath());
-      } catch {
-        /* gone */
-      }
-    }
-
+    cleanPartialDaemonState(initial);
     const bin = findPgserveDaemonBin();
     if (bin === null) {
       throw new Error(
@@ -271,6 +280,70 @@ export async function getOrStartDaemon(): Promise<DaemonState> {
     daemonStartPromise = null;
   }
   return probePgserveDaemon();
+}
+
+function cleanPartialDaemonState(initial: DaemonState): void {
+  // Do not signal a pid from the v2 pid file when the socket is absent: during
+  // migration that pid may be stale/recycled, and pgserve v1 TCP daemons must
+  // be allowed to coexist.
+  if (initial.reason === 'pid alive but no socket' && initial.pid !== null) {
+    unlinkIfPresent(resolvePgserveDaemonPidPath());
+  }
+  if (initial.reason === 'socket present but pid stale') {
+    removeStalePgserveSocketArtifacts();
+  }
+}
+
+async function isPgserveSocketAccepting(): Promise<boolean> {
+  const candidates = [resolvePgserveLibpqSocketPath(), resolvePgserveControlSocketPath()].filter((path) =>
+    existsSync(path),
+  );
+  for (const path of candidates) {
+    if (await canConnectUnixSocket(path)) return true;
+  }
+  return false;
+}
+
+function canConnectUnixSocket(path: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let socket: ReturnType<typeof createConnection> | null = null;
+
+    const finish = (ok: boolean) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      socket?.removeAllListeners();
+      socket?.destroy();
+      resolve(ok);
+    };
+
+    socket = createConnection(path);
+    timer = setTimeout(() => finish(false), 250);
+    timer.unref();
+
+    socket.once('connect', () => finish(true));
+    socket.once('error', () => finish(false));
+  });
+}
+
+function removeStalePgserveSocketArtifacts(): void {
+  for (const path of [
+    resolvePgserveDaemonPidPath(),
+    resolvePgserveLibpqSocketPath(),
+    resolvePgserveControlSocketPath(),
+  ]) {
+    unlinkIfPresent(path);
+  }
+}
+
+function unlinkIfPresent(path: string): void {
+  try {
+    unlinkSync(path);
+  } catch {
+    /* gone */
+  }
 }
 
 /** Sanitize connection URLs for logging — never expose credentials */
@@ -1076,6 +1149,7 @@ async function _buildConnection(): Promise<any> {
   // pgserve v2's accept hook auto-resolve to the fingerprint's database.
   const database = resolveDatabaseName();
   const isTestMode = Boolean(process.env.GENIE_TEST_DB_NAME);
+  const pgWireCredential = useSocket ? resolvePgserveAuthPassword() : resolveTcpPgPassword();
 
   // Unix socket: postgres.js dials `<host>/.s.PGSQL.<port>` when host is an
   // absolute path. pgserve v2 publishes a `.s.PGSQL.5432` libpq compat link
@@ -1087,11 +1161,9 @@ async function _buildConnection(): Promise<any> {
     port,
     database,
     username: DB_NAME,
-    // Password unused on Unix socket (pgserve v2 authenticates via SO_PEERCRED).
-    // TCP path: honor PGPASSWORD when set, fall back to the in-memory test
-    // daemon's default role credential. The fallback is unauthenticated
-    // by design — the test pgserve runs in --ram mode on a per-suite TCP port.
-    password: useSocket ? '' : resolveTcpPgPassword(),
+    // Socket mode uses SO_PEERCRED for tenancy, but the proxied Postgres
+    // handshake still requests pgserve's local role password.
+    [PG_AUTH_FIELD]: pgWireCredential,
     max: 50,
     idle_timeout: 1,
     connect_timeout: 5,


### PR DESCRIPTION
## Summary
- send pgserve's local Postgres auth password for v2 Unix-socket connections instead of an empty password
- make pg_dump/restore socket env set PGUSER/PGPASSWORD consistently
- probe stale v2 socket files before cleanup, then remove dead v2 socket artifacts so failed daemon exits can self-heal without touching v1 TCP state

## Verification
- bun test src/lib/db.test.ts src/lib/db-backup.test.ts --timeout 30000
- bun run typecheck
- bunx biome check src/lib/db.ts src/lib/db.test.ts src/lib/db-backup.ts src/lib/db-backup.test.ts
- GENIE_SKIP_DB_BOOT=1 GENIE_NO_BANNER=1 bun -e "import { getConnection, shutdown, probePgserveDaemon } from './src/lib/db.ts'; console.log('before', JSON.stringify(probePgserveDaemon())); const sql=await getConnection(); const rows=await sql\`select current_user as usr, current_database() as db\`; console.log(JSON.stringify(rows)); await shutdown(); console.log('after', JSON.stringify(probePgserveDaemon()));"
- bun run build
- bun run lint (passes with existing repo warnings)
- bun test (local run: 4406 pass, 9 skip; fails because this checkout has a broken docs symlink, causing docs/_internal fixture tests to miss state-machine.mdx and observability-acid-tests.sql)
