### PR TITLE
fix(tui): use listAgentsForRender to drop shadow rows from work-state refresh (#1521 Gap #1)

### DIFF
--- a/src/tui/db.ts
+++ b/src/tui/db.ts
@@ -84,10 +84,15 @@ function mapAssignment(row: Record<string, unknown>): TuiAssignment {
  * Nav.tsx switch on `wsAgentState` with a unified work-state badge.
  */
 export async function loadAgentWorkStates(): Promise<Map<string, WorkState>> {
-  const { listAgents } = await import('../lib/agent-registry.js');
+  const { listAgentsForRender } = await import('../lib/agent-registry.js');
   const { shouldResume, BOOT_PASS_CONCURRENCY_CAP } = await import('../lib/should-resume.js');
 
-  const agents = await listAgents({ includeArchived: false });
+  // Render-path variant — drops bare-name shadow rows (`dir:*`, pre-UUID
+  // names) so the TUI work-state refresh stops feeding `shouldResume()`
+  // entity_ids that aren't real runtime agents. Each shadow row would
+  // otherwise emit `resume.missing_session` per refresh tick (Gap #1 of
+  // #1521 — `resume.lost_anchor` ghost alerts in idle workspaces).
+  const agents = await listAgentsForRender({ includeArchived: false });
   if (agents.length === 0) return new Map();
 
   const out = new Map<string, WorkState>();


### PR DESCRIPTION
## Summary

Two-line fix for **Gap #1** of #1521. `loadAgentWorkStates` (TUI work-state refresh) was calling `listAgents`, which includes bare-name shadow rows (`dir:*`, pre-UUID names). Each shadow row's missing session caused `shouldResume()` to write `resume.missing_session`, crossing `LostAnchorDetector`'s 3-in-5min threshold and producing ghost `[stuck]`/`[paused]` alerts that never expired (the TUI itself was the writer).

Switch to `listAgentsForRender` — already used by `genie status` and explicitly documented for this case. Drops 4 of the 12 ghost alerts identified in the issue.

## Companion fix

The companion fix for **Gap #2** (move `resume.missing_session` emission from read path to scheduler) shipped via `05fb187b` (#1532). Gap #3 was structural cleanup the issue body itself flagged as "land regardless" — out of scope here.

## Test plan

- [x] `bun test src/tui/db.test.ts src/lib/agent-registry.test.ts` — 95 pass
- [x] `bun run typecheck` clean
- [x] `listAgentsForRender` is already covered by 5 unit tests in `agent-registry.test.ts:914-1029` (dedup semantics) — this PR is a function-name swap with identical signature, no new test surface required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)