### PR TITLE
feat(hooks): trust allowlist + loader + genie hook trust CLI (absorption D3+D4)

### DIFF
--- a/src/hooks/__tests__/loader.test.ts
+++ b/src/hooks/__tests__/loader.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Loader tests — Group 1 of hookify-third-party-absorption.
+ *
+ * Asserts the boot-scan flow: discover three S3 tiers → trust-gate every file
+ * → dynamic-import survivors → validate exports → register. Untrusted files
+ * are rejected; broken files are quarantined; same-name collisions emit warn
+ * (or throw under --strict).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { defineHook } from '../define-hook.js';
+import { getRegistry, setRegistry } from '../index.js';
+import { discoverHooks, loadExternalHooks } from '../loader.js';
+import { type TrustFile, sha256OfFile } from '../trust.js';
+
+let tmpRoot: string;
+let trustPath: string;
+let savedRegistry: ReturnType<typeof getRegistry>;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'genie-loader-test-'));
+  trustPath = join(tmpRoot, 'trusted.json');
+  savedRegistry = getRegistry();
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+  // Restore the canonical registry so other test files see builtins only.
+  setRegistry(savedRegistry);
+});
+
+function writeHookFile(dir: string, name: string, body: string): string {
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, name);
+  writeFileSync(path, body, 'utf-8');
+  return path;
+}
+
+function writeTrust(entries: TrustFile['entries']): void {
+  mkdirSync(join(tmpRoot, 'trust'), { recursive: true });
+  writeFileSync(trustPath, JSON.stringify({ version: 1, entries }, null, 2), 'utf-8');
+}
+
+const sampleHookSource = `
+const handler = {
+  version: '1',
+  source: 'global',
+  manifest_path: '<placeholder>',
+  name: 'sample',
+  event: 'PreToolUse',
+  matcher: /^Bash$/,
+  priority: 50,
+  fn: async () => undefined,
+};
+export default handler;
+`;
+
+describe('discoverHooks', () => {
+  test('finds .ts files under repoRoot/.genie/hooks/', () => {
+    const repoRoot = join(tmpRoot, 'repo');
+    writeHookFile(join(repoRoot, '.genie', 'hooks'), 'one.ts', 'export default {};');
+    writeHookFile(join(repoRoot, '.genie', 'hooks'), 'two.ts', 'export default {};');
+    const found = discoverHooks({ repoRoot });
+    const repoEntries = found.filter((d) => d.scope === 'repo');
+    expect(repoEntries).toHaveLength(2);
+  });
+
+  test('skips _quarantine and dotfiles', () => {
+    const repoRoot = join(tmpRoot, 'repo');
+    writeHookFile(join(repoRoot, '.genie', 'hooks'), '_skip.ts', 'export default {};');
+    writeHookFile(join(repoRoot, '.genie', 'hooks'), 'real.ts', 'export default {};');
+    const found = discoverHooks({ repoRoot });
+    const names = found.filter((d) => d.scope === 'repo').map((d) => d.path.split('/').pop());
+    expect(names).toEqual(['real.ts']);
+  });
+
+  test('skips test files', () => {
+    const repoRoot = join(tmpRoot, 'repo');
+    writeHookFile(join(repoRoot, '.genie', 'hooks'), 'real.ts', 'export default {};');
+    writeHookFile(join(repoRoot, '.genie', 'hooks'), 'real.test.ts', 'export default {};');
+    const found = discoverHooks({ repoRoot });
+    const names = found.filter((d) => d.scope === 'repo').map((d) => d.path.split('/').pop());
+    expect(names).toEqual(['real.ts']);
+  });
+});
+
+describe('loadExternalHooks — trust gate', () => {
+  test('rejects untrusted files (filesystem-presence is not consent)', async () => {
+    const repoRoot = join(tmpRoot, 'repo');
+    writeHookFile(join(repoRoot, '.genie', 'hooks'), 'untrusted.ts', sampleHookSource);
+    writeTrust([]);
+
+    const outcomes = await loadExternalHooks({ repoRoot, trustPath });
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0].kind).toBe('untrusted');
+    if (outcomes[0].kind === 'untrusted') expect(outcomes[0].reason).toBe('not_in_trust_file');
+
+    // Registry only has builtins after rejection.
+    const registry = getRegistry();
+    expect(registry.every((h) => h.source === 'builtin')).toBe(true);
+  });
+
+  test('loads a trusted file with matching SHA', async () => {
+    const repoRoot = join(tmpRoot, 'repo');
+    const filePath = writeHookFile(join(repoRoot, '.genie', 'hooks'), 'trusted.ts', sampleHookSource);
+    writeTrust([
+      { path: filePath, sha256: sha256OfFile(filePath), scope: 'global', trustedAt: '2026-04-29T00:00:00Z' },
+    ]);
+
+    const outcomes = await loadExternalHooks({ repoRoot, trustPath });
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0].kind).toBe('loaded');
+
+    const registry = getRegistry();
+    const sample = registry.find((h) => h.name === 'sample');
+    expect(sample).toBeDefined();
+    expect(sample?.source).toBe('repo'); // loader stamps tier source over author-supplied placeholder
+    expect(sample?.manifest_path).toBe(filePath);
+  });
+
+  test('rejects a trusted file after its SHA changes (post-edit)', async () => {
+    const repoRoot = join(tmpRoot, 'repo');
+    const filePath = writeHookFile(join(repoRoot, '.genie', 'hooks'), 'edited.ts', sampleHookSource);
+    const originalSha = sha256OfFile(filePath);
+    writeTrust([{ path: filePath, sha256: originalSha, scope: 'global', trustedAt: '2026-04-29T00:00:00Z' }]);
+    writeFileSync(filePath, `${sampleHookSource}\n// added a comment after trusting`, 'utf-8');
+
+    const outcomes = await loadExternalHooks({ repoRoot, trustPath });
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0].kind).toBe('untrusted');
+    if (outcomes[0].kind === 'untrusted') expect(outcomes[0].reason).toBe('sha256_mismatch');
+  });
+});
+
+describe('loadExternalHooks — validation + quarantine', () => {
+  test('quarantines a file whose default export is invalid', async () => {
+    const repoRoot = join(tmpRoot, 'repo');
+    const filePath = writeHookFile(
+      join(repoRoot, '.genie', 'hooks'),
+      'invalid.ts',
+      `export default { name: 'x' };`, // missing version, event, priority, fn
+    );
+    writeTrust([
+      { path: filePath, sha256: sha256OfFile(filePath), scope: 'global', trustedAt: '2026-04-29T00:00:00Z' },
+    ]);
+
+    const outcomes = await loadExternalHooks({ repoRoot, trustPath });
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0].kind).toBe('broken');
+
+    const quarantineDir = join(repoRoot, '.genie', 'hooks', '_quarantine');
+    expect(existsSync(quarantineDir)).toBe(true);
+    expect(existsSync(join(quarantineDir, 'invalid.ts'))).toBe(true);
+    expect(existsSync(join(quarantineDir, 'invalid.ts.error'))).toBe(true);
+  });
+
+  test('rejects unknown handler.version', async () => {
+    const repoRoot = join(tmpRoot, 'repo');
+    const filePath = writeHookFile(
+      join(repoRoot, '.genie', 'hooks'),
+      'wrong-version.ts',
+      `export default { version: '99', name: 'x', event: 'PreToolUse', priority: 1, fn: async () => undefined };`,
+    );
+    writeTrust([
+      { path: filePath, sha256: sha256OfFile(filePath), scope: 'global', trustedAt: '2026-04-29T00:00:00Z' },
+    ]);
+
+    const outcomes = await loadExternalHooks({ repoRoot, trustPath });
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0].kind).toBe('broken');
+    if (outcomes[0].kind === 'broken') expect(outcomes[0].error).toContain('unknown handler version');
+  });
+});
+
+describe('loadExternalHooks — name collision shadowing', () => {
+  test('warns and reports shadowed when same name appears in two files', async () => {
+    const repoRoot = join(tmpRoot, 'repo');
+    const f1 = writeHookFile(join(repoRoot, '.genie', 'hooks'), 'a.ts', sampleHookSource);
+    const f2 = writeHookFile(join(repoRoot, '.genie', 'hooks'), 'b.ts', sampleHookSource);
+    writeTrust([
+      { path: f1, sha256: sha256OfFile(f1), scope: 'global', trustedAt: '2026-04-29T00:00:00Z' },
+      { path: f2, sha256: sha256OfFile(f2), scope: 'global', trustedAt: '2026-04-29T00:00:00Z' },
+    ]);
+
+    const outcomes = await loadExternalHooks({ repoRoot, trustPath });
+    expect(outcomes).toHaveLength(2);
+    expect(outcomes[0].kind).toBe('loaded');
+    expect(outcomes[1].kind).toBe('shadowed');
+
+    const registry = getRegistry();
+    expect(registry.filter((h) => h.name === 'sample')).toHaveLength(1);
+  });
+
+  test('--strict-hooks throws on collision', async () => {
+    const repoRoot = join(tmpRoot, 'repo');
+    const f1 = writeHookFile(join(repoRoot, '.genie', 'hooks'), 'a.ts', sampleHookSource);
+    const f2 = writeHookFile(join(repoRoot, '.genie', 'hooks'), 'b.ts', sampleHookSource);
+    writeTrust([
+      { path: f1, sha256: sha256OfFile(f1), scope: 'global', trustedAt: '2026-04-29T00:00:00Z' },
+      { path: f2, sha256: sha256OfFile(f2), scope: 'global', trustedAt: '2026-04-29T00:00:00Z' },
+    ]);
+
+    await expect(loadExternalHooks({ repoRoot, trustPath, strict: true })).rejects.toThrow(/--strict-hooks/);
+  });
+});
+
+describe('loadExternalHooks — defineHook integration', () => {
+  test('handlers built via defineHook validate and register', async () => {
+    // Sanity: a defineHook-produced object passes the loader's validateHandler.
+    const handler = defineHook({
+      name: 'integration',
+      event: 'PreToolUse',
+      run: async () => undefined,
+    });
+    expect(handler.version).toBe('1');
+    expect(typeof handler.fn).toBe('function');
+  });
+});

