### PR TITLE
fix(tui): auto-disable TUI bootstrap when stdout is not a TTY

### DIFF
--- a/src/__tests__/interactivity.test.ts
+++ b/src/__tests__/interactivity.test.ts
@@ -16,6 +16,7 @@ mock.module('@inquirer/prompts', () => ({
 const { isInteractive, ensureWorkspace, commandRequiresWorkspace, installWorkspaceCheck } = await import(
   '../lib/interactivity.js'
 );
+const { isTuiDisabled } = await import('../lib/tui-disable.js');
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -402,5 +403,40 @@ describe('installWorkspaceCheck()', () => {
     } finally {
       exitSpy.mockRestore();
     }
+  });
+});
+
+// ─── isTuiDisabled() ────────────────────────────────────────────────────────
+
+describe('isTuiDisabled()', () => {
+  let originalTuiDisable: string | undefined;
+
+  beforeEach(() => {
+    originalTuiDisable = process.env.GENIE_TUI_DISABLE;
+    // biome-ignore lint/performance/noDelete: process.env requires delete — assignment sets the string "undefined"
+    delete process.env.GENIE_TUI_DISABLE;
+  });
+
+  afterEach(() => {
+    if (originalTuiDisable === undefined) {
+      // biome-ignore lint/performance/noDelete: process.env requires delete — assignment sets the string "undefined"
+      delete process.env.GENIE_TUI_DISABLE;
+    } else {
+      process.env.GENIE_TUI_DISABLE = originalTuiDisable;
+    }
+  });
+
+  test('returns true when stdout is not a TTY (pipe/redirect) even with env+argv unset', () => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+    process.argv = ['node', 'genie', 'ls'];
+
+    expect(isTuiDisabled()).toBe(true);
+  });
+
+  test('returns false when stdout is a TTY and env+argv unset', () => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    process.argv = ['node', 'genie', 'ls'];
+
+    expect(isTuiDisabled()).toBe(false);
   });
 });

--- a/src/lib/tui-disable.ts
+++ b/src/lib/tui-disable.ts
@@ -14,6 +14,10 @@
  * Activation (any of):
  *   - `GENIE_TUI_DISABLE=1` (or any truthy value: 1/true/yes/on, case-insensitive)
  *   - `--no-tui` anywhere in process.argv
+ *   - stdout is not a TTY (piped/redirected) — auto-detected so non-interactive
+ *     contexts (`genie | head`, scripts, CI without --no-tui) never attempt to
+ *     attach the TUI. `--no-tui` becomes a manual override for edge cases
+ *     (e.g. `script -q` wrappers presenting a fake TTY).
  *
  * Callers MUST check this BEFORE any `import('./tui/...')` or
  * `import('@opentui/core')` — otherwise the native dylib loads and the spin
@@ -27,6 +31,7 @@ export function isTuiDisabled(): boolean {
   const envVal = process.env.GENIE_TUI_DISABLE;
   if (envVal && TRUTHY.has(envVal.trim().toLowerCase())) return true;
   if (process.argv.includes('--no-tui')) return true;
+  if (process.stdout.isTTY === false) return true;
   return false;
 }
 


### PR DESCRIPTION
## Summary

One-line guard added to `isTuiDisabled()`: when `process.stdout.isTTY === false` (pipe/redirect), short-circuit the TUI bootstrap. Operator-reflex `--no-tui` becomes a manual override for edge cases (`script -q` wrappers presenting a fake TTY) instead of a daily-use flag.

**Trace report (out-of-tree):** `/tmp/trace-genie-no-tui-pollution.md` §5

### TL;DR from the trace

The original operator complaint was that `[pgserve] connected to postgres` polluted stdout. Investigation confirmed that's **not the bug** — the banner is already on `process.stderr` (`src/lib/db.ts:1617`), and `genie ls --json | jq .` works today. The real bug is that `isTuiDisabled()` consulted env + argv only, never `process.stdout.isTTY` — so bare `genie | head` still attempted TUI attach. Meanwhile `isInteractive()` (`src/lib/interactivity.ts:23`) already does the TTY check; the two should agree.

This PR closes that gap.

## Repro

**Before:**
```bash
$ genie | head     # bare command, no TTY → tries to attach TUI in pipe context
```

**After:**
```bash
$ genie | head     # `isTuiDisabled()` returns true → existing tui-skip path runs
```

No behavior change for users already setting `--no-tui` or `GENIE_TUI_DISABLE=1`. Backward compatible.

## Diff scope

- `src/lib/tui-disable.ts` — 1 line of production logic + doc-comment update describing the new auto-detect rule.
- `src/__tests__/interactivity.test.ts` — 2 test cases for `isTuiDisabled()` (pipe → true, TTY → false), with `GENIE_TUI_DISABLE` env restoration in beforeEach/afterEach so the suite stays isolated.

```
src/__tests__/interactivity.test.ts | 36 ++++++++++++++++++++++++++++++++++++
src/lib/tui-disable.ts              |  5 +++++
2 files changed, 41 insertions(+)
```

## Validation

```bash
$ bun test src/__tests__/interactivity.test.ts
31 pass / 0 fail / 46 expect calls

$ bunx biome check src/lib/tui-disable.ts src/__tests__/interactivity.test.ts
Checked 2 files in 22ms. No fixes applied.

$ bun run typecheck
$ tsc --noEmit   # clean
```

## Optional follow-ons (out of scope, cite trace §5)

- **Document `GENIE_QUIET=1` / `GENIE_NO_BANNER=1`** in `--help` and `genie ls --help`. Both work today (gated at `src/lib/db.ts:1609`) but appear in zero `--help` strings — having reviewed during the trace.
- **`outputError()` ANSI-on-pipe** (`src/genie.ts:135-140`) writes raw `\x1b[31m` to stderr regardless of TTY. When piped to a log file, the file gets escape codes. Same family of "non-TTY discipline" papercut, separate fix.
- **Bare-`genie` no-TTY hang risk** (`src/genie.ts:740-756`). After this PR, `isTuiDisabled()` returns true on pipe so the early `if (isTuiDisabled())` branch at `:732` exits cleanly — but the deeper TUI attach code path at `:740+` should be audited too as a follow-on.