### PR TITLE
fix(spawn+hooks): merge main + 4 spawn-compounding review fixes from PR #1735

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,23 @@
 name: Release
 
 # Creates a GitHub Release object (tag + changelog + signed artifacts) on
-# every push to main. npm publishing is handled separately by version.yml;
-# this workflow owns the signed-tarball path + SLSA Level 3 provenance
-# attestation. See .genie/wishes/genie-supply-chain-signing/WISH.md.
+# every version tag push. version.yml owns the bump-version + git-tag +
+# atomic-push step (refs/heads/<branch> + refs/tags/v<version> in one
+# `git push --atomic`); release.yml fires when the v* tag lands on origin.
+# npm publishing is handled separately by version.yml; this workflow owns
+# the signed-tarball path + SLSA Level 3 provenance attestation. See
+# .genie/wishes/genie-supply-chain-signing/WISH.md.
+#
+# Trigger contract — refs/tags/v* ONLY:
+#   cosign sign-blob runs in-workflow; the GitHub Actions OIDC token issued
+#   to the run binds to the workflow's RUN context (file path @ ref). With
+#   `push.branches`, that ref is `refs/heads/main`, which doesn't match a
+#   `release.yml@refs/tags/v.*$` consumer-side trust regex (e.g. pgserve's
+#   TRUSTED_IDENTITIES at src/cosign/trust-list.js:40). Triggering on
+#   `push.tags: ['v*']` (or workflow_dispatch invoked AGAINST a tag ref)
+#   binds the cert SAN URI to `refs/tags/v<version>` — that's what
+#   downstream verifiers pin against. See SIGNED-APP-PRE-FLIGHT-GENIE.md
+#   (T24 audit) for the empirical reproduction of the pre-fix mismatch.
 #
 # Signing is cosign keyless (OIDC via GitHub Actions) — KEYLESS ONLY.
 # There is no long-lived fallback key: no private key in repo secrets, no
@@ -20,7 +34,7 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    tags: ['v*']
   workflow_dispatch:
 
 permissions:
@@ -155,9 +169,13 @@ jobs:
           TARBALL="${{ steps.pack.outputs.tarball }}"
           # Certificate identity is pinned to THIS workflow file + repo; Fulcio
           # encodes the OIDC identity (workflow path@ref) into the SAN URI.
-          # The regexp tolerates branch/tag ref variance across release triggers
-          # (push-to-main vs workflow_dispatch) without allowing unrelated
-          # workflows to match.
+          # Under the tag-trigger contract documented at the top of this file,
+          # the ref will be `refs/tags/v<version>` for push-tag runs (matched
+          # by downstream `release.yml@refs/tags/v.*$` trust regexes) or
+          # `refs/heads/<ref>` for workflow_dispatch (which an operator must
+          # invoke against a tag ref to keep the trust-loop closed). The
+          # regexp anchors on the workflow path to tolerate either ref shape
+          # without allowing unrelated workflows to match.
           cosign verify-blob \
             --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/release.yml@" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,7 +250,7 @@ jobs:
           cosign-release: 'v2.2.4'
 
       - name: Install slsa-verifier
-        uses: slsa-framework/slsa-verifier/actions/installer@v2.6.0
+        uses: slsa-framework/slsa-verifier/actions/installer@v2.7.1
 
       - name: Download release assets
         env:

--- a/scripts/dedup-team-settings.test.ts
+++ b/scripts/dedup-team-settings.test.ts
@@ -160,6 +160,64 @@ describe('dedupHooks', () => {
     expect(dedupHooks(undefined).changed).toBe(false);
     expect(dedupHooks({}).changed).toBe(false);
   });
