### PR TITLE
fix(test): noDelete lint error in hook-socket-loader.test.ts (#1572 CI fix)

### DIFF
--- a/src/serve/__tests__/hook-socket-loader.test.ts
+++ b/src/serve/__tests__/hook-socket-loader.test.ts
@@ -39,9 +39,9 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  if (savedHookSock === undefined) delete process.env.GENIE_HOOK_SOCK;
+  if (savedHookSock === undefined) Reflect.deleteProperty(process.env, 'GENIE_HOOK_SOCK');
   else process.env.GENIE_HOOK_SOCK = savedHookSock;
-  if (savedHome === undefined) delete process.env.GENIE_HOME;
+  if (savedHome === undefined) Reflect.deleteProperty(process.env, 'GENIE_HOME');
   else process.env.GENIE_HOME = savedHome;
   setRegistry(savedRegistry);
   rmSync(tmpRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Two-line fix for #1572 CI red. \`bunx biome check .\` failed in the Unit Tests job with:

\`\`\`
./src/serve/__tests__/hook-socket-loader.test.ts:42:36 lint/performance/noDelete (FIXABLE)
  × Avoid the delete operator which can impact performance.
./src/serve/__tests__/hook-socket-loader.test.ts:44:32 lint/performance/noDelete (FIXABLE)
  × Avoid the delete operator which can impact performance.
\`\`\`

Replaces \`delete process.env.X\` with \`Reflect.deleteProperty(process.env, 'X')\` — functionally identical for env-var cleanup, avoids the perf rule.

Targets #1572's branch directly so the fix lands inside that PR rather than racing it.

## Test plan

- [x] \`bunx biome check .\` — exit 0, 17 warnings (all pre-existing complexity warnings on \`dev\`), 0 errors
- [x] \`bun test src/serve/__tests__/hook-socket-loader.test.ts\` — 5 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)