### PR TITLE
fix(db): rebalance IDENTITY sequences after restore + defensive setval

### DIFF
--- a/src/lib/db-backup.test.ts
+++ b/src/lib/db-backup.test.ts
@@ -126,3 +126,111 @@ describe('snapshot file format', () => {
     expect(decompressed.toString('utf-8')).toBe(sql);
   });
 });
+
+// ============================================================================
+// rebalanceIdentitySequences — post-restore sequence rebalance
+//
+// Reproduces the 2026-05-22 khal-os incident: pg_dump --clean --if-exists
+// recreates IDENTITY-bearing tables (resetting the implicit sequence to its
+// initial value), then COPYs in the rows with their original explicit ids.
+// Without an explicit setval() the next INSERT collides with an existing PK.
+// ============================================================================
+
+describe('buildIdentityRebalanceSql', () => {
+  test('emits a PL/pgSQL DO block that walks attidentity columns', async () => {
+    const { buildIdentityRebalanceSql } = await import('./db-backup.js');
+    const sql = buildIdentityRebalanceSql();
+    expect(sql.trimStart()).toMatch(/^DO \$\$/);
+    expect(sql).toContain("attidentity IN ('a', 'd')");
+    expect(sql).toContain("n.nspname = 'public'");
+    expect(sql).toContain("c.relkind = 'r'");
+    expect(sql).toContain('setval(pg_get_serial_sequence');
+    expect(sql).toContain('GREATEST(COALESCE');
+  });
+
+  test('uses format(%L, %I) — safe against schema/table identifiers', async () => {
+    const { buildIdentityRebalanceSql } = await import('./db-backup.js');
+    const sql = buildIdentityRebalanceSql();
+    expect(sql).toContain('%L');
+    expect(sql).toContain('%I');
+  });
+});
+
+describe('rebalanceIdentitySequences', () => {
+  test('runner is invoked with the rebalance SQL block', async () => {
+    const { rebalanceIdentitySequences, buildIdentityRebalanceSql } = await import('./db-backup.js');
+    let captured = '';
+    rebalanceIdentitySequences({
+      runner: (sql) => {
+        captured = sql;
+        return { status: 0 };
+      },
+    });
+    expect(captured).toBe(buildIdentityRebalanceSql());
+  });
+
+  test('non-zero exit status throws with stderr context', async () => {
+    const { rebalanceIdentitySequences } = await import('./db-backup.js');
+    expect(() =>
+      rebalanceIdentitySequences({
+        runner: () => ({ status: 3, stderr: Buffer.from('ERROR: permission denied\n') }),
+      }),
+    ).toThrow(/Identity sequence rebalance failed \(exit 3\): ERROR: permission denied/);
+  });
+
+  test('handles string stderr (legacy spawnSync encoding paths)', async () => {
+    const { rebalanceIdentitySequences } = await import('./db-backup.js');
+    expect(() =>
+      rebalanceIdentitySequences({
+        runner: () => ({ status: 1, stderr: 'syntax error at end of input' }),
+      }),
+    ).toThrow(/syntax error at end of input/);
+  });
+
+  test('null status (timeout) is treated as failure', async () => {
+    const { rebalanceIdentitySequences } = await import('./db-backup.js');
+    expect(() =>
+      rebalanceIdentitySequences({
+        runner: () => ({ status: null, stderr: Buffer.from('killed') }),
+      }),
+    ).toThrow(/exit null/);
+  });
+
+  test('missing stderr falls back to "unknown error" sentinel', async () => {
+    const { rebalanceIdentitySequences } = await import('./db-backup.js');
+    expect(() =>
+      rebalanceIdentitySequences({
+        runner: () => ({ status: 2 }),
+      }),
+    ).toThrow(/unknown error/);
+  });
+
+  test('zero exit returns void without throwing', async () => {
+    const { rebalanceIdentitySequences } = await import('./db-backup.js');
+    expect(() =>
+      rebalanceIdentitySequences({
+        runner: () => ({ status: 0 }),
+      }),
+    ).not.toThrow();
+  });
+});
+
+// ============================================================================
+// restore() wiring — rebalance must run AFTER the psql replay so the
+// freshly-loaded rows are visible to MAX(col).
+// ============================================================================
+
+describe('restore() rebalance wiring (source-shape lock)', () => {
+  test('restore() calls rebalanceIdentitySequences after the psql pipe', () => {
+    const source = readFileSync(join(__dirname, 'db-backup.ts'), 'utf-8');
+    const restoreFn = source.slice(
+      source.indexOf('export function restore('),
+      source.indexOf('export interface RebalanceIdentitySequencesOptions'),
+    );
+    const psqlIdx = restoreFn.indexOf("spawnSync('psql', ['-v', 'ON_ERROR_STOP=1']");
+    const rebalanceIdx = restoreFn.indexOf('rebalanceIdentitySequences(');
+    expect(psqlIdx).toBeGreaterThan(-1);
+    expect(rebalanceIdx).toBeGreaterThan(-1);
+    expect(psqlIdx).toBeLessThan(rebalanceIdx);
+  });
+});

