### PR TITLE
fix(tui): stop swallowing tmux errors in startTuiTmuxServer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@
 
 ## Unreleased
 
+### Fixed
+
+- TUI startup no longer crashes with opaque `output: [null, null, null]` when
+  an existing `genie-tui` session has unexpected layout. `startTuiTmuxServer`
+  now probes with `has-session` first, recovers corrupt sessions via
+  `kill-session` + fresh create (logging the original cause to
+  `~/.genie/logs/tui-crash.log`), and surfaces tmux's actual stderr
+  (e.g. `duplicate session: genie-tui`) in any error that does bubble up.
+  Wish: `genie-tui-startup-resilience`.
+
 ### Breaking — pgserve canonical cutover (consumer-only, pm2-supervised)
 
 - **Genie no longer spawns pgserve.** The pre-canonical genie was a daemon

--- a/src/term-commands/serve.test.ts
+++ b/src/term-commands/serve.test.ts
@@ -1,17 +1,85 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as realChildProcess from 'node:child_process';
 import { type ChildProcess, spawn } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import {
+
+// ============================================================================
+// Smart child_process mock for startTuiTmuxServer tests.
+//
+// Bun's mock.module is process-global and leaks across test files. To keep
+// other tests in this file (and other files) safe, the default execSync
+// implementation falls through to the REAL child_process.execSync. Each test
+// in `describe('startTuiTmuxServer')` installs a per-test handler via
+// setExecSyncHandler(); the handler scripts responses for genie-tui tmux
+// commands and lets non-matching commands fall through to the real exec.
+//
+// `spawn` and `spawnSync` are preserved verbatim — the rest of this file's
+// tests rely on them.
+// ============================================================================
+
+type ExecSyncHandler = (
+  cmd: string,
+  opts?: { encoding?: BufferEncoding | 'buffer' } & Record<string, unknown>,
+) => string | Buffer;
+
+let _execSyncHandler: ExecSyncHandler | null = null;
+function setExecSyncHandler(handler: ExecSyncHandler | null): void {
+  _execSyncHandler = handler;
+}
+
+function isTuiTmuxCmd(cmd: string): boolean {
+  return cmd.includes('-L genie-tui');
+}
+
+// IMPORTANT: capture the REAL execSync / spawnSync as `const` references
+// BEFORE registering mock.module. Namespace imports (`* as realChildProcess`)
+// expose live bindings — after mock, `realChildProcess.execSync` would point
+// at the mocked function, causing infinite recursion when the mock falls
+// through to the "real" implementation. A const captured here freezes the
+// binding to the original function.
+const realExecSync: typeof realChildProcess.execSync = realChildProcess.execSync;
+const realSpawnSync: typeof realChildProcess.spawnSync = realChildProcess.spawnSync;
+const realSpawn: typeof realChildProcess.spawn = realChildProcess.spawn;
+
+mock.module('node:child_process', () => ({
+  ...realChildProcess,
+  execSync: (cmd: string, opts?: Parameters<typeof realChildProcess.execSync>[1]) => {
+    if (_execSyncHandler && isTuiTmuxCmd(cmd)) {
+      return _execSyncHandler(cmd, opts as Record<string, unknown>);
+    }
+    return realExecSync(cmd, opts);
+  },
+  spawn: realSpawn,
+  spawnSync: ((file: string, args?: readonly string[], opts?: Record<string, unknown>) => {
+    // While a startTuiTmuxServer test is active, swallow tmux invocations on
+    // the genie-tui socket so setupTuiKeybindings doesn't poke the real tmux
+    // server. Other spawnSync calls (e.g. installer probes) fall through.
+    if (_execSyncHandler && Array.isArray(args) && args.includes('-L') && args.includes('genie-tui')) {
+      return {
+        pid: 0,
+        output: [null, '', ''],
+        stdout: '',
+        stderr: '',
+        status: 0,
+        signal: null,
+      };
+    }
+    return realSpawnSync(file, args as readonly string[], opts as Parameters<typeof realChildProcess.spawnSync>[2]);
+  }) as typeof realChildProcess.spawnSync,
+}));
+
+const {
   autoStartServe,
   clearStoppingLock,
   getTuiKeybindings,
   getTuiQuitBindingArgs,
   isStoppingLockActive,
   startBrainServerIfEnabled,
+  startTuiTmuxServer,
   writeStoppingLockSync,
-} from './serve.js';
+} = await import('./serve.js');
 
 describe('getTuiKeybindings', () => {
   test('includes explicit left and right pane focus bindings', () => {
@@ -586,5 +654,197 @@ describe('pgserve v1/v2 coexistence', () => {
     const startForeground = source.slice(source.indexOf('async function startForeground'));
     expect(startForeground).toContain('removeLegacyPgservePortLockfileIfForcedTcp();');
     expect(startForeground).not.toContain('removePgservePortLockfile();');
+  });
+});
+
+// ============================================================================
+// startTuiTmuxServer — regression tests for the silent-fall-through bug
+//
+// The function used to wrap `has-session` + repair branch in a single
+// `try { ... } catch {}`, so any failure inside the repair branch fell
+// through to `new-session -d -s genie-tui` and crashed with the opaque
+// "duplicate session: genie-tui" / `output: [null, null, null]` error.
+//
+// G1 split the probe from the repair branch and added a kill-session +
+// fresh-create recovery path with forensic logging. These tests lock in
+// every reachable state.
+//
+// Mocking strategy: the file-level `mock.module('node:child_process', ...)`
+// intercepts only commands targeting the `-L genie-tui` socket while the
+// per-test handler is set; everything else falls through to the real
+// child_process module.
+// ============================================================================
+
+describe('startTuiTmuxServer', () => {
+  let tuiHome: string;
+  let originalGenieHome: string | undefined;
+
+  beforeEach(() => {
+    originalGenieHome = process.env.GENIE_HOME;
+    tuiHome = mkdtempSync(join(tmpdir(), 'genie-tui-server-'));
+    process.env.GENIE_HOME = tuiHome;
+  });
+
+  afterEach(() => {
+    setExecSyncHandler(null);
+    if (originalGenieHome === undefined) {
+      // biome-ignore lint/performance/noDelete: env vars must actually be removed
+      delete process.env.GENIE_HOME;
+    } else {
+      process.env.GENIE_HOME = originalGenieHome;
+    }
+    try {
+      rmSync(tuiHome, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  });
+
+  /**
+   * Build a recording handler whose `responder` decides — per matching tmux
+   * subcommand — what to return (or throw). Calls to non-tui-tmux commands
+   * never reach here because the file-level mock filters them out.
+   */
+  function recordHandler(
+    responder: (cmd: string) => { value?: string; error?: { stderr: string; message?: string } },
+  ): { handler: ExecSyncHandler; calls: string[] } {
+    const calls: string[] = [];
+    const handler: ExecSyncHandler = (cmd) => {
+      calls.push(cmd);
+      const out = responder(cmd);
+      if (out.error) {
+        // Mimic Bun/node execSync error shape: `.stderr` is a Buffer, but a
+        // string also satisfies runTuiTmuxCapturing's `.toString('utf-8')`
+        // path because that method only fires on Buffer.
+        const err = new Error(out.error.message ?? `Command failed: ${cmd}`) as Error & {
+          stderr?: string;
+          stdout?: string;
+        };
+        err.stderr = out.error.stderr;
+        err.stdout = '';
+        throw err;
+      }
+      return out.value ?? '';
+    };
+    return { handler, calls };
+  }
+
+  test('(a) session exists with 2 panes — returns early, no new-session', () => {
+    const { handler, calls } = recordHandler((cmd) => {
+      if (cmd.includes('has-session')) return { value: '' };
+      if (cmd.includes('list-panes')) return { value: '%0\n%1' };
+      if (cmd.includes('respawn-pane')) return { value: '' };
+      // Any tui-tmux command we didn't anticipate → empty no-op
+      return { value: '' };
+    });
+    setExecSyncHandler(handler);
+
+    const result = startTuiTmuxServer();
+
+    expect(result).toEqual({ leftPane: '%0', rightPane: '%1' });
+    expect(calls.some((c) => c.includes('new-session'))).toBe(false);
+    expect(calls.some((c) => c.includes('split-window'))).toBe(false);
+    expect(calls.some((c) => c.includes('has-session'))).toBe(true);
+    expect(calls.some((c) => c.includes('respawn-pane'))).toBe(true);
+  });
+
+  test('(b) session exists with 1 pane — split-window invoked once, no new-session', () => {
+    let listPanesCallCount = 0;
+    const { handler, calls } = recordHandler((cmd) => {
+      if (cmd.includes('has-session')) return { value: '' };
+      if (cmd.includes('list-panes')) {
+        listPanesCallCount += 1;
+        // First call sees only %0; after split, second call sees both panes.
+        return { value: listPanesCallCount === 1 ? '%0' : '%0\n%2' };
+      }
+      if (cmd.includes('display-message')) return { value: '120' };
+      if (cmd.includes('split-window')) return { value: '' };
+      return { value: '' };
+    });
+    setExecSyncHandler(handler);
+
+    const result = startTuiTmuxServer();
+
+    expect(result.leftPane).toBe('%0');
+    expect(result.rightPane).toBe('%2');
+    const splitCalls = calls.filter((c) => c.includes('split-window'));
+    expect(splitCalls.length).toBe(1);
+    expect(calls.some((c) => c.includes('new-session'))).toBe(false);
+  });
+
+  test('(c) has-session fails — fresh new-session + split-window each called once', () => {
+    const { handler, calls } = recordHandler((cmd) => {
+      if (cmd.includes('has-session')) {
+        return { error: { stderr: "can't find session: genie-tui", message: 'has-session failed' } };
+      }
+      if (cmd.includes('new-session')) return { value: '' };
+      if (cmd.includes('split-window')) return { value: '' };
+      if (cmd.includes('list-panes')) return { value: '%0\n%1' };
+      return { value: '' };
+    });
+    setExecSyncHandler(handler);
+
+    const result = startTuiTmuxServer();
+
+    expect(result).toEqual({ leftPane: '%0', rightPane: '%1' });
+    const newSessionCalls = calls.filter((c) => c.includes('new-session'));
+    const splitCalls = calls.filter((c) => c.includes('split-window'));
+    expect(newSessionCalls.length).toBe(1);
+    expect(splitCalls.length).toBe(1);
+  });
+
+  test('(d) repair branch throws — kill-session + fresh-create + crash log written', () => {
+    const repairFailureStderr = "can't find window";
+    let listPanesCallCount = 0;
+    let splitWindowCallCount = 0;
+    const { handler, calls } = recordHandler((cmd) => {
+      if (cmd.includes('has-session')) return { value: '' };
+      if (cmd.includes('list-panes')) {
+        listPanesCallCount += 1;
+        // 1st call: 1-pane state triggers repair branch.
+        // 2nd call (after kill + fresh new-session + split-window): 2 panes.
+        return { value: listPanesCallCount === 1 ? '%0' : '%0\n%1' };
+      }
+      if (cmd.includes('display-message')) return { value: '120' };
+      if (cmd.includes('split-window')) {
+        splitWindowCallCount += 1;
+        // 1st split-window is the repair-branch attempt → throw to trigger
+        // the recovery path. 2nd split-window comes from freshCreate after
+        // kill-session, and must succeed.
+        if (splitWindowCallCount === 1) {
+          return { error: { stderr: repairFailureStderr, message: 'Command failed' } };
+        }
+        return { value: '' };
+      }
+      if (cmd.includes('kill-session')) return { value: '' };
+      if (cmd.includes('new-session')) return { value: '' };
+      return { value: '' };
+    });
+    setExecSyncHandler(handler);
+
+    const result = startTuiTmuxServer();
+
+    expect(result).toEqual({ leftPane: '%0', rightPane: '%1' });
+    const killSessionCalls = calls.filter((c) => c.includes('kill-session'));
+    expect(killSessionCalls.length).toBe(1);
+
+    // Verify ordering: kill-session must come before new-session.
+    const killIdx = calls.findIndex((c) => c.includes('kill-session'));
+    const newIdx = calls.findIndex((c) => c.includes('new-session'));
+    expect(killIdx).toBeGreaterThan(-1);
+    expect(newIdx).toBeGreaterThan(killIdx);
+
+    const newSessionCalls = calls.filter((c) => c.includes('new-session'));
+    expect(newSessionCalls.length).toBe(1);
+
+    // Forensic log written with prefix + the original tmux stderr message.
+    const crashLogPath = join(tuiHome, 'logs', 'tui-crash.log');
+    expect(existsSync(crashLogPath)).toBe(true);
+    const logContents = readFileSync(crashLogPath, 'utf-8');
+    const lines = logContents.split('\n').filter((l) => l.length > 0);
+    expect(lines.length).toBeGreaterThan(0);
+    const lastLine = lines[lines.length - 1];
+    expect(lastLine).toContain('[startTuiTmuxServer]');
+    expect(lastLine).toContain(repairFailureStderr);
   });
 });

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -19,6 +19,7 @@
 
 import { execSync, spawn, spawnSync } from 'node:child_process';
 import {
+  appendFileSync,
   closeSync,
   existsSync,
   mkdirSync,
@@ -307,55 +308,60 @@ function setupTuiKeybindings(): void {
 }
 
 /**
- * Start the TUI tmux server with full session setup:
- * left pane (nav) + right pane (agent display).
- * If session already exists (serve restart), reuse it.
+ * Run a tmux command via execSync and re-throw with the captured stderr
+ * embedded in the message. Bun's execSync throws an `Error` whose default
+ * message is the unhelpful `output: [null, null, null]` when stdio is
+ * ignored — capturing stdout/stderr as strings gives us tmux's actual
+ * complaint (e.g. `duplicate session: genie-tui`).
  */
-function startTuiTmuxServer(): { leftPane: string; rightPane: string } {
-  // Check if session already exists
+function runTuiTmuxCapturing(cmd: string): string {
   try {
-    execSync(tuiTmux(`has-session -t ${TUI_SESSION}`), { stdio: 'ignore' });
-    // Session exists — reuse it, but ensure the split is healthy
-    const panes = execSync(tuiTmux(`list-panes -t ${TUI_SESSION}:0 -F '#{pane_id}'`), { encoding: 'utf-8' })
-      .trim()
-      .split('\n');
-
-    if (panes.length >= 2) {
-      // Both panes exist — clear the right pane so it doesn't show stale content
-      // (e.g., a leftover TUI nav renderer from a crashed serve process)
-      try {
-        execSync(tuiTmux(`respawn-pane -k -t ${panes[1]} 'cat'`), { stdio: 'ignore' });
-      } catch {}
-      return { leftPane: panes[0], rightPane: panes[1] };
-    }
-
-    // Only 1 pane — re-create the split
-    const cols =
-      Number.parseInt(
-        execSync(tuiTmux(`display-message -t ${TUI_SESSION}:0 -p '#{window_width}'`), { encoding: 'utf-8' }).trim(),
-        10,
-      ) || 120;
-    execSync(tuiTmux(`split-window -h -t ${TUI_SESSION}:0 -l ${cols - NAV_WIDTH - 1}`), { stdio: 'ignore' });
-    const refreshed = execSync(tuiTmux(`list-panes -t ${TUI_SESSION}:0 -F '#{pane_id}'`), { encoding: 'utf-8' })
-      .trim()
-      .split('\n');
-    applyTuiStyle();
-    setupTuiKeybindings();
-    try {
-      execSync(tuiTmux(`select-pane -t ${refreshed[0]}`), { stdio: 'ignore' });
-    } catch {}
-    return { leftPane: refreshed[0], rightPane: refreshed[1] || refreshed[0] };
-  } catch {
-    // Session doesn't exist — create it
+    return execSync(tuiTmux(cmd), { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch (err) {
+    const e = err as { stderr?: string | Buffer; stdout?: string | Buffer; message?: string };
+    const stderr = typeof e.stderr === 'string' ? e.stderr : e.stderr?.toString('utf-8');
+    const stdout = typeof e.stdout === 'string' ? e.stdout : e.stdout?.toString('utf-8');
+    const detail = (stderr ?? stdout ?? e.message ?? 'unknown tmux error').trim();
+    throw new Error(`tmux ${cmd}: ${detail}`);
   }
+}
 
+/**
+ * Append a single line to ~/.genie/logs/tui-crash.log so the original
+ * inner-branch error survives the recovery `kill-session`. Best-effort:
+ * never throw from here — the whole point is that the user gets a working
+ * TUI even when logging fails.
+ *
+ * Prefix `[startTuiTmuxServer] <ISO timestamp> ` keeps these distinguishable
+ * from `sendTuiLaunchScript`'s native-panic appends to the same file.
+ */
+function logTuiStartupFailure(message: string): void {
+  try {
+    const home = genieHome();
+    const logsDir = join(home, 'logs');
+    mkdirSync(logsDir, { recursive: true });
+    const crashLog = join(logsDir, 'tui-crash.log');
+    const line = `[startTuiTmuxServer] ${new Date().toISOString()} ${message.replace(/\s+/g, ' ').trim()}\n`;
+    appendFileSync(crashLog, line);
+  } catch {
+    // Logging is best-effort; a failed log must not block recovery.
+  }
+}
+
+/**
+ * Build a fresh genie-tui session from scratch: new-session, split-window,
+ * style, keybindings, focus left pane. Used both when no session existed
+ * and when a corrupt session was killed during recovery.
+ *
+ * Errors from `new-session` and `split-window` propagate up with tmux's
+ * stderr embedded — see `runTuiTmuxCapturing`.
+ */
+function freshCreateTuiSession(): { leftPane: string; rightPane: string } {
   const cols = 120;
   const rows = 40;
 
-  execSync(tuiTmux(`new-session -d -s ${TUI_SESSION} -x ${cols} -y ${rows}`), {
-    stdio: 'ignore',
-  });
-  execSync(tuiTmux(`split-window -h -t ${TUI_SESSION}:0 -l ${cols - NAV_WIDTH - 1}`), { stdio: 'ignore' });
+  runTuiTmuxCapturing(`new-session -d -s ${TUI_SESSION} -x ${cols} -y ${rows}`);
+  runTuiTmuxCapturing(`split-window -h -t ${TUI_SESSION}:0 -l ${cols - NAV_WIDTH - 1}`);
 
   const panes = execSync(tuiTmux(`list-panes -t ${TUI_SESSION}:0 -F '#{pane_id}'`), { encoding: 'utf-8' })
     .trim()
@@ -370,6 +376,83 @@ function startTuiTmuxServer(): { leftPane: string; rightPane: string } {
   } catch {}
 
   return { leftPane: panes[0], rightPane: panes[1] || panes[0] };
+}
+
+/**
+ * Start the TUI tmux server with full session setup:
+ * left pane (nav) + right pane (agent display).
+ * If session already exists (serve restart), reuse it.
+ *
+ * Control flow:
+ *   1. `has-session` probe in its own try/catch — non-existence is the ONLY
+ *      path into a fresh `new-session`. This avoids the historical bug
+ *      where any failure inside the repair branch fell through to
+ *      `new-session` and crashed with `duplicate session: genie-tui`.
+ *   2. If the session exists, run the repair branch in its own try. On
+ *      failure: log to ~/.genie/logs/tui-crash.log, kill the corrupt
+ *      session, and rebuild from scratch — the user just typed `genie`
+ *      and wants a working TUI.
+ *
+ * Exported so unit tests can exercise it directly without monkey-patching
+ * `child_process` globally.
+ */
+export function startTuiTmuxServer(): { leftPane: string; rightPane: string } {
+  // Step 1: probe — the ONLY signal that decides "fresh create" vs "repair".
+  try {
+    execSync(tuiTmux(`has-session -t ${TUI_SESSION}`), { stdio: 'ignore' });
+  } catch {
+    // Session genuinely doesn't exist — create it from scratch.
+    return freshCreateTuiSession();
+  }
+
+  // Step 2: session exists — try to repair / reuse. Any throw in this branch
+  // means the session is in a bad state we can't reason about: log, kill,
+  // and rebuild rather than bubbling an opaque error to the user.
+  try {
+    const panes = execSync(tuiTmux(`list-panes -t ${TUI_SESSION}:0 -F '#{pane_id}'`), { encoding: 'utf-8' })
+      .trim()
+      .split('\n')
+      .filter((id) => id.length > 0);
+
+    if (panes.length >= 2) {
+      // Both panes exist — clear the right pane so it doesn't show stale content
+      // (e.g., a leftover TUI nav renderer from a crashed serve process)
+      try {
+        execSync(tuiTmux(`respawn-pane -k -t ${panes[1]} 'cat'`), { stdio: 'ignore' });
+      } catch {}
+      return { leftPane: panes[0], rightPane: panes[1] };
+    }
+
+    // 1 pane (or theoretically 0 — tmux sessions always have ≥1 pane, but
+    // defensively this falls into the same recreate-the-split path) → re-split.
+    const cols =
+      Number.parseInt(
+        execSync(tuiTmux(`display-message -t ${TUI_SESSION}:0 -p '#{window_width}'`), { encoding: 'utf-8' }).trim(),
+        10,
+      ) || 120;
+    runTuiTmuxCapturing(`split-window -h -t ${TUI_SESSION}:0 -l ${cols - NAV_WIDTH - 1}`);
+    const refreshed = execSync(tuiTmux(`list-panes -t ${TUI_SESSION}:0 -F '#{pane_id}'`), { encoding: 'utf-8' })
+      .trim()
+      .split('\n');
+    applyTuiStyle();
+    setupTuiKeybindings();
+    try {
+      execSync(tuiTmux(`select-pane -t ${refreshed[0]}`), { stdio: 'ignore' });
+    } catch {}
+    return { leftPane: refreshed[0], rightPane: refreshed[1] || refreshed[0] };
+  } catch (err) {
+    // Repair failed — corrupt session in unknown state. Persist the original
+    // cause for forensics, then nuke and rebuild.
+    const message = err instanceof Error ? err.message : String(err);
+    logTuiStartupFailure(message);
+    try {
+      execSync(tuiTmux(`kill-session -t ${TUI_SESSION}`), { stdio: 'ignore' });
+    } catch {
+      // If kill-session itself fails, freshCreateTuiSession() will re-throw
+      // a useful error via runTuiTmuxCapturing — let it surface.
+    }
+    return freshCreateTuiSession();
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Restructure `startTuiTmuxServer` so `new-session -d -s genie-tui` is only reachable when no session exists or after a recovery `kill-session`
- Capture tmux stderr (drop `stdio: 'ignore'` on `new-session` / `split-window`) so users see `duplicate session: genie-tui` instead of opaque `output: [ null, null, null ]`
- Recover from corrupt-session states (inner repair branch throws) by appending the original error to `~/.genie/logs/tui-crash.log` (prefix `[startTuiTmuxServer] <ISO>` to disambiguate from `sendTuiLaunchScript`'s native-panic appends), running `kill-session`, then `freshCreateTuiSession()`
- Export `startTuiTmuxServer` as a test seam; add a 4-case regression suite locking in every reachable state

## Original bug

With a stale `genie-tui` tmux session present, `genie` (no args) crashed with:

```
error: Command failed: tmux -L genie-tui ... new-session -d -s genie-tui ...
 status: 1, output: [ null, null, null ]
  at startTuiTmuxServer (genie.js:2616:221)
  at ensureTuiSession (genie.js:2620:1123)
```

Root cause: a single `try { has-session; repair } catch {}` block swallowed every inner failure (split-window, applyTuiStyle, etc.) and fell through to `new-session`, which collided with the still-existing session. `stdio: 'ignore'` hid tmux's `duplicate session: genie-tui` stderr, leaving Bun's execSync shim to emit the opaque `output: [null, null, null]`.

Reproduced directly:
```
$ tmux -L genie-tui -f tui-tmux.conf new-session -d -s genie-tui -x 120 -y 40
duplicate session: genie-tui
$ echo $?
1
```

## Approach

1. **Probe in its own try/catch** — `has-session` is now the *only* signal that decides "fresh create" vs "repair". Non-existence is the only path into `new-session`.
2. **Repair branch in its own try** — list-panes / split-window / styling. Throws here mean the session is in a state we can't reason about, so we log + kill + rebuild rather than bubbling an opaque error.
3. **`runTuiTmuxCapturing` helper** — wraps `execSync` for the failure-prone calls with `stdio: ['ignore', 'pipe', 'pipe']`, re-throws as `Error('tmux <cmd>: <stderr>')` so the user sees tmux's actual complaint.
4. **`freshCreateTuiSession` helper** — extracts the new-session / split-window / list-panes / style / keybindings flow, used both for first-time creation and post-kill recovery.
5. **`logTuiStartupFailure`** — best-effort append to `~/.genie/logs/tui-crash.log`, never throws.

`kill-session` recovery is safe: the genie-tui session is display-only (`sendTuiLaunchScript` rewrites both panes from scratch on every TUI entry), no work is lost.

## Test plan

- [x] `bun test src/term-commands/serve.test.ts` — 15 pass / 0 fail (4 new `startTuiTmuxServer` cases plus the existing suite)
- [x] `bun run typecheck` clean
- [x] `bun build src/genie.ts ...` succeeds
- [x] Diff scope contained: only `serve.ts` + `serve.test.ts` + `CHANGELOG.md`
- [x] `grep -n "new-session -d -s" src/term-commands/serve.ts` shows exactly one occurrence (in `freshCreateTuiSession`)
- [ ] Real-tmux smoke deferred — `kill-server genie-tui` is destructive to any active TUI on the host; the unit tests cover all four reachable states. Reviewer can run the smoke locally with the steps in the original wish.

## Test cases

- **(a) session exists with 2 panes** → returns early; `new-session` never called
- **(b) session exists with 1 pane** → `split-window` called once; no `new-session`
- **(c) `has-session` fails** → `new-session` + `split-window` each called once
- **(d) repair branch throws** → `kill-session` + fresh `new-session`; `~/.genie/logs/tui-crash.log` line contains `[startTuiTmuxServer]` prefix and the original tmux stderr

## Wish

Workspace-local: `genie-tui-startup-resilience`. Two execution groups (G1 = code fix + stderr capture, G2 = test + PR), both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Enhanced Terminal UI startup reliability with improved session management and robust recovery mechanisms for consistent TUI initialization
- Implemented comprehensive crash logging to capture Terminal UI startup diagnostics and simplify troubleshooting of initialization failures
- Strengthened terminal session handling and repair logic to gracefully manage edge cases and unexpected connection interruptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->