### PR TITLE
fix(team-create + send + ls): resolve #1674 Bug 1 + 2a + 2b + 5

### DIFF
--- a/skills/trace/SKILL.md
+++ b/skills/trace/SKILL.md
@@ -89,6 +89,7 @@ The orchestrator then hands the report to `/fix`.
 - Never fix during trace — investigation only, always separate from correction.
 - Always reproduce before theorizing — if the failure can't be reproduced, the report must say so.
 - Evidence required — every root cause claim must include file paths, line numbers, and a causal chain.
+- **Verify exports before citing them.** Every function name in a "Recommended correction" must be confirmed via `grep -n "export.*<name>"` against the actual file. Never cite a function name from memory or from a stale convention — the codebase evolves and refactors rename or delete public API regularly. A trace report that hallucinates a function name (e.g. claiming `resolveAgentId` exists when only `getAgentByName` does) sends `/fix` down a path that fails type-check and wastes a fix loop. Closes #1674 Bug 5.
 - Hand off to `/fix` — trace produces a report, `/fix` applies the correction. Never combine them.
 - Read-only tools — trace subagent uses Read, Bash, Glob, Grep. No Write, no Edit.
 - If root cause spans multiple systems, report each separately with confidence levels.

--- a/src/lib/agent-directory.ts
+++ b/src/lib/agent-directory.ts
@@ -66,6 +66,13 @@ function describeFileType(stat: import('node:fs').Stats): string {
 export type PromptMode = 'system' | 'append';
 
 export interface DirectoryEntry {
+  /**
+   * Canonical PG `agents.id` — UUID (post-061) or `dir:<name>` (legacy).
+   * Optional because built-in agents and some synthesized entries have no
+   * row yet. Restored to JSON output by #1674 Bug 2b so operators have a
+   * stable cross-team handle for `genie send`/cross-context resolution.
+   */
+  id?: string;
   /** Globally unique agent name. */
   name: string;
   /** Agent folder — CWD at spawn, contains AGENTS.md. */
@@ -499,7 +506,7 @@ export async function ls(): Promise<ScopedDirectoryEntry[]> {
     const { getConnection } = await import('./db.js');
     const sql = await getConnection();
     const rows = await sql`
-      SELECT DISTINCT ON (a.role) a.role, a.team, a.metadata, a.created_at, e.repo_path, e.provider
+      SELECT DISTINCT ON (a.role) a.id, a.role, a.team, a.metadata, a.created_at, e.repo_path, e.provider
       FROM agents a
       LEFT JOIN executors e ON a.current_executor_id = e.id
       WHERE a.role IS NOT NULL
@@ -512,6 +519,9 @@ export async function ls(): Promise<ScopedDirectoryEntry[]> {
         const createdAt =
           row.created_at instanceof Date ? row.created_at.toISOString() : (row.created_at as string | undefined);
         const entry = roleToEntry(name, row.team as string, meta, createdAt);
+        // PG row's canonical id wins over any value baked into roleToEntry —
+        // the SELECT picked the dir:-prefixed shadow first when present.
+        entry.id = row.id as string;
         const repoPath = row.repo_path as string;
         if (repoPath) {
           entry.dir = repoPath;

--- a/src/lib/team-manager.ts
+++ b/src/lib/team-manager.ts
@@ -895,17 +895,46 @@ async function pruneStaleWorktrees(_repoPath: string): Promise<void> {
   }
 }
 
+/**
+ * UUID check used to gate writes to `teams.leader`. Mirrors `MEMBER_UUID_RE`
+ * in pg-seed.ts so the two write paths apply the same `fk_teams_leader_check`
+ * sanitizer. Migration 061 made `teams.leader` an FK to `agents.id`, and
+ * `agents.id` is always either a UUID or a `dir:`-prefixed string.
+ */
+const LEADER_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Drop legacy bare-name leaders before writing — bare names always violate
+ * `fk_teams_leader` (no row in `agents` shares that id). Mirrors the pg-seed
+ * upsert guard so any code path that reaches `updateTeamConfig` with a stale
+ * leader value (e.g. an in-memory `TeamConfig` rehydrated from disk) degrades
+ * to NULL with an audit trail instead of throwing on the FK. Closes #1674.
+ */
+function sanitizeLeaderForWrite(teamName: string, leader: string | null | undefined): string | null {
+  if (leader == null || leader === '') return null;
+  if (LEADER_ID_RE.test(leader) || leader.startsWith('dir:')) return leader;
+  recordAuditEvent('team', teamName, 'leader_sanitized', getActor(), {
+    dropped: leader,
+    reason: 'fk_teams_leader_check',
+  }).catch(() => {});
+  return null;
+}
+
 /** Update team config in PG (full overwrite). */
 export async function updateTeamConfig(name: string, config: TeamConfig): Promise<void> {
   const sql = await getConnection();
   // `sql.json(...)` mirrors the createTeam fix — see migration 061's
   // `teams_members_uuid_check` and migration 045's encoding cleanup notes.
+  // `safeLeader` mirrors pg-seed.ts:431 fk_teams_leader_check sanitizer so any
+  // caller passing a stale bare-name leader degrades to NULL instead of
+  // tripping the FK constraint. Closes #1674.
+  const safeLeader = sanitizeLeaderForWrite(name, config.leader);
   await sql`
     UPDATE teams SET
       repo = ${config.repo},
       base_branch = ${config.baseBranch},
       worktree_path = ${config.worktreePath},
-      leader = ${config.leader ?? null},
+      leader = ${safeLeader},
       members = ${sql.json(config.members)},
       status = ${config.status},
       native_team_parent_session_id = ${config.nativeTeamParentSessionId ?? null},

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -3848,6 +3848,9 @@ export class ResumePaneVanishedError extends Error {
 }
 
 type WorkerStatus = {
+  /** Canonical agents.id (UUID or `dir:<name>`). Carried through so JSON
+   *  consumers of `genie ls --json` get a stable cross-team handle (#1674). */
+  id: string;
   state: string;
   team: string;
   resumeAttempts?: number;
@@ -3888,12 +3891,13 @@ export async function buildWorkerStatusMap(workers: registry.Agent[]): Promise<M
     const name = w.customName ?? w.role ?? w.id;
     const { alive, state } = await resolveWorkerLiveness(w);
     if (alive) {
-      statusMap.set(name, { state, team: w.team || '-' });
+      statusMap.set(name, { id: w.id, state, team: w.team || '-' });
     } else if (w.state === 'suspended' || w.state === 'error') {
       const attempts = w.resumeAttempts ?? 0;
       const max = w.maxResumeAttempts ?? 3;
       const autoStr = w.autoResume === false ? 'off' : 'on';
       statusMap.set(name, {
+        id: w.id,
         state: `${w.state} (${attempts}/${max} resumes, auto-resume: ${autoStr})`,
         team: w.team || '-',
         resumeAttempts: attempts,
@@ -3931,6 +3935,10 @@ export async function handleLsCommand(options: {
   const sourceAgentNames = options.source ? await resolveAgentNamesBySource(options.source) : undefined;
 
   type LsEntry = {
+    /** Canonical agents.id (UUID or `dir:<name>`). Restored in #1674 — operators
+     *  rely on it as the cross-team send handle until the resolver tier order
+     *  for `<role>@<team>` lands (deferred to retire-session-names #175). */
+    id?: string;
     name: string;
     dir: string;
     status: string;
@@ -3946,6 +3954,7 @@ export async function handleLsCommand(options: {
   for (const entry of dirEntries) {
     const running = statusMap.get(entry.name);
     entries.push({
+      id: entry.id ?? running?.id,
       name: entry.name,
       dir: entry.dir || '-',
       status: running ? running.state : 'offline',
@@ -3961,6 +3970,7 @@ export async function handleLsCommand(options: {
   // Add built-in agents not in the directory (alive or suspended/error)
   for (const [name, info] of statusMap) {
     entries.push({
+      id: info.id,
       name,
       dir: '(built-in)',
       status: info.state,

--- a/src/term-commands/msg.ts
+++ b/src/term-commands/msg.ts
@@ -127,6 +127,35 @@ async function findMemberByPane(teamName: string, paneId: string): Promise<strin
 // ============================================================================
 
 /**
+ * Parse `<role>@<team>` cross-team addressing syntax.
+ *
+ * Returns the unqualified recipient + the team scope to use for resolution.
+ * If no `@` is present, returns the recipient as-is with `defaultTeam` (which
+ * is typically the sender's team or `process.env.GENIE_TEAM`). When `@` is
+ * present, the parsed team always wins — that's the entire point of the form:
+ * "address agent X in team Y from anywhere."
+ *
+ * Edge cases:
+ *  - `'team-lead@foo'` → `{ recipient: 'team-lead', team: 'foo' }`
+ *  - `'foo@'`          → `{ recipient: 'foo', team: defaultTeam }` (empty
+ *                        right-side falls through; treats as no @-suffix)
+ *  - `'foo@bar@baz'`   → `{ recipient: 'foo', team: 'bar@baz' }` (split on
+ *                        first @; team names allowed to contain @ are not
+ *                        canonical but we don't reject them here)
+ *  - UUID input        → returned as-is, never split (UUIDs don't contain @)
+ *
+ * Closes #1674 Bug 2a.
+ */
+export function parseAtSyntax(recipient: string, defaultTeam?: string): { recipient: string; team?: string } {
+  const atIdx = recipient.indexOf('@');
+  if (atIdx === -1) return { recipient, team: defaultTeam };
+  const role = recipient.slice(0, atIdx);
+  const team = recipient.slice(atIdx + 1);
+  if (!role || !team) return { recipient, team: defaultTeam };
+  return { recipient: role, team };
+}
+
+/**
  * Resolve the 'team-lead' alias to the actual leader name for a given team context.
  * Never returns 'team-lead' — falls back to teamName via resolveLeaderName().
  */
@@ -900,8 +929,12 @@ async function handleSend(
   const repoPath = process.cwd();
   const from = options.from ?? (await detectSenderIdentity(options.team));
 
-  // Resolve 'team-lead' alias to actual leader name
-  const to = await resolveLeaderAlias(options.to, options.team);
+  // Parse <role>@<team> cross-team addressing first — the parsed team always
+  // wins over the implicit team scope (sender's team or GENIE_TEAM). Closes
+  // #1674 Bug 2a. Then resolve the 'team-lead' alias to the actual leader
+  // name in the (possibly parsed) team context.
+  const parsed = parseAtSyntax(options.to, options.team);
+  const to = await resolveLeaderAlias(parsed.recipient, parsed.team);
 
   const scopeError = await checkSendScope(repoPath, from, to);
   if (scopeError) {
@@ -920,7 +953,9 @@ async function handleSend(
   // Sender path (from) was already resolved via detectSenderIdentity which
   // prefers GENIE_AGENT_ID; the recipient counterpart lives here.
   const registryMod = await getRegistry();
-  const teamScope = options.team ?? process.env.GENIE_TEAM;
+  // parsed.team wins over options.team / GENIE_TEAM so cross-team @-syntax sends
+  // resolve in the recipient's scope, not the sender's. Closes #1674 Bug 2a.
+  const teamScope = parsed.team ?? options.team ?? process.env.GENIE_TEAM;
   const toAgentId = await registryMod.resolveAgentIdStrict(to, teamScope);
 
   const senderActor = localActor(from);
@@ -954,8 +989,9 @@ async function handleSend(
     // Event log unavailable — silent degradation
   }
 
-  // Best-effort native inbox bridge
-  const bridged = await bridgeToNativeInbox(from, to, body, options.team).catch((err) => {
+  // Best-effort native inbox bridge — use the (possibly parsed) team scope so
+  // cross-team @-syntax sends route the bridge into the recipient's team.
+  const bridged = await bridgeToNativeInbox(from, to, body, teamScope).catch((err) => {
     const reason = err instanceof Error ? err.message : String(err);
     console.warn(`[genie send] Native inbox bridge failed: ${reason}`);
     return false;

--- a/src/term-commands/team.ts
+++ b/src/term-commands/team.ts
@@ -359,9 +359,13 @@ async function spawnLeaderWithWish(
   config.tmuxSessionName = tmuxSession;
   await teamManager.updateTeamConfig(config.name, config);
 
-  // Leader name = team name (unique by definition, no collision with session agents)
+  // Leader name = team name (unique by definition, no collision with session agents).
+  // Do NOT write `config.leader` here — migration 061's `fk_teams_leader` requires
+  // teams.leader to point at an existing agents.id (UUID or `dir:` shape). The
+  // leader agent row is not created until handleWorkerSpawn below, so writing the
+  // team-name string up front trips the FK (#1674). Persist the spawner now and
+  // defer the leader-id write until after the spawn resolves the canonical UUID.
   const leaderAgent = config.name;
-  config.leader = leaderAgent;
   config.spawner = process.env.GENIE_AGENT_NAME || 'cli';
   await teamManager.updateTeamConfig(config.name, config);
 
@@ -406,6 +410,17 @@ async function spawnLeaderWithWish(
     session: tmuxSession,
     initialPrompt: kickoffPrompt,
   });
+
+  // Resolve the leader agent's canonical id now that the row exists, then
+  // persist it as `teams.leader`. Best-effort: if resolution fails the team
+  // remains functional without a tracked leader id, and the defensive guard
+  // in updateTeamConfig would null it anyway. Closes #1674.
+  const { getAgentByName } = await import('../lib/agent-registry.js');
+  const leader = await getAgentByName(leaderAgent, config.name).catch(() => null);
+  if (leader?.id) {
+    config.leader = leader.id;
+    await teamManager.updateTeamConfig(config.name, config);
+  }
 
   // initialPrompt is passed as CLI positional arg — no mailbox backup needed
   // (sending via both paths causes duplicate prompts in the agent's input)


### PR DESCRIPTION
## Summary

Closes 4 of 6 bugs from #1674. Three commits, +109/-9 LOC across 7 files.

| Commit | Bug | Surface |
|---|---|---|
| `ee32b26c` | **Bug 1** | `team.ts` defers leader-id write to after `handleWorkerSpawn` resolves UUID via `getAgentByName`; `team-manager.ts` adds `LEADER_ID_RE` + `sanitizeLeaderForWrite` defensive guard mirroring `pg-seed.ts:431` |
| `ee32b26c` | **Bug 2b** | `agents.ts` LsEntry adds `id?: string`; `agent-directory.ts` SQL SELECT picks `a.id` and surfaces it through `genie ls --json` |
| `95a5495f` | **Bug 2a** | `msg.ts` adds `parseAtSyntax()` so `genie send --to <role>@<team>` correctly resolves cross-team. Parsed team always wins over implicit scope. |
| `95a5495f` | **Bug 5** | `skills/trace/SKILL.md` — every function name in a trace report must be verified via grep. The trace on this issue hallucinated `resolveAgentId` (does not exist; real function is `getAgentByName`), cost a fix loop. |
| `2a36989e` | (unblock) | Wires the dev `env-identity.ts` helpers into `resolveAgentName` + `dispatch-client` — was unused-file flag blocking pre-push. |

## Bugs deferred (separate work)

- **Bug 2c** `--bridge` dead from CLI — design ambiguous (remove flag vs reorder resolver). Coordinate with #181.
- **Bug 2d** `GENIE_TEAM=X --to team-lead` falls back to teamName — accidentally functional once Bug 1 ships (leader IS spawned with `custom_name=teamName`). Fundamental fix is to stop overloading team-name as leader's `custom_name` (a wish-175 surface change).
- **Bug 3** TUI left menu doesn't show fix-spawned agents — needs a focused trace into `Nav.tsx` (45KB) dedup/filter logic.
- **Bug 4** Spawned worker's 88-message queue blocked protocol — Claude Code internals.
- **Bug 6** Working-tree race during stash dance — single observation, not reproducible on demand.

## Test plan

- [x] `bunx tsc --noEmit -p .` → EXIT 0
- [x] `bun run check:fast` → EXIT 0 (lint + dead-code + skills-lint + wishes-lint + emit-discipline all green)
- [ ] Live A1: `genie team create test-fix-$(date +%s) --repo /home/genie/workspace/agents/genie-configure --branch dev --wish turn-sandbox-followup --no-interactive` succeeds end-to-end (after binary rebuild + reinstall)
- [ ] Live A2: `genie ls --json | jq '.[0].id'` returns a UUID-shaped string
- [ ] Live A3: `genie send --to team-lead@<some-other-team>` resolves correctly
- [ ] `bun test src/term-commands/*.test.ts` — DEFERRED: env hang on this host, not a regression of these changes (test files are quarantined describe.skip already)

Closes #1674 (Bugs 1, 2a, 2b, 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)