### PR TITLE
feat(lint): raise cognitive-complexity budget to 25 + drift script

### DIFF
--- a/.genie/wishes/complexity-budget-simplification/REPORT.md
+++ b/.genie/wishes/complexity-budget-simplification/REPORT.md
@@ -1,0 +1,155 @@
+# Wish: Complexity Budget Simplification — Execution Report
+
+**Branch:** `complexity-budget-simplification`
+**Base:** `f5d7da63` (origin/dev)
+**Engineer:** single-engineer manual orchestration (recovery dispatch after the
+autonomous-team attempt lost work)
+
+## Group 1 — Baseline + Budget Calibration
+
+**Status:** DONE
+**Commit:** `a5540129 feat(lint): raise cognitive-complexity budget to 25 + capture baseline`
+
+### Files
+- `biome.json` — `noExcessiveCognitiveComplexity` set to `{ level: "warn", options: { maxAllowedComplexity: 25 } }` for `src/**` and `packages/**` overrides.
+- `.genie/wishes/complexity-budget-simplification/complexity-baseline.md` — created.
+
+### Validation transcript
+
+```
+$ node_modules/.bin/biome check . --diagnostic-level=warn --max-diagnostics=none
+Checked 778 files in 402ms. No fixes applied.
+Found 27 warnings.
+
+# 7 retained noExcessiveCognitiveComplexity (scores 26, 29, 29, 31, 36, 37, 42).
+# 11 unused-suppression warnings introduced — fed into Group 3.
+```
+
+Acceptance criteria:
+- [x] Baseline file present (`complexity-baseline.md`).
+- [x] Retained >25 hotspots listed with scores.
+- [x] `biome.json` valid against Biome 1.9.4 (no parse error, all 778 files checked).
+- [x] `bunx biome check . --reporter=summary` exits 0.
+
+## Group 2 — Complexity Budget Drift Check
+
+**Status:** DONE
+**Commit:** `492cdcf0 feat(scripts): add complexity-budget drift check`
+
+### Files
+- `scripts/complexity-budget.ts` — drift detector (parses biome diagnostics, counts suppressions via `git grep`, evaluates against ratcheted budget, exits non-zero on regression).
+- `scripts/complexity-budget.test.ts` — 12 unit tests.
+- `package.json` — `lint:complexity-budget` script added.
+
+### Validation transcript
+
+```
+$ bun test scripts/complexity-budget.test.ts
+ 12 pass
+ 0 fail
+ 26 expect() calls
+Ran 12 tests across 1 file. [134.00ms]
+
+$ bun run lint:complexity-budget
+Warnings (score > threshold): 7 / 7
+Max observed score:           42 / 42
+Explicit suppressions:        19 / 19      # before Group 3 cleanup
+OK: budget intact.
+
+$ bun run typecheck   # tsc --noEmit, no errors
+```
+
+Acceptance criteria:
+- [x] Script exits 0 when current state ≤ ratcheted budget.
+- [x] Script exits non-zero on regression of warning count, max score, or suppression count (covered by unit tests).
+- [x] Output prints actionable file/function lines (each retained hotspot listed with score, path:line, function name).
+- [x] No DB / tmux / TUI / network access — `existsSync`, `child_process.execSync` over biome and git grep only.
+
+## Group 3 — Obsolete Suppression Cleanup
+
+**Status:** DONE
+**Commit:** `76f9191b chore(lint): remove 11 unused complexity suppressions`
+
+### Files
+- `src/lib/scheduler-daemon.ts` — removed `stop()` suppression.
+- `src/services/executors/claude-sdk.ts` — removed `_processDelivery` suppression.
+- `src/services/omni-bridge.ts` — removed `spawnSession` suppression.
+- `src/term-commands/agents.ts` — removed `createTmuxPane`, `launchTmuxSpawn`, `resolveTeamAndResume` suppressions.
+- `packages/genie-app/views/scheduler/ui/SchedulerView.tsx` — removed `statusBadge`, `RunStatusIcon` suppressions.
+- `packages/genie-app/views/sessions/ui/SessionsView.tsx` — removed `groupTurns`, `buildTimelineSegments`, `onKey` suppressions.
+- `scripts/complexity-budget.ts` — `maxSuppressionCount` ratcheted from 19 to 8 to lock in the cleanup.
+
+### Validation transcript
+
+```
+$ node_modules/.bin/biome check . --reporter=summary
+  Rule Name                                                    Diagnostics
+  lint/complexity/noExcessiveCognitiveComplexity               7 (warning)
+  lint/correctness/noUnusedVariables                           1 (warning)
+  lint/suspicious/noExplicitAny                                1 (warning)
+  suppressions/unused                                          5 (warning)
+Checked 780 files in 368ms. Found 16 warnings.
+
+# 0 unused complexity suppressions remain.
+# The 5 remaining suppressions/unused warnings are pre-existing,
+# non-complexity (noExplicitAny / noConsoleLog) and out of scope.
+
+$ bun run lint:complexity-budget
+Warnings (score > threshold): 7 / 7
+Max observed score:           42 / 42
+Explicit suppressions:        8 / 8
+OK: budget intact.
+
+$ bun run typecheck   # tsc --noEmit, no errors
+
+$ bun test scripts/complexity-budget.test.ts
+ 12 pass / 0 fail
+```
+
+Acceptance criteria:
+- [x] No unused complexity suppressions remain (5 unused suppressions left over are non-complexity, pre-existing).
+- [x] Remaining 8 complexity suppressions still have explicit, descriptive reasons in their comments.
+- [x] No optional helper inlining performed (kept Group 3 limited to suppression cleanup; the wish allowed only one low-risk inline if all four conditions held).
+- [x] No behavior-oriented test snapshots changed.
+
+## Group 4 — Policy and Hotspot Follow-Up
+
+**Status:** DONE
+**Commit:** _final group commit_
+
+### Files
+- `CLAUDE.md` — added `## Cognitive-complexity budget` section (5 bullet points, well under the 15-line cap).
+- `.genie/wishes/complexity-budget-simplification/hotspots.md` — created with one verdict per retained >25 hotspot.
+
+### Validation transcript
+
+```
+$ rg -n "complexity budget|cognitive complexity|maxAllowedComplexity" CLAUDE.md biome.json .genie/wishes/complexity-budget-simplification
+biome.json:75:            "noExcessiveCognitiveComplexity": {
+biome.json:77:              "options": { "maxAllowedComplexity": 25 }
+biome.json:114:            "noExcessiveCognitiveComplexity": {
+biome.json:116:              "options": { "maxAllowedComplexity": 25 }
+CLAUDE.md:172:## Cognitive-complexity budget
+…
+.genie/wishes/complexity-budget-simplification/WISH.md:* multiple hits *
+.genie/wishes/complexity-budget-simplification/hotspots.md:* multiple hits *
+.genie/wishes/complexity-budget-simplification/complexity-baseline.md:* multiple hits *
+
+$ bun run lint:complexity-budget
+OK: budget intact.
+```
+
+Acceptance criteria:
+- [x] `CLAUDE.md` policy ≤ 15 lines (5 bullet points + heading + intro).
+- [x] `hotspots.md` has one row per retained >25 function (7 rows).
+- [x] Each row carries a named verdict (`leave linear for now` / `simple local refactor candidate` / `needs separate architecture wish`).
+- [x] No large refactor performed inside this group.
+
+## Final budget snapshot
+
+| Metric | Before | After | Budget |
+|--------|-------:|------:|-------:|
+| Unsuppressed cognitive-complexity warnings | 17 | 7 | 7 |
+| Highest observed score | 42 | 42 | 42 |
+| Explicit `biome-ignore` suppressions for the rule | 19 | 8 | 8 |
+| Total Biome warnings (all rules) | 26 | 16 | n/a |

