### PR TITLE
fix(dispatch): runWorkDispatch must throw not exit — preserves sibling spawns in wave dispatch

### DIFF
--- a/src/term-commands/dispatch.test.ts
+++ b/src/term-commands/dispatch.test.ts
@@ -1238,6 +1238,39 @@ describe('#1600 spawn-pipeline silent-fail regression guards', () => {
     });
   });
 
+  describe('Group 4 — runWorkDispatch must never process.exit (kill-siblings prevention)', () => {
+    it('runWorkDispatch contains zero EXECUTABLE process.exit calls — they kill sibling spawns in Promise.allSettled', () => {
+      // ROOT CAUSE of the long-running #1589/#1600 phantom dispatch: when
+      // `autoOrchestrateCommand` runs `Promise.allSettled([runWorkDispatch, …])`
+      // for a parallel wave, ANY group's process.exit(1) terminates the entire
+      // node process — killing every sibling spawn mid-flight before audit
+      // events can fire. The fix: throw instead of exit. The single-group CLI
+      // caller `workDispatchCommand` already re-throws and the outer CLI
+      // handler does process.exit, so single-group semantics are preserved.
+      const fnAnchor = dispatchSrc.indexOf('async function runWorkDispatch');
+      expect(fnAnchor).toBeGreaterThan(-1);
+      // Body ends at the next top-level `export async function` or `async function`.
+      // Use a regex that anchors on lines starting with `}` followed by a blank line then a docstring.
+      const afterFn = dispatchSrc.slice(fnAnchor + 1);
+      const nextFnRel = afterFn.search(/\nasync function |\nexport async function |\nexport function |\nfunction /);
+      const fnEnd = nextFnRel !== -1 ? fnAnchor + 1 + nextFnRel : dispatchSrc.length;
+      const body = dispatchSrc.slice(fnAnchor, fnEnd);
+      // Strip comments before checking — `process.exit(1)` may legitimately
+      // appear in JSDoc / inline comments explaining the OLD behavior.
+      const stripped = body
+        .split('\n')
+        .filter((line) => !line.trim().startsWith('//') && !line.trim().startsWith('*'))
+        .join('\n');
+      // Hard guarantee: zero EXECUTABLE process.exit calls in non-comment code.
+      expect(stripped).not.toContain('process.exit');
+      // Soft guarantee: the function explicitly throws on each error path so
+      // Promise.allSettled in autoOrchestrateCommand collects rejections.
+      const throwCount = (stripped.match(/throw new Error\(/g) ?? []).length;
+      // At minimum: wish-not-found, group-not-found, startGroup-failed.
+      expect(throwCount).toBeGreaterThanOrEqual(3);
+    });
+  });
+
   describe('Group 3 — wish.dispatch.failed surfacing', () => {
     it('autoOrchestrateCommand emits wish.dispatch.failed per failed group', () => {
       const fnAnchor = dispatchSrc.indexOf('async function autoOrchestrateCommand');

--- a/src/term-commands/dispatch.ts
+++ b/src/term-commands/dispatch.ts
@@ -656,10 +656,20 @@ async function runWorkDispatch(
   wishPath: string,
   ref: string,
 ): Promise<void> {
+  // CRITICAL (#1600 Round 3): never call `process.exit(1)` from this function.
+  // `runWorkDispatch` is invoked from TWO callers:
+  //   1. `workDispatchCommand` (single-group CLI) — wraps in try/catch and the
+  //      outer CLI handler calls process.exit(1) with the error message.
+  //   2. `autoOrchestrateCommand` (wave dispatch via Promise.allSettled) —
+  //      collects rejections and reports per-group failures.
+  // If we exit() here from within a parallel wave, we kill the whole node
+  // process mid-dispatch — including SIBLING spawns that are mid-flight in
+  // handleWorkerSpawn. That's THE silent-fail surface from #1589/#1600:
+  // any group's startGroup failure (dependency not done, already in_progress)
+  // killed every other group's spawn before audit events could fire. Throw
+  // instead so the wave-dispatcher's allSettled boundary handles it.
   if (!existsSync(wishPath)) {
-    console.error(`❌ Wish not found: ${wishPath}`);
-    console.error(`   Create it first: genie wish <agent> ${slug}`);
-    process.exit(1);
+    throw new Error(`Wish not found: ${wishPath}. Create it first: genie wish <agent> ${slug}`);
   }
 
   const content = await readFile(wishPath, 'utf-8');
@@ -667,27 +677,23 @@ async function runWorkDispatch(
   // Extract the specific group section
   const groupSection = extractGroup(content, group);
   if (!groupSection) {
-    console.error(`❌ Group "${group}" not found in ${wishPath}`);
-    console.error('   Available groups:');
-    const groups = content.match(/^### Group [A-Za-z0-9]+:.*$/gm);
-    if (groups) {
-      for (const g of groups) console.error(`     ${g}`);
-    }
-    process.exit(1);
+    const availableGroups = content.match(/^### Group [A-Za-z0-9]+:.*$/gm);
+    const availableList = availableGroups ? availableGroups.join(', ') : '(none)';
+    throw new Error(`Group "${group}" not found in ${wishPath}. Available: ${availableList}`);
   }
 
   // Auto-initialize state if missing (prevents polling loop when no state exists)
   const groups = parseWishGroups(content);
   await wishState.getOrCreateState(slug, groups);
 
-  // Start group in state machine (enforces dependencies)
+  // Start group in state machine (enforces dependencies). Throw on failure
+  // (NOT exit) — see top-of-function comment.
   try {
     await wishState.startGroup(slug, group, agentName);
     console.log(`✅ Group "${group}" set to in_progress (assigned to ${agentName})`);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    console.error(`❌ ${message}`);
-    process.exit(1);
+    throw new Error(message);
   }
 
   // Build context with wish-level info + group section


### PR DESCRIPTION
## Summary

**ROOT CAUSE** of the long-running #1589/#1600 phantom-dispatch saga, found empirically on `4.260430.25` after PR #1601's audit observability shipped.

`runWorkDispatch` called `process.exit(1)` on three error paths (wish not found, group not found, startGroup failed). When `autoOrchestrateCommand` runs `Promise.allSettled([runWorkDispatch × N])` for a parallel wave, ANY group's `process.exit` terminates the entire node process — killing every sibling spawn mid-flight before:

- `handleWorkerSpawn`'s `worker.spawn` audit event fires
- `launchTmuxSpawn` reaches the new `validateSpawnedPane` check from #1601
- any of the new `worker.spawn.failed` / `worker.spawn.ok` events fire

This is exactly why .24 + .25 still phantom-dispatched despite the `wish.dispatch.work` event firing correctly: the dispatch event landed during the brief window between Group N's PG state mutation and Group N's spawn pipeline being killed by Group N+1's exit().

## Repro on .25 (with #1601 audit code installed)

```bash
$ cd /home/genie/.genie/worktrees/tui-bottom-bar-opentui
$ env GENIE_TEAM=genie genie work tui-bottom-bar-opentui
🚀 Dispatching Wave 1 (parallel) — data layer for wish "tui-bottom-bar-opentui" — 5 group(s)
✅ Group "1" set to in_progress (assigned to engineer)
🔧 Dispatching work to engineer for "tui-bottom-bar-opentui#1"
   Group: 1
❌ Cannot start group "5": dependency "2" is ready (must be done)

# Then check audit:
$ genie events list --since 3m --type worker.spawn.failed
No audit events found.
$ genie events list --since 3m --type worker.spawn.ok
# Only the dog-fooder's `engineer` shows up — NOT engineer-1
$ genie events list --since 3m --type wish.dispatch.work
1m ago | wish | tui-bottom-bar-opentui | wish.dispatch.work | genie | {"cwd":"/home/genie/.genie/worktrees/tui...
```

The `wish.dispatch.work` event fires (Group 1 reached dispatch.ts) but neither `worker.spawn` (attempt) nor any `.ok`/`.failed` terminal event fires — proof that handleWorkerSpawn was killed mid-flight by Group 5's `process.exit(1)`.

## Fix

Replace each `process.exit(1)` in `runWorkDispatch` with `throw new Error(...)`. Both callers handle the throw correctly:

- **`workDispatchCommand` (single-group CLI)**: the outer commander handler in `registerDispatchCommands` already wraps in try/catch + `process.exit`, so single-group semantics are preserved.
- **`autoOrchestrateCommand` (wave)**: `Promise.allSettled` collects rejections into the `failed` array; PR #1601's `wish.dispatch.failed` event fires per group; stderr summary prints with the `[ErrorClass]` prefix.

## Test plan

- [x] `bun test src/term-commands/dispatch.test.ts` — **86 pass** / 0 fail (was 85 + 1 new Group-4 regression-guard asserting zero EXECUTABLE `process.exit` calls in `runWorkDispatch`, with comment text excluded).
- [x] `bun run typecheck` — clean.
- [ ] **Empirical post-merge:** `genie work tui-bottom-bar-opentui` produces `worker.spawn.ok` for surviving groups OR `worker.spawn.failed` with structured reason for actual spawn failures. Group 5's "dependency not done" no longer kills siblings.

## Files

```
src/term-commands/dispatch.ts      +21 -10  (3× process.exit → throw)
src/term-commands/dispatch.test.ts +25      (1 regression-guard test)
```

## Saga

This is the third PR in the #1589 → #1600 → (this) chain:
- **#1599** (#1589): cwd plumbing + observability + display filter
- **#1601** (#1600): post-spawn validation + audit event taxonomy
- **This PR**: actual root cause — `runWorkDispatch` killing sibling spawns

🤖 Generated with [Claude Code](https://claude.com/claude-code)
