### PR TITLE
feat(tui): adopt OpenTUI 0.2 tmux fixes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,8 +7,8 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.119",
         "@inquirer/prompts": "7.10.1",
-        "@opentui/core": "0.1.103",
-        "@opentui/react": "0.1.103",
+        "@opentui/core": "0.2.0",
+        "@opentui/react": "0.2.0",
         "@tauri-apps/api": "2.10.1",
         "chokidar": "^5.0.0",
         "commander": "12.1.0",
@@ -337,21 +337,21 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@opentui/core": ["@opentui/core@0.1.103", "", { "dependencies": { "bun-ffi-structs": "0.1.2", "diff": "8.0.2", "jimp": "1.6.0", "marked": "17.0.1", "yoga-layout": "3.2.1" }, "optionalDependencies": { "@dimforge/rapier2d-simd-compat": "^0.17.3", "@opentui/core-darwin-arm64": "0.1.103", "@opentui/core-darwin-x64": "0.1.103", "@opentui/core-linux-arm64": "0.1.103", "@opentui/core-linux-x64": "0.1.103", "@opentui/core-win32-arm64": "0.1.103", "@opentui/core-win32-x64": "0.1.103", "bun-webgpu": "0.1.5", "planck": "^1.4.2", "three": "0.177.0" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-PWVv/bDmlk1i6X1f0zXs+jSaTrQ/ByX8wFbP2WinOObTGf//UbcRP4dbWxPXvOyka9QlmRBG/7GbloQSIStyVw=="],
+    "@opentui/core": ["@opentui/core@0.2.0", "", { "dependencies": { "bun-ffi-structs": "0.1.2", "diff": "8.0.2", "jimp": "1.6.0", "marked": "17.0.1", "string-width": "7.2.0", "strip-ansi": "7.1.2", "yoga-layout": "3.2.1" }, "optionalDependencies": { "@dimforge/rapier2d-simd-compat": "^0.17.3", "@opentui/core-darwin-arm64": "0.2.0", "@opentui/core-darwin-x64": "0.2.0", "@opentui/core-linux-arm64": "0.2.0", "@opentui/core-linux-x64": "0.2.0", "@opentui/core-win32-arm64": "0.2.0", "@opentui/core-win32-x64": "0.2.0", "bun-webgpu": "0.1.7", "planck": "^1.4.2", "three": "0.177.0" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-7YOEqPUQmsgrOb9nmLEBlX8RVHPFy4HquK1C489DwfvvPTiws8nTbZ+webNQDWha7shgnYQK4Zo1EcOlpQ5+1Q=="],
 
-    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.1.103", "", { "os": "darwin", "cpu": "arm64" }, "sha512-lxCyedDkcen12IgBtXjkJ7iY66xa7VC4nxRNKCUeLY2ZP9hUE1AsDtbyQzqY+BQadsI/ZME9STzaHDCUFg0TpA=="],
+    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.2.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-VVmKwth3hzsQPjAZ7WGJxmzuzx0uCtynd79JJDg26D7QRM9V5beVGbKwwU5SKsDlK74EyQoY85Mv9xFY5E4jrA=="],
 
-    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.1.103", "", { "os": "darwin", "cpu": "x64" }, "sha512-QMYD+zUDGQliJ6m5nuNvA72jtluFeyVMoHkuA5m/Xmed/u8eLfahAKmDj3kY66ntUroPHWevcpbpvd7NCFEoFQ=="],
+    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.2.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-eX+WNdbSNr7Bozdq/MH6p1vXIALGt0SqBHR4YtWyTh6X7KDz9FTtJT3ylxMPqiVRUGBNAiWOxoqKGXW7JLQ0TA=="],
 
-    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.1.103", "", { "os": "linux", "cpu": "arm64" }, "sha512-GzOvNr9dN6JaQ9qs7m8E75wLAHwT5CyxqkE6rEr1BO23/d2Ix7e3GYw/JRY5VnTge+eXrfDVbqNtPcQamUNiEA=="],
+    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.2.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-ARZa+ywbN/OV7esT5ZdJMlQW3a4Pr56qLlEI/X65ik88C2sgmDze4Kf2FmqtvJ1hbv1YsMfLHH9MfhLl5twyHQ=="],
 
-    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.1.103", "", { "os": "linux", "cpu": "x64" }, "sha512-odywllco5zUKNc60uD3JKaCybK64u6BfmpScs4a8Qn89yH/yk23bzWXDRWaGgQdY65L2/VCbcGs1ezA1S/2YTw=="],
+    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.2.0", "", { "os": "linux", "cpu": "x64" }, "sha512-ZjNxrD45P51cdbABoivVQLBakVYwDqAridJbHhkK6T/+EU7YsTrmAu9ae19N9ZGnrlKzLViQF8GOavNUNjAbhw=="],
 
-    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.1.103", "", { "os": "win32", "cpu": "arm64" }, "sha512-tZL5w3Y0JnO7RkIvfuNDAzJn0j6+JIYl6M8DgPM5p8AQt+162S8LmbumzmqQLZl4cEev2eN7/tw72WIk6b+/CQ=="],
+    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.2.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-ImMjFPOWE8wcZQ2lUz1D418xonS/5EwnItUF1g5dbp1q9+A0vv2P3bxTenLwMqcYvG4wjO6gKT3n2QLnRd6qKg=="],
 
-    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.1.103", "", { "os": "win32", "cpu": "x64" }, "sha512-wqnibt/OE5ldSzVPxEbriA0TjI2B11CJl4uJoLxTZ47KDx7tAFIMdhBf9IRAGNCSbcDuZ8ZGEFhV+SLaftkrlw=="],
+    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.2.0", "", { "os": "win32", "cpu": "x64" }, "sha512-6yfYHTtJ4yzbl8kXCW3Pc4eWbZDYVw21GumwdNgkjJJ2JqQAQ861em0riEoucYAa5qPYYTiMUEw7X4Fv8lGwuQ=="],
 
-    "@opentui/react": ["@opentui/react@0.1.103", "", { "dependencies": { "@opentui/core": "0.1.103", "react-reconciler": "^0.32.0" }, "peerDependencies": { "react": ">=19.0.0", "react-devtools-core": "^7.0.1", "ws": "^8.18.0" } }, "sha512-hOPRM2A0u6L67nv6Op4mBkhYIPvYAC6lL+MRgjD2gBROOTipfyz4gRcjF9onHH6dPGA7w73ddSQrX4hTbxo6ug=="],
+    "@opentui/react": ["@opentui/react@0.2.0", "", { "dependencies": { "@opentui/core": "0.2.0", "react-reconciler": "^0.32.0" }, "peerDependencies": { "react": ">=19.0.0", "react-devtools-core": "^7.0.1", "ws": "^8.18.0" } }, "sha512-wXDpBoj3GQuQJG5MrIfyYRshU3bwaBYuSC6ThYiVHSDgt8PGhy2v2xPzFVvJZDSx7hp9gUaaNzWPsXIRLwrlCQ=="],
 
     "@oven/bun-darwin-aarch64": ["@oven/bun-darwin-aarch64@1.3.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/8IzqSu4/OWGRs7Fs2ROzGVwJMFTBQkgAp6sAthkBYoN7OiM4rY/CpPVs2X9w9N1W61CHSkEdNKi8HrLZKfK3g=="],
 
@@ -533,7 +533,7 @@
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
-    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -565,15 +565,15 @@
 
     "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
-    "bun-webgpu": ["bun-webgpu@0.1.5", "", { "dependencies": { "@webgpu/types": "^0.1.60" }, "optionalDependencies": { "bun-webgpu-darwin-arm64": "^0.1.5", "bun-webgpu-darwin-x64": "^0.1.5", "bun-webgpu-linux-x64": "^0.1.5", "bun-webgpu-win32-x64": "^0.1.5" } }, "sha512-91/K6S5whZKX7CWAm9AylhyKrLGRz6BUiiPiM/kXadSnD4rffljCD/q9cNFftm5YXhx4MvLqw33yEilxogJvwA=="],
+    "bun-webgpu": ["bun-webgpu@0.1.7", "", { "dependencies": { "@webgpu/types": "^0.1.60" }, "optionalDependencies": { "bun-webgpu-darwin-arm64": "^0.1.7", "bun-webgpu-darwin-x64": "^0.1.7", "bun-webgpu-linux-x64": "^0.1.7", "bun-webgpu-win32-x64": "^0.1.7" } }, "sha512-KUxUp+oQIf7pPBMD4Hv1TUu7DWaOZ4ciKulTk9to9+Uc8yHoYrMW7L2SJCJ4FHHkywgf/7aLRgRx0b7i6DvGIQ=="],
 
-    "bun-webgpu-darwin-arm64": ["bun-webgpu-darwin-arm64@0.1.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-lIsDkPzJzPl6yrB5CUOINJFPnTRv6fF/Q8J1mAr43ogSp86WZEg9XZKaT6f3EUJ+9ETogGoMnoj1q0AwHUTbAQ=="],
+    "bun-webgpu-darwin-arm64": ["bun-webgpu-darwin-arm64@0.1.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-mRrFFyHzPWjsTRidAZBRcu808CPQBOUL0P6b4nxLhp+XHcV/mbUHERZMgW9s58tsojQfSdzschiQa8q+JCgRWA=="],
 
-    "bun-webgpu-darwin-x64": ["bun-webgpu-darwin-x64@0.1.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-uEddf5U7GvKIkM/BV18rUKtYHL6d0KeqBjNHwfqDH9QgEo9KVSKvJXS5I/sMefk5V5pIYE+8tQhtrREevhocng=="],
+    "bun-webgpu-darwin-x64": ["bun-webgpu-darwin-x64@0.1.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-g0NXGNgvaVCSH/jCWWlfdiquOHkbUN6vP4zqzSkIxWKQeLnqm3oADcok7SO3yIgI7v5mKpRc/ks7NDEKNH+jNQ=="],
 
-    "bun-webgpu-linux-x64": ["bun-webgpu-linux-x64@0.1.6", "", { "os": "linux", "cpu": "x64" }, "sha512-Y/f15j9r8ba0xUz+3lATtS74OE+PPzQXO7Do/1eCluJcuOlfa77kMjvBK/ShWnem3Y9xqi59pebTPOGRB+CaJA=="],
+    "bun-webgpu-linux-x64": ["bun-webgpu-linux-x64@0.1.7", "", { "os": "linux", "cpu": "x64" }, "sha512-UEP7UZdEhx9otvkZczjsszL8ZVlrODANQvgl+C88/bNVmxDoFi7w1fWzGi1sZyakiETjmtFDq2/xCLhbSZxjqw=="],
 
-    "bun-webgpu-win32-x64": ["bun-webgpu-win32-x64@0.1.6", "", { "os": "win32", "cpu": "x64" }, "sha512-MHSFAKqizISb+C5NfDrFe3g0Al5Njnu0j/A+oO2Q+bIWX+fUYjBSowiYE1ZXJx65KuryuB+tiM7Qh6cQbVvkEg=="],
+    "bun-webgpu-win32-x64": ["bun-webgpu-win32-x64@0.1.7", "", { "os": "win32", "cpu": "x64" }, "sha512-KZktiFkBz6sN7PEm1NVdeaLP5Q5X/PlSHZqefY4nNuWtf0LNvh54NhZe7yVv/Plz/nGbv92b0KHMBY3ki/pp6g=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -643,7 +643,7 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.328", "", {}, "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w=="],
 
-    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
@@ -710,6 +710,8 @@
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
@@ -987,11 +989,11 @@
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
-    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
-    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
@@ -1081,6 +1083,10 @@
 
     "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
+    "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "conventional-commits-parser/meow": ["meow@13.2.0", "", {}, "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA=="],
 
     "image-q/@types/node": ["@types/node@16.9.1", "", {}, "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="],
@@ -1098,6 +1104,20 @@
     "react-reconciler/scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 
     "vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "@inquirer/core/wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
@@ -1150,5 +1170,19 @@
     "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
 
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@inquirer/core/wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "@inquirer/core/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.2.119",
     "@inquirer/prompts": "7.10.1",
-    "@opentui/core": "0.1.103",
-    "@opentui/react": "0.1.103",
+    "@opentui/core": "0.2.0",
+    "@opentui/react": "0.2.0",
     "@tauri-apps/api": "2.10.1",
     "chokidar": "^5.0.0",
     "commander": "12.1.0",

--- a/scripts/tmux/tui-tmux.conf
+++ b/scripts/tmux/tui-tmux.conf
@@ -31,6 +31,18 @@ bind -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "~/.genie/scripts/o
 bind -T root MouseDrag1Pane if-shell -F "#{mouse_any_flag}" "send-keys -M" "copy-mode -M"
 bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "~/.genie/scripts/osc52-copy.sh"
 
+# Forward single-button clicks to the app when it has mouse mode enabled.
+# OpenTUI sets DECSET 1000/1006, which flips tmux's mouse_any_flag. Without
+# this binding, tmux's default MouseDown1Pane only selects the pane and the
+# left nav never receives clicks. The fallback keeps pane selection working
+# when mouse mode is disabled or the click lands on the right terminal pane.
+bind -T root MouseDown1Pane if-shell -F "#{mouse_any_flag}" "send-keys -M" "select-pane -t = ; send-keys -M"
+bind -T root MouseUp1Pane   if-shell -F "#{mouse_any_flag}" "send-keys -M" ""
+bind -T root MouseDown2Pane if-shell -F "#{mouse_any_flag}" "send-keys -M" ""
+bind -T root MouseUp2Pane   if-shell -F "#{mouse_any_flag}" "send-keys -M" ""
+bind -T root WheelUpPane    if-shell -F "#{mouse_any_flag}" "send-keys -M" "copy-mode -e ; send-keys -M"
+bind -T root WheelDownPane  if-shell -F "#{mouse_any_flag}" "send-keys -M" "send-keys -M"
+
 # NO status bars, NO pane-border shell probes — TUI renders its own UI
 set -g status off
 set -g pane-border-status off

--- a/src/__tests__/tmux-config.test.ts
+++ b/src/__tests__/tmux-config.test.ts
@@ -122,6 +122,12 @@ describe('tmux config — OSC 52 clipboard passthrough (#967)', () => {
     expect(hits.length).toBeGreaterThanOrEqual(1);
   });
 
+  test('tui-tmux.conf forwards click events to OpenTUI', () => {
+    expect(activeLinesIn(tuiConf, /MouseDown1Pane.*send-keys -M/).length).toBe(1);
+    expect(activeLinesIn(tuiConf, /MouseUp1Pane\s+if-shell.*send-keys -M/).length).toBe(1);
+    expect(activeLinesIn(tuiConf, /WheelDownPane\s+if-shell.*send-keys -M/).length).toBe(1);
+  });
+
   test('osc52-copy.sh helper script exists and is executable', () => {
     const scriptPath = resolve(import.meta.dirname, '../../scripts/tmux/osc52-copy.sh');
     expect(existsSync(scriptPath)).toBe(true);

--- a/src/tui/opentui-bridge.test.ts
+++ b/src/tui/opentui-bridge.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from 'bun:test';
+import { EventEmitter } from 'node:events';
+import type { CliRenderer, GetPaletteOptions, TerminalColors, ThemeMode } from '@opentui/core';
+import { installOpenTui20Bridge } from './opentui-bridge.js';
+import type { TuiTmuxThemeSnapshot } from './tmux-theme-sync.js';
+
+class FakeRenderer extends EventEmitter {
+  themeMode: ThemeMode | null = null;
+  waitResult: Promise<ThemeMode | null> = new Promise(() => {});
+  paletteResult: Promise<TerminalColors> = new Promise(() => {});
+  paletteOptions: GetPaletteOptions[] = [];
+
+  waitForThemeMode(_timeoutMs?: number): Promise<ThemeMode | null> {
+    return this.waitResult;
+  }
+
+  getPalette(options?: GetPaletteOptions): Promise<TerminalColors> {
+    if (options) this.paletteOptions.push(options);
+    return this.paletteResult;
+  }
+}
+
+function terminalColors(defaultForeground: string | null, defaultBackground: string | null): TerminalColors {
+  return {
+    palette: [],
+    defaultForeground,
+    defaultBackground,
+    cursorColor: null,
+    mouseForeground: null,
+    mouseBackground: null,
+    tekForeground: null,
+    tekBackground: null,
+    highlightBackground: null,
+    highlightForeground: null,
+  };
+}
+
+async function flushPromises(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('installOpenTui20Bridge', () => {
+  test('can disable tmux theme sync with an env flag', async () => {
+    const renderer = new FakeRenderer();
+    const calls: TuiTmuxThemeSnapshot[] = [];
+
+    installOpenTui20Bridge(renderer as unknown as CliRenderer, {
+      env: { GENIE_TUI_TMUX_THEME_SYNC: '0' },
+      syncTheme: (snapshot) => {
+        calls.push(snapshot);
+        return true;
+      },
+    });
+
+    renderer.emit('theme_mode', 'light');
+    await flushPromises();
+
+    expect(calls).toHaveLength(0);
+    expect(renderer.paletteOptions).toHaveLength(0);
+  });
+
+  test('syncs theme_mode events and unsubscribes on cleanup', () => {
+    const renderer = new FakeRenderer();
+    const calls: TuiTmuxThemeSnapshot[] = [];
+    const cleanup = installOpenTui20Bridge(renderer as unknown as CliRenderer, {
+      env: { GENIE_TUI_TMUX_THEME_SYNC_TIMEOUT_MS: '99' },
+      syncTheme: (snapshot, options) => {
+        calls.push({ ...snapshot, terminalForeground: String(options.timeoutMs) });
+        return true;
+      },
+    });
+
+    renderer.emit('theme_mode', 'light');
+    cleanup();
+    renderer.emit('theme_mode', 'dark');
+
+    expect(calls).toEqual([{ mode: 'light', terminalForeground: '99', terminalBackground: undefined }]);
+  });
+
+  test('queries the OpenTUI 0.2 palette path with a small bounded request', async () => {
+    const renderer = new FakeRenderer();
+    renderer.waitResult = Promise.resolve(null);
+    renderer.paletteResult = Promise.resolve(terminalColors('#111111', '#eeeeee'));
+    const calls: TuiTmuxThemeSnapshot[] = [];
+
+    installOpenTui20Bridge(renderer as unknown as CliRenderer, {
+      syncTheme: (snapshot) => {
+        calls.push(snapshot);
+        return true;
+      },
+    });
+    await flushPromises();
+
+    expect(renderer.paletteOptions).toEqual([{ size: 16, timeout: 700 }]);
+    expect(calls).toEqual([{ mode: 'light', terminalForeground: '#111111', terminalBackground: '#eeeeee' }]);
+  });
+
+  test('deduplicates repeated mode-only snapshots', async () => {
+    const renderer = new FakeRenderer();
+    renderer.themeMode = 'dark';
+    renderer.waitResult = Promise.resolve('dark');
+    const calls: TuiTmuxThemeSnapshot[] = [];
+
+    installOpenTui20Bridge(renderer as unknown as CliRenderer, {
+      syncTheme: (snapshot) => {
+        calls.push(snapshot);
+        return true;
+      },
+    });
+    await flushPromises();
+
+    expect(calls).toEqual([{ mode: 'dark', terminalForeground: undefined, terminalBackground: undefined }]);
+  });
+});

--- a/src/tui/opentui-bridge.ts
+++ b/src/tui/opentui-bridge.ts
@@ -1,0 +1,112 @@
+import type { CliRenderer, GetPaletteOptions, TerminalColors, ThemeMode } from '@opentui/core';
+import { type TuiTmuxThemeSnapshot, syncTuiTmuxTheme } from './tmux-theme-sync.js';
+
+type TuiRendererEnv = Record<string, string | undefined>;
+type ThemeSyncFn = (snapshot: TuiTmuxThemeSnapshot, options: { timeoutMs: number }) => boolean;
+
+export interface OpenTuiBridgeOptions {
+  env?: TuiRendererEnv;
+  syncTheme?: ThemeSyncFn;
+}
+
+const TRUTHY = new Set(['1', 'true', 'yes', 'on']);
+const FALSY = new Set(['0', 'false', 'no', 'off']);
+const DEFAULT_THEME_QUERY_TIMEOUT_MS = 700;
+const DEFAULT_TMUX_APPLY_TIMEOUT_MS = 300;
+const OPEN_TUI_02_PALETTE_SIZE = 16;
+
+function readBool(env: TuiRendererEnv, name: string, fallback: boolean): boolean {
+  const raw = env[name];
+  if (!raw) return fallback;
+  const normalized = raw.trim().toLowerCase();
+  if (TRUTHY.has(normalized)) return true;
+  if (FALSY.has(normalized)) return false;
+  return fallback;
+}
+
+function readPositiveInt(env: TuiRendererEnv, name: string, fallback: number): number {
+  const raw = env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function inferThemeMode(background: string | null | undefined): ThemeMode | null {
+  if (!background || !/^#[0-9a-f]{6}$/i.test(background)) return null;
+  const r = Number.parseInt(background.slice(1, 3), 16);
+  const g = Number.parseInt(background.slice(3, 5), 16);
+  const b = Number.parseInt(background.slice(5, 7), 16);
+  const luminance = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
+  return luminance >= 0.5 ? 'light' : 'dark';
+}
+
+function snapshotKey(snapshot: TuiTmuxThemeSnapshot): string {
+  return [snapshot.mode, snapshot.terminalForeground ?? '', snapshot.terminalBackground ?? ''].join('|');
+}
+
+function buildSnapshot(mode: ThemeMode | null, colors?: TerminalColors | null): TuiTmuxThemeSnapshot | null {
+  const resolvedMode = mode ?? inferThemeMode(colors?.defaultBackground);
+  if (!resolvedMode) return null;
+  return {
+    mode: resolvedMode,
+    terminalForeground: colors?.defaultForeground,
+    terminalBackground: colors?.defaultBackground,
+  };
+}
+
+export function installOpenTui20Bridge(renderer: CliRenderer, options: OpenTuiBridgeOptions = {}): () => void {
+  const env = options.env ?? process.env;
+  if (!readBool(env, 'GENIE_TUI_TMUX_THEME_SYNC', true)) {
+    return () => {};
+  }
+
+  const syncTheme = options.syncTheme ?? syncTuiTmuxTheme;
+  const themeQueryTimeoutMs = readPositiveInt(env, 'GENIE_TUI_THEME_QUERY_TIMEOUT_MS', DEFAULT_THEME_QUERY_TIMEOUT_MS);
+  const tmuxApplyTimeoutMs = readPositiveInt(
+    env,
+    'GENIE_TUI_TMUX_THEME_SYNC_TIMEOUT_MS',
+    DEFAULT_TMUX_APPLY_TIMEOUT_MS,
+  );
+  let disposed = false;
+  let lastSnapshot = '';
+
+  const syncSnapshot = (snapshot: TuiTmuxThemeSnapshot | null) => {
+    if (disposed || !snapshot) return;
+    const key = snapshotKey(snapshot);
+    if (key === lastSnapshot) return;
+    lastSnapshot = key;
+    try {
+      syncTheme(snapshot, { timeoutMs: tmuxApplyTimeoutMs });
+    } catch {
+      // Theme sync is best-effort; never let tmux state break the TUI.
+    }
+  };
+
+  const syncFromMode = (mode: ThemeMode | null, colors?: TerminalColors | null) => {
+    syncSnapshot(buildSnapshot(mode, colors));
+  };
+
+  const onThemeMode = (mode: ThemeMode) => syncFromMode(mode);
+  renderer.on('theme_mode', onThemeMode);
+
+  syncFromMode(renderer.themeMode);
+
+  void renderer
+    .waitForThemeMode(themeQueryTimeoutMs)
+    .then((mode) => syncFromMode(mode))
+    .catch(() => {});
+
+  const paletteOptions: GetPaletteOptions = {
+    size: OPEN_TUI_02_PALETTE_SIZE,
+    timeout: themeQueryTimeoutMs,
+  };
+  void renderer
+    .getPalette(paletteOptions)
+    .then((colors) => syncFromMode(renderer.themeMode, colors))
+    .catch(() => {});
+
+  return () => {
+    disposed = true;
+    renderer.off('theme_mode', onThemeMode);
+  };
+}

--- a/src/tui/render.test.ts
+++ b/src/tui/render.test.ts
@@ -2,18 +2,25 @@ import { describe, expect, test } from 'bun:test';
 import { resolveTuiRendererConfig } from './render.js';
 
 describe('resolveTuiRendererConfig', () => {
-  test('uses conservative renderer defaults on macOS', () => {
+  test('uses click-only renderer defaults on macOS', () => {
     const config = resolveTuiRendererConfig({}, 'darwin');
 
     expect(config.exitOnCtrlC).toBe(false);
     expect(config.useThread).toBe(false);
     expect(config.targetFps).toBe(8);
     expect(config.maxFps).toBe(12);
-    expect(config.useMouse).toBe(false);
+    expect(config.useMouse).toBe(true);
     expect(config.enableMouseMovement).toBe(false);
     expect(config.useKittyKeyboard).toBe(null);
     expect(config.consoleMode).toBe('disabled');
     expect(config.openConsoleOnError).toBe(false);
+  });
+
+  test('allows explicit macOS mouse opt-out', () => {
+    const config = resolveTuiRendererConfig({ GENIE_TUI_MOUSE: '0' }, 'darwin');
+
+    expect(config.useMouse).toBe(false);
+    expect(config.enableMouseMovement).toBe(false);
   });
 
   test('allows explicit macOS mouse and FPS overrides', () => {

--- a/src/tui/render.tsx
+++ b/src/tui/render.tsx
@@ -34,7 +34,7 @@ export function resolveTuiRendererConfig(
   const targetFps = readPositiveInt(env, 'GENIE_TUI_TARGET_FPS') ?? (isDarwin ? 8 : 30);
   const configuredMaxFps = readPositiveInt(env, 'GENIE_TUI_MAX_FPS') ?? (isDarwin ? 12 : 60);
   const maxFps = Math.max(configuredMaxFps, targetFps);
-  const useMouse = readBool(env, 'GENIE_TUI_MOUSE', !isDarwin);
+  const useMouse = readBool(env, 'GENIE_TUI_MOUSE', true);
   const enableMouseMovement = useMouse && readBool(env, 'GENIE_TUI_MOUSE_MOVEMENT', !isDarwin);
 
   return {

--- a/src/tui/render.tsx
+++ b/src/tui/render.tsx
@@ -4,6 +4,7 @@
 import { type CliRendererConfig, createCliRenderer } from '@opentui/core';
 import { createRoot } from '@opentui/react';
 import { App } from './app.js';
+import { installOpenTui20Bridge } from './opentui-bridge.js';
 
 const TRUTHY = new Set(['1', 'true', 'yes', 'on']);
 const FALSY = new Set(['0', 'false', 'no', 'off']);
@@ -59,12 +60,16 @@ export async function renderNav(): Promise<void> {
   // macOS local ptys have repeatedly hit OpenTUI native hot loops. Keep the TUI
   // usable there, but default to a conservative renderer and allow env opt-ins.
   const renderer = await createCliRenderer(resolveTuiRendererConfig());
+  const disposeOpenTui20Bridge = installOpenTui20Bridge(renderer);
 
   createRoot(renderer).render(<App rightPane={rightPane} workspaceRoot={workspaceRoot} initialAgent={initialAgent} />);
 
   // Keep process alive until renderer is destroyed (Ctrl+Q, SIGTERM, etc.)
   // Without this, bun exits immediately after render() returns.
   await new Promise<void>((resolve) => {
-    (renderer as unknown as { once: (event: string, fn: () => void) => void }).once('destroy', resolve);
+    (renderer as unknown as { once: (event: string, fn: () => void) => void }).once('destroy', () => {
+      disposeOpenTui20Bridge();
+      resolve();
+    });
   });
 }

--- a/src/tui/tmux-theme-sync.test.ts
+++ b/src/tui/tmux-theme-sync.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import { buildTuiTmuxThemeCommands, syncTuiTmuxTheme } from './tmux-theme-sync.js';
+
+describe('tmux theme sync', () => {
+  test('builds light-mode tmux commands from OpenTUI terminal colors', () => {
+    const commands = buildTuiTmuxThemeCommands({
+      mode: 'light',
+      terminalForeground: '#111111',
+      terminalBackground: '#eeeeee',
+    });
+    const joined = commands.join(' ');
+
+    expect(joined).toContain('set-environment -g GENIE_TUI_THEME_MODE light');
+    expect(joined).toContain('set-environment -g GENIE_TUI_TERMINAL_FG #111111');
+    expect(joined).toContain('set-environment -g GENIE_TUI_TERMINAL_BG #eeeeee');
+    expect(joined).toContain('set-option -g status-style bg=#eeeeee,fg=#111111');
+    expect(joined).toContain('set-option -g pane-active-border-style fg=#2f7a62');
+  });
+
+  test('keeps the Genie dark palette for dark terminals', () => {
+    const commands = buildTuiTmuxThemeCommands({
+      mode: 'dark',
+      terminalForeground: '#ffffff',
+      terminalBackground: '#000000',
+    });
+    const joined = commands.join(' ');
+
+    expect(joined).toContain('set-environment -g GENIE_TUI_THEME_MODE dark');
+    expect(joined).toContain('set-option -g status-style bg=#0a1d2a,fg=#c9cfd4');
+    expect(joined).toContain('set-option -g pane-active-border-style fg=#7fc8a9');
+  });
+
+  test('applies commands through one bounded tmux invocation', () => {
+    const calls: unknown[][] = [];
+    const ok = syncTuiTmuxTheme(
+      { mode: 'light', terminalForeground: '#111111', terminalBackground: '#eeeeee' },
+      {
+        tmuxBin: '/usr/bin/tmux',
+        socketName: 'test-tui',
+        configPath: '/tmp/tui-tmux.conf',
+        timeoutMs: 123,
+        spawnSync: ((command: string, args: string[], options: unknown) => {
+          calls.push([command, args, options]);
+          return { status: 0 };
+        }) as never,
+      },
+    );
+
+    expect(ok).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0]).toBe('/usr/bin/tmux');
+    const args = calls[0][1] as string[];
+    expect(args.slice(0, 5)).toEqual(['-L', 'test-tui', '-f', '/tmp/tui-tmux.conf', 'set-environment']);
+    expect(args).toContain('GENIE_TUI_THEME_MODE');
+    expect(calls[0][2]).toEqual({ stdio: 'ignore', timeout: 123 });
+  });
+});

--- a/src/tui/tmux-theme-sync.ts
+++ b/src/tui/tmux-theme-sync.ts
@@ -1,0 +1,131 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { tmuxBin } from '../lib/ensure-tmux.js';
+import { palette } from './theme.js';
+
+export type OpenTuiThemeMode = 'dark' | 'light';
+
+export interface TuiTmuxThemeSnapshot {
+  mode: OpenTuiThemeMode;
+  terminalForeground?: string | null;
+  terminalBackground?: string | null;
+}
+
+interface TmuxThemePalette {
+  bg: string;
+  bgRaised: string;
+  text: string;
+  textDim: string;
+  textMuted: string;
+  border: string;
+  accent: string;
+  accentDim: string;
+  accentBright: string;
+  warning: string;
+  info: string;
+}
+
+interface SyncTuiTmuxThemeDeps {
+  spawnSync?: typeof spawnSync;
+  tmuxBin?: string;
+  socketName?: string;
+  configPath?: string;
+  timeoutMs?: number;
+}
+
+const TUI_TMUX_SOCKET = 'genie-tui';
+const DEFAULT_TMUX_SYNC_TIMEOUT_MS = 300;
+const HEX_COLOR_RE = /^#[0-9a-f]{6}$/i;
+
+const lightPalette: TmuxThemePalette = {
+  bg: '#f5efe4',
+  bgRaised: '#ebe3d7',
+  text: '#24323a',
+  textDim: '#56656d',
+  textMuted: '#718087',
+  border: '#c8bdae',
+  accent: '#2f7a62',
+  accentDim: '#3e9277',
+  accentBright: '#17694f',
+  warning: '#9a651e',
+  info: '#406f8b',
+};
+
+function resolveTuiTmuxConf(): string {
+  const home = process.env.GENIE_HOME ?? `${process.env.HOME}/.genie`;
+  const tuiConf = `${home}/tui-tmux.conf`;
+  return existsSync(tuiConf) ? tuiConf : '/dev/null';
+}
+
+function safeHex(value: string | null | undefined, fallback: string): string {
+  if (!value) return fallback;
+  const trimmed = value.trim();
+  return HEX_COLOR_RE.test(trimmed) ? trimmed : fallback;
+}
+
+function resolveThemePalette(snapshot: TuiTmuxThemeSnapshot): TmuxThemePalette {
+  if (snapshot.mode === 'dark') {
+    return {
+      bg: palette.bg,
+      bgRaised: palette.bgRaised,
+      text: palette.text,
+      textDim: palette.textDim,
+      textMuted: palette.textMuted,
+      border: palette.border,
+      accent: palette.accent,
+      accentDim: palette.accentDim,
+      accentBright: palette.accentBright,
+      warning: palette.warning,
+      info: palette.info,
+    };
+  }
+
+  return {
+    ...lightPalette,
+    bg: safeHex(snapshot.terminalBackground, lightPalette.bg),
+    text: safeHex(snapshot.terminalForeground, lightPalette.text),
+  };
+}
+
+function flattenTmuxCommands(commands: string[][]): string[] {
+  const args: string[] = [];
+  commands.forEach((command, index) => {
+    if (index > 0) args.push(';');
+    args.push(...command);
+  });
+  return args;
+}
+
+export function buildTuiTmuxThemeCommands(snapshot: TuiTmuxThemeSnapshot): string[] {
+  const theme = resolveThemePalette(snapshot);
+  const terminalForeground = safeHex(snapshot.terminalForeground, theme.text);
+  const terminalBackground = safeHex(snapshot.terminalBackground, theme.bg);
+  return flattenTmuxCommands([
+    ['set-environment', '-g', 'GENIE_TUI_THEME_MODE', snapshot.mode],
+    ['set-environment', '-g', 'GENIE_TUI_TERMINAL_FG', terminalForeground],
+    ['set-environment', '-g', 'GENIE_TUI_TERMINAL_BG', terminalBackground],
+    ['set-environment', '-g', 'GENIE_TUI_TMUX_BG', theme.bg],
+    ['set-environment', '-g', 'GENIE_TUI_TMUX_TEXT', theme.text],
+    ['set-environment', '-g', 'GENIE_TUI_TMUX_ACCENT', theme.accent],
+    ['set-option', '-g', 'pane-border-style', `fg=${theme.border}`],
+    ['set-option', '-g', 'pane-active-border-style', `fg=${theme.accent}`],
+    ['set-option', '-g', 'message-style', `bg=${theme.bgRaised},fg=${theme.info}`],
+    ['set-option', '-g', 'message-command-style', `bg=${theme.bgRaised},fg=${theme.warning}`],
+    ['set-option', '-g', 'status-style', `bg=${theme.bg},fg=${theme.text}`],
+    ['set-window-option', '-g', 'mode-style', `bg=${theme.accent},fg=${theme.bg}`],
+    ['set-window-option', '-g', 'clock-mode-colour', theme.accent],
+  ]);
+}
+
+export function syncTuiTmuxTheme(snapshot: TuiTmuxThemeSnapshot, deps: SyncTuiTmuxThemeDeps = {}): boolean {
+  const run = deps.spawnSync ?? spawnSync;
+  const tmux = deps.tmuxBin ?? tmuxBin();
+  const socketName = deps.socketName ?? TUI_TMUX_SOCKET;
+  const configPath = deps.configPath ?? resolveTuiTmuxConf();
+  const timeoutMs = deps.timeoutMs ?? DEFAULT_TMUX_SYNC_TIMEOUT_MS;
+  const result = run(tmux, ['-L', socketName, '-f', configPath, ...buildTuiTmuxThemeCommands(snapshot)], {
+    stdio: 'ignore',
+    timeout: timeoutMs,
+  });
+  return result.status === 0;
+}


### PR DESCRIPTION
## Summary
- bump OpenTUI core/react to 0.2.0
- restore tmux mouse forwarding so OpenTUI receives left-nav clicks under tmux
- enable click-only mouse defaults on macOS while keeping movement disabled
- use OpenTUI 0.2 theme/palette queries to sync terminal theme facts into the genie-tui tmux server
- keep theme sync bounded, best-effort, deduped, and opt-out via GENIE_TUI_TMUX_THEME_SYNC=0

## Verification
- bun test src/tui/opentui-bridge.test.ts src/tui/tmux-theme-sync.test.ts src/tui/render.test.ts src/__tests__/tmux-config.test.ts
- bun test src/tui
- bun run typecheck
- bunx biome check src/tui/render.tsx src/tui/opentui-bridge.ts src/tui/opentui-bridge.test.ts src/tui/tmux-theme-sync.ts src/tui/tmux-theme-sync.test.ts
- bun run build