### PR TITLE
fix(update): reap stale genie processes during post-update maintenance

### DIFF
--- a/src/genie-commands/doctor.test.ts
+++ b/src/genie-commands/doctor.test.ts
@@ -12,7 +12,12 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { checkGenieAgentTemplate, checkLegacyAgentFrontmatter, findBundledTmuxConfigDir } from './doctor.js';
+import {
+  checkGenieAgentTemplate,
+  checkLegacyAgentFrontmatter,
+  findBundledTmuxConfigDir,
+  findStaleGenieCandidates,
+} from './doctor.js';
 
 let workspaceRoot: string;
 
@@ -268,5 +273,57 @@ describe('pgserve v1/v2 coexistence', () => {
     expect(body).toContain('Leaving legacy pgserve v1 port/data files untouched');
     expect(body).toContain("join(genieHome, 'pgserve.port')");
     expect(body).toContain("join(genieHome, 'data', 'pgserve', 'postmaster.pid')");
+  });
+});
+
+describe('reapStaleGenieProcesses (post-update reaper)', () => {
+  // The reaper runs during `genie update` to kill leftover genie processes
+  // (TUIs, orphan subprocesses, old daemons) whose in-memory binary is the
+  // pre-update version. Without this, those processes hold leaked pgserve
+  // connections from the old code path and saturate `max_connections=1000`.
+
+  test('finds the current process when not in exclude set (sanity)', () => {
+    if (process.platform !== 'linux') {
+      // Reaper is Linux-only; skip on macOS/Windows.
+      expect(true).toBe(true);
+      return;
+    }
+    // The current bun:test process is running `dist/genie.js` on real hosts,
+    // but inside `bun test` the cmdline is the test runner — not genie.
+    // Instead, verify the function honors the exclude set by passing our PID
+    // and confirming we get a coherent (possibly empty) list back.
+    const exclude = new Set<number>([process.pid]);
+    const candidates = findStaleGenieCandidates(exclude);
+    expect(Array.isArray(candidates)).toBe(true);
+    expect(candidates).not.toContain(process.pid);
+    // Every candidate should be a positive integer that is NOT in exclude.
+    for (const pid of candidates) {
+      expect(pid).toBeGreaterThan(1);
+      expect(exclude.has(pid)).toBe(false);
+    }
+  });
+
+  test('reapStaleGenieProcesses surface contract', () => {
+    const source = readFileSync(join(__dirname, 'doctor.ts'), 'utf-8');
+    // The reaper must run BEFORE other maintenance preconditions so freed
+    // connections are available for runDoctorMaintenance's pgserve probes.
+    const postUpdate = source.indexOf('export async function runPostUpdateMaintenance');
+    expect(postUpdate).toBeGreaterThan(-1);
+    const fnEnd = source.indexOf('}', postUpdate + 200);
+    const body = source.slice(postUpdate, fnEnd);
+    const reapIdx = body.indexOf('reapStaleGenieProcessesSafe');
+    const preconditionIdx = body.indexOf('runMaintenancePreconditions');
+    expect(reapIdx).toBeGreaterThan(-1);
+    expect(preconditionIdx).toBeGreaterThan(-1);
+    expect(reapIdx).toBeLessThan(preconditionIdx);
+
+    // Honors the GENIE_UPDATE_NO_REAP=1 opt-out and excludes the serve daemon.
+    expect(source).toContain("process.env.GENIE_UPDATE_NO_REAP === '1'");
+    expect(source).toContain("'serve.pid'");
+    // Walks the parent chain to avoid killing the npm/bun update wrapper.
+    expect(source).toContain('getParentChain(process.pid)');
+    // Escalates SIGTERM → SIGKILL with a 2s grace window.
+    expect(source).toContain("process.kill(pid, 'SIGTERM')");
+    expect(source).toContain("process.kill(pid, 'SIGKILL')");
   });
 });

