### PR TITLE
fix(db): migration 055 errors on archived bare-name rows

### DIFF
--- a/src/db/migrations/055_default_auto_resume_true.sql
+++ b/src/db/migrations/055_default_auto_resume_true.sql
@@ -19,21 +19,43 @@
 -- silent default-off that triggered the misleading message in the first
 -- place.
 --
+-- Heal-not-wipe interaction with migration 061
+-- --------------------------------------------
+-- Migration 061 added `agents_id_shape_check` as `NOT VALID` so legacy
+-- bare-name rows (archived by 050/053) stay in the table. Postgres still
+-- enforces the constraint on every UPDATE — even when the id column is
+-- not in the SET list — so an unconditional `UPDATE agents SET auto_resume
+-- = true` errors out with `agents_id_shape_check` violation on any host
+-- carrying archived bare-name rows. The whole boot path then fails,
+-- because runMigrations runs inside getConnection's post-connect setup.
+--
+-- Filter the UPDATEs to UUID/dir-prefixed ids only. Bare-name rows are
+-- already archived (state='archived', auto_resume=false locked by 050/053)
+-- so flipping their auto_resume is meaningless — they are not resume
+-- candidates regardless of the column value.
+--
 -- Idempotent: re-running this migration is a no-op on rows that are already
 -- true and on a column whose default is already true.
 
 BEGIN;
 
--- 1. Flip every existing false row. No WHERE narrowing — Felipe directive
---    is to flip ALL of them so resume works out-of-the-box.
+-- 1. Flip every existing false row that satisfies the id shape constraint.
+--    Bare-name rows (archived legacy) are skipped — see header comment.
 UPDATE agents
 SET auto_resume = true
-WHERE auto_resume = false;
+WHERE auto_resume = false
+  AND (id ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+       OR id LIKE 'dir:%');
 
 -- 2. Change the column DEFAULT so future spawns inherit the safe value.
 --    NULLs (legacy rows that pre-date the column) become true — same as
---    the safe-default the runtime treats them as.
+--    the safe-default the runtime treats them as. Same id-shape filter
+--    applies for the same reason.
 ALTER TABLE agents ALTER COLUMN auto_resume SET DEFAULT true;
-UPDATE agents SET auto_resume = true WHERE auto_resume IS NULL;
+UPDATE agents
+SET auto_resume = true
+WHERE auto_resume IS NULL
+  AND (id ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+       OR id LIKE 'dir:%');
 
 COMMIT;

