### PR TITLE
fix(release): orphan-alert age window + disable cron (URGENT — 664 false positives)

### DIFF
--- a/.github/workflows/release-orphan-alert.yml
+++ b/.github/workflows/release-orphan-alert.yml
@@ -1,9 +1,17 @@
 name: Release Orphan Alert
 
 # Scheduled tag-orphan detector. Every 30 minutes, enumerate v* tags
-# and GitHub Release objects. If a v* tag is older than 30 minutes
-# and has no corresponding Release, open a release-incident issue
-# linking to the runbook so on-call sees the gap quickly.
+# pushed in the last 24 hours and check each against the GitHub
+# Releases API. If a v* tag is in the [30min, 24h] age window and
+# has no corresponding Release, open a release-incident issue.
+#
+# The age window is critical: the lower bound (30 min) is the grace
+# period for the orchestrator to ship after a tag push; the upper
+# bound (24h) excludes the 1000+ historical tags that pre-date the
+# signed-release pipeline (v1.0.x era) — without the upper bound,
+# every cron fire would file ~12 false-positive issues per second
+# until the 5-min timeout cancelled it (genie issues #2211–#2410+,
+# 664 open false-positives at the time of this fix).
 #
 # The orphan signal is the load-bearing alarm for the new
 # release.yml workflow_call orchestrator (wish:
@@ -13,8 +21,12 @@ name: Release Orphan Alert
 # surface; this workflow makes it automatic.
 
 on:
-  schedule:
-    - cron: '*/30 * * * *'
+  # Schedule disabled while the false-positive backlog is being
+  # cleaned up. Re-enable after the cron logic is verified against
+  # a fresh sample of tags. Until then, this workflow only fires
+  # via manual workflow_dispatch.
+  # schedule:
+  #   - cron: '*/30 * * * *'
   workflow_dispatch:
 
 permissions:
@@ -42,12 +54,11 @@ jobs:
           set -euo pipefail
 
           NOW_EPOCH=$(date -u +%s)
-          AGE_THRESHOLD_S=$((30 * 60))
+          AGE_MIN_S=$((30 * 60))          # grace period: alert only after 30 min
+          AGE_MAX_S=$((24 * 60 * 60))     # lookback window: ignore tags older than 24h
 
           # Pull v* tags with their commit date (tagger date for
           # annotated tags; committer date for lightweight tags).
-          # Use git ls-remote + show-ref + per-tag rev-parse pattern
-          # to avoid pulling the full repo history.
           git fetch --tags origin
           mapfile -t TAGS < <(git tag --list 'v*' --sort=-creatordate)
 
@@ -68,9 +79,14 @@ jobs:
             TAG_TS=$(git log -1 --format=%ct "$TAG" 2>/dev/null || echo 0)
             if [[ "$TAG_TS" -eq 0 ]]; then continue; fi
             AGE=$((NOW_EPOCH - TAG_TS))
-            if [[ "$AGE" -ge "$AGE_THRESHOLD_S" ]]; then
-              ORPHANS+=("$TAG")
+            # Bounded age window: skip historical tags older than the
+            # lookback (they predate the signed-release pipeline and
+            # are not actionable) AND skip tags too fresh for the
+            # orchestrator to have shipped yet.
+            if [[ "$AGE" -lt "$AGE_MIN_S" || "$AGE" -gt "$AGE_MAX_S" ]]; then
+              continue
             fi
+            ORPHANS+=("$TAG")
           done
 
           if [[ ${#ORPHANS[@]} -eq 0 ]]; then


### PR DESCRIPTION
## Summary

**Urgent hotfix direct to main.** The release-orphan-alert workflow shipped in PR #1743 has been spamming false-positive `release-incident` issues every 30 min. **664 open false-positive issues** at the time of this PR (genie #2211 through #2410+).

## Root cause

Original logic: `if AGE >= 30 min → orphan`. The repo has **1091 v* tags** dating back to v1.0.x — all 1000+ historical tags predate the signed-release pipeline (created 2026-04+) and don't have GitHub Release objects by design. Every cron fire matched all of them, opening ~12 issues per 1.5s before the 5-min job timeout cancelled the run.

## Changes

1. **Bounded age window** — `if AGE not in [30 min, 24 h] → skip`. Lower bound is the orchestrator's grace period (tag pushed but pipeline still running); upper bound excludes the historical backlog (anything older isn't actionable).
2. **Cron temporarily disabled** — commented out `schedule: cron: '*/30 * * * *'` while the 664-issue backlog is mass-closed. `workflow_dispatch` remains available for manual smoke-tests of the new logic before the cron is re-enabled.

## Why direct-to-main (not dev → main)

The next cron fire is in <30 min and would add another ~12 issues. Going through dev first means at least one more spam wave. The pipeline isn't waiting on a tag firing right now (no version bump in flight), so the temporary loss of orphan-alert signal is a clear trade-off.

## Follow-up

1. Mass-close the 664 existing false-positive `release-incident` issues with a comment explaining the spam was caused by this bug.
2. Re-enable the cron schedule (a one-line uncomment) after the backlog is cleared and a manual `workflow_dispatch` smoke-test on the new logic confirms zero orphans flagged from the current tag landscape.
3. Sync this fix back into dev via the next dev → main merge cycle.

## Verification

- Workflow file still parses (no YAML changes other than comment-out + new constants).
- workflow_dispatch entry preserved — manual test still possible.
- Logic change is purely additive: an extra upper-bound clause; the existing lower-bound (`>= 30 min`) is now expressed via `< 30 min → skip` rather than `>= 30 min → orphan`. Semantics identical for the lower edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified orphan release detection: switched from automatic scheduling to manual trigger only
  * Updated detection logic to identify orphans within a 30-minute to 24-hour age window

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/automagik-dev/genie/pull/2411)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->