### PR TITLE
[codex] fix template UUID boundary

### DIFF
--- a/packages/genie-app/src-backend/index.ts
+++ b/packages/genie-app/src-backend/index.ts
@@ -605,7 +605,20 @@ function registerHandlers(sql: any): void {
   });
 
   reply(sub.settings.templates(ORG_ID), async () => {
-    return sql`SELECT * FROM agent_templates ORDER BY last_spawned_at DESC`;
+    return sql`
+      SELECT
+        name AS id,
+        provider,
+        team,
+        role,
+        skill,
+        cwd,
+        extra_args,
+        native_team_enabled,
+        last_spawned_at
+      FROM agent_templates
+      ORDER BY last_spawned_at DESC
+    `;
   });
 
   reply(sub.settings.skills(ORG_ID), async () => {
@@ -639,7 +652,7 @@ function registerHandlers(sql: any): void {
       if (!params.id) return { error: 'id is required' };
       await sql`
       INSERT INTO agent_templates (
-        id, provider, team, role, skill, cwd,
+        name, provider, team, role, skill, cwd,
         extra_args, native_team_enabled, last_spawned_at
       ) VALUES (
         ${params.id},
@@ -648,18 +661,18 @@ function registerHandlers(sql: any): void {
         ${params.role ?? null},
         ${params.skill ?? null},
         ${params.cwd ?? ''},
-        ${JSON.stringify(params.extraArgs ?? [])},
+        ${sql.json(params.extraArgs ?? [])},
         ${params.nativeTeamEnabled ?? false},
         ${new Date().toISOString()}
       )
-      ON CONFLICT (id) DO UPDATE SET
+      ON CONFLICT (name, team) WHERE name IS NOT NULL AND team IS NOT NULL DO UPDATE SET
         provider = EXCLUDED.provider,
-        team = EXCLUDED.team,
         role = EXCLUDED.role,
         skill = EXCLUDED.skill,
         cwd = EXCLUDED.cwd,
         extra_args = EXCLUDED.extra_args,
-        native_team_enabled = EXCLUDED.native_team_enabled
+        native_team_enabled = EXCLUDED.native_team_enabled,
+        last_spawned_at = EXCLUDED.last_spawned_at
     `;
       return { ok: true };
     },

--- a/src/__tests__/tui-spawn-dx.integration.test.ts
+++ b/src/__tests__/tui-spawn-dx.integration.test.ts
@@ -49,9 +49,10 @@ async function seedTemplate(id: string, team: string): Promise<void> {
   const { getConnection } = await import('../lib/db.js');
   const sql = await getConnection();
   await sql`
-    INSERT INTO agent_templates (id, provider, team, cwd, last_spawned_at)
+    INSERT INTO agent_templates (name, provider, team, cwd, last_spawned_at)
     VALUES (${id}, 'claude', ${team}, '/tmp/seed', now())
-    ON CONFLICT (id) DO UPDATE SET team = EXCLUDED.team
+    ON CONFLICT (name, team) WHERE name IS NOT NULL AND team IS NOT NULL DO UPDATE SET
+      last_spawned_at = EXCLUDED.last_spawned_at
   `;
 }
 

--- a/src/db/migrations/054_fix_subagent_team_inheritance.sql
+++ b/src/db/migrations/054_fix_subagent_team_inheritance.sql
@@ -23,48 +23,70 @@
 
 BEGIN;
 
--- 1. Backfill: subagent rows inherit their parent's team.
---    `child.id LIKE parent.id || '/%'` matches `parent/anything` whose parent
---    name has no slash itself (avoids matching grandparent/parent/child).
---    Skip when child.team already equals parent.team.
-UPDATE agent_templates AS child
-SET team = parent.team,
-    updated_at = now()
-FROM agent_templates AS parent
-WHERE child.id LIKE parent.id || '/%'
-  AND parent.id NOT LIKE '%/%'
-  AND child.team IS DISTINCT FROM parent.team;
+DO $$
+DECLARE
+  builtin_names text[] := ARRAY[
+    -- BUILTIN_ROLES (plugins/genie/agents/*/AGENTS.md, category=role)
+    'docs',
+    'engineer',
+    'fix',
+    'pm',
+    'qa',
+    'refactor',
+    'reviewer',
+    'team-lead',
+    'trace',
+    -- BUILTIN_COUNCIL_MEMBERS (plugins/genie/agents/council*, category=council)
+    'council',
+    'council--architect',
+    'council--benchmarker',
+    'council--deployer',
+    'council--ergonomist',
+    'council--measurer',
+    'council--operator',
+    'council--questioner',
+    'council--sentinel',
+    'council--simplifier',
+    'council--tracer'
+  ];
+  has_name_column boolean;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = current_schema()
+      AND table_name = 'agent_templates'
+      AND column_name = 'name'
+  ) INTO has_name_column;
 
--- 2. Wipe sticky pins for built-in roles + council members.
---    Built-ins are SHARED — runtime resolution (GENIE_TEAM env, tmux
---    discovery) decides the team per-spawn now. Keeping the rows would let
---    `lookupTemplateTeam` keep returning a stale team for the first caller
---    of every spawn until the rows are overwritten with a fresh team —
---    which the runtime fix now refuses to do.
-DELETE FROM agent_templates
-WHERE id IN (
-  -- BUILTIN_ROLES (plugins/genie/agents/*/AGENTS.md, category=role)
-  'docs',
-  'engineer',
-  'fix',
-  'pm',
-  'qa',
-  'refactor',
-  'reviewer',
-  'team-lead',
-  'trace',
-  -- BUILTIN_COUNCIL_MEMBERS (plugins/genie/agents/council*, category=council)
-  'council',
-  'council--architect',
-  'council--benchmarker',
-  'council--deployer',
-  'council--ergonomist',
-  'council--measurer',
-  'council--operator',
-  'council--questioner',
-  'council--sentinel',
-  'council--simplifier',
-  'council--tracer'
-);
+  IF has_name_column THEN
+    -- Post-061 schema: agent_templates.id is a UUID PK; name is the text
+    -- template key used by roles, built-ins, and parent/child hierarchy.
+    EXECUTE $sql$
+      UPDATE agent_templates AS child
+      SET team = parent.team,
+          updated_at = now()
+      FROM agent_templates AS parent
+      WHERE child.name LIKE parent.name || '/%'
+        AND parent.name NOT LIKE '%/%'
+        AND child.team IS DISTINCT FROM parent.team
+    $sql$;
+
+    EXECUTE 'DELETE FROM agent_templates WHERE name = ANY ($1)' USING builtin_names;
+  ELSE
+    -- Pre-061 / fresh-install ordering: id is still the text template key.
+    EXECUTE $sql$
+      UPDATE agent_templates AS child
+      SET team = parent.team,
+          updated_at = now()
+      FROM agent_templates AS parent
+      WHERE child.id LIKE parent.id || '/%'
+        AND parent.id NOT LIKE '%/%'
+        AND child.team IS DISTINCT FROM parent.team
+    $sql$;
+
+    EXECUTE 'DELETE FROM agent_templates WHERE id = ANY ($1)' USING builtin_names;
+  END IF;
+END $$;
 
 COMMIT;

--- a/src/db/migrations/054_fix_subagent_team_inheritance.test.ts
+++ b/src/db/migrations/054_fix_subagent_team_inheritance.test.ts
@@ -1,0 +1,96 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { type Sql, getConnection } from '../../lib/db.js';
+import { DB_AVAILABLE, setupTestDatabase } from '../../lib/test-db.js';
+
+const MIGRATION_PATH = join(import.meta.dir, '054_fix_subagent_team_inheritance.sql');
+
+async function applyMigration(): Promise<void> {
+  const sql = await getConnection();
+  const migration = await readFile(MIGRATION_PATH, 'utf-8');
+  await sql.begin(async (tx: Sql) => {
+    await tx.unsafe(migration);
+  });
+}
+
+describe.skipIf(!DB_AVAILABLE)('migration 054 — subagent team inheritance', () => {
+  let cleanup: () => Promise<void>;
+
+  beforeAll(async () => {
+    cleanup = await setupTestDatabase();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  beforeEach(async () => {
+    const sql = await getConnection();
+    await sql`DROP TABLE IF EXISTS agent_templates CASCADE`;
+  });
+
+  test('heals pre-061 text-id schema during fresh install ordering', async () => {
+    const sql = await getConnection();
+    await sql`
+      CREATE TABLE agent_templates (
+        id TEXT PRIMARY KEY,
+        provider TEXT NOT NULL DEFAULT 'claude',
+        team TEXT NOT NULL,
+        cwd TEXT NOT NULL DEFAULT '/tmp',
+        last_spawned_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      )
+    `;
+    await sql`
+      INSERT INTO agent_templates (id, team)
+      VALUES
+        ('genie-omni', 'genie'),
+        ('genie-omni/dog-fooder', 'felipe'),
+        ('engineer', 'felipe')
+    `;
+
+    await applyMigration();
+
+    const child = await sql<{ team: string }[]>`
+      SELECT team FROM agent_templates WHERE id = 'genie-omni/dog-fooder'
+    `;
+    expect(child[0].team).toBe('genie');
+
+    const builtin = await sql`SELECT 1 FROM agent_templates WHERE id = 'engineer'`;
+    expect(builtin.length).toBe(0);
+  });
+
+  test('heals post-061 UUID-id schema via template name', async () => {
+    const sql = await getConnection();
+    await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`;
+    await sql`
+      CREATE TABLE agent_templates (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        name TEXT NOT NULL,
+        provider TEXT NOT NULL DEFAULT 'claude',
+        team TEXT NOT NULL,
+        cwd TEXT NOT NULL DEFAULT '/tmp',
+        last_spawned_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      )
+    `;
+    await sql`
+      INSERT INTO agent_templates (name, team)
+      VALUES
+        ('genie-omni', 'genie'),
+        ('genie-omni/dog-fooder', 'felipe'),
+        ('engineer', 'felipe')
+    `;
+
+    await applyMigration();
+
+    const child = await sql<{ team: string }[]>`
+      SELECT team FROM agent_templates WHERE name = 'genie-omni/dog-fooder'
+    `;
+    expect(child[0].team).toBe('genie');
+
+    const builtin = await sql`SELECT 1 FROM agent_templates WHERE name = 'engineer'`;
+    expect(builtin.length).toBe(0);
+  });
+});

--- a/src/lib/agent-registry.test.ts
+++ b/src/lib/agent-registry.test.ts
@@ -213,6 +213,46 @@ describe.skipIf(!DB_AVAILABLE)('register ON CONFLICT preserves protocol fields (
   });
 });
 
+describe.skipIf(!DB_AVAILABLE)('agent template identity after migration 061', () => {
+  let cleanup: () => Promise<void>;
+
+  beforeAll(async () => {
+    cleanup = await setupTestDatabase();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  beforeEach(async () => {
+    const sql = await getConnection();
+    await sql`DELETE FROM agent_templates`;
+  });
+
+  test('listTemplates exposes the template name, not the UUID primary key', async () => {
+    await saveTemplate({
+      id: 'engineer',
+      provider: 'claude',
+      team: 'genie',
+      role: 'engineer',
+      cwd: '/tmp/repo',
+      lastSpawnedAt: new Date().toISOString(),
+    });
+
+    const sql = await getConnection();
+    const rows = await sql<{ id: string; name: string }[]>`
+      SELECT id::text, name FROM agent_templates WHERE name = 'engineer'
+    `;
+    expect(rows.length).toBe(1);
+    expect(rows[0].id).not.toBe('engineer');
+
+    const templates = await listTemplates();
+    expect(templates).toHaveLength(1);
+    expect(templates[0].id).toBe('engineer');
+    expect(templates[0].role).toBe('engineer');
+  });
+});
+
 describe.skip('pg — TODO retire-session-names #175: rewrite fixtures for UUID agents.id', () => {
   let cleanup: () => Promise<void>;
   beforeAll(async () => {

--- a/src/lib/agent-registry.ts
+++ b/src/lib/agent-registry.ts
@@ -138,6 +138,7 @@ interface AgentRow {
 
 interface TemplateRow {
   id: string;
+  name?: string | null;
   provider: ProviderName;
   team: string;
   role: string | null;
@@ -201,7 +202,9 @@ function rowToAgent(r: AgentRow): Agent {
 
 function rowToTemplate(r: TemplateRow): WorkerTemplate {
   const tpl: WorkerTemplate = {
-    id: r.id,
+    // WorkerTemplate.id is the public template key ("engineer", "parent/child").
+    // After migration 061, agent_templates.id is only the UUID primary key.
+    id: r.name ?? r.id,
     provider: r.provider,
     team: r.team,
     cwd: r.cwd,

--- a/src/lib/pg-seed.test.ts
+++ b/src/lib/pg-seed.test.ts
@@ -196,7 +196,7 @@ describe.skip('pg — TODO retire-session-names #175: rewrite fixtures for UUID 
       // Clean up seeded data
       const sql = await getConnection();
       await sql`DELETE FROM agents WHERE id LIKE 'seed-test-%'`;
-      await sql`DELETE FROM agent_templates WHERE id LIKE 'seed-tpl-%'`;
+      await sql`DELETE FROM agent_templates WHERE name LIKE 'seed-tpl-%'`;
       await sql`DELETE FROM teams WHERE name LIKE 'seed-team-%'`;
       await sql`DELETE FROM mailbox WHERE id LIKE 'seed-msg-%'`;
       await sql`DELETE FROM team_chat WHERE id LIKE 'seed-chat-%'`;
@@ -277,7 +277,7 @@ describe.skip('pg — TODO retire-session-names #175: rewrite fixtures for UUID 
       expect(agents[0].team).toBe('seed-team-alpha');
 
       // Verify template in PG
-      const templates = await sql`SELECT * FROM agent_templates WHERE id = 'seed-tpl-1'`;
+      const templates = await sql`SELECT * FROM agent_templates WHERE name = 'seed-tpl-1'`;
       expect(templates.length).toBe(1);
       expect(templates[0].provider).toBe('claude');
 

--- a/src/term-commands/agents.test.ts
+++ b/src/term-commands/agents.test.ts
@@ -429,9 +429,10 @@ describe.skip('directory.resolve team population — TODO retire-session-names #
     const { getConnection } = await import('../lib/db.js');
     const sql = await getConnection();
     await sql`
-      INSERT INTO agent_templates (id, provider, team, cwd, last_spawned_at)
+      INSERT INTO agent_templates (name, provider, team, cwd, last_spawned_at)
       VALUES (${id}, 'claude', ${team}, '/tmp/seed', now())
-      ON CONFLICT (id) DO UPDATE SET team = EXCLUDED.team
+      ON CONFLICT (name, team) WHERE name IS NOT NULL AND team IS NOT NULL DO UPDATE SET
+        last_spawned_at = EXCLUDED.last_spawned_at
     `;
   }
 


### PR DESCRIPTION
## Summary

Fixes the `agent_templates.id` UUID/name boundary regression that broke boot migrations after migration 061.

- Makes `054_fix_subagent_team_inheritance` schema-aware: pre-061 installs still use text `id`, post-061 databases use text `name` while leaving UUID `id` alone.
- Keeps `WorkerTemplate.id` as the public template key by mapping it from `agent_templates.name`, not the UUID primary key.
- Updates Genie app template list/save handlers and affected tests/fixtures to use `name` plus the `(name, team)` conflict target.

## Root Cause

Migration 061 changed `agent_templates.id` from the human template key into a UUID primary key, but later template cleanup code still used `id` for text operations like `LIKE 'parent/%'` and built-in role deletes. That made upgraded installs fail with `operator does not exist: uuid ~~ text`, blocking every DB boot.

## Validation

- `bun test src/db/migrations/054_fix_subagent_team_inheritance.test.ts`
- `bun test src/lib/agent-registry.test.ts --grep "agent template identity after migration 061"`
- `bun test src/__tests__/agent-team-inheritance.test.ts`
- `bun run typecheck`
- `bun run lint` exits 0 with existing unrelated warnings about broken symlinks and legacy test lint warnings
- pre-push hook passed: typecheck, lint, dead-code, skills lint, wishes lint, emit discipline