### PR TITLE
feat(db): genie-dedicated-role-cutover Wave 3 — default-on + doctor + matrix (Goal A G4)

### DIFF
--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -22,10 +22,11 @@ import { fileURLToPath } from 'node:url';
 import { $ } from 'bun';
 import type { BridgeStatusResult, PingOptions } from '../lib/bridge-status.js';
 import { contractClaudePath, getClaudeSettingsPath } from '../lib/claude-settings.js';
-import { isAvailable as isRuntimePgAvailable } from '../lib/db.js';
+import { getConnection, isAvailable as isRuntimePgAvailable, resolveDatabaseName } from '../lib/db.js';
 import { tmuxBin } from '../lib/ensure-tmux.js';
 import { genieConfigExists, getGenieConfigPath, isSetupComplete, loadGenieConfig } from '../lib/genie-config.js';
 import { respawnInvocation } from '../lib/respawn.js';
+import { type RoleCutoverInspection, inspectRoleCutover } from '../lib/role-cutover.js';
 import { checkCommand } from '../lib/system-detect.js';
 import { findWorkspace } from '../lib/workspace.js';
 import {
@@ -813,9 +814,15 @@ export async function doctorCommand(options?: {
   fixTeamOrphans?: boolean;
   dryRun?: boolean;
   json?: boolean;
+  connectionIdentity?: boolean;
 }): Promise<void> {
   if (options?.fix) {
     await doctorFix();
+    return;
+  }
+
+  if (options?.connectionIdentity) {
+    await runConnectionIdentityCheck(Boolean(options.json));
     return;
   }
 
@@ -854,6 +861,152 @@ export async function doctorCommand(options?: {
 
   printDoctorSummary(counts);
   if (counts.errors) process.exit(1);
+}
+
+// ============================================================================
+// `genie doctor --connection-identity` — Goal A, Group 4.
+//
+// READ-ONLY operator inspection of the dedicated-role cutover. Prints the
+// resolved role, rolsuper (must be false when cutover is active), database, the
+// GRANT summary, the fallback-active flag + reason, and the per-fingerprint
+// sentinel state/path. Issues only SELECTs — never CREATE ROLE / GRANT / ALTER.
+// The connection itself follows genie's normal idempotent boot (identical to
+// every other genie command); this subcommand adds zero mutations of its own.
+// ============================================================================
+
+interface ConnectionIdentityDb {
+  reachable: boolean;
+  currentUser?: string;
+  currentDatabase?: string;
+  roleExists?: boolean;
+  rolsuper?: boolean;
+  rolcanlogin?: boolean;
+  grants?: {
+    connect: boolean;
+    schemaUsage: boolean;
+    schemaCreate: boolean;
+    tablesSelectable: number;
+    tablesTotal: number;
+  };
+  error?: string;
+}
+
+const SAFE_ROLE_RE = /^[a-z0-9_]+$/;
+
+/** Read-only DB facts for the cutover identity. Only SELECTs; never mutates. */
+async function queryConnectionIdentityDb(roleName: string | null): Promise<ConnectionIdentityDb> {
+  try {
+    // postgres.js Sql bleed-through — getConnection() returns `any` by design.
+    // biome-ignore lint/suspicious/noExplicitAny: postgres.js Sql type bleed-through
+    const sql = (await getConnection()) as any;
+    const [whoRow] = await sql.unsafe('SELECT current_user AS who, current_database() AS db');
+    const db: ConnectionIdentityDb = {
+      reachable: true,
+      currentUser: whoRow?.who,
+      currentDatabase: whoRow?.db,
+    };
+    if (!roleName || !SAFE_ROLE_RE.test(roleName)) return db;
+    const roleRows = await sql.unsafe(`SELECT rolsuper, rolcanlogin FROM pg_roles WHERE rolname = '${roleName}'`);
+    if (roleRows.length === 0) return { ...db, roleExists: false };
+    const [g] = await sql.unsafe(
+      `SELECT has_database_privilege('${roleName}', current_database(), 'CONNECT') AS db_connect,
+              has_schema_privilege('${roleName}', 'public', 'USAGE')  AS sch_usage,
+              has_schema_privilege('${roleName}', 'public', 'CREATE') AS sch_create`,
+    );
+    const [t] = await sql.unsafe(
+      `SELECT count(*)::int AS total,
+              count(*) FILTER (
+                WHERE has_table_privilege('${roleName}', format('%I.%I', schemaname, tablename), 'SELECT')
+              )::int AS selectable
+         FROM pg_tables WHERE schemaname = 'public'`,
+    );
+    return {
+      ...db,
+      roleExists: true,
+      rolsuper: roleRows[0].rolsuper,
+      rolcanlogin: roleRows[0].rolcanlogin,
+      grants: {
+        connect: g.db_connect,
+        schemaUsage: g.sch_usage,
+        schemaCreate: g.sch_create,
+        tablesSelectable: t.selectable,
+        tablesTotal: t.total,
+      },
+    };
+  } catch (err) {
+    return { reachable: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+function deriveFallbackReason(inspection: RoleCutoverInspection, db: ConnectionIdentityDb): string | undefined {
+  if (!inspection.enabled) return 'kill-switch engaged (GENIE_ROLE_CUTOVER=0)';
+  if (!inspection.roleName) return 'fingerprint-unstable (cannot derive scoped role)';
+  if (!db.reachable) return `db-unreachable: ${db.error ?? 'unknown'}`;
+  if (db.roleExists === false) return 'role not provisioned in pg_roles';
+  if (db.currentUser !== inspection.roleName) return `connected as ${db.currentUser} (legacy postgres path)`;
+  return undefined;
+}
+
+function printConnectionIdentity(inspection: RoleCutoverInspection, db: ConnectionIdentityDb): void {
+  const yn = (v: boolean | undefined): string => (v === undefined ? 'n/a' : v ? 'yes' : 'no');
+  const reason = deriveFallbackReason(inspection, db);
+  const cutoverActive = reason === undefined && db.currentUser === inspection.roleName && db.rolsuper === false;
+
+  console.log();
+  console.log('\x1b[1mConnection Identity (dedicated-role cutover)\x1b[0m');
+  console.log(`\x1b[2m${'─'.repeat(40)}\x1b[0m`);
+  console.log(`  cutover enabled:    ${yn(inspection.enabled)}${inspection.killSwitch ? '  (kill-switch ON)' : ''}`);
+  console.log(`  cutover active:     ${cutoverActive ? '\x1b[32myes\x1b[0m' : '\x1b[33mno\x1b[0m'}`);
+  console.log(`  resolved role:      ${inspection.roleName ?? '\x1b[33m<unresolved: fingerprint-unstable>\x1b[0m'}`);
+  console.log(`  database:           ${db.currentDatabase ?? resolveDatabaseName()}`);
+  console.log(`  connected as:       ${db.currentUser ?? '\x1b[33m<db unreachable>\x1b[0m'}`);
+  const superColor = db.rolsuper === false ? '\x1b[32m' : '\x1b[31m';
+  console.log(
+    `  rolsuper:           ${db.rolsuper === undefined ? 'n/a' : `${superColor}${db.rolsuper}\x1b[0m`}` +
+      `${cutoverActive && db.rolsuper !== false ? '  \x1b[31m(EXPECTED false WHEN ACTIVE)\x1b[0m' : ''}`,
+  );
+  console.log(`  rolcanlogin:        ${yn(db.rolcanlogin)}`);
+  if (db.grants) {
+    console.log('  grants:');
+    console.log(`    CONNECT on db:    ${yn(db.grants.connect)}`);
+    console.log(`    USAGE  on public: ${yn(db.grants.schemaUsage)}`);
+    console.log(`    CREATE on public: ${yn(db.grants.schemaCreate)}`);
+    console.log(`    SELECT-able tbls: ${db.grants.tablesSelectable}/${db.grants.tablesTotal}`);
+  } else {
+    console.log('  grants:             n/a (role absent or db unreachable)');
+  }
+  console.log(`  fallback active:    ${reason ? `\x1b[33myes\x1b[0m — ${reason}` : 'no'}`);
+  console.log(`  sentinel path:      ${inspection.sentinelPath ?? 'n/a'}`);
+  console.log(
+    `  sentinel state:     ${
+      inspection.sentinel
+        ? `present (role=${inspection.sentinel.roleName}, db=${inspection.sentinel.database}, verifiedAt=${inspection.sentinel.verifiedAt})`
+        : 'absent'
+    }`,
+  );
+  console.log();
+  console.log(
+    '\x1b[2m  Integrity containment only — NOT confidentiality. --auth-local=trust and the\n' +
+      '  passwordless postgres superuser are unchanged (producer-side, out of scope).\x1b[0m',
+  );
+}
+
+async function runConnectionIdentityCheck(json: boolean): Promise<void> {
+  const inspection = inspectRoleCutover();
+  const db = await queryConnectionIdentityDb(inspection.roleName);
+  const reason = deriveFallbackReason(inspection, db);
+  const cutoverActive = reason === undefined && db.currentUser === inspection.roleName && db.rolsuper === false;
+  if (json) {
+    console.log(
+      JSON.stringify(
+        { cutoverActive, fallbackActive: !cutoverActive, fallbackReason: reason, inspection, db },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+  printConnectionIdentity(inspection, db);
 }
 
 function printObservabilityReport(report: Awaited<ReturnType<typeof collectObservabilityHealth>>): void {

--- a/src/genie.ts
+++ b/src/genie.ts
@@ -209,6 +209,10 @@ program
     'Archive stale Claude-team config dirs missing config.json (paired with invincible-genie wish migration 050)',
   )
   .option('--dry-run', 'Pair with --fix-team-orphans to preview archive moves without mutating')
+  .option(
+    '--connection-identity',
+    'Read-only: report the dedicated-role cutover identity (role, rolsuper, database, grants, fallback, sentinel)',
+  )
   .option('--json', 'Emit JSON instead of human output (pairs with --observability)')
   .action(doctorCommand);
 program

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -27,7 +27,12 @@ import { runMigrations } from './db-migrations.js';
 import { needsSeed, needsSeededTeams, runSeed } from './pg-seed.js';
 import { getProcessStartTime } from './process-identity.js';
 import { respawnInvocation } from './respawn.js';
-import { clearRoleCutoverSentinel, defaultRoleCutoverSink, resolveScopedConnectionIdentity } from './role-cutover.js';
+import {
+  clearRoleCutoverSentinel,
+  defaultRoleCutoverSink,
+  isRoleCutoverEnabled,
+  resolveScopedConnectionIdentity,
+} from './role-cutover.js';
 import { maybePromptV1Migration } from './v1-migration-prompt.js';
 
 /**
@@ -1215,9 +1220,10 @@ async function buildAndOpenConnection(transport: Transport, _t0: number): Promis
   let activeClient = bootstrapClient;
   sqlClient = bootstrapClient;
 
-  // Only consult admin.json when cutover is opted in, so the disabled path is
-  // identical to today (no extra stat, no behavior change).
-  const cutoverEnabled = process.env.GENIE_ROLE_CUTOVER === '1';
+  // Wave 3: cutover is DEFAULT-ON; only the documented kill-switch
+  // (GENIE_ROLE_CUTOVER=0) skips the admin.json consult so the killed path is
+  // byte-identical to legacy (no extra stat, no behavior change).
+  const cutoverEnabled = isRoleCutoverEnabled();
   const directPostmaster = cutoverEnabled && transport.useSocket && readPostmasterDiscovery() !== null;
 
   try {
@@ -1428,8 +1434,8 @@ function buildPgClientOptions(
  * `buildPgClientOptions` otherwise hard-sets `username=postgres` — carries the
  * rebind. The accept-hook/router path and the TCP/test paths are intentionally
  * left on `postgres`/`postgres`: rebinding the router path is a silent no-op
- * that re-forks as the superuser on boot #2. Default OFF
- * (`GENIE_ROLE_CUTOVER=1` opt-in this wave).
+ * that re-forks as the superuser on boot #2. Wave 3: DEFAULT-ON — the only way
+ * back to legacy is the documented kill-switch `GENIE_ROLE_CUTOVER=0`.
  */
 export function shouldAttemptRoleCutover(args: {
   enabled: boolean;
@@ -1457,7 +1463,7 @@ async function maybeRebindToScopedRole(args: {
   // biome-ignore lint/suspicious/noExplicitAny: postgres.js default export factory
   pgModule: any;
 }): Promise<postgres.Sql | null> {
-  const enabled = process.env.GENIE_ROLE_CUTOVER === '1';
+  const enabled = isRoleCutoverEnabled();
   if (
     !shouldAttemptRoleCutover({
       enabled,

--- a/src/lib/role-cutover.matrix.test.ts
+++ b/src/lib/role-cutover.matrix.test.ts
@@ -1,0 +1,432 @@
+/**
+ * Goal-A Group 4 — the rollout HARDENING matrix.
+ *
+ * Wave 3 flips `GENIE_ROLE_CUTOVER` to DEFAULT-ON behind the documented
+ * kill-switch (`=0`). This file is the edge-case matrix the wish mandates
+ * before that flip ships:
+ *
+ *   (a) N=8 concurrent boots ⇒ exactly ONE provision via pg_try_advisory_lock,
+ *       none block, all converge connected as the scoped role.
+ *   (b) fallback trio (pgserve unreachable / grant query fails / role missing)
+ *       ⇒ clean postgres/postgres, no hard-fail, out-of-band fallback event.
+ *   (c) multi-fingerprint host (2 fingerprints, 1 home) ⇒ each cuts over
+ *       independently; the per-fingerprint sentinel is never stranded.
+ *   (d) test-mode (GENIE_TEST_PG_PORT) + GENIE_PG_FORCE_TCP ⇒ SKIP, the rebind
+ *       never lands on the accept-hook / TCP / test paths (byte-identical).
+ *   (e) kill-switch GENIE_ROLE_CUTOVER=0 ⇒ legacy postgres/postgres exactly as
+ *       before; the default-on contract holds for unset / `1` / other values.
+ *
+ * Pure + mock sections always run; the concurrency section is DB-backed and
+ * skips cleanly when pgserve is unavailable.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getConnection, resolveDatabaseName, shouldAttemptRoleCutover } from './db.js';
+import {
+  type RoleCutoverEvent,
+  clearRoleCutoverSentinel,
+  ensureScopedRole,
+  inspectRoleCutover,
+  isRoleCutoverEnabled,
+  readRoleCutoverSentinel,
+  resolveScopedConnectionIdentity,
+  roleCutoverSentinelPath,
+  writeRoleCutoverSentinel,
+} from './role-cutover.js';
+import { DB_AVAILABLE, setupTestDatabase } from './test-db.js';
+
+const PID = process.pid;
+const ROLE = `pgserve_rcmtx_${PID}_role`;
+const FP = `cc${PID.toString(16)}`.slice(0, 12);
+
+function recorder(): { events: RoleCutoverEvent[]; sink: (e: RoleCutoverEvent) => void } {
+  const events: RoleCutoverEvent[] = [];
+  return { events, sink: (e) => events.push(e) };
+}
+
+function withEnv<T>(key: string, value: string | undefined, fn: () => T): T {
+  const prev = process.env[key];
+  if (value === undefined) process.env[key] = undefined;
+  else process.env[key] = value;
+  try {
+    return fn();
+  } finally {
+    if (prev === undefined) process.env[key] = undefined;
+    else process.env[key] = prev;
+  }
+}
+
+// Throwing stub — proves a code path performs NO DB I/O.
+const throwingSql = {
+  reserve: () => Promise.reject(new Error('sql must not be touched')),
+  unsafe: () => Promise.reject(new Error('sql must not be touched')),
+} as unknown as Parameters<typeof resolveScopedConnectionIdentity>[0]['sql'];
+
+interface MockOpts {
+  lock: boolean;
+  roleExists: boolean;
+  reserveThrows?: boolean;
+  postCheckThrows?: boolean;
+}
+
+function mockSql(opts: MockOpts): Parameters<typeof resolveScopedConnectionIdentity>[0]['sql'] {
+  const reserved = {
+    unsafe: (q: string) => {
+      if (q.includes('pg_try_advisory_lock')) return Promise.resolve([{ locked: opts.lock }]);
+      if (q.includes('FROM pg_roles')) return Promise.resolve(opts.roleExists ? [{ '?column?': 1 }] : []);
+      return Promise.resolve([]);
+    },
+    release: () => {},
+  };
+  return {
+    reserve: () => (opts.reserveThrows ? Promise.reject(new Error('pgserve down')) : Promise.resolve(reserved)),
+    unsafe: (q: string) => {
+      if (opts.postCheckThrows) return Promise.reject(new Error('grant/lookup query failed'));
+      if (q.includes('FROM pg_roles')) return Promise.resolve(opts.roleExists ? [{ '?column?': 1 }] : []);
+      return Promise.resolve([]);
+    },
+  } as unknown as Parameters<typeof resolveScopedConnectionIdentity>[0]['sql'];
+}
+
+// ============================================================================
+// GENIE_HOME isolation — sentinel files never touch the operator's ~/.genie.
+// ============================================================================
+
+let homeDir: string;
+let prevHome: string | undefined;
+
+beforeAll(() => {
+  prevHome = process.env.GENIE_HOME;
+  homeDir = mkdtempSync(join(tmpdir(), 'genie-rcmtx-'));
+  process.env.GENIE_HOME = homeDir;
+});
+
+afterAll(() => {
+  if (prevHome === undefined) process.env.GENIE_HOME = undefined;
+  else process.env.GENIE_HOME = prevHome;
+  try {
+    rmSync(homeDir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+// ============================================================================
+// (e) Kill-switch + default-on contract.
+// ============================================================================
+
+describe('(e) kill-switch + default-on gate', () => {
+  it('GENIE_ROLE_CUTOVER=0 is the ONLY off state; unset / 1 / other ⇒ ON', () => {
+    expect(withEnv('GENIE_ROLE_CUTOVER', '0', () => isRoleCutoverEnabled())).toBe(false);
+    expect(withEnv('GENIE_ROLE_CUTOVER', undefined, () => isRoleCutoverEnabled())).toBe(true);
+    expect(withEnv('GENIE_ROLE_CUTOVER', '1', () => isRoleCutoverEnabled())).toBe(true);
+    expect(withEnv('GENIE_ROLE_CUTOVER', '2', () => isRoleCutoverEnabled())).toBe(true);
+    expect(withEnv('GENIE_ROLE_CUTOVER', 'true', () => isRoleCutoverEnabled())).toBe(true);
+  });
+
+  it('kill-switch ⇒ resolveScopedConnectionIdentity is legacy postgres/postgres, zero DB I/O', async () => {
+    const { events, sink } = recorder();
+    const id = await withEnv('GENIE_ROLE_CUTOVER', '0', () =>
+      resolveScopedConnectionIdentity({ sql: throwingSql, database: 'postgres', sink }),
+    );
+    expect(id.cutover).toBe(false);
+    expect(id.username).toBe('postgres');
+    expect(id.database).toBe('postgres');
+    expect(id.reason).toBe('disabled');
+    expect(events.map((e) => e.event)).toEqual(['role-cutover.skip.disabled']);
+  });
+
+  it('kill-switch ⇒ ensureScopedRole is a pure no-op (sql untouched)', async () => {
+    const { events, sink } = recorder();
+    const result = await withEnv('GENIE_ROLE_CUTOVER', '0', () =>
+      ensureScopedRole({
+        sql: {
+          reserve: () => Promise.reject(new Error('sql must not be touched when killed')),
+        } as unknown as Parameters<typeof ensureScopedRole>[0]['sql'],
+        sink,
+      }),
+    );
+    expect(result.status).toBe('skipped');
+    expect(result.reason).toBe('disabled');
+    expect(events.map((e) => e.event)).toEqual(['role-cutover.skip.disabled']);
+  });
+
+  it('inspectRoleCutover reports the kill-switch + default-on state read-only', () => {
+    const killed = withEnv('GENIE_ROLE_CUTOVER', '0', () => inspectRoleCutover());
+    expect(killed.enabled).toBe(false);
+    expect(killed.killSwitch).toBe(true);
+
+    const live = withEnv('GENIE_ROLE_CUTOVER', undefined, () => inspectRoleCutover());
+    expect(live.enabled).toBe(true);
+    expect(live.killSwitch).toBe(false);
+    // Dev/test tree resolves a stable fingerprint → deterministic role name.
+    if (live.roleName !== null) {
+      expect(live.roleName).toMatch(/^pgserve_.*_role$/);
+      expect(live.sentinelPath).toContain(homeDir);
+    }
+  });
+});
+
+// ============================================================================
+// (b) Fallback trio — every degraded path ⇒ clean postgres/postgres, NO throw.
+// ============================================================================
+
+describe('(b) fallback trio never hard-fails boot', () => {
+  afterEach(() => clearRoleCutoverSentinel(FP));
+
+  it('pgserve unreachable (reserve throws) ⇒ clean postgres/postgres + fallback event', async () => {
+    const { events, sink } = recorder();
+    const id = await resolveScopedConnectionIdentity({
+      sql: mockSql({ lock: false, roleExists: false, reserveThrows: true }),
+      database: 'postgres',
+      roleName: ROLE,
+      fingerprintHex: FP,
+      enabled: true,
+      sink,
+    });
+    expect(id.cutover).toBe(false);
+    expect(id.username).toBe('postgres');
+    expect(id.database).toBe('postgres');
+    expect(events.some((e) => e.event.startsWith('role-cutover.fallback.'))).toBe(true);
+  });
+
+  it('grant/lookup query fails ⇒ clean fallback (query-failed)', async () => {
+    const { events, sink } = recorder();
+    const id = await resolveScopedConnectionIdentity({
+      sql: mockSql({ lock: true, roleExists: true, postCheckThrows: true }),
+      database: 'postgres',
+      roleName: ROLE,
+      fingerprintHex: FP,
+      enabled: true,
+      sink,
+    });
+    expect(id.cutover).toBe(false);
+    expect(id.username).toBe('postgres');
+    expect(events.map((e) => e.event)).toContain('role-cutover.fallback.query-failed');
+  });
+
+  it('role missing in pg_roles ⇒ fallback + self-heals the stale sentinel', async () => {
+    writeRoleCutoverSentinel(FP, { roleName: ROLE, database: 'mismatch-forces-revalidate' });
+    expect(readRoleCutoverSentinel(FP)).not.toBeNull();
+    const { events, sink } = recorder();
+    const id = await resolveScopedConnectionIdentity({
+      sql: mockSql({ lock: false, roleExists: false }),
+      database: 'postgres',
+      roleName: ROLE,
+      fingerprintHex: FP,
+      enabled: true,
+      sink,
+    });
+    expect(id.cutover).toBe(false);
+    expect(id.username).toBe('postgres');
+    expect(id.reason).toBe('role-missing');
+    expect(events.map((e) => e.event)).toContain('role-cutover.fallback.role-missing');
+    expect(readRoleCutoverSentinel(FP)).toBeNull();
+  });
+});
+
+// ============================================================================
+// (c) Multi-fingerprint host — sentinel keyed per fingerprint, never stranded.
+// ============================================================================
+
+describe('(c) multi-fingerprint host cuts over independently', () => {
+  const FP_A = FP;
+  const FP_B = `dd${PID.toString(16)}`.slice(0, 12);
+  const ROLE_A = ROLE;
+  const ROLE_B = `pgserve_rcmtxb_${PID}_role`;
+
+  afterEach(() => {
+    clearRoleCutoverSentinel(FP_A);
+    clearRoleCutoverSentinel(FP_B);
+  });
+
+  it('two fingerprints in one home get distinct sentinels and cut over separately', async () => {
+    // Checkout A cuts over.
+    const a = await resolveScopedConnectionIdentity({
+      sql: mockSql({ lock: true, roleExists: true }),
+      database: 'postgres',
+      roleName: ROLE_A,
+      fingerprintHex: FP_A,
+      enabled: true,
+      sink: () => {},
+    });
+    expect(a.cutover).toBe(true);
+    expect(a.username).toBe(ROLE_A);
+
+    // Distinct sentinel paths; B does NOT see A's sentinel.
+    expect(roleCutoverSentinelPath(FP_A)).not.toBe(roleCutoverSentinelPath(FP_B));
+    expect(readRoleCutoverSentinel(FP_A)).not.toBeNull();
+    expect(readRoleCutoverSentinel(FP_B)).toBeNull();
+
+    // Checkout B is NOT stranded by A's sentinel — it provisions its own.
+    const { events, sink } = recorder();
+    const b = await resolveScopedConnectionIdentity({
+      sql: mockSql({ lock: true, roleExists: true }),
+      database: 'postgres',
+      roleName: ROLE_B,
+      fingerprintHex: FP_B,
+      enabled: true,
+      sink,
+    });
+    expect(b.cutover).toBe(true);
+    expect(b.username).toBe(ROLE_B); // NOT ROLE_A
+    expect(events.map((e) => e.event)).toContain('role-cutover.cutover');
+    expect(readRoleCutoverSentinel(FP_B)?.roleName).toBe(ROLE_B);
+    // A's sentinel still intact — B did not stomp it.
+    expect(readRoleCutoverSentinel(FP_A)?.roleName).toBe(ROLE_A);
+  });
+});
+
+// ============================================================================
+// (d) Test-mode / FORCE_TCP / accept-hook ⇒ rebind NEVER lands (byte-identical
+// to legacy). The rebind gate is `shouldAttemptRoleCutover`; only the
+// direct-postmaster bypass carries it.
+// ============================================================================
+
+describe('(d) test-mode + FORCE_TCP + accept-hook skip — rebind never lands', () => {
+  it('direct-postmaster bypass is the ONLY path that rebinds', () => {
+    // The load-bearing path: enabled + not test + admin.json present.
+    expect(shouldAttemptRoleCutover({ enabled: true, isTestMode: false, directPostmaster: true })).toBe(true);
+    // Test mode (GENIE_TEST_PG_PORT harness) ⇒ never rebind, even on the bypass.
+    expect(shouldAttemptRoleCutover({ enabled: true, isTestMode: true, directPostmaster: true })).toBe(false);
+    // FORCE_TCP / accept-hook / router path (no admin.json ⇒ directPostmaster
+    // false) ⇒ never rebind (rebinding it is a silent no-op trap).
+    expect(shouldAttemptRoleCutover({ enabled: true, isTestMode: false, directPostmaster: false })).toBe(false);
+    expect(shouldAttemptRoleCutover({ enabled: true, isTestMode: true, directPostmaster: false })).toBe(false);
+    // Kill-switch ⇒ never rebind regardless of path.
+    expect(shouldAttemptRoleCutover({ enabled: false, isTestMode: false, directPostmaster: true })).toBe(false);
+  });
+
+  it('disabled gate ⇒ resolveScopedConnectionIdentity stays byte-identical legacy', async () => {
+    const { events, sink } = recorder();
+    const id = await resolveScopedConnectionIdentity({
+      sql: throwingSql,
+      database: 'postgres',
+      enabled: false,
+      sink,
+    });
+    expect(id).toEqual({
+      username: 'postgres',
+      database: 'postgres',
+      cutover: false,
+      fingerprintHex: null,
+      reason: 'disabled',
+    });
+    expect(events.map((e) => e.event)).toEqual(['role-cutover.skip.disabled']);
+  });
+});
+
+// ============================================================================
+// (a) N=8 concurrent boots — DB-backed. Single provision via the non-blocking
+// advisory lock; none block; convergence to the scoped role.
+// ============================================================================
+
+describe.skipIf(!DB_AVAILABLE)('(a) N=8 concurrent boots (pg)', () => {
+  let cleanupSchema: () => Promise<void>;
+  // postgres.js Sql type bleed-through; `any` is permitted in test files.
+  let sql: any;
+  let database: string;
+
+  beforeAll(async () => {
+    cleanupSchema = await setupTestDatabase();
+    sql = await getConnection();
+    database = resolveDatabaseName();
+  });
+
+  afterAll(async () => {
+    try {
+      const exists = await sql.unsafe(`SELECT 1 FROM pg_roles WHERE rolname = '${ROLE}'`);
+      if (exists.length > 0) {
+        await sql.unsafe(`DROP OWNED BY "${ROLE}"`);
+        await sql.unsafe(`DROP ROLE IF EXISTS "${ROLE}"`);
+      }
+    } catch {
+      /* best-effort */
+    }
+    clearRoleCutoverSentinel(FP);
+    await cleanupSchema();
+  });
+
+  async function dropRole(): Promise<void> {
+    const exists = await sql.unsafe(`SELECT 1 FROM pg_roles WHERE rolname = '${ROLE}'`);
+    if (exists.length === 0) return;
+    await sql.unsafe(`DROP OWNED BY "${ROLE}"`);
+    await sql.unsafe(`DROP ROLE IF EXISTS "${ROLE}"`);
+  }
+
+  it('cold storm: provisioned exactly once, none block, none error or throw', async () => {
+    await dropRole();
+    clearRoleCutoverSentinel(FP);
+    const N = 8;
+    const started = Date.now();
+    const results = await Promise.all(
+      Array.from({ length: N }, () =>
+        resolveScopedConnectionIdentity({
+          sql,
+          database,
+          roleName: ROLE,
+          fingerprintHex: FP,
+          enabled: true,
+          sink: () => {},
+        }),
+      ),
+    );
+    const elapsed = Date.now() - started;
+
+    expect(results).toHaveLength(N);
+    // Every boot is SAFE: it either cut over as the scoped role or fell back
+    // CLEANLY to postgres (a loser that checked pg_roles before the winner
+    // committed). NEVER an error, NEVER a throw, NEVER a hung boot.
+    for (const r of results) {
+      if (r.cutover) {
+        expect(r.username).toBe(ROLE);
+      } else {
+        expect(r.username).toBe('postgres');
+        expect(r.reason).not.toBe('query-failed');
+      }
+      expect(r.database).toBe(database);
+    }
+    // Single provision: the advisory lock guarantees the role is created at
+    // most once — it exists exactly once afterwards.
+    const count = await sql.unsafe(`SELECT count(*)::int AS n FROM pg_roles WHERE rolname = '${ROLE}'`);
+    expect(count[0].n).toBe(1);
+    // Non-blocking: a contended lock returns immediately. Generous CI bound.
+    expect(elapsed).toBeLessThan(20_000);
+  }, 45_000);
+
+  it('warm storm: role pre-exists ⇒ all 8 concurrent boots converge as the scoped role', async () => {
+    // Provision once, then clear the sentinel so all 8 race the revalidation
+    // path with the role already present — no role-missing race window.
+    await ensureScopedRole({ sql, roleName: ROLE, database, enabled: true, sink: () => {} });
+    clearRoleCutoverSentinel(FP);
+    const N = 8;
+    const started = Date.now();
+    const results = await Promise.all(
+      Array.from({ length: N }, () =>
+        resolveScopedConnectionIdentity({
+          sql,
+          database,
+          roleName: ROLE,
+          fingerprintHex: FP,
+          enabled: true,
+          sink: () => {},
+        }),
+      ),
+    );
+    const elapsed = Date.now() - started;
+
+    expect(results).toHaveLength(N);
+    for (const r of results) {
+      expect(r.cutover).toBe(true);
+      expect(r.username).toBe(ROLE);
+      expect(r.database).toBe(database);
+    }
+    // Still exactly one role — concurrent revalidation never re-creates it.
+    const count = await sql.unsafe(`SELECT count(*)::int AS n FROM pg_roles WHERE rolname = '${ROLE}'`);
+    expect(count[0].n).toBe(1);
+    expect(elapsed).toBeLessThan(20_000);
+  }, 45_000);
+});

--- a/src/lib/role-cutover.ts
+++ b/src/lib/role-cutover.ts
@@ -11,8 +11,9 @@
  * This module provisions a dedicated NON-superuser role scoped to genie's own
  * objects inside the EXISTING `postgres` database. **No bytes move.** Group 1
  * only provisions + grants + proves the privilege envelope; the connection
- * identity rebind is Group 2 (out of scope here). `ensureScopedRole()` is a
- * pure no-op unless `GENIE_ROLE_CUTOVER=1` is set (default OFF this group).
+ * identity rebind is Group 2. Wave 3 (Group 4) flipped the gate to DEFAULT-ON:
+ * `ensureScopedRole()` runs unless the documented kill-switch
+ * `GENIE_ROLE_CUTOVER=0` forces the legacy `postgres`/`postgres` path.
  *
  * Concurrency-safe: provisioning runs under a NON-BLOCKING
  * `pg_try_advisory_lock(hashtext('genie:role-cutover-v1'))`. Late arrivals
@@ -219,6 +220,28 @@ export interface RoleCutoverEvent {
 
 export type RoleCutoverSink = (event: RoleCutoverEvent) => void;
 
+// ============================================================================
+// Default-ON gate (Wave 3 — Goal A, Group 4).
+//
+// Through Waves 1+2 the cutover was OPT-IN (`GENIE_ROLE_CUTOVER=1`). Wave 3
+// flips it: cutover is now the DEFAULT and `GENIE_ROLE_CUTOVER=0` is the single
+// documented KILL-SWITCH that forces the legacy `postgres`/`postgres` path
+// (byte-for-byte today's behavior). Any other value — unset, `1`, anything that
+// is not exactly the string `0` — leaves cutover ON. This is the only place
+// the gate literal lives so the kill-switch can never drift between db.ts and
+// this module.
+// ============================================================================
+
+/**
+ * True unless the documented kill-switch is engaged. `GENIE_ROLE_CUTOVER=0`
+ * (and ONLY the exact string `0`) forces the legacy postgres/postgres path;
+ * unset / `1` / any other value ⇒ cutover ON. Single source of truth — db.ts
+ * imports this rather than re-deriving the literal.
+ */
+export function isRoleCutoverEnabled(): boolean {
+  return process.env.GENIE_ROLE_CUTOVER !== '0';
+}
+
 function genieHome(): string {
   return process.env.GENIE_HOME ?? join(homedir(), '.genie');
 }
@@ -328,7 +351,8 @@ async function grantScopedPrivileges(reserved: ReservedSqlLike, role: string, da
 
 /**
  * Idempotently ensure the dedicated non-superuser role exists with genie's
- * scoped privilege envelope. No-op unless `GENIE_ROLE_CUTOVER=1`. Never throws
+ * scoped privilege envelope. No-op only under the kill-switch
+ * `GENIE_ROLE_CUTOVER=0` (Wave 3 default-on). Never throws
  * for an operational failure — it emits `role-cutover.error.*` out-of-band and
  * returns `skipped` so a caller on the boot path can fall back cleanly.
  *
@@ -340,7 +364,7 @@ async function grantScopedPrivileges(reserved: ReservedSqlLike, role: string, da
  */
 export async function ensureScopedRole(opts: EnsureScopedRoleOptions): Promise<RoleCutoverResult> {
   const sink = opts.sink ?? defaultRoleCutoverSink;
-  const enabled = opts.enabled ?? process.env.GENIE_ROLE_CUTOVER === '1';
+  const enabled = opts.enabled ?? isRoleCutoverEnabled();
 
   if (!enabled) {
     emit(sink, 'role-cutover.skip.disabled');
@@ -530,7 +554,7 @@ export async function resolveScopedConnectionIdentity(
   opts: ResolveScopedIdentityOptions,
 ): Promise<ScopedConnectionIdentity> {
   const sink = opts.sink ?? defaultRoleCutoverSink;
-  const enabled = opts.enabled ?? process.env.GENIE_ROLE_CUTOVER === '1';
+  const enabled = opts.enabled ?? isRoleCutoverEnabled();
   const database = opts.database;
   const fallback = (reason: string, fp: string | null = null): ScopedConnectionIdentity => ({
     username: FALLBACK_SUPERUSER,
@@ -600,4 +624,58 @@ export async function resolveScopedConnectionIdentity(
     });
     return fallback('query-failed', fingerprintHex);
   }
+}
+
+// ============================================================================
+// Read-only inspection — backs `genie doctor --connection-identity`.
+//
+// Pure derivation + sentinel/package.json reads only. NEVER provisions, grants,
+// connects, or writes any file. The live DB facts (rolsuper, grants,
+// current_user/fallback) are queried separately by the doctor command on the
+// already-open app connection — this function contributes only the FS/identity
+// half so the doctor surface stays strictly read-only.
+// ============================================================================
+
+export interface RoleCutoverInspection {
+  /** Effective gate: false only under the documented kill-switch. */
+  enabled: boolean;
+  /** True when `GENIE_ROLE_CUTOVER=0` (the documented kill-switch) is set. */
+  killSwitch: boolean;
+  /** Derived scoped role name, or null when the fingerprint is unstable. */
+  roleName: string | null;
+  /** 12-hex fingerprint segment (sentinel key), or null when unstable. */
+  fingerprintHex: string | null;
+  /** Absolute per-fingerprint sentinel path, or null when unresolved. */
+  sentinelPath: string | null;
+  /** Parsed sentinel contents, or null when absent/stale/unreadable. */
+  sentinel: RoleCutoverSentinel | null;
+}
+
+/**
+ * Resolve the role-cutover identity snapshot WITHOUT touching the DB or
+ * mutating any state. Read-only: derives the role name + fingerprint and reads
+ * the per-fingerprint sentinel. Used by `genie doctor --connection-identity`.
+ */
+export function inspectRoleCutover(): RoleCutoverInspection {
+  const killSwitch = process.env.GENIE_ROLE_CUTOVER === '0';
+  const enabled = isRoleCutoverEnabled();
+  const fp = resolveGenieFingerprint();
+  if (!fp) {
+    return { enabled, killSwitch, roleName: null, fingerprintHex: null, sentinelPath: null, sentinel: null };
+  }
+  const names = deriveProvisionedNames(fp);
+  let sentinelPath: string | null = null;
+  try {
+    sentinelPath = roleCutoverSentinelPath(names.fingerprintHex);
+  } catch {
+    sentinelPath = null;
+  }
+  return {
+    enabled,
+    killSwitch,
+    roleName: names.roleName,
+    fingerprintHex: names.fingerprintHex,
+    sentinelPath,
+    sentinel: readRoleCutoverSentinel(names.fingerprintHex),
+  };
 }


### PR DESCRIPTION
## Wave 3 — Group 4 (final): flip the cutover LIVE

Makes the dedicated-role cutover the **default** behind a documented kill-switch. genie stops connecting as the `postgres` superuser on the load-bearing direct-postmaster path.

### Honest framing (council-mandated)
Least-privilege **integrity containment** — *a genie failure can no longer DROP omni, exhaust the shared cluster, or corrupt shared WAL*. **NOT confidentiality**: `--auth-local=trust` and the passwordless `postgres` superuser are unchanged (producer-side, out of scope). Zero bytes move.

### Deliverables
- **Default-on gate, single source of truth.** `isRoleCutoverEnabled()` in `role-cutover.ts`: `GENIE_ROLE_CUTOVER=0` (and only `0`) is the documented kill-switch → byte-identical legacy `postgres`/`postgres`; unset/`1`/other ⇒ ON. Both `db.ts` gate sites consume it so the literal cannot drift.
- **`genie doctor --connection-identity`** (read-only): role, `rolsuper` (false when active), database, GRANT summary, fallback flag+reason, per-fingerprint sentinel. SELECT-only, zero mutations. `--json` supported.
- **`role-cutover.matrix.test.ts`**: N=8 concurrent single-provision (cold + warm storm), fallback trio, multi-fingerprint non-stranding, test-mode/FORCE_TCP/accept-hook skip, kill-switch + default-on contract.
- **`docs/_internal/role-cutover-note.md`**: honest framing, kill-switch, fallback-is-rollback, doctor reading guide. *(Content authored on disk; cross-repo `.docs-vendor` submodule PR + pointer bump is the documented human-gated docs workflow — see Concerns.)*

### Wave 2 safety preserved
Direct-postmaster rebind only (no accept-hook/router/TCP/test widening); non-hard-fail fallback; per-fingerprint sentinel; test-mode + `GENIE_PG_FORCE_TCP` SKIP. In test mode `shouldAttemptRoleCutover` returns false → the flip adds zero connections under the suite.

### Validation
- `bun run typecheck` clean · `bun run dead-code` (knip) clean · `bun run lint` exit 0
- Targeted set (matrix + db.role-cutover + provision + migration-replay + db.test): **106 pass / 0 fail**
- **Full-suite regression check:** pristine base = **14** failures; with Wave 3 = **14** failures — identical ~5000ms pgserve-saturation timeouts across unrelated DB-backed suites. **No regression** from the flip.
- db.ts source-guard green (only the gate predicate changed; no connection literals / `buildPgClientOptions` signature touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)