### PR TITLE
fix(release): bind OIDC to refs/tags/v* (cosign trust-loop fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,23 @@
 name: Release
 
 # Creates a GitHub Release object (tag + changelog + signed artifacts) on
-# every push to main. npm publishing is handled separately by version.yml;
-# this workflow owns the signed-tarball path + SLSA Level 3 provenance
-# attestation. See .genie/wishes/genie-supply-chain-signing/WISH.md.
+# every version tag push. version.yml owns the bump-version + git-tag +
+# atomic-push step (refs/heads/<branch> + refs/tags/v<version> in one
+# `git push --atomic`); release.yml fires when the v* tag lands on origin.
+# npm publishing is handled separately by version.yml; this workflow owns
+# the signed-tarball path + SLSA Level 3 provenance attestation. See
+# .genie/wishes/genie-supply-chain-signing/WISH.md.
+#
+# Trigger contract — refs/tags/v* ONLY:
+#   cosign sign-blob runs in-workflow; the GitHub Actions OIDC token issued
+#   to the run binds to the workflow's RUN context (file path @ ref). With
+#   `push.branches`, that ref is `refs/heads/main`, which doesn't match a
+#   `release.yml@refs/tags/v.*$` consumer-side trust regex (e.g. pgserve's
+#   TRUSTED_IDENTITIES at src/cosign/trust-list.js:40). Triggering on
+#   `push.tags: ['v*']` (or workflow_dispatch invoked AGAINST a tag ref)
+#   binds the cert SAN URI to `refs/tags/v<version>` — that's what
+#   downstream verifiers pin against. See SIGNED-APP-PRE-FLIGHT-GENIE.md
+#   (T24 audit) for the empirical reproduction of the pre-fix mismatch.
 #
 # Signing is cosign keyless (OIDC via GitHub Actions) — KEYLESS ONLY.
 # There is no long-lived fallback key: no private key in repo secrets, no
@@ -20,7 +34,7 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    tags: ['v*']
   workflow_dispatch:
 
 permissions:
@@ -155,9 +169,13 @@ jobs:
           TARBALL="${{ steps.pack.outputs.tarball }}"
           # Certificate identity is pinned to THIS workflow file + repo; Fulcio
           # encodes the OIDC identity (workflow path@ref) into the SAN URI.
-          # The regexp tolerates branch/tag ref variance across release triggers
-          # (push-to-main vs workflow_dispatch) without allowing unrelated
-          # workflows to match.
+          # Under the tag-trigger contract documented at the top of this file,
+          # the ref will be `refs/tags/v<version>` for push-tag runs (matched
+          # by downstream `release.yml@refs/tags/v.*$` trust regexes) or
+          # `refs/heads/<ref>` for workflow_dispatch (which an operator must
+          # invoke against a tag ref to keep the trust-loop closed). The
+          # regexp anchors on the workflow path to tolerate either ref shape
+          # without allowing unrelated workflows to match.
           cosign verify-blob \
             --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/release.yml@" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \


### PR DESCRIPTION
## Summary

Closes the trust-loop gap surfaced by the cross-repo `SIGNED-APP-PRE-FLIGHT-GENIE.md` audit (T24) + `ENGINEER-AUDIT-GENIE-SIGNING.md` (T22). Genie's signed releases currently bind cosign certs to `refs/heads/main`; downstream verifiers (e.g. pgserve) pin `refs/tags/v.*$`. **One-line trigger flip** + comment-block sync to align them.

## Root cause (one paragraph)

`cosign sign-blob` runs in-workflow. The GitHub Actions OIDC token issued to the run binds to the workflow's RUN context — the workflow file path AT the triggering ref. With `on: push: branches: [main]`, the cert SAN URI ends up as `…release.yml@refs/heads/main`, even though `version.yml` already creates a `v*` tag in the same atomic push (`git push --atomic refs/heads/main refs/tags/v<version>`). Downstream consumers that pin `release.yml@refs/tags/v.*$` therefore fail to verify even though the signature is valid.

## Repro proof (T24, against `v4.260508.3`)

```text
$ cosign verify-blob \
    --certificate-identity-regexp '^https://github.com/automagik-dev/genie/.github/workflows/release.yml@refs/tags/v.*$' \
    --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
    --certificate ...tgz.cert \
    --signature  ...tgz.sig \
    automagik-genie-4.260508.3.tgz
Error: none of the expected identities matched what was in the certificate, got subjects
[https://github.com/automagik-dev/genie/.github/workflows/release.yml@refs/heads/main]
with issuer https://token.actions.githubusercontent.com
```

Using the actual cert subject (`refs/heads/main`) verifies OK — proving the signing infrastructure is sound; only the binding ref-shape is wrong.

## Fix

```diff
 on:
   push:
-    branches: [main]
+    tags: ['v*']
   workflow_dispatch:
```

Plus two comment-block updates to document the new trigger contract:
1. Top-of-file docstring gains a "Trigger contract — refs/tags/v* ONLY" section explaining the OIDC binding rationale.
2. `Self-verify cosign signature` step's existing branch/tag ref-variance comment is rewritten to reflect the post-fix expectations (push-tag → `refs/tags/v<version>`; workflow_dispatch → operators must invoke against a tag ref).

No logic changes. The existing `Resolve version` step (reads `package.json` at the tagged commit), `Find previous release tag`, `Generate changelog`, `gh release create / upload` paths all work unchanged because the tagged commit IS the version-bumped commit (version.yml already wrote it before pushing the atomic refs pair).

## Why this works with the existing version flow

Looking at `.github/workflows/version.yml`:
- Line 149 — `git tag "v${VERSION}"`
- Line 155 — `git push origin --atomic refs/heads/${BRANCH} refs/tags/v${VERSION}`

The atomic push includes the tag, so flipping release.yml's trigger to `tags: ['v*']` fires the workflow on the SAME push event that previously fired it via `branches: [main]`. The only change is which ref GitHub Actions uses for the OIDC token's RUN context. Net behavior on the happy path: identical timing, identical artifacts, **correct** identity binding.

Edge case: a hand-rolled push to main without a tag (no version bump) used to spawn release.yml + run the hotfix-derive logic in `Resolve version`. Under the new trigger, no tag → no release fires. This is the desired behavior — only intentional version-tag pushes create releases.

## Why I kept workflow_dispatch

`workflow_dispatch` is the manual escape hatch for emergency re-runs. Operators must invoke it AGAINST a tag ref (the GitHub Actions UI lets you pick branch or tag) to keep the trust-loop closed. Documented in the new comment block.

## Verification

- YAML structure: confirmed via `grep` — `on: push: tags: ['v*']` is the sole `push` filter; `workflow_dispatch:` retained.
- Diff: 1 file / +25 / -7 — pure trigger swap + comment sync, no logic edits.
- `actionlint` not installed locally; expect CI to run any actionlint job.

## Expected outcome on next genie release after this lands

- OIDC cert SAN URI: `https://github.com/automagik-dev/genie/.github/workflows/release.yml@refs/tags/v<version>` ✅
- `cosign verify-blob` with the pgserve `^…release.yml@refs/tags/v.*$` regex returns **Verified OK** ✅
- `pgserve verify <genie-binary>` exits 0 (was: exits 2) ✅
- Recipe S3 from `SIGNED-APP-PRE-FLIGHT-GENIE.md` flips from FAIL → PASS ✅

## Cross-references

- pgserve `TRUSTED_IDENTITIES`: [`src/cosign/trust-list.js:40`](https://github.com/namastexlabs/pgserve/blob/main/src/cosign/trust-list.js#L40) — the consumer-side regex this fix targets
- Audit docs (qa-shareable, in pgserve agent workspace):
  - `SIGNED-APP-PRE-FLIGHT-GENIE.md` (T24, empirical reproduction)
  - `ENGINEER-AUDIT-GENIE-SIGNING.md` (T22, structural)
  - `SIGNED-APP-PRE-FLIGHT-PGSERVE.md` (T25, parallel pgserve gap, still pending Wave A)
  - `SIGNED-APP-PRE-FLIGHT-OMNI.md` (T26, parallel omni gap, still pending Wave C)
- Origin of the trust regex shape: pgserve PR #96 (org-correction hot-fix)

## Test plan

- [ ] CI matrix passes (workflow YAML lint / actionlint / etc.)
- [ ] After merge: cut a new genie release (any version-bump path); inspect the new release's `*.tgz.cert` to confirm subject = `…release.yml@refs/tags/v<version>`
- [ ] Cross-repo verification: `pgserve verify <genie-tarball>` returns exit 0 against the new release
- [ ] qa re-runs T24's S1–S4 recipe; expects S3 flip from FAIL → PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to trigger on version tags instead of main branch pushes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/automagik-dev/genie/pull/1725)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->