### PR TITLE
feat(bridge): sign chat lookup via X-Genie-Signature when keys are present

### DIFF
--- a/src/services/executors/claude-code.ts
+++ b/src/services/executors/claude-code.ts
@@ -14,6 +14,7 @@ import * as directory from '../../lib/agent-directory.js';
 import type { DirectoryEntry } from '../../lib/agent-directory.js';
 import * as agents from '../../lib/agent-registry.js';
 import * as registry from '../../lib/executor-registry.js';
+import { signOmniRequest } from '../../lib/omni-signature.js';
 import { buildLaunchCommand } from '../../lib/provider-adapters.js';
 import type { SpawnParams } from '../../lib/provider-adapters.js';
 import { shellQuote } from '../../lib/team-lead-command.js';
@@ -111,9 +112,17 @@ async function lookupChatName(chatId: string, _instanceId: string): Promise<stri
     const apiKey = config.apiKey || '';
     if (!apiKey) return null;
 
-    const url = `${apiUrl}/api/v2/chats?externalId=${encodeURIComponent(chatId)}`;
+    const path = `/api/v2/chats?externalId=${encodeURIComponent(chatId)}`;
+    const url = `${apiUrl}${path}`;
+    // Sign the lookup when this host has run `genie omni handshake`. Falls
+    // back to bearer-only when no key is present, matching pre-fingerprint
+    // behavior. Required so the lookup keeps working when the targeted
+    // omni instance is locked down with `--require-genie-signature`.
+    const sigHeaders = signOmniRequest('GET', path, '');
+    const headers: Record<string, string> = { Authorization: `Bearer ${apiKey}` };
+    if (sigHeaders) Object.assign(headers, sigHeaders);
     const res = await fetch(url, {
-      headers: { Authorization: `Bearer ${apiKey}` },
+      headers,
       signal: AbortSignal.timeout(3000),
     });
     if (!res.ok) return null;


### PR DESCRIPTION
## Summary

Closes the second unsigned callsite in genie→omni HTTP. The bridge calls \`GET /api/v2/chats?externalId=<jid>\` while spawning a claude pane to use the contact's display name as the tmux window title — today bearer-only.

After omni#568 (P0a kill-switch) + omni#569 (P0b operator-host signing), the remaining gap is genie callsites **other** than \`registerAgentInOmni\` (which Group 3 already wraps). If an operator locks down a real instance, this lookup would silently fall back to using the raw JID as the window name.

## Fix

Thread \`signOmniRequest('GET', path, '')\` through the same path used by \`registerAgentInOmni\`. When no host keypair exists locally, \`signOmniRequest\` returns null and we go bearer-only — matching today's behavior, fully backward-compatible.

## Verification

```bash
bun run typecheck                       # clean
bunx biome check src/services/executors/claude-code.ts   # clean
bun test src/services/executors/        # 113 pass / 0 fail
```

## Test plan
- [ ] CI green
- [ ] After merge: lock down an instance with \`omni instances update <id> --require-genie-signature\`, send a WhatsApp message, confirm the bridge spawns a tmux pane with the contact's display name (not the raw JID)
- [ ] Hosts that haven't run \`genie omni handshake\` still work unchanged

## Surface coverage after this PR

| Genie callsite | Signs? |
|---|---|
| \`registerAgentInOmni\` (POST /api/v2/agents) | ✅ since #1539 (group 3) |
| \`findOmniAgent\` (GET /api/v2/agents?name=...) | ✅ since #1539 (group 3) |
| \`lookupChatName\` (GET /api/v2/chats) | ✅ this PR |
| \`genie omni handshake\` (POST /api/v2/trust/handshake) | n/a — bootstrap, auth-exempt by design |

That's all genie→omni HTTP callsites. NATS-side bridge dispatch doesn't go through HTTP auth.

Refs: omni-host-fingerprint-trust wish; P1 follow-up to omni#569