### PR TITLE
fix(pgserve): start v2 daemon from serve

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,21 +66,6 @@ jobs:
         with:
           bun-version: "1.3.11"
 
-      # package.json pins `pgserve: file:../pgserve` until Group 8 of pgserve-v2
-      # publishes pgserve@2.0.0 to npm. Bun install fails on CI without the
-      # sibling checkout. Cloning the v2 branch alongside satisfies the file:
-      # protocol the same way the smoke job's local sibling does.
-      #
-      # `bun install` inside the sibling is required too: pgserve's CLI is
-      # bin/pgserve-wrapper.cjs, which probes for the bun runtime in
-      # ../pgserve/node_modules/.bin/bun. Without that population, the
-      # spawn-test-pgserve preload throws "could not find bun runtime" and
-      # the whole PG suite collapses with ENOENT on /tmp/pgserve socket.
-      - name: Checkout pgserve v2 sibling
-        run: |
-          git clone --depth 1 --branch wish/pgserve-v2 https://github.com/namastexlabs/pgserve.git ../pgserve
-          (cd ../pgserve && bun install --no-save)
-
       - name: Install dependencies
         env:
           BUN_INSTALL_CACHE_DIR: ${{ runner.temp }}/bun-cache-${{ github.run_id }}-${{ github.run_attempt }}
@@ -157,18 +142,6 @@ jobs:
         with:
           bun-version: "1.3.11"
 
-      # See unit-tests for rationale — package.json pins `pgserve:
-      # file:../pgserve` until pgserve@2.0.0 is on npm, so CI must clone the
-      # v2 branch as a sibling before bun install can resolve. PG Tests in
-      # particular also needs the wrapper's bun runtime populated (see
-      # unit-tests note) — without `bun install` inside the sibling, the
-      # test-setup preload throws "could not start pgserve on any port" and
-      # the entire suite collapses with ENOENT on /tmp/pgserve.
-      - name: Checkout pgserve v2 sibling
-        run: |
-          git clone --depth 1 --branch wish/pgserve-v2 https://github.com/namastexlabs/pgserve.git ../pgserve
-          (cd ../pgserve && bun install --no-save)
-
       # Per-run scratch cache dir. Prior config used a persistent
       # ~/.bun/install/cache restored via actions/cache, which cross-
       # polluted runs on the self-hosted Blacksmith runner and was
@@ -195,12 +168,12 @@ jobs:
       # 15s absorbs that jitter without masking slow tests (a test that takes
       # >15s is a real problem worth surfacing).
       #
-      # `|| bun test --timeout 15000`: retry-once wrapper for the PGlite/pgserve
-      # cross-connection imperfections (NOTIFY delivery gaps + post-INSERT read
+      # `|| bun test --timeout 15000`: retry-once wrapper for pgserve
+      # backend imperfections (NOTIFY delivery gaps + post-INSERT read
       # visibility gaps) enumerated in tracker #1335. Measured baseline flake
       # rate is ~1/3626 per test; two consecutive flakes on the same test are
       # ~1 in 10M, so a single retry masks the noise without hiding real
-      # regressions. Long-term fix is a pgserve/PGlite backend audit (out of
+      # regressions. Long-term fix is a pgserve backend audit (out of
       # scope for wish pg-test-perf).
       #
       # History: 7b23046e dropped a prior retry wrapper because hangs on the
@@ -213,11 +186,9 @@ jobs:
         run: bun test --timeout 15000 || bun test --timeout 15000
 
   # Group 7 of the pgserve-v2 wish: smoke-test the v2 Unix-socket consumer
-  # path. Spawns pgserve daemon, runs `genie wish list` against it, asserts
+  # path. Spawns pgserve daemon, runs `genie task list` against it, asserts
   # the round-trip succeeds and the routed DB is auto-fingerprinted (named
-  # `app_genie_<12hex>`). Skipped when pgserve@2 isn't resolvable yet —
-  # the dep is currently pinned to `file:../pgserve` until Group 8 publishes
-  # `pgserve@2.0.0` to npm.
+  # from the sanitized package name, e.g. `app__automagik_genie_<12hex>`).
   pgserve-v2-smoke:
     name: pgserve v2 smoke (Unix socket round-trip)
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -232,36 +203,21 @@ jobs:
         with:
           bun-version: "1.3.11"
 
