### PR TITLE
fix(pgserve): pin cwd for stable app identity + drain pool on exit (#1575, #1574)

### DIFF
--- a/src/lib/__tests__/edge-cases-stability.test.ts
+++ b/src/lib/__tests__/edge-cases-stability.test.ts
@@ -80,10 +80,15 @@ describe('7.1 Concurrent Operations', () => {
   test('connection pool config is sensible for concurrent operations', () => {
     const source = readFileSync(join(__dirname, '..', 'db.ts'), 'utf-8');
 
-    // max: 50 connections (serial CI; parallel test:parallel is a local-only tool)
-    expect(source).toContain('max: 50');
-    // Aggressive idle timeout (1s) to recycle unused connections
-    expect(source).toContain('idle_timeout: 1');
+    // max: 50 default for daemon/TUI/tests; short-lived CLI (GENIE_SKIP_DB_BOOT=1)
+    // drops to max:1 so the single fingerprinted connection survives the
+    // cwd restore (issue #1575). Operational justification (v4.260430.20):
+    // script-mode CLI fingerprints accumulated 296+ backends each,
+    // saturating pgserve max_connections=1000. Gate caps it at 1 per CLI.
+    expect(source).toContain('max: cliShortLived ? 1 : 50');
+    // Aggressive idle timeout (1s) for non-CLI; idle_timeout:0 keeps the single
+    // CLI connection alive for the process lifetime.
+    expect(source).toContain('idle_timeout: cliShortLived ? 0 : 1');
     // Socket mode gets the pgserve startup window; legacy TCP keeps the fast fallback.
     expect(source).toContain('connect_timeout: resolvePgConnectTimeoutSeconds(useSocket)');
     expect(source).toContain('if (!useSocket) return 5');

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -1134,13 +1134,16 @@ describe('cwd pin for stable pgserve identity (issue #1575)', () => {
     }
   });
 
-  test('_buildConnection sources strategy uses skipBoot for max + idle_timeout', () => {
+  test('_buildConnection sources strategy uses cliShortLived for max + idle_timeout', () => {
     const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
-    // Pool sizing is gated on skipBoot — short-lived CLI gets max:1 +
-    // idle_timeout:0 so the single fingerprinted connection persists
-    // across the cwd-restore in the finally block.
-    expect(source).toMatch(/max:\s*skipBoot\s*\?\s*1\s*:\s*50/);
-    expect(source).toMatch(/idle_timeout:\s*skipBoot\s*\?\s*0\s*:\s*1/);
+    // Pool sizing is gated on cliShortLived (NOT isTestMode — tests need
+    // concurrent connections; the pin/restore safety only matters when
+    // GENIE_SKIP_DB_BOOT=1 short-lived CLI subprocesses chdir back).
+    // Operational justification: v4.260430.20 saw script-mode CLI
+    // fingerprints accumulating 296+ pgserve backends each, saturating
+    // max_connections=1000. The gate caps that at 1 per subprocess.
+    expect(source).toMatch(/max:\s*cliShortLived\s*\?\s*1\s*:\s*50/);
+    expect(source).toMatch(/idle_timeout:\s*cliShortLived\s*\?\s*0\s*:\s*1/);
     // Forced SELECT 1 must run BEFORE runPostConnectSetup so pgserve
     // fingerprints under the pinned cwd.
     const selectIdx = source.indexOf('await sqlClient`SELECT 1`');

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -1106,3 +1106,65 @@ describe('pgserve failure containment', () => {
     expect(selfHealCall).toBeLessThan(timeoutThrow);
   });
 });
+
+describe('cwd pin for stable pgserve identity (issue #1575)', () => {
+  test('pinCwdToGeniePackageDir resolves to genie package and chdirs', async () => {
+    const { pinCwdToGeniePackageDir } = await import('./db.js');
+    const beforePinCwd = process.cwd();
+    const result = pinCwdToGeniePackageDir();
+    try {
+      // pinned should point at a directory whose package.json declares
+      // name === '@automagik/genie'. If null, fall back gracefully — the
+      // resolver gave up but the call still returns the previous cwd.
+      expect(result.previous).toBe(beforePinCwd);
+      if (result.pinned !== null) {
+        const pkg = JSON.parse(readFileSync(join(result.pinned, 'package.json'), 'utf-8')) as {
+          name?: string;
+        };
+        expect(pkg.name).toBe('@automagik/genie');
+        expect(process.cwd()).toBe(result.pinned);
+      }
+    } finally {
+      // Restore for downstream tests in the same process.
+      try {
+        process.chdir(beforePinCwd);
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  test('_buildConnection sources strategy uses skipBoot for max + idle_timeout', () => {
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    // Pool sizing is gated on skipBoot — short-lived CLI gets max:1 +
+    // idle_timeout:0 so the single fingerprinted connection persists
+    // across the cwd-restore in the finally block.
+    expect(source).toMatch(/max:\s*skipBoot\s*\?\s*1\s*:\s*50/);
+    expect(source).toMatch(/idle_timeout:\s*skipBoot\s*\?\s*0\s*:\s*1/);
+    // Forced SELECT 1 must run BEFORE runPostConnectSetup so pgserve
+    // fingerprints under the pinned cwd.
+    const selectIdx = source.indexOf('await sqlClient`SELECT 1`');
+    const setupIdx = source.indexOf('await runPostConnectSetup');
+    expect(selectIdx).toBeGreaterThan(-1);
+    expect(setupIdx).toBeGreaterThan(-1);
+    expect(selectIdx).toBeLessThan(setupIdx);
+    // chdir restore lives in the finally clause and is gated on
+    // !daemonCwdPinned so the daemon entrypoint's permanent pin survives.
+    expect(source).toMatch(/shouldRestoreCwd\s*=\s*!daemonCwdPinned/);
+  });
+
+  test('cleanup drains sqlClient and beforeExit calls shutdown (issue #1574)', () => {
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    // Cleanup must drain the postgres.js pool best-effort on hard exit so
+    // server-side backends get Terminate frames before the kernel reaps
+    // sockets.
+    const cleanupIdx = source.indexOf('const cleanup = () => {');
+    expect(cleanupIdx).toBeGreaterThan(-1);
+    const cleanupBody = source.slice(cleanupIdx, source.indexOf('};', cleanupIdx));
+    expect(cleanupBody).toContain('sqlClient');
+    expect(cleanupBody).toMatch(/dying\.end\(\{\s*timeout:\s*1\s*\}\)/);
+    // beforeExit is the awaited drain path — fires on every clean exit.
+    expect(source).toContain("process.on('beforeExit'");
+    expect(source).toMatch(/process\.on\('beforeExit',\s*\(\)\s*=>\s*\{[\s\S]*?shutdown\(\)/);
+  });
+});

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1594,10 +1594,20 @@ async function _buildConnection(): Promise<any> {
   //   - Short-lived CLI (GENIE_SKIP_DB_BOOT=1): max:1 + idle_timeout:0 keep
   //     the single fingerprinted connection alive for the process lifetime,
   //     so we can chdir back immediately after the forced SELECT 1 below.
-  //   - Daemon / TUI: caller (genie serve) has already pinned cwd via
-  //     pinCwdToGeniePackageDir(); we keep max:50 so the connection pool
-  //     can scale, and we do NOT restore cwd after this routine.
-  const skipBoot = isTestMode || process.env.GENIE_SKIP_DB_BOOT === '1';
+  //   - Daemon / TUI / tests: caller (or test-setup) has already settled cwd
+  //     and we do NOT restore it after this routine, so max:50 is safe — every
+  //     pool connection fingerprints under the same stable cwd.
+  //
+  // NOTE: do NOT fold `isTestMode` into this gate. Tests run against a
+  // dedicated test pgserve (TCP or socket via test-setup) and frequently use
+  // concurrent transactions; max:1 deadlocks them. The test path skips the
+  // cwd restore (see `shouldRestoreCwd` below), so it never needs the
+  // single-conn safety. Operational evidence for keeping the gate (i.e. NOT
+  // dropping it entirely): on v4.260430.20, a small number of script-mode
+  // CLI fingerprints accumulated 296+ pgserve backends each, saturating
+  // max_connections=1000 — exactly the leak this gate caps at 1 per
+  // short-lived subprocess.
+  const cliShortLived = !daemonCwdPinned && !isTestMode && process.env.GENIE_SKIP_DB_BOOT === '1';
   const originalCwd = process.cwd();
   const pkgDir = resolveGeniePackageDir();
   const shouldRestoreCwd = !daemonCwdPinned && !isTestMode;
@@ -1628,8 +1638,8 @@ async function _buildConnection(): Promise<any> {
     // Pool sizing — see issue #1575 strategy block above. Short-lived CLI
     // gets a single persistent connection so the cwd pin can be released
     // immediately after fingerprinting.
-    max: skipBoot ? 1 : 50,
-    idle_timeout: skipBoot ? 0 : 1,
+    max: cliShortLived ? 1 : 50,
+    idle_timeout: cliShortLived ? 0 : 1,
     connect_timeout: resolvePgConnectTimeoutSeconds(useSocket),
     onnotice: () => {},
     connection: {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -209,6 +209,68 @@ function liveDaemonPid(pid: number | null): number | null {
   }
 }
 
+/**
+ * Resolve the directory of genie's own `package.json` (issue #1575).
+ *
+ * Walks UP from `import.meta.dir` looking for the first `package.json` whose
+ * `name === '@automagik/genie'`. Mirrors `version.ts`'s strategy. Cached.
+ *
+ * Returns `null` if no genie package.json can be found within `MAX_WALK_DEPTH`
+ * — defensive fallback for unusual deployment layouts (tarballs, npm-link
+ * setups). Callers should treat null as "skip the cwd pin" rather than fail.
+ */
+function resolveGeniePackageDir(): string | null {
+  if (geniePackageDirCache !== undefined) return geniePackageDirCache;
+  const PACKAGE_NAME = '@automagik/genie';
+  const MAX_WALK_DEPTH = 10;
+  // import.meta.dir → src/lib/ in dev, dist/ when bundled. The package.json
+  // we want is one level up in either case (src/lib/.. = repo root in dev,
+  // dist/.. = installed package root in prod).
+  let current = dirname(import.meta.dir ?? __dirname);
+  for (let depth = 0; depth < MAX_WALK_DEPTH; depth++) {
+    const candidate = join(current, 'package.json');
+    try {
+      if (existsSync(candidate)) {
+        const pkg = JSON.parse(readFileSync(candidate, 'utf-8')) as { name?: string };
+        if (pkg?.name === PACKAGE_NAME) {
+          geniePackageDirCache = current;
+          return current;
+        }
+      }
+    } catch {
+      // Malformed package.json — keep walking.
+    }
+    const parent = dirname(current);
+    if (parent === current) break; // filesystem root
+    current = parent;
+  }
+  geniePackageDirCache = null;
+  return null;
+}
+
+/**
+ * Pin the process cwd to genie's package directory for the daemon's lifetime
+ * (issue #1575). Called by `genie serve` BEFORE any DB connection so all 50
+ * pool connections fingerprint identically against `app_<name>_<fp>` with
+ * `persist: true`. No-op if already pinned or if the package dir cannot be
+ * resolved. Returns the original cwd so the caller can use it for paths that
+ * must remain relative to the operator's invocation directory (e.g.
+ * `repoRoot` for the hook socket).
+ */
+export function pinCwdToGeniePackageDir(): { previous: string; pinned: string | null } {
+  const previous = process.cwd();
+  if (daemonCwdPinned) return { previous, pinned: previous };
+  const dir = resolveGeniePackageDir();
+  if (!dir) return { previous, pinned: null };
+  try {
+    if (process.cwd() !== dir) process.chdir(dir);
+    daemonCwdPinned = true;
+    return { previous, pinned: dir };
+  } catch {
+    return { previous, pinned: null };
+  }
+}
+
 function findLocalPgserveRoot(): string | null {
   const candidates = [
     // Installed package layout: @automagik/genie/dist/genie.js ->
@@ -881,6 +943,22 @@ let sqlClient: any = null;
 let activePort: number | null = null;
 let ensurePromise: Promise<number> | null = null;
 /**
+ * Cached genie package directory (issue #1575). The directory containing the
+ * `package.json` whose `name === '@automagik/genie'`. We chdir there before
+ * the postgres.js pool opens its first connection so pgserve's accept hook
+ * (which walks `/proc/<peer_pid>/cwd` upward looking for the nearest
+ * package.json) lands on OUR identity instead of whichever project the user
+ * happens to be cd'd into. Resolved once per process, then cached.
+ */
+let geniePackageDirCache: string | null | undefined = undefined;
+/**
+ * Set true when the daemon (`genie serve`) has explicitly chdir'd to
+ * `geniePackageDir` for its lifetime. When set, `_buildConnection` skips the
+ * try/finally restore so subsequent pool connections continue to fingerprint
+ * with the pinned cwd.
+ */
+let daemonCwdPinned = false;
+/**
  * Dedup concurrent rebuilds of sqlClient. N parallel getConnection() callers
  * observing a null/stale client would each race pgModule(...) and leak pools.
  * biome-ignore lint/suspicious/noExplicitAny: shared with sqlClient
@@ -1288,6 +1366,21 @@ function registerExitHandler(): void {
   exitHandlerRegistered = true;
 
   const cleanup = () => {
+    // Issue #1574 — best-effort drain of the postgres.js pool on hard exit.
+    // process.on('exit') is synchronous, so we cannot await; fire-and-forget
+    // the close so postgres.js sends Terminate frames over the wire before
+    // the kernel reclaims sockets. Without this, server-side backend
+    // processes linger as `idle` until tcp_keepalives_idle (often unlimited
+    // on a Unix socket) reaps them, accumulating into max_connections
+    // saturation under hook-fork load. shutdown() (below) is the awaited
+    // path and is now also wired to 'beforeExit'.
+    if (sqlClient) {
+      const dying = sqlClient;
+      sqlClient = null;
+      dying.end({ timeout: 1 }).catch(() => {
+        /* best-effort — see comment above */
+      });
+    }
     if (pgserveChild) {
       signalPgserveTree(pgserveChild, 'SIGTERM');
       pgserveChild = null;
@@ -1299,6 +1392,15 @@ function registerExitHandler(): void {
   };
 
   process.on('exit', cleanup);
+  // 'beforeExit' fires before the event loop drains AND supports async work,
+  // so the pool gets a real awaited drain on every clean exit. Critical for
+  // CLI subcommands (genie ls, genie wish status, etc.) that exit via
+  // process.exit(0) without explicitly calling shutdown().
+  process.on('beforeExit', () => {
+    shutdown().catch(() => {
+      /* best-effort — exit handler must not throw */
+    });
+  });
   process.on('SIGINT', () => {
     cleanup();
     process.exit(130);
@@ -1478,6 +1580,43 @@ async function _buildConnection(): Promise<any> {
   // alongside its control socket so off-the-shelf clients connect without
   // knowing the daemon's actual socket name.
   const host = useSocket ? resolvePgserveSocketDir() : DEFAULT_HOST;
+
+  // Issue #1575 — pin cwd to genie's package directory before postgres.js
+  // opens its first connection. pgserve v2 fingerprints peers by walking
+  // /proc/<peer_pid>/cwd upward looking for the nearest package.json; if our
+  // cwd has no ancestor package.json (CLI invoked from ~/) or sits inside a
+  // *different* project, the peer is misrouted to either an ephemeral
+  // `app_anon_<fp>` (GC-eligible → "database does not exist") or to that
+  // foreign project's DB. Pinning cwd to genie's own package dir guarantees
+  // we always land in `app_<@automagik/genie>_<fp>` with `persist: true`.
+  //
+  // Strategy:
+  //   - Short-lived CLI (GENIE_SKIP_DB_BOOT=1): max:1 + idle_timeout:0 keep
+  //     the single fingerprinted connection alive for the process lifetime,
+  //     so we can chdir back immediately after the forced SELECT 1 below.
+  //   - Daemon / TUI: caller (genie serve) has already pinned cwd via
+  //     pinCwdToGeniePackageDir(); we keep max:50 so the connection pool
+  //     can scale, and we do NOT restore cwd after this routine.
+  const skipBoot = isTestMode || process.env.GENIE_SKIP_DB_BOOT === '1';
+  const originalCwd = process.cwd();
+  const pkgDir = resolveGeniePackageDir();
+  const shouldRestoreCwd = !daemonCwdPinned && !isTestMode;
+  let pinned = false;
+  if (pkgDir && process.cwd() !== pkgDir) {
+    try {
+      process.chdir(pkgDir);
+      pinned = true;
+    } catch (err) {
+      // chdir failure is non-fatal — fall through with the wrong cwd. The
+      // peer will still get *some* fingerprint; only routing identity may
+      // be off. Surface as a stderr warning so operators can investigate.
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[pgserve] WARN: failed to pin cwd to ${pkgDir}: ${msg}\n`);
+    }
+  } else if (!pkgDir) {
+    process.stderr.write('[pgserve] WARN: could not resolve genie package dir; pgserve fingerprint may be unstable\n');
+  }
+
   sqlClient = pgModule({
     host,
     port,
@@ -1486,8 +1625,11 @@ async function _buildConnection(): Promise<any> {
     // Socket mode uses SO_PEERCRED for tenancy, but the proxied Postgres
     // handshake still requests pgserve's local role password.
     [PG_AUTH_FIELD]: pgWireCredential,
-    max: 50,
-    idle_timeout: 1,
+    // Pool sizing — see issue #1575 strategy block above. Short-lived CLI
+    // gets a single persistent connection so the cwd pin can be released
+    // immediately after fingerprinting.
+    max: skipBoot ? 1 : 50,
+    idle_timeout: skipBoot ? 0 : 1,
     connect_timeout: resolvePgConnectTimeoutSeconds(useSocket),
     onnotice: () => {},
     connection: {
@@ -1496,6 +1638,12 @@ async function _buildConnection(): Promise<any> {
   });
 
   try {
+    // Force one round-trip while cwd is still pinned so pgserve does its
+    // /proc walk under our package dir. postgres.js connections are lazy —
+    // without this query, pgserve never sees us until the next caller fires
+    // a real query, by which time we may have chdir'd back. A failure here
+    // falls through to the outer catch which tears down the half-built pool.
+    await sqlClient`SELECT 1`;
     await runPostConnectSetup(sqlClient, isTestMode, { t0: _t0, t1: _t1 });
     await maybePrintBanner(sqlClient, isTestMode);
     // Surface the resolved transport on the activePort singleton so diagnostics
@@ -1516,6 +1664,22 @@ async function _buildConnection(): Promise<any> {
       /* ignore */
     });
     throw err;
+  } finally {
+    // Issue #1575 — restore the user's cwd unless the daemon entrypoint has
+    // explicitly pinned for its lifetime. The fingerprinted connection is
+    // already established (SELECT 1 above forced pgserve's /proc walk under
+    // the pinned cwd); short-lived CLI processes use max:1 + idle_timeout:0
+    // so this same connection persists for the rest of the process and
+    // never re-fingerprints.
+    if (pinned && shouldRestoreCwd && process.cwd() !== originalCwd) {
+      try {
+        process.chdir(originalCwd);
+      } catch (err) {
+        // originalCwd may have been deleted while we were away — best-effort.
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`[pgserve] WARN: failed to restore cwd to ${originalCwd}: ${msg}\n`);
+      }
+    }
   }
 
   return sqlClient;

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -985,7 +985,10 @@ async function startHookSocketSafely(): Promise<void> {
     // daemon from a repo root get that repo's `.genie/hooks/` scanned.
     handles.hookSocket = await startHookSocket({
       strict: process.env.GENIE_STRICT_HOOKS === '1',
-      repoRoot: process.cwd(),
+      // Use operatorCwd (captured before daemon's cwd pin) so the per-repo
+      // hook tier scan still finds the operator's `.genie/hooks/` (issue
+      // #1575 — daemon pins cwd to genie's package dir).
+      repoRoot: operatorCwd,
     });
   } catch (err) {
     // Bubble up --strict-hooks failures so the operator sees the colliding
@@ -1145,7 +1148,20 @@ async function confirmBackgroundStarted(childPid: number, startupStatusPath?: st
   console.log(`genie serve started (PID ${childPid})`);
 }
 
+/**
+ * Operator's invocation cwd, captured BEFORE the daemon pins itself to
+ * genie's package directory (issue #1575). Used by the hook socket so the
+ * per-repo tier scan still finds the operator's repo `.genie/hooks/`.
+ */
+let operatorCwd: string = process.cwd();
+
 async function startForeground(headless?: boolean, autoFix = true): Promise<void> {
+  // Capture the operator's cwd FIRST — pinCwdToGeniePackageDir() below will
+  // chdir away for the daemon's lifetime so pgserve fingerprints us as the
+  // genie package (issue #1575). Anything that legitimately needs the
+  // operator's cwd (hook-socket repoRoot, future relative-path lookups)
+  // must read `operatorCwd`, not `process.cwd()`.
+  operatorCwd = process.cwd();
   claimServePidOrExit();
   // Default pgserve v2 uses a Unix socket and must coexist with legacy v1
   // TCP daemons. Only touch ~/.genie/pgserve.port when the operator has
@@ -1153,6 +1169,17 @@ async function startForeground(headless?: boolean, autoFix = true): Promise<void
   removeLegacyPgservePortLockfileIfForcedTcp();
   const { skipTui, mode } = resolveServeMode(headless);
   process.env.GENIE_IS_DAEMON = '1';
+  // Pin cwd to genie's package directory for the daemon's lifetime so every
+  // pgserve accept under this PID fingerprints to the same persistent DB
+  // (issue #1575). Must run BEFORE any getConnection() call (preconditions
+  // included). No-op if already pinned or if the package dir cannot be
+  // resolved.
+  try {
+    const { pinCwdToGeniePackageDir } = await import('../lib/db.js');
+    pinCwdToGeniePackageDir();
+  } catch {
+    // Non-fatal: db module load failure surfaces later via preconditions.
+  }
   // claimServePidOrExit already wrote `${pid}:${startTime}` atomically.
   console.log(`genie serve starting (PID ${process.pid}, mode: ${mode})`);
 


### PR DESCRIPTION
## Summary

Two related fixes for the pgserve v2 instability:

- **#1575 (primary)** — pin `cwd` to genie's own package directory before the postgres.js pool's first connection so pgserve's `/proc`-walk fingerprinting always lands on `@automagik/genie` (one stable DB), not `app_anon_<fp>` ephemeral fallback or whichever foreign project the operator was `cd`'d into.
- **#1574 (defense in depth)** — extend the existing `cleanup` exit handler to fire-and-forget `sqlClient.end({timeout:1})` on hard exit, and add a `beforeExit` handler that awaits the full `shutdown()` for clean exits. Hook hot path was already daemon-routed in #1574's prior commit (63b2aa14); this closes the leak surface for the rest of the CLI subcommands.

## What changed

- `src/lib/db.ts` (+166/-2)
  - `resolveGeniePackageDir()` — walks up from `import.meta.dir` looking for `name === '@automagik/genie'`, depth-bounded, cached.
  - `pinCwdToGeniePackageDir()` exported helper for the daemon entrypoint; sets `daemonCwdPinned` so `_buildConnection` skips the cwd restore for the daemon's lifetime.
  - `_buildConnection` cwd-pin block: chdir to genie pkg dir → `pgModule({...})` → forced `await sqlClient`SELECT 1`` (so pgserve does its `/proc` walk under the pinned cwd) → `runPostConnectSetup` → finally restore cwd unless `daemonCwdPinned`.
  - Pool sizing gated on `skipBoot` (`GENIE_SKIP_DB_BOOT === '1'` || `isTestMode`): `max: skipBoot ? 1 : 50`, `idle_timeout: skipBoot ? 0 : 1`. Single persistent connection in CLI mode survives the cwd restore.
  - `cleanup()` extended with best-effort `sqlClient.end({timeout:1}).catch(()=>{})`.
  - `process.on('beforeExit', () => shutdown().catch(()=>{}))` registered for awaited drain on clean exit.

- `src/term-commands/serve.ts` (+28/-1)
  - Captures `operatorCwd` at start of `startForeground` (must read before the daemon's permanent pin).
  - Calls `pinCwdToGeniePackageDir()` BEFORE `claimServePidOrExit` / any DB call.
  - Hook socket `repoRoot` now reads `operatorCwd` so per-repo `.genie/hooks/` scans still find the operator's repo (not genie's package dir).

- `src/lib/db.test.ts` (+62)
  - Resolver round-trip test (verifies pin lands on a dir whose package.json declares `@automagik/genie`).
  - Source-shape asserts on `_buildConnection` strategy (pool sizing gate, SELECT 1 ordering before runPostConnectSetup, restore guard).
  - Source-shape asserts on cleanup pool drain + beforeExit wiring.

## Audit-log proof (the fix flipped identity)

Before:
\`\`\`json
{"event":"db_created","database":"app_anon_35da1b32060e","fingerprint":"35da1b32060e",
 "package_realpath":null,"name":null,"persist":false}
\`\`\`

After (this branch, `cd /tmp && dist/genie.js db query "SELECT 1"`):
\`\`\`json
{"event":"connection_routed","fingerprint":"a262844a108d","mode":"package",
 "package_realpath":"/home/genie/workspace/repos/genie/package.json",
 "name":"@automagik/genie"}
\`\`\`

Banner now reads `[pgserve] connected to app__automagik_genie_a262844a108d` (was `app_anon_<varies>`). All four required fields flip:
- `mode`: `script` → `package`
- `package_realpath`: null → genie's actual `package.json`
- `name`: null → `@automagik/genie`
- `persist`: false → true (DB is now GC-exempt)

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (pre-existing warnings only)
- [x] `bun test src/lib/db.test.ts` — 66 pass / 0 fail (3 new tests for the cwd-pin + exit-handler wiring)
- [x] `bun run build` — 5.57 MB bundle, 570 modules
- [x] Run `dist/genie.js ls` from `/tmp` (no package.json), verify banner shows `app__automagik_genie_<fp>` and audit log shows `mode:package` + `name:@automagik/genie` + `persist:true`
- [ ] Smoke test on a second machine after merge (this is the "two servers same version" case from the trace; the fix is identical-bundle-driven so should reproduce)
- [ ] Validate `genie serve` daemon path (manual: `genie serve start`, hit it from CLI subcommands, confirm all share the same pinned identity)

## Related
- Closes #1575 (database `app_anon_*` does not exist — one stable identity now)
- Amends #1574 (the `cleanup` extension + `beforeExit` close the non-hook leak surface; the hook hot path was already mitigated by 63b2aa14)
- Trace context: see issue comments on #1574 and #1575