### PR TITLE
fix(tui): Ctrl+Q detaches instead of killing daemon (keep serve warm)

### DIFF
--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -2,7 +2,6 @@
 /** Root App component — Sessions nav + tmux right pane management */
 
 import { execSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
 import { useBindings } from '@opentui/keymap/react';
 import { useRenderer } from '@opentui/react';
 import { useCallback, useEffect, useState } from 'react';
@@ -38,16 +37,10 @@ export function App({ rightPane, workspaceRoot, initialAgent }: AppProps) {
   }, [renderer, activeSession]);
 
   const handleQuit = useCallback(() => {
-    // Best-effort: signal genie serve to stop
-    try {
-      const genieHome = process.env.GENIE_HOME ?? `${process.env.HOME}/.genie`;
-      const pid = readFileSync(`${genieHome}/serve.pid`, 'utf-8').trim();
-      process.kill(Number.parseInt(pid, 10), 'SIGTERM');
-    } catch {
-      // PID file missing or unreadable — continue to tmux kill
-    }
-    // Always kill the TUI tmux server directly — the serve PID may be
-    // a zombie (defunct) that accepts signals but never acts on them.
+    // Detach-only semantics: close the TUI window but leave the serve daemon
+    // (and its pgserve, scheduler, hook socket, etc.) running. Next `genie`
+    // attach is a fast reconnect instead of a full cold boot. Use
+    // `genie serve stop` for explicit daemon shutdown.
     try {
       execSync('tmux -L genie-tui kill-server', { stdio: 'ignore' });
     } catch {}
@@ -58,8 +51,8 @@ export function App({ rightPane, workspaceRoot, initialAgent }: AppProps) {
       commands: [
         {
           name: 'app.quit',
-          title: 'Quit',
-          desc: 'Show quit confirmation; press again to quit',
+          title: 'Close TUI',
+          desc: 'Close TUI window (daemon keeps running — use `genie serve stop` to shut down)',
           category: 'app',
           run() {
             if (showQuit) {

--- a/src/tui/components/QuitDialog.tsx
+++ b/src/tui/components/QuitDialog.tsx
@@ -38,17 +38,17 @@ export function QuitDialog({ onConfirm, onCancel }: QuitDialogProps) {
         gap={1}
       >
         <text>
-          <span fg={palette.accent}>Quit genie?</span>
+          <span fg={palette.accent}>Close TUI?</span>
         </text>
         <text>
           <span fg={palette.text}>Enter</span>
-          <span fg={palette.textDim}> to quit </span>
+          <span fg={palette.textDim}> to close </span>
           <span fg={palette.textMuted}> | </span>
           <span fg={palette.text}> Esc</span>
           <span fg={palette.textDim}> to cancel</span>
         </text>
         <text>
-          <span fg={palette.textMuted}>Hint: Ctrl+D to detach (keep running)</span>
+          <span fg={palette.textMuted}>Daemon keeps running. `genie serve stop` to shut down.</span>
         </text>
       </box>
     </box>

--- a/test/visual/__snapshots__/tui-snapshot.test.tsx.snap
+++ b/test/visual/__snapshots__/tui-snapshot.test.tsx.snap
@@ -133,7 +133,7 @@ row 14: [fg=#7fc8a9 bg=#0f2638]"│" [fg=#7fc8a9 bg=#0f2638]"│"
 row 15: [fg=#7fc8a9 bg=#0f2638]"╰──────────────────────────────────────────────────────────────────────────────────────────────────╯""
 `;
 
-exports[`visual: QuitDialog default — overlay + bordered panel + "Quit genie?" prompt 1`] = `
+exports[`visual: QuitDialog default — overlay + bordered panel + "Close TUI?" prompt 1`] = `
 "── visible chars ──
                                                                                 
                                                                                 
@@ -141,25 +141,25 @@ exports[`visual: QuitDialog default — overlay + bordered panel + "Quit genie?"
                                                                                 
                                                                                 
                                                                                 
-                  ┌───────────────────────────────────────────┐                 
-                  │                                           │                 
-                  │                Quit genie?                │                 
-                  │                                           │                 
-                  │      Enter to quit  |  Esc to cancel      │                 
-                  │                                           │                 
-                  │   Hint: Ctrl+D to detach (keep running)   │                 
-                  │                                           │                 
-                  └───────────────────────────────────────────┘
+         ┌────────────────────────────────────────────────────────────┐         
+         │                                                            │         
+         │                         Close TUI?                         │         
+         │                                                            │         
+         │              Enter to close  |  Esc to cancel              │         
+         │                                                            │         
+         │   Daemon keeps running. \`genie serve stop\` to shut down.   │         
+         │                                                            │         
+         └────────────────────────────────────────────────────────────┘
 ── colour spans ──
-row 06: [fg=#7fc8a9 bg=#0f2638]"┌───────────────────────────────────────────┐"
+row 06: [fg=#7fc8a9 bg=#0f2638]"┌────────────────────────────────────────────────────────────┐"
 row 07: [fg=#7fc8a9 bg=#0f2638]"│" [fg=#7fc8a9 bg=#0f2638]"│"
-row 08: [fg=#7fc8a9 bg=#0f2638]"│" [fg=#7fc8a9 bg=#0f2638]"Quit genie?" [fg=#7fc8a9 bg=#0f2638]"│"
+row 08: [fg=#7fc8a9 bg=#0f2638]"│" [fg=#7fc8a9 bg=#0f2638]"Close TUI?" [fg=#7fc8a9 bg=#0f2638]"│"
 row 09: [fg=#7fc8a9 bg=#0f2638]"│" [fg=#7fc8a9 bg=#0f2638]"│"
-row 10: [fg=#7fc8a9 bg=#0f2638]"│" [fg=#c9cfd4 bg=#0f2638]"Enter" [fg=#8a9499 bg=#0f2638]" to quit " [fg=#5e6e74 bg=#0f2638]" | " [fg=#c9cfd4 bg=#0f2638]" Esc" [fg=#8a9499 bg=#0f2638]" to cancel" [fg=#7fc8a9 bg=#0f2638]"│"
+row 10: [fg=#7fc8a9 bg=#0f2638]"│" [fg=#c9cfd4 bg=#0f2638]"Enter" [fg=#8a9499 bg=#0f2638]" to close " [fg=#5e6e74 bg=#0f2638]" | " [fg=#c9cfd4 bg=#0f2638]" Esc" [fg=#8a9499 bg=#0f2638]" to cancel" [fg=#7fc8a9 bg=#0f2638]"│"
 row 11: [fg=#7fc8a9 bg=#0f2638]"│" [fg=#7fc8a9 bg=#0f2638]"│"
-row 12: [fg=#7fc8a9 bg=#0f2638]"│" [fg=#5e6e74 bg=#0f2638]"Hint: Ctrl+D to detach (keep running)" [fg=#7fc8a9 bg=#0f2638]"│"
+row 12: [fg=#7fc8a9 bg=#0f2638]"│" [fg=#5e6e74 bg=#0f2638]"Daemon keeps running. \`genie serve stop\` to shut down." [fg=#7fc8a9 bg=#0f2638]"│"
 row 13: [fg=#7fc8a9 bg=#0f2638]"│" [fg=#7fc8a9 bg=#0f2638]"│"
-row 14: [fg=#7fc8a9 bg=#0f2638]"└───────────────────────────────────────────┘""
+row 14: [fg=#7fc8a9 bg=#0f2638]"└────────────────────────────────────────────────────────────┘""
 `;
 
 exports[`visual: ContextMenu running agent menu — five items with bordered overlay 1`] = `

--- a/test/visual/tui-snapshot.test.tsx
+++ b/test/visual/tui-snapshot.test.tsx
@@ -326,7 +326,7 @@ describe('visual: AgentPicker', () => {
 // ---------------------------------------------------------------------------
 
 describe('visual: QuitDialog', () => {
-  test('default — overlay + bordered panel + "Quit genie?" prompt', async () => {
+  test('default — overlay + bordered panel + "Close TUI?" prompt', async () => {
     testSetup = await testRender(<QuitDialog onConfirm={() => {}} onCancel={() => {}} />, {
       width: 80,
       height: 20,


### PR DESCRIPTION
## Summary
- Ctrl+Q in the TUI no longer SIGTERMs the serve daemon — it just kills the \`genie-tui\` tmux server (closes the window).
- Daemon, pgserve (pm2-supervised), scheduler, hook socket all stay warm. Next \`genie\` is a fast reconnect.
- Updates Quit dialog wording: \`Close TUI?\` instead of \`Quit genie?\` + hints \`genie serve stop\` for explicit shutdown.

## Why
Felipe reported every \`genie\` after Ctrl+Q was \"slow as fuck\" — full cold boot (pgserve cold-start via pm2 fork, migration replay, pg-seed sweep over ~100 teams). Root cause was \`src/tui/app.tsx:handleQuit\` explicitly killing the daemon. With pgserve canonical under pm2, killing the genie daemon on TUI close is the wrong default.

## Behavior

| Action | Before | After |
|--------|--------|-------|
| Ctrl+Q in TUI | Kills daemon + tmux | Kills tmux only |
| Next \`genie\` | Cold boot (\"Starting genie serve...\") | Fast attach (no print) |
| Explicit shutdown | Ctrl+Q | \`genie serve stop\` |

## Test plan
- [x] \`bun run typecheck\` clean
- [x] \`bunx biome check\` clean on modified files
- [ ] Smoke: \`genie\` → Ctrl+Q → \`genie\` → confirms no \"Starting genie serve...\" on second invocation, sub-second attach

🤖 Generated with [Claude Code](https://claude.com/claude-code)