### PR TITLE
fix(pg): recover stale socket-mode clients

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1494,6 +1494,14 @@ export function getActivePort(): number {
 }
 
 /**
+ * Base TCP port for sidecar HTTP services that still need a real local port
+ * even when pgserve itself is connected through the v2 Unix socket.
+ */
+export function getAuxiliaryPortBase(): number {
+  return activePort === SOCKET_PORT_SENTINEL ? getPort() : getActivePort();
+}
+
+/**
  * True when the live connection is the v2 Unix socket. Returns false in TCP
  * mode (legacy + test) and before the first connect.
  *

--- a/src/lib/executor-read.ts
+++ b/src/lib/executor-read.ts
@@ -13,7 +13,7 @@
  * used by consumers that prefer direct SQL over HTTP.
  */
 
-import { type Sql, getActivePort, getConnection } from './db.js';
+import { type Sql, getAuxiliaryPortBase, getConnection } from './db.js';
 import type { ExecutorState, TurnOutcome } from './executor-types.js';
 
 interface ExecutorStateReply {
@@ -55,7 +55,7 @@ export function getExecutorReadPort(): number {
     const parsed = Number.parseInt(envPort, 10);
     if (!Number.isNaN(parsed) && parsed > 0 && parsed < 65536) return parsed;
   }
-  return getActivePort() + 2;
+  return getAuxiliaryPortBase() + 2;
 }
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;

