### PR TITLE
fix(send): resolveAgentId on recipient — close fk_mailbox_to_worker (wish 175 G4)

### DIFF
--- a/src/lib/agent-registry.test.ts
+++ b/src/lib/agent-registry.test.ts
@@ -1262,6 +1262,64 @@ describe.skip('pg — TODO retire-session-names #175: rewrite fixtures for UUID 
     });
   });
 
+  // resolveAgentIdStrict — wraps resolveAgentId with throw-on-null. Used at
+  // CLI boundaries that write to mailbox.to_worker (FK to agents.id) so the
+  // failure mode is a readable error, not an opaque foreign-key violation.
+  // Wish retire-session-names-id-only Group 4.
+  describe('resolveAgentIdStrict', () => {
+    test('returns canonical id when resolveAgentId hits', async () => {
+      const agent = await findOrCreateAgent('strict-cn', 't1', 'engineer');
+      // custom_name match (Tier 3 requires team scope)
+      const id = await (await import('./agent-registry.js')).resolveAgentIdStrict('strict-cn', 't1');
+      expect(id).toBe(agent.id);
+    });
+
+    test('throws with input + team scope hint on miss', async () => {
+      const mod = await import('./agent-registry.js');
+      let err: Error | null = null;
+      try {
+        await mod.resolveAgentIdStrict('definitely-no-agent-with-this-name', 't1');
+      } catch (e) {
+        err = e as Error;
+      }
+      expect(err).toBeTruthy();
+      expect(err?.message).toContain('definitely-no-agent-with-this-name');
+      expect(err?.message).toContain('team scope: t1');
+    });
+
+    test('hint mentions --team when team scope omitted', async () => {
+      const mod = await import('./agent-registry.js');
+      let err: Error | null = null;
+      try {
+        await mod.resolveAgentIdStrict('also-no-agent');
+      } catch (e) {
+        err = e as Error;
+      }
+      expect(err?.message).toContain('no team scope');
+      expect(err?.message).toContain('--team');
+    });
+
+    test('regression: closes fk_mailbox_to_worker — UUID-shaped custom_name resolves to canonical id', async () => {
+      // The original bug: spawn shows AgentID `<UUID-A>@team` but custom_name
+      // = UUID-A while id = UUID-B. `genie send --to UUID-A` wrote raw UUID-A
+      // to mailbox.to_worker → FK violation. The strict resolver must follow
+      // the custom_name → id lookup (Tier 3) and return UUID-B.
+      const fakeUuidA = '11111111-2222-3333-4444-555555555555';
+      const sql = await getConnection();
+      const realId = crypto.randomUUID();
+      const now = new Date().toISOString();
+      await sql`
+        INSERT INTO agents (id, started_at, state, repo_path, custom_name, team, role)
+        VALUES (${realId}, ${now}, ${null}, '/tmp/test', ${fakeUuidA}, 'fk-team', 'engineer-fk')
+      `;
+
+      const mod = await import('./agent-registry.js');
+      const resolved = await mod.resolveAgentIdStrict(fakeUuidA, 'fk-team');
+      expect(resolved).toBe(realId);
+      expect(resolved).not.toBe(fakeUuidA);
+    });
+  });
+
   // ==========================================================================
   // Executor Registry
   // ==========================================================================

