### PR TITLE
feat(done): make --report mandatory on every close

### DIFF
--- a/src/genie.ts
+++ b/src/genie.ts
@@ -298,9 +298,13 @@ registerApprovalCommands(program);
 program
   .command('done [ref]')
   .description('Close the current turn (inside an agent session) or mark a wish group done (team-lead, <slug>#<group>)')
-  .action(async (ref: string | undefined) => {
+  .option(
+    '-r, --report <message>',
+    'One-line summary of what was completed (REQUIRED — your handoff note for the audit trail and orchestrator)',
+  )
+  .action(async (ref: string | undefined, options: { report?: string }) => {
     const { doneAction } = await import('./term-commands/done.js');
-    await doneAction(ref);
+    await doneAction(ref, options);
   });
 
 program

--- a/src/genie.ts
+++ b/src/genie.ts
@@ -300,7 +300,7 @@ program
   .description('Close the current turn (inside an agent session) or mark a wish group done (team-lead, <slug>#<group>)')
   .option(
     '-r, --report <message>',
-    'One-line summary of what was completed (REQUIRED — your handoff note for the audit trail and orchestrator)',
+    'Full session handoff — what shipped, what is verified, what is left, surprises, decisions. REQUIRED. As long as it needs to be (multi-line OK; pass via heredoc).',
   )
   .action(async (ref: string | undefined, options: { report?: string }) => {
     const { doneAction } = await import('./term-commands/done.js');

--- a/src/term-commands/done.test.ts
+++ b/src/term-commands/done.test.ts
@@ -1,6 +1,7 @@
 /**
  * `genie done` command dispatch — agent-session path vs wish-group path
- * vs the Group 6 permanent-agent rejection guard.
+ * vs the Group 6 permanent-agent rejection guard, plus the mandatory
+ * --report nudge that gives every close a one-line audit trail.
  *
  * Uses injected deps (no DB) to isolate routing behavior.
  */
@@ -8,6 +9,8 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import type { TurnCloseResult } from '../lib/turn-close.js';
 import { PermanentAgentDoneRejected, doneAction } from './done.js';
+
+const REPORT = { report: 'shipped foo + bar; smoke green' };
 
 describe('doneAction dispatch', () => {
   const originalAgent = process.env.GENIE_AGENT_NAME;
@@ -20,11 +23,11 @@ describe('doneAction dispatch', () => {
     process.env.GENIE_AGENT_NAME = originalAgent;
   });
 
-  test('agent session + no ref → calls turnClose(outcome=done)', async () => {
+  test('agent session + no ref → calls turnClose(outcome=done) with report as reason', async () => {
     process.env.GENIE_AGENT_NAME = 'engineer-g2';
-    const calls: Array<{ outcome: string }> = [];
-    const turnCloseFn = async (opts: { outcome: string }): Promise<TurnCloseResult> => {
-      calls.push({ outcome: opts.outcome });
+    const calls: Array<{ outcome: string; reason?: string }> = [];
+    const turnCloseFn = async (opts: { outcome: string; reason?: string }): Promise<TurnCloseResult> => {
+      calls.push({ outcome: opts.outcome, reason: opts.reason });
       return { noop: false, executorId: 'exec-1', outcome: 'done', closedAt: new Date().toISOString() };
     };
     let wishCalls = 0;
@@ -33,28 +36,28 @@ describe('doneAction dispatch', () => {
     };
     const lookupCallingAgent = async () => ({ id: 'agent-task', kind: 'task' as const });
 
-    await doneAction(undefined, { turnCloseFn: turnCloseFn as never, wishDone, lookupCallingAgent });
+    await doneAction(undefined, REPORT, { turnCloseFn: turnCloseFn as never, wishDone, lookupCallingAgent });
 
-    expect(calls).toEqual([{ outcome: 'done' }]);
+    expect(calls).toEqual([{ outcome: 'done', reason: REPORT.report }]);
     expect(wishCalls).toBe(0);
   });
 
-  test('positional ref → delegates to wish-group doneCommand', async () => {
+  test('positional ref → delegates to wish-group doneCommand with report', async () => {
     process.env.GENIE_AGENT_NAME = 'engineer-g2';
     let turnCalls = 0;
     const turnCloseFn = async (): Promise<TurnCloseResult> => {
       turnCalls++;
       return { noop: false, executorId: 'x', outcome: 'done', closedAt: null };
     };
-    const wishRefs: string[] = [];
-    const wishDone = async (ref: string) => {
-      wishRefs.push(ref);
+    const wishCalls: Array<{ ref: string; report: string }> = [];
+    const wishDone = async (ref: string, report: string) => {
+      wishCalls.push({ ref, report });
     };
 
-    await doneAction('my-wish#2', { turnCloseFn: turnCloseFn as never, wishDone });
+    await doneAction('my-wish#2', REPORT, { turnCloseFn: turnCloseFn as never, wishDone });
 
     expect(turnCalls).toBe(0);
-    expect(wishRefs).toEqual(['my-wish#2']);
+    expect(wishCalls).toEqual([{ ref: 'my-wish#2', report: REPORT.report }]);
   });
 
   test('positional ref without GENIE_AGENT_NAME → still delegates to wish path', async () => {
@@ -63,15 +66,15 @@ describe('doneAction dispatch', () => {
       turnCalls++;
       return { noop: false, executorId: 'x', outcome: 'done', closedAt: null };
     };
-    const wishRefs: string[] = [];
-    const wishDone = async (ref: string) => {
-      wishRefs.push(ref);
+    const wishCalls: Array<{ ref: string; report: string }> = [];
+    const wishDone = async (ref: string, report: string) => {
+      wishCalls.push({ ref, report });
     };
 
-    await doneAction('other-wish#1', { turnCloseFn: turnCloseFn as never, wishDone });
+    await doneAction('other-wish#1', REPORT, { turnCloseFn: turnCloseFn as never, wishDone });
 
     expect(turnCalls).toBe(0);
-    expect(wishRefs).toEqual(['other-wish#1']);
+    expect(wishCalls).toEqual([{ ref: 'other-wish#1', report: REPORT.report }]);
   });
 
   test('no ref + no GENIE_AGENT_NAME → exits with error', async () => {
@@ -83,7 +86,7 @@ describe('doneAction dispatch', () => {
     }) as never;
 
     try {
-      await expect(doneAction(undefined)).rejects.toThrow(/process.exit stub/);
+      await expect(doneAction(undefined, REPORT)).rejects.toThrow(/process.exit stub/);
       expect(exitCode).toBe(2);
     } finally {
       process.exit = originalExit;
@@ -101,7 +104,61 @@ describe('doneAction dispatch', () => {
     const lookupCallingAgent = async () => ({ id: 'agent-task', kind: 'task' as const });
 
     // Should complete without throwing
-    await doneAction(undefined, { turnCloseFn: turnCloseFn as never, lookupCallingAgent });
+    await doneAction(undefined, REPORT, { turnCloseFn: turnCloseFn as never, lookupCallingAgent });
+  });
+
+  // ==========================================================================
+  // Mandatory --report nudge
+  // ==========================================================================
+
+  describe('mandatory --report', () => {
+    test('missing report → exits 2 with friendly hint, never calls turnClose or wishDone', async () => {
+      process.env.GENIE_AGENT_NAME = 'engineer-g2';
+      const originalExit = process.exit;
+      let exitCode: number | undefined;
+      process.exit = ((code?: number) => {
+        exitCode = code;
+        throw new Error('process.exit stub');
+      }) as never;
+
+      let turnCalls = 0;
+      const turnCloseFn = async (): Promise<TurnCloseResult> => {
+        turnCalls++;
+        return { noop: false, executorId: 'x', outcome: 'done', closedAt: null };
+      };
+      let wishCalls = 0;
+      const wishDone = async () => {
+        wishCalls++;
+      };
+
+      try {
+        await expect(doneAction(undefined, {}, { turnCloseFn: turnCloseFn as never, wishDone })).rejects.toThrow(
+          /process.exit stub/,
+        );
+        expect(exitCode).toBe(2);
+        expect(turnCalls).toBe(0);
+        expect(wishCalls).toBe(0);
+      } finally {
+        process.exit = originalExit;
+      }
+    });
+
+    test('whitespace-only report → treated as missing', async () => {
+      process.env.GENIE_AGENT_NAME = 'engineer-g2';
+      const originalExit = process.exit;
+      let exitCode: number | undefined;
+      process.exit = ((code?: number) => {
+        exitCode = code;
+        throw new Error('process.exit stub');
+      }) as never;
+
+      try {
+        await expect(doneAction(undefined, { report: '   \n  ' })).rejects.toThrow(/process.exit stub/);
+        expect(exitCode).toBe(2);
+      } finally {
+        process.exit = originalExit;
+      }
+    });
   });
 
   // ==========================================================================
@@ -126,13 +183,10 @@ describe('doneAction dispatch', () => {
       const lookupCallingAgent = async () => ({ id: 'team-lead-uuid', kind: 'permanent' as const });
 
       try {
-        await expect(doneAction(undefined, { turnCloseFn: turnCloseFn as never, lookupCallingAgent })).rejects.toThrow(
-          /process.exit stub/,
-        );
+        await expect(
+          doneAction(undefined, REPORT, { turnCloseFn: turnCloseFn as never, lookupCallingAgent }),
+        ).rejects.toThrow(/process.exit stub/);
         expect(exitCode).toBe(4);
-        // turnClose must NOT be reached on rejection — the side effects
-        // (state='done', current_executor_id=NULL) are exactly what the
-        // permanent-agent guard prevents.
         expect(turnCalls).toBe(0);
       } finally {
         process.exit = originalExit;
@@ -148,7 +202,7 @@ describe('doneAction dispatch', () => {
       };
       const lookupCallingAgent = async () => ({ id: 'engineer-g6-uuid', kind: 'task' as const });
 
-      await doneAction(undefined, { turnCloseFn: turnCloseFn as never, lookupCallingAgent });
+      await doneAction(undefined, REPORT, { turnCloseFn: turnCloseFn as never, lookupCallingAgent });
       expect(turnCalls).toBe(1);
     });
 
@@ -161,9 +215,7 @@ describe('doneAction dispatch', () => {
       };
       const lookupCallingAgent = async () => null;
 
-      await doneAction(undefined, { turnCloseFn: turnCloseFn as never, lookupCallingAgent });
-      // We could not prove permanence, so the existing turnClose path runs;
-      // its own ghost-executor recovery / error reporting takes over.
+      await doneAction(undefined, REPORT, { turnCloseFn: turnCloseFn as never, lookupCallingAgent });
       expect(turnCalls).toBe(1);
     });
 
@@ -176,9 +228,7 @@ describe('doneAction dispatch', () => {
       };
       const lookupCallingAgent = async () => ({ id: 'agent-degraded', kind: null });
 
-      await doneAction(undefined, { turnCloseFn: turnCloseFn as never, lookupCallingAgent });
-      // kind=null defaults to "let it through" — same posture as the
-      // shouldResume chokepoint, which treats unknown kind as task-bound.
+      await doneAction(undefined, REPORT, { turnCloseFn: turnCloseFn as never, lookupCallingAgent });
       expect(turnCalls).toBe(1);
     });
 
@@ -204,14 +254,14 @@ describe('doneAction dispatch', () => {
         lookupCalls++;
         return { id: 'team-lead-uuid', kind: 'permanent' as const };
       };
-      const wishRefs: string[] = [];
-      const wishDone = async (ref: string) => {
-        wishRefs.push(ref);
+      const wishCalls: Array<{ ref: string; report: string }> = [];
+      const wishDone = async (ref: string, report: string) => {
+        wishCalls.push({ ref, report });
       };
 
-      await doneAction('my-wish#3', { wishDone, lookupCallingAgent });
+      await doneAction('my-wish#3', REPORT, { wishDone, lookupCallingAgent });
       expect(lookupCalls).toBe(0);
-      expect(wishRefs).toEqual(['my-wish#3']);
+      expect(wishCalls).toEqual([{ ref: 'my-wish#3', report: REPORT.report }]);
     });
   });
 });

--- a/src/term-commands/done.ts
+++ b/src/term-commands/done.ts
@@ -63,17 +63,35 @@ interface DoneActionDeps {
 }
 
 /** User-facing nudge when --report is missing. Mandatory so every close
- * leaves a one-line trail in events + mailbox notifications, instead of
- * the silent "agent vanished" mystery. */
+ * leaves a full handoff trail in events + mailbox notifications, instead
+ * of the silent "agent vanished" mystery. The report is the orchestrator's
+ * primary view into what happened — make it count. */
 const REPORT_MISSING_HINT = [
-  '❌ genie done requires --report "<one-line summary of what you did>".',
-  '   This is your handoff note — it lands in the audit trail and the wave/wish-complete',
-  '   notification so the orchestrator (and humans) can see WHY a close happened',
-  '   without having to read your transcript.',
+  '❌ genie done requires --report "<session handoff>".',
   '',
-  '   Examples:',
-  "     genie done --report 'shipped auth bridge happy-path; CSRF deferred to followup'",
-  "     genie done dev-local-auth-bridge#3 --report 'group 3 done — fixtures + smoke'",
+  '   This is your handoff to the orchestrator. It lands in the audit trail and the',
+  '   wave/wish-complete notification, and is the ONLY summary anyone reading later',
+  '   will see without replaying your transcript. Write it like you are briefing the',
+  '   next person on call.',
+  '',
+  '   Cover:',
+  '     • What you attempted (the actual goal of this turn / group)',
+  '     • What shipped — files changed, PRs opened, migrations run, services touched',
+  '     • What is verified vs unverified (tests passed? smoke run? CI green?)',
+  '     • What is left, blocked, or deferred — and why',
+  '     • Surprises or decisions a future agent needs to know (data losses, infra',
+  '       quirks, hooks fired, anything non-obvious)',
+  '',
+  '   Length: as long as it needs to be. A one-liner is almost never enough.',
+  '   Multi-line is fine — pass via heredoc or a file:',
+  "     genie done --report \"$(cat <<'EOF'",
+  '       Goal: wire dev-local auth bridge for hv tenant.',
+  '       Shipped: PR #143 (fixtures), PR #144 (smoke). Both green on CI.',
+  "       Verified: 'make smoke' passed locally; tenant-A login round-trip OK.",
+  '       Left: CSRF rotation deferred to followup (issue #1245).',
+  '       Notes: had to bump core@1.260507.5 — desktop shell rebuild required.',
+  '     EOF',
+  '     )"',
 ].join('\n');
 
 /**
@@ -121,7 +139,9 @@ async function runAgentSessionPath(deps: DoneActionDeps, report: string): Promis
     console.log(`ℹ️  Executor ${result.executorId} already closed — no-op.`);
   } else {
     console.log(`✅ Turn closed: outcome=done, executor=${result.executorId}`);
-    console.log(`   Report: ${report}`);
+    console.log('--- Handoff ---');
+    console.log(report.trimEnd());
+    console.log('--- End handoff ---');
   }
 }
 

--- a/src/term-commands/done.ts
+++ b/src/term-commands/done.ts
@@ -55,12 +55,26 @@ export interface CallingAgentLookup {
 
 interface DoneActionDeps {
   /** Wish-group-done fallback. Injected for tests. */
-  wishDone?: (ref: string) => Promise<void>;
+  wishDone?: (ref: string, report: string) => Promise<void>;
   /** Turn-close path. Injected for tests. */
   turnCloseFn?: typeof turnClose;
   /** Lookup the calling agent's id + kind. Injected for tests. */
   lookupCallingAgent?: () => Promise<CallingAgentLookup | null>;
 }
+
+/** User-facing nudge when --report is missing. Mandatory so every close
+ * leaves a one-line trail in events + mailbox notifications, instead of
+ * the silent "agent vanished" mystery. */
+const REPORT_MISSING_HINT = [
+  '❌ genie done requires --report "<one-line summary of what you did>".',
+  '   This is your handoff note — it lands in the audit trail and the wave/wish-complete',
+  '   notification so the orchestrator (and humans) can see WHY a close happened',
+  '   without having to read your transcript.',
+  '',
+  '   Examples:',
+  "     genie done --report 'shipped auth bridge happy-path; CSRF deferred to followup'",
+  "     genie done dev-local-auth-bridge#3 --report 'group 3 done — fixtures + smoke'",
+].join('\n');
 
 /**
  * Default lookup: resolve the calling agent's id + kind via GENIE_EXECUTOR_ID.
@@ -99,34 +113,45 @@ async function rejectIfPermanent(deps: DoneActionDeps): Promise<void> {
   }
 }
 
-async function runAgentSessionPath(deps: DoneActionDeps): Promise<void> {
+async function runAgentSessionPath(deps: DoneActionDeps, report: string): Promise<void> {
   await rejectIfPermanent(deps);
   const fn = deps.turnCloseFn ?? turnClose;
-  const result = await fn({ outcome: 'done' });
+  const result = await fn({ outcome: 'done', reason: report });
   if (result.noop) {
     console.log(`ℹ️  Executor ${result.executorId} already closed — no-op.`);
   } else {
     console.log(`✅ Turn closed: outcome=done, executor=${result.executorId}`);
+    console.log(`   Report: ${report}`);
   }
 }
 
-export async function doneAction(ref: string | undefined, deps: DoneActionDeps = {}): Promise<void> {
+export async function doneAction(
+  ref: string | undefined,
+  options: { report?: string },
+  deps: DoneActionDeps = {},
+): Promise<void> {
   const agentName = process.env.GENIE_AGENT_NAME;
+  const report = options.report?.trim();
+
+  if (!report) {
+    console.error(REPORT_MISSING_HINT);
+    process.exit(2);
+  }
 
   try {
     if (!ref && agentName) {
-      await runAgentSessionPath(deps);
+      await runAgentSessionPath(deps, report);
       return;
     }
 
     if (ref) {
       const fallback =
         deps.wishDone ??
-        (async (r: string) => {
+        (async (r: string, rpt: string) => {
           const { doneCommand } = await import('./state.js');
-          await doneCommand(r);
+          await doneCommand(r, rpt);
         });
-      await fallback(ref);
+      await fallback(ref, report);
       return;
     }
 

--- a/src/term-commands/state.ts
+++ b/src/term-commands/state.ts
@@ -366,10 +366,12 @@ async function notifyWaveCompletion(
     const repoPath = process.cwd();
     const { leader, spawner } = await resolveNotificationTargets();
 
-    const reportLine = `\n   Report: ${report}`;
+    // Render the report as a fenced block so multi-line handoffs survive
+    // markdown / mailbox renderers without losing the line structure.
+    const reportBlock = `\n\n--- Handoff ---\n${report.trimEnd()}\n--- End handoff ---\n`;
     const message = wishComplete
-      ? `WISH COMPLETE — all groups done: [${waveResult.waveGroups.join(', ')}].${reportLine}\n   Team will be auto-cleaned. Run \`genie team done\` to confirm or override.`
-      : `${waveResult.waveName} complete. All groups done: [${waveResult.waveGroups.join(', ')}].${reportLine}\n   Run /review or advance to next wave.`;
+      ? `WISH COMPLETE — all groups done: [${waveResult.waveGroups.join(', ')}].${reportBlock}\nTeam will be auto-cleaned. Run \`genie team done\` to confirm or override.`
+      : `${waveResult.waveName} complete. All groups done: [${waveResult.waveGroups.join(', ')}].${reportBlock}\nRun /review or advance to next wave.`;
 
     // Notify leader
     const result = await protocolRouter.sendMessage(repoPath, 'cli', leader, message);
@@ -399,13 +401,17 @@ async function notifyWaveCompletion(
  */
 export async function doneCommand(ref: string, report: string): Promise<void> {
   if (!report?.trim()) {
-    throw new Error('doneCommand: report is required (one-line summary of what shipped in this group).');
+    throw new Error(
+      'doneCommand: report is required — full group handoff (what shipped, verified, left, surprises). Not a one-liner.',
+    );
   }
   try {
     const { slug, group } = parseRef(ref);
     const result = await wishState.completeGroup(slug, group);
     console.log(`✅ Group "${group}" marked as done in wish "${slug}"`);
-    console.log(`   Report: ${report}`);
+    console.log('--- Handoff ---');
+    console.log(report.trimEnd());
+    console.log('--- End handoff ---');
 
     if (result.completedAt) {
       console.log(`   Completed at: ${formatTimestamp(result.completedAt)}`);

--- a/src/term-commands/state.ts
+++ b/src/term-commands/state.ts
@@ -358,6 +358,7 @@ async function resolveNotificationTargets(): Promise<{ leader: string; spawner?:
 async function notifyWaveCompletion(
   waveResult: { waveName: string; waveGroups: string[] },
   wishComplete: boolean,
+  report: string,
 ): Promise<void> {
   console.log(`   🌊 ${waveResult.waveName} complete! All groups done: ${waveResult.waveGroups.join(', ')}`);
   try {
@@ -365,9 +366,10 @@ async function notifyWaveCompletion(
     const repoPath = process.cwd();
     const { leader, spawner } = await resolveNotificationTargets();
 
+    const reportLine = `\n   Report: ${report}`;
     const message = wishComplete
-      ? `WISH COMPLETE — all groups done: [${waveResult.waveGroups.join(', ')}]. Run \`genie team done\` to clean up.`
-      : `${waveResult.waveName} complete. All groups done: [${waveResult.waveGroups.join(', ')}]. Run /review or advance to next wave.`;
+      ? `WISH COMPLETE — all groups done: [${waveResult.waveGroups.join(', ')}].${reportLine}\n   Team will be auto-cleaned. Run \`genie team done\` to confirm or override.`
+      : `${waveResult.waveName} complete. All groups done: [${waveResult.waveGroups.join(', ')}].${reportLine}\n   Run /review or advance to next wave.`;
 
     // Notify leader
     const result = await protocolRouter.sendMessage(repoPath, 'cli', leader, message);
@@ -395,11 +397,15 @@ async function notifyWaveCompletion(
  * `genie done <slug>#<group>` — complete a group, push work, notify team-lead
  * on wave completion, and auto-kill the calling agent's tmux pane.
  */
-export async function doneCommand(ref: string): Promise<void> {
+export async function doneCommand(ref: string, report: string): Promise<void> {
+  if (!report?.trim()) {
+    throw new Error('doneCommand: report is required (one-line summary of what shipped in this group).');
+  }
   try {
     const { slug, group } = parseRef(ref);
     const result = await wishState.completeGroup(slug, group);
     console.log(`✅ Group "${group}" marked as done in wish "${slug}"`);
+    console.log(`   Report: ${report}`);
 
     if (result.completedAt) {
       console.log(`   Completed at: ${formatTimestamp(result.completedAt)}`);
@@ -426,7 +432,7 @@ export async function doneCommand(ref: string): Promise<void> {
     // Wave completion detection + team-lead notification
     const waveResult = await detectWaveCompletion(slug, group);
     if (waveResult) {
-      await notifyWaveCompletion(waveResult, wishComplete);
+      await notifyWaveCompletion(waveResult, wishComplete, report);
     }
 
     // If entire wish is complete, auto-trigger team cleanup

--- a/src/term-commands/wish.ts
+++ b/src/term-commands/wish.ts
@@ -457,8 +457,22 @@ export function registerWishCommands(program: Command): void {
   wish
     .command('done <ref>')
     .description('Mark a wish group as done (format: <slug>#<group>)')
-    .action(async (ref: string) => {
-      await doneCommand(ref);
+    .option(
+      '-r, --report <message>',
+      'One-line summary of what was completed (REQUIRED — handoff note for audit trail and orchestrator)',
+    )
+    .action(async (ref: string, options: { report?: string }) => {
+      const report = options.report?.trim();
+      if (!report) {
+        console.error(
+          '❌ genie wish done requires --report "<one-line summary of what was completed>".\n' +
+            '   This is your handoff note — it lands in the audit trail and the wave/wish-complete\n' +
+            '   notification so the orchestrator can see WHY a close happened.\n' +
+            "   Example: genie wish done my-wish#3 --report 'group 3 done — fixtures + smoke'",
+        );
+        process.exit(2);
+      }
+      await doneCommand(ref, report);
     });
 
   wish

--- a/src/term-commands/wish.ts
+++ b/src/term-commands/wish.ts
@@ -459,16 +459,31 @@ export function registerWishCommands(program: Command): void {
     .description('Mark a wish group as done (format: <slug>#<group>)')
     .option(
       '-r, --report <message>',
-      'One-line summary of what was completed (REQUIRED — handoff note for audit trail and orchestrator)',
+      'Full group handoff — what shipped, what is verified, what is left, surprises, decisions. REQUIRED. Multi-line OK (pass via heredoc).',
     )
     .action(async (ref: string, options: { report?: string }) => {
       const report = options.report?.trim();
       if (!report) {
         console.error(
-          '❌ genie wish done requires --report "<one-line summary of what was completed>".\n' +
-            '   This is your handoff note — it lands in the audit trail and the wave/wish-complete\n' +
-            '   notification so the orchestrator can see WHY a close happened.\n' +
-            "   Example: genie wish done my-wish#3 --report 'group 3 done — fixtures + smoke'",
+          '❌ genie wish done requires --report "<group handoff>".\n' +
+            '\n' +
+            "   This is the orchestrator's handoff. It lands in the audit trail and the\n" +
+            '   wave/wish-complete notification — the ONLY summary anyone reading later\n' +
+            '   will see without replaying your transcript.\n' +
+            '\n' +
+            '   Cover: what was attempted, what shipped, what is verified vs unverified,\n' +
+            '   what is left or deferred, and any surprises or decisions a future agent\n' +
+            '   needs to know. Length: as long as it needs to be. Multi-line is fine.\n' +
+            '\n' +
+            '   Example (heredoc):\n' +
+            "     genie wish done my-wish#3 --report \"$(cat <<'EOF'\n" +
+            '       Goal: wire dev-local fixtures + smoke for group 3.\n' +
+            '       Shipped: PR #143 + PR #144, both merged to dev.\n' +
+            '       Verified: make smoke passed; tenant-A login round-trip OK.\n' +
+            '       Left: CSRF rotation deferred to issue #1245.\n' +
+            '       Notes: bumped core@1.260507.5 — desktop rebuild required.\n' +
+            '     EOF\n' +
+            '     )"',
         );
         process.exit(2);
       }


### PR DESCRIPTION
## Why

When an agent closes a turn — or a team-lead marks a wish group done — the only audit-trail entry today is `Agent <uuid> killed` with no actor, no rationale, no summary. When `autoCleanupTeam()` cascades on wish completion, the parent/orchestrator sees N agents vanish with zero context. I just spent ~30 minutes reconstructing a 3-agent disappearance from systemd-journal and pgserve queries because nothing in the runtime events explained *why* they were gone.

There's also a UX bug worth flagging: `notifyWaveCompletion` sends `"Run \`genie team done\` to clean up."` as the wave-complete message, but the very next line in `doneCommand` calls `autoCleanupTeam()` unconditionally. The message implies cleanup is pending; reality is the team has already been disbanded by the time the message lands. This PR makes the notification honest about what already happened.

(The auto-cleanup over-reach itself — killing team members that weren't part of the completed wish, including the workspace primary agent — is a separate problem worth fixing in a follow-up: scope `killTeamMembers` to agents whose `wish_slug` matches the completed wish.)

## What

Add `-r, --report <message>` as a required option on both `genie done [ref]` and `genie wish done <ref>`.

- Validation lives in the action handlers (not Commander's `requiredOption`) so we can emit a multi-line friendly hint with usage examples instead of Commander's generic `error: required option` line.
- Friendly hint:
  ```
  ❌ genie done requires --report "<one-line summary of what you did>".
     This is your handoff note — it lands in the audit trail and the wave/wish-complete
     notification so the orchestrator (and humans) can see WHY a close happened
     without having to read your transcript.

     Examples:
       genie done --report 'shipped auth bridge happy-path; CSRF deferred to followup'
       genie done dev-local-auth-bridge#3 --report 'group 3 done — fixtures + smoke'
  ```

The report flows through three surfaces:
1. `turnClose()` `reason` for agent-session closes (the field already existed, was just unused for `outcome=done`).
2. `notifyWaveCompletion` mailbox message so the orchestrator sees WHAT shipped, not just WHICH group closed.
3. `console` output of `doneCommand` for terminal observers.

The wave/wish-complete notification also now names auto-cleanup honestly: "Team will be auto-cleaned. Run \`genie team done\` to confirm or override." instead of implying nothing has happened yet.

## Files

- `src/genie.ts` — register `-r, --report` on `done [ref]`
- `src/term-commands/done.ts` — make `report` mandatory; pass through `turnClose` and `wishDone`
- `src/term-commands/state.ts` — `doneCommand(ref, report)`; thread `report` into `notifyWaveCompletion`; honest message
- `src/term-commands/wish.ts` — register `-r, --report` on `wish done <ref>` with same validation hint
- `src/term-commands/done.test.ts` — 12 existing tests updated to new signature, 2 new tests for the mandatory-report path

## Test plan

- [x] `bun test src/term-commands/done.test.ts` — 14 pass, 0 fail
- [x] `bunx biome check` — clean (no fixes applied)
- [x] `bun run build` — clean
- [x] `bun dist/genie.js done --help` — shows new option
- [x] `bun dist/genie.js done some#1` (no `--report`) — exits 2 with friendly hint
- [x] `bun dist/genie.js wish done some#1` (no `--report`) — exits 2 with friendly hint
- [ ] Reviewer: confirm wave-complete mailbox text reads naturally end-to-end

## Out of scope (follow-up)

- `autoCleanupTeam()` over-reach: kills *all* team members on first wish-complete, not just agents tagged to that wish. Includes workspace primary agent and unrelated PR-review workers. Will file separately.