### PR TITLE
docs(wish): draft output-primitives-unified — port omni's output.ts

### DIFF
--- a/.genie/wishes/output-primitives-unified/SHARED-DESIGN.md
+++ b/.genie/wishes/output-primitives-unified/SHARED-DESIGN.md
@@ -1,0 +1,282 @@
+# SHARED-DESIGN: Unified output primitives across genie + omni CLIs
+
+**Status**: design locked 2026-05-04. Companion wishes: `automagik-dev/genie#output-primitives-unified` + `automagik/omni#output-primitives-unified`. Both wishes share this document byte-identically.
+
+**Goal**: One PR per CLI (against `dev`) that converges genie's and omni's command output on a single shared surface — `output.ts` — with identical function names, identical glyphs, identical color semantics, identical JSON-mode dual-output, identical pipe-flush behavior.
+
+---
+
+## 1. Audit at design time (2026-05-04)
+
+### genie (`automagik-dev/genie`, `origin/dev`)
+
+| Path | Files | console.log/error/warn | ANSI escapes (`\x1b[`) | chalk | ora | Centralized helper |
+|------|------:|----------------------:|----------------------:|------:|----:|--------------------|
+| `src/genie-commands/*.ts` | 11 | **175+** across 7 files | **115+** across 7 files | 0 | 0 | **none** |
+| Worst offenders | — | `setup.ts` (66), `doctor.ts` (62), `update.ts` (46), `uninstall.ts` (28), `perf-check.ts` (20), `session.ts` (17), `shortcuts.ts` (9) | `setup.ts` (38), `doctor.ts` (33), `uninstall.ts` (18), `perf-check.ts` (11), `update.ts` (9), `shortcuts.ts` (6) | — | — | — |
+
+**Pattern in genie today** (literal from `src/genie-commands/update.ts`):
+```ts
+function log(message: string): void {
+  console.log(`\x1b[32m▸\x1b[0m ${message}`);
+}
+function success(message: string): void {
+  console.log(`\x1b[32m✔\x1b[0m ${message}`);
+}
+function error(message: string): void {
+  console.log(`\x1b[31m✖\x1b[0m ${message}`);
+}
+```
+
+Each command file has its own variant. No `--json` mode. No `NO_COLOR` honoring. No pipe-buffer drain. Glyph drift between files (some use `▸`, others `→`, others bare text).
+
+### omni (`automagik/omni`, `origin/dev`)
+
+| Path | Files | uses `output.*` already | direct chalk | direct ora | bare ANSI |
+|------|------:|------------------------:|-------------:|-----------:|----------:|
+| `packages/cli/src/commands/*.ts` | 54 | **47 files** | `update.ts` (5 calls) | `update.ts` (5), `install.ts` (3), `providers-setup.ts` (1), `film.ts` (1) | 0 |
+| Helper file | 1 | — | — | — | — |
+
+**Existing `packages/cli/src/output.ts`** (322 LOC, 11 exports):
+- `success(msg, data?)`, `error(msg, details?, exitCode?)`, `warn(msg)`, `tip(msg)`, `info(msg)`
+- `data(value)` — auto-detects array → `printTable`, object → `printObject`, primitive → `String(...)`.
+- `list(items, opts?)` — table render with empty-message fallback.
+- `keyValue(key, value)`, `header(title)`, `dim(text)`, `raw(text)`.
+- `disableColors()`, `areColorsEnabled()`, `getCurrentFormat() → 'human' | 'json'`.
+- `flushStdout()` — pipe-buffer drain via `process.stdout.write(chunk, cb)` so `omni xxx --json | cat > file.json` doesn't truncate at 64KB on Linux.
+
+**Already canonical**. The 9 direct `chalk`/`ora` usages in `update.ts` and `install.ts` are the outliers — explained by the fact that `output.ts` does not yet expose `step` / `spinner` / `banner` / `progress` / `divider` primitives that those flows need.
+
+---
+
+## 2. The asymmetry — what each wish actually has to do
+
+| Work | genie | omni |
+|------|-------|------|
+| Create `output.ts` from scratch | **YES** (new file) | NO (already exists, 322 LOC) |
+| Add `chalk` + `ora` deps to `package.json` | **YES** (zero today) | NO (both already in `packages/cli/package.json`) |
+| Add `boxen` + `cli-progress` deps | YES | YES |
+| Migrate 7 command files from bare ANSI / `console.log` to `output.*` | **YES** (~290 call sites) | NO (already migrated) |
+| Migrate `update.ts` direct chalk/ora to `output.*` | YES (Group 5 of `update-unify-stages` already proposes this; this wish closes the loop) | YES (5 chalk + 5 ora call sites) |
+| Migrate `install.ts` direct ora to `output.spinner` | YES (when it lands) | YES (3 ora call sites) |
+| Migrate `providers-setup.ts` direct ora | — | YES (1 ora call site) |
+| Migrate `film.ts` direct ora | — | YES (1 ora call site) |
+| Add `step` / `spinner` / `banner` / `progress` / `divider` to `output.ts` surface | YES | YES |
+| JSON mode behavior | YES (new) | already there |
+| `NO_COLOR` / TTY auto-detect | YES (new) | already there |
+| Pipe-buffer drain (`flushStdout`) | YES (new — Bun on Linux truncates >64KB pipe writes) | already there |
+
+Estimate: genie ≈ 4-6 engineer-days; omni ≈ 1-2 engineer-days.
+
+---
+
+## 3. The shared surface — what `output.ts` exports in BOTH repos
+
+**Existing in omni (preserved byte-identically)**:
+```ts
+export function success(message: string, data?: unknown): void;
+export function error(message: string, details?: unknown, exitCode?: number): never;
+export function warn(message: string): void;
+export function tip(message: string): void;
+export function info(message: string): void;
+export function data(value: unknown): void;
+export function list<T>(items: T[], options?: { emptyMessage?: string; rawData?: unknown[] }): void;
+export function keyValue(key: string, value: unknown): void;
+export function header(title: string): void;
+export function dim(text: string): void;
+export function raw(text: string): void;
+export function disableColors(): void;
+export function areColorsEnabled(): boolean;
+export function getCurrentFormat(): 'human' | 'json';
+export function flushStdout(): Promise<void>;
+export function setMaxCellWidth(width: number): void;
+```
+
+**NEW additions (both repos add these — identical signatures)**:
+```ts
+/**
+ * Print a stage divider — bold cyan ▸ + bold message + newline above.
+ * In JSON mode: emits `{ step: "<msg>" }` to stderr.
+ * Replaces ad-hoc `console.log("\n\x1b[1;36m▸ <msg>\x1b[0m\n")` patterns.
+ */
+export function step(message: string): void;
+
+/**
+ * Wrap an `ora` spinner with format-awareness.
+ * - Human mode: returns a thin proxy over the real `ora` spinner.
+ * - JSON mode: returns a stub that emits `{ spinner: "start", text }` /
+ *   `{ spinner: "succeed", text }` to stderr but never writes to stdout.
+ *   Stdout stays clean for JSON consumers.
+ * - Non-TTY (`--no-color`, piped, CI): the spinner degrades to plain
+ *   `info(text)` on start and `success(text)` on succeed; no \r animation.
+ */
+export interface OutputSpinner {
+  start(): OutputSpinner;
+  succeed(text?: string): void;
+  fail(text?: string): void;
+  warn(text?: string): void;
+  info(text?: string): void;
+  stop(): void;
+  set text(value: string);
+}
+export function spinner(text: string): OutputSpinner;
+
+/**
+ * Print a boxed banner (boxen wrapper). Used for "Updated to vX.Y.Z"
+ * release-style announcements. Single-line input is centered; multi-line
+ * is left-aligned. Honors NO_COLOR (degrades to ASCII box). In JSON mode
+ * emits `{ banner: "<msg>" }` to stderr.
+ */
+export interface BannerOptions {
+  title?: string;
+  borderStyle?: 'single' | 'double' | 'round' | 'bold';
+  borderColor?: 'green' | 'red' | 'yellow' | 'blue' | 'cyan';
+  padding?: number;
+}
+export function banner(message: string | string[], options?: BannerOptions): void;
+
+/**
+ * Wrap `cli-progress` with format-awareness.
+ * - Human mode TTY: returns the real `cli-progress.SingleBar`.
+ * - JSON mode / non-TTY: returns a stub that emits one
+ *   `{ progress: 0.42, total: 8000000, downloaded: 3360000 }` line per
+ *   second (rate-limited) to stderr; never animates.
+ */
+export interface OutputProgress {
+  start(total: number, startValue?: number): void;
+  update(current: number): void;
+  increment(delta?: number): void;
+  stop(): void;
+}
+export function progress(label: string): OutputProgress;
+
+/**
+ * Print a horizontal divider — `─` × terminal width (or 80 if non-TTY).
+ * In JSON mode: no-op (dividers are decoration; consumers don't need them).
+ */
+export function divider(): void;
+```
+
+**Glyph table (locked)**:
+
+| Severity | Glyph | Color | Usage |
+|----------|-------|-------|-------|
+| step | ▸ | bold cyan | section headers in install/update/setup pipelines |
+| info | ℹ | blue | informational lines (channel, version, path) |
+| ok / success | ✓ | green | step-completed line |
+| warn | ⚠ | yellow | recoverable issue |
+| fail / error | ✗ | red | terminal failure |
+| tip | 💡 | cyan | always-stderr nudges (non-blocking) |
+| dim | — | dim grey | secondary text (paths, dates, timestamps) |
+
+`figures` (transitive dep via `ora`) provides the cross-platform fallback. `boxen` provides the borders. `cli-progress` provides the bars.
+
+---
+
+## 4. New deps both repos add (locked versions)
+
+| Dep | Version | Why | Bundle cost |
+|-----|---------|-----|-------------|
+| `chalk` | `^5.4.0` | Already in omni; genie adds. Same major. | ~22 KB |
+| `ora` | `^8.1.1` | Already in omni; genie adds. Same major. | ~37 KB (includes figures) |
+| `boxen` | `^7.1.1` | Banner rendering with locked border styles. | ~24 KB |
+| `cli-progress` | `^3.12.0` | Download progress bar (used by self-update / install when fetching binaries). | ~18 KB |
+
+All four are pure-JS, zero native deps, ESM-compatible. Combined: ~100 KB additional install size. Both CLIs already weigh several MB; this is rounding error.
+
+**Optional** (deferred, not in v1):
+- `terminal-link` — clickable hyperlinks in iTerm/kitty/wezterm. Add only when a concrete use case appears.
+
+---
+
+## 5. JSON mode contract
+
+When `getCurrentFormat() === 'json'`:
+- `success` writes valid JSON to stdout.
+- `error` writes valid JSON to stderr; exits non-zero.
+- `warn`, `info`, `tip` write valid JSON to **stderr** (so a `--json | jq` consumer of stdout still parses).
+- `step`, `spinner.start/succeed/fail/warn/info`, `banner` emit `{ step|spinner|banner: "..." }` to **stderr**.
+- `progress` emits `{ progress: 0.0–1.0, total, downloaded }` to **stderr** at most once per second.
+- `divider`, `dim`, `header` are **no-ops**.
+- `data`, `list`, `keyValue` write canonical JSON to stdout.
+
+This is the contract omni already implements; genie adopts byte-for-byte.
+
+---
+
+## 6. NO_COLOR / TTY contract
+
+- `NO_COLOR=1` env var → `disableColors()` called at startup; chalk auto-detects via its own NO_COLOR support.
+- `process.stdout.isTTY === false` (piped output) → spinners degrade to `info` lines; progress bars degrade to per-second JSON lines.
+- `--no-color` CLI flag → calls `disableColors()` on each command.
+- `FORCE_COLOR=1` → forces colors even on non-TTY (useful for CI logs that render ANSI). Honored by chalk natively.
+
+---
+
+## 7. Migration order (within each repo)
+
+1. **Land `output.ts` extensions first** (`step`, `spinner`, `banner`, `progress`, `divider`) — additive, no caller changes.
+2. **Migrate the highest-traffic command** (genie: `update.ts` ; omni: `update.ts`) — proves the API in production.
+3. **Migrate the install path** (genie: `install.ts`, `setup.ts` ; omni: `install.ts`).
+4. **Migrate doctor + setup-adjacent commands** (`doctor.ts`, `perf-check.ts`, `uninstall.ts`, `shortcuts.ts`).
+5. **Lint rule** — add a Biome / ESLint custom rule that fails on `console.log` / `console.error` / `console.warn` outside of `output.ts` itself (genie wish G6 ; omni already has an analogous rule via comment-based suppressions, formalize it).
+
+---
+
+## 8. Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | Independent implementations per repo (no shared package) | Same as `update-unify-stages` — coupling cost > duplication cost. |
+| 2 | omni's existing `output.ts` is the reference; genie absorbs byte-for-byte | omni has 322 LOC of battle-tested code (JSON mode, pipe-flush, table render). Don't reinvent. |
+| 3 | Add `step`, `spinner`, `banner`, `progress`, `divider` to BOTH `output.ts` files in the same wish | Locks the surface; prevents future drift. |
+| 4 | Glyphs locked in §3 table | Operators learn one set; cross-CLI muscle memory. |
+| 5 | JSON-mode emits stderr breadcrumbs for spinners/banners/progress | Stdout stays clean for `--json | jq` consumers; observability not lost. |
+| 6 | `figures` (transitive via ora) handles cross-platform glyph fallback | No additional dep needed; macOS/Linux/Windows behave consistently. |
+| 7 | Lint rule banning bare `console.log` outside `output.ts` lands in v1 | Without enforcement, drift returns. |
+| 8 | `terminal-link` deferred to v2 | Optional polish; no current use case justifies the dep. |
+| 9 | Glyph + color choices map 1:1 to the bash `install.sh` helpers | bash and TS sides should look identical to the operator. |
+| 10 | `flushStdout()` is exported and called from each CLI's main entry on exit | Otherwise large `--json` payloads truncate at 64KB on Linux pipes. |
+
+---
+
+## 9. Exit code contract (additive — does not modify existing exit codes)
+
+- `output.error(...)` exits 1 by default; takes optional `exitCode` parameter.
+- `output.spinner(text).fail(...)` does NOT exit on its own; caller chooses.
+- All other output functions never exit.
+
+---
+
+## 10. Tests both repos must ship
+
+- `output.success` / `error` / `warn` / `info` / `tip` shape in human + JSON modes (snapshot or string-match).
+- `output.step` glyph + color + JSON-mode stderr emission.
+- `output.spinner` returns the right type per format mode; non-TTY degradation path.
+- `output.banner` border styles render; multi-line input handled; JSON-mode stderr.
+- `output.progress` rate-limited stderr in JSON mode; TTY animation path.
+- `output.divider` no-op in JSON mode; correct width on TTY.
+- `disableColors()` flips `areColorsEnabled()` and chalk respects it.
+- `flushStdout()` drains pending writes before resolving.
+- Lint rule (Biome custom or grep-based) catches a regression bare-console-log added to a non-`output.ts` file.
+
+---
+
+## 11. Out of scope
+
+- Ink. Not adding. Output is streaming linear; Ink is for componentized TUIs.
+- OpenTUI for non-TUI commands. Not adding. Same reason.
+- Internationalization. Glyphs and color are universal; messages are English-only (matches both CLIs today).
+- Telemetry hooks on output. Separate concern.
+- Replacing `commander`'s built-in help text styling. Help text is commander's surface; not this wish.
+- Cross-CLI shared package. Per Decision #1.
+
+---
+
+## 12. Definition of done (cross-repo)
+
+- Both PRs merged to their respective `dev` branches.
+- `output.ts` exports the same surface in both repos (`diff <(grep -E "^export" genie/output.ts) <(grep -E "^export" omni/output.ts)` is empty modulo path-only differences).
+- Glyph table from §3 produces byte-identical lines for the same logical event in both CLIs.
+- `genie update --json | jq` and `omni update --json | jq` both parse cleanly with no stderr leakage to stdout.
+- Lint rule active in both CLIs; PRs touching command files cannot bypass without explicit `// biome-ignore` comment.

--- a/.genie/wishes/output-primitives-unified/WISH.md
+++ b/.genie/wishes/output-primitives-unified/WISH.md
@@ -1,0 +1,375 @@
+# Wish: Unified output primitives (genie side)
+
+| Field | Value |
+|-------|-------|
+| **Status** | DRAFT |
+| **Slug** | `output-primitives-unified` |
+| **Date** | 2026-05-04 |
+| **Author** | Felipe Rosa <felipe@namastex.ai> |
+| **Appetite** | medium (~4–6 engineer-days) |
+| **Branch** | `wish/output-primitives-unified` |
+| **Repos touched** | `automagik-dev/genie` |
+| **Design** | [SHARED-DESIGN.md](./SHARED-DESIGN.md) |
+
+> **Companion document:** [SHARED-DESIGN.md](./SHARED-DESIGN.md) — cross-repo unification spec (byte-identical to `automagik/omni#output-primitives-unified` SHARED-DESIGN.md).
+> **Sibling wish:** [`automagik/omni#output-primitives-unified`](../../../../omni/.genie/wishes/output-primitives-unified/WISH.md) — both wishes ship in parallel; each repo owns its own implementation; only the public surface (`output.ts` exports, glyph table, JSON-mode contract) is shared.
+
+## Summary
+
+Genie has zero centralized output helpers. Across `src/genie-commands/*.ts` (11 command files), the codebase has **175+ direct `console.log` / `console.error` / `console.warn` calls** and **115+ hardcoded ANSI escape sequences** (literal `\x1b[32m`, `\x1b[31m`, etc.). Worst offenders: `setup.ts` (38 ansi / 66 console calls), `doctor.ts` (33/62), `update.ts` (9/46), `uninstall.ts` (18/28). No JSON output mode. No `NO_COLOR` honoring. No pipe-buffer drain (`bun` truncates `--json | cat > file` writes >64KB on Linux). No table render helper. Glyph drift between files.
+
+This wish ports omni's battle-tested `output.ts` (322 LOC, 11 functions, JSON+human dual-mode, pipe-flush-aware) into `automagik-dev/genie/src/lib/output.ts` byte-for-byte, extends it with the new `step` / `spinner` / `banner` / `progress` / `divider` primitives that the install/update flows need, migrates all 7 affected command files to use it, adds `chalk` + `ora` + `boxen` + `cli-progress` deps, and lands a lint rule banning bare `console.log` outside `output.ts` itself. Result: zero hardcoded ANSI in command files, identical look-and-feel between `genie` and `omni`, JSON mode usable for agent consumption.
+
+## Scope
+
+### IN
+
+**Group 1 — `output.ts` foundation (omni parity)**
+- Create `src/lib/output.ts` byte-similar in shape to omni's reference.
+- Exports: `success`, `error`, `warn`, `tip`, `info`, `data`, `list`, `keyValue`, `header`, `dim`, `raw`, `disableColors`, `areColorsEnabled`, `getCurrentFormat`, `flushStdout`, `setMaxCellWidth`.
+- JSON-mode contract per `SHARED-DESIGN.md` §5.
+- `NO_COLOR` / TTY auto-detect per `SHARED-DESIGN.md` §6.
+- `flushStdout()` wired into `src/genie.ts` exit hook so `--json | cat > file` doesn't truncate.
+- Resolution of "current format" via a new `~/.genie/config.json` field `outputFormat: 'human' | 'json'` defaulting to `'human'`, overridable by CLI `--json` flag.
+
+**Group 2 — `output.ts` extensions (additions to the shared surface)**
+- `step(message)` — bold cyan ▸ stage divider.
+- `spinner(text): OutputSpinner` — ora wrapper with format-aware degradation.
+- `banner(message, options): void` — boxen wrapper.
+- `progress(label): OutputProgress` — cli-progress wrapper.
+- `divider(): void` — `─` × terminal width.
+- Tests for every new export per `SHARED-DESIGN.md` §10.
+
+**Group 3 — Migrate `update.ts`**
+- Replace 9 ANSI escapes + 46 `console.log` calls with `output.*`.
+- Closes the loop on `update-unify-stages` G5 (which proposed `ora` + `chalk` migration; this wish is what actually ships it via `output.spinner` + `output.banner`).
+- The `verify` block of the diagnostic schema gets a final-banner render via `output.banner`.
+
+**Group 4 — Migrate `install.ts` + `setup.ts` + `uninstall.ts`**
+- Replace ~152 `console.log` calls + ~94 ANSI escapes across these three files.
+- Install/uninstall pipelines get `output.step` for stage dividers, `output.spinner` for long ops, `output.banner` for terminal "installation complete" / "uninstall complete" announcements.
+- Setup wizard prompts unchanged (we don't touch input flow); only output flow.
+
+**Group 5 — Migrate `doctor.ts` + `perf-check.ts` + `shortcuts.ts` + `session.ts`**
+- Replace remaining ~108 `console.log` + ~50 ANSI escapes.
+- `doctor.ts` gets `output.list` for check tables, `output.banner` for final pass/fail summary.
+- `perf-check.ts` benchmark output uses `output.list` + `output.keyValue`.
+- `session.ts` ID/name/PID listing uses `output.data` (auto-table).
+
+**Group 6 — Lint rule + CHANGELOG**
+- Custom Biome / regex-based lint rule (`scripts/lint/no-bare-console.cjs`) that fails CI when any file under `src/genie-commands/` or `src/term-commands/` calls `console.{log,error,warn}` without an explicit `// biome-ignore lint/genie/no-bare-console: <reason>` comment.
+- `output.ts` itself is allowlisted.
+- CHANGELOG entry naming the contract: *"Genie command output now flows through `output.ts`. Direct `console.log` calls are lint-blocked outside the helper itself."*
+- Help text in `genie --help` (and per-subcommand help) gets a one-line note: `Run with --json for machine-readable output. Run with --no-color to disable ANSI.`
+
+### OUT
+
+- **Ink, OpenTUI, Solid for command output.** Streaming linear output stays linear; per `SHARED-DESIGN.md` §11.
+- **Modifying genie's existing TUI** (`src/tui/`). OpenTUI keeps owning the TUI; this wish only touches `src/genie-commands/` and `src/term-commands/`.
+- **Internationalization.** Messages stay English-only.
+- **Telemetry on output.** Separate wish.
+- **Cross-CLI shared package.** Independent implementations per `SHARED-DESIGN.md` decision #1.
+- **Replacing `commander` help-text styling.** Commander owns its surface.
+- **Migrating `src/term-commands/*.ts`** beyond what intersects with the 7 files above. Term-commands get a follow-up wish if the audit shows ANSI drift there too.
+- **`terminal-link` adoption.** Deferred to v2 per `SHARED-DESIGN.md` decision #8.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | Port omni's `output.ts` byte-for-byte rather than design our own | omni's 322-LOC version has 6+ months of production hardening (pipe-flush bug fixes, JSON-mode bugs, table-render edge cases). Don't reinvent. |
+| 2 | Land in `src/lib/output.ts` (not `src/genie-commands/output.ts`) | Reusable across `src/genie-commands/`, `src/term-commands/`, `src/lib/` — anywhere the CLI prints. |
+| 3 | `--json` flag added at the root command level (not per subcommand) | One mental model. Subcommands inherit. |
+| 4 | Lint rule lands in same wish as the migration | Without it, drift returns. Tested by deliberately adding a `console.log` and watching CI fail. |
+| 5 | Glyph + color choices match the bash `install.sh` helpers | bash and TS sides look identical to operators. |
+| 6 | `flushStdout()` wired in `src/genie.ts` exit hook (not per-command) | Catch every code path; centrally owned. |
+| 7 | New deps (`chalk`, `ora`, `boxen`, `cli-progress`) added in Group 1 | Without them, Group 1 doesn't compile. |
+| 8 | `outputFormat` config field added to `~/.genie/config.json` | Lets operators set a permanent default without `--json` on every invocation. |
+
+## Success Criteria
+
+- [ ] `src/lib/output.ts` exists with the 16 baseline exports + 5 new exports per `SHARED-DESIGN.md` §3.
+- [ ] `chalk`, `ora`, `boxen`, `cli-progress` added to `package.json` at the locked versions.
+- [ ] All 7 command files (`update.ts`, `install.ts`, `setup.ts`, `uninstall.ts`, `doctor.ts`, `perf-check.ts`, `shortcuts.ts`) have ZERO direct `console.log/error/warn` calls and ZERO hardcoded ANSI escapes.
+- [ ] `genie update --json` produces stdout-only valid JSON; spinner/banner/info/warn/tip messages route to stderr as `{ spinner|banner|info|warn|tip: "..." }` lines.
+- [ ] `genie update | cat > file.txt` (piped, non-TTY) produces no spinner animation, no \r overwrites; `info`/`success` lines render as plain text without color.
+- [ ] `NO_COLOR=1 genie update` produces no color codes anywhere.
+- [ ] `FORCE_COLOR=1 genie update | cat > file.txt` produces ANSI even when piped.
+- [ ] `genie update --json` written to a file >64KB does not truncate (validates `flushStdout` wired in exit hook).
+- [ ] Lint rule blocks a deliberate `console.log` added to `src/genie-commands/test-fixture.ts` (CI red).
+- [ ] CHANGELOG entry present.
+- [ ] All existing `__tests__/*.test.ts` continue to pass byte-identically (visual snapshots updated where applicable).
+- [ ] `bun run check` (typecheck + lint + dead-code + tests) passes on the wish branch.
+
+## Execution Strategy
+
+### Wave 1 — Foundation (sequential)
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 1 | engineer | Create `src/lib/output.ts` (port from omni) + add 4 deps + wire `flushStdout` in exit hook + JSON-mode plumbing. |
+| 2 | engineer | Add `step` / `spinner` / `banner` / `progress` / `divider` to the surface. Tests for every new export. |
+
+### Wave 2 — Migration (sequential after Wave 1, but Groups 3-5 can run parallel by file disjointness)
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 3 | engineer | Migrate `update.ts` (proves the API in production). |
+| 4 | engineer | Migrate `install.ts` + `setup.ts` + `uninstall.ts`. |
+| 5 | engineer | Migrate `doctor.ts` + `perf-check.ts` + `shortcuts.ts` + `session.ts`. |
+
+### Wave 3 — Enforcement (sequential after Wave 2)
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 6 | engineer | Lint rule + CHANGELOG + help-text note. |
+
+## Execution Groups
+
+### Group 1: `output.ts` foundation
+
+**Goal:** Ship the canonical helper with omni-parity surface, no migrations yet.
+
+**Deliverables:**
+1. `src/lib/output.ts` — port byte-similar from `omni/packages/cli/src/output.ts` (322 LOC). Adapt imports for genie's module layout.
+2. `package.json` adds: `chalk@^5.4.0`, `ora@^8.1.1`, `boxen@^7.1.1`, `cli-progress@^3.12.0`. `bun install` re-locks.
+3. `src/lib/genie-config.ts` — extend with `outputFormat?: 'human' | 'json'` field; default `'human'`.
+4. `src/genie.ts` — root-level `--json` flag wired; `--no-color` flag; `flushStdout()` invoked in process-exit hook.
+5. Tests at `src/lib/__tests__/output.test.ts` — every baseline export, JSON mode, NO_COLOR, pipe-flush.
+
+**Acceptance Criteria:**
+- [ ] `import { success, error, warn, info, tip, data, list, keyValue, header, dim, raw } from '../lib/output.js'` resolves and typechecks.
+- [ ] `genie --json --version` emits `{"version":"..."}\n` (canonical JSON) to stdout.
+- [ ] `genie --no-color --version` emits no ANSI.
+- [ ] `flushStdout()` called from a synthetic 70KB `--json` write path; output not truncated.
+- [ ] `__tests__/output.test.ts` passes; >90% line coverage.
+
+**Validation:**
+```bash
+bun test src/lib/__tests__/output.test.ts
+bun run typecheck
+genie --json --version | jq .
+NO_COLOR=1 genie --version | grep -v $'\x1b'
+```
+
+**depends-on:** none
+
+---
+
+### Group 2: `step` / `spinner` / `banner` / `progress` / `divider`
+
+**Goal:** Add the 5 new primitives that install/update flows need. Pure additions to `output.ts`.
+
+**Deliverables:**
+1. `src/lib/output.ts` extension with the 5 new exports per `SHARED-DESIGN.md` §3.
+2. Stub implementations for JSON mode (stderr emission) per `SHARED-DESIGN.md` §5.
+3. Non-TTY degradation for `spinner` and `progress` per `SHARED-DESIGN.md` §6.
+4. Tests covering: human TTY path, human non-TTY path, JSON mode, NO_COLOR.
+
+**Acceptance Criteria:**
+- [ ] `step('Installing dependencies...')` emits bold-cyan `▸ Installing dependencies...` in human mode.
+- [ ] `step` emits `{ step: "..." }` to stderr in JSON mode.
+- [ ] `spinner('Checking version...').start().succeed('v1.2.3')` produces a real ora animation in TTY mode.
+- [ ] `spinner` in non-TTY mode degrades to plain `info` line on start, `success` on succeed, no `\r`.
+- [ ] `banner('Updated to v1.2.3', { borderStyle: 'double', borderColor: 'green' })` produces a 3-line boxed banner.
+- [ ] `progress('Downloading binary')` returns a working `cli-progress.SingleBar` in TTY mode; in JSON mode emits at most one `{ progress: ... }` line per second.
+- [ ] `divider()` prints `─` × `process.stdout.columns || 80` in human mode; no-op in JSON mode.
+
+**Validation:**
+```bash
+bun test src/lib/__tests__/output.test.ts -t "step\|spinner\|banner\|progress\|divider"
+```
+
+**depends-on:** Group 1
+
+---
+
+### Group 3: Migrate `update.ts`
+
+**Goal:** Eliminate all 9 ANSI escapes + 46 `console.log` calls in `src/genie-commands/update.ts`. Final banner uses `output.banner`. Spinners replace each `▸` step. Closes the `update-unify-stages#g5` loop.
+
+**Deliverables:**
+1. `update.ts` — every `console.log`, `console.error`, `console.warn` replaced with the appropriate `output.*` call.
+2. The 3-line success banner (CLI v… / Server v… / Auth …) wrapped in `output.banner` with `borderStyle: 'round'` + `borderColor: 'green'`.
+3. Each install / restart / verify step uses `output.spinner`.
+4. Tests at `src/genie-commands/__tests__/update.test.ts` — the existing locked-string tests need a 1-line update where the literal `\x1b[32m✔\x1b[0m` is replaced by `output.success` invocation; the test asserts the call rather than the literal output. Snapshot tests for the banner.
+
+**Acceptance Criteria:**
+- [ ] `grep -E '\\\\x1b\[|console\.(log|error|warn)' src/genie-commands/update.ts | wc -l` → `0`.
+- [ ] `genie update --json | jq` parses cleanly; spinners/banners go to stderr.
+- [ ] Banner renders identically (visual snapshot lock).
+- [ ] All existing `update.test.ts` cases pass.
+
+**Validation:**
+```bash
+bun test src/genie-commands/__tests__/update.test.ts
+grep -E '\\\\x1b\[|console\.(log|error|warn)' src/genie-commands/update.ts | wc -l
+```
+
+**depends-on:** Group 2
+
+---
+
+### Group 4: Migrate `install.ts` + `setup.ts` + `uninstall.ts`
+
+**Goal:** Eliminate all `console.log` + ANSI in the install/setup/uninstall trio (~152 + 94 occurrences combined).
+
+**Deliverables:**
+1. `install.ts` — all output through `output.*`; each install stage gets `output.step`; final "installation complete" banner via `output.banner`.
+2. `setup.ts` — same pattern. Setup wizard input (prompts) unchanged; only output flow.
+3. `uninstall.ts` — same pattern. Final "uninstall complete" banner.
+4. Tests adjusted; snapshot tests for the banners.
+
+**Acceptance Criteria:**
+- [ ] Each of the 3 files has zero direct `console.*` and zero ANSI literals.
+- [ ] `genie install --dry-run --json` produces parseable stdout JSON.
+- [ ] `genie uninstall --dry-run` shows step-by-step `▸` lines via `output.step`.
+
+**Validation:**
+```bash
+for f in install setup uninstall; do
+  echo "=== $f.ts ==="
+  grep -cE '\\\\x1b\[|console\.(log|error|warn)' "src/genie-commands/$f.ts"
+done
+bun test src/genie-commands/__tests__/install.test.ts
+bun test src/genie-commands/__tests__/setup.test.ts
+bun test src/genie-commands/__tests__/uninstall.test.ts
+```
+
+**depends-on:** Group 2
+
+---
+
+### Group 5: Migrate `doctor.ts` + `perf-check.ts` + `shortcuts.ts` + `session.ts`
+
+**Goal:** Eliminate all `console.log` + ANSI in the diagnostics + ergonomics trio (~108 + 50 occurrences combined).
+
+**Deliverables:**
+1. `doctor.ts` — diagnostic checks render via `output.list` (table) or `output.keyValue` (per-check); final pass/fail summary via `output.banner`.
+2. `perf-check.ts` — benchmark results via `output.list` (sorted descending by ms) + `output.keyValue` for the headline.
+3. `shortcuts.ts` — keymap listing via `output.list`.
+4. `session.ts` — session listing via `output.data` (auto-table).
+5. Tests adjusted.
+
+**Acceptance Criteria:**
+- [ ] Each of the 4 files has zero direct `console.*` and zero ANSI literals.
+- [ ] `genie doctor --json` produces a parseable check-list array.
+- [ ] `genie perf-check --json` produces a parseable benchmark array.
+- [ ] `genie shortcuts --json` produces a parseable keymap object.
+- [ ] `genie session ls --json` produces a parseable session array.
+
+**Validation:**
+```bash
+for f in doctor perf-check shortcuts session; do
+  echo "=== $f.ts ==="
+  grep -cE '\\\\x1b\[|console\.(log|error|warn)' "src/genie-commands/$f.ts"
+done
+bun test src/genie-commands/__tests__/
+```
+
+**depends-on:** Group 2
+
+---
+
+### Group 6: Lint rule + CHANGELOG + help-text
+
+**Goal:** Lock the contract. Make regression a CI fail.
+
+**Deliverables:**
+1. `scripts/lint/no-bare-console.cjs` — Node script that scans `src/genie-commands/` and `src/term-commands/`, fails on any `console.{log,error,warn}` not preceded by `// biome-ignore lint/genie/no-bare-console: <reason>`.
+2. Wire into `bun run check` and `bun run lint`.
+3. `CHANGELOG.md` entry: *"Output unified through `src/lib/output.ts`. Bare `console.log` calls in `src/genie-commands/` and `src/term-commands/` are now lint-blocked. Use `output.{success,info,warn,error,step,spinner,banner,progress,divider}` instead."*
+4. `genie --help` (root) gets a 2-line append: `Output flags: --json (machine-readable), --no-color (no ANSI). Per-subcommand help shows applicable variants.`
+5. Test deliberately adds `console.log("test")` to a fixture file under `src/genie-commands/.test-fixtures/`, runs the lint, asserts non-zero exit.
+
+**Acceptance Criteria:**
+- [ ] `bun run lint` fails on a deliberately-added bare `console.log` in `src/genie-commands/`.
+- [ ] `bun run lint` passes on the migrated tree.
+- [ ] CHANGELOG entry present.
+- [ ] `genie --help | grep -E 'json|no-color'` matches the new lines.
+
+**Validation:**
+```bash
+bun run lint && echo "OK"
+grep -F "Output unified through" CHANGELOG.md
+genie --help | grep -E '(--json|--no-color)'
+```
+
+**depends-on:** Group 5
+
+---
+
+## Cross-wish dependencies
+
+- **paired-with** [`automagik/omni#output-primitives-unified`](../../../../omni/.genie/wishes/output-primitives-unified/WISH.md) — both wishes ship in parallel against their respective `dev` branches. omni's existing `output.ts` is the byte-reference; this wish absorbs it.
+- **builds-on** `update-unify-stages#g5` — that wish proposed migrating `update.ts` to ora+chalk; this wish closes the loop by delivering the actual `output.spinner` + `output.banner` primitives that g5 needs.
+- **enables** future `term-commands` migrations, future `--json` mode for any subcommand.
+
+## QA Criteria
+
+_What must be verified on `dev` after merge._
+
+- [ ] Functional — `genie update`, `genie install`, `genie setup`, `genie doctor`, `genie perf-check`, `genie shortcuts`, `genie session` all visually identical post-migration (checked against pre-migration baseline screenshots; minor formatting drift OK if explained).
+- [ ] Functional — `--json` mode works for every migrated subcommand; stdout is valid JSON; stderr has all human breadcrumbs.
+- [ ] Functional — `--no-color` mode produces zero ANSI for every migrated subcommand.
+- [ ] Functional — `NO_COLOR=1` env var honored equivalently to `--no-color`.
+- [ ] Functional — `FORCE_COLOR=1` honored when piped.
+- [ ] Integration — `genie update --json | jq` produces parseable JSON.
+- [ ] Integration — `genie status --json > status.json` (>64KB output) does not truncate.
+- [ ] Regression — Visual snapshot of each migrated command is captured; diff'd against the pre-migration version; differences justified.
+- [ ] Regression — All current `__tests__/*.test.ts` cases pass.
+- [ ] Regression — Lint rule fails CI on a deliberate bare-console regression.
+- [ ] Cross-CLI parity — `diff <(grep -E "^export" src/lib/output.ts | sort) <(grep -E "^export" ../../../omni/packages/cli/src/output.ts | sort)` produces zero meaningful differences (allowing for path-only or comment-only deltas).
+
+---
+
+## Assumptions / Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Port of omni's `output.ts` introduces a subtle behavior diff (e.g., the pipe-flush logic depends on Bun-specific stream semantics) | High | Group 1 ships with a 70KB `--json` regression test; if Bun semantics differ between repos, the test catches it before Group 2. |
+| Migration causes visual snapshot churn in many test files | Medium | Snapshot tests are easy to update; the diff is reviewable per-snapshot in the PR. Document in PR description which snapshots changed and why. |
+| New deps (4 of them) bloat install size | Low | ~100 KB combined; rounding error vs current 5+ MB binary. |
+| Lint rule misfires on legitimate `console.log` (e.g., in `src/lib/`) | Low | Scope the rule to `src/genie-commands/` and `src/term-commands/` only; allowlist `output.ts` itself. |
+| Banner / spinner / progress wrappers add latency on hot paths | Low | These wrap fast libs (boxen, ora, cli-progress); per-call overhead is microseconds. Benchmark in Group 2 acceptance. |
+| `flushStdout` exit hook conflicts with existing process-exit logic in `src/genie.ts` | Medium | Group 1 acceptance includes the 70KB pipe regression; if conflicts arise, document and refactor the existing exit logic (no architectural change required). |
+| Operators with custom shell aliases that grep stdout for specific ANSI patterns break post-migration | Low | The glyphs and color choices match `install.sh`; the literal text doesn't change. CHANGELOG warns explicitly. |
+| Snapshot test infra (`@opentui` visual snapshots) doesn't cover non-TUI streaming output | Low | Add a separate text-snapshot harness for streaming output if needed; trivial. |
+
+---
+
+## Review Results
+
+_Populated by `/review` after execution completes._
+
+---
+
+## Files to Create/Modify
+
+```
+# Create
+src/lib/output.ts
+src/lib/__tests__/output.test.ts
+scripts/lint/no-bare-console.cjs
+src/genie-commands/.test-fixtures/lint-regression.ts        # only for the lint negative test
+
+# Modify
+package.json                                                # +chalk +ora +boxen +cli-progress
+src/genie.ts                                                # --json flag, --no-color flag, flushStdout exit hook
+src/lib/genie-config.ts                                     # outputFormat field
+src/genie-commands/update.ts
+src/genie-commands/install.ts
+src/genie-commands/setup.ts
+src/genie-commands/uninstall.ts
+src/genie-commands/doctor.ts
+src/genie-commands/perf-check.ts
+src/genie-commands/shortcuts.ts
+src/genie-commands/session.ts
+src/genie-commands/__tests__/update.test.ts
+src/genie-commands/__tests__/install.test.ts                # if it exists; create if not
+# (one test per migrated file — extend or create as needed)
+CHANGELOG.md
+
+# Reference (read-only)
+.genie/wishes/output-primitives-unified/SHARED-DESIGN.md
+```


### PR DESCRIPTION
## Summary

Authors the genie sibling of `automagik/omni#output-primitives-unified`. Both wishes ship in parallel; omni's battle-tested `output.ts` (322 LOC, 6+ months of production) is the byte-reference that this wish absorbs into `automagik-dev/genie/src/lib/output.ts`.

## Audit findings (2026-05-04, origin/dev)

| Metric | Value |
|--------|------:|
| Command files | 11 |
| Direct `console.log/error/warn` calls | **175+** across 7 files |
| Hardcoded ANSI escapes (`\x1b[`) | **115+** across 7 files |
| Files using `chalk` | 0 |
| Files using `ora` | 0 |
| Centralized output helper | **none** |

Worst offenders: `setup.ts` (38 ansi / 66 console), `doctor.ts` (33/62), `update.ts` (9/46), `uninstall.ts` (18/28), `perf-check.ts` (11/20), `shortcuts.ts` (6/9), `session.ts` (0/17).

No `--json` mode. No `NO_COLOR` honoring. No pipe-buffer drain (Bun truncates `--json | cat > file` writes >64KB on Linux). Glyph drift between files.

## Scope (6 groups, 3 waves)

**Wave 1 — Foundation**
- **G1** Create `src/lib/output.ts` byte-similar to omni's. Add deps (`chalk`, `ora`, `boxen`, `cli-progress`). Wire `--json` flag, `--no-color` flag, `flushStdout` exit hook.
- **G2** Extend with `step` / `spinner` / `banner` / `progress` / `divider` per `SHARED-DESIGN.md` §3.

**Wave 2 — Migration (parallel by file disjointness)**
- **G3** Migrate `update.ts` (closes `update-unify-stages` G5 loop).
- **G4** Migrate `install.ts` + `setup.ts` + `uninstall.ts`.
- **G5** Migrate `doctor.ts` + `perf-check.ts` + `shortcuts.ts` + `session.ts`.

**Wave 3 — Enforcement**
- **G6** Lint rule banning bare `console.log` outside `output.ts` + CHANGELOG + help-text.

## Cross-repo shape

16 baseline exports from omni preserved byte-identically + 5 new exports added in both repos (`step`, `spinner`, `banner`, `progress`, `divider`). Glyph table locked in `SHARED-DESIGN.md` §3. JSON-mode contract locked in §5. NO_COLOR / TTY contract locked in §6.

After both wishes merge: \`diff <(grep -E "^export" src/lib/output.ts | sort) <(grep -E "^export" omni/packages/cli/src/output.ts | sort)\` produces zero meaningful differences.

## Why now

The recently-merged `update-unify-stages` wishes proposed migrating to ora+chalk in their G5 (genie) and the omni side already routes through `output.ts`. Without this wish, genie's update.ts ends up with **direct ora+chalk imports** sitting alongside 6 other files still on bare ANSI. This wish closes the loop by giving genie the same centralized helper omni has, and locks the contract via lint.

## Estimated effort

~4-6 engineer-days. Most of the cost is the 290+ call-site migrations across 7 files.

## Test plan

- [ ] `wishes:lint` passes on the new wish
- [ ] `SHARED-DESIGN.md` byte-identical to `automagik/omni#output-primitives-unified`'s copy
- [ ] No code changes — doc-only PR; CI green

## Companion PR

`automagik/omni#output-primitives-unified` opens in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)