### PR TITLE
feat(serve): boot-scan loader + --strict-hooks flag (absorption D5)

### DIFF
--- a/src/hooks/trust.ts
+++ b/src/hooks/trust.ts
@@ -49,9 +49,14 @@ export interface TrustFile {
   entries: TrustEntry[];
 }
 
-/** Default location of the trust file. Override in tests. */
+/**
+ * Default location of the trust file. Honors `GENIE_HOME` for tests + alt-home
+ * deployments (matches the convention `src/serve/hook-socket.ts` already uses
+ * for the UDS path); falls back to `~/.genie/hooks/trusted.json` otherwise.
+ */
 export function defaultTrustPath(): string {
-  return join(homedir(), '.genie', 'hooks', 'trusted.json');
+  const home = process.env.GENIE_HOME ?? join(homedir(), '.genie');
+  return join(home, 'hooks', 'trusted.json');
 }
 
 /** Reasons the verifier rejects a file. Surfaced by `genie hook list`. */

--- a/src/serve/__tests__/hook-socket-loader.test.ts
+++ b/src/serve/__tests__/hook-socket-loader.test.ts
@@ -1,0 +1,168 @@
+/**
+ * hook-socket boot-loader integration tests — Group 1 D5 of
+ * hookify-third-party-absorption.
+ *
+ * Asserts that startHookSocket runs the loader BEFORE listening (single-writer
+ * at boot), surfaces outcomes via the returned handle, and honors strict
+ * mode.
+ *
+ * Trust file + repoRoot are temp dirs so these tests don't touch the host's
+ * `~/.genie/hooks/` or `~/.claude/teams/<team>/hooks/`.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getRegistry, setRegistry } from '../../hooks/index.js';
+import { sha256OfFile } from '../../hooks/trust.js';
+import { startHookSocket } from '../hook-socket.js';
+
+let tmpRoot: string;
+let socketDir: string;
+let savedHookSock: string | undefined;
+let savedHome: string | undefined;
+let savedRegistry: ReturnType<typeof getRegistry>;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'genie-hook-loader-int-'));
+  socketDir = join(tmpRoot, 'sock');
+  mkdirSync(socketDir, { recursive: true });
+
+  savedHookSock = process.env.GENIE_HOOK_SOCK;
+  savedHome = process.env.GENIE_HOME;
+  process.env.GENIE_HOOK_SOCK = join(socketDir, 'hook.sock');
+  // Redirect HOME-derived paths so loader scans empty team + global tiers.
+  process.env.GENIE_HOME = join(tmpRoot, 'genie-home');
+
+  savedRegistry = getRegistry();
+});
+
+afterEach(() => {
+  if (savedHookSock === undefined) delete process.env.GENIE_HOOK_SOCK;
+  else process.env.GENIE_HOOK_SOCK = savedHookSock;
+  if (savedHome === undefined) delete process.env.GENIE_HOME;
+  else process.env.GENIE_HOME = savedHome;
+  setRegistry(savedRegistry);
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('startHookSocket boot-loader integration', () => {
+  test('loadExternal: false skips the boot scan entirely', async () => {
+    const handle = await startHookSocket({ loadExternal: false });
+    try {
+      expect(handle.loaderOutcomes).toEqual([]);
+    } finally {
+      await handle.stop();
+    }
+  });
+
+  test('loaderOutcomes is empty when no external hooks exist', async () => {
+    // No repoRoot → only team + global tiers are scanned, both pointing at
+    // empty directories under our temp HOME redirect.
+    const handle = await startHookSocket({ loadExternal: true });
+    try {
+      expect(handle.loaderOutcomes).toEqual([]);
+    } finally {
+      await handle.stop();
+    }
+  });
+
+  test('loaderOutcomes records untrusted files (filesystem-presence is not consent)', async () => {
+    // Per-repo tier scan finds an untrusted file.
+    const repoRoot = join(tmpRoot, 'repo');
+    mkdirSync(join(repoRoot, '.genie', 'hooks'), { recursive: true });
+    writeFileSync(
+      join(repoRoot, '.genie', 'hooks', 'untrusted.ts'),
+      'export default {};', // missing trust entry
+      'utf-8',
+    );
+
+    const handle = await startHookSocket({ loadExternal: true, repoRoot });
+    try {
+      expect(handle.loaderOutcomes.length).toBeGreaterThanOrEqual(1);
+      const outcome = handle.loaderOutcomes[0];
+      expect(outcome.kind).toBe('untrusted');
+    } finally {
+      await handle.stop();
+    }
+  });
+
+  test('strict: true throws on a same-name collision (refuses to start)', async () => {
+    const repoRoot = join(tmpRoot, 'repo');
+    const hooksDir = join(repoRoot, '.genie', 'hooks');
+    mkdirSync(hooksDir, { recursive: true });
+
+    const sample = `
+      const handler = {
+        version: '1', source: 'global', manifest_path: '<placeholder>',
+        name: 'collision', event: 'PreToolUse', matcher: /^Bash$/,
+        priority: 50, fn: async () => undefined,
+      };
+      export default handler;
+    `;
+    const a = join(hooksDir, 'a.ts');
+    const b = join(hooksDir, 'b.ts');
+    writeFileSync(a, sample, 'utf-8');
+    writeFileSync(b, sample, 'utf-8');
+
+    // Trust both files at their actual SHAs so they pass the trust gate.
+    const trustPath = join(tmpRoot, 'genie-home', 'hooks', 'trusted.json');
+    mkdirSync(join(tmpRoot, 'genie-home', 'hooks'), { recursive: true });
+    writeFileSync(
+      trustPath,
+      JSON.stringify({
+        version: 1,
+        entries: [
+          { path: a, sha256: sha256OfFile(a), scope: 'global', trustedAt: '2026-04-30T00:00:00Z' },
+          { path: b, sha256: sha256OfFile(b), scope: 'global', trustedAt: '2026-04-30T00:00:00Z' },
+        ],
+      }),
+      'utf-8',
+    );
+
+    await expect(startHookSocket({ loadExternal: true, repoRoot, strict: true })).rejects.toThrow(/--strict-hooks/);
+  });
+
+  test('non-strict mode accepts collision (warn + continue, daemon starts)', async () => {
+    const repoRoot = join(tmpRoot, 'repo');
+    const hooksDir = join(repoRoot, '.genie', 'hooks');
+    mkdirSync(hooksDir, { recursive: true });
+
+    const sample = `
+      const handler = {
+        version: '1', source: 'global', manifest_path: '<placeholder>',
+        name: 'duplicate', event: 'PreToolUse', matcher: /^Bash$/,
+        priority: 50, fn: async () => undefined,
+      };
+      export default handler;
+    `;
+    const a = join(hooksDir, 'a.ts');
+    const b = join(hooksDir, 'b.ts');
+    writeFileSync(a, sample, 'utf-8');
+    writeFileSync(b, sample, 'utf-8');
+
+    const trustPath = join(tmpRoot, 'genie-home', 'hooks', 'trusted.json');
+    mkdirSync(join(tmpRoot, 'genie-home', 'hooks'), { recursive: true });
+    writeFileSync(
+      trustPath,
+      JSON.stringify({
+        version: 1,
+        entries: [
+          { path: a, sha256: sha256OfFile(a), scope: 'global', trustedAt: '2026-04-30T00:00:00Z' },
+          { path: b, sha256: sha256OfFile(b), scope: 'global', trustedAt: '2026-04-30T00:00:00Z' },
+        ],
+      }),
+      'utf-8',
+    );
+
+    const handle = await startHookSocket({ loadExternal: true, repoRoot });
+    try {
+      expect(handle.loaderOutcomes.length).toBe(2);
+      expect(handle.loaderOutcomes.find((o) => o.kind === 'loaded')).toBeDefined();
+      expect(handle.loaderOutcomes.find((o) => o.kind === 'shadowed')).toBeDefined();
+    } finally {
+      await handle.stop();
+    }
+  });
+});

--- a/src/serve/__tests__/hook-socket-loader.test.ts
+++ b/src/serve/__tests__/hook-socket-loader.test.ts
@@ -39,9 +39,9 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  if (savedHookSock === undefined) delete process.env.GENIE_HOOK_SOCK;
+  if (savedHookSock === undefined) Reflect.deleteProperty(process.env, 'GENIE_HOOK_SOCK');
   else process.env.GENIE_HOOK_SOCK = savedHookSock;
-  if (savedHome === undefined) delete process.env.GENIE_HOME;
+  if (savedHome === undefined) Reflect.deleteProperty(process.env, 'GENIE_HOME');
   else process.env.GENIE_HOME = savedHome;
   setRegistry(savedRegistry);
   rmSync(tmpRoot, { recursive: true, force: true });

--- a/src/serve/hook-socket.ts
+++ b/src/serve/hook-socket.ts
@@ -33,12 +33,41 @@ import { type Server, type Socket, createServer, connect as netConnect } from 'n
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { dispatch } from '../hooks/index.js';
+import { type LoadStatus, loadExternalHooks } from '../hooks/loader.js';
 
 export interface HookSocketHandle {
   /** Absolute path to the UDS file. */
   path: string;
   /** Stop the server and unlink the socket file. Idempotent. */
   stop: () => Promise<void>;
