### PR TITLE
docs(wishes): add Genie observability roadmap

### DIFF
--- a/.genie/wishes/agent-observability-snapshot/WISH.md
+++ b/.genie/wishes/agent-observability-snapshot/WISH.md
@@ -1,0 +1,208 @@
+# Wish: Agent Observability Snapshot
+
+| Field | Value |
+|-------|-------|
+| **Status** | DRAFT |
+| **Slug** | `agent-observability-snapshot` |
+| **Date** | 2026-05-01 |
+| **Author** | felipe + Codex |
+| **Appetite** | large |
+| **Branch** | `wish/agent-observability-snapshot` |
+| **Repos touched** | `genie`, `packages/genie-app` |
+| **Design** | Direct wish from live DB investigation |
+
+## Summary
+
+Create one canonical agent observability surface that every CLI, TUI, and app view can trust. Today each surface rebuilds partial truth from `agents`, `executors`, `sessions`, `audit_events`, `tool_events`, and `genie_runtime_events`, which makes bugs invisible or misleading. This wish creates a shared SQL/query layer plus user-facing commands for "what is this agent doing, what is slow, what failed, and what data backs that answer?"
+
+**depends-on:** fix-agent-session-linkage, observability-signal-normalization
+
+**blocks:** `genie-command-telemetry-boundary`
+
+## Scope
+
+### IN
+
+- Canonical SQL view or query module for per-agent observability.
+- `genie agent observe <name>` command with machine-readable JSON option.
+- `genie observe agents` fleet summary.
+- App/TUI/status wiring to the same query layer.
+- Derived health signals for stale executor, missing session, missing attribution, high hook latency, recent failure, and cost/token usage.
+- Clear separation of agent rows from harness/system rows in the output.
+
+### OUT
+
+- Mutating repair commands already owned by `fix-agent-session-linkage`.
+- New event ingestion pipelines.
+- Full dashboard redesign.
+- Long-term retention policy.
+- Replacing existing `genie log` transcript behavior.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | One query layer powers all surfaces | Avoids CLI, TUI, and app each encoding different truth. |
+| 2 | Use derived health flags, not just raw states | Operators need "why this is weird" without hand-joining six tables. |
+| 3 | JSON output is required | Agents and scripts need the same observability surface humans use. |
+| 4 | Keep repair out of observe commands | Observability should explain first; mutation stays explicit. |
+
+## Success Criteria
+
+- [ ] `genie agent observe <name>` shows identity, current executor, session, tmux/pid liveness, recent events, recent tools, cost, and health flags.
+- [ ] `genie observe agents --json` returns stable machine-readable records.
+- [ ] App, TUI, and `genie status` use the shared query layer for agent work state.
+- [ ] A stale/spawning executor with live pane is flagged distinctly from a missing pane.
+- [ ] Harness/system activity is not mixed into agent activity unless explicitly requested.
+- [ ] Query performance is acceptable on the richer `felipe` DB.
+
+## Execution Strategy
+
+### Wave 1 (sequential)
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 1 | engineer | Build canonical query/view and fixture tests |
+| 2 | engineer | Add CLI observe commands |
+| 3 | engineer | Wire status, TUI, and app to shared query layer |
+| 4 | qa | Validate against local and `felipe` DBs |
+
+## Execution Groups
+
+### Group 1: Canonical Query Layer
+
+**Goal:** Provide one tested source of truth for agent observability.
+
+**Deliverables:**
+1. `v_agent_observability` SQL view or TypeScript query module.
+2. Joins across `agents`, `executors`, `sessions`, `tool_events`, normalized usage view, and latest runtime/audit events.
+3. Fallback link from `executors.claude_session_id` to `sessions.id` for compatibility.
+4. Derived health flags and timestamps.
+5. Query performance test on fixture data approximating the remote DB scale.
+
+**Acceptance Criteria:**
+- [ ] One row per visible agent by default.
+- [ ] Current executor and session are resolved correctly.
+- [ ] Missing linkage and attribution flags are explicit.
+- [ ] Query includes agent-vs-harness classification.
+
+**Validation:**
+```bash
+bun test src/lib/agent-observability.test.ts
+genie --no-tui db query "select count(*) from v_agent_observability"
+```
+
+**depends-on:** none
+
+---
+
+### Group 2: CLI Observability Commands
+
+**Goal:** Give operators and agents a direct way to inspect agent state.
+
+**Deliverables:**
+1. `genie agent observe <name> [--json]`.
+2. `genie observe agents [--json] [--include-harness]`.
+3. Output sections for lifecycle, session, recent events, recent tools, usage, and health flags.
+4. Exit codes: `0` healthy, `1` degraded, `2` not found or blocked by missing dependencies.
+
+**Acceptance Criteria:**
+- [ ] Human output is concise and actionable.
+- [ ] JSON output is stable and documented.
+- [ ] Degraded agents produce non-zero exit when requested with `--strict`.
+
+**Validation:**
+```bash
+genie --no-tui agent observe genie --json
+genie --no-tui observe agents --json
+```
+
+**depends-on:** Group 1
+
+---
+
+### Group 3: Surface Wiring
+
+**Goal:** Remove duplicate partial joins from status, TUI, and app backend.
+
+**Deliverables:**
+1. `genie status` reads health/work-state from shared query layer.
+2. TUI agent badges read the same work-state fields.
+3. App agent detail and session list use the shared query layer where applicable.
+4. Snapshot output includes "source of truth" version for debugging.
+
+**Acceptance Criteria:**
+- [ ] CLI, TUI, and app agree on current executor/session for the same agent.
+- [ ] No read path emits lifecycle audit events.
+- [ ] Existing app routes keep backward-compatible response fields where needed.
+
+**Validation:**
+```bash
+bun test src/tui packages/genie-app
+genie --no-tui status --json
+```
+
+**depends-on:** Group 2
+
+---
+
+### Group 4: Cross-Instance QA
+
+**Goal:** Validate the unified surface on both development and daily-use data.
+
+**Deliverables:**
+1. Local QA transcript.
+2. `ssh felipe` QA transcript.
+3. Performance notes for query latency on 1.8k sessions and 70k tool events.
+
+**Acceptance Criteria:**
+- [ ] Remote `genie observe agents --json` completes quickly.
+- [ ] Known broken cases appear as degraded with specific health flags.
+- [ ] App and CLI show matching current executor/session state.
+
+**Validation:**
+```bash
+ssh felipe 'export PATH=/home/genie/.bun/bin:/home/genie/.local/share/fnm/node-versions/v24.14.1/installation/bin:$PATH; cd /home/genie/workspace/repos/genie && genie --no-tui observe agents --json'
+```
+
+**depends-on:** Group 3
+
+---
+
+## QA Criteria
+
+- [ ] Agent detail view is explainable from one query result.
+- [ ] Missing data appears as a diagnostic flag, not silent blank UI.
+- [ ] JSON output can be consumed by future agents.
+- [ ] Runtime and audit events are visibly separated.
+
+---
+
+## Assumptions / Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| View becomes too expensive as data grows | Medium | Keep heavy aggregates bounded by recent windows and indexes. |
+| Existing app consumers expect old fields | Medium | Preserve compatibility shape while changing source query. |
+| Harness/system rows need more taxonomy first | Low | Include provisional classification and refine in dependent wish. |
+
+---
+
+## Review Results
+
+_Populated by `/review` after execution completes._
+
+---
+
+## Files to Create/Modify
+
+```text
+src/lib/agent-observability.ts
+src/term-commands/agent.ts
+src/term-commands/observe.ts
+src/term-commands/status.ts
+src/tui/db.ts
+packages/genie-app/src-backend/index.ts
+packages/genie-app/src-backend/pg-bridge.ts
+src/db/migrations/*_agent_observability_view.sql
+```

