### PR TITLE
refactor(doctor): split reapStaleGenieProcesses — complexity 29→<25

### DIFF
--- a/src/genie-commands/doctor.test.ts
+++ b/src/genie-commands/doctor.test.ts
@@ -336,11 +336,15 @@ describe('reapStaleGenieProcesses (post-update reaper)', () => {
     // No exclude.add(serveDaemon) call — distinguishing this from the
     // pre-#1588 reaper which preserved the daemon.
     expect(reapFnBody).not.toMatch(/exclude\.add\(sp\)/);
-    // serve.pid file unlinked after reap to enable clean autospawn.
-    expect(reapFnBody).toContain("'serve.pid'");
-    expect(reapFnBody).toContain('unlinkSync(servePidPath)');
-    // pm2 cleanup runs after process reap.
+    // Post-refactor (#1653): serve.pid cleanup extracted to clearStaleServePidFile
+    // helper, called from reapStaleGenieProcesses. pm2 cleanup remains a direct call.
+    expect(reapFnBody).toContain('clearStaleServePidFile()');
     expect(reapFnBody).toContain('cleanupStalePm2Entries(log)');
+    const helperStart = source.indexOf('function clearStaleServePidFile');
+    expect(helperStart).toBeGreaterThan(-1);
+    const helperBody = source.slice(helperStart, source.indexOf('\n}\n', helperStart));
+    expect(helperBody).toContain("'serve.pid'");
+    expect(helperBody).toContain('unlinkSync(servePidPath)');
   });
 
   test('cleanupStalePm2Entries removes broken legacy genie-serve.ecosystem name', () => {

--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -1419,54 +1419,62 @@ async function reapStaleGenieProcesses(opts: { log?: (line: string) => void } = 
   if (candidates.length === 0) {
     log('  [ok] No stale genie processes to reap');
   } else {
-    log(`  [fix] Reaping ${candidates.length} stale genie process(es) (incl. serve daemon): ${candidates.join(', ')}`);
-    for (const pid of candidates) {
-      try {
-        process.kill(pid, 'SIGTERM');
-      } catch {
-        // Already dead between scan and signal — fine.
-      }
-    }
-
-    // Give SIGTERM 2s to settle. Most genie processes have shutdown handlers
-    // (the same beforeExit handler we added in #1580) that drain pools and
-    // exit cleanly within a second.
-    await new Promise((r) => setTimeout(r, 2000));
-
-    const stragglers: number[] = [];
-    for (const pid of candidates) {
-      try {
-        process.kill(pid, 0); // signal 0 = liveness probe
-        stragglers.push(pid);
-      } catch {
-        // Gone after SIGTERM — good.
-      }
-    }
-    if (stragglers.length > 0) {
-      log(`  [fix] SIGKILL stragglers: ${stragglers.join(', ')}`);
-      for (const pid of stragglers) {
-        try {
-          process.kill(pid, 'SIGKILL');
-        } catch {
-          // Race: died between probe and SIGKILL — fine.
-        }
-      }
-    }
-
-    // Daemon was just killed — clear the stale pid file so the next
-    // genie invocation autospawns cleanly instead of probing a dead pid.
-    try {
-      const home = process.env.GENIE_HOME ?? join(homedir(), '.genie');
-      const servePidPath = join(home, 'serve.pid');
-      if (existsSync(servePidPath)) unlinkSync(servePidPath);
-    } catch {
-      // serve.pid is stale-tolerant — next caller will recover.
-    }
+    await reapCandidates(candidates, log);
+    clearStaleServePidFile();
   }
 
   cleanupStalePm2Entries(log);
 
   log('  [ok] Stale genie reap complete');
+}
+
+async function reapCandidates(candidates: number[], log: (line: string) => void): Promise<void> {
+  log(`  [fix] Reaping ${candidates.length} stale genie process(es) (incl. serve daemon): ${candidates.join(', ')}`);
+  for (const pid of candidates) {
+    try {
+      process.kill(pid, 'SIGTERM');
+    } catch {
+      // Already dead between scan and signal — fine.
+    }
+  }
+
+  // Give SIGTERM 2s to settle. Most genie processes have shutdown handlers
+  // (the same beforeExit handler we added in #1580) that drain pools and
+  // exit cleanly within a second.
+  await new Promise((r) => setTimeout(r, 2000));
+
+  const stragglers = candidates.filter(isPidAlive);
+  if (stragglers.length === 0) return;
+
+  log(`  [fix] SIGKILL stragglers: ${stragglers.join(', ')}`);
+  for (const pid of stragglers) {
+    try {
+      process.kill(pid, 'SIGKILL');
+    } catch {
+      // Race: died between probe and SIGKILL — fine.
+    }
+  }
+}
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0); // signal 0 = liveness probe
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function clearStaleServePidFile(): void {
+  // Daemon was just killed — clear the stale pid file so the next
+  // genie invocation autospawns cleanly instead of probing a dead pid.
+  try {
+    const home = process.env.GENIE_HOME ?? join(homedir(), '.genie');
+    const servePidPath = join(home, 'serve.pid');
+    if (existsSync(servePidPath)) unlinkSync(servePidPath);
+  } catch {
+    // serve.pid is stale-tolerant — next caller will recover.
+  }
 }
 
 /**


### PR DESCRIPTION
biome flagged `reapStaleGenieProcesses` at 29 (cap 25). Refactor extracts 3 helpers: reapCandidates (SIGTERM→2s→SIGKILL), isPidAlive (signal-0 probe), clearStaleServePidFile.

Pure refactor — same SIGTERM→sleep→SIGKILL semantics, same pidfile cleanup, same pm2 cleanup.

Files: src/genie-commands/doctor.ts (+46/-38).

Test: typecheck + biome clean for the fn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)