--- a/src/hooks/__tests__/trust.test.ts
+++ b/src/hooks/__tests__/trust.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Trust allowlist tests — Group 1 of hookify-third-party-absorption.
+ *
+ * Asserts the security boundary: filesystem-presence is NOT consent. A file
+ * that doesn't appear in `trusted.json` with a matching SHA-256 is rejected
+ * by the verifier. Repo-scoped entries pin to `remote.origin.url` so the
+ * same `.ts` in a different clone is independently untrusted.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { type TrustFile, parseCapabilities, readTrustFile, sha256OfFile, verifyTrust } from '../trust.js';
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'genie-trust-test-'));
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function writeFile(path: string, content: string): string {
+  mkdirSync(join(path, '..'), { recursive: true });
+  writeFileSync(path, content, 'utf-8');
+  return path;
+}
+
+describe('readTrustFile', () => {
+  test('returns empty entries when the file is absent', () => {
+    const trust = readTrustFile(join(tmpRoot, 'absent.json'));
+    expect(trust.version).toBe(1);
+    expect(trust.entries).toEqual([]);
+  });
+
+  test('returns empty entries when the file is empty', () => {
+    const path = writeFile(join(tmpRoot, 'empty.json'), '');
+    const trust = readTrustFile(path);
+    expect(trust.entries).toEqual([]);
+  });
+
+  test('rejects unsupported version', () => {
+    const path = writeFile(join(tmpRoot, 'v2.json'), JSON.stringify({ version: 2, entries: [] }));
+    expect(() => readTrustFile(path)).toThrow(/Unsupported trust file version/);
+  });
+
+  test('rejects malformed entries field', () => {
+    const path = writeFile(join(tmpRoot, 'bad.json'), JSON.stringify({ version: 1, entries: 'not-array' }));
+    expect(() => readTrustFile(path)).toThrow(/entries must be an array/);
+  });
+
+  test('reads a well-formed file', () => {
+    const path = writeFile(
+      join(tmpRoot, 'good.json'),
+      JSON.stringify({
+        version: 1,
+        entries: [
+          {
+            path: '/abs/path.ts',
+            sha256: 'a'.repeat(64),
+            scope: 'global',
+            trustedAt: '2026-04-29T00:00:00Z',
+          },
+        ],
+      }),
+    );
+    const trust = readTrustFile(path);
+    expect(trust.entries).toHaveLength(1);
+    expect(trust.entries[0].scope).toBe('global');
+  });
+});
+
+describe('verifyTrust — security boundary', () => {
+  test('rejects a file not listed in trust', () => {
+    const filePath = writeFile(join(tmpRoot, 'untrusted.ts'), 'export default {};');
+    const trustFile: TrustFile = { version: 1, entries: [] };
+    const result = verifyTrust(filePath, trustFile);
+    expect(result.trusted).toBe(false);
+    if (!result.trusted) expect(result.reason).toBe('not_in_trust_file');
+  });
+
+  test('rejects a file when the SHA does not match (post-edit detection)', () => {
+    const filePath = writeFile(join(tmpRoot, 'edited.ts'), 'export default { name: "v1" };');
+    const trustFile: TrustFile = {
+      version: 1,
+      entries: [
+        {
+          path: filePath,
+          sha256: 'a'.repeat(64), // wrong on purpose
+          scope: 'global',
+          trustedAt: '2026-04-29T00:00:00Z',
+        },
+      ],
+    };
+    const result = verifyTrust(filePath, trustFile);
+    expect(result.trusted).toBe(false);
+    if (!result.trusted) expect(result.reason).toBe('sha256_mismatch');
+  });
+
+  test('rejects a missing file', () => {
+    const filePath = join(tmpRoot, 'never-existed.ts');
+    const trustFile: TrustFile = {
+      version: 1,
+      entries: [{ path: filePath, sha256: 'a'.repeat(64), scope: 'global', trustedAt: '2026-04-29T00:00:00Z' }],
+    };
+    const result = verifyTrust(filePath, trustFile);
+    expect(result.trusted).toBe(false);
+    if (!result.trusted) expect(result.reason).toBe('file_missing');
+  });
+
+  test('accepts a file with matching SHA in global scope', () => {
+    const filePath = writeFile(join(tmpRoot, 'ok.ts'), 'export default { v: 1 };');
+    const sha = sha256OfFile(filePath);
+    const trustFile: TrustFile = {
+      version: 1,
+      entries: [{ path: filePath, sha256: sha, scope: 'global', trustedAt: '2026-04-29T00:00:00Z' }],
+    };
+    const result = verifyTrust(filePath, trustFile);
+    expect(result.trusted).toBe(true);
+  });
+
+  test('repo scope rejects when remote URL does not match', () => {
+    const filePath = writeFile(join(tmpRoot, 'repo.ts'), 'export default { v: 1 };');
+    const sha = sha256OfFile(filePath);
+    const trustFile: TrustFile = {
+      version: 1,
+      entries: [
+        {
+          path: filePath,
+          sha256: sha,
+          scope: 'repo',
+          repoRemoteUrl: 'https://github.com/owner/expected.git',
+          trustedAt: '2026-04-29T00:00:00Z',
+        },
+      ],
+    };
+    const result = verifyTrust(filePath, trustFile, {
+      currentRepoRemoteUrl: 'https://github.com/owner/different.git',
+    });
+    expect(result.trusted).toBe(false);
+    if (!result.trusted) expect(result.reason).toBe('repo_remote_mismatch');
+  });
+
+  test('repo scope rejects when entry has no repoRemoteUrl set', () => {
+    const filePath = writeFile(join(tmpRoot, 'repo.ts'), 'export default { v: 1 };');
+    const sha = sha256OfFile(filePath);
+    const trustFile: TrustFile = {
+      version: 1,
+      entries: [{ path: filePath, sha256: sha, scope: 'repo', trustedAt: '2026-04-29T00:00:00Z' }],
+    };
+    const result = verifyTrust(filePath, trustFile, {
+      currentRepoRemoteUrl: 'https://github.com/owner/repo.git',
+    });
+    expect(result.trusted).toBe(false);
+    if (!result.trusted) expect(result.reason).toBe('missing_repo_remote');
+  });
+
+  test('repo scope accepts when remote URL matches', () => {
+    const filePath = writeFile(join(tmpRoot, 'repo.ts'), 'export default { v: 1 };');
+    const sha = sha256OfFile(filePath);
+    const trustFile: TrustFile = {
+      version: 1,
+      entries: [
+        {
+          path: filePath,
+          sha256: sha,
+          scope: 'repo',
+          repoRemoteUrl: 'https://github.com/owner/repo.git',
+          trustedAt: '2026-04-29T00:00:00Z',
+        },
+      ],
+    };
+    const result = verifyTrust(filePath, trustFile, {
+      currentRepoRemoteUrl: 'https://github.com/owner/repo.git',
+    });
+    expect(result.trusted).toBe(true);
+  });
+});
+
+describe('parseCapabilities', () => {
+  test('returns empty array when no declaration', () => {
+    expect(parseCapabilities('export default {};')).toEqual([]);
+  });
+
+  test('parses a single-line declaration', () => {
+    const source = '// @capabilities: pg-read, fs-read .genie/state/, network\nexport default {};';
+    expect(parseCapabilities(source)).toEqual(['pg-read', 'fs-read .genie/state/', 'network']);
+  });
+
+  test('handles whitespace around the colon and commas', () => {
+    const source = '//   @capabilities:   one   ,    two,three\n';
+    expect(parseCapabilities(source)).toEqual(['one', 'two', 'three']);
+  });
+
+  test('drops empty entries', () => {
+    const source = '// @capabilities: pg-read, , fs-read,\n';
+    expect(parseCapabilities(source)).toEqual(['pg-read', 'fs-read']);
+  });
+});

