### PR TITLE
fix(release): close GITHUB_TOKEN tag-push trigger gap (no PAT)

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -75,11 +75,18 @@ jobs:
     # tarballs to a real GitHub Release. We accept:
     #   - our own workflow_dispatch (only triggerable by maintainers)
     #   - workflow_run from upstream `push` events on dev/main/v* tag
+    #   - workflow_run from upstream `workflow_dispatch` events on
+    #     dev/main/v* tag (the version.yml → build-tarballs.yml chain
+    #     uses GITHUB_TOKEN-friendly workflow_dispatch since GITHUB_TOKEN-
+    #     pushed tags can't trigger `push` workflows). Branch check still
+    #     gates the privileged scopes — only protected refs reach this point.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'push' &&
+       (github.event.workflow_run.event == 'push' ||
+        github.event.workflow_run.event == 'workflow_dispatch' ||
+        github.event.workflow_run.event == 'workflow_run') &&
        (github.event.workflow_run.head_branch == 'main' ||
         github.event.workflow_run.head_branch == 'dev' ||
         startsWith(github.event.workflow_run.head_branch, 'v')))

--- a/.github/workflows/sign-attest.yml
+++ b/.github/workflows/sign-attest.yml
@@ -66,11 +66,19 @@ jobs:
     #   - our own workflow_dispatch (only triggerable by maintainers)
     #   - workflow_run from upstream `push` events on dev/main/v* tag (the
     #     trusted release paths); upstream `pull_request` is rejected.
+    #   - workflow_run from upstream `workflow_dispatch` events on
+    #     dev/main/v* tag — version.yml dispatches build-tarballs.yml on
+    #     each new tag because GITHUB_TOKEN-pushed tags can't trigger
+    #     `push` workflows (anti-recursion). The branch/tag check still
+    #     gates the privileged scopes; PR contributors can't dispatch
+    #     against protected refs.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'push' &&
+       (github.event.workflow_run.event == 'push' ||
+        github.event.workflow_run.event == 'workflow_dispatch' ||
+        github.event.workflow_run.event == 'workflow_run') &&
        (github.event.workflow_run.head_branch == 'main' ||
         github.event.workflow_run.head_branch == 'dev' ||
         startsWith(github.event.workflow_run.head_branch, 'v')))
@@ -158,7 +166,9 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'push' &&
+       (github.event.workflow_run.event == 'push' ||
+        github.event.workflow_run.event == 'workflow_dispatch' ||
+        github.event.workflow_run.event == 'workflow_run') &&
        (github.event.workflow_run.head_branch == 'main' ||
         github.event.workflow_run.head_branch == 'dev' ||
         startsWith(github.event.workflow_run.head_branch, 'v')))
@@ -189,7 +199,9 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'push' &&
+       (github.event.workflow_run.event == 'push' ||
+        github.event.workflow_run.event == 'workflow_dispatch' ||
+        github.event.workflow_run.event == 'workflow_run') &&
        (github.event.workflow_run.head_branch == 'main' ||
         github.event.workflow_run.head_branch == 'dev' ||
         startsWith(github.event.workflow_run.head_branch, 'v')))

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -39,7 +39,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: write          # commit + push version bump + tag
+  actions: write           # `gh workflow run` to dispatch Build Tarballs after tag push
 
 concurrency:
   group: version-${{ github.event.workflow_run.head_branch || 'manual' }}
@@ -152,12 +153,47 @@ jobs:
             echo "::notice ::release-race.next-tag-pin-skipped.detected dev advanced past triggering SHA ${SHORT_SHA}; tag push skipped — next merge will republish"
             exit 0
           fi
+          echo "tag_pushed=true" >> "$GITHUB_OUTPUT"
+        id: commit_and_tag
+
+      # GITHUB_TOKEN-pushed tags do NOT trigger workflows on `push.tags`
+      # (documented anti-recursion guard — see GitHub docs:
+      # "Triggering a workflow from a workflow"). Per the same docs, the
+      # exceptions are `workflow_dispatch` and `repository_dispatch` — both
+      # CAN be invoked by GITHUB_TOKEN. Use `gh workflow run` against the
+      # newly-pushed tag ref to start the build → sign → publish chain
+      # without requiring a PAT.
+      #
+      # `--ref refs/tags/v${VERSION}` makes Build Tarballs check out the
+      # tagged commit, which keeps the OIDC SAN URI bound to the tag ref
+      # (`build-tarballs.yml@refs/tags/v<version>`) — preserving the
+      # downstream cosign trust regex semantics in sign-attest.yml +
+      # release-publish.yml.
+      #
+      # Skipped on the main-branch path because `should_bump=false` there
+      # (no new tag is pushed; the pre-existing dev tag's chain already ran).
+      - name: Trigger Build Tarballs for the new tag
+        if: steps.context.outputs.should_bump == 'true' && steps.commit_and_tag.outputs.tag_pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="refs/tags/v${VERSION}"
+          echo "Dispatching Build Tarballs against ${TAG}..."
+          # The dispatch is fire-and-forget — Build Tarballs' workflow_run
+          # chain (Build Tarballs → Sign + Attest → Release Publish) runs
+          # asynchronously after this step exits. A failed dispatch is a
+          # release-pipeline outage; surface loudly.
+          if ! gh workflow run build-tarballs.yml --repo "${GITHUB_REPOSITORY}" --ref "${TAG}"; then
+            echo "::error ::release-trigger.dispatch_failed Build Tarballs dispatch failed for ${TAG} — investigate gh CLI auth or workflow availability before re-running manually"
+            exit 1
+          fi
 
       # npm distribution was discontinued 2026-05-09 (wish
       # genie-distribution-cutover G6). The previous npm-publish, audit,
       # and deprecate steps have been deleted. Tag pushes from this
