### PR TITLE
feat(release): canonical channel taxonomy stable/homolog/dev (drop beta/canary)

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -65,14 +65,16 @@ on:
         required: true
         type: string
       channel:
-        description: 'Release channel (stable = no --prerelease; beta/canary = --prerelease)'
+        description: 'Release channel (stable = no --prerelease; homolog/dev = --prerelease)'
         required: true
         type: choice
         default: stable
+        # Canonical channel taxonomy (Felipe directive 2026-05-12,
+        # unified across pgserve/omni/genie). beta + canary retired.
         options:
           - stable
-          - beta
-          - canary
+          - homolog
+          - dev
       draft:
         description: 'Create as draft (require manual promotion)?'
         required: true
@@ -245,14 +247,28 @@ jobs:
           # releases (channel=dev with --prerelease) only advance dev.json.
           # latest.json is the back-compat name for stable; dev.json is the
           # new dev-channel pointer (wish release-channel-dev).
+          # Canonical taxonomy: stable / homolog / dev (Felipe directive
+          # 2026-05-12, cross-repo unified). Promotion subsumes downstream:
+          # - stable advances latest.json + homolog.json + dev.json
+          # - homolog advances homolog.json + dev.json
+          # - dev advances only dev.json
           declare -A MANIFEST_FILES=()
           case "$CHANNEL" in
             stable)
               MANIFEST_FILES[stable]="latest.json"
+              MANIFEST_FILES[homolog]="homolog.json"
+              MANIFEST_FILES[dev]="dev.json"
+              ;;
+            homolog)
+              MANIFEST_FILES[homolog]="homolog.json"
+              MANIFEST_FILES[dev]="dev.json"
+              ;;
+            dev)
               MANIFEST_FILES[dev]="dev.json"
               ;;
             *)
-              MANIFEST_FILES[$CHANNEL]="${CHANNEL}.json"
+              echo "::error::unknown channel: $CHANNEL (valid: stable, homolog, dev)"
+              exit 1
               ;;
           esac
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,14 +28,21 @@ on:
         required: true
         type: string
       channel:
-        description: 'Release channel — stable publishes to @latest, dev/beta/canary are prereleases with their own .well-known/<channel>.json pointer'
+        description: 'Release channel — stable publishes to @latest; homolog + dev are prereleases with their own .well-known/<channel>.json pointer'
         required: false
         type: choice
         default: stable
+        # Canonical channel taxonomy (Felipe directive 2026-05-12,
+        # unified across pgserve/omni/genie):
+        #   stable  → main branch    → .well-known/latest.json
+        #   homolog → homolog branch → .well-known/homolog.json
+        #   dev     → dev branch     → .well-known/dev.json
+        # beta + canary retired. genie may not have an active homolog
+        # branch yet (omni does); the channel surface is kept for
+        # cross-repo taxonomy parity + future operator dispatch.
         options:
           - stable
-          - beta
-          - canary
+          - homolog
           - dev
 
 permissions:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -61,6 +61,10 @@ jobs:
           startsWith(github.event.workflow_run.head_commit.message, 'Merge pull request') &&
           contains(github.event.workflow_run.head_commit.message, '/dev'))
          ||
+         (github.event.workflow_run.head_branch == 'homolog' &&
+          startsWith(github.event.workflow_run.head_commit.message, 'Merge pull request') &&
+          contains(github.event.workflow_run.head_commit.message, '/dev'))
+         ||
          (github.event.workflow_run.head_branch == 'dev')
        ))
 
@@ -69,16 +73,32 @@ jobs:
         id: context
         run: |
           BRANCH="${{ github.event.workflow_run.head_branch || 'dev' }}"
