### PR TITLE
fix(pgserve): prefer bundled daemon sdk

### DIFF
--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -390,6 +390,29 @@ describe('daemon-owned pgserve', () => {
     const body = source.slice(fnStart, source.indexOf('\nfunction maskCredentials', fnStart));
     expect(body).toContain("['daemon', '--data', DATA_DIR, '--log', 'warn']");
   });
+
+  test('daemon startup prefers Genie bundled pgserve over stale global pgserve', () => {
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+
+    const binStart = source.indexOf('function findPgserveDaemonBin');
+    expect(binStart).toBeGreaterThan(-1);
+    const binBody = source.slice(binStart, source.indexOf('\n/** Sleep helper', binStart));
+    const localBinIdx = binBody.indexOf("join(localRoot, 'bin', 'pgserve-wrapper.cjs')");
+    const requireResolveIdx = binBody.indexOf("require.resolve('pgserve/bin/pgserve-wrapper.cjs')");
+    const globalBinIdx = binBody.indexOf("join(homedir(), '.bun', 'bin', 'pgserve')");
+
+    expect(localBinIdx).toBeGreaterThan(-1);
+    expect(requireResolveIdx).toBeGreaterThan(localBinIdx);
+    expect(globalBinIdx).toBeGreaterThan(requireResolveIdx);
+
+    const sdkStart = source.indexOf('async function importPgserveSdk');
+    const ensureStart = source.indexOf('async function tryEnsureDaemonWithSdk');
+    expect(sdkStart).toBeGreaterThan(-1);
+    expect(ensureStart).toBeGreaterThan(sdkStart);
+    const sdkBody = source.slice(sdkStart, ensureStart);
+    expect(sdkBody).toContain('resolveLocalPgserveEntry()');
+    expect(sdkBody.indexOf('pathToFileURL(localEntry).href')).toBeLessThan(sdkBody.indexOf("import('pgserve')"));
+  });
 });
 
 describe('retention cleanup', () => {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -22,6 +22,7 @@ import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileS
 import { createConnection } from 'node:net';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import type postgres from 'postgres';
 import { runMigrations } from './db-migrations.js';
 import { needsSeed, needsSeededTeams, runSeed } from './pg-seed.js';
@@ -187,8 +188,54 @@ function liveDaemonPid(pid: number | null): number | null {
   }
 }
 
-/** Resolve the v2 daemon binary path — local node_modules → global → PATH. */
+function findLocalPgserveRoot(): string | null {
+  const candidates = [
+    // Installed package layout: @automagik/genie/dist/genie.js ->
+    // @automagik/genie/node_modules/pgserve.
+    join(import.meta.dir, '..', 'node_modules', 'pgserve'),
+    // Source checkout layout: src/lib/db.ts -> ./node_modules/pgserve.
+    join(import.meta.dir, '..', '..', 'node_modules', 'pgserve'),
+  ];
+  for (const root of candidates) {
+    if (existsSync(join(root, 'package.json'))) return root;
+  }
+  return null;
+}
+
+function resolveLocalPgserveEntry(): string | null {
+  const root = findLocalPgserveRoot();
+  if (root === null) return null;
+  try {
+    const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8')) as { main?: string };
+    return join(root, pkg.main ?? 'src/index.js');
+  } catch {
+    return join(root, 'src/index.js');
+  }
+}
+
+async function importPgserveSdk(): Promise<PgserveSdk | null> {
+  const localEntry = resolveLocalPgserveEntry();
+  if (localEntry !== null && existsSync(localEntry)) {
+    try {
+      return (await import(pathToFileURL(localEntry).href)) as PgserveSdk;
+    } catch {
+      /* fall back to package resolution */
+    }
+  }
+  try {
+    return (await import('pgserve')) as PgserveSdk;
+  } catch {
+    return null;
+  }
+}
+
+/** Resolve the v2 daemon binary path — bundled dependency → global → PATH. */
 function findPgserveDaemonBin(): string | null {
+  const localRoot = findLocalPgserveRoot();
+  if (localRoot !== null) {
+    const localBin = join(localRoot, 'bin', 'pgserve-wrapper.cjs');
+    if (existsSync(localBin)) return localBin;
+  }
   try {
     const resolved = require.resolve('pgserve/bin/pgserve-wrapper.cjs');
     if (existsSync(resolved)) return resolved;
@@ -374,12 +421,8 @@ async function waitForDaemonSocket(bin: string): Promise<void> {
 }
 
 async function tryEnsureDaemonWithSdk(): Promise<boolean> {
-  let sdk: PgserveSdk;
-  try {
-    sdk = (await import('pgserve')) as PgserveSdk;
-  } catch {
-    return false;
-  }
+  const sdk = await importPgserveSdk();
+  if (sdk === null) return false;
   if (typeof sdk.ensureDaemon !== 'function') return false;
 
   const timeoutMs = Number(process.env.GENIE_PGSERVE_TIMEOUT) || 16000;


### PR DESCRIPTION
## Summary
- resolve pgserve from @automagik/genie/node_modules before any hoisted/global pgserve package
- import the bundled SDK entry first so stale global pgserve versions cannot shadow the packaged dependency
- keep global/PATH fallback for source and recovery cases

## Verification
- bun test src/lib/db.test.ts
- bun run typecheck
- bun run build
- bun run lint
- git diff --check