### PR TITLE
fix(update): sync bin-sibling VERSION stamp after atomic swap

### DIFF
--- a/src/genie-commands/__tests__/update.test.ts
+++ b/src/genie-commands/__tests__/update.test.ts
@@ -35,6 +35,7 @@ import {
   runVerifyProbe,
   shortCircuitIfCurrent,
   shouldEmitPathDivergenceWarning,
+  syncBinaryVersionStamp,
   verifySwappedBinary,
 } from '../update.js';
 
@@ -1174,6 +1175,106 @@ describe('verifySwappedBinary (post-swap correctness guard)', () => {
         runVersion: () => 'banner with no version string\n',
       }),
     ).toThrow(/emitted no parsable version/);
+  });
+});
+
+describe('syncBinaryVersionStamp (binary-sibling VERSION file)', () => {
+  // The compiled binary reads `dirname(process.execPath)/VERSION` at startup
+  // (src/lib/version.ts). The atomic swap replaces `genie` but leaves the
+  // sibling VERSION stamp untouched — so without this sync, the new binary
+  // reports the OLD version until something else rewrites the stamp. These
+  // tests pin the contract so a future "simplification" can't remove it.
+
+  test('copies VERSION from extractDir → binDir when the tarball ships one', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'genie-stamp-'));
+    try {
+      const extractDir = join(tmp, 'extract');
+      const binDir = join(tmp, 'bin');
+      mkdirSync(extractDir, { recursive: true });
+      mkdirSync(binDir, { recursive: true });
+      writeFileSync(join(extractDir, 'VERSION'), '4.260522.3\n');
+      // Pre-existing stale stamp the swap left behind:
+      writeFileSync(join(binDir, 'VERSION'), '4.260520.3\n');
+
+      syncBinaryVersionStamp(extractDir, binDir, '4.260522.3');
+
+      expect(readFileSync(join(binDir, 'VERSION'), 'utf-8').trim()).toBe('4.260522.3');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('falls back to writing manifestVersion when tarball is missing VERSION', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'genie-stamp-'));
+    try {
+      const extractDir = join(tmp, 'extract');
+      const binDir = join(tmp, 'bin');
+      mkdirSync(extractDir, { recursive: true });
+      mkdirSync(binDir, { recursive: true });
+      // No VERSION file in extractDir — simulates an older build that
+      // pre-dates the G1 stamp convention.
+      writeFileSync(join(binDir, 'VERSION'), '4.260520.3\n');
+
+      syncBinaryVersionStamp(extractDir, binDir, '4.260522.3');
+
+      expect(readFileSync(join(binDir, 'VERSION'), 'utf-8').trim()).toBe('4.260522.3');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('first install (binDir has no prior VERSION) — creates the stamp', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'genie-stamp-'));
+    try {
+      const extractDir = join(tmp, 'extract');
+      const binDir = join(tmp, 'bin');
+      mkdirSync(extractDir, { recursive: true });
+      mkdirSync(binDir, { recursive: true });
+      writeFileSync(join(extractDir, 'VERSION'), '4.260522.3\n');
+
+      syncBinaryVersionStamp(extractDir, binDir, '4.260522.3');
+
+      expect(existsSync(join(binDir, 'VERSION'))).toBe(true);
+      expect(readFileSync(join(binDir, 'VERSION'), 'utf-8').trim()).toBe('4.260522.3');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('preserves the tarball stamp byte-for-byte (no normalisation)', () => {
+    // The G1 build pipeline may include build metadata (`+sha`) or trailing
+    // newlines we don't want to silently strip. Copy verbatim.
+    const tmp = mkdtempSync(join(tmpdir(), 'genie-stamp-'));
+    try {
+      const extractDir = join(tmp, 'extract');
+      const binDir = join(tmp, 'bin');
+      mkdirSync(extractDir, { recursive: true });
+      mkdirSync(binDir, { recursive: true });
+      const exotic = '4.260522.3+abc1234\n';
+      writeFileSync(join(extractDir, 'VERSION'), exotic);
+
+      syncBinaryVersionStamp(extractDir, binDir, '4.260522.3');
+
+      expect(readFileSync(join(binDir, 'VERSION'), 'utf-8')).toBe(exotic);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('swallows fs errors (best-effort; verifySwappedBinary catches mismatch)', () => {
+    // Pass an extractDir that exists but a binDir that doesn't — copy will
+    // fail, write fallback will also fail. Should not throw.
+    const tmp = mkdtempSync(join(tmpdir(), 'genie-stamp-'));
+    try {
+      const extractDir = join(tmp, 'extract');
+      const binDir = join(tmp, 'nonexistent', 'bin');
+      mkdirSync(extractDir, { recursive: true });
+      writeFileSync(join(extractDir, 'VERSION'), '4.260522.3\n');
+
+      expect(() => syncBinaryVersionStamp(extractDir, binDir, '4.260522.3')).not.toThrow();
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -642,6 +642,42 @@ export function atomicBinarySwap(
 }
 
 /**
+ * Sync the per-binary VERSION stamp the compiled binary reads at startup.
+ *
+ * Why this exists: `src/lib/version.ts` resolves the running version by
+ * reading `dirname(process.execPath)/VERSION` — i.e. `~/.genie/bin/VERSION`,
+ * a sibling of the binary itself. The atomic swap replaces `~/.genie/bin/genie`
+ * but never touches that file. Result: a freshly-installed v<new> binary
+ * reports v<old> on `--version` until the next time something rewrites the
+ * stamp. The 2026-05-22 incident on khal-os triggered exactly this — the
+ * release tarball was correct, the swap was correct, but the stale stamp
+ * masqueraded as a swap failure for three consecutive `genie update` runs.
+ *
+ * The G1 tarball convention ships a `VERSION` file at the root of the
+ * extracted tree. Prefer copying that file (preserves whatever format
+ * `build-tarballs.yml` produced); fall back to writing `manifestVersion`
+ * directly when the tarball pre-dates the convention.
+ *
+ * Best-effort by design: write failures don't throw — the immediately-
+ * following `verifySwappedBinary` will catch any resulting mismatch and
+ * surface the structured error with full forensic context.
+ */
+export function syncBinaryVersionStamp(extractDir: string, binDir: string, manifestVersion: string): void {
+  const targetStamp = join(binDir, 'VERSION');
+  const stagedStamp = join(extractDir, 'VERSION');
+  try {
+    if (existsSync(stagedStamp)) {
+      copyFileSync(stagedStamp, targetStamp);
+    } else {
+      writeFileSync(targetStamp, `${manifestVersion}\n`);
+    }
+  } catch {
+    // verifySwappedBinary below will detect any version mismatch loudly;
+    // never abort the update over a non-essential metadata write.
+  }
+}
+
+/**
  * Post-swap correctness guard: execute the freshly-swapped binary and confirm
  * its `--version` output normalises to the version we intended to install.
  *
@@ -1610,6 +1646,19 @@ async function runDelivery(
   const targetBin = join(GENIE_BIN, 'genie');
   const swapResult = atomicBinarySwap(stagedBin, targetBin, GENIE_BIN_PREVIOUS, normalizeVersion(VERSION));
   diagnosticsCtx.previousBackup = swapResult.oldVersionBackup;
+
+  // Sync the per-binary VERSION stamp BEFORE verifying. The compiled binary
+  // reads `dirname(process.execPath)/VERSION` at startup (see src/lib/version.ts
+  // readVersionFromPackageJson). The atomic swap replaces `genie` but leaves
+  // its sibling VERSION file untouched — so `targetBin --version` would still
+  // report the OLD version even when the bytes on disk match the new release.
+  // That's what bit us on 2026-05-22 (host khal-os): three consecutive updates
+  // landed the correct binary but reported the stale version, tripping the
+  // post-swap guard and the PATH advisory both as collateral. Copy the
+  // tarball's VERSION file next to the binary so the executable agrees with
+  // what we just installed; fall back to writing manifest.version directly if
+  // the tarball is missing it (older builds).
+  syncBinaryVersionStamp(extractDir, GENIE_BIN, manifest.version);
 
   // Belt-and-suspenders: re-read the on-disk binary BEFORE printing success.
   // `atomicBinarySwap` returning `{ swapped: true }` is necessary but not


### PR DESCRIPTION
## Summary

Real root cause of the silent-version-drift bug PR #2471 just made loud.

`src/lib/version.ts:68-70` resolves the running version by reading `dirname(process.execPath)/VERSION` — i.e. `~/.genie/bin/VERSION`, a sibling of the binary itself. The G1 release tarball ships that file at the extracted root. `atomicBinarySwap` correctly replaces the `genie` binary but never copies the sibling stamp, so a fresh v<new> binary keeps reporting v<old> indefinitely.

That's not a swap failure — it's a metadata sync gap that has been there since G1.

## Reproduction (khal-os, 2026-05-22)

Three consecutive `genie update --dev` runs (4.260520.3 → 4.260522.2 → 4.260522.3 → 4.260522.4) each reported \`✔ Genie binary updated → v<new>\` while \`~/.genie/bin/genie --version\` continued to return 4.260520.3.

\`\`\`
# same binary, two different version outputs:
\$ sha256sum /home/genie/.genie/bin/genie /tmp/genie-3-test/genie
a56f50c7036a1092cd7fde0ed8843bd9f93d907ee1c508fd319fabe75cb8c06b  /home/genie/.genie/bin/genie
a56f50c7036a1092cd7fde0ed8843bd9f93d907ee1c508fd319fabe75cb8c06b  /tmp/genie-3-test/genie

\$ /home/genie/.genie/bin/genie --version
4.260520.3                                # reads ~/.genie/bin/VERSION (stale)

\$ /tmp/genie-3-test/genie --version
4.260522.3                                # reads /tmp/genie-3-test/VERSION (correct)
\`\`\`

Same bytes, different sibling stamp, different reported version.

## Fix

New \`syncBinaryVersionStamp(extractDir, binDir, manifestVersion)\` helper:
- Prefer \`copyFileSync(<extractDir>/VERSION, <binDir>/VERSION)\` — preserves whatever \`build-tarballs.yml\` produced (including any build metadata, trailing newlines)
- Fall back to \`writeFileSync(<binDir>/VERSION, '<manifestVersion>\\n')\` when the tarball lacks a stamp (older builds pre-G1)
- Best-effort: errors are swallowed because the immediately-following \`verifySwappedBinary\` (PR #2471) catches mismatches with full forensic context

Wired into \`runDelivery\` between \`atomicBinarySwap\` and \`verifySwappedBinary\`, so the verify probe sees the correct stamp on first try and the update completes end-to-end.

## Why PR #2471 didn't catch this in tests

Tests of \`verifySwappedBinary\` inject the \`--version\` output via the \`runVersion\` test seam, so they never exercise the actual on-disk read path. The combination of \"swap succeeds + stamp not synced + binary reads sibling stamp\" only manifests in the live integration where all three meet. The new tests here lock the contract at the file-ops boundary.

## Test plan

- [x] \`bun test src/genie-commands/__tests__/update.test.ts\` — 111 pass, 5 new
- [x] \`bun run typecheck\` — clean
- [x] \`bun run lint\` — clean
- [ ] After release, run \`genie update --dev\` on khal-os and confirm \`genie --version\` reports the new release number

## Files touched

- \`src/genie-commands/update.ts\` (+~50) — new \`syncBinaryVersionStamp\` helper + \`runDelivery\` wiring
- \`src/genie-commands/__tests__/update.test.ts\` (+~100) — 5 regression tests