### PR TITLE
docs(wish): pgserve-singleton-no-proxy (genie consumer wiring + self-healing update)

### DIFF
--- a/.genie/wishes/pgserve-singleton-no-proxy/SHARED-DESIGN.md
+++ b/.genie/wishes/pgserve-singleton-no-proxy/SHARED-DESIGN.md
@@ -1,0 +1,334 @@
+# SHARED-DESIGN: pgserve singleton, no proxy, self-healing updates
+
+**Status**: design locked 2026-05-06.
+
+**Companion wishes** (byte-identical SHARED-DESIGN.md across all three):
+- `automagik/pgserve#pgserve-singleton-no-proxy` — pgserve major v2.3 (kill proxy, add cosign, new CLI verbs)
+- `automagik-dev/genie#pgserve-singleton-no-proxy` — genie consumer-side wiring + self-healing `genie update`
+- `automagik/omni#pgserve-singleton-no-proxy` — omni consumer-side wiring + self-healing `omni update`
+
+**Goal**: One synchronized cutover that converges three things — kill the bun proxy from the data plane, layer cosign-based publisher-attestation on top of host-signed identity, and lock down a self-healing `<cli> update` contract so every update converges drift to known-good state without manual operator intervention.
+
+**Version target**: pgserve **2.3** (not 3.0 — 3.0 reserved for the post-npm-departure cutover per `distribution-exodus`).
+
+---
+
+## 1. Today's friction (the diagnosis)
+
+### Three independent symptoms that have one root
+
+1. **Two pgserves on disk, only one understood.** `pm2 pgserve` (autopg 2.2.4) runs the bun bridge on TCP 8432 → routes to internal postgres on 9432 → exposes `/tmp/pgserve-sock-<pid>-<ts>` Unix socket. Genie expects pgserve socket at `$XDG_RUNTIME_DIR/pgserve/.s.PGSQL.5432`. **Mismatch:** genie's `requirePgserveDaemon()` (`src/lib/db.ts:307`) only checks the canonical Unix socket; throws "no daemon" even when bun bridge + postgres backend are both healthy on TCP. Live diagnostic on this server (2026-05-05): pgserve binary `pgserve port` returns `8432` ✅, postgres backend listening on 9432 ✅, but `/run/user/1000/pgserve/` directory does not exist ❌.
+
+2. **Genie was already cut over to consumer-only — but the cutover is invisible at runtime.** `pgserve-canonical-cutover` shipped on dev (commits `eefc9a94`, `bd8845eb`, `0ae69eb3`). `_ensurePgserve()` (`db.ts:749`) explicitly throws "Genie is consumer-only after the canonical-pgserve cutover; it does not spawn pgserve." Vendored pgserve binary in `node_modules/@automagik/genie/node_modules/pgserve/` was removed. Yet pm2 `genie-serve` (id 14) shows **18 restarts in 3 hours** with scheduler.log spamming "pgserve v2 daemon exited before binding". The canonical socket the cutover code expects doesn't exist; the cutover landed but didn't land cleanly because the **autopg pgserve doesn't publish to the canonical socket path** genie was consuming.
+
+3. **`genie update` is not self-healing.** Operator runs `genie update`, new binary installs to disk, BUT pm2's running process keeps the OLD binary in memory (no `pm2 restart genie-serve --update-env`). `<cli> doctor --fix` is not invoked. Migrations don't run automatically. Result: the cutover code shipped 2 days ago is on disk but not in any running process. Operator manually runs `pm2 restart genie-serve` after every update to actually pick up the new bits — and most don't.
+
+### The pattern
+
+Each symptom looks like a separate bug. The pattern is one architectural drift: the system has two control planes (bun pgserve daemon supervision via pm2, plus genie's own daemon supervision via pm2-and-process-tree-walking), and updates touch one but not the other. Every release widens the drift until the operator does manual reconciliation.
+
+---
+
+## 2. The shift (architectural target)
+
+### 2.1 Data plane: pure postgres, two transports, no proxy
+
+Postgres backend listens on **both** transports natively. Zero bun in the data path:
+
+- **Unix socket** at `$XDG_RUNTIME_DIR/pgserve/.s.PGSQL.5432` (canonical, primary). Set via postmaster `-k $XDG_RUNTIME_DIR/pgserve` argument.
+- **TCP** on port `5432` (canonical port, not 8432). Set via postmaster `-p 5432` and `listen_addresses = 'localhost'`.
+
+Clients connect with libpq directly — `PGHOST=$XDG_RUNTIME_DIR/pgserve` for socket, or `host=localhost port=5432` for TCP. No bridge. No router. No `8432`.
+
+The bun process that exists today as the proxy/router **dies in the data plane**. It survives only as the `pgserve` CLI binary, invoked on-demand for control operations.
+
+### 2.2 Control plane: CLI on-demand, zero always-on bun process
+
+The bun pgserve daemon is **deleted as a process**. All control-plane operations move to `pgserve` CLI subcommands invoked on-demand:
+
+- `pgserve provision <fingerprint>` — creates DB + role, validates trust tier (cosign / host_signed / path), idempotent. Called by client SDK on `3D000` (database-not-found) errors with `pg_advisory_lock` to dedupe concurrent races.
+- `pgserve gc` — sweeps orphaned databases (uid removed, project deleted via project-marker mtime checks). Run by cron / systemd timer, NOT a long-running scheduler. `pgserve install` wires the timer automatically.
+- `pgserve verify <binary-path>` — performs cosign / host_signed validation against trust list, writes HMAC-signed cache token at `$XDG_STATE_HOME/pgserve/verified/<fingerprint>.token`.
+- `pgserve trust add` / `pgserve trust list` / `pgserve trust remove` — manage user-extensible trust roots (cosign keys, OIDC issuer identities).
+- `pgserve doctor` (default) / `pgserve doctor --fix` (auto-mute safe mutations + prompt risky ones) / `pgserve doctor --fix --aggressive` (no prompts, CI mode).
+
+Audit becomes a postgres `pgaudit` extension load — no application-level audit-log writer. Logrotate config shipped with `pgserve install`.
+
+### 2.3 Identity & trust: signed vs not-signed (binary classification)
+
+Two outcomes, both persistent (no ephemeral, no TTL). Persistence is universal; the tier decides only trust + role grants.
+
+| Class | Verifies as | DB | Role grants | UX |
+|-------|-------------|-----|-------------|-----|
+| **signed** | cosign-verified OR host_signed handshake OR operator-pretrusted self-sign | persistent project DB | named role; full owner of own DB; can request explicit cross-DB grants (Tier 2 cosign-named only via `pgserve grant`) | silent run; badge in `pgserve doctor` |
+| **not signed** | everything else (no `pgserve` block in package.json, OR no signature, OR no handshake) | persistent project DB | full owner of own DB; **zero** cross-DB; whitelisted extensions only | RUN with warning banner: "⚠ UNSIGNED — DEV ONLY" |
+
+**Critical**: not-signed apps are NOT ephemeral. They get the same project-scoped persistent DB as signed apps. The differences are: (a) trust attestation, (b) named-role specifics (signed gets `pgserve_app_<publisher>`; not-signed gets generic `app_<fp>`), and (c) cross-DB grant capability (signed only).
+
+### 2.4 Trust list (cosign tier)
+
+- **Hardcoded automagik-dev**: compiled into `pgserve` binary. Identities accepted by default: `https://github.com/automagik-dev/genie/.github/workflows/release.yml@refs/tags/v*`, `https://github.com/automagik/omni/.github/workflows/release.yml@refs/tags/v*`, `https://github.com/automagik/pgserve/.github/workflows/release.yml@refs/tags/v*`. Updates to this list propagate via `pgserve update`.
+- **User self-sign**: `pgserve trust add --identity <issuer> --key <pubkey>` writes to `~/.pgserve/trust/identities.json`. HTTPS-self-signed analog: works locally for the operator, doesn't grant trust globally.
+- **Verification cadence**: HMAC-signed cache token at `$XDG_STATE_HOME/pgserve/verified/<fingerprint>.token` (web-session-style). Sliding expiry (1h idle, 7d max). Re-verify on binary mtime change. Steady-state connections pay 0ms; updates pay re-verify.
+
+### 2.5 No revocation infra v1
+
+Rationale: building a revocation pipeline (Rekor consultation, revoked.json sync, sigstore policy plugins) is overengineering for a local-DB use case where bad versions reach operators via `pgserve update` itself. The release pipeline IS the revocation channel:
+
+1. Bad version published (CVE, accidental data deletion, key compromise).
+2. Namastex publishes new release with the bad version added to the **hardcoded blocklist** in the new `pgserve` binary's compile-time constants.
+3. Operators get the fix via `pgserve update` — which now refuses the bad version.
+
+Trade: hosts that don't update for weeks remain vulnerable. Acceptable: cosign tier = official apps published controllably; if a host doesn't update, the operator has bigger problems than one bad genie release.
+
+### 2.6 No offline / TUF embedding v1
+
+Rationale: cosign keyless OIDC verification needs network for sigstore TUF roots + Rekor inclusion. But: genie/omni install ALREADY needs network to download the binary from the CDN. If the host can hit `cdn.automagik.dev`, it can hit `sigstore.dev`. Air-gap is not the target deployment for v1.
+
+Escape hatch: `pgserve trust add --offline-cosign-key <pubkey>` lets an operator pre-trust a static cosign key and run `pgserve verify --skip-sigstore` for fully air-gapped boxes. Not the default; not the marketing.
+
+### 2.7 Failure modes (Gatekeeper model)
+
+| Scenario | Behavior |
+|----------|----------|
+| App without `pgserve` block in `package.json` | RUN with warning banner; not-signed tier; persistent project DB; isolated role |
+| App with `package.json` `pgserve.identity_chain: ["cosign_signed", ...]`, ALL chain entries fail verify | **REFUSE** with diagnostic. App declared a tier and didn't deliver — that's tampering, not dev. |
+| App with `identity_chain` and at least one entry verifies | RUN at highest verified tier, silent |
+| Operator emergency override | `--unsafe-unverified <INCIDENT_ID>` typed-ack (existing pattern from `genie-supply-chain-signing`, helper `src/sec/unsafe-verify.ts`) |
+| Light dev-mode silence | `--accept-unsigned-dev` flag silences the warning banner for one invocation (no typed-ack required) |
+
+### 2.8 `package.json` opt-in shape
+
+```jsonc
+{
+  "pgserve": {
+    "publisher": "@automagik/genie",
+    "identity_chain": [
+      { "kind": "cosign_signed", "issuer": "https://github.com/automagik-dev/genie/.github/workflows/release.yml@refs/tags/v*" },
+      { "kind": "self_signed", "trust_root": "$HOME/.pgserve/trust/" }
+    ],
+    "on_chain_exhausted": "refuse"
+  }
+}
+```
+
+App declares ordered chain; pgserve tries each in order; falls back to next on miss; refuses if all fail. Apps with no `pgserve` block default to path/not-signed tier.
+
+---
+
+## 3. Self-healing `<cli> update` contract
+
+Every `<cli> update` (pgserve, genie, omni) — after this wish ships — converges drift to known-good state. The contract:
+
+### 3.1 Update pipeline (locked across all three CLIs)
+
+```
+1. resolveChannel(opts, config)             — already shipped (update-unify-stages)
+2. checkLatestVersion(channel)              — already shipped
+3. shortCircuitIfCurrent(...)               — already shipped
+4. preInstallPeerCheck(requirements)        — NEW: query peers' --version, refuse if upgrade would break
+5. confirmIfTTY(--yes)                      — already shipped
+6. confirmIfActiveTasks(genie ls --active)  — NEW: warn about in-flight work that pm2 restart will kill
+7. installBinary(channel)                   — already shipped
+8. runMigrations()                          — NEW: pg-side schema migrations + filesystem cleanup migrations (idempotent)
+9. pm2RestartSelfWithUpdateEnv()            — NEW: pm2 jlist → restart own pm2 entries with --update-env
+10. postRestartVerifyProbe()                — already shipped (verifyProbe + decideVerify)
+11. doctorFix(tiered: cat 1 + cat 2 prompts) — NEW: replaces the JSON dry-run-only post-update maintenance
+12. captureDiagnostics()                    — already shipped
+13. successBanner() OR refuseWithRemediation()
+```
+
+Steps marked NEW are what this wish adds.
+
+### 3.2 `<cli> doctor` tiered modes
+
+| Mode | Mutations | Prompts | Use case |
+|------|-----------|---------|----------|
+| `<cli> doctor` (default) | none — check only | n/a | Operator-initiated audit, exits non-zero on issues with remediation |
+| `<cli> doctor --fix` | auto-mutate **category 1** (safe), prompt **category 2** (data-touching) | one prompt per category-2 mutation | Default invocation by `<cli> update` step 11 |
+| `<cli> doctor --fix --aggressive` | auto-mutate cat 1 + cat 2, refuse cat 3 (irreversible-destructive) | none | CI / automation / explicit operator opt-in |
+
+**Mutation categories**:
+
+| Category | Examples | Authority |
+|----------|----------|-----------|
+| **Cat 1 (auto-mutate)** | pm2 restart, pm2 env update, config file rewrite (with .bak), forward-only schema migrations, install canonical socket symlink, refresh `pg_hba.conf` / `pg_ident.conf` | No prompt; audit-log entry per mutation |
+| **Cat 2 (prompt)** | Archive legacy data dirs (`~/.genie/data/pgserve` → `.legacy/pgserve-<ts>/`), drop dangling DBs over a size threshold, role permission changes | One prompt per mutation; `--yes` skips |
+| **Cat 3 (refuse)** | DROP DATABASE with content > 1MB, role privilege escalation, irreversible destructive | Refuse with `--unsafe-unverified <INCIDENT_ID>` typed-ack as override |
+
+### 3.3 Cross-CLI dependency enforcement
+
+- **Compile-time `requirements` manifest**: each binary has `<cli> --requirements --json` returning `{ pgserve: ">=2.3", omni: ">=2.5" }` etc.
+- **Pre-install check** (step 4 above): `<cli> update` queries `<peer> --version` for each declared peer; if upgrade would create incompatibility, refuses with remediation message: "genie 5.0 requires pgserve ≥3.0, you have 2.2.4. Run `pgserve update` first, then re-run `genie update`."
+- **Runtime check**: `<cli> serve` boot revalidates peer versions; refuses with same remediation if peer was downgraded or rolled back post-update. Reuses the canonical-cutover hard-error pattern.
+- **Override**: `<cli> update --ignore-peer-mismatch` typed-ack `I_ACKNOWLEDGE_PEER_MISMATCH` for debug/exotic flows.
+- **No orchestrator binary**: no `automagik update --all`. 3 sequential CLIs is fine; error messages guide ordering.
+
+### 3.4 Rollback (manual)
+
+If `<cli> update` step 10 (verify) fails:
+- Exit non-zero with remediation that points to existing `<cli> self-update --rollback` (per `genie-self-update` wish).
+- Do NOT auto-revert the binary. Forward-only schema migrations stay applied; partial-update state is operator's call to resolve.
+- Audit log captures the failure point with full diagnostics.
+
+### 3.5 Drain (no drain)
+
+`<cli> update` step 9 (`pm2 restart`) kills in-flight work. Auto-resume infra (worker rows, scheduler lease-recovery, mailbox retry) handles recovery. Step 6 (`confirmIfActiveTasks`) warns operator before kicking restart: "12 active tasks will be interrupted; --yes to proceed".
+
+---
+
+## 4. Roles & GRANTs (SQL preview)
+
+```sql
+-- For NOT SIGNED apps (default fallback when no signature/handshake/cosign)
+CREATE ROLE app_<fp> NOLOGIN NOCREATEDB NOCREATEROLE NOREPLICATION INHERIT;
+ALTER DATABASE app_<fp>_db OWNER TO app_<fp>;
+GRANT ALL PRIVILEGES ON DATABASE app_<fp>_db TO app_<fp>;
+GRANT USAGE ON FUNCTION install_whitelisted_extension(text) TO app_<fp>;
+-- nothing cross-DB. peer auth via pg_hba+ident.
+
+-- For SIGNED apps (host_signed, self_signed, OR cosign_signed)
+-- Same as above, plus:
+ALTER ROLE app_<fp> SET application_name TO 'signed:<identity_kind>:<publisher>';
+-- Visible in pg_stat_activity for ops debugging.
+
+-- For COSIGN_SIGNED with publisher in hardcoded official list:
+CREATE ROLE pgserve_app_<sanitize(name)> NOLOGIN NOCREATEROLE INHERIT;
+GRANT app_<fp> TO pgserve_app_<sanitize(name)>;  -- inherits per-fingerprint role
+-- Allows `pgserve grant <from-publisher> <to-publisher> SELECT ON <table>` for explicit cross-DB grants.
+```
+
+`pg_hba.conf` peer auth on Unix socket maps OS user → role via `pg_ident.conf`:
+```
+# pg_ident.conf (auto-generated by `pgserve provision`)
+pgserve_uid_to_role  <uid>   app_<resolved_fp>
+```
+
+---
+
+## 5. Repository scope
+
+### 5.1 `automagik/pgserve` (the big one, breaking-major v2.3)
+
+**Delete:**
+- Bun proxy from data plane: the libpq protocol routing layer, the always-on daemon listening on TCP 8432, the SO_PEERCRED-based startup-message rewriting, the in-memory connection routing.
+- `pgserve.persist: true` package.json flag (persistence is universal now).
+- Script-fallback fingerprint (`cmdline[1]`-based). Only path-based fingerprint (sha256(uid ‖ realpath(package.json or cwd))).
+- Ephemeral TTL 24h logic.
+
+**Add:**
+- `pgserve provision <fingerprint>` CLI verb (idempotent, `pg_advisory_lock`-deduped).
+- `pgserve verify <binary-path>` CLI verb (cosign + HMAC-signed cache token).
+- `pgserve trust add/list/remove` CLI verbs.
+- `pgserve gc` CLI verb (replaces in-daemon GC sweep).
+- `pgserve doctor` / `--fix` / `--fix --aggressive` tiered modes.
+- Hardcoded blocklist of known-bad versions (compile-time constant).
+- Cosign keyless OIDC verification primitives (reuse `genie-supply-chain-signing` if shared lib emerges; else vendor the verifier).
+- Postmaster boot args: `-k $XDG_RUNTIME_DIR/pgserve -p 5432 listen_addresses=localhost`.
+- `pgserve install` wires postgres systemd user unit / launchd plist / pm2 entry pointing at postmaster directly (no bun bridge).
+- `pgserve install` wires `pgserve gc` cron / systemd timer / launchd job.
+- `pgserve install` enables `pgaudit` extension and ships logrotate config.
+- Self-healing `pgserve update`: detects old proxy layout, stops bun bridge process, reconfigures postmaster args, updates pm2 entry, runs migrations, post-restart `pgserve doctor --fix`.
+- Compile-time `--requirements` manifest output.
+
+**Migration tooling for existing hosts** (one-shot, runs inside `pgserve update`):
+- Detect: pm2 has `pgserve` entry running bun on 8432 (old layout).
+- Action: stop bun process, reconfigure pm2 entry to launch postmaster directly with new args, update `~/.autopg/admin.json` to publish new socket dir, archive old socket dir to `.legacy/`.
+- Rollback: not auto; manual via `pgserve install --restore-bridge` if needed (operator-decided).
+
+### 5.2 `automagik-dev/genie`
+
+**Add:**
+- Active assertion in startup: if `node_modules/@automagik/genie/node_modules/pgserve/bin/` is present (legacy host with stale cache), warn loud + skip + emit `rot.vendored-pgserve.detected` audit event. Defensive against regression.
+- Tier integration in `src/lib/db.ts` connection path: read package.json `pgserve` block, call `pgserve verify` CLI on first connect, present resulting tier identity to postgres via `application_name`.
+- `genie update` step 8 (runMigrations): ensure all genie migrations (incl. cleanup of `~/.genie/data/pgserve` legacy data dir → `.legacy/`) run.
+- `genie update` step 9 (pm2 restart): after binary install, run `pm2 restart genie-serve --update-env`. Honor `--no-pm2-restart` for environments without pm2.
+- `genie update` step 11 (doctor --fix): wire the tiered `genie doctor --fix` invocation, default mode (cat 1 auto + cat 2 prompts).
+- `genie doctor` extended with `--fix` and `--fix --aggressive` flags per the tiered model.
+- Compile-time `requirements` manifest declaring `pgserve: ">=2.3"`. Pre-install check enforces.
+- Pre-install confirm: query `genie ls --active --json` count; if >0, show warning ("N active tasks will be interrupted; --yes to proceed").
+- Update `package.json` to declare `pgserve.identity_chain: [{ kind: "cosign_signed", issuer: "https://github.com/automagik-dev/genie/.github/workflows/release.yml@refs/tags/v*" }]`.
+- `genie pgserve handshake` CLI command continues to work (existing from `pgserve-host-signed-identity`); now also exposes `genie pgserve verify` (alias for `pgserve verify` against the bundled binary path).
+
+**Delete:**
+- Any leftover dependency on TCP 8432 in db.ts connection-string defaults. Default to `host=$XDG_RUNTIME_DIR/pgserve port=5432` (Unix socket) with TCP-localhost fallback.
+
+### 5.3 `automagik/omni`
+
+**Add:**
+- Same self-healing wiring as genie: pm2 restart self, doctor --fix tiered, requirements manifest, pre-install peer check.
+- Tier integration in connection setup: `package.json` `pgserve.identity_chain` declared; `pgserve verify` invoked.
+- `omni doctor --fix` tiered modes (cat 1+2 prompted, --aggressive opts in).
+- Update default `DATABASE_URL` env construction to prefer Unix socket → `$XDG_RUNTIME_DIR/pgserve/.s.PGSQL.5432`. TCP localhost:5432 fallback.
+
+**Delete:**
+- TCP 8432 dependence in `buildRuntimeEnv` and any hardcoded port references.
+- Phase-2 canonical-pgserve preflight `checkCanonicalPgservePreflight` — it was a transitional guard for phase 2; phase 3 (this wish) makes the canonical socket the default.
+
+---
+
+## 6. Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | pgserve **2.3** (not 3.0) | 3.0 reserved for post-npm-departure cutover (`distribution-exodus`). 2.3 captures architectural shift cleanly without conflating with the npm exit. |
+| 2 | Daemon dies entirely; CLI on-demand for control plane | Council 3-of-4 (simplifier, operator, questioner) lean toward kill-the-daemon. Architect's load-bearing concern (provision rate >1/min steady state) doesn't apply: provisions are once-per-fingerprint-per-host-lifetime. |
+| 3 | Postgres exposes BOTH Unix socket AND TCP 5432 natively | Unix socket = canonical fast path (no TCP overhead). TCP 5432 = compat with clients that can't do Unix sockets (some bun runtimes, k8s pod-to-pod, dev tools). Both native = zero proxy. |
+| 4 | Binary classification signed-vs-unsigned (not 3 tiers) | Within "signed" sub-cases (host_signed, self_signed, cosign_signed) differ in role grants but not persistence/UX. Two-state mental model. |
+| 5 | All apps get persistent project-scoped DB (no ephemeral) | Drops complexity (script-fallback fingerprint, TTL sweep, persist flag). Persistence is universal; tier decides only trust + role grants. |
+| 6 | Hardcoded automagik trust list compiled into pgserve binary | Trust root is opaque to operators; updates flow via `pgserve update`. User self-sign via `pgserve trust add` for personal apps. |
+| 7 | No active revocation infra v1 | Rekor consultation + revoked.json sync = overengineering. Bad versions blocked via hardcoded blocklist propagated through `pgserve update`. |
+| 8 | No offline TUF v1; air-gap = `pgserve trust add --offline-cosign-key` escape | Sigstore.dev is reachable from any host that can reach our CDN. Air-gap is a niche; ship escape hatch, don't complicate the default. |
+| 9 | Update step 9 (pm2 restart) without drain; auto-resume recovers in-flight tasks | Drain semantics = engineering effort with marginal payoff. Existing `auto-resume`, `lease-recovery`, mailbox-retry handle the recovery class. |
+| 10 | Manual rollback (no auto-revert on verify failure) | Exit non-zero + remediation; operator decides. Forward-only schema migrations + `genie self-update --rollback` cover the backward path. |
+| 11 | No orchestrator binary | 3 sequential `<cli> update` commands is fine. Error messages guide ordering. `automagik update --all` is YAGNI. |
+| 12 | Independent implementations per repo, byte-identical SHARED-DESIGN.md only | Same pattern as `update-unify-stages`, `output-primitives-unified`. Coupling cost > duplication cost. |
+
+---
+
+## 7. Cross-wish dependencies
+
+- **builds-on** `pgserve-canonical-cutover` (genie, merged) — consumer-only model is the foundation; this wish completes the remaining gap.
+- **builds-on** `pgserve-host-signed-identity` (genie merged, pgserve pending) — this wish adds cosign as Tier 2 on top of the host_signed Tier 1.
+- **builds-on** `update-unify-stages` (all merged) — pre-flight check, decideVerify, diagnostics JSON shape inherited; this wish extends with steps 4, 6, 8, 9, 11 of the pipeline.
+- **builds-on** `genie-supply-chain-signing` — reuses `--unsafe-unverified <INCIDENT_ID>` typed-ack helper.
+- **enables** `distribution-exodus` v3 cutover (post-npm) — clean separation of concerns means npm departure can be its own wish without entangling the proxy/socket cutover.
+
+---
+
+## 8. Breaking-change inventory
+
+| Surface | Old behavior | New behavior | Affected |
+|---------|--------------|--------------|----------|
+| Connection target | `localhost:8432` (bun bridge) | `$XDG_RUNTIME_DIR/pgserve/.s.PGSQL.5432` (Unix) or `localhost:5432` (TCP) | Every consumer; transition handled by self-healing `<cli> update` |
+| pm2 entry `pgserve` | Tracks bun bridge process | Tracks postgres backend directly | Operators (transparent if they only `pgserve update`) |
+| Bun daemon process | Always-on on every host | Deleted | Anyone querying the daemon's API directly (none known) |
+| `pgserve_meta.identity_kind = 'script'` rows | Existed | Migrated to 'path' or archived | Existing pgserve installs |
+| `pgserve.persist: true` package.json flag | Read by daemon for TTL override | Ignored; persistence is universal | Apps that set it (no-op) |
+
+---
+
+## 9. Definition of done
+
+- [ ] All 3 PRs merged to their respective `dev` (or `main` for pgserve) branches.
+- [ ] `pgserve@2.3.0` published to CDN with cosign signature.
+- [ ] On a host with old layout (pm2 pgserve = bun bridge): single `pgserve update` reconfigures everything to new layout; `pgserve doctor` returns all-green; genie + omni + new test app all connect via `$XDG_RUNTIME_DIR/pgserve/.s.PGSQL.5432`; pm2 only has 1 pgserve entry tracking postgres directly.
+- [ ] On a fresh host: `pgserve install` → `genie install` → `omni install` → all green, with `pg_isready -h $XDG_RUNTIME_DIR/pgserve` returning OK and `psql -h $XDG_RUNTIME_DIR/pgserve` connecting cleanly.
+- [ ] Cosign verification: tampered binary at install fails verify with diagnostic; legitimate binary passes; cache token written and reused.
+- [ ] Self-healing: dirty pm2 env (binary on disk newer than running process) → `<cli> update` detects + `pm2 restart --update-env` heals. After update, running process matches filesystem version.
+- [ ] Cross-CLI deps: pre-install check refuses incompatible upgrade; runtime check refuses incompatible peer; `--ignore-peer-mismatch` typed-ack works.
+- [ ] No regression: existing host_signed handshake (genie #1569 merged) continues to work; existing `--unsafe-unverified` ack contract honored.
+- [ ] Audit trail: every `<cli> doctor --fix` mutation logs to diagnostics JSON; every blocked update logs reason; every verify failure logs identity expected vs received.
+
+---
+
+## 10. Out of scope
+
+- Sigstore policy plugins, transparency-log consultation, revoked.json sync (revocation infra v1 = blocklist-via-update).
+- Embedded TUF roots / offline-by-default verifier (escape hatch only).
+- `automagik update --all` orchestrator binary.
+- Cross-host pgserve federation (still single-host design per pgserve-v2).
+- npm departure (`distribution-exodus`-owned; this wish is npm-agnostic but assumes CDN binary distribution exists).
+- Drain-before-restart for in-flight tasks (auto-resume handles recovery).
+- Aegis runtime sandboxing (separate umbrella).
+- Migrating brain, rlmx, hapvida-eugenia, email consumer apps to use the new tier system (each app gets its own follow-up wish; this trio covers genie + omni only).

--- a/.genie/wishes/pgserve-singleton-no-proxy/WISH.md
+++ b/.genie/wishes/pgserve-singleton-no-proxy/WISH.md
@@ -1,0 +1,451 @@
+# Wish: genie consumer of pgserve singleton — no-proxy + tier integration + self-healing update
+
+| Field | Value |
+|-------|-------|
+| **Status** | DRAFT |
+| **Slug** | `pgserve-singleton-no-proxy` |
+| **Date** | 2026-05-06 |
+| **Author** | Felipe Rosa <felipe@namastex.ai> |
+| **Appetite** | medium (~1-2 weeks) |
+| **Branch** | `wish/pgserve-singleton-no-proxy` |
+| **Repos touched** | `automagik-dev/genie` |
+| **Design** | [SHARED-DESIGN.md](./SHARED-DESIGN.md) |
+
+> **Companion wishes** (byte-identical SHARED-DESIGN.md): `automagik/pgserve#pgserve-singleton-no-proxy` (the big one — kills proxy, adds cosign), `automagik/omni#pgserve-singleton-no-proxy` (consumer-side wiring). All three ship in parallel.
+
+## Summary
+
+Wire genie as a clean consumer of the new pgserve 2.3 singleton (no proxy, native socket + TCP 5432). Add tier integration via `pgserve verify` invocation in connection setup. Make `genie update` self-healing: pm2 restart self with `--update-env`, run all migrations, invoke `genie doctor --fix` (tiered) post-restart. Add active-vendored-pgserve assertion to defend against regression. Declare `pgserve: ">=2.3"` in compile-time `requirements` manifest. See `SHARED-DESIGN.md` §1-§9 for full design context, especially §5.2 for genie-specific scope.
+
+## Scope
+
+### IN
+
+**Group 1 — Tier integration in connection setup**
+- New `src/lib/pgserve-tier.ts`: reads `package.json` `pgserve` block; resolves identity_chain; calls `pgserve verify` CLI on first connect; returns resolved `{ tier, identity, role }` triple.
+- Wire into `_buildConnection()` in `src/lib/db.ts`: pass `application_name` to postgres reflecting tier (e.g., `signed:cosign:@automagik/genie`).
+- Update default connection target: prefer `host=$XDG_RUNTIME_DIR/pgserve` (Unix socket) → fallback `host=localhost port=5432` (TCP). Drop any `8432` references.
+- HMAC-cache-token consumer: read `$XDG_STATE_HOME/pgserve/verified/<fp>.token` if present; only call `pgserve verify` on cache miss or mtime change.
+- Add `genie pgserve verify` CLI alias: invokes `pgserve verify <bundled-binary-path>`. Diagnostic output for support cases.
+
+**Group 2 — Vendored-pgserve assertion**
+- Active startup check in `src/genie.ts` boot path: `existsSync(node_modules/@automagik/genie/node_modules/pgserve/bin/pgserve-wrapper.cjs)`.
+- If found: warn loud, emit `rot.vendored-pgserve.detected` audit event, do NOT spawn it (per consumer-only contract from canonical-cutover), continue boot.
+- Add a regression test: synthetic stale-cache fixture with vendored pgserve dir → assert the warning + audit event fire.
+
+**Group 3 — `genie update` self-healing pipeline**
+- Step 4 (preInstallPeerCheck): query `pgserve --version` + `omni --version`; refuse upgrade if peer below required (`pgserve: ">=2.3"`).
+- Step 6 (confirmIfActiveTasks): query `genie ls --active --json` count via local PG; if >0, show "N active tasks will be interrupted; --yes to proceed" warning.
+- Step 8 (runMigrations): wire `runMigrations()` to execute all pending genie migrations including new migration 002-cleanup-legacy-pgserve-datadir (archive `~/.genie/data/pgserve` → `~/.genie/.legacy/pgserve-<ts>/` if canonical detected).
+- Step 9 (pm2RestartSelfWithUpdateEnv): query `pm2 jlist`, identify entries owned by genie (`genie-serve`), `pm2 restart <entry> --update-env`. Honor `--no-pm2-restart` for environments without pm2 (CI fixtures, dev laptops without pm2).
+- Step 11 (doctorFix): replace post-update `runDoctor({ json: true, dryRun: true })` with `runDoctor({ fix: true, mode: 'tiered' })` per `SHARED-DESIGN.md` §3.2. Cat 1 silent; Cat 2 prompts; Cat 3 refuses.
+- Confirm prompt enhancements: pass `--ignore-peer-mismatch` typed-ack `I_ACKNOWLEDGE_PEER_MISMATCH` for debug.
+
+**Group 4 — `genie doctor` tiered modes**
+- Existing `genie doctor`: extend with `--fix` flag (tiered model: cat 1 auto, cat 2 prompt) and `--fix --aggressive` (cat 1+2 no prompt).
+- New mutations the doctor knows about:
+  - **Cat 1**: pm2 restart genie-serve with --update-env when filesystem version > running version; refresh tmux config / theme symlinks; refresh `~/.claude/plugins/cache/automagik/genie/<ver>` symlink; remove stale `.genie/state/*` lockfiles.
+  - **Cat 2**: archive `~/.genie/data/pgserve` legacy dir; clean orphaned worker rows >7 days old; drop ghost executor rows.
+  - **Cat 3**: any DROP DATABASE on a populated genie DB; role privilege escalation; force-overwrite of operator-modified config.
+- Audit-log every mutation with `{ category, action, before, after, durationMs }`.
+
+**Group 5 — `requirements` manifest + `--requirements` flag**
+- New compile-time constant `REQUIREMENTS = { pgserve: ">=2.3", omni: ">=2.5" }` in `src/lib/requirements.ts`.
+- New CLI: `genie --requirements --json` outputs the manifest as JSON.
+- `genie update` step 4 (preInstallPeerCheck) reads the published manifest of the target version (via `bunx npm view @automagik/genie@<channel> requirements` or via the binary's `--requirements` once installed) and verifies against currently-installed peer versions.
+- Refuse with diagnostic: "genie 5.0 requires pgserve ≥3.0, you have 2.2.4. Run `pgserve update` first."
+
+**Group 6 — `package.json` `pgserve` block + cosign identity declaration**
+- Update `package.json` with `pgserve.identity_chain`:
+  ```json
+  "pgserve": {
+    "publisher": "@automagik/genie",
+    "identity_chain": [
+      { "kind": "cosign_signed", "issuer": "https://github.com/automagik-dev/genie/.github/workflows/release.yml@refs/tags/v*" },
+      { "kind": "host_signed" }
+    ],
+    "on_chain_exhausted": "refuse"
+  }
+  ```
+- Drop `pgserve.persist: true` (universal persistence now per `SHARED-DESIGN.md` decision #5).
+- Documentation in `docs/install.md`: explain `identity_chain` semantics for downstream consumers.
+
+**Group 7 — Tests + docs + CHANGELOG**
+- Tier integration tests: `pgserve verify` invocation + cache-token roundtrip + `application_name` propagation.
+- Self-healing update tests: pm2-stale-binary fixture → `genie update` heals; pre-install peer mismatch → refuses; active-tasks confirm prompt.
+- Doctor tiered modes: cat 1 / cat 2 / cat 3 mutation behavior.
+- Vendored-pgserve assertion test.
+- Migration 002 archive idempotency.
+- README + install docs updated for new socket path + cosign tier model.
+- CHANGELOG entry.
+
+### OUT
+
+- Changes to pgserve repo itself (companion wish owns).
+- Changes to omni repo (companion wish owns).
+- New auth model beyond what `pgserve verify` returns (genie has no API-key auth concept today; `auth-invalid` variant of `VerifyResult` stays reserved-null).
+- Source-install path (`GENIE_SRC=...`) overhaul — existing path stays as-is; just the connection default changes.
+- Plugin cache sync changes — orthogonal.
+- Tmux config / theme refresh changes — orthogonal.
+- Aegis runtime sandboxing — separate umbrella.
+- Migrating brain consumer to use the new tier system — separate wish.
+
+## Decisions
+
+See `SHARED-DESIGN.md` §6 for the cross-repo decision table. genie-specific:
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| G1 | Default connection target = Unix socket (`$XDG_RUNTIME_DIR/pgserve`), TCP fallback | Performance + matches `resolvePgserveLibpqSocketPath()` already in `db.ts`. |
+| G2 | `pgserve verify` invocation cached via HMAC-signed token; never re-invoked steady-state | Per `SHARED-DESIGN.md` §2.4: web-session-style cache. Steady-state queries pay 0ms. |
+| G3 | `genie update` step 9 always restarts pm2 entries owned by genie (`genie-serve`); honors `--no-pm2-restart` for pm2-less environments | Self-healing requires the pm2 process to pick up new binary. Without this, the stale-binary defect persists indefinitely. |
+| G4 | Migration 002 archives `~/.genie/data/pgserve` → `.legacy/` (Cat 2 prompted in interactive mode; auto in `--aggressive`) | Forensic preservation; never auto-delete. |
+| G5 | Vendored-pgserve assertion is warn-only (not refuse) | Stale node_modules cache is operator's fault, not actively harmful (we don't spawn it). Loud warning is enough. |
+| G6 | `application_name` carries tier identity (e.g., `signed:cosign:@automagik/genie`) | Visible in `pg_stat_activity` for ops debugging without needing pgserve_meta lookup. |
+| G7 | `--ignore-peer-mismatch` requires typed-ack `I_ACKNOWLEDGE_PEER_MISMATCH` | Reuses pattern from `--unsafe-unverified`; not a casual override. |
+
+## Success Criteria
+
+- [ ] `_buildConnection()` defaults to Unix socket; TCP fallback works when XDG_RUNTIME_DIR unset.
+- [ ] No `8432` literal anywhere in genie source post-this-PR (`grep -rn '8432' src/` returns 0 hits in non-test, non-comment lines).
+- [ ] `genie pgserve verify` invokes `pgserve verify` against bundled binary; outputs tier identity.
+- [ ] First `genie spawn` after fresh install: `pgserve verify` runs, cache token written.
+- [ ] Second `genie spawn`: cache token read, `pgserve verify` not re-invoked.
+- [ ] Vendored `node_modules/.../pgserve/bin/` present: warning emitted, `rot.vendored-pgserve.detected` event written, boot continues.
+- [ ] `genie update` from stale-pm2 fixture: `pm2 jlist` shows running version < filesystem version pre-update; post-update they match.
+- [ ] `genie update` with peer mismatch (synthetic pgserve@2.2.x): refuses with remediation.
+- [ ] `genie update --ignore-peer-mismatch I_ACKNOWLEDGE_PEER_MISMATCH`: proceeds despite mismatch.
+- [ ] `genie update --no-pm2-restart`: skips pm2 restart cleanly.
+- [ ] `genie update` with 5 active tasks: shows warning prompt; `--yes` proceeds; declined exits 0.
+- [ ] `genie doctor --fix` (default): mutates Cat 1 silently; prompts Cat 2; refuses Cat 3.
+- [ ] `genie doctor --fix --aggressive`: cat 1+2 no prompt; refuses cat 3.
+- [ ] `genie --requirements --json` returns valid JSON `{"pgserve":">=2.3","omni":">=2.5"}`.
+- [ ] Migration 002: legacy `~/.genie/data/pgserve` archived to `.legacy/pgserve-<ts>/`; idempotent (re-run is no-op).
+- [ ] `package.json` declares `pgserve.identity_chain` + `publisher` + `on_chain_exhausted`.
+- [ ] Existing tests pass byte-identically.
+- [ ] `bun run check` passes.
+- [ ] CHANGELOG entry references socket path change + tier integration + self-healing update.
+
+## Execution Strategy
+
+### Wave 1 — Foundation (parallel)
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 1 | engineer | Tier integration: pgserve-tier helper + `_buildConnection` rewrite + Unix socket default. |
+| 2 | engineer | Vendored-pgserve assertion + audit event + regression test. |
+| 5 | engineer | Compile-time `requirements` manifest + `--requirements` flag. |
+
+### Wave 2 — Self-healing (sequential after Wave 1)
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 3 | engineer | `genie update` self-healing pipeline: peer check, active-tasks confirm, migrations, pm2 restart, doctor --fix. |
+| 4 | engineer | `genie doctor` tiered modes (--fix / --fix --aggressive). |
+| 6 | engineer | `package.json` `pgserve` block + `identity_chain` declaration + docs. |
+
+### Wave 3 — Validation
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 7 | engineer | Tests + docs + CHANGELOG. |
+
+## Execution Groups
+
+### Group 1: Tier integration in connection setup
+
+**Goal:** Genie connects to canonical pgserve via Unix socket by default; reads tier identity via `pgserve verify`; HMAC cache-token short-circuits steady-state.
+
+**Deliverables:**
+1. New `src/lib/pgserve-tier.ts`:
+   - `resolveTier(): Promise<TierResult>` reads `package.json` pgserve block, walks identity_chain, invokes `pgserve verify` CLI on cache miss.
+   - `TierResult` is tagged-union: `{ kind: 'cosign' | 'host_signed' | 'self_signed' | 'path', identity, role, applicationName }`.
+2. Modify `src/lib/db.ts` `_buildConnection()`:
+   - Default `host` = `$XDG_RUNTIME_DIR/pgserve` (Unix socket).
+   - Fallback `host=localhost port=5432` (TCP) if Unix socket unreachable.
+   - Set `application_name` from `TierResult`.
+3. Drop any `8432` literals from connection-string defaults.
+4. New `genie pgserve verify` CLI alias.
+5. Tests: cache-token roundtrip, fallback path, application_name propagation.
+
+**Acceptance Criteria:**
+- [ ] `_buildConnection()` defaults to Unix socket on hosts where `$XDG_RUNTIME_DIR/pgserve/.s.PGSQL.5432` exists.
+- [ ] `_buildConnection()` falls back to TCP 5432 when Unix socket unreachable.
+- [ ] `pgserve verify` is invoked exactly once per fingerprint per cache window.
+- [ ] `application_name` in `pg_stat_activity` matches resolved tier (e.g., `signed:cosign:@automagik/genie`).
+- [ ] `grep -rn '8432' src/` matches only test fixtures or comments referencing legacy.
+
+**Validation:**
+```bash
+bun test src/lib/__tests__/pgserve-tier.test.ts
+bun test src/lib/__tests__/db.test.ts
+grep -rn '8432' src/ | grep -v test | grep -v '//'
+```
+
+**depends-on:** none
+
+---
+
+### Group 2: Vendored-pgserve assertion
+
+**Goal:** Defensive assertion at boot prevents regression where stale node_modules cache reintroduces vendored pgserve. Warn loud, do not spawn.
+
+**Deliverables:**
+1. New helper `src/lib/vendored-pgserve-check.ts`: `existsSync(node_modules/@automagik/genie/node_modules/pgserve/bin/pgserve-wrapper.cjs)`.
+2. Wire into `src/genie.ts` boot path: emit warning to stderr + audit event `rot.vendored-pgserve.detected` + continue.
+3. Audit event schema: `{ vendored_path, host_pgserve_version, timestamp }`.
+4. Regression test: synthetic node_modules fixture with vendored pgserve → assert warning + event fire.
+
+**Acceptance Criteria:**
+- [ ] On host without vendored pgserve: zero overhead, no event.
+- [ ] On host with vendored pgserve: warning to stderr; audit event written; boot continues.
+- [ ] Boot does not spawn the vendored pgserve.
+- [ ] `genie doctor` reports the rot signal (signal source from existing rot detector pattern).
+
+**Validation:**
+```bash
+bun test src/lib/__tests__/vendored-pgserve-check.test.ts
+```
+
+**depends-on:** none
+
+---
+
+### Group 3: `genie update` self-healing pipeline
+
+**Goal:** `genie update` post-this-PR converges drift to known-good state.
+
+**Deliverables:**
+1. Modify `src/genie-commands/update.ts` to add 5 new pipeline steps per `SHARED-DESIGN.md` §3.1:
+   - **Step 4 (preInstallPeerCheck)**: query `pgserve --version` + `omni --version`; refuse upgrade if peer < required from manifest.
+   - **Step 6 (confirmIfActiveTasks)**: query `genie ls --active --json`; show count + warning prompt; `--yes` skips.
+   - **Step 8 (runMigrations)**: invoke migration runner (already exists from `update-unify-stages` G3); ensure migration 002-cleanup-legacy-pgserve-datadir runs.
+   - **Step 9 (pm2RestartSelfWithUpdateEnv)**: query pm2 jlist; for entries matching `genie-serve` pattern, run `pm2 restart <name> --update-env`. Honor `--no-pm2-restart`.
+   - **Step 11 (doctorFix)**: replace existing post-update maintenance with `runDoctor({ fix: true, mode: 'tiered' })`.
+2. New migration 002 at `src/migrations/steps/002-cleanup-legacy-pgserve-datadir.ts`:
+   - Detect `~/.genie/data/pgserve/` exists + canonical pgserve registered.
+   - Cat 2 prompted (default) or auto in `--aggressive`: `mv ~/.genie/data/pgserve ~/.genie/.legacy/pgserve-<iso>/`.
+   - Idempotent.
+3. `--ignore-peer-mismatch` typed-ack flag (reuse `src/sec/unsafe-verify.ts` pattern).
+4. Tests for all 5 new steps + the migration.
+
+**Acceptance Criteria:**
+- [ ] Stale-pm2 fixture: pre-update `pm2 jlist` shows version A; filesystem has version B; post-update `pm2 jlist` shows version B.
+- [ ] Synthetic pgserve@2.2.x peer: `genie update` refuses with remediation.
+- [ ] `genie update --ignore-peer-mismatch I_ACKNOWLEDGE_PEER_MISMATCH`: proceeds.
+- [ ] `--no-pm2-restart`: skips step 9 cleanly.
+- [ ] 5 active tasks fixture: prompt appears; `--yes` skips; declined exits 0.
+- [ ] Migration 002: legacy dir archived; second run no-op.
+
+**Validation:**
+```bash
+bun test src/genie-commands/__tests__/update.test.ts
+bun test src/migrations/__tests__/002-cleanup-legacy-pgserve-datadir.test.ts
+```
+
+**depends-on:** Group 5 (requirements manifest)
+
+---
+
+### Group 4: `genie doctor` tiered modes
+
+**Goal:** Doctor implements tiered fix authority: cat 1 silent, cat 2 prompt, cat 3 refuse.
+
+**Deliverables:**
+1. Extend `src/genie-commands/doctor.ts`:
+   - `--fix`: tiered (cat 1 auto, cat 2 prompt).
+   - `--fix --aggressive`: cat 1+2 no prompt.
+2. Cat 1 mutations enumerated:
+   - pm2 restart `genie-serve` when filesystem-version > running-version.
+   - Refresh tmux config / theme / `osc52-copy.sh` symlinks (existing logic in update.ts).
+   - Refresh `~/.claude/plugins/cache/automagik/genie/<ver>` symlink.
+   - Remove stale `.genie/state/*` lockfiles older than 1h.
+3. Cat 2 mutations enumerated:
+   - Archive `~/.genie/data/pgserve` legacy dir (delegates to migration 002).
+   - Clean orphaned worker rows >7 days old.
+   - Drop ghost executor rows (no live PID, no recent heartbeat).
+4. Cat 3 refusals enumerated:
+   - DROP DATABASE on populated genie DB.
+   - Role privilege escalation.
+   - Force-overwrite operator-modified config.
+5. Audit-log every mutation: `{ category, action, before, after, durationMs }`.
+6. Tests for each category.
+
+**Acceptance Criteria:**
+- [ ] `genie doctor` (no flags): check-only.
+- [ ] `genie doctor --fix`: mutates cat 1 silently; prompts each cat 2; refuses cat 3.
+- [ ] `genie doctor --fix --aggressive`: mutates cat 1+2 no prompt.
+- [ ] Audit log entry per mutation with full diff.
+
+**Validation:**
+```bash
+bun test src/genie-commands/__tests__/doctor-tiered.test.ts
+```
+
+**depends-on:** Group 3
+
+---
+
+### Group 5: `requirements` manifest + `--requirements` flag
+
+**Goal:** Genie declares peer version requirements at compile time; pre-install check enforces.
+
+**Deliverables:**
+1. New `src/lib/requirements.ts`:
+   - `export const REQUIREMENTS = { pgserve: ">=2.3", omni: ">=2.5" } as const;`
+   - `export function checkPeerVersion(peer, version): { ok: boolean, required: string }`.
+2. New CLI: `genie --requirements --json` outputs JSON.
+3. `genie update` step 4 (preInstallPeerCheck) calls `checkPeerVersion` for each peer; refuses on mismatch.
+4. Tests: requirements parse, peer check satisfied/unsatisfied paths.
+
+**Acceptance Criteria:**
+- [ ] `genie --requirements --json` outputs `{"pgserve":">=2.3","omni":">=2.5"}`.
+- [ ] `checkPeerVersion('pgserve', '2.3.0')` returns `{ok: true}`.
+- [ ] `checkPeerVersion('pgserve', '2.2.4')` returns `{ok: false, required: '>=2.3'}`.
+- [ ] `genie update` with peer < required refuses with remediation.
+
+**Validation:**
+```bash
+bun test src/lib/__tests__/requirements.test.ts
+genie --requirements --json | jq '.pgserve'
+```
+
+**depends-on:** none
+
+---
+
+### Group 6: `package.json` `pgserve` block + identity_chain
+
+**Goal:** Declare genie as cosign-signed app via package.json `pgserve` block.
+
+**Deliverables:**
+1. Update `package.json`:
+   ```json
+   "pgserve": {
+     "publisher": "@automagik/genie",
+     "identity_chain": [
+       { "kind": "cosign_signed", "issuer": "https://github.com/automagik-dev/genie/.github/workflows/release.yml@refs/tags/v*" },
+       { "kind": "host_signed" }
+     ],
+     "on_chain_exhausted": "refuse"
+   }
+   ```
+2. Drop `pgserve.persist: true` (universal persistence).
+3. Update `docs/install.md` with `identity_chain` explanation.
+
+**Acceptance Criteria:**
+- [ ] `package.json` has new `pgserve` block.
+- [ ] `pgserve.persist` flag removed.
+- [ ] Docs updated.
+- [ ] On signed release, `pgserve verify` resolves cosign tier; on local dev build, falls back to host_signed (TOFU); if both fail, refuse.
+
+**Validation:**
+```bash
+jq '.pgserve.identity_chain | length' package.json | grep -q 2
+test -f docs/install.md && grep -q identity_chain docs/install.md
+```
+
+**depends-on:** none
+
+---
+
+### Group 7: Tests + docs + CHANGELOG
+
+**Goal:** Lock the contracts; document the migration; verify cross-repo coordination.
+
+**Deliverables:**
+1. Test suite: tier integration, vendored assertion, self-healing pipeline (5 new steps), doctor tiered, migration 002, requirements manifest.
+2. README + `docs/install.md` updates: new socket path, tier model, identity_chain.
+3. CHANGELOG entry: tier integration, self-healing update, doctor tiered, requirements manifest, breaking-change notice (TCP 8432 → 5432; default Unix socket).
+4. Cross-repo coordination: confirm pgserve + omni companion wishes referenced.
+
+**Acceptance Criteria:**
+- [ ] `bun run check` clean.
+- [ ] CHANGELOG entry present with literal contract sentences.
+- [ ] README + install docs updated.
+- [ ] No regression in existing wishes' acceptance criteria.
+
+**Validation:**
+```bash
+bun run check
+grep -F "self-healing genie update" CHANGELOG.md
+test -f docs/install.md
+```
+
+**depends-on:** Group 4, Group 6
+
+---
+
+## Cross-wish dependencies
+
+- **paired-with** `automagik/pgserve#pgserve-singleton-no-proxy` — needs pgserve 2.3 CLI verbs + canonical socket. This wish targets a `dev` branch where pgserve 2.3 is installed; integration smoke test runs after pgserve sibling lands.
+- **paired-with** `automagik/omni#pgserve-singleton-no-proxy` — same semantics on omni side; ships in lockstep.
+- **builds-on** `pgserve-canonical-cutover` (merged) — consumer-only model is foundation; this wish completes the gap by wiring tier resolution + self-healing pm2 restart.
+- **builds-on** `pgserve-host-signed-identity` (merged) — host_signed Tier 1 stays; cosign Tier 2 layered.
+- **builds-on** `update-unify-stages` (merged) — pre-flight + decideVerify + diagnostics.
+- **builds-on** `genie-supply-chain-signing` — reuses `--unsafe-unverified` typed-ack pattern.
+
+## QA Criteria
+
+- [ ] Functional — `genie spawn engineer` on fresh host with pgserve 2.3: cosign verify runs once, cache persisted, subsequent spawns reuse cache.
+- [ ] Functional — `genie update` with stale pm2 binary: post-update pm2 version matches filesystem.
+- [ ] Functional — `genie update` with peer pgserve below required: refuses; remediation prints exact next command.
+- [ ] Functional — `genie doctor --fix` mutates Cat 1 silently; prompts Cat 2; refuses Cat 3 with remediation.
+- [ ] Functional — Migration 002 archives legacy data dir; idempotent.
+- [ ] Functional — Vendored pgserve fixture: warning + audit event fire; boot continues.
+- [ ] Integration — Companion pgserve provides canonical socket; genie connects via Unix socket primary.
+- [ ] Integration — `application_name` in `pg_stat_activity` reflects resolved tier.
+- [ ] Regression — All existing tests pass byte-identically.
+- [ ] Regression — Locked source-string for "post-update maintenance does not auto-start pgserve" still holds.
+- [ ] Cross-repo — Smoke test on canary host: pgserve 2.3 + genie 5.x + omni equivalent all green.
+
+---
+
+## Assumptions / Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `pgserve verify` slow on cold cache: blocks first connect by ~200ms | Medium | Acceptable for cold path; cache short-circuits steady-state. Benchmark in Group 1. |
+| pm2 restart kills in-flight tasks during update | Medium | Auto-resume infra recovers; confirm prompt warns operator. |
+| `--no-pm2-restart` becomes default in CI by accident | Low | Lint rule against in CI configs; warning emitted on every use. |
+| Vendored pgserve assertion fires on legitimately-old node_modules cache during `bun install` mid-flight | Low | Boot warning is informational; doesn't block. Operator clears cache and re-runs `bun install`. |
+| Identity_chain misconfigured (typo in issuer URL) → tier refusal in production | High | CI lint validates `package.json` pgserve block schema; tests cover the refuse path. |
+| Operator removed `~/.genie/data/pgserve` manually pre-migration | Low | Migration 002 detects absence and is no-op. |
+| Cosign verify requires network on first install in air-gapped CI | Medium | Document `pgserve trust add --offline-cosign-key` + `genie install --skip-cosign-verify` fallback (typed-ack required). |
+| Existing locked-string test "consumer-only after the canonical-pgserve cutover" needs string-mod | Low | Update test fixture; net behavior preserved. |
+
+---
+
+## Review Results
+
+_Populated by `/review` after execution completes._
+
+---
+
+## Files to Create/Modify
+
+```
+# Modify
+src/lib/db.ts                                          # _buildConnection default to Unix socket; drop 8432
+src/genie.ts                                           # vendored-pgserve assertion at boot
+src/genie-commands/update.ts                           # 5 new pipeline steps; --ignore-peer-mismatch
+src/genie-commands/doctor.ts                           # --fix tiered modes
+package.json                                           # pgserve.identity_chain block; drop persist:true
+CHANGELOG.md
+docs/install.md
+README.md
+
+# Create
+src/lib/pgserve-tier.ts
+src/lib/__tests__/pgserve-tier.test.ts
+src/lib/vendored-pgserve-check.ts
+src/lib/__tests__/vendored-pgserve-check.test.ts
+src/lib/requirements.ts
+src/lib/__tests__/requirements.test.ts
+src/migrations/steps/002-cleanup-legacy-pgserve-datadir.ts
+src/migrations/__tests__/002-cleanup-legacy-pgserve-datadir.test.ts
+src/genie-commands/__tests__/doctor-tiered.test.ts
+
+# Reference (read-only)
+.genie/wishes/pgserve-singleton-no-proxy/SHARED-DESIGN.md
+```


### PR DESCRIPTION
Companion wish to `automagik/pgserve#pgserve-singleton-no-proxy` (the big one). Byte-identical SHARED-DESIGN.md.

## Summary

Wire genie as clean consumer of pgserve 2.3 singleton. Add tier integration via `pgserve verify` invocation in connection setup. Make `genie update` self-healing: pm2 restart self with `--update-env`, run migrations, invoke `genie doctor --fix` tiered post-restart. Vendored-pgserve assertion as defensive guard. Compile-time `requirements` manifest.

## Scope

7 execution groups, 3 waves, ~1-2 weeks appetite. See WISH.md.

## Test plan

- [ ] `genie wish lint pgserve-singleton-no-proxy` clean
- [ ] No code changes — doc-only PR

## Companion PRs

- `automagik/pgserve#pgserve-singleton-no-proxy`
- `automagik/omni#pgserve-singleton-no-proxy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)