--- a/src/db/migrations/055_default_auto_resume_true.test.ts
+++ b/src/db/migrations/055_default_auto_resume_true.test.ts
@@ -1,0 +1,103 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { type Sql, getConnection } from '../../lib/db.js';
+import { DB_AVAILABLE, setupTestDatabase } from '../../lib/test-db.js';
+
+const MIGRATION_PATH = join(import.meta.dir, '055_default_auto_resume_true.sql');
+
+async function runMigration(sql: Sql): Promise<void> {
+  const sqlText = await readFile(MIGRATION_PATH, 'utf-8');
+  // The migration file starts/ends with BEGIN/COMMIT, so we cannot wrap it
+  // in another transaction here — postgres rejects nested BEGIN. Run directly.
+  await sql.unsafe(sqlText);
+}
+
+describe.skipIf(!DB_AVAILABLE)('migration 055 — default auto_resume true', () => {
+  let cleanup: () => Promise<void>;
+
+  beforeAll(async () => {
+    cleanup = await setupTestDatabase();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  test('does not fail when archived bare-name rows are present', async () => {
+    const sql = await getConnection();
+
+    // The template DB has migration 055 already applied. To replay it as if
+    // it were pending against a host that carries archived bare-name rows
+    // (legacy 050/053 grandfather), we have to re-create the failure shape:
+    //   1. Drop the id-shape CHECK so we can insert a bare-name row.
+    //   2. Insert one archived bare-name agent (mirrors production data).
+    //   3. Re-add the CHECK as NOT VALID (mirrors migration 061's pattern).
+    //   4. Reset a UUID row's auto_resume to false (something for 055 to flip).
+    //   5. Re-run 055.
+    // The pre-fix migration would error here with agents_id_shape_check;
+    // the post-fix migration filters bare-name rows out of the UPDATE.
+    await sql`ALTER TABLE agents DROP CONSTRAINT IF EXISTS agents_id_shape_check`;
+
+    const bareName = `legacy-bare-${Date.now()}`;
+    await sql`
+      INSERT INTO agents (id, role, custom_name, team, repo_path, started_at, state, auto_resume)
+      VALUES (${bareName}, 'legacy', NULL, 'legacy-team', '/tmp/legacy', now(), 'archived', false)
+      ON CONFLICT (id) DO NOTHING
+    `;
+
+    await sql.unsafe(
+      `ALTER TABLE agents
+         ADD CONSTRAINT agents_id_shape_check
+         CHECK (id ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' OR id LIKE 'dir:%')
+         NOT VALID`,
+    );
+
+    const liveId = randomUUID();
+    await sql`
+      INSERT INTO agents (id, role, custom_name, team, repo_path, started_at, state, auto_resume)
+      VALUES (${liveId}, 'engineer', 'live-engineer', 'live-team', '/tmp/live', now(), 'idle', false)
+      ON CONFLICT (id) DO NOTHING
+    `;
+
+    // The pre-fix migration would throw here with
+    // `new row for relation "agents" violates check constraint "agents_id_shape_check"`.
+    await expect(runMigration(sql)).resolves.toBeUndefined();
+
+    const live = await sql<{ auto_resume: boolean }[]>`
+      SELECT auto_resume FROM agents WHERE id = ${liveId}
+    `;
+    expect(live[0].auto_resume).toBe(true);
+
+    const bare = await sql<{ auto_resume: boolean }[]>`
+      SELECT auto_resume FROM agents WHERE id = ${bareName}
+    `;
+    // Bare-name rows are archived legacy; their auto_resume is intentionally
+    // not flipped because the row would fail the id-shape check.
+    expect(bare[0].auto_resume).toBe(false);
+  });
+
+  test('flips auto_resume on UUID and dir: rows, leaves NULL rows true', async () => {
+    const sql = await getConnection();
+
+    const uuidId = randomUUID();
+    const dirId = `dir:test-dir-${Date.now()}`;
+    await sql`
+      INSERT INTO agents (id, role, custom_name, team, repo_path, started_at, state, auto_resume)
+      VALUES
+        (${uuidId}, 'engineer', 'a', 'team-a', '/tmp/a', now(), 'idle', false),
+        (${dirId}, 'engineer', 'b', 'team-b', '/tmp/b', now(), 'idle', false)
+      ON CONFLICT (id) DO NOTHING
+    `;
+
+    await runMigration(sql);
+
+    const rows = await sql<{ id: string; auto_resume: boolean }[]>`
+      SELECT id, auto_resume FROM agents WHERE id IN (${uuidId}, ${dirId})
+    `;
+    for (const r of rows) {
+      expect(r.auto_resume).toBe(true);
+    }
+  });
+});

--- a/src/db/migrations/055_default_auto_resume_true.test.ts
+++ b/src/db/migrations/055_default_auto_resume_true.test.ts
@@ -9,9 +9,14 @@ const MIGRATION_PATH = join(import.meta.dir, '055_default_auto_resume_true.sql')
 
 async function runMigration(sql: Sql): Promise<void> {
   const sqlText = await readFile(MIGRATION_PATH, 'utf-8');
-  // The migration file starts/ends with BEGIN/COMMIT, so we cannot wrap it
-  // in another transaction here — postgres rejects nested BEGIN. Run directly.
-  await sql.unsafe(sqlText);
+  // Mirror runMigrations() in db-migrations.ts: wrap in sql.begin so the
+  // pool sees a single reserved connection. The migration file's own
+  // BEGIN/COMMIT becomes a no-op inside the outer transaction (postgres
+  // emits a "there is already a transaction in progress" warning and
+  // COMMIT closes the outer txn, same as production).
+  await sql.begin(async (tx) => {
+    await tx.unsafe(sqlText);
+  });
 }
 
 describe.skipIf(!DB_AVAILABLE)('migration 055 — default auto_resume true', () => {


### PR DESCRIPTION
## Summary

- Migration `055_default_auto_resume_true.sql` does an unconditional `UPDATE agents SET auto_resume = true WHERE auto_resume = false`. Postgres re-evaluates row-level CHECK constraints on UPDATE even when the constrained column isn't in the SET list, so on any host with archived bare-name agents (legacy rows grandfathered by 050/053 into 061's `agents_id_shape_check NOT VALID`), the migration errors with `new row for relation "agents" violates check constraint "agents_id_shape_check"`.
- That fails the whole boot path because `runMigrations` runs inside `getConnection`'s `runPostConnectSetup`. Every genie command (`agent ls`, `db migrate`, `dir ls`) exits with the constraint error before doing anything useful, and the TUI's auto-spawn retry floods `~/.genie/logs/tui-spawn/` with identical failures (this is the symptom that surfaced the bug).
- Fix filters both UPDATEs by the same id-shape regex the CHECK uses. Bare-name rows are already archived (state='archived', auto_resume=false locked by 050/053) so skipping them is correct — they aren't resume candidates regardless. Migration stays idempotent.

## Repro on the affected host

```
$ genie db migrate
Error running migrations: new row for relation "agents" violates check constraint "agents_id_shape_check"

$ GENIE_SKIP_DB_BOOT=1 genie agent ls   # works → confirms boot path is the failure site
NAME                ...
```

5 archived bare-name rows on this fingerprint, all `auto_resume=false`, all `state=archived`. Migration 055 was the only pending entry past 062.

## Test plan

- [ ] CI: `bun run check` (typecheck + lint + tests).
- [ ] Locally: `bun run typecheck` passes; `bun run lint` exit 0 (5 pre-existing warnings, none from this change).
- [ ] Test added: `src/db/migrations/055_default_auto_resume_true.test.ts` replays the failure shape (drop CHECK, insert bare-name row, re-add CHECK `NOT VALID`, re-run 055) and asserts the migration succeeds + UUID rows flip to `true` + bare-name rows are left untouched.
- [ ] Could not run the new test on the trace host: `pgserve initdb` fails with `dict_snowball.so: version mismatch (server 17, library 18)` — local environment issue unrelated to this change.

## Follow-up (separate PR)

The user-visible TUI symptom (`spawn "khal-os" exited 1`) comes from a TUI auto-spawn flow trying to spawn an agent name that is neither in `genie dir` nor a built-in. Once boot is unblocked, that lands as a separate UX defect — file under "TUI auto-spawn should fail loudly on unregistered names instead of retrying" rather than this DB fix.