--- a/.genie/wishes/complexity-budget-simplification/WISH.md
+++ b/.genie/wishes/complexity-budget-simplification/WISH.md
@@ -1,0 +1,235 @@
+# Wish: Complexity Budget Simplification
+
+| Field | Value |
+|-------|-------|
+| **Status** | DRAFT |
+| **Slug** | `complexity-budget-simplification` |
+| **Date** | 2026-05-01 |
+| **Author** | Codex |
+| **Appetite** | medium |
+| **Branch** | `wish/complexity-budget-simplification` |
+| **Repos touched** | `genie` |
+| **Design** | _No brainstorm - direct wish_ (origin: 2026-05-01 council discussion on Biome cognitive complexity) |
+
+## Summary
+
+Recalibrate Genie's Biome cognitive-complexity budget so linear command/orchestration code can stay readable instead of being split purely to satisfy the default score of 15. Raise the product-code budget to 25, preserve visibility for true hotspots above 25, and add a lightweight drift check so the rule remains useful instead of becoming forgotten lint noise.
+
+The goal is not to make complex code acceptable everywhere. The goal is to remove artificial fragmentation in the 16-25 range while keeping high-risk workflows visible for review and follow-up architecture work.
+
+## Scope
+
+### IN
+
+- Configure `lint/complexity/noExcessiveCognitiveComplexity` for `src/**` and `packages/**` with `maxAllowedComplexity: 25` at warning level.
+- Keep scripts/plugins exemptions as-is unless baseline evidence shows a specific reason to change them.
+- Create a complexity budget baseline/report that records current warning count, max score, and explicit complexity suppression count.
+- Add a small drift check script and package script that reports complexity warnings and fails only when the agreed budget regresses.
+- Remove obsolete complexity suppressions and comments that exist only because the old threshold was 15, when Biome marks them unused under the new threshold.
+- Document the policy: complexity >25 is a review trigger; complexity 16-25 is acceptable when the flow is linear and tested.
+
+### OUT
+
+- No broad refactor of `agents.ts`, `scheduler-daemon.ts`, `omni-bridge.ts`, or executor internals.
+- No disabling of `noExcessiveCognitiveComplexity`.
+- No hard CI failure on every existing complexity warning unless it exceeds the new ratcheted baseline.
+- No architectural rewrite of the four current >25 hotspots in this wish.
+- No changes to Biome rules unrelated to cognitive complexity, except removing an unused suppression if it blocks clean validation.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | Raise product-code cognitive complexity max from 15 to 25 | Current warnings at 16-23 mostly reflect linear CLI/orchestration branches where splitting can increase indirection. A budget of 25 suppresses low-value churn while still exposing functions scored 29, 36, 37, and 42. |
+| 2 | Keep the rule at `warn`, not `error`, for now | The rule is a maintainability signal, not a release gate. Making it an error before the baseline is stable would create mechanical refactor pressure. |
+| 3 | Preserve high-hotspot visibility above 25 | The current >25 functions are real review targets: `checkPrerequisites`, `dbLsCommand`, `dbMigrateV1Command`, and `trustAction`. Raising the threshold should not hide them. |
+| 4 | Add a drift check instead of relying on human memory | The repo already has discipline scripts. A small budget script keeps the new policy measurable without making every Biome warning a blocker. |
+| 5 | Delete obsolete suppressions before deleting helpers | Suppression cleanup is low-risk and measurable. Inlining helpers should happen only where tests prove behavior is unchanged and LOC/readability actually improve. |
+
+## Success Criteria
+
+- [ ] `biome.json` sets `noExcessiveCognitiveComplexity` to warning level with `maxAllowedComplexity: 25` for `src/**` and `packages/**`.
+- [ ] Baseline report exists at `.genie/wishes/complexity-budget-simplification/complexity-baseline.md`.
+- [ ] Complexity warnings under the new budget are limited to scores above 25, with a documented expected count.
+- [ ] A package script exists to run the complexity budget drift check.
+- [ ] Obsolete complexity suppressions created by the threshold raise are removed or explicitly justified.
+- [ ] `bun run lint`, `bun run typecheck`, and the new complexity budget script pass.
+- [ ] Documentation explains when to prefer linear code over helper extraction and when complexity >25 requires a follow-up design/refactor.
+
+## Execution Strategy
+
+### Wave 1 (sequential)
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 1 | engineer | Capture baseline and update Biome complexity budget to 25 |
+| 2 | engineer | Add complexity drift check and package script |
+| 3 | engineer | Remove obsolete suppressions/comments exposed by the new threshold |
+| 4 | engineer | Document policy and hotspot follow-ups |
+| review | reviewer | Review the wish results against budget, behavior, and DX criteria |
+
+## Execution Groups
+
+### Group 1: Baseline and Budget Calibration
+
+**Goal:** Prove the new threshold preserves signal before changing the rule.
+
+**Deliverables:**
+1. `.genie/wishes/complexity-budget-simplification/complexity-baseline.md` with:
+   - current Biome wall time
+   - current complexity warning count at max 15
+   - projected retained warning count above max 25
+   - explicit complexity suppression count
+   - list of retained >25 hotspots
+2. `biome.json` updated so `src/**` and `packages/**` use:
+   - `level: "warn"`
+   - `options.maxAllowedComplexity: 25`
+
+**Acceptance Criteria:**
+- [ ] Baseline report records the observed starting point: 12 unsuppressed complexity warnings and 16 explicit complexity suppressions.
+- [ ] Baseline report lists the retained >25 functions and their scores.
+- [ ] `biome.json` remains valid against Biome 1.9.4.
+- [ ] `bunx biome check . --reporter=summary` still completes successfully.
+
+**Validation:**
+```bash
+bunx biome check . --reporter=summary
+bunx biome check . --diagnostic-level=warn --max-diagnostics=none
+test -f .genie/wishes/complexity-budget-simplification/complexity-baseline.md
+```
+
+**depends-on:** none
+
+---
+
+### Group 2: Complexity Budget Drift Check
+
+**Goal:** Make the new policy measurable without turning all complexity warnings into a hard gate.
+
+**Deliverables:**
+1. `scripts/complexity-budget.ts` that runs or parses Biome diagnostics and reports:
+   - cognitive-complexity warning count
+   - max observed score
+   - number of explicit `biome-ignore lint/complexity/noExcessiveCognitiveComplexity` suppressions
+   - retained hotspot list
+2. `package.json` script, e.g. `lint:complexity-budget`.
+3. Budget constants aligned to Group 1 baseline.
+
+**Acceptance Criteria:**
+- [ ] The script exits 0 when the current baseline is not worse.
+- [ ] The script exits non-zero if warning count, max score, or suppression count exceeds the ratcheted budget.
+- [ ] The script prints actionable file/function lines, not only counts.
+- [ ] The script does not require a running database, tmux session, TUI, or network access.
+
+**Validation:**
+```bash
+bun run lint:complexity-budget
+bun run typecheck
+```
+
+**depends-on:** Group 1
+
+---
+
+### Group 3: Obsolete Suppression Cleanup
+
+**Goal:** Reduce lint-era clutter that becomes unnecessary once the budget is 25.
+
+**Deliverables:**
+1. Remove unused `biome-ignore lint/complexity/noExcessiveCognitiveComplexity` comments surfaced by Biome after the threshold increase.
+2. Remove stale comments that say code was extracted only to stay under the old complexity cap, when the helper/comment no longer explains a real boundary.
+3. Optional: inline one low-risk helper only if all of these are true:
+   - it was introduced solely for the old complexity budget
+   - the resulting function remains at or below 25
+   - nearby tests already cover the behavior
+   - net LOC decreases
+
+**Acceptance Criteria:**
+- [ ] Biome reports no unused complexity suppressions.
+- [ ] Any remaining complexity suppression explains why extraction would hurt clarity or safety.
+- [ ] Any optional inline cleanup has before/after LOC recorded in the baseline report or a short note in the wish directory.
+- [ ] No behavior-oriented test snapshots are changed without a specific rationale.
+
+**Validation:**
+```bash
+bunx biome check . --diagnostic-level=warn --max-diagnostics=none
+bun test
+```
+
+**depends-on:** Group 1
+
+---
+
+### Group 4: Policy and Hotspot Follow-Up
+
+**Goal:** Turn the new budget into a durable engineering convention.
+
+**Deliverables:**
+1. Update `CLAUDE.md` with a short complexity-budget policy:
+   - prefer linear code when it reads as one workflow
+   - split when there is a real policy, IO, state-machine, or presentation boundary
+   - suppress only with a concrete reason
+   - treat >25 as review-triggering architecture debt
+2. `.genie/wishes/complexity-budget-simplification/hotspots.md` with verdicts for the retained >25 functions:
+   - leave as linear for now
+   - simple local refactor candidate
+   - needs a separate architecture wish
+
+**Acceptance Criteria:**
+- [ ] `CLAUDE.md` documents the budget and review expectations in 15 lines or fewer.
+- [ ] `hotspots.md` has one row per retained >25 function.
+- [ ] Every retained >25 hotspot has a named follow-up decision.
+- [ ] No large refactor is performed inside this policy group.
+
+**Validation:**
+```bash
+rg -n "complexity budget|cognitive complexity|maxAllowedComplexity" CLAUDE.md biome.json .genie/wishes/complexity-budget-simplification
+bun run lint:complexity-budget
+```
+
+**depends-on:** Group 2
+
+---
+
+## QA Criteria
+
+_Verified on dev after merge._
+
+- [ ] `bun run lint` passes with the new Biome rule shape.
+- [ ] `bun run typecheck` passes.
+- [ ] `bun run lint:complexity-budget` passes and prints counts.
+- [ ] Complexity warnings below or equal to 25 do not force helper extraction.
+- [ ] Complexity warnings above 25 are still visible in the budget report.
+- [ ] Existing command behavior is unchanged for any file touched outside config/docs/scripts.
+
+---
+
+## Assumptions / Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Raising the threshold hides a genuinely tangled 20-25 function | Medium | Keep threshold at warning level, add drift script output, and require review judgment for changed functions near the budget. |
+| The budget script becomes another brittle lint tool | Medium | Keep it read-only, dependency-light, and scoped to one rule. It should report clear file/function lines. |
+| Cleanup inlines helpers that were serving real boundaries | Medium | Optional inline cleanup must show net LOC decrease, stay <=25, and pass nearby tests. Otherwise only remove obsolete suppressions/comments. |
+| Future contributors treat 25 as permission to write dense code | Medium | Document that 25 is a ceiling for linear workflows, not a target. >25 remains architecture debt. |
+| Biome output format changes | Low | Pin parsing to Biome 1.9.4 behavior already used by the repo; fall back to summary counts if detailed parsing fails. |
+
+---
+
+## Review Results
+
+_Populated by `/review` after execution completes._
+
+---
+
+## Files to Create/Modify
+
+```
+MODIFY  biome.json
+MODIFY  package.json
+MODIFY  CLAUDE.md
+CREATE  scripts/complexity-budget.ts
+CREATE  .genie/wishes/complexity-budget-simplification/complexity-baseline.md
+CREATE  .genie/wishes/complexity-budget-simplification/hotspots.md
+MODIFY  source files only if Group 3 finds obsolete complexity suppressions/comments
+```

