### PR TITLE
feat(done): make --report mandatory on every close

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,10 +110,13 @@ jobs:
       - name: Pack release tarball
         id: pack
         run: |
-          # npm pack writes the tarball to CWD and prints its filename to stdout.
-          # --silent suppresses the progress banner that would otherwise pollute
-          # the step output value.
-          TARBALL=$(npm pack --silent)
+          # npm pack writes the tarball name to stdout as its final line, but
+          # the prepack hook (`bun run build`) ALSO writes to stdout (build
+          # banner + bundled-assets table). `--silent` only suppresses npm's
+          # own progress banner, not the prepack hook's output. Capturing
+          # the full stdout therefore yields a multi-line blob ending with
+          # the tarball name; `tail -n1` extracts the filename reliably.
+          TARBALL=$(npm pack --silent | tail -n1)
           if [ -z "${TARBALL}" ] || [ ! -f "${TARBALL}" ]; then
             echo "npm pack produced no tarball" >&2
             exit 1

--- a/src/__tests__/agent-team-inheritance.test.ts
+++ b/src/__tests__/agent-team-inheritance.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Subagent team inheritance + built-in pinning regression tests.
+ *
+ * Bug class: subagents (id='parent/child') did not inherit the parent's team,
+ * and built-in agents (engineer, trace, qa, council--*) accumulated sticky
+ * team pins from whichever team spawned them first. Both broke
+ * `genie send`, mailbox routing, and inbox visibility.
+ *
+ * The fix has three parts:
+ *   1. `lookupTemplateTeam(name)` falls back to the parent name when an
+ *      exact-id row is missing.
+ *   2. `directory.resolve()` no longer attaches a template-pinned team to
+ *      built-in entries (let `resolveTeamName` tier 3/4 decide instead).
+ *   3. `finalizeTmuxSpawn` + `lockedSpawnWorker` skip `saveTemplate` for
+ *      built-ins and override `team` with the parent's team for
+ *      hierarchical names before persisting.
+ *
+ * This file locks each part with a focused assertion against the live
+ * agent_templates table.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import * as directory from '../lib/agent-directory.js';
+import { isBuiltinAgent } from '../lib/builtin-agents.js';
+import { DB_AVAILABLE, setupTestDatabase } from '../lib/test-db.js';
+
+async function seedTemplate(id: string, team: string): Promise<void> {
+  const { getConnection } = await import('../lib/db.js');
+  const sql = await getConnection();
+  await sql`
+    INSERT INTO agent_templates (id, provider, team, cwd, last_spawned_at)
+    VALUES (${id}, 'claude', ${team}, '/tmp/seed', now())
+    ON CONFLICT (id) DO UPDATE SET team = EXCLUDED.team, last_spawned_at = EXCLUDED.last_spawned_at
+  `;
+}
+
+describe.skipIf(!DB_AVAILABLE)('subagent team inheritance + built-in pinning', () => {
+  let cleanup: () => Promise<void>;
+
+  beforeAll(async () => {
+    cleanup = await setupTestDatabase();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  beforeEach(async () => {
+    const { getConnection } = await import('../lib/db.js');
+    const sql = await getConnection();
+    await sql`TRUNCATE TABLE agent_templates CASCADE`;
+  });
+
+  // -------------------------------------------------------------------------
+  // (1) Built-ins are SHARED — directory.resolve must not attach a sticky
+  //     team even when a poisoned template row exists.
+  // -------------------------------------------------------------------------
+  test('built-in `engineer` ignores poisoned agent_templates row', async () => {
+    expect(isBuiltinAgent('engineer')).toBe(true);
+    await seedTemplate('engineer', 'felipe'); // simulates pre-fix poisoned row
+
+    const resolved = await directory.resolve('engineer');
+    expect(resolved).not.toBeNull();
+    expect(resolved?.builtin).toBe(true);
+    expect(resolved?.entry.team).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // (2) Subagent name (`parent/child`) inherits the parent template's team
+  //     when no exact-id row exists.
+  // -------------------------------------------------------------------------
+  test('lookupTemplateTeam falls back to parent for `parent/child` names', async () => {
+    await seedTemplate('genie-omni', 'genie-omni');
+
+    const resolved = await directory.lookupTemplateTeam('genie-omni/dog-fooder');
+    expect(resolved).toBe('genie-omni');
+  });
+
+  test('lookupTemplateTeam prefers exact-id row over parent fallback', async () => {
+    await seedTemplate('genie-omni', 'genie-omni');
+    await seedTemplate('genie-omni/dog-fooder', 'override-team');
+
+    const resolved = await directory.lookupTemplateTeam('genie-omni/dog-fooder');
+    expect(resolved).toBe('override-team');
+  });
+
+  test('lookupTemplateTeam returns null when neither exact-id nor parent exists', async () => {
+    const resolved = await directory.lookupTemplateTeam('orphan/child');
+    expect(resolved).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // (3) `lookupTemplateTeam` returns the row team deterministically — id is
+  //     the primary key, so a single id maps to a single row.
+  // -------------------------------------------------------------------------
+  test('lookupTemplateTeam returns the row team for an exact-id match', async () => {
+    await seedTemplate('genie-omni', 'genie-omni');
+
+    const team = await directory.lookupTemplateTeam('genie-omni');
+    expect(team).toBe('genie-omni');
+  });
+
+  // -------------------------------------------------------------------------
+  // (4) Migration 054 backfill: poisoned subagent rows get healed to inherit
+  //     the parent's team; built-in pins are wiped.
+  // -------------------------------------------------------------------------
+  test('migration 054 heals poisoned subagent rows', async () => {
+    const { getConnection } = await import('../lib/db.js');
+    const sql = await getConnection();
+
+    await seedTemplate('genie-omni', 'genie-omni');
+    await seedTemplate('genie-omni/dog-fooder', 'felipe'); // poisoned
+    await seedTemplate('engineer', 'felipe'); // built-in poisoned
+
+    // Run the migration backfill steps inline (mirrors 054_fix_subagent_team_inheritance.sql)
+    await sql`
+      UPDATE agent_templates AS child
+      SET team = parent.team, updated_at = now()
+      FROM agent_templates AS parent
+      WHERE child.id LIKE parent.id || '/%'
+        AND parent.id NOT LIKE '%/%'
+        AND child.team IS DISTINCT FROM parent.team
+    `;
+    await sql`DELETE FROM agent_templates WHERE id = 'engineer'`;
+
+    const subagent = await sql`SELECT team FROM agent_templates WHERE id = 'genie-omni/dog-fooder'`;
+    expect(subagent[0].team).toBe('genie-omni');
+
+    const builtin = await sql`SELECT team FROM agent_templates WHERE id = 'engineer'`;
+    expect(builtin.length).toBe(0);
+  });
+});

--- a/src/db/migrations/044_phase_b_flip_defaults.test.ts
+++ b/src/db/migrations/044_phase_b_flip_defaults.test.ts
@@ -42,7 +42,12 @@ describe.skipIf(!DB_AVAILABLE)('migration 044 — Phase B: flip auto_resume + re
     await cleanup();
   });
 
-  test('fresh DB: agents.auto_resume column default is false after migration 044', async () => {
+  test('fresh DB: agents.auto_resume column default is true after migration 055', async () => {
+    // Migration 055 (PR #1693) flipped the column default from `false` to `true`.
+    // Felipe directive 2026-05-07: default-off was a bug shape — 52/53 agents
+    // had auto_resume=false, meaning no agent could resume without first
+    // running `genie agent recover`. The migration runner applies every
+    // migration under the test schema, so we observe the post-055 state.
     const sql = await getConnection();
     const rows = await sql<{ column_default: string | null }[]>`
       SELECT column_default
@@ -53,10 +58,12 @@ describe.skipIf(!DB_AVAILABLE)('migration 044 — Phase B: flip auto_resume + re
     `;
     expect(rows.length).toBe(1);
     // Postgres reports boolean defaults as 'true' / 'false' literal strings.
-    expect(rows[0].column_default).toBe('false');
+    expect(rows[0].column_default).toBe('true');
   });
 
-  test('fresh-INSERT agent row inherits auto_resume=false', async () => {
+  test('fresh-INSERT agent row inherits auto_resume=true (post-055 default)', async () => {
+    // Migration 055 flipped the default to true. Fresh inserts that don't
+    // explicitly set auto_resume now inherit the safe value.
     const sql = await getConnection();
     const id = `test-fresh-${Date.now()}`;
     await sql`
@@ -66,7 +73,7 @@ describe.skipIf(!DB_AVAILABLE)('migration 044 — Phase B: flip auto_resume + re
     const rows = await sql<{ auto_resume: boolean | null }[]>`
       SELECT auto_resume FROM agents WHERE id = ${id}
     `;
-    expect(rows[0].auto_resume).toBe(false);
+    expect(rows[0].auto_resume).toBe(true);
   });
 
   test('live row (last_state_change < 1h, non-terminal state) preserves auto_resume=true', async () => {

--- a/src/db/migrations/054_fix_subagent_team_inheritance.sql
+++ b/src/db/migrations/054_fix_subagent_team_inheritance.sql
@@ -1,0 +1,70 @@
+-- 054_fix_subagent_team_inheritance.sql — Backfill agent_templates.team for
+-- subagents and wipe sticky team pins on built-in roles + council members.
+--
+-- Why
+-- ---
+-- Two pre-fix defects let the team column drift away from its semantic owner:
+--
+--   1. Subagent rows (id = 'parent/child') were saved with whatever team the
+--      operator's session happened to be in (often 'felipe' or 'genie'),
+--      not the parent agent's team. Downstream `genie send`, mailbox
+--      routing, and inbox visibility used the wrong team.
+--
+--   2. Built-in roles (engineer, trace, qa, fix, reviewer, etc.) and council
+--      members (council, council--*) are SHARED across teams — they were
+--      never meant to carry a sticky team. The first spawn pinned the team
+--      forever via `lookupTemplateTeam`, contaminating every later spawn.
+--
+-- The runtime fix in this PR (skip-saveTemplate for built-ins, parent
+-- override for subagents) prevents the regression going forward; this
+-- migration heals the rows already poisoned in production databases.
+--
+-- Idempotent: re-running this migration is a no-op once the rows are clean.
+
+BEGIN;
+
+-- 1. Backfill: subagent rows inherit their parent's team.
+--    `child.id LIKE parent.id || '/%'` matches `parent/anything` whose parent
+--    name has no slash itself (avoids matching grandparent/parent/child).
+--    Skip when child.team already equals parent.team.
+UPDATE agent_templates AS child
+SET team = parent.team,
+    updated_at = now()
+FROM agent_templates AS parent
+WHERE child.id LIKE parent.id || '/%'
+  AND parent.id NOT LIKE '%/%'
+  AND child.team IS DISTINCT FROM parent.team;
+
+-- 2. Wipe sticky pins for built-in roles + council members.
+--    Built-ins are SHARED — runtime resolution (GENIE_TEAM env, tmux
+--    discovery) decides the team per-spawn now. Keeping the rows would let
+--    `lookupTemplateTeam` keep returning a stale team for the first caller
+--    of every spawn until the rows are overwritten with a fresh team —
+--    which the runtime fix now refuses to do.
+DELETE FROM agent_templates
+WHERE id IN (
+  -- BUILTIN_ROLES (plugins/genie/agents/*/AGENTS.md, category=role)
+  'docs',
+  'engineer',
+  'fix',
+  'pm',
+  'qa',
+  'refactor',
+  'reviewer',
+  'team-lead',
+  'trace',
+  -- BUILTIN_COUNCIL_MEMBERS (plugins/genie/agents/council*, category=council)
+  'council',
+  'council--architect',
+  'council--benchmarker',
+  'council--deployer',
+  'council--ergonomist',
+  'council--measurer',
+  'council--operator',
+  'council--questioner',
+  'council--sentinel',
+  'council--simplifier',
+  'council--tracer'
+);
+
+COMMIT;

--- a/src/db/migrations/055_default_auto_resume_true.sql
+++ b/src/db/migrations/055_default_auto_resume_true.sql
@@ -1,0 +1,39 @@
+-- 055_default_auto_resume_true.sql — Flip the agents.auto_resume default to
+-- TRUE and backfill every existing FALSE row to TRUE.
+--
+-- Why
+-- ---
+-- DB evidence (2026-05-07): 52 of 53 agents had auto_resume=false. The
+-- chokepoint `shouldResume()` treats false as "operator paused or scheduler
+-- exhausted retry budget" — but the column was effectively defaulting off,
+-- so no agent could be resumed without first running `genie agent recover`
+-- to flip the flag. Felipe directive (2026-05-07): default-on is the bug
+-- shape; flip every existing row to true and change the column DEFAULT so
+-- newly-spawned agents get the safe value out of the gate.
+--
+-- This migration also lands the trace-confirmed bug fix where
+-- `MissingResumeSessionError` reported reason='null_session' on rows whose
+-- session UUID was perfectly intact — auto_resume=false was the actual
+-- precondition. The protocol-router error enum now distinguishes the two
+-- (`auto_resume_disabled` vs `null_session`); this migration removes the
+-- silent default-off that triggered the misleading message in the first
+-- place.
+--
+-- Idempotent: re-running this migration is a no-op on rows that are already
+-- true and on a column whose default is already true.
+
+BEGIN;
+
+-- 1. Flip every existing false row. No WHERE narrowing — Felipe directive
+--    is to flip ALL of them so resume works out-of-the-box.
+UPDATE agents
+SET auto_resume = true
+WHERE auto_resume = false;
+
+-- 2. Change the column DEFAULT so future spawns inherit the safe value.
+--    NULLs (legacy rows that pre-date the column) become true — same as
+--    the safe-default the runtime treats them as.
+ALTER TABLE agents ALTER COLUMN auto_resume SET DEFAULT true;
+UPDATE agents SET auto_resume = true WHERE auto_resume IS NULL;
+
+COMMIT;

--- a/src/genie.ts
+++ b/src/genie.ts
@@ -265,9 +265,13 @@ registerApprovalCommands(program);
 program
   .command('done [ref]')
   .description('Close the current turn (inside an agent session) or mark a wish group done (team-lead, <slug>#<group>)')
-  .action(async (ref: string | undefined) => {
+  .option(
+    '-r, --report <message>',
+    'One-line summary of what was completed (REQUIRED — your handoff note for the audit trail and orchestrator)',
+  )
+  .action(async (ref: string | undefined, options: { report?: string }) => {
     const { doneAction } = await import('./term-commands/done.js');
-    await doneAction(ref);
+    await doneAction(ref, options);
   });
 
 program

--- a/src/lib/agent-directory.ts
+++ b/src/lib/agent-directory.ts
@@ -352,20 +352,21 @@ export async function resolve(name: string): Promise<ResolvedAgent | null> {
     /* PG unavailable — fall through to built-ins */
   }
 
-  // 3. Check built-in roles
+  // 3. Check built-in roles. Built-ins are SHARED across teams — they MUST
+  //    NOT carry a sticky team pin from `agent_templates`. Whichever team
+  //    spawned `engineer` first would otherwise become the canonical team
+  //    for every subsequent spawn, breaking `genie send` / mailbox routing
+  //    on every other team. Let `resolveTeamName` tier 3 (GENIE_TEAM env)
+  //    and tier 4 (discoverTeamName) decide team for built-ins.
   const builtinRole = BUILTIN_ROLES.find((r: BuiltinAgent) => r.name === name);
   if (builtinRole) {
-    const entry = builtinToEntry(builtinRole);
-    if (templateTeam) entry.team = templateTeam;
-    return { entry, builtin: true };
+    return { entry: builtinToEntry(builtinRole), builtin: true };
   }
 
-  // 4. Check built-in council members
+  // 4. Check built-in council members — same SHARED-team rule as roles.
   const councilMember = BUILTIN_COUNCIL_MEMBERS.find((m: BuiltinAgent) => m.name === name);
   if (councilMember) {
-    const entry = builtinToEntry(councilMember);
-    if (templateTeam) entry.team = templateTeam;
-    return { entry, builtin: true };
+    return { entry: builtinToEntry(councilMember), builtin: true };
   }
 
   return null;
@@ -376,15 +377,31 @@ export async function resolve(name: string): Promise<ResolvedAgent | null> {
  * Returns null when PG is unavailable, the row does not exist, or the team
  * column is empty. This is an authoritative PG lookup — NOT a synthetic
  * tmux/env fallback — and powers tier 2 of the team-resolution precedence.
+ *
+ * For hierarchical names (`parent/child`), if no exact match exists we fall
+ * back to the parent name — subagents inherit their parent's team. Without
+ * this, `genie-omni/dog-fooder` could not find `genie-omni`'s pinned team
+ * and downstream `genie send` / mailbox routing landed on the wrong team.
  */
-async function lookupTemplateTeam(name: string): Promise<string | null> {
+export async function lookupTemplateTeam(name: string): Promise<string | null> {
   try {
     const { getConnection } = await import('./db.js');
     const sql = await getConnection();
-    const rows = await sql`SELECT team FROM agent_templates WHERE id = ${name} LIMIT 1`;
-    if (rows.length === 0) return null;
-    const team = rows[0].team;
-    return typeof team === 'string' && team.length > 0 ? team : null;
+    const direct = await sql`SELECT team FROM agent_templates WHERE id = ${name} LIMIT 1`;
+    if (direct.length > 0) {
+      const team = direct[0].team;
+      if (typeof team === 'string' && team.length > 0) return team;
+    }
+    const slash = name.indexOf('/');
+    if (slash > 0) {
+      const parent = name.slice(0, slash);
+      const parentRows = await sql`SELECT team FROM agent_templates WHERE id = ${parent} LIMIT 1`;
+      if (parentRows.length > 0) {
+        const team = parentRows[0].team;
+        if (typeof team === 'string' && team.length > 0) return team;
+      }
+    }
+    return null;
   } catch (err) {
     // Previously silently swallowed — real PG failures (connection drops,
     // missing table) hid behind a null return and showed up as mysterious

--- a/src/lib/agent-directory.ts
+++ b/src/lib/agent-directory.ts
@@ -348,6 +348,27 @@ export async function resolve(name: string): Promise<ResolvedAgent | null> {
       if (templateTeam) entry.team = templateTeam;
       return { entry, builtin: false };
     }
+
+    // 1b. Fallback to custom_name when role didn't match. Spawned agents
+    // routinely have a custom_name (e.g. "felipe", "fix-resume-name-flag")
+    // that diverges from `role`; without this fallback, `genie agent
+    // recover felipe` failed at the resolver step even though the row was
+    // there (Felipe directive 2026-05-07).
+    const byCustomName = await sql`
+      SELECT role, custom_name, metadata, created_at FROM agents
+      WHERE custom_name = ${name}
+      ORDER BY (CASE WHEN position('dir:' in id) = 1 THEN 0 ELSE 1 END), started_at DESC
+      LIMIT 1
+    `;
+    if (byCustomName.length > 0) {
+      const row = byCustomName[0];
+      const meta = parseMetadata(row.metadata);
+      const createdAt =
+        row.created_at instanceof Date ? row.created_at.toISOString() : (row.created_at as string | undefined);
+      const entry = roleToEntry(typeof row.role === 'string' ? row.role : name, undefined, meta, createdAt);
+      if (templateTeam) entry.team = templateTeam;
+      return { entry, builtin: false };
+    }
   } catch {
     /* PG unavailable — fall through to built-ins */
   }

--- a/src/lib/builtin-agents.ts
+++ b/src/lib/builtin-agents.ts
@@ -149,3 +149,13 @@ export function listRoleNames(): string[] {
 export function listCouncilNames(): string[] {
   return BUILTIN_COUNCIL_MEMBERS.map((m) => m.name);
 }
+
+/**
+ * Check if a name is a known built-in agent (role or council member).
+ * Built-ins are SHARED across teams — they must not carry sticky team pins
+ * in `agent_templates`, otherwise `lookupTemplateTeam` returns the team of
+ * whichever spawn happened to land first and contaminates every later spawn.
+ */
+export function isBuiltinAgent(name: string): boolean {
+  return ALL_BUILTINS.some((a) => a.name === name);
+}

--- a/src/lib/executor-registry.ts
+++ b/src/lib/executor-registry.ts
@@ -259,13 +259,19 @@ export async function updateClaudeSessionId(executorId: string, sessionId: strin
 
 /**
  * Identity passed to the JSONL fallback scanner. Mirrors the canonical
- * `(team, custom_name)` columns on `agents`. Both fields must be non-null
- * to attempt a match — the fallback refuses to return another agent's
- * transcript when ownership is unknown.
+ * `(team, custom_name)` columns on `agents`. `customName` is required (the
+ * scanner refuses to return another agent's transcript when role identity
+ * is unknown). `team` may be null for legacy / orphan rows where no team
+ * was ever recorded — in that case the scanner matches on `agentName` alone
+ * and additionally accepts JSONL bodies whose `teamName` is null.
  */
 export interface ResumeFallbackIdentity {
-  /** Agent's `team` column. Populated by `findOrCreateAgent`. */
-  team: string;
+  /**
+   * Agent's `team` column. Populated by `findOrCreateAgent`. May be null
+   * for legacy/orphan rows; when null, the scanner relaxes to a customName
+   * match only.
+   */
+  team: string | null;
   /** Agent's `custom_name` column. The role-or-name part of the identity. */
   customName: string;
 }
@@ -432,7 +438,12 @@ async function defaultScanForSession(cwd: string, identity: ResumeFallbackIdenti
 
   for (const candidate of sorted) {
     const { teamName, agentName } = await readJsonlIdentity(candidate.full);
-    if (teamName !== identity.team || agentName !== identity.customName) continue;
+    if (agentName !== identity.customName) continue;
+    // Identity.team is allowed to be null for orphan / legacy rows
+    // (Felipe directive 2026-05-07): in that case match on agentName alone.
+    // When identity.team is set, require strict teamName equality so we
+    // don't attach team A's runtime to team B's transcript.
+    if (identity.team !== null && teamName !== identity.team) continue;
     return candidate.name.replace(/\.jsonl$/, '');
   }
   return null;
@@ -467,12 +478,14 @@ type ResumeRow = {
 /**
  * Try the JSONL on-disk fallback for an agent whose DB resume read missed.
  * Returns the recovered session UUID if a matching JSONL is found, or null
- * if no cwd / no identity / no JSONL match. Emits `resume.recovered_via_jsonl`
- * on hit.
+ * if no cwd / no customName / no JSONL match. Emits
+ * `resume.recovered_via_jsonl` on hit.
  *
- * Identity is `(team, custom_name)` and BOTH must be present — a missing
- * identity makes ownership unverifiable, and we refuse to attach an agent's
- * runtime to another agent's transcript.
+ * Identity is `(team, custom_name)`. `custom_name` is required (the scanner
+ * refuses to attach without role identity), but `team` may be null —
+ * legacy/orphan rows that never got a team assigned still resume off-disk
+ * by matching on `agentName` alone (Felipe directive 2026-05-07: previous
+ * strict-both check stranded rows where team got dropped).
  */
 async function tryJsonlFallback(agentId: string, row: ResumeRow | null, actor: string): Promise<string | null> {
   const cwd = row?.repo_path ?? null;
@@ -480,8 +493,8 @@ async function tryJsonlFallback(agentId: string, row: ResumeRow | null, actor: s
 
   const team = row?.team ?? null;
   const customName = row?.custom_name ?? null;
-  const identity: ResumeFallbackIdentity | null = team && customName ? { team, customName } : null;
-  if (!identity) return null;
+  if (!customName) return null;
+  const identity: ResumeFallbackIdentity = { team, customName };
 
   const scanner = _resumeJsonlScannerDeps.scanForSession ?? defaultScanForSession;
   const recoveredSessionId = await scanner(cwd, identity);

--- a/src/lib/protocol-router.test.ts
+++ b/src/lib/protocol-router.test.ts
@@ -526,6 +526,37 @@ describe.skipIf(!DB_AVAILABLE)('pg', () => {
       expect(legacyAlias.reason).toBe('no_session_id');
       expect(legacyAlias.message).toContain('no_session_id');
     });
+
+    // Felipe directive 2026-05-07: when an agent has auto_resume=false but
+    // its session UUID is intact, the error must NOT pretend the session is
+    // lost. Previously every "I can't resume" outcome collapsed onto
+    // null_session, and operators chased nonexistent missing-session bugs.
+    test('MissingResumeSessionError(reason=auto_resume_disabled) tells the operator the session is intact and to run recover', async () => {
+      const { MissingResumeSessionError } = await import('./protocol-router.js');
+
+      const paused = new MissingResumeSessionError('paused-agent', undefined, 'auto_resume_disabled');
+      expect(paused.reason).toBe('auto_resume_disabled');
+      expect(paused.entityId).toBe('paused-agent');
+      // Message MUST distinguish from the "session lost" case.
+      expect(paused.message).toContain('auto_resume is disabled');
+      expect(paused.message).toContain('session UUID is intact');
+      expect(paused.message).toContain('genie agent recover paused-agent');
+      // Must NOT mislead the operator into thinking the session is lost.
+      expect(paused.message).not.toContain('no claude_session_id recorded');
+      expect(paused.message).not.toContain('genie reset');
+    });
+
+    test('MissingResumeSessionError(reason=null_session) keeps the session-lost runbook hint', async () => {
+      const { MissingResumeSessionError } = await import('./protocol-router.js');
+
+      const lost = new MissingResumeSessionError('lost-agent', undefined, 'null_session');
+      expect(lost.reason).toBe('null_session');
+      // Genuine session-loss path keeps the legacy `genie reset` runbook hint.
+      expect(lost.message).toContain('no claude_session_id recorded');
+      expect(lost.message).toContain('genie reset lost-agent');
+      // And must NOT confuse itself with the auto_resume_disabled message.
+      expect(lost.message).not.toContain('auto_resume is disabled');
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/src/lib/protocol-router.ts
+++ b/src/lib/protocol-router.ts
@@ -47,12 +47,28 @@ interface DeliveryResult {
  * of quietly proceeding with a fresh spawn.
  *
  * `reason` names which precondition failed:
- *   - `no_executor`   — agent has no `current_executor_id` (never spawned, or row pruned)
- *   - `null_session`  — executor row exists but `claude_session_id` is null
- *   - `no_session_id` — legacy alias kept for callers that read `agent.claudeSessionId`
- *                       directly before Group 1's single-reader helper lands.
+ *   - `no_executor`           — agent has no `current_executor_id` (never spawned, or row pruned)
+ *   - `null_session`          — executor row exists but `claude_session_id` is null (genuine session loss)
+ *   - `no_session_id`         — legacy alias kept for callers that read `agent.claudeSessionId`
+ *                                directly before Group 1's single-reader helper lands.
+ *   - `auto_resume_disabled`  — executor HAS a session_id, but `agents.auto_resume = false`
+ *                                (operator paused or scheduler exhausted retries). The session
+ *                                is intact — flip `auto_resume = true` via `genie agent recover`.
  */
-export type MissingResumeSessionReason = 'no_executor' | 'null_session' | 'no_session_id';
+export type MissingResumeSessionReason = 'no_executor' | 'null_session' | 'no_session_id' | 'auto_resume_disabled';
+
+function buildResumeErrorMessage(workerId: string, suffix: string, reason: MissingResumeSessionReason): string {
+  if (reason === 'auto_resume_disabled') {
+    return (
+      `Cannot resume worker "${workerId}"${suffix}: auto_resume is disabled, but the session UUID is intact ` +
+      `(reason: auto_resume_disabled). Run \`genie agent recover ${workerId} --yes\` to flip the flag and resume.`
+    );
+  }
+  return (
+    `Cannot resume worker "${workerId}"${suffix}: executor has no claude_session_id recorded (reason: ${reason}). ` +
+    `This usually means the worker predates the session-sync hook. Run \`genie reset ${workerId}\` or re-spawn the worker to recover.`
+  );
+}
 
 export class MissingResumeSessionError extends Error {
   readonly workerId: string;
@@ -62,9 +78,7 @@ export class MissingResumeSessionError extends Error {
 
   constructor(workerId: string, recipientId?: string, reason: MissingResumeSessionReason = 'null_session') {
     const suffix = recipientId ? ` (recipient "${recipientId}")` : '';
-    super(
-      `Cannot resume worker "${workerId}"${suffix}: executor has no claude_session_id recorded (reason: ${reason}). This usually means the worker predates the session-sync hook. Run \`genie reset ${workerId}\` or re-spawn the worker to recover.`,
-    );
+    super(buildResumeErrorMessage(workerId, suffix, reason));
     this.name = 'MissingResumeSessionError';
     this.workerId = workerId;
     this.entityId = workerId;

--- a/src/lib/protocol-router.ts
+++ b/src/lib/protocol-router.ts
@@ -345,7 +345,21 @@ export async function resolveResumeSessionId(
   const agentIdToProbe = worker?.id ?? `dir:${recipientId}`;
   const decision = await shouldResume(agentIdToProbe);
   if (worker && (await isExecutorResumable(worker))) {
-    if (!decision.sessionId) throw new MissingResumeSessionError(worker.id, recipientId);
+    // CodeRabbit-flagged gap (PR #1693): the chokepoint may return
+    // `resume: false` with a sessionId still attached (e.g.
+    // `auto_resume_disabled` — operator explicitly paused). Without checking
+    // `decision.resume`, the spawn-side path would silently resume a paused
+    // worker. Propagate the chokepoint reason onto the error so operators
+    // see "auto_resume disabled — run recover" instead of "session lost".
+    if (!decision.resume || !decision.sessionId) {
+      const errReason: MissingResumeSessionReason =
+        decision.reason === 'unknown_agent'
+          ? 'no_executor'
+          : decision.reason === 'auto_resume_disabled'
+            ? 'auto_resume_disabled'
+            : 'null_session';
+      throw new MissingResumeSessionError(worker.id, recipientId, errReason);
+    }
   }
   return decision.sessionId;
 }

--- a/src/lib/protocol-router.ts
+++ b/src/lib/protocol-router.ts
@@ -13,7 +13,9 @@
  *   4. Native inbox fallback
  */
 
+import * as directory from './agent-directory.js';
 import * as registry from './agent-registry.js';
+import { isBuiltinAgent } from './builtin-agents.js';
 import * as nativeTeams from './claude-native-teams.js';
 import { getConnection } from './db.js';
 import { findExecutorByPane, getCurrentExecutor } from './executor-registry.js';
@@ -280,7 +282,20 @@ async function lockedSpawnWorker(
 
   if (lockResult.type === 'existing') return { worker: lockResult.worker, respawned: false };
 
-  await registry.saveTemplate({ ...template, lastSpawnedAt: new Date().toISOString() });
+  // Mirror finalizeTmuxSpawn's persistence guard: built-ins are SHARED — never
+  // pin them; subagents (`parent/child`) inherit the parent's team. Without
+  // these guards an auto-respawn refreshes `last_spawned_at` AND can stamp
+  // the wrong team back into agent_templates, defeating the fix at the
+  // primary spawn site.
+  if (!isBuiltinAgent(template.id)) {
+    let team = template.team;
+    const slash = template.id.indexOf('/');
+    if (slash > 0) {
+      const parentTeam = await directory.lookupTemplateTeam(template.id.slice(0, slash));
+      if (parentTeam) team = parentTeam;
+    }
+    await registry.saveTemplate({ ...template, team, lastSpawnedAt: new Date().toISOString() });
+  }
 
   const readyCheck = _deps.waitForWorkerReady ?? waitForWorkerReady;
   await readyCheck(lockResult.paneId);

--- a/src/lib/provider-adapters.test.ts
+++ b/src/lib/provider-adapters.test.ts
@@ -141,6 +141,58 @@ describe('buildClaudeCommand', () => {
     expect(result.command).toContain("--model 'opus'");
   });
 
+  // Felipe directive 2026-05-07: --name was retired because CC stored it as
+  // `customTitle` in the JSONL header and then composed the resume hint as
+  // `claude --resume "<customTitle>"` instead of the canonical UUID, breaking
+  // session resume. Even when callers pass `name`, the launch command MUST
+  // NOT emit --name. Sessions are identified exclusively by --session-id /
+  // --resume <uuid>.
+  it('never emits --name even when params.name is set', () => {
+    const result = buildClaudeCommand({
+      provider: 'claude',
+      team: 'work',
+      role: 'implementor',
+      name: 'felipe',
+    });
+    expect(result.command).not.toContain('--name ');
+  });
+
+  it('never emits --name on a fresh-spawn command', () => {
+    const result = buildClaudeCommand({
+      provider: 'claude',
+      team: 'work',
+      role: 'implementor',
+    });
+    expect(result.command).not.toContain('--name ');
+  });
+
+  it('uses --session-id (not --name) for session identity on fresh spawn', () => {
+    const result = buildClaudeCommand({
+      provider: 'claude',
+      team: 'work',
+      role: 'implementor',
+      sessionId: '11111111-2222-3333-4444-555555555555',
+      name: 'should-be-ignored',
+    });
+    expect(result.command).toContain('--session-id');
+    expect(result.command).toContain("'11111111-2222-3333-4444-555555555555'");
+    expect(result.command).not.toContain('--name ');
+    expect(result.command).not.toContain("'should-be-ignored'");
+  });
+
+  it('uses --resume (not --name) for session identity on resume', () => {
+    const result = buildClaudeCommand({
+      provider: 'claude',
+      team: 'work',
+      role: 'implementor',
+      resume: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      name: 'felipe',
+    });
+    expect(result.command).toContain('--resume');
+    expect(result.command).toContain("'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'");
+    expect(result.command).not.toContain('--name ');
+  });
+
   it('includes --append-system-prompt-file by default when systemPromptFile is set', () => {
     const result = buildClaudeCommand({
       provider: 'claude',

--- a/src/lib/provider-adapters.ts
+++ b/src/lib/provider-adapters.ts
@@ -105,7 +105,13 @@ export interface SpawnParams {
   model?: string;
   /** Initial prompt to send as the first user message (Claude Code positional [prompt] arg). */
   initialPrompt?: string;
-  /** Display name for the CC session (emits --name). Used in /resume and terminal title. */
+  /**
+   * @deprecated 2026-05-07 — `--name` was retired because CC stored it as
+   * `customTitle` in the JSONL header and then composed `claude --resume
+   * "<customTitle>"` instead of the canonical UUID, breaking session resume.
+   * The field remains in the schema for backward compatibility but is no
+   * longer emitted on the launch command. Always use `sessionId` / `resume`.
+   */
   name?: string;
   /** Claude Code permissions (allow/deny lists with Bash() patterns). Merged into --settings. */
   permissions?: { allow?: string[]; deny?: string[] };
@@ -389,7 +395,10 @@ function appendSessionFlags(parts: string[], params: SpawnParams): void {
   const claudeAgentFlag = params.agentTemplate ?? params.role;
   if (claudeAgentFlag) parts.push('--agent', escapeShellArg(claudeAgentFlag));
   if (params.model) parts.push('--model', escapeShellArg(params.model));
-  if (params.name) parts.push('--name', escapeShellArg(params.name));
+  // NOTE: --name intentionally NOT emitted. CC stores --name as `customTitle`
+  // in the JSONL header and then suggests `claude --resume "<customTitle>"`
+  // instead of the canonical UUID, clobbering session resume (Felipe directive
+  // 2026-05-07). The session UUID flows through --session-id / --resume above.
 }
 
 // Inject hook dispatch + permissions via --settings (deep-merges with existing settings).

--- a/src/lib/team-lead-command.test.ts
+++ b/src/lib/team-lead-command.test.ts
@@ -142,7 +142,9 @@ describe('buildTeamLeadCommand resume behavior', () => {
     const cmd = buildTeamLeadCommand('test-team', { promptMode: 'append' });
     expect(cmd).not.toContain('--resume');
     expect(cmd).not.toContain('--session-id');
-    expect(cmd).toContain("--name 'test-team'");
+    // --name retired (Felipe directive 2026-05-07): CC's customTitle
+    // clobbered the UUID resume hint. Always use --session-id / --resume.
+    expect(cmd).not.toContain('--name ');
   });
 
   test('sessionId without resume emits --session-id <uuid>', () => {

--- a/src/lib/team-lead-command.ts
+++ b/src/lib/team-lead-command.ts
@@ -67,8 +67,11 @@ export function buildTeamLeadCommand(teamName: string, options?: BuildTeamLeadCo
     '--permission-mode auto',
   ];
 
-  // Session name for CC's /resume and terminal title
-  parts.push(`--name ${shellQuote(sanitized)}`);
+  // NOTE: --name intentionally omitted. CC stores --name as `customTitle` in
+  // the JSONL header and then composes its resume hint as
+  // `claude --resume "<customTitle>"` instead of the canonical UUID, breaking
+  // session resumption (Felipe directive 2026-05-07). Always use --session-id
+  // / --resume <uuid>.
 
   if (options?.sessionId) {
     const flag = options.resume ? '--resume' : '--session-id';

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -23,7 +23,7 @@ import type { TransportType as ExecutorTransport } from '../lib/executor-types.j
 import { buildLayoutCommand, resolveLayoutMode } from '../lib/mosaic-layout.js';
 import { getOtelPort, startOtelReceiver } from '../lib/otel-receiver.js';
 import { injectResumeContext } from '../lib/protocol-router-spawn.js';
-import { MissingResumeSessionError } from '../lib/protocol-router.js';
+import { MissingResumeSessionError, type MissingResumeSessionReason } from '../lib/protocol-router.js';
 import {
   type ClaudeTeamColor,
   type ProviderName,
@@ -2200,10 +2200,10 @@ export async function handleWorkerSpawn(name: string, options: SpawnOptions): Pr
     name,
   );
 
-  // Set CC session display name if not already set
-  if (!params.name) {
-    params.name = `${params.team}-${effectiveRole}`;
-  }
+  // NOTE: --name intentionally not synthesized. CC stores it as `customTitle`
+  // and then suggests `claude --resume "<customTitle>"` instead of the
+  // canonical UUID, breaking session resume (Felipe directive 2026-05-07).
+  // The session UUID flows through --session-id / --resume.
 
   // Executor model: find/create durable agent identity + concurrent guard.
   // Must happen BEFORE buildLaunchCommand so executorId/agentId propagate
@@ -2498,10 +2498,16 @@ export async function handleWorkerResume(
     // genie.ts surfaces it on stderr with exit 1 and tests can assert on
     // the instance. Previously we used console.error + process.exit(1),
     // which is hostile to unit testing and untyped at the boundary.
-    // Map the chokepoint reason onto the legacy MissingResumeSessionError
-    // enum — `no_executor` keeps its meaning, all other "we can't resume"
-    // outcomes collapse onto `no_session_id` (the legacy catch-all).
-    const errReason = decision.reason === 'unknown_agent' ? 'no_executor' : 'no_session_id';
+    // Map the chokepoint reason onto the MissingResumeSessionError enum:
+    //   unknown_agent        → no_executor
+    //   auto_resume_disabled → auto_resume_disabled (session intact, just paused)
+    //   everything else      → no_session_id (legacy catch-all)
+    const errReason: MissingResumeSessionReason =
+      decision.reason === 'unknown_agent'
+        ? 'no_executor'
+        : decision.reason === 'auto_resume_disabled'
+          ? 'auto_resume_disabled'
+          : 'no_session_id';
     throw new MissingResumeSessionError(w.id, undefined, errReason);
   }
   const _sessionId = decision.sessionId;
@@ -2906,7 +2912,8 @@ async function buildResumeParams(
     skill: template?.skill ?? agent.skill,
     extraArgs: template?.extraArgs,
     resume: resumeSessionId,
-    name: `${team}-${agentName}`,
+    // --name intentionally omitted (Felipe directive 2026-05-07): CC's
+    // customTitle leaked into the resume hint and clobbered the UUID.
     model: dirEntry?.model,
     systemPromptFile,
     promptMode,
@@ -2987,7 +2994,12 @@ export async function buildFullResumeParams(
   // `MissingResumeSessionError` so the caller surfaces the failure.
   const decision = await shouldResume(agent.id);
   if (!decision.resume || !decision.sessionId) {
-    const errReason = decision.reason === 'unknown_agent' ? 'no_executor' : 'null_session';
+    const errReason: MissingResumeSessionReason =
+      decision.reason === 'unknown_agent'
+        ? 'no_executor'
+        : decision.reason === 'auto_resume_disabled'
+          ? 'auto_resume_disabled'
+          : 'null_session';
     throw new MissingResumeSessionError(agent.id, undefined, errReason);
   }
   const params = await buildResumeParams(agent, template, decision.sessionId);

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -12,7 +12,7 @@
 import * as directory from '../lib/agent-directory.js';
 import * as registry from '../lib/agent-registry.js';
 import { getActor, recordAuditEvent } from '../lib/audit.js';
-import { resolveBuiltinAgentPath } from '../lib/builtin-agents.js';
+import { isBuiltinAgent, resolveBuiltinAgentPath } from '../lib/builtin-agents.js';
 import * as nativeTeams from '../lib/claude-native-teams.js';
 import { OTEL_RELAY_PORT, ensureCodexOtelConfig } from '../lib/codex-config.js';
 import { type ResolveContext, resolveField } from '../lib/defaults.js';
@@ -955,17 +955,35 @@ async function finalizeTmuxSpawn(ctx: SpawnCtx, paneId: string, teamWindow: any,
     await tmux.applyPaneColor(paneId, ctx.spawnColor, teamWindow?.windowId);
   }
 
-  await registry.saveTemplate({
-    id: ctx.validated.role ?? ctx.workerId,
-    provider: ctx.validated.provider,
-    team: ctx.validated.team,
-    role: ctx.validated.role,
-    skill: ctx.validated.skill,
-    cwd: ctx.cwd,
-    extraArgs: ctx.extraArgs,
-    nativeTeamEnabled: workerEntry.nativeTeamEnabled,
-    lastSpawnedAt: new Date().toISOString(),
-  });
+  const templateId = ctx.validated.role ?? ctx.workerId;
+  // Built-ins (engineer, trace, qa, council--*, etc.) are SHARED across teams.
+  // Persisting an agent_templates row would pin the team of whichever team
+  // spawned them first, contaminating every later spawn (genie send / mailbox
+  // routing pick the wrong team). Skip the row entirely; runtime resolution
+  // uses GENIE_TEAM env or tmux discovery instead.
+  if (!isBuiltinAgent(templateId)) {
+    // Hierarchical names (`parent/child`) inherit the parent's team. Without
+    // this, `genie-omni/dog-fooder` saved with whatever ctx.validated.team
+    // happened to be (often the operator's session team), and downstream
+    // routing missed because the parent owns the canonical team binding.
+    let team = ctx.validated.team;
+    const slash = templateId.indexOf('/');
+    if (slash > 0) {
+      const parentTeam = await directory.lookupTemplateTeam(templateId.slice(0, slash));
+      if (parentTeam) team = parentTeam;
+    }
+    await registry.saveTemplate({
+      id: templateId,
+      provider: ctx.validated.provider,
+      team,
+      role: ctx.validated.role,
+      skill: ctx.validated.skill,
+      cwd: ctx.cwd,
+      extraArgs: ctx.extraArgs,
+      nativeTeamEnabled: workerEntry.nativeTeamEnabled,
+      lastSpawnedAt: new Date().toISOString(),
+    });
+  }
 
   if (ctx.otelRelayActive && paneId !== '%0') {
     registerOtelRelayPane(ctx.workerId, paneId, ctx.agentName, ctx.spawnColor, ctx.cwd);

--- a/src/term-commands/done.test.ts
+++ b/src/term-commands/done.test.ts
@@ -1,6 +1,7 @@
 /**
  * `genie done` command dispatch — agent-session path vs wish-group path
- * vs the Group 6 permanent-agent rejection guard.
+ * vs the Group 6 permanent-agent rejection guard, plus the mandatory
+ * --report nudge that gives every close a one-line audit trail.
  *
  * Uses injected deps (no DB) to isolate routing behavior.
  */
@@ -8,6 +9,8 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import type { TurnCloseResult } from '../lib/turn-close.js';
 import { PermanentAgentDoneRejected, doneAction } from './done.js';
+
+const REPORT = { report: 'shipped foo + bar; smoke green' };
 
 describe('doneAction dispatch', () => {
   const originalAgent = process.env.GENIE_AGENT_NAME;
@@ -20,11 +23,11 @@ describe('doneAction dispatch', () => {
     process.env.GENIE_AGENT_NAME = originalAgent;
   });
 
-  test('agent session + no ref → calls turnClose(outcome=done)', async () => {
+  test('agent session + no ref → calls turnClose(outcome=done) with report as reason', async () => {
     process.env.GENIE_AGENT_NAME = 'engineer-g2';
-    const calls: Array<{ outcome: string }> = [];
-    const turnCloseFn = async (opts: { outcome: string }): Promise<TurnCloseResult> => {
-      calls.push({ outcome: opts.outcome });
+    const calls: Array<{ outcome: string; reason?: string }> = [];
+    const turnCloseFn = async (opts: { outcome: string; reason?: string }): Promise<TurnCloseResult> => {
+      calls.push({ outcome: opts.outcome, reason: opts.reason });
       return { noop: false, executorId: 'exec-1', outcome: 'done', closedAt: new Date().toISOString() };
     };
     let wishCalls = 0;
@@ -33,28 +36,28 @@ describe('doneAction dispatch', () => {
     };
     const lookupCallingAgent = async () => ({ id: 'agent-task', kind: 'task' as const });
 
-    await doneAction(undefined, { turnCloseFn: turnCloseFn as never, wishDone, lookupCallingAgent });
+    await doneAction(undefined, REPORT, { turnCloseFn: turnCloseFn as never, wishDone, lookupCallingAgent });
 
-    expect(calls).toEqual([{ outcome: 'done' }]);
+    expect(calls).toEqual([{ outcome: 'done', reason: REPORT.report }]);
     expect(wishCalls).toBe(0);
   });
 
-  test('positional ref → delegates to wish-group doneCommand', async () => {
+  test('positional ref → delegates to wish-group doneCommand with report', async () => {
     process.env.GENIE_AGENT_NAME = 'engineer-g2';
     let turnCalls = 0;
     const turnCloseFn = async (): Promise<TurnCloseResult> => {
       turnCalls++;
       return { noop: false, executorId: 'x', outcome: 'done', closedAt: null };
     };
-    const wishRefs: string[] = [];
-    const wishDone = async (ref: string) => {
-      wishRefs.push(ref);
+    const wishCalls: Array<{ ref: string; report: string }> = [];
+    const wishDone = async (ref: string, report: string) => {
+      wishCalls.push({ ref, report });
     };
 
-    await doneAction('my-wish#2', { turnCloseFn: turnCloseFn as never, wishDone });
+    await doneAction('my-wish#2', REPORT, { turnCloseFn: turnCloseFn as never, wishDone });
 
     expect(turnCalls).toBe(0);
-    expect(wishRefs).toEqual(['my-wish#2']);
+    expect(wishCalls).toEqual([{ ref: 'my-wish#2', report: REPORT.report }]);
   });
 
   test('positional ref without GENIE_AGENT_NAME → still delegates to wish path', async () => {
@@ -63,15 +66,15 @@ describe('doneAction dispatch', () => {
       turnCalls++;
       return { noop: false, executorId: 'x', outcome: 'done', closedAt: null };
     };
-    const wishRefs: string[] = [];
-    const wishDone = async (ref: string) => {
-      wishRefs.push(ref);
+    const wishCalls: Array<{ ref: string; report: string }> = [];
+    const wishDone = async (ref: string, report: string) => {
+      wishCalls.push({ ref, report });
     };
 
-    await doneAction('other-wish#1', { turnCloseFn: turnCloseFn as never, wishDone });
+    await doneAction('other-wish#1', REPORT, { turnCloseFn: turnCloseFn as never, wishDone });
 
     expect(turnCalls).toBe(0);
-    expect(wishRefs).toEqual(['other-wish#1']);
+    expect(wishCalls).toEqual([{ ref: 'other-wish#1', report: REPORT.report }]);
   });
 
   test('no ref + no GENIE_AGENT_NAME → exits with error', async () => {
@@ -83,7 +86,7 @@ describe('doneAction dispatch', () => {
     }) as never;
 
     try {
-      await expect(doneAction(undefined)).rejects.toThrow(/process.exit stub/);
+      await expect(doneAction(undefined, REPORT)).rejects.toThrow(/process.exit stub/);
       expect(exitCode).toBe(2);
     } finally {
       process.exit = originalExit;
@@ -101,7 +104,61 @@ describe('doneAction dispatch', () => {
     const lookupCallingAgent = async () => ({ id: 'agent-task', kind: 'task' as const });
 
     // Should complete without throwing
-    await doneAction(undefined, { turnCloseFn: turnCloseFn as never, lookupCallingAgent });
+    await doneAction(undefined, REPORT, { turnCloseFn: turnCloseFn as never, lookupCallingAgent });
+  });
+
+  // ==========================================================================
+  // Mandatory --report nudge
+  // ==========================================================================
+
+  describe('mandatory --report', () => {
+    test('missing report → exits 2 with friendly hint, never calls turnClose or wishDone', async () => {
+      process.env.GENIE_AGENT_NAME = 'engineer-g2';
+      const originalExit = process.exit;
+      let exitCode: number | undefined;
+      process.exit = ((code?: number) => {
+        exitCode = code;
+        throw new Error('process.exit stub');
+      }) as never;
+
+      let turnCalls = 0;
+      const turnCloseFn = async (): Promise<TurnCloseResult> => {
+        turnCalls++;
+        return { noop: false, executorId: 'x', outcome: 'done', closedAt: null };
+      };
+      let wishCalls = 0;
+      const wishDone = async () => {
+        wishCalls++;
+      };
+
+      try {
+        await expect(doneAction(undefined, {}, { turnCloseFn: turnCloseFn as never, wishDone })).rejects.toThrow(
+          /process.exit stub/,
+        );
+        expect(exitCode).toBe(2);
+        expect(turnCalls).toBe(0);
+        expect(wishCalls).toBe(0);
+      } finally {
+        process.exit = originalExit;
+      }
+    });
+
+    test('whitespace-only report → treated as missing', async () => {
+      process.env.GENIE_AGENT_NAME = 'engineer-g2';
+      const originalExit = process.exit;
+      let exitCode: number | undefined;
+      process.exit = ((code?: number) => {
+        exitCode = code;
+        throw new Error('process.exit stub');
+      }) as never;
+
+      try {
+        await expect(doneAction(undefined, { report: '   \n  ' })).rejects.toThrow(/process.exit stub/);
+        expect(exitCode).toBe(2);
+      } finally {
+        process.exit = originalExit;
+      }
+    });
   });
 
   // ==========================================================================
@@ -126,9 +183,9 @@ describe('doneAction dispatch', () => {
       const lookupCallingAgent = async () => ({ id: 'team-lead-uuid', kind: 'permanent' as const });
 
       try {
-        await expect(doneAction(undefined, { turnCloseFn: turnCloseFn as never, lookupCallingAgent })).rejects.toThrow(
-          /process.exit stub/,
-        );
+        await expect(
+          doneAction(undefined, REPORT, { turnCloseFn: turnCloseFn as never, lookupCallingAgent }),
+        ).rejects.toThrow(/process.exit stub/);
         expect(exitCode).toBe(4);
         // turnClose must NOT be reached on rejection — the side effects
         // (state='done', current_executor_id=NULL) are exactly what the
@@ -148,7 +205,7 @@ describe('doneAction dispatch', () => {
       };
       const lookupCallingAgent = async () => ({ id: 'engineer-g6-uuid', kind: 'task' as const });
 
-      await doneAction(undefined, { turnCloseFn: turnCloseFn as never, lookupCallingAgent });
+      await doneAction(undefined, REPORT, { turnCloseFn: turnCloseFn as never, lookupCallingAgent });
       expect(turnCalls).toBe(1);
     });
 
@@ -161,7 +218,7 @@ describe('doneAction dispatch', () => {
       };
       const lookupCallingAgent = async () => null;
 
-      await doneAction(undefined, { turnCloseFn: turnCloseFn as never, lookupCallingAgent });
+      await doneAction(undefined, REPORT, { turnCloseFn: turnCloseFn as never, lookupCallingAgent });
       // We could not prove permanence, so the existing turnClose path runs;
       // its own ghost-executor recovery / error reporting takes over.
       expect(turnCalls).toBe(1);
@@ -176,7 +233,7 @@ describe('doneAction dispatch', () => {
       };
       const lookupCallingAgent = async () => ({ id: 'agent-degraded', kind: null });
 
-      await doneAction(undefined, { turnCloseFn: turnCloseFn as never, lookupCallingAgent });
+      await doneAction(undefined, REPORT, { turnCloseFn: turnCloseFn as never, lookupCallingAgent });
       // kind=null defaults to "let it through" — same posture as the
       // shouldResume chokepoint, which treats unknown kind as task-bound.
       expect(turnCalls).toBe(1);
@@ -204,14 +261,14 @@ describe('doneAction dispatch', () => {
         lookupCalls++;
         return { id: 'team-lead-uuid', kind: 'permanent' as const };
       };
-      const wishRefs: string[] = [];
-      const wishDone = async (ref: string) => {
-        wishRefs.push(ref);
+      const wishCalls: Array<{ ref: string; report: string }> = [];
+      const wishDone = async (ref: string, report: string) => {
+        wishCalls.push({ ref, report });
       };
 
-      await doneAction('my-wish#3', { wishDone, lookupCallingAgent });
+      await doneAction('my-wish#3', REPORT, { wishDone, lookupCallingAgent });
       expect(lookupCalls).toBe(0);
-      expect(wishRefs).toEqual(['my-wish#3']);
+      expect(wishCalls).toEqual([{ ref: 'my-wish#3', report: REPORT.report }]);
     });
   });
 });

--- a/src/term-commands/done.ts
+++ b/src/term-commands/done.ts
@@ -55,12 +55,26 @@ export interface CallingAgentLookup {
 
 interface DoneActionDeps {
   /** Wish-group-done fallback. Injected for tests. */
-  wishDone?: (ref: string) => Promise<void>;
+  wishDone?: (ref: string, report: string) => Promise<void>;
   /** Turn-close path. Injected for tests. */
   turnCloseFn?: typeof turnClose;
   /** Lookup the calling agent's id + kind. Injected for tests. */
   lookupCallingAgent?: () => Promise<CallingAgentLookup | null>;
 }
+
+/** User-facing nudge when --report is missing. Mandatory so every close
+ * leaves a one-line trail in events + mailbox notifications, instead of
+ * the silent "agent vanished" mystery. */
+const REPORT_MISSING_HINT = [
+  '❌ genie done requires --report "<one-line summary of what you did>".',
+  '   This is your handoff note — it lands in the audit trail and the wave/wish-complete',
+  '   notification so the orchestrator (and humans) can see WHY a close happened',
+  '   without having to read your transcript.',
+  '',
+  '   Examples:',
+  "     genie done --report 'shipped auth bridge happy-path; CSRF deferred to followup'",
+  "     genie done dev-local-auth-bridge#3 --report 'group 3 done — fixtures + smoke'",
+].join('\n');
 
 /**
  * Default lookup: resolve the calling agent's id + kind via GENIE_EXECUTOR_ID.
@@ -99,34 +113,45 @@ async function rejectIfPermanent(deps: DoneActionDeps): Promise<void> {
   }
 }
 
-async function runAgentSessionPath(deps: DoneActionDeps): Promise<void> {
+async function runAgentSessionPath(deps: DoneActionDeps, report: string): Promise<void> {
   await rejectIfPermanent(deps);
   const fn = deps.turnCloseFn ?? turnClose;
-  const result = await fn({ outcome: 'done' });
+  const result = await fn({ outcome: 'done', reason: report });
   if (result.noop) {
     console.log(`ℹ️  Executor ${result.executorId} already closed — no-op.`);
   } else {
     console.log(`✅ Turn closed: outcome=done, executor=${result.executorId}`);
+    console.log(`   Report: ${report}`);
   }
 }
 
-export async function doneAction(ref: string | undefined, deps: DoneActionDeps = {}): Promise<void> {
+export async function doneAction(
+  ref: string | undefined,
+  options: { report?: string },
+  deps: DoneActionDeps = {},
+): Promise<void> {
   const agentName = process.env.GENIE_AGENT_NAME;
+  const report = options.report?.trim();
+
+  if (!report) {
+    console.error(REPORT_MISSING_HINT);
+    process.exit(2);
+  }
 
   try {
     if (!ref && agentName) {
-      await runAgentSessionPath(deps);
+      await runAgentSessionPath(deps, report);
       return;
     }
 
     if (ref) {
       const fallback =
         deps.wishDone ??
-        (async (r: string) => {
+        (async (r: string, rpt: string) => {
           const { doneCommand } = await import('./state.js');
-          await doneCommand(r);
+          await doneCommand(r, rpt);
         });
-      await fallback(ref);
+      await fallback(ref, report);
       return;
     }
 

--- a/src/term-commands/state.ts
+++ b/src/term-commands/state.ts
@@ -358,6 +358,7 @@ async function resolveNotificationTargets(): Promise<{ leader: string; spawner?:
 async function notifyWaveCompletion(
   waveResult: { waveName: string; waveGroups: string[] },
   wishComplete: boolean,
+  report: string,
 ): Promise<void> {
   console.log(`   🌊 ${waveResult.waveName} complete! All groups done: ${waveResult.waveGroups.join(', ')}`);
   try {
@@ -365,9 +366,10 @@ async function notifyWaveCompletion(
     const repoPath = process.cwd();
     const { leader, spawner } = await resolveNotificationTargets();
 
+    const reportLine = `\n   Report: ${report}`;
     const message = wishComplete
-      ? `WISH COMPLETE — all groups done: [${waveResult.waveGroups.join(', ')}]. Run \`genie team done\` to clean up.`
-      : `${waveResult.waveName} complete. All groups done: [${waveResult.waveGroups.join(', ')}]. Run /review or advance to next wave.`;
+      ? `WISH COMPLETE — all groups done: [${waveResult.waveGroups.join(', ')}].${reportLine}\n   Team will be auto-cleaned. Run \`genie team done\` to confirm or override.`
+      : `${waveResult.waveName} complete. All groups done: [${waveResult.waveGroups.join(', ')}].${reportLine}\n   Run /review or advance to next wave.`;
 
     // Notify leader
     const result = await protocolRouter.sendMessage(repoPath, 'cli', leader, message);
@@ -395,11 +397,15 @@ async function notifyWaveCompletion(
  * `genie done <slug>#<group>` — complete a group, push work, notify team-lead
  * on wave completion, and auto-kill the calling agent's tmux pane.
  */
-export async function doneCommand(ref: string): Promise<void> {
+export async function doneCommand(ref: string, report: string): Promise<void> {
+  if (!report?.trim()) {
+    throw new Error('doneCommand: report is required (one-line summary of what shipped in this group).');
+  }
   try {
     const { slug, group } = parseRef(ref);
     const result = await wishState.completeGroup(slug, group);
     console.log(`✅ Group "${group}" marked as done in wish "${slug}"`);
+    console.log(`   Report: ${report}`);
 
     if (result.completedAt) {
       console.log(`   Completed at: ${formatTimestamp(result.completedAt)}`);
@@ -426,7 +432,7 @@ export async function doneCommand(ref: string): Promise<void> {
     // Wave completion detection + team-lead notification
     const waveResult = await detectWaveCompletion(slug, group);
     if (waveResult) {
-      await notifyWaveCompletion(waveResult, wishComplete);
+      await notifyWaveCompletion(waveResult, wishComplete, report);
     }
 
     // If entire wish is complete, auto-trigger team cleanup

--- a/src/term-commands/wish.ts
+++ b/src/term-commands/wish.ts
@@ -457,8 +457,22 @@ export function registerWishCommands(program: Command): void {
   wish
     .command('done <ref>')
     .description('Mark a wish group as done (format: <slug>#<group>)')
-    .action(async (ref: string) => {
-      await doneCommand(ref);
+    .option(
+      '-r, --report <message>',
+      'One-line summary of what was completed (REQUIRED — handoff note for audit trail and orchestrator)',
+    )
+    .action(async (ref: string, options: { report?: string }) => {
+      const report = options.report?.trim();
+      if (!report) {
+        console.error(
+          '❌ genie wish done requires --report "<one-line summary of what was completed>".\n' +
+            '   This is your handoff note — it lands in the audit trail and the wave/wish-complete\n' +
+            '   notification so the orchestrator can see WHY a close happened.\n' +
+            "   Example: genie wish done my-wish#3 --report 'group 3 done — fixtures + smoke'",
+        );
+        process.exit(2);
+      }
+      await doneCommand(ref, report);
     });
 
   wish


### PR DESCRIPTION
## Why

When an agent closes a turn — or a team-lead marks a wish group done — the only audit-trail entry today is `Agent <uuid> killed` with no actor, no rationale, no summary. When `autoCleanupTeam()` cascades on wish completion, the parent/orchestrator sees N agents vanish with zero context. I just spent ~30 minutes reconstructing a 3-agent disappearance from systemd-journal and pgserve queries because nothing in the runtime events explained *why* they were gone.

There's also a UX bug worth flagging: `notifyWaveCompletion` sends `"Run \`genie team done\` to clean up."` as the wave-complete message, but the very next line in `doneCommand` calls `autoCleanupTeam()` unconditionally. The message implies cleanup is pending; reality is the team has already been disbanded by the time the message lands. This PR makes the notification honest about what already happened.

(The auto-cleanup over-reach itself — killing team members that weren't part of the completed wish, including the workspace primary agent — is a separate problem worth fixing in a follow-up.)

## What

Add `-r, --report <message>` as a required option on both `genie done [ref]` and `genie wish done <ref>`.

- Validation lives in the action handlers (not Commander's `requiredOption`) so we can emit a multi-line friendly hint with usage examples instead of Commander's generic `error: required option` line.
- Friendly hint:
  ```
  ❌ genie done requires --report ""<one-line summary of what you did>"".
     This is your handoff note — it lands in the audit trail and the wave/wish-complete
     notification so the orchestrator (and humans) can see WHY a close happened
     without having to read your transcript.

     Examples:
       genie done --report 'shipped auth bridge happy-path; CSRF deferred to followup'
       genie done dev-local-auth-bridge#3 --report 'group 3 done — fixtures + smoke'
  ```

The report flows through three surfaces:
1. `turnClose()` `reason` for agent-session closes (the field already existed, was just unused for `outcome=done`).
2. `notifyWaveCompletion` mailbox message so the orchestrator sees WHAT shipped, not just WHICH group closed.
3. `console` output of `doneCommand` for terminal observers.

The wave/wish-complete notification also now names auto-cleanup honestly: ""Team will be auto-cleaned. Run \`genie team done\` to confirm or override."" instead of implying nothing has happened yet.

## Files

- `src/genie.ts` — register `-r, --report` on `done [ref]`
- `src/term-commands/done.ts` — make `report` mandatory; pass through `turnClose` and `wishDone`
- `src/term-commands/state.ts` — `doneCommand(ref, report)`; thread `report` into `notifyWaveCompletion`; honest message
- `src/term-commands/wish.ts` — register `-r, --report` on `wish done <ref>` with same validation hint
- `src/term-commands/done.test.ts` — 14 existing tests updated to new signature, 2 new tests for the mandatory-report path

## Test plan

- [x] `bun test src/term-commands/done.test.ts` — 14 pass
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run build` — clean
- [x] `bun dist/genie.js done --help` — shows new option
- [x] `bun dist/genie.js done some#1` (no `--report`) — exits 2 with friendly hint
- [x] `bun dist/genie.js wish done some#1` (no `--report`) — exits 2 with friendly hint
- [ ] Reviewer: confirm wave-complete mailbox text reads naturally end-to-end

## Out of scope (follow-up)

- `autoCleanupTeam()` over-reach: kills *all* team members on first wish-complete, not just agents tagged to that wish. Includes workspace primary agent and unrelated PR-review workers. Will file separately.