### PR TITLE
fix(pgserve): evict orphan data-dir lock before respawning v2 daemon

### DIFF
--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -529,6 +529,56 @@ describe('daemon-owned pgserve', () => {
     expect(recoverBody).toContain('process.kill(-pid, signal)');
     expect(recoverBody).toContain('process.kill(pid, signal)');
   });
+
+  test('orphan data-dir lock is evicted before respawning the v2 daemon', () => {
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+
+    const detectStart = source.indexOf('function detectOrphanDataDirLock');
+    expect(detectStart).toBeGreaterThan(-1);
+    const detectBody = source.slice(
+      detectStart,
+      source.indexOf('\nasync function evictOrphanDataDirHolder', detectStart),
+    );
+    // Reads <DATA_DIR>/postmaster.pid, validates the PID is alive and our process
+    expect(detectBody).toContain("join(DATA_DIR, 'postmaster.pid')");
+    expect(detectBody).toContain('liveDaemonPid(pid)');
+    expect(detectBody).toContain("'pgserve'");
+    expect(detectBody).toContain("'postgres-server.js'");
+    expect(detectBody).toContain('cmd.includes(DATA_DIR)');
+
+    const evictStart = source.indexOf('async function evictOrphanDataDirHolder');
+    expect(evictStart).toBeGreaterThan(-1);
+    const evictBody = source.slice(evictStart, source.indexOf('\nasync function waitForDaemonSocket', evictStart));
+    // Walks up to the pgserve daemon parent if the holder is the postgres backend
+    expect(evictBody).toContain("'-o', 'ppid='");
+    // Sends SIGTERM, escalates to SIGKILL, then clears stale postmaster.pid + sockets
+    expect(evictBody).toContain("signalPgserveDaemonPid(target, 'SIGTERM')");
+    expect(evictBody).toContain("signalPgserveDaemonPid(target, 'SIGKILL')");
+    expect(evictBody).toContain("unlinkIfPresent(join(DATA_DIR, 'postmaster.pid'))");
+    expect(evictBody).toContain('removeStalePgserveSocketArtifacts()');
+
+    // startPgserveDaemonOnce calls the orphan-eviction path before spawn
+    const spawnStart = source.indexOf('async function startPgserveDaemonOnce');
+    expect(spawnStart).toBeGreaterThan(-1);
+    const spawnBody = source.slice(spawnStart, source.indexOf('\nasync function waitForDaemonSocket', spawnStart));
+    const detectIdx = spawnBody.indexOf('detectOrphanDataDirLock()');
+    const evictIdx = spawnBody.indexOf('evictOrphanDataDirHolder');
+    const spawnIdx = spawnBody.indexOf('spawn(');
+    expect(detectIdx).toBeGreaterThan(-1);
+    expect(evictIdx).toBeGreaterThan(detectIdx);
+    expect(spawnIdx).toBeGreaterThan(evictIdx);
+  });
+
+  test('daemon-exit error names the data-dir holder when one is detected', () => {
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    const waitStart = source.indexOf('async function waitForDaemonSocket');
+    expect(waitStart).toBeGreaterThan(-1);
+    const waitBody = source.slice(waitStart, source.indexOf('\nfunction formatPgserveDaemonCommand', waitStart));
+
+    expect(waitBody).toContain('detectOrphanDataDirLock()');
+    expect(waitBody).toContain('Data directory ${DATA_DIR} is held by PID');
+    expect(waitBody).toContain('genie serve restart');
+  });
 });
 
 describe('retention cleanup', () => {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -492,6 +492,17 @@ function unlinkIfPresent(path: string): void {
 
 async function startPgserveDaemonOnce(initial: DaemonState): Promise<void> {
   cleanPartialDaemonState(initial);
+  // The data directory may be locked by an orphan from a prior daemon — for
+  // example, a pgserve upgrade left the previous version's daemon running on
+  // a different control-socket layout, or the daemon parent died while its
+  // postgres backend kept running. probePgserveDaemon() can't see those
+  // (no current libpq socket / pgserve.pid), so we'd otherwise spawn a fresh
+  // daemon whose postgres backend immediately exits with
+  //   FATAL: lock file "postmaster.pid" already exists
+  // surfaced upstream as the unhelpful "daemon exited before binding …".
+  const orphan = detectOrphanDataDirLock();
+  if (orphan !== null) await evictOrphanDataDirHolder(orphan);
+
   const daemonCommand = findPgserveDaemonCommand();
   if (daemonCommand === null) {
     if (await tryEnsureDaemonWithSdk()) return;
@@ -519,6 +530,79 @@ async function startPgserveDaemonOnce(initial: DaemonState): Promise<void> {
   }
 }
 
+interface OrphanDataDirHolder {
+  pid: number;
+  cmd: string;
+}
+
+/**
+ * Detect a live process holding `<DATA_DIR>/postmaster.pid` that
+ * `probePgserveDaemon` can't see — i.e., a pgserve daemon (or its postgres
+ * backend) from a previous version / a daemon whose libpq compat symlink
+ * was nuked. Only flags processes whose command line proves they belong to
+ * us (pgserve, postgres-server.js, or `postgres -D <DATA_DIR>`); unrelated
+ * postmasters on the same host are left alone.
+ */
+function detectOrphanDataDirLock(): OrphanDataDirHolder | null {
+  const pidFile = join(DATA_DIR, 'postmaster.pid');
+  if (!existsSync(pidFile)) return null;
+  let raw: string;
+  try {
+    raw = readFileSync(pidFile, 'utf-8');
+  } catch {
+    return null;
+  }
+  const firstLine = raw.split('\n', 1)[0]?.trim() ?? '';
+  const pid = Number.parseInt(firstLine, 10);
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  if (liveDaemonPid(pid) === null) return null;
+  let cmd: string;
+  try {
+    cmd = execFileSync('ps', ['-p', String(pid), '-o', 'command='], {
+      encoding: 'utf-8',
+      timeout: 1000,
+    }).trim();
+  } catch {
+    return null;
+  }
+  const ours =
+    cmd.includes('pgserve') ||
+    cmd.includes('postgres-server.js') ||
+    (cmd.includes('postgres') && cmd.includes(DATA_DIR));
+  return ours ? { pid, cmd } : null;
+}
+
+/**
+ * Terminate the orphan that holds `<DATA_DIR>/postmaster.pid`. If the holder
+ * is the postgres backend, walk up to the pgserve daemon parent so we kill
+ * the whole tree; otherwise signal the holder directly. After the process
+ * exits we remove the stale postmaster.pid so the new daemon's first call
+ * to `pg_ctl start` doesn't trip on it.
+ */
+async function evictOrphanDataDirHolder(holder: OrphanDataDirHolder): Promise<void> {
+  let target = holder.pid;
+  try {
+    const ppidStr = execFileSync('ps', ['-p', String(holder.pid), '-o', 'ppid='], {
+      encoding: 'utf-8',
+      timeout: 1000,
+    }).trim();
+    const ppid = Number.parseInt(ppidStr, 10);
+    if (Number.isInteger(ppid) && ppid > 1) {
+      const pcmd = execFileSync('ps', ['-p', String(ppid), '-o', 'command='], {
+        encoding: 'utf-8',
+        timeout: 1000,
+      }).trim();
+      if (pcmd.includes('pgserve') || pcmd.includes('postgres-server.js')) target = ppid;
+    }
+  } catch {
+    /* fall back to direct holder */
+  }
+  await signalPgserveDaemonPid(target, 'SIGTERM');
+  if (liveDaemonPid(target) !== null) await signalPgserveDaemonPid(target, 'SIGKILL');
+  unlinkIfPresent(join(DATA_DIR, 'postmaster.pid'));
+  removeStalePgserveSocketArtifacts();
+}
+
 async function waitForDaemonSocket(daemonCommand: PgserveDaemonCommand, child?: ChildProcess): Promise<void> {
   const socketPath = resolvePgserveLibpqSocketPath();
   const timeout = resolvePgserveTimeoutMs();
@@ -531,8 +615,13 @@ async function waitForDaemonSocket(daemonCommand: PgserveDaemonCommand, child?: 
   while (Date.now() < deadline) {
     if (existsSync(socketPath) && (await isPgserveSocketResponsive())) return;
     if (childExit !== null) {
+      const holder = detectOrphanDataDirLock();
+      const holderHint =
+        holder !== null
+          ? ` Data directory ${DATA_DIR} is held by PID ${holder.pid} (${holder.cmd}); kill it (or run \`genie serve restart\`) and retry.`
+          : '';
       throw new Error(
-        `pgserve v2 daemon exited before binding ${socketPath} (${childExit}). Try starting it manually: ${formatPgserveDaemonCommand(
+        `pgserve v2 daemon exited before binding ${socketPath} (${childExit}).${holderHint} Try starting it manually: ${formatPgserveDaemonCommand(
           daemonCommand,
         )}`,
       );


### PR DESCRIPTION
## Summary

A pgserve update / leftover daemon can leave `<DATA_DIR>/postmaster.pid` held by a process `probePgserveDaemon()` can't see (no current libpq symlink + stale `pgserve.pid`). `startPgserveDaemonOnce` then spawns a fresh daemon whose postgres backend dies immediately with `lock file "postmaster.pid" already exists`, surfaced as the unhelpful **"pgserve v2 daemon exited before binding /run/user/\<uid\>/pgserve/.s.PGSQL.5432"**.

This patch detects the holder before spawn, walks up to the pgserve daemon parent if the holder is the postgres backend, terminates the tree, and clears the stale `postmaster.pid` + control-socket artifacts.

- Only acts on processes whose command line proves they own this data dir (`pgserve`, `postgres-server.js`, or `postgres -D <DATA_DIR>`). Foreign postmasters on the same host are untouched.
- Enriches the daemon-exit error to name the PID + command holding the data dir and recommend `genie serve restart`.

Companion to #1553 / #1554 / #1555 / #1557 — those handle stale sockets and unresponsive daemons; this handles the orthogonal "data directory is locked but daemon is invisible" case.

## Repro (before this PR)

1. `genie serve` is running an old pgserve daemon (e.g. on a layout where the libpq compat symlink at `$XDG_RUNTIME_DIR/pgserve/.s.PGSQL.5432` was never created or has been deleted).
2. Run `genie update --next` to bring in a new pgserve. Old daemon stays running; old `postmaster.pid` (alive PID) keeps the data dir locked.
3. Restart `genie serve` (or any genie subcommand that calls `getOrStartDaemon`).
4. Genie spawns a new daemon → new postgres backend exits code 1 → `pgserve v2 daemon exited before binding ...` → server runs degraded; mailbox/heartbeat/omni-bridge all fail with "pgserve daemon unavailable".

The only escape is to manually `pkill` the old daemon and `rm <DATA_DIR>/postmaster.pid`.

## After this PR

`startPgserveDaemonOnce` calls `detectOrphanDataDirLock()` first; if a holder is found whose command line matches our pgserve/postgres signature, `evictOrphanDataDirHolder()` SIGTERMs (then SIGKILLs) the daemon tree, removes the stale lockfiles, and continues with the normal spawn — no operator intervention needed. If the daemon still fails to bind for any other reason, the error message names the data-dir holder so the operator gets an actionable hint.

## Test plan

- [x] `bun test src/lib/db.test.ts` — 63 pass, 0 fail (2 new source-introspection tests verify the helpers exist, are wired up before `spawn(`, and the error message embeds the holder hint)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — no new warnings introduced
- [ ] Manual: reproduced on host with leftover orphan; after fix, `genie serve` recovers without manual `pkill`

## Files

- `src/lib/db.ts` — `detectOrphanDataDirLock()` + `evictOrphanDataDirHolder()` helpers; called from `startPgserveDaemonOnce` and referenced from `waitForDaemonSocket`'s error message.
- `src/lib/db.test.ts` — two new tests under `describe('daemon-owned pgserve')`.