### PR TITLE
fix(spawn): auto-resume validates resumed pane is alive — fall through on phantom (Round 4)

### DIFF
--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -2416,6 +2416,7 @@ export async function resolveSpawnIdentity(
 }
 
 /** Resolve team name and auto-resume dead workers. Duplicate rejection moved to the state machine. */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: 5-tier team resolution + ResumePaneVanishedError fall-through (#1602 Round 4) — tiers are linear and each branch is doc-blocked
 async function resolveTeamAndResume(
   effectiveRole: string,
   options: SpawnOptions,
@@ -2471,8 +2472,27 @@ async function resolveTeamAndResume(
     const executor = await executorRegistry.getCurrentExecutor(deadResumable.id);
     const sessionShort = executor?.claudeSessionId?.slice(0, 8) ?? 'unknown';
     console.log(`Resuming existing session for "${effectiveRole}" (session: ${sessionShort}...)`);
-    await resumeAgent(deadResumable);
-    return { team, teamWasExplicit, resumed: deadResumable.id };
+    try {
+      await resumeAgent(deadResumable);
+      return { team, teamWasExplicit, resumed: deadResumable.id };
+    } catch (err) {
+      // ROUND 4 / felipe Round 3 brief — resumeAgent now validates the resumed
+      // pane against tmux + the OS process; if the pane vanished, the resume
+      // is treated as a no-op and we fall through to a fresh spawn instead of
+      // returning a phantom paneId. Clear the stale executor record so the
+      // next dispatch doesn't loop on the same dead row.
+      if (err instanceof ResumePaneVanishedError) {
+        console.warn(
+          `⚠ Resume of "${effectiveRole}" produced a dead pane (${err.reason}). Clearing stale executor and falling through to fresh spawn.`,
+        );
+        if (executor?.id) {
+          await executorRegistry.updateExecutorState(executor.id, 'terminated').catch(() => {});
+        }
+        // Fall through to fresh-spawn path (no `resumed` key).
+        return { team, teamWasExplicit };
+      }
+      throw err;
+    }
   }
   // NOTE: rejectDuplicateRole is no longer called here. In the new state-machine
   // model, a live row with id=name IS the parallel-creation signal — handled by
@@ -3604,6 +3624,7 @@ function logResumeSuccess(
   }
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: linear resume pipeline (build → spawn → validate → emit) with post-resume pane validation per #1602 Round 4
 async function resumeAgent(agent: registry.Agent, opts: { resetAttempts?: boolean } = {}): Promise<void> {
   const resetAttempts = opts.resetAttempts !== false;
   const template = (await registry.listTemplates()).find((t) => t.id === (agent.role ?? agent.id));
@@ -3693,9 +3714,80 @@ async function resumeAgent(agent: registry.Agent, opts: { resetAttempts?: boolea
     await tmux.applyPaneColor(paneId, ctx.spawnColor, teamWindow?.windowId);
   }
 
+  // ROUND 4 / felipe Round 3 brief — validate the resumed pane has a live OS
+  // process before declaring success. Without this, the auto-resume path
+  // returns a phantom paneId (createTmuxPane returned successfully but the
+  // launched script exited immediately), and the caller's `if (resumed)
+  // return resumed;` short-circuits handleWorkerSpawn while no actual worker
+  // exists. This is the silent-fail surface that #1599 + #1601 instrumented
+  // around but didn't cover (resume goes through createResumeTmuxPaneOrExit,
+  // not launchTmuxSpawn).
+  recordAuditEvent('worker', agent.id, 'worker.resume.attempted', getActor(), {
+    worker_id: agent.id,
+    agent_role: agent.role ?? agent.id,
+    team: agent.team,
+    claude_session_id: params.resume,
+    pane_id: paneId,
+  }).catch(() => {});
+
+  // Capture pane PID and verify pane + process are both alive.
+  let resumedPid: number | null = null;
+  try {
+    if (paneId !== 'inline') {
+      const { execSync } = require('node:child_process');
+      const pidOutput = execSync(genieTmuxCmd(`display -t '${paneId}' -p '#{pane_pid}'`), {
+        encoding: 'utf-8',
+      }).trim();
+      const parsedPid = Number.parseInt(pidOutput, 10);
+      resumedPid = parsedPid > 0 ? parsedPid : null;
+
+      // Verify pane is still in tmux's pane list.
+      const panesOutput = execSync(genieTmuxCmd(`list-panes -a -F '#{pane_id}'`), { encoding: 'utf-8' });
+      const paneList = panesOutput.split('\n').map((line: string) => line.trim());
+      if (!paneList.includes(paneId)) {
+        throw new ResumePaneVanishedError(agent.id, paneId, resumedPid, 'pane_not_in_list');
+      }
+
+      // Verify the process is alive.
+      if (resumedPid !== null) {
+        try {
+          process.kill(resumedPid, 0);
+        } catch (err) {
+          const e = err as NodeJS.ErrnoException;
+          if (e.code === 'ESRCH') {
+            throw new ResumePaneVanishedError(agent.id, paneId, resumedPid, 'pid_dead');
+          }
+          // EPERM means the process exists but we can't signal it — alive.
+        }
+      }
+    }
+  } catch (err) {
+    if (err instanceof ResumePaneVanishedError) {
+      recordAuditEvent('worker', agent.id, 'worker.resume.skipped', getActor(), {
+        worker_id: agent.id,
+        agent_role: agent.role ?? agent.id,
+        team: agent.team,
+        pane_id: paneId,
+        pid: resumedPid,
+        reason: err.reason,
+        error: err.message,
+      }).catch(() => {});
+      throw err;
+    }
+    throw err;
+  }
+
   recordAuditEvent('worker', agent.id, 'resumed', getActor(), {
     claudeSessionId: params.resume,
     team: agent.team,
+  }).catch(() => {});
+  recordAuditEvent('worker', agent.id, 'worker.resume.completed', getActor(), {
+    worker_id: agent.id,
+    agent_role: agent.role ?? agent.id,
+    team: agent.team,
+    pane_id: paneId,
+    pid: resumedPid,
+    claude_session_id: params.resume,
   }).catch(() => {});
   recordManualResumeTelemetry(shouldEmitTelemetry, 'agent.resume.succeeded', {
     entity_id: agent.id,
@@ -3705,6 +3797,30 @@ async function resumeAgent(agent: registry.Agent, opts: { resetAttempts?: boolea
   });
 
   logResumeSuccess(agent, params.resume, paneId, teamWindow);
+}
+
+/**
+ * Error raised by `resumeAgent` when the resumed tmux pane has vanished
+ * immediately after `createResumeTmuxPaneOrExit` returned. Mirrors
+ * SpawnPaneVanishedError (added separately by #1601) but for the resume code
+ * path — handled by resolveTeamAndResume by clearing the stale executor and
+ * falling through to fresh spawn.
+ */
+export class ResumePaneVanishedError extends Error {
+  readonly agentId: string;
+  readonly paneId: string;
+  readonly expectedPid: number | null;
+  readonly reason: 'pane_not_in_list' | 'pid_dead';
+  constructor(agentId: string, paneId: string, expectedPid: number | null, reason: ResumePaneVanishedError['reason']) {
+    super(
+      `Resumed pane "${paneId}" (pid=${expectedPid ?? 'unknown'}) for agent "${agentId}" vanished immediately after createTmuxPane returned. Reason: ${reason}. The launched resume script likely failed to exec the worker binary.`,
+    );
+    this.name = 'ResumePaneVanishedError';
+    this.agentId = agentId;
+    this.paneId = paneId;
+    this.expectedPid = expectedPid;
+    this.reason = reason;
+  }
 }
 
 type WorkerStatus = {

--- a/src/term-commands/dispatch.test.ts
+++ b/src/term-commands/dispatch.test.ts
@@ -1107,6 +1107,69 @@ describe('#1589 phantom-dispatch regression guards', () => {
     });
   });
 
+  describe('Round 4 — auto-resume validates resumed pane is alive', () => {
+    let agentsSrcR4: string;
+    beforeAll(async () => {
+      const { readFileSync } = await import('node:fs');
+      agentsSrcR4 = readFileSync(join(__dirname, 'agents.ts'), 'utf-8');
+    });
+
+    it('ResumePaneVanishedError class is exported with reason taxonomy', () => {
+      // Resume short-circuit (felipe Round 3 brief): handleWorkerSpawn returns
+      // early on `if (resumed) return resumed;` after resumeAgent succeeds at
+      // tmux pane creation but before the actual worker process exists. The
+      // typed error lets the caller fall through to fresh spawn instead of
+      // returning a phantom paneId.
+      expect(agentsSrcR4).toContain('export class ResumePaneVanishedError');
+      const classAnchor = agentsSrcR4.indexOf('export class ResumePaneVanishedError');
+      const classEnd = agentsSrcR4.indexOf('\n}\n', classAnchor);
+      const body = agentsSrcR4.slice(classAnchor, classEnd);
+      expect(body).toContain('readonly agentId');
+      expect(body).toContain('readonly paneId');
+      expect(body).toContain('readonly expectedPid');
+      expect(body).toContain('readonly reason');
+      expect(body).toContain("'pane_not_in_list'");
+      expect(body).toContain("'pid_dead'");
+    });
+
+    it('resumeAgent emits worker.resume.attempted / .completed / .skipped audit events', () => {
+      const fnAnchor = agentsSrcR4.indexOf('async function resumeAgent');
+      expect(fnAnchor).toBeGreaterThan(-1);
+      // resumeAgent is followed by `export class ResumePaneVanishedError`.
+      const fnEnd = agentsSrcR4.indexOf('\nexport class ResumePaneVanishedError', fnAnchor);
+      const body = agentsSrcR4.slice(fnAnchor, fnEnd !== -1 ? fnEnd : agentsSrcR4.length);
+      expect(body).toContain("'worker.resume.attempted'");
+      expect(body).toContain("'worker.resume.completed'");
+      expect(body).toContain("'worker.resume.skipped'");
+      // Validation must check both pane existence AND PID liveness.
+      expect(body).toContain("list-panes -a -F '#{pane_id}'");
+      expect(body).toContain('process.kill(resumedPid, 0)');
+      // Throw the typed error so resolveTeamAndResume can catch + fall through.
+      expect(body).toContain('throw new ResumePaneVanishedError');
+    });
+
+    it('resolveTeamAndResume catches ResumePaneVanishedError and falls through to fresh spawn', () => {
+      const fnAnchor = agentsSrcR4.indexOf('async function resolveTeamAndResume');
+      expect(fnAnchor).toBeGreaterThan(-1);
+      const fnEnd = agentsSrcR4.indexOf('\nasync function ', fnAnchor + 1);
+      const body = agentsSrcR4.slice(fnAnchor, fnEnd !== -1 ? fnEnd : agentsSrcR4.length);
+      // Try/catch around resumeAgent invocation.
+      expect(body).toContain('try {');
+      expect(body).toContain('await resumeAgent(deadResumable)');
+      // Catches the typed error specifically — not a generic catch.
+      expect(body).toContain('err instanceof ResumePaneVanishedError');
+      // Clears the stale executor so the next dispatch doesn't loop.
+      expect(body).toContain("updateExecutorState(executor.id, 'terminated')");
+      // Falls through by returning without `resumed` key. Verify the function
+      // body has a `return { team, teamWasExplicit };` (without `resumed`)
+      // somewhere inside the catch path.
+      const catchIdx = body.indexOf('err instanceof ResumePaneVanishedError');
+      const tailEnd = Math.min(body.length, catchIdx + 800);
+      const catchBlock = body.slice(catchIdx, tailEnd);
+      expect(catchBlock).toContain('return { team, teamWasExplicit };');
+    });
+  });
+
   describe('Group 3 — wish-status display correlation', () => {
     it('state.ts printWishExecutors filters out executors whose assignment is for a different wish', () => {
       const fnAnchor = stateSrc.indexOf('async function printWishExecutors');


### PR DESCRIPTION
## Summary

Round 4 of the #1589/#1600 phantom-dispatch saga. Felipe identified in parallel with #1602 (process.exit-kills-siblings) that there's ALSO a silent-fail surface in the auto-resume path:

`handleWorkerSpawn` calls `resolveTeamAndResume` which calls `findDeadResumable` to locate a stale dead row matching the requested role+team. If found, it calls `resumeAgent(deadResumable)` and returns the agent id as `resumed`. The caller then short-circuits at `if (resumed) return resumed;` (agents.ts:2356).

**Failure mode:** `resumeAgent` calls `createResumeTmuxPaneOrExit` which calls `createTmuxPane`. tmux split-window returns a paneId atomically, but the script invoked inside that pane (the resume command) can fail to exec — the pane closes immediately. The rest of `resumeAgent` operates on a ghost, `recordAuditEvent('resumed')` fires, the caller short-circuits, and **no actual worker exists**.

This is the same failure mode as #1601's `validateSpawnedPane` but on the OTHER spawn path (`createResumeTmuxPaneOrExit`) that wasn't instrumented yet.

## Felipe's empirical evidence (.25)

- `wish.dispatch.work` event DOES fire
- Context file written 16.5KB
- Wish state moves to `in_progress` with `engineer` assignee
- BUT no `worker.spawn` / `worker.spawn.ok` / `worker.spawn.failed` events
- No new spawn-script in `~/.genie/spawn-scripts/`
- No claude or engineer process at OS level
- `genie agent show engineer` reveals dead canonical row, no active executor
- Stale dead row `3a06b9d5` (team=genie, status=offline since 18:41) being matched by `findDeadResumable` and returned as resumable

## Fix

### 1. Post-resume validation (`agents.ts`)

After `createTmuxPane` returns `paneId` in `resumeAgent`:
- Capture pane PID via `tmux display -p '#{pane_pid}'`
- Verify pane is in `tmux list-panes -a -F '#{pane_id}'`
- Verify PID is alive (`process.kill(pid, 0)` — ESRCH = dead)

Throws `ResumePaneVanishedError` (typed, mirrors `SpawnPaneVanishedError` from #1601) with `reason: 'pane_not_in_list' | 'pid_dead'` if either check fails.

### 2. Resume observability — three new audit events

- `worker.resume.attempted` — before validation, payload: `worker_id`, `agent_role`, `team`, `claude_session_id`, `pane_id`
- `worker.resume.completed` — after validation passes, payload: same + `pid`
- `worker.resume.skipped` — on validation failure, payload: same + `reason`, `error`

`genie events list --type worker.resume.skipped --since 5m` is now the operator's first-line query for stale-row debugging.

### 3. Fall-through to fresh spawn (`resolveTeamAndResume`)

Wraps `resumeAgent` in try/catch; on `ResumePaneVanishedError`:
- Logs warning to stderr
- Marks the stale executor as `terminated` (so next dispatch doesn't loop on the same dead row)
- Returns without `resumed` so `handleWorkerSpawn` proceeds with a fresh spawn

## Test plan

- [x] `bun test src/term-commands/dispatch.test.ts` — **88 pass** / 0 fail (was 85 + **3 new** Round 4 regression-guards covering error class shape, all 3 resume events, validation primitives, and the catch+fall-through).
- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — 0 errors, 18 warnings (pre-existing only; complexity warnings on the modified functions absorbed via biome-ignore matching existing pattern in this file).
- [ ] **Empirical post-merge:** dog-fooder runs `genie work tui-bottom-bar-opentui` on next baseline. Expected: either `worker.resume.skipped` fires (the stale row was hit, fall-through works), `worker.spawn.ok` fires (fresh spawn succeeded), or `worker.spawn.failed` fires (fresh spawn failed loudly with structured reason).

## Files

```
src/term-commands/agents.ts        +103 -1   (validation in resumeAgent, ResumePaneVanishedError,
                                              try/catch in resolveTeamAndResume, 2× biome-ignore)
src/term-commands/dispatch.test.ts +60       (3 new regression-guard tests)
```

## Saga (now 4 PRs)

- **#1599** (closed #1589): cwd plumbing + observability + display filter
- **#1601** (closed #1600): post-spawn validation + audit event taxonomy on the FRESH-spawn path
- **#1602** (this saga's "process.exit" root cause): runWorkDispatch must throw not exit — preserves sibling spawns
- **This PR (Round 4)**: post-resume validation + audit events on the AUTO-RESUME path — closes the parallel root cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)
