### PR TITLE
chore(deps): bump pgserve floor to ^2.0.8

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "ignore": "7.0.5",
         "js-yaml": "4.1.1",
         "nats": "2.29.3",
-        "pgserve": "^2.0.3",
+        "pgserve": "^2.0.8",
         "postgres": "3.4.9",
         "react": "19.2.5",
         "react-dom": "19.2.5",
@@ -161,13 +161,13 @@
 
     "@dimforge/rapier2d-simd-compat": ["@dimforge/rapier2d-simd-compat@0.17.3", "", {}, "sha512-bijvwWz6NHsNj5e5i1vtd3dU2pDhthSaTUZSh14DUGGKJfw8eMnlWZsxwHBxB/a3AXVNDjL9abuHw1k9FGR+jg=="],
 
-    "@embedded-postgres/darwin-arm64": ["@embedded-postgres/darwin-arm64@18.2.0-beta.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wnswaF+uDvGeitqajJ8v8xOG4ttFrzixElwKNe2MIxBXSLWPV3xhi6tBY0Sjw8Lmiu6UG9vNLFZSjHPrIeokBg=="],
+    "@embedded-postgres/darwin-arm64": ["@embedded-postgres/darwin-arm64@18.3.0-beta.17", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Pvrej3Xz5flfyVc9mchVfekrKoTJyvPtM3U0vjuXamZkRKmi+inP2zRmnmzYecIVbr7Zhu82xbsCENMXrwMp9Q=="],
 
-    "@embedded-postgres/darwin-x64": ["@embedded-postgres/darwin-x64@18.2.0-beta.16", "", { "os": "darwin", "cpu": "x64" }, "sha512-u9WtTPxRuO0uOny5IniXHSDaLmtOujwzDoExIV/jFT0Fu8SzpX7wdoPbsSPBLgyQWdr/nPA77K9QI4r6P1/fKA=="],
+    "@embedded-postgres/darwin-x64": ["@embedded-postgres/darwin-x64@18.3.0-beta.17", "", { "os": "darwin", "cpu": "x64" }, "sha512-MVWe+C47pPoMD9LlIWGQkvZ5Xsu3IBo54CYqnIps/Z1byMIUBNc7y/dZ3mfqEwiCbVDVqirG0CU462xnrSEfKA=="],
 
-    "@embedded-postgres/linux-x64": ["@embedded-postgres/linux-x64@18.2.0-beta.16", "", { "os": "linux", "cpu": "x64" }, "sha512-BIt485ioL8/AwDgw37IcdraOfRgHNDOtGM6Hh63vnNaUAG4Z0qtJd5zXS5fr2wZTEsYHyC5PC60k7zkCRZXSzg=="],
+    "@embedded-postgres/linux-x64": ["@embedded-postgres/linux-x64@18.3.0-beta.17", "", { "os": "linux", "cpu": "x64" }, "sha512-8orSD6NNopSLtjqir4dWQBrj+g8j1eJjWd9mB60A3xbWMzIBIPQpzT7XzbacW9YFSl/DejOLnRXfff+Wr13Tgw=="],
 
-    "@embedded-postgres/windows-x64": ["@embedded-postgres/windows-x64@18.2.0-beta.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Sj6GhCZrvtMwchATEtWuEmexEBWpRNMHPTUHsqPuyDrHX/XgKfpIxz2/AMHa4sp7SZ0JOHGouH8AFIVsWQrQsQ=="],
+    "@embedded-postgres/windows-x64": ["@embedded-postgres/windows-x64@18.3.0-beta.17", "", { "os": "win32", "cpu": "x64" }, "sha512-kDC5aBsmhWDjeQjj2V4g+Bk+pMeDU27b7l0rBbaKgtt2gsNmCB34ULg/5cqs2kqUKSk/tiGMHKCNE+zQZ+s4rg=="],
 
     "@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
@@ -885,7 +885,7 @@
 
     "peek-readable": ["peek-readable@4.1.0", "", {}, "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="],
 
-    "pgserve": ["pgserve@2.0.3", "", { "dependencies": { "bun": "^1.3.4" }, "optionalDependencies": { "@embedded-postgres/darwin-arm64": "18.2.0-beta.16", "@embedded-postgres/darwin-x64": "18.2.0-beta.16", "@embedded-postgres/linux-x64": "18.2.0-beta.16", "@embedded-postgres/windows-x64": "18.2.0-beta.16" }, "bin": { "pgserve": "bin/pgserve-wrapper.cjs" } }, "sha512-zoZsuesGaUJ7DKGvnzr71OHqpZ/641JigZIsz26bjLuePBusfPBeOSmZ+M4hBP2jgfQmm/gcaXZok/Abr5KfWA=="],
+    "pgserve": ["pgserve@2.0.8", "", { "dependencies": { "bun": "^1.3.4" }, "optionalDependencies": { "@embedded-postgres/darwin-arm64": "18.3.0-beta.17", "@embedded-postgres/darwin-x64": "18.3.0-beta.17", "@embedded-postgres/linux-x64": "18.3.0-beta.17", "@embedded-postgres/windows-x64": "18.3.0-beta.17" }, "bin": { "pgserve": "bin/pgserve-wrapper.cjs" } }, "sha512-WCY0pmWMTFbjKGSDGxoVmaDD55o/0qNCTD9bc4XdFKTWXZaqbq56bx4bgmvm1U/zOPJs/OKKggMAff738NA+Ig=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "ignore": "7.0.5",
     "js-yaml": "4.1.1",
     "nats": "2.29.3",
-    "pgserve": "^2.0.3",
+    "pgserve": "^2.0.8",
     "postgres": "3.4.9",
     "react": "19.2.5",
     "react-dom": "19.2.5",


### PR DESCRIPTION
## Summary
Bumps the `pgserve` dependency floor from `^2.0.3` to `^2.0.8`.

Picks up the embedded PostgreSQL binary bump from [pgserve#52](https://github.com/namastexlabs/pgserve/pull/52) (PG `18.2.0-beta.16` → `18.3.0-beta.17` across all four platforms) on top of the four pgserve#45 recovery fixes already in 2.0.5 / 2.0.6 / 2.0.7.

## Relationship to #1562
This stacks on the same area #1562 covers. Either merge order is safe:

| If #1562 merges first | If #1564 merges first |
|---|---|
| Diff here becomes a trivial `^2.0.7` → `^2.0.8` floor move | #1562 becomes redundant — close it |

The caret range already accepted 2.0.8 automatically — fresh installs were getting it the moment pgserve#52 published. This PR pins the floor explicitly so `package.json` reflects the version that ships PostgreSQL 18.3.

## What's in 2.0.8
| Version | Change |
|---|---|
| 2.0.4 | Stale `postmaster.pid` cleanup ([pgserve#46](https://github.com/namastexlabs/pgserve/pull/46)) |
| 2.0.5 | Wrapper exits non-zero when backend dies unexpectedly ([pgserve#49](https://github.com/namastexlabs/pgserve/pull/49)) |
| 2.0.6 | Handshake watchdog ([pgserve#50](https://github.com/namastexlabs/pgserve/pull/50)) |
| 2.0.7 | Backend connect retry + 57P03 fallback ([pgserve#51](https://github.com/namastexlabs/pgserve/pull/51)) |
| **2.0.8** | **Embedded PG 18.2 → 18.3 binaries** ([pgserve#52](https://github.com/namastexlabs/pgserve/pull/52)) |

## Risk
Minimal. Caret range preserved. No genie source changes. The PG minor-version bump is exercised by pgserve's own CI matrix (linux-x64 + macos-latest), and pgserve@2.0.8 has been live on npm since the bump landed.

## Test plan
- [x] `bun add pgserve@^2.0.8` updated `package.json` + `bun.lock` cleanly
- [x] No genie source changes
- [ ] CI: existing test suite passes (only the dep floor moved)