### PR TITLE
fix(release): detect new latest.json file in publish diff check

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -237,14 +237,21 @@ jobs:
           }
           EOF
 
-          if git diff --quiet .well-known/latest.json; then
-            echo "latest.json unchanged — nothing to commit"
-            exit 0
-          fi
-
+          # Stage first, then compare against HEAD. `git diff --quiet
+          # <path>` returns 0 (no diff) for *untracked* files because they
+          # aren't in the index at all — so the bootstrap case ("file has
+          # never existed on main") fell through and silently no-op'd
+          # every release until PR #2412 bootstrapped manually. Staging
+          # registers the path; `git diff --cached --quiet HEAD --` then
+          # correctly reports "differs from HEAD" for both new and
+          # modified files.
           git config user.name "release-bot"
           git config user.email "release-bot@namastex.com"
           git add .well-known/latest.json
+          if git diff --cached --quiet HEAD -- .well-known/latest.json; then
+            echo "latest.json unchanged — nothing to commit"
+            exit 0
+          fi
           git commit -m "chore(release): update latest.json → v${VERSION}"
           git push origin main || {
             echo "::warning::push to main failed (likely branch protection or permission); update .well-known/latest.json manually"


### PR DESCRIPTION
Publish job's auto-commit step in release-publish.yml:240 silently no-op'd because `git diff --quiet` returns 0 for untracked files (bootstrap case where .well-known/latest.json never existed on main). PR #2412 bootstrapped it manually; this prevents recurrence. Stage-then-diff-against-HEAD reports changes for both new + modified files. Idempotency preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release publishing stability by fixing change detection logic in the deployment workflow. This ensures version updates are correctly committed, preventing potential issues during the initial setup phase.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/automagik-dev/genie/pull/2413)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->