### PR TITLE
fix(update): verify swapped binary; suppress self-symlink advisory

### DIFF
--- a/src/genie-commands/__tests__/update.test.ts
+++ b/src/genie-commands/__tests__/update.test.ts
@@ -34,6 +34,8 @@ import {
   rollbackBinary,
   runVerifyProbe,
   shortCircuitIfCurrent,
+  shouldEmitPathDivergenceWarning,
+  verifySwappedBinary,
 } from '../update.js';
 
 // ============================================================================
@@ -1092,5 +1094,174 @@ describe('Knip-clean exports (PR #1733 follow-up)', () => {
     const source = readFileSync(join(__dirname, '..', 'update.ts'), 'utf-8');
     expect(source).not.toContain('RELEASES_BASE_URL');
     expect(source).not.toMatch(/^export\s*\{\s*RELEASES_/m);
+  });
+});
+
+// ============================================================================
+// Silent swap + self-symlink regression (trace 2026-05-22).
+//
+// Symptom on operator host (genie@khal-os): `genie update --dev` reported
+// "✔ Genie binary updated → v4.260522.2" but the on-disk binary at
+// `~/.genie/bin/genie` remained v4.260520.3 (mtime unchanged), and the
+// subsequent PATH advisory suggested `ln -sf <path> <path>` — a self-symlink.
+//
+// Root causes:
+//   1. runDelivery printed success based on `manifest.version` (intent),
+//      never re-reading the swapped binary.
+//   2. The PATH heuristic did not guard against `live === canonical`, so a
+//      version mismatch caused by a botched swap was misdiagnosed as a PATH
+//      problem and rendered as `ln -sf X X`.
+//
+// Both helpers below are pure and injectable so the regression is locked in
+// without spawning a real `genie` binary.
+// ============================================================================
+
+describe('verifySwappedBinary (post-swap correctness guard)', () => {
+  test('returns void when reported version matches expected', () => {
+    expect(() =>
+      verifySwappedBinary('/fake/path/genie', '4.260522.2', {
+        runVersion: () => '4.260522.2\n',
+      }),
+    ).not.toThrow();
+  });
+
+  test('strips build metadata before comparison (normalizeVersion parity)', () => {
+    expect(() =>
+      verifySwappedBinary('/fake/path/genie', '4.260522.2', {
+        runVersion: () => '4.260522.2+abc1234\n',
+      }),
+    ).not.toThrow();
+  });
+
+  test('throws with intended-vs-on-disk diff when version mismatches', () => {
+    expect(() =>
+      verifySwappedBinary('/fake/path/genie', '4.260522.2', {
+        runVersion: () => '4.260520.3\n',
+        stagingDir: '/tmp/staging',
+        previousDir: '/tmp/previous',
+      }),
+    ).toThrow(/Intended: v4\.260522\.2[\s\S]*On disk : v4\.260520\.3/);
+  });
+
+  test('mismatch message includes staging + previous hints for forensics', () => {
+    let captured: string | null = null;
+    try {
+      verifySwappedBinary('/fake/path/genie', '4.260522.2', {
+        runVersion: () => '4.260520.3\n',
+        stagingDir: '/home/genie/.genie/bin/.staging',
+        previousDir: '/home/genie/.genie/bin/.previous',
+      });
+    } catch (err) {
+      captured = err instanceof Error ? err.message : String(err);
+    }
+    expect(captured).toContain('/home/genie/.genie/bin/.staging');
+    expect(captured).toContain('/home/genie/.genie/bin/.previous');
+  });
+
+  test('throws when binary cannot be executed (wraps underlying error)', () => {
+    expect(() =>
+      verifySwappedBinary('/fake/path/genie', '4.260522.2', {
+        runVersion: () => {
+          throw new Error('ENOENT: no such file');
+        },
+      }),
+    ).toThrow(/Post-swap verification failed.*could not execute.*ENOENT/);
+  });
+
+  test('throws when binary runs but emits no parseable version', () => {
+    expect(() =>
+      verifySwappedBinary('/fake/path/genie', '4.260522.2', {
+        runVersion: () => 'banner with no version string\n',
+      }),
+    ).toThrow(/emitted no parsable version/);
+  });
+});
+
+describe('shouldEmitPathDivergenceWarning (self-symlink suppression)', () => {
+  const canonical = '/home/genie/.genie/bin/genie';
+
+  test('suppresses when live is null (nothing on PATH)', () => {
+    expect(
+      shouldEmitPathDivergenceWarning({
+        live: null,
+        canonical,
+        canonicalReal: canonical,
+        liveVersion: '4.260520.3',
+        intendedVersion: '4.260522.2',
+      }),
+    ).toBe(false);
+  });
+
+  test('suppresses when live version is unknown', () => {
+    expect(
+      shouldEmitPathDivergenceWarning({
+        live: '/usr/local/bin/genie',
+        canonical,
+        canonicalReal: canonical,
+        liveVersion: null,
+        intendedVersion: '4.260522.2',
+      }),
+    ).toBe(false);
+  });
+
+  test('suppresses when versions match (PATH is fine)', () => {
+    expect(
+      shouldEmitPathDivergenceWarning({
+        live: '/usr/local/bin/genie',
+        canonical,
+        canonicalReal: canonical,
+        liveVersion: '4.260522.2',
+        intendedVersion: '4.260522.2',
+      }),
+    ).toBe(false);
+  });
+
+  test('suppresses when live === canonical (the self-symlink bug)', () => {
+    expect(
+      shouldEmitPathDivergenceWarning({
+        live: canonical,
+        canonical,
+        canonicalReal: canonical,
+        liveVersion: '4.260520.3',
+        intendedVersion: '4.260522.2',
+      }),
+    ).toBe(false);
+  });
+
+  test('suppresses when live === canonicalReal (canonical is itself a symlink)', () => {
+    const realTarget = '/opt/genie/bin/genie';
+    expect(
+      shouldEmitPathDivergenceWarning({
+        live: realTarget,
+        canonical,
+        canonicalReal: realTarget,
+        liveVersion: '4.260520.3',
+        intendedVersion: '4.260522.2',
+      }),
+    ).toBe(false);
+  });
+
+  test('emits when paths differ AND versions disagree (legitimate PATH shadow)', () => {
+    expect(
+      shouldEmitPathDivergenceWarning({
+        live: '/usr/local/bin/genie',
+        canonical,
+        canonicalReal: canonical,
+        liveVersion: '4.260000.0',
+        intendedVersion: '4.260522.2',
+      }),
+    ).toBe(true);
+  });
+
+  test('normalizes build metadata when comparing versions', () => {
+    expect(
+      shouldEmitPathDivergenceWarning({
+        live: '/usr/local/bin/genie',
+        canonical,
+        canonicalReal: canonical,
+        liveVersion: '4.260522.2+abc',
+        intendedVersion: '4.260522.2',
+      }),
+    ).toBe(false);
   });
 });

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -642,6 +642,124 @@ export function atomicBinarySwap(
 }
 
 /**
+ * Post-swap correctness guard: execute the freshly-swapped binary and confirm
+ * its `--version` output normalises to the version we intended to install.
+ *
+ * Why this exists: on 2026-05-22 we observed an update that printed
+ * "✔ Genie binary updated → v4.260522.2" while the on-disk file at
+ * `~/.genie/bin/genie` remained v4.260520.3 with an mtime predating the
+ * update run. `atomicBinarySwap` returned `{ swapped: true }` without
+ * throwing, but the bytes never landed (cause: cleaned-up `.staging/`, no
+ * forensics). The success message was a lie produced from the *intent*
+ * (`manifest.version`), not from re-reading the result.
+ *
+ * The fix is belt-and-suspenders: never claim success without proof. This
+ * helper executes the binary at `targetBin` (injectable via `opts.runVersion`
+ * for tests) and throws a structured `Error` when the reported version does
+ * not match the manifest. The thrown error includes the staging + previous
+ * directories the operator can inspect.
+ */
+export interface VerifySwappedBinaryOptions {
+  /** Test seam — replaces the `execFileSync(targetBin, ['--version'])` call. */
+  runVersion?: (targetBin: string) => string;
+  stagingDir?: string;
+  previousDir?: string;
+}
+
+export function verifySwappedBinary(
+  targetBin: string,
+  expectedVersion: string,
+  opts: VerifySwappedBinaryOptions = {},
+): void {
+  const runner =
+    opts.runVersion ??
+    ((path: string) => execFileSync(path, ['--version'], { encoding: 'utf-8', timeout: 3000 }).toString());
+
+  let raw: string;
+  try {
+    raw = runner(targetBin);
+  } catch (err) {
+    throw new Error(
+      `Post-swap verification failed — could not execute ${targetBin}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+  const match = raw.trim().match(/\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)*/);
+  if (!match) {
+    throw new Error(
+      `Post-swap verification failed — ${targetBin} ran but emitted no parsable version (got: ${JSON.stringify(
+        raw.slice(0, 200),
+      )})`,
+    );
+  }
+  const actual = normalizeVersion(match[0]);
+  const intended = normalizeVersion(expectedVersion);
+  if (actual !== intended) {
+    const hints: string[] = [];
+    if (opts.stagingDir) hints.push(`  Staging : ${opts.stagingDir}`);
+    if (opts.previousDir) hints.push(`  Previous: ${opts.previousDir}`);
+    throw new Error(
+      [
+        'Post-swap verification failed — the atomic swap reported success but the',
+        'on-disk binary holds the wrong version. This usually means the staged file',
+        'was the wrong version or the swap was rolled back by an external watcher.',
+        `  Intended: v${intended}`,
+        `  On disk : v${actual}`,
+        `  Path    : ${targetBin}`,
+        ...hints,
+      ].join('\n'),
+    );
+  }
+}
+
+/**
+ * Decide whether the post-update "PATH `genie` is NOT the binary that was
+ * just updated" advisory should be emitted.
+ *
+ * Pure decision function — separated from I/O so the heuristic is testable
+ * without spawning a real `genie` binary.
+ *
+ * Suppression rules (return `false` = do NOT warn):
+ *   1. No live binary on `$PATH` — nothing to compare against.
+ *   2. No live version probe result — unknowable, stay silent.
+ *   3. Versions match — PATH is fine.
+ *   4. **`live` and `canonical` resolve to the same canonical path** —
+ *      a version mismatch in that case means the swap silently failed
+ *      (caught by `verifySwappedBinary`). The advisory's
+ *      `ln -sf <canonical> <live>` suggestion would devolve into
+ *      `ln -sf X X` — a useless self-symlink — and mislead the operator
+ *      into thinking PATH is the problem when the real defect is upstream.
+ *
+ * Only when paths genuinely differ AND versions disagree do we emit.
+ */
+export interface PathDivergenceInput {
+  /** Realpath-resolved live binary (output of `resolveLiveBinaryPath`). */
+  live: string | null;
+  /** Canonical target path the swap wrote to (`~/.genie/bin/genie`). */
+  canonical: string;
+  /** Realpath-resolved canonical (handles symlinks at the canonical leg). */
+  canonicalReal: string;
+  /** Live binary's reported `--version`, or null when probe failed. */
+  liveVersion: string | null;
+  /** Version the update intended to install. */
+  intendedVersion: string;
+}
+
+export function shouldEmitPathDivergenceWarning(input: PathDivergenceInput): boolean {
+  if (input.live === null) return false;
+  if (!input.liveVersion) return false;
+  if (normalizeVersion(input.liveVersion) === normalizeVersion(input.intendedVersion)) {
+    return false;
+  }
+  // Same physical file → version mismatch is a swap-correctness bug, not a
+  // PATH bug. Suppress the misleading self-symlink advisory.
+  if (input.live === input.canonical) return false;
+  if (input.live === input.canonicalReal) return false;
+  return true;
+}
+
+/**
  * Restore the most recent backup from `~/.genie/bin/.previous/` to the live
  * binary path. Throws if no backup exists.
  */
@@ -1492,6 +1610,17 @@ async function runDelivery(
   const targetBin = join(GENIE_BIN, 'genie');
   const swapResult = atomicBinarySwap(stagedBin, targetBin, GENIE_BIN_PREVIOUS, normalizeVersion(VERSION));
   diagnosticsCtx.previousBackup = swapResult.oldVersionBackup;
+
+  // Belt-and-suspenders: re-read the on-disk binary BEFORE printing success.
+  // `atomicBinarySwap` returning `{ swapped: true }` is necessary but not
+  // sufficient — see verifySwappedBinary for the silent-failure case observed
+  // on 2026-05-22. Any mismatch here throws and aborts the delivery so the
+  // operator never sees a misleading "✔ Genie binary updated" banner.
+  verifySwappedBinary(targetBin, manifest.version, {
+    stagingDir: GENIE_BIN_STAGING,
+    previousDir: GENIE_BIN_PREVIOUS,
+  });
+
   success(`Genie binary updated → v${manifest.version}${swapResult.fallbackUsed ? ' (cross-device fallback)' : ''}`);
 
   try {
@@ -1505,24 +1634,43 @@ async function runDelivery(
   // copy or a shadowing shim) the user keeps running the old version and
   // would never escape the update prompt. Measure the actual outcome and
   // tell them exactly how to fix it rather than silently "succeeding".
+  //
+  // Suppression: when `live` and `canonical` resolve to the same file, a
+  // version mismatch is upstream swap corruption (already caught by
+  // verifySwappedBinary above), not a PATH problem. The legacy heuristic
+  // generated `ln -sf canonical canonical` — a useless self-symlink. See
+  // shouldEmitPathDivergenceWarning for the full rule set.
   try {
     const live = resolveLiveBinaryPath();
     if (live) {
-      let liveVer = '';
+      let liveVer: string | null = null;
       try {
         liveVer =
           execFileSync(live, ['--version'], { encoding: 'utf-8', timeout: 3000 })
             .trim()
-            .match(/\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)*/)?.[0] ?? '';
+            .match(/\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)*/)?.[0] ?? null;
       } catch {
         // unknowable — skip the advisory
       }
-      if (liveVer && normalizeVersion(liveVer) !== normalizeVersion(manifest.version)) {
-        const canonical = join(GENIE_BIN, 'genie');
+      const canonical = join(GENIE_BIN, 'genie');
+      let canonicalReal = canonical;
+      try {
+        canonicalReal = realpathSync(canonical);
+      } catch {
+        // canonical may not be a symlink — keep as-is
+      }
+      const emit = shouldEmitPathDivergenceWarning({
+        live,
+        canonical,
+        canonicalReal,
+        liveVersion: liveVer,
+        intendedVersion: manifest.version,
+      });
+      if (emit) {
         log('');
         log('⚠ Your PATH `genie` is NOT the binary that was just updated.');
         log(`  Updated    : ${canonical} → v${manifest.version}`);
-        log(`  which genie: ${live} (still v${liveVer})`);
+        log(`  which genie: ${live} (still v${liveVer ?? 'unknown'})`);
         log('  Fix it:');
         log(`    ln -sf ${canonical} ${live} && hash -r`);
         log('  (or put ~/.genie/bin first on $PATH)');


### PR DESCRIPTION
## Summary

`genie update --dev` printed `✔ Genie binary updated → v<new>` while `~/.genie/bin/genie` still held the previous version (mtime unchanged, atomic-swap silently no-op'd). The subsequent PATH advisory then misdiagnosed this as a PATH problem and rendered `ln -sf <path> <path>` — a useless self-symlink — sending operators to fix a non-existent PATH issue.

This PR adds two pure helpers and wires them into `runDelivery`:

- **`verifySwappedBinary(targetBin, expectedVersion)`** — re-executes the freshly-swapped binary and throws a structured error (with `.staging` / `.previous` directory hints) when the on-disk version disagrees with the manifest. Wired **before** the `success()` banner, so the operator never sees a false-positive update report again.

- **`shouldEmitPathDivergenceWarning({...})`** — pure decision function. Suppresses the PATH advisory when `live === canonical` (or `live === canonicalReal`). In that case a version mismatch is upstream swap corruption (already caught above), not a PATH problem.

## Trace

On 2026-05-22 07:38 UTC (host `khal-os`), `genie update --dev v4.260520.3 → v4.260522.2`:
- `~/.genie/bin/genie --version` → still `4.260520.3` (mtime 7h before update ran)
- No `4.260522.2` binary anywhere on disk (`find … -name "*genie*4.260522*"` → empty)
- Published tarball verified clean (manually downloaded + extracted → `4.260522.2`)
- Diagnostics report claimed `"verify":{"kind":"ok","version":"4.260522.2"}` — fabricated from intent
- `.previous/genie-4.260520.3` present — confirms swap backup leg ran, suggests the staging→target leg silently rolled back or never landed

The root cause of the silent rollback itself is still unknown (likely external: another watcher/installer racing, FS replication, or a write-protected target). This PR is **defensive**: it makes the silent failure impossible to mistake for success and removes the misleading self-symlink suggestion.

## Test plan

- [x] \`bun test src/genie-commands/__tests__/update.test.ts\` — 106 pass, 13 new
- [x] \`bun run typecheck\` — clean
- [x] \`bun run lint\` — clean (only pre-existing broken-symlink warnings)
- [ ] After merge, re-run \`genie update --dev\` on \`khal-os\` and verify the post-swap guard either succeeds cleanly OR throws with the new structured error (proving the swap really is silently failing on disk)

## Files touched

- \`src/genie-commands/update.ts\` (+150, -5) — two new exported helpers + \`runDelivery\` wiring
- \`src/genie-commands/__tests__/update.test.ts\` (+171) — 13 regression tests across both helpers