### PR TITLE
fix(hooks): seed AskUserQuestion baseline + recognize compiled-binary in team settings (#1688 follow-up)

### DIFF
--- a/src/hooks/__tests__/inject.test.ts
+++ b/src/hooks/__tests__/inject.test.ts
@@ -6,6 +6,20 @@ import { join } from 'node:path';
 import { injectTeamHooks, isTeamHooked } from '../inject.js';
 import { DISPATCHED_EVENTS, DISPATCHED_EVENT_MATCHERS } from '../types.js';
 
+/**
+ * True if `command` is a recognizable genie hook-dispatch command — either the
+ * legacy bun-fork form (`bun run .../src/genie.ts hook dispatch`) or the new
+ * compiled-binary form (`'.../genie-hook'`). Mirrors the production matcher in
+ * `inject.ts::isGenieDispatchCommand`. Tests should assert against this shape
+ * rather than a specific form so they pass on machines where the postinstall
+ * binary is or isn't present.
+ */
+function isRecognizedDispatchCommand(command: string): boolean {
+  if (command.includes('hook dispatch') && command.includes('src/genie.ts')) return true;
+  if (/(?:^|[/\\'"])genie-hook(?:['"]|\s|$)/.test(command)) return true;
+  return false;
+}
+
 describe('hook injection', () => {
   const testDir = join(tmpdir(), `genie-hook-test-${Date.now()}`);
   const originalEnv = process.env.CLAUDE_CONFIG_DIR;
@@ -48,8 +62,7 @@ describe('hook injection', () => {
 
     for (const event of DISPATCHED_EVENTS) {
       expect(settings.hooks[event]).toBeDefined();
-      expect(settings.hooks[event][0].hooks[0].command).toContain('hook dispatch');
-      expect(settings.hooks[event][0].hooks[0].command).toContain('src/genie.ts');
+      expect(isRecognizedDispatchCommand(settings.hooks[event][0].hooks[0].command)).toBe(true);
     }
   });
 
@@ -103,8 +116,7 @@ describe('hook injection', () => {
     const settings = JSON.parse(await readFile(settingsPath, 'utf-8'));
     for (const event of DISPATCHED_EVENTS) {
       const command = settings.hooks[event][0].hooks[0].command;
-      expect(command).toContain('hook dispatch');
-      expect(command).toContain('src/genie.ts');
+      expect(isRecognizedDispatchCommand(command)).toBe(true);
     }
   });
 
@@ -187,6 +199,41 @@ describe('hook injection', () => {
       expect(settings.hooks.PostToolUse).toBeDefined();
       // PostToolUse matcher must be narrowed
       expect(settings.hooks.PostToolUse[0].matcher).toBe('SendMessage');
+    });
+
+    test('injectIntoFile is idempotent when existing entries use compiled-binary form (regression)', async () => {
+      // Regression for the duplicate-hook bug: when settings.json already
+      // contains a genie entry written with the compiled-binary command
+      // (e.g. `'/home/.../genie-hook'`), re-running injection MUST recognize
+      // it as a genie entry and refuse to append another. Prior to this fix,
+      // `isGenieDispatchCommand` only matched the legacy `hook dispatch`
+      // substring → re-injection appended a new entry every run, producing 4+
+      // identical PreToolUse + PostToolUse entries in the wild.
+      const teamDir = join(testDir, 'teams', 'test-team');
+      await mkdir(teamDir, { recursive: true });
+      const settingsPath = join(teamDir, 'settings.json');
+
+      const compiledBinaryCmd = `'${join(testDir, 'genie-home', 'bin', 'genie-hook')}'`;
+      await writeFile(
+        settingsPath,
+        JSON.stringify({
+          hooks: {
+            PreToolUse: [{ matcher: '*', hooks: [{ type: 'command', command: compiledBinaryCmd, timeout: 15 }] }],
+            PostToolUse: [
+              { matcher: 'SendMessage', hooks: [{ type: 'command', command: compiledBinaryCmd, timeout: 15 }] },
+            ],
+          },
+        }),
+      );
+
+      // Re-inject 3× — count of entries per event must remain 1, not grow.
+      await injectTeamHooks('test-team');
+      await injectTeamHooks('test-team');
+      await injectTeamHooks('test-team');
+
+      const settings = JSON.parse(await readFile(settingsPath, 'utf-8'));
+      expect(settings.hooks.PreToolUse).toHaveLength(1);
+      expect(settings.hooks.PostToolUse).toHaveLength(1);
     });
 
     test('injectIntoFile preserves user-defined hooks under obsolete events', async () => {

--- a/src/hooks/__tests__/inject.test.ts
+++ b/src/hooks/__tests__/inject.test.ts
@@ -72,7 +72,7 @@ describe('hook injection', () => {
     expect(result).toBe(false); // already injected
   });
 
-  test('injectTeamHooks preserves existing settings', async () => {
+  test('injectTeamHooks preserves existing settings + appends baseline permissions', async () => {
     const teamDir = join(testDir, 'teams', 'test-team');
     await mkdir(teamDir, { recursive: true });
 
@@ -88,9 +88,58 @@ describe('hook injection', () => {
     await injectTeamHooks('test-team');
 
     const settings = JSON.parse(await readFile(settingsPath, 'utf-8'));
-    expect(settings.permissions.allow).toEqual(['Bash(*)']);
+    // Pre-existing entries preserved + GENIE_BASELINE_ALLOWED_TOOLS appended.
+    expect(settings.permissions.allow).toEqual(['Bash(*)', 'AskUserQuestion']);
     expect(settings.customField).toBe('preserved');
     expect(settings.hooks).toBeDefined();
+  });
+
+  describe('baseline permissions seeding (#1688 team-side gap)', () => {
+    test('seeds AskUserQuestion when team settings has no permissions block', async () => {
+      await injectTeamHooks('test-team');
+
+      const settingsPath = join(testDir, 'teams', 'test-team', 'settings.json');
+      const settings = JSON.parse(await readFile(settingsPath, 'utf-8'));
+
+      expect(settings.permissions).toBeDefined();
+      expect(settings.permissions.allow).toContain('AskUserQuestion');
+    });
+
+    test('does not duplicate AskUserQuestion across re-injections', async () => {
+      await injectTeamHooks('test-team');
+      await injectTeamHooks('test-team');
+      await injectTeamHooks('test-team');
+
+      const settingsPath = join(testDir, 'teams', 'test-team', 'settings.json');
+      const settings = JSON.parse(await readFile(settingsPath, 'utf-8'));
+
+      const askEntries = (settings.permissions.allow as string[]).filter((t) => t === 'AskUserQuestion');
+      expect(askEntries).toHaveLength(1);
+    });
+
+    test('seeds baseline even when hooks are already clean (write triggered by perms-change alone)', async () => {
+      // First inject: hooks fresh + baseline written. Then DELETE permissions
+      // block to simulate an upgrade path where a user (or older genie) wrote
+      // hooks but never seeded permissions. Re-inject must detect the missing
+      // baseline and write it back, even though hooks are already up-to-date.
+      await injectTeamHooks('test-team');
+      const settingsPath = join(testDir, 'teams', 'test-team', 'settings.json');
+      const after = JSON.parse(await readFile(settingsPath, 'utf-8'));
+      after.permissions = undefined;
+      await writeFile(settingsPath, JSON.stringify(after));
+
+      const result = await injectTeamHooks('test-team');
+      expect(result).toBe(true); // a write happened (baseline seed)
+
+      const reseeded = JSON.parse(await readFile(settingsPath, 'utf-8'));
+      expect(reseeded.permissions.allow).toContain('AskUserQuestion');
+    });
+
+    test('idempotent — second call with baseline already present returns false', async () => {
+      await injectTeamHooks('test-team');
+      const result = await injectTeamHooks('test-team');
+      expect(result).toBe(false);
+    });
   });
 
   test('injectTeamHooks upgrades legacy bare genie dispatch commands', async () => {

--- a/src/hooks/inject.ts
+++ b/src/hooks/inject.ts
@@ -10,6 +10,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { ensureBaselineAllowedTools } from '../lib/claude-settings.js';
 import { DISPATCHED_EVENTS, DISPATCHED_EVENT_MATCHERS } from './types.js';
 
 // Re-export `homedir` symbol so the binary-candidates resolver below has a
@@ -204,20 +205,28 @@ async function injectIntoFile(settingsPath: string): Promise<boolean> {
   const hooksConfig = buildHooksConfig();
   const existingHooks = settings.hooks as HooksConfig | undefined;
 
-  if (
-    existingHooks &&
-    allEventsAlreadyInjected(existingHooks, hooksConfig) &&
-    hasNoObsoleteGenieEntries(existingHooks)
-  ) {
+  const hooksAlreadyClean =
+    !!existingHooks && allEventsAlreadyInjected(existingHooks, hooksConfig) && hasNoObsoleteGenieEntries(existingHooks);
+
+  // Seed GENIE_BASELINE_ALLOWED_TOOLS (currently `AskUserQuestion`) into the
+  // team's settings.json. Without this, CC team mode reads team settings with
+  // no permissions block and routes baseline tool calls through the team-lead
+  // approval queue instead of surfacing them to the human — closes the team-
+  // side gap left after #1688's global-only fix in `ensureClaudeSettingsSafe`.
+  const permissionsChanged = ensureBaselineAllowedTools(settings);
+
+  if (hooksAlreadyClean && !permissionsChanged) {
     return false; // already injected and clean — nothing to do
   }
 
-  const mergedHooks: HooksConfig = existingHooks ? { ...existingHooks } : {};
-  pruneObsoleteGenieEntries(mergedHooks);
-  for (const event of DISPATCHED_EVENTS) {
-    upsertGenieEntry(mergedHooks, event, hooksConfig[event][0]);
+  if (!hooksAlreadyClean) {
+    const mergedHooks: HooksConfig = existingHooks ? { ...existingHooks } : {};
+    pruneObsoleteGenieEntries(mergedHooks);
+    for (const event of DISPATCHED_EVENTS) {
+      upsertGenieEntry(mergedHooks, event, hooksConfig[event][0]);
+    }
+    settings.hooks = mergedHooks;
   }
-  settings.hooks = mergedHooks;
 
   // Ensure parent directory exists
   const dir = join(settingsPath, '..');

--- a/src/hooks/inject.ts
+++ b/src/hooks/inject.ts
@@ -72,7 +72,14 @@ export function buildDispatchCommand(): string {
 }
 
 function isGenieDispatchCommand(command: string | undefined): boolean {
-  return typeof command === 'string' && /(?:^|\s)hook\s+dispatch(?:\s|$)/.test(command);
+  if (typeof command !== 'string') return false;
+  // Legacy bun-fork or literal `genie hook dispatch`:
+  if (/(?:^|\s)hook\s+dispatch(?:\s|$)/.test(command)) return true;
+  // Compiled binary path — bare or shell-quoted: `genie-hook`, `/path/to/genie-hook`,
+  // `'/path/to/genie-hook'`, etc. Anchored at a path-or-quote boundary so substrings
+  // like `genie-hook-helper` don't false-positive.
+  if (/(?:^|[/\\'"])genie-hook(?:['"]|\s|$)/.test(command)) return true;
+  return false;
 }
 
 function claudeConfigDir(): string {


### PR DESCRIPTION
## Summary

Two related bugs in `src/hooks/inject.ts` left the team-side path of #1688 (closed earlier today) regressed and added a slow-leak duplicate-hook bug. Both are surfaced + fixed by this PR. Repro was a `/trace` from inside team `genie`: `AskUserQuestion` calls were routed to the "team-lead approval" UI instead of the human, and `~/.claude/teams/genie/settings.json` had grown 4 identical PreToolUse + 4 identical PostToolUse entries.

### Bug 1 — baseline permissions never written to team settings (#1688 team-side gap)

`ensureClaudeSettingsSafe` seeds `GENIE_BASELINE_ALLOWED_TOOLS` (currently `["AskUserQuestion"]`) into the **global** `~/.claude/settings.json`. The team-settings writer (`injectIntoFile`) only wrote `settings.hooks` and never touched `settings.permissions`. CC team-mode reads team settings.json with no permissions block → falls into the team-lead approval queue for baseline tools.

Fix: import the existing `ensureBaselineAllowedTools` helper and call it inside `injectIntoFile`. Reorganized the early-return guard so a missing baseline alone triggers a write (covers upgrade path where older genie wrote hooks-only).

### Bug 2 — dedup regex fails to match compiled-binary command path

`isGenieDispatchCommand` only matched the legacy `bun run …/src/genie.ts hook dispatch` substring. Once the compiled binary at `~/.genie/bin/genie-hook` shipped, `buildDispatchCommand` started writing the binary path — which contained no `hook dispatch` substring → dedup detection returned false on every re-inject → `upsertGenieEntry` appended a fresh entry each call.

Effect in production: `~/.claude/teams/<team>/settings.json` accumulated duplicate entries (observed: 4 identical PreToolUse + 4 identical PostToolUse), each firing the hook 4× per tool call. Worst-case 60s stall on 15s timeouts.

Fix: widened `isGenieDispatchCommand` to also recognize the binary form with a path/quote/start boundary so substrings like `genie-hook-helper` don't false-positive.

## Test plan

- [x] `bun test src/hooks/__tests__/inject.test.ts` — **15 pass / 0 fail** (was 7 pass / 3 fail on dev tip — 3 pre-existing red tests fixed by Bug 2 patch)
- [x] `bun test src/lib/claude-settings.test.ts` — 8 pass / 0 fail (no regression)
- [x] `bun test src/hooks/ src/lib/claude-settings.test.ts` — 243 pass / 1 unrelated PG-fixture fail (`codex-inbox-deliver`, requires live PG, fails on dev too)
- [x] Pre-commit hooks (biome lint + format) green on both commits
- [x] Manual repro: `~/.claude/teams/genie/settings.json` from a real install showed 4 duplicate hook entries + missing `permissions` block — exactly the shape the new tests cover

## New tests

- `injectIntoFile is idempotent when existing entries use compiled-binary form (regression)` — re-inject 3× on binary-form config asserts entry count stays 1
- `seeds AskUserQuestion when team settings has no permissions block`
- `does not duplicate AskUserQuestion across re-injections`
- `seeds baseline even when hooks are already clean (write triggered by perms-change alone)` — covers upgrade path
- `idempotent — second call with baseline already present returns false`
- Existing `preserves existing settings` test updated to expect `Bash(*) + AskUserQuestion`

## Operator workaround until shipped

Existing teams created before this fix need a one-shot patch:

```bash
jq '.permissions = (.permissions // {}) + {"allow": ((.permissions.allow // []) + ["AskUserQuestion"] | unique)} | .hooks.PreToolUse |= unique_by(.matcher) | .hooks.PostToolUse |= unique_by(.matcher)' \
  ~/.claude/teams/<team>/settings.json > /tmp/fix.json && mv /tmp/fix.json ~/.claude/teams/<team>/settings.json
```

Then restart the CC session.

## Closes

Re-opens the team-side surface of #1688 (already closed by global-only fix `ensureClaudeSettingsSafe`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)