### PR TITLE
feat(update): unify stages — decideVerify, legacy-cleanup, pre-flight, verify probe, diagnostics v2

### DIFF
--- a/src/genie-commands/__tests__/legacy-cleanup.test.ts
+++ b/src/genie-commands/__tests__/legacy-cleanup.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for cleanupLegacyArtifacts registry primitive (wish update-unify-stages, Group 2).
+ *
+ * Run with: bun test src/genie-commands/__tests__/legacy-cleanup.test.ts
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  type CleanupReport,
+  type LegacyArtifact,
+  REGISTRY,
+  cleanupLegacyArtifacts,
+  parseSkipCleanupFlag,
+} from '../legacy-cleanup.js';
+
+function makeSyntheticArtifact(
+  name: string,
+  opts: {
+    present?: boolean;
+    removed?: string[];
+    warnings?: string[];
+    onCall?: (event: 'detect' | 'cleanup' | 'summary') => void;
+  } = {},
+): LegacyArtifact {
+  const present = opts.present ?? true;
+  const removed = opts.removed ?? [`${name}.removed`];
+  const warnings = opts.warnings ?? [];
+  return {
+    name,
+    async detect() {
+      opts.onCall?.('detect');
+      return present;
+    },
+    async cleanup() {
+      opts.onCall?.('cleanup');
+      return { removed: [...removed], warnings: [...warnings] };
+    },
+    summary() {
+      opts.onCall?.('summary');
+      return `${name} summary`;
+    },
+  };
+}
+
+describe('cleanupLegacyArtifacts — default (empty) registry', () => {
+  test('REGISTRY is empty by default for genie day-one', () => {
+    expect(REGISTRY).toEqual([]);
+  });
+
+  test('returns { entries: [] } with empty registry and no skips', async () => {
+    const report = await cleanupLegacyArtifacts(new Set());
+    expect(report).toEqual({ entries: [] });
+  });
+
+  test('returns { entries: [] } with empty registry even when skipList has names', async () => {
+    const report = await cleanupLegacyArtifacts(new Set(['nats-reply-sidecar', 'foo']));
+    expect(report).toEqual({ entries: [] });
+  });
+});
+
+describe('cleanupLegacyArtifacts — synthetic registry via dependency injection', () => {
+  test('detect → cleanup are invoked in order on a present artifact', async () => {
+    const calls: Array<'detect' | 'cleanup' | 'summary'> = [];
+    const artifact = makeSyntheticArtifact('foo', {
+      present: true,
+      removed: ['/tmp/foo'],
+      warnings: ['was deprecated'],
+      onCall: (e) => calls.push(e),
+    });
+
+    const report = await cleanupLegacyArtifacts(new Set(), [artifact]);
+
+    expect(calls).toEqual(['detect', 'cleanup']);
+    expect(report.entries).toEqual([
+      {
+        name: 'foo',
+        outcome: 'cleaned',
+        removed: ['/tmp/foo'],
+        warnings: ['was deprecated'],
+      },
+    ]);
+  });
+
+  test('absent artifact yields outcome=absent, cleanup never called', async () => {
+    const calls: Array<'detect' | 'cleanup' | 'summary'> = [];
+    const artifact = makeSyntheticArtifact('ghost', { present: false, onCall: (e) => calls.push(e) });
+
+    const report = await cleanupLegacyArtifacts(new Set(), [artifact]);
+
+    expect(calls).toEqual(['detect']);
+    expect(report.entries).toEqual([{ name: 'ghost', outcome: 'absent', removed: [], warnings: [] }]);
+  });
+
+  test('skipList honored: artifact present + skipList=[name] → outcome=skipped, detect never called', async () => {
+    const calls: Array<'detect' | 'cleanup' | 'summary'> = [];
+    const artifact = makeSyntheticArtifact('x', { present: true, onCall: (e) => calls.push(e) });
+
+    const report = await cleanupLegacyArtifacts(new Set(['x']), [artifact]);
+
+    expect(calls).toEqual([]);
+    expect(report.entries).toEqual([{ name: 'x', outcome: 'skipped', removed: [], warnings: [] }]);
+  });
+
+  test('mixed registry — cleaned, absent, skipped — preserves declaration order', async () => {
+    const a = makeSyntheticArtifact('alpha', { present: true, removed: ['a1'] });
+    const b = makeSyntheticArtifact('beta', { present: false });
+    const c = makeSyntheticArtifact('gamma', { present: true, removed: ['c1'] });
+
+    const report = await cleanupLegacyArtifacts(new Set(['gamma']), [a, b, c]);
+
+    expect(report.entries.map((e) => [e.name, e.outcome])).toEqual([
+      ['alpha', 'cleaned'],
+      ['beta', 'absent'],
+      ['gamma', 'skipped'],
+    ]);
+  });
+
+  test('CleanupReport shape matches the cross-CLI contract', async () => {
+    const report: CleanupReport = await cleanupLegacyArtifacts(new Set());
+    expect(report).toHaveProperty('entries');
+    expect(Array.isArray(report.entries)).toBe(true);
+  });
+});
+
+describe('parseSkipCleanupFlag', () => {
+  test('undefined → empty set', () => {
+    expect(parseSkipCleanupFlag(undefined)).toEqual(new Set());
+  });
+
+  test('empty string → empty set', () => {
+    expect(parseSkipCleanupFlag('')).toEqual(new Set());
+  });
+
+  test('single name', () => {
+    expect(parseSkipCleanupFlag('nats-reply-sidecar')).toEqual(new Set(['nats-reply-sidecar']));
+  });
+
+  test('comma-separated names with whitespace', () => {
+    expect(parseSkipCleanupFlag('a, b ,c')).toEqual(new Set(['a', 'b', 'c']));
+  });
+
+  test('drops empty fragments from trailing commas', () => {
+    expect(parseSkipCleanupFlag('a,,b,')).toEqual(new Set(['a', 'b']));
+  });
+});

--- a/src/genie-commands/__tests__/update.test.ts
+++ b/src/genie-commands/__tests__/update.test.ts
@@ -8,7 +8,16 @@ import { describe, expect, test } from 'bun:test';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { detectFromBinaryPath, detectGlobalInstalls } from '../update.js';
+import {
+  type VerifyResult,
+  decideVerify,
+  detectFromBinaryPath,
+  detectGlobalInstalls,
+  formatVerifyBanner,
+  normalizeVersion,
+  runVerifyProbe,
+  shortCircuitIfCurrent,
+} from '../update.js';
 
 // We can't easily mock runCommandSilent inside the module, so we test
 // detectGlobalInstalls by actually running the detection commands.
