### PR TITLE
fix(tui): evaluate mouse_any_flag against the pane under the cursor

### DIFF
--- a/scripts/tmux/tui-tmux.conf
+++ b/scripts/tmux/tui-tmux.conf
@@ -31,21 +31,26 @@ bind -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "~/.genie/scripts/o
 bind -T root MouseDrag1Pane if-shell -F "#{mouse_any_flag}" "send-keys -M" "copy-mode -M"
 bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "~/.genie/scripts/osc52-copy.sh"
 
-# Forward single-button clicks to the app when it has mouse mode enabled.
-# OpenTUI sets DECSET 1000/1006, which flips tmux's mouse_any_flag. On Down
-# events we select the clicked pane first so cross-pane clicks change focus
-# (e.g. click the right terminal pane while the Nav is active to take focus
-# away from OpenTUI), then evaluate mouse_any_flag against the now-active
-# clicked pane to decide whether to forward the event to its app. Up events
-# inherit the pane that the preceding Down event selected, so they don't
-# need the same prefix. Wheel events intentionally do not steal focus —
-# scrolling a background pane should not pull keyboard focus to it.
-bind -T root MouseDown1Pane select-pane -t = \; if-shell -F "#{mouse_any_flag}" "send-keys -M" ""
-bind -T root MouseUp1Pane   if-shell -F "#{mouse_any_flag}" "send-keys -M" ""
-bind -T root MouseDown2Pane select-pane -t = \; if-shell -F "#{mouse_any_flag}" "send-keys -M" ""
-bind -T root MouseUp2Pane   if-shell -F "#{mouse_any_flag}" "send-keys -M" ""
-bind -T root WheelUpPane    if-shell -F "#{mouse_any_flag}" "send-keys -M" "copy-mode -e ; send-keys -M"
-bind -T root WheelDownPane  if-shell -F "#{mouse_any_flag}" "send-keys -M" "send-keys -M"
+# Forward mouse events to the app when the pane under the cursor has mouse
+# mode enabled. OpenTUI sets DECSET 1000/1006, which flips mouse_any_flag —
+# but the flag is per-pane, and bare `if-shell -F "#{mouse_any_flag}"`
+# evaluates against the *active* pane, not the one under the mouse. With
+# two panes (OpenTUI Nav + agent terminal) that have different mouse-mode
+# state, every cross-pane mouse event would branch wrong.
+#
+# Fix: pass `-t =` ({mouse} target) so the flag is evaluated against the
+# pane the event landed on. For Down events we additionally `select-pane
+# -t =` first so clicking a background pane focuses it (Up/Drag inherit
+# the new active pane). Wheel events intentionally do not steal focus —
+# scrolling a background pane should not pull keyboard focus — and the
+# false-branch `copy-mode -e` also takes `-t =` so scrollback opens on
+# the pane the wheel was on, not the active one.
+bind -T root MouseDown1Pane select-pane -t = \; if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" ""
+bind -T root MouseUp1Pane   if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" ""
+bind -T root MouseDown2Pane select-pane -t = \; if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" ""
+bind -T root MouseUp2Pane   if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" ""
+bind -T root WheelUpPane    if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "copy-mode -e -t = ; send-keys -M"
+bind -T root WheelDownPane  if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "send-keys -M"
 
 # NO status bars, NO pane-border shell probes — TUI renders its own UI
 set -g status off


### PR DESCRIPTION
## Summary

Third in the trilogy after #1716 (left-click cross-pane focus) and #1717 (middle-click parity). Gemini's review on #1717 flagged that the same evaluation bug remains on `MouseUp*Pane` and `Wheel*Pane`, and on closer inspection the point is correct.

The prior fixes used `select-pane -t = \;` to make the clicked pane active *before* `if-shell -F "#{mouse_any_flag}"` reads the flag. That works for Down events (focus-on-click is desired). It does not work for Up and Wheel events: those still evaluate the flag against the active pane, not the pane under the cursor.

### Concrete wheel bug

1. Active pane: OpenTUI Nav, `mouse_any_flag = true` (DECSET 1000/1006).
2. User scrolls on the right pane — plain shell, `mouse_any_flag = false`.
3. `if-shell -F "#{mouse_any_flag}"` reads Nav's flag (true) → fires the true branch (`send-keys -M`).
4. `send-keys -M` mouse-routes to the right pane, which doesn't expect mouse — the shell receives raw SGR escape bytes instead of tmux scrollback.

Expected behavior: take the false branch, enter `copy-mode -e` on the pane under the wheel.

### Fix

Pass `-t =` (the `{mouse}` target — "pane where the most recent mouse event occurred") to `if-shell -F`. The format expands against the pane the event landed on, no focus change required.

Wheel false-branch `copy-mode -e` also takes `-t =`, otherwise it would default to the active pane and scrollback would open on the wrong pane (worse than the original bug).

```diff
-bind -T root MouseDown1Pane select-pane -t = \; if-shell -F "#{mouse_any_flag}" "send-keys -M" ""
-bind -T root MouseUp1Pane   if-shell -F "#{mouse_any_flag}" "send-keys -M" ""
-bind -T root MouseDown2Pane select-pane -t = \; if-shell -F "#{mouse_any_flag}" "send-keys -M" ""
-bind -T root MouseUp2Pane   if-shell -F "#{mouse_any_flag}" "send-keys -M" ""
-bind -T root WheelUpPane    if-shell -F "#{mouse_any_flag}" "send-keys -M" "copy-mode -e; send-keys -M"
-bind -T root WheelDownPane  if-shell -F "#{mouse_any_flag}" "send-keys -M" "send-keys -M"
+bind -T root MouseDown1Pane select-pane -t = \; if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" ""
+bind -T root MouseUp1Pane   if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" ""
+bind -T root MouseDown2Pane select-pane -t = \; if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" ""
+bind -T root MouseUp2Pane   if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" ""
+bind -T root WheelUpPane    if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "copy-mode -e -t =; send-keys -M"
+bind -T root WheelDownPane  if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "send-keys -M"
```

`MouseDrag1Pane` is left as-is — it inherits the pane the preceding `MouseDown1Pane` selected.

Down events keep their `select-pane -t = \;` prefix; focus-on-click is intentional behavior on those, not a side effect of the flag evaluation. Wheel events deliberately do **not** call `select-pane` — scrolling a background pane should not pull keyboard focus.

## Test plan

- [x] `bun test src/__tests__/tmux-config.test.ts` — existing assertions on `MouseDown1Pane.*send-keys -M`, `MouseUp1Pane\s+if-shell.*send-keys -M`, and `WheelDownPane\s+if-shell.*send-keys -M` all still match
- [ ] Reviewer: live-rebound on `tmux -L genie-tui` and verify
  - [ ] Scroll wheel on background shell with Nav focused → enters tmux copy-mode on the right pane (not garbage SGR bytes, not Nav copy-mode)
  - [ ] Scroll wheel on background shell does **not** steal focus from Nav
  - [ ] Click on right pane while Nav focused still focuses the right pane (regression check on #1716)
  - [ ] Drag-select on either pane still copies to clipboard (regression check on existing `MouseDrag1Pane` flow)