--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -1123,5 +1123,171 @@ export interface PostUpdateMaintenanceOptions {
 }
 
 export async function runPostUpdateMaintenance(options: PostUpdateMaintenanceOptions = {}): Promise<void> {
+  await reapStaleGenieProcessesSafe(options);
   await runMaintenancePreconditions(options.silent ?? false, options.log);
+}
+
+/**
+ * Walk a process's parent chain via /proc/<pid>/status. Returns the set of
+ * PIDs from `pid` up to init (1). Used by the stale-genie reaper to avoid
+ * killing ourselves or our caller (the npm/bun update wrapper or the user's
+ * shell).
+ */
+function getParentChain(pid: number): Set<number> {
+  const chain = new Set<number>();
+  let current = pid;
+  while (current > 1 && !chain.has(current)) {
+    chain.add(current);
+    try {
+      const status = readFileSync(`/proc/${current}/status`, 'utf-8');
+      const match = status.match(/^PPid:\s+(\d+)/m);
+      if (!match) break;
+      const next = Number.parseInt(match[1], 10);
+      if (!Number.isFinite(next) || next <= 0) break;
+      current = next;
+    } catch {
+      break;
+    }
+  }
+  return chain;
+}
+
+/**
+ * Identify candidate stale genie processes from /proc.
+ *
+ * A candidate is any process whose argv contains `dist/genie.js` AND is NOT
+ * in the exclude set. Caller is responsible for populating `exclude` with
+ * the current PID, parent chain, and the active serve-daemon PID.
+ *
+ * Exposed for unit tests.
+ */
+export function findStaleGenieCandidates(exclude: Set<number>): number[] {
+  if (process.platform !== 'linux') return [];
+  let entries: string[] = [];
+  try {
+    entries = readdirSync('/proc');
+  } catch {
+    return [];
+  }
+  const candidates: number[] = [];
+  for (const entry of entries) {
+    const pid = Number.parseInt(entry, 10);
+    if (!Number.isFinite(pid) || pid <= 1) continue;
+    if (exclude.has(pid)) continue;
+    let cmdline = '';
+    try {
+      cmdline = readFileSync(`/proc/${pid}/cmdline`, 'utf-8');
+    } catch {
+      continue; // permission denied, exited mid-scan, etc.
+    }
+    // Match the bun-bundle invocation form. Argv pieces are NUL-separated
+    // (file is read whole) so substring match is sufficient.
+    if (!cmdline.includes('dist/genie.js')) continue;
+    candidates.push(pid);
+  }
+  return candidates;
+}
+
+/**
+ * Reap stale genie processes left over from before this update. Runs as
+ * part of `runPostUpdateMaintenance`. Why: the in-memory binary loaded by
+ * a long-running `genie serve` / TUI / orphan subprocess is the OLD
+ * version. Connection-leak fixes (cwd-pin, drain-on-exit, cliShortLived
+ * gate) only protect NEW invocations — old processes keep holding leaked
+ * pgserve connections until they die or pgserve is restarted, which on
+ * busy hosts saturates `max_connections=1000` and locks out everything
+ * else with `sorry, too many clients already`.
+ *
+ * Safety:
+ *   - Excludes self (`process.pid`) and the entire parent chain so we
+ *     don't kill the npm/bun update wrapper or the user's shell.
+ *   - Excludes the active serve daemon (read from `~/.genie/serve.pid`)
+ *     because it owns active TUI sessions and the scheduler. Operators
+ *     who want to recycle the daemon should run `genie doctor --fix`
+ *     which has an explicit `stopExistingDaemon` step.
+ *   - Linux-only (relies on /proc). macOS/Windows skip with a notice.
+ *   - Opt out via `GENIE_UPDATE_NO_REAP=1`.
+ *   - Failures are non-fatal — the update flow continues.
+ */
+async function reapStaleGenieProcesses(opts: { log?: (line: string) => void } = {}): Promise<void> {
+  const log = opts.log ?? ((line: string) => console.log(line));
+  if (process.env.GENIE_UPDATE_NO_REAP === '1') {
+    log('  [--] Stale genie reap skipped (GENIE_UPDATE_NO_REAP=1)');
+    return;
+  }
+  if (process.platform !== 'linux') {
+    log('  [--] Stale genie reap: Linux-only (procfs); skipping on this platform');
+    return;
+  }
+
+  const exclude = getParentChain(process.pid);
+
+  // Exclude the active serve daemon (file format: "<pid>:<startTime>").
+  try {
+    const home = process.env.GENIE_HOME ?? join(homedir(), '.genie');
+    const servePidPath = join(home, 'serve.pid');
+    if (existsSync(servePidPath)) {
+      const raw = readFileSync(servePidPath, 'utf-8').trim().split(':')[0];
+      const sp = Number.parseInt(raw, 10);
+      if (Number.isFinite(sp) && sp > 0) exclude.add(sp);
+    }
+  } catch {
+    // No serve.pid or unreadable — daemon isn't running, nothing to exclude.
+  }
+
+  const candidates = findStaleGenieCandidates(exclude);
+  if (candidates.length === 0) {
+    log('  [ok] No stale genie processes to reap');
+    return;
+  }
+
+  log(`  [fix] Reaping ${candidates.length} stale genie process(es): ${candidates.join(', ')}`);
+  for (const pid of candidates) {
+    try {
+      process.kill(pid, 'SIGTERM');
+    } catch {
+      // Already dead between scan and signal — fine.
+    }
+  }
+
+  // Give SIGTERM 2s to settle. Most genie processes have shutdown handlers
+  // (the same beforeExit handler we added in #1580) that drain pools and
+  // exit cleanly within a second.
+  await new Promise((r) => setTimeout(r, 2000));
+
+  const stragglers: number[] = [];
+  for (const pid of candidates) {
+    try {
+      process.kill(pid, 0); // signal 0 = liveness probe
+      stragglers.push(pid);
+    } catch {
+      // Gone after SIGTERM — good.
+    }
+  }
+  if (stragglers.length > 0) {
+    log(`  [fix] SIGKILL stragglers: ${stragglers.join(', ')}`);
+    for (const pid of stragglers) {
+      try {
+        process.kill(pid, 'SIGKILL');
+      } catch {
+        // Race: died between probe and SIGKILL — fine.
+      }
+    }
+  }
+  log('  [ok] Stale genie reap complete');
+}
+
+/**
+ * Wrapper that swallows reap failures so the rest of post-update maintenance
+ * still runs. The reaper itself catches per-PID errors; this guards against
+ * unexpected throws (e.g. /proc readdir denied in unusual sandboxes).
+ */
+async function reapStaleGenieProcessesSafe(opts: PostUpdateMaintenanceOptions): Promise<void> {
+  try {
+    await reapStaleGenieProcesses({ log: opts.log });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const log = opts.log ?? ((line: string) => console.log(line));
+    log(`  [!!] Stale genie reap failed (non-blocking): ${msg}`);
+  }
 }


