### PR TITLE
feat(db): v1→v2 auto-migration + `genie db ls`

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -27,6 +27,7 @@ import type postgres from 'postgres';
 import { runMigrations } from './db-migrations.js';
 import { needsSeed, needsSeededTeams, runSeed } from './pg-seed.js';
 import { getProcessStartTime } from './process-identity.js';
+import { maybePromptV1Migration } from './v1-migration-prompt.js';
 
 /**
  * Re-export Sql type for callers that need to annotate sql connection parameters.
@@ -1288,6 +1289,11 @@ async function runPostConnectSetup(client: postgres.Sql, isTestMode: boolean, ti
   if (!skipBoot && (needsSeed() || (await needsSeededTeams(client)))) {
     await runSeed(client);
   }
+
+  // v1 → v2 auto-prompt: probes once per process for legacy v1 user DBs;
+  // silenced after a successful `genie db migrate-v1` records itself in
+  // _genie_migration_state. Best-effort: failures degrade silently.
+  if (!skipBoot) await maybePromptV1Migration(client);
   const _t4 = Date.now();
 
   // Retention is no longer run from getConnection — it now lives on a

--- a/src/lib/v1-migration-prompt.ts
+++ b/src/lib/v1-migration-prompt.ts
@@ -1,0 +1,173 @@
+/**
+ * v1-migration auto-detection + prompt (runs at every fresh DB connect).
+ *
+ * Drops into `src/lib/v1-migration-prompt.ts`. Wired into `runPostConnectSetup`
+ * in `src/lib/db.ts` (see patch). One probe per process.
+ *
+ * Flow:
+ *   1. Process-local cache: `promptedThisProcess` — never prompt twice
+ *      in the same genie invocation.
+ *   2. Target DB has `_genie_migration_state` table with a row for the
+ *      source DB → migration already completed → silent.
+ *   3. No row → probe pg_database via admin TCP for any v1-shaped DB.
+ *      Cheap (single query, sub-ms).
+ *   4. v1 found → print one-line offer (TTY) or silent notice (non-TTY).
+ *
+ * Suppressors (any of):
+ *   - GENIE_NO_V1_PROMPT=1
+ *   - GENIE_QUIET=1
+ *   - non-interactive stderr (no TTY)
+ *   - migration already recorded in _genie_migration_state
+ */
+
+import postgres from 'postgres';
+
+const V1_DB_NAME = 'genie';
+const PG_USER = 'postgres';
+const PG_PASS = 'postgres';
+const PG_HOST = '127.0.0.1';
+
+let promptedThisProcess = false;
+
+interface DetectionResult {
+  v1Exists: boolean;
+  v1Counts?: { tasks: number; wishes: number; teams: number; sessions: number };
+  alreadyMigrated: boolean;
+}
+
+/**
+ * Best-effort: probe the target DB's migration-state table + the v1 source.
+ * Never throws — failures degrade silently.
+ */
+export async function maybePromptV1Migration(target: postgres.Sql): Promise<void> {
+  if (promptedThisProcess) return;
+  promptedThisProcess = true;
+
+  if (process.env.GENIE_NO_V1_PROMPT === '1') return;
+  if (process.env.GENIE_QUIET === '1') return;
+  if (process.env.GENIE_TEST_DB_NAME) return; // tests must stay quiet
+  if (process.env.GENIE_NO_BANNER === '1') return;
+
+  let detection: DetectionResult;
+  try {
+    detection = await detectV1State(target);
+  } catch {
+    return;
+  }
+  if (!detection.v1Exists) return;
+  if (detection.alreadyMigrated) return;
+
+  const { tasks = 0, wishes = 0, teams = 0, sessions = 0 } = detection.v1Counts ?? {};
+  const tty = Boolean(process.stderr.isTTY);
+
+  if (!tty) {
+    process.stderr.write(
+      `[genie] ⓘ Legacy v1 data detected (${tasks} tasks, ${wishes} wishes, ${teams} teams, ${sessions} sessions).\n        Run \`genie db migrate-v1\` to import. Suppress with GENIE_NO_V1_PROMPT=1.\n`,
+    );
+    return;
+  }
+
+  // Interactive: print a single-line offer. Don't block the user's command —
+  // they invoked `genie status` (or whatever); migration is interactive +
+  // long-running, must be its own command.
+  process.stderr.write(
+    `[genie] ⚠ Legacy v1 data detected (${tasks} tasks, ${wishes} wishes, ${teams} teams, ${sessions} sessions, last 30d).\n        Run \`genie db migrate-v1\` to import.\n        (one-time offer — silent after first migration; or set GENIE_NO_V1_PROMPT=1)\n`,
+  );
+}
+
+async function detectV1State(target: postgres.Sql): Promise<DetectionResult> {
+  // Step 1: ensure migration-state table + check it
+  await ensureMigrationStateTable(target);
+  const completedRows = await target<{ source_db: string }[]>`
+    SELECT source_db FROM _genie_migration_state WHERE source_db = ${V1_DB_NAME}
+  `;
+  if (completedRows.length > 0) {
+    return { v1Exists: false, alreadyMigrated: true };
+  }
+
+  // Step 2: probe v1 via admin TCP. Use the same port the runtime is
+  // already on (postgres SHOW port returns the per-backend port, but
+  // we know the daemon port from current_setting('port') — works for
+  // both socket-routed and direct connections).
+  const portRows = await target<{ port: string }[]>`SHOW port`;
+  const port = Number(portRows[0]?.port);
+  if (!Number.isFinite(port) || port <= 0) return { v1Exists: false, alreadyMigrated: false };
+
+  const v1 = postgres({
+    host: PG_HOST,
+    port,
+    username: PG_USER,
+    password: PG_PASS,
+    database: V1_DB_NAME,
+    max: 1,
+    onnotice: () => {},
+    connect_timeout: 3,
+    idle_timeout: 1,
+  });
+  try {
+    // If the DB doesn't exist, postgres-js throws 3D000.
+    const probe = await v1<{ relname: string; n_live_tup: bigint }[]>`
+      SELECT relname, n_live_tup FROM pg_stat_user_tables
+      WHERE schemaname='public'
+        AND relname IN ('tasks','wishes','teams','sessions')
+    `;
+    if (probe.length === 0) return { v1Exists: false, alreadyMigrated: false };
+    const counts = { tasks: 0, wishes: 0, teams: 0, sessions: 0 };
+    for (const r of probe) {
+      const n = Number(r.n_live_tup);
+      if (r.relname === 'tasks') counts.tasks = n;
+      else if (r.relname === 'wishes') counts.wishes = n;
+      else if (r.relname === 'teams') counts.teams = n;
+      else if (r.relname === 'sessions') counts.sessions = n;
+    }
+    return { v1Exists: true, v1Counts: counts, alreadyMigrated: false };
+  } catch (_err) {
+    // 3D000 = database does not exist. Any other error: degrade silently.
+    return { v1Exists: false, alreadyMigrated: false };
+  } finally {
+    try {
+      await v1.end({ timeout: 1 });
+    } catch {
+      /* swallow */
+    }
+  }
+}
+
+/**
+ * Schema for the prompt-once + migration-completed marker. Idempotent.
+ *
+ * One row per source DB that has been migrated. The migrate-v1 command
+ * INSERTs a row on success. The startup detector checks for the row's
+ * presence to suppress the offer.
+ */
+async function ensureMigrationStateTable(target: postgres.Sql): Promise<void> {
+  await target.unsafe(`
+    CREATE TABLE IF NOT EXISTS _genie_migration_state (
+      source_db    TEXT PRIMARY KEY,
+      completed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      rows_copied  JSONB NOT NULL DEFAULT '{}'::jsonb,
+      notes        TEXT
+    )
+  `);
+}
+
+/**
+ * Called by the migrate-v1 command on success to suppress future prompts.
+ *
+ * @param target — the v2 fingerprinted DB the data was migrated INTO
+ * @param sourceDb — the v1 DB name (default 'genie')
+ * @param rowsCopied — per-table counts for the operator audit
+ */
+export async function recordMigrationComplete(
+  target: postgres.Sql,
+  sourceDb: string,
+  rowsCopied: Record<string, number>,
+): Promise<void> {
+  await ensureMigrationStateTable(target);
+  await target.unsafe(
+    `INSERT INTO _genie_migration_state (source_db, rows_copied)
+     VALUES ($1, $2::jsonb)
+     ON CONFLICT (source_db) DO UPDATE SET completed_at = now(), rows_copied = EXCLUDED.rows_copied`,
+    [sourceDb, JSON.stringify(rowsCopied)],
+  );
+}