--- a/src/lib/otel-receiver.test.ts
+++ b/src/lib/otel-receiver.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test';
-import { getActivePort } from './db.js';
+import { getAuxiliaryPortBase } from './db.js';
 import {
   getOtelPort,
   isOtelReceiverRunning,
@@ -112,7 +112,7 @@ describe('otel-receiver', () => {
   });
 
   test('getOtelPort returns pgserve port + 1 by default', () => {
-    expect(getOtelPort()).toBe(getActivePort() + 1);
+    expect(getOtelPort()).toBe(getAuxiliaryPortBase() + 1);
   });
 
   test('getOtelPort returns a valid default without env overrides', () => {

--- a/src/lib/otel-receiver.ts
+++ b/src/lib/otel-receiver.ts
@@ -11,7 +11,7 @@
  * Graceful: if port busy, logs warning and returns (non-fatal).
  */
 
-import { getActivePort } from './db.js';
+import { getAuxiliaryPortBase } from './db.js';
 
 // ============================================================================
 // Types — OTLP JSON protocol (subset we care about)
@@ -160,7 +160,7 @@ function parseProbeMax(): number {
 function getConfiguredOtelPort(): { port: number; explicit: boolean } {
   const envPort = parseValidPort(process.env.GENIE_OTEL_PORT);
   if (envPort !== null) return { port: envPort, explicit: true };
-  return { port: getActivePort() + 1, explicit: false };
+  return { port: getAuxiliaryPortBase() + 1, explicit: false };
 }
 
 function getCandidatePorts(startPort: number, explicit: boolean): number[] {

--- a/src/lib/session-filewatch.test.ts
+++ b/src/lib/session-filewatch.test.ts
@@ -23,6 +23,7 @@ import {
   extractSessionInfo,
   handleFileChange,
   isForeignKeyViolation,
+  isTransientPgConnectionError,
   resetUnrecoverableSessions,
 } from './session-filewatch.js';
 
@@ -80,6 +81,25 @@ describe('isForeignKeyViolation', () => {
     expect(isForeignKeyViolation(new Error('ECONNRESET'))).toBe(false);
     expect(isForeignKeyViolation(null)).toBe(false);
     expect(isForeignKeyViolation('string error')).toBe(false);
+  });
+});
+
+describe('isTransientPgConnectionError', () => {
+  test('detects postgres.js socket/pool errors', () => {
+    expect(isTransientPgConnectionError(Object.assign(new Error('pool ended'), { code: 'CONNECTION_ENDED' }))).toBe(
+      true,
+    );
+    expect(isTransientPgConnectionError(new Error('write CONNECTION_DESTROYED /tmp/pgserve/.s.PGSQL.5432'))).toBe(true);
+    expect(isTransientPgConnectionError(new Error('write CONNECT_TIMEOUT /run/user/1000/pgserve/.s.PGSQL.5432'))).toBe(
+      true,
+    );
+  });
+
+  test('rejects unrelated errors', () => {
+    expect(isTransientPgConnectionError(Object.assign(new Error('foreign key constraint'), { code: '23503' }))).toBe(
+      false,
+    );
+    expect(isTransientPgConnectionError(null)).toBe(false);
   });
 });
 
@@ -193,5 +213,42 @@ describe('handleFileChange — FK violation', () => {
     await handleFileChange(filePath, fakeSql, deps);
     expect(ingestCallCount).toBe(2); // retried
     expect(errors.length).toBe(2);
+  });
+
+  test('transient PG connection error resets pool and retries once in same event', async () => {
+    const filePath = makeSubagentFile(tmpRoot, 'parent-123', 'flaky-session-c');
+    const firstSql = { name: 'old' };
+    const freshSql = { name: 'fresh' };
+    const ingestSqls: unknown[] = [];
+    let resetCalls = 0;
+    let getConnectionCalls = 0;
+    const errors: string[] = [];
+
+    const deps = makeDeps({
+      ingestFileFull: async (sql) => {
+        ingestSqls.push(sql);
+        if (ingestSqls.length === 1) {
+          throw Object.assign(new Error('write CONNECTION_ENDED /run/user/1000/pgserve/.s.PGSQL.5432'), {
+            code: 'CONNECTION_ENDED',
+          });
+        }
+        return { newOffset: 42, contentRowsInserted: 1, toolEventsInserted: 0 };
+      },
+      resetConnection: async () => {
+        resetCalls++;
+      },
+      getConnection: async () => {
+        getConnectionCalls++;
+        return freshSql as never;
+      },
+      logError: (msg) => errors.push(msg),
+    });
+
+    await handleFileChange(filePath, firstSql, deps);
+
+    expect(ingestSqls).toEqual([firstSql, freshSql]);
+    expect(resetCalls).toBe(1);
+    expect(getConnectionCalls).toBe(1);
+    expect(errors).toEqual([]);
   });
 });

--- a/src/lib/session-filewatch.ts
+++ b/src/lib/session-filewatch.ts
@@ -10,6 +10,7 @@ import { homedir } from 'node:os';
 import { basename, isAbsolute, join, resolve } from 'node:path';
 import { type FSWatcher, watch } from 'chokidar';
 
+import { getConnection, resetConnection } from './db.js';
 import { buildWorkerMap, ingestFileFull, setLiveWorkPending } from './session-capture.js';
 
 // biome-ignore lint/suspicious/noExplicitAny: postgres.js Sql type
@@ -52,6 +53,21 @@ export function isForeignKeyViolation(err: unknown): boolean {
   if (typeof code === 'string' && code === '23503') return true;
   const message = err instanceof Error ? err.message : String(err);
   return message.toLowerCase().includes('foreign key constraint');
+}
+
+export function isTransientPgConnectionError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const code = (err as { code?: unknown }).code;
+  if (
+    typeof code === 'string' &&
+    ['CONNECTION_ENDED', 'CONNECTION_DESTROYED', 'CONNECT_TIMEOUT', 'ECONNRESET', 'EPIPE'].includes(code)
+  ) {
+    return true;
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return /CONNECTION_ENDED|CONNECTION_DESTROYED|CONNECT_TIMEOUT|ECONNRESET|EPIPE|connection terminated|connection closed|server closed the connection/i.test(
+    message,
+  );
 }
 
 // ============================================================================
@@ -119,6 +135,8 @@ export interface FilewatchDeps {
   ingestFileFull: typeof ingestFileFull;
   setLiveWorkPending: typeof setLiveWorkPending;
   logError: (msg: string) => void;
+  getConnection?: typeof getConnection;
+  resetConnection?: typeof resetConnection;
 }
 
 const defaultDeps: FilewatchDeps = {
@@ -126,7 +144,101 @@ const defaultDeps: FilewatchDeps = {
   ingestFileFull,
   setLiveWorkPending,
   logError: (msg) => console.error(msg),
+  getConnection,
+  resetConnection,
 };
+
+type SessionInfo = NonNullable<ReturnType<typeof extractSessionInfo>>;
+
+async function ingestFileChange(
+  sql: SqlClient,
+  info: SessionInfo,
+  filePath: string,
+  storedOffset: number,
+  deps: FilewatchDeps,
+): Promise<number> {
+  const workerMap = await deps.buildWorkerMap(sql);
+  const result = await deps.ingestFileFull(sql, info.sessionId, filePath, info.projectPath, storedOffset, {
+    parentSessionId: info.parentSessionId,
+    isSubagent: info.isSubagent,
+    workerMap,
+  });
+  return result.newOffset;
+}
+
+function markSessionUnrecoverable(info: SessionInfo, filePath: string, message: string, deps: FilewatchDeps): void {
+  unrecoverableSessions.add(info.sessionId);
+  offsetCache.set(info.sessionId, Number.POSITIVE_INFINITY);
+  deps.logError(
+    `[filewatch] skipping ${filePath} — FK constraint violation (orphan session, parent not registered): ${message}`,
+  );
+}
+
+async function reconnectAfterTransientPgError(err: unknown, deps: FilewatchDeps): Promise<SqlClient | null> {
+  if (!isTransientPgConnectionError(err) || !deps.getConnection || !deps.resetConnection) return null;
+  try {
+    await deps.resetConnection();
+    return await deps.getConnection();
+  } catch {
+    return null;
+  }
+}
+
+async function tryIngestFileChange(
+  sql: SqlClient,
+  info: SessionInfo,
+  filePath: string,
+  storedOffset: number,
+  deps: FilewatchDeps,
+): Promise<{ ok: true; newOffset: number } | { ok: false; error: unknown }> {
+  try {
+    return { ok: true, newOffset: await ingestFileChange(sql, info, filePath, storedOffset, deps) };
+  } catch (err) {
+    return { ok: false, error: err };
+  }
+}
+
+function recordIngestFailure(
+  err: unknown,
+  info: SessionInfo,
+  filePath: string,
+  storedOffset: number,
+  deps: FilewatchDeps,
+): void {
+  const message = err instanceof Error ? err.message : String(err);
+  if (isForeignKeyViolation(err)) {
+    markSessionUnrecoverable(info, filePath, message, deps);
+    return;
+  }
+
+  // Transient error (connection reset, deadlock, etc.) — DO NOT advance
+  // offset. Retry on next write event preserves at-least-once semantics.
+  deps.logError(`[filewatch] error ingesting ${filePath} at offset ${storedOffset}: ${message}`);
+}
+
+async function ingestWithOneReconnect(
+  sql: SqlClient,
+  info: SessionInfo,
+  filePath: string,
+  storedOffset: number,
+  deps: FilewatchDeps,
+): Promise<void> {
+  const first = await tryIngestFileChange(sql, info, filePath, storedOffset, deps);
+  if (first.ok) {
+    offsetCache.set(info.sessionId, first.newOffset);
+    return;
+  }
+
+  const freshSql = await reconnectAfterTransientPgError(first.error, deps);
+  if (!freshSql) {
+    recordIngestFailure(first.error, info, filePath, storedOffset, deps);
+    return;
+  }
+
+  const second = await tryIngestFileChange(freshSql, info, filePath, storedOffset, deps);
+  if (second.ok) offsetCache.set(info.sessionId, second.newOffset);
+  else recordIngestFailure(second.error, info, filePath, storedOffset, deps);
+}
 
 export async function handleFileChange(
   filePath: string,
@@ -144,29 +256,7 @@ export async function handleFileChange(
 
   try {
     deps.setLiveWorkPending(true);
-    const workerMap = await deps.buildWorkerMap(sql);
-    const result = await deps.ingestFileFull(sql, info.sessionId, filePath, info.projectPath, storedOffset, {
-      parentSessionId: info.parentSessionId,
-      isSubagent: info.isSubagent,
-      workerMap,
-    });
-    offsetCache.set(info.sessionId, result.newOffset);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (isForeignKeyViolation(err)) {
-      // Unrecoverable at this layer — orphan subagent, parent not in sessions
-      // table. Pin offset to Infinity and mark the session so subsequent
-      // fs.watch events skip ingest entirely. Log once.
-      unrecoverableSessions.add(info.sessionId);
-      offsetCache.set(info.sessionId, Number.POSITIVE_INFINITY);
-      deps.logError(
-        `[filewatch] skipping ${filePath} — FK constraint violation (orphan session, parent not registered): ${message}`,
-      );
-    } else {
-      // Transient error (connection reset, deadlock, etc.) — DO NOT advance
-      // offset. Retry on next write event preserves at-least-once semantics.
-      deps.logError(`[filewatch] error ingesting ${filePath} at offset ${storedOffset}: ${message}`);
-    }
+    await ingestWithOneReconnect(sql, info, filePath, storedOffset, deps);
   } finally {
     deps.setLiveWorkPending(false);
   }
@@ -180,7 +270,7 @@ function normalizeWatchEventPath(claudeDir: string, filePath: string): string {
   return isAbsolute(filePath) ? filePath : resolve(claudeDir, filePath);
 }
 
-function scheduleFileChange(filePath: string, sql: SqlClient): void {
+function scheduleFileChange(filePath: string): void {
   if (!filePath.endsWith('.jsonl')) return;
 
   const existing = debounceTimers.get(filePath);
@@ -190,10 +280,12 @@ function scheduleFileChange(filePath: string, sql: SqlClient): void {
     filePath,
     setTimeout(() => {
       debounceTimers.delete(filePath);
-      handleFileChange(filePath, sql).catch((err) => {
-        const message = err instanceof Error ? err.message : String(err);
-        console.error(`[filewatch] unhandled error for ${filePath}: ${message}`);
-      });
+      getConnection()
+        .then((freshSql) => handleFileChange(filePath, freshSql))
+        .catch((err) => {
+          const message = err instanceof Error ? err.message : String(err);
+          console.error(`[filewatch] unhandled error for ${filePath}: ${message}`);
+        });
     }, DEBOUNCE_MS),
   );
 }
@@ -234,7 +326,7 @@ export async function startFilewatch(sql: SqlClient): Promise<boolean> {
   await loadOffsets(sql);
 
   try {
-    watcher = createJsonlWatcher(claudeDir, (fullPath) => scheduleFileChange(fullPath, sql));
+    watcher = createJsonlWatcher(claudeDir, (fullPath) => scheduleFileChange(fullPath));
 
     watcher.on('error', (err) => {
       const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary\n- reconnect session filewatch ingestion through fresh pgserve socket connections and retry once on transient pool failures\n- route executor-read and OTel sidecar ports from the configured TCP base when pgserve v2 uses Unix socket mode\n\n## Verification\n- bun test src/lib/session-filewatch.test.ts src/lib/db.test.ts\n- bun test src/lib/executor-read.test.ts src/lib/otel-receiver.test.ts src/lib/db.test.ts\n- bun run typecheck\n- bun run check:fast\n- dogfood: source genie serve with patched pgserve, TUI session renders, db query passes, executor read endpoint healthy on 19644