@@ -129,5 +138,372 @@ describe('updateCommand dual-install logic', () => {
     expect(source).toContain('will not auto-start it');
     expect(source).toContain('update-diagnostics-');
     expect(source).toContain('Recent scheduler signals');
+  });
+});
+
+describe('updateCommand legacy-cleanup wiring (Group 2)', () => {
+  test('runUpdate calls cleanupLegacyArtifacts after install, before maintenance', () => {
+    const source = readFileSync(join(__dirname, '..', 'update.ts'), 'utf-8');
+    const cleanupIdx = source.indexOf('runLegacyCleanupSafe(cleanupSkipList)');
+    const maintenanceIdx = source.indexOf('runPostUpdateMaintenanceSafe(');
+    const syncPluginIdx = source.indexOf('await syncPlugin(installType)');
+    expect(cleanupIdx).toBeGreaterThan(-1);
+    expect(maintenanceIdx).toBeGreaterThan(-1);
+    expect(syncPluginIdx).toBeGreaterThan(-1);
+    expect(syncPluginIdx).toBeLessThan(cleanupIdx);
+    expect(cleanupIdx).toBeLessThan(maintenanceIdx);
+  });
+
+  test('--no-sidecar-cleanup adds nats-reply-sidecar to skipList and logs the notice', () => {
+    const source = readFileSync(join(__dirname, '..', 'update.ts'), 'utf-8');
+    expect(source).toContain("skipList.add('nats-reply-sidecar')");
+    expect(source).toContain('no-op for genie, retained for cross-CLI portability');
+  });
+
+  test('--skip-cleanup parsed via parseSkipCleanupFlag', () => {
+    const source = readFileSync(join(__dirname, '..', 'update.ts'), 'utf-8');
+    expect(source).toContain('parseSkipCleanupFlag(options.skipCleanup)');
+  });
+});
+
+// ============================================================================
+// Group 1 — `decideVerify` + `VerifyResult` tagged-union + `normalizeVersion`.
+// Pure-function tests; every kind variant pinned. Shape mirrors omni's
+// SHARED-DESIGN §4.3 so reviewers/operators learn one mental model.
+// ============================================================================
+
+describe('normalizeVersion (Group 1)', () => {
+  test('strips +gitsha build metadata', () => {
+    expect(normalizeVersion('4.260504.21+abc1234')).toBe('4.260504.21');
+  });
+
+  test('returns input unchanged when no +metadata is present', () => {
+    expect(normalizeVersion('4.260504.21')).toBe('4.260504.21');
+  });
+
+  test('trims surrounding whitespace before parsing', () => {
+    expect(normalizeVersion('  4.260504.21+abc  ')).toBe('4.260504.21');
+    expect(normalizeVersion('\n4.260504.21\n')).toBe('4.260504.21');
+  });
+
+  test('preserves SemVer pre-release (-rc.N) tags; only build metadata after + is stripped', () => {
+    expect(normalizeVersion('1.0.0-rc.1+build.42')).toBe('1.0.0-rc.1');
+    expect(normalizeVersion('2.0.0-next.0')).toBe('2.0.0-next.0');
+  });
+
+  test('strips multi-segment build metadata after the first +', () => {
+    expect(normalizeVersion('4.260504.21+sha.deadbeef.dirty')).toBe('4.260504.21');
+  });
+});
+
+describe('decideVerify (Group 1)', () => {
+  test('skipReason "no-restart" returns skipped variant regardless of other inputs', () => {
+    const result = decideVerify({
+      cliVersion: '1.0.0',
+      serverHealthBody: { version: '1.0.0' },
+      endpoint: 'genie doctor --json',
+      skipReason: 'no-restart',
+    });
+    expect(result).toEqual({ kind: 'skipped', reason: 'no-restart' });
+  });
+
+  test('skipReason "no-verify-flag" returns skipped variant', () => {
+    const result = decideVerify({
+      cliVersion: '1.0.0',
+      serverHealthBody: null,
+      endpoint: 'genie doctor --json',
+      skipReason: 'no-verify-flag',
+    });
+    expect(result).toEqual({ kind: 'skipped', reason: 'no-verify-flag' });
+  });
+
+  test('skipReason "no-running-services" returns skipped variant', () => {
+    const result = decideVerify({
+      cliVersion: '1.0.0',
+      serverHealthBody: null,
+      endpoint: 'genie doctor --json',
+      skipReason: 'no-running-services',
+    });
+    expect(result).toEqual({ kind: 'skipped', reason: 'no-running-services' });
+  });
+
+  test('null serverHealthBody (no skipReason) returns health-unreachable with endpoint', () => {
+    const result = decideVerify({
+      cliVersion: '1.0.0',
+      serverHealthBody: null,
+      endpoint: 'genie doctor --json',
+    });
+    expect(result).toEqual({ kind: 'health-unreachable', endpoint: 'genie doctor --json' });
+  });
+
+  test('mismatched versions return version-mismatch with normalized strings', () => {
+    const result = decideVerify({
+      cliVersion: '1.0.0',
+      serverHealthBody: { version: '0.9.0+abc' },
+      endpoint: 'genie doctor --json',
+    });
+    expect(result).toEqual({
+      kind: 'version-mismatch',
+      cliVersion: '1.0.0',
+      serverVersion: '0.9.0',
+    });
+  });
+
+  test('server reachable but version field absent returns version-mismatch with null serverVersion', () => {
+    const result = decideVerify({
+      cliVersion: '1.0.0',
+      serverHealthBody: {},
+      endpoint: 'genie doctor --json',
+    });
+    expect(result).toEqual({
+      kind: 'version-mismatch',
+      cliVersion: '1.0.0',
+      serverVersion: null,
+    });
+  });
+
+  test('matching versions (after +gitsha strip) return ok variant', () => {
+    const result = decideVerify({
+      cliVersion: '1.0.0',
+      serverHealthBody: { version: '1.0.0+abc1234' },
+      endpoint: 'genie doctor --json',
+    });
+    expect(result).toEqual({ kind: 'ok', cliVersion: '1.0.0', serverVersion: '1.0.0' });
+  });
+
+  test('matching versions both with +gitsha differ in metadata only → ok', () => {
+    const result = decideVerify({
+      cliVersion: '4.260504.21+abc1234',
+      serverHealthBody: { version: '4.260504.21+def5678' },
+      endpoint: 'genie doctor --json',
+    });
+    expect(result).toEqual({ kind: 'ok', cliVersion: '4.260504.21', serverVersion: '4.260504.21' });
+  });
+
+  test('VerifyResult tagged-union shape is exhaustive (auth-invalid variant reserved for shape parity)', () => {
+    // The auth-invalid variant exists in the type for cross-CLI shape parity with
+    // omni; decideVerify never returns it for genie inputs today. This test
+    // exists to lock the union shape — adding/removing a variant should
+    // require touching this exhaustiveness check.
+    const variants: VerifyResult[] = [
+      { kind: 'ok', cliVersion: '1.0.0', serverVersion: '1.0.0' },
+      { kind: 'health-unreachable', endpoint: 'x' },
+      { kind: 'version-mismatch', cliVersion: '1.0.0', serverVersion: '0.9.0' },
+      { kind: 'auth-invalid' },
+      { kind: 'skipped', reason: 'no-restart' },
+      { kind: 'skipped', reason: 'no-running-services' },
+      { kind: 'skipped', reason: 'no-verify-flag' },
+    ];
+    expect(variants).toHaveLength(7);
+  });
+});
+
+// ============================================================================
+// Group 3 — pre-flight version check + confirmation prompt + `--yes`.
+// `shortCircuitIfCurrent` is the pure decider; `fetchLatestVersion` is the
+// I/O wrapper covered separately by integration tests.
+// ============================================================================
+
+describe('shortCircuitIfCurrent (Group 3)', () => {
+  test('null/undefined latestVersion → false (proceed with install)', () => {
+    expect(shortCircuitIfCurrent('1.0.0', null)).toBe(false);
+    expect(shortCircuitIfCurrent('1.0.0', undefined)).toBe(false);
+  });
+
+  test('empty-string latestVersion → false (defensive against parse failure)', () => {
+    expect(shortCircuitIfCurrent('1.0.0', '')).toBe(false);
+  });
+
+  test('exact match returns true', () => {
+    expect(shortCircuitIfCurrent('4.260504.21', '4.260504.21')).toBe(true);
+  });
+
+  test('build metadata strip lets +gitsha CLI match registry-published version', () => {
+    expect(shortCircuitIfCurrent('4.260504.21+abc1234', '4.260504.21')).toBe(true);
+    expect(shortCircuitIfCurrent('4.260504.21', '4.260504.21+def5678')).toBe(true);
+    expect(shortCircuitIfCurrent('4.260504.21+abc', '4.260504.21+def')).toBe(true);
+  });
+
+  test('different versions return false', () => {
+    expect(shortCircuitIfCurrent('1.0.0', '1.0.1')).toBe(false);
+    expect(shortCircuitIfCurrent('1.0.0', '0.9.9')).toBe(false);
+  });
+
+  test('whitespace in inputs is normalized away', () => {
+    expect(shortCircuitIfCurrent('  1.0.0  ', '1.0.0\n')).toBe(true);
+  });
+});
+
+describe('updateCommand flag wiring (Group 3)', () => {
+  test('--yes flag plumbs through UpdateCommandOptions.yes', () => {
+    const source = readFileSync(join(__dirname, '..', 'update.ts'), 'utf-8');
+    expect(source).toContain('shouldAutoConfirm(options)');
+    expect(source).toContain('isTruthyEnv(process.env.GENIE_UPDATE_YES)');
+  });
+
+  test('CLI exposes -y / --yes / --no-restart / --no-verify flags', () => {
+    const source = readFileSync(join(__dirname, '..', '..', 'genie.ts'), 'utf-8');
+    expect(source).toContain('-y, --yes');
+    expect(source).toContain('--no-restart');
+    expect(source).toContain('--no-verify');
+  });
+
+  test('pre-flight version check runs BEFORE detectInstallationType', () => {
+    const source = readFileSync(join(__dirname, '..', 'update.ts'), 'utf-8');
+    const fetchIdx = source.indexOf('await fetchLatestVersion(channel)');
+    const detectIdx = source.indexOf('await detectInstallationType()');
+    expect(fetchIdx).toBeGreaterThan(-1);
+    expect(detectIdx).toBeGreaterThan(-1);
+    expect(fetchIdx).toBeLessThan(detectIdx);
+  });
+
+  test('"Already up to date" exit logs version and channel', () => {
+    const source = readFileSync(join(__dirname, '..', 'update.ts'), 'utf-8');
+    expect(source).toContain('Already up to date');
+    expect(source).toContain('shortCircuitIfCurrent(VERSION, latestVersion)');
+  });
+});
+
+// ============================================================================
+// Group 4 — post-restart health probe + `--no-verify` + `--no-restart`.
+// Probe I/O is exercised via the test seam `readHealth` injection so the
+// suite never depends on a live daemon.
+// ============================================================================
+
+describe('runVerifyProbe (Group 4)', () => {
+  test('skipReason "no-restart" returns skipped variant without polling', async () => {
+    let calls = 0;
+    const result = await runVerifyProbe({
+      cliVersion: '1.0.0',
+      skipReason: 'no-restart',
+      readHealth: async () => {
+        calls++;
+        return { version: '1.0.0' };
+      },
+    });
+    expect(result).toEqual({ kind: 'skipped', reason: 'no-restart' });
+    expect(calls).toBe(0); // skip path never invokes the reader
+  });
+
+  test('skipReason "no-verify-flag" returns skipped variant', async () => {
+    const result = await runVerifyProbe({
+      cliVersion: '1.0.0',
+      skipReason: 'no-verify-flag',
+      readHealth: async () => null,
+    });
+    expect(result).toEqual({ kind: 'skipped', reason: 'no-verify-flag' });
+  });
+
+  test('reader returns body on first poll → ok', async () => {
+    const result = await runVerifyProbe({
+      cliVersion: '4.260504.21',
+      readHealth: async () => ({ version: '4.260504.21+abc' }),
+    });
+    expect(result).toEqual({ kind: 'ok', cliVersion: '4.260504.21', serverVersion: '4.260504.21' });
+  });
+
+  test('reader returns mismatched version → version-mismatch', async () => {
+    const result = await runVerifyProbe({
+      cliVersion: '1.0.0',
+      readHealth: async () => ({ version: '0.9.0' }),
+    });
+    expect(result).toEqual({ kind: 'version-mismatch', cliVersion: '1.0.0', serverVersion: '0.9.0' });
+  });
+
+  test('reader returns null until deadline → health-unreachable with endpoint', async () => {
+    let calls = 0;
+    const result = await runVerifyProbe({
+      cliVersion: '1.0.0',
+      readHealth: async () => {
+        calls++;
+        return null;
+      },
+      deadlineMs: 50, // shortened via test seam
+      intervalMs: 10,
+    });
+    expect(result.kind).toBe('health-unreachable');
+    if (result.kind === 'health-unreachable') {
+      expect(result.endpoint).toContain('pgserve');
+    }
+    expect(calls).toBeGreaterThan(0);
+  });
+
+  test('reader exception is caught and treated as null read', async () => {
+    let firstCall = true;
+    const result = await runVerifyProbe({
+      cliVersion: '1.0.0',
+      readHealth: async () => {
+        if (firstCall) {
+          firstCall = false;
+          throw new Error('connection refused');
+        }
+        return { version: '1.0.0' };
+      },
+      deadlineMs: 200,
+      intervalMs: 10,
+    });
+    // Recovery path: first call throws, second call succeeds → ok.
+    expect(result.kind).toBe('ok');
+  });
+});
+
+describe('formatVerifyBanner (Group 4)', () => {
+  test('ok variant emits CLI + Server lines with healthy marker', () => {
+    const lines = formatVerifyBanner({ kind: 'ok', cliVersion: '1.0.0', serverVersion: '1.0.0' });
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain('CLI');
+    expect(lines[0]).toContain('1.0.0');
+    expect(lines[1]).toContain('Server');
+    expect(lines[1]).toContain('healthy');
+  });
+
+  test('skipped variant collapses to single-line note with reason', () => {
+    const lines = formatVerifyBanner({ kind: 'skipped', reason: 'no-restart' });
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines.some((l) => l.includes('skipped'))).toBe(true);
+    expect(lines.some((l) => l.includes('no-restart'))).toBe(true);
+  });
+
+  test('health-unreachable surfaces the probe endpoint', () => {
+    const lines = formatVerifyBanner({ kind: 'health-unreachable', endpoint: 'doctor --json' });
+    expect(lines.some((l) => l.includes('Server'))).toBe(true);
+    expect(lines.some((l) => l.includes('doctor --json'))).toBe(true);
+  });
+
+  test('version-mismatch reports both versions', () => {
+    const lines = formatVerifyBanner({ kind: 'version-mismatch', cliVersion: '1.0.0', serverVersion: '0.9.0' });
+    expect(lines.some((l) => l.includes('1.0.0'))).toBe(true);
+    expect(lines.some((l) => l.includes('0.9.0'))).toBe(true);
+    expect(lines.some((l) => l.includes('mismatch'))).toBe(true);
+  });
+});
+
+// ============================================================================
+// Group 5 — diagnostics `verify` block + schema bump 1 → 2 + ora/chalk polish.
+// These are source-shape lock tests; behavior is exercised end-to-end via
+// the smoke flow on a real install (out of scope for unit tests).
+// ============================================================================
+
+describe('Diagnostics schema (Group 5)', () => {
+  test('schema version bumped to 2', () => {
+    const source = readFileSync(join(__dirname, '..', 'update.ts'), 'utf-8');
+    expect(source).toContain('UPDATE_DIAGNOSTIC_SCHEMA_VERSION = 2');
+  });
+
+  test('diagnostics object includes verify and cleanups blocks', () => {
+    const source = readFileSync(join(__dirname, '..', 'update.ts'), 'utf-8');
+    expect(source).toContain('verify: extras.verify');
+    expect(source).toContain('cleanups: extras.cleanups');
+  });
+
+  test('schema bump policy is documented in the file header', () => {
+    const source = readFileSync(join(__dirname, '..', 'update.ts'), 'utf-8');
+    expect(source).toContain('Bump on every additive change');
+  });
+
+  test('NO_COLOR honored via colorEnabled() helper', () => {
+    const source = readFileSync(join(__dirname, '..', 'update.ts'), 'utf-8');
+    expect(source).toContain('process.env.NO_COLOR');
+    expect(source).toContain('colorEnabled');
   });
 });

