### PR TITLE
fix(tui): exit on SIGHUP to prevent orphan pgserve clients

### DIFF
--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -126,10 +126,31 @@ async function recordTuiLaunchBreadcrumb(): Promise<void> {
 }
 
 /**
+ * Exit the TUI process when its controlling tty disappears. Without this,
+ * OpenTUI keeps its render loop alive after SSH disconnect / tmux pane teardown,
+ * leaving an orphaned `bun` reparented to PID 1 that holds its postgres pool
+ * open forever. Multiple stale TUIs eventually exhaust pgserve's
+ * `max_connections`, surfacing as `[filewatch] sorry, too many clients already`.
+ *
+ * Default Node/bun behavior terminates on SIGHUP, but OpenTUI's raw-mode stdin
+ * handling masks it — install an explicit handler. Mirror SIGINT/SIGTERM for
+ * symmetry with operator-driven shutdown.
+ */
+function installTuiExitSignals(): void {
+  const exitOnSignal = (signal: NodeJS.Signals) => {
+    process.exit(signal === 'SIGHUP' ? 0 : 128 + (signal === 'SIGINT' ? 2 : 15));
+  };
+  process.on('SIGHUP', exitOnSignal);
+  process.on('SIGINT', exitOnSignal);
+  process.on('SIGTERM', exitOnSignal);
+}
+
+/**
  * Render the TUI nav panel.
  * Called from genie.ts when GENIE_TUI_PANE=left.
  */
 export async function launchTui(): Promise<void> {
+  installTuiExitSignals();
   await recordTuiLaunchBreadcrumb();
   const { renderNav } = await import('./render.js');
   await renderNav();


### PR DESCRIPTION
## Summary

- TUI processes weren't exiting when their controlling tty disappeared (SSH disconnect, tmux pane teardown), getting reparented to PID 1 with their postgres pool still open.
- Stale TUIs accumulated and exhausted `pgserve`'s `max_connections=100`, surfacing as `[filewatch] sorry, too many clients already` and breaking every subsequent `getConnection()` across the daemon.
- Adds explicit `SIGHUP`/`SIGINT`/`SIGTERM` handlers in `launchTui()` so bun exits cleanly when the tty dies — OpenTUI's raw-mode stdin was masking the default terminate-on-SIGHUP behavior.

## Root cause (from `/trace`)

Found 4 orphan `bun dist/genie.js` processes (PIDs 903, 4345, 8098, 86137) all reparented to `PPid=1` with deleted ttys (`/dev/pts/4 (deleted)` etc.), each holding a `postgres({ max: 50 })` pool. With `max_connections=100` server-side, just 2 such orphans is enough to exhaust the limit before any new `genie serve` can boot cleanly.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bunx biome check src/tui/index.ts` clean
- [x] `bun test src/tui/` — 109 pass, 0 fail
- [x] Reaped existing orphans on the dev host; `psql` reaches auth instead of "too many clients"; `serve.log` shows healthy `[filewatch]`/`[omni-bridge]` activity with zero `too many clients` errors after the fix
- [ ] Manual: SSH-disconnect a TUI session and verify the bun process exits within seconds (no `PPid=1` orphan in `ps -ef`)

## Notes

- Doesn't change the `max:50` pool size or pgserve `max_connections` — those are belt-and-suspenders the SIGHUP handler should make unnecessary. Worth revisiting only if recurrence is observed.
- Independent of the existing `fix/pgserve-orphan-data-dir-lock` work (#TBD) — that fixes a different startup race; this fixes the steady-state connection leak from runaway TUIs.