### PR TITLE
fix(session-linkage): repair orphan sessions + repair-links command (P0)

### DIFF
--- a/.genie/wishes/fix-agent-session-linkage/REPORT.md
+++ b/.genie/wishes/fix-agent-session-linkage/REPORT.md
@@ -293,3 +293,162 @@ ssh felipe 'export PATH=…; cd /home/genie/workspace/repos/genie && genie --no-
 ```
 
 The wish's reference numbers (1854 sessions, 1852 NULL `executor_id` on the felipe instance) suggest the apply will link a few thousand sessions; tool_events backfill will be similarly large.
+
+## QA Results
+
+Captured 2026-05-01 by `qa` agent on local DB after Groups 1-3 landed. Group 4 (`ssh felipe`) remains BLOCKED on operator key provisioning — out of QA scope. All checks executed via `./dist/genie.js` (worktree dist 4.260501.4).
+
+### Wish QA Criteria
+
+| # | Criterion | Method | Evidence | Status |
+|---|-----------|--------|----------|--------|
+| 1 | `genie sessions list` shows linked agent/executor ownership | `./dist/genie.js --no-tui sessions list` | Repaired sessions render with non-empty Agent + Team columns (e.g. `1df7eb0f-69b → engineer → fix-agent-session-linkage`, `8ef8af95-c81 → genie-pgserve → genie`, `b8075629-c63 → genie → genie`). All 14 executor-linked sessions show `status=active`. Pre-existing standalone orphans (no matching executor) correctly remain `(orphaned)`. | PASS |
+| 2 | `genie log <agent>` includes session/tool history from repaired rows | `./dist/genie.js --no-tui log engineer` | Returned 32 events for the `engineer` agent on the previously-orphaned session `1df7eb0f`. Cross-check `select count(*) from tool_events te join sessions s on s.id=te.session_id where s.id='1df7eb0f-…' and te.agent_id is not null and te.agent_id != ''` → **153** attributed events on that one repaired session. | PASS |
+| 3 | Re-running `--apply` is idempotent | Engineer transcript at REPORT.md:264-273 shows successive applies converge to `(0,0)`. Re-execution of `--apply` blocked per operator instructions ("DO NOT run `--apply` again"). Code path confirmed at `src/term-commands/sessions.ts:517-525` (`noWork` short-circuit returns before the transaction). | First post-fix apply linked 10 / 688; second `(0,1)`; third `(0,0)`. New audit row at 18:39:05 also shows `linked=0, te=20, preview_count=0` — same idempotent shape on a follow-up run. | PASS |
+| 4 | Safe on a DB with zero affected rows | `./dist/genie.js --no-tui sessions repair-links --dry-run` on current DB | First dry-run: `linkable orphans: 0`, dry-run reports `Run with --apply to repair 0 session(s) and up to 765 tool_event(s)`. The 765 are pre-existing tool_events with empty-string attribution that `--apply` would still backfill — the command is *safe* (zero session writes when count is 0) but not yet at the (0,0) terminal state because legacy empty-string tool_events keep accumulating from the OLD global daemon. See INFO #1 below. | PASS |
+
+### Additional Structured Checks
+
+**1. Audit event integrity** — `select created_at, jsonb_typeof(details), details::text from audit_events where event_type = 'sessions.repair_links' order by created_at desc limit 5`
+
+```
+created_at  | outer_type | details
+18:39:05    | object     | {"forced": false, "recount": 0, "preview_count": 0, "sessions_linked": 0, "tool_events_backfilled": 20}
+18:30:15    | object     | {"forced": false, "recount": 0, "preview_count": 0, "sessions_linked": 0, "tool_events_backfilled": 0}
+18:30:14    | object     | {"forced": false, "recount": 0, "preview_count": 0, "sessions_linked": 0, "tool_events_backfilled": 1}
+18:29:52    | object     | {"forced": false, "recount": 0, "preview_count": 0, "sessions_linked": 0, "tool_events_backfilled": 12}
+18:27:28    | string     | "{\"sessions_linked\":0,\"tool_events_backfilled\":0,\"preview_count\":0,\"recount\":0,\"forced\":false}"
+```
+
+- All 4 latest rows are JSONB `object` type with the 5 required keys (`sessions_linked`, `tool_events_backfilled`, `preview_count`, `recount`, `forced`). PASS.
+- Zero raw session content / paths / agent identifiers stored — `details` is totals-only as the wish required. PASS.
+- 5 of 9 historical `sessions.repair_links` rows have `outer_type = 'string'` — pre-fix artifacts from the engineer's earlier iteration before adopting `tx.json(...)`. Inert legacy data, not a regression. **WARN**: see INFO #2.
+
+**2. Empty-string regression (new tool_events should write NULL not '')** — `select count filter (where agent_id = '') / (where agent_id is null) ... from tool_events where timestamp > now() - interval '10 minutes'`
+
+```
+empty_agent | null_agent | empty_team | null_team | empty_wish | null_wish | empty_task | null_task | total
+4           | 0          | 4          | 0         | 63         | 5         | 63         | 5         | 68
+```
+
+- Source code at `src/lib/session-capture.ts:714-717` correctly uses `?? null` for all four observability fields (verified by direct read). PASS at code level.
+- Unit tests confirm: `bun test src/lib/session-capture.test.ts src/services/executors/__tests__/sdk-session-capture.test.ts` → 32 pass / 0 fail. PASS.
+- Live DB still shows empty-string writes from concurrent ingestion. Cause: the running daemons execute the OLD globally-installed binary (`/home/genie/.bun/.../genie.js` v4.260501.5, zero `repair-links` matches in compiled source) — this branch's fix is in `./dist/genie.js` (5 `repair-links` matches) but not yet promoted globally. Production fix lands on merge + reinstall. **INFO**: see INFO #1.
+
+**3. JSON mode** — `./dist/genie.js --no-tui sessions repair-links --json | jq '. | keys, .diagnostics.linkableOrphanSessions, .sample | length'`
+
+```
+3            ← 3 top-level keys: diagnostics, sample, ambiguous
+2            ← linkableOrphanSessions
+2            ← sample length
+```
+
+JSON parses cleanly through `jq`. Shape matches expectation: `{ diagnostics, sample, ambiguous }` with `diagnostics` carrying all the count fields. PASS.
+
+**4. --force gating code path** — drift gate at `src/term-commands/sessions.ts:375-380`:
+
+```ts
+if (recount.n !== previewCount && !force) {
+  result.driftDetected = true;
+  throw new Error(`repair-links: candidate count drifted between preview (${previewCount}) and apply (${recount.n}). Re-run --dry-run or pass --force to override.`);
+}
+```
+
+Ambiguity gate at `src/term-commands/sessions.ts:510-515`:
+
+```ts
+if (ambiguous.length > 0 && !options.force) {
+  console.error(`repair-links: ${ambiguous.length} ambiguous claude_session_id value(s) found. ... refusing --apply.`);
+  process.exit(2);
+}
+```
+
+Both gates present and correctly check `!force`. PASS at code level. **WARN**: zero automated test coverage — `grep -rln "applyRepairTransaction\|findAmbiguousExecutorSessions\|diagnoseSessionLinks" src --include='*.test.ts'` returns no matches. The gates are exercised only by manual operator runs. Not blocking but flagged for follow-up tightening (see INFO #3).
+
+**5. Build/install discipline** — global `genie` binary lags this branch:
+
+```
+$ which genie               → /home/genie/.local/bin/genie → /home/genie/.bun/bin/genie → .../node_modules/@automagik/genie/dist/genie.js
+$ genie --version           → 4.260501.5
+$ ./dist/genie.js --version → 4.260501.4
+$ grep -c repair-links /home/genie/.bun/install/global/.../genie.js  → 0
+$ grep -c repair-links dist/genie.js                                  → 5
+```
+
+The new `genie sessions repair-links` subcommand is **not** discoverable via the global binary. All operator-facing commands during QA had to be invoked as `./dist/genie.js`. PASS — this is the expected feature-branch state pre-merge — but **WARN**: post-merge, the global install must be rebuilt and re-published before operators can run the canonical `genie sessions repair-links --dry-run` from any cwd. See INFO #1.
+
+### Anomalies
+
+| Severity | ID | Description |
+|----------|----|-------------|
+| INFO | 1 | Global `genie` (4.260501.5) does not contain the Group 1-3 fix; running daemons still write empty-string attribution. Code-level fix is correct (`?? null` at `src/lib/session-capture.ts:714-717`); live remediation requires merge + global rebuild. Pre-merge expected; not a regression. |
+| WARN | 2 | 5 of 9 `audit_events.sessions.repair_links` rows have `details` stored as JSONB string (not object) — pre-fix artifacts from before the engineer switched to `tx.json(...)`. Inert legacy data. Optional cleanup: `UPDATE audit_events SET details = (details #>> '{}')::jsonb WHERE event_type = 'sessions.repair_links' AND jsonb_typeof(details) = 'string'`. Not blocking. |
+| WARN | 3 | The `applyRepairTransaction` drift gate, the `findAmbiguousExecutorSessions` ambiguity gate, and `diagnoseSessionLinks` have zero automated test coverage. Functionality verified manually; future regressions would land silently. Recommend a `src/term-commands/sessions.test.ts` companion with table-driven tests over the gates. |
+
+### Test suite
+
+```
+$ bun test src/lib/session-capture.test.ts src/services/executors/__tests__/sdk-session-capture.test.ts
+32 pass / 0 fail / 122 expect() calls
+```
+
+Wish-scoped unit tests stay green. Engineer's tree-wide run (REPORT.md:182-184) showed 2824 pass / 0 fail across `src/lib/` + `src/services/`.
+
+### Verdict
+
+**PASS**
+
+All four wish QA criteria verified with evidence. All four additional structured checks pass at code level with three INFO/WARN observations, none of which block ship. The Group 1-3 deliverables are functionally and structurally correct on the local DB; Group 4 (`ssh felipe` cross-instance) remains operator-blocked and is appropriately deferred.
+
+---
+
+## Review Results
+
+**Verdict: SHIP**
+
+Reviewed commits `595060f8`, `2e94b06c`, `b25d1ef3` against `WISH.md` Groups 1–3. Group 4 explicitly out of scope (operator key blocker).
+
+### Phase 1 — Spec Compliance (independently verified — read each cited line, did not just trust REPORT)
+
+**Group 2 acceptance — all PASS:**
+- [x] Existing orphan upgrade: `src/lib/session-capture.ts:333-412` — SELECT broadened to read `executor_id, role, status`; `needsUpgrade` flips on any-NULL-or-orphaned; UPDATE uses `COALESCE(field, $worker)` per column. Test `src/lib/session-capture.test.ts:361` exercises end-to-end.
+- [x] SDK conflict path fills missing linkage: `src/services/executors/sdk-session-capture.ts:48-62` — `ON CONFLICT (id) DO UPDATE SET <field> = COALESCE(sessions.<field>, EXCLUDED.<field>)` for all five linkage columns plus `orphaned → active` status flip. Test `__tests__/sdk-session-capture.test.ts:139` pins.
+- [x] Tool events store NULL not '': `session-capture.ts:714-717` — `?? null` for `agent_id`, `team`, `wish_slug`, `task_id`. Test `__tests__/sdk-session-capture.test.ts:148` (`expect(...).not.toContain('')`).
+- [x] No downgrade: COALESCE guards both ingestion and SDK paths. Regression test `session-capture.test.ts:411` (`does NOT downgrade an existing fully-linked session`) is green.
+
+**Group 3 acceptance — all PASS:**
+- [x] Dry-run mutates zero rows: `src/term-commands/sessions.ts:502-507` returns before any UPDATE; `src/lib/session-link-repair.ts` is pure SELECT (read-verified, zero `INSERT/UPDATE/DELETE`). Live re-run during this review on local DB confirmed: 3 candidates printed, count unchanged.
+- [x] Apply links by `executors.claude_session_id`: `sessions.ts:382-396` — exact `WHERE s.id = e.claude_session_id AND s.executor_id IS NULL`. Risk 1 mitigated as wish demanded.
+- [x] Apply backfills tool_events: `sessions.ts:408-423` — `COALESCE(NULLIF(te.<field>, ''), s.<field>)` treats legacy empty-string writes as missing while preserving any non-empty existing value. Risk 2 mitigated.
+- [x] Idempotent: `IS DISTINCT FROM` filter at `sessions.ts:417-422` skips no-op rows. REPORT transcript shows convergence to (0,0). Confirmed.
+
+**Risk register — all addressed in code:**
+- Risk 1 (genuine non-executor orphans): exact-id join — confirmed.
+- Risk 2 (overwrite better history): `COALESCE(NULLIF(...), …)` — confirmed.
+- Risk 3 (ambiguous executors): `findAmbiguousExecutorSessions` wired at `sessions.ts:500`; gate at `sessions.ts:510-515` exits with code 2 unless `--force` — confirmed.
+
+**Drift gate (Group 3 deliverable #4):** `sessions.ts:368-380` re-counts inside the transaction, throws on drift unless `--force`. Acknowledged TOCTOU window between dry-run and apply is documented in code comment.
+
+**Audit event:** `'sessions.repair_links'` added to `src/lib/audit-events.ts:30`; `sessions.ts:429-444` writes via `tx.json({ totals })` matching the existing `src/lib/audit.ts:35` (`sql.json`) idiom. Payload is totals-only — verified, no raw session content.
+
+**Files-to-Modify drift:** Wish lists 7 files; engineer touched all 7 plus a single-line type union addition to `src/lib/audit-events.ts` (necessary for Group 3 deliverable #3 — not scope creep). Version bumps in `package.json`/`marketplace.json` belong to prior auto-version commit `d0b834f2`, not the engineer's three commits.
+
+**Validation re-run during this review:**
+- `bun test src/lib/session-capture.test.ts src/services/executors/__tests__/sdk-session-capture.test.ts` → 32/32 pass
+- `bun run typecheck` → clean
+- `./dist/genie.js --no-tui sessions repair-links --dry-run` → 3 linkable orphans, 867 backfillable tool_events, zero mutations
+
+### Phase 2 — Code Quality
+
+Zero CRITICAL, zero HIGH findings. Code is well-commented (explains *why* COALESCE, *why* NULLIF, *why* IS DISTINCT FROM, *why* tx.json). Single-transaction apply, parameterized queries throughout, proper exit codes on gates.
+
+**Optional follow-on (advisory only — do not block ship):**
+
+- **[LOW] sessions.ts:519-523** — JSON output for the no-work apply path is `{ sessionsLinked, toolEventsBackfilled, idempotent }`, a different shape from the regular `RepairLinksApplyResult` (which carries `ambiguousCount`, `forced`, `driftDetected` too). Consider returning a unified shape so JSON consumers see one schema.
+- **[LOW] sessions.ts:325** — `empty-string wish_slug:70865` is missing the space after the colon that other lines have. Cosmetic.
+- **[LOW] No automated coverage on the `applyRepairTransaction` drift / ambiguity gates** (already flagged by QA WARN #3). Recommend a `src/term-commands/sessions.test.ts` companion with table-driven gate tests as a follow-up.
+
+None of these block ship. The core repair surface — transaction boundaries, COALESCE-with-NULLIF semantics, gate logic, audit shape — is correct and production-ready.
+
+**Verdict: SHIP** — all Group 1–3 acceptance bullets met, all wish risks mitigated in code, dry-run-by-default verified non-mutating, applies idempotent. Group 4 deferral is appropriate and documented.
+

--- a/.genie/wishes/fix-agent-session-linkage/REPORT.md
+++ b/.genie/wishes/fix-agent-session-linkage/REPORT.md
@@ -129,3 +129,58 @@ All three are pure SELECTs. No `INSERT/UPDATE/DELETE`. They are wired up to be t
 - [x] Test fails on current code because the session remains orphaned.
 - [x] Diagnostic query reports affected counts without mutating data.
 - [x] Baseline includes local `genie db query` evidence; **remote (`ssh felipe`) blocked** — see above.
+
+## Group 2 — Ingestion Fix
+
+### Code changes
+
+- `src/lib/session-capture.ts` (`ensureSession`):
+  - Replaced the early-return-on-existing-row path with a COALESCE-style upgrade.
+  - SELECT now reads `executor_id, role, status` in addition to the previous five columns so we can detect when an orphan can be linked.
+  - When `workerMap.get(sessionId)` returns context AND the existing row has any of `executor_id / agent_id / team / wish_slug / task_id / role` set to NULL (or `status = 'orphaned'`), we run `UPDATE … SET <field> = COALESCE(<field>, $worker_value), …, status = CASE WHEN status = 'orphaned' AND $agent IS NOT NULL THEN 'active' ELSE status END … RETURNING …` and return the upgraded row.
+  - Fully-linked rows are detected by `needsUpgrade === false` and skip the UPDATE entirely (zero churn for already-correct sessions). `completed` / `crashed` statuses are untouched.
+- `src/lib/session-capture.ts` (`batchInsertToolEvents`):
+  - `agent_id`, `team`, `wish_slug`, `task_id` array fallbacks changed from `?? ''` to `?? null`. The `::text[]` cast on the unnest still works — postgres.js passes JS `null` through as SQL `NULL`. The other fields (`sub_tool`, `tool_use_id`, `input_raw`, `output_raw`, `error_message`, `duration_ms`) are out of scope per the wish.
+- `src/services/executors/sdk-session-capture.ts` (`startSession`):
+  - `ON CONFLICT (id) DO NOTHING` → `ON CONFLICT (id) DO UPDATE SET agent_id = COALESCE(sessions.agent_id, EXCLUDED.agent_id), … status = CASE … END, updated_at = now()`.
+  - Same COALESCE protection: a previously-linked session never gets downgraded.
+  - Same status flip: `orphaned` → `active` only when the SDK call brings a non-null agent.
+
+### Acceptance — Group 2
+
+- [x] Both Group 1 failing tests now pass (orphan upgrade + SDK `ON CONFLICT DO UPDATE`).
+- [x] Pre-existing linked sessions are not downgraded — covered by the regression test added in Group 1 (`ingestion does NOT downgrade an existing fully-linked session (stays linked)`), now passing alongside the new bug fix.
+- [x] New tool_events store NULL for missing optional fields, not empty strings — covered by the Group 1 regression test on the SDK side (`does not write empty strings for missing observability fields`) plus the `?? null` change to `batchInsertToolEvents`.
+
+### Validation
+
+```text
+$ bun test src/lib/session-capture.test.ts src/services/executors/__tests__/sdk-session-capture.test.ts
+bun test v1.3.11 (af24e281)
+
+src/lib/session-capture.test.ts:
+[test-setup] reusing pgserve on port 20900 (pid 2140350)
+
+ 32 pass
+ 0 fail
+ 122 expect() calls
+Ran 32 tests across 2 files. [534.00ms]
+```
+
+```text
+$ bun run typecheck
+$ tsc --noEmit
+(clean — no errors)
+```
+
+Tree-wide regression check (informational, not in the wish's validation block):
+
+```text
+$ bun test src/lib/ src/services/
+ 2824 pass
+ 0 fail
+ 6997 expect() calls
+Ran 2824 tests across 125 files.
+```
+
+No fix downgrades any existing context — confirmed by both the unit-level `… does NOT downgrade an existing fully-linked session …` regression test and the broader 2824-test run staying green.

--- a/.genie/wishes/fix-agent-session-linkage/REPORT.md
+++ b/.genie/wishes/fix-agent-session-linkage/REPORT.md
@@ -184,3 +184,112 @@ Ran 2824 tests across 125 files.
 ```
 
 No fix downgrades any existing context — confirmed by both the unit-level `… does NOT downgrade an existing fully-linked session …` regression test and the broader 2824-test run staying green.
+
+## Group 3 — Repair Command
+
+### Code added
+
+- `src/term-commands/sessions.ts` — new `genie sessions repair-links` subcommand:
+  - `--dry-run` (default) — calls `diagnoseSessionLinks` / `sampleLinkableOrphanSessions` / `findAmbiguousExecutorSessions` from `src/lib/session-link-repair.ts`. Prints counts and a 10-row preview. Mutates nothing.
+  - `--apply` — runs the repair inside a single `sql.begin(...)` transaction:
+    1. Re-counts candidates inside the transaction; aborts with a non-zero exit if the count drifted from the pre-transaction preview AND `--force` was not passed.
+    2. `UPDATE sessions … FROM executors e LEFT JOIN agents a … WHERE s.id = e.claude_session_id AND s.executor_id IS NULL` with COALESCE for every nullable field. `status = CASE WHEN s.status = 'orphaned' THEN 'active' ELSE s.status END` so completed/crashed never get clobbered.
+    3. `UPDATE tool_events te … FROM sessions s WHERE s.id = te.session_id AND s.executor_id IS NOT NULL AND ((te.X IS DISTINCT FROM COALESCE(NULLIF(te.X, ''), s.X)) OR …)` — `IS DISTINCT FROM` filters out no-op updates so the transaction count is the *effective* repair count, not the broad "anything missing" count. `NULLIF(field, '')` lets the legacy empty-string writes inherit linked-session attribution.
+    4. Audit row written via `tx.json(...)` (not `JSON.stringify`, which silently stores a JSONB string-of-string instead of a real object — verified the existing repo idiom in `src/lib/audit.ts:35`). `details` carries `sessions_linked`, `tool_events_backfilled`, `preview_count`, `recount`, `forced` — totals only, never raw session content.
+  - `--force` overrides both the candidate-count drift gate AND the ambiguity gate (`findAmbiguousExecutorSessions` returns multi-executor matches).
+  - `--json` output for both modes.
+- `src/lib/audit-events.ts` — added `'sessions.repair_links'` to the `AuditEventType` union.
+
+### Acceptance — Group 3
+
+- [x] `--dry-run` mutates zero rows — verified by row-count snapshot before/after the dry-run (sessions: 1861 → 1861, tool_events: 71397 → 71397, last `sessions.repair_links` audit timestamp identical).
+- [x] `--apply` links sessions by `executors.claude_session_id` — first apply on local DB linked 10 sessions, post-apply linkable-orphan count = 0.
+- [x] `--apply` backfills tool_events attribution from linked sessions — first apply backfilled 688 rows.
+- [x] Idempotent — successive applies converge to `sessions linked: 0, tool_events backfilled: 0` (intermediate runs may show small non-zero counts due to concurrent ingestion landing new rows; once ingestion is quiet the count is 0).
+
+### Local repair transcript (canonical run)
+
+Pre-apply snapshot:
+
+```text
+$ ./dist/genie.js --no-tui db query "select (select count(*) from sessions) as total_sessions, (select count(*) from sessions s join executors e on s.id = e.claude_session_id where s.executor_id is null) as linkable_orphans, (select count(*) from sessions where status = 'orphaned') as status_orphaned, (select count(*) from tool_events) as total_te, (select count(*) from tool_events where agent_id = '') as te_empty_agent"
+total_sessions | linkable_orphans | status_orphaned | total_te | te_empty_agent
+---------------+------------------+-----------------+----------+---------------
+1861           | 10               | 1852            | 71374    | 71005
+```
+
+Dry-run (excerpt):
+
+```text
+$ ./dist/genie.js --no-tui sessions repair-links --dry-run
+repair-links --dry-run (no rows mutated)
+-----------------------------------------
+Sessions:
+  total: 1861
+  linkable orphans (sessions.id = executors.claude_session_id ∧ executor_id IS NULL): 10
+  status='orphaned': 1852
+  NULL executor_id: 1859
+Tool events:
+  total: 71373
+  ...
+  linkable (session has executor_id, event missing attribution): 160
+
+Linkable orphan sample (up to 10):
+  11d32a40-…  executor=9e8ebbac-c33  agent=e322c2a5-ca0  status=orphaned
+  ac889140-…  executor=b2b6319d-828  agent=52a3d02c-97c  status=orphaned
+  …
+Run with --apply to repair 10 session(s) and up to 160 tool_event(s).
+```
+
+Apply:
+
+```text
+$ ./dist/genie.js --no-tui sessions repair-links --apply
+repair-links --apply complete
+  sessions linked:        10
+  tool_events backfilled: 688
+```
+
+Post-apply verification (the wish's headline query):
+
+```text
+$ ./dist/genie.js --no-tui db query "select count(*) from sessions s join executors e on s.id = e.claude_session_id where s.executor_id is null"
+count
+-----
+0
+(1 row)
+```
+
+Idempotent re-apply (after concurrent ingestion settled):
+
+```text
+$ ./dist/genie.js --no-tui sessions repair-links --apply
+repair-links --apply complete
+  sessions linked:        0
+  tool_events backfilled: 1
+$ ./dist/genie.js --no-tui sessions repair-links --apply
+repair-links --apply complete
+  sessions linked:        0
+  tool_events backfilled: 0
+```
+
+Audit row landed correctly (JSONB outer type = `object`, keys extract):
+
+```text
+$ ./dist/genie.js --no-tui db query "select jsonb_typeof(details) as outer_type, details->>'sessions_linked' as linked, details->>'tool_events_backfilled' as te, details->>'forced' as forced from audit_events where event_type = 'sessions.repair_links' order by created_at desc limit 1"
+outer_type | linked | te | forced
+-----------+--------+----+-------
+object     | 0      | 12 | false
+```
+
+### Group 4 — DEFERRED
+
+Group 4 (cross-instance verification on `ssh felipe`) remains blocked on operator key provisioning for the `felipe-personal` tailscale alias (see Group 1 baseline). When that lands, the Group 4 plan is:
+
+```bash
+ssh felipe 'export PATH=…; cd /home/genie/workspace/repos/genie && genie --no-tui sessions repair-links --dry-run'
+ssh felipe 'export PATH=…; cd /home/genie/workspace/repos/genie && genie --no-tui sessions repair-links --apply'
+ssh felipe 'export PATH=…; cd /home/genie/workspace/repos/genie && genie --no-tui db query "select count(*) from sessions s join executors e on s.id = e.claude_session_id where s.executor_id is null"'
+```
+
+The wish's reference numbers (1854 sessions, 1852 NULL `executor_id` on the felipe instance) suggest the apply will link a few thousand sessions; tool_events backfill will be similarly large.

--- a/.genie/wishes/fix-agent-session-linkage/REPORT.md
+++ b/.genie/wishes/fix-agent-session-linkage/REPORT.md
@@ -1,0 +1,131 @@
+# Wish Report — fix-agent-session-linkage
+
+## Baseline (Group 1)
+
+Captured 2026-05-01 from worktree `/home/genie/.genie/worktrees/dev-pin/fix-agent-session-linkage` on branch `fix-agent-session-linkage` before any production code changed.
+
+### Local DB — pgserve auto-discovered
+
+Linkable orphan sessions (the wish's primary signature):
+
+```text
+$ genie --no-tui db query "select count(*) from sessions s join executors e on s.id = e.claude_session_id where s.executor_id is null"
+[pgserve] connected to postgres
+count
+-----
+6
+(1 row)
+```
+
+Sessions table breakdown:
+
+```text
+$ genie --no-tui db query "select count(*) as total_sessions, count(*) filter (where executor_id is null) as null_executor, count(*) filter (where status = 'orphaned') as status_orphaned, count(*) filter (where team = '') as empty_team, count(*) filter (where wish_slug = '') as empty_wish, count(*) filter (where role = '') as empty_role from sessions"
+total_sessions | null_executor | status_orphaned | empty_team | empty_wish | empty_role
+---------------+---------------+-----------------+------------+------------+-----------
+1857           | 1855          | 1848            | 0          | 0          | 0
+(1 row)
+```
+
+Sample of the 6 linkable orphans (executor + agent already known, session row left orphaned):
+
+```text
+$ genie --no-tui db query "select s.id as session_id, e.id as executor_id, e.agent_id, s.status, s.team, s.wish_slug from sessions s join executors e on s.id = e.claude_session_id where s.executor_id is null limit 10"
+session_id                           | executor_id                          | agent_id                             | status   | team | wish_slug
+-------------------------------------+--------------------------------------+--------------------------------------+----------+------+----------
+510349ac-1ed1-4711-9848-e3fcf20e97bf | dcb65000-9b96-4a80-86d7-34c68e9231f3 | 3a177ff1-74bb-4afc-a5a1-515632b5244b | orphaned | NULL | NULL
+9fa74a42-8906-4b60-b3ca-7f12e45308ac | 5eca1579-122f-4cd4-9c3f-4ebb75454e69 | 6dc4f849-d00c-402e-b458-f76ce13e9d0c | orphaned | NULL | NULL
+8ef8af95-c81c-4005-9de3-c79955e3d56f | 43c1de18-7a1f-4ad6-9414-cee60e46f3f7 | 0a1ee6d2-0c21-4e4f-a6e1-22d246f36c46 | orphaned | NULL | NULL
+1df7eb0f-69b7-4f2e-a760-cc3528827e81 | 44d0bf5b-a320-4b97-baa4-96f8d608dbeb | 7aceb6fd-d27b-4c91-8866-d1f10b8c0a64 | orphaned | NULL | NULL
+36a3a605-65a9-4764-b4b8-e3088a7b2180 | 8ec2ef6d-e5bb-4155-bf11-2bf8bb0434db | dd88f205-ea8a-4e7b-a553-1ce33c9c9fd5 | orphaned | NULL | NULL
+908c62d7-d1a2-470a-9cd1-388b1bbb80dd | b9a56d84-11b1-48b7-b5ad-ea3a97132bac | c4b74dc0-34cd-48e8-a79b-2cae7292755e | orphaned | NULL | NULL
+(6 rows)
+```
+
+`tool_events` attribution baseline (the empty-string vs NULL bug from wish decision #4):
+
+```text
+$ genie --no-tui db query "SELECT count(*) FILTER (WHERE agent_id IS NULL OR agent_id = '') AS missing_agent, count(*) FILTER (WHERE wish_slug IS NULL OR wish_slug = '') AS missing_wish, count(*) FILTER (WHERE agent_id = '') AS empty_agent_str, count(*) FILTER (WHERE wish_slug = '') AS empty_wish_str, count(*) AS total FROM tool_events"
+missing_agent | missing_wish | empty_agent_str | empty_wish_str | total
+--------------+--------------+-----------------+----------------+------
+70735         | 71052        | 70735           | 71052          | 71052
+(1 row)
+```
+
+Read: 70 735 of 71 052 tool_events have empty-string `agent_id` (and `team`); 71 052 — i.e. **every** row — has empty-string `wish_slug` and `task_id`. None of these are NULL — the bug is exactly the empty-string write the wish flagged.
+
+### Remote DB (`ssh felipe`) — BLOCKED
+
+The wish's validation block contains:
+
+```bash
+ssh felipe 'export PATH=…; cd /home/genie/workspace/repos/genie && genie --no-tui db query "select count(*) from sessions s join executors e on s.id = e.claude_session_id where s.executor_id is null"'
+```
+
+Three resolution attempts from this worktree:
+
+```text
+$ ssh felipe 'echo ok'
+ssh: Could not resolve hostname felipe: Name or service not known
+
+$ ssh -o StrictHostKeyChecking=accept-new felipe-personal 'echo ok'   # tailscale alias
+genie@felipe-personal: Permission denied (publickey,password).
+
+$ ssh -i ~/.ssh/id_ed25519 felipe 'echo ok'
+ssh: Could not resolve hostname felipe: Name or service not known
+```
+
+`tailscale status | grep felipe` shows reachable hosts (`felipe-personal`, `hapvida-genie-1`, etc.) but none of them accept this worker's keypair as `genie@…`. The pre-existing reference numbers from the wish (1854 sessions, 1852 with NULL `executor_id`) stand as the remote baseline until a key is provisioned. Group 4 (cross-instance verification) will need this resolved before it can run.
+
+### Failing test reproduction (acceptance criterion #1)
+
+```text
+$ bun test src/lib/session-capture.test.ts src/services/executors/__tests__/sdk-session-capture.test.ts
+…
+src/lib/session-capture.test.ts:
+…
+399 |     expect(row.executor_id).toBe(executorId);
+                                  ^
+error: expect(received).toBe(expected)
+Expected: "exec-orphan-upgrade"
+Received: null
+(fail) ingestion upgrades existing orphan sessions when executor context appears later > orphan session matching executors.claude_session_id is linked after ingestion
+
+src/services/executors/__tests__/sdk-session-capture.test.ts:
+…
+144 |       expect(sql).toContain('ON CONFLICT (id) DO UPDATE');
+                        ^
+error: expect(received).toContain(expected)
+Expected to contain: "ON CONFLICT (id) DO UPDATE"
+Received: "INSERT INTO sessions (id, agent_id, executor_id, team, role, wish_slug, status, jsonl_path, project_path)
+          VALUES (?, ?, ?, ?, ?, ?, 'active', '', '')
+          ON CONFLICT (id) DO NOTHING
+          RETURNING id"
+(fail) sdk-session-capture > startSession > uses ON CONFLICT DO UPDATE so existing orphan rows get linkage filled in
+
+ 30 pass
+ 2 fail
+ 116 expect() calls
+Ran 32 tests across 2 files.
+```
+
+The two failures pin the two distinct symptoms Group 2 must repair:
+
+1. **Tmux JSONL ingestion path** — `ensureSession()` in `src/lib/session-capture.ts:333-364` early-returns when the session row already exists, so a row inserted as `orphaned` before the executor was known is never upgraded.
+2. **SDK capture path** — `startSession()` in `src/services/executors/sdk-session-capture.ts:38-44` uses `ON CONFLICT (id) DO NOTHING`, so when ingestion has already created the orphan row, the SDK insert silently drops the linkage.
+
+### Diagnostic helper
+
+`src/lib/session-link-repair.ts` exposes:
+
+- `diagnoseSessionLinks(sql)` — counts (linkable orphans, NULL `executor_id`, status='orphaned', tool-event missing-attribution, empty-string vs NULL split for both `sessions` and `tool_events`).
+- `sampleLinkableOrphanSessions(sql, limit)` — preview of rows a future repair would touch.
+- `findAmbiguousExecutorSessions(sql)` — surfaces duplicate `claude_session_id` claims so Group 3 can refuse `--apply` on ambiguity (per the Risk register).
+
+All three are pure SELECTs. No `INSERT/UPDATE/DELETE`. They are wired up to be the engine behind the future `genie sessions repair-links --dry-run` (Group 3).
+
+### Acceptance — Group 1
+
+- [x] Test fails on current code because the session remains orphaned.
+- [x] Diagnostic query reports affected counts without mutating data.
+- [x] Baseline includes local `genie db query` evidence; **remote (`ssh felipe`) blocked** — see above.

--- a/.genie/wishes/fix-agent-session-linkage/REPORT.md
+++ b/.genie/wishes/fix-agent-session-linkage/REPORT.md
@@ -452,3 +452,45 @@ None of these block ship. The core repair surface — transaction boundaries, CO
 
 **Verdict: SHIP** — all Group 1–3 acceptance bullets met, all wish risks mitigated in code, dry-run-by-default verified non-mutating, applies idempotent. Group 4 deferral is appropriate and documented.
 
+## Tightening Pass
+
+After review converged on three LOW findings (two from reviewer, one from qa) — all advisory — the following tightening commit landed before pushing.
+
+### Code changes
+
+- **`src/term-commands/sessions.ts`**
+  - Extracted `evaluateAmbiguityGate(ambiguousCount, force)` and `buildNoWorkResultIfApplicable(diag, ambiguousCount, force)` as exported pure functions so the gate decisions are unit-testable without `process.exit` / live DB.
+  - Promoted `applyRepairTransaction(sql, previewCount, force)` from internal to `export`ed for the same reason.
+  - Wired the new helpers into `sessionsRepairLinksCommand` — single source of truth, command stays thin.
+  - **Closes [LOW] sessions.ts:519-523** — no-work apply path now returns a full `RepairLinksApplyResult` shape (`sessionsLinked / toolEventsBackfilled / ambiguousCount / forced / driftDetected`) instead of the ad-hoc `{ sessionsLinked, toolEventsBackfilled, idempotent }`. JSON consumers see one schema regardless of whether work happened.
+  - **Closes [LOW] sessions.ts:325** — `empty-string wish_slug:` now has a space before its value, matching the other diagnostic lines.
+
+- **`src/term-commands/sessions.test.ts`** (NEW, 10 tests)
+  - **Drift gate** (3 tests): in-tx recount mismatch + no `--force` throws with the documented message and skips both UPDATEs; same scenario with `--force` proceeds and runs both UPDATEs + audit insert; matching recount runs cleanly without `--force`.
+  - **Ambiguity gate** (3 tests): `ambiguousCount > 0` + no `--force` blocks with the documented message; `--force` lifts the block; zero ambiguous sessions never blocks.
+  - **No-work short-circuit** (4 tests): zero linkable orphans + zero linkable tool_events returns the unified zero-valued `RepairLinksApplyResult` shape; `ambiguousCount` and `forced` are threaded through transparently; non-zero linkable orphans returns `null` (work pending); non-zero linkable tool_events returns `null` (work pending).
+  - Tests use a stubbed postgres.js `Sql` client (tagged-template + `.begin(cb)` + `.json(...)`) — no live DB required.
+
+### Validation
+
+```text
+$ bun test src/term-commands/sessions.test.ts
+ 10 pass
+ 0 fail
+ 25 expect() calls
+
+$ bun test src/lib/session-capture.test.ts src/services/executors/__tests__/sdk-session-capture.test.ts
+ 32 pass
+ 0 fail
+ 122 expect() calls
+
+$ bun run typecheck
+$ tsc --noEmit
+(clean)
+
+$ bunx biome check src/term-commands/sessions.ts src/term-commands/sessions.test.ts
+Found 5 warnings.   # pre-existing complexity warnings only — zero errors
+```
+
+Two of the three reviewer LOWs are now closed in code (`525-Inconsistent-JSON-shape`, `325-cosmetic-spacing`); the third (`No automated coverage on gates`) is closed by the new test file. QA WARN #3 (same finding) is also closed.
+

--- a/src/lib/audit-events.ts
+++ b/src/lib/audit-events.ts
@@ -25,7 +25,9 @@ export type AuditEventType =
   // Resume (Group 7)
   | 'session.resumed'
   | 'session.resume_rejected'
-  | 'session.created_fresh';
+  | 'session.created_fresh'
+  // Sessions repair (fix-agent-session-linkage wish, Group 3)
+  | 'sessions.repair_links';
 
 // ============================================================================
 // Record helper

--- a/src/lib/session-capture.test.ts
+++ b/src/lib/session-capture.test.ts
@@ -12,8 +12,11 @@
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { getConnection, resetConnection } from './db.js';
-import { extractSubTool, reconcileSubagentParents } from './session-capture.js';
+import { buildWorkerMap, extractSubTool, ingestFile, reconcileSubagentParents } from './session-capture.js';
 import { DB_AVAILABLE, setupTestDatabase } from './test-db.js';
 
 /**
@@ -313,3 +316,137 @@ describe.skipIf(!DB_AVAILABLE)('reconcileSubagentParents — metadata inheritanc
     expect(result.metadataFilled).toBeGreaterThanOrEqual(1);
   });
 });
+
+// ============================================================================
+// Group 1 (fix-agent-session-linkage wish): orphan-upgrade reproduction
+//
+// Bug signature on the live `felipe` DB and locally:
+//   - sessions.id == executors.claude_session_id
+//   - sessions.executor_id IS NULL, status='orphaned'
+//
+// Root cause (this test asserts the symptom — the fix lands in Group 2):
+//   ensureSession() in session-capture.ts SELECTs the existing orphan row
+//   and early-returns. It never UPDATEs the orphan with the now-known
+//   worker context, so the row stays orphaned for the lifetime of the row.
+//
+// Expected after Group 2:
+//   ingestFile() upgrades sessions.executor_id, agent_id, team, wish_slug,
+//   task_id, role from the workerMap when the row already exists with NULLs.
+// ============================================================================
+
+describe.skipIf(!DB_AVAILABLE)(
+  'ingestion upgrades existing orphan sessions when executor context appears later',
+  () => {
+    let cleanup: () => Promise<void>;
+    let workDir: string;
+
+    beforeAll(async () => {
+      cleanup = await setupTestDatabase();
+      workDir = await mkdtemp(join(tmpdir(), 'session-link-repro-'));
+    });
+
+    beforeEach(async () => {
+      await warmConnection();
+    });
+
+    afterAll(async () => {
+      await cleanup();
+      try {
+        await rm(workDir, { recursive: true, force: true });
+      } catch {
+        // best-effort cleanup
+      }
+    });
+
+    test('orphan session matching executors.claude_session_id is linked after ingestion', async () => {
+      const sql = await getConnection();
+      const agentId = 'agent-orphan-upgrade';
+      const executorId = 'exec-orphan-upgrade';
+      const sessionId = 'sess-orphan-upgrade';
+      const projectPath = '/tmp/proj-orphan-upgrade';
+      const jsonlPath = join(workDir, `${sessionId}.jsonl`);
+
+      // Empty JSONL is enough — ingestFile still runs ensureSession() before
+      // returning when the file is 0 bytes, which is exactly the path we want
+      // to exercise. (No assistant turns to parse, so no extra writes.)
+      await writeFile(jsonlPath, '');
+
+      await sql`
+      INSERT INTO agents (id, role, started_at, team, wish_slug, task_id)
+      VALUES (${agentId}, 'engineer', now(), 'team-link-x', 'wish-link-x', 'task-link-x')
+      ON CONFLICT DO NOTHING
+    `;
+      await sql`
+      INSERT INTO executors (id, agent_id, provider, transport, claude_session_id)
+      VALUES (${executorId}, ${agentId}, 'claude', 'process', ${sessionId})
+      ON CONFLICT DO NOTHING
+    `;
+      // Pre-existing orphan row — this is the row Genie failed to upgrade.
+      await sql`
+      INSERT INTO sessions (id, executor_id, agent_id, team, role, wish_slug, task_id,
+                            project_path, jsonl_path, status, last_ingested_offset, total_turns)
+      VALUES (${sessionId}, NULL, NULL, NULL, NULL, NULL, NULL,
+              ${projectPath}, ${jsonlPath}, 'orphaned', 0, 0)
+    `;
+
+      // Build a fresh worker map so the in-module 5-minute cache from prior
+      // tests in this file cannot mask the new executor row.
+      const workerMap = await buildWorkerMap(sql);
+
+      await ingestFile(sql, sessionId, jsonlPath, projectPath, 0, { workerMap });
+
+      const [row] =
+        await sql`SELECT executor_id, agent_id, team, wish_slug, task_id, role, status FROM sessions WHERE id = ${sessionId}`;
+
+      // The four assertions a fix in Group 2 must satisfy:
+      expect(row.executor_id).toBe(executorId);
+      expect(row.agent_id).toBe(agentId);
+      expect(row.team).toBe('team-link-x');
+      expect(row.wish_slug).toBe('wish-link-x');
+      expect(row.task_id).toBe('task-link-x');
+      // Status transitioning out of 'orphaned' is the user-visible signal.
+      expect(row.status).not.toBe('orphaned');
+    });
+
+    test('ingestion does NOT downgrade an existing fully-linked session (stays linked)', async () => {
+      // Counterpart to the upgrade test: a session that is already linked to
+      // the right executor/agent must keep its values. Group 2 must use
+      // COALESCE-style upgrades, never blanket overwrites.
+      const sql = await getConnection();
+      const agentId = 'agent-keep-linked';
+      const executorId = 'exec-keep-linked';
+      const sessionId = 'sess-keep-linked';
+      const projectPath = '/tmp/proj-keep-linked';
+      const jsonlPath = join(workDir, `${sessionId}.jsonl`);
+      await writeFile(jsonlPath, '');
+
+      await sql`
+      INSERT INTO agents (id, role, started_at, team, wish_slug)
+      VALUES (${agentId}, 'engineer', now(), 'team-keep', 'wish-keep')
+      ON CONFLICT DO NOTHING
+    `;
+      await sql`
+      INSERT INTO executors (id, agent_id, provider, transport, claude_session_id)
+      VALUES (${executorId}, ${agentId}, 'claude', 'process', ${sessionId})
+      ON CONFLICT DO NOTHING
+    `;
+      await sql`
+      INSERT INTO sessions (id, executor_id, agent_id, team, wish_slug,
+                            project_path, jsonl_path, status, last_ingested_offset, total_turns)
+      VALUES (${sessionId}, ${executorId}, ${agentId}, 'team-keep', 'wish-keep',
+              ${projectPath}, ${jsonlPath}, 'active', 0, 0)
+    `;
+
+      const workerMap = await buildWorkerMap(sql);
+      await ingestFile(sql, sessionId, jsonlPath, projectPath, 0, { workerMap });
+
+      const [row] =
+        await sql`SELECT executor_id, agent_id, team, wish_slug, status FROM sessions WHERE id = ${sessionId}`;
+      expect(row.executor_id).toBe(executorId);
+      expect(row.agent_id).toBe(agentId);
+      expect(row.team).toBe('team-keep');
+      expect(row.wish_slug).toBe('wish-keep');
+      expect(row.status).toBe('active');
+    });
+  },
+);

--- a/src/lib/session-capture.ts
+++ b/src/lib/session-capture.ts
@@ -338,10 +338,59 @@ async function ensureSession(
   workerMap: Map<string, WorkerMatch>,
   opts?: { parentSessionId?: string | null; isSubagent?: boolean; fileSize?: number; mtime?: number },
 ): Promise<SessionContext> {
-  const existing =
-    await sql`SELECT agent_id, team, wish_slug, task_id, last_ingested_offset, total_turns FROM sessions WHERE id = ${sessionId}`;
+  const worker = workerMap.get(sessionId);
+  const existing = await sql`
+    SELECT executor_id, agent_id, team, wish_slug, task_id, role, status, last_ingested_offset, total_turns
+    FROM sessions WHERE id = ${sessionId}
+  `;
   if (existing.length > 0) {
     const row = existing[0];
+
+    // Upgrade path: row already exists (was inserted as orphaned because the
+    // worker wasn't yet known to ingestion), and now workerMap can fill in
+    // executor_id / agent_id / team / wish_slug / task_id / role. COALESCE
+    // protects any field that already has a non-null value — we never
+    // downgrade better context, only fill NULLs. Status flips
+    // 'orphaned' → 'active' iff the worker brings real attribution; we
+    // never overwrite 'completed' / 'crashed' / 'active'.
+    const needsUpgrade =
+      worker !== undefined &&
+      (row.executor_id === null ||
+        row.agent_id === null ||
+        row.team === null ||
+        row.wish_slug === null ||
+        row.task_id === null ||
+        row.role === null ||
+        row.status === 'orphaned');
+
+    if (needsUpgrade) {
+      const [upgraded] = await sql`
+        UPDATE sessions SET
+          executor_id = COALESCE(executor_id, ${worker.executorId ?? null}),
+          agent_id    = COALESCE(agent_id,    ${worker.agentId ?? null}),
+          team        = COALESCE(team,        ${worker.team ?? null}),
+          wish_slug   = COALESCE(wish_slug,   ${worker.wishSlug ?? null}),
+          task_id     = COALESCE(task_id,     ${worker.taskId ?? null}),
+          role        = COALESCE(role,        ${worker.role ?? null}),
+          status      = CASE
+            WHEN status = 'orphaned' AND ${worker.agentId ?? null}::text IS NOT NULL
+              THEN 'active'
+            ELSE status
+          END,
+          updated_at  = now()
+        WHERE id = ${sessionId}
+        RETURNING agent_id, team, wish_slug, task_id, last_ingested_offset, total_turns
+      `;
+      return {
+        agentId: upgraded.agent_id,
+        team: upgraded.team,
+        wishSlug: upgraded.wish_slug,
+        taskId: upgraded.task_id,
+        lastOffset: upgraded.last_ingested_offset ?? 0,
+        totalTurns: upgraded.total_turns ?? 0,
+      };
+    }
+
     return {
       agentId: row.agent_id,
       team: row.team,
@@ -352,7 +401,6 @@ async function ensureSession(
     };
   }
 
-  const worker = workerMap.get(sessionId);
   const parentSessionId = await resolveSafeParentId(sql, opts?.parentSessionId);
 
   await sql`
@@ -663,10 +711,10 @@ async function batchInsertToolEvents(sql: SqlClient, rows: ToolEventRow[]): Prom
       ${sql.array(rows.map((r) => r.is_error))}::bool[],
       ${sql.array(rows.map((r) => r.error_message ?? ''))}::text[],
       ${sql.array(rows.map((r) => r.duration_ms ?? 0))}::int[],
-      ${sql.array(rows.map((r) => r.agent_id ?? ''))}::text[],
-      ${sql.array(rows.map((r) => r.team ?? ''))}::text[],
-      ${sql.array(rows.map((r) => r.wish_slug ?? ''))}::text[],
-      ${sql.array(rows.map((r) => r.task_id ?? ''))}::text[]
+      ${sql.array(rows.map((r) => r.agent_id ?? null))}::text[],
+      ${sql.array(rows.map((r) => r.team ?? null))}::text[],
+      ${sql.array(rows.map((r) => r.wish_slug ?? null))}::text[],
+      ${sql.array(rows.map((r) => r.task_id ?? null))}::text[]
     )
     ON CONFLICT (session_id, tool_use_id) DO NOTHING
   `;

--- a/src/lib/session-link-repair.ts
+++ b/src/lib/session-link-repair.ts
@@ -1,0 +1,177 @@
+/**
+ * Session-link diagnostics + (future) repair primitives.
+ *
+ * Group 1 of the `fix-agent-session-linkage` wish ships READ-ONLY queries
+ * that quantify the current breakage so an operator can see the damage
+ * before any mutation runs. Group 3 will layer
+ * `genie sessions repair-links --dry-run/--apply` on top of these helpers.
+ *
+ * This module deliberately does NOT mutate data. Every function returns
+ * counts or row samples, suitable to be wired into a future preview step.
+ */
+
+// biome-ignore lint/suspicious/noExplicitAny: postgres.js Sql type
+type SqlClient = any;
+
+// ============================================================================
+// Diagnostics
+// ============================================================================
+
+export interface SessionLinkDiagnostics {
+  /** Sessions whose id == executors.claude_session_id but executor_id is NULL. */
+  linkableOrphanSessions: number;
+  /** Total sessions table row count (sanity check / change ratio). */
+  totalSessions: number;
+  /** Sessions with status = 'orphaned'. */
+  statusOrphanedSessions: number;
+  /** Sessions with NULL executor_id (regardless of executors join). */
+  nullExecutorIdSessions: number;
+  /** tool_events rows. */
+  totalToolEvents: number;
+  /** tool_events missing agent_id (NULL or empty string). */
+  toolEventsMissingAgent: number;
+  /** tool_events missing team. */
+  toolEventsMissingTeam: number;
+  /** tool_events missing wish_slug. */
+  toolEventsMissingWish: number;
+  /** tool_events missing task_id. */
+  toolEventsMissingTask: number;
+  /** tool_events that are *linkable*: their session has a populated executor_id but the event row is missing attribution. */
+  toolEventsLinkableMissingAttribution: number;
+  /** Empty-string occurrences specifically — wish decision #4 says these should be NULL. */
+  toolEventsEmptyStringAgent: number;
+  toolEventsEmptyStringTeam: number;
+  toolEventsEmptyStringWish: number;
+  toolEventsEmptyStringTask: number;
+  sessionsEmptyStringTeam: number;
+  sessionsEmptyStringWishSlug: number;
+  sessionsEmptyStringRole: number;
+}
+
+/**
+ * Compute diagnostic counts. Pure read — no UPDATE / INSERT / DELETE.
+ *
+ * The intent is for `genie sessions repair-links --dry-run` to call this
+ * (Group 3), print the numbers, and exit without touching the DB.
+ */
+export async function diagnoseSessionLinks(sql: SqlClient): Promise<SessionLinkDiagnostics> {
+  const [linkableOrphanRow] = await sql`
+    SELECT count(*)::int AS n
+    FROM sessions s
+    JOIN executors e ON s.id = e.claude_session_id
+    WHERE s.executor_id IS NULL
+  `;
+
+  const [sessionRow] = await sql`
+    SELECT
+      count(*)::int AS total,
+      count(*) FILTER (WHERE status = 'orphaned')::int AS status_orphaned,
+      count(*) FILTER (WHERE executor_id IS NULL)::int AS null_executor,
+      count(*) FILTER (WHERE team = '')::int AS empty_team,
+      count(*) FILTER (WHERE wish_slug = '')::int AS empty_wish_slug,
+      count(*) FILTER (WHERE role = '')::int AS empty_role
+    FROM sessions
+  `;
+
+  const [toolEventRow] = await sql`
+    SELECT
+      count(*)::int AS total,
+      count(*) FILTER (WHERE agent_id IS NULL OR agent_id = '')::int AS missing_agent,
+      count(*) FILTER (WHERE team IS NULL OR team = '')::int AS missing_team,
+      count(*) FILTER (WHERE wish_slug IS NULL OR wish_slug = '')::int AS missing_wish,
+      count(*) FILTER (WHERE task_id IS NULL OR task_id = '')::int AS missing_task,
+      count(*) FILTER (WHERE agent_id = '')::int AS empty_agent,
+      count(*) FILTER (WHERE team = '')::int AS empty_team,
+      count(*) FILTER (WHERE wish_slug = '')::int AS empty_wish,
+      count(*) FILTER (WHERE task_id = '')::int AS empty_task
+    FROM tool_events
+  `;
+
+  // tool_events whose owning session HAS attribution but the event row is missing it —
+  // i.e. rows that a future backfill could safely repair from the linked session.
+  const [linkableTeRow] = await sql`
+    SELECT count(*)::int AS n
+    FROM tool_events te
+    JOIN sessions s ON s.id = te.session_id
+    WHERE s.executor_id IS NOT NULL
+      AND (
+        (te.agent_id IS NULL OR te.agent_id = '') OR
+        (te.team     IS NULL OR te.team     = '') OR
+        (te.wish_slug IS NULL OR te.wish_slug = '') OR
+        (te.task_id  IS NULL OR te.task_id  = '')
+      )
+  `;
+
+  return {
+    linkableOrphanSessions: Number(linkableOrphanRow?.n ?? 0),
+    totalSessions: Number(sessionRow?.total ?? 0),
+    statusOrphanedSessions: Number(sessionRow?.status_orphaned ?? 0),
+    nullExecutorIdSessions: Number(sessionRow?.null_executor ?? 0),
+    sessionsEmptyStringTeam: Number(sessionRow?.empty_team ?? 0),
+    sessionsEmptyStringWishSlug: Number(sessionRow?.empty_wish_slug ?? 0),
+    sessionsEmptyStringRole: Number(sessionRow?.empty_role ?? 0),
+    totalToolEvents: Number(toolEventRow?.total ?? 0),
+    toolEventsMissingAgent: Number(toolEventRow?.missing_agent ?? 0),
+    toolEventsMissingTeam: Number(toolEventRow?.missing_team ?? 0),
+    toolEventsMissingWish: Number(toolEventRow?.missing_wish ?? 0),
+    toolEventsMissingTask: Number(toolEventRow?.missing_task ?? 0),
+    toolEventsEmptyStringAgent: Number(toolEventRow?.empty_agent ?? 0),
+    toolEventsEmptyStringTeam: Number(toolEventRow?.empty_team ?? 0),
+    toolEventsEmptyStringWish: Number(toolEventRow?.empty_wish ?? 0),
+    toolEventsEmptyStringTask: Number(toolEventRow?.empty_task ?? 0),
+    toolEventsLinkableMissingAttribution: Number(linkableTeRow?.n ?? 0),
+  };
+}
+
+// ============================================================================
+// Sample helpers (read-only)
+// ============================================================================
+
+export interface OrphanSessionSample {
+  sessionId: string;
+  executorId: string;
+  agentId: string | null;
+  status: string | null;
+}
+
+/**
+ * Return up to `limit` linkable orphan sessions for previewing what a
+ * future `repair-links --dry-run` would update. Read-only.
+ */
+export async function sampleLinkableOrphanSessions(sql: SqlClient, limit = 20): Promise<OrphanSessionSample[]> {
+  const rows = await sql`
+    SELECT s.id AS session_id, e.id AS executor_id, e.agent_id, s.status
+    FROM sessions s
+    JOIN executors e ON s.id = e.claude_session_id
+    WHERE s.executor_id IS NULL
+    ORDER BY s.created_at DESC NULLS LAST
+    LIMIT ${limit}
+  `;
+  return rows.map((r: { session_id: string; executor_id: string; agent_id: string | null; status: string | null }) => ({
+    sessionId: r.session_id,
+    executorId: r.executor_id,
+    agentId: r.agent_id,
+    status: r.status,
+  }));
+}
+
+/**
+ * Detect ambiguous matches — same `claude_session_id` claimed by multiple
+ * executor rows. Group 3 must refuse `--apply` when this is non-zero
+ * (or require `--force`) per the wish risk register.
+ */
+export async function findAmbiguousExecutorSessions(
+  sql: SqlClient,
+): Promise<{ claudeSessionId: string; executorIds: string[] }[]> {
+  const rows = await sql`
+    SELECT claude_session_id, array_agg(id) AS executor_ids
+    FROM executors
+    WHERE claude_session_id IS NOT NULL
+    GROUP BY claude_session_id
+    HAVING count(*) > 1
+  `;
+  return rows.map((r: { claude_session_id: string; executor_ids: string[] }) => ({
+    claudeSessionId: r.claude_session_id,
+    executorIds: r.executor_ids,
+  }));
+}

--- a/src/services/executors/__tests__/sdk-session-capture.test.ts
+++ b/src/services/executors/__tests__/sdk-session-capture.test.ts
@@ -122,6 +122,41 @@ describe('sdk-session-capture', () => {
       const sessionId = await startSession(degraded, 'exec-3', 'sess-x', 'agent-3');
       expect(sessionId).toBeNull();
     });
+
+    // ----------------------------------------------------------------------
+    // Group 1 (fix-agent-session-linkage wish): orphan-upgrade reproduction
+    //
+    // Today the SDK insert uses `ON CONFLICT (id) DO NOTHING`. When session
+    // ingestion has already inserted an orphaned row for this id (executor
+    // not yet known), the SDK call drops the new linkage on the floor and
+    // the row stays orphaned forever — this is the exact bug live on the
+    // `felipe` DB (1854 sessions, 1852 with NULL executor_id) and locally
+    // (6 linkable orphans). Group 2 must change the conflict clause to
+    // `DO UPDATE` so missing executor_id / agent_id / team / wish_slug
+    // / role are filled in. These two tests pin that contract.
+    // ----------------------------------------------------------------------
+
+    it('uses ON CONFLICT DO UPDATE so existing orphan rows get linkage filled in', async () => {
+      // FAILS today (current SQL: `ON CONFLICT (id) DO NOTHING`).
+      // PASSES after Group 2 swaps to `ON CONFLICT (id) DO UPDATE SET ...`.
+      await startSession(safePgCall, 'exec-orphan-sdk', 'claude-orphan-sdk', 'agent-orphan-sdk');
+      const sql = calls[0].sqlStrings.join('?');
+      expect(sql).toContain('ON CONFLICT (id) DO UPDATE');
+      expect(sql).not.toContain('ON CONFLICT (id) DO NOTHING');
+    });
+
+    it('does not write empty strings for missing observability fields', async () => {
+      // Wish decision #4: nullable observability fields must be inserted as
+      // SQL NULL, not '', so partial indexes and `IS NULL` diagnostics work.
+      // The current code already does ${team ?? null} for these — this test
+      // pins that contract so a future regression does not silently drift back
+      // to empty-string writes (which is what tool_events currently has:
+      // 70713/71025 rows with empty agent/team/wish/task locally).
+      await startSession(safePgCall, 'exec-empty-check', 'sess-empty-check', null);
+      // null for omitted optional params must reach the SQL layer as null,
+      // never the empty string.
+      expect(calls[0].sqlValues).not.toContain('');
+    });
   });
 
   // --------------------------------------------------------------------------

--- a/src/services/executors/sdk-session-capture.ts
+++ b/src/services/executors/sdk-session-capture.ts
@@ -35,12 +35,30 @@ export async function startSession(
 ): Promise<string | null> {
   const sessionId = claudeSessionId ?? `sdk-${executorId}-${Date.now()}`;
 
+  // ON CONFLICT DO UPDATE (not DO NOTHING) so the session row gets its
+  // executor / agent / attribution filled even when ingestion has already
+  // inserted an orphaned placeholder for this id. COALESCE protects every
+  // field that already has a non-null value — we only ever fill NULLs,
+  // never overwrite better context. Status flips 'orphaned' → 'active'
+  // when the SDK call brings real attribution; we never overwrite
+  // 'completed' / 'crashed' / 'active'.
   const created = await safePgCall(
     'sdk-session-start',
     (sql) =>
       sql`INSERT INTO sessions (id, agent_id, executor_id, team, role, wish_slug, status, jsonl_path, project_path)
           VALUES (${sessionId}, ${agentId}, ${executorId}, ${team ?? null}, ${role ?? null}, ${wishSlug ?? null}, 'active', '', '')
-          ON CONFLICT (id) DO NOTHING
+          ON CONFLICT (id) DO UPDATE SET
+            agent_id    = COALESCE(sessions.agent_id,    EXCLUDED.agent_id),
+            executor_id = COALESCE(sessions.executor_id, EXCLUDED.executor_id),
+            team        = COALESCE(sessions.team,        EXCLUDED.team),
+            role        = COALESCE(sessions.role,        EXCLUDED.role),
+            wish_slug   = COALESCE(sessions.wish_slug,   EXCLUDED.wish_slug),
+            status      = CASE
+              WHEN sessions.status = 'orphaned' AND EXCLUDED.agent_id IS NOT NULL
+                THEN 'active'
+              ELSE sessions.status
+            END,
+            updated_at  = now()
           RETURNING id`,
     null,
     { executorId, chatId: '' },

--- a/src/term-commands/sessions.test.ts
+++ b/src/term-commands/sessions.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for the `genie sessions repair-links --apply` safety gates.
+ *
+ * Convergent advisory finding from reviewer (3 LOW) and qa (2 WARN) on
+ * Groups 1–3 of fix-agent-session-linkage: the gates exist and work but
+ * had zero automated coverage.
+ *
+ * Coverage in this file:
+ *   1. Drift gate — preview vs in-tx recount mismatch, no --force → throws
+ *   2. Drift gate with --force → does not throw, returns result
+ *   3. Ambiguity gate — ambiguous>0 + no --force → blocked
+ *   4. Ambiguity gate with --force → not blocked
+ *   5. No-work short-circuit — returns RepairLinksApplyResult-shaped zero result
+ *      (closes JSON-shape inconsistency LOW from reviewer)
+ *
+ * Strategy: the safety-gate decisions live in two pure helpers
+ * (`evaluateAmbiguityGate`, `buildNoWorkResultIfApplicable`) and one
+ * transaction wrapper (`applyRepairTransaction`). All three are exported
+ * from sessions.ts. Tests stub the postgres.js Sql client with the minimum
+ * surface the transaction touches: tagged-template SQL, `.begin(cb)`, and
+ * `tx.json(...)`. No live DB is required.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { applyRepairTransaction, buildNoWorkResultIfApplicable, evaluateAmbiguityGate } from './sessions.js';
+
+import type { SessionLinkDiagnostics } from '../lib/session-link-repair.js';
+
+// ============================================================================
+// Test fixtures — minimal SessionLinkDiagnostics builder
+// ============================================================================
+
+function makeDiag(overrides: Partial<SessionLinkDiagnostics> = {}): SessionLinkDiagnostics {
+  return {
+    linkableOrphanSessions: 0,
+    totalSessions: 0,
+    statusOrphanedSessions: 0,
+    nullExecutorIdSessions: 0,
+    totalToolEvents: 0,
+    toolEventsMissingAgent: 0,
+    toolEventsMissingTeam: 0,
+    toolEventsMissingWish: 0,
+    toolEventsMissingTask: 0,
+    toolEventsLinkableMissingAttribution: 0,
+    toolEventsEmptyStringAgent: 0,
+    toolEventsEmptyStringTeam: 0,
+    toolEventsEmptyStringWish: 0,
+    toolEventsEmptyStringTask: 0,
+    sessionsEmptyStringTeam: 0,
+    sessionsEmptyStringWishSlug: 0,
+    sessionsEmptyStringRole: 0,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Stubbed postgres.js Sql client for applyRepairTransaction
+//
+// applyRepairTransaction issues four queries inside sql.begin(...):
+//   1. SELECT count(*)::int AS n FROM sessions s JOIN executors e ...   (recount)
+//   2. UPDATE sessions s SET ... FROM executors e ...                    (link)
+//   3. UPDATE tool_events te SET ... FROM sessions s ...                 (backfill)
+//   4. INSERT INTO audit_events ...                                      (audit row)
+// We dispatch on substring of the rendered template to return shaped results.
+// ============================================================================
+
+interface StubScenario {
+  recount: number;
+  linkUpdateCount: number;
+  teUpdateCount: number;
+}
+
+interface StubSql {
+  // biome-ignore lint/suspicious/noExplicitAny: postgres.js Sql tagged template surface
+  (strings: TemplateStringsArray, ...values: unknown[]): any;
+  // biome-ignore lint/suspicious/noExplicitAny: postgres.js helper surface
+  begin: (cb: (tx: StubSql) => Promise<unknown>) => Promise<unknown>;
+  json: (obj: unknown) => unknown;
+  /** Captured SQL templates for assertion. */
+  capturedSql: string[];
+}
+
+function makeStubSql(scenario: StubScenario): StubSql {
+  const captured: string[] = [];
+
+  // biome-ignore lint/suspicious/noExplicitAny: postgres.js result shape varies
+  const dispatch = (strings: TemplateStringsArray, ..._values: unknown[]): any => {
+    const text = strings.join('?');
+    captured.push(text);
+
+    if (text.includes('SELECT count(*)::int AS n')) {
+      return [{ n: scenario.recount }];
+    }
+    if (text.includes('UPDATE sessions s SET')) {
+      // postgres.js UPDATE returns an array with a `.count` property.
+      const arr: unknown[] & { count?: number } = [];
+      arr.count = scenario.linkUpdateCount;
+      return arr;
+    }
+    if (text.includes('UPDATE tool_events te SET')) {
+      const arr: unknown[] & { count?: number } = [];
+      arr.count = scenario.teUpdateCount;
+      return arr;
+    }
+    if (text.includes('INSERT INTO audit_events')) {
+      return [];
+    }
+    return [];
+  };
+
+  const sql = dispatch as unknown as StubSql;
+  sql.capturedSql = captured;
+  sql.json = (obj: unknown) => obj;
+  sql.begin = async (cb) => {
+    return cb(sql);
+  };
+  return sql;
+}
+
+// ============================================================================
+// 1+2. Drift gate
+// ============================================================================
+
+describe('applyRepairTransaction — drift gate', () => {
+  test('throws when in-tx recount differs from previewCount and not forced', async () => {
+    const sql = makeStubSql({ recount: 7, linkUpdateCount: 0, teUpdateCount: 0 });
+    // previewCount=5, recount=7 → drift, force=false → throws
+    await expect(applyRepairTransaction(sql, 5, false)).rejects.toThrow(
+      /candidate count drifted between preview \(5\) and apply \(7\)/,
+    );
+    // The drift abort lands BEFORE either UPDATE runs.
+    expect(sql.capturedSql.some((s) => s.includes('UPDATE sessions s SET'))).toBe(false);
+    expect(sql.capturedSql.some((s) => s.includes('UPDATE tool_events te SET'))).toBe(false);
+  });
+
+  test('does not throw when forced — proceeds through the transaction', async () => {
+    const sql = makeStubSql({ recount: 7, linkUpdateCount: 7, teUpdateCount: 42 });
+    // previewCount=5, recount=7 → drift, force=true → proceeds
+    const result = await applyRepairTransaction(sql, 5, true);
+    expect(result.sessionsLinked).toBe(7);
+    expect(result.toolEventsBackfilled).toBe(42);
+    expect(result.forced).toBe(true);
+    expect(result.driftDetected).toBe(false);
+    // Both UPDATEs and the audit row landed.
+    expect(sql.capturedSql.some((s) => s.includes('UPDATE sessions s SET'))).toBe(true);
+    expect(sql.capturedSql.some((s) => s.includes('UPDATE tool_events te SET'))).toBe(true);
+    expect(sql.capturedSql.some((s) => s.includes('INSERT INTO audit_events'))).toBe(true);
+  });
+
+  test('does not throw when recount matches preview (no drift)', async () => {
+    const sql = makeStubSql({ recount: 5, linkUpdateCount: 5, teUpdateCount: 12 });
+    const result = await applyRepairTransaction(sql, 5, false);
+    expect(result.sessionsLinked).toBe(5);
+    expect(result.toolEventsBackfilled).toBe(12);
+    expect(result.forced).toBe(false);
+  });
+});
+
+// ============================================================================
+// 3+4. Ambiguity gate
+// ============================================================================
+
+describe('evaluateAmbiguityGate', () => {
+  test('blocks --apply when ambiguous > 0 and not forced', () => {
+    const r = evaluateAmbiguityGate(3, false);
+    expect(r.blocked).toBe(true);
+    expect(r.message).toContain('3 ambiguous claude_session_id');
+    expect(r.message).toContain('refusing --apply');
+  });
+
+  test('does not block when --force is passed even with ambiguous matches', () => {
+    const r = evaluateAmbiguityGate(3, true);
+    expect(r.blocked).toBe(false);
+    expect(r.message).toBeNull();
+  });
+
+  test('does not block when ambiguous count is zero', () => {
+    const r = evaluateAmbiguityGate(0, false);
+    expect(r.blocked).toBe(false);
+    expect(r.message).toBeNull();
+  });
+});
+
+// ============================================================================
+// 5. No-work short-circuit + JSON-shape consistency (closes reviewer LOW B)
+// ============================================================================
+
+describe('buildNoWorkResultIfApplicable', () => {
+  test('returns a RepairLinksApplyResult-shaped zero object when nothing to repair', () => {
+    const diag = makeDiag({ linkableOrphanSessions: 0, toolEventsLinkableMissingAttribution: 0 });
+    const r = buildNoWorkResultIfApplicable(diag, 0, false);
+    expect(r).not.toBeNull();
+    // Same keys as RepairLinksApplyResult on the apply path — JSON consumers
+    // see one schema regardless of whether work was performed.
+    expect(r).toEqual({
+      sessionsLinked: 0,
+      toolEventsBackfilled: 0,
+      ambiguousCount: 0,
+      forced: false,
+      driftDetected: false,
+    });
+  });
+
+  test('threads ambiguousCount and forced into the result for transparency', () => {
+    const diag = makeDiag({ linkableOrphanSessions: 0, toolEventsLinkableMissingAttribution: 0 });
+    const r = buildNoWorkResultIfApplicable(diag, 4, true);
+    expect(r).toEqual({
+      sessionsLinked: 0,
+      toolEventsBackfilled: 0,
+      ambiguousCount: 4,
+      forced: true,
+      driftDetected: false,
+    });
+  });
+
+  test('returns null when there is repair work pending (linkable orphans)', () => {
+    const diag = makeDiag({ linkableOrphanSessions: 5, toolEventsLinkableMissingAttribution: 0 });
+    expect(buildNoWorkResultIfApplicable(diag, 0, false)).toBeNull();
+  });
+
+  test('returns null when there is repair work pending (tool_events backlog)', () => {
+    const diag = makeDiag({ linkableOrphanSessions: 0, toolEventsLinkableMissingAttribution: 200 });
+    expect(buildNoWorkResultIfApplicable(diag, 0, false)).toBeNull();
+  });
+});

--- a/src/term-commands/sessions.ts
+++ b/src/term-commands/sessions.ts
@@ -322,7 +322,7 @@ function printRepairDiagnostics(
   console.log(`  missing task_id (NULL or ''): ${diag.toolEventsMissingTask}`);
   console.log(`  empty-string agent_id: ${diag.toolEventsEmptyStringAgent}`);
   console.log(`  empty-string team:     ${diag.toolEventsEmptyStringTeam}`);
-  console.log(`  empty-string wish_slug:${diag.toolEventsEmptyStringWish}`);
+  console.log(`  empty-string wish_slug: ${diag.toolEventsEmptyStringWish}`);
   console.log(`  empty-string task_id:  ${diag.toolEventsEmptyStringTask}`);
   console.log(
     `  linkable (session has executor_id, event missing attribution): ${diag.toolEventsLinkableMissingAttribution}`,
@@ -348,8 +348,47 @@ function printRepairDiagnostics(
   }
 }
 
+/**
+ * Pure decision helpers for the apply-mode safety gates. Extracted so unit
+ * tests can exercise the gate logic without spinning up a DB or trapping
+ * `process.exit`. Used by `sessionsRepairLinksCommand` directly below.
+ */
+export function evaluateAmbiguityGate(
+  ambiguousCount: number,
+  force: boolean,
+): { blocked: boolean; message: string | null } {
+  if (ambiguousCount > 0 && !force) {
+    return {
+      blocked: true,
+      message: `repair-links: ${ambiguousCount} ambiguous claude_session_id value(s) found. Multiple executors claim the same session id — refusing --apply.\nRun with --dry-run to inspect, or pass --force to override.`,
+    };
+  }
+  return { blocked: false, message: null };
+}
+
+export function buildNoWorkResultIfApplicable(
+  diag: SessionLinkDiagnostics,
+  ambiguousCount: number,
+  force: boolean,
+): RepairLinksApplyResult | null {
+  if (diag.linkableOrphanSessions === 0 && diag.toolEventsLinkableMissingAttribution === 0) {
+    return {
+      sessionsLinked: 0,
+      toolEventsBackfilled: 0,
+      ambiguousCount,
+      forced: force,
+      driftDetected: false,
+    };
+  }
+  return null;
+}
+
 // biome-ignore lint/suspicious/noExplicitAny: postgres.js Sql type
-async function applyRepairTransaction(sql: any, previewCount: number, force: boolean): Promise<RepairLinksApplyResult> {
+export async function applyRepairTransaction(
+  sql: any,
+  previewCount: number,
+  force: boolean,
+): Promise<RepairLinksApplyResult> {
   let result: RepairLinksApplyResult = {
     sessionsLinked: 0,
     toolEventsBackfilled: 0,
@@ -507,17 +546,17 @@ async function sessionsRepairLinksCommand(options: RepairLinksOptions): Promise<
   }
 
   // --apply path
-  if (ambiguous.length > 0 && !options.force) {
-    console.error(
-      `repair-links: ${ambiguous.length} ambiguous claude_session_id value(s) found. Multiple executors claim the same session id — refusing --apply.\nRun with --dry-run to inspect, or pass --force to override.`,
-    );
+  const force = options.force === true;
+  const ambiguityGate = evaluateAmbiguityGate(ambiguous.length, force);
+  if (ambiguityGate.blocked) {
+    console.error(ambiguityGate.message);
     process.exit(2);
   }
 
-  const noWork = diag.linkableOrphanSessions === 0 && diag.toolEventsLinkableMissingAttribution === 0;
-  if (noWork) {
+  const noWorkResult = buildNoWorkResultIfApplicable(diag, ambiguous.length, force);
+  if (noWorkResult) {
     if (options.json) {
-      console.log(JSON.stringify({ sessionsLinked: 0, toolEventsBackfilled: 0, idempotent: true }, null, 2));
+      console.log(JSON.stringify(noWorkResult, null, 2));
     } else {
       console.log('repair-links: nothing to repair (0 candidates).');
     }

--- a/src/term-commands/sessions.ts
+++ b/src/term-commands/sessions.ts
@@ -11,6 +11,13 @@
 import type { Command } from 'commander';
 import { getConnection, isAvailable } from '../lib/db.js';
 import { getBackfillStatus } from '../lib/session-backfill.js';
+import {
+  type OrphanSessionSample,
+  type SessionLinkDiagnostics,
+  diagnoseSessionLinks,
+  findAmbiguousExecutorSessions,
+  sampleLinkableOrphanSessions,
+} from '../lib/session-link-repair.js';
 import { formatRelativeTimestamp as formatTimestamp, padRight } from '../lib/term-format.js';
 
 // ============================================================================
@@ -271,6 +278,263 @@ async function sessionsSearchCommand(query: string, options: { json?: boolean; l
   console.log(`\n(${rows.length} result${rows.length === 1 ? '' : 's'})`);
 }
 
+// ============================================================================
+// repair-links — diagnose and (with --apply) repair linkable orphan sessions.
+//
+// Reads from src/lib/session-link-repair.ts (pure-read diagnostics) and
+// performs the mutation in a single transaction with a re-count gate so a
+// concurrent ingestion that changes the candidate count between preview and
+// apply forces the operator to re-confirm with --force.
+// ============================================================================
+
+interface RepairLinksOptions {
+  apply?: boolean;
+  dryRun?: boolean;
+  force?: boolean;
+  json?: boolean;
+}
+
+interface RepairLinksApplyResult {
+  sessionsLinked: number;
+  toolEventsBackfilled: number;
+  ambiguousCount: number;
+  forced: boolean;
+  driftDetected: boolean;
+}
+
+function printRepairDiagnostics(
+  diag: SessionLinkDiagnostics,
+  sample: OrphanSessionSample[],
+  ambiguous: { claudeSessionId: string; executorIds: string[] }[],
+): void {
+  console.log('Sessions:');
+  console.log(`  total: ${diag.totalSessions}`);
+  console.log(
+    `  linkable orphans (sessions.id = executors.claude_session_id ∧ executor_id IS NULL): ${diag.linkableOrphanSessions}`,
+  );
+  console.log(`  status='orphaned': ${diag.statusOrphanedSessions}`);
+  console.log(`  NULL executor_id: ${diag.nullExecutorIdSessions}`);
+  console.log('Tool events:');
+  console.log(`  total: ${diag.totalToolEvents}`);
+  console.log(`  missing agent_id (NULL or ''): ${diag.toolEventsMissingAgent}`);
+  console.log(`  missing team    (NULL or ''): ${diag.toolEventsMissingTeam}`);
+  console.log(`  missing wish_slug (NULL or ''): ${diag.toolEventsMissingWish}`);
+  console.log(`  missing task_id (NULL or ''): ${diag.toolEventsMissingTask}`);
+  console.log(`  empty-string agent_id: ${diag.toolEventsEmptyStringAgent}`);
+  console.log(`  empty-string team:     ${diag.toolEventsEmptyStringTeam}`);
+  console.log(`  empty-string wish_slug:${diag.toolEventsEmptyStringWish}`);
+  console.log(`  empty-string task_id:  ${diag.toolEventsEmptyStringTask}`);
+  console.log(
+    `  linkable (session has executor_id, event missing attribution): ${diag.toolEventsLinkableMissingAttribution}`,
+  );
+
+  if (sample.length > 0) {
+    console.log('\nLinkable orphan sample (up to 10):');
+    for (const s of sample) {
+      console.log(
+        `  ${s.sessionId}  executor=${s.executorId.slice(0, 12)}  agent=${(s.agentId ?? '-').slice(0, 12)}  status=${s.status ?? '-'}`,
+      );
+    }
+  }
+
+  if (ambiguous.length > 0) {
+    console.log(
+      `\n⚠️ Ambiguous claude_session_id values (${ambiguous.length}) — multiple executors claim the same session id:`,
+    );
+    for (const a of ambiguous) {
+      console.log(`  ${a.claudeSessionId} -> ${a.executorIds.join(', ')}`);
+    }
+    console.log('  --apply will refuse unless --force is passed.');
+  }
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: postgres.js Sql type
+async function applyRepairTransaction(sql: any, previewCount: number, force: boolean): Promise<RepairLinksApplyResult> {
+  let result: RepairLinksApplyResult = {
+    sessionsLinked: 0,
+    toolEventsBackfilled: 0,
+    ambiguousCount: 0,
+    forced: force,
+    driftDetected: false,
+  };
+
+  // biome-ignore lint/suspicious/noExplicitAny: postgres.js Sql type
+  await sql.begin(async (tx: any) => {
+    // Re-count INSIDE the transaction so a concurrent ingestion changing the
+    // candidate set between preview and apply trips the gate. With READ
+    // COMMITTED (postgres default) this still leaves a tiny TOCTOU window,
+    // but the gate catches the common case ("ingestion ran while operator
+    // was reading the dry-run output").
+    const [recount] = await tx`
+      SELECT count(*)::int AS n
+      FROM sessions s
+      JOIN executors e ON s.id = e.claude_session_id
+      WHERE s.executor_id IS NULL
+    `;
+
+    if (recount.n !== previewCount && !force) {
+      result.driftDetected = true;
+      throw new Error(
+        `repair-links: candidate count drifted between preview (${previewCount}) and apply (${recount.n}). Re-run --dry-run or pass --force to override.`,
+      );
+    }
+
+    const linkResult = await tx`
+      UPDATE sessions s SET
+        executor_id = e.id,
+        agent_id    = COALESCE(s.agent_id,    e.agent_id),
+        team        = COALESCE(s.team,        a.team),
+        wish_slug   = COALESCE(s.wish_slug,   a.wish_slug),
+        task_id     = COALESCE(s.task_id,     a.task_id),
+        role        = COALESCE(s.role,        a.role),
+        status      = CASE WHEN s.status = 'orphaned' THEN 'active' ELSE s.status END,
+        updated_at  = now()
+      FROM executors e
+      LEFT JOIN agents a ON e.agent_id = a.id
+      WHERE s.id = e.claude_session_id
+        AND s.executor_id IS NULL
+    `;
+
+    // Backfill tool_events from linked sessions. NULLIF(field, '') treats the
+    // legacy empty-string writes (wish decision #4) as missing so the linked
+    // session value can replace them. We never overwrite a non-empty,
+    // non-null value.
+    //
+    // Idempotency: the WHERE filters to rows where the post-COALESCE result
+    // would actually differ from the current value. Without this, a second
+    // --apply still "touches" rows where session.X is also NULL, producing
+    // a non-zero row count for a no-op update. IS DISTINCT FROM treats
+    // NULL = NULL as same, so unchanged rows are skipped.
+    const teResult = await tx`
+      UPDATE tool_events te SET
+        agent_id  = COALESCE(NULLIF(te.agent_id, ''),  s.agent_id),
+        team      = COALESCE(NULLIF(te.team, ''),      s.team),
+        wish_slug = COALESCE(NULLIF(te.wish_slug, ''), s.wish_slug),
+        task_id   = COALESCE(NULLIF(te.task_id, ''),   s.task_id)
+      FROM sessions s
+      WHERE s.id = te.session_id
+        AND s.executor_id IS NOT NULL
+        AND (
+          te.agent_id  IS DISTINCT FROM COALESCE(NULLIF(te.agent_id, ''),  s.agent_id)  OR
+          te.team      IS DISTINCT FROM COALESCE(NULLIF(te.team, ''),      s.team)      OR
+          te.wish_slug IS DISTINCT FROM COALESCE(NULLIF(te.wish_slug, ''), s.wish_slug) OR
+          te.task_id   IS DISTINCT FROM COALESCE(NULLIF(te.task_id, ''),   s.task_id)
+        )
+    `;
+
+    // Audit row records totals only — never raw session content. Use
+    // tx.json(...) so the JSONB column gets a real object, not a
+    // string-of-string (the JSON.stringify trap that postgres.js silently
+    // accepts as JSON-typed string).
+    await tx`
+      INSERT INTO audit_events (entity_type, entity_id, event_type, actor, details)
+      VALUES (
+        'sessions',
+        'repair-links',
+        'sessions.repair_links',
+        'cli',
+        ${tx.json({
+          sessions_linked: linkResult.count ?? 0,
+          tool_events_backfilled: teResult.count ?? 0,
+          preview_count: previewCount,
+          recount: recount.n,
+          forced: force,
+        })}
+      )
+    `;
+
+    result = {
+      sessionsLinked: linkResult.count ?? 0,
+      toolEventsBackfilled: teResult.count ?? 0,
+      ambiguousCount: 0,
+      forced: force,
+      driftDetected: false,
+    };
+  });
+
+  return result;
+}
+
+function renderDryRun(
+  diag: SessionLinkDiagnostics,
+  sample: OrphanSessionSample[],
+  ambiguous: { claudeSessionId: string; executorIds: string[] }[],
+  json: boolean,
+): void {
+  if (json) {
+    console.log(JSON.stringify({ diagnostics: diag, sample, ambiguous }, null, 2));
+    return;
+  }
+  console.log('repair-links --dry-run (no rows mutated)');
+  console.log('-----------------------------------------');
+  printRepairDiagnostics(diag, sample, ambiguous);
+  if (diag.linkableOrphanSessions === 0 && diag.toolEventsLinkableMissingAttribution === 0) {
+    console.log('\nNothing to repair.');
+  } else {
+    console.log(
+      `\nRun with --apply to repair ${diag.linkableOrphanSessions} session(s) and up to ${diag.toolEventsLinkableMissingAttribution} tool_event(s).`,
+    );
+  }
+}
+
+function renderApplyResult(result: RepairLinksApplyResult, json: boolean): void {
+  if (json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  console.log('repair-links --apply complete');
+  console.log(`  sessions linked:        ${result.sessionsLinked}`);
+  console.log(`  tool_events backfilled: ${result.toolEventsBackfilled}`);
+  if (result.forced) console.log('  --force was used');
+}
+
+async function sessionsRepairLinksCommand(options: RepairLinksOptions): Promise<void> {
+  if (!(await isAvailable())) {
+    console.error('Database not available.');
+    process.exit(1);
+  }
+
+  const sql = await getConnection();
+  const diag = await diagnoseSessionLinks(sql);
+  const sample = await sampleLinkableOrphanSessions(sql, 10);
+  const ambiguous = await findAmbiguousExecutorSessions(sql);
+
+  // Default = dry-run. --apply explicitly enters mutation mode.
+  const apply = options.apply === true;
+  if (!apply) {
+    renderDryRun(diag, sample, ambiguous, options.json === true);
+    return;
+  }
+
+  // --apply path
+  if (ambiguous.length > 0 && !options.force) {
+    console.error(
+      `repair-links: ${ambiguous.length} ambiguous claude_session_id value(s) found. Multiple executors claim the same session id — refusing --apply.\nRun with --dry-run to inspect, or pass --force to override.`,
+    );
+    process.exit(2);
+  }
+
+  const noWork = diag.linkableOrphanSessions === 0 && diag.toolEventsLinkableMissingAttribution === 0;
+  if (noWork) {
+    if (options.json) {
+      console.log(JSON.stringify({ sessionsLinked: 0, toolEventsBackfilled: 0, idempotent: true }, null, 2));
+    } else {
+      console.log('repair-links: nothing to repair (0 candidates).');
+    }
+    return;
+  }
+
+  let result: RepairLinksApplyResult;
+  try {
+    result = await applyRepairTransaction(sql, diag.linkableOrphanSessions, options.force === true);
+  } catch (err) {
+    console.error((err as Error).message);
+    process.exit(2);
+  }
+
+  renderApplyResult(result, options.json === true);
+}
+
 async function sessionsSyncStatusCommand(): Promise<void> {
   if (!(await isAvailable())) {
     console.error('Database not available.');
@@ -333,5 +597,16 @@ export function registerSessionsCommands(program: Command): void {
     .description('Check session backfill progress')
     .action(async () => {
       await sessionsSyncStatusCommand();
+    });
+
+  sessions
+    .command('repair-links')
+    .description('Diagnose and (with --apply) repair linkable orphan sessions + tool_events attribution')
+    .option('--dry-run', 'Preview only — never mutates rows (default)')
+    .option('--apply', 'Run the repair transaction')
+    .option('--force', 'Override the candidate-count drift gate and ambiguity gate')
+    .option('--json', 'Output as JSON')
+    .action(async (options: RepairLinksOptions) => {
+      await sessionsRepairLinksCommand(options);
     });
 }


### PR DESCRIPTION
## Summary

P0 data-linkage bug from PR #1607's roadmap (`fix-agent-session-linkage` wish). Fixes the agent observability bug where executor-owned Claude sessions were left as orphaned session rows: ingestion never upgraded existing rows when worker context appeared later, the SDK insert silently dropped linkage via `ON CONFLICT DO NOTHING`, and missing observability fields were written as empty strings instead of SQL `NULL`.

**Live evidence on local DB before merge:** 10 sessions linked + 688 tool_events backfilled by `--apply` on first run; subsequent applies converged to `(0,0)` (idempotent). The trace forensic agent's session was IN the orphan list and got linked in the same pass — bleeding stopped.

**Out of scope (deferred):** Group 4 cross-instance verification on the richer `ssh felipe` instance is BLOCKED on operator key provisioning. Will land as a follow-up PR with the `genie sessions repair-links --apply` transcript on that instance once access is provisioned. The wish docs the pre-fix remote baseline (1854 sessions, 1852 NULL `executor_id` — suggests apply will link a few thousand sessions there).

## Changes (5 commits, Groups 1-3 + tightening)

| Commit | What |
|---|---|
| `51e86541` | test: failing tests pinning the two ingestion bugs + diagnostic helper (`src/lib/session-link-repair.ts`) |
| `aa67330d` | fix: `ensureSession()` COALESCE upgrade path + SDK `ON CONFLICT DO UPDATE` + `?? null` for tool_event optional fields |
| `faa8a293` | feat: `genie sessions repair-links --dry-run | --apply | --force | --json` with audit-event recording (`sessions.repair_links` event type) |
| `97fb712d` | docs: append QA + Reviewer verdicts to wish report |
| `83a687ca` | test: 10 cases covering drift gate + ambiguity gate + `--force` overrides + no-work `--json` shape; 2 reviewer LOWs (JSON shape inconsistency + cosmetic spacing) |

## Validation

```
$ bun test src/term-commands/sessions.test.ts src/lib/session-capture.test.ts src/services/executors/__tests__/sdk-session-capture.test.ts
42 pass / 0 fail / 147 expect() calls

$ bun run typecheck
clean

$ bun test src/lib/ src/services/   # tree-wide regression
2824 pass / 0 fail
```

**Live local-DB transcript** (full evidence in `.genie/wishes/fix-agent-session-linkage/REPORT.md`):

```
$ ./dist/genie.js --no-tui sessions repair-links --apply
repair-links --apply complete
  sessions linked:        10
  tool_events backfilled: 688

$ ./dist/genie.js --no-tui db query "select count(*) from sessions s join executors e on s.id = e.claude_session_id where s.executor_id is null"
0
```

## Verdicts

- **Reviewer:** SHIP — 0 CRITICAL/HIGH, 3 LOW (all 3 closed in `83a687ca`). All Group 2 + 3 acceptance criteria independently verified at file:line. All 3 wish risks mitigated.
- **QA:** PASS — 4/4 wish criteria + 5/5 structured checks. 1 INFO (global-binary lag, expected pre-merge) + 2 WARN (5 stale audit-string rows are inert legacy data; test gap was the converge point and is now closed).

## Follow-ons (not in this PR)

1. Group 4 cross-instance verification once `ssh felipe` access is provisioned (single-PR docs follow-up — appends a transcript to REPORT.md, no code changes).
2. Optional one-shot cleanup query for the 5 stale audit-string rows from before the engineer switched to `tx.json(...)` (REPORT.md has the SQL).
3. Unblocks wish #2 of the PR-1607 observability roadmap (`observability-signal-normalization` — clean session linkage is its `depends-on`).

## Test plan

- [ ] CI: typecheck + lint + non-PG tests
- [ ] CI: PG tests matrix (4 shards + aggregate)
- [ ] CI: pgserve v2 smoke
- [ ] CI: secrets scan + Snyk + Socket
- [ ] Manual: rebuild global `genie` binary post-merge, re-run `genie sessions repair-links --dry-run` on this DB to confirm zero pending work
- [ ] Manual: once `ssh felipe` is up, run `--dry-run` then `--apply` on that instance and append transcript to REPORT.md as Group 4 follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)