### PR TITLE
fix(serve): run daemon in-process under pm2 supervision

### DIFF
--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -1260,6 +1260,16 @@ async function startForeground(headless?: boolean, autoFix = true): Promise<void
  *  @param headless If true, pass --headless to the foreground process.
  */
 async function startBackground(headless?: boolean, autoFix = true): Promise<void> {
+  // PM2-supervised mode: the calling process IS the supervised entry. Forking
+  // a detached --foreground child and exiting would trigger an
+  // unstable-restart loop (pm2 sees the parent exit, respawns it, repeat) AND
+  // leave the actual long-running daemon untracked by pm2. Instead, run the
+  // daemon in-process so pm2 tracks the real PID. Detection: pm2 sets `pm_id`
+  // on supervised processes (alongside `name`, `exec_mode`, etc.).
+  if (process.env.pm_id) {
+    return startForeground(headless, autoFix);
+  }
+
   const existingEntry = readServePid();
   if (existingEntry && isProcessAlive(existingEntry.pid)) {
     console.log(`genie serve already running (PID ${existingEntry.pid})`);


### PR DESCRIPTION
## Summary
\`genie serve start\` (the command pm2 invokes when supervising genie) currently fork-spawns a detached \`--foreground\` child and exits. Since pm2 only tracks the parent, this triggers an unstable-restart loop: pm2 sees the parent exit, respawns it, the new parent forks another detached child, exits, repeat.

This fix detects pm2 supervision via \`process.env.pm_id\` and runs the daemon in-process (calls \`startForeground\` directly) so pm2 tracks the actual long-running PID.

## Why
Felipe's local \`pm2 list\`:
\`\`\`
genie-serve   restarts: 39   unstable_restarts: 37   uptime: 4h
\`\`\`
And two competing daemons running concurrently:
- pm2-managed parent (PID 2184028) — keeps fork-exit-respawning
- detached child (PID 2766947) — the real daemon, untracked by pm2

After fix:
- pm2 process becomes the actual daemon
- restart count stays flat
- \`serve.pid\` reflects pm2's PID, so \`isServeRunning()\` returns true → \`genie\` (no-args) hits fast-attach instead of cold-boot

## Behavior
| Mode | Before | After |
|------|--------|-------|
| Bare \`genie serve start\` (no pm2) | fork+exit (legacy) | fork+exit (unchanged) |
| \`pm2 start genie-serve\` | fork+exit → unstable loop | runs in-process |

Detection: \`process.env.pm_id\` is set by pm2 on supervised processes (alongside \`name\`, \`exec_mode\`, \`NODE_APP_INSTANCE\`).

## Test plan
- [x] \`bun run typecheck\` clean
- [x] \`bunx biome check\` clean
- [ ] User-facing: \`pm2 restart genie-serve\` after this version deploys → restart counter stops climbing
- [ ] \`genie\` (no-args) after the restart → no \"Starting genie serve...\" print, fast attach

🤖 Generated with [Claude Code](https://claude.com/claude-code)