### PR TITLE
fix(test): stop executor-read port flake via OS-assigned ephemeral port

### DIFF
--- a/src/lib/executor-read.test.ts
+++ b/src/lib/executor-read.test.ts
@@ -7,8 +7,30 @@
  */
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { createServer } from 'node:net';
 import { findOrCreateAgent } from './agent-registry.js';
 import { getConnection } from './db.js';
+
+/**
+ * Bind 127.0.0.1:0 to let the OS assign a free port, then release it. The
+ * port-rebind race is tiny (close → next Bun.serve is microseconds wide on
+ * the same loop) and is the standard pattern for picking a test port. This
+ * replaces the previous `50000 + rand(6000)` random pick that produced
+ * birthday-paradox collisions across parallel CI shards — observed as
+ * "Failed to start server. Is port X in use?" flakes in executor-read.
+ */
+async function findFreePort(): Promise<number> {
+  const srv = createServer();
+  await new Promise<void>((resolve, reject) => {
+    srv.once('error', reject);
+    srv.listen(0, '127.0.0.1', () => resolve());
+  });
+  const addr = srv.address();
+  const port = typeof addr === 'object' && addr !== null ? addr.port : 0;
+  await new Promise<void>((resolve) => srv.close(() => resolve()));
+  if (port <= 0) throw new Error('findFreePort: failed to obtain ephemeral port');
+  return port;
+}
 import {
   getExecutorReadPort,
   isExecutorReadEndpointRunning,
@@ -39,8 +61,11 @@ describe.skipIf(!DB_AVAILABLE)('executor-read', () => {
     await sql`DELETE FROM agents`;
 
     origPort = process.env.GENIE_EXECUTOR_READ_PORT;
-    // High random port — avoids collisions with pgserve, OTel receiver, and parallel tests.
-    process.env.GENIE_EXECUTOR_READ_PORT = String(50000 + Math.floor(Math.random() * 6000));
+    // OS-assigned ephemeral port — avoids collisions with pgserve, OTel
+    // receiver, parallel test shards, and lingering TIME_WAIT sockets that
+    // the previous random-range pick (50000..56000) hit at non-trivial rates
+    // across CI matrix shards.
+    process.env.GENIE_EXECUTOR_READ_PORT = String(await findFreePort());
   });
 
   afterEach(async () => {


### PR DESCRIPTION
## Symptom

PG Tests (matrix shard 2/4) flake on PR #2416 (dev → main):

\`\`\`
Executor read endpoint: failed to start on port 52584:
  Failed to start server. Is port 52584 in use?
error: Unable to connect. Is the computer able to access the url?
  path: \"http://127.0.0.1:52584/executors/00000000-0000-0000-0000-000000000000/state\",
  code: \"ConnectionRefused\"
(fail) executor-read > GET /executors/:id/state returns 404 for unknown id
\`\`\`

Same shard passes on the parallel run for the same SHA — classic port-allocation flake.

## Root cause

\`src/lib/executor-read.test.ts\` \`beforeEach\`:

\`\`\`ts
process.env.GENIE_EXECUTOR_READ_PORT = String(50000 + Math.floor(Math.random() * 6000));
\`\`\`

The 6000-candidate range collides on CI runners because:
- 4 parallel matrix shards x N test files each pick from the same range
- pgserve + OTel receiver + other \`Bun.serve\` test instances co-exist
- TIME_WAIT sockets linger across test files

When the picked port is busy, \`startExecutorReadEndpoint()\` correctly returns \`false\` on EADDRINUSE and logs a warning — but the test keeps going and \`fetch\`s the dead port → ConnectionRefused.

## Fix

Replace the random pick with \`findFreePort()\`: bind \`127.0.0.1:0\`, let the kernel pick a free ephemeral port, release it, return the number. The TOCTOU window between close and the next \`Bun.serve\` bind is microseconds on the same event loop — the canonical pattern for test ports.

## Test plan

- [x] \`bun test src/lib/executor-read.test.ts\` x 5 → 12/12 pass each, no flakes
- [x] \`bun run typecheck\` clean
- [x] \`bunx biome check --write\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)