--- a/src/hooks/dispatch-command.ts
+++ b/src/hooks/dispatch-command.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Command } from 'commander';
+import { registerHookTrustCommand } from '../term-commands/hook/trust.js';
 import { dispatch } from './index.js';
 
 async function readStdin(): Promise<string> {
@@ -54,4 +55,11 @@ export function registerHookNamespace(program: Command): void {
     .command('dispatch')
     .description('Dispatch a CC hook event (reads JSON from stdin, writes decision to stdout)')
     .action(dispatchAction);
+
+  // Group 1 of hookify-third-party-absorption: trust subcommand. Subsequent
+  // groups extend this namespace with `list`, `scaffold`, `test`, `reload`,
+  // `quarantine`, `import`, `prune`. Registered synchronously so commander's
+  // parse pass sees it; the trust handler itself only runs when the user
+  // invokes `genie hook trust` so the dispatch hot path doesn't pay for it.
+  registerHookTrustCommand(hook);
 }

--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -1,0 +1,268 @@
+/**
+ * Hook loader — boot-scan over the three S3 tiers, trust-gate every file,
+ * dynamic-`import()` the survivors, validate exports, register them.
+ *
+ * Tier precedence (highest → lowest):
+ *   1. per-team   — ~/.claude/teams/<team>/hooks/*.ts
+ *   2. per-repo   — <repo>/.genie/hooks/*.ts
+ *   3. global     — ~/.genie/hooks/*.ts
+ *
+ * Higher tiers shadow lower tiers when a hook with the same `name` is present
+ * in both. Shadowing emits `console.warn` listing both source paths and is
+ * surfaced as `[shadowed by <path>]` in `genie hook list`. When `genie serve`
+ * is started with `--strict-hooks`, any same-`name` collision REFUSES boot.
+ *
+ * Broken files (parse error, validation failure, import throw) are moved to
+ * `_quarantine/<basename>` next to the source dir with a sidecar `.error`
+ * file containing the parse-error message + line number; the daemon ALWAYS
+ * starts even when every hook is broken (builtin handlers still dispatch).
+ *
+ * The boot-scan runs once during `startHookSocket()` BEFORE `server.listen()`
+ * so the registry is single-writer at boot. Subsequent reloads go through
+ * `genie hook reload` which holds a CLI-level lock (Group 2).
+ */
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, statSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, resolve as resolvePath } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { getRegistry, setRegistry } from './index.js';
+import {
+  type TrustFile,
+  type TrustScope,
+  defaultTrustPath,
+  parseCapabilities,
+  readTrustFile,
+  verifyTrust,
+} from './trust.js';
+import type { Handler, HandlerSource } from './types.js';
+
+/** A discovered hook file (regardless of trust state). */
+export interface DiscoveredHook {
+  /** Absolute path to the .ts file. */
+  path: string;
+  /** Tier the file lives under. */
+  scope: TrustScope;
+  /** Repo remote URL when `scope === 'repo'`; otherwise undefined. */
+  repoRemoteUrl?: string;
+  /** Team name when `scope === 'team'`; otherwise undefined. */
+  teamName?: string;
+}
+
+/** Outcome row from the loader — one per discovered file. */
+export type LoadStatus =
+  | { kind: 'loaded'; handler: Handler; source: DiscoveredHook }
+  | { kind: 'shadowed'; handler: Handler; source: DiscoveredHook; shadowedBy: DiscoveredHook }
+  | { kind: 'untrusted'; reason: string; source: DiscoveredHook }
+  | { kind: 'broken'; error: string; source: DiscoveredHook; quarantined: string };
+
+export interface LoaderOptions {
+  /**
+   * Repo root used for the `repo` tier scan. Pass the cwd of the running
+   * `genie serve --headless` process.
+   */
+  repoRoot?: string;
+  /** Override the trust file path. Defaults to `~/.genie/hooks/trusted.json`. */
+  trustPath?: string;
+  /** Resolver for the active repo's remote URL — null if `repoRoot` is not a git repo. */
+  resolveRepoRemoteUrl?: (repoRoot: string) => string | null;
+  /**
+   * Custom dynamic-import function (testability). Defaults to `import(url.href)`.
+   * Implementations must throw on broken files so the loader can quarantine them.
+   */
+  importer?: (fileUrl: URL) => Promise<unknown>;
+  /** Refuse to boot on same-`name` collisions. Wired up to `genie serve --strict-hooks`. */
+  strict?: boolean;
+}
+
+/** Scan one directory for `.ts` files (non-recursive, ignores `_quarantine`). */
+function scanDir(dirAbs: string): string[] {
+  if (!existsSync(dirAbs)) return [];
+  const entries = readdirSync(dirAbs);
+  return entries
+    .filter((name) => name.endsWith('.ts') && !name.startsWith('_') && !name.endsWith('.test.ts'))
+    .map((name) => join(dirAbs, name))
+    .filter((p) => {
+      try {
+        return statSync(p).isFile();
+      } catch {
+        return false;
+      }
+    });
+}
+
+/** List discovered hook files across the three tiers in PRECEDENCE order (team > repo > global). */
+export function discoverHooks(opts: LoaderOptions): DiscoveredHook[] {
+  const home = homedir();
+  const discovered: DiscoveredHook[] = [];
+
+  // Tier 1 — per-team. Scan every team directory the operator has registered.
+  const teamsRoot = join(home, '.claude', 'teams');
+  if (existsSync(teamsRoot)) {
+    for (const teamName of readdirSync(teamsRoot)) {
+      if (teamName.startsWith('_')) continue; // skip _archived/, etc.
+      const teamHooksDir = join(teamsRoot, teamName, 'hooks');
+      for (const path of scanDir(teamHooksDir)) {
+        discovered.push({ path, scope: 'team', teamName });
+      }
+    }
+  }
+
+  // Tier 2 — per-repo.
+  if (opts.repoRoot) {
+    const repoHooksDir = join(opts.repoRoot, '.genie', 'hooks');
+    const repoRemoteUrl = opts.resolveRepoRemoteUrl?.(opts.repoRoot) ?? undefined;
+    for (const path of scanDir(repoHooksDir)) {
+      discovered.push({ path, scope: 'repo', repoRemoteUrl });
+    }
+  }
+
+  // Tier 3 — global.
+  const globalHooksDir = join(home, '.genie', 'hooks');
+  for (const path of scanDir(globalHooksDir)) {
+    discovered.push({ path, scope: 'global' });
+  }
+
+  return discovered;
+}
+
+/** Move a broken file to `_quarantine/<basename>` with a sidecar `.error` file. */
+function quarantine(filePath: string, errorMessage: string): string {
+  const dir = dirname(filePath);
+  const quarantineDir = join(dir, '_quarantine');
+  if (!existsSync(quarantineDir)) mkdirSync(quarantineDir, { recursive: true });
+  const basename = filePath.split('/').pop() ?? 'unknown.ts';
+  const target = join(quarantineDir, basename);
+  try {
+    renameSync(filePath, target);
+  } catch {
+    /* best-effort — file may have been removed mid-scan */
+  }
+  try {
+    writeFileSync(`${target}.error`, errorMessage, 'utf-8');
+  } catch {
+    /* best-effort */
+  }
+  return target;
+}
+
+/** Validate the shape of an imported handler. Returns null if valid; error message otherwise. */
+function validateHandler(imported: unknown): string | null {
+  if (typeof imported !== 'object' || imported === null) {
+    return 'expected default export to be an object';
+  }
+  const handler = imported as Partial<Handler>;
+  if (handler.version !== '1') {
+    return `unknown handler version: ${String(handler.version)} (expected '1')`;
+  }
+  if (typeof handler.name !== 'string' || handler.name.length === 0) {
+    return 'handler.name must be a non-empty string';
+  }
+  if (typeof handler.event !== 'string') {
+    return 'handler.event must be a HookEventName string';
+  }
+  if (typeof handler.priority !== 'number' || Number.isNaN(handler.priority)) {
+    return 'handler.priority must be a finite number';
+  }
+  if (typeof handler.fn !== 'function') {
+    return 'handler.fn must be a function';
+  }
+  return null;
+}
+
+/**
+ * Boot-scan loader entry point.
+ *
+ * Returns the per-file outcome list AND replaces the live handler registry
+ * with `[builtins, ...newly-loaded]`. Builtins are preserved as the first
+ * tier; external handlers are appended in scope-precedence order so that
+ * `resolveHandlers()` returns them in the right priority order on the next
+ * dispatch.
+ *
+ * Same-`name` shadowing: the FIRST occurrence (highest precedence by scan
+ * order) wins; subsequent occurrences emit `console.warn` and appear in the
+ * outcome list as `kind: 'shadowed'`. Strict mode throws instead.
+ */
+export async function loadExternalHooks(opts: LoaderOptions = {}): Promise<LoadStatus[]> {
+  const trustPath = opts.trustPath ?? defaultTrustPath();
+  let trustFile: TrustFile;
+  try {
+    trustFile = readTrustFile(trustPath);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[hook-loader] trust file unreadable at ${trustPath}: ${msg} — refusing to load any external hooks`);
+    return [];
+  }
+
+  const importer = opts.importer ?? ((url: URL) => import(url.href));
+  const discovered = discoverHooks(opts);
+  const loaded: Handler[] = [];
+  const seenNames = new Map<string, DiscoveredHook>();
+  const outcomes: LoadStatus[] = [];
+
+  for (const source of discovered) {
+    const verify = verifyTrust(source.path, trustFile, { currentRepoRemoteUrl: source.repoRemoteUrl });
+    if (!verify.trusted) {
+      outcomes.push({ kind: 'untrusted', reason: verify.reason, source });
+      continue;
+    }
+
+    let imported: { default?: unknown };
+    try {
+      imported = (await importer(pathToFileURL(resolvePath(source.path)))) as { default?: unknown };
+    } catch (err) {
+      const msg = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+      const quarantined = quarantine(source.path, msg);
+      outcomes.push({ kind: 'broken', error: msg, source, quarantined });
+      continue;
+    }
+
+    const handlerCandidate = imported.default;
+    const validationError = validateHandler(handlerCandidate);
+    if (validationError !== null) {
+      const quarantined = quarantine(source.path, validationError);
+      outcomes.push({ kind: 'broken', error: validationError, source, quarantined });
+      continue;
+    }
+
+    // Stamp source + manifest_path from the loader's perspective; ignore any
+    // values the author may have set via defineHook (the helper intentionally
+    // produces placeholder values for these fields).
+    const stamped: Handler = {
+      ...(handlerCandidate as Handler),
+      source: source.scope as HandlerSource,
+      manifest_path: source.path,
+    };
+
+    const existing = seenNames.get(stamped.name);
+    if (existing) {
+      // Shadowing: the FIRST occurrence in scan order keeps the slot. We scan
+      // in tier-precedence order (team > repo > global) so the higher-tier
+      // file wins, the lower-tier file is reported as shadowed.
+      console.warn(
+        `[hook-loader] handler name collision: "${stamped.name}" registered from ${existing.path} (${existing.scope}) shadows ${source.path} (${source.scope})`,
+      );
+      if (opts.strict) {
+        throw new Error(
+          `--strict-hooks: handler name collision on "${stamped.name}" between ${existing.path} and ${source.path}`,
+        );
+      }
+      outcomes.push({ kind: 'shadowed', handler: stamped, source, shadowedBy: existing });
+      continue;
+    }
+
+    // Capabilities are advisory metadata for `genie hook trust` UX; the loader
+    // doesn't enforce them at runtime (vm.Context isolation lands in delivery #4).
+    void parseCapabilities(readFileSync(source.path, 'utf-8'));
+
+    seenNames.set(stamped.name, source);
+    loaded.push(stamped);
+    outcomes.push({ kind: 'loaded', handler: stamped, source });
+  }
+
+  // Atomic registry swap — builtins kept as the first tier, external handlers
+  // appended in tier-precedence order.
+  const builtins = getRegistry().filter((h) => h.source === 'builtin');
+  setRegistry([...builtins, ...loaded]);
+  return outcomes;
+}

--- a/src/hooks/trust.ts
+++ b/src/hooks/trust.ts
@@ -1,0 +1,137 @@
+/**
+ * Trust allowlist — the security boundary of the .genie/hooks/ loader.
+ *
+ * Filesystem-presence is NOT consent. Every external `.ts` hook file (per-team,
+ * per-repo, or global) must be listed in `~/.genie/hooks/trusted.json` with a
+ * matching SHA-256 before the loader will dynamic-`import()` it. A file landing
+ * in a repo via `git clone`, npm postinstall, or hostile PR does not silently
+ * arm — the loader rejects it as `[BROKEN]`.
+ *
+ * Threat model: single-operator machine, $HOME assumed trusted (an attacker who
+ * can write `trusted.json` already owns the box). The allowlist is a guard
+ * against ACCIDENTAL inclusion (drive-by clones), not against a $HOME-write
+ * adversary; real isolation is the deferred `vm.Context` work in delivery #4.
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/** Tier scopes — which directory the trusted file lives under. */
+export type TrustScope = 'global' | 'team' | 'repo';
+
+/**
+ * On-disk shape for a single trust entry.
+ *
+ * `path` is always absolute. `sha256` is the lowercase hex digest of the file's
+ * bytes at trust time — re-trust is required after any edit. `repoRemoteUrl`
+ * is set only for `scope: 'repo'` entries and pins the trust to a specific
+ * git remote; the same `.ts` in a different clone is independently untrusted.
+ */
+export interface TrustEntry {
+  path: string;
+  sha256: string;
+  scope: TrustScope;
+  /** Required when `scope === 'repo'`. */
+  repoRemoteUrl?: string;
+  /** ISO 8601 timestamp of when the entry was added. */
+  trustedAt: string;
+  /** Optional human-readable note set at trust time. */
+  note?: string;
+  /** Capabilities declared in the file's `// @capabilities: ...` JSDoc. */
+  capabilities?: string[];
+}
+
+/** On-disk shape of `~/.genie/hooks/trusted.json`. */
+export interface TrustFile {
+  version: 1;
+  entries: TrustEntry[];
+}
+
+/** Default location of the trust file. Override in tests. */
+export function defaultTrustPath(): string {
+  return join(homedir(), '.genie', 'hooks', 'trusted.json');
+}
+
+/** Reasons the verifier rejects a file. Surfaced by `genie hook list`. */
+export type RejectReason =
+  | 'not_in_trust_file'
+  | 'sha256_mismatch'
+  | 'repo_remote_mismatch'
+  | 'missing_repo_remote'
+  | 'file_missing';
+
+export type VerifyResult = { trusted: true; entry: TrustEntry } | { trusted: false; reason: RejectReason };
+
+/**
+ * Compute SHA-256 (lowercase hex) of a file's bytes.
+ *
+ * Throws if the file doesn't exist — callers map ENOENT to `file_missing`.
+ */
+export function sha256OfFile(path: string): string {
+  const hash = createHash('sha256');
+  hash.update(readFileSync(path));
+  return hash.digest('hex');
+}
+
+/** Read the trust file from disk. Returns an empty `entries` array if absent. */
+export function readTrustFile(path: string = defaultTrustPath()): TrustFile {
+  if (!existsSync(path)) return { version: 1, entries: [] };
+  const raw = readFileSync(path, 'utf-8');
+  if (raw.trim().length === 0) return { version: 1, entries: [] };
+  const parsed = JSON.parse(raw) as TrustFile;
+  if (parsed.version !== 1) {
+    throw new Error(`Unsupported trust file version: ${parsed.version} (expected 1)`);
+  }
+  if (!Array.isArray(parsed.entries)) {
+    throw new Error('Malformed trust file: entries must be an array');
+  }
+  return parsed;
+}
+
+/**
+ * Verify a single file path against the trust file.
+ *
+ * For `scope: 'repo'` entries, callers must supply `currentRepoRemoteUrl`
+ * (resolved via `git config --get remote.origin.url` at the file's repo root)
+ * so the verifier can pin the trust to the active clone.
+ */
+export function verifyTrust(
+  filePath: string,
+  trustFile: TrustFile,
+  options: { currentRepoRemoteUrl?: string } = {},
+): VerifyResult {
+  if (!existsSync(filePath)) return { trusted: false, reason: 'file_missing' };
+
+  const entry = trustFile.entries.find((e) => e.path === filePath);
+  if (!entry) return { trusted: false, reason: 'not_in_trust_file' };
+
+  const actualSha = sha256OfFile(filePath);
+  if (actualSha !== entry.sha256) return { trusted: false, reason: 'sha256_mismatch' };
+
+  if (entry.scope === 'repo') {
+    if (!entry.repoRemoteUrl) return { trusted: false, reason: 'missing_repo_remote' };
+    if (options.currentRepoRemoteUrl !== entry.repoRemoteUrl) {
+      return { trusted: false, reason: 'repo_remote_mismatch' };
+    }
+  }
+
+  return { trusted: true, entry };
+}
+
+/**
+ * Parse capability declarations from a file's source.
+ *
+ * Looks for a single line of the form `// @capabilities: cap1, cap2, cap3` —
+ * surfaced at trust time so the operator approves the blast radius explicitly.
+ * Returns an empty array if no declaration is found.
+ */
+export function parseCapabilities(source: string): string[] {
+  const match = source.match(/^\/\/\s*@capabilities:\s*(.+)$/m);
+  if (!match) return [];
+  return match[1]
+    .split(',')
+    .map((c) => c.trim())
+    .filter((c) => c.length > 0);
+}

--- a/src/term-commands/hook/trust.ts
+++ b/src/term-commands/hook/trust.ts
@@ -1,0 +1,191 @@
+/**
+ * `genie hook trust [path]` — add a hook file to the trust allowlist.
+ *
+ * Without a path, prints the current trust file. With a path, computes the
+ * file's SHA-256, scopes the entry (default global; --repo for per-repo),
+ * surfaces declared capabilities, and writes the entry. Re-trusting an
+ * existing path with a different SHA overwrites silently — that's the
+ * expected flow when the operator edits a trusted hook.
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+import type { Command } from 'commander';
+import {
+  type TrustEntry,
+  type TrustFile,
+  defaultTrustPath,
+  parseCapabilities,
+  readTrustFile,
+  sha256OfFile,
+} from '../../hooks/trust.js';
+
+interface TrustOptions {
+  repo?: boolean;
+  global?: boolean;
+  team?: string;
+  note?: string;
+  yes?: boolean;
+}
+
+/** Resolve current repo's `remote.origin.url` via git. Returns null on failure. */
+function resolveOriginUrl(repoRoot: string): string | null {
+  try {
+    const out = execSync('git config --get remote.origin.url', { cwd: repoRoot, encoding: 'utf-8' });
+    return out.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/** Walk up from `start` until a directory containing `.git` is found. */
+function findRepoRoot(start: string): string | null {
+  let current = start;
+  while (current !== '/') {
+    if (existsSync(join(current, '.git'))) return current;
+    current = dirname(current);
+  }
+  return null;
+}
+
+function writeTrustFile(path: string, file: TrustFile): void {
+  const dir = dirname(path);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+
+  // Atomic write via temp + rename so a crash mid-write doesn't corrupt the
+  // trust file (the security boundary). Stable JSON (sorted keys, 2-space
+  // indent, trailing newline) so byte-equal diffs survive cosmetic edits.
+  const sorted: TrustFile = {
+    version: 1,
+    entries: [...file.entries].sort((a, b) => a.path.localeCompare(b.path)),
+  };
+  const serialized = `${JSON.stringify(sorted, null, 2)}\n`;
+  const tmpPath = `${path}.tmp.${process.pid}`;
+  writeFileSync(tmpPath, serialized, 'utf-8');
+  renameSync(tmpPath, path);
+}
+
+async function trustAction(target: string | undefined, options: TrustOptions): Promise<void> {
+  const trustPath = defaultTrustPath();
+
+  if (!target) {
+    // List mode — print the current trust file.
+    const current = readTrustFile(trustPath);
+    if (current.entries.length === 0) {
+      console.log(`(trust file empty: ${trustPath})`);
+      return;
+    }
+    console.log(`Trusted hooks (${current.entries.length}, from ${trustPath}):`);
+    for (const entry of current.entries) {
+      const scope = entry.scope === 'repo' ? `repo:${entry.repoRemoteUrl ?? '?'}` : entry.scope;
+      console.log(`  ${entry.path}`);
+      console.log(`    scope:    ${scope}`);
+      console.log(`    sha256:   ${entry.sha256}`);
+      console.log(`    trusted:  ${entry.trustedAt}`);
+      if (entry.capabilities && entry.capabilities.length > 0) {
+        console.log(`    caps:     ${entry.capabilities.join(', ')}`);
+      }
+      if (entry.note) console.log(`    note:     ${entry.note}`);
+    }
+    return;
+  }
+
+  // Add mode.
+  const filePath = isAbsolute(target) ? target : resolve(process.cwd(), target);
+  if (!existsSync(filePath)) {
+    console.error(`Error: file not found: ${filePath}`);
+    process.exit(1);
+  }
+  if (!filePath.endsWith('.ts')) {
+    console.error(`Error: trust target must be a .ts file: ${filePath}`);
+    process.exit(1);
+  }
+
+  // Determine scope. Default 'global' unless --repo or --team is passed.
+  let scope: TrustEntry['scope'];
+  let repoRemoteUrl: string | undefined;
+  if (options.repo) {
+    scope = 'repo';
+    const repoRoot = findRepoRoot(dirname(filePath));
+    if (!repoRoot) {
+      console.error(`Error: --repo passed but no .git directory found above ${filePath}`);
+      process.exit(1);
+    }
+    const remote = resolveOriginUrl(repoRoot);
+    if (!remote) {
+      console.error(`Error: --repo passed but ${repoRoot} has no remote.origin.url`);
+      process.exit(1);
+    }
+    repoRemoteUrl = remote;
+  } else if (options.team) {
+    scope = 'team';
+  } else {
+    scope = 'global';
+  }
+
+  const sha = sha256OfFile(filePath);
+  const source = readFileSync(filePath, 'utf-8');
+  const capabilities = parseCapabilities(source);
+
+  // Surface what we're about to trust.
+  console.log(`About to trust: ${filePath}`);
+  console.log(`  scope:    ${scope === 'repo' ? `repo:${repoRemoteUrl}` : scope}`);
+  console.log(`  sha256:   ${sha}`);
+  if (capabilities.length > 0) console.log(`  caps:     ${capabilities.join(', ')}`);
+  if (options.note) console.log(`  note:     ${options.note}`);
+
+  if (!options.yes && process.stdin.isTTY) {
+    process.stdout.write('Confirm? (y/N) ');
+    // Synchronous-ish read; bun supports readSync on stdin fd 0.
+    const buf = Buffer.alloc(8);
+    let read = 0;
+    try {
+      const fs = await import('node:fs');
+      read = fs.readSync(0, buf, 0, buf.length, null);
+    } catch {
+      console.error('Error: cannot read confirmation; pass --yes to trust non-interactively');
+      process.exit(1);
+    }
+    const answer = buf.subarray(0, read).toString().trim().toLowerCase();
+    if (answer !== 'y' && answer !== 'yes') {
+      console.log('Aborted.');
+      process.exit(1);
+    }
+  }
+
+  const current = readTrustFile(trustPath);
+  const newEntry: TrustEntry = {
+    path: filePath,
+    sha256: sha,
+    scope,
+    repoRemoteUrl,
+    trustedAt: new Date().toISOString(),
+    note: options.note,
+    capabilities: capabilities.length > 0 ? capabilities : undefined,
+  };
+  // Replace any existing entry for the same path.
+  const next: TrustFile = {
+    version: 1,
+    entries: [...current.entries.filter((e) => e.path !== filePath), newEntry],
+  };
+  writeTrustFile(trustPath, next);
+  console.log(`Trusted ${filePath} → ${trustPath}`);
+}
+
+export function registerHookTrustCommand(parent: Command): void {
+  parent
+    .command('trust [path]')
+    .description('Add a .ts hook file to the trust allowlist (or list current entries when [path] is omitted)')
+    .option('--repo', 'Scope to current repo (pinned to remote.origin.url)')
+    .option('--global', 'Scope globally (default)')
+    .option('--team <name>', 'Scope to a specific team directory')
+    .option('--note <text>', 'Free-form note saved with the entry')
+    .option('--yes', 'Skip the interactive confirmation prompt')
+    .action(trustAction);
+}
+
+/** Re-export defaultTrustPath for callers that want to display it. */
+export { defaultTrustPath } from '../../hooks/trust.js';
+/** Re-export readTrustFile for callers that want to inspect entries. */
+export { readTrustFile } from '../../hooks/trust.js';


### PR DESCRIPTION
## Summary

Second slice of Group 1 (hookify-third-party-absorption). Builds on PR #1544's foundation. Adds the trust-gated loader and the trust CLI — the security boundary that lets external `.ts` hook files participate in the dispatch chain.

### What lands

- **`src/hooks/trust.ts`** — `TrustFile` schema for `~/.genie/hooks/trusted.json`, SHA-256 verifier, repo-remote URL pinning, `// @capabilities:` JSDoc parser
- **`src/hooks/loader.ts`** — boot-scan over the three S3 tiers (per-team > per-repo > global), trust-gate every file, dynamic-`import()` survivors, validate `default` export is a `HandlerV1`, quarantine invalids to `_quarantine/<basename>` with sidecar `.error`. Same-name collisions warn (or throw under `--strict-hooks`)
- **`src/term-commands/hook/trust.ts`** — `genie hook trust [path]` CLI. Lists entries when no path given. Adds entry with SHA + scope + capabilities + interactive confirm; atomically writes via temp+rename
- **`src/hooks/dispatch-command.ts`** wires the trust subcommand into the hook namespace

### Threat model

Single-operator machine. Filesystem-presence is **NOT** consent — a file landing in `<repo>/.genie/hooks/` via `git clone` or npm postinstall does not silently arm. The trust allowlist is a guard against accidental inclusion, **not** against a `\$HOME`-write adversary (real isolation is `vm.Context` work deferred to delivery #4).

## Group 1 progress

| Deliverable | State |
|---|---|
| D1 mutable registryRef + setRegistry | ✅ shipped in #1544 |
| D2 Handler v1 discriminated union | ✅ shipped in #1544 |
| D3 loader.ts (boot-scan + trust + quarantine) | ✅ this PR |
| D4 trust.ts + \`genie hook trust\` CLI | ✅ this PR |
| D5 \`genie serve --strict-hooks\` + loader-at-boot wiring | follow-up |
| D6 defineHook helper | ✅ shipped in #1544 |
| D7 dispatch-command wires trust subcommand | ✅ this PR |

## Test plan

- [x] \`bun test src/hooks/__tests__/\` → 161 pass / 0 fail / 389 expect calls
- [x] \`bun run check:fast\` → green
- [x] Untrusted file rejected
- [x] SHA mismatch (post-edit) rejected
- [x] Repo-scope rejects on remote URL mismatch
- [x] Repo-scope accepts on remote URL match
- [x] Invalid handler shape → \`_quarantine/\` with sidecar \`.error\`
- [x] Unknown handler.version → \`[BROKEN]\`
- [x] Same-name collision warns; \`strict: true\` throws
- [x] Capability declaration parsed from \`// @capabilities:\` JSDoc

🤖 Generated with [Claude Code](https://claude.com/claude-code)