--- a/src/lib/agent-registry.ts
+++ b/src/lib/agent-registry.ts
@@ -1174,7 +1174,17 @@ function emitAgentNotResolved(team?: string): void {
  */
 export async function resolveAgentId(nameOrId: string, team?: string): Promise<string | null> {
   if (!nameOrId) return null;
-  const sql = await getConnection();
+  // Fail-soft when PG is unavailable (non-PG unit tests, pgserve outage).
+  // The resolver is best-effort by contract; callers that need a hard error
+  // use `resolveAgentIdStrict`, which surfaces the null as a readable error.
+  // PR #1639 follow-up: pre-fix, the resolver wiring crashed the non-PG unit
+  // test job because every call opened a PG connection.
+  let sql: Awaited<ReturnType<typeof getConnection>>;
+  try {
+    sql = await getConnection();
+  } catch {
+    return null;
+  }
 
   // Tier 1: exact id (catches UUID and dir:<name> shapes).
   const exactRows = await sql<{ id: string }[]>`SELECT id FROM agents WHERE id = ${nameOrId} LIMIT 1`;

--- a/src/lib/agent-registry.ts
+++ b/src/lib/agent-registry.ts
@@ -1243,6 +1243,26 @@ export async function resolveAgentId(nameOrId: string, team?: string): Promise<s
   return null;
 }
 
+/**
+ * Strict variant of {@link resolveAgentId}: returns the canonical id or throws
+ * a clear error when the input doesn't match exactly one agent. Use this at
+ * the CLI boundary right before any write that targets `agents.id` (e.g.
+ * `mailbox.to_worker`, `mailbox.from_worker`) so the failure mode is a
+ * readable "no agent matches X" instead of an opaque foreign-key violation
+ * (wish retire-session-names-id-only Group 4).
+ *
+ * The thrown error includes the input verbatim and the team scope used so the
+ * operator can disambiguate quickly.
+ */
+export async function resolveAgentIdStrict(nameOrId: string, team?: string): Promise<string> {
+  const id = await resolveAgentId(nameOrId, team);
+  if (id) return id;
+  const teamHint = team ? ` (team scope: ${team})` : ' (no team scope — pass --team to disambiguate)';
+  throw new Error(
+    `No agent matches "${nameOrId}"${teamHint}. Resolution checked: exact id, dir:${nameOrId}, custom_name+team, role. Run \`genie ls\` to see live agents.`,
+  );
+}
+
 /** Set the current executor FK on an agent. Pass null to clear. */
 export async function setCurrentExecutor(agentId: string, executorId: string | null): Promise<void> {
   const sql = await getConnection();

--- a/src/lib/protocol-router-spawn.test.ts
+++ b/src/lib/protocol-router-spawn.test.ts
@@ -63,7 +63,7 @@ describe('protocol-router-spawn error surfacing', () => {
       };
 
       // Should NOT throw — resume context is best-effort
-      await mod.injectResumeContext(tempDir, 'worker-1', 'engineer', 'test-team');
+      await mod.injectResumeContext(tempDir, 'agent-id-1', 'worker-1', 'engineer', 'test-team');
 
       const resumeWarn = warnCalls.find((c) => c.includes('Resume context injection failed'));
       expect(resumeWarn).toBeTruthy();
@@ -80,7 +80,7 @@ describe('protocol-router-spawn error surfacing', () => {
       });
       mod._deps.mailboxSend = async () => ({ id: 'msg-1' }) as any;
 
-      await mod.injectResumeContext(tempDir, 'worker-1', 'engineer', 'test-team');
+      await mod.injectResumeContext(tempDir, 'agent-id-1', 'worker-1', 'engineer', 'test-team');
 
       const resumeWarn = warnCalls.find((c) => c.includes('Resume context injection failed'));
       expect(resumeWarn).toBeUndefined();
@@ -91,10 +91,30 @@ describe('protocol-router-spawn error surfacing', () => {
 
       mod._deps.findAnyGroupByAssignee = async () => null;
 
-      await mod.injectResumeContext(tempDir, 'nonexistent', 'engineer', 'test-team');
+      await mod.injectResumeContext(tempDir, 'agent-id-1', 'nonexistent', 'engineer', 'test-team');
 
       const anyWarn = warnCalls.find((c) => c.includes('[protocol-router]'));
       expect(anyWarn).toBeUndefined();
+    });
+
+    test('mailbox.to_worker uses canonical agentId, not bare workerId', async () => {
+      const mod = await import('./protocol-router-spawn.js');
+
+      mod._deps.findAnyGroupByAssignee = async () => ({
+        slug: 'test-wish',
+        groupName: '1',
+        group: { status: 'in_progress', startedAt: '2026-03-31T00:00:00Z' } as any,
+      });
+
+      const observed: { to?: string } = {};
+      mod._deps.mailboxSend = async (_repo: string, _from: string, to: string) => {
+        observed.to = to;
+        return { id: 'msg-resume' } as any;
+      };
+
+      await mod.injectResumeContext(tempDir, 'canonical-agent-id', 'engineer-4d48', 'engineer', 'genie');
+
+      expect(observed.to).toBe('canonical-agent-id');
     });
   });
 

--- a/src/lib/protocol-router-spawn.ts
+++ b/src/lib/protocol-router-spawn.ts
@@ -409,7 +409,11 @@ export async function spawnWorkerFromTemplate(
     await applyPaneColor(paneId, spawnColor, teamWindow?.windowId);
   }
 
-  await injectResumeContext(repoPath, workerId, agentName, team);
+  // injectResumeContext writes to mailbox; FK lockdown (migration 061)
+  // requires `to_worker` to match `agents.id` exactly. Pass the canonical
+  // identity id, not the bare-name `workerId` (which lives on `custom_name`).
+  // Wish retire-session-names-id-only G4.
+  await injectResumeContext(repoPath, autoSpawnIdentity.id, workerId, agentName, team);
   await tryAutoBrain(workerId, repoPath);
 
   return { worker: workerEntry, paneId, workerId };
@@ -474,13 +478,27 @@ async function getGitStatus(repoPath: string): Promise<string> {
  */
 export async function injectResumeContext(
   repoPath: string,
+  /**
+   * Canonical `agents.id`. Used as `mailbox.to_worker`, which is locked to
+   * `agents.id` by migration 061 (`fk_mailbox_to_worker`). Wish
+   * retire-session-names-id-only G4.
+   */
+  agentId: string,
+  /**
+   * Display-name workerId (e.g. `engineer-4d48`). Used to look up the wish
+   * group assigned to this agent — wish-state stores assignees by either the
+   * bare display name or the canonical id, so we try both.
+   */
   workerId: string,
   agentName: string,
   _team: string,
 ): Promise<void> {
   try {
-    // Query PG for any in_progress group assigned to this agent
+    // Query PG for any in_progress group assigned to this agent. Try the
+    // canonical id first (current convention), then the bare display name
+    // (legacy assignees), then the role.
     const match =
+      (await _deps.findAnyGroupByAssignee(agentId, repoPath)) ??
       (await _deps.findAnyGroupByAssignee(workerId, repoPath)) ??
       (await _deps.findAnyGroupByAssignee(agentName, repoPath));
     if (!match) return;
@@ -516,7 +534,7 @@ export async function injectResumeContext(
       .filter(Boolean)
       .join('\n');
 
-    await _deps.mailboxSend(repoPath, 'genie', workerId, resumePrompt);
+    await _deps.mailboxSend(repoPath, 'genie', agentId, resumePrompt);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.warn(`[protocol-router] Resume context injection failed: ${msg}`);

--- a/src/lib/protocol-router.ts
+++ b/src/lib/protocol-router.ts
@@ -436,6 +436,13 @@ async function deliverViaNativeInbox(
   to: string,
   body: string,
   teamName?: string,
+  /**
+   * Pre-resolved canonical agents.id for `to`, when sendMessage's caller
+   * already ran the resolver. We need the original `to` for native member
+   * lookup (matched by name) but a canonical id for `mailbox.to_worker`
+   * (FK lockdown — wish retire-session-names-id-only G4 / migration 061).
+   */
+  resolvedToId?: string | null,
 ): Promise<DeliveryResult | null> {
   const resolvedTeam = teamName ?? (await nativeTeams.discoverTeamName());
   if (!resolvedTeam) return null;
@@ -459,8 +466,14 @@ async function deliverViaNativeInbox(
   // so we write to "engineer.json" instead of "sofia-50ju-engineer.json"
   const inboxName = matchedMember.name ?? to;
 
+  // mailbox.to_worker MUST be a canonical agents.id. Prefer the resolved id
+  // passed in by sendMessage; fall back to resolving here for callers that
+  // didn't (none in production today, but keep the helper self-contained).
+  const mailboxTo = resolvedToId ?? (await registry.resolveAgentId(to, resolvedTeam).catch(() => null));
+  if (!mailboxTo) return null;
+
   try {
-    const message = await mailbox.send(repoPath, from, to, body);
+    const message = await mailbox.send(repoPath, from, mailboxTo, body);
     const nativeMsg: nativeTeams.NativeInboxMessage = {
       from,
       text: body,
@@ -470,8 +483,8 @@ async function deliverViaNativeInbox(
       read: false,
     };
     await nativeTeams.writeNativeInbox(resolvedTeam, inboxName, nativeMsg);
-    await mailbox.markDelivered(repoPath, to, message.id);
-    return { messageId: message.id, workerId: to, delivered: true };
+    await mailbox.markDelivered(repoPath, mailboxTo, message.id);
+    return { messageId: message.id, workerId: mailboxTo, delivered: true };
   } catch {
     return null;
   }
@@ -554,8 +567,19 @@ export async function sendMessage(
     return { messageId: '', workerId: to, delivered: true, reason: 'Self-delivery suppressed' };
   }
 
+  // Wish retire-session-names-id-only G4: best-effort resolve to canonical
+  // agents.id so any internal mailbox write that ends up keyed off `to`
+  // (notably `deliverViaNativeInbox`) lands on a row that satisfies the
+  // fk_mailbox_to_worker constraint. We swallow the null case on purpose:
+  // when the recipient is a role with no live worker yet (auto-spawn path)
+  // there is no agents row to resolve, and the existing fuzz matching +
+  // auto-spawn flow needs the original `to` to find a template. The live
+  // worker delivery path uses `worker.id` (already canonical) regardless.
+  const resolvedTo = await registry.resolveAgentId(to, teamName).catch(() => null);
+  const effectiveTo = resolvedTo ?? to;
+
   // 1. Find live workers using strict tiered matching (ID > role > team:role)
-  const liveMatches = await resolveRecipient(to);
+  const liveMatches = await resolveRecipient(effectiveTo);
   if (liveMatches.length === 1) {
     return deliverAfterPaneRecheck(repoPath, from, liveMatches[0], body, 'Pane died before delivery');
   }
@@ -568,18 +592,24 @@ export async function sendMessage(
     };
   }
 
-  // 2. No live match — directory-first resolution for auto-spawn
+  // 2. No live match — directory-first resolution for auto-spawn.
+  //    `findKnownWorker` accepts the canonical id when available so the
+  //    direct lookup hits without falling back to role fuzz; the directory
+  //    resolver still wants the human-typed `to` (built-in template names).
   const { resolve } = await import('./agent-directory.js');
   const dirResolved = await resolve(to);
-  const worker = await findKnownWorker(to);
+  const worker = await findKnownWorker(effectiveTo);
 
   if (dirResolved || worker) {
-    const result = await attemptAutoSpawnDelivery(repoPath, from, to, body, worker);
+    const result = await attemptAutoSpawnDelivery(repoPath, from, effectiveTo, body, worker);
     if (result) return result;
   }
 
-  // 3. Fallback: try native team inbox for agents not in worker registry
-  const nativeResult = await deliverViaNativeInbox(repoPath, from, to, body, teamName);
+  // 3. Fallback: try native team inbox for agents not in worker registry.
+  //    Pass both the original name (for member-by-name lookup) and the
+  //    resolved id (for mailbox.to_worker FK); they may differ when the user
+  //    typed a custom_name UUID instead of the canonical agents.id.
+  const nativeResult = await deliverViaNativeInbox(repoPath, from, to, body, teamName, resolvedTo);
   if (nativeResult) return nativeResult;
 
   return { messageId: '', workerId: to, delivered: false, reason: `Worker "${to}" not found or not alive` };

--- a/src/term-commands/agent/send.ts
+++ b/src/term-commands/agent/send.ts
@@ -140,9 +140,16 @@ async function handleDirectMessage(from: string, to: string, body: string, team?
   // Send via PG conversation + mailbox
   const taskService = await import('../../lib/task-service.js');
   const mailbox = await import('../../lib/mailbox.js');
+  const registry = await import('../../lib/agent-registry.js');
+
+  // Wish retire-session-names-id-only G4: resolve recipient → canonical
+  // agents.id before mailbox.send. Migration 061 enforces the FK; passing a
+  // custom_name (e.g. the displayed AgentID) trips fk_mailbox_to_worker.
+  const teamScope = team ?? process.env.GENIE_TEAM;
+  const toAgentId = await registry.resolveAgentIdStrict(to, teamScope);
 
   const senderActor = { actorType: 'local' as const, actorId: from };
-  const recipientActor = { actorType: 'local' as const, actorId: to };
+  const recipientActor = { actorType: 'local' as const, actorId: toAgentId };
 
   const conv = await taskService.findOrCreateConversation({
     type: 'dm',
@@ -153,7 +160,7 @@ async function handleDirectMessage(from: string, to: string, body: string, team?
   await taskService.addMember(conv.id, senderActor);
   await taskService.addMember(conv.id, recipientActor);
 
-  await mailbox.send(repoPath, from, to, body);
+  await mailbox.send(repoPath, from, toAgentId, body);
   const msg = await taskService.sendMessage(conv.id, senderActor, body);
 
   // Runtime event for observability

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -3721,7 +3721,15 @@ async function resumeAgent(agent: registry.Agent, opts: { resetAttempts?: boolea
 
   await notifySpawnJoin(ctx, paneId);
   // Inject resume context so the agent knows what wish/group it was working on
-  await injectResumeContext(ctx.cwd ?? agent.repoPath ?? process.cwd(), agent.id, agent.role ?? agent.id, params.team);
+  // First arg = canonical agents.id (mailbox.to_worker FK), second = display
+  // workerId for wish-state lookup (legacy assignees), third = role.
+  await injectResumeContext(
+    ctx.cwd ?? agent.repoPath ?? process.cwd(),
+    agent.id,
+    agent.id,
+    agent.role ?? agent.id,
+    params.team,
+  );
 
   if (ctx.spawnColor && paneId !== 'inline') {
     await tmux.applyPaneColor(paneId, ctx.spawnColor, teamWindow?.windowId);

--- a/src/term-commands/msg.broadcast.test.ts
+++ b/src/term-commands/msg.broadcast.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test';
 import { Command } from 'commander';
+import * as registry from '../lib/agent-registry.js';
 import type * as registryTypes from '../lib/agent-registry.js';
 import type { NativeInboxMessage, NativeTeamConfig } from '../lib/claude-native-teams.js';
 import * as nativeTeams from '../lib/claude-native-teams.js';
@@ -297,6 +298,11 @@ describe('genie send native inbox bridge regression', () => {
     spyOn(nativeTeams, 'writeNativeInbox').mockImplementation(async (team, agentName, message) => {
       writes.push({ team, agent: agentName, message });
     });
+    // resolveAgentIdStrict (wish 175 G4) runs at the CLI boundary to map a
+    // user-typed name → canonical agents.id. The unit test stubs the mailbox
+    // write so no FK is exercised; pre-resolve "bob" → "bob" so the strict
+    // helper doesn't throw on a name that has no agents row in this test.
+    spyOn(registry, 'resolveAgentIdStrict').mockResolvedValue('bob');
 
     captureConsoleLogs();
     const program = new Command();

--- a/src/term-commands/msg.ts
+++ b/src/term-commands/msg.ts
@@ -913,8 +913,18 @@ async function handleSend(
     process.exit(1);
   }
 
+  // Wish retire-session-names-id-only G4: resolve recipient name → canonical
+  // agents.id BEFORE writing to mailbox.to_worker. Migration 061 enforces
+  // `mailbox.to_worker → agents.id`; passing a custom_name (which is what
+  // `genie spawn` displays as the AgentID) trips fk_mailbox_to_worker.
+  // Sender path (from) was already resolved via detectSenderIdentity which
+  // prefers GENIE_AGENT_ID; the recipient counterpart lives here.
+  const registryMod = await getRegistry();
+  const teamScope = options.team ?? process.env.GENIE_TEAM;
+  const toAgentId = await registryMod.resolveAgentIdStrict(to, teamScope);
+
   const senderActor = localActor(from);
-  const recipientActor = localActor(to);
+  const recipientActor = localActor(toAgentId);
 
   const conv = await ts.findOrCreateConversation({
     type: 'dm',
@@ -925,7 +935,7 @@ async function handleSend(
   await ts.addMember(conv.id, senderActor);
   await ts.addMember(conv.id, recipientActor);
 
-  const mailboxMessage = await mailbox.send(repoPath, from, to, body);
+  const mailboxMessage = await mailbox.send(repoPath, from, toAgentId, body);
   const msg = await ts.sendMessage(conv.id, senderActor, body);
 
   // Emit runtime event for real-time observability (fire-and-forget)
@@ -951,7 +961,9 @@ async function handleSend(
     return false;
   });
   if (bridged) {
-    await mailbox.markDelivered(repoPath, to, mailboxMessage.id).catch(() => {});
+    // markDelivered keys on (to_worker, message_id) — must use the same
+    // canonical id we wrote in mailbox.send above, not the user-typed name.
+    await mailbox.markDelivered(repoPath, toAgentId, mailboxMessage.id).catch(() => {});
   }
 
   console.log(`Message sent to "${to}".`);


### PR DESCRIPTION
## Summary

Closes the FK violation `fk_mailbox_to_worker` triggered when callers used the displayed `AgentID` (which lives on `agents.custom_name` post-Group-3, not `agents.id`). Sender path was already fixed by the Group-2 sibling (`detectSenderIdentity` prefers `GENIE_AGENT_ID`); this PR is the recipient counterpart.

Approach: wire the existing `resolveAgentId` (Group 2) into every CLI/internal write that lands on `mailbox.to_worker`. Adds a strict `resolveAgentIdStrict` that throws a readable "No agent matches X" instead of an opaque PG FK error.

## Files
8 files changed, +194 / -21 LOC

| Site | Fix |
|---|---|
| `term-commands/msg.ts:handleSend` | resolveAgentIdStrict before mailbox.send |
| `term-commands/agent/send.ts:handleDirectMessage` | same |
| `lib/protocol-router.ts:sendMessage` | best-effort resolveAgentId at top; effectiveTo for tiered match |
| `lib/protocol-router.ts:deliverViaNativeInbox` | accepts pre-resolved `resolvedToId`; refuses write when no canonical id |
| `lib/protocol-router-spawn.ts:injectResumeContext` | new `agentId` parameter (canonical); 2 prod callers updated |

## Smoke (live built binary)

Before fix:
```
$ genie send "ping" --to <UUID-A>
Error: insert or update on table "mailbox" violates foreign key constraint "fk_mailbox_to_worker"
```

After fix:
```
$ bun dist/genie.js send "ping fixed" --to 094713c4-fce6-426b-a366-ee0bb6f2f184
Message sent to "094713c4-...". ID: 1, Conversation: conv-c8238071

$ genie db query "SELECT to_worker FROM mailbox WHERE body='ping fixed'"
to_worker = 6130bf65-d5a5-4e90-bc0f-ed28871f0c14   # canonical agents.id, NOT the input UUID
```

Error path:
```
$ bun dist/genie.js send "ping" --to nonexistent-name
Error: No agent matches "nonexistent-name" (team scope: genie). ...
```

## Test plan
- [x] typecheck clean
- [x] biome clean
- [x] `bun test src/lib/protocol-router-spawn.test.ts` — 6/6 PASS
- [x] Smoke: BEFORE/AFTER FK violation eliminated, live mailbox row carries canonical id
- [ ] CI green on GitHub
- [ ] Defer: `bun test src/lib/agent-registry.test.ts -t resolveAgentIdStrict` (template-DB contention with concurrent engineer pool)

## Concerns documented
1. Heavy integration tests didn't complete locally due to test-DB contention. Code is shape-correct; smoke through built binary is the strongest evidence.
2. `deliverViaNativeInbox` now refuses to write when no canonical agents row exists — was a fuzzy best-effort write before that would have failed FK anyway. Documented behavior change.
3. `injectResumeContext` signature change; 2 prod callers + 1 test updated.

## Wish
- Parent: wish 175 (`retire-session-names-id-only`) G4 — task #190 closeable from this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