### PR DESCRIPTION
## Summary

Add automatic reaper to \`runPostUpdateMaintenance\` so \`genie update\` kills leftover genie processes (daemons, TUIs, orphan subprocesses) whose in-memory binary is the pre-update version.

## Why

PR #1580 (cwd-pin + drain-on-exit + \`cliShortLived\` gate) only protects NEW invocations. Long-running pre-fix processes don't pick up the new code until they're restarted. On hosts with bursty multi-agent workloads, those leaked processes consume hundreds of pgserve backends each, saturating \`max_connections=1000\` even after fresh code is installed.

## Note

This is an **interim** fix. The companion PR #1585 (\`fix/pgserve-direct-postmaster\`) eliminates the router that imposes the 1000 cap entirely. Once #1585 lands, this reaper is still useful (cleans up zombie processes during upgrade) but the urgency is gone.

## Implementation

- \`src/genie-commands/doctor.ts\` — adds \`reapStaleGenieProcesses()\` + \`reapStaleGenieProcessesSafe()\` wrapper, called from \`runPostUpdateMaintenance\` BEFORE \`runMaintenancePreconditions\`.
- Scans \`/proc\` for processes whose argv contains \`dist/genie.js\`.
- Excludes: current PID, parent chain, active serve daemon (\`~/.genie/serve.pid\`).
- SIGTERM with 2s grace, SIGKILL stragglers.
- Linux-only (procfs); macOS/Windows skip with notice.
- Opt out via \`GENIE_UPDATE_NO_REAP=1\`.
- Failures non-blocking.

## Test plan

- [x] \`bun test src/genie-commands/doctor.test.ts\` — passes including new \`findStaleGenieCandidates\` surface tests + reaper ordering assertion.
- [x] \`bun run typecheck\` — clean.
- [ ] Manual: install on a host with leaked pre-fix processes, run \`genie update\`, confirm output shows reap and pgserve cap drops back to baseline.
- [ ] Verify \`GENIE_UPDATE_NO_REAP=1 genie update\` skips reap.
- [ ] Verify active \`genie serve\` daemon NOT killed.

Refs: #1574 (saturation report v4.260430.20), #1580 (production identity fix), #1585 (router bypass — supersedes the urgency).