### PR TITLE
fix(task): validate activeBoard exists before delegating to PG trigger

### DIFF
--- a/src/term-commands/task.ts
+++ b/src/term-commands/task.ts
@@ -113,7 +113,23 @@ async function resolveBoardOption(boardName?: string): Promise<string | undefine
     return board.id;
   }
   const defaultId = await resolveDefaultBoardId();
-  return defaultId ?? undefined;
+  if (!defaultId) return undefined;
+  // Defense: validate the configured activeBoard still exists. A stale id (e.g.
+  // workspace config pointing at an archived board) used to surface as the
+  // opaque PG trigger error `Unknown board: <id>` from migration 008. Catch it
+  // here with an actionable hint instead.
+  const bs = await getBoardService();
+  const board = await bs.getBoard(defaultId);
+  if (!board) {
+    console.error(
+      `Error: configured activeBoard "${defaultId}" no longer exists.
+  Run \`genie board list\` to see available boards, then either:
+    - update .genie/config.json's "activeBoard" key, or
+    - pass --board <name> explicitly`,
+    );
+    process.exit(1);
+  }
+  return board.id;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

`resolveBoardOption` read `.genie/config.json`'s `activeBoard` key and passed it straight to taskService. Migration 008's PG trigger then threw the unhelpful `Unknown board: <id>` with no recovery hint when the configured id was stale (board archived/deleted but config not updated).

## Fix
After `resolveDefaultBoardId()` returns an id, look it up via `boardService.getBoard`. If null, exit 1 with an actionable error pointing at `genie board list` + the two recovery paths (edit config, or pass `--board`).

## Smoke
Live this host had stale `activeBoard="board-3bce345b"` against a boards table containing only `board-20235568`. Pre-fix: bare PG trigger error. Post-fix: friendly hint.

## Files
`src/term-commands/task.ts` (+13 / -1)

## Test plan
- [x] typecheck clean
- [x] biome clean
- [ ] CI green on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)