+  /** Per-file outcome from the boot-time loader scan. Empty when no external hooks are present. */
+  loaderOutcomes: ReadonlyArray<LoadStatus>;
+}
+
+/**
+ * Options accepted by `startHookSocket()`. The defaults preserve the pre-loader
+ * behavior — no external hooks discovered, no strict mode — so existing callers
+ * that don't pass options keep working unchanged.
+ */
+export interface StartHookSocketOptions {
+  /**
+   * Run the boot-scan loader against the three S3 tiers before listening.
+   * Defaults to `true` so daemons pick up trusted external hooks at startup.
+   * Set `false` in tests / one-shot scripts that don't want side-effects from
+   * the host's `~/.genie/hooks/` or `~/.claude/teams/<team>/hooks/` directories.
+   */
+  loadExternal?: boolean;
+  /**
+   * Repository root for the per-repo tier scan (`<repoRoot>/.genie/hooks/*.ts`).
+   * When omitted, the per-repo tier is skipped — team and global tiers still
+   * scanned. Pass the cwd of the running daemon.
+   */
+  repoRoot?: string;
+  /**
+   * Refuse to start when the loader finds two external hooks with the same
+   * `name` (any tier). Wired up to the `genie serve --strict-hooks` CLI flag.
+   */
+  strict?: boolean;
 }
 
 /** 1 MB cap on a single hook payload. CC payloads are normally a few KB. */