--- a/src/genie-commands/legacy-cleanup.ts
+++ b/src/genie-commands/legacy-cleanup.ts
@@ -1,0 +1,67 @@
+/**
+ * Legacy artifact cleanup registry.
+ *
+ * Day-one registry is intentionally empty for genie — the primitive lives
+ * here so future migrations (orphaned tmux configs, stale plugin caches, …)
+ * can plug in via the `LegacyArtifact` interface, and the sibling omni
+ * wish (see `.genie/wishes/update-unify-stages/SHARED-DESIGN.md` decision #5)
+ * absorbs the type signature verbatim.
+ */
+
+export interface LegacyArtifact {
+  readonly name: string;
+  detect(): Promise<boolean>;
+  cleanup(): Promise<{ removed: string[]; warnings: string[] }>;
+  summary(): string;
+}
+
+export type CleanupOutcome = 'cleaned' | 'skipped' | 'absent';
+
+export interface CleanupEntry {
+  name: string;
+  outcome: CleanupOutcome;
+  removed: string[];
+  warnings: string[];
+}
+
+export interface CleanupReport {
+  entries: CleanupEntry[];
+}
+
+export const REGISTRY: LegacyArtifact[] = [];
+
+export async function cleanupLegacyArtifacts(
+  skipList: Set<string>,
+  registry: LegacyArtifact[] = REGISTRY,
+): Promise<CleanupReport> {
+  const entries: CleanupEntry[] = [];
+  for (const artifact of registry) {
+    if (skipList.has(artifact.name)) {
+      entries.push({ name: artifact.name, outcome: 'skipped', removed: [], warnings: [] });
+      continue;
+    }
+    const present = await artifact.detect();
+    if (!present) {
+      entries.push({ name: artifact.name, outcome: 'absent', removed: [], warnings: [] });
+      continue;
+    }
+    const result = await artifact.cleanup();
+    entries.push({
+      name: artifact.name,
+      outcome: 'cleaned',
+      removed: result.removed,
+      warnings: result.warnings,
+    });
+  }
+  return { entries };
+}
+
+export function parseSkipCleanupFlag(value: string | undefined): Set<string> {
+  const skip = new Set<string>();
+  if (!value) return skip;
+  for (const part of value.split(',')) {
+    const name = part.trim();
+    if (name) skip.add(name);
+  }
+  return skip;
+}

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -17,24 +17,327 @@ import { chmod, copyFile, mkdir, unlink } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { genieConfigExists, loadGenieConfig, saveGenieConfig } from '../lib/genie-config.js';
+import { VERSION } from '../lib/version.js';
+import { type CleanupReport, cleanupLegacyArtifacts, parseSkipCleanupFlag } from './legacy-cleanup.js';
 
 const GENIE_HOME = process.env.GENIE_HOME || join(homedir(), '.genie');
 const GENIE_SRC = join(GENIE_HOME, 'src');
 const GENIE_BIN = join(GENIE_HOME, 'bin');
 const LOCAL_BIN = join(homedir(), '.local', 'bin');
 const TRUTHY = new Set(['1', 'true', 'yes', 'on']);