--- a/.genie/wishes/fix-agent-session-linkage/WISH.md
+++ b/.genie/wishes/fix-agent-session-linkage/WISH.md
@@ -1,0 +1,207 @@
+# Wish: Fix Agent Session Linkage
+
+| Field | Value |
+|-------|-------|
+| **Status** | DRAFT |
+| **Slug** | `fix-agent-session-linkage` |
+| **Date** | 2026-05-01 |
+| **Author** | felipe + Codex |
+| **Appetite** | medium |
+| **Branch** | `wish/fix-agent-session-linkage` |
+| **Repos touched** | `genie` |
+| **Design** | Direct wish from live DB investigation |
+
+## Summary
+
+Fix the agent observability bug where executor-owned Claude sessions are left as orphaned session rows. Live DB checks show this is not cosmetic: the everyday `felipe` instance has `1854` sessions, `1852` with no `executor_id`, and current executor `claude_session_id` values that match session rows still marked `orphaned`. This breaks agent views, tool attribution, cost joins, replay ownership, and any future unified observability surface.
+
+**depends-on:** none
+
+**blocks:** observability-signal-normalization, agent-observability-snapshot, genie-command-telemetry-boundary
+
+## Scope
+
+### IN
+
+- Fix session ingestion so existing orphan session rows are updated when executor context becomes known.
+- Backfill `sessions.executor_id`, `sessions.agent_id`, `team`, `role`, `wish_slug`, and `task_id` from `executors.claude_session_id` and agent metadata.
+- Backfill `tool_events.agent_id`, `team`, `wish_slug`, and `task_id` from linked sessions.
+- Stop writing empty strings for nullable observability fields during ingestion.
+- Add dry-run and apply commands for production-safe repair.
+- Add regression tests that reproduce "executor session exists but row remains orphaned".
+
+### OUT
+
+- New dashboards or app UI.
+- New event taxonomy.
+- Full executor state-machine redesign.
+- Historical content redaction or deletion.
+- Changes to Omni bridge ownership beyond preserving correct executor/session links.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | Treat this as a P0 data linkage bug | The rows already exist and are matchable; leaving them orphaned makes every higher-level view wrong. |
+| 2 | Repair linkable orphan rows by `sessions.id = executors.claude_session_id` | This is the strongest existing identity relationship and works on both sampled DBs. |
+| 3 | Use dry-run before apply | The richer daily-use DB has 1800+ affected sessions; operators need a preview before mutation. |
+| 4 | Normalize missing observability fields to SQL `NULL` | Empty strings hide missing attribution from partial indexes and ordinary `IS NULL` diagnostics. |
+
+## Success Criteria
+
+- [ ] Linkable executor sessions no longer remain `orphaned` with null `executor_id`.
+- [ ] New ingestion updates existing orphan rows when worker context appears later.
+- [ ] Tool events inherit agent/team/wish/task attribution from linked sessions.
+- [ ] Empty-string attribution fields are no longer inserted for new rows.
+- [ ] Repair command supports `--dry-run` and `--apply`.
+- [ ] Regression tests cover tmux JSONL ingestion and SDK session capture.
+
+## Execution Strategy
+
+### Wave 1 (sequential)
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 1 | engineer | Diagnose and codify the broken linkage as tests and dry-run SQL |
+| 2 | engineer | Fix ingestion and SDK capture upsert semantics |
+| 3 | engineer | Add repair/backfill command with dry-run/apply |
+| 4 | reviewer | Verify local and remote DB health queries after repair |
+
+## Execution Groups
+
+### Group 1: Repro and Diagnostics
+
+**Goal:** Make the bug measurable and reproducible before changing behavior.
+
+**Deliverables:**
+1. Test fixture with an executor whose `claude_session_id` matches an existing orphan session.
+2. Diagnostic query helper that reports linkable orphan sessions, missing tool attribution, and empty-string fields.
+3. Documentation of current local and `felipe` remote baseline counts in the wish report.
+
+**Acceptance Criteria:**
+- [ ] Test fails on current code because the session remains orphaned.
+- [ ] Diagnostic query reports affected counts without mutating data.
+- [ ] Baseline includes local and remote `genie db query` evidence.
+
+**Validation:**
+```bash
+bun test src/lib/session-capture.test.ts src/services/executors/__tests__/sdk-session-capture.test.ts
+genie --no-tui db query "select count(*) from sessions s join executors e on s.id = e.claude_session_id where s.executor_id is null"
+```
+
+**depends-on:** none
+
+---
+
+### Group 2: Ingestion Fix
+
+**Goal:** Ensure new and incrementally ingested sessions preserve executor and agent ownership.
+
+**Deliverables:**
+1. Update `session-capture.ts` so existing orphan sessions are upgraded when `workerMap` has context.
+2. Update SDK session start to use `ON CONFLICT DO UPDATE` for missing linkage fields.
+3. Insert nullable observability fields as `NULL`, not empty strings.
+4. Preserve explicit non-null existing values and avoid overwriting better context with null.
+
+**Acceptance Criteria:**
+- [ ] Existing orphan session becomes linked after ingestion sees matching executor context.
+- [ ] SDK session conflict path fills missing `executor_id` and `agent_id`.
+- [ ] New tool events store null for missing optional fields.
+- [ ] Existing linked session context is not downgraded.
+
+**Validation:**
+```bash
+bun test src/lib/session-capture.test.ts src/services/executors/__tests__/sdk-session-capture.test.ts
+bun run typecheck
+```
+
+**depends-on:** Group 1
+
+---
+
+### Group 3: Repair Command
+
+**Goal:** Safely repair existing Genie Postgres data.
+
+**Deliverables:**
+1. `genie sessions repair-links --dry-run` prints candidate sessions and tool event counts.
+2. `genie sessions repair-links --apply` updates `sessions` and `tool_events` in one transaction.
+3. Audit event records repair totals without storing raw session content.
+4. Command refuses apply if candidate count changed between preview and apply unless `--force` is passed.
+
+**Acceptance Criteria:**
+- [ ] Dry-run mutates zero rows.
+- [ ] Apply links sessions by `executors.claude_session_id`.
+- [ ] Apply backfills tool event attribution from linked sessions.
+- [ ] Command is idempotent.
+
+**Validation:**
+```bash
+genie --no-tui sessions repair-links --dry-run
+genie --no-tui sessions repair-links --apply
+genie --no-tui db query "select count(*) from sessions s join executors e on s.id = e.claude_session_id where s.executor_id is null"
+```
+
+**depends-on:** Group 2
+
+---
+
+### Group 4: Cross-Instance Verification
+
+**Goal:** Prove the bug is fixed on both a local dev DB and the richer `felipe` instance.
+
+**Deliverables:**
+1. Before/after query transcript for local DB.
+2. Before/after query transcript for `ssh felipe` DB.
+3. Short report at `.genie/wishes/fix-agent-session-linkage/REPORT.md`.
+
+**Acceptance Criteria:**
+- [ ] Linkable orphan session count is zero after apply on test DB.
+- [ ] Tool events with missing attribution decrease for sessions that are now linkable.
+- [ ] No unrelated session content rows are modified.
+
+**Validation:**
+```bash
+ssh felipe 'export PATH=/home/genie/.bun/bin:/home/genie/.local/share/fnm/node-versions/v24.14.1/installation/bin:$PATH; cd /home/genie/workspace/repos/genie && genie --no-tui sessions repair-links --dry-run'
+```
+
+**depends-on:** Group 3
+
+---
+
+## QA Criteria
+
+- [ ] `genie sessions list` shows linked agent/executor ownership for repaired sessions.
+- [ ] `genie log <agent>` can include session/tool history from repaired rows.
+- [ ] Re-running repair is idempotent.
+- [ ] The command is safe on a DB with zero affected rows.
+
+---
+
+## Assumptions / Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Some orphan sessions are genuinely not owned by an executor | Medium | Only repair rows with exact `sessions.id = executors.claude_session_id`. |
+| Tool attribution backfill could overwrite better historical context | Medium | Use `COALESCE(existing, session_context)` and never replace non-empty values. |
+| Remote DB has stale executors pointing at reused session IDs | Low | Dry-run reports duplicate matches and refuses apply on ambiguity. |
+
+---
+
+## Review Results
+
+_Populated by `/review` after execution completes._
+
+---
+
+## Files to Create/Modify
+
+```text
+src/lib/session-capture.ts
+src/services/executors/sdk-session-capture.ts
+src/term-commands/sessions.ts
+src/lib/session-link-repair.ts
+src/lib/session-capture.test.ts
+src/services/executors/__tests__/sdk-session-capture.test.ts
+.genie/wishes/fix-agent-session-linkage/REPORT.md
+```