-      # workflow drive release-publish.yml, which attaches the signed
-      # GitHub Release tarballs operators install via install.sh.
+      # workflow drive build-tarballs.yml via the gh-workflow-run dispatch
+      # above, which then triggers sign-attest.yml + release-publish.yml.
       # The npm OIDC trusted-publisher entry on npmjs.com and any
       # NPM_TOKEN secrets are no longer used by this repo and can be
       # removed from repo + org settings.


### PR DESCRIPTION
Fixes the broken release pipeline that's been silently dropping every release since the cutover. **No PAT, no shared secret** — all credentials flow from per-run GITHUB_TOKEN.

## Symptom

PR #1735 merged to main → version.yml succeeded → `package.json` bumped to `4.260510.3` → tag `v4.260510.3` pushed to origin → **no GitHub Release was created.**

| Check | State |
|---|---|
| Latest GitHub Release | `v4.260509.2` (May 9, 17:29Z) |
| Latest tag | `v4.260510.3` (today, 02:41Z) |
| `build-tarballs.yml` runs since cutover | only PR events |
| `sign-attest.yml` runs ever | **0** |
| `release-publish.yml` runs ever | **0** |

## Root cause — two-part trigger gap

### (1) `GITHUB_TOKEN`-pushed tags don't fire `push.tags` workflows

Documented anti-recursion guard ([GitHub docs](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)). `version.yml` uses the default `GITHUB_TOKEN` to push tags, so `build-tarballs.yml`'s `push: tags: ['v*']` trigger never observes the new tag.

### (2) Pre-existing bug — release-publish guard rejects chained workflow_run

`release-publish.yml` sits **two workflow_run hops** downstream of the originating event:

```
Build Tarballs (push)
  → Sign + Attest (workflow_run)
    → Release Publish (workflow_run)
```

In Release Publish, `github.event.workflow_run.event` reflects the *immediate* upstream (Sign + Attest's triggering event = `'workflow_run'`), **not** the original `'push'`. The current guard requires `event == 'push'`, so the guard rejects the chain even if step (1) were fixed. This is why release-publish.yml has zero runs *ever* since it shipped.

## Fix (no PAT)

GitHub docs explicitly exempt `workflow_dispatch` and `repository_dispatch` from the anti-recursion rule — both **can** be invoked by `GITHUB_TOKEN`. Use that.

### `version.yml`

After `git push --atomic` succeeds for a fresh tag, invoke:

```yaml
gh workflow run build-tarballs.yml --ref refs/tags/v$VERSION
```

`--ref` keeps Build Tarballs' OIDC SAN URI bound to the tag ref so the cosign trust regex in `sign-attest.yml`/`release-publish.yml` stays unchanged. New `actions: write` permission scope for the dispatch call. Skipped on the main-branch path (`should_bump=false` — no new tag is pushed there).

### `sign-attest.yml` + `release-publish.yml`

Extend the SECURITY GUARD's accepted upstream events:

```diff
-  github.event.workflow_run.event == 'push' &&
+  (github.event.workflow_run.event == 'push' ||
+   github.event.workflow_run.event == 'workflow_dispatch' ||
+   github.event.workflow_run.event == 'workflow_run') &&
```

The branch/tag check (`head_branch == main/dev || startsWith 'v'`) remains as the security boundary. PR contributors still can't reach privileged scopes — PR-triggered runs come through as `pull_request`, which is **not** in the accepted-event list.

## Trigger chain (post-fix)

```
PR merge to main → CI (push)
  → Version (workflow_run on CI success)
    [pushes tag v$VERSION via GITHUB_TOKEN]
    [calls gh workflow run build-tarballs.yml --ref refs/tags/v$VERSION]
  → Build Tarballs (workflow_dispatch on tag ref)
    → Sign + Attest (workflow_run on Build Tarballs success, event=workflow_dispatch)
      → Release Publish (workflow_run on Sign + Attest success, event=workflow_run)
        [creates v$VERSION GitHub Release with signed tarballs + cosign + SLSA]
```

## Verification post-merge

```bash
# Watch the chain on the next dev → main merge:
gh run list --repo automagik-dev/genie --limit=10
# Build Tarballs should appear within seconds of Version's success.
# Sign + Attest 4-platform matrix follows.
# Release Publish writes .well-known/latest.json + creates the release.
```

To unblock **the v4.260510.3 release that's currently stuck**, manually fire the chain once after this merges:

```bash
gh workflow run build-tarballs.yml --repo automagik-dev/genie --ref refs/tags/v4.260510.3
```

(After this fix lands, future tags fire automatically.)

## Out of scope

CR comments on `release-publish.yml` from PR #1735 review (#5/#6/#7/#8/#9) are not addressed here — those are separate quality issues:
- #5 missing `actions: read` for cross-run downloads
- #6 `gh release edit` missing on existing-release rerun
- #9 main merges no longer auto-publish stable

This PR fixes the pipeline so it actually fires; CR's improvements ship in a follow-up. One bug at a time.