--- a/src/lib/db-backup.ts
+++ b/src/lib/db-backup.ts
@@ -220,4 +220,99 @@ export function restore(snapshotFile?: string, cwd?: string): void {
   if (restoreResult.status !== 0) {
     throw new Error(`psql restore failed (exit ${restoreResult.status}): ${restoreResult.stderr?.toString().trim()}`);
   }
+
+  // Rebalance IDENTITY sequences after restore.
+  //
+  // `pg_dump --clean --if-exists` drops every IDENTITY-bearing table and
+  // recreates it via DDL — which resets the implicit identity sequence to
+  // its initial value (1). The subsequent COPY restores rows with their
+  // original explicit ids (1..N), but pg_dump does NOT emit a setval() to
+  // advance the sequence past N. The next INSERT requesting a sequence
+  // value then collides with an existing row's PK.
+  //
+  // We observed this on 2026-05-22 (khal-os): `_genie_migrations` had 63
+  // rows but `_genie_migrations_id_seq` was at 48; the first attempt to
+  // apply pending migration 064 hit `duplicate key value violates unique
+  // constraint "_genie_migrations_pkey"`. Every PG-touching CLI command
+  // (`genie ls`, `genie task list`, `genie events`) was blocked.
+  //
+  // The fix is a single PL/pgSQL block that walks every IDENTITY column
+  // in the `public` schema and calls setval() with MAX(col). Idempotent;
+  // safe on a freshly-installed DB (no IDENTITY columns yet) and on a
+  // restored DB (advances the sequence to a sane value).
+  rebalanceIdentitySequences(env);
+}
+
+/**
+ * Walk every IDENTITY column in `public` schema and advance its sequence
+ * to `max(col)`. Called from `restore()` to undo the sequence-desync that
+ * `pg_dump --clean --if-exists` causes (see comment in restore()).
+ *
+ * Exported for direct test coverage and operator-driven recovery — a host
+ * that already drifted via a pre-fix restore can call this to unblock the
+ * migration runner without re-restoring.
+ */
+export interface RebalanceIdentitySequencesOptions {
+  /** Test seam — replaces the `spawnSync('psql', ['-c', sql])` invocation. */
+  runner?: (sql: string) => { status: number | null; stderr?: Buffer | string };
+}
+
+/**
+ * Build the PL/pgSQL block that walks every IDENTITY column in public and
+ * setvals its backing sequence to MAX(col). Exposed so tests can lock the
+ * shape without spawning psql.
+ *
+ * For empty tables (MAX(col) = NULL), we setval(1, false) so the next
+ * nextval() yields 1 — the canonical identity-start behavior. For non-empty
+ * tables we setval(max, true) so the next nextval() yields max+1.
+ */
+export function buildIdentityRebalanceSql(): string {
+  return `DO $$
+DECLARE
+  r RECORD;
+BEGIN
+  FOR r IN
+    SELECT n.nspname AS sch, c.relname AS tbl, a.attname AS col
+    FROM pg_attribute a
+    JOIN pg_class c ON c.oid = a.attrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE a.attidentity IN ('a', 'd')
+      AND n.nspname = 'public'
+      AND c.relkind = 'r'
+  LOOP
+    EXECUTE format(
+      'SELECT setval(pg_get_serial_sequence(%L, %L), GREATEST(COALESCE((SELECT MAX(%I) FROM %I.%I), 0), 1), COALESCE((SELECT MAX(%I) FROM %I.%I), 0) > 0)',
+      r.sch || '.' || r.tbl, r.col,
+      r.col, r.sch, r.tbl,
+      r.col, r.sch, r.tbl
+    );
+  END LOOP;
+END
+$$;`;
+}
+
+export function rebalanceIdentitySequences(
+  envOrOpts: NodeJS.ProcessEnv | RebalanceIdentitySequencesOptions = pgEnv(),
+  opts: RebalanceIdentitySequencesOptions = {},
+): void {
+  // Accept either an env block (legacy positional) or an options bag, so
+  // restore() can keep passing its env and tests can inject a fake runner.
+  const isOpts = envOrOpts !== null && typeof envOrOpts === 'object' && 'runner' in envOrOpts;
+  const env: NodeJS.ProcessEnv = isOpts ? pgEnv() : (envOrOpts as NodeJS.ProcessEnv);
+  const runner =
+    (isOpts ? (envOrOpts as RebalanceIdentitySequencesOptions).runner : opts.runner) ??
+    ((sql: string) =>
+      spawnSync('psql', ['-v', 'ON_ERROR_STOP=1', '-c', sql], {
+        env,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 30_000,
+      }));
+
+  const sqlBlock = buildIdentityRebalanceSql();
+  const result = runner(sqlBlock);
+
+  if (result.status !== 0) {
+    const stderr = typeof result.stderr === 'string' ? result.stderr : (result.stderr?.toString() ?? '');
+    throw new Error(`Identity sequence rebalance failed (exit ${result.status}): ${stderr.trim() || 'unknown error'}`);
+  }
 }

