### PR TITLE
fix(spawn): generateWorkerId returns uuid for agents_id_shape_check

### DIFF
--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -443,14 +443,11 @@ process.on('SIGINT', () => { server.close(); process.exit(0); });
 // Helper: Generate Worker ID (teams)
 // ============================================================================
 
-async function generateWorkerId(team: string, role?: string): Promise<string> {
-  const base = role ? `${team}-${role}` : team;
-  const existing = await registry.list();
-  if (!existing.some((w) => w.id === base)) return base;
-
-  // Use crypto.randomUUID() for the suffix to avoid race conditions
-  const suffix = crypto.randomUUID().slice(0, 8);
-  return `${base}-${suffix}`;
+async function generateWorkerId(_team: string, _role?: string): Promise<string> {
+  // Always return a UUID. agents.id constraint (migration 061) requires
+  // UUID shape or 'dir:%' prefix. Legacy team-role-suffix shape failed
+  // agents_id_shape_check on every new spawn after that migration.
+  return crypto.randomUUID();
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

After migration 061 (`agents_id_invariant_and_fk_lockdown`) shipped in v4.260503.7/.8, every new spawn (both `genie work` and `genie spawn`) hits:

```
PostgresError: new row for relation "agents" violates check constraint "agents_id_shape_check"
```

Constraint requires `agents.id` to be a UUID (8-4-4-4-12 hex) or `dir:%` prefix. But `generateWorkerId` still produces the legacy `team-role[-8hex]` shape — neither matches.

## Root cause

`src/term-commands/agents.ts:446`:
```ts
const base = role ? `${team}-${role}` : team;
if (!existing.some((w) => w.id === base)) return base;
const suffix = crypto.randomUUID().slice(0, 8);
return `${base}-${suffix}`;
```

Both return paths produce non-UUID strings. Constraint rejects every new INSERT.

## Fix (1-line semantic change)

```ts
async function generateWorkerId(_team: string, _role?: string): Promise<string> {
  return crypto.randomUUID();
}
```

`agents.id` becomes a pure UUID surrogate key. `agents.role` and `agents.customName` still carry human-readable identity for display/listing.

## Companion to PR #1626

#1626 fixed dispatch role-collision (`engineer-3` colliding across wishes). This PR fixes the deeper INSERT-time constraint violation that surfaces after #1626 unblocks the role check. Both are needed.

## Validation

- `bun run typecheck` clean
- After merge: `genie work <wish>` and `genie spawn <role>` produce agents with UUID `id` that pass `agents_id_shape_check`

## Test plan

- [ ] `genie work autopg-distribution-cutover` from a fresh shell dispatches G3 without `agents_id_shape_check` error
- [ ] `genie spawn engineer --team genie` produces agent row with UUID id
- [ ] Existing agents with legacy ids continue working (NOT VALID grandfather clause from migration 061)
- [ ] No regression in `genie ls`, `genie agent show <name>` — name resolution still works

## Out of scope (followups)

- Wider unification of the 3 worker-id paths (TUI `nextRoleSuffix`, dispatch `effectiveRole`, this `generateWorkerId`) — wish-territory
- Migration to backfill legacy non-UUID ids — separate effort

🤖 Generated with [Claude Code](https://claude.com/claude-code)