--- a/.genie/wishes/complexity-budget-simplification/complexity-baseline.md
+++ b/.genie/wishes/complexity-budget-simplification/complexity-baseline.md
@@ -1,0 +1,100 @@
+# Complexity Baseline
+
+**Date:** 2026-05-03
+**Branch:** `complexity-budget-simplification`
+**Biome version:** 1.9.4
+**Source command:** `bunx biome check . --diagnostic-level=warn --max-diagnostics=none`
+**Wall time:** 420 ms (778 files checked)
+
+## Summary at the old threshold (`maxAllowedComplexity: 15`)
+
+| Metric | Value |
+|--------|-------|
+| Total Biome warnings (all rules) | 26 |
+| `noExcessiveCognitiveComplexity` warnings (unsuppressed) | 17 |
+| Explicit `biome-ignore` suppressions for the rule | 19 (18 in product code, 1 in tests) |
+| Highest observed complexity score | 42 (`dbMigrateV1Command`) |
+
+> Note: the original wish text quoted 12 unsuppressed warnings and 16 suppressions. The baseline numbers above are what is actually present at the head of the worktree (`f5d7da63`); the wish text was an estimate from earlier in the cycle.
+
+## Score distribution (unsuppressed)
+
+| Score | Count |
+|-------|-------|
+| 16 | 4 |
+| 17 | 2 |
+| 18 | 1 |
+| 19 | 1 |
+| 20 | 1 |
+| 23 | 1 |
+| 26 | 1 |
+| 29 | 2 |
+| 31 | 1 |
+| 36 | 1 |
+| 37 | 1 |
+| 42 | 1 |
+| **Total** | **17** |
+
+## Projection at the new threshold (`maxAllowedComplexity: 25`)
+
+| Metric | Value |
+|--------|-------|
+| Warnings silenced (scores 16–25) | 10 |
+| Warnings retained (scores ≥ 26) | 7 |
+
+### Retained hotspots (score > 25)
+
+| Score | Function | Location |
+|-------|----------|----------|
+| 42 | `dbMigrateV1Command` | `src/term-commands/db-migrate-v1.ts:105` |
+| 37 | `trustAction` | `src/term-commands/hook/trust.ts:69` |
+| 36 | `dbLsCommand` | `src/term-commands/db-ls.ts:48` |
+| 31 | `_buildConnection` | `src/lib/db.ts:1554` |
+| 29 | `checkPrerequisites` | `src/genie-commands/doctor.ts:76` |
+| 29 | `reapStaleGenieProcesses` | `src/genie-commands/doctor.ts:1387` |
+| 26 | `ensureSession` | `src/lib/session-capture.ts:333` |
+
+Architectural verdicts for each retained function are captured in `hotspots.md` (Group 4).
+
+### Warnings that disappear under the new budget (scores 16–25)
+
+| Score | Function | Location |
+|-------|----------|----------|
+| 23 | `buildSpawnParams` | `src/term-commands/agents.ts:2063` |
+| 20 | `loadExternalHooks` | `src/hooks/loader.ts:186` |
+| 19 | `handleHandshake` | `src/term-commands/omni/handshake.ts:171` |
+| 18 | `refresh` (Nav component) | `src/tui/components/Nav.tsx:47` |
+| 17 | `diagnoseSessionLinks` | `src/lib/session-link-repair.ts:57` |
+| 17 | `updateSource` | `src/genie-commands/update.ts:461` |
+| 16 | `handleDirAdd` | `src/term-commands/dir.ts:198` |
+| 16 | spawn action callback | `src/term-commands/agent/spawn.ts:45` |
+| 16 | `detectV1State` | `src/lib/v1-migration-prompt.ts:78` |
+| 16 | `attemptAgentResume` | `src/lib/scheduler-daemon.ts:1460` |
+
+## Suppression inventory
+
+19 explicit `biome-ignore lint/complexity/noExcessiveCognitiveComplexity` directives at baseline:
+
+```
+src/term-commands/agents.ts:892
+src/term-commands/agents.ts:1107
+src/term-commands/agents.ts:1215
+src/term-commands/agents.ts:2419
+src/term-commands/agents.ts:3627
+src/lib/scheduler-daemon.ts:2252
+src/lib/agent-registry.ts:156
+src/lib/agent-registry.ts:233
+src/lib/agent-registry.ts:379
+src/lib/agent-registry.ts:685
+src/lib/pg-seed.ts:193
+src/lib/scheduler-daemon.test.ts:56
+src/services/omni-bridge.ts:1126
+src/services/executors/claude-sdk.ts:459
+packages/genie-app/views/sessions/ui/SessionsView.tsx:104
+packages/genie-app/views/sessions/ui/SessionsView.tsx:135
+packages/genie-app/views/sessions/ui/SessionsView.tsx:932
+packages/genie-app/views/scheduler/ui/SchedulerView.tsx:181
+packages/genie-app/views/scheduler/ui/SchedulerView.tsx:262
+```
+
+Group 3 will identify which of these become unused once the threshold is raised to 25 and remove them.