-      - name: Resolve pgserve v2 (skip if unavailable)
-        id: pgserve_check
-        run: |
-          set -eo pipefail
-          if [ -d "../pgserve" ] && [ -f "../pgserve/bin/pgserve-wrapper.cjs" ]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-            echo "pgserve v2 sibling checkout found at ../pgserve"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::pgserve v2 not resolvable (no ../pgserve sibling). Smoke test skipped until Group 8 publishes pgserve@2.0.0 to npm."
-          fi
-
       - name: Install dependencies
-        if: steps.pgserve_check.outputs.available == 'true'
         env:
           BUN_INSTALL_CACHE_DIR: ${{ runner.temp }}/bun-cache-${{ github.run_id }}-${{ github.run_attempt }}
         run: bun install
 
       - name: Build
-        if: steps.pgserve_check.outputs.available == 'true'
         run: bun run build
 
       - name: Start pgserve v2 daemon
-        if: steps.pgserve_check.outputs.available == 'true'
         run: |
           set -eo pipefail
           export XDG_RUNTIME_DIR="${RUNNER_TEMP}/xdg"
           mkdir -p "$XDG_RUNTIME_DIR"
           echo "XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR" >> "$GITHUB_ENV"
-          ../pgserve/bin/pgserve-wrapper.cjs daemon &
+          ./node_modules/.bin/pgserve daemon --data "${RUNNER_TEMP}/pgserve-data" --log warn &
           # Wait up to 30s for the libpq socket to appear.
           for i in $(seq 1 60); do
             if [ -S "$XDG_RUNTIME_DIR/pgserve/.s.PGSQL.5432" ]; then
@@ -273,16 +229,17 @@ jobs:
           echo "::error::pgserve daemon did not bind libpq socket within 30s"
           exit 1
 
-      - name: Smoke — genie wish list round-trip
-        if: steps.pgserve_check.outputs.available == 'true'
+      - name: Smoke — genie task list round-trip
         env:
           GENIE_NO_BANNER: ""
         run: |
           set -eo pipefail
+          mkdir -p .genie
+          printf '{"name":"ci-smoke"}\n' > .genie/workspace.json
           # Capture stderr to assert the banner printed the resolved DB.
-          OUT=$(./dist/genie.js wish list 2>&1)
+          OUT=$(./dist/genie.js task list 2>&1)
           echo "$OUT"
-          echo "$OUT" | grep -E '\[pgserve\] connected to app_genie_[0-9a-f]{12}' \
+          echo "$OUT" | grep -E '\[pgserve\] connected to app__automagik_genie_[0-9a-f]{12}' \
             || (echo "::error::Banner did not print fingerprinted DB name"; exit 1)
 
   # Umbrella status check. Branch protection is configured to require

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -100,14 +100,6 @@ jobs:
         with:
           bun-version: "1.3.10"
 
-      # package.json pins `pgserve: file:../pgserve` until pgserve@2.0.0 is
-      # published to npm. Version publishes run outside CI's test jobs, so they
-      # need the same sibling checkout before `bun install` can resolve deps.
-      - name: Checkout pgserve v2 sibling
-        run: |
-          git clone --depth 1 --branch wish/pgserve-v2 https://github.com/namastexlabs/pgserve.git ../pgserve
-          (cd ../pgserve && bun install --no-save)
-
       - name: Install dependencies
         run: bun install
 

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "ignore": "7.0.5",
         "js-yaml": "4.1.1",
         "nats": "2.29.3",
-        "pgserve": "^2.0.0",
+        "pgserve": "^2.0.2",
         "postgres": "3.4.9",
         "react": "19.2.5",
         "react-dom": "19.2.5",
@@ -883,7 +883,7 @@
 
     "peek-readable": ["peek-readable@4.1.0", "", {}, "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="],
 
