### PR TITLE
feat(db): pgserve transport discovery — UDS-first, TCP fallback

### DIFF
--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -1152,10 +1152,15 @@ describe('resolvePgserveTransport (transport discovery)', () => {
     const originalPath = process.env.PATH;
     const originalForceTcp = process.env.GENIE_PG_FORCE_TCP;
     const originalForceSocket = process.env.GENIE_PG_FORCE_SOCKET;
+    const originalPgPort = process.env.GENIE_PG_PORT;
     process.env.PATH = '/nonexistent';
     process.env.GENIE_PG_FORCE_TCP = '1'; // skip UDS probe
     // biome-ignore lint/performance/noDelete: process.env requires actual unset
     delete process.env.GENIE_PG_FORCE_SOCKET;
+    // GENIE_PG_PORT must NOT be set — that path takes precedence over
+    // discovery and would let this test pass for the wrong reason.
+    // biome-ignore lint/performance/noDelete: process.env requires actual unset
+    delete process.env.GENIE_PG_PORT;
     try {
       const { resolvePgserveTransport } = await import('./db.js');
       await expect(resolvePgserveTransport()).rejects.toThrow(/pgserve is not reachable/);
@@ -1169,6 +1174,79 @@ describe('resolvePgserveTransport (transport discovery)', () => {
       // biome-ignore lint/performance/noDelete: process.env requires actual unset
       if (originalForceSocket === undefined) delete process.env.GENIE_PG_FORCE_SOCKET;
       else process.env.GENIE_PG_FORCE_SOCKET = originalForceSocket;
+      // biome-ignore lint/performance/noDelete: process.env requires actual unset
+      if (originalPgPort === undefined) delete process.env.GENIE_PG_PORT;
+      else process.env.GENIE_PG_PORT = originalPgPort;
     }
+  });
+
+  test('GENIE_PG_PORT escape hatch returns tcp transport without invoking pgserve CLI', async () => {
+    // Codex review-finding on PR #1667: `GENIE_PG_FORCE_TCP=1 GENIE_PG_PORT=N`
+    // was the legacy escape hatch for hosts without the pgserve CLI on PATH.
+    // The new resolver must honor it before falling through to `pgserve port`
+    // discovery so this contract survives transport-discovery rollout.
+    const originalPath = process.env.PATH;
+    const originalForceTcp = process.env.GENIE_PG_FORCE_TCP;
+    const originalForceSocket = process.env.GENIE_PG_FORCE_SOCKET;
+    const originalPgPort = process.env.GENIE_PG_PORT;
+    process.env.PATH = '/nonexistent'; // no pgserve binary
+    process.env.GENIE_PG_FORCE_TCP = '1';
+    // biome-ignore lint/performance/noDelete: process.env requires actual unset
+    delete process.env.GENIE_PG_FORCE_SOCKET;
+    process.env.GENIE_PG_PORT = '12345';
+    try {
+      const { resolvePgserveTransport } = await import('./db.js');
+      const result = await resolvePgserveTransport();
+      expect(result).toEqual({ kind: 'tcp', host: '127.0.0.1', port: 12345 });
+    } finally {
+      if (originalPath !== undefined) process.env.PATH = originalPath;
+      // biome-ignore lint/performance/noDelete: process.env requires actual unset
+      else delete process.env.PATH;
+      // biome-ignore lint/performance/noDelete: process.env requires actual unset
+      if (originalForceTcp === undefined) delete process.env.GENIE_PG_FORCE_TCP;
+      else process.env.GENIE_PG_FORCE_TCP = originalForceTcp;
+      // biome-ignore lint/performance/noDelete: process.env requires actual unset
+      if (originalForceSocket === undefined) delete process.env.GENIE_PG_FORCE_SOCKET;
+      else process.env.GENIE_PG_FORCE_SOCKET = originalForceSocket;
+      // biome-ignore lint/performance/noDelete: process.env requires actual unset
+      if (originalPgPort === undefined) delete process.env.GENIE_PG_PORT;
+      else process.env.GENIE_PG_PORT = originalPgPort;
+    }
+  });
+
+  test('GENIE_PG_PORT with invalid value falls through to discovery', async () => {
+    // Out-of-range / non-numeric / empty values must not short-circuit to a
+    // bogus transport — caller falls back to discovery (which then fails on
+    // /nonexistent PATH and throws the both-unavailable hint).
+    const originalPath = process.env.PATH;
+    const originalForceTcp = process.env.GENIE_PG_FORCE_TCP;
+    const originalForceSocket = process.env.GENIE_PG_FORCE_SOCKET;
+    const originalPgPort = process.env.GENIE_PG_PORT;
+    process.env.PATH = '/nonexistent';
+    process.env.GENIE_PG_FORCE_TCP = '1';
+    // biome-ignore lint/performance/noDelete: process.env requires actual unset
+    delete process.env.GENIE_PG_FORCE_SOCKET;
+    for (const bogus of ['not-a-number', '0', '-1', '99999', '   ']) {
+      process.env.GENIE_PG_PORT = bogus;
+      try {
+        const { resolvePgserveTransport } = await import('./db.js');
+        await expect(resolvePgserveTransport()).rejects.toThrow(/pgserve is not reachable/);
+      } catch (err) {
+        // Re-throw with context so the failing input is obvious.
+        throw new Error(`GENIE_PG_PORT=${JSON.stringify(bogus)}: ${(err as Error).message}`);
+      }
+    }
+    if (originalPath !== undefined) process.env.PATH = originalPath;
+    // biome-ignore lint/performance/noDelete: process.env requires actual unset
+    else delete process.env.PATH;
+    // biome-ignore lint/performance/noDelete: process.env requires actual unset
+    if (originalForceTcp === undefined) delete process.env.GENIE_PG_FORCE_TCP;
+    else process.env.GENIE_PG_FORCE_TCP = originalForceTcp;
+    // biome-ignore lint/performance/noDelete: process.env requires actual unset
+    if (originalForceSocket === undefined) delete process.env.GENIE_PG_FORCE_SOCKET;
+    else process.env.GENIE_PG_FORCE_SOCKET = originalForceSocket;
+    // biome-ignore lint/performance/noDelete: process.env requires actual unset
+    if (originalPgPort === undefined) delete process.env.GENIE_PG_PORT;
+    else process.env.GENIE_PG_PORT = originalPgPort;
   });
 });

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -394,33 +394,37 @@ describe('daemon-owned pgserve', () => {
     expect(optionsBody).toContain('connect_timeout: resolvePgConnectTimeoutSeconds(transport.useSocket)');
   });
 
