### PR TITLE
[codex] fix canonical agent resume from TUI

### DIFF
--- a/src/genie-commands/session.ts
+++ b/src/genie-commands/session.ts
@@ -75,7 +75,7 @@ interface SessionOptions {
 async function resolveSessionLeaderName(teamName: string): Promise<string> {
   try {
     const { resolveLeaderName } = await import('../lib/team-manager.js');
-    return await resolveLeaderName(teamName);
+    return (await resolveLeaderName(teamName)) ?? teamName;
   } catch {
     return teamName; // Fallback when DB is unavailable — never return 'team-lead'
   }
@@ -147,7 +147,7 @@ export async function registerSessionInRegistry(
     const paneId = (await _deps.executeTmux(`display -t ${shellQuote(target)} -p '#{pane_id}'`)).trim();
     const now = new Date().toISOString();
     const sanitized = sanitizeTeamName(windowName);
-    const leaderName = await _deps.resolveLeaderName(windowName);
+    const leaderName = (await _deps.resolveLeaderName(windowName)) ?? windowName;
     const sanitizedLeader = sanitizeTeamName(leaderName);
     // Wish retire-session-names-id-only Group 3: spawn writes ONE row.
     // Resolve the durable identity UUID before registering runtime fields so
@@ -481,7 +481,7 @@ async function reconcileLeaderConfigs(): Promise<void> {
         const raw = readFileSync(configPath, 'utf-8');
         const config = JSON.parse(raw);
         if (config.leadAgentId?.startsWith('team-lead@')) {
-          const actualLeader = await resolveLeaderName(team);
+          const actualLeader = (await resolveLeaderName(team)) ?? team;
           const sanitized = sanitizeTeamName(team);
           config.leadAgentId = `${sanitizeTeamName(actualLeader)}@${sanitized}`;
           writeFileSync(configPath, JSON.stringify(config, null, 2));

--- a/src/lib/agent-registry.ts
+++ b/src/lib/agent-registry.ts
@@ -1287,12 +1287,12 @@ export async function resolveAgentId(nameOrId: string, team?: string): Promise<s
  * The thrown error includes the input verbatim and the team scope used so the
  * operator can disambiguate quickly.
  */
-export async function resolveAgentIdStrict(nameOrId: string, team?: string): Promise<string> {
+export async function resolveAgentIdStrict(nameOrId: string, team?: string, displayInput = nameOrId): Promise<string> {
   const id = await resolveAgentId(nameOrId, team);
   if (id) return id;
   const teamHint = team ? ` (team scope: ${team})` : ' (no team scope — pass --team to disambiguate)';
   throw new Error(
-    `No agent matches "${nameOrId}"${teamHint}. Resolution checked: exact id, dir:${nameOrId}, custom_name+team, role. Run \`genie ls\` to see live agents.`,
+    `No agent matches "${displayInput}"${teamHint}. Resolution checked: exact id, dir:${nameOrId}, custom_name+team, role. Run \`genie ls\` to see live agents.`,
   );
 }
 

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -151,11 +151,32 @@ function discoverSubAgents(parentDir: string, parentName: string, agents: AgentI
   }
 }
 
-/** Discover a single agent by name. */
+function isSafeAgentName(name: string): boolean {
+  const parts = name.split('/');
+  return parts.length > 0 && parts.length <= 2 && parts.every((part) => part !== '' && part !== '.' && part !== '..');
+}
+
+/** Discover a single agent by name, including one-level scoped sub-agents. */
 function discoverSingleAgent(workspaceRoot: string, agentName: string): AgentInfo | null {
+  if (!isSafeAgentName(agentName)) return null;
+
+  const parts = agentName.split('/');
+  if (parts.length === 2) {
+    const [parentName, subName] = parts;
+    const parentDir = join(workspaceRoot, 'agents', parentName);
+    const subDir = join(parentDir, '.genie', 'agents', subName);
+    if (!existsSync(join(subDir, 'AGENTS.md'))) return null;
+
+    return {
+      name: agentName,
+      dir: subDir,
+      repoUrl: getGitRemoteUrl(parentDir),
+      productRepo: getRepoPathForAgent(parentDir),
+    };
+  }
+
   const agentDir = join(workspaceRoot, 'agents', agentName);
   if (!existsSync(join(agentDir, 'AGENTS.md'))) return null;
-
   return {
     name: agentName,
     dir: agentDir,

--- a/src/lib/protocol-router-spawn.ts
+++ b/src/lib/protocol-router-spawn.ts
@@ -48,7 +48,10 @@ async function resolveParentSession(_repoPath: string, team: string): Promise<st
   // `teams.native_team_parent_session_id` column is no longer read here.
   const leaderName = await teamManager.resolveLeaderName(team);
   const sanitized = nativeTeams.sanitizeTeamName(team);
-  const leaderAgent = await registry.getAgentByName(leaderName, sanitized).catch(() => null);
+  const leaderAgent = leaderName
+    ? ((await registry.getAgent(leaderName).catch(() => null)) ??
+      (await registry.getAgentByName(leaderName, sanitized).catch(() => null)))
+    : null;
   if (leaderAgent) {
     // Route through the canonical chokepoint. We want the leader's session
     // UUID for use as a parent_session_id — `shouldResume` exposes it
@@ -260,7 +263,7 @@ async function registerNativeTeamMember(
   let leaderInboxTarget: string;
   try {
     const { resolveLeaderName } = await import('./team-manager.js');
-    leaderInboxTarget = await resolveLeaderName(team);
+    leaderInboxTarget = (await resolveLeaderName(team)) ?? team;
   } catch {
     leaderInboxTarget = team;
   }

--- a/src/lib/team-auto-spawn.ts
+++ b/src/lib/team-auto-spawn.ts
@@ -177,7 +177,7 @@ export async function ensureTeamLead(teamName: string, workingDir: string): Prom
 
   // Resolve the actual leader name from team config (never returns 'team-lead')
   const { resolveLeaderName } = await import('./team-manager.js');
-  const leaderName = await resolveLeaderName(teamName);
+  const leaderName = (await resolveLeaderName(teamName)) ?? teamName;
 
   // Resolve (or create) the team-lead agent identity first so executor lookups
   // are stable across respawns. If a prior executor has a captured Claude

--- a/src/lib/team-manager.test.ts
+++ b/src/lib/team-manager.test.ts
@@ -23,7 +23,7 @@ import {
   updateTeamConfig,
   validateBranchName,
 } from './team-manager.js';
-import { setupTestDatabase } from './test-db.js';
+import { DB_AVAILABLE, setupTestDatabase } from './test-db.js';
 
 // ============================================================================
 // Test Setup
@@ -516,5 +516,74 @@ describe.skip('pg — TODO retire-session-names #175: rewrite fixtures for UUID 
         process.env.CLAUDE_CONFIG_DIR = undefined;
       });
     });
+  });
+});
+
+describe.skipIf(!DB_AVAILABLE)('team members after UUID identity migration', () => {
+  let cleanupSchema: () => Promise<void>;
+
+  beforeAll(async () => {
+    cleanupSchema = await setupTestDatabase();
+  });
+
+  afterAll(async () => {
+    if (cleanupSchema) await cleanupSchema();
+  });
+
+  async function seedTeam(name: string, members: string[] = [], leader?: string): Promise<void> {
+    const sql = await getConnection();
+    await sql`
+      INSERT INTO teams (name, repo, base_branch, worktree_path, leader, members, status, created_at)
+      VALUES (${name}, '/tmp/repo', 'dev', ${`/tmp/repo/.worktrees/${name}`}, ${leader ?? null}, ${sql.json(members)}, 'in_progress', now())
+      ON CONFLICT (name) DO UPDATE SET members = ${sql.json(members)}, leader = ${leader ?? null}
+    `;
+  }
+
+  test('hireAgent stores a UUID/dir member id instead of the bare requested name', async () => {
+    const team = `member-id-${Date.now()}`;
+    const name = `worker-${Date.now()}`;
+    await seedTeam(team);
+
+    const added = await hireAgent(team, name);
+
+    const config = await getTeam(team);
+    expect(added).toEqual([name]);
+    expect(config?.members).toHaveLength(1);
+    expect(config?.members[0]).not.toBe(name);
+    expect(config?.members[0]).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$|^dir:/i);
+  });
+
+  test('duplicate hire resolves through the same canonical member id', async () => {
+    const team = `member-dup-${Date.now()}`;
+    const name = `worker-${Date.now()}`;
+    await seedTeam(team);
+
+    await hireAgent(team, name);
+    const added = await hireAgent(team, name);
+
+    const config = await getTeam(team);
+    expect(added).toEqual([]);
+    expect(config?.members).toHaveLength(1);
+  });
+
+  test('fireAgent removes a member by resolving the same bare name', async () => {
+    const team = `member-fire-${Date.now()}`;
+    const name = `worker-${Date.now()}`;
+    await seedTeam(team);
+    await hireAgent(team, name);
+
+    const removed = await fireAgent(team, name);
+
+    const config = await getTeam(team);
+    expect(removed).toBe(true);
+    expect(config?.members).toEqual([]);
+  });
+
+  test('resolveLeaderName returns null instead of masquerading as the team name', async () => {
+    const team = `leaderless-${Date.now()}`;
+    await seedTeam(team);
+
+    await expect(resolveLeaderName(team)).resolves.toBeNull();
+    await expect(resolveLeaderName(`missing-${team}`)).resolves.toBeNull();
   });
 });

--- a/src/lib/team-manager.ts
+++ b/src/lib/team-manager.ts
@@ -28,6 +28,23 @@ import * as tmux from './tmux.js';
 // Types
 // ============================================================================
 
+const AGENT_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isValidTeamMemberId(member: string): boolean {
+  return AGENT_ID_RE.test(member) || member.startsWith('dir:');
+}
+
+function sanitizeMembersForWrite(teamName: string, members: string[]): string[] {
+  const kept = members.filter(isValidTeamMemberId);
+  if (kept.length !== members.length) {
+    recordAuditEvent('team', teamName, 'members_sanitized', getActor(), {
+      dropped: members.filter((member) => !isValidTeamMemberId(member)),
+      reason: 'teams_members_uuid_check',
+    }).catch(() => {});
+  }
+  return kept;
+}
+
 /** Team lifecycle status. */
 export type TeamStatus = 'in_progress' | 'done' | 'blocked' | 'archived';
 
@@ -41,9 +58,9 @@ export interface TeamConfig {
   baseBranch: string;
   /** Absolute path to the git worktree directory. */
   worktreePath: string;
-  /** Agent name of the team leader (if assigned). */
+  /** Agent name or canonical id of the team leader (if assigned). */
   leader?: string;
-  /** Array of agent names that are members of this team. */
+  /** Canonical agent ids that are members of this team. */
   members: string[];
   /** Team lifecycle status. */
   status: TeamStatus;
@@ -492,6 +509,7 @@ function buildFallbackConfig(name: string, optsRepo: string | undefined): TeamCo
 async function insertTeamRow(config: TeamConfig, source: 'native-config' | 'cwd-fallback'): Promise<TeamConfig | null> {
   try {
     const sql = await getConnection();
+    const safeMembers = sanitizeMembersForWrite(config.name, config.members);
     await sql`
       INSERT INTO teams (
         name, repo, base_branch, worktree_path, leader,
@@ -500,7 +518,7 @@ async function insertTeamRow(config: TeamConfig, source: 'native-config' | 'cwd-
       ) VALUES (
         ${config.name}, ${config.repo}, ${config.baseBranch},
         ${config.worktreePath}, ${config.leader ?? null},
-        ${sql.json(config.members)}, ${config.status},
+        ${sql.json(safeMembers)}, ${config.status},
         ${config.nativeTeamsEnabled ?? false}, ${config.createdAt},
         ${config.tmuxSessionName ?? null},
         ${config.nativeTeamParentSessionId ?? null},
@@ -566,13 +584,16 @@ export async function hireAgent(teamName: string, agentName: string): Promise<st
   if (agentName === 'council') {
     // Hire all 10 council members
     const councilNames = BUILTIN_COUNCIL_MEMBERS.map((m) => m.name);
-    added = councilNames.filter((n) => !config.members.includes(n));
-    config.members.push(...added);
+    const targets = await Promise.all(councilNames.map((name) => resolveTeamMemberId(teamName, name)));
+    const addedTargets = targets.filter((target) => !config.members.includes(target.id));
+    config.members.push(...addedTargets.map((target) => target.id));
+    added = addedTargets.map((target) => target.name);
   } else {
-    if (config.members.includes(agentName)) {
+    const target = await resolveTeamMemberId(teamName, agentName);
+    if (config.members.includes(target.id)) {
       return []; // Already a member
     }
-    config.members.push(agentName);
+    config.members.push(target.id);
     added = [agentName];
   }
 
@@ -587,6 +608,16 @@ export async function hireAgent(teamName: string, agentName: string): Promise<st
   return added;
 }
 
+async function resolveTeamMemberId(teamName: string, agentName: string): Promise<{ name: string; id: string }> {
+  if (isValidTeamMemberId(agentName)) return { name: agentName, id: agentName };
+
+  const resolved = await registry.resolveAgentId(agentName, teamName);
+  if (resolved) return { name: agentName, id: resolved };
+
+  const identity = await registry.findOrCreateAgent(agentName, teamName, agentName);
+  return { name: agentName, id: identity.id };
+}
+
 /**
  * Remove an agent from a team's members list.
  * Returns true if the agent was removed, false if not found.
@@ -597,7 +628,9 @@ export async function fireAgent(teamName: string, agentName: string): Promise<bo
     throw new Error(`Team "${teamName}" not found.`);
   }
 
-  const idx = config.members.indexOf(agentName);
+  const resolved = isValidTeamMemberId(agentName) ? agentName : await registry.resolveAgentId(agentName, teamName);
+  let idx = resolved ? config.members.indexOf(resolved) : -1;
+  if (idx === -1) idx = config.members.indexOf(agentName);
   if (idx === -1) return false;
 
   config.members.splice(idx, 1);
@@ -929,13 +962,14 @@ export async function updateTeamConfig(name: string, config: TeamConfig): Promis
   // caller passing a stale bare-name leader degrades to NULL instead of
   // tripping the FK constraint. Closes #1674.
   const safeLeader = sanitizeLeaderForWrite(name, config.leader);
+  const safeMembers = sanitizeMembersForWrite(name, config.members);
   await sql`
     UPDATE teams SET
       repo = ${config.repo},
       base_branch = ${config.baseBranch},
       worktree_path = ${config.worktreePath},
       leader = ${safeLeader},
-      members = ${sql.json(config.members)},
+      members = ${sql.json(safeMembers)},
       status = ${config.status},
       native_team_parent_session_id = ${config.nativeTeamParentSessionId ?? null},
       native_teams_enabled = ${config.nativeTeamsEnabled ?? false},
@@ -997,18 +1031,18 @@ export async function killTeamMembers(teamName: string): Promise<void> {
 }
 
 /**
- * Resolve the actual leader name for a team. Never returns 'team-lead'.
- * Resolution order: team config DB → teamName as fallback.
- * If DB is unreachable or team doesn't exist, returns teamName (never 'team-lead').
+ * Resolve the actual leader id for a team. Never returns 'team-lead' or the
+ * team name as a synthetic fallback; callers must handle teams whose leader
+ * has not been spawned/persisted yet.
  */
-export async function resolveLeaderName(teamName: string): Promise<string> {
+export async function resolveLeaderName(teamName: string): Promise<string | null> {
   try {
     const config = await getTeam(teamName);
     if (config?.leader && config.leader !== 'team-lead') return config.leader;
   } catch {
-    // DB unreachable — fall through to teamName
+    // DB unreachable — no authoritative leader.
   }
-  return teamName;
+  return null;
 }
 
 /** Set team lifecycle status. */

--- a/src/term-commands/agents.spawn-autosync.test.ts
+++ b/src/term-commands/agents.spawn-autosync.test.ts
@@ -90,6 +90,35 @@ describe('spawn auto-sync', () => {
     expect(syncCalls).toEqual([{ root: workspaceRoot, name }]);
   });
 
+  test('auto-registers a post-migration agent.yaml agent without AGENTS.md frontmatter', async () => {
+    const name = 'autosync-yaml';
+    const { agentDir, workspaceRoot } = createWorkspaceAgent(
+      name,
+      '',
+      'description: Spawnable YAML agent\npromptMode: system\nmodel: opus\n',
+    );
+
+    const { result, errors } = await captureConsoleError(() => agents.resolveAgentForSpawn(name, {}));
+
+    expect(result.entry.name).toBe(name);
+    expect(result.entry.dir).toBe(agentDir);
+    expect(result.entry.description).toBe('Spawnable YAML agent');
+    expect(errors).toEqual([`Auto-registered agent '${name}' from ${agentDir}`]);
+    expect(syncCalls).toEqual([{ root: workspaceRoot, name }]);
+  });
+
+  test('auto-registers a scoped sub-agent from parent .genie/agents', async () => {
+    const name = 'genie/engineer';
+    const { agentDir, workspaceRoot } = createWorkspaceSubAgent(name, validFrontmatter(name));
+
+    const { result, errors } = await captureConsoleError(() => agents.resolveAgentForSpawn(name, {}));
+
+    expect(result.entry.name).toBe(name);
+    expect(result.entry.dir).toBe(agentDir);
+    expect(errors).toEqual([`Auto-registered agent '${name}' from ${agentDir}`]);
+    expect(syncCalls).toEqual([{ root: workspaceRoot, name }]);
+  });
+
   test('missing workspace preserves not-found behavior and creates no row', async () => {
     const name = 'autosync-no-workspace';
     createAgentWithoutWorkspace(name, validFrontmatter(name));
@@ -100,9 +129,9 @@ describe('spawn auto-sync', () => {
     expect(syncCalls).toEqual([]);
   });
 
-  test('invalid frontmatter preserves not-found behavior and creates no row', async () => {
+  test('frontmatter mismatch does not block directory-name auto-register', async () => {
     const mismatch = 'autosync-name-mismatch';
-    createWorkspaceAgent(
+    const { agentDir, workspaceRoot } = createWorkspaceAgent(
       mismatch,
       `---
 name: different-agent
@@ -110,22 +139,13 @@ description: Spawnable test agent
 ---`,
     );
 
-    await expectResolveNotFound(mismatch, {});
-    expect([...directoryRows.keys()]).toEqual([]);
-    expect(syncCalls).toEqual([]);
+    const { result, errors } = await captureConsoleError(() => agents.resolveAgentForSpawn(mismatch, {}));
 
-    const emptyDescription = 'autosync-empty-description';
-    createWorkspaceAgent(
-      emptyDescription,
-      `---
-name: ${emptyDescription}
-description: "   "
----`,
-    );
-
-    await expectResolveNotFound(emptyDescription, {});
-    expect([...directoryRows.keys()]).toEqual([]);
-    expect(syncCalls).toEqual([]);
+    expect(result.entry.name).toBe(mismatch);
+    expect(result.entry.dir).toBe(agentDir);
+    expect(errors).toEqual([`Auto-registered agent '${mismatch}' from ${agentDir}`]);
+    expect([...directoryRows.keys()]).toEqual([mismatch]);
+    expect(syncCalls).toEqual([{ root: workspaceRoot, name: mismatch }]);
   });
 
   test('GENIE_DISABLE_AUTO_SYNC=1 prevents auto-register', async () => {
@@ -149,7 +169,11 @@ description: "   "
     expect(syncCalls).toEqual([]);
   });
 
-  function createWorkspaceAgent(name: string, frontmatter: string): { workspaceRoot: string; agentDir: string } {
+  function createWorkspaceAgent(
+    name: string,
+    frontmatter: string,
+    agentYaml?: string,
+  ): { workspaceRoot: string; agentDir: string } {
     const workspaceRoot = realpathSync(mkdtempSync(join(tmpdir(), 'genie-spawn-autosync-workspace-')));
     tempRoots.push(workspaceRoot);
 
@@ -157,6 +181,29 @@ description: "   "
     writeFileSync(join(workspaceRoot, '.genie', 'workspace.json'), JSON.stringify({ name: 'autosync-test' }));
 
     const agentDir = join(workspaceRoot, 'agents', name);
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'AGENTS.md'), `${frontmatter}\n# ${name}\n`, 'utf-8');
+    if (agentYaml !== undefined) {
+      writeFileSync(join(agentDir, 'agent.yaml'), agentYaml, 'utf-8');
+    }
+
+    process.chdir(workspaceRoot);
+    return { workspaceRoot, agentDir };
+  }
+
+  function createWorkspaceSubAgent(name: string, frontmatter: string): { workspaceRoot: string; agentDir: string } {
+    const [parent, sub] = name.split('/');
+    const workspaceRoot = realpathSync(mkdtempSync(join(tmpdir(), 'genie-spawn-autosync-workspace-')));
+    tempRoots.push(workspaceRoot);
+
+    mkdirSync(join(workspaceRoot, '.genie'), { recursive: true });
+    writeFileSync(join(workspaceRoot, '.genie', 'workspace.json'), JSON.stringify({ name: 'autosync-test' }));
+
+    const parentDir = join(workspaceRoot, 'agents', parent);
+    mkdirSync(parentDir, { recursive: true });
+    writeFileSync(join(parentDir, 'AGENTS.md'), `${validFrontmatter(parent)}\n# ${parent}\n`, 'utf-8');
+
+    const agentDir = join(parentDir, '.genie', 'agents', sub);
     mkdirSync(agentDir, { recursive: true });
     writeFileSync(join(agentDir, 'AGENTS.md'), `${frontmatter}\n# ${name}\n`, 'utf-8');
 
@@ -196,20 +243,33 @@ description: Spawnable test agent
   async function fakeSyncSingleAgentByName(root: string, name: string): Promise<string> {
     syncCalls.push({ root, name });
 
-    const agentDir = join(root, 'agents', name);
+    const agentDir = resolveAgentDir(root, name);
     const agentsMd = join(agentDir, 'AGENTS.md');
     if (!existsSync(agentsMd)) return 'not-found';
 
     const existed = directoryRows.has(name);
     const frontmatter = parseFrontmatter(readFileSync(agentsMd, 'utf-8'));
+    const description = frontmatter.description ?? readYamlDescription(join(agentDir, 'agent.yaml'));
     directoryRows.set(name, {
       name,
       dir: agentDir,
       promptMode: 'append',
       registeredAt: 'test',
-      description: frontmatter.description,
+      description,
     });
     return existed ? 'updated' : 'registered';
+  }
+
+  function resolveAgentDir(root: string, name: string): string {
+    const parts = name.split('/');
+    if (parts.length === 2) return join(root, 'agents', parts[0], '.genie', 'agents', parts[1]);
+    return join(root, 'agents', name);
+  }
+
+  function readYamlDescription(path: string): string | undefined {
+    if (!existsSync(path)) return undefined;
+    const match = readFileSync(path, 'utf-8').match(/^description:\s*["']?([^"'\n]+)["']?\s*$/m);
+    return match?.[1];
   }
 
   async function captureConsoleError<T>(fn: () => Promise<T>): Promise<{ result: T; errors: string[] }> {

--- a/src/term-commands/agents.test.ts
+++ b/src/term-commands/agents.test.ts
@@ -12,6 +12,7 @@ import type { Agent } from '../lib/agent-registry.js';
 import * as registry from '../lib/agent-registry.js';
 import { resolveBuiltinAgentPath } from '../lib/builtin-agents.js';
 import * as executorRegistry from '../lib/executor-registry.js';
+import type { AgentIdentity } from '../lib/executor-types.js';
 import { DB_AVAILABLE, setupTestDatabase } from '../lib/test-db.js';
 import * as wishState from '../lib/wish-state.js';
 import {
@@ -1116,6 +1117,90 @@ describe.skip('spawn state machine — TODO retire-session-names #175: rewrite f
 // ============================================================================
 // buildWorkerStatusMap — native-team name visibility (#1302)
 // ============================================================================
+
+describe.skipIf(!DB_AVAILABLE)('findDeadResumable: UUID identity anchors', () => {
+  beforeEach(async () => {
+    await truncateAgentsSurface();
+  });
+
+  async function seedUuidAnchor(opts: {
+    name: string;
+    team: string;
+    sessionId: string;
+    paneId: string;
+    provider?: 'claude' | 'codex' | 'claude-sdk';
+    transport?: 'tmux' | 'api' | 'process';
+  }): Promise<AgentIdentity> {
+    const identity = await registry.findOrCreateAgent(opts.name, opts.team, opts.name);
+    await executorRegistry.createAndLinkExecutor(identity.id, opts.provider ?? 'claude', opts.transport ?? 'tmux', {
+      claudeSessionId: opts.sessionId,
+      tmuxPaneId: opts.paneId,
+      tmuxSession: opts.team,
+    });
+    return identity;
+  }
+
+  test('finds a dead UUID identity by current executor, even when agent row runtime fields are null', async () => {
+    const team = `team-uuid-resume-${Date.now()}`;
+    const identity = await seedUuidAnchor({
+      name: 'genie',
+      team,
+      sessionId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      paneId: '%dead',
+    });
+
+    const found = await findDeadResumable(team, 'genie', async (paneId) => {
+      expect(paneId).toBe('%dead');
+      return false;
+    });
+
+    expect(found?.id).toBe(identity.id);
+    expect(found?.customName).toBe('genie');
+    expect(found?.paneId).toBe('%dead');
+  });
+
+  test('alive UUID permanent identity still blocks duplicate owner spawn', async () => {
+    const team = `team-uuid-owner-${Date.now()}`;
+    const identity = await seedUuidAnchor({
+      name: 'genie',
+      team,
+      sessionId: 'bbbbbbbb-cccc-dddd-eeee-ffffffffffff',
+      paneId: '%live',
+    });
+
+    let caught: unknown = null;
+    try {
+      await findDeadResumable(team, 'genie', async (paneId) => {
+        expect(paneId).toBe('%live');
+        return true;
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(OwnerSpawnCollisionError);
+    const err = caught as OwnerSpawnCollisionError;
+    expect(err.conflictId).toBe(identity.id);
+    expect(err.conflictPaneId).toBe('%live');
+  });
+
+  test('uses executor transport as the resume authority', async () => {
+    const team = `team-uuid-process-${Date.now()}`;
+    await seedUuidAnchor({
+      name: 'genie',
+      team,
+      sessionId: 'cccccccc-dddd-eeee-ffff-000000000000',
+      paneId: '%process',
+      transport: 'process',
+    });
+
+    const found = await findDeadResumable(team, 'genie', async () => {
+      throw new Error('liveness should not be checked for non-tmux executors');
+    });
+
+    expect(found).toBeNull();
+  });
+});
 
 describe.skipIf(!DB_AVAILABLE)('buildWorkerStatusMap: customName keying', () => {
   // This describe builds Agent values in memory and never writes to PG, but

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -79,7 +79,7 @@ async function isPaneAliveOrDead(paneId: string): Promise<boolean> {
  * Never returns 'team-lead' — uses resolveLeaderName() which falls back to teamName.
  */
 async function resolveTeamLeaderName(teamNameOrDefault: string): Promise<string> {
-  return teamManager.resolveLeaderName(teamNameOrDefault);
+  return (await teamManager.resolveLeaderName(teamNameOrDefault)) ?? teamNameOrDefault;
 }
 
 /** Check if a process is alive by PID file. */
@@ -690,8 +690,12 @@ async function registerSpawnWorker(
   if (role !== 'council') {
     try {
       await teamManager.hireAgent(ctx.validated.team, role);
-    } catch {
-      // Team may not exist in team-manager (e.g., native-only teams) — that's fine
+    } catch (err) {
+      if (err instanceof Error && err.message.includes('not found')) {
+        // Team may not exist in team-manager (e.g., native-only teams) — that's fine.
+        return workerEntry;
+      }
+      throw err;
     }
   }
 
@@ -1851,7 +1855,10 @@ async function resolveNativeTeam(
   // until an explicit `/clear` reset it.
   const leaderName = await teamManager.resolveLeaderName(team);
   const sanitizedTeam = nativeTeams.sanitizeTeamName(team);
-  const leaderAgent = await registry.getAgentByName(leaderName, sanitizedTeam).catch(() => null);
+  const leaderAgent = leaderName
+    ? ((await registry.getAgent(leaderName).catch(() => null)) ??
+      (await registry.getAgentByName(leaderName, sanitizedTeam).catch(() => null)))
+    : null;
   let parentSessionId: string | undefined;
   if (leaderAgent && !options.isIdentitySpawn) {
     // Route through the canonical chokepoint. We want the leader's session

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -1711,28 +1711,37 @@ export async function findDeadResumable(
   // the "has a session we can resume" predicate must traverse
   // `agents.current_executor_id → executors.claude_session_id`. Narrow by
   // cheap fields first, then consult the executor JOIN.
-  const prefiltered = existing.filter(
-    (w) => w.role === role && w.team === team && w.provider === 'claude' && w.transport === 'tmux',
-  );
+  const prefiltered = existing.filter((w) => (w.role === role || w.customName === role) && w.team === team);
   let candidate: registry.Agent | null = null;
+  let candidatePaneId: string | null = null;
   for (const w of prefiltered) {
     const executor = await executorRegistry.getCurrentExecutor(w.id);
-    if (executor?.claudeSessionId) {
+    const provider = executor?.provider ?? w.provider;
+    const transport = executor?.transport ?? w.transport;
+    if (executor?.claudeSessionId && provider === 'claude' && transport === 'tmux') {
       candidate = w;
+      candidatePaneId = executor.tmuxPaneId ?? w.paneId;
       break;
     }
   }
   if (!candidate) return null;
   // `isPaneAliveOrDead` swallows TmuxUnreachableError → dead, so a zombie
   // tmux socket doesn't crash the spawn path.
-  const alive = await isAliveFn(candidate.paneId);
+  const alive = candidatePaneId ? await isAliveFn(candidatePaneId) : false;
+  const resumableCandidate = candidatePaneId ? { ...candidate, paneId: candidatePaneId } : candidate;
   if (alive) {
-    if (candidate.kind === 'permanent') {
-      throw new OwnerSpawnCollisionError(role, team, candidate.id, candidate.paneId, candidate.state);
+    if (resumableCandidate.kind === 'permanent') {
+      throw new OwnerSpawnCollisionError(
+        role,
+        team,
+        resumableCandidate.id,
+        resumableCandidate.paneId,
+        resumableCandidate.state,
+      );
     }
     return null;
   }
-  return candidate;
+  return resumableCandidate;
 }
 
 /**
@@ -1944,12 +1953,28 @@ function isWithinAgentsRoot(agentsRoot: string, agentDir: string): boolean {
   return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
 }
 
+function resolveAutoRegisterAgentDir(workspaceRoot: string, name: string): string | null {
+  const parts = name.split('/');
+  if (parts.length < 1 || parts.length > 2) return null;
+  if (parts.some((part) => part === '' || part === '.' || part === '..')) return null;
+
+  const agentsRoot = join(workspaceRoot, 'agents');
+  const agentDir =
+    parts.length === 2
+      ? resolvePath(agentsRoot, parts[0], '.genie', 'agents', parts[1])
+      : resolvePath(agentsRoot, parts[0]);
+
+  return isWithinAgentsRoot(agentsRoot, agentDir) ? agentDir : null;
+}
+
 /**
  * On first spawn, register a valid workspace agent directory on demand.
  *
- * This intentionally does not scan, watch, prune, or reconcile the directory.
- * It only checks the exact requested <workspace>/agents/<name>/AGENTS.md and
- * delegates the real upsert to syncSingleAgentByName.
+ * This intentionally does not scan, watch, prune, or reconcile the directory;
+ * it only checks the requested on-disk agent path and delegates the real
+ * upsert to syncSingleAgentByName. That keeps spawn working for both
+ * post-migration agent.yaml agents and scoped sub-agents such as
+ * "genie/engineer".
  */
 export async function tryAutoRegisterAgent(
   name: string,
@@ -1960,22 +1985,11 @@ export async function tryAutoRegisterAgent(
   const workspace = _spawnAutoSyncDeps.findWorkspace();
   if (!workspace) return null;
 
-  const agentsRoot = join(workspace.root, 'agents');
-  const agentDir = resolvePath(agentsRoot, name);
-  if (!isWithinAgentsRoot(agentsRoot, agentDir)) return null;
+  const agentDir = resolveAutoRegisterAgentDir(workspace.root, name);
+  if (!agentDir) return null;
 
   const agentsMdPath = join(agentDir, 'AGENTS.md');
   if (!_spawnAutoSyncDeps.existsSync(agentsMdPath)) return null;
-
-  let frontmatter: ReturnType<typeof parseFrontmatter>;
-  try {
-    frontmatter = _spawnAutoSyncDeps.parseFrontmatter(_spawnAutoSyncDeps.readFileSync(agentsMdPath, 'utf-8'));
-  } catch {
-    return null;
-  }
-
-  if (frontmatter.name !== name) return null;
-  if (typeof frontmatter.description !== 'string' || frontmatter.description.trim().length === 0) return null;
 
   try {
     const action = await _spawnAutoSyncDeps.syncSingleAgentByName(workspace.root, name);

--- a/src/term-commands/dispatch.ts
+++ b/src/term-commands/dispatch.ts
@@ -356,7 +356,7 @@ async function resolveLeaderTarget(): Promise<string> {
 
   try {
     const { resolveLeaderName } = await import('../lib/team-manager.js');
-    return await resolveLeaderName(teamName);
+    return (await resolveLeaderName(teamName)) ?? teamName;
   } catch {
     return teamName;
   }

--- a/src/term-commands/msg.test.ts
+++ b/src/term-commands/msg.test.ts
@@ -24,6 +24,7 @@ import {
   isCliSender,
   printBridgeSuggestion,
   registerSendInboxCommands,
+  resolveLeaderAlias,
   resolveSenderTeams,
   suggestRelayLeader,
 } from './msg.js';
@@ -51,8 +52,8 @@ async function insertTeam(name: string, repo: string, members: string[], leader?
   const sql = await getConnection();
   await sql`
     INSERT INTO teams (name, repo, base_branch, worktree_path, leader, members, status, created_at)
-    VALUES (${name}, ${repo}, 'dev', ${join(repo, '.worktrees', name)}, ${leader ?? null}, ${JSON.stringify(members)}, 'in_progress', now())
-    ON CONFLICT (name) DO UPDATE SET members = ${JSON.stringify(members)}, leader = ${leader ?? null}
+    VALUES (${name}, ${repo}, 'dev', ${join(repo, '.worktrees', name)}, ${leader ?? null}, ${sql.json(members)}, 'in_progress', now())
+    ON CONFLICT (name) DO UPDATE SET members = ${sql.json(members)}, leader = ${leader ?? null}
   `;
 }
 
@@ -123,6 +124,45 @@ describe('isCliSender', () => {
     expect(isCliSender('CLI')).toBe(false); // case-sensitive
     expect(isCliSender('')).toBe(false);
     expect(isCliSender(':cli')).toBe(false);
+  });
+});
+
+describe.skipIf(!DB_AVAILABLE)('resolveLeaderAlias', () => {
+  test('does not use GENIE_TEAM as an implicit team-lead scope', async () => {
+    const previousTeam = process.env.GENIE_TEAM;
+    process.env.GENIE_TEAM = 'sender-team';
+
+    try {
+      const resolved = await resolveLeaderAlias('team-lead');
+
+      expect(resolved).toBe('team-lead');
+    } finally {
+      if (previousTeam === undefined) process.env.GENIE_TEAM = undefined;
+      else process.env.GENIE_TEAM = previousTeam;
+    }
+  });
+
+  test('resolves team-lead only when an explicit team has a persisted leader id', async () => {
+    const sql = await getConnection();
+    const leaderId = '11111111-1111-4111-8111-111111111111';
+    await sql`
+      INSERT INTO agents (id, pane_id, session, repo_path, state, team, role, custom_name, started_at)
+      VALUES (${leaderId}, '', '', '/tmp', 'idle', 'leader-alias-team', 'team-lead', 'team-lead', now())
+      ON CONFLICT (id) DO NOTHING
+    `;
+    await insertTeam('leader-alias-team', '/tmp/repo', [leaderId], leaderId);
+
+    const resolved = await resolveLeaderAlias('team-lead', 'leader-alias-team');
+
+    expect(resolved).toBe(leaderId);
+  });
+
+  test('throws a clear error when an explicit team has no leader', async () => {
+    await insertTeam('leaderless-alias-team', '/tmp/repo', []);
+
+    await expect(resolveLeaderAlias('team-lead', 'leaderless-alias-team')).rejects.toThrow(
+      'has no leader; cannot resolve "team-lead"',
+    );
   });
 });
 

--- a/src/term-commands/msg.ts
+++ b/src/term-commands/msg.ts
@@ -156,19 +156,25 @@ export function parseAtSyntax(recipient: string, defaultTeam?: string): { recipi
 }
 
 /**
- * Resolve the 'team-lead' alias to the actual leader name for a given team context.
- * Never returns 'team-lead' — falls back to teamName via resolveLeaderName().
+ * Resolve the 'team-lead' alias to the actual leader id for an explicit team
+ * context. Deliberately does not fall back to GENIE_TEAM: without an explicit
+ * recipient scope, `team-lead` points at the sender's team and can silently
+ * route to the wrong inbox.
  */
-async function resolveLeaderAlias(recipient: string, teamContext?: string): Promise<string> {
+export async function resolveLeaderAlias(recipient: string, teamContext?: string): Promise<string> {
   if (recipient !== 'team-lead') return recipient;
 
-  const teamName = teamContext ?? process.env.GENIE_TEAM;
-  if (teamName) {
-    const teamManager = await getTeamManager();
-    return teamManager.resolveLeaderName(teamName);
+  if (!teamContext) return recipient;
+
+  const teamManager = await getTeamManager();
+  const leader = await teamManager.resolveLeaderName(teamContext);
+  if (!leader) {
+    throw new Error(
+      `Team "${teamContext}" has no leader; cannot resolve "team-lead". Use an explicit agent id or spawn the team leader first.`,
+    );
   }
 
-  return recipient;
+  return leader;
 }
 
 // ============================================================================
@@ -313,9 +319,10 @@ export function resolveSenderTeams(
     walkParentChain(teams, team, visited, result);
   }
 
-  // Leader fallback: if sender is the leader (by name or legacy 'team-lead'
-  // alias), include the leader's team resolved from the ambient GENIE_TEAM.
-  const isLeader = teams.some((t) => t.leader === sender) || sender === 'team-lead';
+  // Leader fallback: if sender is the persisted leader id, include the
+  // leader's team resolved from the ambient GENIE_TEAM. Do not treat the
+  // bare alias "team-lead" as a global wildcard; it has no team scope.
+  const isLeader = teams.some((t) => t.leader === sender);
   if (isLeader) {
     const envTeam = process.env.GENIE_TEAM;
     if (envTeam) {
@@ -349,8 +356,8 @@ export async function suggestRelayLeader(sender: string): Promise<{ leader: stri
 
 /** Check whether a recipient is reachable within a given team (direct member, leader, or prefixed name). */
 function isRecipientInTeam(team: teamManagerTypes.TeamConfig, recipient: string): boolean {
-  // Direct member, actual leader name, or legacy 'team-lead' alias (backwards compat)
-  if (team.members.includes(recipient) || recipient === team.leader || recipient === 'team-lead') return true;
+  // Direct member or actual persisted leader id.
+  if (team.members.includes(recipient) || recipient === team.leader) return true;
   if (recipient.startsWith(`${team.name}-`)) {
     const roleOnly = recipient.slice(team.name.length + 1);
     if (team.members.includes(roleOnly)) return true;
@@ -368,8 +375,8 @@ async function findAgentTeam(_repoPath: string, agentName: string): Promise<team
   const memberTeam = teams.find((t) => t.members.includes(agentName));
   if (memberTeam) return memberTeam;
 
-  // Match by leader name or legacy 'team-lead' alias (backwards compat)
-  if (agentName === 'team-lead' || teams.some((t) => t.leader === agentName)) {
+  // Match by persisted leader id.
+  if (teams.some((t) => t.leader === agentName)) {
     const envTeam = process.env.GENIE_TEAM;
     if (envTeam) return teams.find((t) => t.name === envTeam) ?? null;
     // Also find by leader field directly
@@ -934,17 +941,11 @@ async function handleSend(
   // #1674 Bug 2a. Then resolve the 'team-lead' alias to the actual leader
   // name in the (possibly parsed) team context.
   const parsed = parseAtSyntax(options.to, options.team);
-  const to = await resolveLeaderAlias(parsed.recipient, parsed.team);
-
-  const scopeError = await checkSendScope(repoPath, from, to);
-  if (scopeError) {
-    if (options.bridge) {
-      await printBridgeSuggestion(from, to, body, scopeError);
-      return;
-    }
-    console.error(`Error: ${scopeError}`);
+  if (parsed.recipient === 'team-lead' && !parsed.team) {
+    console.error('Error: "team-lead" requires an explicit team scope. Use "team-lead@<team>" or --team <team>.');
     process.exit(1);
   }
+  const to = await resolveLeaderAlias(parsed.recipient, parsed.team);
 
   // Wish retire-session-names-id-only G4: resolve recipient name → canonical
   // agents.id BEFORE writing to mailbox.to_worker. Migration 061 enforces
@@ -956,7 +957,17 @@ async function handleSend(
   // parsed.team wins over options.team / GENIE_TEAM so cross-team @-syntax sends
   // resolve in the recipient's scope, not the sender's. Closes #1674 Bug 2a.
   const teamScope = parsed.team ?? options.team ?? process.env.GENIE_TEAM;
-  const toAgentId = await registryMod.resolveAgentIdStrict(to, teamScope);
+  const toAgentId = await registryMod.resolveAgentIdStrict(to, teamScope, options.to);
+
+  const scopeError = await checkSendScope(repoPath, from, toAgentId);
+  if (scopeError) {
+    if (options.bridge) {
+      await printBridgeSuggestion(from, toAgentId, body, scopeError);
+      return;
+    }
+    console.error(`Error: ${scopeError}`);
+    process.exit(1);
+  }
 
   const senderActor = localActor(from);
   const recipientActor = localActor(toAgentId);

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -475,6 +475,7 @@ function sendTuiLaunchScript(leftPane: string, rightPane: string, workspaceRoot?
 
   const envVars = ['GENIE_TUI_PANE=left', `GENIE_TUI_RIGHT=${rightPane}`];
   if (workspaceRoot) envVars.push(`GENIE_TUI_WORKSPACE=${workspaceRoot}`);
+  if (process.env.GENIE_TEAM) envVars.push(`GENIE_TUI_TEAM=${process.env.GENIE_TEAM}`);
 
   const content = [
     '#!/bin/sh',

--- a/src/term-commands/state.ts
+++ b/src/term-commands/state.ts
@@ -343,7 +343,7 @@ async function resolveNotificationTargets(): Promise<{ leader: string; spawner?:
     const leader = await teamManager.resolveLeaderName(teamName);
     const config = await teamManager.getTeam(teamName);
     return {
-      leader,
+      leader: leader ?? teamName,
       spawner: config?.spawner,
     };
   } catch {

--- a/src/term-commands/team.ts
+++ b/src/term-commands/team.ts
@@ -383,8 +383,10 @@ async function spawnLeaderWithWish(
   await copyFile(sourceWishPath, destWishPath);
   console.log(`  Wish: copied ${slug}/WISH.md into worktree`);
 
-  // Hire the standard team: leader (team-lead template) + engineer + reviewer + qa + fix
-  const standardRoles = ['team-lead', 'engineer', 'reviewer', 'qa', 'fix'];
+  // Hire the standard workers before kickoff. The leader is added after its
+  // spawn resolves the durable UUID; writing bare "team-lead" here violates
+  // migration 061's teams.members invariant.
+  const standardRoles = ['engineer', 'reviewer', 'qa', 'fix'];
   for (const role of standardRoles) {
     await teamManager.hireAgent(config.name, role);
   }
@@ -420,6 +422,7 @@ async function spawnLeaderWithWish(
   if (leader?.id) {
     config.leader = leader.id;
     await teamManager.updateTeamConfig(config.name, config);
+    await teamManager.hireAgent(config.name, leader.id);
   }
 
   // initialPrompt is passed as CLI positional arg — no mailbox backup needed

--- a/src/tui/components/Nav.test.tsx
+++ b/src/tui/components/Nav.test.tsx
@@ -11,8 +11,9 @@
  */
 
 import { describe, expect, mock, test } from 'bun:test';
+import type { TmuxSession } from '../diagnostics.js';
 import { buildWorkspaceTree } from '../session-tree.js';
-import type { TreeNode } from '../types.js';
+import type { TreeNode, TuiExecutor } from '../types.js';
 import { computeNavCounts, handleEnterAgent } from './Nav.js';
 
 function makeAgentNode(overrides: Partial<TreeNode> = {}): TreeNode {
@@ -78,6 +79,75 @@ describe('handleEnterAgent — Enter on stopped agent (G2)', () => {
     expect(spawn).not.toHaveBeenCalled();
     expect(onTmuxSelect).toHaveBeenCalledTimes(1);
     expect(onTmuxSelect.mock.calls[0][0]).toBe('felipe');
+    expect(onTmuxSelect.mock.calls[0][1]).toBe(1);
+  });
+
+  test('running canonical agent inside a team session attaches instead of spawning', () => {
+    const teamSession: TmuxSession = {
+      name: 'genie-bernardo',
+      attached: false,
+      windowCount: 2,
+      created: 0,
+      windows: [
+        {
+          sessionName: 'genie-bernardo',
+          index: 0,
+          name: 'zsh',
+          active: false,
+          paneCount: 1,
+          panes: [],
+        },
+        {
+          sessionName: 'genie-bernardo',
+          index: 1,
+          name: 'genie',
+          active: true,
+          paneCount: 1,
+          panes: [
+            {
+              sessionName: 'genie-bernardo',
+              windowIndex: 1,
+              paneIndex: 0,
+              paneId: '%825',
+              pid: 123,
+              command: 'claude',
+              processCommand: '/home/genie/.local/bin/claude',
+              title: 'claude',
+              size: '120x40',
+              isDead: false,
+            },
+          ],
+        },
+      ],
+    };
+    const executor: TuiExecutor = {
+      id: 'exec-genie',
+      agentId: 'agent-genie',
+      agentName: 'genie',
+      provider: 'claude',
+      transport: 'tmux',
+      pid: 123,
+      tmuxSession: 'genie-bernardo',
+      tmuxPaneId: '%825',
+      state: 'idle',
+      metadata: {},
+      startedAt: new Date(0).toISOString(),
+      role: 'genie',
+      team: 'genie-bernardo',
+    };
+    const [node] = buildWorkspaceTree({
+      agentNames: ['genie'],
+      sessions: [teamSession],
+      executors: [executor],
+    });
+    const spawn = mock<(name: string) => void>(() => undefined);
+    const onTmuxSelect = mock<(s: string, w?: number) => void>(() => undefined);
+
+    handleEnterAgent(node, onTmuxSelect, spawn);
+
+    expect(spawn).not.toHaveBeenCalled();
+    expect(onTmuxSelect).toHaveBeenCalledTimes(1);
+    expect(onTmuxSelect.mock.calls[0][0]).toBe('genie-bernardo');
     expect(onTmuxSelect.mock.calls[0][1]).toBe(1);
   });
 

--- a/src/tui/components/Nav.tsx
+++ b/src/tui/components/Nav.tsx
@@ -91,6 +91,7 @@ function useSessionTreeBuilder(
         sessions: diagnostics.sessions,
         executors: diagnostics.executors,
         workStates: diagnostics.workStates,
+        teamScope: process.env.GENIE_TUI_TEAM ?? process.env.GENIE_TEAM,
       });
     } else {
       newTree = buildSessionTree(diagnostics);
@@ -992,7 +993,8 @@ function spawnAgent(name: string, onTmuxSessionSelect?: (sessionName: string, wi
       GENIE_TUI_PANE: _a,
       GENIE_TUI_RIGHT: _b,
       GENIE_TUI_WORKSPACE: _c,
-      GENIE_IS_DAEMON: _d,
+      GENIE_TUI_TEAM: _d,
+      GENIE_IS_DAEMON: _e,
       ...cleanEnv
     } = process.env;
     // Route stdout/stderr to a per-spawn log file instead of /dev/null so that

--- a/src/tui/session-tree.test.ts
+++ b/src/tui/session-tree.test.ts
@@ -348,6 +348,126 @@ describe('buildWorkspaceTree', () => {
     expect(getSessionTarget(tree[0])).toEqual({ sessionName: 'genie-bernardo', windowIndex: 1 });
   });
 
+  test('same-name team executors do not bind a canonical node to the first arbitrary team session', () => {
+    const alphaWindow = makeWindow({
+      sessionName: 'genie-alpha',
+      index: 1,
+      name: 'genie',
+      panes: [
+        makePane({
+          sessionName: 'genie-alpha',
+          windowIndex: 1,
+          paneId: '%101',
+          command: 'claude',
+          title: 'claude',
+        }),
+      ],
+    });
+    const betaWindow = makeWindow({
+      sessionName: 'genie-beta',
+      index: 1,
+      name: 'genie',
+      panes: [
+        makePane({
+          sessionName: 'genie-beta',
+          windowIndex: 1,
+          paneId: '%202',
+          command: 'claude',
+          title: 'claude',
+        }),
+      ],
+    });
+    const execBeta = makeExecutor({
+      id: 'exec-beta',
+      agentName: 'genie',
+      team: 'genie-beta',
+      tmuxSession: 'genie-beta',
+      tmuxPaneId: '%202',
+      state: 'idle',
+    });
+    const execAlpha = makeExecutor({
+      id: 'exec-alpha',
+      agentName: 'genie',
+      team: 'genie-alpha',
+      tmuxSession: 'genie-alpha',
+      tmuxPaneId: '%101',
+      state: 'idle',
+    });
+
+    const tree = buildWorkspaceTree({
+      agentNames: ['genie'],
+      sessions: [makeSession('genie-alpha', [alphaWindow]), makeSession('genie-beta', [betaWindow])],
+      executors: [execBeta, execAlpha],
+    });
+
+    expect(tree[0].label).toBe('genie');
+    expect(tree[0].data.sessionName).toBe('genie');
+    expect(tree[0].wsAgentState).toBe('stopped');
+    expect(tree.map((node) => node.label)).toEqual(['genie', 'genie-alpha', 'genie-beta']);
+  });
+
+  test('team scope disambiguates same-name team executors before attaching', () => {
+    const alphaWindow = makeWindow({
+      sessionName: 'genie-alpha',
+      index: 1,
+      name: 'genie',
+      active: true,
+      panes: [
+        makePane({
+          sessionName: 'genie-alpha',
+          windowIndex: 1,
+          paneId: '%101',
+          command: 'claude',
+          title: 'claude',
+        }),
+      ],
+    });
+    const betaWindow = makeWindow({
+      sessionName: 'genie-beta',
+      index: 1,
+      name: 'genie',
+      active: true,
+      panes: [
+        makePane({
+          sessionName: 'genie-beta',
+          windowIndex: 1,
+          paneId: '%202',
+          command: 'claude',
+          title: 'claude',
+        }),
+      ],
+    });
+    const execBeta = makeExecutor({
+      id: 'exec-beta',
+      agentName: 'genie',
+      team: 'genie-beta',
+      tmuxSession: 'genie-beta',
+      tmuxPaneId: '%202',
+      state: 'idle',
+    });
+    const execAlpha = makeExecutor({
+      id: 'exec-alpha',
+      agentName: 'genie',
+      team: 'genie-alpha',
+      tmuxSession: 'genie-alpha',
+      tmuxPaneId: '%101',
+      state: 'idle',
+    });
+
+    const tree = buildWorkspaceTree({
+      agentNames: ['genie'],
+      sessions: [makeSession('genie-alpha', [alphaWindow]), makeSession('genie-beta', [betaWindow])],
+      executors: [execBeta, execAlpha],
+      teamScope: 'genie-alpha',
+    });
+
+    expect(tree[0].label).toBe('genie');
+    expect(tree[0].data.sessionName).toBe('genie-alpha');
+    expect(tree[0].wsAgentState).toBe('running');
+    expect(getSessionTarget(tree[0])).toEqual({ sessionName: 'genie-alpha', windowIndex: 1 });
+    expect(tree.map((node) => node.label)).toEqual(['genie', 'genie-beta']);
+  });
+
   test('permission executor state reflected on agentState', () => {
     const sofiaSession = makeSession('sofia');
     const executor = makeExecutor({

--- a/src/tui/session-tree.test.ts
+++ b/src/tui/session-tree.test.ts
@@ -308,6 +308,46 @@ describe('buildWorkspaceTree', () => {
     expect(pane.data.command).toBe('2.1.123');
   });
 
+  test('executor tmux session links a canonical agent running inside a team session', () => {
+    const shell = makeWindow({ sessionName: 'genie-bernardo', index: 0, name: 'zsh' });
+    const genieWindow = makeWindow({
+      sessionName: 'genie-bernardo',
+      index: 1,
+      name: 'genie',
+      active: true,
+      panes: [
+        makePane({
+          sessionName: 'genie-bernardo',
+          windowIndex: 1,
+          paneId: '%825',
+          command: 'claude',
+          title: 'claude',
+        }),
+      ],
+    });
+    const teamSession = makeSession('genie-bernardo', [shell, genieWindow]);
+    const executor = makeExecutor({
+      agentName: 'genie',
+      team: 'genie-bernardo',
+      tmuxSession: 'genie-bernardo',
+      tmuxPaneId: '%825',
+      state: 'idle',
+    });
+
+    const tree = buildWorkspaceTree({
+      agentNames: ['genie'],
+      sessions: [teamSession],
+      executors: [executor],
+    });
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0].label).toBe('genie');
+    expect(tree[0].wsAgentState).toBe('running');
+    expect(tree[0].data.sessionName).toBe('genie-bernardo');
+    expect(tree[0].data.attachWindowIndex).toBe(1);
+    expect(getSessionTarget(tree[0])).toEqual({ sessionName: 'genie-bernardo', windowIndex: 1 });
+  });
+
   test('permission executor state reflected on agentState', () => {
     const sofiaSession = makeSession('sofia');
     const executor = makeExecutor({

--- a/src/tui/session-tree.ts
+++ b/src/tui/session-tree.ts
@@ -85,10 +85,11 @@ export function buildWorkspaceTree(input: WorkspaceTreeInput): TreeNode[] {
   const { topLevel, subsByParent } = groupAgentNames(agentNames);
 
   const nodes = topLevel.map((name) => {
+    const agentExecutors = executorsByAgent.get(name) ?? [];
     const node = buildAgentNode(
       name,
-      sessionByName.get(toSessionName(name)),
-      executorsByAgent.get(name) ?? [],
+      resolveAgentSession(name, sessionByName, agentExecutors),
+      agentExecutors,
       executorByPaneId,
       workStates.get(name),
       'canonical',
@@ -98,7 +99,7 @@ export function buildWorkspaceTree(input: WorkspaceTreeInput): TreeNode[] {
   });
 
   // Add orphan sessions (tmux sessions with no matching agent in filesystem)
-  const claimedSessions = new Set(agentNames.map(toSessionName));
+  const claimedSessions = collectClaimedAgentSessions(nodes, sessionByName);
   for (const [name, session] of sessionByName) {
     if (!claimedSessions.has(name)) {
       nodes.push(sessionToNode(session, executorByPaneId));
@@ -156,10 +157,11 @@ function appendSubAgentNodes(
   if (!subs) return;
   for (const subName of subs) {
     const subLabel = subName.slice(subName.indexOf('/') + 1);
+    const agentExecutors = executorsByAgent.get(subName) ?? [];
     const subNode = buildAgentNode(
       subName,
-      sessionByName.get(toSessionName(subName)),
-      executorsByAgent.get(subName) ?? [],
+      resolveAgentSession(subName, sessionByName, agentExecutors),
+      agentExecutors,
       executorByPaneId,
       workStates.get(subName),
       'subagent',
@@ -168,6 +170,34 @@ function appendSubAgentNodes(
     subNode.depth = 1;
     parent.children.push(subNode);
   }
+}
+
+function resolveAgentSession(
+  name: string,
+  sessionByName: Map<string, TmuxSession>,
+  agentExecutors: TuiExecutor[],
+): TmuxSession | undefined {
+  for (const exec of agentExecutors) {
+    if (!exec.tmuxSession) continue;
+    const session = sessionByName.get(exec.tmuxSession);
+    if (session) return session;
+  }
+  return sessionByName.get(toSessionName(name));
+}
+
+function collectClaimedAgentSessions(nodes: TreeNode[], sessionByName: Map<string, TmuxSession>): Set<string> {
+  const claimed = new Set<string>();
+  const visit = (node: TreeNode) => {
+    if (node.type === 'agent') {
+      const sessionName = node.data.sessionName;
+      if (typeof sessionName === 'string' && sessionByName.has(sessionName)) {
+        claimed.add(sessionName);
+      }
+    }
+    for (const child of node.children) visit(child);
+  };
+  for (const node of nodes) visit(node);
+  return claimed;
 }
 
 function countClaudePanes(session: TmuxSession): number {
@@ -201,7 +231,7 @@ function buildAgentNode(
     expanded: children.length > 0,
     children,
     data: {
-      sessionName: toSessionName(name),
+      sessionName: session?.name ?? toSessionName(name),
       windowCount: session ? session.windows.length : 0,
       attachWindowIndex,
       provider: agentExecutors[0]?.provider ?? null,

--- a/src/tui/session-tree.ts
+++ b/src/tui/session-tree.ts
@@ -45,6 +45,8 @@ interface WorkspaceTreeInput {
   sessions: TmuxSession[];
   /** Executors from PG */
   executors: TuiExecutor[];
+  /** Explicit team scope for resolving same-name executors across teams. */
+  teamScope?: string;
   /**
    * Per-agent work state derived from `shouldResume()` (invincible-genie /
    * Group 2). Optional — empty map means workState badges are hidden, the
@@ -56,6 +58,7 @@ interface WorkspaceTreeInput {
 /** Build workspace-aware tree: all agents from filesystem, enriched with tmux + executor state. */
 export function buildWorkspaceTree(input: WorkspaceTreeInput): TreeNode[] {
   const { agentNames, sessions, executors } = input;
+  const teamScope = input.teamScope;
   const workStates = input.workStates ?? new Map<string, WorkState>();
 
   // Index tmux sessions by name
@@ -88,13 +91,21 @@ export function buildWorkspaceTree(input: WorkspaceTreeInput): TreeNode[] {
     const agentExecutors = executorsByAgent.get(name) ?? [];
     const node = buildAgentNode(
       name,
-      resolveAgentSession(name, sessionByName, agentExecutors),
+      resolveAgentSession(name, sessionByName, agentExecutors, teamScope),
       agentExecutors,
       executorByPaneId,
       workStates.get(name),
       'canonical',
     );
-    appendSubAgentNodes(node, subsByParent.get(name), sessionByName, executorsByAgent, executorByPaneId, workStates);
+    appendSubAgentNodes(
+      node,
+      subsByParent.get(name),
+      sessionByName,
+      executorsByAgent,
+      executorByPaneId,
+      workStates,
+      teamScope,
+    );
     return node;
   });
 
@@ -153,6 +164,7 @@ function appendSubAgentNodes(
   executorsByAgent: Map<string, TuiExecutor[]>,
   executorByPaneId: Map<string, TuiExecutor>,
   workStates: Map<string, WorkState>,
+  teamScope: string | undefined,
 ): void {
   if (!subs) return;
   for (const subName of subs) {
@@ -160,7 +172,7 @@ function appendSubAgentNodes(
     const agentExecutors = executorsByAgent.get(subName) ?? [];
     const subNode = buildAgentNode(
       subName,
-      resolveAgentSession(subName, sessionByName, agentExecutors),
+      resolveAgentSession(subName, sessionByName, agentExecutors, teamScope),
       agentExecutors,
       executorByPaneId,
       workStates.get(subName),
@@ -176,13 +188,45 @@ function resolveAgentSession(
   name: string,
   sessionByName: Map<string, TmuxSession>,
   agentExecutors: TuiExecutor[],
+  teamScope?: string,
 ): TmuxSession | undefined {
+  const executorSessions = collectExecutorSessions(agentExecutors, sessionByName);
+  const scoped = teamScope
+    ? uniqueSessions(
+        executorSessions.filter((candidate) => candidate.exec.team === teamScope).map((candidate) => candidate.session),
+      )
+    : [];
+  if (scoped.length === 1) return scoped[0];
+
+  const unscoped = uniqueSessions(executorSessions.map((candidate) => candidate.session));
+  if (unscoped.length === 1) return unscoped[0];
+
+  return sessionByName.get(toSessionName(name));
+}
+
+function collectExecutorSessions(
+  agentExecutors: TuiExecutor[],
+  sessionByName: Map<string, TmuxSession>,
+): Array<{ exec: TuiExecutor; session: TmuxSession }> {
+  const candidates: Array<{ exec: TuiExecutor; session: TmuxSession }> = [];
   for (const exec of agentExecutors) {
     if (!exec.tmuxSession) continue;
     const session = sessionByName.get(exec.tmuxSession);
-    if (session) return session;
+    if (!session) continue;
+    if (exec.tmuxPaneId && !sessionHasPane(session, exec.tmuxPaneId)) continue;
+    candidates.push({ exec, session });
   }
-  return sessionByName.get(toSessionName(name));
+  return candidates;
+}
+
+function sessionHasPane(session: TmuxSession, paneId: string): boolean {
+  return session.windows.some((window) => window.panes.some((pane) => pane.paneId === paneId));
+}
+
+function uniqueSessions(sessions: TmuxSession[]): TmuxSession[] {
+  const byName = new Map<string, TmuxSession>();
+  for (const session of sessions) byName.set(session.name, session);
+  return [...byName.values()];
 }
 
 function collectClaimedAgentSessions(nodes: TreeNode[], sessionByName: Map<string, TmuxSession>): Set<string> {


### PR DESCRIPTION
## Summary

Fixes canonical agent startup/resume behavior after the UUID identity and executor split, plus the extra bugs traced by `genie-bernardo/trace`.

- resume canonical agents from the current executor session instead of falling through to fresh spawn
- make the TUI workspace tree attach agents running inside team tmux sessions, e.g. `genie-bernardo/genie`
- restore spawn auto-sync for post-migration `agent.yaml` agents and one-level scoped sub-agents
- store `teams.members` as canonical UUID/`dir:` IDs instead of bare names so migration 061 constraints hold
- keep `team-lead` alias routing explicit (`team-lead@<team>` or `--team`) instead of silently resolving to the sender team
- stop swallowing real `hireAgent` failures during worker registration; only native-only missing teams are ignored

## Root Cause

The CLI resume path filtered durable agent rows using runtime fields that may now live on the current executor. When those fields were missing on the identity row, `findDeadResumable` missed the existing Claude session and fresh-spawned with a new session id.

Separately, the TUI assumed a workspace agent named `genie` lived in a tmux session named `genie`. Canonical team agents actually run in the team session, such as `genie-bernardo`, so Enter could classify the visible canonical node as stopped and spawn again.

The trace agent also found two post-migration regressions: team hiring still wrote bare role names into `teams.members`, violating `teams_members_uuid_check`, and `genie send --to team-lead` could use ambient `GENIE_TEAM` scope and route to the sender's leader instead of the intended target.

## Validation

- `bun test src/term-commands/agents.test.ts src/term-commands/agents.spawn-autosync.test.ts src/tui/session-tree.test.ts src/tui/components/Nav.test.tsx src/term-commands/msg.test.ts src/lib/team-manager.test.ts --grep "findDeadResumable: UUID identity anchors|spawn auto-sync|buildWorkspaceTree|handleEnterAgent|resolveLeaderAlias|team members after UUID identity migration"`
- `bun test src/term-commands/msg.test.ts src/lib/team-manager.test.ts --grep "resolveLeaderAlias|team members after UUID identity migration"`
- `bunx biome check src/lib/team-manager.ts src/lib/team-manager.test.ts src/term-commands/msg.ts src/term-commands/msg.test.ts src/term-commands/team.ts src/term-commands/agents.ts src/lib/protocol-router-spawn.ts src/lib/team-auto-spawn.ts src/genie-commands/session.ts src/term-commands/state.ts src/term-commands/dispatch.ts src/lib/agent-registry.ts`
- `bun run typecheck`
- `bun run build`
- `git diff --check`
- pre-push hook: `typecheck`, `lint`, `dead-code`, `skills:lint`, `wishes:lint`, `lint:emit`

Note: repo-wide Biome currently reports pre-existing warnings in unrelated files plus a broken symlink warning; the hook completed successfully.