-    "pgserve": ["pgserve@2.0.0", "", { "dependencies": { "bun": "^1.3.4" }, "optionalDependencies": { "@embedded-postgres/darwin-arm64": "18.2.0-beta.16", "@embedded-postgres/darwin-x64": "18.2.0-beta.16", "@embedded-postgres/linux-x64": "18.2.0-beta.16", "@embedded-postgres/windows-x64": "18.2.0-beta.16" }, "bin": { "pgserve": "bin/pgserve-wrapper.cjs" } }, "sha512-XUFjROjhQqM3KBkR6zqkfmQMXLUH4mp8GE9KmnFMbAN5j/FRyfLsGBtncQjdmFXIoMDrNERvIe+ViuxkFMBw5w=="],
+    "pgserve": ["pgserve@2.0.2", "", { "dependencies": { "bun": "^1.3.4" }, "optionalDependencies": { "@embedded-postgres/darwin-arm64": "18.2.0-beta.16", "@embedded-postgres/darwin-x64": "18.2.0-beta.16", "@embedded-postgres/linux-x64": "18.2.0-beta.16", "@embedded-postgres/windows-x64": "18.2.0-beta.16" }, "bin": { "pgserve": "bin/pgserve-wrapper.cjs" } }, "sha512-1p6kEKWHLiajLly2abnXP73LGZFA9Lvaqt67SBsFSEWsU5E7AHpJask3NrNCSeJwoW8DnQoXXkjsoNUnpwrzZA=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "ignore": "7.0.5",
     "js-yaml": "4.1.1",
     "nats": "2.29.3",
-    "pgserve": "^2.0.0",
+    "pgserve": "^2.0.2",
     "postgres": "3.4.9",
     "react": "19.2.5",
     "react-dom": "19.2.5",

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -367,6 +367,29 @@ describe('daemon-owned pgserve', () => {
     );
     expect(connectionConfig).toContain('[PG_AUTH_FIELD]: pgWireCredential');
   });
