### PR TITLE
fix(tui): restore cross-pane focus on mouse click

### DIFF
--- a/scripts/tmux/tui-tmux.conf
+++ b/scripts/tmux/tui-tmux.conf
@@ -32,11 +32,12 @@ bind -T root MouseDrag1Pane if-shell -F "#{mouse_any_flag}" "send-keys -M" "copy
 bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "~/.genie/scripts/osc52-copy.sh"
 
 # Forward single-button clicks to the app when it has mouse mode enabled.
-# OpenTUI sets DECSET 1000/1006, which flips tmux's mouse_any_flag. Without
-# this binding, tmux's default MouseDown1Pane only selects the pane and the
-# left nav never receives clicks. The fallback keeps pane selection working
-# when mouse mode is disabled or the click lands on the right terminal pane.
-bind -T root MouseDown1Pane if-shell -F "#{mouse_any_flag}" "send-keys -M" "select-pane -t = ; send-keys -M"
+# OpenTUI sets DECSET 1000/1006, which flips tmux's mouse_any_flag. We always
+# select the clicked pane first so cross-pane clicks change focus (e.g. click
+# the right terminal pane while the Nav is active to take focus away from
+# OpenTUI), then evaluate mouse_any_flag against the now-active clicked pane
+# to decide whether to forward the event to its app.
+bind -T root MouseDown1Pane select-pane -t = \; if-shell -F "#{mouse_any_flag}" "send-keys -M" ""
 bind -T root MouseUp1Pane   if-shell -F "#{mouse_any_flag}" "send-keys -M" ""
 bind -T root MouseDown2Pane if-shell -F "#{mouse_any_flag}" "send-keys -M" ""
 bind -T root MouseUp2Pane   if-shell -F "#{mouse_any_flag}" "send-keys -M" ""


### PR DESCRIPTION
## Summary

Click on the right terminal pane stopped focusing it after #1561 (OpenTUI 0.2 tmux fixes). Focus stayed on the Nav and keystrokes kept routing to OpenTUI until the user hit `Tab`.

`MouseDown1Pane` was evaluating `#{mouse_any_flag}` against the **previously active** pane. While Nav (OpenTUI) was focused, that flag was always true (DECSET 1000/1006 set), so every click — including ones landing on the right pane — took the true branch (`send-keys -M`) and forwarded the mouse event without changing pane focus.

Fix: `select-pane -t =` first, then evaluate `mouse_any_flag` against the now-active clicked pane and forward conditionally. Click on Nav → Nav still receives the click; click on right pane → focus follows the click and the agent app receives the event.

```diff
-bind -T root MouseDown1Pane if-shell -F "#{mouse_any_flag}" "send-keys -M" "select-pane -t =; send-keys -M"
+bind -T root MouseDown1Pane select-pane -t = \; if-shell -F "#{mouse_any_flag}" "send-keys -M" ""
```

`MouseDrag1Pane` does not need the same change — drag inherits the pane that the preceding `MouseDown1Pane` selected.

## Test plan

- [x] `bun test src/__tests__/tmux-config.test.ts` (16/16 pass — existing regression coverage on `MouseDown1Pane.*send-keys -M` still satisfied)
- [x] Live-rebound on `tmux -L genie-tui` and verified clicking the right pane while Nav is active now moves focus
- [ ] Reviewer: confirm no regression on Nav clicks (selecting agents in the tree) under both `mouse on` and `GENIE_TMUX_MOUSE=off`