### PR TITLE
fix(doctor): GENIE_WATCHDOG_SKIP + auto-skip for bundle installs (PR-B G7)

### DIFF
--- a/src/term-commands/serve/ensure-ready.test.ts
+++ b/src/term-commands/serve/ensure-ready.test.ts
@@ -257,6 +257,34 @@ describe('runDoctorMaintenance — watchdog precondition', () => {
     expect(report.ok).toBe(false);
     expect(audits.find((a) => a.name === 'watchdog')?.eventType).toBe('serve.precondition.refused');
   });
+
+  test('GENIE_WATCHDOG_SKIP=1 → skipped, install not invoked, report ok', async () => {
+    const prev = process.env.GENIE_WATCHDOG_SKIP;
+    process.env.GENIE_WATCHDOG_SKIP = '1';
+    try {
+      let installCalls = 0;
+      const { deps, audits } = buildDeps({
+        collectHealth: async () => fakeHealth({ watchdog: 'warn', watchdog_detail: 'units missing' }),
+        installWatchdog: async () => {
+          installCalls++;
+          return { filesWritten: [], filesSkipped: [] };
+        },
+      });
+      const report = await runDoctorMaintenance({ deps, silent: true });
+      const wd = report.results.find((r) => r.name === 'watchdog');
+      expect(wd?.status).toBe('skipped');
+      expect(wd?.detail).toBe('GENIE_WATCHDOG_SKIP=1');
+      expect(installCalls).toBe(0);
+      expect(audits.find((a) => a.name === 'watchdog')).toBeUndefined();
+      expect(report.ok).toBe(true);
+    } finally {
+      if (prev === undefined) {
+        Reflect.deleteProperty(process.env, 'GENIE_WATCHDOG_SKIP');
+      } else {
+        process.env.GENIE_WATCHDOG_SKIP = prev;
+      }
+    }
+  });
 });
 
 // ============================================================================

--- a/src/term-commands/serve/ensure-ready.ts
+++ b/src/term-commands/serve/ensure-ready.ts
@@ -478,8 +478,31 @@ async function checkWatchdog(
       detail: 'watchdog install is Linux/systemd only',
     };
   }
+  // Explicit opt-out for bundled installs and operators who manage the
+  // systemd unit out-of-band. Set GENIE_WATCHDOG_SKIP=1 to silence the
+  // precondition without affecting any other doctor checks.
+  if (process.env.GENIE_WATCHDOG_SKIP === '1') {
+    return {
+      name: 'watchdog',
+      status: 'skipped',
+      detail: 'GENIE_WATCHDOG_SKIP=1',
+    };
+  }
   if (health.watchdog === 'ok') {
     return { name: 'watchdog', status: 'ok' };
+  }
+  // Bundle-mode installs ship `dist/genie.js` only — `packages/watchdog/`
+  // is not inlined, so resolveWatchdogCliPath returns null. Without an
+  // override, the install will inevitably fail. Surface that as `skipped`
+  // (informational) instead of `refused` (warning), since the user can't
+  // recover without changing their install layout.
+  if (!process.env.GENIE_WATCHDOG_INSTALL_CMD && !resolveWatchdogCliPath()) {
+    return {
+      name: 'watchdog',
+      status: 'skipped',
+      detail:
+        'watchdog optional in this install — set GENIE_WATCHDOG_SKIP=1 to silence, or run from source repo to enable',
+    };
   }
   if (!autoFix) {
     return {


### PR DESCRIPTION
## Summary

Cli-noise-and-hygiene-cleanup G7 — silence the recurring `[!!] watchdog — auto-install failed` warning that fires on every `genie doctor --fix` for bundle-mode installs.

Adds two short-circuits to `checkWatchdog`:
1. **Explicit opt-out:** `GENIE_WATCHDOG_SKIP=1` → `{status: 'skipped', detail: 'GENIE_WATCHDOG_SKIP=1'}`. `installWatchdog` never runs. `report.ok` stays true.
2. **Auto-skip for bundle installs:** If `resolveWatchdogCliPath()` returns null AND `GENIE_WATCHDOG_INSTALL_CMD` is unset → skipped with informational hint. The install would have failed anyway; informational beats `[!!]`.

Source-repo installs and operators using `GENIE_WATCHDOG_INSTALL_CMD` keep their existing autoFix path.

## Files
- `src/term-commands/serve/ensure-ready.ts` (+23 / -0)
- `src/term-commands/serve/ensure-ready.test.ts` (+28 / -0)

## Test plan
- [x] typecheck clean
- [x] biome clean (after switching `delete process.env.X` → `Reflect.deleteProperty` to satisfy lint/performance/noDelete)
- [x] Smoke: `GENIE_WATCHDOG_SKIP=1` skip path tested live; bundle-install path verified by absence of `packages/watchdog/`
- [ ] CI green on GitHub

## Wish
- Parent: `cli-noise-and-hygiene-cleanup` PR-B G7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
