### PR TITLE
fix(tui): report `stdout is not a TTY` when auto-detect skips TUI

### DIFF
--- a/src/__tests__/interactivity.test.ts
+++ b/src/__tests__/interactivity.test.ts
@@ -16,7 +16,7 @@ mock.module('@inquirer/prompts', () => ({
 const { isInteractive, ensureWorkspace, commandRequiresWorkspace, installWorkspaceCheck } = await import(
   '../lib/interactivity.js'
 );
-const { isTuiDisabled } = await import('../lib/tui-disable.js');
+const { isTuiDisabled, noticeTuiSkipped } = await import('../lib/tui-disable.js');
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -451,5 +451,64 @@ describe('isTuiDisabled()', () => {
     process.argv = ['node', 'genie', 'ls'];
 
     expect(isTuiDisabled()).toBe(false);
+  });
+});
+
+// ─── noticeTuiSkipped() reason precedence ───────────────────────────────────
+
+describe('noticeTuiSkipped()', () => {
+  let originalTuiDisable: string | undefined;
+  let errorSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    originalTuiDisable = process.env.GENIE_TUI_DISABLE;
+    // biome-ignore lint/performance/noDelete: process.env requires delete — assignment sets the string "undefined"
+    delete process.env.GENIE_TUI_DISABLE;
+    errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    if (originalTuiDisable === undefined) {
+      // biome-ignore lint/performance/noDelete: process.env requires delete — assignment sets the string "undefined"
+      delete process.env.GENIE_TUI_DISABLE;
+    } else {
+      process.env.GENIE_TUI_DISABLE = originalTuiDisable;
+    }
+  });
+
+  test('reports `GENIE_TUI_DISABLE is set` when env wins', () => {
+    process.env.GENIE_TUI_DISABLE = '1';
+    process.argv = ['node', 'genie', '--no-tui', 'ls']; // env should still win
+    Object.defineProperty(process.stdout, 'isTTY', { value: undefined, configurable: true });
+
+    noticeTuiSkipped('attach');
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy.mock.calls[0]?.[0]).toContain('GENIE_TUI_DISABLE is set');
+  });
+
+  test('reports `--no-tui flag present` when argv wins (env unset)', () => {
+    process.argv = ['node', 'genie', '--no-tui', 'ls'];
+    Object.defineProperty(process.stdout, 'isTTY', { value: undefined, configurable: true });
+
+    noticeTuiSkipped('attach');
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy.mock.calls[0]?.[0]).toContain('--no-tui flag present');
+  });
+
+  test('reports `stdout is not a TTY` when only the auto-detect path fires', () => {
+    // No env, no --no-tui — only the new TTY auto-detect should trip. The
+    // pre-fix code would have misreported `--no-tui flag present` here
+    // because the reason calculation lacked a third branch.
+    process.argv = ['node', 'genie', 'ls'];
+    Object.defineProperty(process.stdout, 'isTTY', { value: undefined, configurable: true });
+
+    noticeTuiSkipped('attach');
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy.mock.calls[0]?.[0]).toContain('stdout is not a TTY');
+    expect(errorSpy.mock.calls[0]?.[0]).not.toContain('--no-tui flag present');
   });
 });

--- a/src/lib/tui-disable.ts
+++ b/src/lib/tui-disable.ts
@@ -42,10 +42,21 @@ export function isTuiDisabled(): boolean {
  * Emit a one-line stderr notice explaining that a TUI path was skipped and why.
  * `context` is a short label for the call site (e.g. "renderer", "attach",
  * "serve"). Kept as a single helper so the message stays consistent.
+ *
+ * Reason precedence mirrors `isTuiDisabled()`: env > argv > non-TTY auto-detect.
+ * Pre-PR-1614 this only had two branches; the third was added so the auto-skip
+ * path (`genie | head`) doesn't misreport `--no-tui flag present` to users
+ * who never passed the flag.
  */
 export function noticeTuiSkipped(context: string): void {
   // Single line, stderr, no ANSI — easy to grep from logs and CI output.
-  const reason = process.env.GENIE_TUI_DISABLE ? 'GENIE_TUI_DISABLE is set' : '--no-tui flag present';
+  const envVal = process.env.GENIE_TUI_DISABLE;
+  const reason =
+    envVal && TRUTHY.has(envVal.trim().toLowerCase())
+      ? 'GENIE_TUI_DISABLE is set'
+      : process.argv.includes('--no-tui')
+        ? '--no-tui flag present'
+        : 'stdout is not a TTY';
   console.error(
     `genie: TUI ${context} skipped (${reason}). See https://github.com/automagik-dev/genie for status of the upstream OpenTUI kqueue spin on macOS.`,
   );


### PR DESCRIPTION
## Summary

Cosmetic follow-on to PR #1610 / #1614. The merged TTY auto-detect works, but `noticeTuiSkipped()` still misreports the reason when the new auto-skip path fires:

```
$ genie | head -1
genie: TUI attach skipped (--no-tui flag present). ...
                          ^^^^^^^^^^^^^^^^^^^^^^^^
                          User never passed --no-tui.
```

`isTuiDisabled()` now has three triggers (env, argv, non-TTY) but the reason calculation in `noticeTuiSkipped()` only had two branches. Adding the third closes the gap.

## Fix

`src/lib/tui-disable.ts` — extend the reason-precedence ladder to mirror `isTuiDisabled()`: env > argv > non-TTY.

```ts
const reason =
  envVal && TRUTHY.has(envVal.trim().toLowerCase())
    ? 'GENIE_TUI_DISABLE is set'
    : process.argv.includes('--no-tui')
      ? '--no-tui flag present'
      : 'stdout is not a TTY';
```

Bonus tightening: the env check now uses the same `TRUTHY` set as the disabler. Pre-fix, `GENIE_TUI_DISABLE=invalid` would not actually disable the TUI (good — `isTuiDisabled` rejects it) but the skip notice would still attribute the reason to the env var (bad). Now consistent with the disabler.

## Tests (3 new, 35 total)

- `noticeTuiSkipped()` reports `GENIE_TUI_DISABLE is set` when env wins (even with `--no-tui` also set — pins precedence)
- reports `--no-tui flag present` when argv wins (env unset)
- reports `stdout is not a TTY` when only auto-detect fires, with explicit `not.toContain('--no-tui flag present')` regression guard

## Real-world QA

Bun harness importing the live source from this branch:

```
=== A. piped (no env, no flag) — EXPECT 'stdout is not a TTY' ===
genie: TUI attach skipped (stdout is not a TTY). ...

=== B. piped + --no-tui — EXPECT '--no-tui flag present' ===
genie: TUI attach skipped (--no-tui flag present). ...

=== C. piped + GENIE_TUI_DISABLE=1 — EXPECT 'GENIE_TUI_DISABLE is set' ===
genie: TUI attach skipped (GENIE_TUI_DISABLE is set). ...

=== D. precedence: both set — EXPECT env wins ===
genie: TUI attach skipped (GENIE_TUI_DISABLE is set). ...
```

## Validation

```
$ bun test src/__tests__/interactivity.test.ts
35 pass / 0 fail / 54 expect calls

$ bunx biome check src/lib/tui-disable.ts src/__tests__/interactivity.test.ts
Checked 2 files in 30ms. No fixes applied.

$ bun run typecheck   # clean
```

## Diff scope

```
src/__tests__/interactivity.test.ts | +60 -1
src/lib/tui-disable.ts              | +12 -1
2 files changed, 72 insertions, 2 deletions
```

No behavior change beyond the reported reason string. `isTuiDisabled()` is untouched.