### PR TITLE
fix(log): link lifecycle runtime events

### DIFF
--- a/src/lib/unified-log.ts
+++ b/src/lib/unified-log.ts
@@ -19,6 +19,7 @@ import {
   type RuntimeEventKind,
   type RuntimeEventSource,
   followRuntimeEvents,
+  listRuntimeEvents,
 } from './runtime-events.js';
 import { type ChatMessage, readMessages } from './team-chat.js';
 import type { TranscriptEntry } from './transcript.js';
@@ -280,14 +281,18 @@ export async function readAgentLog(agent: Agent, repoPath: string, filter?: LogF
   const agentName = agent.id;
   const team = agent.team;
   const mailboxKeys = mailboxActorKeys(agent);
+  const runtimeAgentIds = [
+    ...new Set([agent.id, agent.customName, agent.role, agent.nativeAgentId].filter(Boolean) as string[]),
+  ];
 
   // Read all sources in parallel
-  const [transcriptEntries, inboxMessages, outboxMessages, chatMessages, sdkEvents] = await Promise.all([
+  const [transcriptEntries, inboxMessages, outboxMessages, chatMessages, sdkEvents, runtimeEvents] = await Promise.all([
     readTranscriptSafe(agent),
     inbox(repoPath, mailboxKeys),
     readOutbox(repoPath, mailboxKeys),
     team ? readMessages(repoPath, team) : Promise.resolve([]),
     readSdkAuditEvents(agentName, filter),
+    readRuntimeEventsSafe({ repoPath, agentIds: runtimeAgentIds, filter }),
   ]);
 
   // Convert to LogEvents
@@ -313,6 +318,7 @@ export async function readAgentLog(agent: Agent, repoPath: string, filter?: LogF
   }
 
   events.push(...sdkEvents);
+  events.push(...runtimeEvents);
 
   // Sort by time, then filter
   const sorted = sortByTimestamp(events);
@@ -362,8 +368,14 @@ export async function readTeamLog(
     }),
   );
 
+  const teamRuntimeEvents = await readRuntimeEventsSafe({
+    repoPath,
+    team: teamName === 'all' ? undefined : teamName,
+    filter,
+  });
+
   // Merge all sources
-  const allEvents = [...chatEvents, ...perAgentEvents.flat()];
+  const allEvents = [...chatEvents, ...perAgentEvents.flat(), ...teamRuntimeEvents];
   const sorted = sortByTimestamp(allEvents);
   return applyLogFilter(sorted, filter);
 }