-const UPDATE_DIAGNOSTIC_SCHEMA_VERSION = 1;
+
+/**
+ * Diagnostics schema version. Bump on every additive change so consumers
+ * branch on `schemaVersion` rather than file presence.
+ *
+ * - v1 (pre-update-unify-stages): `update`, `runtime`, `paths`, `processSnapshot`,
+ *   `maintenance`, `recentLogSignals`.
+ * - v2 (this wish): adds `verify: VerifyResult` and `cleanups: CleanupReport`
+ *   blocks. Existing v1 fields preserved byte-identically.
+ *
+ * Genie's number diverges from omni's (omni stays at v1) per
+ * SHARED-DESIGN.md decision #4 — each repo evolves its own schema.
+ */
+const UPDATE_DIAGNOSTIC_SCHEMA_VERSION = 2;
+
+/** Verify probe deadline. Wish §10: 15s — genie's daemon stack (pgserve +
+ *  scheduler + tmux) takes longer to bounce than pm2-managed processes. */
+const VERIFY_PROBE_DEADLINE_MS = 15_000;
+const VERIFY_PROBE_POLL_INTERVAL_MS = 500;
+const FETCH_LATEST_TIMEOUT_MS = 5_000;
+
+// ============================================================================
+// Verify decision shape — shared with omni#update-unify-stages (SHARED-DESIGN §4.3).
+// `decideVerify` is a pure function so the tagged-union outcome can be unit-tested
+// in isolation from the daemon-probe side effects. The `auth-invalid` variant is
+// reserved for cross-CLI shape parity (omni has auth; genie does not) — it exists
+// in the type but `decideVerify` never returns it for genie inputs today.
+// ============================================================================
+
+export type VerifySkipReason = 'no-restart' | 'no-running-services' | 'no-verify-flag';
+
+export type VerifyResult =
+  | { kind: 'ok'; cliVersion: string; serverVersion: string | null }
+  | { kind: 'health-unreachable'; endpoint: string }
+  | { kind: 'version-mismatch'; cliVersion: string; serverVersion: string | null }
+  | { kind: 'auth-invalid' }
+  | { kind: 'skipped'; reason: VerifySkipReason };
+
+export interface ServerHealthBody {
+  version?: string | null;
+}
+
+export interface DecideVerifyArgs {
+  cliVersion: string;
+  serverHealthBody: ServerHealthBody | null;
+  endpoint: string;
+  skipReason?: VerifySkipReason | null;
+}
+
+/**
+ * Strip build metadata (anything after `+`) so a `4.260504.21+abc1234` CLI build
+ * compares equal to the `4.260504.21` registry-published string. Mirrors omni's
+ * `normalizeVersion` helper.
+ */
+export function normalizeVersion(value: string): string {
+  const trimmed = value.trim();
+  const plusIdx = trimmed.indexOf('+');
+  return plusIdx === -1 ? trimmed : trimmed.slice(0, plusIdx);
+}
+
+export function decideVerify(args: DecideVerifyArgs): VerifyResult {
+  if (args.skipReason) {
+    return { kind: 'skipped', reason: args.skipReason };
+  }
+  if (args.serverHealthBody === null) {
+    return { kind: 'health-unreachable', endpoint: args.endpoint };
+  }
+  const cliVersion = normalizeVersion(args.cliVersion);
+  const rawServerVersion = args.serverHealthBody.version ?? null;
+  const serverVersion = rawServerVersion === null ? null : normalizeVersion(rawServerVersion);
+  if (serverVersion === null || serverVersion !== cliVersion) {
+    return { kind: 'version-mismatch', cliVersion, serverVersion };
+  }
+  return { kind: 'ok', cliVersion, serverVersion };
+}
+
+// ============================================================================
+// Group 3 — pre-flight registry version check + confirmation prompt + `--yes`.
+// Both helpers are pure (the network call is split out) so the decision logic
+// is unit-testable independent of the registry round-trip.
+// ============================================================================
+
+/**
+ * Compare a current install to the registry-published version. Both inputs are
+ * normalized (build metadata stripped) before comparison so a `4.260504.21+sha`
+ * CLI build matches the `4.260504.21` registry string.
+ *
+ * Returns `true` only when both strings normalize equal AND `latestVersion`
+ * is non-null. A null/empty `latestVersion` (network failure, parse error)
+ * conservatively returns `false` so the caller proceeds with the update —
+ * never block on a transient registry hiccup.
+ */
+export function shortCircuitIfCurrent(currentVersion: string, latestVersion: string | null | undefined): boolean {
+  if (!latestVersion) return false;
+  return normalizeVersion(currentVersion) === normalizeVersion(latestVersion);
+}
+
+/**
+ * Resolve the registry-published version for a channel. Calls
+ * `bunx npm view @automagik/genie@<channel> version` (so we ride whatever
+ * registry config is already set up — npm/bun share the auth + registry
+ * config in practice). Returns `null` on any failure: missing tools, network
+ * timeout, parse error, empty stdout. Caller treats null as "proceed with
+ * install" — defensive against the operator being offline mid-update.
+ */
+export async function fetchLatestVersion(channel: string): Promise<string | null> {
+  const candidates = [
+    { cmd: 'npm', args: ['view', `@automagik/genie@${channel}`, 'version'] },
+    { cmd: 'bunx', args: ['npm', 'view', `@automagik/genie@${channel}`, 'version'] },
+  ];
+  for (const { cmd, args } of candidates) {
+    const result = await runCommandSilent(cmd, args, undefined, FETCH_LATEST_TIMEOUT_MS);
+    if (!result.success) continue;
+    const trimmed = result.output.trim();
+    if (!trimmed) continue;
+    // Take the last non-empty token — `npm view` may print the package name on
+    // some setups; the version is always the trailing token.
+    const lines = trimmed.split(/\r?\n/).filter(Boolean);
+    const lastLine = lines[lines.length - 1];
+    const tokens = lastLine.split(/\s+/);
+    const candidate = tokens[tokens.length - 1].replace(/^['"]|['"]$/g, '');
+    if (/^\d+\.\d+/.test(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * TTY confirmation prompt. Auto-confirms in non-TTY environments so CI
+ * pipelines never hang waiting for stdin. The `--yes` / `GENIE_UPDATE_YES`
+ * caller-side bypass is checked before this function runs (see
+ * `shouldAutoConfirm`); this helper is the actual stdin read.
+ */
+async function promptConfirm(question: string): Promise<boolean> {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return true;
+  process.stdout.write(`${question} [Y/n] `);
+  return new Promise((resolve) => {
+    const onData = (chunk: Buffer) => {
+      process.stdin.removeListener('data', onData);
+      process.stdin.pause();
+      const answer = chunk.toString('utf-8').trim().toLowerCase();
+      // Empty (just Enter) defaults to yes.
+      if (answer === '' || answer === 'y' || answer === 'yes') resolve(true);
+      else resolve(false);
+    };
+    process.stdin.resume();
+    process.stdin.once('data', onData);
+  });
+}
+
+/** Bypass logic for the prompt: `--yes` flag OR `GENIE_UPDATE_YES` env. */
+function shouldAutoConfirm(opts: { yes?: boolean }): boolean {
+  if (opts.yes) return true;
+  return isTruthyEnv(process.env.GENIE_UPDATE_YES);
+}
+
+// ============================================================================
+// Group 4 — post-restart verify probe via genie doctor / pgserve health.
+// `runVerifyProbe` is the I/O wrapper; it polls until the deadline, then
+// hands the parsed health body to `decideVerify` (the pure decider above).
+// ============================================================================
+
+const VERIFY_PROBE_ENDPOINT = 'pgserve status --json + ~/.genie/serve.pid';
+
+interface VerifyProbeOptions {
+  cliVersion: string;
+  skipReason?: VerifySkipReason | null;
+  /**
+   * Test seam: synchronous read of the probe result. Production callers leave
+   * this undefined; tests inject a stub to exercise the I/O wrapping without a
+   * live daemon.
+   */
+  readHealth?: () => Promise<ServerHealthBody | null>;
+  /** Test seam: shorten the poll deadline. Production uses
+   *  `VERIFY_PROBE_DEADLINE_MS`. */
+  deadlineMs?: number;
+  /** Test seam: shorten the poll interval. Production uses
+   *  `VERIFY_PROBE_POLL_INTERVAL_MS`. */
+  intervalMs?: number;
+}
+
+/**
+ * Daemon health probe. Tries pgserve's `status --json` and falls back to the
+ * scheduler PID + serve.pid existence. Returns a `ServerHealthBody` with the
+ * detected version, or `null` when no daemon is reachable.
+ *
+ * Why we don't shell out to `genie doctor` directly: doctor's main flow is
+ * text-only (the `--json` mode covers `--observability` / `--fix-team-orphans`
+ * sub-flows, not the top-level health). A thin probe is faster and avoids the
+ * "doctor recurses into update which spawns doctor" pitfall.
+ */
+async function readServerHealth(): Promise<ServerHealthBody | null> {
+  // Step 1: pgserve must answer status (this is the canonical backbone check
+  // every other genie subsystem depends on). If pgserve is down, nothing else
+  // matters.
+  const pgServeStatus = await runCommandSilent('pgserve', ['status', '--json'], undefined, 3000);
+  if (!pgServeStatus.success) return null;
+
+  // Step 2: serve.pid must exist AND the pid must be alive. We don't actually
+  // need a JSON body — the running daemon IS our installed CLI (same package),
+  // so `version === VERSION` by construction. We surface the version field so
+  // `decideVerify` can compare normalized strings.
+  const pidPath = join(GENIE_HOME, 'serve.pid');
+  const rawPid = safeRead(pidPath, 32);
+  if (!rawPid) return null;
+  const pid = Number.parseInt(rawPid.trim(), 10);
+  if (!Number.isFinite(pid) || pid <= 0) return null;
+  try {
+    process.kill(pid, 0); // signal 0 = aliveness probe, throws if dead
+  } catch {
+    return null;
+  }
+  return { version: VERSION };
+}
+
+/**
+ * Poll `readHealth` until the deadline expires. First successful read wins;
+ * a stream of nulls returns `null` so `decideVerify` can emit
+ * `health-unreachable`.
+ */
+async function pollHealth(
+  readHealth: () => Promise<ServerHealthBody | null>,
+  deadlineMs: number,
+  intervalMs: number,
+): Promise<ServerHealthBody | null> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < deadlineMs) {
+    let body: ServerHealthBody | null = null;
+    try {
+      body = await readHealth();
+    } catch {
+      // Reader threw — treat as unreachable. Same outcome as a `null` read.
+    }
+    if (body !== null) return body;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  return null;
+}
+
+export async function runVerifyProbe(opts: VerifyProbeOptions): Promise<VerifyResult> {
+  if (opts.skipReason) {
+    return decideVerify({
+      cliVersion: opts.cliVersion,
+      serverHealthBody: null,
+      endpoint: VERIFY_PROBE_ENDPOINT,
+      skipReason: opts.skipReason,
+    });
+  }
+  const reader = opts.readHealth ?? readServerHealth;
+  const deadline = opts.deadlineMs ?? VERIFY_PROBE_DEADLINE_MS;
+  const interval = opts.intervalMs ?? VERIFY_PROBE_POLL_INTERVAL_MS;
+  const body = await pollHealth(reader, deadline, interval);
+  return decideVerify({
+    cliVersion: opts.cliVersion,
+    serverHealthBody: body,
+    endpoint: VERIFY_PROBE_ENDPOINT,
+  });
+}
+
+/** Format the post-restart 3-line banner. Genie has no auth model, so the
+ *  auth row from omni's banner is omitted. */
+export function formatVerifyBanner(result: VerifyResult): string[] {
+  const lines: string[] = [];
+  switch (result.kind) {
+    case 'ok':
+      lines.push(`${colorize('\x1b[32m', '\x1b[0m', '✔')} CLI:    v${result.cliVersion}`);
+      lines.push(`${colorize('\x1b[32m', '\x1b[0m', '✔')} Server: v${result.serverVersion} (healthy)`);
+      break;
+    case 'health-unreachable':
+      lines.push(`${colorize('\x1b[33m', '\x1b[0m', '!')} CLI:    v${VERSION}`);
+      lines.push(`${colorize('\x1b[31m', '\x1b[0m', '✖')} Server: unreachable (probe: ${result.endpoint})`);
+      break;
+    case 'version-mismatch':
+      lines.push(`${colorize('\x1b[32m', '\x1b[0m', '✔')} CLI:    v${result.cliVersion}`);
+      lines.push(`${colorize('\x1b[31m', '\x1b[0m', '✖')} Server: v${result.serverVersion ?? 'unknown'} (mismatch)`);
+      break;
+    case 'auth-invalid':
+      lines.push(`${colorize('\x1b[31m', '\x1b[0m', '✖')} Auth: invalid`);
+      break;
+    case 'skipped':
+      lines.push(`${colorize('\x1b[32m', '\x1b[0m', '✔')} CLI:    v${VERSION}`);
+      lines.push(`${colorize('\x1b[2m', '\x1b[0m', `· Server: v… (skipped: ${result.reason})`)}`);
+      break;
+  }
+  return lines;
+}
+
+// ============================================================================
+// Output primitives — direct ANSI today; will migrate to output.ts (the
+// `output-primitives-unified` wish) in a follow-up so the whole CLI shares one
+// chalk/ora abstraction. NO_COLOR is honored here so behavior already matches
+// the post-migration contract (see `colorize` below).
+// ============================================================================
+
+function colorEnabled(): boolean {
+  if (process.env.NO_COLOR) return false;
+  if (process.env.FORCE_COLOR && process.env.FORCE_COLOR !== '0') return true;
+  return Boolean(process.stdout.isTTY);
+}
+
+function colorize(open: string, close: string, text: string): string {
+  return colorEnabled() ? `${open}${text}${close}` : text;
+}
 
 function log(message: string): void {
-  console.log(`\x1b[32m▸\x1b[0m ${message}`);
+  console.log(`${colorize('\x1b[32m', '\x1b[0m', '▸')} ${message}`);
 }
 
 function success(message: string): void {
-  console.log(`\x1b[32m✔\x1b[0m ${message}`);
+  console.log(`${colorize('\x1b[32m', '\x1b[0m', '✔')} ${message}`);
 }
 
 function error(message: string): void {
-  console.log(`\x1b[31m✖\x1b[0m ${message}`);
+  console.log(`${colorize('\x1b[31m', '\x1b[0m', '✖')} ${message}`);
 }
 
 function formatDuration(ms: number): string {
@@ -73,6 +376,10 @@ interface UpdateDiagnosticsContext {
   primaryMethod: 'npm' | 'bun';
   globalInstalls: Array<'npm' | 'bun'>;
   plugin: PluginSyncInfo;
+  /** Latest registry version observed pre-flight, or null when fetch failed. */
+  latestVersion: string | null;
+  /** Local CLI version at the time the diagnostics file was written. */
+  cliVersion: string;
 }
 
 interface RecentLogSignal {
@@ -155,9 +462,15 @@ function summarizeJsonlSignals(path: string): RecentLogSignal[] {
   return [...signals.values()].sort((a, b) => b.count - a.count).slice(0, 10);
 }
 
+interface UpdateDiagnosticsExtras {
+  verify: VerifyResult;
+  cleanups: CleanupReport;
+}
+
 async function collectUpdateDiagnostics(
   ctx: UpdateDiagnosticsContext,
   maintenance: { outcome: 'completed' | 'failed'; durationMs: number; lines: string[]; error?: string },
+  extras: UpdateDiagnosticsExtras,
 ): Promise<{ path: string; signals: RecentLogSignal[] }> {
   const logsDir = join(GENIE_HOME, 'logs');
   mkdirSync(logsDir, { recursive: true });
@@ -170,7 +483,10 @@ async function collectUpdateDiagnostics(
 
   const diagnostics = {
     schemaVersion: UPDATE_DIAGNOSTIC_SCHEMA_VERSION,
+    cli: 'genie',
     generatedAt,
+    verify: extras.verify,
+    cleanups: extras.cleanups,
     update: ctx,
     runtime: {
       platform: process.platform,
@@ -907,14 +1223,36 @@ async function persistChannel(channel: string): Promise<void> {
   }
 }
 
-export async function updateCommand(
-  options: { next?: boolean; stable?: boolean; skipMaintenance?: boolean } = {},
-): Promise<void> {
+export interface UpdateCommandOptions {
+  next?: boolean;
+  stable?: boolean;
+  skipMaintenance?: boolean;
+  skipCleanup?: string;
+  /**
+   * Mirrors commander's `--no-sidecar-cleanup` convention: defaults to `true`
+   * (i.e. cleanup permitted), set to `false` when the flag is present. Accepted
+   * for cross-CLI portability with omni; genie's day-one registry is empty so
+   * the flag is logged and otherwise has no effect.
+   */
+  sidecarCleanup?: boolean;
+  /** `--yes` / `-y`. Skips the TTY confirmation. `GENIE_UPDATE_YES=1` env
+   *  has the same effect for CI / scripted callers. */
+  yes?: boolean;
+  /** `--no-restart`. Skips post-update maintenance AND the verify probe. */
+  restart?: boolean;
+  /** `--no-verify`. Runs maintenance but skips the post-restart probe. */
+  verify?: boolean;
+}
+
+export async function updateCommand(options: UpdateCommandOptions = {}): Promise<void> {
   console.log();
-  console.log('\x1b[1m🧞 Genie CLI Update\x1b[0m');
-  console.log('\x1b[2m────────────────────────────────────\x1b[0m');
+  console.log(`${colorize('\x1b[1m', '\x1b[0m', '🧞 Genie CLI Update')}`);
+  console.log(`${colorize('\x1b[2m', '\x1b[0m', '────────────────────────────────────')}`);
   console.log();
 
+  const cleanupSkipList = buildCleanupSkipList(options);
+  const noRestart = options.restart === false || isTruthyEnv(process.env.GENIE_UPDATE_NO_RESTART);
+  const noVerify = options.verify === false || isTruthyEnv(process.env.GENIE_UPDATE_NO_VERIFY);
   const channel = await resolveChannel(options);
 
   // Persist channel when explicitly switching
@@ -922,9 +1260,22 @@ export async function updateCommand(
     await persistChannel(channel);
   }
 
+  // Group 3: pre-flight version check. Short-circuit when already current.
+  const latestVersion = await fetchLatestVersion(channel);
+  if (shortCircuitIfCurrent(VERSION, latestVersion)) {
+    success(`Already up to date (v${normalizeVersion(VERSION)}, channel ${channel})`);
+    console.log();
+    return;
+  }
+
   const installType = await detectInstallationType();
   log(`Detected installation: ${installType}`);
   log(`Channel: ${channel}${channel === 'next' ? ' (dev builds)' : ' (stable)'}`);
+  if (latestVersion) {
+    log(`Update available: ${normalizeVersion(VERSION)} → ${normalizeVersion(latestVersion)}`);
+  } else {
+    log(`Registry version unavailable (proceeding with reinstall of channel ${channel})`);
+  }
   console.log();
 
   if (installType === 'unknown') {
@@ -932,10 +1283,24 @@ export async function updateCommand(
     console.log();
     console.log('Install method not configured. Please reinstall genie:');
     console.log(
-      '\x1b[36m  curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash\x1b[0m',
+      `${colorize('\x1b[36m', '\x1b[0m', '  curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash')}`,
     );
     console.log();
     process.exit(1);
+  }
+
+  // Group 3: confirmation prompt (TTY) / `--yes` / GENIE_UPDATE_YES bypass.
+  if (!shouldAutoConfirm(options)) {
+    const proceedQuestion = latestVersion
+      ? `Update v${normalizeVersion(VERSION)} → v${normalizeVersion(latestVersion)}?`
+      : `Reinstall channel "${channel}"?`;
+    const proceed = await promptConfirm(proceedQuestion);
+    if (!proceed) {
+      console.log();
+      log('Update declined.');
+      console.log();
+      return;
+    }
   }
 
   if (installType === 'source') {
@@ -965,13 +1330,39 @@ export async function updateCommand(
   }
 
   const plugin = await syncPlugin(installType);
-  await runPostUpdateMaintenanceSafe(options, {
-    channel,
-    installType,
-    primaryMethod,
-    globalInstalls: [...globalInstalls].sort(),
-    plugin,
-  });
+  const cleanupReport = await runLegacyCleanupSafe(cleanupSkipList);
+  await runPostUpdateMaintenanceSafe(
+    { ...options, noRestart, noVerify },
+    {
+      channel,
+      installType,
+      primaryMethod,
+      globalInstalls: [...globalInstalls].sort(),
+      plugin,
+      latestVersion,
+      cliVersion: VERSION,
+    },
+    cleanupReport,
+  );
+}
+
+function buildCleanupSkipList(options: UpdateCommandOptions): Set<string> {
+  const skipList = parseSkipCleanupFlag(options.skipCleanup);
+  if (options.sidecarCleanup === false) {
+    skipList.add('nats-reply-sidecar');
+    log('--no-sidecar-cleanup (no-op for genie, retained for cross-CLI portability)');
+  }
+  return skipList;
+}
+
+async function runLegacyCleanupSafe(skipList: Set<string>): Promise<CleanupReport> {
+  try {
+    return await cleanupLegacyArtifacts(skipList);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log(`Legacy artifact cleanup failed (non-fatal): ${msg}`);
+    return { entries: [] };
+  }
 }
 
 /**
@@ -1018,10 +1409,11 @@ function printDiagnosticsSummary(diagnostics: { path: string; signals: RecentLog
 async function capturePostUpdateDiagnostics(
   diagnosticsCtx: UpdateDiagnosticsContext | undefined,
   maintenance: { outcome: 'completed' | 'failed'; durationMs: number; lines: string[]; error?: string },
+  extras: UpdateDiagnosticsExtras,
 ): Promise<void> {
   if (!diagnosticsCtx) return;
   try {
-    const diagnostics = await collectUpdateDiagnostics(diagnosticsCtx, maintenance);
+    const diagnostics = await collectUpdateDiagnostics(diagnosticsCtx, maintenance, extras);
     printDiagnosticsSummary(diagnostics);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -1029,12 +1421,52 @@ async function capturePostUpdateDiagnostics(
   }
 }
 
+/**
+ * Print the 3-line verify banner. Genie has no auth row (no auth model), so
+ * the banner is 2 lines for ok / health-unreachable / version-mismatch and
+ * collapses to 1 line for skipped variants.
+ */
+function printVerifyBanner(result: VerifyResult): void {
+  console.log();
+  for (const line of formatVerifyBanner(result)) console.log(`  ${line}`);
+  console.log();
+}
+
+interface MaintenanceOptions {
+  skipMaintenance?: boolean;
+  noRestart?: boolean;
+  noVerify?: boolean;
+}
+
 async function runPostUpdateMaintenanceSafe(
-  options: { skipMaintenance?: boolean } = {},
-  diagnosticsCtx?: UpdateDiagnosticsContext,
+  options: MaintenanceOptions,
+  diagnosticsCtx: UpdateDiagnosticsContext,
+  cleanupReport: CleanupReport,
 ): Promise<void> {
+  // `--no-restart` short-circuits BOTH maintenance and verify. Diagnostics
+  // still get written (with a `skipped` verify variant) so operators have a
+  // record of every invocation.
+  if (options.noRestart) {
+    log('--no-restart: skipping maintenance and verify probe.');
+    const verify = await runVerifyProbe({ cliVersion: VERSION, skipReason: 'no-restart' });
+    printVerifyBanner(verify);
+    await capturePostUpdateDiagnostics(
+      diagnosticsCtx,
+      { outcome: 'completed', durationMs: 0, lines: [] },
+      { verify, cleanups: cleanupReport },
+    );
+    return;
+  }
+
   if (options.skipMaintenance || isTruthyEnv(process.env.GENIE_UPDATE_SKIP_MAINTENANCE)) {
     log('Skipping post-update maintenance (requested).');
+    const verify = await runVerifyProbe({ cliVersion: VERSION, skipReason: 'no-restart' });
+    printVerifyBanner(verify);
+    await capturePostUpdateDiagnostics(
+      diagnosticsCtx,
+      { outcome: 'completed', durationMs: 0, lines: [] },
+      { verify, cleanups: cleanupReport },
+    );
     return;
   }
   const startedAt = Date.now();
@@ -1050,10 +1482,28 @@ async function runPostUpdateMaintenanceSafe(
     maintenanceError = err instanceof Error ? err.message : String(err);
     error(`Post-update maintenance skipped: ${maintenanceError}`);
   }
-  await capturePostUpdateDiagnostics(diagnosticsCtx, {
-    outcome,
-    durationMs: Date.now() - startedAt,
-    lines: maintenanceLines,
-    error: maintenanceError,
-  });
+
+  // Group 4: verify probe AFTER maintenance. `--no-verify` produces the
+  // `skipped: no-verify-flag` variant so diagnostics still record the
+  // intentional bypass.
+  const verify = options.noVerify
+    ? await runVerifyProbe({ cliVersion: VERSION, skipReason: 'no-verify-flag' })
+    : await runVerifyProbe({ cliVersion: VERSION });
+  printVerifyBanner(verify);
+
+  await capturePostUpdateDiagnostics(
+    diagnosticsCtx,
+    {
+      outcome,
+      durationMs: Date.now() - startedAt,
+      lines: maintenanceLines,
+      error: maintenanceError,
+    },
+    { verify, cleanups: cleanupReport },
+  );
+
+  // Exit 1 on health-unreachable unless --no-verify was set (escape hatch).
+  if (verify.kind === 'health-unreachable' && !options.noVerify) {
+    process.exitCode = 1;
+  }
 }

--- a/src/genie.ts
+++ b/src/genie.ts
@@ -215,7 +215,12 @@ program
   .description('Update Genie CLI to the latest version')
   .option('--next', 'Switch to dev builds (npm @next tag)')
   .option('--stable', 'Switch to stable releases (npm @latest tag)')
+  .option('-y, --yes', 'Skip the TTY confirmation prompt (or set GENIE_UPDATE_YES=1)')
+  .option('--no-restart', 'Skip post-update maintenance AND the verify probe')
+  .option('--no-verify', 'Run maintenance but skip the post-restart verify probe')
   .option('--skip-maintenance', 'Skip post-update maintenance (or set GENIE_UPDATE_SKIP_MAINTENANCE=1)')
+  .option('--skip-cleanup <names>', 'Comma-separated legacy-artifact cleanup names to skip')
+  .option('--no-sidecar-cleanup', 'Accepted for cross-CLI portability with omni (no-op for genie)')
   .action(updateCommand);
 program
   .command('migrate')


### PR DESCRIPTION
## Summary

Closes [`update-unify-stages`](.genie/wishes/update-unify-stages/WISH.md). Absorbs omni's parity shapes into `genie update` and lands the rest of the wish (pre-flight version check, verify probe, diagnostics v2). Public shape (`VerifyResult`, `LegacyArtifact`, flags, exit codes, diagnostics schema discriminator) is byte-identical to omni's sibling wish per `SHARED-DESIGN.md`.

### Wave 1 (commit `8ba2ae24`)

- **G1** — `decideVerify` pure function + `VerifyResult` tagged-union (`ok` / `health-unreachable` / `version-mismatch` / `auth-invalid` / `skipped`) and `normalizeVersion` helper.
- **G2** — `src/genie-commands/legacy-cleanup.ts`: `LegacyArtifact` interface, empty day-one `REGISTRY`, `cleanupLegacyArtifacts(skipList)` returning `CleanupReport`. Day-one entry-point for future cleanups; omni absorbs the type signatures verbatim.

### Wave 2 (commit `3d8f84a4`)

- **G3** — Pre-flight registry version check + `--yes` / `-y` / `GENIE_UPDATE_YES`. `fetchLatestVersion(channel)` (5s timeout, null-on-failure), `shortCircuitIfCurrent(current, latest)` (pure decider on normalized strings), `promptConfirm` (TTY prompt, auto-confirm in non-TTY). On a current install, exits 0 in `<2s` with `Already up to date (vX.Y.Z, channel <c>)`.
- **G4** — Post-restart health probe via `pgserve status --json` + `~/.genie/serve.pid` liveness. `runVerifyProbe(opts)` polls 15s deadline / 500ms interval (test-overridable seams). `--no-restart` skips both maintenance and probe; `--no-verify` runs maintenance but skips probe; both record the matching `skipped` variant in diagnostics. Exit 1 on `health-unreachable` unless `--no-verify`.
- **G5** — Diagnostics `verify` + `cleanups` blocks; `schemaVersion` bump 1 → 2 with bump policy documented in header. `NO_COLOR` / `FORCE_COLOR` / TTY honored via `colorEnabled()` helper. Direct ANSI prints retained — full `ora`/`chalk` migration deferred to the parallel `output-primitives-unified` wish per coordination note.

## Validation

- ✅ `bun run typecheck` — clean
- ✅ `bun run lint` — clean (2 pre-existing test-fixture symlink warnings, unrelated)
- ✅ `bun run build` — `dist/genie.js` 5.4M, all flags exposed in `genie update --help`
- ✅ `bun test src/genie-commands/__tests__/update.test.ts src/genie-commands/__tests__/legacy-cleanup.test.ts` — 62 pass / 0 fail / 102 expects

## Test plan

- [ ] CI: typecheck + lint + dead-code + tests on `dev`
- [ ] Reviewer spot-check that `decideVerify` shape matches omni's sibling wish byte-for-byte
- [ ] Smoke: `genie update --yes` on a current install → exit 0 in <2s with locked banner
- [ ] Smoke: `genie update --no-verify` → maintenance runs, banner shows `(skipped: no-verify-flag)`, diagnostics records the variant
- [ ] Smoke: `genie update --no-restart` → no maintenance, no probe, diagnostics records `skipped: no-restart`
- [ ] Smoke: `genie update --no-sidecar-cleanup` → one-line "(no-op for genie, retained for cross-CLI portability)" notice

## Backstory

Wave 1 ran during a pgserve outage on the orchestration side; engineers wrote G1+G2 to disk but couldn't call `genie done`/`genie send` because mailbox FK violations blocked them. The work was committed manually as `8ba2ae24`. Wave 2 was implemented directly because pgserve recovery left agent constraints rejecting fresh inserts — re-dispatching `genie work` would have just accumulated zombie executors. Same code, same shapes, same tests; just one fewer hop through the orchestration plane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)