### PR TITLE
fix(g1): respawn from compiled binary uses execPath, not bunfs argv

### DIFF
--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -25,6 +25,7 @@ import { contractClaudePath, getClaudeSettingsPath } from '../lib/claude-setting
 import { isAvailable as isRuntimePgAvailable } from '../lib/db.js';
 import { tmuxBin } from '../lib/ensure-tmux.js';
 import { genieConfigExists, getGenieConfigPath, isSetupComplete, loadGenieConfig } from '../lib/genie-config.js';
+import { respawnInvocation } from '../lib/respawn.js';
 import { checkCommand } from '../lib/system-detect.js';
 import { findWorkspace } from '../lib/workspace.js';
 import {
@@ -1020,9 +1021,8 @@ async function restartDaemon(): Promise<void> {
   console.log('  Restarting daemon...');
   try {
     const { spawn } = await import('node:child_process');
-    const bunPath = process.execPath ?? 'bun';
-    const genieBin = process.argv[1] ?? 'genie';
-    const child = spawn(bunPath, [genieBin, 'daemon', 'start'], {
+    const { command, args } = respawnInvocation(['daemon', 'start']);
+    const child = spawn(command, args, {
       detached: true,
       stdio: 'ignore',
     });

--- a/src/genie-commands/install.ts
+++ b/src/genie-commands/install.ts
@@ -249,8 +249,12 @@ function resolveGenieBinary(): string {
   if (wired) return wired;
   // Fall back to the path of the currently running script. Less ideal
   // because pm2 will point at this exact path forever, but better than
-  // failing the install.
-  return process.argv[1] ?? 'genie';
+  // failing the install. In a Bun-compiled standalone, process.argv[1] is a
+  // virtual bunfs path (`/$bunfs/root/genie`) that is not usable from outside
+  // the binary — fall back to process.execPath (the compiled binary itself).
+  const argv1 = process.argv[1];
+  if (argv1 && !argv1.startsWith('/$bunfs/')) return argv1;
+  return process.execPath || 'genie';
 }
 
 /**

--- a/src/lib/__tests__/respawn.test.ts
+++ b/src/lib/__tests__/respawn.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from 'bun:test';
+import { isCompiledBunStandalone, respawnInvocation, respawnShellCommand } from '../respawn.js';
+
+describe('isCompiledBunStandalone', () => {
+  test('detects bunfs virtual entry path', () => {
+    expect(isCompiledBunStandalone('/$bunfs/root/genie')).toBe(true);
+    expect(isCompiledBunStandalone('/$bunfs/root/sub/dir/entry.js')).toBe(true);
+  });
+
+  test('rejects host filesystem paths', () => {
+    expect(isCompiledBunStandalone('/home/user/.genie/dist/genie.js')).toBe(false);
+    expect(isCompiledBunStandalone('/usr/local/bin/genie')).toBe(false);
+    expect(isCompiledBunStandalone('src/genie.ts')).toBe(false);
+  });
+
+  test('treats undefined / empty as not compiled', () => {
+    expect(isCompiledBunStandalone(undefined)).toBe(false);
+    expect(isCompiledBunStandalone('')).toBe(false);
+  });
+});
+
+describe('respawnInvocation', () => {
+  test('compiled binary: invokes execPath alone (no bunfs argv leak)', () => {
+    const result = respawnInvocation(['serve', '--foreground'], {
+      execPath: '/home/u/.genie/bin/genie',
+      argv1: '/$bunfs/root/genie',
+    });
+    expect(result.command).toBe('/home/u/.genie/bin/genie');
+    expect(result.args).toEqual(['serve', '--foreground']);
+  });
+
+  test('dev mode (bun src/genie.ts): passes entry as first arg', () => {
+    const result = respawnInvocation(['spawn', 'reviewer'], {
+      execPath: '/usr/local/bin/bun',
+      argv1: '/repo/src/genie.ts',
+    });
+    expect(result.command).toBe('/usr/local/bin/bun');
+    expect(result.args).toEqual(['/repo/src/genie.ts', 'spawn', 'reviewer']);
+  });
+
+  test('dist mode (bun dist/genie.js): passes entry as first arg', () => {
+    const result = respawnInvocation(['agent', 'list'], {
+      execPath: '/opt/bun/bin/bun',
+      argv1: '/repo/dist/genie.js',
+    });
+    expect(result.command).toBe('/opt/bun/bin/bun');
+    expect(result.args).toEqual(['/repo/dist/genie.js', 'agent', 'list']);
+  });
+
+  test('falls back to PATH lookup when argv1 missing', () => {
+    const result = respawnInvocation(['serve'], { execPath: '/usr/local/bin/bun', argv1: undefined });
+    expect(result.command).toBe('genie');
+    expect(result.args).toEqual(['serve']);
+  });
+
+  test('no extra args produces a bare invocation', () => {
+    const result = respawnInvocation([], {
+      execPath: '/home/u/.genie/bin/genie',
+      argv1: '/$bunfs/root/genie',
+    });
+    expect(result.command).toBe('/home/u/.genie/bin/genie');
+    expect(result.args).toEqual([]);
+  });
+});
+
+describe('respawnShellCommand', () => {
+  test('compiled binary emits only the binary path — no bunfs literal', () => {
+    const cmd = respawnShellCommand([], {
+      execPath: '/home/u/.genie/bin/genie',
+      argv1: '/$bunfs/root/genie',
+    });
+    expect(cmd).toBe('/home/u/.genie/bin/genie');
+    expect(cmd).not.toContain('bunfs');
+    expect(cmd).not.toContain('$');
+  });
+
+  test('dev mode quotes the entry path safely', () => {
+    const cmd = respawnShellCommand(['serve', '--foreground'], {
+      execPath: '/usr/local/bin/bun',
+      argv1: '/repo/src/genie.ts',
+    });
+    expect(cmd).toBe('/usr/local/bin/bun /repo/src/genie.ts serve --foreground');
+  });
+
+  test('escapes spaces and special chars', () => {
+    const cmd = respawnShellCommand(['hello world'], {
+      execPath: '/path with spaces/bun',
+      argv1: '/repo/dist/genie.js',
+    });
+    expect(cmd).toBe(`'/path with spaces/bun' /repo/dist/genie.js 'hello world'`);
+  });
+
+  test('escapes embedded single quotes', () => {
+    const cmd = respawnShellCommand([`it's`], {
+      execPath: '/bin/bun',
+      argv1: '/$bunfs/root/genie',
+    });
+    expect(cmd).toBe(`/bin/bun 'it'"'"'s'`);
+  });
+});

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -26,6 +26,7 @@ import type postgres from 'postgres';
 import { runMigrations } from './db-migrations.js';
 import { needsSeed, needsSeededTeams, runSeed } from './pg-seed.js';
 import { getProcessStartTime } from './process-identity.js';
+import { respawnInvocation } from './respawn.js';
 import { maybePromptV1Migration } from './v1-migration-prompt.js';
 
 /**
@@ -772,31 +773,21 @@ export async function ensurePgserve(): Promise<number> {
  * Spawn `genie serve start --headless` in the background.
  * Overridable for tests via {@link __setSpawnDaemonForTest}.
  */
-let spawnDaemon: () => void = () => {
-  const bunPath = process.execPath ?? 'bun';
-  const genieBin = process.argv[1] ?? 'genie';
-  const child = spawn(bunPath, [genieBin, 'serve', 'start', '--headless', '--foreground'], {
+function defaultSpawnDaemon(): void {
+  const { command, args } = respawnInvocation(['serve', 'start', '--headless', '--foreground']);
+  const child = spawn(command, args, {
     detached: true,
     stdio: 'ignore',
     env: { ...process.env, GENIE_IS_DAEMON: '1' },
   });
   child.unref();
-};
+}
+
+let spawnDaemon: () => void = defaultSpawnDaemon;
 
 /** Test-only hook: swap the spawn implementation so tests don't launch real serves. */
 export function __setSpawnDaemonForTest(fn: (() => void) | null): void {
-  spawnDaemon =
-    fn ??
-    (() => {
-      const bunPath = process.execPath ?? 'bun';
-      const genieBin = process.argv[1] ?? 'genie';
-      const child = spawn(bunPath, [genieBin, 'serve', 'start', '--headless', '--foreground'], {
-        detached: true,
-        stdio: 'ignore',
-        env: { ...process.env, GENIE_IS_DAEMON: '1' },
-      });
-      child.unref();
-    });
+  spawnDaemon = fn ?? defaultSpawnDaemon;
 }
 
 /**

--- a/src/lib/respawn.ts
+++ b/src/lib/respawn.ts
@@ -1,0 +1,85 @@
+/**
+ * Re-spawn invocation resolver — produces the correct `{ command, args }` to
+ * launch genie from inside an already-running genie process.
+ *
+ * Why this exists: in a Bun-compiled single-file standalone (the distribution
+ * shape since the G1 cutover), `process.argv[1]` is a virtual path inside the
+ * embedded bunfs (e.g. `/$bunfs/root/genie`) that has no host-filesystem
+ * meaning. The legacy pattern of `spawn(process.execPath, [process.argv[1],
+ * ...args])` therefore passes a bogus literal to the new process, and the
+ * shell variant emitted to `tui-launch.sh` is even worse: `$bunfs` expands to
+ * the empty string, so the launch script becomes
+ *   exec /path/to/genie //root/genie
+ * which makes genie treat `//root/genie` as its subcommand and exit silently
+ * — the symptom users on the new installer report as "genie does nothing".
+ *
+ * Detection: a bunfs argv[1] always starts with `/$bunfs/`. When detected,
+ * we re-spawn `process.execPath` alone — the compiled binary is self-hosting,
+ * so no entry path is needed.
+ *
+ * In dev (`bun src/genie.ts`) and the older dist mode (`bun dist/genie.js`),
+ * we keep the previous behavior: `bunPath argv[1] ...args`.
+ */
+
+const BUNFS_PREFIX = '/$bunfs/';
+
+/** True when the current process is a Bun-compiled standalone binary. */
+export function isCompiledBunStandalone(argv1: string | undefined = process.argv[1]): boolean {
+  return typeof argv1 === 'string' && argv1.startsWith(BUNFS_PREFIX);
+}
+
+export interface RespawnDeps {
+  execPath?: string;
+  argv1?: string;
+}
+
+/**
+ * Returns the spawn command + args to re-launch genie with the given
+ * subcommand args. Use with `child_process.spawn` or anywhere structured
+ * argv is expected.
+ *
+ * When `deps` is omitted, values come from `process.execPath` / `process.argv[1]`.
+ * When `deps` is provided, its fields win — including explicit `undefined`,
+ * which lets tests model the missing-argv1 edge case without leaking the
+ * test runner's argv into the result.
+ */
+export function respawnInvocation(
+  extraArgs: readonly string[] = [],
+  deps?: RespawnDeps,
+): { command: string; args: string[] } {
+  const execPath = deps ? (deps.execPath ?? 'bun') : (process.execPath ?? 'bun');
+  const argv1 = deps ? deps.argv1 : process.argv[1];
+
+  if (isCompiledBunStandalone(argv1)) {
+    return { command: execPath, args: [...extraArgs] };
+  }
+
+  if (!argv1 || argv1 === 'genie') {
+    // Last-resort fallback: rely on PATH lookup of the `genie` shim. Matches
+    // the pre-helper behavior in TUI components that defaulted to plain
+    // `'genie'` when argv[1] was missing.
+    return { command: 'genie', args: [...extraArgs] };
+  }
+
+  return { command: execPath, args: [argv1, ...extraArgs] };
+}
+
+/**
+ * Returns a fully shell-escaped one-liner that re-launches genie. Use this
+ * when generating shell scripts (e.g. `~/.genie/tui-launch.sh`) or systemd
+ * unit `ExecStart=` lines, where structured argv is not available.
+ */
+export function respawnShellCommand(extraArgs: readonly string[] = [], deps?: RespawnDeps): string {
+  const { command, args } = respawnInvocation(extraArgs, deps);
+  return [command, ...args].map(shellEscape).join(' ');
+}
+
+/**
+ * POSIX shell-escape: single-quote unless the value is a "safe" identifier.
+ * Embedded single quotes are emitted as `'"'"'` which is the standard
+ * portable trick that does not require shell-specific extensions.
+ */
+function shellEscape(value: string): string {
+  if (value.length > 0 && /^[A-Za-z0-9_\-./:@=+]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}

--- a/src/term-commands/daemon.ts
+++ b/src/term-commands/daemon.ts
@@ -16,6 +16,7 @@ import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from '
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { Command } from 'commander';
+import { respawnInvocation, respawnShellCommand } from '../lib/respawn.js';
 
 // ============================================================================
 // Paths
@@ -116,8 +117,7 @@ function removeServePid(): void {
 
 /** Generate a systemd user service unit file pointing to genie serve --headless. */
 export function generateSystemdUnit(): string {
-  const genieBin = process.argv[1] ?? 'genie';
-  const bunPath = process.execPath ?? 'bun';
+  const execStart = respawnShellCommand(['serve', 'start', '--headless', '--foreground']);
 
   return `[Unit]
 Description=Genie Serve (headless) — pgserve + scheduler + services
@@ -126,7 +126,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=${bunPath} ${genieBin} serve start --headless --foreground
+ExecStart=${execStart}
 Restart=on-failure
 RestartSec=5
 Environment=GENIE_HOME=${genieHome()}
@@ -206,27 +206,17 @@ async function daemonStartCommand(options: StartOptions): Promise<void> {
   console.log('      Use `genie serve --headless` directly in the future.\n');
 
   const { spawn: spawnChild } = await import('node:child_process');
-  const bunPath = process.execPath ?? 'bun';
-  const genieBin = process.argv[1] ?? 'genie';
 
+  const mode = options.foreground ? '--foreground' : '--daemon';
+  const { command, args } = respawnInvocation(['serve', 'start', '--headless', mode]);
+  const child = spawnChild(command, args, {
+    stdio: 'inherit',
+    env: { ...process.env },
+  });
+  child.on('exit', (code) => process.exit(code ?? 0));
   if (options.foreground) {
-    // In foreground mode (systemd), delegate to genie serve --headless --foreground
-    const args = [genieBin, 'serve', 'start', '--headless', '--foreground'];
-    const child = spawnChild(bunPath, args, {
-      stdio: 'inherit',
-      env: { ...process.env },
-    });
-    child.on('exit', (code) => process.exit(code ?? 0));
     // Keep this process alive while child runs
     await new Promise(() => {});
-  } else {
-    // Background mode: spawn genie serve --headless --daemon
-    const args = [genieBin, 'serve', 'start', '--headless', '--daemon'];
-    const child = spawnChild(bunPath, args, {
-      stdio: 'inherit',
-      env: { ...process.env },
-    });
-    child.on('exit', (code) => process.exit(code ?? 0));
   }
 }
 

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -41,6 +41,7 @@ import {
 } from '../lib/brain-vaults.js';
 import { ensureTmux, tmuxBin } from '../lib/ensure-tmux.js';
 import { getProcessStartTime } from '../lib/process-identity.js';
+import { respawnInvocation, respawnShellCommand } from '../lib/respawn.js';
 import { genieTmuxCmd } from '../lib/tmux-wrapper.js';
 import { isTuiDisabled, noticeTuiSkipped } from '../lib/tui-disable.js';
 
@@ -467,8 +468,6 @@ export function startTuiTmuxServer(): { leftPane: string; rightPane: string } {
  */
 function sendTuiLaunchScript(leftPane: string, rightPane: string, workspaceRoot?: string): void {
   const home = genieHome();
-  const bunPath = process.execPath || 'bun';
-  const genieBin = process.argv[1] || 'genie';
   const scriptPath = join(home, 'tui-launch.sh');
   const logsDir = join(home, 'logs');
   const crashLog = join(logsDir, 'tui-crash.log');
@@ -485,7 +484,7 @@ function sendTuiLaunchScript(leftPane: string, rightPane: string, workspaceRoot?
     `exec 2>> '${crashLog}'`,
     `printf -- '--- tui-launch %s pid=%s ---\\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$$" >&2`,
     `export ${envVars.join('\nexport ')}`,
-    `exec ${bunPath} ${genieBin}`,
+    `exec ${respawnShellCommand()}`,
     '',
   ].join('\n');
   writeFileSync(scriptPath, content, { mode: 0o755 });
@@ -539,11 +538,10 @@ export async function autoStartServe(): Promise<void> {
   }
   if (isServeRunning()) return;
 
-  const bunPath = process.execPath ?? 'bun';
-  const genieBin = process.argv[1] ?? 'genie';
+  const { command, args } = respawnInvocation(['serve', '--foreground']);
 
   const { spawn: spawnChild } = await import('node:child_process');
-  const child = spawnChild(bunPath, [genieBin, 'serve', '--foreground'], {
+  const child = spawnChild(command, args, {
     detached: true,
     stdio: 'ignore',
     env: { ...process.env, GENIE_IS_DAEMON: '1' },
@@ -1372,15 +1370,14 @@ async function startBackground(headless?: boolean, autoFix = true): Promise<void
     forceRemoveServePid();
   }
 
-  const bunPath = process.execPath ?? 'bun';
-  const genieBin = process.argv[1] ?? 'genie';
   const startupStatusPath = autoFix ? undefined : serveStartupStatusPath();
 
-  const args = [genieBin, 'serve', '--foreground'];
-  if (headless) args.push('--headless');
-  if (!autoFix) args.push('--no-fix');
+  const extraArgs = ['serve', '--foreground'];
+  if (headless) extraArgs.push('--headless');
+  if (!autoFix) extraArgs.push('--no-fix');
+  const { command, args } = respawnInvocation(extraArgs);
 
-  const child = spawn(bunPath, args, {
+  const child = spawn(command, args, {
     detached: true,
     stdio: 'ignore',
     env: {

--- a/src/tui/components/AgentPicker.tsx
+++ b/src/tui/components/AgentPicker.tsx
@@ -17,6 +17,7 @@
 
 import { useKeyboard } from '@opentui/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { respawnInvocation } from '../../lib/respawn.js';
 import type { SpawnIntent } from '../../lib/spawn-invocation.js';
 import { palette } from '../theme.js';
 import { CliPreviewLine } from './CliPreviewLine.js';
@@ -48,12 +49,7 @@ interface AgentPickerProps {
 /** Default loader — shells out to `genie dir ls --json` and parses stdout. */
 async function defaultLoadAgents(): Promise<AgentPickerEntry[]> {
   const { spawn } = await import('node:child_process');
-  const bunPath = process.execPath || 'bun';
-  const genieBin = process.argv[1];
-  const [command, args] =
-    genieBin && genieBin !== 'genie'
-      ? [bunPath, [genieBin, 'dir', 'ls', '--json']]
-      : ['genie', ['dir', 'ls', '--json']];
+  const { command, args } = respawnInvocation(['dir', 'ls', '--json']);
 
   const stdout = await new Promise<string>((resolve, reject) => {
     const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'ignore'] });

--- a/src/tui/components/Nav.tsx
+++ b/src/tui/components/Nav.tsx
@@ -9,6 +9,7 @@
 
 import { useKeyboard } from '@opentui/react';
 import { type MutableRefObject, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { respawnInvocation } from '../../lib/respawn.js';
 import { type SpawnIntent, buildSpawnInvocation } from '../../lib/spawn-invocation.js';
 import { scanAgents } from '../../lib/workspace.js';
 import { buildMenuItems } from '../context-menu-items.js';
@@ -981,8 +982,6 @@ function spawnAgent(name: string, onTmuxSessionSelect?: (sessionName: string, wi
     const { join, resolve } = require('node:path') as typeof import('node:path');
     const { existsSync, mkdirSync, openSync } = require('node:fs') as typeof import('node:fs');
     const { homedir } = require('node:os') as typeof import('node:os');
-    const bunPath = process.execPath || 'bun';
-    const genieBin = process.argv[1];
     const wsRoot = process.env.GENIE_TUI_WORKSPACE;
     // tmux session names use the agent name (/ replaced with -)
     const sessionName = name.replace(/\//g, '-');
@@ -1028,10 +1027,8 @@ function spawnAgent(name: string, onTmuxSessionSelect?: (sessionName: string, wi
             env: cleanEnv,
           } as const)
         : ({ detached: true, stdio: 'ignore' as const, cwd, env: cleanEnv } as const);
-    const child =
-      genieBin && genieBin !== 'genie'
-        ? spawn(bunPath, [genieBin, 'spawn', name, '--session', sessionName, '--new-window'], spawnOpts)
-        : spawn('genie', ['spawn', name, '--session', sessionName, '--new-window'], spawnOpts);
+    const { command, args } = respawnInvocation(['spawn', name, '--session', sessionName, '--new-window']);
+    const child = spawn(command, args, spawnOpts);
     child.on('exit', (code) => {
       if (code && code !== 0) {
         console.error(`TUI: spawn "${name}" exited ${code}. See ${logPath}`);
@@ -1098,12 +1095,8 @@ function executeTmux(args: string[]): void {
 function executeGenie(args: string[]): void {
   try {
     const { spawn } = require('node:child_process') as typeof import('node:child_process');
-    const bunPath = process.execPath || 'bun';
-    const genieBin = process.argv[1];
-    const child =
-      genieBin && genieBin !== 'genie'
-        ? spawn(bunPath, [genieBin, ...args], { detached: true, stdio: 'ignore' })
-        : spawn('genie', args, { detached: true, stdio: 'ignore' });
+    const { command, args: spawnArgs } = respawnInvocation(args);
+    const child = spawn(command, spawnArgs, { detached: true, stdio: 'ignore' });
     child.unref();
   } catch {
     // best-effort
@@ -1122,12 +1115,8 @@ function executeGenieAwaited(args: string[]): Promise<number | null> {
   return new Promise((resolve, reject) => {
     try {
       const { spawn } = require('node:child_process') as typeof import('node:child_process');
-      const bunPath = process.execPath || 'bun';
-      const genieBin = process.argv[1];
-      const child =
-        genieBin && genieBin !== 'genie'
-          ? spawn(bunPath, [genieBin, ...args], { stdio: 'ignore' })
-          : spawn('genie', args, { stdio: 'ignore' });
+      const { command, args: spawnArgs } = respawnInvocation(args);
+      const child = spawn(command, spawnArgs, { stdio: 'ignore' });
       child.on('exit', (code) => resolve(code));
       child.on('error', reject);
     } catch (err) {

--- a/src/tui/tmux.ts
+++ b/src/tui/tmux.ts
@@ -7,6 +7,7 @@
 
 import { spawnSync } from 'node:child_process';
 import { tmuxBin } from '../lib/ensure-tmux.js';
+import { respawnInvocation } from '../lib/respawn.js';
 
 const SESSION_NAME = 'genie-tui';
 const TMUX_SOCKET = 'genie-tui';
@@ -128,8 +129,6 @@ export function newAgentWindow(agentName: string): void {
     const { spawn } = require('node:child_process') as typeof import('node:child_process');
     const { join, resolve } = require('node:path') as typeof import('node:path');
     const { existsSync } = require('node:fs') as typeof import('node:fs');
-    const bunPath = process.execPath || 'bun';
-    const genieBin = process.argv[1];
     const wsRoot = process.env.GENIE_TUI_WORKSPACE;
 
     let cwd: string | undefined;
@@ -142,11 +141,16 @@ export function newAgentWindow(agentName: string): void {
     const suffix = nextRoleSuffix(agentName);
     const role = `${agentName}-${suffix}`;
     const sessionName = agentName.replace(/\//g, '-');
-    const args = ['spawn', agentName, '--role', role, '--session', sessionName, '--new-window'];
-    const child =
-      genieBin && genieBin !== 'genie'
-        ? spawn(bunPath, [genieBin, ...args], { detached: true, stdio: 'ignore', cwd })
-        : spawn('genie', args, { detached: true, stdio: 'ignore', cwd });
+    const { command, args } = respawnInvocation([
+      'spawn',
+      agentName,
+      '--role',
+      role,
+      '--session',
+      sessionName,
+      '--new-window',
+    ]);
+    const child = spawn(command, args, { detached: true, stdio: 'ignore', cwd });
     child.unref();
   })();
 }


### PR DESCRIPTION
## Symptom

After installing genie from the new `https://get.automagik.dev/genie | bash` flow (G1 compiled-binary distribution), running `genie` brings up the TUI tmux session but the left pane immediately self-destructs — the user sees nothing but a returned shell prompt. Reported live by Felipe:

```
genie@felipe-personal:~/workspace$ /home/genie/.genie/tui-launch│genie@felipe-personal:~/workspace$
.sh                                                             │
```

## Root cause

In a Bun-compiled single-file standalone binary (the shape since G1), `process.argv[1]` is a **virtual bunfs path** — `/$bunfs/root/genie` — that has no meaning on the host filesystem. The legacy re-spawn pattern

```ts
spawn(process.execPath, [process.argv[1], ...args])
```

writes the bunfs literal directly into every child invocation. The TUI launcher in `serve.ts` made the failure visible because it serialized the same shape into a shell script (`~/.genie/tui-launch.sh`):

```sh
exec /home/genie/.genie/bin/genie /$bunfs/root/genie
```

`sh` expands `$bunfs` to the empty string → `exec .../genie //root/genie` → commander gets an unknown subcommand → silent exit → tmux closes the pane → user sees nothing.

## Fix

New `src/lib/respawn.ts` helper detects compiled-binary mode (`argv[1]` starts with `/$bunfs/`) and returns `{ command: process.execPath, args: [] }` so the standalone re-launches itself with no spurious entry arg. Dev (`bun src/genie.ts`) and dist (`bun dist/genie.js`) modes keep the previous shape.

Applied to every re-spawn site:

| File | Site |
|---|---|
| `src/term-commands/serve.ts` | `sendTuiLaunchScript` (the user-visible bug), `autoStartServe`, `serveStartCommand` |
| `src/term-commands/daemon.ts` | `generateSystemdUnit`, `daemonStartCommand` |
| `src/lib/db.ts` | `spawnDaemon` |
| `src/genie-commands/doctor.ts` | `restartDaemon` |
| `src/genie-commands/install.ts` | `resolveGenieBinary` fallback |
| `src/tui/tmux.ts` | `newAgentWindow` |
| `src/tui/components/Nav.tsx` | `spawnAgent`, `executeGenie`, `executeGenieAwaited` |
| `src/tui/components/AgentPicker.tsx` | `defaultLoadAgents` |

## Test plan

- [x] `bun test src/lib/__tests__/respawn.test.ts` — 12 cases: compiled / dev / dist / missing-argv1 / shell-escape; explicit assertion that the shell variant cannot emit a `$bunfs` literal
- [x] `bun test src/term-commands/serve.test.ts src/term-commands/daemon.test.ts` — 47 pass
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (only pre-existing symlink-cycle warning)
- [x] `bun run check` — only pre-existing failure (`codex-inject.test.ts > writes a fresh config.toml when none exists`) reproduces on origin/dev; not related to this hotfix
- [ ] Manual: rebuild `dist/genie` standalone, run `genie` on the install layout, verify the TUI renders and `tui-launch.sh` no longer contains `/$bunfs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)