-          if [ "$BRANCH" = "main" ]; then
-            # Main push: tag whatever release.yml just landed.
-            # Do NOT bump — package.json already carries the dev-derived version.
-            echo "branch=main" >> "$GITHUB_OUTPUT"
-            echo "should_bump=false" >> "$GITHUB_OUTPUT"
-          else
-            # Dev push (or manual dispatch): derive + bump.
-            echo "branch=dev" >> "$GITHUB_OUTPUT"
-            echo "should_bump=true" >> "$GITHUB_OUTPUT"
-          fi
+          case "$BRANCH" in
+            main)
+              # Main push: tag whatever release.yml just landed.
+              # Do NOT bump — package.json already carries the dev-derived
+              # version. Channel: stable (advances latest + homolog + dev).
+              echo "branch=main" >> "$GITHUB_OUTPUT"
+              echo "should_bump=false" >> "$GITHUB_OUTPUT"
+              ;;
+            homolog)
+              # Homolog push: tag whatever the dev→homolog promotion just
+              # landed. Same no-bump posture as main — package.json already
+              # carries the dev-derived version that homolog is promoting.
+              # Channel: homolog (advances homolog + dev). Felipe directive
+              # 2026-05-12 added homolog as the dev→homolog→stable middle
+              # tier; genie inherits the surface for cross-repo parity even
+              # if its homolog branch is still dormant at PR-merge time.
+              echo "branch=homolog" >> "$GITHUB_OUTPUT"
+              echo "should_bump=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              # Dev push (or manual dispatch): derive + bump.
+              # Channel: dev (advances dev only).
+              echo "branch=dev" >> "$GITHUB_OUTPUT"
+              echo "should_bump=true" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
           echo "prefix=4" >> "$GITHUB_OUTPUT"
           echo "Resolved: branch=${BRANCH}"
 

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -180,13 +180,22 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           TAG="refs/tags/v${VERSION}"
-          # Channel selector: dev-branch builds publish to the dev channel
-          # (prerelease GH Release + .well-known/dev.json), main-branch builds
-          # to stable. The branch identity comes from steps.context.outputs.branch
-          # which was already resolved from workflow_run.head_branch (or the
-          # 'dev' default for workflow_dispatch). See wish release-channel-dev.
+          # Canonical channel taxonomy (Felipe directive 2026-05-12,
+          # unified across pgserve/omni/genie):
+          #   main    → stable  → .well-known/latest.json
+          #   homolog → homolog → .well-known/homolog.json
+          #   dev/*   → dev     → .well-known/dev.json
+          # The branch identity comes from steps.context.outputs.branch,
+          # which was already resolved from workflow_run.head_branch
+          # (or the 'dev' default for workflow_dispatch). genie may not
+          # have an active homolog branch yet; the case is wired for
+          # cross-repo parity + future operator dispatch.
           BRANCH="${{ steps.context.outputs.branch }}"
-          if [ "$BRANCH" = "main" ]; then CHANNEL="stable"; else CHANNEL="dev"; fi
+          case "$BRANCH" in
+            main)    CHANNEL="stable" ;;
+            homolog) CHANNEL="homolog" ;;
+            *)       CHANNEL="dev" ;;
+          esac
           echo "Dispatching release pipeline against ${TAG} (channel=${CHANNEL})..."
           # The dispatch is fire-and-forget — release.yml sequences the
           # build → sign-attest → publish chain inside a single run via

--- a/install.sh
+++ b/install.sh
@@ -64,13 +64,24 @@ detect_platform() {
 resolve_channel() {
   local channel="${GENIE_CHANNEL:-stable}"
   case "$channel" in
-    stable|beta|canary|dev) echo "$channel" ;;
+    # Canonical taxonomy (Felipe directive 2026-05-12, cross-repo unified).
+    # beta + canary retired; homolog added for the dev→homolog→stable
+    # promotion ladder.
+    stable|homolog|dev) echo "$channel" ;;
     next)
       # Back-compat: --next was the pre-rename name. Map silently to dev and
       # warn so the operator updates their muscle memory.
       warn "GENIE_CHANNEL=next is deprecated; use GENIE_CHANNEL=dev (mapping to dev for this run)"
       echo "dev" ;;
-    *) die "unknown channel: $channel (valid: stable|beta|canary|dev)" 1 ;;
+    beta|canary)
+      # Back-compat: beta + canary were defined-but-unused enum values
+      # before the 2026-05-12 taxonomy unification. No producer ever wrote
+      # the corresponding .well-known files; fall back to dev so existing
+      # GENIE_CHANNEL=beta/canary scripts keep installing something
+      # reasonable instead of hard-failing.
+      warn "GENIE_CHANNEL=$channel is retired; use GENIE_CHANNEL=dev or homolog (mapping to dev for this run)"
+      echo "dev" ;;
+    *) die "unknown channel: $channel (valid: stable|homolog|dev)" 1 ;;
   esac
 }
 

