### PR TITLE
fix(ci): refresh pgserve retry harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,11 @@ jobs:
       # regressions. Long-term fix is a pgserve backend audit (out of
       # scope for wish pg-test-perf).
       #
+      # The retry disables shared-daemon reuse because the first failed run may
+      # have left the pgserve process accepting TCP but timing out handshakes.
+      # Reusing that daemon contaminates the second run with stale databases and
+      # turns one backend failure into unrelated row-count failures.
+      #
       # History: 7b23046e dropped a prior retry wrapper because hangs on the
       # self-hosted runner produced orphaned bun processes. Mitigated now by
       # Blacksmith ephemeral runners + `timeout-minutes: 15` (a hang is killed
@@ -183,7 +188,12 @@ jobs:
       - name: Test (serial, PG-backed)
         env:
           BUN_INSTALL_CACHE_DIR: ${{ runner.temp }}/bun-cache-${{ github.run_id }}-${{ github.run_attempt }}
-        run: bun test --timeout 15000 || bun test --timeout 15000
+          GENIE_HOME: ${{ runner.temp }}/genie-pg-home-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          bun test --timeout 15000 || (
+            rm -f "$GENIE_HOME/data/test-pgserve.lock"
+            GENIE_TEST_PG_NO_REUSE=1 bun test --timeout 15000
+          )
 
   # Group 7 of the pgserve-v2 wish: smoke-test the v2 Unix-socket consumer
   # path. Spawns pgserve daemon, runs `genie task list` against it, asserts

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "ignore": "7.0.5",
         "js-yaml": "4.1.1",
         "nats": "2.29.3",
-        "pgserve": "^2.0.2",
+        "pgserve": "^2.0.3",
         "postgres": "3.4.9",
         "react": "19.2.5",
         "react-dom": "19.2.5",
@@ -883,7 +883,7 @@
 
     "peek-readable": ["peek-readable@4.1.0", "", {}, "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="],
 
-    "pgserve": ["pgserve@2.0.2", "", { "dependencies": { "bun": "^1.3.4" }, "optionalDependencies": { "@embedded-postgres/darwin-arm64": "18.2.0-beta.16", "@embedded-postgres/darwin-x64": "18.2.0-beta.16", "@embedded-postgres/linux-x64": "18.2.0-beta.16", "@embedded-postgres/windows-x64": "18.2.0-beta.16" }, "bin": { "pgserve": "bin/pgserve-wrapper.cjs" } }, "sha512-1p6kEKWHLiajLly2abnXP73LGZFA9Lvaqt67SBsFSEWsU5E7AHpJask3NrNCSeJwoW8DnQoXXkjsoNUnpwrzZA=="],
+    "pgserve": ["pgserve@2.0.3", "", { "dependencies": { "bun": "^1.3.4" }, "optionalDependencies": { "@embedded-postgres/darwin-arm64": "18.2.0-beta.16", "@embedded-postgres/darwin-x64": "18.2.0-beta.16", "@embedded-postgres/linux-x64": "18.2.0-beta.16", "@embedded-postgres/windows-x64": "18.2.0-beta.16" }, "bin": { "pgserve": "bin/pgserve-wrapper.cjs" } }, "sha512-zoZsuesGaUJ7DKGvnzr71OHqpZ/641JigZIsz26bjLuePBusfPBeOSmZ+M4hBP2jgfQmm/gcaXZok/Abr5KfWA=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "ignore": "7.0.5",
     "js-yaml": "4.1.1",
     "nats": "2.29.3",
-    "pgserve": "^2.0.2",
+    "pgserve": "^2.0.3",
     "postgres": "3.4.9",
     "react": "19.2.5",
     "react-dom": "19.2.5",

--- a/src/lib/test-setup.test.ts
+++ b/src/lib/test-setup.test.ts
@@ -116,6 +116,19 @@ describe('test-setup shared-daemon lockfile', () => {
     expect(typeof lock?.startedAt).toBe('number');
   });
 
+  test('lockfile path stays bound to the preload GENIE_HOME', async () => {
+    const { __testing } = await import('./test-setup.js');
+    const originalPath = __testing.lockFilePath();
+    const prev = process.env.GENIE_HOME;
+    try {
+      process.env.GENIE_HOME = '/tmp/genie-test-mutated-home';
+      expect(__testing.lockFilePath()).toBe(originalPath);
+    } finally {
+      if (prev === undefined) Reflect.deleteProperty(process.env, 'GENIE_HOME');
+      else process.env.GENIE_HOME = prev;
+    }
+  });
+
   test('reuse case: lockfile pid is alive and lockfile is within max age', async () => {
     if (noReuse) return;
     const { __testing } = await import('./test-setup.js');

--- a/src/lib/test-setup.ts
+++ b/src/lib/test-setup.ts
@@ -78,6 +78,8 @@ type PgserveLock = {
 
 let child: ChildProcess | null = null;
 let activeTestPort: number | null = null;
+const initialGenieHome = process.env.GENIE_HOME ?? join(homedir(), '.genie');
+const testPgserveLockPath = join(initialGenieHome, 'data', 'test-pgserve.lock');
 // Module-scoped admin client bound to the `postgres` maintenance DB. Opened
 // once after pgserve is healthy and reused by createTestDatabase /
 // dropTestDatabase / buildTemplateDatabase. Previously each call opened and
@@ -244,8 +246,7 @@ function killPidsLeavesFirst(pids: number[]): void {
 
 /** Resolve the lockfile path under GENIE_HOME (or ~/.genie). */
 function lockFilePath(): string {
-  const home = process.env.GENIE_HOME ?? join(homedir(), '.genie');
-  return join(home, 'data', 'test-pgserve.lock');
+  return testPgserveLockPath;
 }
 
 /** Read and validate the shared-daemon lockfile; returns null when missing or malformed. */


### PR DESCRIPTION
## Summary
- bump locked pgserve to ^2.0.3 so CI and bun installs use the published socket/daemon recovery fix
- make the macOS PG retry path use an isolated GENIE_HOME and disable test pgserve reuse after a failed first attempt
- pin the test pgserve lock path to preload-time GENIE_HOME so later tests that mutate GENIE_HOME cannot redirect shared setup state

## Verification
- GENIE_HOME=/tmp/genie-ci-fix-focused2-$$ bun test --timeout 15000 src/lib/test-setup.test.ts src/lib/db.test.ts src/lib/runtime-events-thread.test.ts src/lib/session-filewatch.test.ts
- GENIE_HOME=/tmp/genie-ci-fix-order-$$ bun test --timeout 15000 src/lib/db.test.ts src/lib/test-setup.test.ts
- bun run typecheck
- bunx biome check src/lib/test-setup.ts src/lib/test-setup.test.ts package.json

Note: a broader local bun test run in the temp worktree still hits pre-existing local-only failures from missing docs symlink targets and a noisy macOS hook perf threshold; the PG failure set from dev CI is covered above.