### PR TITLE
chore(deps): bump pgserve floor to ^2.0.7

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "ignore": "7.0.5",
         "js-yaml": "4.1.1",
         "nats": "2.29.3",
-        "pgserve": "^2.0.3",
+        "pgserve": "^2.0.7",
         "postgres": "3.4.9",
         "react": "19.2.5",
         "react-dom": "19.2.5",
@@ -885,7 +885,7 @@
 
     "peek-readable": ["peek-readable@4.1.0", "", {}, "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="],
 
-    "pgserve": ["pgserve@2.0.3", "", { "dependencies": { "bun": "^1.3.4" }, "optionalDependencies": { "@embedded-postgres/darwin-arm64": "18.2.0-beta.16", "@embedded-postgres/darwin-x64": "18.2.0-beta.16", "@embedded-postgres/linux-x64": "18.2.0-beta.16", "@embedded-postgres/windows-x64": "18.2.0-beta.16" }, "bin": { "pgserve": "bin/pgserve-wrapper.cjs" } }, "sha512-zoZsuesGaUJ7DKGvnzr71OHqpZ/641JigZIsz26bjLuePBusfPBeOSmZ+M4hBP2jgfQmm/gcaXZok/Abr5KfWA=="],
+    "pgserve": ["pgserve@2.0.7", "", { "dependencies": { "bun": "^1.3.4" }, "optionalDependencies": { "@embedded-postgres/darwin-arm64": "18.2.0-beta.16", "@embedded-postgres/darwin-x64": "18.2.0-beta.16", "@embedded-postgres/linux-x64": "18.2.0-beta.16", "@embedded-postgres/windows-x64": "18.2.0-beta.16" }, "bin": { "pgserve": "bin/pgserve-wrapper.cjs" } }, "sha512-vKxE+tf+Wr7c9CbeeSd6to4h1HGTVehBQaCVSAM4GfjxFRg0S3P0gQjzHPKcIlFpUKbqPc7zxYhfKr8ywnxbEw=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "ignore": "7.0.5",
     "js-yaml": "4.1.1",
     "nats": "2.29.3",
-    "pgserve": "^2.0.3",
+    "pgserve": "^2.0.7",
     "postgres": "3.4.9",
     "react": "19.2.5",
     "react-dom": "19.2.5",


### PR DESCRIPTION
## Summary
Bumps the `pgserve` dependency floor from `^2.0.3` to `^2.0.7`.

`^2.0.3` already accepted `2.0.7` automatically — fresh installs were getting it. This PR documents the floor explicitly so package.json reflects the version that contains the four pgserve-side recovery fixes the daemon-recovery code in `src/lib/db.ts` (PRs #1553, #1554, #1557) was designed against.

## What's in 2.0.4 → 2.0.7

| Version | Fix |
|---|---|
| 2.0.4 | Clear stale `postmaster.pid` before `_startPostgres` — no more manual `rm` after unclean shutdown ([pgserve#46](https://github.com/namastexlabs/pgserve/pull/46)) |
| 2.0.5 | Wrapper exits non-zero when postgres backend dies unexpectedly, so a process supervisor restarts it cleanly ([pgserve#49](https://github.com/namastexlabs/pgserve/pull/49)) |
| 2.0.6 | Handshake watchdog closes peers stuck pre-handshake past `PGSERVE_HANDSHAKE_DEADLINE_MS` (default 30s) ([pgserve#50](https://github.com/namastexlabs/pgserve/pull/50)) |
| 2.0.7 | Control-socket startup retries backend connect once + 57P03 fallback instead of silent TCP drop ([pgserve#51](https://github.com/namastexlabs/pgserve/pull/51)) |

All four close pgserve#45 (the daemon-mode hang reported during the genie post-reboot recovery session that produced PRs #1553-#1557 here).

## End-to-end validation
Local smoke test on this host with `pgserve@2.0.7` installed:
```
T+0:  kill -9 <postgres backend pid>
T+1s: pgserve wrapper exits non-zero
T+8s: genie db query "SELECT 1" returns 1
      Fresh wrapper + backend running cleanly
Total recovery: ~8s, zero human intervention.
```

## Risk
Minimal. Caret range preserved (`^2.0.7` accepts any 2.x). No behaviour changes in genie itself; we just get the pgserve-side fixes with stronger version guarantees.

## Test plan
- [x] `bun add pgserve@^2.0.7` updated `package.json` + `bun.lock` cleanly
- [x] No genie source changes
- [ ] CI: existing test suite passes (no genie code changed; only the dep floor)