### PR TITLE
fix(tui): drop redundant registerMetadataFields call (silences 5 keymap errors per launch)

### DIFF
--- a/src/tui/keymap.ts
+++ b/src/tui/keymap.ts
@@ -1,14 +1,25 @@
 import type { CliRenderer, KeyEvent, Renderable } from '@opentui/core';
 import type { Keymap } from '@opentui/keymap';
-import { registerEscapeClearsPendingSequence, registerLeader, registerMetadataFields } from '@opentui/keymap/addons';
+import { registerEscapeClearsPendingSequence, registerLeader } from '@opentui/keymap/addons';
 import { createDefaultOpenTuiKeymap } from '@opentui/keymap/opentui';
 
 export type TuiKeymap = Keymap<Renderable, KeyEvent>;
 
 export function createTuiKeymap(renderer: CliRenderer): TuiKeymap {
+  // `createDefaultOpenTuiKeymap` already runs `registerMetadataFields(keymap)`
+  // internally (see @opentui/keymap/opentui.js — it composes
+  // `registerDefaultKeys` + `registerEnabledFields` + `registerMetadataFields`).
+  // We previously called `registerMetadataFields(keymap)` again here, which
+  // tripped the library's duplicate-registration guard and emitted
+  //   [duplicate-binding-field] Keymap binding field "desc"  is already registered
+  //   [duplicate-binding-field] Keymap binding field "group" is already registered
+  //   [duplicate-command-field] Keymap command field "desc"     is already registered
+  //   [duplicate-command-field] Keymap command field "title"    is already registered
+  //   [duplicate-command-field] Keymap command field "category" is already registered
+  // on every TUI launch. The fields ARE registered (first call wins) so the
+  // keymap was functionally correct, but every operator saw five red error
+  // lines in the TUI console at startup. Drop the redundant call.
   const keymap = createDefaultOpenTuiKeymap(renderer);
-
-  registerMetadataFields(keymap);
 
   registerLeader(keymap, { trigger: { name: 'space' } });
 


### PR DESCRIPTION
## Summary

`createTuiKeymap` was calling `registerMetadataFields(keymap)` after `createDefaultOpenTuiKeymap(renderer)` — but the latter already runs `registerMetadataFields` internally:

```js
// @opentui/keymap/opentui.js
function createDefaultOpenTuiKeymap(renderer) {
  const keymap = createOpenTuiKeymap(renderer);
  registerDefaultKeys(keymap);
  registerEnabledFields(keymap);
  registerMetadataFields(keymap);   // ← already registers desc/group/title/category
  return keymap;
}
```

Then `src/tui/keymap.ts:11` ran it again. The library's duplicate-registration guard emitted these on **every TUI launch**:

```
[ERROR] [duplicate-binding-field] Keymap binding field "desc"  is already registered
[ERROR] [duplicate-binding-field] Keymap binding field "group" is already registered
[ERROR] [duplicate-command-field] Keymap command field "desc"     is already registered
[ERROR] [duplicate-command-field] Keymap command field "title"    is already registered
[ERROR] [duplicate-command-field] Keymap command field "category" is already registered
```

The keymap was functionally correct — first registration wins, duplicates are rejected before they can overwrite anything. But every operator saw five red error lines in the TUI console on startup, which makes the harness look like it's crashing.

## Fix

Drop the redundant `registerMetadataFields(keymap)` call. Removed the now-unused import too. Added an inline comment explaining why we don't call it (so the next person doesn't put it back thinking the universal metadata fields aren't registered).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bunx biome check src/tui/keymap.ts` — clean
- [x] Live verification: launching the TUI no longer prints any `[duplicate-binding-field]` / `[duplicate-command-field]` lines on the console.

## Live evidence (from this server)

User pasted these from their TUI console at 19:02:34 BRT during a stability survey:

```
[19:02:34] [ERROR] '[duplicate-binding-field] Keymap binding field "desc" is already registered'
[19:02:34] [ERROR] '[duplicate-binding-field] Keymap binding field "group" is already registered'
[19:02:34] [ERROR] '[duplicate-command-field] Keymap command field "desc" is already registered'
[19:02:34] [ERROR] '[duplicate-command-field] Keymap command field "title" is already registered'
[19:02:34] [ERROR] '[duplicate-command-field] Keymap command field "category" is already registered'
```

These five errors fire on every `genie` TUI invocation. After this PR they'll go silent.