### PR TITLE
fix(pack): include host-migrations files in npm tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
     "plugins/genie/",
     "scripts/postinstall-tmux.js",
     "scripts/postinstall-hook-binary.js",
+    "scripts/postinstall-migrations.js",
     "scripts/sec-scan.cjs",
     "scripts/sec-remediate.cjs",
     "scripts/sec-fix.cjs",
     "scripts/tmux/",
     "src/db/migrations/",
+    "src/migrations/",
     "templates/",
     "README.md",
     "LICENSE"


### PR DESCRIPTION
## Summary

Two-line fix to `package.json` `files` array. PR #1619 added the host-migrations framework but the `files` whitelist was not updated, so the published tarball excluded both the postinstall hook script and the entire `src/migrations/` source directory.

## Symptom on the just-released `4.260503.5`

After `genie update --next` on a host:

```
$ genie --no-tui migrate --status
No migrations discovered.
```

Verified via tarball inspection:
```
$ curl -sL https://registry.npmjs.org/@automagik/genie/-/genie-4.260503.5.tgz | tar -tzf - | grep migration
package/src/db/migrations/...   # only DB migrations
# scripts/postinstall-migrations.js MISSING
# src/migrations/{runner,discover,store,steps/*}.ts MISSING
```

So the `migrate` command in the bundled `dist/genie.js` runs, but `discoverMigrations()` scans a `src/migrations/steps/` path that doesn't exist in the installed package → empty list → silent "no migrations." The whole framework is non-functional in published artifacts. Postinstall chain `... && node scripts/postinstall-migrations.js` also silently fails (bun's default trust policy blocks it on global installs anyway).

## Wish acceptance bullet broken

`.genie/wishes/genie-host-migrations/WISH.md`:
> "Auto-runs on `bun add -g @automagik/genie@latest` via postinstall hook so users get fixes transparently."

This was impossible until both files ship in the tarball.

## Diff

```diff
   "scripts/postinstall-tmux.js",
   "scripts/postinstall-hook-binary.js",
+  "scripts/postinstall-migrations.js",
   "scripts/sec-scan.cjs",
   ...
   "src/db/migrations/",
+  "src/migrations/",
   "templates/",
```

## Verification

```
$ npm pack --dry-run | grep -E "(postinstall-migrations|src/migrations)"
npm notice 2.2kB scripts/postinstall-migrations.js
npm notice 1.8kB src/migrations/discover.ts
npm notice 3.8kB src/migrations/index.ts
npm notice 2.4kB src/migrations/runner.ts
npm notice 3.4kB src/migrations/steps/001-pm2-env-databaseurl-bake.ts
npm notice 3.8kB src/migrations/steps/002-kill-embedded-pgserve-legacy.ts
npm notice 2.6kB src/migrations/store.ts
npm notice 2.8kB src/migrations/README.md
npm notice 3.7kB src/migrations/__tests__/orchestrator.test.ts
```

## Test plan

- [ ] CI green
- [ ] After merge + auto-version bump + npm publish: `bun add -g @automagik/genie@next` on a fresh host → tarball includes both new entries
- [ ] `genie migrate --status` lists the 2 shipped steps (or "no pending" if already applied)
- [ ] `genie update --next` → post-update maintenance section shows a `[ok]/[fix]/[!!] migrations` line (if/when the post-update flow is taught to surface migrations status — separate follow-up)

## Out of scope

- Migration step files include `src/migrations/__tests__/orchestrator.test.ts` (3.7kB) — minor waste, not worth a glob exclusion
- Adding a `migrations` line to the post-update maintenance summary — separate cosmetic follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)
