### PR TITLE
fix(ci): pin pgserve@2.3.0 (upstream 2.4.0 removed daemon subcommand)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
       # canonical install path operators use in production
       # (`bun add -g pgserve@^2.1.0`).
       - name: Install pgserve globally (test harness needs the binary)
-        run: bun add -g pgserve@^2.1.0
+        run: bun add -g pgserve@2.3.0
 
       # Serial bun test inside this shard, with the file list pre-filtered to
       # this shard's portion. The retry-once wrapper that the previous
@@ -243,7 +243,7 @@ jobs:
       # the smoke test so it lives at ~/.bun/bin/pgserve, matching the canonical
       # install path operators use in production (`bun add -g pgserve@^2.1.0`).
       - name: Install pgserve globally (canonical install path)
-        run: bun add -g pgserve@^2.1.0
+        run: bun add -g pgserve@2.3.0
 
       - name: Build
         run: bun run build

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -1266,7 +1266,6 @@ describe('no default stderr emit on connect', () => {
   beforeEach(() => {
     stderrLines = [];
     origWrite = process.stderr.write.bind(process.stderr);
-    // biome-ignore lint/suspicious/noExplicitAny: stderr.write signature is overloaded
     (process.stderr as any).write = (chunk: unknown) => {
       if (typeof chunk === 'string') stderrLines.push(chunk);
       else if (chunk instanceof Uint8Array) stderrLines.push(Buffer.from(chunk).toString('utf8'));
@@ -1276,7 +1275,6 @@ describe('no default stderr emit on connect', () => {
   });
 
   afterEach(() => {
-    // biome-ignore lint/suspicious/noExplicitAny: restoring spied write
     (process.stderr as any).write = origWrite;
     if (savedDebug === undefined) {
       // biome-ignore lint/performance/noDelete: process.env requires real unset

--- a/src/lib/provider-adapters.test.ts
+++ b/src/lib/provider-adapters.test.ts
@@ -814,10 +814,7 @@ describe('buildCodexCommand', () => {
   // "error: unexpected argument '---...'". See
   // .genie/wishes/spawn-compounding-defects/evidence/codex-spawn-trace.md.
   it('inserts -- before merged-prompt positional (clap end-of-options sentinel)', () => {
-    const systemPromptFile = writeCodexSourcePromptFile(
-      'AGENTS.md',
-      '---\nname: engineer\n---\nbody',
-    );
+    const systemPromptFile = writeCodexSourcePromptFile('AGENTS.md', '---\nname: engineer\n---\nbody');
     const result = buildCodexCommand({
       provider: 'codex',
       team: 'work',

--- a/src/term-commands/serve.test.ts
+++ b/src/term-commands/serve.test.ts
@@ -797,8 +797,16 @@ describe('startTuiTmuxServer', () => {
     const repairFailureStderr = "can't find window";
     let listPanesCallCount = 0;
     let splitWindowCallCount = 0;
+    // 1st split-window is the repair-branch attempt → throw to trigger
+    // the recovery path. 2nd split-window comes from freshCreate after
+    // kill-session, and must succeed.
+    const handleSplitWindow = () => {
+      splitWindowCallCount += 1;
+      return splitWindowCallCount === 1
+        ? { error: { stderr: repairFailureStderr, message: 'Command failed' } }
+        : { value: '' };
+    };
     const { handler, calls } = recordHandler((cmd) => {
-      if (cmd.includes('has-session')) return { value: '' };
       if (cmd.includes('list-panes')) {
         listPanesCallCount += 1;
         // 1st call: 1-pane state triggers repair branch.
@@ -806,18 +814,7 @@ describe('startTuiTmuxServer', () => {
         return { value: listPanesCallCount === 1 ? '%0' : '%0\n%1' };
       }
       if (cmd.includes('display-message')) return { value: '120' };
-      if (cmd.includes('split-window')) {
-        splitWindowCallCount += 1;
-        // 1st split-window is the repair-branch attempt → throw to trigger
-        // the recovery path. 2nd split-window comes from freshCreate after
-        // kill-session, and must succeed.
-        if (splitWindowCallCount === 1) {
-          return { error: { stderr: repairFailureStderr, message: 'Command failed' } };
-        }
-        return { value: '' };
-      }
-      if (cmd.includes('kill-session')) return { value: '' };
-      if (cmd.includes('new-session')) return { value: '' };
+      if (cmd.includes('split-window')) return handleSplitWindow();
       return { value: '' };
     });
     setExecSyncHandler(handler);


### PR DESCRIPTION
## Problem (P0 — CI red)

Caret-range install (`bun add -g pgserve@^2.1.0`) pulled `pgserve@2.4.0+`, which removed the `daemon` subcommand and changed the no-subcommand default from "start postmaster" to "print usage and exit 0". CI smoke + pg-tests-aggregate have been red since **2026-05-08T17:14 UTC**.

This is a SemVer violation by pgserve upstream — major-incompatible CLI redesign shipped in a minor bump.

## Fix (Primary)

Exact pin to `pgserve@2.3.0` — last known green CI version (verified on run [25562043249](https://github.com/automagik-dev/genie/actions/runs/25562043249)).

- `.github/workflows/ci.yml:174` — Quality Gate matrix install
- `.github/workflows/ci.yml:246` — pgserve-v2-smoke install

Exact pin (not `~`) chosen because upstream just demonstrated they ship breaking changes in minor bumps; trust is reset until SemVer story is fixed upstream.

## Bundled (Secondary)

Pre-existing lint regressions on `dev` were blocking the pre-push gate on every PR touching CI files. Bundled here so this hotfix can land cleanly:

- `src/term-commands/serve.test.ts` — extract `handleSplitWindow` helper + drop two redundant if-branches; cogcomplex 26 → under 25.
- `src/lib/db.test.ts` — remove two unused `biome-ignore` comments (Biome: "Suppression comment has no effect").
- `src/lib/provider-adapters.test.ts` — Biome formatter collapse of a 4-line call to one line.

No behavior change. All 169 affected tests pass.

## Validation

- ✅ `bun run lint` — clean (0 errors; 1 warning is the pre-existing `test-fixtures/symlink-cycle` Biome internal-error, tracked separately).
- ✅ `bun test src/term-commands/serve.test.ts src/lib/db.test.ts src/lib/provider-adapters.test.ts` — 169/169 pass.
- 🟡 CI on this PR is the real validation — if green, ship.

## Trace report

Full root-cause analysis with version timeline, reproduction steps, and confidence ratings:
`.genie/wishes/fix-ci-pgserve-version-pin/evidence/trace-report.md`

## Follow-up (out of scope)

Separate wish to evaluate either:
- (a) migrate genie's CLI invocations to `pgserve postmaster`/`pgserve serve` for v2.4+ uptake, OR
- (b) wait for upstream to re-publish a `daemon` shim.

Not in scope here — this is purely the unstick.