### PR TITLE
Sync dev → main: SLSA reusable workflow contents:write fix (#1740)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "4.260510.4",
+      "version": "4.260510.5",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/.github/workflows/sign-attest.yml
+++ b/.github/workflows/sign-attest.yml
@@ -174,7 +174,19 @@ jobs:
         startsWith(github.event.workflow_run.head_branch, 'v')))
     permissions:
       id-token: write    # OIDC for SLSA provenance signing
-      contents: read     # read repo for builder ref pinning
+      # `contents: write` is required even though we pass `upload-assets: false`
+      # below. The SLSA generator's reusable workflow declares a nested
+      # `upload-assets` job whose `permissions: contents: write` is validated
+      # STATICALLY at workflow init — before `with.upload-assets` is evaluated.
+      # Granting only `contents: read` produces a startup_failure with no logs:
+      #   "Error calling workflow '...generator_generic_slsa3.yml@v2.1.0'.
+      #    The nested job 'upload-assets' is requesting 'contents: write',
+      #    but is only allowed 'contents: read'."
+      # Diagnosis: run 25619410370 (first chain firing post-#1738/#1739).
+      # Note: the upload-assets job still does NOT execute at runtime because
+      # `with: upload-assets: false` is honored — only the static permission
+      # check requires the elevated grant.
+      contents: write
       actions: read      # read upstream workflow run metadata
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/genie",
-  "version": "4.260510.4",
+  "version": "4.260510.5",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
   "type": "module",
   "bin": {

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "4.260510.4",
+  "version": "4.260510.5",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "4.260510.4",
+  "version": "4.260510.5",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "type": "module",


### PR DESCRIPTION
## Summary

Sync the SLSA-generator startup_failure fix (PR #1740) to main so the release pipeline chain can complete end-to-end. Without this on main, the next Sign + Attest firing will continue to startup_failure because `workflow_run`-triggered workflows always load their YAML from the default branch (main).

## Commits being synced

\`\`\`
$(git log origin/main..origin/dev --oneline)
\`\`\`

- \`dfb57331 fix(release): grant provenance job contents:write for SLSA reusable validation\` (PR #1740)
- \`e5226110 chore(version): bump to 4.260510.4\` (auto-version after #1738)

## Why this matters

The release pipeline activation involves three sequential blockers:

1. ~~**GITHUB_TOKEN tag-push trigger gap**~~ — fixed in #1738, synced via #1739.
2. **SLSA reusable workflow static permission validation** — fixed in #1740, this PR.
3. *(none known — chain has not been observed past Sign + Attest yet)*

Each blocker has been hidden behind the prior one. We only know about (2) because (1)'s fix landed and let the chain advance one hop. After this sync lands and the next dev push triggers a fresh tag, we'll see whether Sign + Attest → Release Publish completes cleanly or surfaces a new blocker.

## Validation post-merge

The first dev push after this sync will exercise the full chain:
1. CI green on dev push
2. Version workflow bumps to next patch + pushes tag
3. version.yml's "Trigger Build Tarballs" step (#1738) dispatches Build Tarballs against the new tag
4. Build Tarballs succeeds → workflow_run triggers Sign + Attest
5. **Sign + Attest** now passes init (this PR's fix) → cosign + SLSA + GitHub attestations
6. workflow_run triggers Release Publish → GitHub Release + \`.well-known/latest.json\` commit on main

If steps 5-6 complete, the release pipeline is fully operational for the first time post-cutover.

## Test plan

- [ ] No CI test impact — workflow file changes only, behind static-permission validation that runs before any test job.
- [ ] After merge, monitor: \`gh run list --workflow=sign-attest.yml --limit 3\` for the next chain firing.
- [ ] Verify GitHub Release for the next bumped version exists with all 4 platform tarballs + signatures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 4.260510.5 released with updated plugin and package manifests across the project.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/automagik-dev/genie/pull/1741)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->