### PR TITLE
fix(release): grant provenance job contents:write for SLSA reusable validation

### DIFF
--- a/.github/workflows/sign-attest.yml
+++ b/.github/workflows/sign-attest.yml
@@ -174,7 +174,19 @@ jobs:
         startsWith(github.event.workflow_run.head_branch, 'v')))
     permissions:
       id-token: write    # OIDC for SLSA provenance signing
-      contents: read     # read repo for builder ref pinning
+      # `contents: write` is required even though we pass `upload-assets: false`
+      # below. The SLSA generator's reusable workflow declares a nested
+      # `upload-assets` job whose `permissions: contents: write` is validated
+      # STATICALLY at workflow init — before `with.upload-assets` is evaluated.
+      # Granting only `contents: read` produces a startup_failure with no logs:
+      #   "Error calling workflow '...generator_generic_slsa3.yml@v2.1.0'.
+      #    The nested job 'upload-assets' is requesting 'contents: write',
+      #    but is only allowed 'contents: read'."
+      # Diagnosis: run 25619410370 (first chain firing post-#1738/#1739).
+      # Note: the upload-assets job still does NOT execute at runtime because
+      # `with: upload-assets: false` is honored — only the static permission
+      # check requires the elevated grant.
+      contents: write
       actions: read      # read upstream workflow run metadata
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:


### PR DESCRIPTION
## Summary

- One-line workflow fix: change `provenance` job's `contents: read` → `contents: write` in `.github/workflows/sign-attest.yml` so the SLSA generator's reusable workflow passes static permission validation at init.
- Closes the second hop in the release pipeline activation. After Felipe's #1738 (GITHUB_TOKEN trigger gap) and #1739 (dev→main sync) landed, Sign + Attest finally fired and immediately surfaced this **previously dormant** validation error — every prior tag push had silently failed earlier in the chain.

## Root cause

The SLSA generator's reusable workflow (`slsa-framework/slsa-github-generator/.../generator_generic_slsa3.yml@v2.1.0`) declares a nested `upload-assets` job with `permissions: contents: write`. GitHub validates reusable-workflow permissions **statically** at workflow init — even when the caller passes `with: upload-assets: false` to disable that job at runtime, the static check still rejects insufficient grants.

The exact error (extracted from the run's HTML page; not surfaced via API per a known startup_failure annotation regression — github/community discussion #26746):

> The workflow is not valid. .github/workflows/sign-attest.yml (Line: 159, Col: 3): Error calling workflow 'slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0'. The nested job 'upload-assets' is requesting 'contents: write', but is only allowed 'contents: read'.

Diagnostic run: [25619410370](https://github.com/automagik-dev/genie/actions/runs/25619410370) — startup_failure, 0 check_runs, 1s duration, logs endpoint 404.

## Fix

Grant `contents: write` at the `provenance` job level only. The workflow-level ceiling stays `contents: read` so other jobs are unaffected. The `upload-assets` job still does NOT execute (we keep `upload-assets: false`) — only the static init check needs the elevated grant.

A 13-line reviewer-grade comment in the diff documents the exact error and references the diagnostic run, so future maintainers don't strip what looks like an unnecessary permission grant.

## Test plan

- [ ] CI green on this PR (no test impact — workflow file change only).
- [ ] After merge to dev → main, validate Sign + Attest no longer hits startup_failure by dispatching:
      `gh workflow run build-tarballs.yml --ref refs/tags/v<version>`
- [ ] Confirm `prepare` job runs (not startup_failure) and SLSA generator's `provenance` job initializes.
- [ ] If the chain completes, the GitHub Release for the dispatched version + `.well-known/latest.json` commit on main are the ultimate validation artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)