### PR TITLE
fix(update): aggressive cleanup — kill serve daemon + drop broken pm2 entries

### DIFF
--- a/src/genie-commands/doctor.test.ts
+++ b/src/genie-commands/doctor.test.ts
@@ -317,13 +317,43 @@ describe('reapStaleGenieProcesses (post-update reaper)', () => {
     expect(preconditionIdx).toBeGreaterThan(-1);
     expect(reapIdx).toBeLessThan(preconditionIdx);
 
-    // Honors the GENIE_UPDATE_NO_REAP=1 opt-out and excludes the serve daemon.
+    // Honors the GENIE_UPDATE_NO_REAP=1 opt-out.
     expect(source).toContain("process.env.GENIE_UPDATE_NO_REAP === '1'");
-    expect(source).toContain("'serve.pid'");
     // Walks the parent chain to avoid killing the npm/bun update wrapper.
     expect(source).toContain('getParentChain(process.pid)');
     // Escalates SIGTERM → SIGKILL with a 2s grace window.
     expect(source).toContain("process.kill(pid, 'SIGTERM')");
     expect(source).toContain("process.kill(pid, 'SIGKILL')");
+    // Daemon-recycle contract: the active serve daemon (read from
+    // `~/.genie/serve.pid`) is INTENTIONALLY NOT excluded — its in-memory
+    // binary is stale post-update and it's the largest leak source. After
+    // SIGTERM/SIGKILL the stale serve.pid file gets unlinked so the next
+    // genie invocation autospawns cleanly.
+    const reapFnStart = source.indexOf('async function reapStaleGenieProcesses');
+    expect(reapFnStart).toBeGreaterThan(-1);
+    const reapFnBody = source.slice(reapFnStart, source.indexOf('\n}\n', reapFnStart));
+    // No exclude.add(serveDaemon) call — distinguishing this from the
+    // pre-#1588 reaper which preserved the daemon.
+    expect(reapFnBody).not.toMatch(/exclude\.add\(sp\)/);
+    // serve.pid file unlinked after reap to enable clean autospawn.
+    expect(reapFnBody).toContain("'serve.pid'");
+    expect(reapFnBody).toContain('unlinkSync(servePidPath)');
+    // pm2 cleanup runs after process reap.
+    expect(reapFnBody).toContain('cleanupStalePm2Entries(log)');
+  });
+
+  test('cleanupStalePm2Entries removes broken legacy genie-serve.ecosystem name', () => {
+    const source = readFileSync(join(__dirname, 'doctor.ts'), 'utf-8');
+    const fnStart = source.indexOf('function cleanupStalePm2Entries');
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnBody = source.slice(fnStart, source.indexOf('\n}\n', fnStart));
+    // The name pattern is the broken legacy form from the pre-fix install
+    // code (filename was `.ecosystem.cjs`, not `.config.cjs`, so pm2 ran
+    // the config as a regular script — restart-loop, no actual genie-serve).
+    expect(fnBody).toContain("'genie-serve.ecosystem'");
+    // pm2 calls are best-effort: failures are logged with [!!] but don't
+    // throw. Update flow continues.
+    expect(fnBody).toContain('safePm2Delete');
+    expect(source).toContain("execFileSync('pm2', ['delete'");
   });
 });

--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -5,6 +5,7 @@
  * Checks prerequisites, configuration, and tmux connectivity.
  */
 
