### PR TITLE
fix(pgserve): tolerate slow socket startup

### DIFF
--- a/src/lib/__tests__/edge-cases-stability.test.ts
+++ b/src/lib/__tests__/edge-cases-stability.test.ts
@@ -84,8 +84,9 @@ describe('7.1 Concurrent Operations', () => {
     expect(source).toContain('max: 50');
     // Aggressive idle timeout (1s) to recycle unused connections
     expect(source).toContain('idle_timeout: 1');
-    // 5s connect timeout prevents hanging
-    expect(source).toContain('connect_timeout: 5');
+    // Socket mode gets the pgserve startup window; legacy TCP keeps the fast fallback.
+    expect(source).toContain('connect_timeout: resolvePgConnectTimeoutSeconds(useSocket)');
+    expect(source).toContain('if (!useSocket) return 5');
   });
 
   // -------------------------------------------------------------------------

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -368,6 +368,22 @@ describe('daemon-owned pgserve', () => {
     expect(connectionConfig).toContain('[PG_AUTH_FIELD]: pgWireCredential');
   });
 
+  test('socket connections use the pgserve startup timeout window', () => {
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    const helperStart = source.indexOf('function resolvePgConnectTimeoutSeconds');
+    expect(helperStart).toBeGreaterThan(-1);
+    const helperBody = source.slice(helperStart, source.indexOf('\n/** Back-compat', helperStart));
+
+    expect(helperBody).toContain('process.env.GENIE_PG_CONNECT_TIMEOUT');
+    expect(helperBody).toContain('if (!useSocket) return 5');
+    expect(helperBody).toContain('Math.max(16, Math.ceil(resolvePgserveTimeoutMs() / 1000))');
+
+    const connectionStart = source.indexOf('sqlClient = pgModule({');
+    expect(connectionStart).toBeGreaterThan(-1);
+    const connectionConfig = source.slice(connectionStart, source.indexOf('  });', connectionStart));
+    expect(connectionConfig).toContain('connect_timeout: resolvePgConnectTimeoutSeconds(useSocket)');
+  });
+
   test('socket connections ensure the v2 daemon before dialing libpq path', () => {
     const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
     const fnStart = source.indexOf('async function _buildConnection');
@@ -412,6 +428,25 @@ describe('daemon-owned pgserve', () => {
     const sdkBody = source.slice(sdkStart, ensureStart);
     expect(sdkBody).toContain('resolveLocalPgserveEntry()');
     expect(sdkBody.indexOf('pathToFileURL(localEntry).href')).toBeLessThan(sdkBody.indexOf("import('pgserve')"));
+  });
+
+  test('daemon startup falls back to CLI when SDK ensure fails', () => {
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    const fnStart = source.indexOf('async function tryEnsureDaemonWithSdk');
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnBody = source.slice(fnStart, source.indexOf('/** Sanitize connection URLs', fnStart));
+
+    const tryIdx = fnBody.indexOf('try {');
+    const ensureIdx = fnBody.indexOf('const state = await sdk.ensureDaemon');
+    const catchIdx = fnBody.indexOf('} catch {');
+    const cleanupIdx = fnBody.indexOf('cleanPartialDaemonState(probePgserveDaemon())');
+    const falseIdx = fnBody.indexOf('return false', catchIdx);
+
+    expect(tryIdx).toBeGreaterThan(-1);
+    expect(ensureIdx).toBeGreaterThan(tryIdx);
+    expect(catchIdx).toBeGreaterThan(ensureIdx);
+    expect(cleanupIdx).toBeGreaterThan(catchIdx);
+    expect(falseIdx).toBeGreaterThan(cleanupIdx);
   });
 });
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -100,6 +100,18 @@ export function resolvePgserveAuthPassword(): string {
   return password && password.length > 0 ? password : DB_NAME;
 }
 
+function resolvePgserveTimeoutMs(): number {
+  const parsed = Number(process.env.GENIE_PGSERVE_TIMEOUT);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 16000;
+}
+
+function resolvePgConnectTimeoutSeconds(useSocket: boolean): number {
+  const parsed = Number(process.env.GENIE_PG_CONNECT_TIMEOUT);
+  if (Number.isFinite(parsed) && parsed > 0) return Math.ceil(parsed);
+  if (!useSocket) return 5;
+  return Math.max(16, Math.ceil(resolvePgserveTimeoutMs() / 1000));
+}
+
 /** Back-compat name for the legacy/test TCP path. */
 export function resolveTcpPgPassword(): string {
   return resolvePgserveAuthPassword();
@@ -409,7 +421,7 @@ function requirePgserveDaemonBin(): string {
 
 async function waitForDaemonSocket(bin: string): Promise<void> {
   const socketPath = resolvePgserveLibpqSocketPath();
-  const timeout = Number(process.env.GENIE_PGSERVE_TIMEOUT) || 16000;
+  const timeout = resolvePgserveTimeoutMs();
   const deadline = Date.now() + timeout;
   while (Date.now() < deadline) {
     if (existsSync(socketPath)) return;
@@ -425,14 +437,18 @@ async function tryEnsureDaemonWithSdk(): Promise<boolean> {
   if (sdk === null) return false;
   if (typeof sdk.ensureDaemon !== 'function') return false;
 
-  const timeoutMs = Number(process.env.GENIE_PGSERVE_TIMEOUT) || 16000;
-  const state = await sdk.ensureDaemon({
-    dataDir: DATA_DIR,
-    logLevel: 'warn',
-    timeoutMs,
-    controlSocketDir: resolvePgserveSocketDir(),
-  });
-  return Boolean(state.running && (state.libpqSocketPresent ?? state.socketPresent ?? true));
+  try {
+    const state = await sdk.ensureDaemon({
+      dataDir: DATA_DIR,
+      logLevel: 'warn',
+      timeoutMs: resolvePgserveTimeoutMs(),
+      controlSocketDir: resolvePgserveSocketDir(),
+    });
+    return Boolean(state.running && (state.libpqSocketPresent ?? state.socketPresent ?? true));
+  } catch {
+    cleanPartialDaemonState(probePgserveDaemon());
+    return false;
+  }
 }
 
 /** Sanitize connection URLs for logging — never expose credentials */
@@ -1255,7 +1271,7 @@ async function _buildConnection(): Promise<any> {
     [PG_AUTH_FIELD]: pgWireCredential,
     max: 50,
     idle_timeout: 1,
-    connect_timeout: 5,
+    connect_timeout: resolvePgConnectTimeoutSeconds(useSocket),
     onnotice: () => {},
     connection: {
       client_min_messages: 'warning',


### PR DESCRIPTION
## Summary
- extend socket-mode postgres.js connect timeout to the pgserve startup window while preserving the 5s TCP fallback
- fall back to the bundled pgserve CLI when SDK ensureDaemon times out or throws
- add regression coverage for socket timeout config and SDK fallback behavior

## Verification
- bun test src/lib/db.test.ts src/lib/__tests__/edge-cases-stability.test.ts
- bun run typecheck
- bun run lint
- bun run build
- bun run check:fast
- git diff --check