### PR TITLE
fix(tl-spawn): write executors.claude_session_id at team-lead spawn (closes orphan-JSONL leak)

### DIFF
--- a/src/genie-commands/session.test.ts
+++ b/src/genie-commands/session.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for session.ts — registerSessionInRegistry session-id propagation.
+ *
+ * Regression test for #212: the operator's interactive `genie session start`
+ * launches claude with `--session-id <uuid>` but did not persist the UUID on
+ * the executor row, so session-capture's filewatch never associated the JSONL
+ * with any agent. The leader's transcript became orphaned and `genie agent
+ * show <leader>` reported "No active executor" while claude was live.
+ *
+ * Uses _deps injection (no mock.module) to avoid bun shared-module-cache leaks.
+ *
+ * Run with: bun test src/genie-commands/session.test.ts
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { CreateExecutorOpts } from '../lib/executor-registry.js';
+
+import { _deps, registerSessionInRegistry } from './session.js';
+
+interface CreateExecutorCall {
+  agentId: string;
+  provider: string;
+  transport: string;
+  opts: CreateExecutorOpts;
+}
+
+describe('registerSessionInRegistry — session-id propagation (#212)', () => {
+  let origDeps: typeof _deps;
+  let createCalls: CreateExecutorCall[];
+
+  beforeEach(() => {
+    origDeps = { ...(_deps as typeof _deps) };
+    createCalls = [];
+
+    _deps.executeTmux = mock(async (cmd: string) => {
+      if (cmd.includes("'#{pane_id}'")) return '%999';
+      if (cmd.includes("'#{pane_pid}'")) return '12345';
+      return '';
+    });
+    _deps.registerWorker = mock(async () => {});
+    _deps.resolveLeaderName = mock(async () => 'leader');
+    _deps.findOrCreateAgent = mock(async () => ({
+      id: 'agent-uuid',
+      name: 'leader',
+      team: 'leader',
+      role: 'leader',
+      currentExecutorId: null,
+    })) as unknown as typeof _deps.findOrCreateAgent;
+    _deps.createAndLinkExecutor = mock(
+      async (agentId: string, provider: string, transport: string, opts: CreateExecutorOpts) => {
+        createCalls.push({ agentId, provider, transport, opts });
+        return {} as never;
+      },
+    ) as unknown as typeof _deps.createAndLinkExecutor;
+  });
+
+  afterEach(() => {
+    Object.assign(_deps, origDeps);
+  });
+
+  test('persists claude_session_id on executor row when sessionId is provided', async () => {
+    const sessionId = 'cafef00d-1234-5678-9abc-def012345678';
+
+    await registerSessionInRegistry('test-session', 'test-window', '/tmp/test-workspace', sessionId);
+
+    expect(createCalls).toHaveLength(1);
+    expect(createCalls[0].opts.claudeSessionId).toBe(sessionId);
+    expect(createCalls[0].provider).toBe('claude');
+    expect(createCalls[0].transport).toBe('tmux');
+  });
+
+  test('falls back to null claudeSessionId when sessionId is omitted (back-compat)', async () => {
+    await registerSessionInRegistry('test-session', 'test-window', '/tmp/test-workspace');
+
+    expect(createCalls).toHaveLength(1);
+    expect(createCalls[0].opts.claudeSessionId).toBeNull();
+  });
+});

--- a/src/genie-commands/session.ts
+++ b/src/genie-commands/session.ts
@@ -113,20 +113,43 @@ export function buildClaudeCommand(
 }
 
 /**
+ * Testable dependency injection — overridable in tests to avoid mock.module
+ * leaking across the shared module cache. Mirrors `protocol-router-spawn._deps`.
+ */
+export const _deps = {
+  executeTmux: tmux.executeTmux as typeof tmux.executeTmux,
+  registerWorker: registry.register as typeof registry.register,
+  findOrCreateAgent: registry.findOrCreateAgent as typeof registry.findOrCreateAgent,
+  createAndLinkExecutor: executorRegistry.createAndLinkExecutor as typeof executorRegistry.createAndLinkExecutor,
+  resolveLeaderName: resolveSessionLeaderName as (team: string) => Promise<string>,
+};
+
+/**
  * Register the interactive genie session in `~/.genie/workers.json`.
  *
  * This allows spawned agents to resolve the team-lead for messaging
  * via the agent registry (e.g., for SendMessage bidirectional comms).
+ *
+ * `sessionId` is the Claude Code session UUID emitted to `--session-id`
+ * at launch. It MUST be persisted on the executor row so session-capture's
+ * filewatch (which joins `agents → executors WHERE claude_session_id IS NOT
+ * NULL`) ingests the leader's JSONL. Without it the JSONL becomes orphaned
+ * and `genie agent show <leader>` reports "No active executor" (#212).
  */
-async function registerSessionInRegistry(sessionName: string, windowName: string, workspaceDir: string): Promise<void> {
+export async function registerSessionInRegistry(
+  sessionName: string,
+  windowName: string,
+  workspaceDir: string,
+  sessionId?: string,
+): Promise<void> {
   try {
     const target = `${sessionName}:${windowName}`;
-    const paneId = (await tmux.executeTmux(`display -t ${shellQuote(target)} -p '#{pane_id}'`)).trim();
+    const paneId = (await _deps.executeTmux(`display -t ${shellQuote(target)} -p '#{pane_id}'`)).trim();
     const now = new Date().toISOString();
     const sanitized = sanitizeTeamName(windowName);
-    const leaderName = await resolveSessionLeaderName(windowName);
+    const leaderName = await _deps.resolveLeaderName(windowName);
     const sanitizedLeader = sanitizeTeamName(leaderName);
-    await registry.register({
+    await _deps.registerWorker({
       id: `${sanitized}-${sanitizedLeader}`,
       paneId,
       session: sessionName,
@@ -144,11 +167,11 @@ async function registerSessionInRegistry(sessionName: string, windowName: string
     });
 
     // Executor model: create agent identity + executor for leader session
-    const agentIdentity = await registry.findOrCreateAgent(leaderName, sanitized, leaderName);
+    const agentIdentity = await _deps.findOrCreateAgent(leaderName, sanitized, leaderName);
 
     let pid: number | null = null;
     try {
-      const pidStr = (await tmux.executeTmux(`display -t ${shellQuote(target)} -p '#{pane_pid}'`)).trim();
+      const pidStr = (await _deps.executeTmux(`display -t ${shellQuote(target)} -p '#{pane_pid}'`)).trim();
       const parsed = Number.parseInt(pidStr, 10);
       if (parsed > 0) pid = parsed;
     } catch {
@@ -162,11 +185,12 @@ async function registerSessionInRegistry(sessionName: string, windowName: string
     // the parent process itself). Regular workers go through spawnAgent which
     // does 'spawning'→'running' explicitly; team-leads do not.
     // Fixes #1184.
-    await executorRegistry.createAndLinkExecutor(agentIdentity.id, 'claude', 'tmux', {
+    await _deps.createAndLinkExecutor(agentIdentity.id, 'claude', 'tmux', {
       pid,
       tmuxSession: sessionName,
       tmuxPaneId: paneId,
       tmuxWindow: windowName,
+      claudeSessionId: sessionId ?? null,
       state: 'running',
       repoPath: workspaceDir,
     });
@@ -270,7 +294,7 @@ async function createSession(
   }
 
   // Register interactive session so spawned agents can find the team-lead
-  await registerSessionInRegistry(sessionName, windowName, workspaceDir);
+  await registerSessionInRegistry(sessionName, windowName, workspaceDir, sessionId);
 }
 
 /**
@@ -354,7 +378,7 @@ async function focusTeamWindow(
     }
 
     // Register interactive session so spawned agents can find the team-lead
-    await registerSessionInRegistry(sessionName, windowName, workingDir);
+    await registerSessionInRegistry(sessionName, windowName, workingDir, sessionId);
   } else {
     // Window exists — check if Claude Code is still running
     const target = `${sessionName}:${windowName}`;
@@ -391,7 +415,7 @@ async function focusTeamWindow(
         // Best-effort guard
       }
 
-      await registerSessionInRegistry(sessionName, windowName, workingDir);
+      await registerSessionInRegistry(sessionName, windowName, workingDir, sessionId);
     }
     // else: Claude Code is still running — just select the window below
   }


### PR DESCRIPTION
## Summary
- Closes the operator-session orphan-JSONL leak that caused `genie agent show <leader>` to report **"No active executor"** while a Claude session was live in tmux. (Felipe lost ongoing work tonight from this exact failure mode.)
- `genie session start` was launching claude with `--session-id <uuid>` but never persisting the UUID on the executor row, so `session-capture`'s filewatch (which joins `agents → executors WHERE claude_session_id IS NOT NULL`) never associated the JSONL with any agent.
- Plumb the minted (or resumed) UUID through `registerSessionInRegistry` to `executorRegistry.createAndLinkExecutor` as `claudeSessionId`. All three call sites in `createSession` / `focusTeamWindow` already had the UUID in scope.

## Why this path
- `genie team create --wish` (`spawnLeaderWithWish` → `handleWorkerSpawn`) was already correct: `buildSpawnParams` mints `params.sessionId`, `SpawnCtx.claudeSessionId` flows it into `createTmuxExecutor`.
- `team-auto-spawn.ts ensureTeamLead` was already correct via `recordTeamLeadExecutor`.
- The gap was **`genie-commands/session.ts`** — the operator's interactive entry point, which the dogfood team-lead (`genie`) actually uses every day. Three call sites passed through to a 4-arg helper that dropped the session UUID on the floor.

## Diff scope
- 1 source file (`src/genie-commands/session.ts`): +34 / -10
- 1 new test file (`src/genie-commands/session.test.ts`): 2 tests covering propagation + back-compat fallback
- `_deps` injection block follows the existing `protocol-router-spawn._deps` pattern so tests don't pollute bun's shared module cache via `mock.module`.

## Test plan
- [x] `bun test src/genie-commands/session.test.ts` — both new tests pass
- [x] `bun test src/lib/team-lead-command.test.ts src/lib/team-auto-spawn.test.ts src/lib/executor-registry.test.ts` — 118 pass, 0 fail (no regressions in the surrounding spawn/executor surface)
- [x] `bun run typecheck`
- [x] `bunx biome check src/genie-commands/session.ts src/genie-commands/session.test.ts`
- [ ] Manual smoke (operator): `genie session start` in a fresh dir, capture session UUID from `~/.claude/projects/<encoded-cwd>/<uuid>.jsonl`, then `genie agent show <leader>` — `claudeSessionId` should be that exact UUID, not null.

Closes #212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for session registration functionality, including backward compatibility verification.

* **Improvements**
  * Enhanced session identification and tracking to ensure proper association of execution data with individual sessions throughout session lifecycle operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->