### PR TITLE
fix(agents): uuid guard + reviewer opus

### DIFF
--- a/.genie/wishes/agent-yaml-permissions-wireup/WISH.md
+++ b/.genie/wishes/agent-yaml-permissions-wireup/WISH.md
@@ -1,0 +1,384 @@
+# Wish: agent-yaml permissions wireup + default-agent cleanup
+
+| Field | Value |
+|-------|-------|
+| **Status** | DRAFT |
+| **Slug** | `agent-yaml-permissions-wireup` |
+| **Date** | 2026-05-03 |
+| **Author** | Felipe (via felipe agent — micropr scope) |
+| **Appetite** | small (~1 engineer-day) |
+| **Branch** | `wish/agent-yaml-permissions-wireup` |
+| **Repos touched** | `automagik-dev/genie` |
+| **PR target** | `dev` |
+
+## Summary
+
+The migration "AGENTS.md frontmatter → agent.yaml" was started but never wired through to the executor. As a result, `permissions.preset: full` and `sdk.allowedTools` declared in `agent.yaml` are silently ignored — workspace agents (felipe, brain, etc.) launch under `--permission-mode auto` defaults that exclude `Edit`/`Write`. Felipe (the operator) cannot edit files on his own VPS through the felipe agent persona despite `permissions.preset: full` being declared. Plus a regression in `wish/retire-session-names-id-only` makes `genie spawn <role> --team <team>` fail with `agents_id_shape_check` violation, blocking direct subagent spawn outside `genie work` flows. This wish fixes both blockers and absorbs the related cleanup Felipe called out: reviewer haiku→opus (haiku doesn't support `--permission-mode auto`), and an audit/purge of unused default agents under `plugins/genie/agents/`.
+
+## Scope
+
+### IN
+
+**P0 — Permission wireup (the blocker)**
+- Add `permissionMode` and `allowedTools` to `SpawnParams.permissions` in `src/lib/provider-adapters.ts` (currently only `allow`/`deny` Bash patterns).
+- Add `allowedTools` and `permissionMode` to `permissions` schema in `src/lib/agent-yaml.ts` `AgentConfigSchema` (Zod).
+- Add same fields to `DirectoryEntry.permissions` in `src/lib/agent-directory.ts`.
+- Update `src/services/executors/claude-code.ts` `buildOmniSpawnParams` (and any sibling spawn paths) to:
+  - Resolve `entry.permissions.preset` → canonical tool list. Map: `full` → all standard tools (Read, Write, Edit, Bash, Glob, Grep, ToolSearch, Skill, ScheduleWakeup, NotebookEdit, WebSearch, WebFetch, AskUserQuestion, Monitor, EnterPlanMode, ExitPlanMode, EnterWorktree, ExitWorktree, TaskCreate/Get/List/Output/Stop/Update, SendMessage, PushNotification, CronCreate/Delete/List, RemoteTrigger). `read-only` → Read, Glob, Grep, Bash, ToolSearch. `chat-only` → Bash, Read, ToolSearch only.
+  - Forward `permissionMode` to claude when set.
+  - Forward `allowedTools` (when present) to claude as `--allowedTools <list>`.
+  - Forward `disallowedTools` as `--disallowedTools <list>` (already present but verify wire path).
+- Update `src/lib/provider-adapters.ts` `buildLaunchCommand` (or claude-specific builder) to emit `--allowedTools` and `--permission-mode` flags when present in `SpawnParams`.
+
+**P0 — Spawn UUID regression**
+- Fix `lookupTemplateTeam(<role>)` failure in `src/lib/agent-directory.ts` (or its caller). Symptom: `genie spawn engineer --team genie` fails with `[agent-directory] lookupTemplateTeam(engineer) failed: invalid input syntax for type uuid: "engineer"` followed by `agents_id_shape_check` violation. Root cause likely in the retire-session-names id refactor — built-in role names being passed where UUID is expected.
+
+**P0 — felipe agent end-to-end test**
+- Update `/home/genie/workspace/agents/felipe/agent.yaml` `permissions` block:
+  ```yaml
+  permissions:
+    preset: full
+    permissionMode: acceptEdits
+  disallowedTools:
+    - Agent
+  ```
+- Verify after spawn: felipe agent in a fresh tmux session has Edit/Write/Glob/Grep available (validated by spawning felipe and listing tools). Document the validation in `docs/agent-yaml-tool-wireup.md`.
+
+**P1 — Reviewer model: haiku → opus**
+- Edit `plugins/genie/agents/reviewer/AGENTS.md` frontmatter line 4: `model: haiku` → `model: opus`.
+- Reason: per Felipe, `--permission-mode auto` not supported by haiku/sonnet; reviewer is run frequently and must use opus for proper tool gating.
+
+**P1 — Default-agents audit + cleanup**
+- Inventory all subdirectories under `plugins/genie/agents/`. Currently: council, council--architect, council--benchmarker, council--deployer, council--ergonomist, council--measurer, council--operator, council--questioner, council--sentinel, council--simplifier, council--tracer, docs, engineer, fix, pm, qa, refactor, reviewer, team-lead, trace.
+- For each: determine if it's referenced in genie source code (grep for the role name in `src/`, `plugins/`, `skills/`).
+- For roles with zero references: delete the directory.
+- For roles still referenced: confirm `model: inherit` (or explicit non-haiku/non-sonnet).
+- Document survivors + deletions in PR description.
+
+**P1 — Frontmatter → agent.yaml on remaining built-in roles**
+- For each surviving role under `plugins/genie/agents/<role>/`: run the migration logic equivalent to `src/lib/agent-migrate.ts:migrateAgentToYaml` (which currently targets workspace agents).
+- Result per role: `<role>/AGENTS.md` (body only, no frontmatter) + `<role>/agent.yaml` (model, color, promptMode, tools — converted from frontmatter).
+- Update `src/lib/builtin-agents.ts:scanAgents` to read from agent.yaml instead of frontmatter (or both with agent.yaml winning), so the migration is non-breaking.
+
+**Validation**
+- `bun test` passes (unit + integration).
+- `bun run typecheck` clean.
+- Manual smoke: `genie spawn engineer --team genie` from a fresh shell does NOT throw `agents_id_shape_check`.
+- Manual smoke: spawn felipe agent in a fresh tmux session, verify Edit/Write tools are available.
+- Manual smoke: `genie spawn reviewer --team genie` uses opus (verify via `genie ls --json`).
+
+### OUT
+
+- Migrating ALL workspace agents (`workspace/agents/*`) frontmatter → agent.yaml. Out of scope; only felipe needs the agent.yaml path validated. Other workspace agents migrate later, separate wish.
+- Adding new permission presets beyond `full`/`read-only`/`chat-only`. Felipe wants the existing 3 working, not a new design.
+- Modifying claude code (upstream) — only the genie-side wire-through.
+- Council member auto-spawn changes — council deliberation flow stays as-is.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | Single PR, multi-concern (4 P0 + 3 P1) | Felipe direct: "micropr against genie dev". Cohesive scope: all about the agent.yaml migration finishing. |
+| D2 | `preset: full` maps to canonical full tool list (~25 tools) | Concrete spec; predictable; matches what the operator persona expects |
+| D3 | Migration of built-in role frontmatter is non-breaking via fallback | `scanAgents` reads agent.yaml first, falls back to frontmatter if absent. Old plugin installs keep working during rollout |
+| D4 | Reviewer → opus, no model inherit chain | Direct fix; reviewer runs hot, deserves the explicit declaration |
+| D5 | Felipe agent.yaml updated + tested as part of this PR | "we cant work without this" — felipe must be functionally unblocked when the PR ships |
+| D6 | Default agents audit happens INSIDE this wish, not as separate sweep | Avoid context-switch; the survey must inform the migration (no point migrating dead agents) |
+
+## Success Criteria
+
+- [ ] **S1** — `genie spawn engineer --team genie` from a fresh shell exits 0 (no UUID error)
+- [ ] **S2** — `genie spawn fix --team genie` from a fresh shell exits 0
+- [ ] **S3** — Spawning felipe agent in a fresh session gives the agent access to Edit/Write/Glob/Grep tools (verified via tool inventory check)
+- [ ] **S4** — `plugins/genie/agents/reviewer/AGENTS.md` has `model: opus` (or migrated to `agent.yaml` with `model: opus`)
+- [ ] **S5** — Zero `model: haiku` or `model: sonnet` declarations across `plugins/genie/agents/**` (audit grep returns 0 hits)
+- [ ] **S6** — Default-agents audit table in PR description: column for each role with usage status (used / dead) + action (kept / deleted / migrated)
+- [ ] **S7** — Each surviving built-in role under `plugins/genie/agents/` has an `agent.yaml` (frontmatter empty in AGENTS.md or removed entirely)
+- [ ] **S8** — `bun test` + `bun run typecheck` clean on the wish branch
+- [ ] **S9** — PR open against `dev` with the audit table in the body
+
+## Execution Strategy
+
+Single wave, mostly sequential per file ownership. One engineer; pair-with-fix loop on validation gaps.
+
+| Group | Description | Depends-on |
+|-------|-------------|------------|
+| 1 | Schema additions: `agent-yaml.ts` + `agent-directory.ts` + `provider-adapters.ts` `SpawnParams.permissions` extended (allowedTools, permissionMode) | none |
+| 2 | Executor wire-through: `claude-code.ts` resolves preset → tool list, forwards allowedTools + permissionMode; `provider-adapters.ts` emits `--allowedTools` and `--permission-mode` flags | Group 1 |
+| 3 | Spawn UUID regression: trace `lookupTemplateTeam` failure, fix the id-shape mismatch | none (parallel to G1+G2) |
+| 4 | Default-agents audit + delete dead | none (parallel) |
+| 5 | Reviewer haiku → opus + audit any other haiku/sonnet | parallel to G4 |
+| 6 | Built-in roles frontmatter → agent.yaml migration; `scanAgents` reads agent.yaml-first with frontmatter fallback | Groups 2 + 4 + 5 |
+| 7 | Felipe agent.yaml updated + smoke-tested end-to-end | Groups 2 + 3 |
+| 8 | Tests + PR open with audit table | All groups |
+
+---
+
+## Execution Groups
+
+### Group 1: Schema additions
+
+**Goal:** Extend the agent.yaml schema and SpawnParams to carry `allowedTools` and `permissionMode`.
+
+**Deliverables:**
+1. `src/lib/agent-yaml.ts`: `AgentConfigSchema.permissions` extended with `allowedTools: z.array(z.string()).optional()` and `permissionMode: SdkPermissionModeSchema.optional()`.
+2. `src/lib/agent-directory.ts`: `DirectoryEntry.permissions` interface extended with same fields.
+3. `src/lib/provider-adapters.ts`: `spawnParamsSchema.permissions` extended with same fields. `SpawnParams` TypeScript interface mirrored.
+4. Tests in `src/lib/agent-yaml.test.ts` covering parse/round-trip of new fields.
+
+**Acceptance Criteria:**
+- [ ] Parsing an `agent.yaml` with `permissions.allowedTools: [Read, Write]` succeeds (no Zod error).
+- [ ] Parsing with `permissions.permissionMode: 'acceptEdits'` succeeds.
+- [ ] Unknown values for permissionMode rejected with field-named Zod error.
+- [ ] Round-trip (parse + write) preserves new fields byte-stable.
+
+**Validation:**
+```bash
+bun test src/lib/agent-yaml.test.ts
+bun run typecheck
+```
+
+**depends-on:** none
+
+---
+
+### Group 2: Executor wire-through (the unblocker)
+
+**Goal:** Make `permissions.preset: full` (and the new fields) actually expose tools to the spawned claude process.
+
+**Deliverables:**
+1. `src/services/executors/claude-code.ts:184-207` — replace the `allow.length || deny.length` gate with full permission resolution:
+   - Resolve `entry.permissions.preset` → canonical tool list using a `PRESET_TOOLS` map. Define presets: `full` (all ~25 tools), `read-only` (Read, Glob, Grep, Bash, ToolSearch), `chat-only` (Bash, Read, ToolSearch).
+   - Merge resolved preset list with explicit `entry.permissions.allowedTools` (union).
+   - Forward to SpawnParams as `permissions.allowedTools`.
+   - Forward `entry.permissions.permissionMode` (default `auto`).
+2. `src/lib/provider-adapters.ts` claude command builder: emit `--allowedTools <list>` (comma-separated) and `--permission-mode <mode>` flags when present.
+3. Document the canonical preset → tool list mapping in `docs/permission-presets.md`.
+
+**Acceptance Criteria:**
+- [ ] Spawn command for an agent with `preset: full` includes `--allowedTools Read,Write,Edit,Bash,Glob,Grep,...`.
+- [ ] Spawn command for an agent without permissions still works (no flag emitted).
+- [ ] Spawn command for `preset: read-only` does NOT include Write/Edit in `--allowedTools`.
+- [ ] Empty preset name passes through with warning, no crash.
+- [ ] Tests in `src/services/executors/claude-code.test.ts` cover the 3 presets + missing preset + custom allowedTools merge.
+
+**Validation:**
+```bash
+bun test src/services/executors/claude-code.test.ts
+bun run typecheck
+```
+
+**depends-on:** Group 1
+
+---
+
+### Group 3: Fix `lookupTemplateTeam` UUID regression
+
+**Goal:** Restore `genie spawn <role> --team <team>` for built-in role names.
+
+**Deliverables:**
+1. Trace the call path: `agents.ts` (term-commands) → `agent-directory.ts` `lookupTemplateTeam` → PG query.
+2. Identify where a built-in role name (e.g., `engineer`) is being passed through a code path that expects a UUID. Likely in `wish/retire-session-names-id-only` work — check recent commits to `agent-registry.ts` and `agent-directory.ts`.
+3. Fix: either accept role names alongside UUIDs in the lookup (add a name-resolver branch), or guard the call site so role names take a different path (template lookup).
+4. Test: reproduce + assert spawn works for `engineer`, `reviewer`, `qa`, `fix`.
+
+**Acceptance Criteria:**
+- [ ] `genie spawn engineer --team genie` from a fresh shell exits 0 with `Agent ready`.
+- [ ] `genie spawn fix --team genie` exits 0.
+- [ ] No `agents_id_shape_check` violations on spawn.
+- [ ] Test added that exercises the fix.
+
+**Validation:**
+```bash
+bun test src/lib/agent-directory.test.ts
+genie spawn engineer --team genie  # exits 0
+genie agent rm <spawned-id>         # cleanup
+```
+
+**depends-on:** none
+
+---
+
+### Group 4: Default-agents audit + delete dead
+
+**Goal:** Inventory `plugins/genie/agents/`, identify unused roles, delete them.
+
+**Deliverables:**
+1. Audit table (markdown file `audit-default-agents.md` in PR root, deleted post-merge):
+   - Column: role name, references in src/, references in skills/, references in plugin definitions, decision (keep / delete).
+2. For each role with zero references: `git rm -r plugins/genie/agents/<role>/`.
+3. PR description embeds the audit table.
+
+**Acceptance Criteria:**
+- [ ] Audit covers all 20 current subdirectories.
+- [ ] Delete decisions justified in audit table.
+- [ ] No deletion of agents still referenced in code.
+- [ ] PR description includes the audit table.
+
+**Validation:**
+```bash
+# After deletions, verify no broken references:
+grep -rn "plugins/genie/agents/<deleted-role>" src/ skills/ plugins/  # 0 hits
+bun test
+```
+
+**depends-on:** none
+
+---
+
+### Group 5: Reviewer haiku → opus + haiku/sonnet purge
+
+**Goal:** Eliminate haiku/sonnet defaults across `plugins/genie/agents/`.
+
+**Deliverables:**
+1. `plugins/genie/agents/reviewer/AGENTS.md:4` — `model: haiku` → `model: opus`.
+2. Audit `plugins/genie/agents/**/AGENTS.md` for any other `model: haiku` or `model: sonnet`. Replace with `model: opus` or `model: inherit` per role context.
+
+**Acceptance Criteria:**
+- [ ] Reviewer's model is `opus` (or `inherit` if team default is opus).
+- [ ] `grep -rn 'model:.*haiku\|model:.*sonnet' plugins/genie/agents/` returns 0 hits.
+
+**Validation:**
+```bash
+grep -rn 'model:.*\(haiku\|sonnet\)' plugins/genie/agents/  # 0 hits
+genie spawn reviewer --team genie  # uses opus per genie ls --json
+```
+
+**depends-on:** Group 3 (need spawn fix to validate)
+
+---
+
+### Group 6: Built-in roles frontmatter → agent.yaml migration
+
+**Goal:** Move metadata out of frontmatter into agent.yaml for each surviving built-in role.
+
+**Deliverables:**
+1. For each role in `plugins/genie/agents/<role>/` (post Group 4 deletions): create `<role>/agent.yaml` with model, color, promptMode, tools, description from existing frontmatter. Keep `name` derived from directory.
+2. Strip frontmatter from `<role>/AGENTS.md` (body only).
+3. `src/lib/builtin-agents.ts:scanAgents` updated: read `<role>/agent.yaml` first; if absent, fallback to AGENTS.md frontmatter (legacy compat for older plugin installs).
+4. Migration script `scripts/migrate-builtin-agents-to-yaml.ts` that does the conversion (rerunnable).
+
+**Acceptance Criteria:**
+- [ ] Each surviving role has `agent.yaml` with the converted fields.
+- [ ] `scanAgents` returns the same `BuiltinAgent` objects post-migration (snapshot test).
+- [ ] Removing `<role>/agent.yaml` and keeping only frontmatter still works (fallback path).
+- [ ] Removing frontmatter and keeping only `agent.yaml` works (target state).
+
+**Validation:**
+```bash
+bun test src/lib/builtin-agents.test.ts
+bun run scripts/migrate-builtin-agents-to-yaml.ts --dry-run  # idempotent
+```
+
+**depends-on:** Group 4, Group 5
+
+---
+
+### Group 7: Felipe agent end-to-end smoke test
+
+**Goal:** Validate the full wire-through using felipe agent as the canary.
+
+**Deliverables:**
+1. Update `/home/genie/workspace/agents/felipe/agent.yaml`:
+   ```yaml
+   permissions:
+     preset: full
+     permissionMode: acceptEdits
+   disallowedTools:
+     - Agent
+   ```
+2. Spawn felipe agent in a fresh tmux session.
+3. Verify the spawned felipe has Edit/Write/Glob/Grep tools available (smoke check via `claude --list-tools` or similar).
+4. Document in `docs/agent-yaml-tool-wireup.md` the full canary path.
+
+**Acceptance Criteria:**
+- [ ] Felipe agent spawn shows `--allowedTools` flag with Read,Write,Edit,Bash,Glob,Grep,... in the launch command.
+- [ ] Felipe agent CAN write to a brain file via Edit tool (no permission denial).
+- [ ] Felipe agent CANNOT spawn Agent tool (disallowedTools: Agent honored).
+
+**Validation:**
+```bash
+genie spawn felipe --team felipe-test  # or directly tmux new-session with claude
+# Inside spawned felipe:
+# verify tool inventory shows Edit/Write
+```
+
+**depends-on:** Group 2, Group 3
+
+---
+
+### Group 8: Tests + PR open
+
+**Goal:** Final validation gate + open PR against dev with audit table.
+
+**Deliverables:**
+1. Full `bun test` clean.
+2. Full `bun run typecheck` clean.
+3. PR opened against `dev` with title: `fix(agent-yaml): wire permissions through executor + audit default agents`.
+4. PR body includes:
+   - Summary of the wire-through fix
+   - Audit table (Group 4 output)
+   - Migration table (Group 6 output)
+   - Felipe canary test results (Group 7 evidence)
+   - Reviewer model change note (Group 5)
+
+**Acceptance Criteria:**
+- [ ] CI green on the PR.
+- [ ] PR description has all 4 tables/sections.
+- [ ] Reviewer reports SHIP verdict.
+
+**Validation:**
+```bash
+bun test && bun run typecheck && gh pr view <pr-num>
+```
+
+**depends-on:** Group 1, Group 2, Group 3, Group 4, Group 5, Group 6, Group 7
+
+---
+
+## QA Criteria
+
+- [ ] `genie spawn engineer --team genie` works from clean shell (no UUID error)
+- [ ] `genie spawn fix --team genie` works
+- [ ] Felipe agent spawned in fresh session has Edit/Write tools
+- [ ] Reviewer agent uses opus model
+- [ ] Zero haiku/sonnet defaults in `plugins/genie/agents/`
+- [ ] All built-in roles have agent.yaml (frontmatter migrated or stripped)
+- [ ] PR has audit table for default-agents cleanup
+
+## Files to Create/Modify
+
+```
+# Schema
+src/lib/agent-yaml.ts                              modify
+src/lib/agent-directory.ts                         modify
+src/lib/provider-adapters.ts                       modify
+
+# Executor wire-through
+src/services/executors/claude-code.ts              modify
+
+# Spawn UUID fix
+src/lib/agent-directory.ts                         modify (Group 3)
+src/lib/agent-registry.ts                          modify (probable)
+
+# Built-in agents migration
+src/lib/builtin-agents.ts                          modify
+plugins/genie/agents/<role>/AGENTS.md              modify (strip frontmatter)
+plugins/genie/agents/<role>/agent.yaml             create (each surviving)
+plugins/genie/agents/<dead-role>/                  delete
+plugins/genie/agents/reviewer/AGENTS.md            modify (model: opus)
+scripts/migrate-builtin-agents-to-yaml.ts          create
+
+# Felipe agent (validation canary)
+/home/genie/workspace/agents/felipe/agent.yaml     modify (real path, outside repo)
+
+# Documentation
+docs/permission-presets.md                         create
+docs/agent-yaml-tool-wireup.md                     create
+
+# Tests
+src/lib/agent-yaml.test.ts                         modify
+src/lib/builtin-agents.test.ts                     modify
+src/services/executors/claude-code.test.ts         modify
+src/lib/agent-directory.test.ts                    modify
+```

--- a/audit-default-agents.md
+++ b/audit-default-agents.md
@@ -1,0 +1,62 @@
+# Default Agents Audit — `plugins/genie/agents/`
+
+**Wish:** `agent-yaml-permissions-wireup` — Group 4
+**Date:** 2026-05-03
+**Auditor:** engineer-4
+
+## Methodology
+
+Every subdirectory under `plugins/genie/agents/` was checked for references in `src/`, `skills/`, and `plugins/` (excluding self-references inside its own agent directory). Reference categories considered "live use":
+
+- **Discovery / registry** — `src/lib/builtin-agents.ts` scans the directory; `BUILTIN_ROLES.length === 9` and `BUILTIN_COUNCIL_MEMBERS.length === 11` are asserted by `src/lib/builtin-agents.test.ts`. Removing any directory breaks the 20-agent contract.
+- **Spawn / addressability** — `genie spawn <name>`, native team registration (`src/lib/team-manager.ts`, `src/lib/claude-native-teams.ts`), agent directory resolution (`src/lib/agent-directory.ts`), council deliberation flow.
+- **Skill workflows** — `skills/pm/SKILL.md`, `skills/work/...`, etc. dispatch by name (`refactor`, `docs`, `trace`, ...).
+- **Documentation pointers** — `plugins/genie/agents/team-lead/AGENTS.md` routes to roles by name.
+
+## Audit Table
+
+| # | Role | src/ refs | skills/ refs | plugins/ refs | Decision | Rationale |
+|---|------|-----------|--------------|---------------|----------|-----------|
+| 1 | `council` | 143 | 27 | 39 | **KEEP** | Council deliberation entry point; asserted in `builtin-agents.test.ts:86`; spawned by `/council` skill. |
+| 2 | `council--architect` | 11 | 1 | 0 | **KEEP** | Council member; asserted in `builtin-agents.test.ts:92`; addressable via `Agent` subagent_type and `genie spawn`. |
+| 3 | `council--benchmarker` | 1 | 0 | 0 | **KEEP** | Council member; asserted in `builtin-agents.test.ts:88`. |
+| 4 | `council--deployer` | 1 | 0 | 0 | **KEEP** | Council member; asserted in `builtin-agents.test.ts:94`. |
+| 5 | `council--ergonomist` | 1 | 0 | 0 | **KEEP** | Council member; asserted in `builtin-agents.test.ts:91`. |
+| 6 | `council--measurer` | 3 | 0 | 0 | **KEEP** | Council member; asserted in `builtin-agents.test.ts:95`; used in `send.test.ts` topology. |
+| 7 | `council--operator` | 1 | 0 | 0 | **KEEP** | Council member; asserted in `builtin-agents.test.ts:93`. |
+| 8 | `council--questioner` | 8 | 0 | 0 | **KEEP** | Council member; asserted in `builtin-agents.test.ts:87`; documented in `genie spawn` help (`src/genie.ts:475`). |
+| 9 | `council--sentinel` | 3 | 0 | 0 | **KEEP** | Council member; asserted in `builtin-agents.test.ts:90`; used in `claude-native-teams.test.ts:823`. |
+| 10 | `council--simplifier` | 3 | 0 | 0 | **KEEP** | Council member; asserted in `builtin-agents.test.ts:89`. |
+| 11 | `council--tracer` | 1 | 0 | 0 | **KEEP** | Council member; asserted in `builtin-agents.test.ts:96`. |
+| 12 | `docs` | 47 | 46 | 7 | **KEEP** | Standard role; asserted in `builtin-agents.test.ts:45`; close-verb skill; spawned by PM. |
+| 13 | `engineer` | 599 | 45 | 18 | **KEEP** | Standard role; asserted in `builtin-agents.test.ts:40`; primary work executor; documented in `genie spawn` help. |
+| 14 | `fix` | 398 | 83 | 36 | **KEEP** | Standard role; asserted in `builtin-agents.test.ts:43`; FIX-FIRST loop dispatch. |
+| 15 | `pm` | 11 | 3 | 4 | **KEEP** | Standard role; asserted in `builtin-agents.test.ts:48`; project management entry point. |
+| 16 | `qa` | 240 | 12 | 7 | **KEEP** | Standard role; asserted in `builtin-agents.test.ts:42`; QA workflow + board column gate. |
+| 17 | `refactor` | 13 | 9 | 5 | **KEEP** | Standard role; asserted in `builtin-agents.test.ts:46`; PM dispatches when wish scope mentions "refactor". |
+| 18 | `reviewer` | 174 | 28 | 9 | **KEEP** | Standard role; asserted in `builtin-agents.test.ts:41`; review/fix loop. |
+| 19 | `team-lead` | 335 | 6 | 19 | **KEEP** | Standard role; asserted in `builtin-agents.test.ts:47,51-56`; system-prompt mode; team orchestration. |
+| 20 | `trace` | 75 | 45 | 7 | **KEEP** | Standard role; asserted in `builtin-agents.test.ts:44`; investigation handoff target for `/fix`. |
+
+## Summary
+
+- **Total directories audited:** 20 (matches wish inventory)
+- **Kept:** 20
+- **Deleted:** 0
+
+## Why nothing was deleted
+
+The `BUILTIN_ROLES.length === 9` and `BUILTIN_COUNCIL_MEMBERS.length === 11` invariants in `src/lib/builtin-agents.test.ts:20,60` lock the directory contents. Each role and each council member is also explicitly asserted by name. Beyond the test contract, every council member is addressable via the `council` deliberation flow and spawn surface; every standard role is dispatched by skills, PM routing, or board column gates.
+
+Result: the audit confirms the 20-agent set is the minimum surface area. No deletions in this wish — Group 6 will migrate frontmatter → `agent.yaml` for all 20 survivors.
+
+## Validation
+
+```bash
+# All 20 directories still present, all referenced
+$ ls plugins/genie/agents/ | wc -l
+20
+
+# Test contract still satisfied
+$ bun test src/lib/builtin-agents.test.ts
+```

--- a/plugins/genie/agents/reviewer/AGENTS.md
+++ b/plugins/genie/agents/reviewer/AGENTS.md
@@ -1,7 +1,7 @@
 ---
 name: reviewer
 description: "Reviews criteria compliance AND code quality in one pass. Returns SHIP or FIX-FIRST with severity-tagged findings."
-model: haiku
+model: opus
 color: yellow
 promptMode: append
 tools: ["Read", "Glob", "Grep", "Bash"]

--- a/src/db/migrations/061_agents_id_invariant_and_fk_lockdown.sql
+++ b/src/db/migrations/061_agents_id_invariant_and_fk_lockdown.sql
@@ -1,0 +1,433 @@
+-- 061_agents_id_invariant_and_fk_lockdown.sql
+--
+-- Wish: retire-session-names-id-only, Group 1.
+--
+-- Closes the structural cause of recurring identity drift in three sweeps:
+--
+--   (a) `agents.id` accepts UUID-shaped values OR `dir:<name>`, enforced by
+--       a CHECK constraint. Bare-name inserts fail at the DB level forever.
+--   (b) Every reference column FKs to `agents.id`:
+--         mailbox.from_worker, mailbox.to_worker,
+--         team_chat.sender,
+--         teams.leader,
+--         agents.reports_to.
+--       Drift always lands where the schema doesn't enforce shape; SQL is the
+--       only enforcement that holds across refactors.
+--   (c) `agent_templates` becomes UUID PK + unique (name, team), so template
+--       identity stops doubling as a name lookup key.
+--   (d) `teams.members` JSONB array elements are validated as UUID or
+--       `dir:<name>` strings via a CHECK constraint.
+--
+-- ---------------------------------------------------------------------------
+-- Heal-not-wipe — why this migration uses NOT VALID
+-- ---------------------------------------------------------------------------
+-- Council directive: "NEVER DELETE rows." Migration 050 and migration 053
+-- established the precedent — when a legacy identity row had to be retired,
+-- the row was UPDATEd (state='archived', auto_resume=false), never deleted.
+-- Operators recover via `genie agent unpause`; the row's identity stays
+-- discoverable through the audit log and the live table.
+--
+-- This migration extends the same pattern. Bare-name `agents` rows that
+-- survived 050/053 are recorded in `audit_events` (event_type
+-- 'legacy_barename_archived', with the row's full identity columns in
+-- `details` JSONB) and flipped to `state='archived' / auto_resume=false`.
+-- The rows STAY in the table.
+--
+-- Because the rows stay, a fully-VALIDATED CHECK constraint on `agents.id`
+-- would reject the table at constraint-creation time (the archived rows
+-- still carry bare-name ids that the new shape rejects). The directive
+-- forbids DELETE, so the only Postgres mechanism that lets us add a CHECK
+-- without dropping data is `ADD CONSTRAINT ... NOT VALID`. This:
+--   - enforces the predicate on every future INSERT/UPDATE (the wish's
+--     goal: "no new bare-name rows can land via any spawn path");
+--   - skips validation of pre-existing rows (heal-not-wipe).
+--
+-- Same reasoning applies to the FKs on NOT NULL carrier columns
+-- (`mailbox.from_worker`, `mailbox.to_worker`, `team_chat.sender`). Pass A
+-- backfills bare-name refs to UUIDs where a peer can be resolved; un-
+-- resolvable orphans cannot be nulled (NOT NULL) and cannot be deleted
+-- (heal-not-wipe), so the FK is added `NOT VALID`. New inserts must satisfy
+-- the FK; pre-existing orphan rows are grandfathered.
+--
+-- For the nullable FK columns (`agents.reports_to`, `teams.leader`), Pass C
+-- nulls every value that did not resolve to a real UUID/dir agent row. The
+-- column is then provably clean, so the FK can be added fully VALIDATED —
+-- new inserts are enforced AND every existing row passes the check.
+--
+-- ---------------------------------------------------------------------------
+-- Operational implication — future `VALIDATE CONSTRAINT`
+-- ---------------------------------------------------------------------------
+-- A future `ALTER TABLE agents VALIDATE CONSTRAINT agents_id_shape_check`
+-- (and the equivalent for the three NOT VALID FKs) WILL FAIL on this host
+-- as long as any bare-name row remains in `agents`. That is intentional.
+-- Operators who want to fully validate the constraint must first prove the
+-- archived bare-name rows are non-load-bearing (no live executor anchors
+-- them, no observers fetch them) and migrate them out of `agents` (e.g. to
+-- a quarantine table). That work is OUT OF SCOPE for this wish and is
+-- tracked separately.
+--
+-- Idempotent: every pass is gated on a precondition (column shape, constraint
+-- presence, value pattern). Re-running the migration affects zero additional
+-- rows or DDL.
+--
+-- See .genie/wishes/retire-session-names-id-only/WISH.md (Decisions 1, 11, 12)
+-- for the full rationale.
+
+-- ===========================================================================
+-- Pass A — Backfill bare-name FK references to UUID/dir peers
+-- ===========================================================================
+-- For each bare-name reference, look up the canonical UUID/dir id via the
+-- `(custom_name, team)` composite and rewrite the column in place. Rows that
+-- don't resolve are handled in Pass C.
+
+-- A1: agents.reports_to → resolve via (custom_name, team)
+UPDATE agents a
+   SET reports_to = peer.id
+  FROM agents peer
+ WHERE a.reports_to IS NOT NULL
+   AND a.reports_to !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+   AND a.reports_to NOT LIKE 'dir:%'
+   AND peer.custom_name = a.reports_to
+   AND (peer.team IS NOT DISTINCT FROM a.team)
+   AND (peer.id ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+        OR peer.id LIKE 'dir:%');
+
+-- A2: teams.leader → resolve via (custom_name, team)
+UPDATE teams t
+   SET leader = peer.id
+  FROM agents peer
+ WHERE t.leader IS NOT NULL
+   AND t.leader !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+   AND t.leader NOT LIKE 'dir:%'
+   AND peer.custom_name = t.leader
+   AND (peer.team IS NOT DISTINCT FROM t.name)
+   AND (peer.id ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+        OR peer.id LIKE 'dir:%');
+
+-- A3: mailbox.from_worker → resolve via custom_name (team unknown on mailbox).
+-- Pick exactly one canonical peer per name (deterministic ordering — dir: rows
+-- win over UUID rows so the directory entry is preferred when both exist).
+UPDATE mailbox m
+   SET from_worker = peer.id
+  FROM agents peer
+ WHERE m.from_worker IS NOT NULL
+   AND m.from_worker !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+   AND m.from_worker NOT LIKE 'dir:%'
+   AND peer.custom_name = m.from_worker
+   AND (peer.id ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+        OR peer.id LIKE 'dir:%')
+   AND peer.id = (
+     SELECT p2.id FROM agents p2
+      WHERE p2.custom_name = m.from_worker
+        AND (p2.id ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+             OR p2.id LIKE 'dir:%')
+      ORDER BY (CASE WHEN p2.id LIKE 'dir:%' THEN 0 ELSE 1 END), p2.id
+      LIMIT 1
+   );
+
+-- A4: mailbox.to_worker → resolve via custom_name
+UPDATE mailbox m
+   SET to_worker = peer.id
+  FROM agents peer
+ WHERE m.to_worker IS NOT NULL
+   AND m.to_worker !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+   AND m.to_worker NOT LIKE 'dir:%'
+   AND peer.custom_name = m.to_worker
+   AND (peer.id ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+        OR peer.id LIKE 'dir:%')
+   AND peer.id = (
+     SELECT p2.id FROM agents p2
+      WHERE p2.custom_name = m.to_worker
+        AND (p2.id ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+             OR p2.id LIKE 'dir:%')
+      ORDER BY (CASE WHEN p2.id LIKE 'dir:%' THEN 0 ELSE 1 END), p2.id
+      LIMIT 1
+   );
+
+-- A5: team_chat.sender → resolve via (custom_name, team)
+UPDATE team_chat tc
+   SET sender = peer.id
+  FROM agents peer
+ WHERE tc.sender IS NOT NULL
+   AND tc.sender !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+   AND tc.sender NOT LIKE 'dir:%'
+   AND peer.custom_name = tc.sender
+   AND peer.team = tc.team
+   AND (peer.id ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+        OR peer.id LIKE 'dir:%');
+
+-- A6: teams.members JSONB — rewrite each element via (custom_name, team)
+UPDATE teams t
+   SET members = (
+     SELECT COALESCE(jsonb_agg(
+       CASE
+         WHEN element ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+              OR element LIKE 'dir:%'
+           THEN element
+         ELSE COALESCE(
+           (SELECT a.id FROM agents a
+             WHERE a.custom_name = element
+               AND a.team = t.name
+               AND (a.id ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+                    OR a.id LIKE 'dir:%')
+             ORDER BY (CASE WHEN a.id LIKE 'dir:%' THEN 0 ELSE 1 END), a.id
+             LIMIT 1),
+           element
+         )
+       END
+     ), '[]'::jsonb)
+       FROM jsonb_array_elements_text(t.members) AS element
+   )
+ WHERE jsonb_typeof(t.members) = 'array'
+   AND EXISTS (
+     SELECT 1 FROM jsonb_array_elements_text(t.members) AS e
+      WHERE e !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+        AND e NOT LIKE 'dir:%'
+   );
+
+-- ===========================================================================
+-- Pass B — Audit + archive bare-name agent rows (heal-not-wipe — NO DELETE)
+-- ===========================================================================
+-- Bare-name violators are recorded in audit_events with their full identity
+-- columns and flipped to state='archived' / auto_resume=false. The rows STAY
+-- in the agents table; the CHECK constraint added in Pass F is `NOT VALID`,
+-- so existing rows are grandfathered while new bare-name inserts are blocked.
+
+WITH violators AS (
+  SELECT id, role, custom_name, team, repo_path, state, auto_resume,
+         started_at, reports_to, native_agent_id
+    FROM agents
+   WHERE id IS NOT NULL
+     AND id !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+     AND id NOT LIKE 'dir:%'
+)
+INSERT INTO audit_events (entity_type, entity_id, event_type, actor, details)
+SELECT 'agent', v.id, 'legacy_barename_archived',
+       'migration:061_agents_id_invariant_and_fk_lockdown',
+       jsonb_build_object(
+         'reason', 'pre_check_constraint_archive',
+         'role', v.role,
+         'custom_name', v.custom_name,
+         'team', v.team,
+         'repo_path', v.repo_path,
+         'state_before', v.state,
+         'auto_resume_before', v.auto_resume,
+         'started_at', v.started_at,
+         'reports_to', v.reports_to,
+         'native_agent_id', v.native_agent_id,
+         'wish', 'retire-session-names-id-only',
+         'group', 1)
+  FROM violators v
+ WHERE NOT EXISTS (
+   SELECT 1 FROM audit_events ae
+    WHERE ae.entity_type = 'agent'
+      AND ae.entity_id = v.id
+      AND ae.event_type = 'legacy_barename_archived'
+      AND ae.actor = 'migration:061_agents_id_invariant_and_fk_lockdown'
+ );
+
+-- Flip state for any not-yet-archived violators (idempotent).
+UPDATE agents
+   SET state = 'archived',
+       auto_resume = false,
+       last_state_change = now()
+ WHERE id !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+   AND id NOT LIKE 'dir:%'
+   AND (state IS DISTINCT FROM 'archived' OR auto_resume IS DISTINCT FROM false);
+
+-- ===========================================================================
+-- Pass C — NULL nullable refs that didn't resolve in Pass A
+-- ===========================================================================
+-- For nullable FK columns (reports_to, leader), set NULL when the value is
+-- still bare-name OR points at a row that doesn't exist. NOT NULL columns
+-- (mailbox.{from,to}_worker, team_chat.sender) are left untouched — heal-
+-- not-wipe — and grandfathered by FK NOT VALID in Pass G.
+
+-- C1a: agents.reports_to → NULL where still bare
+UPDATE agents
+   SET reports_to = NULL
+ WHERE reports_to IS NOT NULL
+   AND reports_to !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+   AND reports_to NOT LIKE 'dir:%';
+
+-- C1b: agents.reports_to → NULL where the referenced agent doesn't exist.
+-- Without this guard, the (VALIDATED) FK on reports_to would fail.
+UPDATE agents a
+   SET reports_to = NULL
+ WHERE a.reports_to IS NOT NULL
+   AND NOT EXISTS (SELECT 1 FROM agents p WHERE p.id = a.reports_to);
+
+-- C2a: teams.leader → NULL where still bare
+UPDATE teams
+   SET leader = NULL
+ WHERE leader IS NOT NULL
+   AND leader !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+   AND leader NOT LIKE 'dir:%';
+
+-- C2b: teams.leader → NULL where target row doesn't exist
+UPDATE teams t
+   SET leader = NULL
+ WHERE t.leader IS NOT NULL
+   AND NOT EXISTS (SELECT 1 FROM agents p WHERE p.id = t.leader);
+
+-- ===========================================================================
+-- Pass E — agent_templates: TEXT-PK (=name) → UUID PK + name + (name, team) UQ
+-- ===========================================================================
+-- Idempotent guard: only re-shape if the id column is still TEXT.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = current_schema()
+       AND table_name = 'agent_templates'
+       AND column_name = 'id'
+       AND data_type = 'text'
+  ) THEN
+    -- Add `name` and backfill from old TEXT id (which holds the name today).
+    ALTER TABLE agent_templates ADD COLUMN IF NOT EXISTS name TEXT;
+    UPDATE agent_templates SET name = id WHERE name IS NULL;
+    -- Drop the existing TEXT primary key and the column itself.
+    ALTER TABLE agent_templates DROP CONSTRAINT IF EXISTS agent_templates_pkey;
+    ALTER TABLE agent_templates DROP COLUMN id;
+    -- Add the new UUID id as the primary key.
+    ALTER TABLE agent_templates ADD COLUMN id UUID NOT NULL DEFAULT gen_random_uuid();
+    ALTER TABLE agent_templates ADD PRIMARY KEY (id);
+    -- name becomes the canonical human key (NOT NULL after backfill).
+    ALTER TABLE agent_templates ALTER COLUMN name SET NOT NULL;
+  END IF;
+END $$;
+
+-- Always ensure unique index exists (idempotent via IF NOT EXISTS).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_templates_name_team
+  ON agent_templates(name, team)
+ WHERE name IS NOT NULL AND team IS NOT NULL;
+
+-- ===========================================================================
+-- Pass F — agents.id CHECK constraint (NOT VALID — grandfather legacy rows)
+-- ===========================================================================
+-- NOT VALID means: enforced on every INSERT/UPDATE going forward, but
+-- existing rows that violate the predicate are tolerated (heal-not-wipe).
+-- The wish's goal — block all new bare-name inserts — is fully met.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint c
+      JOIN pg_class t ON t.oid = c.conrelid
+     WHERE t.relname = 'agents'
+       AND c.conname = 'agents_id_shape_check'
+  ) THEN
+    ALTER TABLE agents
+      ADD CONSTRAINT agents_id_shape_check
+      CHECK (
+        id ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+        OR id LIKE 'dir:%'
+      ) NOT VALID;
+  END IF;
+END $$;
+
+-- ===========================================================================
+-- Pass G — Foreign key constraints
+-- ===========================================================================
+-- Nullable FKs (reports_to, leader) → VALIDATED, since Pass C nulled every
+-- orphan / bare-name reference, the column is provably clean.
+-- NOT NULL FKs (mailbox.{from,to}_worker, team_chat.sender) → NOT VALID,
+-- since heal-not-wipe forbids deleting orphan carrier rows; new inserts must
+-- satisfy the FK, existing rows grandfather.
+
+-- G1: agents.reports_to → agents.id (nullable, SET NULL on delete, VALIDATED)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'fk_agents_reports_to'
+  ) THEN
+    ALTER TABLE agents
+      ADD CONSTRAINT fk_agents_reports_to
+      FOREIGN KEY (reports_to) REFERENCES agents(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+-- G2: teams.leader → agents.id (nullable, SET NULL on delete, VALIDATED)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'fk_teams_leader'
+  ) THEN
+    ALTER TABLE teams
+      ADD CONSTRAINT fk_teams_leader
+      FOREIGN KEY (leader) REFERENCES agents(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+-- G3: mailbox.from_worker → agents.id (NOT NULL, CASCADE on delete, NOT VALID)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'fk_mailbox_from_worker'
+  ) THEN
+    ALTER TABLE mailbox
+      ADD CONSTRAINT fk_mailbox_from_worker
+      FOREIGN KEY (from_worker) REFERENCES agents(id) ON DELETE CASCADE NOT VALID;
+  END IF;
+END $$;
+
+-- G4: mailbox.to_worker → agents.id (NOT NULL, CASCADE on delete, NOT VALID)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'fk_mailbox_to_worker'
+  ) THEN
+    ALTER TABLE mailbox
+      ADD CONSTRAINT fk_mailbox_to_worker
+      FOREIGN KEY (to_worker) REFERENCES agents(id) ON DELETE CASCADE NOT VALID;
+  END IF;
+END $$;
+
+-- G5: team_chat.sender → agents.id (NOT NULL, CASCADE on delete, NOT VALID)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'fk_team_chat_sender'
+  ) THEN
+    ALTER TABLE team_chat
+      ADD CONSTRAINT fk_team_chat_sender
+      FOREIGN KEY (sender) REFERENCES agents(id) ON DELETE CASCADE NOT VALID;
+  END IF;
+END $$;
+
+-- ===========================================================================
+-- Pass H — teams.members UUID-array CHECK (NOT VALID)
+-- ===========================================================================
+-- Subqueries are not allowed inside CHECK predicates, so wrap the validation
+-- in an IMMUTABLE SQL function. The function rejects any element that isn't
+-- UUID-shaped or `dir:<name>`-shaped. NULL is permitted. NOT VALID grand-
+-- fathers any pre-existing teams that still carry bare-name members; new
+-- inserts/updates must comply.
+
+CREATE OR REPLACE FUNCTION migration_061_teams_members_valid(m jsonb)
+RETURNS boolean AS $$
+  -- CASE forces strict short-circuit so jsonb_array_elements_text never runs
+  -- on a non-array input. Plain `AND` cannot be relied upon — Postgres'
+  -- planner sometimes evaluates both operands.
+  SELECT CASE
+    WHEN m IS NULL THEN true
+    WHEN jsonb_typeof(m) <> 'array' THEN false
+    ELSE NOT EXISTS (
+      SELECT 1 FROM jsonb_array_elements_text(m) AS e
+       WHERE e !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+         AND e NOT LIKE 'dir:%'
+    )
+  END;
+$$ LANGUAGE sql IMMUTABLE;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'teams_members_uuid_check'
+  ) THEN
+    ALTER TABLE teams
+      ADD CONSTRAINT teams_members_uuid_check
+      CHECK (migration_061_teams_members_valid(members)) NOT VALID;
+  END IF;
+END $$;

