### PR TITLE
chore: back-merge main hotfixes into dev (option 2 — accept dev for conflicts)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,10 +110,13 @@ jobs:
       - name: Pack release tarball
         id: pack
         run: |
-          # npm pack writes the tarball to CWD and prints its filename to stdout.
-          # --silent suppresses the progress banner that would otherwise pollute
-          # the step output value.
-          TARBALL=$(npm pack --silent)
+          # npm pack writes the tarball name to stdout as its final line, but
+          # the prepack hook (`bun run build`) ALSO writes to stdout (build
+          # banner + bundled-assets table). `--silent` only suppresses npm's
+          # own progress banner, not the prepack hook's output. Capturing
+          # the full stdout therefore yields a multi-line blob ending with
+          # the tarball name; `tail -n1` extracts the filename reliably.
+          TARBALL=$(npm pack --silent | tail -n1)
           if [ -z "${TARBALL}" ] || [ ! -f "${TARBALL}" ]; then
             echo "npm pack produced no tarball" >&2
             exit 1

--- a/src/__tests__/agent-team-inheritance.test.ts
+++ b/src/__tests__/agent-team-inheritance.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Subagent team inheritance + built-in pinning regression tests.
+ *
+ * Bug class: subagents (id='parent/child') did not inherit the parent's team,
+ * and built-in agents (engineer, trace, qa, council--*) accumulated sticky
+ * team pins from whichever team spawned them first. Both broke
+ * `genie send`, mailbox routing, and inbox visibility.
+ *
+ * The fix has three parts:
+ *   1. `lookupTemplateTeam(name)` falls back to the parent name when an
+ *      exact-id row is missing.
+ *   2. `directory.resolve()` no longer attaches a template-pinned team to
+ *      built-in entries (let `resolveTeamName` tier 3/4 decide instead).
+ *   3. `finalizeTmuxSpawn` + `lockedSpawnWorker` skip `saveTemplate` for
+ *      built-ins and override `team` with the parent's team for
+ *      hierarchical names before persisting.
+ *
+ * This file locks each part with a focused assertion against the live
+ * agent_templates table.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import * as directory from '../lib/agent-directory.js';
+import { isBuiltinAgent } from '../lib/builtin-agents.js';
+import { DB_AVAILABLE, setupTestDatabase } from '../lib/test-db.js';
+
+async function seedTemplate(id: string, team: string): Promise<void> {
+  const { getConnection } = await import('../lib/db.js');
+  const sql = await getConnection();
+  await sql`
+    INSERT INTO agent_templates (id, provider, team, cwd, last_spawned_at)
+    VALUES (${id}, 'claude', ${team}, '/tmp/seed', now())
+    ON CONFLICT (id) DO UPDATE SET team = EXCLUDED.team, last_spawned_at = EXCLUDED.last_spawned_at
+  `;
+}
+
+describe.skipIf(!DB_AVAILABLE)('subagent team inheritance + built-in pinning', () => {
+  let cleanup: () => Promise<void>;
+
+  beforeAll(async () => {
+    cleanup = await setupTestDatabase();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  beforeEach(async () => {
+    const { getConnection } = await import('../lib/db.js');
+    const sql = await getConnection();
+    await sql`TRUNCATE TABLE agent_templates CASCADE`;
+  });
+
+  // -------------------------------------------------------------------------
+  // (1) Built-ins are SHARED — directory.resolve must not attach a sticky
+  //     team even when a poisoned template row exists.
+  // -------------------------------------------------------------------------
+  test('built-in `engineer` ignores poisoned agent_templates row', async () => {
+    expect(isBuiltinAgent('engineer')).toBe(true);
+    await seedTemplate('engineer', 'felipe'); // simulates pre-fix poisoned row
+
+    const resolved = await directory.resolve('engineer');
+    expect(resolved).not.toBeNull();
+    expect(resolved?.builtin).toBe(true);
+    expect(resolved?.entry.team).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // (2) Subagent name (`parent/child`) inherits the parent template's team
+  //     when no exact-id row exists.
+  // -------------------------------------------------------------------------
+  test('lookupTemplateTeam falls back to parent for `parent/child` names', async () => {
+    await seedTemplate('genie-omni', 'genie-omni');
+
+    const resolved = await directory.lookupTemplateTeam('genie-omni/dog-fooder');
+    expect(resolved).toBe('genie-omni');
+  });
+
+  test('lookupTemplateTeam prefers exact-id row over parent fallback', async () => {
+    await seedTemplate('genie-omni', 'genie-omni');
+    await seedTemplate('genie-omni/dog-fooder', 'override-team');
+
+    const resolved = await directory.lookupTemplateTeam('genie-omni/dog-fooder');
+    expect(resolved).toBe('override-team');
+  });
+
+  test('lookupTemplateTeam returns null when neither exact-id nor parent exists', async () => {
+    const resolved = await directory.lookupTemplateTeam('orphan/child');
+    expect(resolved).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // (3) `lookupTemplateTeam` returns the row team deterministically — id is
+  //     the primary key, so a single id maps to a single row.
+  // -------------------------------------------------------------------------
+  test('lookupTemplateTeam returns the row team for an exact-id match', async () => {
+    await seedTemplate('genie-omni', 'genie-omni');
+
+    const team = await directory.lookupTemplateTeam('genie-omni');
+    expect(team).toBe('genie-omni');
+  });
+
+  // -------------------------------------------------------------------------
+  // (4) Migration 054 backfill: poisoned subagent rows get healed to inherit
+  //     the parent's team; built-in pins are wiped.
+  // -------------------------------------------------------------------------
+  test('migration 054 heals poisoned subagent rows', async () => {
+    const { getConnection } = await import('../lib/db.js');
+    const sql = await getConnection();
+
+    await seedTemplate('genie-omni', 'genie-omni');
+    await seedTemplate('genie-omni/dog-fooder', 'felipe'); // poisoned
+    await seedTemplate('engineer', 'felipe'); // built-in poisoned
+
+    // Run the migration backfill steps inline (mirrors 054_fix_subagent_team_inheritance.sql)
+    await sql`
+      UPDATE agent_templates AS child
+      SET team = parent.team, updated_at = now()
+      FROM agent_templates AS parent
+      WHERE child.id LIKE parent.id || '/%'
+        AND parent.id NOT LIKE '%/%'
+        AND child.team IS DISTINCT FROM parent.team
+    `;
+    await sql`DELETE FROM agent_templates WHERE id = 'engineer'`;
+
+    const subagent = await sql`SELECT team FROM agent_templates WHERE id = 'genie-omni/dog-fooder'`;
+    expect(subagent[0].team).toBe('genie-omni');
+
+    const builtin = await sql`SELECT team FROM agent_templates WHERE id = 'engineer'`;
+    expect(builtin.length).toBe(0);
+  });
+});

--- a/src/db/migrations/044_phase_b_flip_defaults.test.ts
+++ b/src/db/migrations/044_phase_b_flip_defaults.test.ts
@@ -42,7 +42,12 @@ describe.skip('migration 044 — Phase B: flip auto_resume + reconciler defaults
     await cleanup();
   });
 
-  test('fresh DB: agents.auto_resume column default is false after migration 044', async () => {
+  test('fresh DB: agents.auto_resume column default is true after migration 055', async () => {
+    // Migration 055 (PR #1693) flipped the column default from `false` to `true`.
+    // Felipe directive 2026-05-07: default-off was a bug shape — 52/53 agents
+    // had auto_resume=false, meaning no agent could resume without first
+    // running `genie agent recover`. The migration runner applies every
+    // migration under the test schema, so we observe the post-055 state.
     const sql = await getConnection();
     const rows = await sql<{ column_default: string | null }[]>`
       SELECT column_default
@@ -53,10 +58,12 @@ describe.skip('migration 044 — Phase B: flip auto_resume + reconciler defaults
     `;
     expect(rows.length).toBe(1);
     // Postgres reports boolean defaults as 'true' / 'false' literal strings.
-    expect(rows[0].column_default).toBe('false');
+    expect(rows[0].column_default).toBe('true');
   });
 
-  test('fresh-INSERT agent row inherits auto_resume=false', async () => {
+  test('fresh-INSERT agent row inherits auto_resume=true (post-055 default)', async () => {
+    // Migration 055 flipped the default to true. Fresh inserts that don't
+    // explicitly set auto_resume now inherit the safe value.
     const sql = await getConnection();
     const id = `test-fresh-${Date.now()}`;
     await sql`
@@ -66,7 +73,7 @@ describe.skip('migration 044 — Phase B: flip auto_resume + reconciler defaults
     const rows = await sql<{ auto_resume: boolean | null }[]>`
       SELECT auto_resume FROM agents WHERE id = ${id}
     `;
-    expect(rows[0].auto_resume).toBe(false);
+    expect(rows[0].auto_resume).toBe(true);
   });
 
   test('live row (last_state_change < 1h, non-terminal state) preserves auto_resume=true', async () => {

--- a/src/db/migrations/054_fix_subagent_team_inheritance.sql
+++ b/src/db/migrations/054_fix_subagent_team_inheritance.sql
@@ -1,0 +1,70 @@
+-- 054_fix_subagent_team_inheritance.sql — Backfill agent_templates.team for
+-- subagents and wipe sticky team pins on built-in roles + council members.
+--
+-- Why
+-- ---
+-- Two pre-fix defects let the team column drift away from its semantic owner:
+--
+--   1. Subagent rows (id = 'parent/child') were saved with whatever team the
+--      operator's session happened to be in (often 'felipe' or 'genie'),
+--      not the parent agent's team. Downstream `genie send`, mailbox
+--      routing, and inbox visibility used the wrong team.
+--
+--   2. Built-in roles (engineer, trace, qa, fix, reviewer, etc.) and council
+--      members (council, council--*) are SHARED across teams — they were
+--      never meant to carry a sticky team. The first spawn pinned the team
+--      forever via `lookupTemplateTeam`, contaminating every later spawn.
+--
+-- The runtime fix in this PR (skip-saveTemplate for built-ins, parent
+-- override for subagents) prevents the regression going forward; this
+-- migration heals the rows already poisoned in production databases.
+--
+-- Idempotent: re-running this migration is a no-op once the rows are clean.
+
+BEGIN;
+
+-- 1. Backfill: subagent rows inherit their parent's team.
+--    `child.id LIKE parent.id || '/%'` matches `parent/anything` whose parent
+--    name has no slash itself (avoids matching grandparent/parent/child).
+--    Skip when child.team already equals parent.team.
+UPDATE agent_templates AS child
+SET team = parent.team,
+    updated_at = now()
+FROM agent_templates AS parent
+WHERE child.id LIKE parent.id || '/%'
+  AND parent.id NOT LIKE '%/%'
+  AND child.team IS DISTINCT FROM parent.team;
+
+-- 2. Wipe sticky pins for built-in roles + council members.
+--    Built-ins are SHARED — runtime resolution (GENIE_TEAM env, tmux
+--    discovery) decides the team per-spawn now. Keeping the rows would let
+--    `lookupTemplateTeam` keep returning a stale team for the first caller
+--    of every spawn until the rows are overwritten with a fresh team —
+--    which the runtime fix now refuses to do.
+DELETE FROM agent_templates
+WHERE id IN (
+  -- BUILTIN_ROLES (plugins/genie/agents/*/AGENTS.md, category=role)
+  'docs',
+  'engineer',
+  'fix',
+  'pm',
+  'qa',
+  'refactor',
+  'reviewer',
+  'team-lead',
+  'trace',
+  -- BUILTIN_COUNCIL_MEMBERS (plugins/genie/agents/council*, category=council)
+  'council',
+  'council--architect',
+  'council--benchmarker',
+  'council--deployer',
+  'council--ergonomist',
+  'council--measurer',
+  'council--operator',
+  'council--questioner',
+  'council--sentinel',
+  'council--simplifier',
+  'council--tracer'
+);
+
+COMMIT;

--- a/src/db/migrations/055_default_auto_resume_true.sql
+++ b/src/db/migrations/055_default_auto_resume_true.sql
@@ -1,0 +1,39 @@
+-- 055_default_auto_resume_true.sql — Flip the agents.auto_resume default to
+-- TRUE and backfill every existing FALSE row to TRUE.
+--
+-- Why
+-- ---
+-- DB evidence (2026-05-07): 52 of 53 agents had auto_resume=false. The
+-- chokepoint `shouldResume()` treats false as "operator paused or scheduler
+-- exhausted retry budget" — but the column was effectively defaulting off,
+-- so no agent could be resumed without first running `genie agent recover`
+-- to flip the flag. Felipe directive (2026-05-07): default-on is the bug
+-- shape; flip every existing row to true and change the column DEFAULT so
+-- newly-spawned agents get the safe value out of the gate.
+--
+-- This migration also lands the trace-confirmed bug fix where
+-- `MissingResumeSessionError` reported reason='null_session' on rows whose
+-- session UUID was perfectly intact — auto_resume=false was the actual
+-- precondition. The protocol-router error enum now distinguishes the two
+-- (`auto_resume_disabled` vs `null_session`); this migration removes the
+-- silent default-off that triggered the misleading message in the first
+-- place.
+--
+-- Idempotent: re-running this migration is a no-op on rows that are already
+-- true and on a column whose default is already true.
+
+BEGIN;
+
+-- 1. Flip every existing false row. No WHERE narrowing — Felipe directive
+--    is to flip ALL of them so resume works out-of-the-box.
+UPDATE agents
+SET auto_resume = true
+WHERE auto_resume = false;
+
+-- 2. Change the column DEFAULT so future spawns inherit the safe value.
+--    NULLs (legacy rows that pre-date the column) become true — same as
+--    the safe-default the runtime treats them as.
+ALTER TABLE agents ALTER COLUMN auto_resume SET DEFAULT true;
+UPDATE agents SET auto_resume = true WHERE auto_resume IS NULL;
+
+COMMIT;

--- a/src/genie-commands/__tests__/recover-orphans.test.ts
+++ b/src/genie-commands/__tests__/recover-orphans.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Tests for `genie recover-orphans` — the JSONL backfill scanner.
+ *
+ * Pure-function coverage runs unconditionally (filename pattern + first-message
+ * preview parsing). The DB-touching paths are gated on DB_AVAILABLE so the
+ * suite is skippable on hosts without pgserve.
+ *
+ * Run with: bun test src/genie-commands/__tests__/recover-orphans.test.ts
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { findOrCreateAgent } from '../../lib/agent-registry.js';
+import { getConnection } from '../../lib/db.js';
+import { findExecutorBySession } from '../../lib/executor-registry.js';
+import { DB_AVAILABLE, setupTestDatabase } from '../../lib/test-db.js';
+import { _internal, recoverOrphansCommand, scanOrphans } from '../recover-orphans.js';
+
+// ============================================================================
+// Pure helpers — no DB
+// ============================================================================
+
+describe('recover-orphans helpers', () => {
+  test('encodeCwdForClaudeProjects matches Claude Code projects-dir naming', () => {
+    expect(_internal.encodeCwdForClaudeProjects('/tmp/myagent')).toBe('-tmp-myagent');
+    expect(_internal.encodeCwdForClaudeProjects('/home/genie/workspace/repos/genie')).toBe(
+      '-home-genie-workspace-repos-genie',
+    );
+  });
+
+  test('isSessionJsonl accepts uuid.jsonl, rejects backups and trimmed copies', () => {
+    expect(_internal.isSessionJsonl('1ee92ab4-9fec-4839-99b5-1a90e5899e70.jsonl')).toBe(true);
+    expect(_internal.isSessionJsonl('1ee92ab4-9fec-4839-99b5-1a90e5899e70.jsonl.bak')).toBe(false);
+    expect(_internal.isSessionJsonl('1ee92ab4-9fec-4839-99b5-1a90e5899e70.trimmed.jsonl')).toBe(false);
+    expect(_internal.isSessionJsonl('not-a-uuid.jsonl')).toBe(false);
+    expect(_internal.isSessionJsonl('README.md')).toBe(false);
+  });
+
+  test('readFirstUserMessagePreview extracts the first user text turn', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'recover-orphans-'));
+    const path = join(dir, 'fixture.jsonl');
+    const lines = [
+      JSON.stringify({ type: 'agent-name', agentName: 'genie' }),
+      JSON.stringify({
+        type: 'user',
+        message: { role: 'user', content: [{ type: 'text', text: 'hello world from felipe' }] },
+      }),
+      JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: 'hi' } }),
+    ];
+    writeFileSync(path, `${lines.join('\n')}\n`);
+    expect(_internal.readFirstUserMessagePreview(path)).toBe('hello world from felipe');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('readFirstUserMessagePreview tolerates malformed JSON and returns null on no match', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'recover-orphans-'));
+    const path = join(dir, 'fixture.jsonl');
+    writeFileSync(path, 'not json at all\n{"type":"system","content":"x"}\n');
+    expect(_internal.readFirstUserMessagePreview(path)).toBeNull();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('pickCanonicalAgent prefers dir:* master, then lex-smallest UUID', () => {
+    const rows = [
+      {
+        id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        repo_path: '/x',
+        team: null,
+        custom_name: null,
+        current_executor_id: null,
+      },
+      { id: 'dir:my-cwd', repo_path: '/x', team: null, custom_name: null, current_executor_id: null },
+    ];
+    expect(_internal.pickCanonicalAgent(rows)?.id).toBe('dir:my-cwd');
+
+    const noDir = [
+      {
+        id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        repo_path: '/x',
+        team: null,
+        custom_name: null,
+        current_executor_id: null,
+      },
+      {
+        id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        repo_path: '/x',
+        team: null,
+        custom_name: null,
+        current_executor_id: null,
+      },
+    ];
+    expect(_internal.pickCanonicalAgent(noDir)?.id).toBe('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
+
+    expect(_internal.pickCanonicalAgent([])).toBeNull();
+  });
+});
+
+// ============================================================================
+// DB-backed integration
+// ============================================================================
+
+describe.skipIf(!DB_AVAILABLE)('recover-orphans integration', () => {
+  let cleanup: () => Promise<void>;
+  let claudeRoot: string;
+  let projectsRoot: string;
+  let origConfigDir: string | undefined;
+
+  beforeAll(async () => {
+    cleanup = await setupTestDatabase();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  beforeEach(async () => {
+    // Each test gets its own CLAUDE_CONFIG_DIR so projects/ scans are
+    // hermetic and don't pick up the developer's real ~/.claude state.
+    claudeRoot = mkdtempSync(join(tmpdir(), 'claude-cfg-'));
+    projectsRoot = join(claudeRoot, 'projects');
+    mkdirSync(projectsRoot, { recursive: true });
+    origConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    process.env.CLAUDE_CONFIG_DIR = claudeRoot;
+
+    const sql = await getConnection();
+    await sql`DELETE FROM audit_events`;
+    await sql`DELETE FROM executors`;
+    await sql`DELETE FROM agents`;
+  });
+
+  afterEach(() => {
+    rmSync(claudeRoot, { recursive: true, force: true });
+    process.env.CLAUDE_CONFIG_DIR = origConfigDir;
+  });
+
+  async function seedAgentWithRepoPath(name: string, team: string, repoPath: string): Promise<string> {
+    const identity = await findOrCreateAgent(name, team, 'engineer');
+    const sql = await getConnection();
+    await sql`UPDATE agents SET repo_path = ${repoPath} WHERE id = ${identity.id}`;
+    return identity.id;
+  }
+
+  function writeJsonlFixture(encodedDir: string, sessionId: string, opts: { mtime?: Date } = {}): string {
+    const dir = join(projectsRoot, encodedDir);
+    mkdirSync(dir, { recursive: true });
+    const file = join(dir, `${sessionId}.jsonl`);
+    const lines = [
+      JSON.stringify({ type: 'summary', summary: 'Test session' }),
+      JSON.stringify({
+        type: 'user',
+        message: { role: 'user', content: [{ type: 'text', text: 'do the work' }] },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: 'on it' },
+      }),
+    ];
+    writeFileSync(file, `${lines.join('\n')}\n`);
+    if (opts.mtime) {
+      const { utimesSync } = require('node:fs');
+      utimesSync(file, opts.mtime, opts.mtime);
+    }
+    return file;
+  }
+
+  test('scan + parse: detects orphan JSONL and maps it to the right agent', async () => {
+    const repoPath = '/tmp/recover-orphans-fixture-a';
+    await seedAgentWithRepoPath('engineer', 'fixture-a', repoPath);
+    const sessionId = '11111111-1111-4111-8111-111111111111';
+    writeJsonlFixture('-tmp-recover-orphans-fixture-a', sessionId);
+
+    const summaries = await scanOrphans({ dir: repoPath });
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0].agent?.team).toBe('fixture-a');
+    expect(summaries[0].agent?.customName).toBe('engineer');
+    expect(summaries[0].orphans).toHaveLength(1);
+    expect(summaries[0].orphans[0].sessionId).toBe(sessionId);
+    expect(summaries[0].orphans[0].firstMessagePreview).toBe('do the work');
+    expect(summaries[0].agentHasLiveExecutor).toBe(false);
+  });
+
+  test('--apply --newest attaches the newest orphan and links it as current_executor', async () => {
+    const repoPath = '/tmp/recover-orphans-fixture-b';
+    const agentId = await seedAgentWithRepoPath('engineer', 'fixture-b', repoPath);
+
+    const newestId = '22222222-2222-4222-8222-222222222222';
+    const olderId = '22222222-2222-4222-8222-222222222221';
+    writeJsonlFixture('-tmp-recover-orphans-fixture-b', olderId, { mtime: new Date(Date.now() - 86400_000) });
+    writeJsonlFixture('-tmp-recover-orphans-fixture-b', newestId);
+
+    await recoverOrphansCommand({ dir: repoPath, apply: true, newest: true });
+
+    const linked = await findExecutorBySession(newestId);
+    expect(linked).not.toBeNull();
+    expect(linked?.agentId).toBe(agentId);
+    expect(linked?.claudeSessionId).toBe(newestId);
+
+    const sql = await getConnection();
+    const agentRows = await sql<{ current_executor_id: string | null }[]>`
+      SELECT current_executor_id FROM agents WHERE id = ${agentId} LIMIT 1
+    `;
+    expect(agentRows[0].current_executor_id).toBe(linked?.id ?? '');
+  });
+
+  test('idempotent: running --apply --newest twice does not duplicate the executor row', async () => {
+    const repoPath = '/tmp/recover-orphans-fixture-c';
+    const agentId = await seedAgentWithRepoPath('engineer', 'fixture-c', repoPath);
+    const sessionId = '33333333-3333-4333-8333-333333333333';
+    writeJsonlFixture('-tmp-recover-orphans-fixture-c', sessionId);
+
+    await recoverOrphansCommand({ dir: repoPath, apply: true, newest: true });
+    await recoverOrphansCommand({ dir: repoPath, apply: true, newest: true });
+
+    const sql = await getConnection();
+    const rows = await sql<{ id: string }[]>`
+      SELECT id FROM executors WHERE agent_id = ${agentId} AND claude_session_id = ${sessionId}
+    `;
+    expect(rows).toHaveLength(1);
+  });
+
+  test('refuses to overwrite a live executor', async () => {
+    const repoPath = '/tmp/recover-orphans-fixture-d';
+    const agentId = await seedAgentWithRepoPath('engineer', 'fixture-d', repoPath);
+    const sql = await getConnection();
+    // Seed a LIVE executor (no ended_at) and link it as current.
+    const liveExecId = '44444444-4444-4444-4444-444444444411';
+    await sql`
+      INSERT INTO executors (id, agent_id, provider, transport, state, started_at)
+      VALUES (${liveExecId}, ${agentId}, 'claude', 'tmux', 'running', now())
+    `;
+    await sql`UPDATE agents SET current_executor_id = ${liveExecId} WHERE id = ${agentId}`;
+
+    const orphanId = '44444444-4444-4444-8444-444444444444';
+    writeJsonlFixture('-tmp-recover-orphans-fixture-d', orphanId);
+
+    await recoverOrphansCommand({ dir: repoPath, apply: true, newest: true });
+
+    // The orphan must NOT have been attached.
+    const found = await findExecutorBySession(orphanId);
+    expect(found).toBeNull();
+    // The live executor stays current.
+    const agentRows = await sql<{ current_executor_id: string | null }[]>`
+      SELECT current_executor_id FROM agents WHERE id = ${agentId} LIMIT 1
+    `;
+    expect(agentRows[0].current_executor_id).toBe(liveExecId);
+  });
+
+  test('--list never mutates', async () => {
+    const repoPath = '/tmp/recover-orphans-fixture-e';
+    await seedAgentWithRepoPath('engineer', 'fixture-e', repoPath);
+    const sessionId = '55555555-5555-4555-8555-555555555555';
+    writeJsonlFixture('-tmp-recover-orphans-fixture-e', sessionId);
+
+    await recoverOrphansCommand({ dir: repoPath, list: true });
+
+    const found = await findExecutorBySession(sessionId);
+    expect(found).toBeNull();
+  });
+});

--- a/src/genie-commands/recover-orphans.ts
+++ b/src/genie-commands/recover-orphans.ts
@@ -1,0 +1,575 @@
+/**
+ * Genie Recover-Orphans Command
+ *
+ * Backfills `executors.claude_session_id` for Claude Code session JSONLs that
+ * survived an executor crash, host reboot, or pre-#1684 spawn path that
+ * forgot to write the session row. Without this, `genie agent resume` /
+ * `genie history` cannot find the on-disk transcript even though the
+ * conversation is still on disk and Claude itself would happily resume it.
+ *
+ * The scanner walks `<claudeConfigDir>/projects/<encoded-cwd>/*.jsonl`,
+ * cross-references each session UUID against the `executors` table, maps
+ * each project dir to a candidate agent via `agents.repo_path`, and either
+ * reports the orphans (default / `--list`) or attaches them to a fresh
+ * executor row (`--apply --newest` or `--apply --uuid`).
+ *
+ * Heal-not-wipe: this command never overwrites a live executor. If the
+ * candidate agent already has `current_executor_id` set to a row whose
+ * `ended_at IS NULL`, the orphan is reported but not attached.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { recordAuditEvent } from '../lib/audit.js';
+import { getConnection, isAvailable } from '../lib/db.js';
+import { createAndLinkExecutor, createExecutor } from '../lib/executor-registry.js';
+
+// ============================================================================
+// Public types & options
+// ============================================================================
+
+export interface RecoverOrphansOptions {
+  /** Restrict the scan to a single agent cwd (real path, not encoded). */
+  dir?: string;
+  /** Dry-run — list orphans grouped by agent dir; never mutate. */
+  list?: boolean;
+  /** Mutate: insert/update executor rows. Requires --newest or --uuid. */
+  apply?: boolean;
+  /** Pair with `--apply` to auto-attach the newest orphan per agent dir. */
+  newest?: boolean;
+  /** Pair with `--apply` to attach exactly one session UUID. */
+  uuid?: string;
+}
+
+interface OrphanCandidate {
+  sessionId: string;
+  jsonlPath: string;
+  size: number;
+  mtime: Date;
+  firstMessagePreview: string | null;
+}
+
+interface ProjectDirSummary {
+  encoded: string;
+  realCwd: string | null;
+  agent: { id: string; team: string | null; customName: string | null } | null;
+  agentHasLiveExecutor: boolean;
+  attachedSessionIds: string[];
+  orphans: OrphanCandidate[];
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Same encoder Claude Code uses to derive `<config-dir>/projects/<encoded>/`
+ * from a cwd. Mirrors `sanitizeCwdForProjects` in `executor-registry.ts`.
+ *
+ * Lossy by design — we cannot decode an encoded dir back to a unique cwd
+ * (multiple cwds collapse to the same dir). The decode side queries the
+ * `agents` table and matches by re-encoding each `repo_path`.
+ */
+export function encodeCwdForClaudeProjects(cwd: string): string {
+  return cwd.replace(/[^a-zA-Z0-9]/g, '-');
+}
+
+function resolveClaudeConfigDir(): string {
+  return process.env.CLAUDE_CONFIG_DIR ?? join(homedir(), '.claude');
+}
+
+function resolveProjectsRoot(): string {
+  return join(resolveClaudeConfigDir(), 'projects');
+}
+
+/**
+ * Read the head of a JSONL and return a short user-facing preview of the
+ * first user message. Returns null if the file is unreadable, empty, or
+ * has no parseable user message in the first ~16 KiB.
+ */
+export function readFirstUserMessagePreview(jsonlPath: string, maxChars = 80): string | null {
+  let head: string;
+  try {
+    const fd = readFileSync(jsonlPath, { encoding: 'utf-8', flag: 'r' });
+    head = fd.slice(0, 16384);
+  } catch {
+    return null;
+  }
+  for (const line of head.split('\n').slice(0, 60)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let entry: { type?: unknown; role?: unknown; message?: unknown };
+    try {
+      entry = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    const text = extractUserText(entry);
+    if (text) {
+      const oneLine = text.replace(/\s+/g, ' ').trim();
+      return oneLine.length > maxChars ? `${oneLine.slice(0, maxChars - 1)}…` : oneLine;
+    }
+  }
+  return null;
+}
+
+function extractUserText(entry: { type?: unknown; role?: unknown; message?: unknown }): string | null {
+  // Newer schema: `{type: 'user', message: {role: 'user', content: '…' | [{type:'text', text:'…'}]}}`
+  if (entry.type !== 'user') return null;
+  const message = entry.message as { role?: unknown; content?: unknown } | undefined;
+  if (!message || typeof message !== 'object') return null;
+  if (message.role !== 'user' && entry.role !== 'user') return null;
+  const content = message.content;
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return null;
+  for (const part of content) {
+    if (part && typeof part === 'object' && 'type' in part && (part as { type: unknown }).type === 'text') {
+      const text = (part as { text?: unknown }).text;
+      if (typeof text === 'string') return text;
+    }
+  }
+  return null;
+}
+
+function isSessionJsonl(name: string): boolean {
+  // Session files are named `<uuid>.jsonl`. The dir also collects backups
+  // (`<uuid>.jsonl.<timestamp>.bak`) and trimmed copies (`<uuid>.trimmed.jsonl`)
+  // — neither is a live session, so skip.
+  if (!name.endsWith('.jsonl')) return false;
+  const stem = name.slice(0, -'.jsonl'.length);
+  if (stem.includes('.')) return false;
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(stem);
+}
+
+interface AgentRepoRow {
+  id: string;
+  repo_path: string | null;
+  team: string | null;
+  custom_name: string | null;
+  current_executor_id: string | null;
+}
+
+interface CurrentExecutorRow {
+  id: string;
+  ended_at: Date | string | null;
+}
+
+async function loadAgentsByEncodedCwd(): Promise<Map<string, AgentRepoRow[]>> {
+  const sql = await getConnection();
+  const rows = await sql<AgentRepoRow[]>`
+    SELECT id, repo_path, team, custom_name, current_executor_id
+    FROM agents
+    WHERE repo_path IS NOT NULL
+  `;
+  const map = new Map<string, AgentRepoRow[]>();
+  for (const row of rows) {
+    if (!row.repo_path) continue;
+    const encoded = encodeCwdForClaudeProjects(row.repo_path);
+    const bucket = map.get(encoded) ?? [];
+    bucket.push(row);
+    map.set(encoded, bucket);
+  }
+  return map;
+}
+
+/**
+ * Pick the canonical agent for an encoded project dir.
+ *
+ * Preference order:
+ *   1. `id` starts with `dir:` (the master row for the directory — durable
+ *      across teammate spawns, see migration 049).
+ *   2. Lexicographically smallest id (deterministic across reruns).
+ *
+ * Returns null if no agents claim that cwd.
+ */
+function pickCanonicalAgent(rows: AgentRepoRow[]): AgentRepoRow | null {
+  if (rows.length === 0) return null;
+  const dirRow = rows.find((r) => r.id.startsWith('dir:'));
+  if (dirRow) return dirRow;
+  return [...rows].sort((a, b) => a.id.localeCompare(b.id))[0];
+}
+
+async function loadAttachedSessionIds(): Promise<Set<string>> {
+  const sql = await getConnection();
+  const rows = await sql<{ claude_session_id: string }[]>`
+    SELECT DISTINCT claude_session_id
+    FROM executors
+    WHERE claude_session_id IS NOT NULL
+  `;
+  return new Set(rows.map((r: { claude_session_id: string }) => r.claude_session_id));
+}
+
+async function isExecutorLive(executorId: string | null): Promise<boolean> {
+  if (!executorId) return false;
+  const sql = await getConnection();
+  const rows = await sql<CurrentExecutorRow[]>`
+    SELECT id, ended_at FROM executors WHERE id = ${executorId} LIMIT 1
+  `;
+  if (rows.length === 0) return false;
+  return rows[0].ended_at === null;
+}
+
+function listProjectDirs(projectsRoot: string, restrictEncoded: string | null): string[] {
+  if (!existsSync(projectsRoot)) return [];
+  let entries: string[];
+  try {
+    entries = readdirSync(projectsRoot);
+  } catch {
+    return [];
+  }
+  const candidates = entries.filter((name) => {
+    try {
+      return statSync(join(projectsRoot, name)).isDirectory();
+    } catch {
+      return false;
+    }
+  });
+  if (restrictEncoded === null) return candidates;
+  return candidates.filter((c) => c === restrictEncoded);
+}
+
+function scanDirForOrphans(projectsRoot: string, encodedDir: string, attached: Set<string>) {
+  const dirPath = join(projectsRoot, encodedDir);
+  let entries: string[];
+  try {
+    entries = readdirSync(dirPath);
+  } catch {
+    return { orphans: [] as OrphanCandidate[], attachedSessionIds: [] as string[] };
+  }
+  const orphans: OrphanCandidate[] = [];
+  const attachedHere: string[] = [];
+  for (const name of entries) {
+    if (!isSessionJsonl(name)) continue;
+    const sessionId = name.slice(0, -'.jsonl'.length);
+    if (attached.has(sessionId)) {
+      attachedHere.push(sessionId);
+      continue;
+    }
+    const full = join(dirPath, name);
+    let stats: ReturnType<typeof statSync>;
+    try {
+      stats = statSync(full);
+    } catch {
+      continue;
+    }
+    orphans.push({
+      sessionId,
+      jsonlPath: full,
+      size: stats.size,
+      mtime: stats.mtime,
+      firstMessagePreview: readFirstUserMessagePreview(full),
+    });
+  }
+  orphans.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+  return { orphans, attachedSessionIds: attachedHere };
+}
+
+// ============================================================================
+// Core scan + apply
+// ============================================================================
+
+export async function scanOrphans(opts: { dir?: string }): Promise<ProjectDirSummary[]> {
+  const projectsRoot = resolveProjectsRoot();
+  const restrictEncoded = opts.dir ? encodeCwdForClaudeProjects(opts.dir) : null;
+
+  const [agentsByEncoded, attached] = await Promise.all([loadAgentsByEncodedCwd(), loadAttachedSessionIds()]);
+  const dirs = listProjectDirs(projectsRoot, restrictEncoded);
+
+  const summaries: ProjectDirSummary[] = [];
+  for (const encoded of dirs) {
+    const agentRows = agentsByEncoded.get(encoded) ?? [];
+    const canonical = pickCanonicalAgent(agentRows);
+    const { orphans, attachedSessionIds } = scanDirForOrphans(projectsRoot, encoded, attached);
+    if (orphans.length === 0 && attachedSessionIds.length === 0) continue;
+    const live = canonical ? await isExecutorLive(canonical.current_executor_id) : false;
+    summaries.push({
+      encoded,
+      realCwd: canonical?.repo_path ?? null,
+      agent: canonical ? { id: canonical.id, team: canonical.team, customName: canonical.custom_name } : null,
+      agentHasLiveExecutor: live,
+      attachedSessionIds,
+      orphans,
+    });
+  }
+  // Stable order: dirs with the most orphans first, then alphabetically.
+  summaries.sort((a, b) => b.orphans.length - a.orphans.length || a.encoded.localeCompare(b.encoded));
+  return summaries;
+}
+
+interface AttachOutcome {
+  sessionId: string;
+  agentId: string;
+  executorId: string;
+  linked: boolean;
+}
+
+async function attachOrphan(opts: {
+  agentRow: AgentRepoRow;
+  agentLive: boolean;
+  candidate: OrphanCandidate;
+}): Promise<AttachOutcome> {
+  const { agentRow, agentLive, candidate } = opts;
+  if (agentLive) {
+    throw new Error(
+      `agent ${agentRow.id} already has a live executor (current_executor_id=${agentRow.current_executor_id}); refusing to overwrite. Stop the live executor first, or pick a different session.`,
+    );
+  }
+
+  const metadata = {
+    source: 'recover-orphans',
+    jsonl_path: candidate.jsonlPath,
+    jsonl_mtime: candidate.mtime.toISOString(),
+    jsonl_size: candidate.size,
+  } as Record<string, unknown>;
+
+  const linkable = agentRow.current_executor_id === null;
+  const factory = linkable ? createAndLinkExecutor : createExecutor;
+  const executor = await factory(agentRow.id, 'claude', 'tmux', {
+    claudeSessionId: candidate.sessionId,
+    state: 'terminated',
+    metadata,
+    repoPath: agentRow.repo_path,
+  });
+
+  await recordAuditEvent('executor', executor.id, 'executor.recovered_from_orphan', 'cli', {
+    agent_id: agentRow.id,
+    claude_session_id: candidate.sessionId,
+    jsonl_path: candidate.jsonlPath,
+    linked_as_current: linkable,
+  });
+
+  return { sessionId: candidate.sessionId, agentId: agentRow.id, executorId: executor.id, linked: linkable };
+}
+
+// ============================================================================
+// Renderers
+// ============================================================================
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n}B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)}KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+function formatRelative(date: Date, now = new Date()): string {
+  const diffMs = now.getTime() - date.getTime();
+  const minutes = Math.round(diffMs / 60000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+}
+
+function formatAgentLabel(summary: ProjectDirSummary): string {
+  if (!summary.agent) return 'unmapped';
+  const team = summary.agent.team;
+  const name = summary.agent.customName;
+  if (!team && !name) return summary.agent.id;
+  return `${summary.agent.id} (${team ?? '?'}/${name ?? '?'})`;
+}
+
+function renderOrphanDetails(orphans: OrphanCandidate[]): void {
+  if (orphans.length === 0) return;
+  const newest = orphans[0];
+  const oldest = orphans[orphans.length - 1];
+  const totalBytes = orphans.reduce((acc, o) => acc + o.size, 0);
+  console.log(
+    `  newest:   ${newest.sessionId.slice(0, 8)} · ${formatBytes(newest.size)} · ${formatRelative(newest.mtime)}`,
+  );
+  if (oldest !== newest) {
+    console.log(
+      `  oldest:   ${oldest.sessionId.slice(0, 8)} · ${formatBytes(oldest.size)} · ${formatRelative(oldest.mtime)}`,
+    );
+  }
+  console.log(`  total:    ${formatBytes(totalBytes)} across ${orphans.length} JSONL(s)`);
+  console.log('  top:');
+  for (const o of orphans.slice(0, 5)) {
+    const preview = o.firstMessagePreview ? ` — ${o.firstMessagePreview}` : '';
+    console.log(`    · ${o.sessionId} · ${formatBytes(o.size)} · ${formatRelative(o.mtime)}${preview}`);
+  }
+}
+
+function renderProjectDirSummary(summary: ProjectDirSummary): void {
+  console.log();
+  const cwdLabel = summary.realCwd ?? `(encoded: ${summary.encoded})`;
+  const liveTag = summary.agentHasLiveExecutor ? ' \x1b[33m[live executor]\x1b[0m' : '';
+  console.log(`\x1b[1m${cwdLabel}\x1b[0m`);
+  console.log(`  agent:    ${formatAgentLabel(summary)}${liveTag}`);
+  console.log(`  orphans:  ${summary.orphans.length}    attached: ${summary.attachedSessionIds.length}`);
+  renderOrphanDetails(summary.orphans);
+}
+
+function renderSummary(summaries: ProjectDirSummary[]): void {
+  if (summaries.length === 0) {
+    console.log('No orphaned Claude session JSONLs detected.');
+    return;
+  }
+  let totalOrphans = 0;
+  let totalAttached = 0;
+  for (const summary of summaries) {
+    totalOrphans += summary.orphans.length;
+    totalAttached += summary.attachedSessionIds.length;
+    renderProjectDirSummary(summary);
+  }
+  console.log();
+  console.log(
+    `\x1b[1mTotal:\x1b[0m ${totalOrphans} orphan(s), ${totalAttached} already attached, ${summaries.length} dir(s).`,
+  );
+}
+
+function renderApplyReport(
+  outcomes: AttachOutcome[],
+  skipped: { reason: string; sessionId?: string; encoded?: string }[],
+): void {
+  if (outcomes.length === 0 && skipped.length === 0) {
+    console.log('Nothing to attach.');
+    return;
+  }
+  for (const o of outcomes) {
+    const linkNote = o.linked ? ' (linked as current_executor)' : ' (executor created, agent already had current)';
+    console.log(`  \x1b[32m✓\x1b[0m ${o.sessionId} → ${o.agentId}${linkNote}`);
+  }
+  for (const s of skipped) {
+    const target = s.sessionId ?? s.encoded ?? '?';
+    console.log(`  \x1b[33m!\x1b[0m skipped ${target} — ${s.reason}`);
+  }
+  console.log();
+  console.log(`Attached ${outcomes.length}; skipped ${skipped.length}.`);
+}
+
+// ============================================================================
+// Apply paths
+// ============================================================================
+
+async function applyNewest(summaries: ProjectDirSummary[]): Promise<{
+  outcomes: AttachOutcome[];
+  skipped: { reason: string; sessionId?: string; encoded?: string }[];
+}> {
+  const outcomes: AttachOutcome[] = [];
+  const skipped: { reason: string; sessionId?: string; encoded?: string }[] = [];
+  for (const s of summaries) {
+    if (s.orphans.length === 0) continue;
+    if (!s.agent) {
+      skipped.push({ reason: 'no agent claims this cwd', encoded: s.encoded });
+      continue;
+    }
+    const newest = s.orphans[0];
+    if (s.agentHasLiveExecutor) {
+      skipped.push({ reason: `agent ${s.agent.id} has a live executor`, sessionId: newest.sessionId });
+      continue;
+    }
+    try {
+      const agentRow: AgentRepoRow = {
+        id: s.agent.id,
+        repo_path: s.realCwd,
+        team: s.agent.team,
+        custom_name: s.agent.customName,
+        current_executor_id: null, // refreshed by query below
+      };
+      const sql = await getConnection();
+      const rows = await sql<{ current_executor_id: string | null }[]>`
+        SELECT current_executor_id FROM agents WHERE id = ${agentRow.id} LIMIT 1
+      `;
+      agentRow.current_executor_id = rows[0]?.current_executor_id ?? null;
+
+      const outcome = await attachOrphan({ agentRow, agentLive: false, candidate: newest });
+      outcomes.push(outcome);
+    } catch (err) {
+      skipped.push({ reason: err instanceof Error ? err.message : String(err), sessionId: newest.sessionId });
+    }
+  }
+  return { outcomes, skipped };
+}
+
+async function applyUuid(summaries: ProjectDirSummary[], uuid: string) {
+  for (const s of summaries) {
+    const candidate = s.orphans.find((o) => o.sessionId === uuid);
+    if (!candidate) continue;
+    if (!s.agent) {
+      return {
+        outcomes: [] as AttachOutcome[],
+        skipped: [{ reason: 'no agent claims this cwd', sessionId: uuid }],
+      };
+    }
+    if (s.agentHasLiveExecutor) {
+      return {
+        outcomes: [] as AttachOutcome[],
+        skipped: [{ reason: `agent ${s.agent.id} has a live executor`, sessionId: uuid }],
+      };
+    }
+    const sql = await getConnection();
+    const rows = await sql<{ current_executor_id: string | null }[]>`
+      SELECT current_executor_id FROM agents WHERE id = ${s.agent.id} LIMIT 1
+    `;
+    const agentRow: AgentRepoRow = {
+      id: s.agent.id,
+      repo_path: s.realCwd,
+      team: s.agent.team,
+      custom_name: s.agent.customName,
+      current_executor_id: rows[0]?.current_executor_id ?? null,
+    };
+    try {
+      const outcome = await attachOrphan({ agentRow, agentLive: false, candidate });
+      return { outcomes: [outcome], skipped: [] as { reason: string; sessionId?: string }[] };
+    } catch (err) {
+      return {
+        outcomes: [] as AttachOutcome[],
+        skipped: [{ reason: err instanceof Error ? err.message : String(err), sessionId: uuid }],
+      };
+    }
+  }
+  return {
+    outcomes: [] as AttachOutcome[],
+    skipped: [{ reason: 'session UUID not found among orphans', sessionId: uuid }],
+  };
+}
+
+// ============================================================================
+// Entry point
+// ============================================================================
+
+export async function recoverOrphansCommand(options: RecoverOrphansOptions = {}): Promise<void> {
+  const projectsRoot = resolveProjectsRoot();
+  if (!existsSync(projectsRoot)) {
+    console.log(`No Claude projects directory at ${projectsRoot} — nothing to scan.`);
+    return;
+  }
+  if (!(await isAvailable())) {
+    console.error('Genie database is unreachable. Start it with `genie serve` and retry.');
+    process.exit(1);
+  }
+
+  if (options.apply && !options.newest && !options.uuid) {
+    console.error('--apply requires either --newest (attach the newest orphan per dir) or --uuid <session-id>.');
+    process.exit(2);
+  }
+
+  const summaries = await scanOrphans({ dir: options.dir });
+
+  if (!options.apply) {
+    renderSummary(summaries);
+    return;
+  }
+
+  let outcomes: AttachOutcome[] = [];
+  let skipped: { reason: string; sessionId?: string; encoded?: string }[] = [];
+  if (options.uuid) {
+    ({ outcomes, skipped } = await applyUuid(summaries, options.uuid));
+  } else if (options.newest) {
+    ({ outcomes, skipped } = await applyNewest(summaries));
+  }
+  renderApplyReport(outcomes, skipped);
+}
+
+// Exposed for tests.
+export const _internal = {
+  encodeCwdForClaudeProjects,
+  isSessionJsonl,
+  pickCanonicalAgent,
+  readFirstUserMessagePreview,
+  scanDirForOrphans,
+  attachOrphan,
+};

--- a/src/genie-commands/session.test.ts
+++ b/src/genie-commands/session.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for session.ts — registerSessionInRegistry session-id propagation.
+ *
+ * Regression test for #212: the operator's interactive `genie session start`
+ * launches claude with `--session-id <uuid>` but did not persist the UUID on
+ * the executor row, so session-capture's filewatch never associated the JSONL
+ * with any agent. The leader's transcript became orphaned and `genie agent
+ * show <leader>` reported "No active executor" while claude was live.
+ *
+ * Uses _deps injection (no mock.module) to avoid bun shared-module-cache leaks.
+ *
+ * Run with: bun test src/genie-commands/session.test.ts
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { CreateExecutorOpts } from '../lib/executor-registry.js';
+
+import { _deps, registerSessionInRegistry } from './session.js';
+
+interface CreateExecutorCall {
+  agentId: string;
+  provider: string;
+  transport: string;
+  opts: CreateExecutorOpts;
+}
+
+describe('registerSessionInRegistry — session-id propagation (#212)', () => {
+  let origDeps: typeof _deps;
+  let createCalls: CreateExecutorCall[];
+
+  beforeEach(() => {
+    origDeps = { ...(_deps as typeof _deps) };
+    createCalls = [];
+
+    _deps.executeTmux = mock(async (cmd: string) => {
+      if (cmd.includes("'#{pane_id}'")) return '%999';
+      if (cmd.includes("'#{pane_pid}'")) return '12345';
+      return '';
+    });
+    _deps.registerWorker = mock(async () => {});
+    _deps.resolveLeaderName = mock(async () => 'leader');
+    _deps.findOrCreateAgent = mock(async () => ({
+      id: 'agent-uuid',
+      name: 'leader',
+      team: 'leader',
+      role: 'leader',
+      currentExecutorId: null,
+    })) as unknown as typeof _deps.findOrCreateAgent;
+    _deps.createAndLinkExecutor = mock(
+      async (agentId: string, provider: string, transport: string, opts: CreateExecutorOpts) => {
+        createCalls.push({ agentId, provider, transport, opts });
+        return {} as never;
+      },
+    ) as unknown as typeof _deps.createAndLinkExecutor;
+  });
+
+  afterEach(() => {
+    Object.assign(_deps, origDeps);
+  });
+
+  test('persists claude_session_id on executor row when sessionId is provided', async () => {
+    const sessionId = 'cafef00d-1234-5678-9abc-def012345678';
+
+    await registerSessionInRegistry('test-session', 'test-window', '/tmp/test-workspace', sessionId);
+
+    expect(createCalls).toHaveLength(1);
+    expect(createCalls[0].opts.claudeSessionId).toBe(sessionId);
+    expect(createCalls[0].provider).toBe('claude');
+    expect(createCalls[0].transport).toBe('tmux');
+  });
+
+  test('falls back to null claudeSessionId when sessionId is omitted (back-compat)', async () => {
+    await registerSessionInRegistry('test-session', 'test-window', '/tmp/test-workspace');
+
+    expect(createCalls).toHaveLength(1);
+    expect(createCalls[0].opts.claudeSessionId).toBeNull();
+  });
+});

--- a/src/genie-commands/session.ts
+++ b/src/genie-commands/session.ts
@@ -113,18 +113,41 @@ export function buildClaudeCommand(
 }
 
 /**
+ * Testable dependency injection — overridable in tests to avoid mock.module
+ * leaking across the shared module cache. Mirrors `protocol-router-spawn._deps`.
+ */
+export const _deps = {
+  executeTmux: tmux.executeTmux as typeof tmux.executeTmux,
+  registerWorker: registry.register as typeof registry.register,
+  findOrCreateAgent: registry.findOrCreateAgent as typeof registry.findOrCreateAgent,
+  createAndLinkExecutor: executorRegistry.createAndLinkExecutor as typeof executorRegistry.createAndLinkExecutor,
+  resolveLeaderName: resolveSessionLeaderName as (team: string) => Promise<string>,
+};
+
+/**
  * Register the interactive genie session in `~/.genie/workers.json`.
  *
  * This allows spawned agents to resolve the team-lead for messaging
  * via the agent registry (e.g., for SendMessage bidirectional comms).
+ *
+ * `sessionId` is the Claude Code session UUID emitted to `--session-id`
+ * at launch. It MUST be persisted on the executor row so session-capture's
+ * filewatch (which joins `agents → executors WHERE claude_session_id IS NOT
+ * NULL`) ingests the leader's JSONL. Without it the JSONL becomes orphaned
+ * and `genie agent show <leader>` reports "No active executor" (#212).
  */
-async function registerSessionInRegistry(sessionName: string, windowName: string, workspaceDir: string): Promise<void> {
+export async function registerSessionInRegistry(
+  sessionName: string,
+  windowName: string,
+  workspaceDir: string,
+  sessionId?: string,
+): Promise<void> {
   try {
     const target = `${sessionName}:${windowName}`;
-    const paneId = (await tmux.executeTmux(`display -t ${shellQuote(target)} -p '#{pane_id}'`)).trim();
+    const paneId = (await _deps.executeTmux(`display -t ${shellQuote(target)} -p '#{pane_id}'`)).trim();
     const now = new Date().toISOString();
     const sanitized = sanitizeTeamName(windowName);
-    const leaderName = await resolveSessionLeaderName(windowName);
+    const leaderName = await _deps.resolveLeaderName(windowName);
     const sanitizedLeader = sanitizeTeamName(leaderName);
 
     // Wish retire-session-names-id-only Group 3: spawn writes ONE row.
@@ -153,7 +176,7 @@ async function registerSessionInRegistry(sessionName: string, windowName: string
 
     let pid: number | null = null;
     try {
-      const pidStr = (await tmux.executeTmux(`display -t ${shellQuote(target)} -p '#{pane_pid}'`)).trim();
+      const pidStr = (await _deps.executeTmux(`display -t ${shellQuote(target)} -p '#{pane_pid}'`)).trim();
       const parsed = Number.parseInt(pidStr, 10);
       if (parsed > 0) pid = parsed;
     } catch {
@@ -167,11 +190,12 @@ async function registerSessionInRegistry(sessionName: string, windowName: string
     // the parent process itself). Regular workers go through spawnAgent which
     // does 'spawning'→'running' explicitly; team-leads do not.
     // Fixes #1184.
-    await executorRegistry.createAndLinkExecutor(agentIdentity.id, 'claude', 'tmux', {
+    await _deps.createAndLinkExecutor(agentIdentity.id, 'claude', 'tmux', {
       pid,
       tmuxSession: sessionName,
       tmuxPaneId: paneId,
       tmuxWindow: windowName,
+      claudeSessionId: sessionId ?? null,
       state: 'running',
       repoPath: workspaceDir,
     });
@@ -275,7 +299,7 @@ async function createSession(
   }
 
   // Register interactive session so spawned agents can find the team-lead
-  await registerSessionInRegistry(sessionName, windowName, workspaceDir);
+  await registerSessionInRegistry(sessionName, windowName, workspaceDir, sessionId);
 }
 
 /**
@@ -359,7 +383,7 @@ async function focusTeamWindow(
     }
 
     // Register interactive session so spawned agents can find the team-lead
-    await registerSessionInRegistry(sessionName, windowName, workingDir);
+    await registerSessionInRegistry(sessionName, windowName, workingDir, sessionId);
   } else {
     // Window exists — check if Claude Code is still running
     const target = `${sessionName}:${windowName}`;
@@ -396,7 +420,7 @@ async function focusTeamWindow(
         // Best-effort guard
       }
 
-      await registerSessionInRegistry(sessionName, windowName, workingDir);
+      await registerSessionInRegistry(sessionName, windowName, workingDir, sessionId);
     }
     // else: Claude Code is still running — just select the window below
   }

--- a/src/genie.ts
+++ b/src/genie.ts
@@ -211,6 +211,17 @@ program
   .option('--json', 'Emit JSON instead of human output (pairs with --observability)')
   .action(doctorCommand);
 program
+  .command('recover-orphans')
+  .description('Attach orphaned Claude session JSONLs to executor rows so resume works')
+  .option('--dir <agent-dir>', 'Restrict the scan to one agent cwd (real path, not the encoded form)')
+  .option('--list', 'Dry-run — list orphaned JSONLs grouped by agent dir; never mutates')
+  .option('--apply', 'Mutate: attach orphans to executors. Requires --newest or --uuid.')
+  .option('--newest', 'Pair with --apply to auto-attach the newest orphan per agent dir')
+  .option('--uuid <session-id>', 'Pair with --apply to attach exactly one Claude session UUID')
+  .action(async (options: RecoverOrphansOptions) => {
+    await recoverOrphansCommand(options);
+  });
+program
   .command('update')
   .description('Update Genie CLI to the latest version')
   .option('--next', 'Switch to dev builds (npm @next tag)')

--- a/src/genie.ts
+++ b/src/genie.ts
@@ -21,6 +21,7 @@ import { Command } from 'commander';
 import { doctorCommand } from './genie-commands/doctor.js';
 import { type InstallOptions, installCommand } from './genie-commands/install.js';
 import { migrateCommand } from './genie-commands/migrate.js';
+import { type RecoverOrphansOptions, recoverOrphansCommand } from './genie-commands/recover-orphans.js';
 import { type SetupOptions, setupCommand } from './genie-commands/setup.js';
 import {
   shortcutsInstallCommand,

--- a/src/lib/agent-directory.ts
+++ b/src/lib/agent-directory.ts
@@ -412,24 +412,46 @@ export async function resolve(name: string): Promise<ResolvedAgent | null> {
       }
       return { entry, builtin: false };
     }
+
+    // 1b. Fallback to custom_name when role didn't match. Spawned agents
+    // routinely have a custom_name (e.g. "felipe", "fix-resume-name-flag")
+    // that diverges from `role`; without this fallback, `genie agent
+    // recover felipe` failed at the resolver step even though the row was
+    // there (Felipe directive 2026-05-07).
+    const byCustomName = await sql`
+      SELECT role, custom_name, metadata, created_at FROM agents
+      WHERE custom_name = ${name}
+      ORDER BY (CASE WHEN position('dir:' in id) = 1 THEN 0 ELSE 1 END), started_at DESC
+      LIMIT 1
+    `;
+    if (byCustomName.length > 0) {
+      const row = byCustomName[0];
+      const meta = parseMetadata(row.metadata);
+      const createdAt =
+        row.created_at instanceof Date ? row.created_at.toISOString() : (row.created_at as string | undefined);
+      const entry = roleToEntry(typeof row.role === 'string' ? row.role : name, undefined, meta, createdAt);
+      if (templateTeam) entry.team = templateTeam;
+      return { entry, builtin: false };
+    }
   } catch {
     /* PG unavailable — fall through to built-ins */
   }
 
-  // 3. Check built-in roles
+  // 3. Check built-in roles. Built-ins are SHARED across teams — they MUST
+  //    NOT carry a sticky team pin from `agent_templates`. Whichever team
+  //    spawned `engineer` first would otherwise become the canonical team
+  //    for every subsequent spawn, breaking `genie send` / mailbox routing
+  //    on every other team. Let `resolveTeamName` tier 3 (GENIE_TEAM env)
+  //    and tier 4 (discoverTeamName) decide team for built-ins.
   const builtinRole = BUILTIN_ROLES.find((r: BuiltinAgent) => r.name === name);
   if (builtinRole) {
-    const entry = builtinToEntry(builtinRole);
-    if (templateTeam) entry.team = templateTeam;
-    return { entry, builtin: true };
+    return { entry: builtinToEntry(builtinRole), builtin: true };
   }
 
-  // 4. Check built-in council members
+  // 4. Check built-in council members — same SHARED-team rule as roles.
   const councilMember = BUILTIN_COUNCIL_MEMBERS.find((m: BuiltinAgent) => m.name === name);
   if (councilMember) {
-    const entry = builtinToEntry(councilMember);
-    if (templateTeam) entry.team = templateTeam;
-    return { entry, builtin: true };
+    return { entry: builtinToEntry(councilMember), builtin: true };
   }
 
   return null;
@@ -440,8 +462,13 @@ export async function resolve(name: string): Promise<ResolvedAgent | null> {
  * Returns null when PG is unavailable, the row does not exist, or the team
  * column is empty. This is an authoritative PG lookup — NOT a synthetic
  * tmux/env fallback — and powers tier 2 of the team-resolution precedence.
+ *
+ * For hierarchical names (`parent/child`), if no exact match exists we fall
+ * back to the parent name — subagents inherit their parent's team. Without
+ * this, `genie-omni/dog-fooder` could not find `genie-omni`'s pinned team
+ * and downstream `genie send` / mailbox routing landed on the wrong team.
  */
-async function lookupTemplateTeam(name: string): Promise<string | null> {
+export async function lookupTemplateTeam(name: string): Promise<string | null> {
   try {
     const { getConnection } = await import('./db.js');
     const sql = await getConnection();

--- a/src/lib/builtin-agents.ts
+++ b/src/lib/builtin-agents.ts
@@ -149,3 +149,13 @@ export function listRoleNames(): string[] {
 export function listCouncilNames(): string[] {
   return BUILTIN_COUNCIL_MEMBERS.map((m) => m.name);
 }
+
+/**
+ * Check if a name is a known built-in agent (role or council member).
+ * Built-ins are SHARED across teams — they must not carry sticky team pins
+ * in `agent_templates`, otherwise `lookupTemplateTeam` returns the team of
+ * whichever spawn happened to land first and contaminates every later spawn.
+ */
+export function isBuiltinAgent(name: string): boolean {
+  return ALL_BUILTINS.some((a) => a.name === name);
+}

--- a/src/lib/executor-registry.ts
+++ b/src/lib/executor-registry.ts
@@ -259,13 +259,19 @@ export async function updateClaudeSessionId(executorId: string, sessionId: strin
 
 /**
  * Identity passed to the JSONL fallback scanner. Mirrors the canonical
- * `(team, custom_name)` columns on `agents`. Both fields must be non-null
- * to attempt a match — the fallback refuses to return another agent's
- * transcript when ownership is unknown.
+ * `(team, custom_name)` columns on `agents`. `customName` is required (the
+ * scanner refuses to return another agent's transcript when role identity
+ * is unknown). `team` may be null for legacy / orphan rows where no team
+ * was ever recorded — in that case the scanner matches on `agentName` alone
+ * and additionally accepts JSONL bodies whose `teamName` is null.
  */
 export interface ResumeFallbackIdentity {
-  /** Agent's `team` column. Populated by `findOrCreateAgent`. */
-  team: string;
+  /**
+   * Agent's `team` column. Populated by `findOrCreateAgent`. May be null
+   * for legacy/orphan rows; when null, the scanner relaxes to a customName
+   * match only.
+   */
+  team: string | null;
   /** Agent's `custom_name` column. The role-or-name part of the identity. */
   customName: string;
 }
@@ -432,7 +438,12 @@ async function defaultScanForSession(cwd: string, identity: ResumeFallbackIdenti
 
   for (const candidate of sorted) {
     const { teamName, agentName } = await readJsonlIdentity(candidate.full);
-    if (teamName !== identity.team || agentName !== identity.customName) continue;
+    if (agentName !== identity.customName) continue;
+    // Identity.team is allowed to be null for orphan / legacy rows
+    // (Felipe directive 2026-05-07): in that case match on agentName alone.
+    // When identity.team is set, require strict teamName equality so we
+    // don't attach team A's runtime to team B's transcript.
+    if (identity.team !== null && teamName !== identity.team) continue;
     return candidate.name.replace(/\.jsonl$/, '');
   }
   return null;
@@ -488,9 +499,11 @@ type ResumeSessionLookup = {
  * **Pure** — no emission. Audit emission belongs to the eventful path
  * ({@link acquireResumeSessionForAttempt}).
  *
- * Identity is `(team, custom_name)` and BOTH must be present — a missing
- * identity makes ownership unverifiable, and we refuse to attach an agent's
- * runtime to another agent's transcript.
+ * Identity is `(team, custom_name)`. `custom_name` is required (the scanner
+ * refuses to attach without role identity), but `team` may be null —
+ * legacy/orphan rows that never got a team assigned still resume off-disk
+ * by matching on `agentName` alone (Felipe directive 2026-05-07: previous
+ * strict-both check stranded rows where team got dropped).
  */
 async function tryJsonlFallback(row: ResumeRow | null): Promise<ResumeSessionLookup | null> {
   const cwd = row?.repo_path ?? null;
@@ -498,8 +511,8 @@ async function tryJsonlFallback(row: ResumeRow | null): Promise<ResumeSessionLoo
 
   const team = row?.team ?? null;
   const customName = row?.custom_name ?? null;
-  const identity: ResumeFallbackIdentity | null = team && customName ? { team, customName } : null;
-  if (!identity) return null;
+  if (!customName) return null;
+  const identity: ResumeFallbackIdentity = { team, customName };
 
   const scanner = _resumeJsonlScannerDeps.scanForSession ?? defaultScanForSession;
   const recoveredSessionId = await scanner(cwd, identity);

--- a/src/lib/protocol-router.test.ts
+++ b/src/lib/protocol-router.test.ts
@@ -526,6 +526,37 @@ describe.skip('pg — TODO retire-session-names #175: rewrite fixtures for UUID 
       expect(legacyAlias.reason).toBe('no_session_id');
       expect(legacyAlias.message).toContain('no_session_id');
     });
+
+    // Felipe directive 2026-05-07: when an agent has auto_resume=false but
+    // its session UUID is intact, the error must NOT pretend the session is
+    // lost. Previously every "I can't resume" outcome collapsed onto
+    // null_session, and operators chased nonexistent missing-session bugs.
+    test('MissingResumeSessionError(reason=auto_resume_disabled) tells the operator the session is intact and to run recover', async () => {
+      const { MissingResumeSessionError } = await import('./protocol-router.js');
+
+      const paused = new MissingResumeSessionError('paused-agent', undefined, 'auto_resume_disabled');
+      expect(paused.reason).toBe('auto_resume_disabled');
+      expect(paused.entityId).toBe('paused-agent');
+      // Message MUST distinguish from the "session lost" case.
+      expect(paused.message).toContain('auto_resume is disabled');
+      expect(paused.message).toContain('session UUID is intact');
+      expect(paused.message).toContain('genie agent recover paused-agent');
+      // Must NOT mislead the operator into thinking the session is lost.
+      expect(paused.message).not.toContain('no claude_session_id recorded');
+      expect(paused.message).not.toContain('genie reset');
+    });
+
+    test('MissingResumeSessionError(reason=null_session) keeps the session-lost runbook hint', async () => {
+      const { MissingResumeSessionError } = await import('./protocol-router.js');
+
+      const lost = new MissingResumeSessionError('lost-agent', undefined, 'null_session');
+      expect(lost.reason).toBe('null_session');
+      // Genuine session-loss path keeps the legacy `genie reset` runbook hint.
+      expect(lost.message).toContain('no claude_session_id recorded');
+      expect(lost.message).toContain('genie reset lost-agent');
+      // And must NOT confuse itself with the auto_resume_disabled message.
+      expect(lost.message).not.toContain('auto_resume is disabled');
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/src/lib/protocol-router.ts
+++ b/src/lib/protocol-router.ts
@@ -13,7 +13,9 @@
  *   4. Native inbox fallback
  */
 
+import * as directory from './agent-directory.js';
 import * as registry from './agent-registry.js';
+import { isBuiltinAgent } from './builtin-agents.js';
 import * as nativeTeams from './claude-native-teams.js';
 import { getConnection } from './db.js';
 import { findExecutorByPane, getCurrentExecutor } from './executor-registry.js';
@@ -45,12 +47,28 @@ interface DeliveryResult {
  * of quietly proceeding with a fresh spawn.
  *
  * `reason` names which precondition failed:
- *   - `no_executor`   — agent has no `current_executor_id` (never spawned, or row pruned)
- *   - `null_session`  — executor row exists but `claude_session_id` is null
- *   - `no_session_id` — legacy alias kept for callers that read `agent.claudeSessionId`
- *                       directly before Group 1's single-reader helper lands.
+ *   - `no_executor`           — agent has no `current_executor_id` (never spawned, or row pruned)
+ *   - `null_session`          — executor row exists but `claude_session_id` is null (genuine session loss)
+ *   - `no_session_id`         — legacy alias kept for callers that read `agent.claudeSessionId`
+ *                                directly before Group 1's single-reader helper lands.
+ *   - `auto_resume_disabled`  — executor HAS a session_id, but `agents.auto_resume = false`
+ *                                (operator paused or scheduler exhausted retries). The session
+ *                                is intact — flip `auto_resume = true` via `genie agent recover`.
  */
-export type MissingResumeSessionReason = 'no_executor' | 'null_session' | 'no_session_id';
+export type MissingResumeSessionReason = 'no_executor' | 'null_session' | 'no_session_id' | 'auto_resume_disabled';
+
+function buildResumeErrorMessage(workerId: string, suffix: string, reason: MissingResumeSessionReason): string {
+  if (reason === 'auto_resume_disabled') {
+    return (
+      `Cannot resume worker "${workerId}"${suffix}: auto_resume is disabled, but the session UUID is intact ` +
+      `(reason: auto_resume_disabled). Run \`genie agent recover ${workerId} --yes\` to flip the flag and resume.`
+    );
+  }
+  return (
+    `Cannot resume worker "${workerId}"${suffix}: executor has no claude_session_id recorded (reason: ${reason}). ` +
+    `This usually means the worker predates the session-sync hook. Run \`genie reset ${workerId}\` or re-spawn the worker to recover.`
+  );
+}
 
 export class MissingResumeSessionError extends Error {
   readonly workerId: string;
@@ -60,9 +78,7 @@ export class MissingResumeSessionError extends Error {
 
   constructor(workerId: string, recipientId?: string, reason: MissingResumeSessionReason = 'null_session') {
     const suffix = recipientId ? ` (recipient "${recipientId}")` : '';
-    super(
-      `Cannot resume worker "${workerId}"${suffix}: executor has no claude_session_id recorded (reason: ${reason}). This usually means the worker predates the session-sync hook. Run \`genie reset ${workerId}\` or re-spawn the worker to recover.`,
-    );
+    super(buildResumeErrorMessage(workerId, suffix, reason));
     this.name = 'MissingResumeSessionError';
     this.workerId = workerId;
     this.entityId = workerId;
@@ -279,7 +295,20 @@ async function lockedSpawnWorker(
 
   if (lockResult.type === 'existing') return { worker: lockResult.worker, respawned: false };
 
-  await registry.saveTemplate({ ...template, lastSpawnedAt: new Date().toISOString() });
+  // Mirror finalizeTmuxSpawn's persistence guard: built-ins are SHARED — never
+  // pin them; subagents (`parent/child`) inherit the parent's team. Without
+  // these guards an auto-respawn refreshes `last_spawned_at` AND can stamp
+  // the wrong team back into agent_templates, defeating the fix at the
+  // primary spawn site.
+  if (!isBuiltinAgent(template.id)) {
+    let team = template.team;
+    const slash = template.id.indexOf('/');
+    if (slash > 0) {
+      const parentTeam = await directory.lookupTemplateTeam(template.id.slice(0, slash));
+      if (parentTeam) team = parentTeam;
+    }
+    await registry.saveTemplate({ ...template, team, lastSpawnedAt: new Date().toISOString() });
+  }
 
   const readyCheck = _deps.waitForWorkerReady ?? waitForWorkerReady;
   await readyCheck(lockResult.paneId);

--- a/src/lib/provider-adapters.test.ts
+++ b/src/lib/provider-adapters.test.ts
@@ -365,6 +365,58 @@ describe('buildClaudeCommand', () => {
     expect(result.command).toContain("--model 'opus'");
   });
 
+  // Felipe directive 2026-05-07: --name was retired because CC stored it as
+  // `customTitle` in the JSONL header and then composed the resume hint as
+  // `claude --resume "<customTitle>"` instead of the canonical UUID, breaking
+  // session resume. Even when callers pass `name`, the launch command MUST
+  // NOT emit --name. Sessions are identified exclusively by --session-id /
+  // --resume <uuid>.
+  it('never emits --name even when params.name is set', () => {
+    const result = buildClaudeCommand({
+      provider: 'claude',
+      team: 'work',
+      role: 'implementor',
+      name: 'felipe',
+    });
+    expect(result.command).not.toContain('--name ');
+  });
+
+  it('never emits --name on a fresh-spawn command', () => {
+    const result = buildClaudeCommand({
+      provider: 'claude',
+      team: 'work',
+      role: 'implementor',
+    });
+    expect(result.command).not.toContain('--name ');
+  });
+
+  it('uses --session-id (not --name) for session identity on fresh spawn', () => {
+    const result = buildClaudeCommand({
+      provider: 'claude',
+      team: 'work',
+      role: 'implementor',
+      sessionId: '11111111-2222-3333-4444-555555555555',
+      name: 'should-be-ignored',
+    });
+    expect(result.command).toContain('--session-id');
+    expect(result.command).toContain("'11111111-2222-3333-4444-555555555555'");
+    expect(result.command).not.toContain('--name ');
+    expect(result.command).not.toContain("'should-be-ignored'");
+  });
+
+  it('uses --resume (not --name) for session identity on resume', () => {
+    const result = buildClaudeCommand({
+      provider: 'claude',
+      team: 'work',
+      role: 'implementor',
+      resume: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      name: 'felipe',
+    });
+    expect(result.command).toContain('--resume');
+    expect(result.command).toContain("'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'");
+    expect(result.command).not.toContain('--name ');
+  });
+
   it('includes --append-system-prompt-file by default when systemPromptFile is set', () => {
     const result = buildClaudeCommand({
       provider: 'claude',

--- a/src/lib/provider-adapters.ts
+++ b/src/lib/provider-adapters.ts
@@ -108,7 +108,13 @@ export interface SpawnParams {
   model?: string;
   /** Initial prompt to send as the first user message (Claude Code positional [prompt] arg). */
   initialPrompt?: string;
-  /** Display name for the CC session (emits --name). Used in /resume and terminal title. */
+  /**
+   * @deprecated 2026-05-07 — `--name` was retired because CC stored it as
+   * `customTitle` in the JSONL header and then composed `claude --resume
+   * "<customTitle>"` instead of the canonical UUID, breaking session resume.
+   * The field remains in the schema for backward compatibility but is no
+   * longer emitted on the launch command. Always use `sessionId` / `resume`.
+   */
   name?: string;
   /**
    * Claude Code permissions. `allow`/`deny` are merged into `--settings`
@@ -413,7 +419,10 @@ function appendSessionFlags(parts: string[], params: SpawnParams): void {
   const claudeAgentFlag = params.agentTemplate ?? params.role;
   if (claudeAgentFlag) parts.push('--agent', escapeShellArg(claudeAgentFlag));
   if (params.model) parts.push('--model', escapeShellArg(params.model));
-  if (params.name) parts.push('--name', escapeShellArg(params.name));
+  // NOTE: --name intentionally NOT emitted. CC stores --name as `customTitle`
+  // in the JSONL header and then suggests `claude --resume "<customTitle>"`
+  // instead of the canonical UUID, clobbering session resume (Felipe directive
+  // 2026-05-07). The session UUID flows through --session-id / --resume above.
 }
 
 // Inject hook dispatch + permissions via --settings (deep-merges with existing settings).

--- a/src/lib/team-lead-command.test.ts
+++ b/src/lib/team-lead-command.test.ts
@@ -142,7 +142,9 @@ describe('buildTeamLeadCommand resume behavior', () => {
     const cmd = buildTeamLeadCommand('test-team', { promptMode: 'append' });
     expect(cmd).not.toContain('--resume');
     expect(cmd).not.toContain('--session-id');
-    expect(cmd).toContain("--name 'test-team'");
+    // --name retired (Felipe directive 2026-05-07): CC's customTitle
+    // clobbered the UUID resume hint. Always use --session-id / --resume.
+    expect(cmd).not.toContain('--name ');
   });
 
   test('sessionId without resume emits --session-id <uuid>', () => {

--- a/src/lib/team-lead-command.ts
+++ b/src/lib/team-lead-command.ts
@@ -68,8 +68,11 @@ export function buildTeamLeadCommand(teamName: string, options?: BuildTeamLeadCo
     '--permission-mode auto',
   ];
 
-  // Session name for CC's /resume and terminal title
-  parts.push(`--name ${shellQuote(sanitized)}`);
+  // NOTE: --name intentionally omitted. CC stores --name as `customTitle` in
+  // the JSONL header and then composes its resume hint as
+  // `claude --resume "<customTitle>"` instead of the canonical UUID, breaking
+  // session resumption (Felipe directive 2026-05-07). Always use --session-id
+  // / --resume <uuid>.
 
   if (options?.sessionId) {
     const flag = options.resume ? '--resume' : '--session-id';

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -15,7 +15,7 @@ import * as directory from '../lib/agent-directory.js';
 import * as registry from '../lib/agent-registry.js';
 import { syncSingleAgentByName } from '../lib/agent-sync.js';
 import { getActor, recordAuditEvent } from '../lib/audit.js';
-import { resolveBuiltinAgentPath } from '../lib/builtin-agents.js';
+import { isBuiltinAgent, resolveBuiltinAgentPath } from '../lib/builtin-agents.js';
 import * as nativeTeams from '../lib/claude-native-teams.js';
 import { OTEL_RELAY_PORT, ensureCodexOtelConfig } from '../lib/codex-config.js';
 import { type ResolveContext, resolveField } from '../lib/defaults.js';
@@ -27,7 +27,7 @@ import { parseFrontmatter } from '../lib/frontmatter.js';
 import { buildLayoutCommand, resolveLayoutMode } from '../lib/mosaic-layout.js';
 import { getOtelPort, startOtelReceiver } from '../lib/otel-receiver.js';
 import { injectResumeContext } from '../lib/protocol-router-spawn.js';
-import { MissingResumeSessionError } from '../lib/protocol-router.js';
+import { MissingResumeSessionError, type MissingResumeSessionReason } from '../lib/protocol-router.js';
 import {
   type ClaudeTeamColor,
   type ProviderName,
@@ -1056,17 +1056,35 @@ async function finalizeTmuxSpawn(ctx: SpawnCtx, paneId: string, teamWindow: any,
     await tmux.applyPaneColor(paneId, ctx.spawnColor, teamWindow?.windowId);
   }
 
-  await registry.saveTemplate({
-    id: ctx.validated.role ?? ctx.workerId,
-    provider: ctx.validated.provider,
-    team: ctx.validated.team,
-    role: ctx.validated.role,
-    skill: ctx.validated.skill,
-    cwd: ctx.cwd,
-    extraArgs: ctx.extraArgs,
-    nativeTeamEnabled: workerEntry.nativeTeamEnabled,
-    lastSpawnedAt: new Date().toISOString(),
-  });
+  const templateId = ctx.validated.role ?? ctx.workerId;
+  // Built-ins (engineer, trace, qa, council--*, etc.) are SHARED across teams.
+  // Persisting an agent_templates row would pin the team of whichever team
+  // spawned them first, contaminating every later spawn (genie send / mailbox
+  // routing pick the wrong team). Skip the row entirely; runtime resolution
+  // uses GENIE_TEAM env or tmux discovery instead.
+  if (!isBuiltinAgent(templateId)) {
+    // Hierarchical names (`parent/child`) inherit the parent's team. Without
+    // this, `genie-omni/dog-fooder` saved with whatever ctx.validated.team
+    // happened to be (often the operator's session team), and downstream
+    // routing missed because the parent owns the canonical team binding.
+    let team = ctx.validated.team;
+    const slash = templateId.indexOf('/');
+    if (slash > 0) {
+      const parentTeam = await directory.lookupTemplateTeam(templateId.slice(0, slash));
+      if (parentTeam) team = parentTeam;
+    }
+    await registry.saveTemplate({
+      id: templateId,
+      provider: ctx.validated.provider,
+      team,
+      role: ctx.validated.role,
+      skill: ctx.validated.skill,
+      cwd: ctx.cwd,
+      extraArgs: ctx.extraArgs,
+      nativeTeamEnabled: workerEntry.nativeTeamEnabled,
+      lastSpawnedAt: new Date().toISOString(),
+    });
+  }
 
   if (ctx.otelRelayActive && paneId !== '%0') {
     registerOtelRelayPane(ctx.workerId, paneId, ctx.agentName, ctx.spawnColor, ctx.cwd);
@@ -2648,10 +2666,10 @@ export async function handleWorkerSpawn(name: string, options: SpawnOptions): Pr
     name,
   );
 
-  // Set CC session display name if not already set
-  if (!params.name) {
-    params.name = `${params.team}-${effectiveRole}`;
-  }
+  // NOTE: --name intentionally not synthesized. CC stores it as `customTitle`
+  // and then suggests `claude --resume "<customTitle>"` instead of the
+  // canonical UUID, breaking session resume (Felipe directive 2026-05-07).
+  // The session UUID flows through --session-id / --resume.
 
   // Executor model: find/create durable agent identity + concurrent guard.
   // Must happen BEFORE buildLaunchCommand so executorId/agentId propagate
@@ -3032,10 +3050,16 @@ export async function handleWorkerResume(
     // genie.ts surfaces it on stderr with exit 1 and tests can assert on
     // the instance. Previously we used console.error + process.exit(1),
     // which is hostile to unit testing and untyped at the boundary.
-    // Map the chokepoint reason onto the legacy MissingResumeSessionError
-    // enum — `no_executor` keeps its meaning, all other "we can't resume"
-    // outcomes collapse onto `no_session_id` (the legacy catch-all).
-    const errReason = decision.reason === 'unknown_agent' ? 'no_executor' : 'no_session_id';
+    // Map the chokepoint reason onto the MissingResumeSessionError enum:
+    //   unknown_agent        → no_executor
+    //   auto_resume_disabled → auto_resume_disabled (session intact, just paused)
+    //   everything else      → no_session_id (legacy catch-all)
+    const errReason: MissingResumeSessionReason =
+      decision.reason === 'unknown_agent'
+        ? 'no_executor'
+        : decision.reason === 'auto_resume_disabled'
+          ? 'auto_resume_disabled'
+          : 'no_session_id';
     throw new MissingResumeSessionError(w.id, undefined, errReason);
   }
   const _sessionId = decision.sessionId;
@@ -3416,7 +3440,8 @@ async function buildResumeParams(
     skill: template?.skill ?? agent.skill,
     extraArgs: template?.extraArgs,
     resume: resumeSessionId,
-    name: `${team}-${agentName}`,
+    // --name intentionally omitted (Felipe directive 2026-05-07): CC's
+    // customTitle leaked into the resume hint and clobbered the UUID.
     model: dirEntry?.model,
     systemPromptFile,
     promptMode,
@@ -3497,7 +3522,12 @@ export async function buildFullResumeParams(
   // `MissingResumeSessionError` so the caller surfaces the failure.
   const decision = await shouldResume(agent.id);
   if (!decision.resume || !decision.sessionId) {
-    const errReason = decision.reason === 'unknown_agent' ? 'no_executor' : 'null_session';
+    const errReason: MissingResumeSessionReason =
+      decision.reason === 'unknown_agent'
+        ? 'no_executor'
+        : decision.reason === 'auto_resume_disabled'
+          ? 'auto_resume_disabled'
+          : 'null_session';
     throw new MissingResumeSessionError(agent.id, undefined, errReason);
   }
   // We're about to actually resume — emit the lifecycle event from the


### PR DESCRIPTION
## Why

Main and dev diverged from common ancestor \`ca0a1d8100\`:
- **main** has 11 commits ahead (6 PRs by @felipehowit, all legitimate)
- **dev** has 481 commits ahead (active integration)

Six main-only PRs never reached dev:

| PR | What |
|---|---|
| #1689 | fix(agent): subagent team inheritance + builtin pinning + parent fallback |
| #1690 | fix(agent): retire \`--name\` + distinguish \`auto_resume_disabled\` |
| #1690 (follow-up) | fix(ci): extract npm pack tarball name |
| #1693 | fix: address CI failures + CodeRabbit major |
| #1698 | fix(tl-spawn): write \`executors.claude_session_id\` at team-lead spawn |
| #1699 | feat(cli): \`genie recover-orphans\` |

## Strategy

Standard \`git merge --no-ff\` with \`-X ours\`:

- **Conflicts** → resolved to dev's version (dev evolved past these files; main's edits are obsolete where dev moved on).
- **New files from main** → kept (genuinely new content has no conflict).
- **Main's non-conflicting edits to evolved files** → applied (they came in cleanly because dev didn't touch the same hunks).

This matches user intent: "accept dev for everything except genuinely new content from those 6 PRs."

## What lands

20 files / +1479 / −73 — mostly the new content, plus modest edits to wire it in:

**New files (725 LOC of genuinely new content)**:
- \`src/genie-commands/recover-orphans.ts\` (575 LOC, from #1699)
- \`src/genie-commands/__tests__/recover-orphans.test.ts\` (261 LOC)
- \`src/genie-commands/session.test.ts\` (78 LOC, from #1698)
- \`src/__tests__/agent-team-inheritance.test.ts\` (132 LOC, from #1689)
- \`src/db/migrations/054_fix_subagent_team_inheritance.sql\` (70 LOC, from #1689)
- \`src/db/migrations/055_default_auto_resume_true.sql\` (39 LOC, from #1690)
- \`src/lib/protocol-router.test.ts\` (31 LOC)
- \`src/lib/provider-adapters.test.ts\` (52 LOC)

**Modified files** (main edits wiring in the new functionality):
- \`src/genie.ts\` — register \`recover-orphans\` command + import
- \`src/genie-commands/session.ts\` — write \`claude_session_id\` at team-lead spawn (#1698)
- \`src/lib/agent-directory.ts\`, \`src/lib/builtin-agents.ts\`, \`src/lib/executor-registry.ts\`, \`src/lib/protocol-router.ts\`, \`src/lib/provider-adapters.ts\`, \`src/lib/team-lead-command.ts\`, \`src/term-commands/agents.ts\`, \`src/db/migrations/044_phase_b_flip_defaults.test.ts\`, \`.github/workflows/release.yml\`
- \`src/lib/team-lead-command.test.ts\`

## Notes

One follow-up commit (\`fix(merge): restore recoverOrphansCommand import\`) was needed: the \`-X ours\` resolution of the imports block in \`genie.ts\` kept dev's version, which dropped main's import line — but the command registration line survived, breaking the build (\`TS2304: Cannot find name recoverOrphansCommand\`). Re-added the import + biome organize-imports.

## Test plan

- [x] \`bun test src/term-commands/done.test.ts\` — 14 pass (verifies the recently-merged --report mandatory feature still works after the back-merge)
- [x] \`bun run build\` — clean
- [x] \`bun dist/genie.js --help\` — both \`done\` (with \`--report\`) and \`recover-orphans\` registered
- [ ] \`bun test\` (full DB-integration suite) — needs pgserve booted; deferred to CI runner
- [ ] Reviewer: confirm \`recover-orphans\`, migrations 054 + 055, and team-lead session-id writer all work end-to-end on dev

## What this is NOT

This is **not** a wholesale main → dev merge. With plain \`git merge\`, dev would resurrect 7 stale files and lose conflicts in 219 modified files to main's older versions. \`-X ours\` prevents that.