--- a/.genie/wishes/genie-command-telemetry-boundary/WISH.md
+++ b/.genie/wishes/genie-command-telemetry-boundary/WISH.md
@@ -1,0 +1,212 @@
+# Wish: Genie Command Telemetry Boundary
+
+| Field | Value |
+|-------|-------|
+| **Status** | DRAFT |
+| **Slug** | `genie-command-telemetry-boundary` |
+| **Date** | 2026-05-01 |
+| **Author** | felipe + Codex |
+| **Appetite** | large |
+| **Branch** | `wish/genie-command-telemetry-boundary` |
+| **Repos touched** | `genie` |
+| **Design** | Direct wish from live DB investigation |
+
+## Summary
+
+Make Genie faster and easier to operate by wrapping CLI commands with consistent telemetry and separating "agent world" from "harness world". Agents need to know what happened, what is slow, what failed, and whether the problem belongs to an agent session or to Genie infrastructure itself. This wish creates the command instrumentation and taxonomy that turns Genie into an inspectable harness instead of a pile of unrelated event streams.
+
+**depends-on:** agent-observability-snapshot, genie-serve-structured-observability, hookify-perf-foundation
+
+**blocks:** none
+
+## Scope
+
+### IN
+
+- Command wrapper telemetry for every public `genie` CLI command.
+- Standard fields: command, args shape, actor, cwd, duration, exit code, failure class, world, subsystem, trace id, and DB/query counts where available.
+- Taxonomy separating `world = agent` from `world = harness`.
+- Slow/failing command summaries in `genie doctor --perf`, `genie status`, and events queries.
+- Regression tests preventing new commands from bypassing the wrapper.
+- Documentation for when work is "improving agents" vs "improving Genie itself".
+
+### OUT
+
+- Rewriting every command implementation.
+- External APM integration.
+- Full security/RBAC event substrate.
+- UI dashboard redesign.
+- Hook daemon implementation already owned by `hookify-perf-foundation`.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | Command telemetry is a wrapper concern | Every command gets baseline observability without hand-instrumenting each handler. |
+| 2 | Agent world and harness world are first-class fields | The operator question is usually "is the agent stuck, or is Genie broken?" |
+| 3 | Args are shape-summarized, not raw captured | Prevents leaking secrets or long prompts while keeping command behavior diagnosable. |
+| 4 | Slow/fail reporting is CLI-first | Agents and humans both operate from terminal surfaces today. |
+
+## Success Criteria
+
+- [ ] Every public `genie` command emits a bounded command telemetry record.
+- [ ] New commands fail CI if they bypass the wrapper.
+- [ ] `genie status --perf` or equivalent shows slowest and failing command families.
+- [ ] `genie doctor --perf` distinguishes harness failures from agent/session failures.
+- [ ] `genie observe agents` can exclude harness rows by default and include them explicitly.
+- [ ] Command telemetry has no raw secret-shaped arguments.
+
+## Execution Strategy
+
+### Wave 1 (sequential)
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 1 | engineer | Define taxonomy and command telemetry envelope |
+| 2 | engineer | Wrap public CLI command execution |
+| 3 | engineer | Add slow/failure query surfaces |
+| 4 | qa | Validate coverage and performance overhead |
+
+## Execution Groups
+
+### Group 1: Taxonomy and Envelope
+
+**Goal:** Define the minimum durable vocabulary for command and world classification.
+
+**Deliverables:**
+1. `world` enum: `agent`, `harness`, `bridge`, `system`.
+2. `subsystem` enum aligned with existing command namespaces.
+3. Command telemetry schema with redacted argument shape.
+4. Mapping table for existing commands to world/subsystem.
+5. Documentation at `docs/observability/agent-vs-harness.md`.
+
+**Acceptance Criteria:**
+- [ ] Every public command maps to a world and subsystem.
+- [ ] Ambiguous commands document their classification rule.
+- [ ] Redaction tests cover flags, env-shaped strings, and paths.
+
+**Validation:**
+```bash
+bun test src/lib/command-telemetry.test.ts
+test -s docs/observability/agent-vs-harness.md
+```
+
+**depends-on:** none
+
+---
+
+### Group 2: CLI Wrapper Instrumentation
+
+**Goal:** Emit command telemetry consistently without changing command behavior.
+
+**Deliverables:**
+1. Central wrapper around Commander command action execution.
+2. Duration, exit status, thrown error class, cwd, actor, and trace context.
+3. DB query count and elapsed DB time where pgserve client exposes it.
+4. CI lint that detects public commands without telemetry registration.
+5. Low-overhead benchmark.
+
+**Acceptance Criteria:**
+- [ ] All current public commands are covered.
+- [ ] Command telemetry overhead is below 5 ms p99 for no-op commands.
+- [ ] Failed commands emit failure class without raw stack traces by default.
+
+**Validation:**
+```bash
+bun test src/term-commands src/lib/command-telemetry.test.ts
+bun run check
+```
+
+**depends-on:** Group 1
+
+---
+
+### Group 3: Slow and Failing Command Surfaces
+
+**Goal:** Make command telemetry useful to humans and agents.
+
+**Deliverables:**
+1. `genie events commands --slow --since <dur>`.
+2. `genie events commands --failures --since <dur>`.
+3. `genie doctor --perf` section for command latency, hook latency, and DB query latency.
+4. `genie status --perf` concise summary.
+5. Query fixtures using the richer remote data scale.
+
+**Acceptance Criteria:**
+- [ ] Slowest command families are visible without raw SQL.
+- [ ] Failure summaries include world/subsystem.
+- [ ] Agent-caused failures and harness-caused failures are separated.
+
+**Validation:**
+```bash
+genie --no-tui events commands --slow --since 24h
+genie --no-tui events commands --failures --since 24h
+genie --no-tui doctor --perf
+```
+
+**depends-on:** Group 2
+
+---
+
+### Group 4: Coverage and Overhead QA
+
+**Goal:** Prove the wrapper is complete, cheap, and safe.
+
+**Deliverables:**
+1. Coverage report listing all commands and telemetry status.
+2. Overhead benchmark report.
+3. Secret probe report for redacted args.
+4. Remote `ssh felipe` smoke run.
+
+**Acceptance Criteria:**
+- [ ] Coverage is 100 percent for public commands.
+- [ ] No secret probe appears in stored telemetry.
+- [ ] Remote smoke run produces readable slow/failure output.
+
+**Validation:**
+```bash
+bun run scripts/check-command-telemetry-coverage.ts
+ssh felipe 'export PATH=/home/genie/.bun/bin:/home/genie/.local/share/fnm/node-versions/v24.14.1/installation/bin:$PATH; cd /home/genie/workspace/repos/genie && genie --no-tui doctor --perf'
+```
+
+**depends-on:** Group 3
+
+---
+
+## QA Criteria
+
+- [ ] A human can answer "agent stuck or Genie slow?" from CLI output.
+- [ ] An agent can consume JSON telemetry without shelling into Postgres directly.
+- [ ] New command additions require explicit telemetry classification.
+- [ ] Command telemetry does not leak raw prompts, tokens, or secrets.
+
+---
+
+## Assumptions / Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Command wrapper changes can subtly alter exit behavior | High | Snapshot tests for exit codes and thrown errors before/after wrapping. |
+| DB timing may not be available everywhere | Medium | Make DB timing optional and record `unknown` instead of failing. |
+| Taxonomy may need iteration | Low | Keep enum small and document ambiguous cases. |
+
+---
+
+## Review Results
+
+_Populated by `/review` after execution completes._
+
+---
+
+## Files to Create/Modify
+
+```text
+src/cli.ts
+src/term-commands/events.ts
+src/term-commands/doctor.ts
+src/term-commands/status.ts
+src/lib/command-telemetry.ts
+src/lib/events/registry.ts
+docs/observability/agent-vs-harness.md
+scripts/check-command-telemetry-coverage.ts
+```