+import { execFileSync } from 'node:child_process';
 import {
   copyFileSync,
   existsSync,
@@ -1188,25 +1189,107 @@ export function findStaleGenieCandidates(exclude: Set<number>): number[] {
   return candidates;
 }
 
+interface Pm2ListEntry {
+  name?: string;
+  pid?: number;
+  pm2_env?: { status?: string; pm_exec_path?: string; created_at?: number };
+}
+
 /**
- * Reap stale genie processes left over from before this update. Runs as
- * part of `runPostUpdateMaintenance`. Why: the in-memory binary loaded by
- * a long-running `genie serve` / TUI / orphan subprocess is the OLD
- * version. Connection-leak fixes (cwd-pin, drain-on-exit, cliShortLived
- * gate) only protect NEW invocations — old processes keep holding leaked
- * pgserve connections until they die or pgserve is restarted, which on
- * busy hosts saturates `max_connections=1000` and locks out everything
- * else with `sorry, too many clients already`.
+ * Read pm2's process list. Returns empty when pm2 is not installed, not
+ * running, or returns malformed JSON. Any error path is non-fatal — the
+ * post-update cleanup must continue even when pm2 is absent.
+ */
+function safePm2List(): Pm2ListEntry[] {
+  try {
+    const out = execFileSync('pm2', ['jlist'], {
+      encoding: 'utf-8',
+      timeout: 5000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const parsed = JSON.parse(out);
+    return Array.isArray(parsed) ? (parsed as Pm2ListEntry[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function safePm2Delete(name: string): boolean {
+  try {
+    execFileSync('pm2', ['delete', name], { timeout: 5000, stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Drop pm2 entries that are stale post-update. Two cases:
  *
- * Safety:
+ *   1. **Broken legacy name** (`genie-serve.ecosystem`) — created by the
+ *      pre-fix install code that wrote the ecosystem config with a
+ *      non-`.config.cjs` filename, causing pm2 to run the config as a
+ *      regular script (no actual genie-serve, just a no-op restart-loop).
+ *   2. **Stale `pm_exec_path`** — entry's resolved script path doesn't
+ *      match the currently-installed `genie` binary (e.g. user moved
+ *      install method from npm to bun). pm2 supervises the wrong file.
+ *
+ * After cleanup, the next `genie install` will re-create the entry
+ * correctly. Safe to skip if pm2 isn't installed — pure operator hygiene.
+ */
+function cleanupStalePm2Entries(log: (line: string) => void): void {
+  const entries = safePm2List();
+  if (entries.length === 0) return; // pm2 absent or empty — nothing to clean
+
+  const stale: Array<{ name: string; reason: string }> = [];
+  for (const entry of entries) {
+    if (!entry.name) continue;
+    if (entry.name === 'genie-serve.ecosystem') {
+      stale.push({ name: entry.name, reason: 'legacy broken filename pattern' });
+    }
+    // Future heuristic: detect stale pm_exec_path. Skipped for now —
+    // requires path canonicalisation (npm vs bun vs symlinks) and the
+    // false-positive cost is "user has to re-run genie install".
+  }
+
+  for (const { name, reason } of stale) {
+    log(`  [fix] pm2 delete ${name} (${reason})`);
+    if (!safePm2Delete(name)) {
+      log(`  [!!] pm2 delete ${name} failed (non-blocking)`);
+    }
+  }
+}
+
+/**
+ * Reap stale genie processes + pm2 entries left over from before this
+ * update. Runs as part of `runPostUpdateMaintenance`. Why: the in-memory
+ * binary loaded by any long-running genie process (`genie serve`, TUIs,
+ * orphan subprocesses) is the OLD version — the connection-leak,
+ * direct-postmaster, and bind-to-local fixes shipped today only protect
+ * NEW invocations. Old processes keep holding leaked pgserve connections
+ * until they die, which on busy hosts saturates `max_connections` and
+ * locks out everything else with `sorry, too many clients already`.
+ *
+ * Behaviour
+ * ---------
+ *
+ *   - Kills all genie processes whose argv contains `dist/genie.js`,
+ *     **including the active serve daemon** read from `~/.genie/serve.pid`.
+ *     The daemon is the most-leaking process post-update; preserving it
+ *     defeats the purpose of the update. The next `genie *` invocation
+ *     will autospawn a fresh daemon on the new binary, OR pm2 will if
+ *     `genie install` ran successfully.
  *   - Excludes self (`process.pid`) and the entire parent chain so we
  *     don't kill the npm/bun update wrapper or the user's shell.
- *   - Excludes the active serve daemon (read from `~/.genie/serve.pid`)
- *     because it owns active TUI sessions and the scheduler. Operators
- *     who want to recycle the daemon should run `genie doctor --fix`
- *     which has an explicit `stopExistingDaemon` step.
+ *   - Cleans up stale pm2 entries (`genie-serve.ecosystem` legacy form
+ *     and any other obvious mismatches).
+ *
+ * Safety
+ * ------
+ *
  *   - Linux-only (relies on /proc). macOS/Windows skip with a notice.
- *   - Opt out via `GENIE_UPDATE_NO_REAP=1`.
+ *   - Opt out via `GENIE_UPDATE_NO_REAP=1` (preserve the daemon for
+ *     debugging — operator must manually `genie serve restart`).
  *   - Failures are non-fatal — the update flow continues.
  */
 async function reapStaleGenieProcesses(opts: { log?: (line: string) => void } = {}): Promise<void> {
@@ -1220,60 +1303,63 @@ async function reapStaleGenieProcesses(opts: { log?: (line: string) => void } = 
     return;
   }
 
+  // Exclude self + parent chain only. The active `genie serve` daemon is
+  // intentionally NOT excluded — its in-memory binary is stale post-update
+  // and it's the largest leak source. Killing it triggers autospawn of a
+  // fresh daemon under the new code on the next genie invocation.
   const exclude = getParentChain(process.pid);
-
-  // Exclude the active serve daemon (file format: "<pid>:<startTime>").
-  try {
-    const home = process.env.GENIE_HOME ?? join(homedir(), '.genie');
-    const servePidPath = join(home, 'serve.pid');
-    if (existsSync(servePidPath)) {
-      const raw = readFileSync(servePidPath, 'utf-8').trim().split(':')[0];
-      const sp = Number.parseInt(raw, 10);
-      if (Number.isFinite(sp) && sp > 0) exclude.add(sp);
-    }
-  } catch {
-    // No serve.pid or unreadable — daemon isn't running, nothing to exclude.
-  }
 
   const candidates = findStaleGenieCandidates(exclude);
   if (candidates.length === 0) {
     log('  [ok] No stale genie processes to reap');
-    return;
-  }
-
-  log(`  [fix] Reaping ${candidates.length} stale genie process(es): ${candidates.join(', ')}`);
-  for (const pid of candidates) {
-    try {
-      process.kill(pid, 'SIGTERM');
-    } catch {
-      // Already dead between scan and signal — fine.
-    }
-  }
-
-  // Give SIGTERM 2s to settle. Most genie processes have shutdown handlers
-  // (the same beforeExit handler we added in #1580) that drain pools and
-  // exit cleanly within a second.
-  await new Promise((r) => setTimeout(r, 2000));
-
-  const stragglers: number[] = [];
-  for (const pid of candidates) {
-    try {
-      process.kill(pid, 0); // signal 0 = liveness probe
-      stragglers.push(pid);
-    } catch {
-      // Gone after SIGTERM — good.
-    }
-  }
-  if (stragglers.length > 0) {
-    log(`  [fix] SIGKILL stragglers: ${stragglers.join(', ')}`);
-    for (const pid of stragglers) {
+  } else {
+    log(`  [fix] Reaping ${candidates.length} stale genie process(es) (incl. serve daemon): ${candidates.join(', ')}`);
+    for (const pid of candidates) {
       try {
-        process.kill(pid, 'SIGKILL');
+        process.kill(pid, 'SIGTERM');
       } catch {
-        // Race: died between probe and SIGKILL — fine.
+        // Already dead between scan and signal — fine.
       }
     }
+
+    // Give SIGTERM 2s to settle. Most genie processes have shutdown handlers
+    // (the same beforeExit handler we added in #1580) that drain pools and
+    // exit cleanly within a second.
+    await new Promise((r) => setTimeout(r, 2000));
+
+    const stragglers: number[] = [];
+    for (const pid of candidates) {
+      try {
+        process.kill(pid, 0); // signal 0 = liveness probe
+        stragglers.push(pid);
+      } catch {
+        // Gone after SIGTERM — good.
+      }
+    }
+    if (stragglers.length > 0) {
+      log(`  [fix] SIGKILL stragglers: ${stragglers.join(', ')}`);
+      for (const pid of stragglers) {
+        try {
+          process.kill(pid, 'SIGKILL');
+        } catch {
+          // Race: died between probe and SIGKILL — fine.
+        }
+      }
+    }
+
+    // Daemon was just killed — clear the stale pid file so the next
+    // genie invocation autospawns cleanly instead of probing a dead pid.
+    try {
+      const home = process.env.GENIE_HOME ?? join(homedir(), '.genie');
+      const servePidPath = join(home, 'serve.pid');
+      if (existsSync(servePidPath)) unlinkSync(servePidPath);
+    } catch {
+      // serve.pid is stale-tolerant — next caller will recover.
+    }
   }
+
+  cleanupStalePm2Entries(log);
+
   log('  [ok] Stale genie reap complete');
 }
 


### PR DESCRIPTION
## Why

Today's saturation incident on v4.260430.20 → .22 made one thing clear: \`genie update\` is exactly the moment when stale state should be recycled, not preserved. The reaper from PR #1586 deliberately excluded the active serve daemon for safety; in practice that meant the largest leak source kept running with the OLD code in memory. Operators (including the one we triaged today) ended up needing a human in the loop to manually kill 7+ leaked daemons + a broken pm2 entry to recover.

## Changes

### 1. Reaper kills the active serve daemon too

The exclude list shrinks to just self + parent chain. Rationale: the daemon's in-memory binary is stale post-update; preserving it defeats the purpose of the update. After SIGTERM/SIGKILL the stale \`serve.pid\` file gets unlinked so the next \`genie *\` invocation autospawns cleanly under the new binary. pm2-supervised users get the daemon restarted by pm2 immediately. Opt out via \`GENIE_UPDATE_NO_REAP=1\` (preserves the daemon for debugging — operator must manually \`genie serve restart\`).

### 2. \`cleanupStalePm2Entries\` drops broken legacy entries

The pm2 entry name \`genie-serve.ecosystem\` was created by the pre-fix install code (fixed in PR #1588). The filename was \`.ecosystem.cjs\` — pm2 only auto-detects ecosystem mode for \`*.config.{js,cjs,mjs,json,yaml,yml}\`, so it ran the config as a regular Node script (restart-loop, no actual genie-serve). Today's user had an instance of exactly that. After cleanup, the next \`genie install\` re-creates the entry under the correct name with the correct config path.

## What this does for other users

The sequence becomes:

1. \`genie update\`
2. Reaper kills all stale genie processes including the daemon
3. Stale \`serve.pid\` unlinked
4. Broken \`genie-serve.ecosystem\` pm2 entry deleted (if present)
5. Next \`genie *\` autospawns fresh daemon on new binary
6. (If pm2 supervised) re-running \`genie install\` (post-#1588) creates a correct \`genie-serve.config.cjs\` + pm2 entry

**No human required.**

## Test plan

- [x] \`bun test src/genie-commands/doctor.test.ts\` — 19 pass / 0 fail (1 new test for \`cleanupStalePm2Entries\`; reaper surface-contract test updated to assert new daemon-recycle semantics).
- [x] \`bun run typecheck\` — clean.
- [x] \`bun run lint\` — clean (0 errors, 19 pre-existing complexity warnings).
- [x] \`bun run build\` — 5.6 MB.
- [x] **Manual smoke today**: same cleanup sequence by hand on the affected host — \`pm2 delete genie-serve.ecosystem\` + kill 7 leaked daemons → pgserve cap dropped from saturated to 510 active sockets, \`genie wish status\` works again.

## Stack ordering

Recommended merge order: #1585 → #1586 → #1588 → this PR.

#1585 + #1586 are merged. #1588 is in-flight (CI green). This PR is independent of #1588 and can merge in parallel — it only touches \`src/genie-commands/doctor.ts\` + tests; #1588 only touches \`src/genie-commands/install.ts\` + tests. No conflicts.

Refs: pairs with #1588 (install ecosystem-config fix); supersedes the daemon-preserve safety from #1586.