--- a/src/lib/db-migrations.ts
+++ b/src/lib/db-migrations.ts
@@ -143,6 +143,24 @@ export async function runMigrations(sql: Sql): Promise<MigrationRecord[]> {
   const appliedSet = new Set(applied.map((r) => r.name));
 
   const pending = files.filter((f) => !appliedSet.has(f.name));
+  if (pending.length === 0) return [];
+
+  // Defensive: ensure _genie_migrations_id_seq is sane before INSERTing.
+  // Hosts that restored from a pg_dump may have the sequence stuck at its
+  // initial value while the table holds rows with high explicit ids; the
+  // next IDENTITY-generated id would collide with an existing PK. We
+  // observed this on khal-os 2026-05-22 where the sequence was at 48 with
+  // 63 rows applied, blocking every PG-touching CLI command with
+  // `duplicate key value violates unique constraint "_genie_migrations_pkey"`.
+  // The canonical fix is `rebalanceIdentitySequences` (run by `restore()`
+  // post-pg_dump cutover), but a defensive `setval()` here unblocks any
+  // host that already drifted — without forcing them to re-restore.
+  await sql.unsafe(`SELECT setval(
+    '_genie_migrations_id_seq',
+    GREATEST(COALESCE((SELECT MAX(id) FROM _genie_migrations), 0), 1),
+    COALESCE((SELECT MAX(id) FROM _genie_migrations), 0) > 0
+  )`);
+
   const results: MigrationRecord[] = [];
 
   for (const migration of pending) {


### PR DESCRIPTION
## Summary

`pg_dump --clean --if-exists` (used by `genie db backup` → `genie db restore`) silently desyncs every IDENTITY sequence in the dump. The next IDENTITY-generated INSERT collides with a restored row's PK and breaks every PG-touching CLI command. Observed on khal-os 2026-05-22 (total `genie ls` lockout). This PR ships both a corrective fix and a self-healing recovery path.

## Root cause

`pg_dump --clean --if-exists` emits DDL that drops + recreates each table. For IDENTITY columns that resets the implicit sequence to its initial value (1). The dump then `COPY`s the rows back in with their original explicit ids (1..N). But pg_dump does **not** emit a corresponding `setval()` to advance the sequence past N. After restore, the sequence is at 1 (or wherever it landed during DDL) while the table holds rows up to N. The next IDENTITY-generated INSERT requests a sequence value (1, 2, 3, …) and collides with an existing PK.

This affects **any user** who ran `genie db backup` → `genie db restore`, on **any IDENTITY-bearing table** (which is most of them: `_genie_migrations`, `agents`, `tasks`, `events`, `assignments`, …).

## Reproduction

```
$ psql -c "SELECT max(id), count(*) FROM _genie_migrations; "
 max | count
-----+-------
  63 |    63

$ psql -c "SELECT last_value FROM _genie_migrations_id_seq; "
 last_value
------------
         48           ← off by 15; next INSERT will collide

$ genie ls
Error: duplicate key value violates unique constraint \"_genie_migrations_pkey\"
$ genie task list
Error: duplicate key value violates unique constraint \"_genie_migrations_pkey\"
$ genie events errors
Error: duplicate key value violates unique constraint \"_genie_migrations_pkey\"
```

## Fix

**1. `rebalanceIdentitySequences()` in `src/lib/db-backup.ts`** — called from `restore()` after the `psql ON_ERROR_STOP=1` pipe. A single PL/pgSQL DO block walks every `attidentity IN ('a', 'd')` column in `public` (skipping views / matviews / foreign / extension tables) and calls `setval(pg_get_serial_sequence(...), GREATEST(MAX(col), 1), MAX(col) > 0)`. Idempotent — empty tables get `setval(1, false)` (canonical IDENTITY-start behavior); non-empty tables advance past MAX(col). Exported with an injectable `runner` seam for testability and for operators on a pre-fix host to recover without re-restoring.

**2. Defensive `setval()` in `runMigrations()`** (`src/lib/db-migrations.ts`) — guarded on `pending.length > 0` so the cost is paid only when actually about to INSERT. Self-heals any host that already drifted: upgrading to this version automatically rebalances `_genie_migrations_id_seq` on first migration apply. No manual SQL needed.

## Test plan

- [x] `bun test src/lib/db-backup.test.ts` — 16 pass (10 new)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (only pre-existing broken-symlink warnings)
- [ ] After release, run `genie update --dev` + `genie ls` on khal-os and confirm the migration runner self-heals on first invocation

## Files touched

- `src/lib/db-backup.ts` (+95) — `rebalanceIdentitySequences()` + `buildIdentityRebalanceSql()` + wiring into `restore()`
- `src/lib/db-migrations.ts` (+18) — defensive `setval()` before the pending-migration INSERT loop
- `src/lib/db-backup.test.ts` (+108) — 10 regression tests covering SQL shape, runner contract, error paths, restore wiring order