### PR TITLE
chore(team-manager): delete unused removeWorktree fn + dead test

### DIFF
--- a/src/lib/__tests__/edge-cases-stability.test.ts
+++ b/src/lib/__tests__/edge-cases-stability.test.ts
@@ -236,16 +236,6 @@ describe('7.2 tmux Compatibility', () => {
     expect(source).toContain('DELETE FROM teams WHERE name =');
   });
 
-  test('removeWorktree falls back to rm for non-worktree clones', () => {
-    const source = readFileSync(join(__dirname, '..', 'team-manager.ts'), 'utf-8');
-
-    // Primary: git worktree remove
-    expect(source).toContain('git worktree remove --force');
-
-    // Fallback: rm for shared clones
-    expect(source).toContain('recursive: true, force: true');
-  });
-
   test('archiveTeam kills members BEFORE DB update to prevent zombie writes', () => {
     const source = readFileSync(join(__dirname, '..', 'team-manager.ts'), 'utf-8');
 

--- a/src/lib/team-manager.ts
+++ b/src/lib/team-manager.ts
@@ -11,7 +11,7 @@
  */
 
 import { existsSync } from 'node:fs';
-import { mkdir, rm, symlink } from 'node:fs/promises';
+import { mkdir, symlink } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import path, { join } from 'node:path';
 import { $ } from 'bun';
@@ -616,21 +616,6 @@ export async function fireAgent(teamName: string, agentName: string): Promise<bo
   }
 
   return true;
-}
-
-async function removeWorktree(worktreePath: string | undefined): Promise<void> {
-  if (!worktreePath || !existsSync(worktreePath)) return;
-  try {
-    // Use git worktree remove for proper cleanup of object store references
-    await $`git worktree remove --force ${worktreePath}`.quiet();
-  } catch {
-    // Fallback to rm for non-worktree clones (e.g., --shared clones)
-    try {
-      await rm(worktreePath, { recursive: true, force: true });
-    } catch {
-      // Best-effort
-    }
-  }
 }
 
 /**


### PR DESCRIPTION
Pre-existing biome flag from cli-noise PR-A investigation. `removeWorktree` had no runtime callers — the live cleanup is `cleanupTeamGitArtifacts`. The dead source-string test in edge-cases-stability.test.ts referenced unique fs option strings only the deleted fn used; since the fn is gone, the test has nothing to assert.

Files: src/lib/team-manager.ts (-17), src/lib/__tests__/edge-cases-stability.test.ts (-10). 26 LOC net delete.

Test: typecheck + biome clean. `grep -rn removeWorktree src/` returns 0 matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)