### PR TITLE
fix(install): route every pgserve consumer through autopg-v3 resolver

### DIFF
--- a/src/genie-commands/__tests__/install.test.ts
+++ b/src/genie-commands/__tests__/install.test.ts
@@ -267,21 +267,24 @@ describe('buildCanonicalPgserveHint — pgserve fatal install hint (cutover G1)'
     expect(text).toContain('(exit code 17)');
   });
 
-  test('hint lists the three copy-paste recovery commands', () => {
+  test('hint lists the canonical autopg-v3 recovery commands', () => {
     const text = buildCanonicalPgserveHint('exit code 1');
-    expect(text).toContain('bun add -g pgserve@^2');
-    expect(text).toContain('pgserve install');
+    // Post v2 → v3 cutover: hint points at the autopg installer, NOT
+    // `bun add -g pgserve@^2` (the obsolete v2 package).
+    expect(text).toContain('automagik-dev/autopg/main/install.sh');
     expect(text).toContain('genie install');
+    expect(text).not.toContain('bun add -g pgserve@^2');
   });
 
-  test('hint points at the canonical install docs URL', () => {
+  test('hint points at the canonical autopg docs URL', () => {
     const text = buildCanonicalPgserveHint('exit code 1');
-    expect(text).toContain('https://github.com/automagik-dev/genie/blob/main/docs/install.md');
+    expect(text).toContain('https://github.com/automagik-dev/autopg');
   });
 
-  test('hint explains genie depends on pm2-supervised pgserve', () => {
+  test('hint explains genie depends on pm2-supervised pgserve (autopg v3)', () => {
     const text = buildCanonicalPgserveHint('exit code 1');
     expect(text).toContain('pm2-supervised pgserve');
+    expect(text).toContain('autopg v3');
   });
 });
 

--- a/src/genie-commands/install.ts
+++ b/src/genie-commands/install.ts
@@ -40,6 +40,7 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
+import { canonicalPgserveInstallHint, resolvePgserveBinary } from '../lib/canonical-pgserve-binary.js';
 
 /**
  * Canonical pm2 process name. See file header for the rename rationale.
@@ -185,22 +186,26 @@ function pm2IsAvailable(): boolean {
 }
 
 function pgserveIsAvailable(): boolean {
-  return which('pgserve') !== null;
+  return resolvePgserveBinary() !== null;
 }
 
 /**
  * Build the canonical-install hint message printed before exiting non-zero
  * when pgserve is missing or its install fails. Exported via `_internals`
  * for unit tests.
+ *
+ * The hint points operators at the autopg v3 install.sh — the v2
+ * `bun add -g pgserve@^2` recovery is intentionally retired because it
+ * installs the obsolete v2 distribution and a v3 host has no use for it.
+ * Legacy `pgserve` binaries still resolve at runtime via
+ * {@link resolvePgserveBinary} but new installs go through autopg only.
  */
 function buildCanonicalPgserveHint(reason: string): string {
   return [
     `Error: canonical pgserve registration failed (${reason}).`,
-    'Genie depends on pm2-supervised pgserve. To proceed:',
-    '  bun add -g pgserve@^2',
-    '  pgserve install',
-    '  genie install',
-    'See https://github.com/automagik-dev/genie/blob/main/docs/install.md for details.',
+    'Genie depends on pm2-supervised pgserve (autopg v3). To proceed:',
+    ...canonicalPgserveInstallHint(),
+    'See https://github.com/automagik-dev/autopg for details.',
     '',
   ].join('\n');
 }
@@ -245,8 +250,9 @@ interface PgserveStatus {
 }
 
 function readPgserveStatus(): PgserveStatus | null {
-  if (!pgserveIsAvailable()) return null;
-  const result = spawnSync('pgserve', ['status', '--json'], { encoding: 'utf8', timeout: 5000 });
+  const bin = resolvePgserveBinary();
+  if (!bin) return null;
+  const result = spawnSync(bin, ['status', '--json'], { encoding: 'utf8', timeout: 5000 });
   if (result.status !== 0 && !result.stdout) return null;
   try {
     const parsed = JSON.parse(result.stdout ?? '') as PgserveStatus;
@@ -265,7 +271,9 @@ function isPgserveReadyStatus(status: PgserveStatus | null): boolean {
 }
 
 function restartPgserve(): boolean {
-  const result = spawnSync('pgserve', ['restart'], { stdio: 'inherit' });
+  const bin = resolvePgserveBinary();
+  if (!bin) return false;
+  const result = spawnSync(bin, ['restart'], { stdio: 'inherit' });
   return result.status === 0;
 }
 
@@ -282,8 +290,9 @@ function isPgserveOnlinePm2(entry: Pm2Process | null): boolean {
 }
 
 function requirePgserveInstall(): void {
-  if (!pgserveIsAvailable()) {
-    failCanonicalPgserve('pgserve binary not found in PATH');
+  const bin = resolvePgserveBinary();
+  if (!bin) {
+    failCanonicalPgserve('canonical binary (autopg v3 or pgserve v2) not found in PATH');
   }
 
   const status = readPgserveStatus();
@@ -316,7 +325,7 @@ function requirePgserveInstall(): void {
     );
     return;
   }
-  const result = spawnSync('pgserve', ['install'], { stdio: 'inherit' });
+  const result = spawnSync(bin, ['install'], { stdio: 'inherit' });
   if (result.status !== 0) {
     failCanonicalPgserve(`exit code ${result.status}`);
   }
@@ -332,8 +341,9 @@ function requirePgserveInstall(): void {
  * regression in `omni doctor --fix`).
  */
 function tryPgservePort(): number | null {
-  if (!pgserveIsAvailable()) return null;
-  const result = spawnSync('pgserve', ['port'], { encoding: 'utf8', timeout: 5000 });
+  const bin = resolvePgserveBinary();
+  if (!bin) return null;
+  const result = spawnSync(bin, ['port'], { encoding: 'utf8', timeout: 5000 });
   if (result.status !== 0) return null;
   const port = Number.parseInt((result.stdout ?? '').trim(), 10);
   if (!Number.isFinite(port) || port <= 0 || port > 65535) return null;

--- a/src/lib/canonical-pgserve-binary.ts
+++ b/src/lib/canonical-pgserve-binary.ts
@@ -1,0 +1,77 @@
+/**
+ * Canonical pgserve binary resolver.
+ *
+ * The autopg-distribution-cutover-finalize wish (autopg repo) renamed the
+ * published v3 binary from `pgserve` to `autopg`. Both binaries expose an
+ * identical command surface (`install`, `port`, `url`, `status`, `restart`);
+ * only the on-disk name differs. Genie consumers (install.ts, db.ts) used
+ * to hardcode `'pgserve'` everywhere — that broke `genie install` on every
+ * v3 host that only had `autopg` on PATH, and pointed users at the obsolete
+ * `bun add -g pgserve@^2` recovery command. This module is the single
+ * resolver every consumer routes through.
+ *
+ * Resolution policy:
+ *   - Prefer `autopg` (v3 canonical) when present.
+ *   - Fall back to `pgserve` (v2 legacy) for hosts mid-cutover.
+ *   - Return null when neither is on PATH — caller surfaces an actionable
+ *     install hint via {@link canonicalPgserveInstallHint}.
+ *
+ * The pm2 process-name layer is orthogonal: v3 supervises under
+ * `autopg-server`, v2 under `pgserve`. The `PGSERVE_PM2_PROCESS_NAMES`
+ * constant in install.ts already checks both.
+ */
+
+import { execFileSync } from 'node:child_process';
+
+export const CANONICAL_PGSERVE_BINARY = 'autopg';
+export const LEGACY_PGSERVE_BINARY = 'pgserve';
+
+let cached: string | null | undefined;
+
+function which(cmd: string): string | null {
+  try {
+    const result = execFileSync('which', [cmd], {
+      encoding: 'utf8',
+      timeout: 3000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return result.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the canonical pgserve binary on this host. Memoized — the first
+ * call probes PATH; subsequent calls return the cached answer. Tests can
+ * invalidate via {@link _resetPgserveBinaryCache}.
+ */
+export function resolvePgserveBinary(): string | null {
+  if (cached !== undefined) return cached;
+  if (which(CANONICAL_PGSERVE_BINARY)) {
+    cached = CANONICAL_PGSERVE_BINARY;
+    return cached;
+  }
+  if (which(LEGACY_PGSERVE_BINARY)) {
+    cached = LEGACY_PGSERVE_BINARY;
+    return cached;
+  }
+  cached = null;
+  return cached;
+}
+
+/**
+ * Copy-paste recovery commands for the "binary not found" path. Points at
+ * the autopg v3 installer; ordered so the operator runs them top-to-bottom.
+ */
+export function canonicalPgserveInstallHint(): string[] {
+  return [
+    '  curl -fsSL https://raw.githubusercontent.com/automagik-dev/autopg/main/install.sh | bash',
+    '  genie install',
+  ];
+}
+
+/** Reset memoization. Test-only. */
+export function _resetPgserveBinaryCache(): void {
+  cached = undefined;
+}

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -999,8 +999,10 @@ describe('canonical-pgserve cutover hint surface', () => {
     const body = source.slice(fnStart, fnEnd);
     expect(body).toContain('canonical-pgserve cutover');
     expect(body).toContain('pm2 status');
-    expect(body).toContain('pm2 restart pgserve');
-    expect(body).toContain('pgserve install');
+    // Post v2 → v3 cutover: hint names autopg first, keeps pgserve as
+    // legacy fallback. Either form must remain present for backward compat.
+    expect(body).toMatch(/pm2 restart (autopg-server|pgserve)/);
+    expect(body).toMatch(/(autopg|pgserve) install/);
   });
 
   test('requirePgserveDaemon throws with a pm2-recovery hint when the canonical socket is dead', () => {
@@ -1012,8 +1014,8 @@ describe('canonical-pgserve cutover hint surface', () => {
     const hintEnd = source.indexOf('\n}\n', hintStart);
     const hintBody = source.slice(hintStart, hintEnd);
     expect(hintBody).toContain('pm2 status');
-    expect(hintBody).toContain('pm2 restart pgserve');
-    expect(hintBody).toContain('pgserve install');
+    expect(hintBody).toMatch(/pm2 restart (autopg-server|pgserve)/);
+    expect(hintBody).toMatch(/(autopg|pgserve) install/);
     expect(hintBody).toContain('docs/install.md');
   });
 });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -23,6 +23,7 @@ import { createConnection } from 'node:net';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import type postgres from 'postgres';
+import { resolvePgserveBinary } from './canonical-pgserve-binary.js';
 import { runMigrations } from './db-migrations.js';
 import { needsSeed, needsSeededTeams, runSeed } from './pg-seed.js';
 import { getProcessStartTime } from './process-identity.js';
@@ -469,10 +470,11 @@ export async function requirePgserveDaemon(): Promise<DaemonState> {
 function buildPgserveUnavailableHint(state: DaemonState): string {
   return [
     `pgserve canonical daemon is not reachable (${state.reason ?? 'no daemon'}).`,
-    'Genie depends on the pm2-supervised pgserve singleton. Recovery:',
-    '  pm2 status              # is pgserve registered?',
-    '  pm2 restart pgserve     # OR: autopg restart',
-    '  pgserve install         # if not registered yet',
+    'Genie depends on the pm2-supervised pgserve singleton (autopg v3). Recovery:',
+    '  pm2 status                  # is autopg-server registered?',
+    '  pm2 restart autopg-server   # OR: pm2 restart pgserve (v2 legacy)',
+    '  autopg install              # OR: pgserve install (v2 legacy)',
+    'Fresh hosts: curl -fsSL https://raw.githubusercontent.com/automagik-dev/autopg/main/install.sh | bash',
     'See https://github.com/automagik-dev/genie/blob/main/docs/install.md for details.',
   ].join('\n');
 }
@@ -589,10 +591,12 @@ function parseExplicitTcpPort(raw: string | undefined): number | null {
  * timeout. Caller treats null as "no TCP fallback available".
  */
 async function discoverTcpPgservePort(): Promise<number | null> {
+  const bin = resolvePgserveBinary();
+  if (!bin) return null;
   return new Promise((resolve) => {
     let settled = false;
     let stdout = '';
-    const proc = spawn('pgserve', ['port'], { stdio: ['ignore', 'pipe', 'ignore'] });
+    const proc = spawn(bin, ['port'], { stdio: ['ignore', 'pipe', 'ignore'] });
     const timer = setTimeout(() => {
       if (settled) return;
       settled = true;
@@ -642,14 +646,15 @@ function buildBothTransportsUnavailableHint(forceTcp: boolean, forceSocket: bool
     lines.push('  • Unix socket probe: skipped (GENIE_PG_FORCE_TCP=1)');
   }
   if (!forceSocket) {
-    lines.push('  • TCP discovery via `pgserve port`: failed (binary missing or no daemon)');
+    lines.push('  • TCP discovery via `autopg port` (or `pgserve port`): failed (binary missing or no daemon)');
   } else {
     lines.push('  • TCP discovery: skipped (GENIE_PG_FORCE_SOCKET=1)');
   }
-  lines.push('Recovery:');
-  lines.push('  pm2 status              # is pgserve registered?');
-  lines.push('  pgserve install         # register foreground TCP-mode pgserve under pm2');
-  lines.push('  pgserve daemon          # OR start daemon-mode (canonical UDS) standalone');
+  lines.push('Recovery (autopg v3):');
+  lines.push('  pm2 status                  # is autopg-server registered?');
+  lines.push('  autopg install              # register foreground TCP-mode autopg under pm2');
+  lines.push('  pgserve install             # v2 legacy equivalent');
+  lines.push('Fresh hosts: curl -fsSL https://raw.githubusercontent.com/automagik-dev/autopg/main/install.sh | bash');
   lines.push('See https://github.com/automagik-dev/genie/blob/main/docs/install.md for details.');
   return lines.join('\n');
 }
@@ -1066,9 +1071,10 @@ async function _ensurePgserve(): Promise<number> {
       'Genie is consumer-only after the canonical-pgserve cutover; it does not spawn pgserve.',
       'Force-TCP mode (GENIE_PG_FORCE_TCP=1) requires you to start a TCP-listening pgserve yourself.',
       'Recommended: drop GENIE_PG_FORCE_TCP and let genie connect via the canonical Unix socket:',
-      '  pm2 status              # is pgserve registered?',
-      '  pm2 restart pgserve     # OR: autopg restart',
-      '  pgserve install         # if not registered yet',
+      '  pm2 status                  # is autopg-server registered?',
+      '  pm2 restart autopg-server   # OR: pm2 restart pgserve (v2 legacy)',
+      '  autopg install              # OR: pgserve install (v2 legacy)',
+      'Fresh hosts: curl -fsSL https://raw.githubusercontent.com/automagik-dev/autopg/main/install.sh | bash',
     ].join('\n'),
   );
 }


### PR DESCRIPTION
## Summary
Closes the genie-install gap on every v3-only host: every spawn/which site that used to hardcode the v2 binary `'pgserve'` now routes through a single resolver that prefers `autopg` (v3) and falls back to `pgserve` (v2) for cutover hosts.

## The gap
Pre-fix, `which('pgserve')` returned null on every fresh autopg-v3 host → `failCanonicalPgserve('pgserve binary not found in PATH')` → recovery hint told users to `bun add -g pgserve@^2` (which installs the **obsolete v2 package**). Same root cause on `discoverTcpPgservePort` in `db.ts`.

## Compatibility matrix after this PR
| Host state | `genie install` | `genie` runtime port-discovery |
|---|---|---|
| autopg v3 only | ✅ works (uses `autopg`) | ✅ works |
| pgserve v2 only | ✅ works (uses `pgserve`) | ✅ works |
| both installed | ✅ works (prefers `autopg`) | ✅ works |
| neither | ❌ fails with autopg recovery hint | ❌ no TCP fallback (correct) |

## Changes
- **NEW** `src/lib/canonical-pgserve-binary.ts` — `resolvePgserveBinary()`, `canonicalPgserveInstallHint()`. Memoized; tests can invalidate via `_resetPgserveBinaryCache`.
- `src/genie-commands/install.ts` — 5 sites (pgserveIsAvailable, readPgserveStatus, restartPgserve, requirePgserveInstall, tryPgservePort) + the hint message.
- `src/lib/db.ts` — `discoverTcpPgservePort` + 3 hint messages now name `autopg-server` first, `pgserve` as legacy fallback.
- Tests in `install.test.ts` and `db.test.ts` updated: regex-match either autopg or pgserve in the surfaced hints.

## Hint message — before vs after
**Before:**
```
Error: canonical pgserve registration failed (pgserve binary not found in PATH).
Genie depends on pm2-supervised pgserve. To proceed:
  bun add -g pgserve@^2     ← obsolete v2 package
  pgserve install
  genie install
```
**After:**
```
Error: canonical pgserve registration failed (canonical binary (autopg v3 or pgserve v2) not found in PATH).
Genie depends on pm2-supervised pgserve (autopg v3). To proceed:
  curl -fsSL https://raw.githubusercontent.com/automagik-dev/autopg/main/install.sh | bash
  genie install
See https://github.com/automagik-dev/autopg for details.
```

## Validated
- `bun test install.test.ts db.test.ts` — 103 pass / 0 fail
- `bun run typecheck` — clean
- `biome check` on all touched files — clean

## Test plan
- [ ] dev CI green
- [ ] dev release publishes (next tag bump)
- [ ] Felipe dogfood: fresh-host install via dev install.sh → `genie install` walks the autopg path without surfacing the obsolete v2 hint
- [ ] Promote to main — opens the omni-handoff window

🤖 Generated with [Claude Code](https://claude.com/claude-code)