### PR TITLE
Dev → main (stable: exercise #2444 release-flag reconcile)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "4.260517.5",
+      "version": "4.260518.1",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -188,6 +188,25 @@ jobs:
               ${DRAFT_FLAG} ${PRERELEASE_FLAG}
           fi
 
+          # Reconcile release flags to the channel — idempotent, and the
+          # whole point on the stable re-dispatch path: the dev chain
+          # creates v${VERSION} as --prerelease, then a dev→main merge
+          # re-dispatches this workflow with channel=stable. The release
+          # already exists, so the `gh release create` branch above is
+          # skipped and the prerelease flag would never flip. Without this
+          # block, .well-known/latest.json advances but GitHub's "Latest"
+          # badge stays stuck on the old stable tag (the v4.260511.5
+          # symptom). Drafts can't be marked latest, so skip when drafting.
+          if [[ -z "${DRAFT_FLAG}" ]]; then
+            if [[ "${CHANNEL}" == "stable" ]]; then
+              gh release edit "v${VERSION}" --repo "${{ github.repository }}" \
+                --prerelease=false --latest
+            else
+              gh release edit "v${VERSION}" --repo "${{ github.repository }}" \
+                --prerelease=true --latest=false
+            fi
+          fi
+
           if [[ -d dist && -n "$(ls -A dist 2>/dev/null)" ]]; then
             gh release upload "v${VERSION}" \
               --repo "${{ github.repository }}" \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/genie",
-  "version": "4.260517.5",
+  "version": "4.260518.1",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
   "type": "module",
   "bin": {

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "4.260517.5",
+  "version": "4.260518.1",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "4.260517.5",
+  "version": "4.260518.1",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "type": "module",


### PR DESCRIPTION
## Promote dev → main

Carries the merged #2444 (`release-publish.yml` stable-flag reconcile) plus the dev-derived version it just produced.

### MERGE METHOD: merge commit — NOT squash
The `version.yml` main-arm gate needs the head commit to start with `Merge pull request` and contain `/dev`. Use **Create a merge commit** (message → `Merge pull request #N from automagik-dev/dev`). A squash produces `Dev ... (#N)` → gate fails → no stable release.

### What this proves (end-to-end)
1. CI on main → success
2. `version.yml` (main, `should_bump=false`) → the #2442 no-bump step dispatches `release-publish` `channel=stable` against the existing dev tag
3. **NEW from #2444:** the stable re-dispatch now runs `gh release edit --prerelease=false --latest` on that existing release → it flips from Pre-release to a non-prerelease **Latest** release
4. `.well-known/latest.json` advances **and** GitHub's "Latest" badge finally tracks it — the original symptom fully closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 4.260518.1 across all packages
  * Improved release workflow for better handling of release channel flags during GitHub Release creation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/automagik-dev/genie/pull/2445?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->