@@ -193,13 +222,31 @@ async function handleConnection(socket: Socket): Promise<void> {
  * Start the hook socket listener. Returns a handle with the path and a stop fn.
  * Throws if a live listener is already on the path (refusing to race).
  */
-export async function startHookSocket(): Promise<HookSocketHandle> {
+export async function startHookSocket(options: StartHookSocketOptions = {}): Promise<HookSocketHandle> {
   // Group 4 of hookify-perf-foundation: turn on the wide-emit flag for the
   // hook subsystem by default in daemon mode so per-handler timing spans land
   // in `genie_runtime_events` and feed the `hook_perf_baseline` view. If the
   // operator has set GENIE_WIDE_EMIT explicitly we honor their value.
   if (process.env.GENIE_WIDE_EMIT === undefined) {
     process.env.GENIE_WIDE_EMIT = '1';
+  }
+
+  // Group 1 of hookify-third-party-absorption (D5): boot-scan the three S3
+  // tiers BEFORE the server listens so the registry is single-writer at boot.
+  // Loader outcomes are surfaced through the returned handle for `genie doctor
+  // --hooks` (Group 2) and the daemon stdout summary below.
+  //
+  // The loader is fail-soft on external hooks: untrusted / broken / shadowed
+  // files are recorded in outcomes but the daemon ALWAYS starts. The only
+  // failure mode that aborts boot is `strict: true` + a same-name collision,
+  // wired up to `genie serve --strict-hooks`.
+  let loaderOutcomes: LoadStatus[] = [];
+  if (options.loadExternal !== false) {
+    loaderOutcomes = await loadExternalHooks({
+      repoRoot: options.repoRoot,
+      strict: options.strict,
+    });
+    summarizeLoaderOutcomes(loaderOutcomes);
   }
 
   const socketPath = defaultHookSocketPath();
@@ -264,5 +311,29 @@ export async function startHookSocket(): Promise<HookSocketHandle> {
     }
   };
 
-  return { path: socketPath, stop };
+  return { path: socketPath, stop, loaderOutcomes };
+}
+
+/**
+ * Print a one-line summary of loader outcomes to stdout so `genie serve` logs
+ * make it obvious whether external hooks are participating. Detailed per-file
+ * status is available via `genie hook list` (Group 2 surface).
+ */
+function summarizeLoaderOutcomes(outcomes: ReadonlyArray<LoadStatus>): void {
+  if (outcomes.length === 0) return;
+  let loaded = 0;
+  let untrusted = 0;
+  let broken = 0;
+  let shadowed = 0;
+  for (const outcome of outcomes) {
+    if (outcome.kind === 'loaded') loaded += 1;
+    else if (outcome.kind === 'untrusted') untrusted += 1;
+    else if (outcome.kind === 'broken') broken += 1;
+    else shadowed += 1;
+  }
+  const parts: string[] = [`hook-loader: ${loaded} loaded`];
+  if (untrusted > 0) parts.push(`${untrusted} untrusted`);
+  if (broken > 0) parts.push(`${broken} broken (quarantined)`);
+  if (shadowed > 0) parts.push(`${shadowed} shadowed`);
+  console.log(parts.join(', '));
 }

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -980,8 +980,20 @@ function sigKillRegisteredServices(): void {
 async function startHookSocketSafely(): Promise<void> {
   try {
     const { startHookSocket } = await import('../serve/hook-socket.js');
-    handles.hookSocket = await startHookSocket();
+    // GENIE_STRICT_HOOKS is set by `genie serve --strict-hooks`. The repoRoot
+    // for the per-repo tier scan is the daemon's cwd — operators running the
+    // daemon from a repo root get that repo's `.genie/hooks/` scanned.
+    handles.hookSocket = await startHookSocket({
+      strict: process.env.GENIE_STRICT_HOOKS === '1',
+      repoRoot: process.cwd(),
+    });
   } catch (err) {
+    // Bubble up --strict-hooks failures so the operator sees the colliding
+    // hook names and can fix the deployment. Other failures (socket EADDRINUSE,
+    // etc.) keep the soft-disable behavior so the daemon stays up.
+    if (process.env.GENIE_STRICT_HOOKS === '1' && (err as Error).message.includes('--strict-hooks')) {
+      throw err;
+    }
     console.warn(`  Hook socket: DISABLED — ${(err as Error).message}`);
     handles.hookSocket = null;
   }
@@ -1521,6 +1533,13 @@ interface ServeStartOptions {
   foreground?: boolean;
   headless?: boolean;
   fix?: boolean;
+  /**
+   * Refuse to start when the boot-scan loader finds two external `.ts` hook
+   * files declaring the same `name`. Default behavior is to log a warning,
+   * keep the higher-precedence file, and continue. Operators who want a hard
+   * gate (e.g. CI / fleet rollouts) pass `--strict-hooks`.
+   */
+  strictHooks?: boolean;
 }
 
 /**
@@ -1563,9 +1582,16 @@ export function registerServeCommands(program: Command): void {
     .option('--foreground', 'Run in foreground (default)')
     .option('--headless', 'Run without TUI (services only: pgserve, scheduler, inbox-watcher)')
     .option('--no-fix', 'Refuse to start when any precondition is not ok (default: auto-fix)')
+    .option('--strict-hooks', 'Refuse to start on any same-name external hook collision (default: warn + continue)')
     .action(async (options: ServeStartOptions) => {
       // commander's `--no-fix` flips `options.fix` to false. Default is true.
       const autoFix = options.fix !== false;
+      // Propagate --strict-hooks to startHookSocketSafely via env so the
+      // signature stays narrow (the daemon-startup graph is deep). Read once
+      // by hook-socket.ts at boot; never mutated thereafter.
+      if (options.strictHooks) {
+        process.env.GENIE_STRICT_HOOKS = '1';
+      }
       if (options.daemon) {
         await startBackground(options.headless, autoFix);
       } else {


### PR DESCRIPTION
## Summary

Final slice of Group 1 (hookify-third-party-absorption). Wires the boot-scan loader into the daemon startup so external `.ts` hooks land in the registry BEFORE `server.listen()`. After this PR, **Group 1 is complete (7/7 deliverables)**.

### What lands

- **`src/serve/hook-socket.ts`** — `startHookSocket()` now accepts `{ loadExternal?, repoRoot?, strict? }`. Calls `loadExternalHooks()` before listening so the registry is single-writer at boot. Surfaces per-file outcomes through `HookSocketHandle.loaderOutcomes` for `genie doctor --hooks` (Group 2). Prints a one-line stdout summary (`hook-loader: 3 loaded, 1 untrusted`).
- **`src/term-commands/serve.ts`** — `genie serve --strict-hooks` flag. Sets `GENIE_STRICT_HOOKS=1` which `startHookSocketSafely` reads and forwards. Strict-mode collisions abort startup; other socket failures keep the existing soft-disable behavior.
- **`src/hooks/trust.ts`** — `defaultTrustPath()` honors `GENIE_HOME` env so tests + alt-home deployments don't have to override real `$HOME`.

## Group 1 progress (now complete)

| Deliverable | State |
|---|---|
| D1 mutable registryRef + setRegistry | ✅ #1544 |
| D2 Handler v1 discriminated union | ✅ #1544 |
| D3 \`loader.ts\` (boot-scan + trust + quarantine) | ✅ #1558 |
| D4 \`trust.ts\` + \`genie hook trust\` CLI | ✅ #1558 |
| **D5 boot-loader wiring + \`--strict-hooks\` flag** | ✅ this PR |
| D6 \`defineHook\` helper | ✅ #1544 |
| D7 dispatch-command wires trust subcommand | ✅ #1558 |

## Test plan

- [x] \`bun test src/serve/__tests__/hook-socket-loader.test.ts src/hooks/__tests__/\` → 166 pass / 0 fail / 397 expect calls
- [x] \`loadExternal: false\` skips boot scan (back-compat for callers that don't want side-effects)
- [x] Empty discovery returns empty outcomes
- [x] Untrusted file recorded with \`kind: 'untrusted'\` (filesystem-presence is not consent)
- [x] \`strict: true\` throws on same-name collision (refuses to start)
- [x] Non-strict mode accepts collision (warn + continue, daemon starts)
- [x] \`GENIE_HOME\` redirect works for tests without polluting real \`\$HOME\`

## What's next

Group 1 done. Group 2 (operator inner loop — scaffold / list / test / reload / quarantine commands) is unblocked and can ship next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)