### PR TITLE
fix(ci): extract npm pack tarball name from final stdout line

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,10 +110,13 @@ jobs:
       - name: Pack release tarball
         id: pack
         run: |
-          # npm pack writes the tarball to CWD and prints its filename to stdout.
-          # --silent suppresses the progress banner that would otherwise pollute
-          # the step output value.
-          TARBALL=$(npm pack --silent)
+          # npm pack writes the tarball name to stdout as its final line, but
+          # the prepack hook (`bun run build`) ALSO writes to stdout (build
+          # banner + bundled-assets table). `--silent` only suppresses npm's
+          # own progress banner, not the prepack hook's output. Capturing
+          # the full stdout therefore yields a multi-line blob ending with
+          # the tarball name; `tail -n1` extracts the filename reliably.
+          TARBALL=$(npm pack --silent | tail -n1)
           if [ -z "${TARBALL}" ] || [ ! -f "${TARBALL}" ]; then
             echo "npm pack produced no tarball" >&2
             exit 1


### PR DESCRIPTION
## Summary

Fixes the `Pack release tarball` step in `.github/workflows/release.yml`, which has been failing on **every push to main since 2026-04-23** when cosign keyless signing landed (`a9ae5649`). Latest casualty: the merge commit for #1689 (`668e9a8b`).

## Root cause

`TARBALL=\$(npm pack --silent)` captures **all** stdout, not just the tarball name. The `prepack` hook (`bun run build`) writes its own output to stdout — banner + bundled-assets table — and that output is **not** silenced by `npm --silent` (which only suppresses npm's own progress banner, not script-hook stdout).

So `\$TARBALL` ends up being a multi-line blob:

```
$ bun build src/genie.ts ...
Bundled 544 modules in 183ms

  genie.js                                    5.15 MB  (entry point)
  ...
automagik-genie-4.260428.3.tgz   <-- the actual filename
```

`[ ! -f "\${TARBALL}" ]` then fails because `\$TARBALL` is a multi-line string, exiting 1 with `npm pack produced no tarball`.

## Fix

Pipe through `tail -n1` to extract only the final stdout line. `npm pack` always emits the tarball filename as its last line of stdout, so this is robust regardless of what the prepack hook writes.

## Why the workflow has been silently failing

Release runs on push-to-main only. Every Release run on main since 2026-04-28 has failed at the Pack step with this exact symptom — the merge commit and the workflow author both saw `--silent` and assumed it covered prepack output too. The signing infrastructure downstream is fine; nothing ever got far enough to exercise it.

## Test plan

- [x] Reproduce locally: `npm pack --silent` returns 17 lines, original `[ -f \$TARBALL ]` check fails
- [x] Apply fix: `TARBALL=\$(npm pack --silent | tail -n1)` returns `automagik-genie-4.260428.3.tgz`, file check passes
- [ ] Verify Release workflow succeeds end-to-end after merge (cosign sign + verify + SLSA provenance + tamper-detection self-test)

## Notes

- This regression is **not caused by #1689** — that PR's merge commit was just the latest occurrence. The same step failed on `ca0a1d81`, `b32f761b`, etc.
- No source code changes; workflow YAML only. No risk to runtime behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)