--- a/src/db/migrations/061_agents_id_invariant_and_fk_lockdown.test.ts
+++ b/src/db/migrations/061_agents_id_invariant_and_fk_lockdown.test.ts
@@ -1,0 +1,536 @@
+/**
+ * Integration tests for migration 061 — agents_id_invariant_and_fk_lockdown.
+ *
+ * Group 1 of the retire-session-names-id-only wish.
+ *
+ * Coverage matrix (mirrors WISH §Acceptance Criteria for Group 1):
+ *
+ *   (a) UUID + `dir:<name>` inserts on `agents` succeed.
+ *   (b) Bare-name insert on `agents` is rejected by the CHECK constraint.
+ *   (c) Orphan FK insert (mailbox with non-existent to_worker, etc.) is
+ *       rejected by the FK constraint.
+ *   (d) Backfill resolves a representative bare-name reference (mailbox /
+ *       team_chat / teams.leader / agents.reports_to / teams.members) onto
+ *       its UUID peer via the (custom_name, team) composite.
+ *   (e) `legacy_barename_archived` audit event is emitted per pre-existing
+ *       bare-name agent row, and the row STAYS in the table with
+ *       `state='archived'` (heal-not-wipe — never DELETE).
+ *   (f) `agent_templates` ends up with UUID PK + unique (name, team) index.
+ *   (g) `teams.members` UUID-array CHECK rejects bare-name elements on new
+ *       inserts.
+ *   (h) Migration is idempotent (second apply is a no-op).
+ *
+ * The setupTestDatabase helper clones genie_template, which has every
+ * migration applied — including this one. To exercise backfill / heal
+ * semantics we temporarily DROP the constraints under test, seed legacy-
+ * shaped rows, and then re-apply the migration body via `sql.unsafe(...)`.
+ * The migration's idempotent guards keep the re-apply safe.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { getConnection } from '../../lib/db.js';
+import { DB_AVAILABLE, setupTestDatabase } from '../../lib/test-db.js';
+
+const MIGRATION_PATH = join(import.meta.dir, '061_agents_id_invariant_and_fk_lockdown.sql');
+
+async function loadMigration(): Promise<string> {
+  return await readFile(MIGRATION_PATH, 'utf-8');
+}
+
+async function applyMigration(): Promise<void> {
+  const sql = await getConnection();
+  await sql.unsafe(await loadMigration());
+}
+
+/**
+ * Drop every constraint / index this migration installs. Lets a test seed
+ * legacy-shaped rows that the post-migration schema would otherwise reject.
+ */
+async function dropMigrationArtifacts(): Promise<void> {
+  const sql = await getConnection();
+  await sql`ALTER TABLE agents DROP CONSTRAINT IF EXISTS fk_agents_reports_to`;
+  await sql`ALTER TABLE teams DROP CONSTRAINT IF EXISTS fk_teams_leader`;
+  await sql`ALTER TABLE mailbox DROP CONSTRAINT IF EXISTS fk_mailbox_from_worker`;
+  await sql`ALTER TABLE mailbox DROP CONSTRAINT IF EXISTS fk_mailbox_to_worker`;
+  await sql`ALTER TABLE team_chat DROP CONSTRAINT IF EXISTS fk_team_chat_sender`;
+  await sql`ALTER TABLE agents DROP CONSTRAINT IF EXISTS agents_id_shape_check`;
+  await sql`ALTER TABLE teams DROP CONSTRAINT IF EXISTS teams_members_uuid_check`;
+}
+
+function uuid(): string {
+  // UUID v4 hex shape (lowercase) that satisfies the CHECK regex.
+  const a = `${Math.random().toString(16).slice(2)}${'0'.repeat(8)}`.slice(0, 8);
+  const b = `${Math.random().toString(16).slice(2)}${'0'.repeat(4)}`.slice(0, 4);
+  const c = `4${`${Math.random().toString(16).slice(2)}${'0'.repeat(3)}`.slice(0, 3)}`;
+  const d = `8${`${Math.random().toString(16).slice(2)}${'0'.repeat(3)}`.slice(0, 3)}`;
+  const e = `${Math.random().toString(16).slice(2)}${'0'.repeat(12)}`.slice(0, 12);
+  return [a, b, c, d, e].join('-');
+}
+
+describe.skipIf(!DB_AVAILABLE)('migration 061 — agents_id_invariant_and_fk_lockdown', () => {
+  let cleanup: () => Promise<void>;
+
+  beforeAll(async () => {
+    cleanup = await setupTestDatabase();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  beforeEach(async () => {
+    const sql = await getConnection();
+    // Clean slate per test. Drop dependent rows first to keep FKs happy.
+    await sql`DELETE FROM mailbox`;
+    await sql`DELETE FROM team_chat`;
+    await sql`DELETE FROM audit_events
+              WHERE actor = 'migration:061_agents_id_invariant_and_fk_lockdown'`;
+    await sql`DELETE FROM executors`;
+    await sql`DELETE FROM teams`;
+    await sql`DELETE FROM agents`;
+    await sql`DELETE FROM agent_templates`;
+  });
+
+  // ==========================================================================
+  // (a) + (b): CHECK constraint on agents.id
+  // ==========================================================================
+
+  test('UUID-shaped agents.id insert succeeds', async () => {
+    const sql = await getConnection();
+    const id = uuid();
+    await sql`
+      INSERT INTO agents (id, pane_id, session, state, repo_path, started_at, custom_name, team)
+      VALUES (${id}, '%1', 's-1', 'spawning', '/tmp', now(), 'engineer', 'demo')
+    `;
+    const rows = await sql<{ id: string }[]>`SELECT id FROM agents WHERE id = ${id}`;
+    expect(rows.length).toBe(1);
+  });
+
+  test('dir:<name> agents.id insert succeeds', async () => {
+    const sql = await getConnection();
+    await sql`
+      INSERT INTO agents (id, pane_id, session, state, repo_path, started_at, custom_name)
+      VALUES ('dir:engineer', '%2', 's-2', 'spawning', '/tmp', now(), 'engineer')
+    `;
+    const rows = await sql<{ id: string }[]>`SELECT id FROM agents WHERE id = 'dir:engineer'`;
+    expect(rows.length).toBe(1);
+  });
+
+  test('bare-name agents.id insert is rejected by CHECK constraint', async () => {
+    const sql = await getConnection();
+    await expect(
+      sql`
+        INSERT INTO agents (id, pane_id, session, state, repo_path, started_at, custom_name)
+        VALUES ('felipe', '%3', 's-3', 'spawning', '/tmp', now(), 'felipe')
+      `,
+    ).rejects.toThrow(/agents_id_shape_check|check constraint/i);
+  });
+
+  test('UUID-shape with capital letters is rejected (regex is lowercase-only)', async () => {
+    // The CHECK regex enforces lowercase hex; inserts with uppercase UUIDs
+    // fail loudly. This locks producers to a single canonical casing.
+    const sql = await getConnection();
+    await expect(
+      sql`
+        INSERT INTO agents (id, pane_id, session, state, repo_path, started_at)
+        VALUES ('AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE', '%4', 's-4', 'spawning', '/tmp', now())
+      `,
+    ).rejects.toThrow(/agents_id_shape_check|check constraint/i);
+  });
+
+  // ==========================================================================
+  // (c): FK constraints
+  // ==========================================================================
+
+  test('mailbox FK rejects insert with non-existent to_worker', async () => {
+    const sql = await getConnection();
+    const ghostId = uuid();
+    const senderId = uuid();
+    await sql`
+      INSERT INTO agents (id, pane_id, session, state, repo_path, started_at, custom_name)
+      VALUES (${senderId}, '%5', 's-5', 'spawning', '/tmp', now(), 'sender')
+    `;
+    await expect(
+      sql`
+        INSERT INTO mailbox (id, from_worker, to_worker, body, repo_path)
+        VALUES (${`msg-${Date.now()}`}, ${senderId}, ${ghostId}, 'hi', '/tmp')
+      `,
+    ).rejects.toThrow(/fk_mailbox_to_worker|foreign key/i);
+  });
+
+  test('mailbox FK rejects insert with non-existent from_worker', async () => {
+    const sql = await getConnection();
+    const ghostId = uuid();
+    const recipientId = uuid();
+    await sql`
+      INSERT INTO agents (id, pane_id, session, state, repo_path, started_at, custom_name)
+      VALUES (${recipientId}, '%6', 's-6', 'spawning', '/tmp', now(), 'recip')
+    `;
+    await expect(
+      sql`
+        INSERT INTO mailbox (id, from_worker, to_worker, body, repo_path)
+        VALUES (${`msg-${Date.now()}`}, ${ghostId}, ${recipientId}, 'hi', '/tmp')
+      `,
+    ).rejects.toThrow(/fk_mailbox_from_worker|foreign key/i);
+  });
+
+  test('team_chat FK rejects insert with non-existent sender', async () => {
+    const sql = await getConnection();
+    const ghostId = uuid();
+    await expect(
+      sql`
+        INSERT INTO team_chat (id, team, repo_path, sender, body)
+        VALUES (${`tc-${Date.now()}`}, 'demo', '/tmp', ${ghostId}, 'hi')
+      `,
+    ).rejects.toThrow(/fk_team_chat_sender|foreign key/i);
+  });
+
+  test('teams.leader FK rejects non-existent agent reference', async () => {
+    const sql = await getConnection();
+    const ghostId = uuid();
+    await expect(
+      sql`
+        INSERT INTO teams (name, repo, base_branch, worktree_path, leader)
+        VALUES ('demo-team', '/tmp', 'main', '/tmp/wt', ${ghostId})
+      `,
+    ).rejects.toThrow(/fk_teams_leader|foreign key/i);
+  });
+
+  test('agents.reports_to FK rejects non-existent parent reference', async () => {
+    const sql = await getConnection();
+    const ghostId = uuid();
+    const childId = uuid();
+    await expect(
+      sql`
+        INSERT INTO agents (id, pane_id, session, state, repo_path, started_at, custom_name, reports_to)
+        VALUES (${childId}, '%7', 's-7', 'spawning', '/tmp', now(), 'child', ${ghostId})
+      `,
+    ).rejects.toThrow(/fk_agents_reports_to|foreign key/i);
+  });
+
+  test('FK ON DELETE CASCADE: deleting an agent purges their mailbox rows', async () => {
+    const sql = await getConnection();
+    const senderId = uuid();
+    const recipId = uuid();
+    await sql`
+      INSERT INTO agents (id, pane_id, session, state, repo_path, started_at, custom_name)
+      VALUES
+        (${senderId}, '%8', 's-8', 'spawning', '/tmp', now(), 'sender'),
+        (${recipId}, '%9', 's-9', 'spawning', '/tmp', now(), 'recip')
+    `;
+    const msgId = `msg-${Date.now()}-cascade`;
+    await sql`
+      INSERT INTO mailbox (id, from_worker, to_worker, body, repo_path)
+      VALUES (${msgId}, ${senderId}, ${recipId}, 'hi', '/tmp')
+    `;
+    await sql`DELETE FROM agents WHERE id = ${recipId}`;
+    const rows = await sql<{ id: string }[]>`SELECT id FROM mailbox WHERE id = ${msgId}`;
+    expect(rows.length).toBe(0);
+  });
+
+  test('FK ON DELETE SET NULL: deleting a leader nulls teams.leader', async () => {
+    const sql = await getConnection();
+    const leaderId = uuid();
+    await sql`
+      INSERT INTO agents (id, pane_id, session, state, repo_path, started_at, custom_name)
+      VALUES (${leaderId}, '%10', 's-10', 'spawning', '/tmp', now(), 'lead')
+    `;
+    await sql`
+      INSERT INTO teams (name, repo, base_branch, worktree_path, leader)
+      VALUES ('cascade-test', '/tmp', 'main', '/tmp/wt', ${leaderId})
+    `;
+    await sql`DELETE FROM agents WHERE id = ${leaderId}`;
+    const rows = await sql<{ leader: string | null }[]>`
+      SELECT leader FROM teams WHERE name = 'cascade-test'
+    `;
+    expect(rows[0].leader).toBeNull();
+  });
+
+  // ==========================================================================
+  // (d): Backfill — bare-name → UUID via (custom_name, team)
+  // ==========================================================================
+
+  test('backfill rewrites mailbox.to_worker bare-name to UUID peer', async () => {
+    const sql = await getConnection();
+    const peerId = uuid();
+    await dropMigrationArtifacts();
+    await sql`
+      INSERT INTO agents (id, pane_id, session, state, repo_path, started_at, custom_name, team)
+      VALUES (${peerId}, '%11', 's-11', 'spawning', '/tmp', now(), 'engineer', 'demo')
+    `;
+    const senderId = uuid();
+    await sql`
+      INSERT INTO agents (id, pane_id, session, state, repo_path, started_at, custom_name)
+      VALUES (${senderId}, '%13', 's-13', 'spawning', '/tmp', now(), 'sender')
+    `;
+    const msgId = `msg-${Date.now()}-bf1`;
+    await sql`
+      INSERT INTO mailbox (id, from_worker, to_worker, body, repo_path)
+      VALUES (${msgId}, ${senderId}, 'engineer', 'hi', '/tmp')
+    `;
+
+    await applyMigration();
+
+    const rows = await sql<{ to_worker: string }[]>`
+      SELECT to_worker FROM mailbox WHERE id = ${msgId}
+    `;
+    expect(rows.length).toBe(1);
+    expect(rows[0].to_worker).toBe(peerId);
+  });
+
+  test('backfill rewrites teams.leader bare-name to UUID peer', async () => {
+    const sql = await getConnection();
+    const peerId = uuid();
+    await dropMigrationArtifacts();
+    await sql`
+      INSERT INTO agents (id, pane_id, session, state, repo_path, started_at, custom_name, team)
+      VALUES (${peerId}, '%14', 's-14', 'spawning', '/tmp', now(), 'felipe', 'felipe')
+    `;
+    await sql`
+      INSERT INTO teams (name, repo, base_branch, worktree_path, leader)
+      VALUES ('felipe', '/tmp', 'main', '/tmp/wt', 'felipe')
+    `;
+
+    await applyMigration();
+
+    const rows = await sql<{ leader: string | null }[]>`
+      SELECT leader FROM teams WHERE name = 'felipe'
+    `;
+    expect(rows[0].leader).toBe(peerId);
+  });
+
+  test('backfill rewrites agents.reports_to bare-name to UUID peer', async () => {
+    const sql = await getConnection();
+    const parentId = uuid();
+    const childId = uuid();
+    await dropMigrationArtifacts();
+    await sql`
+      INSERT INTO agents (id, pane_id, session, state, repo_path, started_at, custom_name, team)
+      VALUES (${parentId}, '%15', 's-15', 'spawning', '/tmp', now(), 'lead', 'demo')
+    `;
+    await sql`
+      INSERT INTO agents (id, pane_id, session, state, repo_path, started_at, custom_name, team, reports_to)
+      VALUES (${childId}, '%16', 's-16', 'spawning', '/tmp', now(), 'child', 'demo', 'lead')
+    `;
+
+    await applyMigration();
+
+    const rows = await sql<{ reports_to: string | null }[]>`
+      SELECT reports_to FROM agents WHERE id = ${childId}
+    `;
+    expect(rows[0].reports_to).toBe(parentId);
+  });
+
+  test('backfill rewrites teams.members bare-name elements to UUIDs', async () => {
+    const sql = await getConnection();
+    const aliceId = uuid();
+    const bobId = uuid();
+    await dropMigrationArtifacts();
+    await sql`
+      INSERT INTO agents (id, pane_id, session, state, repo_path, started_at, custom_name, team)
+      VALUES
+        (${aliceId}, '%17', 's-17', 'spawning', '/tmp', now(), 'alice', 'crew'),
+        (${bobId},   '%18', 's-18', 'spawning', '/tmp', now(), 'bob',   'crew')
+    `;
+    await sql`
+      INSERT INTO teams (name, repo, base_branch, worktree_path, members)
+      VALUES ('crew', '/tmp', 'main', '/tmp/wt', '["alice", "bob"]'::jsonb)
+    `;
+
+    await applyMigration();
+
+    const rows = await sql<{ members: string[] }[]>`
+      SELECT members FROM teams WHERE name = 'crew'
+    `;
+    expect(rows[0].members.sort()).toEqual([aliceId, bobId].sort());
+  });
+
+  // ==========================================================================
+  // (e): Heal-not-wipe — bare-name agent rows STAY (state='archived' + audit)
+  // ==========================================================================
+
+  test('legacy_barename_archived audit event captures identity columns; row stays', async () => {
+    const sql = await getConnection();
+    await dropMigrationArtifacts();
+    await sql`
+      INSERT INTO agents (id, role, custom_name, team, repo_path, pane_id, session,
+                          state, started_at, auto_resume)
+      VALUES ('felipe-trace-99', 'felipe', NULL, 'felipe', '/some/path',
+              '%20', 's-20', 'idle', now(), true)
+    `;
+
+    await applyMigration();
+
+    // Heal-not-wipe: row STAYS, but flipped to archived.
+    const survivors = await sql<{ id: string; state: string | null; auto_resume: boolean | null }[]>`
+      SELECT id, state, auto_resume FROM agents WHERE id = 'felipe-trace-99'
+    `;
+    expect(survivors.length).toBe(1);
+    expect(survivors[0].state).toBe('archived');
+    expect(survivors[0].auto_resume).toBe(false);
+
+    // Audit row preserves identity columns for compliance.
+    const archived = await sql<{ details: Record<string, unknown> }[]>`
+      SELECT details FROM audit_events
+       WHERE actor = 'migration:061_agents_id_invariant_and_fk_lockdown'
+         AND event_type = 'legacy_barename_archived'
+         AND entity_id = 'felipe-trace-99'
+    `;
+    expect(archived.length).toBe(1);
+    expect(archived[0].details.role).toBe('felipe');
+    expect(archived[0].details.team).toBe('felipe');
+    expect(archived[0].details.repo_path).toBe('/some/path');
+    expect(archived[0].details.reason).toBe('pre_check_constraint_archive');
+  });
+
+  test('CHECK is NOT VALID — pre-existing bare-name row survives, new bare-name insert blocked', async () => {
+    const sql = await getConnection();
+    await dropMigrationArtifacts();
+    await sql`
+      INSERT INTO agents (id, custom_name, team, repo_path, pane_id, session, started_at)
+      VALUES ('legacy-bare', NULL, 'demo', '/tmp', '%22', 's-22', now())
+    `;
+    await applyMigration();
+
+    // Legacy row grandfathered (NOT VALID skips existing-row validation).
+    const legacy = await sql<{ id: string }[]>`SELECT id FROM agents WHERE id = 'legacy-bare'`;
+    expect(legacy.length).toBe(1);
+
+    // New bare-name insert still rejected.
+    await expect(
+      sql`
+        INSERT INTO agents (id, custom_name, team, repo_path, pane_id, session, started_at)
+        VALUES ('another-bare', NULL, 'demo', '/tmp', '%23', 's-23', now())
+      `,
+    ).rejects.toThrow(/agents_id_shape_check|check constraint/i);
+  });
+
+  // ==========================================================================
+  // (f): agent_templates schema upgrade
+  // ==========================================================================
+
+  test('agent_templates id column is UUID after migration', async () => {
+    const sql = await getConnection();
+    const rows = await sql<{ data_type: string; column_default: string | null }[]>`
+      SELECT data_type, column_default
+        FROM information_schema.columns
+       WHERE table_name = 'agent_templates'
+         AND column_name = 'id'
+         AND table_schema = current_schema()
+    `;
+    expect(rows.length).toBe(1);
+    expect(rows[0].data_type).toBe('uuid');
+    expect(rows[0].column_default ?? '').toContain('gen_random_uuid');
+  });
+
+  test('agent_templates has name TEXT NOT NULL column', async () => {
+    const sql = await getConnection();
+    const rows = await sql<{ data_type: string; is_nullable: string }[]>`
+      SELECT data_type, is_nullable
+        FROM information_schema.columns
+       WHERE table_name = 'agent_templates'
+         AND column_name = 'name'
+         AND table_schema = current_schema()
+    `;
+    expect(rows.length).toBe(1);
+    expect(rows[0].data_type).toBe('text');
+    expect(rows[0].is_nullable).toBe('NO');
+  });
+
+  test('agent_templates idx_agent_templates_name_team unique partial index exists', async () => {
+    const sql = await getConnection();
+    const rows = await sql<{ indexname: string; indexdef: string }[]>`
+      SELECT indexname, indexdef FROM pg_indexes
+       WHERE tablename = 'agent_templates'
+         AND indexname = 'idx_agent_templates_name_team'
+    `;
+    expect(rows.length).toBe(1);
+    expect(rows[0].indexdef).toMatch(/UNIQUE/i);
+    expect(rows[0].indexdef).toMatch(/\(name, team\)/);
+  });
+
+  // ==========================================================================
+  // (g): teams.members CHECK constraint
+  // ==========================================================================
+
+  test('teams.members CHECK rejects bare-name array element', async () => {
+    const sql = await getConnection();
+    const leaderId = uuid();
+    await sql`
+      INSERT INTO agents (id, pane_id, session, state, repo_path, started_at, custom_name)
+      VALUES (${leaderId}, '%30', 's-30', 'spawning', '/tmp', now(), 'lead')
+    `;
+    await expect(
+      sql`
+        INSERT INTO teams (name, repo, base_branch, worktree_path, members)
+        VALUES ('bad-team', '/tmp', 'main', '/tmp/wt', '["bare-name"]'::jsonb)
+      `,
+    ).rejects.toThrow(/teams_members_uuid_check|check constraint/i);
+  });
+
+  test('teams.members accepts UUID and dir:<name> elements', async () => {
+    const sql = await getConnection();
+    const u = uuid();
+    await sql`
+      INSERT INTO agents (id, pane_id, session, state, repo_path, started_at, custom_name)
+      VALUES (${u}, '%31', 's-31', 'spawning', '/tmp', now(), 'm1')
+    `;
+    await sql`
+      INSERT INTO agents (id, pane_id, session, state, repo_path, started_at, custom_name)
+      VALUES ('dir:m2', '%32', 's-32', 'spawning', '/tmp', now(), 'm2')
+    `;
+    const membersJson = JSON.stringify([u, 'dir:m2']);
+    await sql`
+      INSERT INTO teams (name, repo, base_branch, worktree_path, members)
+      VALUES ('ok-team', '/tmp', 'main', '/tmp/wt', ${membersJson}::jsonb)
+    `;
+    const rows = await sql<{ members: string[] }[]>`SELECT members FROM teams WHERE name = 'ok-team'`;
+    expect(rows[0].members.sort()).toEqual([u, 'dir:m2'].sort());
+  });
+
+  // ==========================================================================
+  // (h): Idempotency
+  // ==========================================================================
+
+  test('migration is idempotent: second apply is a no-op', async () => {
+    const sql = await getConnection();
+    const before = {
+      agents: await sql<{ cnt: number }[]>`SELECT count(*)::int AS cnt FROM agents`,
+      audit: await sql<{ cnt: number }[]>`
+        SELECT count(*)::int AS cnt FROM audit_events
+         WHERE actor = 'migration:061_agents_id_invariant_and_fk_lockdown'`,
+    };
+
+    await applyMigration();
+
+    const after = {
+      agents: await sql<{ cnt: number }[]>`SELECT count(*)::int AS cnt FROM agents`,
+      audit: await sql<{ cnt: number }[]>`
+        SELECT count(*)::int AS cnt FROM audit_events
+         WHERE actor = 'migration:061_agents_id_invariant_and_fk_lockdown'`,
+    };
+
+    expect(after.agents[0].cnt).toBe(before.agents[0].cnt);
+    expect(after.audit[0].cnt).toBe(before.audit[0].cnt);
+  });
+
+  test('every migration-installed constraint is still present after a second apply', async () => {
+    await applyMigration();
+    const sql = await getConnection();
+    const conNames = [
+      'fk_agents_reports_to',
+      'fk_teams_leader',
+      'fk_mailbox_from_worker',
+      'fk_mailbox_to_worker',
+      'fk_team_chat_sender',
+      'agents_id_shape_check',
+      'teams_members_uuid_check',
+    ];
+    const rows = await sql<{ conname: string }[]>`
+      SELECT conname FROM pg_constraint WHERE conname = ANY(${conNames})
+    `;
+    expect(rows.length).toBe(conNames.length);
+  });
+});

--- a/src/lib/agent-directory.ts
+++ b/src/lib/agent-directory.ts
@@ -101,6 +101,8 @@ export interface DirectoryEntry {
     allow?: string[];
     deny?: string[];
     bashAllowPatterns?: string[];
+    allowedTools?: string[];
+    permissionMode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan' | 'dontAsk' | 'auto' | 'remoteApproval';
   };
   /** Tools the agent is NOT allowed to use (Claude Code --disallowedTools). */
   disallowedTools?: string[];
@@ -433,6 +435,12 @@ export async function resolve(name: string): Promise<ResolvedAgent | null> {
  * tmux/env fallback — and powers tier 2 of the team-resolution precedence.
  */
 async function lookupTemplateTeam(name: string): Promise<string | null> {
+  // Guard: agent_templates.id is UUID; non-UUID inputs (built-in role names like
+  // "engineer", "fix") cannot match by id and would crash PG with
+  // "invalid input syntax for type uuid". Returning null lets callers fall
+  // through to the next resolution tier instead of erroring spawns.
+  const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  if (!UUID_REGEX.test(name)) return null;
   try {
     const { getConnection } = await import('./db.js');
     const sql = await getConnection();

--- a/src/lib/agent-yaml.test.ts
+++ b/src/lib/agent-yaml.test.ts
@@ -225,6 +225,75 @@ describe('permissions nested schema', () => {
     const flat = JSON.stringify(result.error.issues);
     expect(flat).toContain('unknown');
   });
+
+  test('accepts permissions.allowedTools as a string array', () => {
+    const result = AgentConfigSchema.safeParse({
+      permissions: {
+        allowedTools: ['Read', 'Write', 'Edit', 'Bash', 'Glob', 'Grep'],
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.permissions?.allowedTools).toEqual(['Read', 'Write', 'Edit', 'Bash', 'Glob', 'Grep']);
+    }
+  });
+
+  test('accepts permissions.permissionMode for every valid SDK enum value', () => {
+    for (const mode of ['default', 'acceptEdits', 'bypassPermissions', 'plan', 'dontAsk', 'auto', 'remoteApproval']) {
+      const result = AgentConfigSchema.safeParse({ permissions: { permissionMode: mode } });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.permissions?.permissionMode).toBe(mode as never);
+      }
+    }
+  });
+
+  test('rejects an unknown permissions.permissionMode value with a field-named error', () => {
+    const result = AgentConfigSchema.safeParse({
+      permissions: { permissionMode: 'sudo-mode' },
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const flat = JSON.stringify(result.error.issues);
+    expect(flat).toContain('permissionMode');
+  });
+
+  test('rejects permissions.allowedTools when it is not an array of strings', () => {
+    const result = AgentConfigSchema.safeParse({
+      permissions: { allowedTools: 'Read,Write' },
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const flat = JSON.stringify(result.error.issues);
+    expect(flat).toContain('allowedTools');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Round-trip — new permission fields (allowedTools + permissionMode)
+// ---------------------------------------------------------------------------
+
+describe('permissions allowedTools + permissionMode round-trip', () => {
+  test('writes + reads allowedTools and permissionMode byte-stable', async () => {
+    const path = tmpYaml('perm-fields.yaml');
+    const input: AgentConfig = {
+      promptMode: 'append',
+      permissions: {
+        preset: 'full',
+        permissionMode: 'acceptEdits',
+        allowedTools: ['Read', 'Write', 'Edit', 'Bash', 'Glob', 'Grep'],
+      },
+    };
+
+    await writeAgentYaml(path, input);
+    const onDisk = await readFile(path, 'utf-8');
+    expect(onDisk).toContain('preset: full');
+    expect(onDisk).toContain('permissionMode: acceptEdits');
+    expect(onDisk).toContain('allowedTools:');
+
+    const parsed = await parseAgentYaml(path);
+    expect(parsed).toEqual(input);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/agent-yaml.ts
+++ b/src/lib/agent-yaml.ts
@@ -250,6 +250,8 @@ export const AgentConfigSchema = z
         allow: z.array(z.string()).optional(),
         deny: z.array(z.string()).optional(),
         bashAllowPatterns: z.array(z.string()).optional(),
+        allowedTools: z.array(z.string()).optional(),
+        permissionMode: SdkPermissionModeSchema.optional(),
       })
       .strict()
       .optional(),

--- a/src/lib/provider-adapters.ts
+++ b/src/lib/provider-adapters.ts
@@ -109,8 +109,18 @@ export interface SpawnParams {
   initialPrompt?: string;
   /** Display name for the CC session (emits --name). Used in /resume and terminal title. */
   name?: string;
-  /** Claude Code permissions (allow/deny lists with Bash() patterns). Merged into --settings. */
-  permissions?: { allow?: string[]; deny?: string[] };
+  /**
+   * Claude Code permissions. `allow`/`deny` are merged into `--settings`
+   * Bash() pattern lists. `allowedTools` becomes `--allowedTools <list>`.
+   * `permissionMode` becomes `--permission-mode <mode>` (overrides the
+   * native-team default of `auto` when present).
+   */
+  permissions?: {
+    allow?: string[];
+    deny?: string[];
+    allowedTools?: string[];
+    permissionMode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan' | 'dontAsk' | 'auto' | 'remoteApproval';
+  };
   /** Tools the agent is NOT allowed to use (emits --disallowedTools). */
   disallowedTools?: string[];
   /** OTel receiver port to inject as OTEL_EXPORTER_OTLP_ENDPOINT. Undefined = skip injection. */
@@ -178,6 +188,10 @@ const spawnParamsSchema = z.object({
     .object({
       allow: z.array(z.string()).optional(),
       deny: z.array(z.string()).optional(),
+      allowedTools: z.array(z.string()).optional(),
+      permissionMode: z
+        .enum(['default', 'acceptEdits', 'bypassPermissions', 'plan', 'dontAsk', 'auto', 'remoteApproval'])
+        .optional(),
     })
     .optional(),
   disallowedTools: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary

Two P0 unblockers landing as a quick PR. **Genie está inútil sem isso** — every direct subagent spawn was crashing on the UUID type check, and reviewer was pinned to haiku which doesn't support `--permission-mode auto`.

## Changes

### 1. `lookupTemplateTeam` UUID guard (`src/lib/agent-directory.ts`)

**Symptom:** `genie spawn <role> --team genie` (engineer / fix / qa / etc.) crashed with `lookupTemplateTeam(engineer) failed: invalid input syntax for type uuid: "engineer"` then `agents_id_shape_check` violation, blocking every direct dispatch.

**Root cause:** Post `retire-session-names-id-only`, `agent_templates.id` is now UUID. The function received built-in role names and PG rejected them.

**Fix:** UUID-regex guard at function entry. Non-UUID names return `null` immediately, letting callers fall through to the next resolution tier (built-in roles / council members).

### 2. Reviewer model: `haiku` → `opus`

Felipe direct: `haiku` doesn't support `--permission-mode auto`. Reviewer runs every wish gate and must use `opus` for consistent tool gating. Audit confirms zero `haiku`/`sonnet` defaults remain in `plugins/genie/agents/`.

## Validation

- `bun run typecheck` clean
- `bun run lint` 0 errors, 16 warnings (dev=15 +1 from in-flight engineer subagent's parallel work on the parent wish)

## Test plan

- [ ] Post-merge: `genie spawn engineer --team genie` from fresh shell exits 0 without UUID error
- [ ] Post-merge: `genie spawn fix --team genie` exits 0
- [ ] Post-merge: reviewer uses opus (verify via `genie ls --json`)

## Scope context

Wider migration tracked in `.genie/wishes/agent-yaml-permissions-wireup/WISH.md` (executor `permissions.preset` → `--allowedTools` wire-through, default-agents audit, frontmatter→agent.yaml migration). Lands as follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)