### PR TITLE
fix(tui): ensure tmux-tui session before attach (post-update no-sessions)

### DIFF
--- a/src/genie.ts
+++ b/src/genie.ts
@@ -831,8 +831,15 @@ if (args.length === 0) {
   if (!isServeRunning()) {
     console.log('Starting genie serve...');
     await autoStartServe();
-  } else if (!isTuiSessionReady()) {
-    // Serve is alive but TUI tmux session died — recreate it
+  }
+  // Belt + suspenders: even after autoStartServe returns successfully, the TUI
+  // tmux session may not be present (autoStartServe's 15s poll exits silently
+  // when serve is up but the session creation lagged, and the post-update
+  // reaper kills the genie-tui server in lock-step with the daemon — the
+  // exact path that produced the "no sessions" attach failure right after
+  // `genie update --next`). Idempotently ensure the session exists before
+  // attempting attach.
+  if (!isTuiSessionReady()) {
     ensureTuiSession(ws.root);
   }
 


### PR DESCRIPTION
## Bug

After `genie update --next` reaper kills the daemon + tmux-tui server, running `genie` (no args) shows:
```
Starting genie serve...
no sessions
```
…and exits to the bash prompt. User sees the TUI never launches.

## Root cause

`src/genie.ts:830-837` only ensures the tmux-tui session via `ensureTuiSession()` in the **else** branch (serve already running). After update:
1. `isServeRunning()` → false
2. `autoStartServe()` spawns daemon + polls for `isTuiSessionReady()` for 15s
3. `autoStartServe` returns silently if serve is up but tui session creation lagged past 15s (only throws when serve itself failed)
4. `attachTuiSession()` runs → bare tmux "no sessions" → exit

## Fix

Belt-and-suspenders: after the conditional auto-start path, ALWAYS call `ensureTuiSession(ws.root)` if `isTuiSessionReady()` is still false. Idempotent — no-op when session already exists.

## Files
`src/genie.ts` (+8 / -3)

## Test plan
- [x] typecheck + biome clean
- [ ] CI green on GitHub
- [ ] Smoke: `genie update` then `genie` should attach to TUI without 'no sessions' (felipe to verify post-merge)