### PR TITLE
fix(scheduler): consult shouldResume for every dead pane in boot mode

### DIFF
--- a/src/lib/scheduler-daemon.ts
+++ b/src/lib/scheduler-daemon.ts
@@ -1203,12 +1203,26 @@ export async function runAgentRecoveryPass(
       // `.catch(() => null)` mis-attributed transient errors as orphans
       // and ticked their resume_attempts toward the auto_resume=false cap
       // (CodeRabbit major on #2461).
+      //
+      // Always consult the chokepoint, even when `currentSessionId` is
+      // already populated. `sessionId` alone isn't permission — a task
+      // agent whose latest assignment closed (`decision.resume === false`,
+      // reason `assignment_closed`) still has a valid `currentSessionId`
+      // from the executor join, so the previous "only call shouldResume
+      // when sessionId is missing" shortcut let those rows fall through
+      // to `handleDeadPane(mode='boot')` where `isLegitimatelyClosed`
+      // checks the executor outcome (not the assignment outcome) and
+      // missed them — re-invoking task agents the boot pass had already
+      // classified as `lazy_surface`. Short-circuit boot-mode here when
+      // resume is denied; sweep mode is unaffected because idle dead-pane
+      // → `terminalizeCleanExitUnverified` is the correct cleanup for
+      // done agents (CodeRabbit major on #2461 follow-up).
+      const decision = await shouldResume(worker.id);
+      if (mode === 'boot' && !decision.resume) continue;
+
       let enriched = worker;
-      if (!enriched.currentSessionId) {
-        const decision = await shouldResume(worker.id);
-        if (decision.resume && decision.sessionId) {
-          enriched = { ...worker, currentSessionId: decision.sessionId };
-        }
+      if (!enriched.currentSessionId && decision.resume && decision.sessionId) {
+        enriched = { ...worker, currentSessionId: decision.sessionId };
       }
 
       const outcome = await handleDeadPane(deps, resolvedConfig, daemonId, enriched, turnAware, mode);


### PR DESCRIPTION
## Summary
CodeRabbit follow-up on PR #2461 (line 1211, posted 07:03Z, after #2462 merged).

## The bug
The fix in #2462 only called `shouldResume` when `currentSessionId` was missing. Task agents with a closed assignment usually KEEP their `currentSessionId` populated from the `executors.claude_session_id` join — so they bypassed the chokepoint and fell straight into `handleDeadPane(mode='boot')`.

`isLegitimatelyClosed` there checks the **executor's** outcome, not the **assignment's** outcome — so when the agent finished its task but the executor session didn't terminalize cleanly (common), the check returns false → `attemptAgentResume` re-spawns the agent. The boot pass had already classified that agent as `lazy_surface`; the recovery pass disagrees and re-invokes it. Exactly the regression class invariant 3 / the chokepoint exists to prevent.

## Why it's real
```
state: 'idle' (passes prefilter)
paneId: '%42' (tmux-shaped, passes prefilter)
currentSessionId: <uuid> (executor join non-null)
shouldResume → { resume: false, reason: 'assignment_closed', sessionId: <uuid>, rehydrate: 'lazy' }
```
Pre-fix: skipped chokepoint check → handleDeadPane → isLegitimatelyClosed false → attemptAgentResume → re-spawn. Done task agent comes back to life on every reboot.

## Fix (surgical, ~14 lines)
- Always consult `shouldResume` for dead-pane survivors (one extra call per dead pane in the worst case; dead-pane survivors are already the narrow set).
- Boot mode: short-circuit with `continue` when `decision.resume === false` (matches the boot pass's `lazy_surface` / `skip` classification upstream).
- Sweep mode: intentionally unaffected — `idle dead-pane → terminalizeCleanExitUnverified` is the correct cleanup for done agents.

## Validated
- `bun test src/__tests__/state-machine.invariants.test.ts` — 1 pass / 0 fail (invariant 3 still green)
- `bun test --test-name-pattern recovery` — 10 pass / 0 fail
- `bun run typecheck` — clean
- `biome check src/lib/scheduler-daemon.ts` — clean

## Downstream
- Merge → dev CI → version.yml folds this + #2462 + #2460 into a single tag bump (v4.260520.2 or higher) → dev release published
- PR #2461 (dev → main) auto-picks up the corrected payload for the stable merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)