### PR TITLE
[codex] fix update attestation fallback

### DIFF
--- a/src/genie-commands/__tests__/update.test.ts
+++ b/src/genie-commands/__tests__/update.test.ts
@@ -564,11 +564,11 @@ describe('downloadAndVerifyTarball (G5)', () => {
   test('issues gh release download with the correct version tag and pattern set', async () => {
     const tmp = mkdtempSync(join(tmpdir(), 'genie-update-dl-'));
     try {
-      const calls: Array<{ cmd: string; args: string[] }> = [];
+      const calls: Array<{ cmd: string; args: string[]; timeoutMs?: number }> = [];
       // Stub runner: capture every gh invocation, place the tarball where
       // downloadAndVerifyTarball expects it on the success path.
-      const runner = async (cmd: string, args: string[]) => {
-        calls.push({ cmd, args });
+      const runner = async (cmd: string, args: string[], timeoutMs?: number) => {
+        calls.push({ cmd, args, timeoutMs });
         if (cmd === 'gh' && args[0] === 'release') {
           // Drop a placeholder tarball so the existsSync check passes.
           const tarballName = `genie-${manifest.version}-linux-x64-glibc.tar.gz`;
@@ -588,9 +588,20 @@ describe('downloadAndVerifyTarball (G5)', () => {
       expect(argString).toContain(`genie-${manifest.version}-linux-x64-glibc.tar.gz`);
       expect(argString).toContain('.bundle');
       expect(argString).toContain('.intoto.jsonl');
-      // Second call — gh attestation verify.
+      // Second call — gh attestation verify with workflow identity pinned.
       expect(calls[1].cmd).toBe('gh');
-      expect(calls[1].args).toEqual(['attestation', 'verify', tarballPath, '--owner', 'automagik-dev']);
+      expect(calls[1].args).toEqual([
+        'attestation',
+        'verify',
+        tarballPath,
+        '--repo',
+        'automagik-dev/genie',
+        '--cert-identity-regex',
+        '^https://github.com/automagik-dev/genie/.github/workflows/sign-attest.yml@',
+        '--cert-oidc-issuer',
+        'https://token.actions.githubusercontent.com',
+      ]);
+      expect(calls[1].timeoutMs).toBe(60_000);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
@@ -630,7 +641,67 @@ describe('downloadAndVerifyTarball (G5)', () => {
     }
   });
 
-  test('skipAttestation skips the gh attestation verify call', async () => {
+  test('falls back to cosign bundle when gh attestation verify fails', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'genie-update-dl-'));
+    try {
+      const tarballPath = join(tmp, `genie-${manifest.version}-linux-x64-glibc.tar.gz`);
+      const bundlePath = `${tarballPath}.bundle`;
+      const calls: Array<{ cmd: string; args: string[]; timeoutMs?: number }> = [];
+      const runner = async (cmd: string, args: string[], timeoutMs?: number) => {
+        calls.push({ cmd, args, timeoutMs });
+        if (cmd === 'gh' && args[0] === 'release') {
+          writeFileSync(tarballPath, 'x');
+          writeFileSync(bundlePath, 'bundle');
+          return { success: true, output: '' };
+        }
+        if (cmd === 'gh' && args[0] === 'attestation') {
+          return { success: false, output: 'Timed out after 60000ms' };
+        }
+        return { success: true, output: '' };
+      };
+
+      await expect(downloadAndVerifyTarball(manifest, 'linux-x64-glibc', tmp, { runner })).resolves.toBe(tarballPath);
+      expect(calls.map((call) => call.cmd)).toEqual(['gh', 'gh', 'cosign']);
+      expect(calls[2].args).toEqual([
+        'verify-blob',
+        '--bundle',
+        bundlePath,
+        '--certificate-identity-regexp',
+        '^https://github.com/automagik-dev/genie/.github/workflows/sign-attest.yml@',
+        '--certificate-oidc-issuer',
+        'https://token.actions.githubusercontent.com',
+        tarballPath,
+      ]);
+      expect(calls[2].timeoutMs).toBe(30_000);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('throws with both verifier errors when gh and cosign verification fail', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'genie-update-dl-'));
+    try {
+      const tarballPath = join(tmp, `genie-${manifest.version}-linux-x64-glibc.tar.gz`);
+      const runner = async (cmd: string, args: string[]) => {
+        if (cmd === 'gh' && args[0] === 'release') {
+          writeFileSync(tarballPath, 'x');
+          writeFileSync(`${tarballPath}.bundle`, 'bundle');
+          return { success: true, output: '' };
+        }
+        if (cmd === 'gh' && args[0] === 'attestation') {
+          return { success: false, output: 'no matching attestation' };
+        }
+        return { success: false, output: 'invalid signature' };
+      };
+      await expect(downloadAndVerifyTarball(manifest, 'linux-x64-glibc', tmp, { runner })).rejects.toThrow(
+        /cosign verify-blob: invalid signature/,
+      );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('skipAttestation skips signature verification calls', async () => {
     const tmp = mkdtempSync(join(tmpdir(), 'genie-update-dl-'));
     try {
       const calls: Array<{ cmd: string; args: string[] }> = [];

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -53,6 +53,9 @@ const FETCH_LATEST_TIMEOUT_MS = 5_000;
 const RELEASES_OWNER = 'automagik-dev';
 const RELEASES_REPO = 'genie';
 const RAW_BASE_URL = 'https://raw.githubusercontent.com';
+const RELEASES_SLUG = `${RELEASES_OWNER}/${RELEASES_REPO}`;
+const EXPECTED_COSIGN_IDENTITY = `^https://github.com/${RELEASES_SLUG}/.github/workflows/sign-attest.yml@`;
+const EXPECTED_COSIGN_ISSUER = 'https://token.actions.githubusercontent.com';
 
 // ============================================================================
 // Verify decision shape — shared with omni#update-unify-stages (SHARED-DESIGN §4.3).
@@ -350,8 +353,8 @@ async function defaultManifestFetcher(url: string): Promise<string | null> {
 interface DownloadAndVerifyOptions {
   /** Test seam: stubs the network/cli surface for deterministic unit tests. */
   runner?: (cmd: string, args: string[], timeoutMs?: number) => Promise<{ success: boolean; output: string }>;
-  /** Test seam: skip `gh attestation verify` (used by integration smokes
-   *  where the real gh CLI is not available). */
+  /** Test seam: skip release signature verification (used by integration
+   *  smokes where the real gh/cosign CLIs are not available). */
   skipAttestation?: boolean;
 }
 
@@ -367,11 +370,69 @@ interface DownloadAndVerifyOptions {
  * out at 4000ms on a healthy connection (Felipe, 2026-05-12).
  */
 const ATTESTATION_VERIFY_TIMEOUT_MS = 60_000;
+const COSIGN_VERIFY_TIMEOUT_MS = 30_000;
+
+interface SignatureVerificationResult {
+  method: 'gh-attestation' | 'cosign-bundle';
+}
+
+async function verifyTarballSignature(
+  tarballName: string,
+  tarballPath: string,
+  bundlePath: string,
+  runner: (cmd: string, args: string[], timeoutMs?: number) => Promise<{ success: boolean; output: string }>,
+): Promise<SignatureVerificationResult> {
+  const ghVerifyResult = await runner(
+    'gh',
+    [
+      'attestation',
+      'verify',
+      tarballPath,
+      '--repo',
+      RELEASES_SLUG,
+      '--cert-identity-regex',
+      EXPECTED_COSIGN_IDENTITY,
+      '--cert-oidc-issuer',
+      EXPECTED_COSIGN_ISSUER,
+    ],
+    ATTESTATION_VERIFY_TIMEOUT_MS,
+  );
+  if (ghVerifyResult.success) return { method: 'gh-attestation' };
+
+  const failures = [
+    `gh attestation verify: ${ghVerifyResult.output.trim() || `failed after ${ATTESTATION_VERIFY_TIMEOUT_MS}ms`}`,
+  ];
+
+  if (!existsSync(bundlePath)) {
+    failures.push(`cosign verify-blob: missing bundle ${bundlePath}`);
+    throw new Error(`signature verification failed for ${tarballName}: ${failures.join('; ')}`);
+  }
+
+  const cosignVerifyResult = await runner(
+    'cosign',
+    [
+      'verify-blob',
+      '--bundle',
+      bundlePath,
+      '--certificate-identity-regexp',
+      EXPECTED_COSIGN_IDENTITY,
+      '--certificate-oidc-issuer',
+      EXPECTED_COSIGN_ISSUER,
+      tarballPath,
+    ],
+    COSIGN_VERIFY_TIMEOUT_MS,
+  );
+  if (cosignVerifyResult.success) return { method: 'cosign-bundle' };
+
+  failures.push(`cosign verify-blob: ${cosignVerifyResult.output.trim() || 'no output'}`);
+  throw new Error(`signature verification failed for ${tarballName}: ${failures.join('; ')}`);
+}
 
 /**
  * Download the platform-specific tarball + cosign bundle + attestation, then
- * verify with `gh attestation verify`. Returns the path to the downloaded
- * tarball on success; throws on failure (caller surfaces the error).
+ * verify with GitHub native attestations or the local cosign bundle fallback.
+ * Returns the path to the downloaded tarball on success; throws on failure
+ * (caller surfaces the error).
  */
 export async function downloadAndVerifyTarball(
   manifest: LatestManifest,
@@ -390,6 +451,7 @@ export async function downloadAndVerifyTarball(
   const versionTag = `v${manifest.version}`;
   const tarballName = `genie-${manifest.version}-${platform}.tar.gz`;
   const tarballPath = join(destDir, tarballName);
+  const bundlePath = `${tarballPath}.bundle`;
 
   // gh release download retries by name; --pattern lets us pull the tarball
   // and its sidecar (.bundle, .intoto.jsonl) in one shot via wildcards.
@@ -419,14 +481,7 @@ export async function downloadAndVerifyTarball(
   }
 
   if (!opts.skipAttestation) {
-    const verifyResult = await runner(
-      'gh',
-      ['attestation', 'verify', tarballPath, '--owner', RELEASES_OWNER],
-      ATTESTATION_VERIFY_TIMEOUT_MS,
-    );
-    if (!verifyResult.success) {
-      throw new Error(`gh attestation verify failed for ${tarballName}: ${verifyResult.output.trim() || 'no output'}`);
-    }
+    await verifyTarballSignature(tarballName, tarballPath, bundlePath, runner);
   }
 
   return tarballPath;
@@ -1376,7 +1431,7 @@ async function runDelivery(
   const tarballPath = await downloadAndVerifyTarball(manifest, platform, GENIE_BIN_STAGING);
   diagnosticsCtx.tarballPath = tarballPath;
   diagnosticsCtx.attestationVerified = true;
-  success(`Verified attestation for ${tarballPath.split('/').pop()}`);
+  success(`Verified signed tarball for ${tarballPath.split('/').pop()}`);
 
   log('Extracting tarball...');
   const extractDir = join(GENIE_BIN_STAGING, `extract-${manifest.version}`);


### PR DESCRIPTION
## Summary

Hardens `genie update` release verification so slow or unavailable GitHub-native attestation checks do not block signed updates when the downloaded cosign bundle can verify the same tarball.

## Root Cause

Older updater code depended on `gh attestation verify` completing quickly. Hosts on `4.260511.5` were failing updates when that command timed out after 4000ms before the newer updater could install itself.

## Changes

- Pins GitHub attestation verification to `automagik-dev/genie` and the release workflow signing identity.
- Keeps the 60s `gh attestation verify` timeout.
- Falls back to `cosign verify-blob --bundle <tarball>.bundle` with the same identity and issuer pins.
- Reports both verifier failures when neither path succeeds.
- Adds regression coverage for timeout propagation, identity-pinned args, cosign fallback, and combined failure output.

## Validation

- `bun test src/genie-commands/__tests__/update.test.ts`
- `bun run typecheck`
- `bun run lint` (passes with existing broken symlink warning under `test-fixtures/symlink-cycle/real/cycle`)
- pre-push hook: `bun run typecheck && bun run lint && bun run dead-code && bun run skills:lint && bun run wishes:lint && bun run lint:emit`