### PR TITLE
fix(omni-bridge): drop trigger from buffer to end double-delivery race on first message

### DIFF
--- a/src/services/omni-bridge.ts
+++ b/src/services/omni-bridge.ts
@@ -1152,7 +1152,7 @@ export class OmniBridge {
       session: null as unknown as ExecutorSession, // Will be set after spawn
       instanceId: message.instanceId,
       spawning: true,
-      buffer: [message], // Buffer the triggering message too
+      buffer: [], // Spawn delivers the triggering message via Claude's [prompt] CLI arg; deliver()-replay would race the TUI bootstrap
       idleTimer: null,
     };
     this.sessions.set(key, placeholder);
@@ -1228,8 +1228,8 @@ export class OmniBridge {
       console.log(`[omni-bridge] Session active: ${key} ${sessionTag}`);
     } catch (err) {
       console.error(`[omni-bridge] Failed to spawn session for ${key}:`, err);
-      // Re-queue buffered messages before deleting the placeholder
-      const lostMessages = placeholder.buffer;
+      // Re-queue the trigger (never reached the agent because spawn threw) plus any concurrent buffered messages
+      const lostMessages = [message, ...placeholder.buffer];
       if (lostMessages.length > 0) {
         console.warn(
           `[omni-bridge] Re-queuing ${lostMessages.length} buffered message(s) from failed spawn for ${key}`,


### PR DESCRIPTION
## Summary

Fixes the **double-delivery race** in `OmniBridge.spawnSession()` that caused first messages on the **tmux executor** to either get stuck in Claude Code's input or produce duplicate replies.

The triggering message is already passed as `initialMessage` to `executor.spawn()` at `src/services/omni-bridge.ts:1176`, which embeds it as Claude Code's positional `[prompt]` CLI arg via `buildLaunchCommand` (`src/lib/provider-adapters.ts:336-339`). The placeholder buffer was *also* initialized with the same message, so the post-spawn replay loop at `omni-bridge.ts:1219-1221` called `executor.deliver()` → `tmux send-keys` (`src/services/executors/claude-code.ts:336-339`) typing the same body into Claude's still-bootstrapping TUI. With a 200 ms settle before the trailing `Enter`, the body often lands before the TUI input handler is bound, so `Enter` is dropped and the text sits stuck in the input. When the TUI bootstraps in time, the user sees a duplicate reply instead. Removing the trigger from the buffer ends the race; Claude's CLI prompt-arg already delivers the first turn correctly.

**Affected:** every first-message-after-fresh-spawn AND idle-timeout / window-killed respawn flow on the tmux executor. SDK executor unaffected (it implements the same contract natively without the typing race).

## Evidence (from /trace report)

- `src/services/omni-bridge.ts:1081` (pre-fix) — `buffer: [message],  // Buffer the triggering message too`
- `src/services/omni-bridge.ts:1102` (pre-fix line ref) — same content also passed to `executor.spawn(... , message.content)`
- `src/services/omni-bridge.ts:1140-1142` (pre-fix line ref) — buffered trigger replayed via `deliver()`
- `src/services/executors/claude-code.ts:336-339` — `deliver()` two-phase send (text → 200 ms → Enter)
- `src/lib/provider-adapters.ts:336-339` — `initialPrompt` becomes the claude positional `[prompt]` arg

## Side-effect handled (not in the original one-line patch)

The spawn-failure catch block previously relied on `placeholder.buffer` containing the trigger to recover lost messages when `executor.spawn()` threw. With `buffer: []`, the trigger would have been silently dropped on spawn failure (it never reached the agent in that case). To preserve correctness, the catch block now explicitly re-queues `message`:

```ts
const lostMessages = [message, ...placeholder.buffer];
```

This keeps both existing re-queue tests passing (`omni-bridge.test.ts:677` and `:708`).

## Validation

- `bun run typecheck` → **0 errors**
- `bunx biome check src/services/omni-bridge.ts` → clean
- `bun test src/services/__tests__/omni-bridge.test.ts` → **27 pass / 0 fail / 82 expect calls**
- `bun run check:fast` → green (typecheck + lint + dead-code + skills:lint + wishes:lint + lint:emit) — verified by pre-push hook

No tests required modification. No tests asserted `buffer.length === 1` after placeholder creation; the only buffer-related assertions are spawn-failure re-queue checks at `omni-bridge.test.ts:677,708`, both of which still pass thanks to the catch-block adjustment.

## Out of scope

Bug 2 (resume contract for the tmux executor — `claude-code.ts` lacks any `--resume` / `claudeSessionId` plumbing) is a separate follow-up per the trace report. This PR does not touch `src/services/executors/claude-code.ts`, `src/services/executors/registry.ts`, or `src/lib/provider-adapters.ts`.

Fixes #1679 (Bug 1 only — Bug 2 follow-up will close)