-  test('socket connections require the canonical daemon before dialing libpq path', () => {
+  test('production connections use UDS-first / TCP-fallback transport discovery', () => {
+    // Post-pgserve-transport-discovery: `_buildConnection` no longer hard-fails
+    // when the canonical UDS is missing. Instead it asks `resolvePgserveTransport()`
+    // for the live transport (UDS preferred, TCP via `pgserve port` as
+    // fallback). Test mode (GENIE_TEST_PG_PORT) keeps the legacy in-process
+    // TCP path because the test harness provisions its own pgserve --ram
+    // instance and exposes the port via env.
     const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
     const fnStart = source.indexOf('async function _buildConnection');
     expect(fnStart).toBeGreaterThan(-1);
     const body = source.slice(fnStart, source.indexOf('\n}\n', fnStart));
 
-    const useSocketIdx = body.indexOf('const useSocket = shouldUseUnixSocket()');
-    // Post-cutover: the daemon-ensure step is `requirePgserveDaemon` (probe
-    // only; never spawns). Locks out reintroduction of getOrStartDaemon as
-    // the call-site here.
-    const requireIdx = body.indexOf('if (useSocket) await requirePgserveDaemon()');
-    // Post-refactor (#1651): port resolution moved into resolveTransport. The
-    // dispatcher must call requirePgserveDaemon BEFORE resolveTransport (which
-    // dials the postmaster's port).
-    const transportIdx = body.indexOf('await resolveTransport(useSocket)');
+    // Test-mode short-circuit: keeps the existing TCP path for unit tests.
+    expect(body).toContain('const useTestModeTcp = Boolean(process.env.GENIE_TEST_PG_PORT)');
+    expect(body).toContain('await resolveTransport(false)');
 
-    expect(useSocketIdx).toBeGreaterThan(-1);
-    expect(requireIdx).toBeGreaterThan(useSocketIdx);
-    expect(transportIdx).toBeGreaterThan(requireIdx);
+    // Production path: probe transports via the new resolver.
+    expect(body).toContain('await resolvePgserveTransport()');
 
-    // The actual port-resolution pattern still exists, just inside resolveTransport.
-    const transportFnStart = source.indexOf('async function resolveTransport');
-    expect(transportFnStart).toBeGreaterThan(-1);
-    const transportBody = source.slice(transportFnStart, source.indexOf('\n}\n', transportFnStart));
-    expect(transportBody).toMatch(
-      /const port = useSocket \? \(discovery\?\.port \?\? 5432\) : await ensurePgserve\(\)/,
-    );
+    // Resolver must contain both probe primitives.
+    const resolverStart = source.indexOf('export async function resolvePgserveTransport');
+    expect(resolverStart).toBeGreaterThan(-1);
+    const resolverBody = source.slice(resolverStart, source.indexOf('\n}\n', resolverStart));
+    expect(resolverBody).toContain('probePgserveDaemon()');
+    expect(resolverBody).toContain('isPgserveSocketResponsive()');
+    expect(resolverBody).toContain('discoverTcpPgservePort()');
+    // Force-flag overrides: both legacy GENIE_PG_FORCE_TCP and new
+    // GENIE_PG_FORCE_SOCKET must remain wired so operators can pin one
+    // transport for diagnostics.
+    expect(resolverBody).toContain("process.env.GENIE_PG_FORCE_TCP === '1'");
+    expect(resolverBody).toContain("process.env.GENIE_PG_FORCE_SOCKET === '1'");
   });
 
   test('canonical-cutover removed every spawn helper from db.ts', () => {
@@ -453,8 +457,26 @@ describe('daemon-owned pgserve', () => {
     ]) {
       expect(source).not.toContain(symbol);
     }
-    // Also lock out the pgserve binary spawn invocation in any form.
-    expect(source).not.toMatch(/spawn\(\s*[^)]*pgserve/);
+    // Lock out pgserve binary spawn invocation, EXCEPT the read-only discovery
+    // subcommands (`port`, `url`, `status`). Discovery is consumer-only —
+    // it doesn't own the daemon's lifecycle, just reads the published state.
+    // The post-pgserve-transport-discovery TCP fallback uses `pgserve port`.
+    //
+    // Forbidden patterns (daemon ownership):
+    //   spawn('pgserve', ['daemon', ...])    // owning the daemon process
+    //   spawn('pgserve', [<no subcommand>])  // bare pgserve (foreground TCP install)
+    //   spawn('pgserve', ['install', ...])   // pm2 registration (genie shouldn't own it)
+    //
+    // Allowed patterns (read-only discovery):
+    //   spawn('pgserve', ['port'])
+    //   spawn('pgserve', ['url'])
+    //   spawn('pgserve', ['status', '--json'])
+    const spawnPgserveMatches = source.matchAll(/spawn(?:Sync)?\(\s*['"]pgserve['"]\s*,\s*\[([^\]]*)\]/g);
+    for (const match of spawnPgserveMatches) {
+      const args = match[1];
+      const firstArg = args.match(/['"]([^'"]+)['"]/)?.[1] ?? '';
+      expect(['port', 'url', 'status']).toContain(firstArg);
+    }
     expect(source).not.toContain('pkill');
   });
 
@@ -682,11 +704,14 @@ describe('parallel dispatch race (issue #1207)', () => {
     expect(body).toMatch(/finally\s*\{[^}]*buildPromise\s*=\s*null/);
   });
 
-  test('_buildConnection fire-and-forget teardown on post-connect failure', () => {
+  test('buildAndOpenConnection fire-and-forget teardown on post-connect failure', () => {
     // Same pattern as healthCheckCachedClient — if runPostConnectSetup fails,
     // tear down the doomed client without blocking concurrent work.
+    // Post-pgserve-transport-discovery: the catch lives in `buildAndOpenConnection`
+    // (the post-resolution helper); `_buildConnection` is now just the
+    // dispatcher that picks UDS vs. TCP.
     const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
-    const fnStart = source.indexOf('async function _buildConnection');
+    const fnStart = source.indexOf('async function buildAndOpenConnection');
     expect(fnStart).toBeGreaterThan(-1);
     const fnEnd = source.indexOf('\n}\n', fnStart);
     const body = source.slice(fnStart, fnEnd);
@@ -700,23 +725,25 @@ describe('parallel dispatch race (issue #1207)', () => {
     expect(catchBody).toMatch(/\.end\([^)]*\)\.catch\(/);
   });
 
-  test('_buildConnection probes the canonical daemon before socket connect', () => {
+  test('_buildConnection dispatches via resolvePgserveTransport (UDS-first / TCP-fallback)', () => {
+    // Post-pgserve-transport-discovery: the dispatcher no longer probes the
+    // canonical daemon directly — it asks `resolvePgserveTransport()` for the
+    // live transport (UDS preferred, TCP via `pgserve port` fallback). This
+    // test locks the new contract; the old probe-then-libpq-path is enforced
+    // inside `resolvePgserveTransport` itself by 'source enforces probe order'.
     const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
     const fnStart = source.indexOf('async function _buildConnection');
     expect(fnStart).toBeGreaterThan(-1);
+    const fnEnd = source.indexOf('\n}\n', fnStart);
+    const body = source.slice(fnStart, fnEnd);
 
-    const socketDecision = source.indexOf('const useSocket = shouldUseUnixSocket();', fnStart);
-    // Post-cutover: probe-only `requirePgserveDaemon()`; never spawns.
-    const daemonProbe = source.indexOf('if (useSocket) await requirePgserveDaemon();', fnStart);
-    // Direct-postmaster path: port comes from admin.json discovery when
-    // useSocket; falls back to libpq compat 5432 if discovery is missing.
-    const portDecision = source.search(
-      /const port = useSocket \? \(discovery\?\.port \?\? 5432\) : await ensurePgserve\(\)/,
-    );
+    // Test-mode path remains for unit-test harness compatibility.
+    const testModeIdx = body.indexOf('Boolean(process.env.GENIE_TEST_PG_PORT)');
+    // Production dispatch: always through resolvePgserveTransport.
+    const dispatchIdx = body.indexOf('await resolvePgserveTransport()');
 
-    expect(socketDecision).toBeGreaterThan(-1);
-    expect(daemonProbe).toBeGreaterThan(socketDecision);
-    expect(portDecision).toBeGreaterThan(daemonProbe);
+    expect(testModeIdx).toBeGreaterThan(-1);
+    expect(dispatchIdx).toBeGreaterThan(testModeIdx);
   });
 });
 
@@ -1046,5 +1073,102 @@ describe('cwd pin for stable pgserve identity (issue #1575)', () => {
     // beforeExit is the awaited drain path — fires on every clean exit.
     expect(source).toContain("process.on('beforeExit'");
     expect(source).toMatch(/process\.on\('beforeExit',\s*\(\)\s*=>\s*\{[\s\S]*?shutdown\(\)/);
+  });
+});
+
+// ============================================================================
+// pgserve transport discovery (UDS-first / TCP-fallback).
+//
+// Behavioral tests for `resolvePgserveTransport` — exercises real
+// system behavior with controlled env-var overrides. The function itself
+// is hermetic (no side effects beyond reading env + filesystem + spawning
+// `pgserve port`); we don't mock — instead we set GENIE_PG_FORCE_TCP=1 to
+// pin the deterministic TCP path and assert the resulting shape.
+// ============================================================================
+
+describe('resolvePgserveTransport (transport discovery)', () => {
+  test('GENIE_PG_FORCE_TCP=1 + reachable pgserve port → tcp transport', async () => {
+    // This test only runs when `pgserve port` is reachable on the host. CI
+    // hosts without pgserve installed get a skipped/no-op assertion.
+    const previous = process.env.GENIE_PG_FORCE_TCP;
+    process.env.GENIE_PG_FORCE_TCP = '1';
+    try {
+      const { resolvePgserveTransport } = await import('./db.js');
+      const result = await resolvePgserveTransport().catch((err: Error) => err);
+      if (result instanceof Error) {
+        // No pgserve binary or daemon → resolver throws the both-unavailable
+        // hint. Assert the message shape so future copy edits are caught.
+        expect(result.message).toContain('pgserve is not reachable');
+        expect(result.message).toContain('Recovery:');
+        return;
+      }
+      // pgserve was discoverable on TCP — assert the shape.
+      expect(result.kind).toBe('tcp');
+      if (result.kind === 'tcp') {
+        expect(result.host).toBe('127.0.0.1');
+        expect(Number.isInteger(result.port)).toBe(true);
+        expect(result.port).toBeGreaterThan(0);
+        expect(result.port).toBeLessThan(65536);
+      }
+    } finally {
+      // biome-ignore lint/performance/noDelete: process.env requires actual unset; assigning undefined leaves the literal string "undefined"
+      if (previous === undefined) delete process.env.GENIE_PG_FORCE_TCP;
+      else process.env.GENIE_PG_FORCE_TCP = previous;
+    }
+  });
+
+  test('PgserveTransport tagged-union shape is exhaustive', () => {
+    // Lock the surface so adding/removing a variant requires touching this
+    // exhaustiveness check. Mirrors the VerifyResult pattern from
+    // update-unify-stages G1.
+    type Probe = import('./db.ts').PgserveTransport;
+    const variants: Probe[] = [
+      { kind: 'unix', socketDir: '/tmp/pgserve-sock-x', port: 5432 },
+      { kind: 'tcp', host: '127.0.0.1', port: 8432 },
+    ];
+    expect(variants).toHaveLength(2);
+  });
+
+  test('source enforces probe order: UDS first, TCP fallback', () => {
+    const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
+    const fnStart = source.indexOf('export async function resolvePgserveTransport');
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnEnd = source.indexOf('\n}\n', fnStart);
+    const body = source.slice(fnStart, fnEnd);
+
+    const udsProbeIdx = body.indexOf('probePgserveDaemon()');
+    const tcpFallbackIdx = body.indexOf('discoverTcpPgservePort()');
+
+    expect(udsProbeIdx).toBeGreaterThan(-1);
+    expect(tcpFallbackIdx).toBeGreaterThan(-1);
+    // UDS probe must precede TCP fallback in the function body — that's the
+    // "native socket as default" contract.
+    expect(udsProbeIdx).toBeLessThan(tcpFallbackIdx);
+  });
+
+  test('discoverTcpPgservePort returns null when pgserve binary is absent', async () => {
+    // Force PATH to a directory with no pgserve binary so the spawn fails
+    // cleanly. Resolver falls back to throwing the both-unavailable hint.
+    const originalPath = process.env.PATH;
+    const originalForceTcp = process.env.GENIE_PG_FORCE_TCP;
+    const originalForceSocket = process.env.GENIE_PG_FORCE_SOCKET;
+    process.env.PATH = '/nonexistent';
+    process.env.GENIE_PG_FORCE_TCP = '1'; // skip UDS probe
+    // biome-ignore lint/performance/noDelete: process.env requires actual unset
+    delete process.env.GENIE_PG_FORCE_SOCKET;
+    try {
+      const { resolvePgserveTransport } = await import('./db.js');
+      await expect(resolvePgserveTransport()).rejects.toThrow(/pgserve is not reachable/);
+    } finally {
+      if (originalPath !== undefined) process.env.PATH = originalPath;
+      // biome-ignore lint/performance/noDelete: process.env requires actual unset
+      else delete process.env.PATH;
+      // biome-ignore lint/performance/noDelete: process.env requires actual unset
+      if (originalForceTcp === undefined) delete process.env.GENIE_PG_FORCE_TCP;
+      else process.env.GENIE_PG_FORCE_TCP = originalForceTcp;
+      // biome-ignore lint/performance/noDelete: process.env requires actual unset
+      if (originalForceSocket === undefined) delete process.env.GENIE_PG_FORCE_SOCKET;
+      else process.env.GENIE_PG_FORCE_SOCKET = originalForceSocket;
+    }
   });
 });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -371,15 +371,19 @@ const TCP_DISCOVERY_TIMEOUT_MS = 5_000;
  * Order:
  *   1. Canonical UDS: probe `$XDG_RUNTIME_DIR/pgserve/.s.PGSQL.5432` and
  *      complete a Postgres greet to confirm liveness. Use it if reachable.
- *   2. TCP via `pgserve port`: shell out to the pgserve CLI's published
+ *   2. Explicit TCP port (`GENIE_PG_PORT`): legacy escape hatch — when set,
+ *      bypass discovery and dial `127.0.0.1:<port>` directly. Survives hosts
+ *      without `pgserve` on PATH and dev shells that pin a known port.
+ *   3. TCP via `pgserve port`: shell out to the pgserve CLI's published
  *      discovery primitive (no daemon-mode auth requirement). Use the
  *      returned port at `127.0.0.1`.
- *   3. Throw with a hint that mentions both probe attempts.
+ *   4. Throw with a hint that mentions every probe attempt.
  *
  * Force-flag overrides:
- *   - `GENIE_PG_FORCE_SOCKET=1` skips step 2 (UDS-only).
- *   - `GENIE_PG_FORCE_TCP=1` skips step 1 (TCP-only). This was the legacy
- *     test/CI escape hatch and is still honored verbatim.
+ *   - `GENIE_PG_FORCE_SOCKET=1` skips steps 2 + 3 (UDS-only).
+ *   - `GENIE_PG_FORCE_TCP=1` skips step 1 (TCP-only). Legacy escape hatch;
+ *     pairs with `GENIE_PG_PORT` to pin to a known port without invoking the
+ *     `pgserve` CLI. Still honored verbatim post-transport-discovery.
  */
 export async function resolvePgserveTransport(): Promise<PgserveTransport> {
   const forceTcp = process.env.GENIE_PG_FORCE_TCP === '1';
@@ -403,13 +407,39 @@ export async function resolvePgserveTransport(): Promise<PgserveTransport> {
     }
   }
 
+  // Step 2: explicit TCP port via GENIE_PG_PORT env. Legacy contract — set
+  // this to dial a known port without running `pgserve port` discovery.
+  // Useful on hosts where pgserve isn't on PATH (CI, dev shells, custom
+  // build environments) but a postgres listener is up at a known port.
+  const explicitPort = parseExplicitTcpPort(process.env.GENIE_PG_PORT);
+  if (explicitPort !== null) {
+    return { kind: 'tcp', host: DEFAULT_HOST, port: explicitPort };
+  }
+
+  // Step 3: discover the TCP port via `pgserve port` subcommand.
   const tcpPort = await discoverTcpPgservePort();
   if (tcpPort !== null) {
     return { kind: 'tcp', host: DEFAULT_HOST, port: tcpPort };
   }
 
-  // Both probes failed. Build a richer hint that mentions both attempts.
+  // Step 4: every probe failed. Build a hint that mentions all attempts.
   throw new Error(buildBothTransportsUnavailableHint(forceTcp, forceSocket));
+}
+
+/**
+ * Parse the `GENIE_PG_PORT` env var into a valid TCP port number. Returns
+ * null when unset, malformed, or out of the valid `1..65535` range.
+ *
+ * Pre-transport-discovery contract: callers used this to pin force-TCP mode
+ * to a known port when pgserve discovery wasn't available. Preserved here so
+ * `GENIE_PG_FORCE_TCP=1 GENIE_PG_PORT=12345 genie ...` keeps working without
+ * the `pgserve` CLI on PATH (codex review-finding on PR #1667).
+ */
+function parseExplicitTcpPort(raw: string | undefined): number | null {
+  if (raw === undefined || raw === '') return null;
+  const parsed = Number.parseInt(raw.trim(), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 65535) return null;
+  return parsed;
 }
 
 /**
@@ -433,8 +463,14 @@ async function discoverTcpPgservePort(): Promise<number | null> {
     }, TCP_DISCOVERY_TIMEOUT_MS);
     timer.unref();
 
-    proc.stdout?.on('data', (chunk: Buffer) => {
-      stdout += chunk.toString('utf-8');
+    // setEncoding('utf8') guarantees stdout chunks arrive as already-decoded
+    // strings — no risk of a multi-byte character splitting across two
+    // chunks. `pgserve port` only emits ASCII (a port number + newline) so
+    // the practical risk is zero, but the explicit encoding documents intent
+    // and matches Node best practice for stdout-as-string consumers.
+    proc.stdout?.setEncoding('utf8');
+    proc.stdout?.on('data', (chunk: string) => {
+      stdout += chunk;
     });
     proc.on('error', () => {
       if (settled) return;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -339,6 +339,147 @@ function buildPgserveUnavailableHint(state: DaemonState): string {
   ].join('\n');
 }
 
+// ============================================================================
+// Transport discovery — Unix-socket first, TCP fallback.
+//
+// Genie historically required the canonical-daemon Unix socket at
+// `$XDG_RUNTIME_DIR/pgserve/.s.PGSQL.5432` (the daemon-mode listener) and
+// hard-failed when missing. After pgserve@^2.2 the `pgserve install` command
+// supervises FOREGROUND TCP mode (port 8432 by default; see
+// pgserve/src/cli-install.cjs:225-249 for the rationale: daemon mode requires
+// fingerprint+token auth which breaks plain libpq peers like genie+omni).
+//
+// This left genie self-defeating: the same install path that registered
+// pgserve also guaranteed the canonical UDS would never exist. To unify both
+// modes under one consumer, genie now tries the canonical UDS first
+// (preserves zero-config local-perf for hosts that opted into daemon mode),
+// then falls back to TCP discovered via `pgserve port`.
+//
+// `GENIE_PG_FORCE_TCP=1` skips the UDS probe entirely. `GENIE_PG_FORCE_SOCKET=1`
+// inverts: skip TCP fallback and require UDS. No flag → try both in order.
+// ============================================================================
+
+export type PgserveTransport =
+  | { kind: 'unix'; socketDir: string; port: number }
+  | { kind: 'tcp'; host: string; port: number };
+
+const TCP_DISCOVERY_TIMEOUT_MS = 5_000;
+
+/**
+ * Resolve the active pgserve transport with UDS preference and TCP fallback.
+ *
+ * Order:
+ *   1. Canonical UDS: probe `$XDG_RUNTIME_DIR/pgserve/.s.PGSQL.5432` and
+ *      complete a Postgres greet to confirm liveness. Use it if reachable.
+ *   2. TCP via `pgserve port`: shell out to the pgserve CLI's published
+ *      discovery primitive (no daemon-mode auth requirement). Use the
+ *      returned port at `127.0.0.1`.
+ *   3. Throw with a hint that mentions both probe attempts.
+ *
+ * Force-flag overrides:
+ *   - `GENIE_PG_FORCE_SOCKET=1` skips step 2 (UDS-only).
+ *   - `GENIE_PG_FORCE_TCP=1` skips step 1 (TCP-only). This was the legacy
+ *     test/CI escape hatch and is still honored verbatim.
+ */
+export async function resolvePgserveTransport(): Promise<PgserveTransport> {
+  const forceTcp = process.env.GENIE_PG_FORCE_TCP === '1';
+  const forceSocket = process.env.GENIE_PG_FORCE_SOCKET === '1';
+
+  if (!forceTcp) {
+    const udsState = probePgserveDaemon();
+    if (udsState.running && (await isPgserveSocketResponsive())) {
+      const discovery = readPostmasterDiscovery();
+      return {
+        kind: 'unix',
+        socketDir: discovery?.socketDir ?? resolvePgserveSocketDir(),
+        port: discovery?.port ?? 5432,
+      };
+    }
+    if (udsState.reason === 'socket present but pid stale' && (await isPgserveSocketResponsive())) {
+      return { kind: 'unix', socketDir: resolvePgserveSocketDir(), port: 5432 };
+    }
+    if (forceSocket) {
+      throw new Error(buildPgserveUnavailableHint(udsState));
+    }
+  }
+
+  const tcpPort = await discoverTcpPgservePort();
+  if (tcpPort !== null) {
+    return { kind: 'tcp', host: DEFAULT_HOST, port: tcpPort };
+  }
+
+  // Both probes failed. Build a richer hint that mentions both attempts.
+  throw new Error(buildBothTransportsUnavailableHint(forceTcp, forceSocket));
+}
+
+/**
+ * Discover the TCP port a pgserve foreground/install-mode process is bound
+ * on by shelling out to `pgserve port` — pgserve's published discovery
+ * primitive (see pgserve/src/cli-install.cjs `pgserve port` subcommand).
+ *
+ * Returns null on any failure: missing binary, non-zero exit, parse error,
+ * timeout. Caller treats null as "no TCP fallback available".
+ */
+async function discoverTcpPgservePort(): Promise<number | null> {
+  return new Promise((resolve) => {
+    let settled = false;
+    let stdout = '';
+    const proc = spawn('pgserve', ['port'], { stdio: ['ignore', 'pipe', 'ignore'] });
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      proc.kill('SIGTERM');
+      resolve(null);
+    }, TCP_DISCOVERY_TIMEOUT_MS);
+    timer.unref();
+
+    proc.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf-8');
+    });
+    proc.on('error', () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(null);
+    });
+    proc.on('close', (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (code !== 0) {
+        resolve(null);
+        return;
+      }
+      const parsed = Number.parseInt(stdout.trim(), 10);
+      if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 65535) {
+        resolve(null);
+        return;
+      }
+      resolve(parsed);
+    });
+  });
+}
+
+function buildBothTransportsUnavailableHint(forceTcp: boolean, forceSocket: boolean): string {
+  const lines = ['pgserve is not reachable on either transport.'];
+  if (!forceTcp) {
+    lines.push(`  • Unix socket probe: ${resolvePgserveLibpqSocketPath()} (not present or not responsive)`);
+  } else {
+    lines.push('  • Unix socket probe: skipped (GENIE_PG_FORCE_TCP=1)');
+  }
+  if (!forceSocket) {
+    lines.push('  • TCP discovery via `pgserve port`: failed (binary missing or no daemon)');
+  } else {
+    lines.push('  • TCP discovery: skipped (GENIE_PG_FORCE_SOCKET=1)');
+  }
+  lines.push('Recovery:');
+  lines.push('  pm2 status              # is pgserve registered?');
+  lines.push('  pgserve install         # register foreground TCP-mode pgserve under pm2');
+  lines.push('  pgserve daemon          # OR start daemon-mode (canonical UDS) standalone');
+  lines.push('See https://github.com/automagik-dev/genie/blob/main/docs/install.md for details.');
+  return lines.join('\n');
+}
+
 async function isPgserveSocketResponsive(): Promise<boolean> {
   const candidates = [resolvePgserveLibpqSocketPath(), resolvePgserveControlSocketPath()].filter((path) =>
     existsSync(path),
@@ -926,17 +1067,10 @@ export async function getConnection() {
   }
 }
 
-/**
- * Decide between Unix socket (pgserve v2 production path) and TCP loopback
- * (legacy + test mode). Test mode is selected by GENIE_TEST_PG_PORT — that
- * env var is set by src/lib/test-setup.ts (bun preload) which boots a
- * dedicated `pgserve --ram` instance for the suite. Production never sets it.
- */
-function shouldUseUnixSocket(): boolean {
-  if (process.env.GENIE_PG_FORCE_TCP === '1') return false;
-  if (process.env.GENIE_TEST_PG_PORT) return false;
-  return true;
-}
+// Note: `shouldUseUnixSocket` was the pre-transport-discovery toggle. It's
+// superseded by `resolvePgserveTransport()` (UDS-first / TCP-fallback) in
+// `_buildConnection`. Keeping the legacy env-var contract via `GENIE_PG_FORCE_TCP`
+// and `GENIE_PG_FORCE_SOCKET` inside the new resolver.
 
 let bannerPrinted = false;
 
@@ -966,10 +1100,30 @@ async function maybePrintBanner(client: postgres.Sql, isTestMode: boolean): Prom
 // biome-ignore lint/suspicious/noExplicitAny: postgres.js Sql type requires generics we don't need
 async function _buildConnection(): Promise<any> {
   const _t0 = Date.now();
-  const useSocket = shouldUseUnixSocket();
-  if (useSocket) await requirePgserveDaemon();
+  // Test mode (GENIE_TEST_PG_PORT) keeps the legacy in-process TCP path so
+  // src/lib/test-setup.ts's per-suite `pgserve --ram` instances stay
+  // observable without needing pgserve's CLI on PATH.
+  const useTestModeTcp = Boolean(process.env.GENIE_TEST_PG_PORT);
+  if (useTestModeTcp) {
+    const transport = await resolveTransport(false);
+    return await buildAndOpenConnection(transport, _t0);
+  }
 
-  const transport = await resolveTransport(useSocket);
+  // Production: try Unix socket first, fall back to TCP. The new
+  // `resolvePgserveTransport` handles both probes and force-flag overrides.
+  const probed = await resolvePgserveTransport();
+  const transport: Transport = {
+    useSocket: probed.kind === 'unix',
+    host: probed.kind === 'unix' ? probed.socketDir : probed.host,
+    port: probed.port,
+    pgWireCredential: probed.kind === 'unix' ? resolvePgserveAuthPassword() : resolveTcpPgPassword(),
+  };
+  return await buildAndOpenConnection(transport, _t0);
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: postgres.js Sql type bleed-through
+async function buildAndOpenConnection(transport: Transport, _t0: number): Promise<any> {
+  const useSocket = transport.useSocket;
   const _t1 = Date.now();
   const pgModule = (await import('postgres')).default;
 
@@ -1007,11 +1161,14 @@ async function _buildConnection(): Promise<any> {
     // Surface the resolved transport on the activePort singleton so diagnostics
     // (db status, printPgserveHealth) report the truth. Socket mode uses the
     // SOCKET_PORT_SENTINEL (0) since there is no TCP port to advertise; TCP
-    // mode already updates activePort via ensurePgserve().
+    // discovery via `pgserve port` writes the discovered port directly so the
+    // legacy ensurePgserve path no longer owns this side effect.
     if (useSocket) {
       activePort = SOCKET_PORT_SENTINEL;
-      process.env.GENIE_PG_AVAILABLE = 'true';
+    } else {
+      activePort = transport.port;
     }
+    process.env.GENIE_PG_AVAILABLE = 'true';
   } catch (err) {
     if (sqlClient === client) sqlClient = null;
     activePort = null;


### PR DESCRIPTION
## Summary

Genie hard-failed when the canonical daemon UDS at `\$XDG_RUNTIME_DIR/pgserve/.s.PGSQL.5432` was missing — but the supported registration path post-pgserve@^2.2 (`pgserve install`) supervises **foreground TCP mode**, never daemon mode (per [`pgserve/src/cli-install.cjs:225-249`](https://github.com/automagik-dev/pgserve/blob/main/src/cli-install.cjs#L225-L249): daemon mode requires a fingerprint+token handshake that breaks plain libpq peers like genie + omni). The same install path that registered pgserve guaranteed the canonical UDS would never exist — self-defeating loop.

This change replaces the hard fail with a **transport-discovery resolver**:

1. Probe canonical UDS first — preserves zero-config local-perf for hosts that opted into daemon mode standalone.
2. Fall back to TCP via `pgserve port` — pgserve's published discovery primitive (read-only consumer call, not a daemon-spawn).
3. Throw a richer hint that mentions both probe attempts when neither transport is reachable.

Force-flag overrides remain backward-compatible: `GENIE_PG_FORCE_TCP=1` skips the UDS probe (legacy test/CI escape hatch); new `GENIE_PG_FORCE_SOCKET=1` inverts to UDS-only for diagnostics.

## Public surface

```ts
export type PgserveTransport =
  | { kind: 'unix'; socketDir: string; port: number }
  | { kind: 'tcp'; host: string; port: number };

export async function resolvePgserveTransport(): Promise<PgserveTransport>;
```

## Smoke test

Live `resolvePgserveTransport()` on a host with `pgserve install` running (TCP-only foreground mode, no canonical daemon):

```
{ kind: 'tcp', host: '127.0.0.1', port: 8432 }
```

Pre-this-PR: throws `pgserve canonical daemon is not reachable (no daemon)`. Post-this-PR: succeeds via TCP fallback.

## Validation

- ✅ `bun run typecheck` clean
- ✅ `bun run lint` clean
- ✅ `bun run dead-code` no new findings
- ✅ `bun run build` — `dist/genie.js` 5.4M
- ✅ `bun test src/lib/db.test.ts` — 60 pass / 0 fail / 212 expects (with `GENIE_TEST_SKIP_PGSERVE=1` since pgserve is currently broken on the dev host and unrelated to this change)

## Test plan

- [ ] CI: typecheck + lint + dead-code + tests on `dev`
- [ ] Reviewer spot-check: confirm UDS probe still preferred when canonical daemon is up (run `pgserve daemon` standalone, verify `resolvePgserveTransport()` returns `{ kind: 'unix', … }`)
- [ ] Smoke: on a host with only `pgserve install` (foreground TCP) and no canonical daemon, confirm `genie wish status <slug>` succeeds via TCP fallback instead of erroring with "canonical daemon unreachable"

## Backstory

While dogfooding the genie + omni `update-unify-stages` PRs, the dev host's pgserve canonical daemon repeatedly went unreachable, blocking every `genie wish status` / `genie work` / `genie team create` call. Inspection showed the pm2-supervised pgserve was online on TCP `127.0.0.1:8432` (per `pgserve install`), and the new pgserve binary's foreground mode embeds a Postgres listener on TCP, but the canonical UDS-only probe in genie's `db.ts` was hardcoded to fail. The root cause was a contract drift between pgserve's install command (foreground TCP) and genie's connection probe (canonical-daemon UDS). This PR closes the drift on the genie consumer side; a separate pgserve-side wish (`autopg-distribution-cutover`) will eventually rename the pm2 entry and add a discovery file for the foreground socketDir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)