### PR TITLE
fix(spawn): guard resolveSpawnIdentity against non-uuid names

### DIFF
--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -2334,6 +2334,12 @@ export async function resolveSpawnIdentity(
   isAliveFn: (agent: { id: string; paneId: string }) => Promise<boolean> = (agent) =>
     executorRegistry.resolveWorkerLivenessByTransport(agent),
 ): Promise<SpawnIdentity> {
+  // Migration 061 + PR #1627: agents.id is UUID. Non-UUID names cannot match
+  // by id; skip the canonical-lookup query and return a fresh canonical with
+  // a generated UUID workerId. Keeps role-based dispatch working post-061.
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(name)) {
+    return { kind: 'canonical', workerId: uuidFactory(), sessionUuid: uuidFactory() };
+  }
   const { getConnection } = await import('../lib/db.js');
   const sql = await getConnection();
   // `agents.id` is the PRIMARY KEY (migrations/005_pg_state.sql), so the


### PR DESCRIPTION
## Summary

After PR #1627 (`generateWorkerId` returns UUID) merged, every fresh dispatch hits a NEW spot of the same `agents.id` UUID assumption:

```
PostgresError: invalid input syntax for type uuid: "engineer-4-eac7"
```

`resolveSpawnIdentity` (`src/term-commands/agents.ts:2330`) runs:
```sql
SELECT id, pane_id, team FROM agents WHERE id = ${name} LIMIT 1
```
with the role-name string, but `agents.id` is now UUID-only.

## Fix

Add UUID-regex guard at function entry. Non-UUID names skip the lookup and return a fresh canonical immediately. UUID-keyed lookups still flow through the original code path.

```ts
if (!/^[0-9a-f]{8}-...-[0-9a-f]{12}$/i.test(name)) {
  return { kind: 'canonical', workerId: uuidFactory(), sessionUuid: uuidFactory() };
}
```

## Companion to PRs #1626 + #1627

- #1626 fixed dispatch role-collision (`engineer-3` colliding across wishes)
- #1627 fixed `generateWorkerId` to return UUID
- **#1628 (this)** fixes `resolveSpawnIdentity` — same UUID-coercion blind spot in a different code path

After all three merge, spawn pipeline is fully unblocked end-to-end post-migration-061.

## Validation

- `bun run typecheck` clean

## Test plan

- [ ] After merge: `genie work autopg-distribution-cutover` dispatches G4 without `invalid input syntax` error
- [ ] After merge: `genie spawn engineer --team genie` produces fresh canonical row with UUID id
- [ ] Existing UUID-keyed lookups still work (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)