--- a/.genie/wishes/complexity-budget-simplification/hotspots.md
+++ b/.genie/wishes/complexity-budget-simplification/hotspots.md
@@ -1,0 +1,68 @@
+# Cognitive-Complexity Hotspots (score > 25)
+
+These are the seven product-code functions that still warn under the new
+`maxAllowedComplexity: 25` budget set by this wish. Each row gets one
+explicit verdict so future contributors do not need to re-derive whether
+the score is "real architecture debt" or "deliberately linear".
+
+| # | Score | Function | Location | Verdict |
+|---|------:|----------|----------|---------|
+| 1 | 42 | `dbMigrateV1Command` | `src/term-commands/db-migrate-v1.ts:105` | leave linear for now |
+| 2 | 37 | `trustAction` | `src/term-commands/hook/trust.ts:69` | simple local refactor candidate |
+| 3 | 36 | `dbLsCommand` | `src/term-commands/db-ls.ts:48` | simple local refactor candidate |
+| 4 | 31 | `_buildConnection` | `src/lib/db.ts:1554` | needs separate architecture wish |
+| 5 | 29 | `checkPrerequisites` | `src/genie-commands/doctor.ts:76` | simple local refactor candidate |
+| 6 | 29 | `reapStaleGenieProcesses` | `src/genie-commands/doctor.ts:1387` | simple local refactor candidate |
+| 7 | 26 | `ensureSession` | `src/lib/session-capture.ts:333` | leave linear for now |
+
+## Rationale
+
+### 1. `dbMigrateV1Command` — leave linear for now
+One-shot v1→v2 migration entrypoint. The branching is per migration sub-step
+(port discovery, schema copy, row copy, validation, snapshotting, error rollback).
+The whole function is doomed code that will be deleted once v1 is removed in
+the field; carving helpers out adds ceremony for code that should not survive
+a release cycle. Suppression-with-rationale, not refactor.
+
+### 2. `trustAction` — simple local refactor candidate
+`genie hook trust` dispatches three independent verbs (list / add / remove /
+clear) that share only the trust file path. A small local refactor that splits
+each verb into its own private function would drop the score and read more
+cleanly. Worth a focused PR; out of scope for a policy wish.
+
+### 3. `dbLsCommand` — simple local refactor candidate
+Presentation logic for `genie db ls` (databases, tables, connections, JSON vs
+human output). Each presentation mode is independent. A per-mode helper split
+would lower the score without losing the linear narrative.
+
+### 4. `_buildConnection` — needs separate architecture wish
+Connection bootstrap: Unix socket vs TCP, daemon vs direct postmaster, retry,
+pooling, and observability hooks all live in one body for performance reasons
+(see "Mac CPU hook-dispatch fix A" history). Refactoring without a deliberate
+contract for `db_authority` semantics is risky. File a separate wish if the
+score is to be reduced; do not opportunistically inline or extract.
+
+### 5. `checkPrerequisites` — simple local refactor candidate
+`genie doctor` walks a fixed list of binaries (`tmux`, `jq`, `bun`, Claude Code,
+…). Each block is independent and shaped identically. A list-driven loop with
+per-tool metadata would collapse the score and the line count. Local refactor
+candidate.
+
+### 6. `reapStaleGenieProcesses` — simple local refactor candidate
+Procfs-walking reaper for the update flow. The branching is mostly platform
+guards plus per-process classification. Splitting platform logic into a small
+helper would drop the score; local refactor candidate.
+
+### 7. `ensureSession` — leave linear for now
+Session-ingest fast path. Score is exactly one above the threshold and the
+function is the load-bearing core of session capture. The branching reads as
+a state machine over (worker hit/miss, parent inheritance, offset, status).
+Refactor would obscure rather than clarify. Suppression-with-rationale if
+ever needed; do not refactor speculatively.
+
+## Follow-up
+
+This wish does not perform any of the refactors above. The verdicts exist so
+that future contributors picking up `genie doctor` polish, `genie db ls`
+ergonomics, or a `db_authority` rework can decide quickly whether to tackle
+the score along with their primary change or leave it for an explicit wish.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,16 @@ Single-file bundle: `bun build` inlines all dependencies into `dist/genie.js` (~
 - Conventional commits (commitlint)
 - No `console.log` in source (biome rule, relaxed in tests)
 
+## Cognitive-complexity budget
+
+Biome's `noExcessiveCognitiveComplexity` is set to `maxAllowedComplexity: 25` (warn-level) for `src/**` and `packages/**`. Treat 25 as a ceiling for **linear** workflows, not a target.
+
+- Prefer linear code when a function reads as one workflow (CLI command body, orchestration step, request handler). Helpers extracted purely to reduce a score under 25 usually add indirection without clarity.
+- Split when there is a real boundary: a distinct policy decision, an IO concern, a state-machine transition, a presentation/data divide, or reused logic with at least two callers.
+- Only suppress with `biome-ignore lint/complexity/noExcessiveCognitiveComplexity:` when extraction would obscure a linear flow or break a tested invariant. The comment must explain the reason — never just "complexity".
+- Score >25 is review-triggering architecture debt, not a hard error. Track it in `.genie/wishes/complexity-budget-simplification/hotspots.md` and address via a separate refactor wish, not opportunistic edits.
+- Drift is enforced by `bun run lint:complexity-budget` (script in `scripts/complexity-budget.ts`). Raising any of the budget ceilings requires updating the script with a written justification.
+
 ## Gotchas
 
 - **File lock timeout force-removes are intentional** — prevents permanent deadlocks from crashed processes. The `open('wx')` after unlink is still atomic, so only one process wins.

--- a/biome.json
+++ b/biome.json
@@ -70,7 +70,10 @@
             "noMisleadingCharacterClass": "warn"
           },
           "complexity": {
-            "noExcessiveCognitiveComplexity": "warn",
+            "noExcessiveCognitiveComplexity": {
+              "level": "warn",
+              "options": { "maxAllowedComplexity": 25 }
+            },
             "noForEach": "warn"
           },
           "style": {
@@ -107,7 +110,10 @@
             "noArrayIndexKey": "warn"
           },
           "complexity": {
-            "noExcessiveCognitiveComplexity": "warn",
+            "noExcessiveCognitiveComplexity": {
+              "level": "warn",
+              "options": { "maxAllowedComplexity": 25 }
+            },
             "noForEach": "warn"
           },
           "style": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "wishes:lint": "bun run scripts/wishes-lint.ts",
     "skills:audit": "bun run scripts/skills-audit.ts",
     "lint:emit": "bun run scripts/lint-emit-discipline.ts",