+
+  test('socket connections ensure the v2 daemon before dialing libpq path', () => {
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    const fnStart = source.indexOf('async function _buildConnection');
+    expect(fnStart).toBeGreaterThan(-1);
+    const body = source.slice(fnStart, source.indexOf('\n}\n', fnStart));
+
+    const useSocketIdx = body.indexOf('const useSocket = shouldUseUnixSocket()');
+    const ensureIdx = body.indexOf('if (useSocket) await getOrStartDaemon()');
+    const portIdx = body.indexOf('const port = useSocket ? 5432 : await ensurePgserve()');
+
+    expect(useSocketIdx).toBeGreaterThan(-1);
+    expect(ensureIdx).toBeGreaterThan(useSocketIdx);
+    expect(portIdx).toBeGreaterThan(ensureIdx);
+  });
+
+  test('v2 daemon autostart uses persistent Genie data dir', () => {
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    const fnStart = source.indexOf('export async function getOrStartDaemon');
+    expect(fnStart).toBeGreaterThan(-1);
+    const body = source.slice(fnStart, source.indexOf('\nfunction maskCredentials', fnStart));
+    expect(body).toContain("['daemon', '--data', DATA_DIR, '--log', 'warn']");
+  });
 });
 
 describe('retention cleanup', () => {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -126,6 +126,23 @@ interface DaemonState {
   reason?: string;
 }
 
+interface PgserveSdkDaemonState {
+  running: boolean;
+  pid: number | null;
+  libpqSocketPresent?: boolean;
+  socketPresent?: boolean;
+  reason?: string | null;
+}
+
+interface PgserveSdk {
+  ensureDaemon?: (options?: {
+    dataDir?: string;
+    logLevel?: string;
+    timeoutMs?: number;
+    controlSocketDir?: string;
+  }) => Promise<PgserveSdkDaemonState>;
+}
+
 /**
  * Probe the v2 daemon. Returns running=true only when both the libpq socket
  * file exists AND the recorded pid is alive. A pid file with no socket (or
@@ -214,8 +231,10 @@ let daemonStartPromise: Promise<void> | null = null;
  * downstream commits; exported here so those call-sites land cleanly.
  */
 export async function getOrStartDaemon(): Promise<DaemonState> {
-  if (process.env.GENIE_PG_DISABLE_AUTOSTART === '1') {
-    return probePgserveDaemon();
+  if (process.env.GENIE_PG_DISABLE_AUTOSTART === '1' || isPgAutostartDisabled()) {
+    const state = probePgserveDaemon();
+    if (state.running) return state;
+    throw new Error('pgserve daemon unavailable and PG autostart is disabled');
   }
   const initial = probePgserveDaemon();
   if (initial.running) return initial;
@@ -244,35 +263,7 @@ export async function getOrStartDaemon(): Promise<DaemonState> {
     return probePgserveDaemon();
   }
 
-  daemonStartPromise = (async () => {
-    cleanPartialDaemonState(initial);
-    const bin = findPgserveDaemonBin();
-    if (bin === null) {
-      throw new Error(
-        'pgserve binary not found. Install with `bun add pgserve@^2.0.0` (or `npm i pgserve@^2.0.0`), or start `pgserve daemon` manually before running genie.',
-      );
-    }
-
-    mkdirSync(resolvePgserveSocketDir(), { recursive: true, mode: 0o700 });
-
-    const child = spawn(bin, ['daemon'], {
-      detached: true,
-      stdio: 'ignore',
-      env: { ...process.env },
-    });
-    child.unref();
-
-    const socketPath = resolvePgserveLibpqSocketPath();
-    const timeout = Number(process.env.GENIE_PGSERVE_TIMEOUT) || 16000;
-    const deadline = Date.now() + timeout;
-    while (Date.now() < deadline) {
-      if (existsSync(socketPath)) return;
-      await sleep(250);
-    }
-    throw new Error(
-      `pgserve v2 daemon did not bind ${socketPath} within ${Math.round(timeout / 1000)}s. Try starting it manually: ${bin} daemon`,
-    );
-  })();
+  daemonStartPromise = startPgserveDaemonOnce(initial);
 
   try {
     await daemonStartPromise;
@@ -344,6 +335,61 @@ function unlinkIfPresent(path: string): void {
   } catch {
     /* gone */
   }
+}
+
+async function startPgserveDaemonOnce(initial: DaemonState): Promise<void> {
+  cleanPartialDaemonState(initial);
+  if (await tryEnsureDaemonWithSdk()) return;
+  const bin = requirePgserveDaemonBin();
+  mkdirSync(resolvePgserveSocketDir(), { recursive: true, mode: 0o700 });
+
+  const child = spawn(bin, ['daemon', '--data', DATA_DIR, '--log', 'warn'], {
+    detached: true,
+    stdio: 'ignore',
+    env: { ...process.env },
+  });
+  child.unref();
+  await waitForDaemonSocket(bin);
+}
+
+function requirePgserveDaemonBin(): string {
+  const bin = findPgserveDaemonBin();
+  if (bin !== null) return bin;
+  throw new Error(
+    'pgserve binary not found. Install with `bun add pgserve@^2.0.2` (or `npm i pgserve@^2.0.2`), or start `pgserve daemon` manually before running genie.',
+  );
+}
+
+async function waitForDaemonSocket(bin: string): Promise<void> {
+  const socketPath = resolvePgserveLibpqSocketPath();
+  const timeout = Number(process.env.GENIE_PGSERVE_TIMEOUT) || 16000;
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if (existsSync(socketPath)) return;
+    await sleep(250);
+  }
+  throw new Error(
+    `pgserve v2 daemon did not bind ${socketPath} within ${Math.round(timeout / 1000)}s. Try starting it manually: ${bin} daemon`,
+  );
+}
+
+async function tryEnsureDaemonWithSdk(): Promise<boolean> {
+  let sdk: PgserveSdk;
+  try {
+    sdk = (await import('pgserve')) as PgserveSdk;
+  } catch {
+    return false;
+  }
+  if (typeof sdk.ensureDaemon !== 'function') return false;
+
+  const timeoutMs = Number(process.env.GENIE_PGSERVE_TIMEOUT) || 16000;
+  const state = await sdk.ensureDaemon({
+    dataDir: DATA_DIR,
+    logLevel: 'warn',
+    timeoutMs,
+    controlSocketDir: resolvePgserveSocketDir(),
+  });
+  return Boolean(state.running && (state.libpqSocketPresent ?? state.socketPresent ?? true));
 }
 
 /** Sanitize connection URLs for logging — never expose credentials */

--- a/src/lib/test-setup.ts
+++ b/src/lib/test-setup.ts
@@ -142,7 +142,7 @@ async function isPostgresHealthy(port: number): Promise<boolean> {
  * macOS with GENIE_TEST_MAC_RAM=1: pass `--data <ram-disk>/pgserve` so
  * pgserve writes to the hdiutil-backed RAM volume (Group 6).
  * macOS default / no shm: omit `--data` entirely — pgserve defaults to its
- * own ephemeral temp dir (see pgserve/bin/pglite-server.js lines 44-64),
+ * own ephemeral temp dir (see pgserve/bin/postgres-server.js lines 44-64),
  * and auto-cleans the dir on child exit.
  */
 function buildPgserveArgs(port: number, useRam: boolean, dataDir: string | null): string[] {
@@ -196,7 +196,7 @@ async function tryStartOnPort(port: number, useRam: boolean, dataDir: string | n
 
 /**
  * Recursively collect all descendant PIDs of a given root. Returns [root, ...children].
- * Used to walk the wrapper → pglite-server → postgres tree when reaping orphans.
+ * Used to walk the wrapper → postgres-server → postgres tree when reaping orphans.
  */
 function collectDescendants(rootPid: number): number[] {
   const all = new Set<number>([rootPid]);

--- a/src/term-commands/serve.test.ts
+++ b/src/term-commands/serve.test.ts
@@ -56,9 +56,10 @@ describe('pgserve failure containment', () => {
     const body = source.slice(fnStart, fnEnd);
 
     expect(body).toContain('getOrStartDaemon');
-    expect(body).toContain('resolvePgserveLibpqSocketPath');
+    expect(body).toContain('resolvePgserveSocketDir');
+    expect(body).toContain('getDataDir');
     expect(body).not.toContain('ensurePgserve');
-    expect(body).not.toContain('registerService');
+    expect(body).toContain("registerService('pgserve-owner'");
     expect(body).not.toContain('pgserve ready on port');
   });
 
@@ -70,6 +71,19 @@ describe('pgserve failure containment', () => {
     const retryGuard = source.indexOf("process.env.GENIE_PG_NO_AUTOSTART = '1'", catchStart);
     expect(catchStart).toBeGreaterThan(-1);
     expect(retryGuard).toBeGreaterThan(-1);
+  });
+
+  test('serve starts pgserve daemon instead of legacy TCP router', () => {
+    const source = readFileSync(join(__dirname, 'serve.ts'), 'utf-8');
+    const fnStart = source.indexOf('async function startPgserve');
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnEnd = source.indexOf('/** Start the scheduler daemon', fnStart);
+    const body = source.slice(fnStart, fnEnd);
+
+    expect(body).toContain('getOrStartDaemon');
+    expect(body).toContain('pgserve daemon ready');
+    expect(body).not.toContain('ensurePgserve');
+    expect(body).not.toContain('pgserve ready on port');
   });
 });
 
@@ -142,9 +156,11 @@ describe('brain startup integration', () => {
         setBrainHandles: mock(() => {}),
       });
 
-      expect(result.map((handle) => handle.brainPath)).toEqual([valid]);
+      expect(result.map((handle) => handle.brainPath)).toEqual([realpathSync(valid)]);
       expect(startEmbeddedBrainServer.mock.calls.length).toBe(1);
-      expect(warnings.some((message) => message.includes(`skipped registered vault ${missing}`))).toBe(true);
+      expect(warnings.some((message) => message.includes(`skipped registered vault ${realpathSync(missing)}`))).toBe(
+        true,
+      );
       expect(warnings.some((message) => message.includes('registry drift: started 1/2'))).toBe(true);
     } finally {
       rmSync(root, { recursive: true, force: true });
@@ -182,11 +198,11 @@ describe('brain startup integration', () => {
       });
 
       await eventually(() => startEmbeddedBrainServer.mock.calls.length >= 2);
-      expect(started).toEqual([first, second]);
+      expect(started).toEqual([realpathSync(first), realpathSync(second)]);
 
       releaseFirst?.();
       const result = await pending;
-      expect(result.map((handle) => handle.brainPath)).toEqual([first, second]);
+      expect(result.map((handle) => handle.brainPath)).toEqual([realpathSync(first), realpathSync(second)]);
     } finally {
       releaseFirst?.();
       rmSync(root, { recursive: true, force: true });

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -596,15 +596,23 @@ async function startAgentSync(): Promise<{ close: () => void } | null> {
 
 /** Start pgserve and register it in the service registry. */
 async function startPgserve(): Promise<void> {
-  console.log('  Starting pgserve...');
+  console.log('  Starting pgserve daemon...');
   try {
-    const { getOrStartDaemon, resolvePgserveLibpqSocketPath } = await import('../lib/db.js');
-    const daemon = await getOrStartDaemon();
-    console.log(`  pgserve ready at ${resolvePgserveLibpqSocketPath()}${daemon.pid ? ` (pid ${daemon.pid})` : ''}`);
+    const { getDataDir, getOrStartDaemon, resolvePgserveSocketDir } = await import('../lib/db.js');
+    const state = await getOrStartDaemon();
+    const pid = state.pid ? `, pid ${state.pid}` : '';
+    console.log(`  pgserve daemon ready on ${resolvePgserveSocketDir()} (data: ${getDataDir()}${pid})`);
+    try {
+      const { registerService } = await import('../lib/service-registry.js');
+      registerService('pgserve-owner', process.pid);
+    } catch {
+      // Registry not available — non-fatal
+    }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`  pgserve failed: ${msg}`);
     process.env.GENIE_PG_NO_AUTOSTART = '1';
+    process.env.GENIE_PG_DISABLE_AUTOSTART = '1';
     console.error('  pgserve retries disabled for this serve process; fix pgserve and restart `genie serve`.');
   }
 }
@@ -1316,9 +1324,10 @@ async function stopServe(): Promise<void> {
 /** Check pgserve health and print status */
 async function printPgserveHealth(): Promise<void> {
   try {
-    const { isAvailable, getActivePort } = await import('../lib/db.js');
+    const { isAvailable, getActivePort, isSocketMode, resolvePgserveSocketDir } = await import('../lib/db.js');
     const dbOk = await isAvailable();
-    console.log(`  pgserve:    ${dbOk ? `healthy (port ${getActivePort()})` : 'unreachable'}`);
+    const where = isSocketMode() ? `socket ${resolvePgserveSocketDir()}` : `port ${getActivePort()}`;
+    console.log(`  pgserve:    ${dbOk ? `healthy (${where})` : 'unreachable'}`);
   } catch {
     console.log('  pgserve:    unavailable');
   }

--- a/src/types/pgserve.d.ts
+++ b/src/types/pgserve.d.ts
@@ -1,0 +1,16 @@
+declare module 'pgserve' {
+  export interface PgserveDaemonState {
+    running: boolean;
+    pid: number | null;
+    libpqSocketPresent?: boolean;
+    socketPresent?: boolean;
+    reason?: string | null;
+  }
+
+  export function ensureDaemon(options?: {
+    dataDir?: string;
+    logLevel?: string;
+    timeoutMs?: number;
+    controlSocketDir?: string;
+  }): Promise<PgserveDaemonState>;
+}


### PR DESCRIPTION
## Summary
- consume pgserve@2.0.2 from npm and remove sibling pgserve checkout assumptions from CI/version workflows
- start pgserve v2 through the SDK with a daemon CLI fallback using Genie’s existing data dir
- keep serve diagnostics on socket mode and add regression coverage for the daemon path

## Verification
- bun test src/lib/db.test.ts src/term-commands/serve.test.ts
- bun run typecheck
- bun run build
- bun run lint
- git diff --check
- YAML parse for ci/version workflows
- isolated pgserve v2 Unix-socket smoke via ./dist/genie.js task list