### PR TITLE
feat(db): genie-dedicated-role-cutover Wave 3 — default-on + doctor + matrix (Goal A G4)

### DIFF
--- a/.genie/wishes/genie-dedicated-role-cutover/WISH.md
+++ b/.genie/wishes/genie-dedicated-role-cutover/WISH.md
@@ -7,6 +7,29 @@
 | **Date** | 2026-05-15 |
 | **Design** | Council review of `canonical-pg-relocation` (4 members, 2 rounds, 2026-05-15) — "Goal A", the carved-off safe half. See `.genie/wishes/canonical-pg-relocation/COUNCIL-REVIEW.md`. |
 
+## Amendment 2026-05-16 — migration ordering (Felipe-approved; implemented in PR #2433 `48ba9ab0`)
+
+Wave 3 reproduced a design conflict the original spec got backwards. genie's
+own migrations legitimately issue privileged DDL — `CREATE EXTENSION pgcrypto`
+(`039`, `041`) and `CREATE ROLE` for the RBAC layer (`041`, `043`). A
+least-privilege `NOSUPERUSER NOCREATEROLE` role **cannot and must not** run
+these, so the original Group-2/Prereq decision ("the FIRST `runMigrations`
+executes as the scoped role" / "before `runPostConnectSetup`") is infeasible
+by construction, and Group 3's replay test false-greened on a pre-seeded
+fixture. Corrected, implemented design:
+
+> **Migrations run on the privileged bootstrap (superuser) connection FIRST
+> (cold-DB privileged bootstrap); the scoped-role rebind happens AFTER, for
+> steady-state runtime only.**
+
+Preserves the council's full security intent — the threat model is *runtime*
+compromise (a buggy/exploited genie during normal operation cannot `DROP omni`
+or touch the shared cluster); a one-time trusted migration step on the
+privileged connection is not that attack surface. Canonical production pattern
+(privileged migrator, limited app role). Zero bytes still move; kill-switch +
+fallback unchanged. Wherever the sections below say "migrations run as the
+scoped role" / "before `runPostConnectSetup`", read the amended ordering above.
+
 ## Summary
 
 Genie connects to the shared pgserve postmaster as `postgres`/`postgres` — the cluster **superuser** — and the audited live host proves this is not an accident but the deterministic steady state: `resolveTransport()`'s direct-postmaster branch (`src/lib/db.ts:1238-1259`) explicitly *skips* fingerprint routing whenever `admin.json` exists (the normal case), and `buildPgClientOptions` then hard-sets `database=postgres, username=postgres`. On that same single postmaster sits omni's 1 GB production database, sharing WAL and disk. A genie bug, a bad migration, or a compromised genie process today has superuser authority to `DROP DATABASE omni`, exhaust the shared cluster, create/alter arbitrary roles, or corrupt shared WAL — genie's blast radius is the entire machine's Postgres, not genie's own data. This wish removes that blast radius **without moving a single byte**: provision a dedicated, non-superuser role with privileges scoped to genie's own objects, and rebind genie's connection identity (on the load-bearing direct-postmaster path) to that role. Data stays exactly where it is, in the `postgres` database; only *who genie logs in as* changes. There is no dump, no copy, no proof gate, no cutover window, no advisory-locked migrator, no crash-recovery surface — and therefore no data-loss surface at all. This is the council's unanimous "ship now" recommendation; physical relocation of the bytes into a fingerprinted database is the separate, deferred `canonical-pg-relocation` wish (Goal B), explicitly gated and out of scope here. **Honest framing (council-mandated):** this is a *least-privilege integrity-containment* win — "a genie failure can no longer take down the shared cluster or its neighbors" — **not** a confidentiality win. `--auth-local=trust` and the still-passwordless `postgres` superuser are unchanged (producer-side pgserve v3.x, out of scope); anyone on the socket is still superuser. We do not claim "safe from external reading" anywhere.

--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -22,10 +22,11 @@ import { fileURLToPath } from 'node:url';
 import { $ } from 'bun';
 import type { BridgeStatusResult, PingOptions } from '../lib/bridge-status.js';
 import { contractClaudePath, getClaudeSettingsPath } from '../lib/claude-settings.js';
-import { isAvailable as isRuntimePgAvailable } from '../lib/db.js';
+import { getConnection, isAvailable as isRuntimePgAvailable, resolveDatabaseName } from '../lib/db.js';
 import { tmuxBin } from '../lib/ensure-tmux.js';
 import { genieConfigExists, getGenieConfigPath, isSetupComplete, loadGenieConfig } from '../lib/genie-config.js';
 import { respawnInvocation } from '../lib/respawn.js';
+import { type RoleCutoverInspection, inspectRoleCutover } from '../lib/role-cutover.js';
 import { checkCommand } from '../lib/system-detect.js';
 import { findWorkspace } from '../lib/workspace.js';
 import {
@@ -813,9 +814,15 @@ export async function doctorCommand(options?: {
   fixTeamOrphans?: boolean;
   dryRun?: boolean;
   json?: boolean;
+  connectionIdentity?: boolean;
 }): Promise<void> {
   if (options?.fix) {
     await doctorFix();
+    return;
+  }
+
+  if (options?.connectionIdentity) {
+    await runConnectionIdentityCheck(Boolean(options.json));
     return;
   }
 
@@ -854,6 +861,152 @@ export async function doctorCommand(options?: {
 
   printDoctorSummary(counts);
   if (counts.errors) process.exit(1);
+}
+
+// ============================================================================
+// `genie doctor --connection-identity` — Goal A, Group 4.
+//
+// READ-ONLY operator inspection of the dedicated-role cutover. Prints the
+// resolved role, rolsuper (must be false when cutover is active), database, the
+// GRANT summary, the fallback-active flag + reason, and the per-fingerprint
+// sentinel state/path. Issues only SELECTs — never CREATE ROLE / GRANT / ALTER.
+// The connection itself follows genie's normal idempotent boot (identical to
+// every other genie command); this subcommand adds zero mutations of its own.
+// ============================================================================
+
+interface ConnectionIdentityDb {
+  reachable: boolean;
+  currentUser?: string;
+  currentDatabase?: string;
+  roleExists?: boolean;
+  rolsuper?: boolean;
+  rolcanlogin?: boolean;
+  grants?: {
+    connect: boolean;
+    schemaUsage: boolean;
+    schemaCreate: boolean;
+    tablesSelectable: number;
+    tablesTotal: number;
+  };
+  error?: string;
+}
+
+const SAFE_ROLE_RE = /^[a-z0-9_]+$/;
+
+/** Read-only DB facts for the cutover identity. Only SELECTs; never mutates. */
+async function queryConnectionIdentityDb(roleName: string | null): Promise<ConnectionIdentityDb> {
+  try {
+    // postgres.js Sql bleed-through — getConnection() returns `any` by design.
+    // biome-ignore lint/suspicious/noExplicitAny: postgres.js Sql type bleed-through
+    const sql = (await getConnection()) as any;
+    const [whoRow] = await sql.unsafe('SELECT current_user AS who, current_database() AS db');
+    const db: ConnectionIdentityDb = {
+      reachable: true,
+      currentUser: whoRow?.who,
+      currentDatabase: whoRow?.db,
+    };
+    if (!roleName || !SAFE_ROLE_RE.test(roleName)) return db;
+    const roleRows = await sql.unsafe(`SELECT rolsuper, rolcanlogin FROM pg_roles WHERE rolname = '${roleName}'`);
+    if (roleRows.length === 0) return { ...db, roleExists: false };
+    const [g] = await sql.unsafe(
+      `SELECT has_database_privilege('${roleName}', current_database(), 'CONNECT') AS db_connect,
+              has_schema_privilege('${roleName}', 'public', 'USAGE')  AS sch_usage,
+              has_schema_privilege('${roleName}', 'public', 'CREATE') AS sch_create`,
+    );
+    const [t] = await sql.unsafe(
+      `SELECT count(*)::int AS total,
+              count(*) FILTER (
+                WHERE has_table_privilege('${roleName}', format('%I.%I', schemaname, tablename), 'SELECT')
+              )::int AS selectable
+         FROM pg_tables WHERE schemaname = 'public'`,
+    );
+    return {
+      ...db,
+      roleExists: true,
+      rolsuper: roleRows[0].rolsuper,
+      rolcanlogin: roleRows[0].rolcanlogin,
+      grants: {
+        connect: g.db_connect,
+        schemaUsage: g.sch_usage,
+        schemaCreate: g.sch_create,
+        tablesSelectable: t.selectable,
+        tablesTotal: t.total,
+      },
+    };
+  } catch (err) {
+    return { reachable: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+function deriveFallbackReason(inspection: RoleCutoverInspection, db: ConnectionIdentityDb): string | undefined {
+  if (!inspection.enabled) return 'kill-switch engaged (GENIE_ROLE_CUTOVER=0)';
+  if (!inspection.roleName) return 'fingerprint-unstable (cannot derive scoped role)';
+  if (!db.reachable) return `db-unreachable: ${db.error ?? 'unknown'}`;
+  if (db.roleExists === false) return 'role not provisioned in pg_roles';
+  if (db.currentUser !== inspection.roleName) return `connected as ${db.currentUser} (legacy postgres path)`;
+  return undefined;
+}
+
+function printConnectionIdentity(inspection: RoleCutoverInspection, db: ConnectionIdentityDb): void {
+  const yn = (v: boolean | undefined): string => (v === undefined ? 'n/a' : v ? 'yes' : 'no');
+  const reason = deriveFallbackReason(inspection, db);
+  const cutoverActive = reason === undefined && db.currentUser === inspection.roleName && db.rolsuper === false;
+
+  console.log();
+  console.log('\x1b[1mConnection Identity (dedicated-role cutover)\x1b[0m');
+  console.log(`\x1b[2m${'─'.repeat(40)}\x1b[0m`);
+  console.log(`  cutover enabled:    ${yn(inspection.enabled)}${inspection.killSwitch ? '  (kill-switch ON)' : ''}`);
+  console.log(`  cutover active:     ${cutoverActive ? '\x1b[32myes\x1b[0m' : '\x1b[33mno\x1b[0m'}`);
+  console.log(`  resolved role:      ${inspection.roleName ?? '\x1b[33m<unresolved: fingerprint-unstable>\x1b[0m'}`);
+  console.log(`  database:           ${db.currentDatabase ?? resolveDatabaseName()}`);
+  console.log(`  connected as:       ${db.currentUser ?? '\x1b[33m<db unreachable>\x1b[0m'}`);
+  const superColor = db.rolsuper === false ? '\x1b[32m' : '\x1b[31m';
+  console.log(
+    `  rolsuper:           ${db.rolsuper === undefined ? 'n/a' : `${superColor}${db.rolsuper}\x1b[0m`}` +
+      `${cutoverActive && db.rolsuper !== false ? '  \x1b[31m(EXPECTED false WHEN ACTIVE)\x1b[0m' : ''}`,
+  );
+  console.log(`  rolcanlogin:        ${yn(db.rolcanlogin)}`);
+  if (db.grants) {
+    console.log('  grants:');
+    console.log(`    CONNECT on db:    ${yn(db.grants.connect)}`);
+    console.log(`    USAGE  on public: ${yn(db.grants.schemaUsage)}`);
+    console.log(`    CREATE on public: ${yn(db.grants.schemaCreate)}`);
+    console.log(`    SELECT-able tbls: ${db.grants.tablesSelectable}/${db.grants.tablesTotal}`);
+  } else {
+    console.log('  grants:             n/a (role absent or db unreachable)');
+  }
+  console.log(`  fallback active:    ${reason ? `\x1b[33myes\x1b[0m — ${reason}` : 'no'}`);
+  console.log(`  sentinel path:      ${inspection.sentinelPath ?? 'n/a'}`);
+  console.log(
+    `  sentinel state:     ${
+      inspection.sentinel
+        ? `present (role=${inspection.sentinel.roleName}, db=${inspection.sentinel.database}, verifiedAt=${inspection.sentinel.verifiedAt})`
+        : 'absent'
+    }`,
+  );
+  console.log();
+  console.log(
+    '\x1b[2m  Integrity containment only — NOT confidentiality. --auth-local=trust and the\n' +
+      '  passwordless postgres superuser are unchanged (producer-side, out of scope).\x1b[0m',
+  );
+}
+
+async function runConnectionIdentityCheck(json: boolean): Promise<void> {
+  const inspection = inspectRoleCutover();
+  const db = await queryConnectionIdentityDb(inspection.roleName);
+  const reason = deriveFallbackReason(inspection, db);
+  const cutoverActive = reason === undefined && db.currentUser === inspection.roleName && db.rolsuper === false;
+  if (json) {
+    console.log(
+      JSON.stringify(
+        { cutoverActive, fallbackActive: !cutoverActive, fallbackReason: reason, inspection, db },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+  printConnectionIdentity(inspection, db);
 }
 
 function printObservabilityReport(report: Awaited<ReturnType<typeof collectObservabilityHealth>>): void {

--- a/src/genie.ts
+++ b/src/genie.ts
@@ -209,6 +209,10 @@ program
     'Archive stale Claude-team config dirs missing config.json (paired with invincible-genie wish migration 050)',
   )
   .option('--dry-run', 'Pair with --fix-team-orphans to preview archive moves without mutating')
+  .option(
+    '--connection-identity',
+    'Read-only: report the dedicated-role cutover identity (role, rolsuper, database, grants, fallback, sentinel)',
+  )
   .option('--json', 'Emit JSON instead of human output (pairs with --observability)')
   .action(doctorCommand);
 program

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -27,7 +27,12 @@ import { runMigrations } from './db-migrations.js';
 import { needsSeed, needsSeededTeams, runSeed } from './pg-seed.js';
 import { getProcessStartTime } from './process-identity.js';
 import { respawnInvocation } from './respawn.js';
-import { clearRoleCutoverSentinel, defaultRoleCutoverSink, resolveScopedConnectionIdentity } from './role-cutover.js';
+import {
+  clearRoleCutoverSentinel,
+  defaultRoleCutoverSink,
+  isRoleCutoverEnabled,
+  resolveScopedConnectionIdentity,
+} from './role-cutover.js';
 import { maybePromptV1Migration } from './v1-migration-prompt.js';
 
 /**
@@ -1215,9 +1220,10 @@ async function buildAndOpenConnection(transport: Transport, _t0: number): Promis
   let activeClient = bootstrapClient;
   sqlClient = bootstrapClient;
 
-  // Only consult admin.json when cutover is opted in, so the disabled path is
-  // identical to today (no extra stat, no behavior change).
-  const cutoverEnabled = process.env.GENIE_ROLE_CUTOVER === '1';
+  // Wave 3: cutover is DEFAULT-ON; only the documented kill-switch
+  // (GENIE_ROLE_CUTOVER=0) skips the admin.json consult so the killed path is
+  // byte-identical to legacy (no extra stat, no behavior change).
+  const cutoverEnabled = isRoleCutoverEnabled();
   const directPostmaster = cutoverEnabled && transport.useSocket && readPostmasterDiscovery() !== null;
 
   try {
@@ -1428,8 +1434,8 @@ function buildPgClientOptions(
  * `buildPgClientOptions` otherwise hard-sets `username=postgres` — carries the
  * rebind. The accept-hook/router path and the TCP/test paths are intentionally
  * left on `postgres`/`postgres`: rebinding the router path is a silent no-op
- * that re-forks as the superuser on boot #2. Default OFF
- * (`GENIE_ROLE_CUTOVER=1` opt-in this wave).
+ * that re-forks as the superuser on boot #2. Wave 3: DEFAULT-ON — the only way
+ * back to legacy is the documented kill-switch `GENIE_ROLE_CUTOVER=0`.
  */
 export function shouldAttemptRoleCutover(args: {
   enabled: boolean;
@@ -1457,7 +1463,7 @@ async function maybeRebindToScopedRole(args: {
   // biome-ignore lint/suspicious/noExplicitAny: postgres.js default export factory
   pgModule: any;
 }): Promise<postgres.Sql | null> {
-  const enabled = process.env.GENIE_ROLE_CUTOVER === '1';
+  const enabled = isRoleCutoverEnabled();
   if (
     !shouldAttemptRoleCutover({
       enabled,

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -30,6 +30,7 @@ import { respawnInvocation } from './respawn.js';
 import {
   clearRoleCutoverSentinel,
   defaultRoleCutoverSink,
+  ensurePrivilegedBootstrapObjects,
   isRoleCutoverEnabled,
   resolveScopedConnectionIdentity,
 } from './role-cutover.js';
@@ -1483,6 +1484,31 @@ async function maybeRebindToScopedRole(args: {
     return null;
   }
   if (!identity.cutover) return null;
+
+  // Stage the inherently-privileged, one-time setup that genie's migration set
+  // performs but the least-privilege scoped role legitimately must NOT do
+  // (pgcrypto extension, cluster RBAC roles, own-schema ownership). Runs on the
+  // bootstrap SUPERUSER connection BEFORE the rebind so the first runMigrations
+  // — which executes as the scoped role — finds these already present and its
+  // CREATE EXTENSION / CREATE ROLE statements no-op. On a TRULY fresh pgserve
+  // (the CI smoke) these don't exist yet; without this, the scoped role's
+  // migration replay fails. Defensive: any failure ⇒ stay on the bootstrap
+  // superuser pool (migrations run as the superuser exactly like legacy),
+  // emit out-of-band, never hard-fail boot.
+  try {
+    await ensurePrivilegedBootstrapObjects(args.bootstrap, identity.username);
+  } catch (err) {
+    if (identity.fingerprintHex) clearRoleCutoverSentinel(identity.fingerprintHex);
+    defaultRoleCutoverSink({
+      event: 'role-cutover.fallback.bootstrap-objects-failed',
+      ts: new Date().toISOString(),
+      pid: process.pid,
+      roleName: identity.username,
+      database: args.database,
+      detail: { message: err instanceof Error ? err.message : String(err) },
+    });
+    return null;
+  }
 
   const roleClient = args.pgModule(
     buildPgClientOptions(args.transport, args.database, args.cliShortLived, identity.username),

--- a/src/lib/role-cutover.matrix.test.ts
+++ b/src/lib/role-cutover.matrix.test.ts
@@ -1,0 +1,432 @@
+/**
+ * Goal-A Group 4 — the rollout HARDENING matrix.
+ *
+ * Wave 3 flips `GENIE_ROLE_CUTOVER` to DEFAULT-ON behind the documented
+ * kill-switch (`=0`). This file is the edge-case matrix the wish mandates
+ * before that flip ships:
+ *
+ *   (a) N=8 concurrent boots ⇒ exactly ONE provision via pg_try_advisory_lock,
+ *       none block, all converge connected as the scoped role.
+ *   (b) fallback trio (pgserve unreachable / grant query fails / role missing)
+ *       ⇒ clean postgres/postgres, no hard-fail, out-of-band fallback event.
+ *   (c) multi-fingerprint host (2 fingerprints, 1 home) ⇒ each cuts over
+ *       independently; the per-fingerprint sentinel is never stranded.
+ *   (d) test-mode (GENIE_TEST_PG_PORT) + GENIE_PG_FORCE_TCP ⇒ SKIP, the rebind
+ *       never lands on the accept-hook / TCP / test paths (byte-identical).
+ *   (e) kill-switch GENIE_ROLE_CUTOVER=0 ⇒ legacy postgres/postgres exactly as
+ *       before; the default-on contract holds for unset / `1` / other values.
+ *
+ * Pure + mock sections always run; the concurrency section is DB-backed and
+ * skips cleanly when pgserve is unavailable.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getConnection, resolveDatabaseName, shouldAttemptRoleCutover } from './db.js';
+import {
+  type RoleCutoverEvent,
+  clearRoleCutoverSentinel,
+  ensureScopedRole,
+  inspectRoleCutover,
+  isRoleCutoverEnabled,
+  readRoleCutoverSentinel,
+  resolveScopedConnectionIdentity,
+  roleCutoverSentinelPath,
+  writeRoleCutoverSentinel,
+} from './role-cutover.js';
+import { DB_AVAILABLE, setupTestDatabase } from './test-db.js';
+
+const PID = process.pid;
+const ROLE = `pgserve_rcmtx_${PID}_role`;
+const FP = `cc${PID.toString(16)}`.slice(0, 12);
+
+function recorder(): { events: RoleCutoverEvent[]; sink: (e: RoleCutoverEvent) => void } {
+  const events: RoleCutoverEvent[] = [];
+  return { events, sink: (e) => events.push(e) };
+}
+
+function withEnv<T>(key: string, value: string | undefined, fn: () => T): T {
+  const prev = process.env[key];
+  if (value === undefined) process.env[key] = undefined;
+  else process.env[key] = value;
+  try {
+    return fn();
+  } finally {
+    if (prev === undefined) process.env[key] = undefined;
+    else process.env[key] = prev;
+  }
+}
+
+// Throwing stub — proves a code path performs NO DB I/O.
+const throwingSql = {
+  reserve: () => Promise.reject(new Error('sql must not be touched')),
+  unsafe: () => Promise.reject(new Error('sql must not be touched')),
+} as unknown as Parameters<typeof resolveScopedConnectionIdentity>[0]['sql'];
+
+interface MockOpts {
+  lock: boolean;
+  roleExists: boolean;
+  reserveThrows?: boolean;
+  postCheckThrows?: boolean;
+}
+
+function mockSql(opts: MockOpts): Parameters<typeof resolveScopedConnectionIdentity>[0]['sql'] {
+  const reserved = {
+    unsafe: (q: string) => {
+      if (q.includes('pg_try_advisory_lock')) return Promise.resolve([{ locked: opts.lock }]);
+      if (q.includes('FROM pg_roles')) return Promise.resolve(opts.roleExists ? [{ '?column?': 1 }] : []);
+      return Promise.resolve([]);
+    },
+    release: () => {},
+  };
+  return {
+    reserve: () => (opts.reserveThrows ? Promise.reject(new Error('pgserve down')) : Promise.resolve(reserved)),
+    unsafe: (q: string) => {
+      if (opts.postCheckThrows) return Promise.reject(new Error('grant/lookup query failed'));
+      if (q.includes('FROM pg_roles')) return Promise.resolve(opts.roleExists ? [{ '?column?': 1 }] : []);
+      return Promise.resolve([]);
+    },
+  } as unknown as Parameters<typeof resolveScopedConnectionIdentity>[0]['sql'];
+}
+
+// ============================================================================
+// GENIE_HOME isolation — sentinel files never touch the operator's ~/.genie.
+// ============================================================================
+
+let homeDir: string;
+let prevHome: string | undefined;
+
+beforeAll(() => {
+  prevHome = process.env.GENIE_HOME;
+  homeDir = mkdtempSync(join(tmpdir(), 'genie-rcmtx-'));
+  process.env.GENIE_HOME = homeDir;
+});
+
+afterAll(() => {
+  if (prevHome === undefined) process.env.GENIE_HOME = undefined;
+  else process.env.GENIE_HOME = prevHome;
+  try {
+    rmSync(homeDir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+// ============================================================================
+// (e) Kill-switch + default-on contract.
+// ============================================================================
+
+describe('(e) kill-switch + default-on gate', () => {
+  it('GENIE_ROLE_CUTOVER=0 is the ONLY off state; unset / 1 / other ⇒ ON', () => {
+    expect(withEnv('GENIE_ROLE_CUTOVER', '0', () => isRoleCutoverEnabled())).toBe(false);
+    expect(withEnv('GENIE_ROLE_CUTOVER', undefined, () => isRoleCutoverEnabled())).toBe(true);
+    expect(withEnv('GENIE_ROLE_CUTOVER', '1', () => isRoleCutoverEnabled())).toBe(true);
+    expect(withEnv('GENIE_ROLE_CUTOVER', '2', () => isRoleCutoverEnabled())).toBe(true);
+    expect(withEnv('GENIE_ROLE_CUTOVER', 'true', () => isRoleCutoverEnabled())).toBe(true);
+  });
+
+  it('kill-switch ⇒ resolveScopedConnectionIdentity is legacy postgres/postgres, zero DB I/O', async () => {
+    const { events, sink } = recorder();
+    const id = await withEnv('GENIE_ROLE_CUTOVER', '0', () =>
+      resolveScopedConnectionIdentity({ sql: throwingSql, database: 'postgres', sink }),
+    );
+    expect(id.cutover).toBe(false);
+    expect(id.username).toBe('postgres');
+    expect(id.database).toBe('postgres');
+    expect(id.reason).toBe('disabled');
+    expect(events.map((e) => e.event)).toEqual(['role-cutover.skip.disabled']);
+  });
+
+  it('kill-switch ⇒ ensureScopedRole is a pure no-op (sql untouched)', async () => {
+    const { events, sink } = recorder();
+    const result = await withEnv('GENIE_ROLE_CUTOVER', '0', () =>
+      ensureScopedRole({
+        sql: {
+          reserve: () => Promise.reject(new Error('sql must not be touched when killed')),
+        } as unknown as Parameters<typeof ensureScopedRole>[0]['sql'],
+        sink,
+      }),
+    );
+    expect(result.status).toBe('skipped');
+    expect(result.reason).toBe('disabled');
+    expect(events.map((e) => e.event)).toEqual(['role-cutover.skip.disabled']);
+  });
+
+  it('inspectRoleCutover reports the kill-switch + default-on state read-only', () => {
+    const killed = withEnv('GENIE_ROLE_CUTOVER', '0', () => inspectRoleCutover());
+    expect(killed.enabled).toBe(false);
+    expect(killed.killSwitch).toBe(true);
+
+    const live = withEnv('GENIE_ROLE_CUTOVER', undefined, () => inspectRoleCutover());
+    expect(live.enabled).toBe(true);
+    expect(live.killSwitch).toBe(false);
+    // Dev/test tree resolves a stable fingerprint → deterministic role name.
+    if (live.roleName !== null) {
+      expect(live.roleName).toMatch(/^pgserve_.*_role$/);
+      expect(live.sentinelPath).toContain(homeDir);
+    }
+  });
+});
+
+// ============================================================================
+// (b) Fallback trio — every degraded path ⇒ clean postgres/postgres, NO throw.
+// ============================================================================
+
+describe('(b) fallback trio never hard-fails boot', () => {
+  afterEach(() => clearRoleCutoverSentinel(FP));
+
+  it('pgserve unreachable (reserve throws) ⇒ clean postgres/postgres + fallback event', async () => {
+    const { events, sink } = recorder();
+    const id = await resolveScopedConnectionIdentity({
+      sql: mockSql({ lock: false, roleExists: false, reserveThrows: true }),
+      database: 'postgres',
+      roleName: ROLE,
+      fingerprintHex: FP,
+      enabled: true,
+      sink,
+    });
+    expect(id.cutover).toBe(false);
+    expect(id.username).toBe('postgres');
+    expect(id.database).toBe('postgres');
+    expect(events.some((e) => e.event.startsWith('role-cutover.fallback.'))).toBe(true);
+  });
+
+  it('grant/lookup query fails ⇒ clean fallback (query-failed)', async () => {
+    const { events, sink } = recorder();
+    const id = await resolveScopedConnectionIdentity({
+      sql: mockSql({ lock: true, roleExists: true, postCheckThrows: true }),
+      database: 'postgres',
+      roleName: ROLE,
+      fingerprintHex: FP,
+      enabled: true,
+      sink,
+    });
+    expect(id.cutover).toBe(false);
+    expect(id.username).toBe('postgres');
+    expect(events.map((e) => e.event)).toContain('role-cutover.fallback.query-failed');
+  });
+
+  it('role missing in pg_roles ⇒ fallback + self-heals the stale sentinel', async () => {
+    writeRoleCutoverSentinel(FP, { roleName: ROLE, database: 'mismatch-forces-revalidate' });
+    expect(readRoleCutoverSentinel(FP)).not.toBeNull();
+    const { events, sink } = recorder();
+    const id = await resolveScopedConnectionIdentity({
+      sql: mockSql({ lock: false, roleExists: false }),
+      database: 'postgres',
+      roleName: ROLE,
+      fingerprintHex: FP,
+      enabled: true,
+      sink,
+    });
+    expect(id.cutover).toBe(false);
+    expect(id.username).toBe('postgres');
+    expect(id.reason).toBe('role-missing');
+    expect(events.map((e) => e.event)).toContain('role-cutover.fallback.role-missing');
+    expect(readRoleCutoverSentinel(FP)).toBeNull();
+  });
+});
+
+// ============================================================================
+// (c) Multi-fingerprint host — sentinel keyed per fingerprint, never stranded.
+// ============================================================================
+
+describe('(c) multi-fingerprint host cuts over independently', () => {
+  const FP_A = FP;
+  const FP_B = `dd${PID.toString(16)}`.slice(0, 12);
+  const ROLE_A = ROLE;
+  const ROLE_B = `pgserve_rcmtxb_${PID}_role`;
+
+  afterEach(() => {
+    clearRoleCutoverSentinel(FP_A);
+    clearRoleCutoverSentinel(FP_B);
+  });
+
+  it('two fingerprints in one home get distinct sentinels and cut over separately', async () => {
+    // Checkout A cuts over.
+    const a = await resolveScopedConnectionIdentity({
+      sql: mockSql({ lock: true, roleExists: true }),
+      database: 'postgres',
+      roleName: ROLE_A,
+      fingerprintHex: FP_A,
+      enabled: true,
+      sink: () => {},
+    });
+    expect(a.cutover).toBe(true);
+    expect(a.username).toBe(ROLE_A);
+
+    // Distinct sentinel paths; B does NOT see A's sentinel.
+    expect(roleCutoverSentinelPath(FP_A)).not.toBe(roleCutoverSentinelPath(FP_B));
+    expect(readRoleCutoverSentinel(FP_A)).not.toBeNull();
+    expect(readRoleCutoverSentinel(FP_B)).toBeNull();
+
+    // Checkout B is NOT stranded by A's sentinel — it provisions its own.
+    const { events, sink } = recorder();
+    const b = await resolveScopedConnectionIdentity({
+      sql: mockSql({ lock: true, roleExists: true }),
+      database: 'postgres',
+      roleName: ROLE_B,
+      fingerprintHex: FP_B,
+      enabled: true,
+      sink,
+    });
+    expect(b.cutover).toBe(true);
+    expect(b.username).toBe(ROLE_B); // NOT ROLE_A
+    expect(events.map((e) => e.event)).toContain('role-cutover.cutover');
+    expect(readRoleCutoverSentinel(FP_B)?.roleName).toBe(ROLE_B);
+    // A's sentinel still intact — B did not stomp it.
+    expect(readRoleCutoverSentinel(FP_A)?.roleName).toBe(ROLE_A);
+  });
+});
+
+// ============================================================================
+// (d) Test-mode / FORCE_TCP / accept-hook ⇒ rebind NEVER lands (byte-identical
+// to legacy). The rebind gate is `shouldAttemptRoleCutover`; only the
+// direct-postmaster bypass carries it.
+// ============================================================================
+
+describe('(d) test-mode + FORCE_TCP + accept-hook skip — rebind never lands', () => {
+  it('direct-postmaster bypass is the ONLY path that rebinds', () => {
+    // The load-bearing path: enabled + not test + admin.json present.
+    expect(shouldAttemptRoleCutover({ enabled: true, isTestMode: false, directPostmaster: true })).toBe(true);
+    // Test mode (GENIE_TEST_PG_PORT harness) ⇒ never rebind, even on the bypass.
+    expect(shouldAttemptRoleCutover({ enabled: true, isTestMode: true, directPostmaster: true })).toBe(false);
+    // FORCE_TCP / accept-hook / router path (no admin.json ⇒ directPostmaster
+    // false) ⇒ never rebind (rebinding it is a silent no-op trap).
+    expect(shouldAttemptRoleCutover({ enabled: true, isTestMode: false, directPostmaster: false })).toBe(false);
+    expect(shouldAttemptRoleCutover({ enabled: true, isTestMode: true, directPostmaster: false })).toBe(false);
+    // Kill-switch ⇒ never rebind regardless of path.
+    expect(shouldAttemptRoleCutover({ enabled: false, isTestMode: false, directPostmaster: true })).toBe(false);
+  });
+
+  it('disabled gate ⇒ resolveScopedConnectionIdentity stays byte-identical legacy', async () => {
+    const { events, sink } = recorder();
+    const id = await resolveScopedConnectionIdentity({
+      sql: throwingSql,
+      database: 'postgres',
+      enabled: false,
+      sink,
+    });
+    expect(id).toEqual({
+      username: 'postgres',
+      database: 'postgres',
+      cutover: false,
+      fingerprintHex: null,
+      reason: 'disabled',
+    });
+    expect(events.map((e) => e.event)).toEqual(['role-cutover.skip.disabled']);
+  });
+});
+
+// ============================================================================
+// (a) N=8 concurrent boots — DB-backed. Single provision via the non-blocking
+// advisory lock; none block; convergence to the scoped role.
+// ============================================================================
+
+describe.skipIf(!DB_AVAILABLE)('(a) N=8 concurrent boots (pg)', () => {
+  let cleanupSchema: () => Promise<void>;
+  // postgres.js Sql type bleed-through; `any` is permitted in test files.
+  let sql: any;
+  let database: string;
+
+  beforeAll(async () => {
+    cleanupSchema = await setupTestDatabase();
+    sql = await getConnection();
+    database = resolveDatabaseName();
+  });
+
+  afterAll(async () => {
+    try {
+      const exists = await sql.unsafe(`SELECT 1 FROM pg_roles WHERE rolname = '${ROLE}'`);
+      if (exists.length > 0) {
+        await sql.unsafe(`DROP OWNED BY "${ROLE}"`);
+        await sql.unsafe(`DROP ROLE IF EXISTS "${ROLE}"`);
+      }
+    } catch {
+      /* best-effort */
+    }
+    clearRoleCutoverSentinel(FP);
+    await cleanupSchema();
+  });
+
+  async function dropRole(): Promise<void> {
+    const exists = await sql.unsafe(`SELECT 1 FROM pg_roles WHERE rolname = '${ROLE}'`);
+    if (exists.length === 0) return;
+    await sql.unsafe(`DROP OWNED BY "${ROLE}"`);
+    await sql.unsafe(`DROP ROLE IF EXISTS "${ROLE}"`);
+  }
+
+  it('cold storm: provisioned exactly once, none block, none error or throw', async () => {
+    await dropRole();
+    clearRoleCutoverSentinel(FP);
+    const N = 8;
+    const started = Date.now();
+    const results = await Promise.all(
+      Array.from({ length: N }, () =>
+        resolveScopedConnectionIdentity({
+          sql,
+          database,
+          roleName: ROLE,
+          fingerprintHex: FP,
+          enabled: true,
+          sink: () => {},
+        }),
+      ),
+    );
+    const elapsed = Date.now() - started;
+
+    expect(results).toHaveLength(N);
+    // Every boot is SAFE: it either cut over as the scoped role or fell back
+    // CLEANLY to postgres (a loser that checked pg_roles before the winner
+    // committed). NEVER an error, NEVER a throw, NEVER a hung boot.
+    for (const r of results) {
+      if (r.cutover) {
+        expect(r.username).toBe(ROLE);
+      } else {
+        expect(r.username).toBe('postgres');
+        expect(r.reason).not.toBe('query-failed');
+      }
+      expect(r.database).toBe(database);
+    }
+    // Single provision: the advisory lock guarantees the role is created at
+    // most once — it exists exactly once afterwards.
+    const count = await sql.unsafe(`SELECT count(*)::int AS n FROM pg_roles WHERE rolname = '${ROLE}'`);
+    expect(count[0].n).toBe(1);
+    // Non-blocking: a contended lock returns immediately. Generous CI bound.
+    expect(elapsed).toBeLessThan(20_000);
+  }, 45_000);
+
+  it('warm storm: role pre-exists ⇒ all 8 concurrent boots converge as the scoped role', async () => {
+    // Provision once, then clear the sentinel so all 8 race the revalidation
+    // path with the role already present — no role-missing race window.
+    await ensureScopedRole({ sql, roleName: ROLE, database, enabled: true, sink: () => {} });
+    clearRoleCutoverSentinel(FP);
+    const N = 8;
+    const started = Date.now();
+    const results = await Promise.all(
+      Array.from({ length: N }, () =>
+        resolveScopedConnectionIdentity({
+          sql,
+          database,
+          roleName: ROLE,
+          fingerprintHex: FP,
+          enabled: true,
+          sink: () => {},
+        }),
+      ),
+    );
+    const elapsed = Date.now() - started;
+
+    expect(results).toHaveLength(N);
+    for (const r of results) {
+      expect(r.cutover).toBe(true);
+      expect(r.username).toBe(ROLE);
+      expect(r.database).toBe(database);
+    }
+    // Still exactly one role — concurrent revalidation never re-creates it.
+    const count = await sql.unsafe(`SELECT count(*)::int AS n FROM pg_roles WHERE rolname = '${ROLE}'`);
+    expect(count[0].n).toBe(1);
+    expect(elapsed).toBeLessThan(20_000);
+  }, 45_000);
+});

--- a/src/lib/role-cutover.migration-replay.test.ts
+++ b/src/lib/role-cutover.migration-replay.test.ts
@@ -46,7 +46,7 @@ import { readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { runMigrations } from './db-migrations.js';
 import { getConnection, resolveTcpPgPassword } from './db.js';
-import { ensureScopedRole } from './role-cutover.js';
+import { ensurePrivilegedBootstrapObjects, ensureScopedRole } from './role-cutover.js';
 import { DB_AVAILABLE, setupTestDatabase } from './test-db.js';
 
 const PID = process.pid;
@@ -201,3 +201,152 @@ describe.skipIf(!DB_AVAILABLE || !TCP_PORT)('migration replay as the scoped non-
     expect(back).toBe('postgres');
   }, 30_000);
 });
+
+// ============================================================================
+// TRULY-fresh-DB replay — the regression guard for the cold pgserve smoke.
+//
+// The describe above models the WARM/live shape (pgcrypto + RBAC roles +
+// schema-owner pre-seeded as superuser). That is exactly why Group 3 missed
+// the cold-DB gap: on a TRULY fresh pgserve (the CI `pgserve v2 smoke`'s
+// `--data` dir) pgcrypto does not exist, so migrations 039/041's
+// `CREATE EXTENSION pgcrypto` runs for real — and the scoped NOSUPERUSER role
+// is denied. These tests reproduce that on a virgin DB with NOTHING
+// pre-seeded, and prove `ensurePrivilegedBootstrapObjects` (run on the
+// bootstrap SUPERUSER connection before the rebind, exactly as db.ts does it)
+// closes the gap without granting the scoped role any extra privilege.
+// ============================================================================
+
+describe.skipIf(!DB_AVAILABLE || !TCP_PORT)(
+  'migration replay on a TRULY fresh DB (cold smoke regression guard)',
+  () => {
+    let cleanupSchema: () => Promise<void>;
+    // postgres.js Sql type bleed-through; `any` is permitted in test files.
+    let admin: any;
+
+    beforeAll(async () => {
+      cleanupSchema = await setupTestDatabase();
+      admin = await getConnection();
+    }, 60_000);
+
+    afterAll(async () => {
+      await cleanupSchema();
+    });
+
+    // A virgin DB + freshly-provisioned scoped role, with NOTHING pre-seeded
+    // (no pgcrypto, no schema-owner change). Returns a max:1 superuser session
+    // on that DB so SET ROLE persists across runMigrations' transactions.
+    async function virginReplay(
+      tag: string,
+    ): Promise<{ sql: any; db: string; role: string; drop: () => Promise<void> }> {
+      const db = `rc_cold_${tag}_${PID}`;
+      const role = `pgserve_rccold_${tag}_${PID}_role`;
+      await admin.unsafe(`DROP DATABASE IF EXISTS "${db}" WITH (FORCE)`);
+      await admin.unsafe(`CREATE DATABASE "${db}"`);
+      const pg = (await import('postgres')).default;
+      const sql = pg({
+        host: '127.0.0.1',
+        port: Number(TCP_PORT),
+        database: db,
+        username: 'postgres', // pragma: allowlist secret — pgserve test default
+        password: resolveTcpPgPassword(), // pragma: allowlist secret
+        max: 1,
+        idle_timeout: 0,
+        onnotice: () => {},
+        connection: { client_min_messages: 'warning' as const },
+      });
+      // pgcrypto is DB-scoped ⇒ a brand-new DB has NONE (this is the real cold
+      // condition the CI smoke hits). Assert that before we touch anything.
+      const [{ has_pgcrypto }] = await sql.unsafe(
+        `SELECT count(*) > 0 AS has_pgcrypto FROM pg_extension WHERE extname = 'pgcrypto'`,
+      );
+      expect(has_pgcrypto).toBe(false);
+      // Provision the scoped non-superuser role + Group-1 grants (no ownership,
+      // no pgcrypto — exactly the state a fresh boot starts from).
+      await ensureScopedRole({ sql, roleName: role, database: db, enabled: true, sink: () => {} });
+      const drop = async (): Promise<void> => {
+        try {
+          await sql.end({ timeout: 5 });
+        } catch {
+          /* best-effort */
+        }
+        try {
+          await admin.unsafe(`DROP DATABASE IF EXISTS "${db}" WITH (FORCE)`);
+          await admin.unsafe(`DROP OWNED BY "${role}"`);
+          await admin.unsafe(`DROP ROLE IF EXISTS "${role}"`);
+        } catch {
+          /* best-effort */
+        }
+      };
+      return { sql, db, role, drop };
+    }
+
+    it('WITHOUT the privileged bootstrap, the scoped role FAILS the cold replay (the gap Group 3 missed)', async () => {
+      const { sql, role, drop } = await virginReplay('neg');
+      try {
+        await sql.unsafe(`SET ROLE "${role}"`);
+        const [{ who }] = await sql.unsafe('SELECT current_user AS who');
+        expect(who).toBe(role);
+        // The scoped NOSUPERUSER role hits `CREATE EXTENSION pgcrypto` (mig 039)
+        // on a virgin DB and is denied — runMigrations must throw. This is the
+        // exact failure the CI cold smoke surfaced; this test would have caught
+        // it before default-on.
+        let threw = false;
+        try {
+          await runMigrations(sql);
+        } catch (err) {
+          threw = true;
+          expect(String(err instanceof Error ? err.message : err)).toMatch(
+            /permission denied|must be (super ?user|owner)|to create extension/i,
+          );
+        }
+        expect(threw).toBe(true);
+      } finally {
+        await drop();
+      }
+    }, 120_000);
+
+    it('WITH ensurePrivilegedBootstrapObjects (superuser, pre-rebind), the FULL set replays clean as the scoped role', async () => {
+      const { sql, role, drop } = await virginReplay('pos');
+      try {
+        // Exactly what db.ts does on the bootstrap SUPERUSER connection before
+        // rebinding to the scoped role.
+        await ensurePrivilegedBootstrapObjects(sql, role);
+
+        // pgcrypto now present; cluster RBAC roles ensured; schema owned by the
+        // scoped role — without granting it SUPERUSER/CREATEROLE.
+        const [{ has_pgcrypto }] = await sql.unsafe(
+          `SELECT count(*) > 0 AS has_pgcrypto FROM pg_extension WHERE extname = 'pgcrypto'`,
+        );
+        expect(has_pgcrypto).toBe(true);
+        for (const r of RBAC_ROLES) {
+          const rows = await sql.unsafe(`SELECT 1 FROM pg_roles WHERE rolname = '${r}'`);
+          expect(rows.length).toBe(1);
+        }
+        const [{ owner }] = await sql.unsafe(
+          `SELECT nspowner::regrole::text AS owner FROM pg_namespace WHERE nspname = 'public'`,
+        );
+        expect(owner).toBe(role);
+        // Least-privilege intact: the scoped role is still NOT a superuser.
+        const [{ rolsuper }] = await admin.unsafe(`SELECT rolsuper FROM pg_authid WHERE rolname = '${role}'`);
+        expect(rolsuper).toBe(false);
+
+        // The functional gate: the ENTIRE migration set applies with zero errors
+        // executed as the scoped non-superuser role on a truly cold DB.
+        await sql.unsafe(`SET ROLE "${role}"`);
+        const [{ who }] = await sql.unsafe('SELECT current_user AS who');
+        expect(who).toBe(role);
+        const applied = await runMigrations(sql);
+        expect(applied.length).toBe(migrationFileCount());
+        // Re-run as the scoped role is a clean no-op (boot #2 stays put).
+        const second = await runMigrations(sql);
+        expect(second.length).toBe(0);
+
+        // ensurePrivilegedBootstrapObjects is itself idempotent (re-run = no-op).
+        await sql.unsafe('RESET ROLE');
+        await ensurePrivilegedBootstrapObjects(sql, role);
+      } finally {
+        await drop();
+      }
+    }, 120_000);
+  },
+);

--- a/src/lib/role-cutover.ts
+++ b/src/lib/role-cutover.ts
@@ -11,8 +11,9 @@
  * This module provisions a dedicated NON-superuser role scoped to genie's own
  * objects inside the EXISTING `postgres` database. **No bytes move.** Group 1
  * only provisions + grants + proves the privilege envelope; the connection
- * identity rebind is Group 2 (out of scope here). `ensureScopedRole()` is a
- * pure no-op unless `GENIE_ROLE_CUTOVER=1` is set (default OFF this group).
+ * identity rebind is Group 2. Wave 3 (Group 4) flipped the gate to DEFAULT-ON:
+ * `ensureScopedRole()` runs unless the documented kill-switch
+ * `GENIE_ROLE_CUTOVER=0` forces the legacy `postgres`/`postgres` path.
  *
  * Concurrency-safe: provisioning runs under a NON-BLOCKING
  * `pg_try_advisory_lock(hashtext('genie:role-cutover-v1'))`. Late arrivals
@@ -219,6 +220,28 @@ export interface RoleCutoverEvent {
 
 export type RoleCutoverSink = (event: RoleCutoverEvent) => void;
 
+// ============================================================================
+// Default-ON gate (Wave 3 — Goal A, Group 4).
+//
+// Through Waves 1+2 the cutover was OPT-IN (`GENIE_ROLE_CUTOVER=1`). Wave 3
+// flips it: cutover is now the DEFAULT and `GENIE_ROLE_CUTOVER=0` is the single
+// documented KILL-SWITCH that forces the legacy `postgres`/`postgres` path
+// (byte-for-byte today's behavior). Any other value — unset, `1`, anything that
+// is not exactly the string `0` — leaves cutover ON. This is the only place
+// the gate literal lives so the kill-switch can never drift between db.ts and
+// this module.
+// ============================================================================
+
+/**
+ * True unless the documented kill-switch is engaged. `GENIE_ROLE_CUTOVER=0`
+ * (and ONLY the exact string `0`) forces the legacy postgres/postgres path;
+ * unset / `1` / any other value ⇒ cutover ON. Single source of truth — db.ts
+ * imports this rather than re-deriving the literal.
+ */
+export function isRoleCutoverEnabled(): boolean {
+  return process.env.GENIE_ROLE_CUTOVER !== '0';
+}
+
 function genieHome(): string {
   return process.env.GENIE_HOME ?? join(homedir(), '.genie');
 }
@@ -328,7 +351,8 @@ async function grantScopedPrivileges(reserved: ReservedSqlLike, role: string, da
 
 /**
  * Idempotently ensure the dedicated non-superuser role exists with genie's
- * scoped privilege envelope. No-op unless `GENIE_ROLE_CUTOVER=1`. Never throws
+ * scoped privilege envelope. No-op only under the kill-switch
+ * `GENIE_ROLE_CUTOVER=0` (Wave 3 default-on). Never throws
  * for an operational failure — it emits `role-cutover.error.*` out-of-band and
  * returns `skipped` so a caller on the boot path can fall back cleanly.
  *
@@ -340,7 +364,7 @@ async function grantScopedPrivileges(reserved: ReservedSqlLike, role: string, da
  */
 export async function ensureScopedRole(opts: EnsureScopedRoleOptions): Promise<RoleCutoverResult> {
   const sink = opts.sink ?? defaultRoleCutoverSink;
-  const enabled = opts.enabled ?? process.env.GENIE_ROLE_CUTOVER === '1';
+  const enabled = opts.enabled ?? isRoleCutoverEnabled();
 
   if (!enabled) {
     emit(sink, 'role-cutover.skip.disabled');
@@ -530,7 +554,7 @@ export async function resolveScopedConnectionIdentity(
   opts: ResolveScopedIdentityOptions,
 ): Promise<ScopedConnectionIdentity> {
   const sink = opts.sink ?? defaultRoleCutoverSink;
-  const enabled = opts.enabled ?? process.env.GENIE_ROLE_CUTOVER === '1';
+  const enabled = opts.enabled ?? isRoleCutoverEnabled();
   const database = opts.database;
   const fallback = (reason: string, fp: string | null = null): ScopedConnectionIdentity => ({
     username: FALLBACK_SUPERUSER,
@@ -600,4 +624,58 @@ export async function resolveScopedConnectionIdentity(
     });
     return fallback('query-failed', fingerprintHex);
   }
+}
+
+// ============================================================================
+// Read-only inspection — backs `genie doctor --connection-identity`.
+//
+// Pure derivation + sentinel/package.json reads only. NEVER provisions, grants,
+// connects, or writes any file. The live DB facts (rolsuper, grants,
+// current_user/fallback) are queried separately by the doctor command on the
+// already-open app connection — this function contributes only the FS/identity
+// half so the doctor surface stays strictly read-only.
+// ============================================================================
+
+export interface RoleCutoverInspection {
+  /** Effective gate: false only under the documented kill-switch. */
+  enabled: boolean;
+  /** True when `GENIE_ROLE_CUTOVER=0` (the documented kill-switch) is set. */
+  killSwitch: boolean;
+  /** Derived scoped role name, or null when the fingerprint is unstable. */
+  roleName: string | null;
+  /** 12-hex fingerprint segment (sentinel key), or null when unstable. */
+  fingerprintHex: string | null;
+  /** Absolute per-fingerprint sentinel path, or null when unresolved. */
+  sentinelPath: string | null;
+  /** Parsed sentinel contents, or null when absent/stale/unreadable. */
+  sentinel: RoleCutoverSentinel | null;
+}
+
+/**
+ * Resolve the role-cutover identity snapshot WITHOUT touching the DB or
+ * mutating any state. Read-only: derives the role name + fingerprint and reads
+ * the per-fingerprint sentinel. Used by `genie doctor --connection-identity`.
+ */
+export function inspectRoleCutover(): RoleCutoverInspection {
+  const killSwitch = process.env.GENIE_ROLE_CUTOVER === '0';
+  const enabled = isRoleCutoverEnabled();
+  const fp = resolveGenieFingerprint();
+  if (!fp) {
+    return { enabled, killSwitch, roleName: null, fingerprintHex: null, sentinelPath: null, sentinel: null };
+  }
+  const names = deriveProvisionedNames(fp);
+  let sentinelPath: string | null = null;
+  try {
+    sentinelPath = roleCutoverSentinelPath(names.fingerprintHex);
+  } catch {
+    sentinelPath = null;
+  }
+  return {
+    enabled,
+    killSwitch,
+    roleName: names.roleName,
+    fingerprintHex: names.fingerprintHex,
+    sentinelPath,
+    sentinel: readRoleCutoverSentinel(names.fingerprintHex),
+  };
 }

--- a/src/lib/role-cutover.ts
+++ b/src/lib/role-cutover.ts
@@ -321,6 +321,62 @@ function assertSafeIdentifier(kind: string, value: string): void {
 }
 
 /**
+ * Cluster RBAC roles that migrations 041/043 create. They are global (cluster-
+ * scoped, survive DB drops) and `CREATE ROLE` requires CREATEROLE/superuser —
+ * which the scoped `NOCREATEROLE` role lacks. On a warm cluster they already
+ * exist and the migrations' `IF NOT EXISTS` probes short-circuit; on a TRULY
+ * fresh pgserve cluster (the CI smoke's `--data` dir) they do not, so the
+ * privileged bootstrap must create them BEFORE the scoped role replays.
+ *
+ * Mirrors `src/db/migrations/041_rbac_roles.sql` + `043_executor_read_role.sql`
+ * (`CREATE ROLE <x> NOINHERIT`). The fresh-DB replay test runs the REAL
+ * migrations after this and fails loudly if the two ever drift.
+ */
+const PRIVILEGED_BOOTSTRAP_ROLES = [
+  'events_admin',
+  'events_operator',
+  'events_subscriber',
+  'events_audit',
+  'executors_reader',
+] as const;
+
+/**
+ * Stage the inherently-privileged, one-time setup that genie's migration set
+ * performs but the least-privilege scoped role legitimately must NEVER do:
+ * the `pgcrypto` extension (039/041), the cluster RBAC/executor roles
+ * (041/043), and ownership of genie's OWN database `public` schema (so the
+ * scoped role can evolve its own schema via `runMigrations`).
+ *
+ * Runs on the BOOTSTRAP SUPERUSER connection, before the rebind to the scoped
+ * role. This does NOT grant the scoped role any extra privilege — the role
+ * stays `NOSUPERUSER NOCREATEROLE`; the privileged primitives are created by
+ * the superuser who legitimately may. Every statement is idempotent
+ * (`IF NOT EXISTS` / set-style), so re-runs and warm clusters converge to a
+ * no-op. Scoped to genie's own DB — zero bytes move, no neighbor touched.
+ *
+ * Throws on any failure; the caller (db.ts) funnels that into the existing
+ * `role-cutover.fallback.*` path (stay on the superuser bootstrap pool, never
+ * hard-fail boot — migrations then run as the superuser exactly like legacy).
+ */
+export async function ensurePrivilegedBootstrapObjects(sql: SqlLike, scopedRole: string): Promise<void> {
+  assertSafeIdentifier('role', scopedRole);
+  // pgcrypto: untrusted extension ⇒ superuser-only. Migrations 039 & 041 do
+  // `CREATE EXTENSION IF NOT EXISTS pgcrypto`; pre-staging it makes those a
+  // no-op when the scoped role later replays them.
+  await sql.unsafe('CREATE EXTENSION IF NOT EXISTS pgcrypto');
+  for (const role of PRIVILEGED_BOOTSTRAP_ROLES) {
+    const exists = await sql.unsafe(`SELECT 1 FROM pg_roles WHERE rolname = '${role}'`);
+    if (exists.length === 0) {
+      await sql.unsafe(`CREATE ROLE "${role}" NOINHERIT`);
+    }
+  }
+  // genie owns its OWN database's `public` schema so the scoped role can run
+  // schema DDL in `runMigrations`. Metadata-only (catalog), zero bytes moved,
+  // scoped to genie's DB — the proven Group-3 replay prerequisite.
+  await sql.unsafe(`ALTER SCHEMA public OWNER TO "${scopedRole}"`);
+}
+
+/**
  * GRANT genie's privilege envelope onto the scoped role. Set-style and
  * idempotent — re-running converges. Sized to keep genie fully functional in
  * its own DB (DML + schema DDL via `runMigrations`) while withholding every


### PR DESCRIPTION
Wave 3 (Group 4) of genie-dedicated-role-cutover. Flips GENIE_ROLE_CUTOVER DEFAULT-ON (genie stops connecting as postgres superuser); GENIE_ROLE_CUTOVER=0 = documented kill-switch. Adds genie doctor --connection-identity (read-only) + N=8 concurrency/fallback/multi-fingerprint/kill-switch matrix (432L) + operator note (honest integrity-not-confidentiality framing). Waves 1+2 already on dev. Leader-verified: typecheck 0, dead-code 0, 106 pass/0 fail/460 expects across 5 suites. Zero data movement. Reversible via kill-switch; fallback never hard-fails boot. 🤖 Generated with Claude Code