### PR TITLE
fix(tui): apply cross-pane focus fix to middle-click

### DIFF
--- a/scripts/tmux/tui-tmux.conf
+++ b/scripts/tmux/tui-tmux.conf
@@ -32,14 +32,17 @@ bind -T root MouseDrag1Pane if-shell -F "#{mouse_any_flag}" "send-keys -M" "copy
 bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "~/.genie/scripts/osc52-copy.sh"
 
 # Forward single-button clicks to the app when it has mouse mode enabled.
-# OpenTUI sets DECSET 1000/1006, which flips tmux's mouse_any_flag. We always
-# select the clicked pane first so cross-pane clicks change focus (e.g. click
-# the right terminal pane while the Nav is active to take focus away from
-# OpenTUI), then evaluate mouse_any_flag against the now-active clicked pane
-# to decide whether to forward the event to its app.
+# OpenTUI sets DECSET 1000/1006, which flips tmux's mouse_any_flag. On Down
+# events we select the clicked pane first so cross-pane clicks change focus
+# (e.g. click the right terminal pane while the Nav is active to take focus
+# away from OpenTUI), then evaluate mouse_any_flag against the now-active
+# clicked pane to decide whether to forward the event to its app. Up events
+# inherit the pane that the preceding Down event selected, so they don't
+# need the same prefix. Wheel events intentionally do not steal focus —
+# scrolling a background pane should not pull keyboard focus to it.
 bind -T root MouseDown1Pane select-pane -t = \; if-shell -F "#{mouse_any_flag}" "send-keys -M" ""
 bind -T root MouseUp1Pane   if-shell -F "#{mouse_any_flag}" "send-keys -M" ""
-bind -T root MouseDown2Pane if-shell -F "#{mouse_any_flag}" "send-keys -M" ""
+bind -T root MouseDown2Pane select-pane -t = \; if-shell -F "#{mouse_any_flag}" "send-keys -M" ""
 bind -T root MouseUp2Pane   if-shell -F "#{mouse_any_flag}" "send-keys -M" ""
 bind -T root WheelUpPane    if-shell -F "#{mouse_any_flag}" "send-keys -M" "copy-mode -e ; send-keys -M"
 bind -T root WheelDownPane  if-shell -F "#{mouse_any_flag}" "send-keys -M" "send-keys -M"


### PR DESCRIPTION
## Summary

Follow-up to #1716. Gemini's review on that PR flagged that `MouseDown2Pane` has the same `mouse_any_flag` evaluation bug that #1716 fixed for `MouseDown1Pane` — and it does. Middle-clicking on a non-focused pane evaluates `mouse_any_flag` against the previously-active pane, so the click forwards to the wrong app (or doesn't forward when expected).

Fix: apply the same `select-pane -t = \;` prefix.

```diff
-bind -T root MouseDown2Pane if-shell -F "#{mouse_any_flag}" "send-keys -M" ""
+bind -T root MouseDown2Pane select-pane -t = \; if-shell -F "#{mouse_any_flag}" "send-keys -M" ""
```

## Why not the other bindings Gemini suggested?

- **`MouseUp1Pane` / `MouseUp2Pane`** — already correct. The preceding Down event selects the pane, so the Up event's `mouse_any_flag` evaluates against the now-active clicked pane (same reasoning as `MouseDrag1Pane` in #1716).
- **`WheelUpPane` / `WheelDownPane`** — intentionally left alone. Adding `select-pane -t = \;` to wheel bindings would make scrolling a background pane steal keyboard focus, which is a UX regression, not a bug fix. Most users expect to scroll a background pane without losing focus on the active one.

The comment block above the bindings is expanded to record both decisions so future readers don't re-derive them.

## Test plan

- [x] `bun test src/__tests__/tmux-config.test.ts` — existing assertions on `MouseDown1Pane.*send-keys -M`, `MouseUp1Pane`, and `WheelDownPane` still match (none assert on `MouseDown2Pane`)
- [ ] Reviewer: live-rebound on `tmux -L genie-tui` and verify middle-clicking the right pane while Nav is active now selects the right pane and forwards the paste event to the right pane's app
- [ ] Reviewer: confirm scroll-on-background-pane still does not steal focus