--- a/.genie/wishes/observability-signal-normalization/WISH.md
+++ b/.genie/wishes/observability-signal-normalization/WISH.md
@@ -1,0 +1,206 @@
+# Wish: Observability Signal Normalization
+
+| Field | Value |
+|-------|-------|
+| **Status** | DRAFT |
+| **Slug** | `observability-signal-normalization` |
+| **Date** | 2026-05-01 |
+| **Author** | felipe + Codex |
+| **Appetite** | medium |
+| **Branch** | `wish/observability-signal-normalization` |
+| **Repos touched** | `genie` |
+| **Design** | Direct wish from live DB investigation |
+
+## Summary
+
+Normalize Genie observability so signal is trustworthy before adding more dashboards. The daily-use `felipe` DB shows `242553` `resume.found` audit rows in 24 hours, `32177` `hook.delivery` runtime rows with `agent = unknown`, and OTel cost stored under `details.value` while app queries expect `details.cost_usd`. This wish removes self-noise and fixes metric shape mismatches.
+
+**depends-on:** none
+
+**blocks:** agent-observability-snapshot, genie-command-telemetry-boundary
+
+## Scope
+
+### IN
+
+- Make resume/session lookup read paths pure.
+- Move resume lifecycle events to actual resume attempts and transitions.
+- Normalize Claude usage metrics into one queryable view.
+- Fix app and CLI cost queries to use the normalized view.
+- Pass real agent context into hook spans instead of defaulting to `unknown`.
+- Redact or drop sensitive OTel resource attributes before they enter `audit_events`.
+
+### OUT
+
+- Replacing `audit_events` or `genie_runtime_events`.
+- New UI screens.
+- Full RBAC or WORM audit tier.
+- Hook daemon performance work from `hookify-perf-foundation`.
+- Historical deletion of old noisy rows.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | Reads must not emit lifecycle audit events | Status, TUI, and list commands can run frequently; read amplification poisoned audit signal. |
+| 2 | Usage normalization belongs in SQL first | App, CLI, and diagnostics need the same cost/token interpretation. |
+| 3 | Hook spans must derive agent from payload or executor context | `GENIE_AGENT_NAME` is not reliable enough for all hook invocation paths. |
+| 4 | Redaction happens before insert | Once sensitive user/account attributes are in JSONB, every reader becomes part of the risk surface. |
+
+## Success Criteria
+
+- [ ] `resume.found` no longer grows from `genie ls`, `genie status`, or TUI refresh.
+- [ ] Resume attempts still emit explicit lifecycle events when an actual resume is attempted.
+- [ ] `genie db query` usage view returns non-zero cost for OTel `claude_code.cost.usage`.
+- [ ] App cost summary matches CLI cost summary on the same DB.
+- [ ] New hook delivery rows have meaningful agent context or a clear non-agent harness classification.
+- [ ] New OTel audit rows do not include `user.email`, `user.id`, `user.account_id`, `user.account_uuid`, or `organization.id`.
+
+## Execution Strategy
+
+### Wave 1 (sequential)
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 1 | engineer | Purify resume/session lookup read paths |
+| 2 | engineer | Normalize usage/cost metrics |
+| 3 | engineer | Fix hook context and sensitive OTel resource handling |
+| 4 | reviewer | Verify signal-to-noise on local and `felipe` DBs |
+
+## Execution Groups
+
+### Group 1: Pure Read Paths
+
+**Goal:** Stop read-only commands from writing audit rows.
+
+**Deliverables:**
+1. Split `getResumeSessionId()` into a pure lookup and an eventful resume-attempt helper.
+2. Update `shouldResume()`, `status`, `ls`, and TUI work-state calls to use the pure lookup.
+3. Add regression tests proving repeated status/list calls do not insert audit rows.
+
+**Acceptance Criteria:**
+- [ ] `genie status` repeated 10 times inserts zero `resume.found` rows.
+- [ ] Actual resume attempt still records an explicit event.
+- [ ] Existing state-machine invariant tests are updated to the new ownership boundary.
+
+**Validation:**
+```bash
+bun test src/__tests__/state-machine.invariants.test.ts src/lib/should-resume.test.ts
+genie --no-tui db query "select count(*) from audit_events where event_type = 'resume.found' and created_at > now() - interval '1 minute'"
+```
+
+**depends-on:** none
+
+---
+
+### Group 2: Usage Metric Normalization
+
+**Goal:** Make cost and token reporting correct across app, CLI, and SQL.
+
+**Deliverables:**
+1. SQL view `v_claude_usage_events` that maps OTel metrics and legacy rows into `model`, `cost_usd`, token fields, `agent_id`, `executor_id`, `session_id`, and `created_at`.
+2. App backend cost routes read from the normalized view.
+3. CLI cost summaries read from the same view.
+4. Tests with OTel metric rows using `details.value`.
+
+**Acceptance Criteria:**
+- [ ] `claude_code.cost.usage` with `details.value` contributes to cost totals.
+- [ ] Legacy rows with `details.cost_usd` still work.
+- [ ] App and CLI totals match on the same fixture.
+
+**Validation:**
+```bash
+bun test packages/genie-app src/term-commands/events.test.ts
+genie --no-tui db query "select sum(cost_usd) from v_claude_usage_events"
+```
+
+**depends-on:** Group 1
+
+---
+
+### Group 3: Hook Context and OTel Redaction
+
+**Goal:** Prevent unknown-agent hook spans and sensitive OTel attributes from becoming default data.
+
+**Deliverables:**
+1. Hook span context resolver that checks payload, executor env, session context, and harness fallback in that order.
+2. Classify non-agent hook activity as harness/system instead of `unknown`.
+3. OTel receiver allowlist for resource attributes copied into `details`.
+4. Regression tests for sensitive user/account fields.
+
+**Acceptance Criteria:**
+- [ ] New hook rows do not use `agent = 'unknown'` when payload/session context identifies an agent.
+- [ ] Harness-owned rows are explicitly marked as harness/system.
+- [ ] Sensitive OTel resource keys are absent from inserted rows.
+
+**Validation:**
+```bash
+bun test src/hooks src/lib/otel-receiver.test.ts
+genie --no-tui db query "select count(*) from audit_events where created_at > now() - interval '5 minutes' and (details ? 'user.email' or details ? 'user.account_id')"
+```
+
+**depends-on:** Group 1
+
+---
+
+### Group 4: Signal Verification
+
+**Goal:** Confirm the normalized signals behave on both small and daily-use DBs.
+
+**Deliverables:**
+1. Verification report with before/after counts for `resume.found`, unknown hook rows, usage totals, and sensitive OTel keys.
+2. Remote `ssh felipe` dry-run query transcript.
+3. Short operator note explaining the new metric shapes.
+
+**Acceptance Criteria:**
+- [ ] `resume.found` does not increase from read-only command loops.
+- [ ] Unknown hook rate drops sharply for new rows.
+- [ ] Cost totals are non-zero on the remote DB without special-case app code.
+
+**Validation:**
+```bash
+ssh felipe 'export PATH=/home/genie/.bun/bin:/home/genie/.local/share/fnm/node-versions/v24.14.1/installation/bin:$PATH; cd /home/genie/workspace/repos/genie && genie --no-tui db query "select sum(cost_usd) from v_claude_usage_events"'
+```
+
+**depends-on:** Group 2, Group 3
+
+---
+
+## QA Criteria
+
+- [ ] `genie status`, `genie ls`, and TUI refresh do not create audit storms.
+- [ ] App dashboard and CLI cost summary agree.
+- [ ] Hook delivery timeline shows agent or harness ownership.
+- [ ] Redaction test prevents new sensitive OTel keys.
+
+---
+
+## Assumptions / Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Some consumers depend on `resume.found` volume | Low | Keep a deliberate resume-attempt event with clearer semantics. |
+| Cost rows have multiple historical shapes | Medium | Normalize through a view with fixture coverage for each shape. |
+| Hook payload may lack enough context | Medium | Use explicit harness/system classification instead of `unknown`. |
+
+---
+
+## Review Results
+
+_Populated by `/review` after execution completes._
+
+---
+
+## Files to Create/Modify
+
+```text
+src/lib/executor-registry.ts
+src/lib/should-resume.ts
+src/tui/db.ts
+src/term-commands/status.ts
+src/lib/otel-receiver.ts
+src/hooks/index.ts
+packages/genie-app/src-backend/index.ts
+src/db/migrations/*_claude_usage_view.sql
+.genie/wishes/observability-signal-normalization/REPORT.md
+```


