### PR TITLE
refactor(db-migrate-v1): split dbMigrateV1Command — complexity 42→<25

### DIFF
--- a/src/term-commands/db-migrate-v1.ts
+++ b/src/term-commands/db-migrate-v1.ts
@@ -103,22 +103,13 @@ interface TableResult {
 }
 
 async function dbMigrateV1Command(options: MigrateOptions): Promise<void> {
-  const available = await isAvailable();
-  if (!available) {
+  if (!(await isAvailable())) {
     console.error('Database is not running. Start it with: genie db status');
     process.exit(1);
   }
 
-  // We need a TCP port to read v1 directly. The runtime may be on a Unix
-  // socket; ask the live admin client for the port via SHOW port.
   const v2 = await getConnection();
-  const portRows = await v2.unsafe('SHOW port');
-  const port = Number((portRows as Array<{ port: string }>)[0]?.port);
-  if (!Number.isFinite(port) || port <= 0) {
-    console.error('Could not resolve pgserve TCP port from runtime connection.');
-    await shutdown();
-    process.exit(1);
-  }
+  const port = await resolveV1Port(v2);
 
   console.log('[genie db migrate-v1] Detecting v1 data…');
   const detected = await detectV1(port);
@@ -129,14 +120,64 @@ async function dbMigrateV1Command(options: MigrateOptions): Promise<void> {
   }
 
   const targetRows = await v2.unsafe('SELECT current_database() AS db');
-  const targetDb = (targetRows as Array<{ db: string }>)[0]?.db;
-  console.log(`  Source: ${V1_DB_NAME} (v1, port ${port}, ${formatBytes(detected.totalSizeBytes)} on disk)`);
-  console.log(`  Target: ${targetDb} (your v2 workspace)`);
-  console.log();
-
+  const targetDb = (targetRows as unknown as Array<{ db: string }>)[0]?.db ?? '';
   const sessionDays = parseDayWindow(options.includeSessions, 30);
   const auditDays = parseDayWindow(options.includeAudit, 0); // OFF by default — too large
 
+  printMigrationPreview(detected, port, targetDb, options, sessionDays, auditDays);
+
+  if (options.dryRun) {
+    console.log('--dry-run set, exiting.');
+    await shutdown();
+    return;
+  }
+  if (!options.yes && !(await confirm('Proceed with migration?'))) {
+    console.log('Aborted.');
+    await shutdown();
+    return;
+  }
+
+  const { v1, v2Bypass } = openMigrationClients(port, targetDb);
+  const summary: Record<string, number> = {};
+  const failures: string[] = [];
+
+  try {
+    await runMigrations(v1, v2Bypass, options, sessionDays, auditDays, summary, failures);
+  } finally {
+    await v1.end({ timeout: 5 });
+    await v2Bypass.end({ timeout: 5 });
+  }
+
+  await finalizeMigration(v2, summary, failures, port, options);
+  await shutdown();
+}
+
+// We need a TCP port to read v1 directly. The runtime may be on a Unix
+// socket; ask the live admin client for the port via SHOW port.
+async function resolveV1Port(v2: V2Sql): Promise<number> {
+  const portRows = await v2.unsafe('SHOW port');
+  const port = Number((portRows as unknown as Array<{ port: string }>)[0]?.port);
+  if (!Number.isFinite(port) || port <= 0) {
+    console.error('Could not resolve pgserve TCP port from runtime connection.');
+    await shutdown();
+    process.exit(1);
+  }
+  return port;
+}
+
+type V2Sql = Awaited<ReturnType<typeof getConnection>>;
+
+function printMigrationPreview(
+  detected: { rowCounts: Record<string, number>; totalSizeBytes: number },
+  port: number,
+  targetDb: string,
+  options: MigrateOptions,
+  sessionDays: number,
+  auditDays: number,
+): void {
+  console.log(`  Source: ${V1_DB_NAME} (v1, port ${port}, ${formatBytes(detected.totalSizeBytes)} on disk)`);
+  console.log(`  Target: ${targetDb} (your v2 workspace)`);
+  console.log();
   console.log('Row counts in v1:');
   for (const t of FOUNDATION_TABLES) {
     const c = detected.rowCounts[t];
@@ -156,18 +197,9 @@ async function dbMigrateV1Command(options: MigrateOptions): Promise<void> {
     console.log(`Will ARCHIVE: source DB renamed to ${archiveName()} (kept indefinitely; persist=true)`);
   }
   console.log();
+}
 
-  if (options.dryRun) {
-    console.log('--dry-run set, exiting.');
-    await shutdown();
-    return;
-  }
-  if (!options.yes && !(await confirm('Proceed with migration?'))) {
-    console.log('Aborted.');
-    await shutdown();
-    return;
-  }
-
+function openMigrationClients(port: number, targetDb: string): { v1: postgres.Sql; v2Bypass: postgres.Sql } {
   // Migration session — bypass FK triggers for cross-row inserts (sessions self-FK).
   const v1 = postgres({
     host: V1_HOST,
@@ -179,7 +211,7 @@ async function dbMigrateV1Command(options: MigrateOptions): Promise<void> {
     onnotice: () => {},
     idle_timeout: 5,
   });
-  // Get a dedicated v2 client with replica role so FK triggers don't fire.
+  // Dedicated v2 client with replica role so FK triggers don't fire.
   const v2Bypass = postgres({
     host: V1_HOST,
     port,
@@ -191,62 +223,74 @@ async function dbMigrateV1Command(options: MigrateOptions): Promise<void> {
     idle_timeout: 5,
     connection: { session_replication_role: 'replica' },
   });
+  return { v1, v2Bypass };
+}
 
-  const summary: Record<string, number> = {};
-  const failures: string[] = [];
-
-  try {
-    for (const table of FOUNDATION_TABLES) {
-      if (NEVER_MIGRATE.has(table)) continue;
-      const r = await migrateOne(v1, v2Bypass, table);
-      report(table, r);
-      if (r.failed) failures.push(`${table}: ${r.failed}`);
-      else summary[table] = r.copied;
-    }
-    if (sessionDays > 0) {
-      const r = await migrateOne(v1, v2Bypass, 'sessions', { dateColumn: 'created_at', days: sessionDays });
-      report('sessions', r);
-      if (r.failed) failures.push(`sessions: ${r.failed}`);
-      else summary.sessions = r.copied;
-    }
-    if (auditDays > 0) {
-      const r = await migrateOne(v1, v2Bypass, 'audit_events', { dateColumn: 'created_at', days: auditDays });
-      report('audit_events', r);
-      if (r.failed) failures.push(`audit_events: ${r.failed}`);
-      else summary.audit_events = r.copied;
-    }
-    if (options.includeContent && sessionDays > 0) {
-      const r = await migrateOne(v1, v2Bypass, 'session_content', { dateColumn: 'created_at', days: sessionDays });
-      report('session_content', r);
-      if (r.failed) failures.push(`session_content: ${r.failed}`);
-      else summary.session_content = r.copied;
-    }
-  } finally {
-    await v1.end({ timeout: 5 });
-    await v2Bypass.end({ timeout: 5 });
+async function runMigrations(
+  v1: postgres.Sql,
+  v2Bypass: postgres.Sql,
+  options: MigrateOptions,
+  sessionDays: number,
+  auditDays: number,
+  summary: Record<string, number>,
+  failures: string[],
+): Promise<void> {
+  for (const table of FOUNDATION_TABLES) {
+    if (NEVER_MIGRATE.has(table)) continue;
+    await runOne(v1, v2Bypass, table, summary, failures);
   }
+  if (sessionDays > 0) {
+    await runOne(v1, v2Bypass, 'sessions', summary, failures, { dateColumn: 'created_at', days: sessionDays });
+  }
+  if (auditDays > 0) {
+    await runOne(v1, v2Bypass, 'audit_events', summary, failures, { dateColumn: 'created_at', days: auditDays });
+  }
+  if (options.includeContent && sessionDays > 0) {
+    await runOne(v1, v2Bypass, 'session_content', summary, failures, { dateColumn: 'created_at', days: sessionDays });
+  }
+}
 
+async function runOne(
+  v1: postgres.Sql,
+  v2Bypass: postgres.Sql,
+  table: string,
+  summary: Record<string, number>,
+  failures: string[],
+  windowOpt?: { dateColumn: string; days: number },
+): Promise<void> {
+  const r = await migrateOne(v1, v2Bypass, table, windowOpt);
+  report(table, r);
+  if (r.failed) failures.push(`${table}: ${r.failed}`);
+  else summary[table] = r.copied;
+}
+
+async function finalizeMigration(
+  v2: V2Sql,
+  summary: Record<string, number>,
+  failures: string[],
+  port: number,
+  options: MigrateOptions,
+): Promise<void> {
   console.log();
   const total = Object.values(summary).reduce((a, b) => a + b, 0);
   console.log(`Migrated ${total} rows across ${Object.keys(summary).length} tables. ${failures.length} failed.`);
   for (const f of failures) console.log(`  - ${f}`);
 
-  if (failures.length === 0) {
-    // Mark migration complete in the target DB so the startup prompt is silenced
-    await recordMigrationComplete(v2, V1_DB_NAME, summary);
-    console.log('Migration recorded in _genie_migration_state — startup prompt will be silenced.');
-
-    if (options.archive !== false) {
-      const archive = archiveName();
-      console.log(`Archiving v1 → ${archive}`);
-      await archiveV1(port, archive);
-      console.log(`Done. ${archive} renamed and marked persist=true.`);
-    }
-  } else {
+  if (failures.length > 0) {
     console.log(`Skipping archive due to ${failures.length} failures. Re-run after resolving (idempotent).`);
+    return;
   }
 
-  await shutdown();
+  // Mark migration complete in the target DB so the startup prompt is silenced
+  await recordMigrationComplete(v2, V1_DB_NAME, summary);
+  console.log('Migration recorded in _genie_migration_state — startup prompt will be silenced.');
+
+  if (options.archive !== false) {
+    const archive = archiveName();
+    console.log(`Archiving v1 → ${archive}`);
+    await archiveV1(port, archive);
+    console.log(`Done. ${archive} renamed and marked persist=true.`);
+  }
 }
 
 async function detectV1(port: number): Promise<{ rowCounts: Record<string, number>; totalSizeBytes: number } | null> {


### PR DESCRIPTION
biome flagged dbMigrateV1Command at cognitive complexity 42 (cap 25). Refactor splits 146-line command into thin orchestrator + 6 helpers (resolveV1Port, printMigrationPreview, openMigrationClients, runMigrations, runOne, finalizeMigration).

Pure refactor — same control flow, no behavior change. Net +44 LOC (extra signatures + V2Sql type alias).

Files: src/term-commands/db-migrate-v1.ts (+117 / -73).

Test: typecheck clean. biome clean on file (was 1 warning, now 0). Codebase complexity warnings 7→6.