### PR TITLE
fix(update): preserve prerelease/build suffix in version regex (follow-up to #2446)

### DIFF
--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -262,7 +262,7 @@ export function resolveInstalledVersion(): string {
         encoding: 'utf-8',
         timeout: 3000,
       }).trim();
-      const m = out.match(/\d+\.\d+\.\d+/);
+      const m = out.match(/\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)*/);
       if (m) return m[0];
     } catch {
       // fall through to on-disk / compile-time
@@ -1505,7 +1505,7 @@ async function runDelivery(
         liveVer =
           execFileSync(live, ['--version'], { encoding: 'utf-8', timeout: 3000 })
             .trim()
-            .match(/\d+\.\d+\.\d+/)?.[0] ?? '';
+            .match(/\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)*/)?.[0] ?? '';
       } catch {
         // unknowable — skip the advisory
       }


### PR DESCRIPTION
## Why a separate PR

#2446 (merged `808cab68`) shipped the installed-version detection fix. The review-bot feedback on the prerelease-stripping regex was pushed to that branch **after** the merge, so it never landed. dev still has the lossy regex at `update.ts:265` and `:1508`.

## The fix (review feedback — gemini HIGH / codex P1)

`/\d+\.\d+\.\d+/` strips `-rc.N` / `+build`. `resolveInstalledVersion()` and the post-swap divergence guard would therefore treat `4.260518.1-rc.1` as `4.260518.1` → wrong short-circuit ("already up to date") and possible mis-fire of the divergence warning. `normalizeVersion()` is purpose-built to preserve `-rc` while stripping `+build`; the lossy regex defeated it.

Change: `/\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)*/` — capture the full SemVer token, defer canonicalization to `normalizeVersion`.

## Validation

- `bun run typecheck` — clean
- `bun test update.test.ts` — 93 pass / 0 fail
- 2 lines changed (the two extraction regexes only; unrelated `/^\d+\.\d+/` prefix-validity checks at 743/744 left as-is).

🤖 Generated with [Claude Code](https://claude.com/claude-code)