+
+  test('CR #1735.13: canonicalForEvent replaces survivor with synthesized canonical', () => {
+    const canonicalForEvent = (event: string) => {
+      if (event === 'PreToolUse') {
+        return { matcher: '*', hook: { type: 'command', command: "'/canonical/path/genie-hook'", timeout: 15 } };
+      }
+      if (event === 'PostToolUse') {
+        return {
+          matcher: 'SendMessage',
+          hook: { type: 'command', command: "'/canonical/path/genie-hook'", timeout: 15 },
+        };
+      }
+      return null;
+    };
+    const input = {
+      // Stale: drifted command path AND wrong timeout for PreToolUse.
+      PreToolUse: [{ matcher: '*', hooks: [genieHook('genie hook dispatch', 30)] }],
+      // Stale: wrong matcher (`*` instead of `SendMessage`) for PostToolUse.
+      PostToolUse: [{ matcher: '*', hooks: [genieHook('/old/path/genie-hook', 15)] }],
+    };
+    const out = dedupHooks(input, canonicalForEvent);
+    expect(out.changed).toBe(true);
+
+    // PreToolUse — survivor REPLACED with canonical (timeout fixed).
+    expect(out.hooks.PreToolUse).toHaveLength(1);
+    expect(out.hooks.PreToolUse?.[0]?.matcher).toBe('*');
+    expect(out.hooks.PreToolUse?.[0]?.hooks?.[0]?.command).toBe("'/canonical/path/genie-hook'");
+    expect(out.hooks.PreToolUse?.[0]?.hooks?.[0]?.timeout).toBe(15);
+
+    // PostToolUse — matcher upgraded from '*' to 'SendMessage' (canonical).
+    expect(out.hooks.PostToolUse).toHaveLength(1);
+    expect(out.hooks.PostToolUse?.[0]?.matcher).toBe('SendMessage');
+    expect(out.hooks.PostToolUse?.[0]?.hooks?.[0]?.command).toBe("'/canonical/path/genie-hook'");
+  });
+
+  test('CR #1735.13: canonicalForEvent returning null falls back to first-survivor', () => {
+    // When the canonical resolver returns null for an event we keep first-
+    // survivor behavior so we never lose data on unknown events.
+    const canonicalForEvent = () => null;
+    const input = {
+      PreToolUse: [{ matcher: '*', hooks: [genieHook('legacy-cmd', 15)] }],
+    };
+    const out = dedupHooks(input, canonicalForEvent);
+    expect(out.hooks.PreToolUse?.[0]?.hooks?.[0]?.command).toBe('legacy-cmd');
+  });
+
+  test('CR #1735.13: omitted canonicalForEvent preserves prior first-survivor behavior', () => {
+    // Back-compat — the existing test fixture worked without a canonical
+    // provider. New code must not change that behavior when omitted.
+    const input = {
+      PreToolUse: [
+        { matcher: '*', hooks: [genieHook("'/home/genie/.genie/bin/genie-hook'")] },
+        { matcher: '*', hooks: [genieHook('genie hook dispatch')] },
+      ],
+    };
+    const out = dedupHooks(input);
+    expect(out.hooks.PreToolUse?.[0]?.hooks?.[0]?.command).toBe("'/home/genie/.genie/bin/genie-hook'");
+  });
 });
 
 // ============================================================================

--- a/scripts/dedup-team-settings.ts
+++ b/scripts/dedup-team-settings.ts
@@ -148,6 +148,16 @@ export interface DedupOutcome {
 }
 
 /**
+ * Optional canonical-entry provider — given an event name, returns the
+ * canonical `{matcher, hook}` shape for that event. When supplied (CLI
+ * default), the migration writes the canonical shape rather than preserving
+ * the first drifted survivor. Tests can pass a stub; omitting it falls back
+ * to first-survivor behavior (used by the unit suite to keep assertions
+ * about specific commands deterministic). Addresses CR PR #1735.13.
+ */
+export type CanonicalForEvent = (event: string) => { matcher: string; hook: HookEntry } | null;
+
+/**
  * Dedup a single `hooks` config in-memory. Pure: input is not mutated.
  *
  * Within each event:
@@ -156,12 +166,16 @@ export interface DedupOutcome {
  *     in their original order.
  *   - All genie-shape hooks (across every matcher entry of this event) are
  *     collected, deduped by `{matcher, command, timeout}` triplet, then
- *     drift-collapsed to the FIRST surviving triplet — yielding at most one
- *     genie matcher entry per event.
- *   - The single surviving genie matcher entry is appended after any
- *     preserved non-genie matcher entries.
+ *     drift-collapsed to a single survivor.
+ *   - When a `canonicalForEvent` provider is passed, the survivor is REPLACED
+ *     with the canonical shape for that event (matcher + hook from the host's
+ *     `buildHooksConfig()`). When omitted, the first triplet survives verbatim
+ *     — back-compat for tests + safety net when the canonical builder is
+ *     unavailable.
+ *   - The single genie matcher entry is appended after any preserved non-
+ *     genie matcher entries.
  */