+    "lint:complexity-budget": "bun run scripts/complexity-budget.ts",
     "check:perf": "bun run test/perf/observability/gate.ts --duration=30000",
     "check": "bun run typecheck && bun run lint && bun run dead-code && bun run skills:lint && bun run wishes:lint && bun run lint:emit && bun test",
     "check:fast": "bun run typecheck && bun run lint && bun run dead-code && bun run skills:lint && bun run wishes:lint && bun run lint:emit",

--- a/packages/genie-app/views/scheduler/ui/SchedulerView.tsx
+++ b/packages/genie-app/views/scheduler/ui/SchedulerView.tsx
@@ -178,7 +178,6 @@ const styles = {
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap' as const,
   },
-  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: status color mapper
   statusBadge: (s: string) => ({
     display: 'inline-flex',
     alignItems: 'center',
@@ -259,7 +258,6 @@ const styles = {
 // Status Icon
 // ============================================================================
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: status icon dispatch
 function RunStatusIcon({ status }: { status: string }) {
   const icon =
     status === 'success'

--- a/packages/genie-app/views/sessions/ui/SessionsView.tsx
+++ b/packages/genie-app/views/sessions/ui/SessionsView.tsx
@@ -101,7 +101,6 @@ function formatCost(usd: number): string {
  * Consecutive tool calls (role=assistant + toolName) are nested under the
  * preceding assistant message.
  */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: turn grouping state machine
 function groupTurns(turns: TurnRow[]): MessageGroup[] {
   const groups: MessageGroup[] = [];
   let currentGroup: MessageGroup | null = null;
@@ -132,7 +131,6 @@ function groupTurns(turns: TurnRow[]): MessageGroup[] {
 /**
  * Build timeline density segments from turns.
  */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: timeline segmentation state machine
 function buildTimelineSegments(turns: TurnRow[]): TimelineSegment[] {
   if (turns.length === 0) return [];
   const segments: TimelineSegment[] = [];
@@ -929,7 +927,6 @@ export function SessionsView({ windowId, meta: _meta }: AppComponentProps) {
 
   // ---- Keyboard navigation ----
   useEffect(() => {
-    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: multi-key keyboard handler dispatch
     function onKey(e: KeyboardEvent) {
       const tag = (e.target as HTMLElement)?.tagName;
       if (tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA') return;

--- a/scripts/complexity-budget.test.ts
+++ b/scripts/complexity-budget.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from 'bun:test';
+import { BUDGET, type BudgetReport, buildReport, evaluateBudget, parseBiomeOutput } from './complexity-budget';
+
+const FIXTURE_TWO_HOTSPOTS = `
+Some unrelated header text
+./src/term-commands/db-migrate-v1.ts:105:16 lint/complexity/noExcessiveCognitiveComplexity ━━━━━━━━━━
+
+  ! Excessive complexity of 42 detected (max: 25).
+
+    103 │ }
+    104 │
+  > 105 │ async function dbMigrateV1Command(options: MigrateOptions): Promise<void> {
+        │                ^^^^^^^^^^^^^^^^^^
+    106 │   const { from, to } = options;
+
+  i Please refactor this function to reduce its complexity score from 42 to the max allowed complexity 25.
+
+
+./src/genie-commands/doctor.ts:76:16 lint/complexity/noExcessiveCognitiveComplexity ━━━━━━━━━━━━━━━━━
+
+  ! Excessive complexity of 29 detected (max: 25).
+
+    74 │ }
+    75 │
+  > 76 │ async function checkPrerequisites(): Promise<CheckResult[]> {
+       │                ^^^^^^^^^^^^^^^^^^
+    77 │   const results: CheckResult[] = [];
+
+
+Checked 778 files in 402ms. No fixes applied.
+Found 7 warnings.
+`;
+
+describe('parseBiomeOutput', () => {
+  test('extracts file, line, column, score, and function name from each diagnostic', () => {
+    const warnings = parseBiomeOutput(FIXTURE_TWO_HOTSPOTS);
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toEqual({
+      file: 'src/term-commands/db-migrate-v1.ts',
+      line: 105,
+      column: 16,
+      score: 42,
+      function: 'dbMigrateV1Command',
+    });
+    expect(warnings[1]).toEqual({
+      file: 'src/genie-commands/doctor.ts',
+      line: 76,
+      column: 16,
+      score: 29,
+      function: 'checkPrerequisites',
+    });
+  });
+
+  test('returns empty list when biome output has no complexity diagnostics', () => {
+    const out = `
+./src/foo.ts:1:1 lint/correctness/noUnusedImports ━━━━━
+
+  ! 'bar' is unused.
+
+Checked 1 file in 1ms. No fixes applied.
+Found 1 warning.
+`;
+    expect(parseBiomeOutput(out)).toEqual([]);
+  });
+
+  test('skips diagnostics that have no score line', () => {
+    const malformed = `
+./src/x.ts:10:5 lint/complexity/noExcessiveCognitiveComplexity ━━━━━━━━━
+
+  ! Some other variant without the score sentence.
+
+  > 10 │ function broken() {
+
+`;
+    expect(parseBiomeOutput(malformed)).toEqual([]);
+  });
+
+  test('handles function name being absent from the pointer line', () => {
+    const out = `
+./src/y.ts:5:3 lint/complexity/noExcessiveCognitiveComplexity ━━━━━━━━━
+
+  ! Excessive complexity of 27 detected (max: 25).
+
+  > 5 │   .action(async (name) => {
+
+`;
+    const warnings = parseBiomeOutput(out);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].score).toBe(27);
+    expect(warnings[0].function).toBeUndefined();
+  });
+});
+
+describe('buildReport', () => {
+  test('aggregates warnings, max score, and suppression count', () => {
+    const suppressions = [
+      'src/a.ts:1:// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: reason a',
+      'src/b.ts:2:// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: reason b',
+    ];
+    const report = buildReport(FIXTURE_TWO_HOTSPOTS, suppressions);
+    expect(report.warnings).toHaveLength(2);
+    expect(report.maxScore).toBe(42);
+    expect(report.suppressionCount).toBe(2);
+    expect(report.suppressions).toEqual(suppressions);
+  });
+
+  test('maxScore is 0 when there are no warnings', () => {
+    const report = buildReport('Checked 1 file. Found 0 warnings.\n', []);
+    expect(report.maxScore).toBe(0);
+    expect(report.warnings).toHaveLength(0);
+  });
+});
+
+describe('evaluateBudget', () => {
+  function fakeReport(over: Partial<BudgetReport>): BudgetReport {
+    return {
+      warnings: [],
+      maxScore: 0,
+      suppressionCount: 0,
+      suppressions: [],
+      ...over,
+    };
+  }
+
+  test('passes when every metric is within budget', () => {
+    const report = fakeReport({
+      warnings: new Array(BUDGET.maxWarningCount).fill(0).map((_, i) => ({
+        file: 'src/x.ts',
+        line: i,
+        column: 1,
+        score: 26,
+      })),
+      maxScore: BUDGET.maxScore,
+      suppressionCount: BUDGET.maxSuppressionCount,
+    });
+    const verdict = evaluateBudget(report);
+    expect(verdict.ok).toBe(true);
+    expect(verdict.failures).toEqual([]);
+  });
+
+  test('fails when warning count regresses', () => {
+    const report = fakeReport({
+      warnings: new Array(BUDGET.maxWarningCount + 1).fill(0).map((_, i) => ({
+        file: 'src/x.ts',
+        line: i,
+        column: 1,
+        score: 26,
+      })),
+    });
+    const verdict = evaluateBudget(report);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.failures.join('\n')).toMatch(/retained warning count/);
+  });
+
+  test('fails when max score regresses', () => {
+    const report = fakeReport({ maxScore: BUDGET.maxScore + 1 });
+    const verdict = evaluateBudget(report);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.failures.join('\n')).toMatch(/max score/);
+  });
+
+  test('fails when suppression count regresses', () => {
+    const report = fakeReport({ suppressionCount: BUDGET.maxSuppressionCount + 1 });
+    const verdict = evaluateBudget(report);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.failures.join('\n')).toMatch(/suppression count/);
+  });
+
+  test('reports every regressing metric, not just the first', () => {
+    const report = fakeReport({
+      warnings: new Array(BUDGET.maxWarningCount + 2).fill(0).map((_, i) => ({
+        file: 'src/x.ts',
+        line: i,
+        column: 1,
+        score: BUDGET.maxScore + 5,
+      })),
+      maxScore: BUDGET.maxScore + 5,
+      suppressionCount: BUDGET.maxSuppressionCount + 3,
+    });
+    const verdict = evaluateBudget(report);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.failures).toHaveLength(3);
+  });
+
+  test('uses a custom budget when provided', () => {
+    const report = fakeReport({ maxScore: 10 });
+    expect(evaluateBudget(report, { maxWarningCount: 0, maxScore: 9, maxSuppressionCount: 0 }).ok).toBe(false);
+    expect(evaluateBudget(report, { maxWarningCount: 0, maxScore: 10, maxSuppressionCount: 0 }).ok).toBe(true);
+  });
+});

--- a/scripts/complexity-budget.ts
+++ b/scripts/complexity-budget.ts
@@ -1,0 +1,215 @@
+#!/usr/bin/env bun
+/**
+ * complexity-budget: drift check for Biome's
+ * `lint/complexity/noExcessiveCognitiveComplexity` rule.
+ *
+ * Reports the current state of the cognitive-complexity budget and exits
+ * non-zero when any of the ratcheted ceilings is exceeded:
+ *   - retained warning count (functions still scoring above the threshold)
+ *   - highest observed complexity score
+ *   - explicit `biome-ignore lint/complexity/noExcessiveCognitiveComplexity`
+ *     suppression count
+ *
+ * No database, tmux, TUI, or network access required — only `biome check` and
+ * a recursive grep over `src/` and `packages/`.
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
+
+/** Budget ceilings — ratcheted from the Group 1 baseline (2026-05-03). */
+export const BUDGET = {
+  maxWarningCount: 7,
+  maxScore: 42,
+  maxSuppressionCount: 19,
+} as const;
+
+export interface ComplexityWarning {
+  file: string;
+  line: number;
+  column: number;
+  score: number;
+  function?: string;
+}
+
+export interface BudgetReport {
+  warnings: ComplexityWarning[];
+  maxScore: number;
+  suppressionCount: number;
+  suppressions: string[];
+}
+
+const HEADER_RE = /^\.\/(\S+?):(\d+):(\d+)\s+lint\/complexity\/noExcessiveCognitiveComplexity\b/;
+const SCORE_RE = /Excessive complexity of (\d+) detected/;
+const POINTER_RE = /^\s*>\s*\d+\s+│\s*(.*)$/;
+
+/**
+ * Parse Biome's default text output for cognitive-complexity diagnostics.
+ *
+ * Pure function, exported for testing. Robust against unrelated diagnostics
+ * interleaved with complexity ones — pairs each `noExcessiveCognitiveComplexity`
+ * header with the next `Excessive complexity of N` line and the next pointer
+ * (`> NNN │ async function …`) line within the same diagnostic block.
+ */
+export function parseBiomeOutput(text: string): ComplexityWarning[] {
+  const lines = text.split('\n');
+  const warnings: ComplexityWarning[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const headerMatch = HEADER_RE.exec(lines[i]);
+    if (!headerMatch) continue;
+    const [, file, lineStr, colStr] = headerMatch;
+    let score: number | undefined;
+    let funcLine: string | undefined;
+    for (let j = i + 1; j < lines.length && j < i + 30; j++) {
+      // Stop scanning if we hit the next diagnostic header.
+      if (HEADER_RE.test(lines[j])) break;
+      if (score === undefined) {
+        const sm = SCORE_RE.exec(lines[j]);
+        if (sm) score = Number(sm[1]);
+      }
+      if (funcLine === undefined) {
+        const pm = POINTER_RE.exec(lines[j]);
+        if (pm) funcLine = pm[1].trim();
+      }
+      if (score !== undefined && funcLine !== undefined) break;
+    }
+    if (score === undefined) continue;
+    warnings.push({
+      file,
+      line: Number(lineStr),
+      column: Number(colStr),
+      score,
+      function: extractFunctionName(funcLine),
+    });
+  }
+
+  return warnings;
+}
+
+function extractFunctionName(pointer?: string): string | undefined {
+  if (!pointer) return undefined;
+  const cleaned = pointer.replace(/^export\s+/, '').replace(/^async\s+/, '');
+  const fnMatch = /function\s+([A-Za-z_$][A-Za-z0-9_$]*)/.exec(cleaned);
+  if (fnMatch) return fnMatch[1];
+  const arrowMatch = /([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*(?:async\s+)?\(/.exec(cleaned);
+  if (arrowMatch) return arrowMatch[1];
+  return undefined;
+}
+
+function runBiome(): string {
+  const biomeBin = join(ROOT, 'node_modules/.bin/biome');
+  if (!existsSync(biomeBin)) {
+    throw new Error(`biome binary not found at ${biomeBin}; run \`bun install\` first`);
+  }
+  // Biome writes diagnostics to stderr and exits non-zero when warnings exist;
+  // both are normal here. Combine streams via `sh -c "biome … 2>&1"` so the
+  // captured `stdout` includes diagnostics regardless of biome's exit code.
+  const cmd = `"${biomeBin}" check . --diagnostic-level=warn --max-diagnostics=none 2>&1`;
+  try {
+    return execSync(cmd, {
+      cwd: ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+  } catch (err: unknown) {
+    const e = err as { stdout?: Buffer | string };
+    if (e?.stdout) return typeof e.stdout === 'string' ? e.stdout : e.stdout.toString('utf8');
+    throw err;
+  }
+}
+
+function countSuppressions(): string[] {
+  // Use git grep so we honor .gitignore and stay portable.
+  try {
+    const out = execSync('git grep -nE "biome-ignore lint/complexity/noExcessiveCognitiveComplexity" -- src packages', {
+      cwd: ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return out
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+export function buildReport(biomeOutput: string, suppressions: string[]): BudgetReport {
+  const warnings = parseBiomeOutput(biomeOutput);
+  const maxScore = warnings.reduce((acc, w) => Math.max(acc, w.score), 0);
+  return {
+    warnings,
+    maxScore,
+    suppressionCount: suppressions.length,
+    suppressions,
+  };
+}
+
+export interface BudgetVerdict {
+  ok: boolean;
+  failures: string[];
+}
+
+export function evaluateBudget(report: BudgetReport, budget = BUDGET): BudgetVerdict {
+  const failures: string[] = [];
+  if (report.warnings.length > budget.maxWarningCount) {
+    failures.push(`retained warning count ${report.warnings.length} exceeds budget ${budget.maxWarningCount}`);
+  }
+  if (report.maxScore > budget.maxScore) {
+    failures.push(`max score ${report.maxScore} exceeds budget ${budget.maxScore}`);
+  }
+  if (report.suppressionCount > budget.maxSuppressionCount) {
+    failures.push(`suppression count ${report.suppressionCount} exceeds budget ${budget.maxSuppressionCount}`);
+  }
+  return { ok: failures.length === 0, failures };
+}
+
+function formatReport(report: BudgetReport, verdict: BudgetVerdict): string {
+  const lines: string[] = [];
+  lines.push('Cognitive-complexity budget report');
+  lines.push('==================================');
+  lines.push('');
+  lines.push(`Warnings (score > threshold): ${report.warnings.length} / ${BUDGET.maxWarningCount}`);
+  lines.push(`Max observed score:           ${report.maxScore} / ${BUDGET.maxScore}`);
+  lines.push(`Explicit suppressions:        ${report.suppressionCount} / ${BUDGET.maxSuppressionCount}`);
+  lines.push('');
+  if (report.warnings.length) {
+    lines.push('Retained hotspots (score, location, function):');
+    for (const w of [...report.warnings].sort((a, b) => b.score - a.score)) {
+      const fn = w.function ? ` ${w.function}` : '';
+      lines.push(`  - ${String(w.score).padStart(3)}  ${w.file}:${w.line}${fn}`);
+    }
+    lines.push('');
+  }
+  if (verdict.ok) {
+    lines.push('OK: budget intact.');
+  } else {
+    lines.push('FAIL: budget regressed:');
+    for (const f of verdict.failures) lines.push(`  - ${f}`);
+    lines.push('');
+    lines.push('See .genie/wishes/complexity-budget-simplification/complexity-baseline.md for context.');
+  }
+  return lines.join('\n');
+}
+
+async function main() {
+  const biomeOutput = runBiome();
+  const suppressions = countSuppressions();
+  const report = buildReport(biomeOutput, suppressions);
+  const verdict = evaluateBudget(report);
+  process.stdout.write(`${formatReport(report, verdict)}\n`);
+  process.exit(verdict.ok ? 0 : 1);
+}
+
+if (import.meta.main) {
+  main().catch((err) => {
+    process.stderr.write(`complexity-budget: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(2);
+  });
+}

--- a/scripts/complexity-budget.ts
+++ b/scripts/complexity-budget.ts
@@ -20,11 +20,11 @@ import { join } from 'node:path';
 
 const ROOT = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
 
-/** Budget ceilings — ratcheted from the Group 1 baseline (2026-05-03). */
+/** Budget ceilings — ratcheted from the post-cleanup baseline (2026-05-03). */
 export const BUDGET = {
   maxWarningCount: 7,
   maxScore: 42,
-  maxSuppressionCount: 19,
+  maxSuppressionCount: 8,
 } as const;
 
 export interface ComplexityWarning {

--- a/src/lib/scheduler-daemon.ts
+++ b/src/lib/scheduler-daemon.ts
@@ -2249,7 +2249,6 @@ export function startDaemon(
   // getConnection (Mac CPU hook-dispatch fix A).
   let retentionTimer: ReturnType<typeof setInterval> | null = null;
 
-  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: stop() is a flat cleanup sequence for all daemon resources
   const stop = () => {
     running = false;
     if (pollTimeout) {

--- a/src/services/executors/claude-sdk.ts
+++ b/src/services/executors/claude-sdk.ts
@@ -456,7 +456,6 @@ export class ClaudeSdkOmniExecutor implements IExecutor {
     return state.running && state.inFlightDeliveries > 0;
   }
 
-  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: delivery pipeline with prompt assembly, MCP setup, and session capture
   private async _processDelivery(
     session: ExecutorSession,
     state: SdkSessionState,

--- a/src/services/omni-bridge.ts
+++ b/src/services/omni-bridge.ts
@@ -1123,7 +1123,6 @@ export class OmniBridge {
   /**
    * Spawn a new agent session for a chat.
    */
-  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: spawn orchestration with concurrent guard, env resolution, and error recovery
   private async spawnSession(message: OmniMessage): Promise<void> {
     const key = `${message.agent}:${message.chatId}`;
 

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -889,7 +889,6 @@ async function autoConfirmTrustPrompt(paneId: string): Promise<void> {
  * First agent in a newly created team window reuses the blank pane via send-keys.
  * Subsequent agents split-window into the same team window.
  */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: pre-existing tmux pane routing logic, split targets and launch modes are interdependent
 function createTmuxPane(ctx: SpawnCtx & { sessionOverride?: string }, teamWindow: TeamWindowInfo | null): string {
   const { execSync } = require('node:child_process');
   const useLaunchScript = ctx.validated.provider === 'claude' && Boolean(ctx.validated.nativeTeam?.enabled);
@@ -1104,7 +1103,6 @@ async function awaitAgentReadiness(paneId: string, role: string, tolerateReadine
   throw new AgentReadinessTimeoutError(role, paneId, result.elapsedMs);
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: each branch is a distinct spawn-pipeline step (createTmuxPane / capturePanePid / validateSpawnedPane / awaitAgentReadiness) with structured worker.spawn.failed emissions per #1600 — splitting would obscure the linear flow
 async function launchTmuxSpawn(ctx: SpawnCtx): Promise<string> {
   // Skip team-window creation for isolated-session spawns. When the caller asks
   // for `--new-window` with an explicit `--session <name>`, the agent runs in
@@ -2416,7 +2414,6 @@ export async function resolveSpawnIdentity(
 }
 
 /** Resolve team name and auto-resume dead workers. Duplicate rejection moved to the state machine. */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: 5-tier team resolution + ResumePaneVanishedError fall-through (#1602 Round 4) — tiers are linear and each branch is doc-blocked
 async function resolveTeamAndResume(
   effectiveRole: string,
   options: SpawnOptions,


### PR DESCRIPTION
## Summary

Raise Biome's `noExcessiveCognitiveComplexity` ceiling from 15 to 25 for `src/**` and `packages/**`, add a small drift-check script so the policy stays measurable, prune the suppression comments that the threshold raise made obsolete, and document when 25 is the ceiling vs. when >25 is real architecture debt.

Pre-push gate (`bun run typecheck`, `bun test scripts/complexity-budget.test.ts`, `bunx biome check . --reporter=summary`, and the new `bun run lint:complexity-budget`) all pass.

### Group transcript

- **Group 1** — `biome.json` set to `noExcessiveCognitiveComplexity: { level: warn, options: { maxAllowedComplexity: 25 } }` for both `src/**` and `packages/**` overrides; baseline captured in `.genie/wishes/complexity-budget-simplification/complexity-baseline.md`.
- **Group 2** — `scripts/complexity-budget.ts` (parses biome diagnostics, evaluates against ratcheted ceilings, exits non-zero on regression) + `scripts/complexity-budget.test.ts` (12 cases) + `lint:complexity-budget` package script.
- **Group 3** — Removed 11 `biome-ignore lint/complexity/noExcessiveCognitiveComplexity` directives that became no-ops at the new threshold (5 in `src/`, 6 across `packages/genie-app/`). Suppression count: 19 → 8; budget script ratcheted to 8 to lock the gain in.
- **Group 4** — `CLAUDE.md` policy block (5 bullets, <15 lines) + `.genie/wishes/complexity-budget-simplification/hotspots.md` with one verdict per retained >25 function.

### Baseline numbers

| Metric | Before | After |
|--------|-------:|------:|
| Unsuppressed `noExcessiveCognitiveComplexity` warnings | 17 | 7 |
| Highest observed score | 42 | 42 |
| Explicit complexity suppressions | 19 | 8 |
| Total Biome warnings (all rules) | 26 | 16 |

### Retained >25 hotspots (all kept visible by design)

| Score | Function | Verdict |
|------:|----------|---------|
| 42 | `dbMigrateV1Command` (`src/term-commands/db-migrate-v1.ts:105`) | leave linear for now (one-shot migration code) |
| 37 | `trustAction` (`src/term-commands/hook/trust.ts:69`) | simple local refactor candidate |
| 36 | `dbLsCommand` (`src/term-commands/db-ls.ts:48`) | simple local refactor candidate |
| 31 | `_buildConnection` (`src/lib/db.ts:1554`) | needs separate architecture wish |
| 29 | `checkPrerequisites` (`src/genie-commands/doctor.ts:76`) | simple local refactor candidate |
| 29 | `reapStaleGenieProcesses` (`src/genie-commands/doctor.ts:1387`) | simple local refactor candidate |
| 26 | `ensureSession` (`src/lib/session-capture.ts:333`) | leave linear for now |

Out of scope (explicit per the wish):
- No refactor of any of the >25 hotspots themselves.
- No changes to other Biome rules.

## Test plan

- [x] `bunx biome check . --reporter=summary` — 16 warnings (down from 26), 7 complexity warnings, 0 unused complexity suppressions.
- [x] `bun run lint:complexity-budget` — exits 0 with `OK: budget intact.`
- [x] `bun run typecheck` — passes (no errors).
- [x] `bun test scripts/complexity-budget.test.ts` — 12/12 pass.
- [ ] CI pre-merge gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)