--- a/src/term-commands/db-ls.ts
+++ b/src/term-commands/db-ls.ts
@@ -1,0 +1,248 @@
+/**
+ * `genie db ls` — list all pgserve databases on the host.
+ *
+ * Drops into `src/term-commands/db-ls.ts`. Operator visibility for the
+ * proliferation of per-fingerprint DBs in pgserve v2.
+ *
+ * Default output (table): name, size, persist, last_connection, package_realpath
+ * --json: machine-readable, full row from pgserve_meta + size
+ * --counts: extra column showing tasks/wishes counts per DB (slow — opens
+ *           one connection per DB; off by default)
+ * --all: include system DBs (postgres / template0 / template1)
+ * --orphans: only show DBs that don't match `app_*_<12hex>` AND aren't tracked
+ *
+ * No destructive actions — read-only by design.
+ */
+
+import type { Command } from 'commander';
+import postgres from 'postgres';
+import { getConnection, isAvailable, shutdown } from '../lib/db.js';
+
+const PG_USER = 'postgres';
+const PG_PASS = 'postgres';
+const PG_HOST = '127.0.0.1';
+const SYSTEM_DBS = new Set(['postgres', 'template0', 'template1']);
+const V2_TENANT_DB_PATTERN = /^app_[a-z0-9_]{1,50}_[0-9a-f]{12}$/;
+
+interface DbRow {
+  name: string;
+  sizeBytes: number;
+  fingerprint: string | null;
+  persist: boolean;
+  lastConnectionAt: Date | null;
+  packageRealpath: string | null;
+  livenessPid: number | null;
+  isV2Pattern: boolean;
+  isSystem: boolean;
+  /** Optional: filled when --counts is set. */
+  counts?: { tasks?: number; wishes?: number; teams?: number; sessions?: number };
+}
+
+interface LsOptions {
+  json?: boolean;
+  counts?: boolean;
+  all?: boolean;
+  orphans?: boolean;
+}
+
+async function dbLsCommand(options: LsOptions): Promise<void> {
+  const available = await isAvailable();
+  if (!available) {
+    console.error('Database is not running.');
+    process.exit(1);
+  }
+
+  const v2 = await getConnection();
+  const portRows = await v2.unsafe('SHOW port');
+  const port = Number((portRows as Array<{ port: string }>)[0]?.port);
+  if (!Number.isFinite(port) || port <= 0) {
+    console.error('Could not resolve pgserve TCP port.');
+    await shutdown();
+    process.exit(1);
+  }
+
+  // Use TCP admin so we can see ALL DBs (not just the caller's fingerprint).
+  const admin = postgres({
+    host: PG_HOST,
+    port,
+    username: PG_USER,
+    password: PG_PASS,
+    database: 'postgres',
+    max: 1,
+    onnotice: () => {},
+    idle_timeout: 5,
+  });
+
+  try {
+    const rows = await loadAllDbs(admin);
+    let filtered = rows;
+    if (!options.all) filtered = filtered.filter((r) => !r.isSystem);
+    if (options.orphans) filtered = filtered.filter((r) => !r.isV2Pattern && !r.isSystem && !r.fingerprint);
+
+    if (options.counts) {
+      // Connect to each DB and probe genie tables
+      for (const row of filtered) {
+        if (row.isSystem) continue;
+        try {
+          const c = postgres({
+            host: PG_HOST,
+            port,
+            username: PG_USER,
+            password: PG_PASS,
+            database: row.name,
+            max: 1,
+            onnotice: () => {},
+            idle_timeout: 1,
+            connect_timeout: 3,
+          });
+          const probe = await c<{ relname: string; n_live_tup: bigint }[]>`
+            SELECT relname, n_live_tup FROM pg_stat_user_tables
+            WHERE schemaname='public' AND relname IN ('tasks','wishes','teams','sessions')
+          `;
+          const counts: NonNullable<DbRow['counts']> = {};
+          for (const p of probe) {
+            const n = Number(p.n_live_tup);
+            if (p.relname === 'tasks') counts.tasks = n;
+            else if (p.relname === 'wishes') counts.wishes = n;
+            else if (p.relname === 'teams') counts.teams = n;
+            else if (p.relname === 'sessions') counts.sessions = n;
+          }
+          row.counts = counts;
+          await c.end({ timeout: 1 });
+        } catch {
+          // Ignore — DB may not have genie schema; report blank counts
+        }
+      }
+    }
+
+    if (options.json) {
+      console.log(JSON.stringify(filtered, null, 2));
+    } else {
+      printTable(filtered, { showCounts: !!options.counts });
+    }
+  } finally {
+    await admin.end({ timeout: 5 });
+  }
+
+  await shutdown();
+}
+
+async function loadAllDbs(admin: postgres.Sql): Promise<DbRow[]> {
+  // Outer join: every DB in pg_database, optional pgserve_meta row.
+  const rows = await admin<
+    {
+      datname: string;
+      size_bytes: bigint;
+      fingerprint: string | null;
+      persist: boolean | null;
+      last_connection_at: Date | null;
+      package_realpath: string | null;
+      liveness_pid: number | null;
+    }[]
+  >`
+    SELECT
+      d.datname AS datname,
+      pg_database_size(d.datname) AS size_bytes,
+      m.fingerprint,
+      m.persist,
+      m.last_connection_at,
+      m.package_realpath,
+      m.liveness_pid
+    FROM pg_database d
+    LEFT JOIN pgserve_meta m ON m.database_name = d.datname
+    ORDER BY pg_database_size(d.datname) DESC
+  `;
+  return rows.map((r) => ({
+    name: r.datname,
+    sizeBytes: Number(r.size_bytes),
+    fingerprint: r.fingerprint,
+    persist: !!r.persist,
+    lastConnectionAt: r.last_connection_at,
+    packageRealpath: r.package_realpath,
+    livenessPid: r.liveness_pid,
+    isV2Pattern: V2_TENANT_DB_PATTERN.test(r.datname),
+    isSystem: SYSTEM_DBS.has(r.datname),
+  }));
+}
+
+function printTable(rows: DbRow[], opts: { showCounts: boolean }): void {
+  if (rows.length === 0) {
+    console.log('(no databases)');
+    return;
+  }
+
+  const cols = [
+    { header: 'NAME', getter: (r: DbRow) => r.name },
+    { header: 'SIZE', getter: (r: DbRow) => formatBytes(r.sizeBytes) },
+    { header: 'PERSIST', getter: (r: DbRow) => (r.persist ? 'yes' : 'no') },
+    { header: 'LAST CONNECT', getter: (r: DbRow) => formatDate(r.lastConnectionAt) },
+    { header: 'FINGERPRINT', getter: (r: DbRow) => r.fingerprint ?? '(no meta row)' },
+    { header: 'PACKAGE', getter: (r: DbRow) => r.packageRealpath ?? '(script-mode)' },
+  ];
+  if (opts.showCounts) {
+    cols.push({
+      header: 'TASKS / WISHES / TEAMS / SESSIONS',
+      getter: (r: DbRow) => {
+        if (!r.counts) return '-';
+        return `${r.counts.tasks ?? '-'} / ${r.counts.wishes ?? '-'} / ${r.counts.teams ?? '-'} / ${r.counts.sessions ?? '-'}`;
+      },
+    });
+  }
+
+  const widths = cols.map((c) => Math.max(c.header.length, ...rows.map((r) => c.getter(r).length)));
+  const sep = widths.map((w) => '-'.repeat(w)).join('  ');
+  console.log(cols.map((c, i) => c.header.padEnd(widths[i])).join('  '));
+  console.log(sep);
+  for (const r of rows) {
+    console.log(cols.map((c, i) => c.getter(r).padEnd(widths[i])).join('  '));
+  }
+  console.log();
+
+  // Summary footer
+  const total = rows.reduce((acc, r) => acc + r.sizeBytes, 0);
+  const persistCount = rows.filter((r) => r.persist).length;
+  const orphanCount = rows.filter((r) => !r.fingerprint && !r.isSystem).length;
+  const v2Count = rows.filter((r) => r.isV2Pattern).length;
+  console.log(
+    `${rows.length} databases (${formatBytes(total)} total) — ` +
+      `${persistCount} persist, ${orphanCount} orphans, ${v2Count} v2-pattern`,
+  );
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n}B`;
+  const u = ['KB', 'MB', 'GB', 'TB'];
+  let v = n / 1024;
+  let i = 0;
+  while (v >= 1024 && i < u.length - 1) {
+    v /= 1024;
+    i++;
+  }
+  return `${v.toFixed(1)} ${u[i]}`;
+}
+
+function formatDate(d: Date | null): string {
+  if (!d) return '-';
+  const now = Date.now();
+  const elapsedMs = now - d.getTime();
+  const sec = Math.floor(elapsedMs / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  return `${day}d ago`;
+}
+
+export function registerDbLsCommand(db: Command): void {
+  db.command('ls')
+    .description('List all pgserve databases on this host')
+    .option('--json', 'Machine-readable JSON output')
+    .option('--counts', 'Probe each DB for tasks/wishes/teams/sessions row counts (slower)')
+    .option('--all', 'Include system DBs (postgres, template0, template1)')
+    .option('--orphans', 'Only show DBs without a pgserve_meta row (legacy / unmanaged)')
+    .action(dbLsCommand);
+}
+
+export { loadAllDbs };

--- a/src/term-commands/db-migrate-v1.ts
+++ b/src/term-commands/db-migrate-v1.ts
@@ -1,0 +1,425 @@
+/**
+ * `genie db migrate-v1` — migrate v1-era genie data into the current v2
+ * fingerprinted workspace.
+ *
+ * Drops into `src/term-commands/db-migrate-v1.ts`. Companion file:
+ * `src/lib/v1-migration-prompt.ts` (auto-detect + prompt-once at startup).
+ *
+ * Background
+ * ----------
+ * pgserve v1 served arbitrary database names freely. After v2 upgrade, the
+ * bare `genie` database with months of tasks/wishes/sessions is silently
+ * unreachable to v2 peers (no fingerprint owns the name) and reapable by
+ * the GC sweep. This command does the ETL: v1 → caller's v2 fingerprinted
+ * DB, then archives v1 with persist=true so it can never be reaped.
+ *
+ * Connection model
+ * ----------------
+ *   - V1 source: TCP `127.0.0.1:<port>` user=postgres pass=postgres database=genie.
+ *     Postgres itself does not enforce fingerprints — the wrapper does.
+ *   - V2 target: caller's `getConnection()` (already routed via socket).
+ *
+ * Schema-aware ETL (lessons from real migration)
+ * ----------------------------------------------
+ *   1. Identity columns (attidentity='a' GENERATED ALWAYS): excluded from
+ *      INSERT column list. Otherwise: "cannot insert a non-DEFAULT value".
+ *   2. Stored generated columns (attgenerated='s'): excluded.
+ *   3. Bare `ON CONFLICT DO NOTHING` (no constraint target) — handles any
+ *      unique violation, including junction tables without `id` PK.
+ *   4. FK ordering: executors → agents (genie schema has agents.current_executor_id).
+ *   5. Self-FKs (sessions.parent_session_id): `session_replication_role='replica'`
+ *      bypasses ALL FK triggers for the session. Standard Postgres bulk-load.
+ *
+ * Idempotency & safety
+ * --------------------
+ *   - `ON CONFLICT DO NOTHING` makes every table idempotent.
+ *   - On full success, v1 DB is renamed to `genie_archive_<YYYYMMDD>` and
+ *     marked persist=true in pgserve_meta — GC cannot reap it.
+ *   - Completion is recorded in `_genie_migration_state` on the target,
+ *     so the startup auto-prompt suppresses future offers.
+ */
+
+import type { Command } from 'commander';
+import postgres from 'postgres';
+import { getConnection, isAvailable, shutdown } from '../lib/db.js';
+import { recordMigrationComplete } from '../lib/v1-migration-prompt.js';
+
+const V1_DB_NAME = 'genie';
+const V1_USER = 'postgres';
+const V1_PASS = 'postgres';
+const V1_HOST = '127.0.0.1';
+
+/** FK-safe order. Parents BEFORE children. */
+const FOUNDATION_TABLES = [
+  'organizations',
+  'projects',
+  'executors',
+  'agents',
+  'agent_projects',
+  'teams',
+  'board_templates',
+  'boards',
+  'task_types',
+  'wishes',
+  'tasks',
+  'task_actors',
+  'task_dependencies',
+  'task_stage_log',
+  'tags',
+  'task_tags',
+  'assignments',
+] as const;
+
+/** Tables NEVER migrated — high-volume runtime logs that regenerate. */
+const NEVER_MIGRATE = new Set([
+  'tool_events',
+  'genie_runtime_events',
+  'heartbeats',
+  'machine_snapshots',
+  'genie_bridge_sessions',
+  'mailbox',
+  'messages',
+]);
+
+interface MigrateOptions {
+  dryRun?: boolean;
+  yes?: boolean;
+  includeSessions?: string;
+  includeAudit?: string;
+  includeContent?: boolean;
+  archive?: boolean;
+}
+
+interface ColumnInfo {
+  name: string;
+  identity: 'a' | 'd' | '';
+  generated: 's' | '';
+}
+
+interface TableResult {
+  copied: number;
+  skipped: number;
+  failed?: string;
+}
+
+async function dbMigrateV1Command(options: MigrateOptions): Promise<void> {
+  const available = await isAvailable();
+  if (!available) {
+    console.error('Database is not running. Start it with: genie db status');
+    process.exit(1);
+  }
+
+  // We need a TCP port to read v1 directly. The runtime may be on a Unix
+  // socket; ask the live admin client for the port via SHOW port.
+  const v2 = await getConnection();
+  const portRows = await v2.unsafe('SHOW port');
+  const port = Number((portRows as Array<{ port: string }>)[0]?.port);
+  if (!Number.isFinite(port) || port <= 0) {
+    console.error('Could not resolve pgserve TCP port from runtime connection.');
+    await shutdown();
+    process.exit(1);
+  }
+
+  console.log('[genie db migrate-v1] Detecting v1 data…');
+  const detected = await detectV1(port);
+  if (!detected) {
+    console.log('  No v1 `genie` database found. Nothing to migrate.');
+    await shutdown();
+    return;
+  }
+
+  const targetRows = await v2.unsafe('SELECT current_database() AS db');
+  const targetDb = (targetRows as Array<{ db: string }>)[0]?.db;
+  console.log(`  Source: ${V1_DB_NAME} (v1, port ${port}, ${formatBytes(detected.totalSizeBytes)} on disk)`);
+  console.log(`  Target: ${targetDb} (your v2 workspace)`);
+  console.log();
+
+  const sessionDays = parseDayWindow(options.includeSessions, 30);
+  const auditDays = parseDayWindow(options.includeAudit, 0); // OFF by default — too large
+
+  console.log('Row counts in v1:');
+  for (const t of FOUNDATION_TABLES) {
+    const c = detected.rowCounts[t];
+    if (typeof c === 'number') console.log(`  ${t.padEnd(22)} ${c}`);
+  }
+  if (sessionDays > 0)
+    console.log(`  ${'sessions'.padEnd(22)} ${detected.rowCounts.sessions ?? 0}  (last ${sessionDays} days)`);
+  if (auditDays > 0)
+    console.log(`  ${'audit_events'.padEnd(22)} ${detected.rowCounts.audit_events ?? 0}  (last ${auditDays} days)`);
+  if (options.includeContent)
+    console.log(
+      `  ${'session_content'.padEnd(22)} ${detected.rowCounts.session_content ?? 0}  (last ${sessionDays} days, --include-content)`,
+    );
+  console.log();
+  console.log(`Will SKIP:    ${[...NEVER_MIGRATE].join(', ')}`);
+  if (options.archive !== false) {
+    console.log(`Will ARCHIVE: source DB renamed to ${archiveName()} (kept indefinitely; persist=true)`);
+  }
+  console.log();
+
+  if (options.dryRun) {
+    console.log('--dry-run set, exiting.');
+    await shutdown();
+    return;
+  }
+  if (!options.yes && !(await confirm('Proceed with migration?'))) {
+    console.log('Aborted.');
+    await shutdown();
+    return;
+  }
+
+  // Migration session — bypass FK triggers for cross-row inserts (sessions self-FK).
+  const v1 = postgres({
+    host: V1_HOST,
+    port,
+    username: V1_USER,
+    password: V1_PASS,
+    database: V1_DB_NAME,
+    max: 1,
+    onnotice: () => {},
+    idle_timeout: 5,
+  });
+  // Get a dedicated v2 client with replica role so FK triggers don't fire.
+  const v2Bypass = postgres({
+    host: V1_HOST,
+    port,
+    username: V1_USER,
+    password: V1_PASS,
+    database: targetDb,
+    max: 1,
+    onnotice: () => {},
+    idle_timeout: 5,
+    connection: { session_replication_role: 'replica' },
+  });
+
+  const summary: Record<string, number> = {};
+  const failures: string[] = [];
+
+  try {
+    for (const table of FOUNDATION_TABLES) {
+      if (NEVER_MIGRATE.has(table)) continue;
+      const r = await migrateOne(v1, v2Bypass, table);
+      report(table, r);
+      if (r.failed) failures.push(`${table}: ${r.failed}`);
+      else summary[table] = r.copied;
+    }
+    if (sessionDays > 0) {
+      const r = await migrateOne(v1, v2Bypass, 'sessions', { dateColumn: 'created_at', days: sessionDays });
+      report('sessions', r);
+      if (r.failed) failures.push(`sessions: ${r.failed}`);
+      else summary.sessions = r.copied;
+    }
+    if (auditDays > 0) {
+      const r = await migrateOne(v1, v2Bypass, 'audit_events', { dateColumn: 'created_at', days: auditDays });
+      report('audit_events', r);
+      if (r.failed) failures.push(`audit_events: ${r.failed}`);
+      else summary.audit_events = r.copied;
+    }
+    if (options.includeContent && sessionDays > 0) {
+      const r = await migrateOne(v1, v2Bypass, 'session_content', { dateColumn: 'created_at', days: sessionDays });
+      report('session_content', r);
+      if (r.failed) failures.push(`session_content: ${r.failed}`);
+      else summary.session_content = r.copied;
+    }
+  } finally {
+    await v1.end({ timeout: 5 });
+    await v2Bypass.end({ timeout: 5 });
+  }
+
+  console.log();
+  const total = Object.values(summary).reduce((a, b) => a + b, 0);
+  console.log(`Migrated ${total} rows across ${Object.keys(summary).length} tables. ${failures.length} failed.`);
+  for (const f of failures) console.log(`  - ${f}`);
+
+  if (failures.length === 0) {
+    // Mark migration complete in the target DB so the startup prompt is silenced
+    await recordMigrationComplete(v2, V1_DB_NAME, summary);
+    console.log('Migration recorded in _genie_migration_state — startup prompt will be silenced.');
+
+    if (options.archive !== false) {
+      const archive = archiveName();
+      console.log(`Archiving v1 → ${archive}`);
+      await archiveV1(port, archive);
+      console.log(`Done. ${archive} renamed and marked persist=true.`);
+    }
+  } else {
+    console.log(`Skipping archive due to ${failures.length} failures. Re-run after resolving (idempotent).`);
+  }
+
+  await shutdown();
+}
+
+async function detectV1(port: number): Promise<{ rowCounts: Record<string, number>; totalSizeBytes: number } | null> {
+  const v1 = postgres({
+    host: V1_HOST,
+    port,
+    username: V1_USER,
+    password: V1_PASS,
+    database: V1_DB_NAME,
+    max: 1,
+    onnotice: () => {},
+    connect_timeout: 5,
+    idle_timeout: 1,
+  });
+  try {
+    const tableRows = await v1<{ relname: string; n_live_tup: bigint }[]>`
+      SELECT relname, n_live_tup FROM pg_stat_user_tables WHERE schemaname='public'
+    `;
+    if (tableRows.length === 0) return null;
+    const counts: Record<string, number> = {};
+    for (const r of tableRows) counts[r.relname] = Number(r.n_live_tup);
+    const sizeRows = await v1<{ size: bigint }[]>`SELECT pg_database_size(${V1_DB_NAME}) AS size`;
+    return { rowCounts: counts, totalSizeBytes: Number(sizeRows[0]?.size ?? 0) };
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (['3D000', '08001', '08006', 'ECONNREFUSED'].includes(code ?? '')) return null;
+    throw err;
+  } finally {
+    try {
+      await v1.end({ timeout: 1 });
+    } catch {
+      /* swallow */
+    }
+  }
+}
+
+async function getInsertableColumns(client: postgres.Sql, table: string): Promise<ColumnInfo[]> {
+  return client<ColumnInfo[]>`
+    SELECT a.attname AS name, a.attidentity::text AS identity, a.attgenerated::text AS generated
+    FROM pg_attribute a JOIN pg_class c ON c.oid=a.attrelid JOIN pg_namespace n ON n.oid=c.relnamespace
+    WHERE n.nspname='public' AND c.relname=${table} AND a.attnum>0 AND NOT a.attisdropped
+    ORDER BY a.attnum
+  `;
+}
+
+async function migrateOne(
+  v1: postgres.Sql,
+  v2: postgres.Sql,
+  table: string,
+  windowOpt?: { dateColumn: string; days: number },
+): Promise<TableResult> {
+  try {
+    const v1Cols = await getInsertableColumns(v1, table);
+    const v2Cols = await getInsertableColumns(v2, table);
+    if (v1Cols.length === 0) return { copied: 0, skipped: 0 };
+    if (v2Cols.length === 0) return { copied: 0, skipped: 0, failed: 'target lacks table' };
+
+    const v2Map = new Map(v2Cols.map((c) => [c.name, c]));
+    const cols = v1Cols
+      .map((c) => c.name)
+      .filter((name) => {
+        const v2c = v2Map.get(name);
+        if (!v2c) return false;
+        if (v2c.identity === 'a') return false;
+        if (v2c.generated === 's') return false;
+        return true;
+      });
+    if (cols.length === 0) return { copied: 0, skipped: 0, failed: 'no insertable shared columns' };
+
+    const colList = cols.map((c) => `"${c}"`).join(',');
+    const where = windowOpt ? `WHERE "${windowOpt.dateColumn}" > now() - interval '${windowOpt.days} days'` : '';
+    const rows = await v1.unsafe(`SELECT ${colList} FROM "${table}" ${where}`);
+    if (rows.length === 0) return { copied: 0, skipped: 0 };
+
+    let copied = 0;
+    const batchSize = 200;
+    for (let i = 0; i < rows.length; i += batchSize) {
+      const batch = rows.slice(i, i + batchSize);
+      const placeholders = batch
+        .map((_, ri) => `(${cols.map((_, ci) => `$${ri * cols.length + ci + 1}`).join(',')})`)
+        .join(',');
+      const values = batch.flatMap((row) => cols.map((c) => (row as Record<string, unknown>)[c]));
+      const stmt = `INSERT INTO "${table}" (${colList}) VALUES ${placeholders} ON CONFLICT DO NOTHING`;
+      // biome-ignore lint/suspicious/noExplicitAny: postgres.js unsafe() typed as ParameterOrJSON<never>[] but accepts any param shape at runtime
+      const r = await v2.unsafe(stmt, values as any);
+      copied += Number((r as unknown as { count?: number }).count ?? 0);
+    }
+    return { copied, skipped: rows.length - copied };
+  } catch (err) {
+    return { copied: 0, skipped: 0, failed: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+async function archiveV1(port: number, archive: string): Promise<void> {
+  const admin = postgres({
+    host: V1_HOST,
+    port,
+    username: V1_USER,
+    password: V1_PASS,
+    database: 'postgres',
+    max: 1,
+    onnotice: () => {},
+  });
+  try {
+    await admin.unsafe(
+      'SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname=$1 AND pid<>pg_backend_pid()',
+      [V1_DB_NAME],
+    );
+    await admin.unsafe(`ALTER DATABASE "${V1_DB_NAME}" RENAME TO "${archive}"`);
+    await admin.unsafe(
+      `INSERT INTO pgserve_meta (database_name, fingerprint, peer_uid, persist) VALUES ($1, $2, $3, true)
+       ON CONFLICT (database_name) DO UPDATE SET persist=true`,
+      [archive, 'legacy_v1_archive', 0],
+    );
+  } finally {
+    await admin.end({ timeout: 5 });
+  }
+}
+
+function report(table: string, r: TableResult): void {
+  if (r.failed) console.log(`  ✗ ${table.padEnd(22)} FAILED: ${r.failed}`);
+  else if (r.copied === 0 && r.skipped === 0) console.log(`  - ${table.padEnd(22)} (no rows)`);
+  else console.log(`  ✓ ${table.padEnd(22)} +${r.copied} copied, ${r.skipped} already present`);
+}
+
+function archiveName(): string {
+  const d = new Date();
+  return `genie_archive_${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, '0')}${String(d.getDate()).padStart(2, '0')}`;
+}
+
+function parseDayWindow(value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const n = Number.parseInt(value, 10);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  const u = ['KB', 'MB', 'GB', 'TB'];
+  let v = n / 1024;
+  let i = 0;
+  while (v >= 1024 && i < u.length - 1) {
+    v /= 1024;
+    i++;
+  }
+  return `${v.toFixed(1)} ${u[i]}`;
+}
+
+async function confirm(prompt: string): Promise<boolean> {
+  process.stdout.write(`${prompt} [Y/n]: `);
+  return new Promise((resolve) => {
+    process.stdin.setEncoding('utf8');
+    const onData = (chunk: string): void => {
+      const v = chunk.trim().toLowerCase();
+      process.stdin.removeListener('data', onData);
+      process.stdin.pause();
+      resolve(v === '' || v === 'y' || v === 'yes');
+    };
+    process.stdin.resume();
+    process.stdin.once('data', onData);
+  });
+}
+
+export function registerDbMigrateV1Command(db: Command): void {
+  db.command('migrate-v1')
+    .description('Migrate v1-era genie data into your v2 fingerprinted workspace')
+    .option('--dry-run', 'Show what would migrate without writing')
+    .option('-y, --yes', 'Skip confirmation prompt')
+    .option('--include-sessions <days>', 'Days of session history to migrate (default 30)')
+    .option('--include-audit <days>', 'Days of audit_events to migrate (default 0 = skipped)')
+    .option('--include-content', 'Also migrate session_content (skipped by default — large)')
+    .option('--no-archive', `Don't rename source DB to genie_archive_<date> after migration`)
+    .action(dbMigrateV1Command);
+}
+
+export { detectV1, migrateOne };

