### PR TITLE
fix(release): download SLSA provenance by deterministic name (unblock genie publish)

### DIFF
--- a/.github/workflows/sign-attest.yml
+++ b/.github/workflows/sign-attest.yml
@@ -211,7 +211,16 @@ jobs:
           # SLSA generator v2.1.0 uploads the provenance as an artifact whose
           # name == the provenance-name input. The artifact contains one file
           # at the same path. After download the file lands at dist/<name>.
-          name: ${{ needs.provenance.outputs.provenance-name }}
+          #
+          # The reusable `provenance` job declares no `outputs`, so referencing
+          # `needs.provenance.outputs.provenance-name` resolves to EMPTY and
+          # download-artifact silently no-ops (run 25997850533: the artifact
+          # genie-<version>.intoto.jsonl was produced but never staged at
+          # dist/, failing "Stage provenance per-platform"). genie controls
+          # the artifact name via the provenance-name INPUT (line ~171), so
+          # reconstruct the same deterministic string from the same version
+          # source instead of depending on a nonexistent job output.
+          name: genie-${{ needs.prepare.outputs.version }}.intoto.jsonl
           path: dist
 
       - name: Stage provenance per-platform


### PR DESCRIPTION
## Problem

Release run `25997850533` (tag `v4.260517.3`) failed in the `sign` job at **Stage provenance per-platform**:

```
::error::missing or empty SLSA provenance dist/genie-4.260517.3.intoto.jsonl
```

The SLSA artifact `genie-4.260517.3.intoto.jsonl` **was produced** (9972 bytes) but never landed at `dist/`.

## Root cause

The `provenance` job is a reusable-workflow call:

```
uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
```

It declares **no `outputs` block**, so the `sign` job's "Download SLSA provenance artifact" step referencing `needs.provenance.outputs.provenance-name` resolved to an **empty string**. `actions/download-artifact@v4` with an empty `name` silently no-ops, so the provenance file was never staged and the next step failed.

## Fix

genie controls the artifact name via the `provenance-name` **input** to the generator (SLSA generator contract: uploaded artifact name == the `provenance-name` input value, set at sign-attest.yml ~line 171). Bind the download `name` to the **same deterministic expression** used for that input — `genie-${{ needs.prepare.outputs.version }}.intoto.jsonl`, same version source (`needs.prepare.outputs.version`) — removing the dependency on the nonexistent job output entirely.

Scope: **only** the download-artifact name binding in `sign-attest.yml` (10 insertions, 1 deletion). No signing/verification step weakened.

## Verification

- `grep` confirms no remaining functional `needs.provenance.outputs.provenance-name` reference (only a one-word mention inside the explanatory comment).
- Download `name` expression string-matches the `provenance-name` input byte-for-byte (`genie-${{ needs.prepare.outputs.version }}.intoto.jsonl`).
- `bun run typecheck` clean (no TS touched; ran for completeness).
- **Real proof is a green release run post-merge** — to be confirmed by re-dispatching the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)