### PR TITLE
chore(release): bootstrap .well-known/latest.json → v4.260511.2

### DIFF
--- a/.well-known/latest.json
+++ b/.well-known/latest.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": 1,
+  "channel": "stable",
+  "version": "4.260511.2",
+  "released_at": "2026-05-11T05:01:37Z",
+  "tarball_base": "https://github.com/automagik-dev/genie/releases/download/v4.260511.2",
+  "platforms": ["linux-x64-glibc", "linux-x64-musl", "linux-arm64", "darwin-arm64"]
+}


### PR DESCRIPTION
## Why

The publish job's auto-commit step in \`release-publish.yml:240\` silently no-ops because \`git diff --quiet <untracked-file>\` returns 0 (no-diff) for new files not yet in HEAD. Every release publishes successfully but the channel pointer never advances — \`install.sh\` can't bootstrap because \`LATEST_URL\` returns 404.

## What

One-time bootstrap of \`.well-known/latest.json\` matching the content the publish job *would have* produced for v4.260511.2 (current Latest GitHub Release).

\`\`\`json
{
  "schema_version": 1,
  "channel": "stable",
  "version": "4.260511.2",
  "released_at": "2026-05-11T05:01:37Z",
  "tarball_base": "https://github.com/automagik-dev/genie/releases/download/v4.260511.2",
  "platforms": ["linux-x64-glibc", "linux-x64-musl", "linux-arm64", "darwin-arm64"]
}
\`\`\`

Asset URLs resolve (\`curl -I\` → HTTP 302 → release-assets CDN).

## Unsticks

Operators on the legacy npm install can now run:
\`\`\`
curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash
\`\`\`
…to migrate to the GH-Releases canonical layout at \`~/.genie/bin/\`.

## Follow-up

Separate PR will fix \`release-publish.yml:240\` diff check (use \`git status --porcelain\` or \`git ls-files --error-unmatch\` to detect untracked-vs-modified) so future releases self-update the pointer without manual bootstrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)