--- a/src/term-commands/db.ts
+++ b/src/term-commands/db.ts
@@ -25,6 +25,8 @@ import {
   shutdown,
 } from '../lib/db.js';
 import { padRight } from '../lib/term-format.js';
+import { registerDbLsCommand } from './db-ls.js';
+import { registerDbMigrateV1Command } from './db-migrate-v1.js';
 
 /**
  * Walk up from `start` looking for a package.json. Mirrors pgserve v2's
@@ -417,4 +419,10 @@ export function registerDbCommands(program: Command): void {
     .description('Restore database from snapshot (default: .genie/snapshot.sql.gz)')
     .option('-y, --yes', 'Skip confirmation prompt')
     .action(dbRestoreCommand);
+
+  // v1 → v2 data migration (one-shot, idempotent)
+  registerDbMigrateV1Command(db);
+
+  // List all pgserve databases on this host
+  registerDbLsCommand(db);
 }


### PR DESCRIPTION
## Summary

Three operator surfaces for the silent-orphan defect when pgserve upgrades from v1 (single shared `genie` DB, no fingerprints) to v2 (per-fingerprint isolation, GC-reapable). Tonight's incident reproducer: a real user upgraded, lost visibility of 189 tasks / 31 wishes / months of session history. This PR makes that path automatic for everyone else.

## What lands

### 1. `src/lib/v1-migration-prompt.ts` — auto-detect + offer at startup

Wired into `runPostConnectSetup` in `src/lib/db.ts`. Probes once per process for legacy v1 user databases. If found and not yet migrated, prints a one-line offer:

```
[genie] ⚠ Legacy v1 data detected (189 tasks, 31 wishes, 34 teams, 2930 sessions, last 30d).
        Run `genie db migrate-v1` to import.
        (one-time offer — silent after first migration; or set GENIE_NO_V1_PROMPT=1)
```

Suppressors: `GENIE_NO_V1_PROMPT=1`, `GENIE_QUIET=1`, non-TTY (notice only), test mode (`GENIE_TEST_DB_NAME` set), and — most importantly — a row in `_genie_migration_state` recording a prior successful migration.

### 2. `src/term-commands/db-migrate-v1.ts` — the ETL command

`genie db migrate-v1 [--dry-run] [--include-sessions <days>] [--include-audit <days>] [--include-content] [--no-archive] [-y|--yes]`

- **FK-safe order**: `executors → agents` (genie schema has `agents.current_executor_id`).
- **Schema-aware columns**: identity (`attidentity='a'`) and stored generated (`attgenerated='s'`) columns excluded from INSERT.
- **Bare `ON CONFLICT DO NOTHING`** — handles junction-table PKs that aren't `id`.
- **`session_replication_role='replica'`** for the migrating session — bypasses FK triggers including `sessions.parent_session_id` self-reference. Standard Postgres bulk-load idiom.
- **Foundation tables**: organizations, projects, executors, agents, agent_projects, teams, board_templates, boards, task_types, wishes, tasks, task_actors, task_dependencies, task_stage_log, tags, task_tags, assignments. All full-copy.
- **Windowed**: sessions (default 30 days), audit_events (default 0 = OFF), session_content (off by default — large; opt-in via `--include-content`).
- **Always skipped**: tool_events, genie_runtime_events, heartbeats, machine_snapshots, genie_bridge_sessions, mailbox, messages.
- **Idempotent**: re-runnable safely after partial failure.
- **On full success**: source DB renamed to `genie_archive_<YYYYMMDD>`, marked `persist=true` in `pgserve_meta` (GC cannot reap), and a row inserted into `_genie_migration_state` on the target so the startup prompt is silenced forever.

### 3. `src/term-commands/db-ls.ts` — fleet visibility

`genie db ls [--json] [--counts] [--all] [--orphans]`

Lists every pgserve database on the host. Columns: NAME, SIZE, PERSIST, LAST CONNECT, FINGERPRINT, PACKAGE. Read-only. Footer summary: `N databases (X total) — N persist, N orphans, N v2-pattern`.

`--counts` opens one connection per DB to probe row counts of `tasks/wishes/teams/sessions`.
`--orphans` filters to only DBs without a `pgserve_meta` row (legacy / unmanaged).

## Validation

- Live tested against a real v1 dataset tonight: 189 tasks, 31 wishes, 34 teams, 2930 sessions, full schema. **0 failures, 0 manual interventions** after pass-3 of the design (FK ordering + replica role).
- v1 source preserved at `genie_archive_20260430` (5.6 GB, persist=true).
- Verified completion marker silences the startup prompt on subsequent connects.
- `bunx tsc --noEmit`: clean.
- `bunx biome check --fix`: clean.
- `husky pre-push` (knip dead-code, lint, emit-discipline, wishes-lint): all green.

## Companion

- pgserve floor already at `^2.0.8` via #1563.

## Origin context

Reproducer + recovery story for the original incident lives in this session's transcript. The 953KB recovery dump from the live machine is at `/home/genie/genie-v1-recovery-20260430T025552Z.sql.gz` if forensics are wanted — but the data is already migrated and verified in the target DB.