### PR TITLE
fix(task,chat): validate tag_id + conversation_id before FK trigger

### DIFF
--- a/src/lib/task-service.ts
+++ b/src/lib/task-service.ts
@@ -1426,6 +1426,20 @@ export async function tagTask(idOrSeq: string, tagIds: string[], actor?: Actor, 
   const id = await resolveTaskId(idOrSeq, repo);
   if (!id) throw new Error(`Task not found: ${idOrSeq}`);
 
+  // Defense: validate each tag_id exists before INSERT. Without this, a typo
+  // surfaces as the bare `task_tags_tag_id_fkey` PG error. List available
+  // tags so the user can pick a real one.
+  const existing = await sql`SELECT id FROM tags WHERE id = ANY(${tagIds})`;
+  const existingIds = new Set(existing.map((r: { id: string }) => r.id));
+  const missing = tagIds.filter((t) => !existingIds.has(t));
+  if (missing.length > 0) {
+    const all = await sql`SELECT id FROM tags ORDER BY id`;
+    const available = all.map((r: { id: string }) => r.id).join(', ') || '(none registered)';
+    throw new Error(
+      `Tag(s) not found: ${missing.join(', ')}.\n  Available tags: ${available}\n  Create a tag first with \`genie tag create <id>\`.`,
+    );
+  }
+
   for (const tagId of tagIds) {
     await sql`
       INSERT INTO task_tags (task_id, tag_id, added_by_type, added_by_id)

--- a/src/term-commands/msg.ts
+++ b/src/term-commands/msg.ts
@@ -1109,6 +1109,17 @@ Examples:
     .action(async (conversationId: string, message: string, options: { replyTo?: string; from?: string }) => {
       try {
         const ts = await getTaskService();
+        // Defense: validate the conversation exists before INSERT. Without this,
+        // a bad/stale conversationId surfaces as the bare
+        // `messages_conversation_id_fkey` PG error. Surface a clear hint with
+        // the recovery path.
+        const conv = await ts.getConversation(conversationId);
+        if (!conv) {
+          console.error(
+            `Error: conversation "${conversationId}" not found.\n  Run \`genie chat list\` to see available conversations, or \`genie inbox\` to start one.`,
+          );
+          process.exit(1);
+        }
         const from = options.from ?? (await detectSenderIdentity());
         const actor = localActor(from);
         const replyTo = options.replyTo ? Number(options.replyTo) : undefined;


### PR DESCRIPTION
Two more FK defenses after #1649 (board) and #1655 (type):

1. `task tag <id> <bad-tag>` — `task_tags_tag_id_fkey`. Validate each tag_id; hint with available list.
2. `chat send <bad-conv> ...` — `messages_conversation_id_fkey`. Validate conversation; hint with `genie chat list`.

Both mirror the resolveBoardOption pattern: lookup → exit 1 with recovery path.

Smoke (live):
- task tag X bogus: PRE bare PG FK / POST 'Tag(s) not found: bogus. Available tags: ...'
- chat send conv-bogus ...: PRE bare PG FK / POST 'conversation conv-bogus not found. Run genie chat list ...'

Files: src/lib/task-service.ts +13, src/term-commands/msg.ts +11