### PR TITLE
fix(db): bun-compile fallback for resolveGeniePackageDir

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -18,7 +18,7 @@
  */
 
 import { spawn } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
 import { createConnection } from 'node:net';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -233,12 +233,17 @@ function liveDaemonPid(pid: number | null): number | null {
 /**
  * Resolve the directory of genie's own `package.json` (issue #1575).
  *
- * Walks UP from `import.meta.dir` looking for the first `package.json` whose
- * `name === '@automagik/genie'`. Mirrors `version.ts`'s strategy. Cached.
+ * Two-stage strategy mirroring `version.ts:64-105`:
+ *   1. Walk UP from `import.meta.dir` looking for `name === '@automagik/genie'`.
+ *      Works in dev mode and for installed-via-source layouts.
+ *   2. Fall back to `dirname(realpathSync(process.execPath))`. For
+ *      `bun --compile` binaries `import.meta.dir` lives inside the bunfs
+ *      overlay and the walk above never reaches a real on-disk package.json;
+ *      the binary's own location is install-deterministic and works as a
+ *      stable cwd-pin anchor.
  *
- * Returns `null` if no genie package.json can be found within `MAX_WALK_DEPTH`
- * — defensive fallback for unusual deployment layouts (tarballs, npm-link
- * setups). Callers should treat null as "skip the cwd pin" rather than fail.
+ * Returns `null` only when both strategies fail. Callers treat null as
+ * "skip the cwd pin" rather than fail.
  */
 function resolveGeniePackageDir(): string | null {
   if (geniePackageDirCache !== undefined) return geniePackageDirCache;
@@ -264,6 +269,22 @@ function resolveGeniePackageDir(): string | null {
     const parent = dirname(current);
     if (parent === current) break; // filesystem root
     current = parent;
+  }
+  // Bun --compile fallback: the binary's own directory. Stable across all
+  // invocations of the same install, so the pgserve fingerprint stays
+  // deterministic even when no @automagik/genie package.json is reachable
+  // on disk (bunfs overlay case).
+  try {
+    const execPath = process.execPath;
+    if (execPath) {
+      const execDir = dirname(realpathSync(execPath));
+      if (execDir && existsSync(execDir)) {
+        geniePackageDirCache = execDir;
+        return execDir;
+      }
+    }
+  } catch {
+    // execPath unavailable or realpathSync failed — fall through to null.
   }
   geniePackageDirCache = null;
   return null;


### PR DESCRIPTION
## Summary

- Adds a `dirname(realpathSync(process.execPath))` fallback to `resolveGeniePackageDir` in `src/lib/db.ts`
- Eliminates the spurious `[pgserve] WARN: could not resolve genie package dir; pgserve fingerprint may be unstable` line emitted by every short-lived CLI invocation of the bun-compiled binary
- Mirrors the proven two-stage strategy from `src/lib/version.ts:64-105` (same root cause: bunfs overlay hides on-disk package.json from the walk)

## Why

Compiled binaries run with `import.meta.dir` pointing inside the bunfs overlay. The existing walk-up looking for `name === '@automagik/genie'` package.json can never succeed there, so:

1. `resolveGeniePackageDir()` returns `null`
2. `pinCwdForFingerprint` skips the chdir → stderr WARN emitted
3. pgserve's per-process fingerprint loses determinism — the peer drifts toward `app_anon_<fp>` (GC-eligible) instead of the canonical `app_<@automagik/genie>_<fp>` with `persist: true`

The fallback uses the binary's own location, which is install-deterministic across all invocations of the same binary install — restoring fingerprint stability and silencing the WARN.

## Test plan

- [x] `bun run typecheck` clean
- [ ] Smoke: run a freshly-compiled binary (post-merge) and confirm `genie inbox list 2>&1 | grep "could not resolve genie package dir"` returns empty
- [ ] Verify pgserve fingerprint stability: two consecutive CLI invocations of the compiled binary connect to the same `app_*` database

🤖 Generated with [Claude Code](https://claude.com/claude-code)