### PR TITLE
fix(release): bump slsa-verifier to v2.7.1 (handles dssev001 tlog entries)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,7 +250,7 @@ jobs:
           cosign-release: 'v2.2.4'
 
       - name: Install slsa-verifier
-        uses: slsa-framework/slsa-verifier/actions/installer@v2.6.0
+        uses: slsa-framework/slsa-verifier/actions/installer@v2.7.1
 
       - name: Download release assets
         env:


### PR DESCRIPTION
## Problem

Release pipeline red on `main` since 2026-05-09T17:17 UTC. The `Verify Signed Release` job fails verbatim:

```
Verifying artifact automagik-genie-4.260508.4.tgz: FAILED: matching bundle entry with content: unexpected tlog entry type: expected intoto:0.0.2, got dsse:0.0.1
```

Sigstore/Rekor flipped the canonical tlog entry encoding for newly-issued provenance bundles between the last green release (run [25527351970](https://github.com/automagik-dev/genie/actions/runs/25527351970), 2026-05-07T23:18 UTC) and the failing release (run [25606982253](https://github.com/automagik-dev/genie/actions/runs/25606982253), 2026-05-09T17:17 UTC). `slsa-verifier@v2.6.0` only understands `intoto:0.0.2` and hard-fails on `dsse:0.0.1`. **The producer side (`slsa-github-generator@v2.1.0`) is fine.** This is a server-side ecosystem change, not a workflow regression on our side — both runs used identical pinned versions; only Rekor's output shape moved.

`@next` dist-tag publish for **4.260508.4** is gated on this verify step and never happened.

## Fix

Single-line bump at `.github/workflows/release.yml:253`:

```diff
-uses: slsa-framework/slsa-verifier/actions/installer@v2.6.0
+uses: slsa-framework/slsa-verifier/actions/installer@v2.7.1
```

`v2.7.0` shipped [`feat: handle dssev001 tlog entry types` (PR #799)](https://github.com/slsa-framework/slsa-verifier/pull/799). `v2.7.1` (2025-06-27) is latest stable. The change is **additive** — v2.7.1 still validates `intoto:0.0.2` entries and still rejects mutated artifacts, so the tamper-detection self-test (release.yml:295-336) keeps its contract.

## Upstream evidence

[**aquaproj/aqua#3744**](https://github.com/aquaproj/aqua/issues/3744) reports the *identical* error string with the same verifier version and confirms `v2.7.0` resolves it:

> slsa-verifier: v2.6.0 [FAILED]
> slsa-verifier v2.7.0 [PASSED]

[slsa-verifier v2.7.0 release notes](https://github.com/slsa-framework/slsa-verifier/releases/tag/v2.7.0) document the fix explicitly.

## Validation

- PR CI exercises the standard pre-merge gates on a `.yml`-only diff (no source code touched).
- Real validation = the next release run after merge will exercise the verify step against a fresh Rekor `dsse:0.0.1` bundle.
- Reproducer (off-CI) included in the trace report — `slsa-verifier@v2.6.0` fails deterministically against any provenance bundle minted after the encoding flip; `v2.7.1` accepts it.

## Risk

**LOW.** Forwards-compatible upgrade across two minor versions; no breaking changes between v2.6.0 and v2.7.1 (verifier v2 stays SemVer-stable). Producer pin (`slsa-github-generator@v2.1.0`, line 224) is **not** modified — it's already on the latest stable tag. Tamper-detection negative-path test still rejects mutated tarballs.

## Trace report

Full evidence, confidence ratings, and reproducer:
[`.genie/wishes/fix-release-slsa-tlog-mismatch/evidence/trace-report.md`](.genie/wishes/fix-release-slsa-tlog-mismatch/evidence/trace-report.md) (in the parent wish branch — not part of this hotfix diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)