### PR TITLE
fix(tui): detect Claude panes with active title

### DIFF
--- a/src/tui/pane-detection.ts
+++ b/src/tui/pane-detection.ts
@@ -2,6 +2,11 @@ import type { TmuxPane } from './diagnostics.js';
 
 export const CLAUDE_CODE_ACTIVE_TITLE_PREFIX = '\u2733 ';
 const CLAUDE_EXECUTABLE = /(^|[/\s])claude(\s|$)/i;
+const PLAIN_SHELL_COMMANDS = new Set(['bash', 'fish', 'login', 'sh', 'tmux', 'zsh']);
+
+function hasClaudeActiveTitle(title: string | undefined, command: string): boolean {
+  return (title ?? '').startsWith(CLAUDE_CODE_ACTIVE_TITLE_PREFIX) && !PLAIN_SHELL_COMMANDS.has(command);
+}
 
 export function isClaudeLikeCommandTitle(
   command: string | undefined,
@@ -12,6 +17,7 @@ export function isClaudeLikeCommandTitle(
   const lowerTitle = (title ?? '').toLowerCase();
   return (
     CLAUDE_EXECUTABLE.test(processCommand ?? '') ||
+    hasClaudeActiveTitle(title, cmd) ||
     cmd === 'claude' ||
     cmd.includes('claude') ||
     lowerTitle.includes('claude')

--- a/src/tui/session-tree.test.ts
+++ b/src/tui/session-tree.test.ts
@@ -4,8 +4,6 @@ import { CLAUDE_CODE_ACTIVE_TITLE_PREFIX } from './pane-detection.js';
 import { buildSessionTree, buildWorkspaceTree, getSessionTarget, resolvePreferredWindowIndex } from './session-tree.js';
 import type { TreeNode, TuiExecutor } from './types.js';
 
-const CLAUDE_CODE_V2_TMUX_COMMAND = 'opaque-runtime-title';
-const CLAUDE_CODE_V2_PROCESS_COMMAND = '/Users/example/.local/bin/claude --agent-id genie@genie';
 const CLAUDE_CODE_V2_TMUX_TITLE = `${CLAUDE_CODE_ACTIVE_TITLE_PREFIX}genie-genie`;
 
 function flattenTree(nodes: TreeNode[]): TreeNode[] {
@@ -269,9 +267,9 @@ describe('buildWorkspaceTree', () => {
     expect(tree[0].wsAgentState).toBe('running');
   });
 
-  test('Claude Code v2 pane title counts as a live agent pane', () => {
-    // Reproduces Claude Code v2 on macOS: tmux may report a non-claude
-    // pane_current_command, while ps still shows the stable claude executable.
+  test('Claude Code v2 active pane title counts as a live agent pane', () => {
+    // Reproduces Claude Code v2 on macOS: tmux may report the runtime
+    // version as pane_current_command, while ps only sees the parent shell.
     const win0 = makeWindow({ sessionName: 'genie', index: 0, name: 'zsh' });
     const win1 = makeWindow({
       sessionName: 'genie',
@@ -283,8 +281,8 @@ describe('buildWorkspaceTree', () => {
           sessionName: 'genie',
           windowIndex: 1,
           paneId: '%3',
-          command: CLAUDE_CODE_V2_TMUX_COMMAND,
-          processCommand: CLAUDE_CODE_V2_PROCESS_COMMAND,
+          command: '2.1.123',
+          processCommand: '/bin/zsh',
           title: CLAUDE_CODE_V2_TMUX_TITLE,
         }),
       ],
@@ -305,7 +303,9 @@ describe('buildWorkspaceTree', () => {
     expect(tree[0].activePanes).toBe(1);
     expect(tree[0].data.attachWindowIndex).toBe(1);
     expect(tree[0].children[0].activePanes).toBe(1);
-    expect(tree[0].children[0].children[0].data.isClaudeLike).toBe(true);
+    const pane = tree[0].children[0].children[0];
+    expect(pane.data.isClaudeLike).toBe(true);
+    expect(pane.data.command).toBe('2.1.123');
   });
 
   test('permission executor state reflected on agentState', () => {


### PR DESCRIPTION
## Summary
- recognize Claude Code active panes when tmux reports a runtime version like `2.1.123` as `pane_current_command`
- keep the existing guard so a plain shell with an active-looking title is not treated as Claude
- add a macOS-shaped regression where `ps` only sees the parent shell and the title carries the active Claude marker

## Verification
- bun test src/tui/session-tree.test.ts src/tui/pane-detection.test.ts
- bun run typecheck
- bunx biome check src/tui/pane-detection.ts src/tui/session-tree.test.ts