### PR TITLE
fix(hooks): route bun-fork hot path through daemon socket first (#1574)

### DIFF
--- a/src/hooks/dispatch-command.ts
+++ b/src/hooks/dispatch-command.ts
@@ -3,10 +3,29 @@
  *
  * Reads CC hook payload from stdin, dispatches to handlers,
  * writes result to stdout. Designed for minimal startup time.
+ *
+ * **Hot-path strategy** (issue #1574):
+ *
+ * The bun-fork hot path used to dispatch in-process — every hook event opened
+ * its own PG connection (max: 50 client-side pool) and `process.exit(0)`'d
+ * without `shutdown()`, leaking server-side backends until pgserve hit
+ * `max_connections=1000`. Operators saw "FATAL: sorry, too many clients
+ * already" at steady state.
+ *
+ * Now: bun fork connects to `~/.genie/hook.sock` (the daemon's UDS) FIRST.
+ * The daemon owns the PG pool; the fork stays stateless and never opens a
+ * connection of its own. Only when the socket is missing/refused/timed-out
+ * does the fork fall back to in-process dispatch (which still opens a pool;
+ * acceptable as a degraded mode because the daemon is supposed to be up).
+ *
+ * This is a strict perf improvement on the existing path AND a fix for the
+ * #1574 PG leak — every "happy path" hook now does a 4-byte UDS roundtrip
+ * with zero PG state in the fork.
  */
 
 import type { Command } from 'commander';
 import { registerHookTrustCommand } from '../term-commands/hook/trust.js';
+import { runDispatchClient } from './dispatch-client.js';
 import { dispatch } from './index.js';
 
 async function readStdin(): Promise<string> {
@@ -19,24 +38,28 @@ async function readStdin(): Promise<string> {
 }
 
 async function dispatchAction(): Promise<void> {
-  // Mac-CPU fix C — short-circuit DB boot for hook dispatch forks.
-  //
-  // The long-lived `genie serve` daemon owns migrations + seed (it ran
-  // them at startup). Each `genie hook dispatch` fork (hundreds/min on a
-  // busy Mac dev machine) is short-lived; making each fork re-run
-  // `runMigrations` + `needsSeed` (which loops all 92 ~/.claude/teams
-  // entries on every call) is the second-largest contributor to the
-  // .18 100%-CPU regression on Mac.
-  //
-  // Setting this env BEFORE `dispatch(stdin)` ensures the first
-  // `getConnection()` inside any handler skips migrations + seed.
-  // Handlers that need DB still get a working connection — they just
-  // skip the boot-time setup that the daemon already handled.
-  //
-  // Set unconditionally for the dispatch entrypoint; daemon and CLI
-  // code paths never enter this function.
+  // Mac-CPU fix C — short-circuit DB boot for hook dispatch forks. Only the
+  // legacy in-process fallback below pays the cost; the default daemon path
+  // never opens PG in this fork at all.
   process.env.GENIE_SKIP_DB_BOOT = '1';
 
+  // Issue #1574 fix — default path: hand off to the daemon socket via
+  // runDispatchClient(). On socket miss the client emits the F1 fallback
+  // (empty stdout, allow-by-default, audit log entry) and returns 0 itself.
+  // Either way the fork stays stateless, no PG connection, no shutdown leak.
+  //
+  // Set GENIE_HOOK_FORCE_INPROC=1 to bypass the daemon and run handlers
+  // in-process (legacy behavior, kept for tests/debugging — DOES open a
+  // PG pool that won't be cleanly shut down on process.exit, so don't
+  // enable in production).
+  if (process.env.GENIE_HOOK_FORCE_INPROC !== '1') {
+    const code = await runDispatchClient();
+    process.exit(code);
+  }
+
+  // Legacy in-process path — opt-in only. Reads stdin, dispatches against
+  // the local handler registry, writes stdout. Same code that ran before
+  // PR-#XXXX shipped the daemon-first hot path.
   const stdin = await readStdin();
   if (!stdin.trim()) {
     process.exit(0);

--- a/src/hooks/dispatch-command.ts
+++ b/src/hooks/dispatch-command.ts
@@ -15,8 +15,10 @@
  * Now: bun fork connects to `~/.genie/hook.sock` (the daemon's UDS) FIRST.
  * The daemon owns the PG pool; the fork stays stateless and never opens a
  * connection of its own. Only when the socket is missing/refused/timed-out
- * does the fork fall back to in-process dispatch (which still opens a pool;
- * acceptable as a degraded mode because the daemon is supposed to be up).
+ * does the fork fall back to "fail-open" (empty stdout = allow-by-default,
+ * audit entry to ~/.genie/hook-fallback.log) — operations never block on a
+ * daemon outage. The legacy in-process fallback (which DOES open a PG pool)
+ * is preserved behind GENIE_HOOK_FORCE_INPROC=1 for tests + debugging only.
  *
  * This is a strict perf improvement on the existing path AND a fix for the
  * #1574 PG leak — every "happy path" hook now does a 4-byte UDS roundtrip
@@ -54,12 +56,19 @@ async function dispatchAction(): Promise<void> {
   // enable in production).
   if (process.env.GENIE_HOOK_FORCE_INPROC !== '1') {
     const code = await runDispatchClient();
+    // Drain stdout BEFORE process.exit so the daemon's decision payload is
+    // fully delivered to CC. Calling process.exit() with stdout still
+    // buffered can truncate the write under load and silently downgrade
+    // `deny` decisions to allow-by-default — a real security gap caught
+    // in PR review (codex P1 finding on dispatch-command.ts). Drain is a
+    // no-op when the buffer is already empty (typical case), so this
+    // costs <1ms on the hot path.
+    await drainStdout();
     process.exit(code);
   }
 
   // Legacy in-process path — opt-in only. Reads stdin, dispatches against
-  // the local handler registry, writes stdout. Same code that ran before
-  // PR-#XXXX shipped the daemon-first hot path.
+  // the local handler registry, writes stdout.
   const stdin = await readStdin();
   if (!stdin.trim()) {
     process.exit(0);
@@ -69,6 +78,23 @@ async function dispatchAction(): Promise<void> {
   if (result) {
     process.stdout.write(result);
   }
+  await drainStdout();
+  process.exit(0);
+}
+
+/**
+ * Wait for stdout to flush — required before relying on process exit when the
+ * caller wrote a payload that mustn't be truncated. Resolves on the next
+ * 'drain' event, or immediately when the buffer is already empty.
+ */
+function drainStdout(): Promise<void> {
+  return new Promise((resolve) => {
+    // Bun + node accept an empty write whose callback fires after the buffer
+    // is flushed. This is the documented way to ensure data reaches the pipe
+    // before exit; avoids the race where process.exit truncates a deny
+    // decision into an empty allow.
+    process.stdout.write('', () => resolve());
+  });
 }
 
 export function registerHookNamespace(program: Command): void {


### PR DESCRIPTION
## Summary

Fixes #1574 — \`genie hook dispatch\` (bun-fork hot path) now routes to the daemon UDS first, eliminating the per-fork PG pool that was leaking server-side connections and saturating \`pgserve max_connections=1000\`.

## Measured impact

Same machine that hit the #1574 saturation, 10 calls each, payload = simple PreToolUse Bash:

| Path | Total | Per-call | PG conns in fork |
|---|---|---|---|
| **Socket-first (default, this PR)** | **5.97s** | **0.60s** | **0** |
| Force in-proc (legacy = today's reality) | 58.5s | 5.85s | up to 50 (pool max) |

**9.8× speedup on the hot path AND zero PG leak.**

## Mechanism

- \`dispatchAction\` now defaults to handing stdin off to \`runDispatchClient\` (the existing thin-client logic in \`src/hooks/dispatch-client.ts\`). The fork connects to \`~/.genie/hook.sock\`, sends one length-prefixed frame, reads one length-prefixed reply, exits. **No PG connection in the fork at all.**
- On socket miss the thin-client emits the F1 fallback (empty stdout = allow, audit entry to \`~/.genie/hook-fallback.log\`) and returns 0 — operators see daemon outages in metrics instead of CC stalls.
- Legacy in-process path is preserved behind \`GENIE_HOOK_FORCE_INPROC=1\` for tests + debugging only.

## Why this didn't ship in delivery #1

Hookify-perf-foundation (PR #1485) shipped the daemon socket + the compiled thin-client \`dispatch-client.ts\`, but the binary install layer (\`bun build --compile\` → \`~/.genie/bin/genie-hook\`) didn't ship — operators still hit the bun-fork path on every CC tool call. This commit closes the gap until the binary install lands.

## Test plan

- [x] \`bun test src/hooks/__tests__/\` → 161 pass / 0 fail / 389 expect calls
- [x] \`bun run check:fast\` → green
- [x] Microbench: 10 calls socket-first vs force-in-proc → 9.8× speedup confirmed
- [x] On daemon outage: F1 fallback engages, audit log appended, exit 0 (allow)
- [x] \`GENIE_HOOK_FORCE_INPROC=1\` preserves legacy behavior for tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)