### PR TITLE
Sync dev → main: release pipeline trigger fix (#1738) + spawn-compounding fixes (#1737)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "4.260510.3",
+      "version": "4.260510.4",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -75,11 +75,18 @@ jobs:
     # tarballs to a real GitHub Release. We accept:
     #   - our own workflow_dispatch (only triggerable by maintainers)
     #   - workflow_run from upstream `push` events on dev/main/v* tag
+    #   - workflow_run from upstream `workflow_dispatch` events on
+    #     dev/main/v* tag (the version.yml → build-tarballs.yml chain
+    #     uses GITHUB_TOKEN-friendly workflow_dispatch since GITHUB_TOKEN-
+    #     pushed tags can't trigger `push` workflows). Branch check still
+    #     gates the privileged scopes — only protected refs reach this point.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'push' &&
+       (github.event.workflow_run.event == 'push' ||
+        github.event.workflow_run.event == 'workflow_dispatch' ||
+        github.event.workflow_run.event == 'workflow_run') &&
        (github.event.workflow_run.head_branch == 'main' ||
         github.event.workflow_run.head_branch == 'dev' ||
         startsWith(github.event.workflow_run.head_branch, 'v')))

--- a/.github/workflows/sign-attest.yml
+++ b/.github/workflows/sign-attest.yml
@@ -66,11 +66,19 @@ jobs:
     #   - our own workflow_dispatch (only triggerable by maintainers)
     #   - workflow_run from upstream `push` events on dev/main/v* tag (the
     #     trusted release paths); upstream `pull_request` is rejected.
+    #   - workflow_run from upstream `workflow_dispatch` events on
+    #     dev/main/v* tag — version.yml dispatches build-tarballs.yml on
+    #     each new tag because GITHUB_TOKEN-pushed tags can't trigger
+    #     `push` workflows (anti-recursion). The branch/tag check still
+    #     gates the privileged scopes; PR contributors can't dispatch
+    #     against protected refs.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'push' &&
+       (github.event.workflow_run.event == 'push' ||
+        github.event.workflow_run.event == 'workflow_dispatch' ||
+        github.event.workflow_run.event == 'workflow_run') &&
        (github.event.workflow_run.head_branch == 'main' ||
         github.event.workflow_run.head_branch == 'dev' ||
         startsWith(github.event.workflow_run.head_branch, 'v')))
@@ -158,7 +166,9 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'push' &&
+       (github.event.workflow_run.event == 'push' ||
+        github.event.workflow_run.event == 'workflow_dispatch' ||
+        github.event.workflow_run.event == 'workflow_run') &&
        (github.event.workflow_run.head_branch == 'main' ||
         github.event.workflow_run.head_branch == 'dev' ||
         startsWith(github.event.workflow_run.head_branch, 'v')))
@@ -189,7 +199,9 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'push' &&
+       (github.event.workflow_run.event == 'push' ||
+        github.event.workflow_run.event == 'workflow_dispatch' ||
+        github.event.workflow_run.event == 'workflow_run') &&
        (github.event.workflow_run.head_branch == 'main' ||
         github.event.workflow_run.head_branch == 'dev' ||
         startsWith(github.event.workflow_run.head_branch, 'v')))

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -39,7 +39,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: write          # commit + push version bump + tag
+  actions: write           # `gh workflow run` to dispatch Build Tarballs after tag push
 
 concurrency:
   group: version-${{ github.event.workflow_run.head_branch || 'manual' }}
@@ -152,12 +153,47 @@ jobs:
             echo "::notice ::release-race.next-tag-pin-skipped.detected dev advanced past triggering SHA ${SHORT_SHA}; tag push skipped — next merge will republish"
             exit 0
           fi
