### PR TITLE
fix(v1-prompt): suppress legacy-data banner when all counts are zero

### DIFF
--- a/src/lib/v1-migration-prompt.ts
+++ b/src/lib/v1-migration-prompt.ts
@@ -58,6 +58,12 @@ export async function maybePromptV1Migration(target: postgres.Sql): Promise<void
   if (detection.alreadyMigrated) return;
 
   const { tasks = 0, wishes = 0, teams = 0, sessions = 0 } = detection.v1Counts ?? {};
+
+  // v1 DB exists but is empty (e.g. pristine install whose schema was
+  // initialized but never written to). There is nothing to migrate, so
+  // suppress the banner — the operator has no actionable choice to make.
+  if (tasks === 0 && wishes === 0 && teams === 0 && sessions === 0) return;
+
   const tty = Boolean(process.stderr.isTTY);
 
   if (!tty) {


### PR DESCRIPTION
Banner '[genie] ⓘ Legacy v1 data detected (0 tasks, 0 wishes, 0 teams, 0 sessions)' fired on every CLI invocation for hosts with an empty v1 DB. `genie db migrate-v1` would copy zero rows and never record completion, so the banner was effectively forever-on. Workaround was `GENIE_NO_V1_PROMPT=1` env var.

Fix: early-return when all v1 counts are zero. Probe still runs (cheap query); populated v1 DBs still emit the banner.

Files: src/lib/v1-migration-prompt.ts (+6 / -0). 1 file, 6 LOC.

Test plan:
- [x] typecheck clean
- [x] biome clean
- [x] Smoke: BEFORE banner fires; AFTER suppressed (verified on this host's empty v1)
- [ ] CI green on GitHub