### PR TITLE
chore(lint): drop 6 stale biome-ignore suppressions + relocate misplaced ones

### DIFF
--- a/src/lib/executor-registry.test.ts
+++ b/src/lib/executor-registry.test.ts
@@ -1599,7 +1599,6 @@ describe.skipIf(!DB_AVAILABLE)('executor-registry', () => {
       // The dedupe map was removed entirely in this hotfix. The reset helper
       // is kept as an exported no-op so any external/in-flight tests that
       // imported it don't break their import resolution.
-      // biome-ignore lint/suspicious/noConsoleLog: explicit no-op verification
       _resetMissingSessionDedupeForTests();
       expect(true).toBe(true);
     });

--- a/src/term-commands/sessions.test.ts
+++ b/src/term-commands/sessions.test.ts
@@ -71,9 +71,7 @@ interface StubScenario {
 }
 
 interface StubSql {
-  // biome-ignore lint/suspicious/noExplicitAny: postgres.js Sql tagged template surface
-  (strings: TemplateStringsArray, ...values: unknown[]): any;
-  // biome-ignore lint/suspicious/noExplicitAny: postgres.js helper surface
+  (strings: TemplateStringsArray, ...values: unknown[]): unknown;
   begin: (cb: (tx: StubSql) => Promise<unknown>) => Promise<unknown>;
   json: (obj: unknown) => unknown;
   /** Captured SQL templates for assertion. */
@@ -83,8 +81,7 @@ interface StubSql {
 function makeStubSql(scenario: StubScenario): StubSql {
   const captured: string[] = [];
 
-  // biome-ignore lint/suspicious/noExplicitAny: postgres.js result shape varies
-  const dispatch = (strings: TemplateStringsArray, ..._values: unknown[]): any => {
+  const dispatch = (strings: TemplateStringsArray, ..._values: unknown[]): unknown => {
     const text = strings.join('?');
     captured.push(text);
 

--- a/src/term-commands/sessions.ts
+++ b/src/term-commands/sessions.ts
@@ -383,8 +383,8 @@ export function buildNoWorkResultIfApplicable(
   return null;
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: postgres.js Sql type
 export async function applyRepairTransaction(
+  // biome-ignore lint/suspicious/noExplicitAny: postgres.js Sql type — caller is the test stub
   sql: any,
   previewCount: number,
   force: boolean,
@@ -397,7 +397,7 @@ export async function applyRepairTransaction(
     driftDetected: false,
   };
 
-  // biome-ignore lint/suspicious/noExplicitAny: postgres.js Sql type
+  // biome-ignore lint/suspicious/noExplicitAny: postgres.js tx callback type
   await sql.begin(async (tx: any) => {
     // Re-count INSIDE the transaction so a concurrent ingestion changing the
     // candidate set between preview and apply trips the gate. With READ


### PR DESCRIPTION
## Summary

Drop 6 stale `biome-ignore` comments that named the wrong rule, sat above the wrong line, or referred to removed code. Reduces `bunx biome check src/` warnings 14 → 8.

## Files
- `src/term-commands/sessions.test.ts` (+2 / -5) — drop 3 stale, tighten 2× any → unknown
- `src/term-commands/sessions.ts` (+2 / -2) — relocate 2 biome-ignore comments to actual `any` lines
- `src/lib/executor-registry.test.ts` (+0 / -1) — drop stale `noConsoleLog` suppression

## Test plan
- [x] typecheck clean (including new `unknown` returns)
- [x] biome check src/ — 8 warnings (was 14)
- [ ] CI green on GitHub

## Notes
- Tried `applyRepairTransaction(sql: any, ...)` → `sql: Sql` proper type, but the test's `StubSql` mock doesn't satisfy the full `Sql` interface. Kept `any` and just relocated the suppression. Filed as next-PR if someone wants to refactor the mock.
- 8 remaining warnings: 7× cognitive-complexity refactor candidates (out of micro-PR scope), 1× pre-existing `removeWorktree` unused fn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