+          echo "tag_pushed=true" >> "$GITHUB_OUTPUT"
+        id: commit_and_tag
+
+      # GITHUB_TOKEN-pushed tags do NOT trigger workflows on `push.tags`
+      # (documented anti-recursion guard — see GitHub docs:
+      # "Triggering a workflow from a workflow"). Per the same docs, the
+      # exceptions are `workflow_dispatch` and `repository_dispatch` — both
+      # CAN be invoked by GITHUB_TOKEN. Use `gh workflow run` against the
+      # newly-pushed tag ref to start the build → sign → publish chain
+      # without requiring a PAT.
+      #
+      # `--ref refs/tags/v${VERSION}` makes Build Tarballs check out the
+      # tagged commit, which keeps the OIDC SAN URI bound to the tag ref
+      # (`build-tarballs.yml@refs/tags/v<version>`) — preserving the
+      # downstream cosign trust regex semantics in sign-attest.yml +
+      # release-publish.yml.
+      #
+      # Skipped on the main-branch path because `should_bump=false` there
+      # (no new tag is pushed; the pre-existing dev tag's chain already ran).
+      - name: Trigger Build Tarballs for the new tag
+        if: steps.context.outputs.should_bump == 'true' && steps.commit_and_tag.outputs.tag_pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="refs/tags/v${VERSION}"
+          echo "Dispatching Build Tarballs against ${TAG}..."
+          # The dispatch is fire-and-forget — Build Tarballs' workflow_run
+          # chain (Build Tarballs → Sign + Attest → Release Publish) runs
+          # asynchronously after this step exits. A failed dispatch is a
+          # release-pipeline outage; surface loudly.
+          if ! gh workflow run build-tarballs.yml --repo "${GITHUB_REPOSITORY}" --ref "${TAG}"; then
+            echo "::error ::release-trigger.dispatch_failed Build Tarballs dispatch failed for ${TAG} — investigate gh CLI auth or workflow availability before re-running manually"
+            exit 1
+          fi
 
       # npm distribution was discontinued 2026-05-09 (wish
       # genie-distribution-cutover G6). The previous npm-publish, audit,
       # and deprecate steps have been deleted. Tag pushes from this
-      # workflow drive release-publish.yml, which attaches the signed
-      # GitHub Release tarballs operators install via install.sh.
+      # workflow drive build-tarballs.yml via the gh-workflow-run dispatch
+      # above, which then triggers sign-attest.yml + release-publish.yml.
       # The npm OIDC trusted-publisher entry on npmjs.com and any
       # NPM_TOKEN secrets are no longer used by this repo and can be
       # removed from repo + org settings.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/genie",
-  "version": "4.260510.3",
+  "version": "4.260510.4",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
   "type": "module",
   "bin": {

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "4.260510.3",
+  "version": "4.260510.4",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "4.260510.3",
+  "version": "4.260510.4",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "type": "module",


### PR DESCRIPTION
Brings dev → main so the release pipeline fix from PR #1738 actually starts running. Workflow_run-triggered workflows execute from the default branch (main), so the new \`gh workflow run build-tarballs.yml\` dispatch step in version.yml has zero effect until it lands here.

## What's in this PR

3 dev-side commits not yet on main:

```
e5226110 chore(version): bump to 4.260510.4 [auto-version]
6d9e812d Merge pull request #1738 from automagik-dev/fix/release-trigger-no-pat
04cd42c9 fix(release): close GITHUB_TOKEN tag-push trigger gap (no PAT)
```

## Why this is needed

Empirical proof from this morning's merge cycle:
- 03:54Z PR #1738 merged into dev → CI on dev → SUCCESS
- 03:55Z Version workflow fired → SUCCESS, bumped to v4.260510.4, pushed tag
- **But Version was running from main's version.yml** (pre-fix), so the new dispatch step didn't exist
- Build Tarballs / Sign + Attest / Release Publish: zero new runs
- GitHub Releases: still stuck at v4.260509.2 (May 9)

Once this PR merges to main, the NEXT Version run (on the next dev → main merge) will use the post-fix workflow file and dispatch Build Tarballs against the new tag, kicking the chain back to life.

## To unblock the currently stuck releases

After this lands, fire one manual dispatch each for the tags that didn't auto-chain:

\`\`\`bash
gh workflow run build-tarballs.yml --repo automagik-dev/genie --ref refs/tags/v4.260510.3
gh workflow run build-tarballs.yml --repo automagik-dev/genie --ref refs/tags/v4.260510.4
\`\`\`

(Future tags fire automatically.)

## What changed in dev

See PR #1738 for full detail. tl;dr: 3 workflow files —
- \`version.yml\`: dispatch Build Tarballs after \`git push --atomic\` succeeds; new \`actions: write\` permission
- \`sign-attest.yml\`: extend security guard's accepted upstream events
- \`release-publish.yml\`: same guard extension (also fixes a pre-existing bug — release-publish has had zero runs since it shipped because its guard rejected chained workflow_run events)

No PAT, no shared secret. All credentials flow from per-run \`GITHUB_TOKEN\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 4.260510.4 of the genie plugin.
  * Enhanced release workflow automation to support expanded trigger scenarios and improved build dispatch coordination.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/automagik-dev/genie/pull/1739)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->