-export function dedupHooks(input: HooksConfig | undefined): DedupOutcome {
+export function dedupHooks(input: HooksConfig | undefined, canonicalForEvent?: CanonicalForEvent): DedupOutcome {
   const out: HooksConfig = {};
   const perEvent: Record<string, { before: number; after: number }> = {};
   let entriesRemoved = 0;
@@ -219,16 +233,23 @@ export function dedupHooks(input: HooksConfig | undefined): DedupOutcome {
     }
 
     // Drift collapse: if multiple distinct triplets remain (different command
-    // paths or different matchers), keep ONLY the first survivor. The next
-    // `genie spawn` will normalize this entry to the host's canonical form
-    // via Group 2's hardened `upsertGenieEntry`.
+    // paths or different matchers), keep ONLY the first survivor — then
+    // OPTIONALLY replace it with the canonical shape for this event. Without
+    // the canonical replacement, teams that are never re-spawned would keep
+    // the legacy triplet on disk indefinitely (CR PR #1735.13). With it, the
+    // migration normalizes shape AND content in a single pass.
     const surviving = tripletDedup.slice(0, 1);
     const afterGenieCount = surviving.length;
 
     const finalMatchers: HookMatcher[] = [...preserved];
     if (surviving.length === 1) {
-      const s = surviving[0];
-      finalMatchers.push({ matcher: s.matcher, hooks: [s.hook] });
+      const canonical = canonicalForEvent?.(event) ?? null;
+      if (canonical) {
+        finalMatchers.push({ matcher: canonical.matcher, hooks: [canonical.hook] });
+      } else {
+        const s = surviving[0];
+        finalMatchers.push({ matcher: s.matcher, hooks: [s.hook] });
+      }
     }
 
     out[event] = finalMatchers;
@@ -256,7 +277,12 @@ export interface FileResult {
 }
 
 /** Read, dedup, and (when `apply`) write a single settings.json file. */
-export function processSettingsFile(filePath: string, apply: boolean, teamName: string): FileResult {
+export function processSettingsFile(
+  filePath: string,
+  apply: boolean,
+  teamName: string,
+  canonicalForEvent?: CanonicalForEvent,
+): FileResult {
   let raw: string;
   try {
     raw = readFileSync(filePath, 'utf-8');
@@ -275,7 +301,7 @@ export function processSettingsFile(filePath: string, apply: boolean, teamName: 
     return { team: teamName, path: filePath, status: 'no-hooks-key', entriesRemoved: 0, perEvent: {} };
   }
 
-  const outcome = dedupHooks(hooks);
+  const outcome = dedupHooks(hooks, canonicalForEvent);
   if (!outcome.changed) {
     return {
       team: teamName,
@@ -314,6 +340,14 @@ export interface ScanOpts {
   baseDir?: string;
   /** Override the marker base directory (defaults to claudeConfigDir()). */
   markerBaseDir?: string;
+  /**
+   * Canonical-shape provider — when supplied, surviving genie matcher
+   * entries are REPLACED with the canonical shape for their event instead
+   * of preserving the first drifted survivor verbatim. CLI default wires
+   * this to the host's `buildHooksConfig()` so the migration writes the
+   * normalized hook contract on every cleaned file. CR PR #1735.13.
+   */
+  canonicalForEvent?: CanonicalForEvent;
 }
 
 export interface ScanReport {
@@ -413,7 +447,7 @@ export function dedupTeamSettings(opts: ScanOpts = {}): ScanReport {
     if (!existsSync(settings)) continue;
 
     filesScanned++;
-    const result = processSettingsFile(settings, apply, name);
+    const result = processSettingsFile(settings, apply, name, opts.canonicalForEvent);
     results.push(result);
     if (result.status === 'modified') {
       filesModified++;
@@ -482,12 +516,37 @@ async function emitDedupAudit(eventType: string, details: Record<string, unknown
 // CLI entry — `bun scripts/dedup-team-settings.ts [--dry-run|--apply] [--force]`
 // ============================================================================
 
+/**
+ * Build a `CanonicalForEvent` lookup from the host's live `buildHooksConfig()`.
+ * Best-effort: if the inject module can't be loaded (e.g. running outside a
+ * built dist), returns null so `dedupHooks` falls back to first-survivor
+ * behavior. CR PR #1735.13.
+ */
+async function loadCanonicalForEvent(): Promise<CanonicalForEvent | undefined> {
+  try {
+    const { buildHooksConfig } = await import('../src/hooks/inject.js');
+    const config = buildHooksConfig();
+    return (event: string) => {
+      const matchers = config[event];
+      if (!Array.isArray(matchers) || matchers.length === 0) return null;
+      const first = matchers[0];
+      const hook = first?.hooks?.[0];
+      if (!first?.matcher || !hook) return null;
+      return { matcher: first.matcher, hook };
+    };
+  } catch {
+    // Inject module unavailable — fall back to first-survivor behavior.
+    return undefined;
+  }
+}
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const apply = args.includes('--apply');
   const force = args.includes('--force');
 
-  const report = dedupTeamSettings({ apply, force });
+  const canonicalForEvent = await loadCanonicalForEvent();
+  const report = dedupTeamSettings({ apply, force, canonicalForEvent });
 
   if (report.skippedDueToMarker) {
     console.log('  marker present at', markerPath(), '— skipping. Pass --force to re-scan.');

--- a/src/hooks/__tests__/inject.test.ts
+++ b/src/hooks/__tests__/inject.test.ts
@@ -468,4 +468,63 @@ describe('hook injection', () => {
       expect(settings.hooks.SessionStart[0].hooks[0].command).toBe('echo user-hook');
     });
   });
+
+  // CR feedback on PR #1735 (#20): malformed hooks.<event> values must not
+  // crash the inject path. The new defensive guards in upsertGenieEntry only
+  // helped if the prune step survived the malformed shape first.
+  describe('CR #1735: malformed user-authored configs do not crash inject', () => {
+    test('hooks.<event> as object instead of array does not throw', async () => {
+      const teamDir = join(testDir, 'teams', 'test-team');
+      await mkdir(teamDir, { recursive: true });
+      const settingsPath = join(teamDir, 'settings.json');
+      await writeFile(
+        settingsPath,
+        JSON.stringify({
+          hooks: {
+            // Malformed shape — a real settings.json the wild can carry an
+            // object here when a user/script writes the file by hand.
+            PreToolUse: {},
+            // Valid shape alongside, to confirm the inject path still proceeds.
+            PostToolUse: [],
+          },
+        }),
+      );
+      // Must not throw.
+      const result = await injectTeamHooks('test-team');
+      expect(result).toBe(true);
+      // Inject overwrites PreToolUse with the canonical entry.
+      const settings = JSON.parse(await readFile(settingsPath, 'utf-8'));
+      expect(Array.isArray(settings.hooks.PreToolUse)).toBe(true);
+      expect(settings.hooks.PreToolUse.length).toBeGreaterThan(0);
+    });
+
+    test('matcher entry with non-array hooks key does not throw', async () => {
+      const teamDir = join(testDir, 'teams', 'test-team');
+      await mkdir(teamDir, { recursive: true });
+      const settingsPath = join(teamDir, 'settings.json');
+      await writeFile(
+        settingsPath,
+        JSON.stringify({
+          hooks: {
+            PreToolUse: [
+              // Matcher entry with hooks=null — schema we don't recognize.
+              { matcher: '*', hooks: null },
+              // Matcher entry with no hooks key at all.
+              { matcher: 'Bash' },
+            ],
+          },
+        }),
+      );
+      const result = await injectTeamHooks('test-team');
+      expect(result).toBe(true);
+      const settings = JSON.parse(await readFile(settingsPath, 'utf-8'));
+      // Inject completed without throwing; canonical entry appended.
+      const genie = settings.hooks.PreToolUse.find(
+        (e: { matcher?: string; hooks?: Array<{ command?: string }> }) =>
+          e.matcher === '*' &&
+          e.hooks?.some((h) => h.command?.includes('hook dispatch') || /genie-hook/.test(h.command ?? '')),
+      );
+      expect(genie).toBeDefined();
+    });
+  });
 });

--- a/src/hooks/inject.ts
+++ b/src/hooks/inject.ts
@@ -162,12 +162,22 @@ async function readSettings(settingsPath: string): Promise<Record<string, unknow
   }
 }
 
-/** True if no obsolete events (removed from DISPATCHED_EVENT_MATCHERS) still carry a genie entry. */
+/**
+ * True if no obsolete events (removed from DISPATCHED_EVENT_MATCHERS) still
+ * carry a genie entry. Defensive against malformed user-authored configs
+ * (`hooks.<event>` not an array, matcher entries with non-array `hooks`):
+ * non-array shapes count as "no genie entry present" and are safely skipped.
+ */
 function hasNoObsoleteGenieEntries(existingHooks: HooksConfig): boolean {
   return Object.keys(existingHooks).every((event) => {
     if (DISPATCHED_EVENTS.includes(event as never)) return true;
     const entries = existingHooks[event];
-    return !entries?.some((m) => m.hooks?.some((h) => isGenieDispatchCommand(h.command)));
+    if (!Array.isArray(entries)) return true;
+    return !entries.some((m) => {
+      if (!m || typeof m !== 'object') return false;
+      const hooksArr = Array.isArray(m.hooks) ? m.hooks : [];
+      return hooksArr.some((h) => h && isGenieDispatchCommand(h.command));
+    });
   });
 }
 
@@ -179,12 +189,26 @@ function hasNoObsoleteGenieEntries(existingHooks: HooksConfig): boolean {
 function pruneObsoleteGenieEntries(mergedHooks: HooksConfig): void {
   for (const event of Object.keys(mergedHooks)) {
     if (DISPATCHED_EVENTS.includes(event as never)) continue;
-    const cleaned = (mergedHooks[event] ?? [])
-      .map((matcher) => ({
-        ...matcher,
-        hooks: matcher.hooks?.filter((hook) => !isGenieDispatchCommand(hook.command)),
-      }))
-      .filter((matcher) => (matcher.hooks?.length ?? 0) > 0);
+    // Defensive: real-world settings.json can have malformed values like
+    // `hooks: { PreToolUse: {} }` (object instead of array). Coerce to an
+    // empty array so the prune step never throws on user-authored configs.
+    // Mirrors the same Array.isArray guard that `upsertGenieEntry` uses below.
+    // CR feedback on PR #1735.
+    const raw = mergedHooks[event];
+    const list: HookMatcher[] = Array.isArray(raw) ? raw : [];
+    const cleaned = list
+      .map((matcher) => {
+        if (!matcher || typeof matcher !== 'object') return matcher;
+        const hooksArr = Array.isArray(matcher.hooks) ? matcher.hooks : [];
+        return {
+          ...matcher,
+          hooks: hooksArr.filter((hook) => hook && !isGenieDispatchCommand(hook.command)),
+        };
+      })
+      .filter((matcher) => {
+        if (!matcher || typeof matcher !== 'object') return false;
+        return (matcher.hooks?.length ?? 0) > 0;
+      });
     if (cleaned.length === 0) {
       delete mergedHooks[event];
     } else {
@@ -218,7 +242,11 @@ type UpsertResult = 'injected' | 'dedup.skip' | 'dedup.collapse_drift';
  * variant) is collapsed to exactly one canonical entry per event.
  */
 function upsertGenieEntry(mergedHooks: HooksConfig, event: string, genieEntry: HookMatcher): UpsertResult {
-  const existing = mergedHooks[event] ?? [];
+  // Defensive: malformed user-authored settings can have `hooks.<event>` as
+  // an object, string, etc. Coerce to an empty array so the iteration below
+  // never throws on a non-iterable value. CR feedback on PR #1735.
+  const raw = mergedHooks[event];
+  const existing: HookMatcher[] = Array.isArray(raw) ? raw : [];
 
   const canonicalCommand = genieEntry.hooks[0].command;
   const canonicalTimeout = genieEntry.hooks[0].timeout;
@@ -282,10 +310,17 @@ function upsertGenieEntry(mergedHooks: HooksConfig, event: string, genieEntry: H
   return 'dedup.collapse_drift';
 }
 
-/** Roll up per-event upsert results into a single classification for audit. */
+/**
+ * Roll up per-event upsert results into a single classification for audit.
+ *
+ * Drift cleanup outranks fresh injection — when one event injects fresh AND
+ * another event collapses drift in the same call, the audit signal must
+ * surface the drift (dirty host state) rather than the injection (a
+ * back-fillable normal-case event). CR feedback on PR #1735.
+ */
 function classifyInject(perEvent: UpsertResult[], hadObsolete: boolean): UpsertResult {
-  if (perEvent.includes('injected')) return 'injected';
   if (hadObsolete || perEvent.includes('dedup.collapse_drift')) return 'dedup.collapse_drift';
+  if (perEvent.includes('injected')) return 'injected';
   return 'dedup.skip';
 }
 

--- a/src/hooks/inject.ts
+++ b/src/hooks/inject.ts
@@ -127,7 +127,14 @@ function teamSettingsPath(teamName: string): string {
   return join(claudeConfigDir(), 'teams', sanitized, 'settings.json');
 }
 
-function buildHooksConfig(): HooksConfig {
+/**
+ * Canonical hooks-config for the running host — exported so the one-time
+ * cleanup migration (`scripts/dedup-team-settings.ts`) can synthesize
+ * canonical entries instead of preserving stale first-survivor shapes
+ * (CR feedback on PR #1735.13). Keeping the function colocated with the
+ * inject path ensures both paths use the same canonical source of truth.
+ */
+export function buildHooksConfig(): HooksConfig {
   const hooks: HooksConfig = {};
   const dispatchCommand = buildDispatchCommand();
 

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -2534,18 +2534,29 @@ async function resolveSpawnTeam(
   misbound: boolean;
   multiTeamCollision: boolean;
 }> {
+  // The agent's canonical identity (directory/template name) — used for
+  // canonical-self-leader lookup and the misbinding WARN. `--role <custom>`
+  // overrides only affect registration/resume identity; the underlying
+  // agent's canonical team is invariant across role overrides. Using
+  // effectiveRole here would break `genie spawn <agent> --role <custom>` by
+  // probing `~/.claude/teams/<custom>/` instead of `~/.claude/teams/<agent>/`,
+  // silently dropping canonical-team resolution. CR feedback on PR #1735.
+  const spawnedName = agent.entry?.name ?? effectiveRole;
+
   const outcome = await resolveTeamForSpawnWithDeps({
     explicitTeam: options.team ?? null,
     entryTeam: agent.entry?.team ?? null,
-    agentName: effectiveRole,
+    agentName: spawnedName,
   });
   let team: string | null = outcome.team;
   let source: ResolveSource | null = outcome.source;
 
   // Bug 4 fix: surface misbinding loudly on stderr so silent corruption of
-  // master-agent bindings can't burn another session.
+  // master-agent bindings can't burn another session. Identify the agent by
+  // its directory name (`spawnedName`), not the role override — the user's
+  // mental model is "I spawned <agent>".
   if (outcome.misbound && outcome.canonicalTeam && team) {
-    console.error(formatMisbindingWarning(effectiveRole, outcome.canonicalTeam, team));
+    console.error(formatMisbindingWarning(spawnedName, outcome.canonicalTeam, team));
   }
 
   // Tier 5 (last-resort): scan on-disk team configs for one that lists this


### PR DESCRIPTION
Bundles five things into one PR so the dev → main flow goes from 0 mergeable to 1 mergeable in a single review pass:

1. **Merge main into dev** with a commitlint-conformant subject (`chore: merge main into dev — resolve PR #1735 release.yml conflict`). PR #1735 (dev → main) becomes mergeable after this lands.
2. **CR #1735.19 — drift cleanup outranks injection** in `classifyInject` audit ordering. 2-line swap so dirty-host state surfaces in the event stream.
3. **CR #1735.20 — guard malformed `hooks.<event>`** values across `pruneObsoleteGenieEntries`, `hasNoObsoleteGenieEntries`, and `upsertGenieEntry`. User-authored shapes like `{"hooks": {"PreToolUse": {}}}` no longer crash the inject path.
4. **CR #1735.21 — canonical lookup uses agent identity, not `--role` override**. `genie spawn genie --role custom` now correctly probes `~/.claude/teams/genie/config.json` for canonical_self_leader.
5. **CR #1735.13 — synthesize canonical hook entry** in the dedup migration. `buildHooksConfig` is exported; the script's `dedupHooks` takes an optional `canonicalForEvent` provider; CLI wires it to the live host config so teams that never re-spawn still get normalized.

## Conflict resolution detail (`.github/workflows/release.yml`)

Four divergent regions between dev (G6 cutover) and main (security hotfixes shipped post-cutover):

| Region | Resolution |
|---|---|
| Header comment (lines 3-22) | dev's npm-cutover G6 note + main's tag-trigger contract block (both are load-bearing) |
| `on.push` trigger (line 39) | **main** — `tags: ['v*']` is load-bearing for OIDC SAN URI binding (consumer-side trust regex anchors on `refs/tags/v.*`) |
| Cosign verify comment (~line 175) | **main** — matches the trigger above |
| `slsa-verifier` (line 273) | **main** — `@v2.7.1` security fix for dssev001 tlog entries |

## Validation

```
bun test scripts/dedup-team-settings.test.ts        → 28 pass / 0 fail (+3 new CR #1735.13 cases)
bun test src/hooks/__tests__/inject.test.ts         → 20 pass / 0 fail (+2 new CR #1735.20 cases)
bun test src/lib/__tests__/team-resolver.test.ts    → 11 pass / 0 fail (regression)
bun test src/term-commands/__tests__/{agents-resume,spawn-identity-name-guard}.test.ts → 8 pass / 0 fail (regression)
bun run typecheck                                   → clean
bunx biome check src/hooks/inject.ts src/term-commands/agents.ts scripts/dedup-team-settings*  → clean
```

## Commits

```
6f259e7c fix(scripts): synthesize canonical hook entry in dedup migration (CR #1735)
b305edec fix(spawn): canonical lookup uses agent identity, not --role override (CR #1735)
ada1952b fix(hooks): harden inject path against malformed user configs (CR #1735)
2ba65dbc chore: merge main into dev — resolve PR #1735 release.yml conflict
```

## Out of scope

CR comments on the distribution-cutover work (G1-G7) are NOT addressed here — those belong to a separate fix-up PR by whoever owns that wish. Notably real findings:
- **#16** `update.ts:507` — live binary stranded on swap failure
- **#9** `version.yml:79` — main merges no longer auto-publish stable
- **#6** `release-publish.yml:177` — existing releases never promoted out of draft
- **#5/#8** missing `actions: read` for cross-run artifact downloads
- **#1/#2** `update.ts` — channel persisted before manifest validates + 4s timeout too tight for 80MB tarballs

Spawn-compounding `agents.ts:2636` (CR #22 about `teamWasExplicit`) is intentionally NOT touched — the wish explicitly decided that flag stays tier-1 only; the downstream `spawnIntoCurrentWindow` consumer reading the wrong signal is a separate issue.