### PR TITLE
feat(cli): genie install — pm2 supervision (canonical-pgserve-pm2 wave 2)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -709,6 +709,62 @@ CONFIG_EOF
 # tmux Installation and Configuration
 # ─────────────────────────────────────────────────────────────────────────────
 
+# ─────────────────────────────────────────────────────────────────────────────
+# pm2 Supervision (canonical-pgserve-pm2-supervision wave 2)
+#
+# Idempotent. Installs pm2 globally if missing, then runs `genie install` so
+# genie-serve survives shell exits and host reboots. Skipped when --no-pm2
+# is passed or when GENIE_INSTALL_PM2=0.
+#
+# Mirrors `omni install`'s ensure_pm2 + post-CLI step. The `genie install`
+# command is wave 2 of the canonical-pgserve-pm2-supervision wish; it shells
+# out to `pgserve install` first (idempotent) so all four pm2 services in
+# the canonical stack converge on the same hardened defaults.
+# ─────────────────────────────────────────────────────────────────────────────
+
+ensure_pm2() {
+    if check_command pm2; then
+        success "pm2 $(pm2 --version 2>/dev/null || echo '?')"
+        return 0
+    fi
+
+    log "Installing pm2..."
+    bun add -g pm2 >/dev/null 2>&1 || npm install -g pm2 >/dev/null 2>&1
+    if check_command pm2; then
+        success "pm2 installed"
+    else
+        warn "Could not install PM2 globally. Install manually: bun add -g pm2"
+        return 1
+    fi
+}
+
+install_pm2_supervision() {
+    if [[ "${GENIE_INSTALL_PM2:-1}" == "0" ]] || [[ "${INSTALL_PM2:-true}" == "false" ]]; then
+        info "Skipping pm2 supervision (GENIE_INSTALL_PM2=0 or --no-pm2)"
+        return 0
+    fi
+
+    header "Configuring pm2 supervision..."
+
+    if ! ensure_pm2; then
+        warn "Skipping pm2 supervision — pm2 install failed"
+        return 0
+    fi
+
+    if ! check_command genie; then
+        warn "genie not on PATH; skipping `genie install` (re-run after CLI install completes)"
+        return 0
+    fi
+
+    info "Running genie install (registers genie-serve under pm2 with hardened defaults)..."
+    if genie install; then
+        success "genie-serve registered under pm2"
+        info "Run 'pm2 save && pm2 startup' to persist across reboots"
+    else
+        warn "genie install failed — bridge will not survive shell exit. Re-run manually: genie install"
+    fi
+}
+
 install_tmux_if_needed() {
     if check_command tmux; then
         success "tmux found"
@@ -831,6 +887,9 @@ run_install() {
     # ─── Genie CLI Install/Update ───
     header "Installing Genie CLI..."
     install_genie_cli
+
+    # ─── pm2 Supervision (canonical-pgserve-pm2-supervision wave 2) ───
+    install_pm2_supervision
 
     # ─── Locate package directory ───
     if ! locate_package_dir; then

--- a/src/genie-commands/__tests__/install.test.ts
+++ b/src/genie-commands/__tests__/install.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for `genie install` — Wave 2 of the canonical-pgserve-pm2-supervision
+ * wish (PR pgserve#55, Wave 1 = pgserve#57).
+ *
+ * The interesting paths here are:
+ *   - The pm2 launch args list (pinned values flow through `buildPm2StartArgs`)
+ *   - Memory-ceiling env override (`GENIE_SERVE_MAX_MEMORY`)
+ *   - `--interpreter none` and `serve start --headless --no-tui --no-interactive`
+ *     (the empirically-validated invocation from the wish's beachhead)
+ *
+ * The full install flow (which spawns `pgserve install` and `pm2 start`) is
+ * exercised in CI via the install.sh smoke test on a clean container; here
+ * we just lock down the pure helpers so refactors don't drift the
+ * canonical-stack behavior.
+ *
+ * Run with: bun test src/genie-commands/__tests__/install.test.ts
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { _internals } from '../install.js';
+
+const { HARDENED_DEFAULTS, PM2_PROCESS_NAME, buildPm2StartArgs } = _internals;
+
+describe('install._internals — canonical-stack constants', () => {
+  test('process name is genie-serve', () => {
+    expect(PM2_PROCESS_NAME).toBe('genie-serve');
+  });
+
+  test('hardened defaults match the canonical pgserve/omni values', () => {
+    // These numbers are pinned across all four pm2 services in the wish so
+    // every service in the stack behaves identically under crash-loop and
+    // resource pressure. If any of these change here without a matching
+    // change in pgserve/cli-install.cjs and omni/packages/cli/src/pm2.ts,
+    // the stack drifts. Fail loudly.
+    expect(HARDENED_DEFAULTS.maxRestarts).toBe(50);
+    expect(HARDENED_DEFAULTS.minUptimeMs).toBe(10_000);
+    expect(HARDENED_DEFAULTS.restartDelayMs).toBe(4000);
+    expect(HARDENED_DEFAULTS.expBackoffRestartDelayMs).toBe(100);
+    expect(HARDENED_DEFAULTS.killTimeoutMs).toBe(60_000);
+    expect(HARDENED_DEFAULTS.logDateFormat).toBe('YYYY-MM-DD HH:mm:ss.SSS');
+  });
+
+  test('default memory ceiling is 4G when no env override', () => {
+    // Re-importing under cleared env is awkward in bun:test, so we just
+    // check that whatever value HARDENED_DEFAULTS captured on module load
+    // is one of the supported shapes. The env-override path is verified
+    // separately in install-env.test.ts (loads the module with env set).
+    expect(HARDENED_DEFAULTS.maxMemory).toMatch(/^\d+G$/);
+  });
+});
+
+describe('buildPm2StartArgs — pm2 invocation locked down', () => {
+  test('emits all hardened pm2 flags in the right order', () => {
+    const args = buildPm2StartArgs('/usr/local/bin/genie');
+    expect(args[0]).toBe('start');
+    expect(args[1]).toBe('/usr/local/bin/genie');
+    // Sanity: the args list contains every hardening flag.
+    const flagsExpected = [
+      '--name',
+      '--interpreter',
+      '--max-restarts',
+      '--min-uptime',
+      '--restart-delay',
+      '--exp-backoff-restart-delay',
+      '--max-memory-restart',
+      '--kill-timeout',
+      '--log-date-format',
+      '--output',
+      '--error',
+    ];
+    for (const flag of flagsExpected) {
+      expect(args).toContain(flag);
+    }
+  });
+
+  test('uses --interpreter none for shebang resolution (NOT --interpreter bun)', () => {
+    // pm2's bun launcher errors out on top-level await with
+    // "require() async module ... is unsupported. use await import()".
+    // Validated empirically 2026-04-30. If anyone "fixes" this to
+    // --interpreter bun, the install will pass but the supervised process
+    // immediately crashes — exactly the silent dead-code class the
+    // host-fingerprint pipeline smoke test guards against.
+    const args = buildPm2StartArgs('/usr/local/bin/genie');
+    const interpreterIdx = args.indexOf('--interpreter');
+    expect(args[interpreterIdx + 1]).toBe('none');
+    expect(args).not.toContain('bun');
+  });
+
+  test('forwards `serve start --headless --no-tui --no-interactive` to genie', () => {
+    // pm2's child has no controlling terminal so a TUI would wedge.
+    // Headless + no-tui + no-interactive matches the invocation pinned in
+    // the wish's Decisions 4 & 5.
+    const args = buildPm2StartArgs('/usr/local/bin/genie');
+    const sepIdx = args.indexOf('--');
+    expect(sepIdx).toBeGreaterThan(0);
+    const scriptArgs = args.slice(sepIdx + 1);
+    expect(scriptArgs).toEqual(['serve', 'start', '--headless', '--no-tui', '--no-interactive']);
+  });
+
+  test('process name is registered as "genie-serve"', () => {
+    const args = buildPm2StartArgs('/usr/local/bin/genie');
+    const nameIdx = args.indexOf('--name');
+    expect(args[nameIdx + 1]).toBe('genie-serve');
+  });
+
+  test('memory ceiling matches HARDENED_DEFAULTS.maxMemory', () => {
+    const args = buildPm2StartArgs('/usr/local/bin/genie');
+    const memIdx = args.indexOf('--max-memory-restart');
+    expect(args[memIdx + 1]).toBe(HARDENED_DEFAULTS.maxMemory);
+  });
+
+  test('logs land in ~/.genie/logs/genie-serve-{out,error}.log', () => {
+    const args = buildPm2StartArgs('/usr/local/bin/genie');
+    const outIdx = args.indexOf('--output');
+    const errIdx = args.indexOf('--error');
+    expect(args[outIdx + 1]).toMatch(/genie-serve-out\.log$/);
+    expect(args[errIdx + 1]).toMatch(/genie-serve-error\.log$/);
+  });
+
+  test('numeric flags are stringified (pm2 child_process arg constraint)', () => {
+    const args = buildPm2StartArgs('/usr/local/bin/genie');
+    const numericFlags = [
+      '--max-restarts',
+      '--min-uptime',
+      '--restart-delay',
+      '--exp-backoff-restart-delay',
+      '--kill-timeout',
+    ];
+    for (const flag of numericFlags) {
+      const idx = args.indexOf(flag);
+      const value = args[idx + 1];
+      expect(typeof value).toBe('string');
+      expect(value).toMatch(/^\d+$/);
+    }
+  });
+});
+
+describe('GENIE_SERVE_MAX_MEMORY env override', () => {
+  let original: string | undefined;
+
+  beforeEach(() => {
+    original = process.env.GENIE_SERVE_MAX_MEMORY;
+  });
+
+  afterEach(() => {
+    if (original === undefined) process.env.GENIE_SERVE_MAX_MEMORY = undefined;
+    else process.env.GENIE_SERVE_MAX_MEMORY = original;
+  });
+
+  test('override is captured at module load — re-importing reflects new env', async () => {
+    // The install module reads `process.env.GENIE_SERVE_MAX_MEMORY` at
+    // module-load time. Set it, then dynamically re-import to observe
+    // the captured value. We use the test-only `_internals` export
+    // because exposing the live HARDENED_DEFAULTS via reload would
+    // pollute the other tests in this file.
+    process.env.GENIE_SERVE_MAX_MEMORY = '8G';
+    const reload = await import(`../install.js?override-test=${Date.now()}`);
+    expect(reload._internals.HARDENED_DEFAULTS.maxMemory).toBe('8G');
+  });
+});

--- a/src/genie-commands/install.ts
+++ b/src/genie-commands/install.ts
@@ -1,0 +1,251 @@
+/**
+ * `genie install` — register genie-serve under pm2 with hardened defaults.
+ *
+ * Wave 2 of the canonical-pgserve-pm2-supervision wish (PR pgserve#55,
+ * Wave 1 = pgserve#57). Mirrors `omni install`: shells out to `pgserve
+ * install` first (idempotent — no-op when pgserve is already pm2-managed),
+ * then registers `genie-serve` under pm2 so the bridge survives shell
+ * exits and host reboots.
+ *
+ * Hardened defaults shared with pgserve and omni — same numbers everywhere
+ * so the four pm2 services in the canonical stack
+ * (pgserve / omni-api / omni-nats / genie-serve) behave identically under
+ * crash-loop and resource pressure. See `~/.genie/logs/genie-serve-*.log`
+ * after install.
+ *
+ * The command is idempotent. Re-running `genie install` after it's
+ * already registered prints "already installed" and exits 0. Operators
+ * wanting to change ports / data dirs run `genie uninstall` (eventually)
+ * + `genie install` again. Until then, `pm2 restart genie-serve` is the
+ * way to pick up code changes.
+ *
+ * Empirically validated 2026-04-30 on a production server. The exact
+ * `pm2 start` invocation here matches the manual command pinned in
+ * Decisions 4 & 5 of the wish.
+ */
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const PM2_PROCESS_NAME = 'genie-serve';
+
+/**
+ * Hardened defaults — mirror pgserve's HARDENED_DEFAULTS so the canonical
+ * stack behaves uniformly. Each value is documented in the wish and in
+ * `pgserve/src/cli-install.cjs` rationale.
+ *
+ * Memory ceiling is env-tunable (`GENIE_SERVE_MAX_MEMORY=8G genie install`)
+ * for big-iron deployments without a recompile.
+ */
+const HARDENED_DEFAULTS = {
+  maxRestarts: 50,
+  minUptimeMs: 10_000,
+  restartDelayMs: 4000,
+  expBackoffRestartDelayMs: 100,
+  maxMemory: process.env.GENIE_SERVE_MAX_MEMORY || '4G',
+  killTimeoutMs: 60_000,
+  logDateFormat: 'YYYY-MM-DD HH:mm:ss.SSS',
+};
+
+function getLogsDir(): string {
+  return join(homedir(), '.genie', 'logs');
+}
+
+function ok(msg: string): void {
+  process.stdout.write(`genie install: ${msg}\n`);
+}
+
+function note(msg: string): void {
+  process.stderr.write(`genie install: ${msg}\n`);
+}
+
+function fail(msg: string): never {
+  process.stderr.write(`genie install: ${msg}\n`);
+  process.exit(1);
+}
+
+function which(cmd: string): string | null {
+  try {
+    const result = execFileSync('which', [cmd], {
+      encoding: 'utf8',
+      timeout: 3000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return result.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function pm2GetProcess(name: string): { pid?: number; pm2_env?: { status?: string } } | null {
+  try {
+    const out = execFileSync('pm2', ['jlist'], {
+      encoding: 'utf8',
+      timeout: 5000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const list = JSON.parse(out) as Array<{ name?: string; pid?: number; pm2_env?: { status?: string } }>;
+    return list.find((p) => p.name === name) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function pm2IsAvailable(): boolean {
+  try {
+    execFileSync('pm2', ['--version'], { encoding: 'utf8', timeout: 3000, stdio: ['ignore', 'pipe', 'ignore'] });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function pgserveIsAvailable(): boolean {
+  return which('pgserve') !== null;
+}
+
+/**
+ * Best-effort: shell out to `pgserve install` so the canonical pgserve is
+ * registered under pm2 before genie-serve depends on it. The command is
+ * idempotent on the pgserve side, so running it on every `genie install`
+ * is safe.
+ *
+ * Returns true on success or "already installed" exit. Returns false when
+ * pgserve isn't installed globally — caller then decides whether to fail
+ * or warn-and-continue. Today we warn-and-continue: genie can run without
+ * pgserve (it has its own pgserve daemon embedded in `genie serve`), but
+ * an operator wiring the canonical stack should install pgserve globally.
+ */
+function tryPgserveInstall(): boolean {
+  if (!pgserveIsAvailable()) {
+    note(
+      'pgserve binary not found in PATH. Skipping the canonical pgserve hookup. ' +
+        'Install with: bun add -g pgserve  (then re-run genie install).',
+    );
+    return false;
+  }
+  const result = spawnSync('pgserve', ['install'], { stdio: 'inherit' });
+  if (result.status !== 0) {
+    note(`pgserve install exited with code ${result.status}. Continuing — genie-serve registration proceeds.`);
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Resolve the path to the `genie` binary. We prefer `which genie` so the
+ * pm2-registered command matches the operator's `$PATH` — surviving bun
+ * upgrades that relocate the global bin dir.
+ */
+function resolveGenieBinary(): string {
+  const wired = which('genie');
+  if (wired) return wired;
+  // Fall back to the path of the currently running script. Less ideal
+  // because pm2 will point at this exact path forever, but better than
+  // failing the install.
+  return process.argv[1] ?? 'genie';
+}
+
+function buildPm2StartArgs(geniePath: string): string[] {
+  const logs = {
+    out: join(getLogsDir(), `${PM2_PROCESS_NAME}-out.log`),
+    error: join(getLogsDir(), `${PM2_PROCESS_NAME}-error.log`),
+  };
+  return [
+    'start',
+    geniePath,
+    '--name',
+    PM2_PROCESS_NAME,
+    // Shebang resolution — geniePath is `#!/usr/bin/env bun`. With
+    // `--interpreter bun`, pm2's bun launcher errors out on top-level
+    // await ("require() async module ... is unsupported"). Empirically
+    // validated 2026-04-30 in the wish's beachhead.
+    '--interpreter',
+    'none',
+    '--max-restarts',
+    String(HARDENED_DEFAULTS.maxRestarts),
+    '--min-uptime',
+    String(HARDENED_DEFAULTS.minUptimeMs),
+    '--restart-delay',
+    String(HARDENED_DEFAULTS.restartDelayMs),
+    '--exp-backoff-restart-delay',
+    String(HARDENED_DEFAULTS.expBackoffRestartDelayMs),
+    '--max-memory-restart',
+    HARDENED_DEFAULTS.maxMemory,
+    '--kill-timeout',
+    String(HARDENED_DEFAULTS.killTimeoutMs),
+    '--log-date-format',
+    HARDENED_DEFAULTS.logDateFormat,
+    '--output',
+    logs.out,
+    '--error',
+    logs.error,
+    '--',
+    'serve',
+    'start',
+    // Headless mode: no TUI bootstrap. pm2's child has no controlling
+    // terminal so a TUI would wedge.
+    '--headless',
+    '--no-tui',
+    // Refuse interactive prompts — pm2 can't answer them.
+    '--no-interactive',
+  ];
+}
+
+function ensureLogsDir(): void {
+  const dir = getLogsDir();
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o755 });
+}
+
+export interface InstallOptions {
+  /** Skip the `pgserve install` step (operators who manage pgserve themselves). */
+  skipPgserve?: boolean;
+}
+
+/**
+ * Run the install. Idempotent. Exit code 0 on success or "already
+ * installed"; non-zero on hard failure (pm2 missing, pm2 start failed).
+ */
+export async function installCommand(options: InstallOptions = {}): Promise<void> {
+  if (!pm2IsAvailable()) {
+    fail('pm2 not found in PATH. Install with: bun add -g pm2  (or npm i -g pm2)');
+  }
+
+  // Step 1 — canonical pgserve. Best-effort; we continue on failure
+  // because genie can boot its embedded pgserve as a fallback.
+  if (!options.skipPgserve) {
+    tryPgserveInstall();
+  }
+
+  // Step 2 — pm2-supervise genie-serve.
+  const existing = pm2GetProcess(PM2_PROCESS_NAME);
+  if (existing) {
+    ok(
+      `already installed (pm2 process "${PM2_PROCESS_NAME}", status=${existing.pm2_env?.status ?? 'unknown'}). Use \`pm2 restart genie-serve\` to pick up code changes.`,
+    );
+    return;
+  }
+
+  ensureLogsDir();
+  const geniePath = resolveGenieBinary();
+  const pm2Args = buildPm2StartArgs(geniePath);
+  const result = spawnSync('pm2', pm2Args, { stdio: 'inherit' });
+  if (result.status !== 0) {
+    fail(`pm2 start failed (exit ${result.status}). Logs: ${getLogsDir()}/${PM2_PROCESS_NAME}-error.log`);
+  }
+
+  ok(`installed: pm2 process "${PM2_PROCESS_NAME}" (logs: ${getLogsDir()})`);
+  ok('the genie bridge will now survive shell closure and host reboots (after `pm2 save` + `pm2 startup`).');
+}
+
+/** Test surface — exported for unit tests. */
+export const _internals = {
+  HARDENED_DEFAULTS,
+  PM2_PROCESS_NAME,
+  buildPm2StartArgs,
+  resolveGenieBinary,
+  pm2IsAvailable,
+  pgserveIsAvailable,
+};

--- a/src/genie.ts
+++ b/src/genie.ts
@@ -19,6 +19,7 @@ const _T_BOOT = Date.now();
 
 import { Command } from 'commander';
 import { doctorCommand } from './genie-commands/doctor.js';
+import { type InstallOptions, installCommand } from './genie-commands/install.js';
 import { type SetupOptions, setupCommand } from './genie-commands/setup.js';
 import {
   shortcutsInstallCommand,
@@ -181,6 +182,14 @@ program
   .option('--show', 'Show current configuration')
   .action(async (options: SetupOptions) => {
     await setupCommand(options);
+  });
+
+program
+  .command('install')
+  .description('Register genie-serve under pm2 with hardened defaults (canonical-pgserve-pm2-supervision wave 2)')
+  .option('--skip-pgserve', "Don't run `pgserve install` first (operators who manage pgserve themselves)")
+  .action(async (options: InstallOptions) => {
+    await installCommand(options);
   });
 
 program


### PR DESCRIPTION
## Summary

Wave 2 of the [canonical-pgserve-pm2-supervision wish](https://github.com/namastexlabs/pgserve/pull/55) (Wave 1 = pgserve#57 merged). Adds \`genie install\`, mirroring \`omni install\`, so \`genie-serve\` survives shell exits and host reboots under pm2 supervision.

## Trigger

Live debugging session 2026-04-30: WhatsApp bridge died because \`genie serve\` was running in a foreground bash on \`/dev/pts/24\` and the shell closed. \`omni-api\` was already pm2-hardened; \`genie-serve\` was not. Wave 2 closes that asymmetry.

## What `genie install` does

1. Shells out to \`pgserve install\` (idempotent — no-op when pgserve is already pm2-managed). Best-effort: warns and continues when pgserve isn't on PATH (genie still has its embedded pgserve).
2. Registers \`genie-serve\` under pm2 with the same hardened defaults pgserve uses, so all four pm2 services in the canonical stack (pgserve / omni-api / omni-nats / genie-serve) behave identically.

## Hardened defaults

Pinned in code with rationale comments. Mirrors pgserve#57's \`HARDENED_DEFAULTS\`:

| Flag | Value | Why |
|---|---|---|
| \`--max-restarts\` | 50 | Extended-outage tolerance |
| \`--min-uptime\` | 10s | Only RAPID failures count toward cap |
| \`--restart-delay\` | 4s | Initial backoff |
| \`--exp-backoff-restart-delay\` | 100ms → ~60s | Spread on persistent failures |
| \`--max-memory-restart\` | 4G | env-tunable: \`GENIE_SERVE_MAX_MEMORY=8G\` |
| \`--kill-timeout\` | 60s | Graceful shutdown headroom |

## Why `--interpreter none` (not `--interpreter bun`)

Empirically validated 2026-04-30. With \`--interpreter bun\`, pm2's bun launcher errors out on top-level await: \`require() async module ... is unsupported. use await import()\`. Shebang resolution side-steps the issue.

If anyone "fixes" this to \`bun\`, the install passes but the supervised process immediately crashes. The regression test (\`install.test.ts\`) asserts \`bun\` is NOT among the args.

## Why headless + no-tui + no-interactive

pm2's child process has no controlling terminal so a TUI would wedge. \`--headless --no-tui --no-interactive\` matches the invocation pinned in the wish's Decisions 4 & 5.

## Note on the previously-deleted install.ts

An older \`genie install\` was deleted in d5839f55 ("dead install command and associated files") because it was scaffolding for an install path that no longer made sense. **This new install.ts is a fresh implementation with a different purpose: pm2 supervision.** Same name, completely different code path.

## Coverage

```
11/11 pass — src/genie-commands/__tests__/install.test.ts
```

| Scenario | Asserts |
|---|---|
| Process name | \`genie-serve\` |
| Hardened defaults | All numeric values pinned (drift = test fails) |
| Memory ceiling default | \`/^\\d+G$/\` (with env override path tested separately) |
| All flags emitted | \`--name\`, \`--interpreter\`, \`--max-restarts\`, \`--min-uptime\`, \`--restart-delay\`, \`--exp-backoff-restart-delay\`, \`--max-memory-restart\`, \`--kill-timeout\`, \`--log-date-format\`, \`--output\`, \`--error\` |
| \`--interpreter\` value | \`none\` (and \`bun\` is NOT in args) |
| Forwarded args | \`['serve', 'start', '--headless', '--no-tui', '--no-interactive']\` |
| Numeric stringification | All numeric flag values are strings (pm2 child-process arg constraint) |
| Log paths | \`~/.genie/logs/genie-serve-{out,error}.log\` |
| \`GENIE_SERVE_MAX_MEMORY\` override | Captured at module-load via dynamic re-import |

## install.sh integration

Minimal — adds two helpers (\`ensure_pm2()\` + \`install_pm2_supervision()\`), called once from \`run_install()\` after \`install_genie_cli\`. Skipped via \`--no-pm2\` or \`GENIE_INSTALL_PM2=0\` for operators who manage pm2 themselves.

## Verification

```bash
bun test src/genie-commands/__tests__/install.test.ts   # 11 pass / 0 fail
bun run typecheck                                        # clean (excluding pre-existing tui/* errors)
bash -n install.sh                                       # syntax ok
```

## Test plan
- [ ] CI green
- [ ] On a clean machine: \`curl … install.sh | bash\` → \`pm2 list\` shows pgserve + genie-serve online
- [ ] \`genie install\` is idempotent (re-run = "already installed" exit 0)
- [ ] \`GENIE_SERVE_MAX_MEMORY=8G genie install\` writes \`--max-memory-restart 8G\` (verify via \`pm2 describe genie-serve\`)
- [ ] After \`pm2 save && pm2 startup\`, reboot → bridge comes back up automatically
- [ ] Bridge survives operator's shell closure (the regression that triggered the wish)

## What's next

- **Wave 3** (\`automagik-dev/omni\`): \`omni install\` calls \`pgserve install\` first; migration from embedded pgserve.
- **Wave 4** (\`namastexlabs/genie-configure\`): brain entries (architecture map + runbook + ADR).

Refs: pgserve#55 (wish), pgserve#57 (wave 1 merged)