### PR TITLE
fix(pgserve): launch bundled daemon with active bun

### DIFF
--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -404,22 +404,35 @@ describe('daemon-owned pgserve', () => {
     const fnStart = source.indexOf('export async function getOrStartDaemon');
     expect(fnStart).toBeGreaterThan(-1);
     const body = source.slice(fnStart, source.indexOf('\nfunction maskCredentials', fnStart));
-    expect(body).toContain("['daemon', '--data', DATA_DIR, '--log', 'warn']");
+    expect(body).toContain("'daemon', '--data', DATA_DIR, '--log', 'warn'");
   });
 
-  test('daemon startup prefers Genie bundled pgserve over stale global pgserve', () => {
+  test('daemon startup prefers Genie bundled pgserve with active Bun runtime', () => {
     const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
 
-    const binStart = source.indexOf('function findPgserveDaemonBin');
+    const binStart = source.indexOf('function findPgserveDaemonCommand');
     expect(binStart).toBeGreaterThan(-1);
     const binBody = source.slice(binStart, source.indexOf('\n/** Sleep helper', binStart));
-    const localBinIdx = binBody.indexOf("join(localRoot, 'bin', 'pgserve-wrapper.cjs')");
+    const localBinIdx = binBody.indexOf('resolvePgservePackageCommand(localRoot)');
     const requireResolveIdx = binBody.indexOf("require.resolve('pgserve/bin/pgserve-wrapper.cjs')");
     const globalBinIdx = binBody.indexOf("join(homedir(), '.bun', 'bin', 'pgserve')");
 
     expect(localBinIdx).toBeGreaterThan(-1);
     expect(requireResolveIdx).toBeGreaterThan(localBinIdx);
     expect(globalBinIdx).toBeGreaterThan(requireResolveIdx);
+
+    const packageStart = source.indexOf('function resolvePgservePackageCommand');
+    expect(packageStart).toBeGreaterThan(-1);
+    const packageBody = source.slice(packageStart, source.indexOf('\nfunction findBunRuntime', packageStart));
+    expect(packageBody).toContain("join(root, 'bin', 'postgres-server.js')");
+    expect(packageBody).toContain('argsPrefix: [script]');
+    expect(packageBody).toContain("join(root, 'bin', 'pgserve-wrapper.cjs')");
+
+    const bunStart = source.indexOf('function findBunRuntime');
+    expect(bunStart).toBeGreaterThan(-1);
+    const bunBody = source.slice(bunStart, source.indexOf('\n/** Sleep helper', bunStart));
+    expect(bunBody).toContain('process.execPath');
+    expect(bunBody).toContain('which bun');
 
     const sdkStart = source.indexOf('async function importPgserveSdk');
     const ensureStart = source.indexOf('async function tryEnsureDaemonWithSdk');
@@ -428,6 +441,17 @@ describe('daemon-owned pgserve', () => {
     const sdkBody = source.slice(sdkStart, ensureStart);
     expect(sdkBody).toContain('resolveLocalPgserveEntry()');
     expect(sdkBody.indexOf('pathToFileURL(localEntry).href')).toBeLessThan(sdkBody.indexOf("import('pgserve')"));
+  });
+
+  test('daemon startup surfaces child exit before socket timeout', () => {
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    const waitStart = source.indexOf('async function waitForDaemonSocket');
+    expect(waitStart).toBeGreaterThan(-1);
+    const waitBody = source.slice(waitStart, source.indexOf('\nasync function tryEnsureDaemonWithSdk', waitStart));
+
+    expect(waitBody).toContain("child?.once('exit'");
+    expect(waitBody).toContain('pgserve v2 daemon exited before binding');
+    expect(waitBody).toContain('formatPgserveDaemonCommand(daemonCommand)');
   });
 
   test('daemon startup falls back to CLI when SDK ensure fails', () => {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -21,7 +21,7 @@ import { type ChildProcess, execFileSync, execSync, spawn } from 'node:child_pro
 import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
 import { createConnection } from 'node:net';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type postgres from 'postgres';
 import { runMigrations } from './db-migrations.js';
@@ -158,6 +158,12 @@ interface PgserveSdk {
   }) => Promise<PgserveSdkDaemonState>;
 }
 
+interface PgserveDaemonCommand {
+  command: string;
+  argsPrefix: string[];
+  display: string;
+}
+
 /**
  * Probe the v2 daemon. Returns running=true only when both the libpq socket
  * file exists AND the recorded pid is alive. A pid file with no socket (or
@@ -243,23 +249,53 @@ async function importPgserveSdk(): Promise<PgserveSdk | null> {
   }
 }
 
-/** Resolve the v2 daemon binary path — bundled dependency → global → PATH. */
-function findPgserveDaemonBin(): string | null {
+/** Resolve the v2 daemon command — bundled dependency → global → PATH. */
+function findPgserveDaemonCommand(): PgserveDaemonCommand | null {
   const localRoot = findLocalPgserveRoot();
   if (localRoot !== null) {
-    const localBin = join(localRoot, 'bin', 'pgserve-wrapper.cjs');
-    if (existsSync(localBin)) return localBin;
+    const localCommand = resolvePgservePackageCommand(localRoot);
+    if (localCommand !== null) return localCommand;
   }
   try {
     const resolved = require.resolve('pgserve/bin/pgserve-wrapper.cjs');
-    if (existsSync(resolved)) return resolved;
+    const packageCommand = resolvePgservePackageCommand(join(dirname(resolved), '..'));
+    if (packageCommand !== null) return packageCommand;
   } catch {
     /* not in local deps */
   }
   const globalBin = join(homedir(), '.bun', 'bin', 'pgserve');
-  if (existsSync(globalBin)) return globalBin;
+  if (existsSync(globalBin)) return { command: globalBin, argsPrefix: [], display: globalBin };
   try {
     const fromPath = execSync('which pgserve', { encoding: 'utf-8', timeout: 3000 }).trim();
+    if (fromPath.length > 0) return { command: fromPath, argsPrefix: [], display: fromPath };
+  } catch {
+    /* not on PATH */
+  }
+  return null;
+}
+
+function resolvePgservePackageCommand(root: string): PgserveDaemonCommand | null {
+  const script = join(root, 'bin', 'postgres-server.js');
+  const bun = findBunRuntime();
+  if (existsSync(script) && bun !== null) {
+    return { command: bun, argsPrefix: [script], display: `${bun} ${script}` };
+  }
+
+  const wrapper = join(root, 'bin', 'pgserve-wrapper.cjs');
+  if (existsSync(wrapper)) return { command: wrapper, argsPrefix: [], display: wrapper };
+  return null;
+}
+
+function findBunRuntime(): string | null {
+  if (process.execPath && existsSync(process.execPath) && basename(process.execPath).startsWith('bun')) {
+    return process.execPath;
+  }
+
+  const homeBun = join(homedir(), '.bun', 'bin', process.platform === 'win32' ? 'bun.exe' : 'bun');
+  if (existsSync(homeBun)) return homeBun;
+
+  try {
+    const fromPath = execSync('which bun', { encoding: 'utf-8', timeout: 3000 }).trim();
     if (fromPath.length > 0) return fromPath;
   } catch {
     /* not on PATH */
@@ -455,38 +491,62 @@ function unlinkIfPresent(path: string): void {
 
 async function startPgserveDaemonOnce(initial: DaemonState): Promise<void> {
   cleanPartialDaemonState(initial);
-  if (await tryEnsureDaemonWithSdk()) return;
-  const bin = requirePgserveDaemonBin();
+  const daemonCommand = findPgserveDaemonCommand();
+  if (daemonCommand === null) {
+    if (await tryEnsureDaemonWithSdk()) return;
+    throw new Error(
+      'pgserve binary not found. Install with `bun add pgserve@^2.0.2` (or `npm i pgserve@^2.0.2`), or start `pgserve daemon` manually before running genie.',
+    );
+  }
   mkdirSync(resolvePgserveSocketDir(), { recursive: true, mode: 0o700 });
 
-  const child = spawn(bin, ['daemon', '--data', DATA_DIR, '--log', 'warn'], {
-    detached: true,
-    stdio: 'ignore',
-    env: { ...process.env },
-  });
-  child.unref();
-  await waitForDaemonSocket(bin);
-}
-
-function requirePgserveDaemonBin(): string {
-  const bin = findPgserveDaemonBin();
-  if (bin !== null) return bin;
-  throw new Error(
-    'pgserve binary not found. Install with `bun add pgserve@^2.0.2` (or `npm i pgserve@^2.0.2`), or start `pgserve daemon` manually before running genie.',
+  const child = spawn(
+    daemonCommand.command,
+    [...daemonCommand.argsPrefix, 'daemon', '--data', DATA_DIR, '--log', 'warn'],
+    {
+      detached: true,
+      stdio: 'ignore',
+      env: { ...process.env },
+    },
   );
+  try {
+    await waitForDaemonSocket(daemonCommand, child);
+    child.unref();
+  } catch (err) {
+    await terminatePgserveTree(child);
+    throw err;
+  }
 }
 
-async function waitForDaemonSocket(bin: string): Promise<void> {
+async function waitForDaemonSocket(daemonCommand: PgserveDaemonCommand, child?: ChildProcess): Promise<void> {
   const socketPath = resolvePgserveLibpqSocketPath();
   const timeout = resolvePgserveTimeoutMs();
   const deadline = Date.now() + timeout;
+  let childExit: string | null = null;
+  child?.once('exit', (code, signal) => {
+    childExit = signal ? `signal ${signal}` : `exit code ${code ?? 'unknown'}`;
+  });
+
   while (Date.now() < deadline) {
     if (existsSync(socketPath) && (await isPgserveSocketResponsive())) return;
+    if (childExit !== null) {
+      throw new Error(
+        `pgserve v2 daemon exited before binding ${socketPath} (${childExit}). Try starting it manually: ${formatPgserveDaemonCommand(
+          daemonCommand,
+        )}`,
+      );
+    }
     await sleep(250);
   }
   throw new Error(
-    `pgserve v2 daemon did not bind ${socketPath} within ${Math.round(timeout / 1000)}s. Try starting it manually: ${bin} daemon`,
+    `pgserve v2 daemon did not bind ${socketPath} within ${Math.round(
+      timeout / 1000,
+    )}s. Try starting it manually: ${formatPgserveDaemonCommand(daemonCommand)}`,
   );
+}
+
+function formatPgserveDaemonCommand(daemonCommand: PgserveDaemonCommand): string {
+  return `${daemonCommand.display} daemon --data ${DATA_DIR} --log warn`;
 }
 
 async function tryEnsureDaemonWithSdk(): Promise<boolean> {


### PR DESCRIPTION
## Summary
- launch bundled pgserve via the active Bun runtime and pgserve's postgres-server.js instead of the wrapper that cannot see Bun's global hoisted runtime
- keep wrapper/global pgserve fallbacks for non-bundled layouts
- surface daemon child exit before waiting the full socket timeout

## Local dogfood on this Mac
- genie update --next installed 4.260430.1, but genie task list failed after 32s because bundled pgserve-wrapper.cjs could not find Bun under @automagik/genie/node_modules
- direct installed script works: /Users/feliperosa/.bun/bin/bun .../@automagik/genie/node_modules/pgserve/bin/postgres-server.js daemon ... bound /tmp/.../pgserve/control.sock
- patched source, clean real-state start from empty /tmp/pgserve: bun /private/tmp/genie-pgserve-resolve/src/genie.ts serve start --daemon -> pgserve healthy, hook socket listening, scheduler integrated
- patched source db query 'select 1 as ok' returned 1
- patched source ls returned the genie agent instead of empty state
- captured genie-tui pane showed Agents 0/1 and the genie tree; no new CONNECT_TIMEOUT after patched TUI launch

## Verification
- bun test src/lib/db.test.ts
- bun run build
- bun run check:fast
- git diff --check