@@ -520,6 +532,38 @@ async function startPgFollow(
 // ============================================================================
 // Helpers
 // ============================================================================
+
+async function readRuntimeEventsSafe(opts: {
+  repoPath: string;
+  agentIds?: string[];
+  team?: string;
+  filter?: LogFilter;
+}): Promise<LogEvent[]> {
+  try {
+    const events = await listRuntimeEvents({
+      repoPath: opts.repoPath,
+      agentIds: opts.agentIds,
+      team: opts.team,
+      kinds: opts.filter?.kinds,
+      since: opts.filter?.since,
+      limit: opts.filter?.last ?? 500,
+      scopeMode: opts.agentIds && opts.team ? 'any' : 'all',
+    });
+    return events.map((event) => ({
+      timestamp: event.timestamp,
+      kind: event.kind,
+      agent: event.agent,
+      team: event.team,
+      direction: event.direction,
+      peer: event.peer,
+      text: event.text,
+      data: event.data,
+      source: event.source,
+    }));
+  } catch {
+    return [];
+  }
+}
 
 /** Safely read transcript entries, returning [] on any error. */
 async function readTranscriptSafe(agent: Agent): Promise<TranscriptEntry[]> {

--- a/src/term-commands/log.test.ts
+++ b/src/term-commands/log.test.ts
@@ -5,9 +5,11 @@
  * filters, NDJSON output, and human-readable output.
  *
  * Run with: bun test src/term-commands/log.test.ts
+ * @requires GENIE_TEST_PG
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { randomUUID } from 'node:crypto';
 import * as registry from '../lib/agent-registry.js';
 import type { Agent } from '../lib/agent-registry.js';
 import { send } from '../lib/mailbox.js';
@@ -54,6 +56,90 @@ function makeAgent(id: string, team?: string, repoPath?: string): Agent {
     team,
   };
 }
+
+describe.skipIf(!DB_AVAILABLE)('log command: lifecycle lookup regressions', () => {
+  function registerUuidAgent(overrides: Partial<Agent> & { id?: string }): Promise<Agent> {
+    const agent: Agent = {
+      id: overrides.id ?? randomUUID(),
+      paneId: 'inline',
+      session: 'test',
+      worktree: null,
+      startedAt: new Date().toISOString(),
+      state: 'suspended',
+      lastStateChange: new Date().toISOString(),
+      repoPath: '/tmp/log-lifecycle-regression',
+      ...overrides,
+    };
+    return registry.register(agent).then(() => agent);
+  }
+
+  test('findAgent resolves exact customName without requiring --team', async () => {
+    const agent = await registerUuidAgent({
+      customName: `log-role-${Date.now()}`,
+      role: 'engineer',
+      team: 'MixedCase-Team',
+    });
+    try {
+      const found = await findAgent(agent.customName!);
+      expect(found?.id).toBe(agent.id);
+    } finally {
+      await registry.unregister(agent.id);
+    }
+  });
+
+  test('findAgent resolves exact role with case-insensitive team scope', async () => {
+    const agent = await registerUuidAgent({
+      customName: `agent-${Date.now()}`,
+      role: `log-role-${Date.now()}`,
+      team: 'Hermes-LogFix-Team',
+    });
+    try {
+      const found = await findAgent(agent.role!, 'hermes-logfix-team');
+      expect(found?.id).toBe(agent.id);
+    } finally {
+      await registry.unregister(agent.id);
+    }
+  });
+
+  test('readAgentLog includes stored PG runtime events, not only follow-mode events', async () => {
+    const repo = '/tmp/log-lifecycle-runtime-events';
+    const agent = await registerUuidAgent({
+      customName: `runtime-${Date.now()}`,
+      role: `runtime-role-${Date.now()}`,
+      team: 'runtime-team',
+      repoPath: repo,
+    });
+    try {
+      await publishRuntimeEvent({
+        repoPath: repo,
+        kind: 'state',
+        agent: agent.id,
+        team: 'runtime-team',
+        text: 'spawned-through-lifecycle',
+        source: 'registry',
+      });
+      const events = await readAgentLog(agent, repo, { last: 20 });
+      expect(events.some((event) => event.text === 'spawned-through-lifecycle')).toBe(true);
+    } finally {
+      await registry.unregister(agent.id);
+    }
+  });
+
+  test('readTeamLog returns stored PG team events even before local agent resolution finds members', async () => {
+    const repo = '/tmp/log-lifecycle-team-events';
+    await publishRuntimeEvent({
+      repoPath: repo,
+      kind: 'message',
+      agent: 'late-worker',
+      team: 'empty-runtime-team',
+      text: 'team-event-without-registry-member',
+      source: 'mailbox',
+    });
+
+    const events = await readTeamLog([], repo, 'empty-runtime-team', { last: 20 });
+    expect(events.some((event) => event.text === 'team-event-without-registry-member')).toBe(true);
+  });
+});
 
 // ============================================================================
 // readAgentLog integration (used by log command)

--- a/src/term-commands/log.ts
+++ b/src/term-commands/log.ts
@@ -221,26 +221,39 @@ export async function findAgent(identifier: string, teamName?: string): Promise<
   if (byTask) return byTask;
 
   const all = await agentRegistry.list();
-  const teamPool = teamName ? all.filter((a) => a.team === teamName) : [];
+  const sameTeam = (a: agentRegistry.Agent) =>
+    teamName === undefined || (a.team ?? '').toLowerCase() === teamName.toLowerCase();
+  const pool = all.filter(sameTeam);
+  const displayName = (w: agentRegistry.Agent) => w.customName ?? w.role ?? w.id;
+  const exactName = (w: agentRegistry.Agent) =>
+    w.customName === identifier || w.role === identifier || w.nativeAgentId === identifier;
   const prefix = (w: agentRegistry.Agent) =>
     (w.customName !== undefined && w.customName !== identifier && w.customName.startsWith(identifier)) ||
     (w.role !== undefined && w.role !== identifier && w.role.startsWith(identifier));
-  const displayName = (w: agentRegistry.Agent) => w.customName ?? w.role ?? w.id;
 
-  const teamPrefix = teamPool.filter(prefix);
-  if (teamPrefix.length === 1) return teamPrefix[0];
-  if (teamPrefix.length > 1) {
+  // Lifecycle/observe rows can be addressable by their exact customName/role
+  // even when the canonical resolver cannot use the composite custom_name tier
+  // because the caller did not pass --team. Prefer exact display-name matches
+  // before prefix fallback; this is the missing bridge for short-lived role
+  // process agents captured by `observe agents` but rejected by `genie log`.
+  const exactPool = pool.filter(exactName);
+  if (exactPool.length === 1) return exactPool[0];
+  if (exactPool.length > 1) {
     throw new Error(
-      `Agent "${identifier}" is ambiguous in team "${teamName}". Did you mean: ${teamPrefix
+      `Agent "${identifier}" is ambiguous${teamName ? ` in team "${teamName}"` : ''}. Did you mean: ${exactPool
         .map(displayName)
         .join(', ')}?`,
     );
   }
 
-  const globalPrefix = all.filter(prefix);
-  if (globalPrefix.length === 1) return globalPrefix[0];
-  if (globalPrefix.length > 1) {
-    throw new Error(`Agent "${identifier}" is ambiguous. Did you mean: ${globalPrefix.map(displayName).join(', ')}?`);
+  const prefixPool = pool.filter(prefix);
+  if (prefixPool.length === 1) return prefixPool[0];
+  if (prefixPool.length > 1) {
+    throw new Error(
+      `Agent "${identifier}" is ambiguous${teamName ? ` in team "${teamName}"` : ''}. Did you mean: ${prefixPool
+        .map(displayName)
+        .join(', ')}?`,
+    );
   }
 
   return null;
@@ -248,7 +261,8 @@ export async function findAgent(identifier: string, teamName?: string): Promise<
 
 async function findTeamAgents(teamName: string): Promise<agentRegistry.Agent[]> {
   const all = await agentRegistry.list();
-  return all.filter((a) => a.team === teamName);
+  const normalizedTeam = teamName.toLowerCase();
+  return all.filter((a) => (a.team ?? '').toLowerCase() === normalizedTeam);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- resolve exact customName/role/nativeAgentId in `genie log` even when no `--team` is supplied
- make team lookup case-insensitive for log surfaces
- include stored `genie_runtime_events` in historical agent/team log reads, matching follow-mode visibility
- add PG regression tests for lifecycle lookup/runtime-event gaps

## Tests
- `bun run typecheck`
- `GENIE_TEST_SKIP_PGSERVE=1 GENIE_PG_AVAILABLE=true bun test src/term-commands/log.test.ts --timeout 20000`
- `bun run build`

## Notes
Running the targeted test without `GENIE_TEST_SKIP_PGSERVE=1` fails in this environment before test execution with `test-setup: could not start pgserve on any port in 20900..20999`; the live reusable pgserve path was used for targeted verification.