### PR TITLE
fix(deps): sync bun.lock — unblock frozen-lockfile release build

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
         "postgres": "3.4.9",
         "react": "19.2.5",
         "react-dom": "19.2.5",
-        "systeminformation": "5.31.5",
+        "systeminformation": "5.31.6",
         "uuid": "14.0.0",
         "zod": "3.25.76",
       },
@@ -827,7 +827,7 @@
 
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
-    "systeminformation": ["systeminformation@5.31.5", "", { "os": "!aix", "bin": { "systeminformation": "lib/cli.js" } }, "sha512-5SyLdip4/3alxD4Kh+63bUQTJmu7YMfYQTC+koZy7X73HgNqZSD2P4wOZQWtUncvPvcEmnfIjCoygN4MRoEejQ=="],
+    "systeminformation": ["systeminformation@5.31.6", "", { "os": "!aix", "bin": { "systeminformation": "lib/cli.js" } }, "sha512-Uv2b2uGGM6ns+26czgW2cYRabYdnswM0ddSOOlryHOaelzsmDSet1iM/NT7VOYxW8x/BW+HkY+b1Ve2pLTSGSA=="],
 
     "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
 


### PR DESCRIPTION
dev's package.json declared systeminformation@5.31.6 but bun.lock was never regenerated, so release.yml `bun install --frozen-lockfile` fails on every build platform — this is why v4.260517.2 didn't publish and Felipe is stuck on 16.3. Lockfile-only sync (+2/-2), no dependency or code change. Merge → I re-dispatch version.yml to cut the Goal-A release. 🤖 Generated with Claude Code