### PR DESCRIPTION
## Summary

Adds a set of wish documents for the Genie observability and performance roadmap:

- `fix-agent-session-linkage`: P0 bugfix plan for executor-owned Claude sessions being left as orphaned session rows.
- `observability-signal-normalization`: plan to remove read-path audit noise, normalize usage metrics, improve hook context, and redact sensitive OTel fields.
- `agent-observability-snapshot`: plan for a canonical agent observability query/view and shared CLI/TUI/app surfaces.
- `genie-command-telemetry-boundary`: plan for CLI command telemetry and an explicit agent-world vs harness-world distinction.
- `complexity-budget-simplification`: plan for revisiting the Biome complexity limit and simplification strategy.

## Why

Live `genie db query` checks on both the local DB and the richer `ssh felipe` instance showed concrete observability bugs and signal gaps, especially broken session linkage, missing tool attribution, audit write amplification, unknown-agent hook events, and cost metric shape mismatch.

## Validation

- `genie --no-tui wish lint complexity-budget-simplification`
- `genie --no-tui wish lint fix-agent-session-linkage`
- `genie --no-tui wish lint observability-signal-normalization`
- `genie --no-tui wish lint agent-observability-snapshot`
- `genie --no-tui wish lint genie-command-telemetry-boundary`
- Pre-push hook completed successfully: `typecheck`, `lint`, `dead-code`, `skills:lint`, `wishes:lint`, `lint:emit`

Note: pre-push reported existing Biome/Knip warnings unrelated to these docs, but exited successfully.