### PR TITLE
fix(update): restart pm2 daemon after every swap (not only stale inode)

### DIFF
--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -852,9 +852,17 @@ async function pm2GenieServe(): Promise<Pm2GenieServe | null> {
 export async function restartServeIfStale(): Promise<{ oldPid: number; newPid: number } | null> {
   const before = await pm2GenieServe();
   if (!before) return null;
+  // A successful binary swap means the pm2-managed daemon is still
+  // executing the OLD process image (open inode / mmap), whether or not
+  // the swap also unlinked its cwd. The restart must therefore be
+  // unconditional whenever a pm2 daemon exists — the previous
+  // `staleInode`-only gate left the common file-rename swap serving
+  // pre-update bytes forever (daemon stuck on its boot version, every
+  // `genie update` re-offering the same upgrade). `--no-restart` is
+  // honored upstream before this is ever reached.
   const cwdInfo = readDaemonCwd(before.pid);
-  if (!cwdInfo || !cwdInfo.staleInode) return null;
-  log(`Restarting pm2 ${before.name} (stale inode detected: ${cwdInfo.cwd})`);
+  const reason = cwdInfo?.staleInode ? `stale inode: ${cwdInfo.cwd}` : 'binary swapped under running daemon';
+  log(`Restarting pm2 ${before.name} (${reason})`);
   let configPath: string | null = null;
   try {
     configPath = regenerateEcosystemConfig();


### PR DESCRIPTION
## Root cause — "genie update never sticks" (Felipe, pm2 host)

`genie update` swapped the binary correctly, but the pm2-managed Genie daemon kept reporting its **boot version** (`4.260516.3`) across many updates — pid stable for days, every run re-offering the same upgrade. Verified on host: `~/.genie/bin/genie --version` old even with `GENIE_NO_DAEMON`; `~/.genie/VERSION` new; pm2 "Genie" `status=waiting restart`, `restart_time=7056`.

`restartServeIfStale()` — the only thing that bounces the daemon — had:

```ts
const cwdInfo = readDaemonCwd(before.pid);
if (!cwdInfo || !cwdInfo.staleInode) return null;   // bails unless inode "(deleted)"
```

`atomicBinarySwap` does a **file `renameSync`**, not a directory swap, so `staleInode` is **false** on the common path → early return → daemon never restarted → serves pre-update bytes indefinitely. The stale-inode trigger was Group-6 directory-swap-only.

## Fix

Drop the `staleInode`-only early return. A successful swap means the running daemon is on the old image regardless of inode state → restart unconditionally when a pm2 Genie daemon exists. `staleInode` kept only as a log reason. `--no-restart` still honored upstream in `runPostUpdateMaintenanceSafe` (line 1725), so opted-out behavior is unchanged. Downstream regenerate-ecosystem / startOrReload / pid-change verify untouched.

## Validation

- `bun run typecheck` — clean
- `bun test update.test.ts` — 93 pass / 0 fail (wiring/exit-code/Linux-gate guards green)

## Out of scope

Why the pm2 "Genie" process itself flaps (`restart_time=7056`) is being traced separately; this PR closes the update→restart gap only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)