### PR TITLE
fix(pgserve): bypass daemon-control router via admin.json discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,10 +257,15 @@ jobs:
           mkdir -p .genie
           printf '{"name":"ci-smoke"}\n' > .genie/workspace.json
           # Capture stderr to assert the banner printed the resolved DB.
+          # Post #1585 (direct-postmaster bypass), the banner reports the bare
+          # `postgres` database — we connect to the postmaster's own socket via
+          # admin.json discovery, skipping the daemon-control router and its
+          # auto-fingerprinted `app_<name>_<fp>` tenant routing. Accept either
+          # form so the smoke survives both old and new daemons during rollout.
           OUT=$(./dist/genie.js task list 2>&1)
           echo "$OUT"
-          echo "$OUT" | grep -E '\[pgserve\] connected to app__automagik_genie_[0-9a-f]{12}' \
-            || (echo "::error::Banner did not print fingerprinted DB name"; exit 1)
+          echo "$OUT" | grep -E '\[pgserve\] connected to (postgres|app__automagik_genie_[0-9a-f]{12})' \
+            || (echo "::error::Banner did not print a recognized resolved DB name"; exit 1)
 
   # Umbrella status check. Branch protection is configured to require
   # "Quality Gate (typecheck + lint + test)" as a required status, so the

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -357,7 +357,10 @@ describe('daemon-owned pgserve', () => {
     }
 
     const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
-    const connectionStart = source.indexOf('sqlClient = pgModule({');
+    // Connection is bound to a local first so concurrent rebuilds can't
+    // make this caller observe a nulled `sqlClient` (trace finding from
+    // v4.260430.20). After construction the global is set for sharing.
+    const connectionStart = source.indexOf('const client = pgModule({');
     expect(connectionStart).toBeGreaterThan(-1);
     const connectionConfig = source.slice(connectionStart, source.indexOf('  });', connectionStart));
     expect(connectionConfig).toContain('username: DB_NAME');
@@ -366,6 +369,8 @@ describe('daemon-owned pgserve', () => {
       'const pgWireCredential = useSocket ? resolvePgserveAuthPassword() : resolveTcpPgPassword()',
     );
     expect(connectionConfig).toContain('[PG_AUTH_FIELD]: pgWireCredential');
+    // Sharing the global happens AFTER local construction.
+    expect(source).toContain('sqlClient = client');
   });
 
   test('socket connections use the pgserve startup timeout window', () => {
@@ -378,7 +383,7 @@ describe('daemon-owned pgserve', () => {
     expect(helperBody).toContain('if (!useSocket) return 5');
     expect(helperBody).toContain('Math.max(16, Math.ceil(resolvePgserveTimeoutMs() / 1000))');
 
-    const connectionStart = source.indexOf('sqlClient = pgModule({');
+    const connectionStart = source.indexOf('const client = pgModule({');
     expect(connectionStart).toBeGreaterThan(-1);
     const connectionConfig = source.slice(connectionStart, source.indexOf('  });', connectionStart));
     expect(connectionConfig).toContain('connect_timeout: resolvePgConnectTimeoutSeconds(useSocket)');
@@ -392,7 +397,11 @@ describe('daemon-owned pgserve', () => {
 
     const useSocketIdx = body.indexOf('const useSocket = shouldUseUnixSocket()');
     const ensureIdx = body.indexOf('if (useSocket) await getOrStartDaemon()');
-    const portIdx = body.indexOf('const port = useSocket ? 5432 : await ensurePgserve()');
+    // Direct-postmaster path reads admin.json (when useSocket) for the
+    // postmaster's actual port, falls back to the libpq compat port (5432)
+    // when discovery is missing. Both forms must keep the daemon-ensure
+    // step ahead of port resolution.
+    const portIdx = body.search(/const port = useSocket \? \(discovery\?\.port \?\? 5432\) : await ensurePgserve\(\)/);
 
     expect(useSocketIdx).toBeGreaterThan(-1);
     expect(ensureIdx).toBeGreaterThan(useSocketIdx);
@@ -404,7 +413,14 @@ describe('daemon-owned pgserve', () => {
     const fnStart = source.indexOf('export async function getOrStartDaemon');
     expect(fnStart).toBeGreaterThan(-1);
     const body = source.slice(fnStart, source.indexOf('\nfunction maskCredentials', fnStart));
-    expect(body).toContain("'daemon', '--data', DATA_DIR, '--log', 'warn'");
+    // Spawn args carry --data DATA_DIR + --max-connections; latter lifts the
+    // postmaster ceiling above the historical 1000 cap (configurable via
+    // GENIE_PG_MAX_CONNECTIONS).
+    expect(body).toContain("'daemon'");
+    expect(body).toContain("'--data'");
+    expect(body).toContain('DATA_DIR');
+    expect(body).toContain("'--max-connections'");
+    expect(body).toContain('GENIE_PG_MAX_CONNECTIONS');
   });
 
   test('daemon startup prefers Genie bundled pgserve with active Bun runtime', () => {
@@ -784,7 +800,11 @@ describe('parallel dispatch race (issue #1207)', () => {
 
     const socketDecision = source.indexOf('const useSocket = shouldUseUnixSocket();', fnStart);
     const daemonStart = source.indexOf('if (useSocket) await getOrStartDaemon();', fnStart);
-    const portDecision = source.indexOf('const port = useSocket ? 5432 : await ensurePgserve();', fnStart);
+    // Direct-postmaster path: port comes from admin.json discovery when
+    // useSocket; falls back to libpq compat 5432 if discovery is missing.
+    const portDecision = source.search(
+      /const port = useSocket \? \(discovery\?\.port \?\? 5432\) : await ensurePgserve\(\)/,
+    );
 
     expect(socketDecision).toBeGreaterThan(-1);
     expect(daemonStart).toBeGreaterThan(socketDecision);

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -135,6 +135,58 @@ export function resolvePgserveDaemonPidPath(): string {
   return join(resolvePgserveSocketDir(), 'pgserve.pid');
 }
 
+/**
+ * Discovery payload pgserve writes at `<controlSocketDir>/admin.json` after
+ * the postmaster is up. Lets clients reach the postmaster's socket directly
+ * (bypassing the daemon-control router) so we get raw postgres semantics —
+ * no SO_PEERCRED routing, no per-accept /proc walk, no router-side
+ * `max_connections=1000` ceiling. The router still owns connection-routed
+ * audit emission for clients that DO go through control.sock; we just
+ * don't.
+ */
+export interface PostmasterDiscovery {
+  socketDir: string;
+  port: number;
+  pid: number;
+}
+
+/**
+ * Read the postmaster's discovery file written by pgserve@2.x. Returns null
+ * if the file is missing, malformed, or points at a stale/dead postmaster.
+ *
+ * Schema (validated below): `{ socketDir: string, port: number, pid: number }`
+ * — see `node_modules/pgserve/src/admin-client.js:writeAdminDiscovery`.
+ */
+export function readPostmasterDiscovery(): PostmasterDiscovery | null {
+  const file = join(resolvePgserveSocketDir(), 'admin.json');
+  if (!existsSync(file)) return null;
+  let raw: string;
+  try {
+    raw = readFileSync(file, 'utf-8');
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const obj = parsed as Record<string, unknown>;
+  const socketDir = typeof obj.socketDir === 'string' && obj.socketDir.length > 0 ? obj.socketDir : null;
+  const port = typeof obj.port === 'number' && Number.isFinite(obj.port) && obj.port > 0 ? obj.port : null;
+  const pid = typeof obj.pid === 'number' && Number.isFinite(obj.pid) && obj.pid > 0 ? obj.pid : null;
+  if (!socketDir || !port) return null;
+  // Validate the postmaster socket file exists. If pgserve crashed without
+  // cleaning up admin.json, the file path will be stale.
+  if (!existsSync(join(socketDir, `.s.PGSQL.${port}`))) return null;
+  // pid is informational — we don't gate on liveness here because the daemon
+  // process supervises the postmaster lifecycle. Stale pid + present socket
+  // is impossible under normal operation.
+  return { socketDir, port, pid: pid ?? -1 };
+}
+
 interface DaemonState {
   running: boolean;
   pid: number | null;
@@ -574,9 +626,14 @@ async function startPgserveDaemonOnce(initial: DaemonState): Promise<void> {
   }
   mkdirSync(resolvePgserveSocketDir(), { recursive: true, mode: 0o700 });
 
+  // GENIE_PG_MAX_CONNECTIONS overrides the postmaster's max_connections.
+  // Default 10000 — see startPgserveOnPort for rationale (~10 MB RAM per
+  // backend, real load far lower than the cap, the connection problem we
+  // kept patching was the router, not postgres itself).
+  const maxConnections = process.env.GENIE_PG_MAX_CONNECTIONS ?? '10000';
   const child = spawn(
     daemonCommand.command,
-    [...daemonCommand.argsPrefix, 'daemon', '--data', DATA_DIR, '--log', 'warn'],
+    [...daemonCommand.argsPrefix, 'daemon', '--data', DATA_DIR, '--log', 'warn', '--max-connections', maxConnections],
     {
       detached: true,
       stdio: 'ignore',
@@ -1334,6 +1391,13 @@ async function startPgserveOnPort(port: number): Promise<number> {
       '--no-stats',
       '--no-cluster',
       '--pgvector',
+      // Lift the postmaster ceiling well past the historical 1000 cap.
+      // RAM cost is ~10 MB per backend — 10000 caps at ~100 GB worst-case
+      // (real usage is far lower; idle backends are slim). The connection
+      // problem we kept patching was the router, not postgres itself.
+      // Override via GENIE_PG_MAX_CONNECTIONS for tighter-RAM hosts.
+      '--max-connections',
+      process.env.GENIE_PG_MAX_CONNECTIONS ?? '10000',
     ],
     { detached: true, stdio: 'ignore' },
   );
@@ -1563,7 +1627,20 @@ async function _buildConnection(): Promise<any> {
   const _t0 = Date.now();
   const useSocket = shouldUseUnixSocket();
   if (useSocket) await getOrStartDaemon();
-  const port = useSocket ? 5432 : await ensurePgserve();
+  // Direct-postmaster path (bypasses pgserve's daemon-control router):
+  //   - Eliminates per-accept SO_PEERCRED + /proc walk latency.
+  //   - Talks to the postmaster's own Unix socket (auto-created at
+  //     <tmpdir>/pgserve-sock-<wrapper_pid>-<ts>/) — postgres-native, no
+  //     router cap. The postmaster's `max_connections` is what limits us
+  //     (configurable via genie's spawn args).
+  //   - Skips fingerprint-based DB routing — we explicitly select our DB
+  //     by name. Fewer moving parts; no surprise `database does not exist`
+  //     after GC of an `app_anon_*` tenant.
+  // Falls back to the libpq-compat symlink (still through the router) when
+  // admin.json is missing or stale. Keeps the legacy path alive for hosts
+  // that haven't refreshed the daemon since pgserve@2.0.x.
+  const discovery = useSocket ? readPostmasterDiscovery() : null;
+  const port = useSocket ? (discovery?.port ?? 5432) : await ensurePgserve();
   const _t1 = Date.now();
   const pgModule = (await import('postgres')).default;
 
@@ -1576,10 +1653,10 @@ async function _buildConnection(): Promise<any> {
   const pgWireCredential = useSocket ? resolvePgserveAuthPassword() : resolveTcpPgPassword();
 
   // Unix socket: postgres.js dials `<host>/.s.PGSQL.<port>` when host is an
-  // absolute path. pgserve v2 publishes a `.s.PGSQL.5432` libpq compat link
-  // alongside its control socket so off-the-shelf clients connect without
-  // knowing the daemon's actual socket name.
-  const host = useSocket ? resolvePgserveSocketDir() : DEFAULT_HOST;
+  // absolute path. When discovery is available, point at the postmaster's
+  // own socket dir (direct path, no router). Fallback uses pgserve v2's
+  // libpq compat symlink in the control socket dir (legacy router path).
+  const host = useSocket ? (discovery?.socketDir ?? resolvePgserveSocketDir()) : DEFAULT_HOST;
 
   // Issue #1575 — pin cwd to genie's package directory before postgres.js
   // opens its first connection. pgserve v2 fingerprints peers by walking
@@ -1627,7 +1704,13 @@ async function _buildConnection(): Promise<any> {
     process.stderr.write('[pgserve] WARN: could not resolve genie package dir; pgserve fingerprint may be unstable\n');
   }
 
-  sqlClient = pgModule({
+  // Bind to a local first so concurrent rebuilds (where another caller's
+  // healthCheckCachedClient may null `sqlClient` mid-build) cannot make
+  // this caller's getConnection() resolve to `null`. Trace finding from
+  // v4.260430.20 saturation report: scheduler reconciler crashed with
+  // "null is not a function" after returning the module-level sqlClient
+  // that had been nulled between assign and return.
+  const client = pgModule({
     host,
     port,
     database,
@@ -1646,6 +1729,7 @@ async function _buildConnection(): Promise<any> {
       client_min_messages: 'warning',
     },
   });
+  sqlClient = client;
 
   try {
     // Force one round-trip while cwd is still pinned so pgserve does its
@@ -1653,9 +1737,9 @@ async function _buildConnection(): Promise<any> {
     // without this query, pgserve never sees us until the next caller fires
     // a real query, by which time we may have chdir'd back. A failure here
     // falls through to the outer catch which tears down the half-built pool.
-    await sqlClient`SELECT 1`;
-    await runPostConnectSetup(sqlClient, isTestMode, { t0: _t0, t1: _t1 });
-    await maybePrintBanner(sqlClient, isTestMode);
+    await client`SELECT 1`;
+    await runPostConnectSetup(client, isTestMode, { t0: _t0, t1: _t1 });
+    await maybePrintBanner(client, isTestMode);
     // Surface the resolved transport on the activePort singleton so diagnostics
     // (db status, printPgserveHealth) report the truth. Socket mode uses the
     // SOCKET_PORT_SENTINEL (0) since there is no TCP port to advertise; TCP
@@ -1665,12 +1749,11 @@ async function _buildConnection(): Promise<any> {
       process.env.GENIE_PG_AVAILABLE = 'true';
     }
   } catch (err) {
-    const dying = sqlClient;
-    sqlClient = null;
+    if (sqlClient === client) sqlClient = null;
     activePort = null;
     // Fire-and-forget teardown — match healthCheckCachedClient so we never
     // block on a dying pool while other work is in flight.
-    dying?.end({ timeout: 2 }).catch(() => {
+    client.end({ timeout: 2 }).catch(() => {
       /* ignore */
     });
     throw err;
@@ -1692,7 +1775,7 @@ async function _buildConnection(): Promise<any> {
     }
   }
 
-  return sqlClient;
+  return client;
 }
 
 /**

--- a/src/lib/session-backfill.ts
+++ b/src/lib/session-backfill.ts
@@ -160,16 +160,28 @@ async function processBackfillFile(
 }
 
 async function processAllFiles(
-  sql: SqlClient,
+  initialSql: SqlClient,
   allFiles: BackfillFile[],
   progress: BackfillProgress,
   workerMap: WorkerMap,
 ): Promise<void> {
+  // Re-acquire the connection per iteration via getConnection() instead of
+  // holding the captured `initialSql` reference. Why: when pgserve cycles a
+  // backend (saturation, idle timeout, daemon respawn), the original sql
+  // tag goes dead and every subsequent ingestFile(sql, …) call throws
+  // CONNECTION_ENDED with the same dead reference — producing the "hundreds
+  // of identical [backfill] error" log floods seen on v4.260430.20+.
+  // getConnection() health-checks and rebuilds transparently.
+  const { getConnection } = await import('./db.js');
+  // initialSql is consumed only to satisfy the type contract — every actual
+  // query inside the loop calls getConnection() afresh.
+  void initialSql;
   for (const file of allFiles) {
     if (!running) break;
     await yieldToLiveWork();
 
     try {
+      const sql = await getConnection();
       await processBackfillFile(sql, file, progress, workerMap);
     } catch (err) {
       progress.errors++;
@@ -178,7 +190,13 @@ async function processAllFiles(
     }
 
     if (progress.processedFiles % 50 === 0) {
-      await updateSyncState(sql, progress);
+      try {
+        const sql = await getConnection();
+        await updateSyncState(sql, progress);
+      } catch {
+        // Sync-state write failure is best-effort — don't break the loop;
+        // next 50-file boundary will retry.
+      }
     }
 
     await sleep(SLEEP_BETWEEN_FILES_MS);


### PR DESCRIPTION
## TL;DR

Talk directly to the postmaster's Unix socket (the one pgserve auto-creates at \`<tmpdir>/pgserve-sock-<wrapper_pid>-<ts>/\`) instead of going through pgserve's daemon-control router. This is what's been causing all the pain — cap saturation, fingerprint races, \`database does not exist\`, the \`app_anon_*\` traps. Postgres-native semantics, no router cap, no SO_PEERCRED + /proc walk on every accept.

## What's in this commit

1. **\`readPostmasterDiscovery()\`** — reads \`<controlSocketDir>/admin.json\` (written by pgserve, see \`node_modules/pgserve/src/admin-client.js\`). Returns \`{ socketDir, port, pid }\` or null if missing/stale.

2. **\`_buildConnection\` prefers discovered postmaster** — \`host\` and \`port\` come from \`admin.json\` when available. Falls back to libpq compat symlink + port 5432 when discovery is missing (legacy router path) so existing deployments keep working through the upgrade.

3. **Bind-to-local in \`_buildConnection\`** — \`const client = pgModule(...)\` then \`sqlClient = client\`, return \`client\`. Closes the trace finding from v4.260430.20: a concurrent rebuild's \`healthCheckCachedClient\` could null the global between assign and return, making this caller's \`getConnection()\` resolve to null and throw \`null is not a function\` on the next tagged-template call.

4. **Per-iteration \`getConnection()\` in backfill** — \`session-backfill.ts:processAllFiles\` no longer holds a captured \`sql\`. Closes the \`[backfill] error: write CONNECTION_ENDED\` log floods on v4.260430.20+: pgserve cycling a backend made every subsequent \`ingestFile(sql, …)\` hit the same dead reference forever.

5. **Postmaster \`--max-connections=10000\`** (was 1000) on both spawn paths. Override via \`GENIE_PG_MAX_CONNECTIONS\`. The connection problem was router policy, not postgres.

## What's NOT in this commit (intentionally)

The now-dead scaffolding from PR #1580 (cwd-pin chain, \`cliShortLived\` gate, forced \`SELECT 1\` fingerprinting hack, \`resolveGeniePackageDir\`/\`pinCwdToGeniePackageDir\`) — keeping this PR focused on the routing change so it's easy to revert if anything surfaces. Cleanup is a follow-up.

## Smoke evidence

\`\`\`
$ cd /tmp && /home/genie/workspace/repos/genie/dist/genie.js db query "SELECT current_database(), inet_server_addr(), inet_server_port(); "
[pgserve] connected to postgres            ← was: app__automagik_genie_<fp>
 current_database | inet_server_addr | inet_server_port
------------------+------------------+------------------
 postgres         | NULL             | NULL              ← NULLs confirm Unix socket
\`\`\`

Audit log: NO new \`connection_routed\` event for the smoke connection — router bypassed.

## Test plan

- [x] \`bun test src/lib/db.test.ts src/lib/__tests__/edge-cases-stability.test.ts src/lib/task-close-merged.test.ts\` — 134 pass / 0 fail (5 source-shape assertions updated for the new shape).
- [x] \`bun run typecheck\` — clean.
- [x] \`bun run lint\` — 0 errors (18 pre-existing complexity warnings).
- [ ] Production smoke: install on a host that's been hitting the cap, verify \`genie wish status\` works without saturation, audit log shows new connections NOT going through control.sock.
- [ ] Verify the LEGACY fallback path still works on a host without \`admin.json\` (older pgserve daemon).

## Refs
- v4.260430.20 saturation trace report (in #1574 comment).
- Trace #1 (\`null is not a function\` race) — addressed by the bind-to-local.
- PR #1580 cwd-pin work — superseded; cleanup follow-up TBD.
- The reaper-on-update branch (\`fix/update-reaps-stale-genie-processes\`) — interim fix for stale pre-fix processes; complementary to this PR.