### PR TITLE
fix(tui-host): embed render — live viewport + dirty-gate (real-use disaster)

### DIFF
--- a/src/tui/widgets/TerminalPane.tsx
+++ b/src/tui/widgets/TerminalPane.tsx
@@ -124,6 +124,34 @@ export class TerminalPaneCore {
   private outputUnsubscribe: (() => void) | null = null;
   private disposed = false;
 
+  /**
+   * Change-detection gate (wish risk R2). Without it `paintInto()` ran a full
+   * O(rows × cols) `setCell` blit on EVERY OpenTUI frame (30–60 fps) even for a
+   * static screen, burning ~300k–600k `setCell`/sec doing nothing.
+   *
+   * xterm-headless 5.5.0 exposes NO parse/render event (verified at runtime:
+   * only onBell/onBinary/onCursorMove/onData/onLineFeed/onResize/onScroll/
+   * onTitleChange — neither `onWriteParsed` nor `onRender` exists). Every
+   * content mutation flows through this core's own `terminal.write()` calls,
+   * so we mark dirty in xterm's `write(data, cb)` parse-complete callback (cb
+   * fires after the chunk is parsed, so the buffer is current). `resize()`
+   * reflows synchronously and sets the flag directly. Starts `true` so the
+   * first paint is unconditional.
+   */
+  private dirty = true;
+  /** Painted-cell count from the last real paint, returned on skipped frames. */
+  private lastPaintedCells = 0;
+
+  /** Mark the buffer dirty once xterm has finished parsing a written chunk. */
+  private readonly markDirty = (): void => {
+    this.dirty = true;
+  };
+
+  /** Single write path: feed xterm and arm the dirty flag post-parse. */
+  private writeToTerminal(data: Buffer | string): void {
+    this.terminal.write(data, this.markDirty);
+  }
+
   constructor(options: TerminalPaneCoreOptions) {
     this.sessionName = options.sessionName;
     this.paneIdFilter = options.paneId;
@@ -159,7 +187,7 @@ export class TerminalPaneCore {
     if (this.controlSession) {
       const handler = (paneId: string, data: Buffer): void => {
         if (this.paneIdFilter && paneId !== this.paneIdFilter) return;
-        this.terminal.write(data);
+        this.writeToTerminal(data);
       };
       this.controlSession.on('output', handler);
       this.outputUnsubscribe = () => {
@@ -208,7 +236,7 @@ export class TerminalPaneCore {
     let written = 0;
     for (const line of lines) {
       if (this.replayedLines >= this.historyLimit) break;
-      this.terminal.write(line);
+      this.writeToTerminal(line);
       this.replayedLines++;
       written++;
     }
@@ -239,6 +267,9 @@ export class TerminalPaneCore {
     const r = Math.max(1, Math.floor(rows));
     if (c !== this.terminal.cols || r !== this.terminal.rows) {
       this.terminal.resize(c, r);
+      // resize() reflows the buffer synchronously (no write callback) — arm
+      // the gate directly so the next frame repaints the new geometry.
+      this.dirty = true;
     }
     this.resizer.schedule({ cols: c, rows: r });
     if (this.onResizeForward) this.onResizeForward(c, r);
@@ -247,10 +278,17 @@ export class TerminalPaneCore {
   /** Paint the xterm cell buffer into the given OpenTUI buffer. */
   paintInto(out: OptimizedBuffer, originX = 0, originY = 0): number {
     if (this.disposed) return 0;
-    return paintXtermBufferToFrame(this.terminal.buffer.active, out, originX, originY, {
+    // Change-detection gate: skip the full O(rows × cols) blit when nothing
+    // changed since the last paint. Return the prior painted-cell count
+    // WITHOUT walking the buffer.
+    if (!this.dirty) return this.lastPaintedCells;
+    const painted = paintXtermBufferToFrame(this.terminal.buffer.active, out, originX, originY, {
       cols: this.terminal.cols,
       rows: this.terminal.rows,
     });
+    this.dirty = false;
+    this.lastPaintedCells = painted;
+    return painted;
   }
 
   /** Tear down xterm + control session + stdin listener + debouncer. Idempotent. */

--- a/src/tui/widgets/__tests__/TerminalPane.test.tsx
+++ b/src/tui/widgets/__tests__/TerminalPane.test.tsx
@@ -197,6 +197,67 @@ describe('paintXtermBufferToFrame', () => {
   });
 });
 
+describe('paintXtermBufferToFrame — viewport offset (root cause 1)', () => {
+  test('paints the LIVE tail, not the oldest scrollback lines', async () => {
+    // 3-row viewport, generous scrollback. Write 10 logical lines so 7 scroll
+    // off the top into history. The live screen must show R7/R8/R9; the buggy
+    // `getLine(y)` (y from 0) would paint R0/R1/R2 — the oldest scrollback.
+    const ROWS = 3;
+    const COLS = 5;
+    const term = new Terminal({ cols: COLS, rows: ROWS, scrollback: 100, allowProposedApi: true });
+    await writeSync(term, Array.from({ length: 10 }, (_, i) => `R${i}`).join('\r\n'));
+
+    // Sanity: the buffer really did scroll (viewportY advanced past 0).
+    expect(term.buffer.active.viewportY).toBeGreaterThan(0);
+
+    const { buffer, cells } = makeRecordingBuffer();
+    paintXtermBufferToFrame(term.buffer.active, buffer, 0, 0, { cols: COLS, rows: ROWS });
+
+    const rowText = (y: number) =>
+      cells
+        .filter((c) => c.y === y)
+        .sort((a, b) => a.x - b.x)
+        .map((c) => c.char)
+        .join('')
+        .trimEnd();
+    expect([rowText(0), rowText(1), rowText(2)]).toEqual(['R7', 'R8', 'R9']);
+    // And explicitly NOT the oldest scrollback lines.
+    expect([rowText(0), rowText(1), rowText(2)]).not.toEqual(['R0', 'R1', 'R2']);
+    term.dispose();
+  });
+});
+
+describe('TerminalPaneCore.paintInto — dirty gate (root cause 2)', () => {
+  test('skips the full blit when nothing changed, repaints after a write', async () => {
+    const { core, control } = makeCore();
+    const { buffer, cells } = makeRecordingBuffer();
+
+    // First paint is unconditional and walks the whole buffer.
+    const firstCount = core.paintInto(buffer);
+    expect(firstCount).toBeGreaterThan(0);
+    expect(cells.length).toBe(firstCount);
+
+    // No intervening write → second paint must NOT walk the buffer.
+    cells.length = 0;
+    const cachedCount = core.paintInto(buffer);
+    expect(cells.length).toBe(0);
+    expect(cachedCount).toBe(firstCount);
+
+    // A control-mode `%output` chunk flows through `terminal.write(_, cb)`.
+    // Writes/callbacks are processed in order, so once a trailing empty
+    // write's callback fires, the data chunk has been parsed and `markDirty`
+    // has already run.
+    control.emit('output', '%42', Buffer.from('NEW OUTPUT'));
+    await new Promise<void>((resolve) => core.terminal.write('', () => resolve()));
+
+    cells.length = 0;
+    const repaintCount = core.paintInto(buffer);
+    expect(cells.length).toBeGreaterThan(0);
+    expect(repaintCount).toBe(cells.length);
+    core.dispose();
+  });
+});
+
 describe('cellColor / cellAttributes — color resolution', () => {
   test('default cell → host theme default fg + bg', async () => {
     const term = new Terminal({ cols: 1, rows: 1, scrollback: 0, allowProposedApi: true });

--- a/src/tui/widgets/xterm-cell-paint.ts
+++ b/src/tui/widgets/xterm-cell-paint.ts
@@ -143,8 +143,14 @@ export function paintXtermBufferToFrame(
   const rows = Math.max(0, opts.rows);
   const cols = Math.max(0, opts.cols);
   let painted = 0;
+  // `IBuffer.getLine(y)` indexes the WHOLE buffer (scrollback included), so
+  // `y = 0` is the OLDEST scrollback line. The live viewport starts at
+  // `viewportY` (== `baseY` for a follow terminal, honours user scrollback
+  // otherwise). Offset every source line by it so we paint the live screen,
+  // not frozen ancient scrollback. Read once before the loop.
+  const base = xtermBuffer.viewportY;
   for (let y = 0; y < rows; y++) {
-    const line = xtermBuffer.getLine(y);
+    const line = xtermBuffer.getLine(base + y);
     if (!line) continue;
     let x = 0;
     while (x < cols) {


### PR DESCRIPTION
## What

Two surgical fixes to the embed-mode TUI (`GENIE_TUI_HOST=embed`), which Felipe reproduced live as "renders like an ASCII mirror, not a usable terminal, and slow as fuck" on v4.260513.1.

### Root cause 1 — the "ASCII mirror" (CRITICAL)
`src/tui/widgets/xterm-cell-paint.ts` painted `xtermBuffer.getLine(y)` for `y in [0,rows)`. In xterm-headless, `getLine(0)` is the **oldest scrollback line**, not the live screen. The viewport starts at `buffer.viewportY` (verified: `@xterm/headless` 5.5.0 typings L939/L945). So the pane rendered the first ~`rows` lines the agent ever printed, frozen forever — cursor-addressed/alt-screen apps showed as garbage.
**Fix:** `const base = xtermBuffer.viewportY; getLine(base + y)` (honors live-follow *and* user scrollback; `viewportY === baseY` for a follow terminal).

### Root cause 2 — "slow as fuck" (CRITICAL, wish risk R2)
`TerminalPane.renderSelf()` did a full `O(rows×cols)` `setCell` blit **every OpenTUI frame**, unconditionally — ~300k–600k pointless cell writes/sec on a static screen at 30–60 fps.
**Fix:** a `dirty` gate in `TerminalPaneCore`. The fixer verified xterm-headless exposes **neither** `onWriteParsed` nor `onRender`, so it arms `dirty` from xterm's `write(data, cb)` parse-complete callback (plus on `resize()`/`replayHistory()`). `paintInto()` early-returns the prior painted count on a clean frame.

## Evidence (non-vacuous regression test)

| Code | `paintXtermBufferToFrame — viewport offset` |
|---|---|
| old `getLine(y)` (dev tip) | ❌ **fail** — "paints the LIVE tail, not the oldest scrollback lines" (24 pass / **1 fail**) |
| fix `getLine(viewportY+y)` | ✅ pass — `bun test src/tui/widgets/ src/tui/tmux-control/` → **76 pass / 0 fail / 363 expect()** |

Proven by reverting *only* `xterm-cell-paint.ts` to dev tip and re-running the new test (fails), then restoring (passes). A second test asserts the dirty gate issues zero `setCell` on a no-op frame and repaints after a `write()`.

## Why this slipped to real use

The wish risk table predicted **both** (R1 cell-attr/geometry, R2 blit-per-frame). The mitigation was the G5 8-terminal smoke matrix — which was **never executed** (all cells `PENDING_OPERATOR`, no sign-off) before #1744 merged. The synthetic microbench passed because it measured line-append, not cursor-addressed redraw. These two regression tests are the guard that should have existed.

## ⚠️ Pre-existing dev-wide CI red (NOT introduced here)

`bun run check` is red on the `dead-code` (knip) gate — `Unlisted binaries: husky, biome, tsc`. This **reproduces identically on pristine dev tip (`2218afb8`)**, caused by `f0133754 fix(dead-code): drop stale knip ignores`. This PR's 3 files don't touch `package.json`/`knip.json` and cannot cause it. Deliberately **not** absorbed here — re-adding the ignores may revert f0133754's intent. Flagging for a separate owner decision; the render fix is independently proven via the targeted suites above.

## Scope
- `src/tui/widgets/xterm-cell-paint.ts` (+8 −? viewport offset)
- `src/tui/widgets/TerminalPane.tsx` (+44 dirty gate)
- `src/tui/widgets/__tests__/TerminalPane.test.tsx` (+61 two regression tests)
- No scope creep. G6 (legacy deletion) still gated on real smoke validation — do not ship until embed is verified usable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)