### PR TITLE
fix(release): flip prerelease=false + mark Latest on stable re-dispatch

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -188,6 +188,25 @@ jobs:
               ${DRAFT_FLAG} ${PRERELEASE_FLAG}
           fi
 
+          # Reconcile release flags to the channel — idempotent, and the
+          # whole point on the stable re-dispatch path: the dev chain
+          # creates v${VERSION} as --prerelease, then a dev→main merge
+          # re-dispatches this workflow with channel=stable. The release
+          # already exists, so the `gh release create` branch above is
+          # skipped and the prerelease flag would never flip. Without this
+          # block, .well-known/latest.json advances but GitHub's "Latest"
+          # badge stays stuck on the old stable tag (the v4.260511.5
+          # symptom). Drafts can't be marked latest, so skip when drafting.
+          if [[ -z "${DRAFT_FLAG}" ]]; then
+            if [[ "${CHANNEL}" == "stable" ]]; then
+              gh release edit "v${VERSION}" --repo "${{ github.repository }}" \
+                --prerelease=false --latest
+            else
+              gh release edit "v${VERSION}" --repo "${{ github.repository }}" \
+                --prerelease=true --latest=false
+            fi
+          fi
+
           if [[ -d dist && -n "$(ls -A dist 2>/dev/null)" ]]; then
             gh release upload "v${VERSION}" \
               --repo "${{ github.repository }}" \


### PR DESCRIPTION
## Problem (the leftover from #2442)

#2442 fixed the *trigger* — a dev→main merge now correctly dispatches `release-publish` with `channel=stable`, and `.well-known/latest.json` advances (verified: `v4.260511.5` → `4.260517.5`).

But the GitHub Release object stays `prerelease=true` and the **"Latest" badge stays frozen on `v4.260511.5`**. That's exactly the original "why is there no Latest release in GitHub" symptom — now isolated to the release-flag layer.

## Root cause

In `release-publish.yml`, the `Create or update GitHub Release` step only applies the prerelease flag inside the `gh release create` branch:

```bash
if ! gh release view "v${VERSION}" ...; then
  gh release create ... ${PRERELEASE_FLAG}
fi
```

Flow: the **dev chain** creates `v<version>` as `--prerelease`. The **dev→main merge** then re-dispatches this workflow with `channel=stable` against the **same existing tag**. The release already exists → the `create` branch is skipped → the prerelease flag is never flipped and the release is never marked Latest.

## Fix

Add an idempotent reconcile right after the create-if-missing block:

- `channel=stable` → `gh release edit --prerelease=false --latest`
- `homolog`/`dev` → `gh release edit --prerelease=true --latest=false`

Skipped while drafting (a draft cannot be marked Latest). Pure flag reconcile — no asset or manifest behavior changes.

## Effect after merge → promote

Next dev→main promotion: the stable re-dispatch will flip the release to a non-prerelease **Latest** release, so GitHub's badge finally tracks the (already-correct) stable pointer. Existing `v4.260517.5` can be flipped immediately by hand if desired (`gh release edit v4.260517.5 --prerelease=false --latest`) — independent of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)