### PR TITLE
fix(tui): fail-soft diagnostics under pgserve saturation

### DIFF
--- a/src/tui/components/Nav.tsx
+++ b/src/tui/components/Nav.tsx
@@ -42,15 +42,29 @@ function useDiagnosticsRefresh(
 ): void {
   useEffect(() => {
     let active = true;
+    let lastErrorMessage: string | null = null;
+    let lastErrorLoggedAt = 0;
     async function refresh() {
       try {
         const snap = await collectDiagnostics();
         if (!active) return;
         setDiagnostics(snap);
+        // Reset the error-debounce on the first success after a saturation episode
+        lastErrorMessage = null;
         const signaledAgent = consumeInitialAgentSignal();
         if (signaledAgent) setRequestedInitialAgent(signaledAgent);
       } catch (err) {
-        console.error('TUI: diagnostics failed:', err);
+        // Quiet the 2s-tick spam under sustained pgserve saturation.
+        // Log only when the error message changes or once per 30s for the
+        // same message — operators still see something is wrong without
+        // having the panel buried under repeats.
+        const message = err instanceof Error ? err.message : String(err);
+        const now = Date.now();
+        if (message !== lastErrorMessage || now - lastErrorLoggedAt > 30_000) {
+          console.error('TUI: diagnostics failed:', message);
+          lastErrorMessage = message;
+          lastErrorLoggedAt = now;
+        }
       }
     }
     refresh();

--- a/src/tui/diagnostics.ts
+++ b/src/tui/diagnostics.ts
@@ -247,17 +247,35 @@ function detectGaps(executors: TuiExecutor[], sessions: TmuxSession[]): Diagnost
 
 // ─── Full Snapshot ────────────────────────────────────────────────────────────
 
-/** Collect a complete diagnostic snapshot: executors from DB + tmux inventory + gaps. */
+/** Collect a complete diagnostic snapshot: executors from DB + tmux inventory + gaps.
+ *
+ * Every PG-touching loader is fail-soft. Under transient pgserve saturation
+ * (`too many clients already`, `CONNECTION_ENDED`, etc.) the snapshot still
+ * renders with empty/stale data instead of crashing the TUI refresh — the
+ * Nav.tsx interval will retry every 2s. Single-error spam in the TUI console
+ * was the original symptom of /trace report 2026-04-30.
+ */
 export async function collectDiagnostics(): Promise<DiagnosticSnapshot> {
   const { loadExecutors, loadAssignments, loadAgentWorkStates } = await import('./db.js');
 
-  // Collect tmux inventory (shell) and executors (DB) in parallel
+  // Collect tmux inventory (shell, no DB) and executors (DB, fail-soft) in parallel
   const sessions = getTmuxInventory();
-  const executors = await loadExecutors();
 
-  // Load assignments for active executors
+  let executors: Awaited<ReturnType<typeof loadExecutors>> = [];
+  try {
+    executors = await loadExecutors();
+  } catch {
+    /* keep empty — Nav still renders with sessions only */
+  }
+
+  // Load assignments for active executors (DB, fail-soft)
   const executorIds = executors.map((e) => e.id);
-  const assignments = await loadAssignments(executorIds);
+  let assignments: Awaited<ReturnType<typeof loadAssignments>> = [];
+  try {
+    assignments = await loadAssignments(executorIds);
+  } catch {
+    /* keep empty — Nav hides assignment column */
+  }
 
   // Load per-agent work-state via shouldResume() and active-signal count.
   // Both are best-effort: if PG is degraded, we still ship a usable
@@ -280,19 +298,25 @@ export async function collectDiagnostics(): Promise<DiagnosticSnapshot> {
   const gaps = detectGaps(executors, sessions);
 
   // Auto-terminate dead-PID executors so stale rows don't block re-spawning.
+  // Fail-soft: under DB saturation, defer cleanup to the next refresh tick
+  // rather than crashing the snapshot.
   if (gaps.deadPidExecutors.length > 0) {
-    const { terminateExecutor } = await import('../lib/executor-registry.js');
-    const { getConnection } = await import('../lib/db.js');
-    const sql = await getConnection();
-    await Promise.allSettled(
-      gaps.deadPidExecutors.map(async (exec) => {
-        await terminateExecutor(exec.id);
-        // Clear the agent FK so the duplicate guard won't block new spawns
-        if (exec.agentId) {
-          await sql`UPDATE agents SET current_executor_id = NULL WHERE current_executor_id = ${exec.id}`;
-        }
-      }),
-    );
+    try {
+      const { terminateExecutor } = await import('../lib/executor-registry.js');
+      const { getConnection } = await import('../lib/db.js');
+      const sql = await getConnection();
+      await Promise.allSettled(
+        gaps.deadPidExecutors.map(async (exec) => {
+          await terminateExecutor(exec.id);
+          // Clear the agent FK so the duplicate guard won't block new spawns
+          if (exec.agentId) {
+            await sql`UPDATE agents SET current_executor_id = NULL WHERE current_executor_id = ${exec.id}`;
+          }
+        }),
+      );
+    } catch {
+      /* keep gaps surfaced — next refresh tick retries cleanup */
+    }
   }
 
   return {


### PR DESCRIPTION
## Symptom

Under sustained pgserve saturation (`too many clients already` / `CONNECTION_ENDED` — see [pgserve#53](https://github.com/namastexlabs/pgserve/issues/53)), the TUI refresh tick spams the operator's panel every 2 seconds with `TUI: diagnostics failed: ...`. Live measurement on the demo host: 850/1000 pgserve backends, 803 leaked-idle, scheduler.log full of identical errors.

## Root cause

`collectDiagnostics()` in `src/tui/diagnostics.ts` calls `loadExecutors()` and `loadAssignments()` outside any try/catch. When pgserve refuses, these throw and the entire snapshot collection unwinds. Nav.tsx's outer try/catch logs the error every 2s. Compare to `loadAgentWorkStates` (line 267) which is already fail-soft.

## Fix

Wrap each PG-touching loader in its own try/catch, defaulting to `[]` on error — same pattern `loadAgentWorkStates` already uses. Defer dead-PID auto-terminate cleanup to the next refresh tick when the pool is saturated.

Nav.tsx debounces the error log: same error class within 30 seconds is suppressed. Operators still see the first occurrence of a new error type but don't get buried under repeats during a saturation episode.

## What this is NOT

This is the **cosmetic / fragility fix** — the TUI survives saturation cleanly. The actual leak fix (per-peer backend lifecycle in `daemon-control.js`) lives in [pgserve#53](https://github.com/namastexlabs/pgserve/issues/53) and the broader cross-repo solution in [genie#1569](https://github.com/automagik-dev/genie/pull/1569) (host-signed identity wish). After those land, the saturation goes away; this PR makes the TUI graceful in the meantime.

## Trace evidence

[Trace report 2026-04-30] — `/genie:trace` against the live saturation episode identified two compound defects: (1) pgserve daemon backend leak, (2) TUI lacks error isolation. This PR addresses (2). (1) tracked in pgserve#53.

## Verification

- ✅ `bunx tsc --noEmit` clean
- ✅ `bunx biome check` clean (one pre-existing complexity warning, not new)
- Manual: under simulated saturation, TUI still renders sessions + (empty) executors + (empty) assignments instead of error-spamming.