### PR TITLE
fix(prune): broaden TTL-archive filter to include stale_spawn_dead_pane (PR-B G3 #1)

### DIFF
--- a/src/lib/__tests__/zombie-spawns.test.ts
+++ b/src/lib/__tests__/zombie-spawns.test.ts
@@ -107,6 +107,20 @@ describe('reconcileStaleSpawns dead-pane pass', () => {
     // does not incorrectly mark agents as dead
     expect(source).toContain('// TmuxUnreachableError or other');
   });
+
+  test('TTL-archive reason filter accepts both stale_spawn and dead_pane reasons', () => {
+    // Without this, a `state=spawning` worker that the reconciler flips with
+    // `reason='stale_spawn_dead_pane'` never matches the archive filter,
+    // accumulating forever in `genie ls` even after auto_resume exhaustion.
+    const source = readFileSync(join(__dirname, '..', 'agent-registry.ts'), 'utf-8');
+
+    const archiveFilter = "e.details->>'reason' IN ('dead_pane_zombie', 'stale_spawn_dead_pane')";
+
+    // Both archive (mutating) and list (dry-run) queries must use the
+    // broadened filter, otherwise dry-run lies about what archive will do.
+    const matches = source.split(archiveFilter).length - 1;
+    expect(matches).toBeGreaterThanOrEqual(2);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/agent-registry.ts
+++ b/src/lib/agent-registry.ts
@@ -604,10 +604,11 @@ export async function reconcileStaleSpawns(thresholdSeconds = 60): Promise<strin
  * Default TTL (hours) after which an exhausted dead-pane zombie is archived.
  *
  * A zombie is any agent whose reconciler audit trail shows
- * `reason=dead_pane_zombie` AND whose `auto_resume` has been flipped to false
- * by the scheduler's exhaustion branch. Without this TTL, such rows stayed
- * visible in `genie ls` forever (#1293), holding registry slots and confusing
- * users into thinking the agent is still recoverable.
+ * `reason IN ('dead_pane_zombie', 'stale_spawn_dead_pane')` AND whose
+ * `auto_resume` has been flipped to false by the scheduler's exhaustion
+ * branch. Without this TTL, such rows stayed visible in `genie ls` forever
+ * (#1293), holding registry slots and confusing users into thinking the
+ * agent is still recoverable.
  */
 const DEAD_PANE_ZOMBIE_TTL_HOURS = 24;
 
@@ -619,8 +620,9 @@ const DEAD_PANE_ZOMBIE_TTL_HOURS = 24;
  *   2. Have `auto_resume = false` (retry budget exhausted)
  *   3. Were last transitioned > `ttlHours` ago
  *   4. Have at least one reconciler audit event tagged
- *      `reason = 'dead_pane_zombie'` (distinguishes them from other error
- *      causes the user might want to keep visible, e.g. manual error states).
+ *      `reason IN ('dead_pane_zombie', 'stale_spawn_dead_pane')` —
+ *      both reconciler reasons indicate a dead pane and are TTL-eligible.
+ *      Other error causes (manual error states, app errors) stay visible.
  *
  * Transitions matching rows to `state = 'archived'` so the default listing
  * filter hides them. An audit event is emitted per row for traceability.
@@ -642,7 +644,7 @@ export async function archiveExhaustedZombies(ttlHours = DEAD_PANE_ZOMBIE_TTL_HO
           WHERE e.entity_type = 'worker'
             AND e.entity_id = a.id
             AND e.event_type = 'state_changed'
-            AND e.details->>'reason' = 'dead_pane_zombie'
+            AND e.details->>'reason' IN ('dead_pane_zombie', 'stale_spawn_dead_pane')
         )
       RETURNING id
     `;
@@ -685,7 +687,7 @@ export async function listExhaustedZombies(
           WHERE e.entity_type = 'worker'
             AND e.entity_id = a.id
             AND e.event_type = 'state_changed'
-            AND e.details->>'reason' = 'dead_pane_zombie'
+            AND e.details->>'reason' IN ('dead_pane_zombie', 'stale_spawn_dead_pane')
         )
       ORDER BY a.last_state_change ASC
     `;


### PR DESCRIPTION
## Summary

Cli-noise-and-hygiene-cleanup G3 deliverable #1 — broaden `archiveExhaustedZombies` + `listExhaustedZombies` reason filter from `'dead_pane_zombie'` (only) to `IN ('dead_pane_zombie', 'stale_spawn_dead_pane')`.

Before this fix, `genie prune --zombies` ignored spawning-flavor dead-pane workers; they accumulated in `genie ls` indefinitely after auto_resume exhausted. After: both flavors are eligible for TTL-based archive once their auto_resume budget is spent.

Behavior for `dead_pane_zombie` rows is unchanged. TTL + auto_resume=false guards still apply.

## Files
- `src/lib/agent-registry.ts` (+10 / -8) — broaden SQL filter on both queries + update doc comment
- `src/lib/__tests__/zombie-spawns.test.ts` (+14 / -0) — source-grep regression test

## Test plan
- [x] typecheck clean
- [x] biome clean
- [x] Smoke: seeded 2h-old `stale_spawn_dead_pane` row → `listExhaustedZombies(1)` now surfaces it (returned 0 pre-fix)
- [ ] CI green on GitHub

## Wish + sequencing
- Parent: `cli-noise-and-hygiene-cleanup` PR-B G3 (deliverable #1 of 5)
- Next PR: `genie prune --errored` mode + 1h default TTL (G3 deliverables #2-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
