### PR TITLE
docs(watchdog): document GENIE_WATCHDOG_SKIP + auto-skip (PR-B G7 docs)

### DIFF
--- a/packages/watchdog/README.md
+++ b/packages/watchdog/README.md
@@ -23,6 +23,20 @@ bun run src/cli.ts install
 systemctl enable --now genie-watchdog.timer
 ```
 
+## Skipping the install
+
+`genie doctor --fix` runs a watchdog install precondition. Two ways to opt out:
+
+```bash
+# Explicit skip — any install layout (managed-systemd, CI envs, dev hosts)
+GENIE_WATCHDOG_SKIP=1 genie doctor --fix
+```
+
+Bundled npm/CDN installs (where `packages/watchdog/` is not shipped) are
+auto-skipped — the precondition surfaces as informational rather than as a
+warning, and no install is attempted. Set `GENIE_WATCHDOG_INSTALL_CMD=<cmd>`
+if you have a custom install layout you want the precondition to invoke.
+
 ## Manual probe
 
 ```bash


### PR DESCRIPTION
PR #1638 shipped GENIE_WATCHDOG_SKIP=1 opt-out + auto-skip for bundle installs without documentation. Adds 'Skipping the install' section to packages/watchdog/README.md (+14/-0). Markdown-only, no code changes. Wish: cli-noise-and-hygiene-cleanup PR-B G7 deliverable #3.