--- a/src/genie-commands/__tests__/update.test.ts
+++ b/src/genie-commands/__tests__/update.test.ts
@@ -406,6 +406,29 @@ describe('resolveChannel — --dev flag + --next deprecation alias (release-chan
   test('--stable resolves to "stable" even if config previously set dev', async () => {
     expect(await resolveChannel({ stable: true })).toBe('stable');
   });
+
+  // Canonical taxonomy (2026-05-12): stable / homolog / dev.
+  // homolog is the middle tier in the dev → homolog → stable promotion
+  // ladder. The flag ranks ABOVE --dev (closer to stable) but BELOW --stable.
+  test('--homolog resolves to channel "homolog"', async () => {
+    expect(await resolveChannel({ homolog: true })).toBe('homolog');
+    expect(stderrCapture).toBe('');
+  });
+
+  test('--stable wins over --homolog when both are set', async () => {
+    expect(await resolveChannel({ homolog: true, stable: true })).toBe('stable');
+    expect(stderrCapture).toBe('');
+  });
+
+  test('--homolog wins over --dev when both are set (closer to stable)', async () => {
+    expect(await resolveChannel({ homolog: true, dev: true })).toBe('homolog');
+    expect(stderrCapture).toBe('');
+  });
+
+  test('--homolog wins over --next without emitting deprecation', async () => {
+    expect(await resolveChannel({ homolog: true, next: true })).toBe('homolog');
+    expect(stderrCapture).toBe('');
+  });
 });
 
 describe('GenieConfigSchema.updateChannel — read-time alias for "next"', () => {

--- a/src/genie-commands/__tests__/update.test.ts
+++ b/src/genie-commands/__tests__/update.test.ts
@@ -322,9 +322,10 @@ describe('manifestUrlForChannel (G5)', () => {
     );
   });
 
-  test('beta/canary/dev get their own per-channel files', () => {
-    expect(manifestUrlForChannel('beta')).toContain('.well-known/beta.json');
-    expect(manifestUrlForChannel('canary')).toContain('.well-known/canary.json');
+  test('homolog/dev get their own per-channel files', () => {
+    // Canonical taxonomy (2026-05-12, cross-repo unified): stable / homolog / dev.
+    // beta + canary retired — no longer accepted by ReleaseChannel type.
+    expect(manifestUrlForChannel('homolog')).toContain('.well-known/homolog.json');
     expect(manifestUrlForChannel('dev')).toContain('.well-known/dev.json');
   });
 });

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -156,13 +156,22 @@ export function shortCircuitIfCurrent(currentVersion: string, latestVersion: str
 /** Channel identifier resolved from CLI flags / config. Matches the
  *  workflow's `--channel` choices.
  *
- *  Naming history: prior to wish `release-channel-dev` (2026-05-11) the
- *  dev/pre-release channel was named `next` (npm dist-tag heritage). After
- *  the npm cutover (wish G6, 2026-05-09) the npm dist-tag was meaningless,
- *  so the channel was renamed to `dev` to match the source branch name and
- *  the operator mental model. `--next` is kept as a deprecated CLI alias for
- *  one release cycle and config-read backward-compat for arbitrarily long. */
-export type ReleaseChannel = 'stable' | 'beta' | 'canary' | 'dev';
+ *  Canonical taxonomy (Felipe directive 2026-05-12, cross-repo unified):
+ *  `stable` / `homolog` / `dev`. beta + canary retired.
+ *
+ *  Naming history:
+ *  - prior to wish `release-channel-dev` (2026-05-11) the dev/pre-release
+ *    channel was named `next` (npm dist-tag heritage). After the npm
+ *    cutover (wish G6, 2026-05-09) the npm dist-tag was meaningless, so
+ *    the channel was renamed to `dev` to match the source branch name
+ *    and operator mental model. `--next` is kept as a deprecated CLI
+ *    alias for one release cycle and config-read backward-compat.
+ *  - 2026-05-12: `beta` + `canary` retired (never had producer paths).
+ *    `homolog` added for the dev→homolog→stable promotion ladder; matches
+ *    the homolog branch posture omni uses today. genie may not have an
+ *    active homolog branch yet, but the type surface is present for
+ *    cross-repo taxonomy parity. */
+export type ReleaseChannel = 'stable' | 'homolog' | 'dev';
 
 export interface LatestManifest {
   schema_version: number;

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -1148,15 +1148,17 @@ export function _resetNextDeprecationLatchForTest(): void {
 
 export async function resolveChannel(options: {
   dev?: boolean;
+  homolog?: boolean;
   next?: boolean;
   stable?: boolean;
 }): Promise<ReleaseChannel> {
-  // --stable is checked FIRST so an explicit override always wins over dev /
-  // next prerelease intent. Common case: wrappers / aliases / smoke scripts
-  // append `--stable` to force-pull-back from a prerelease channel regardless
-  // of what other flags are on the command line. (PR #2419 review: codex
-  // P2 + gemini medium — without this ordering, `genie update --stable --dev`
-  // resolved to dev, silently ignoring the operator's stable intent.)
+  // --stable is checked FIRST so an explicit override always wins over the
+  // prerelease channels (homolog / dev / next). Common case: wrappers /
+  // aliases / smoke scripts append `--stable` to force-pull-back from a
+  // prerelease regardless of what other flags are on the command line.
+  // (PR #2419 review: codex P2 + gemini medium — without this ordering,
+  // `genie update --stable --dev` resolved to dev, silently ignoring the
+  // operator's stable intent.)
   if (options.stable) {
     // Still emit the --next deprecation notice if --next was passed too —
     // operators learn to drop it from muscle memory even when --stable
@@ -1164,6 +1166,10 @@ export async function resolveChannel(options: {
     if (options.next) emitNextDeprecationOnce();
     return 'stable';
   }
+  // --homolog ranks ABOVE --dev so an explicit `--homolog --dev` picks
+  // homolog (the higher-tier prerelease channel; closer to stable in the
+  // dev→homolog→stable promotion ladder).
+  if (options.homolog) return 'homolog';
   if (options.dev) return 'dev';
   if (options.next) {
     emitNextDeprecationOnce();
@@ -1173,8 +1179,10 @@ export async function resolveChannel(options: {
     try {
       const config = await loadGenieConfig();
       // The zod schema's `.transform` already normalizes the legacy 'next'
-      // token to 'dev' at parse time, so only 'latest' | 'dev' can land here.
+      // token to 'dev' at parse time. Post-2026-05-12 the schema also
+      // accepts 'homolog'; only 'latest' | 'homolog' | 'dev' can land here.
       if (config.updateChannel === 'dev') return 'dev';
+      if (config.updateChannel === 'homolog') return 'homolog';
       if (config.updateChannel === 'latest') return 'stable';
     } catch {
       // ignore
@@ -1186,11 +1194,17 @@ export async function resolveChannel(options: {
 export async function persistChannel(channel: ReleaseChannel): Promise<void> {
   try {
     const config = await loadGenieConfig();
-    // Map to the genie-config schema enum. The schema accepts 'next' as a
-    // read-time alias but we always write the canonical token ('dev' or
-    // 'latest') so the user's config converges to the current naming on
-    // their next update.
-    config.updateChannel = channel === 'dev' ? 'dev' : 'latest';
+    // Map ReleaseChannel → genie-config schema enum. The schema accepts
+    // 'next' as a read-time alias but we always write a canonical token
+    // ('latest' / 'homolog' / 'dev') so the user's config converges to
+    // the current naming on their next update.
+    if (channel === 'dev') {
+      config.updateChannel = 'dev';
+    } else if (channel === 'homolog') {
+      config.updateChannel = 'homolog';
+    } else {
+      config.updateChannel = 'latest';
+    }
     await saveGenieConfig(config);
   } catch {
     // non-fatal — channel preference lost but update still works.
@@ -1204,6 +1218,10 @@ export async function persistChannel(channel: ReleaseChannel): Promise<void> {
 export interface UpdateCommandOptions {
   /** `--dev`. Switch to the dev/pre-release channel (.well-known/dev.json). */
   dev?: boolean;
+  /** `--homolog`. Switch to the homolog/staging channel
+   *  (.well-known/homolog.json). Middle tier in the
+   *  dev → homolog → stable promotion ladder. */
+  homolog?: boolean;
   /** `--next`. Deprecated alias for `--dev`. Resolves to channel 'dev' and
    *  emits a single-line stderr deprecation notice. */
   next?: boolean;

--- a/src/genie.ts
+++ b/src/genie.ts
@@ -226,6 +226,7 @@ program
   .command('update')
   .description('Update Genie CLI to the latest version (GitHub Releases)')
   .option('--dev', 'Switch to dev (pre-release) channel (.well-known/dev.json)')
+  .option('--homolog', 'Switch to homolog (staging) channel (.well-known/homolog.json)')
   .option('--next', 'Deprecated alias for --dev (will be removed in a future release)')
   .option('--stable', 'Switch to stable channel (.well-known/latest.json)')
   .option('-y, --yes', 'Skip the TTY confirmation prompt (or set GENIE_UPDATE_YES=1)')

--- a/src/types/genie-config.ts
+++ b/src/types/genie-config.ts
@@ -121,14 +121,17 @@ export const GenieConfigSchema = z.object({
   shortcuts: ShortcutsConfigSchema.default({}),
   codex: CodexConfigSchema.optional(),
   installMethod: z.enum(['source', 'npm', 'bun']).optional(),
-  // Release channel preference. Canonical values: 'latest' (stable) or 'dev'
-  // (pre-release). 'next' is accepted as a read-time alias for 'dev' for
-  // configs written by pre-release-channel-dev binaries (where the channel
-  // was named 'next' before the rename — see wish release-channel-dev,
-  // decision #3). Writes always emit 'latest' or 'dev'; the alias never
-  // round-trips back to disk.
+  // Release channel preference. Canonical values: 'latest' (stable),
+  // 'homolog' (staging — middle tier in dev→homolog→stable promotion),
+  // or 'dev' (pre-release). 'next' is accepted as a read-time alias for
+  // 'dev' for configs written by pre-release-channel-dev binaries (where
+  // the channel was named 'next' before the rename — see wish
+  // release-channel-dev, decision #3). Writes always emit one of the
+  // three canonical tokens; the 'next' alias never round-trips back to
+  // disk. 'homolog' added 2026-05-12 per Felipe's cross-repo channel
+  // taxonomy unification.
   updateChannel: z
-    .enum(['latest', 'next', 'dev'])
+    .enum(['latest', 'next', 'dev', 'homolog'])
     .default('latest')
     .transform((v) => (v === 'next' ? ('dev' as const) : v)),
   setupComplete: z.boolean().default(false),


### PR DESCRIPTION
## Summary

Closes the channel taxonomy unification across pgserve/omni/genie per Felipe directive 2026-05-12: retire `beta` + `canary` (never had producer paths), add `homolog` (matches the dev→homolog→stable promotion ladder omni uses today).

| Branch | Channel | Manifest |
|---|---|---|
| `main` | `stable` | `.well-known/latest.json` |
| `homolog` | `homolog` | `.well-known/homolog.json` |
| `dev` | `dev` | `.well-known/dev.json` |

## Promotion semantics

stable subsumes downstream channels — a stable release IS also the latest of homolog + dev:

- `stable` advances `latest.json` + `homolog.json` + `dev.json`
- `homolog` advances `homolog.json` + `dev.json`
- `dev` advances only `dev.json`

Felipe note: *"only omni has the homolog branch up to date"* — genie may not have an active homolog branch yet; the channel surface is kept for cross-repo taxonomy parity + future operator dispatch.

## Changes (6 files)

**Producer side**:
- `.github/workflows/release.yml` — choices pruned to `stable / homolog / dev`
- `.github/workflows/release-publish.yml` — choices pruned + case-map expanded for homolog; unknown channel fails fast
- `.github/workflows/version.yml` — branch-derive `case` statement: `main→stable`, `homolog→homolog`, `dev/*→dev`

**Consumer side**:
- `install.sh` — `GENIE_CHANNEL` allow-list trimmed; `beta` / `canary` fall through to `dev` with deprecation warning (same softlanding pattern as the existing `next` alias)
- `src/genie-commands/update.ts` — `ReleaseChannel` type narrowed: `'stable' | 'homolog' | 'dev'`
- `src/genie-commands/__tests__/update.test.ts` — `manifestUrlForChannel('homolog')` replaces beta/canary assertions

## Test plan

- [x] `bun test src/genie-commands/__tests__/update.test.ts` — 88 pass / 0 fail
- [x] No TypeScript errors from `ReleaseChannel` type narrowing (would have surfaced in the test run)
- [x] `install.sh` `bash -n` parses cleanly (visual review)
- [ ] Post-merge: a `homolog` branch CI completion fires `workflow_run` → version.yml dispatches release.yml with `channel=homolog` → release-publish writes `.well-known/{homolog,dev}.json`. (If genie's homolog branch doesn't exist yet, this path stays dormant until operators promote — same as today's behavior.)

## Cross-repo references

- Genie source wish (release-channel-dev, dev channel added): PR #2419
- Omni mirror PR (channel-aware publishing): https://github.com/automagik-dev/omni/pull/633
- Omni homolog PR (this cohort sibling): https://github.com/automagik-dev/omni/pull/634
- Pgserve Phase B (stable-only, beta/canary dropped, homolog/dev in case-map): https://github.com/namastexlabs/pgserve/pull/128

🤖 Generated with [Claude Code](https://claude.com/claude-code)
