### PR TITLE
fix(test): accept v3 'Recovery (autopg v3):' heading variant

### DIFF
--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -1108,7 +1108,10 @@ describe('resolvePgserveTransport (transport discovery)', () => {
         // No pgserve binary or daemon → resolver throws the both-unavailable
         // hint. Assert the message shape so future copy edits are caught.
         expect(result.message).toContain('pgserve is not reachable');
-        expect(result.message).toContain('Recovery:');
+        // Recovery heading post-cutover: 'Recovery (autopg v3):' for v3
+        // hosts, plain 'Recovery:' would be the v2-era heading. Either
+        // shape is acceptable; both name a recovery section.
+        expect(result.message).toMatch(/Recovery( \(autopg v3\))?:/);
         return;
       }
       // pgserve was discoverable on TCP — assert the shape.


### PR DESCRIPTION
## Summary
Follow-up to #2465. `db.test.ts:1111` asserts the both-transports-unavailable hint contains the literal `'Recovery:'`. The autopg v3 cutover renamed that heading to `'Recovery (autopg v3):'` to signal which install path the operator should follow first. Test now accepts either shape via regex.

## Validated
- `bun test db.test.ts` — 68 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)