### PR TITLE
fix(ci): repair dev red CI from role-cutover merge (PR #2429 fallout)

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -56,8 +56,8 @@
     "src/migrations/steps/*.ts"
   ],
   "project": ["src/**/*.ts", "src/**/*.tsx"],
-  "ignore": ["src/lib/design-tokens.ts", "src/tui/widgets/__benches__/**"],
-  "ignoreBinaries": ["which", "scripts/verify-release.sh", "pgserve"],
+  "ignore": ["src/tui/widgets/__benches__/**"],
+  "ignoreBinaries": ["which", "scripts/verify-release.sh"],
   "ignoreExportsUsedInFile": true,
   "ignoreDependencies": [
     "@khal-os/brain",
@@ -66,7 +66,6 @@
     "react-dom",
     "@vitejs/plugin-react",
     "vite",
-    "@types/react-dom",
-    "esbuild"
+    "@types/react-dom"
   ]
 }

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -361,12 +361,19 @@ describe('daemon-owned pgserve', () => {
     const source = readFileSync(join(__dirname, 'db.ts'), 'utf-8');
     // Post-refactor (#1651): pgModule call delegates to buildPgClientOptions.
     // Connection is still bound to a local first so concurrent rebuilds can't
-    // make this caller observe a nulled `sqlClient`.
-    expect(source).toContain('const client = pgModule(buildPgClientOptions(');
+    // make this caller observe a nulled `sqlClient`. The local was renamed
+    // `client` -> `bootstrapClient` by the role-cutover wave (Goal A G2): the
+    // bootstrap connection is established as the default identity, then a
+    // scoped-role connection may be rebound on top of it.
+    expect(source).toContain('const bootstrapClient = pgModule(buildPgClientOptions(');
     const optionsStart = source.indexOf('function buildPgClientOptions');
     expect(optionsStart).toBeGreaterThan(-1);
     const optionsBody = source.slice(optionsStart, source.indexOf('\n}\n', optionsStart));
-    expect(optionsBody).toContain('username: DB_NAME');
+    // buildPgClientOptions now takes an optional `username` that DEFAULTS to
+    // DB_NAME (postgres) — preserving the legacy identity when cutover is off
+    // — and the returned options use that param.
+    expect(optionsBody).toContain('username: string = DB_NAME');
+    expect(optionsBody).toContain('username,');
     expect(optionsBody).toContain('[PG_AUTH_FIELD]: transport.pgWireCredential');
     expect(source).toContain('const PG_AUTH_FIELD');
     // pgWireCredential resolution moved into resolveTransport.
@@ -374,7 +381,7 @@ describe('daemon-owned pgserve', () => {
       'const pgWireCredential = useSocket ? resolvePgserveAuthPassword() : resolveTcpPgPassword()',
     );
     // Sharing the global happens AFTER local construction.
-    expect(source).toContain('sqlClient = client');
+    expect(source).toContain('sqlClient = bootstrapClient');
   });
 
   test('socket connections use the pgserve startup timeout window', () => {

--- a/src/lib/role-cutover.ts
+++ b/src/lib/role-cutover.ts
@@ -601,10 +601,3 @@ export async function resolveScopedConnectionIdentity(
     return fallback('query-failed', fingerprintHex);
   }
 }
-
-export const __testInternals = Object.freeze({
-  ADVISORY_LOCK_KEY,
-  FALLBACK_SUPERUSER,
-  resolveGenieFingerprint,
-  resolveGeniePackageDir,
-});


### PR DESCRIPTION
## Problem

PR #2429 (genie-dedicated-role-cutover Wave 1+2) was merged to `dev` with 4 red CI checks. `dev` now carries them — every PR branched off dev inherits the failures.

## Root causes (both fixed here)

1. **PG shard 1/4 + aggregate** — Wave 2 renamed the db.ts bootstrap local `client` → `bootstrapClient` and parameterized `buildPgClientOptions(username = DB_NAME)`. The `db.ts` source-introspection guard test (`src/lib/db.test.ts`) still pinned the old literals. Reconciled the assertions to the post-rename shape; protective intent (local-bound-before-global-share, postgres default preserved when cutover off) unchanged.
2. **Quality Gate (dead-code)** — knip drift: `esbuild` / `pgserve` / `design-tokens.ts` ignore entries are now unnecessary, and Wave 2 left an unused `__testInternals` export in `role-cutover.ts` (zero importers — suites use the public API). Removed all four.

## Validation (on this dev-based branch)

- `bun run typecheck` → exit 0
- `bun run dead-code` (knip) → exit 0
- `bun test` db.test + role-cutover provision + db.role-cutover + migration-replay → **94 pass / 0 fail / 365 expects**

Unblocks dev CI. No behavior change — test/lint reconciliation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)