### PR TITLE
fix(tui): use falsy isTTY check, not strict === false (PR #1610 follow-up)

### DIFF
--- a/src/__tests__/interactivity.test.ts
+++ b/src/__tests__/interactivity.test.ts
@@ -426,7 +426,20 @@ describe('isTuiDisabled()', () => {
     }
   });
 
-  test('returns true when stdout is not a TTY (pipe/redirect) even with env+argv unset', () => {
+  test('returns true when stdout.isTTY is undefined (pipe — Node default for non-TTY stdout)', () => {
+    // This is the production case: Node sets `isTTY` to `undefined` (not
+    // `false`) when stdout is piped or redirected. Mirrors the
+    // `isInteractive()` undefined-pipe test above.
+    Object.defineProperty(process.stdout, 'isTTY', { value: undefined, configurable: true });
+    process.argv = ['node', 'genie', 'ls'];
+
+    expect(isTuiDisabled()).toBe(true);
+  });
+
+  test('returns true when stdout.isTTY is explicitly false', () => {
+    // Defensive case — some test runners and shell wrappers may set isTTY
+    // to literal `false` instead of leaving it undefined. Both must trip
+    // the guard.
     Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
     process.argv = ['node', 'genie', 'ls'];
 

--- a/src/lib/tui-disable.ts
+++ b/src/lib/tui-disable.ts
@@ -31,7 +31,10 @@ export function isTuiDisabled(): boolean {
   const envVal = process.env.GENIE_TUI_DISABLE;
   if (envVal && TRUTHY.has(envVal.trim().toLowerCase())) return true;
   if (process.argv.includes('--no-tui')) return true;
-  if (process.stdout.isTTY === false) return true;
+  // Node sets `process.stdout.isTTY` to `undefined` (not `false`) when stdout
+  // is piped/redirected — strict `=== false` would miss the common case.
+  // Falsy check matches `isInteractive()` in `src/lib/interactivity.ts:23`.
+  if (!process.stdout.isTTY) return true;
   return false;
 }
 


### PR DESCRIPTION
## Summary

PR #1610 added a `process.stdout.isTTY === false` guard to `isTuiDisabled()` to auto-skip the TUI in piped contexts. **That guard never fires in production** — Node and Bun both leave `process.stdout.isTTY` as `undefined` (not literal `false`) when stdout is not a TTY. The merged code was a no-op for the actual operator repro.

## Real-world QA failure on PR #1610

```bash
$ node -e "console.log('typeof:', typeof process.stdout.isTTY, '| value:', process.stdout.isTTY)" | cat
typeof: undefined | value: undefined

$ bun -e "console.log('typeof:', typeof process.stdout.isTTY, '| value:', process.stdout.isTTY)" | cat
typeof: undefined | value: undefined
```

Test harness importing the live ` isTuiDisabled()` from PR #1610's merged code:
```
piped (no env/flag)         → isTuiDisabled=false   ← BUG: should be true
piped + GENIE_TUI_DISABLE=1 → true (env path OK)
piped + --no-tui            → true (argv path OK)
PTY                          → false (correct)
```

PR #1610 unit tests passed because they mocked `Object.defineProperty(process.stdout, 'isTTY', { value: false, ... })` — testing literal `false`, never `undefined`. The pre-existing `isInteractive()` test at `interactivity.test.ts:79` correctly mocks to `undefined`; PR #1610's new tests didn't follow that pattern. My oversight.

## Fix

`src/lib/tui-disable.ts`:
```ts
// Before (PR #1610, broken):
if (process.stdout.isTTY === false) return true;

// After:
if (!process.stdout.isTTY) return true;
```

The falsy check matches `isInteractive()` in `src/lib/interactivity.ts:23` — both `undefined` and literal `false` now trip the guard. Comment added explaining why.

## Test fixes

- Replace the broken `value: false` mock with `value: undefined` to mirror real Node behavior (mirrors the existing isInteractive undefined-pipe test pattern).
- Keep an explicit `value: false` test as a defensive case for shell wrappers that may present a literal-false isTTY.
- TTY case unchanged.

## Validation

```
$ bun test src/__tests__/interactivity.test.ts
32 pass / 0 fail / 47 expect calls

$ bunx biome check src/lib/tui-disable.ts src/__tests__/interactivity.test.ts
Checked 2 files in 22ms. No fixes applied.

$ bun run typecheck
$ tsc --noEmit   # clean
```

**Real-world repro post-fix** (bun harness importing this branch's source):
```
piped (no env/flag)         → isTuiDisabled=true  ✓
piped + GENIE_TUI_DISABLE=1 → true                ✓
piped + --no-tui            → true                ✓
PTY                          → false              ✓
```

## Diff scope

```
src/__tests__/interactivity.test.ts | 15 ++++++++++++++-
src/lib/tui-disable.ts              |  5 ++++-
2 files changed, 18 insertions(+), 2 deletions(-)
```

## Lesson

Trace recommendations and unit-test mocks must be verified against real-runtime behavior. `=== false` was the wrong check; the trace report (`/tmp/trace-genie-no-tui-pollution.md` §5) recommended exactly the broken form because it didn't probe Node's actual isTTY value on a pipe. Should have been a `node -e | cat` repro at trace time, not at QA time.