### PR TITLE
fix(serve): boot probe uses resolvePgserveTransport (matches connection probe)

### DIFF
--- a/src/term-commands/serve.test.ts
+++ b/src/term-commands/serve.test.ts
@@ -46,8 +46,8 @@ describe('getTuiKeybindings', () => {
   });
 });
 
-describe('pgserve failure containment', () => {
-  test('serve startup probes the canonical pgserve daemon (consumer-only)', () => {
+describe('pgserve boot probe — UDS-first / TCP-fallback (post-#1667)', () => {
+  test('boot probe uses the unified resolvePgserveTransport resolver', () => {
     const source = readFileSync(join(__dirname, 'serve.ts'), 'utf-8');
     const fnStart = source.indexOf('async function requirePgserveReady');
     const fnEnd = source.indexOf('/** Start the scheduler daemon', fnStart);
@@ -55,18 +55,38 @@ describe('pgserve failure containment', () => {
     expect(fnEnd).toBeGreaterThan(fnStart);
     const body = source.slice(fnStart, fnEnd);
 
-    // Probe-only path uses the renamed `requirePgserveDaemon` API. The legacy
-    // `getOrStartDaemon`, the embedded TCP-router fallback (`ensurePgserve`),
-    // and the spawn-bound port banner are gone.
-    expect(body).toContain('requirePgserveDaemon');
-    expect(body).toContain('resolvePgserveSocketDir');
+    // Post-#1667: the boot probe must match the connection probe so a host
+    // running pgserve in foreground TCP mode (no canonical daemon UDS) gets
+    // the correct "ready on tcp" banner instead of the misleading
+    // "pgserve unreachable" warning the old `requirePgserveDaemon` printed.
+    expect(body).toContain('resolvePgserveTransport');
+    // Legacy hard-fail-on-UDS-only API must be gone from the boot path.
+    expect(body).not.toContain('requirePgserveDaemon');
+    // Legacy embedded TCP-router fallback and spawn-bound port banner stay
+    // gone (canonical-cutover regression locks).
     expect(body).not.toContain('ensurePgserve');
     expect(body).not.toContain('getOrStartDaemon');
-    expect(body).toContain("registerService('pgserve-owner'");
     expect(body).not.toContain('pgserve ready on port');
+    // Registry hook stays — observability tools still want to know which
+    // serve is talking to pgserve.
+    expect(body).toContain("registerService('pgserve-owner'");
   });
 
-  test('serve disables in-process pgserve retries after startup failure', () => {
+  test('boot probe branches on transport.kind for the ready banner', () => {
+    // Both transports must produce a ready banner (UDS-style vs TCP-style)
+    // so operators see the truth on hosts where only TCP is reachable.
+    const source = readFileSync(join(__dirname, 'serve.ts'), 'utf-8');
+    const fnStart = source.indexOf('async function requirePgserveReady');
+    const fnEnd = source.indexOf('/** Start the scheduler daemon', fnStart);
+    const body = source.slice(fnStart, fnEnd);
+
+    expect(body).toContain("transport.kind === 'unix'");
+    expect(body).toContain('socketDir');
+    expect(body).toContain('.s.PGSQL.');
+    expect(body).toContain('tcp');
+  });
+
+  test('boot probe disables in-process pgserve retries after startup failure', () => {
     const source = readFileSync(join(__dirname, 'serve.ts'), 'utf-8');
     const fnStart = source.indexOf('async function requirePgserveReady');
     expect(fnStart).toBeGreaterThan(-1);
@@ -74,19 +94,6 @@ describe('pgserve failure containment', () => {
     const retryGuard = source.indexOf("process.env.GENIE_PG_NO_AUTOSTART = '1'", catchStart);
     expect(catchStart).toBeGreaterThan(-1);
     expect(retryGuard).toBeGreaterThan(-1);
-  });
-
-  test('serve emits the canonical-cutover ready banner on success', () => {
-    const source = readFileSync(join(__dirname, 'serve.ts'), 'utf-8');
-    const fnStart = source.indexOf('async function requirePgserveReady');
-    expect(fnStart).toBeGreaterThan(-1);
-    const fnEnd = source.indexOf('/** Start the scheduler daemon', fnStart);
-    const body = source.slice(fnStart, fnEnd);
-
-    expect(body).toContain('requirePgserveDaemon');
-    expect(body).toContain('canonical, pm2-supervised');
-    expect(body).not.toContain('ensurePgserve');
-    expect(body).not.toContain('pgserve ready on port');
   });
 });
 

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -595,18 +595,32 @@ async function startAgentSync(): Promise<{ close: () => void } | null> {
 }
 
 /**
- * Probe the canonical pm2-supervised pgserve daemon. Genie is consumer-only
- * after the canonical-cutover wish — `genie serve` no longer spawns or
- * supervises pgserve. If the daemon is not reachable, log a clear
- * canonical-install hint and disable subsequent autostart attempts so the
- * rest of the serve boot doesn't loop on the same failure.
+ * Probe pgserve via the unified transport-discovery resolver (UDS-first,
+ * TCP-fallback). Genie is consumer-only after the canonical-cutover wish —
+ * `genie serve` no longer spawns or supervises pgserve. If neither transport
+ * is reachable, log a clear canonical-install hint and disable subsequent
+ * autostart attempts so the rest of the serve boot doesn't loop on the same
+ * failure.
+ *
+ * Pre-#1667: this function called `requirePgserveDaemon()` which only
+ * accepted the canonical Unix socket. On hosts where `pgserve install`
+ * registered foreground TCP mode (the supported install path post
+ * pgserve@^2.2), the boot probe would print a misleading
+ * "pgserve unreachable" error AND then real connections would still succeed
+ * via the resolver's TCP fallback — confusing operators into thinking
+ * something was broken when it wasn't. Now the boot probe matches the
+ * connection probe.
  */
 async function requirePgserveReady(): Promise<void> {
-  console.log('  Probing canonical pgserve daemon...');
+  console.log('  Probing pgserve transport...');
   try {
-    const { requirePgserveDaemon, resolvePgserveSocketDir } = await import('../lib/db.js');
-    await requirePgserveDaemon();
-    console.log(`  pgserve daemon ready (canonical, pm2-supervised) on ${resolvePgserveSocketDir()}`);
+    const { resolvePgserveTransport } = await import('../lib/db.js');
+    const transport = await resolvePgserveTransport();
+    if (transport.kind === 'unix') {
+      console.log(`  pgserve ready: unix socket ${transport.socketDir}/.s.PGSQL.${transport.port}`);
+    } else {
+      console.log(`  pgserve ready: tcp ${transport.host}:${transport.port}`);
+    }
     try {
       // Service registry entry stays for diagnostics — genie no longer OWNS
       // pgserve, but observability tools still want to know which serve is
@@ -619,11 +633,6 @@ async function requirePgserveReady(): Promise<void> {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`  pgserve unreachable: ${msg}`);
-    console.error('  Recovery:');
-    console.error('    pm2 status              # is pgserve registered?');
-    console.error('    pm2 restart pgserve     # OR: autopg restart');
-    console.error('    pgserve install         # if not registered yet');
-    console.error('  See https://github.com/automagik-dev/genie/blob/main/docs/install.md');
     process.env.GENIE_PG_NO_AUTOSTART = '1';
     process.env.GENIE_PG_DISABLE_AUTOSTART = '1';
   }


### PR DESCRIPTION
## Summary

Cosmetic followup to [#1667](https://github.com/automagik-dev/genie/pull/1667). Pre-this-fix, `genie serve` boot called `requirePgserveDaemon()` (UDS-only) and printed a misleading "pgserve unreachable" warning on hosts where `pgserve install` registered foreground TCP mode — even though real connections then succeeded via the resolver's TCP fallback. Operators read the warning, assumed something was broken, wasted time on the wrong fix.

## What changed

```diff
-async function requirePgserveReady(): Promise<void> {
-  console.log('  Probing canonical pgserve daemon...');
-  try {
-    const { requirePgserveDaemon, resolvePgserveSocketDir } = await import('../lib/db.js');
-    await requirePgserveDaemon();
-    console.log(`  pgserve daemon ready (canonical, pm2-supervised) on ${resolvePgserveSocketDir()}`);
+async function requirePgserveReady(): Promise<void> {
+  console.log('  Probing pgserve transport...');
+  try {
+    const { resolvePgserveTransport } = await import('../lib/db.js');
+    const transport = await resolvePgserveTransport();
+    if (transport.kind === 'unix') {
+      console.log(`  pgserve ready: unix socket ${transport.socketDir}/.s.PGSQL.${transport.port}`);
+    } else {
+      console.log(`  pgserve ready: tcp ${transport.host}:${transport.port}`);
+    }
```

Same retry-guard semantics on failure (both `GENIE_PG_NO_AUTOSTART` env vars set, no exit). The misleading legacy "Recovery: pm2 status / pm2 restart pgserve / pgserve install" lines drop because the resolver throws a richer message that already mentions both probe attempts and recovery steps.

## After this ships

Fresh `genie update` + `pm2 restart genie-serve` on a TCP-only host will show:

```
  Probing pgserve transport...
  pgserve ready: tcp 127.0.0.1:8432
```

…instead of the noisy "unreachable" warning. No operator action required.

## Diagnostic context

While the user was dogfooding the post-#1667 binary, their `~/.genie/logs/update-diagnostics-2026-05-06T15-20-52-347Z.json` showed 141 scheduler errors over 30 min: 7 distinct event types (`process_cycle_error`, `agent_resume_timer_error`, `mailbox_retry_error`, `heartbeat_error`, `lease_recovery_error`, `orphan_reconciliation_error`, `retention_error`), each with the legacy "pgserve canonical daemon is not reachable" hint. Investigation showed those errors were all from the **pre-#1667 daemon process** still running pre-restart — once the daemon picks up the new code via `pm2 restart genie-serve`, every error path goes through `_buildConnection() → resolvePgserveTransport()` and succeeds via TCP fallback. **No scheduler-side change needed in this PR.**

## Validation

- ✅ `bun run typecheck`
- ✅ `bun run lint` (2 pre-existing test-fixture symlink warnings)
- ✅ `bun test src/term-commands/serve.test.ts` — 19 pass / 0 fail / 71 expects

## Test plan

- [ ] CI: typecheck + lint + dead-code + tests on `dev`
- [ ] On a TCP-only pgserve host, run `genie serve` → confirm `pgserve ready: tcp ...` banner instead of legacy "unreachable" warning
- [ ] On a UDS host (running `pgserve daemon` standalone), confirm `pgserve ready: unix socket ...` banner
- [ ] On a host with neither, confirm retry-guard still fires (`GENIE_PG_NO_AUTOSTART=1` set)

## Related

- [#1665](https://github.com/automagik-dev/genie/pull/1665) — `update-unify-stages` G1-G5 (merged)
- [#1667](https://github.com/automagik-dev/genie/pull/1667) — pgserve transport discovery (merged)
- [#1668](https://github.com/automagik-dev/genie/pull/1668) — SHARED-DESIGN.md §4.6 sync (merged)
- [#1671](https://github.com/automagik-dev/genie/pull/1671) — skills `.orphaned_at` regression fix
- **THIS PR** — boot-probe migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)