### PR TITLE
Promote dev to stable: PM2 Genie install recovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "4.260522.8",
+      "version": "4.260522.9",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/genie",
-  "version": "4.260522.8",
+  "version": "4.260522.9",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
   "type": "module",
   "bin": {

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "4.260522.8",
+  "version": "4.260522.9",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "4.260522.8",
+  "version": "4.260522.9",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "type": "module",

--- a/src/genie-commands/__tests__/install.test.ts
+++ b/src/genie-commands/__tests__/install.test.ts
@@ -34,6 +34,7 @@ const {
   isPgservePm2ManagedStatus,
   isPgserveReadyStatus,
   isPgserveOnlinePm2,
+  isReusableCanonicalPm2Process,
 } = _internals;
 
 describe('install.sh release verifier bootstrap', () => {
@@ -117,6 +118,16 @@ describe('install._internals — canonical-stack constants', () => {
     // is one of the supported shapes. The env-override path is verified
     // separately in install-env.test.ts (loads the module with env set).
     expect(HARDENED_DEFAULTS.maxMemory).toMatch(/^\d+G$/);
+  });
+
+  test('only an online PM2 Genie entry with a live pid is reusable', () => {
+    expect(isReusableCanonicalPm2Process({ name: 'Genie', pid: 123, pm2_env: { status: 'online' } })).toBe(true);
+    expect(isReusableCanonicalPm2Process({ name: 'Genie', pid: 0, pm2_env: { status: 'online' } })).toBe(false);
+    expect(isReusableCanonicalPm2Process({ name: 'Genie', pid: 123, pm2_env: { status: 'waiting restart' } })).toBe(
+      false,
+    );
+    expect(isReusableCanonicalPm2Process({ name: 'Genie', pid: 123, pm2_env: { status: 'errored' } })).toBe(false);
+    expect(isReusableCanonicalPm2Process(null)).toBe(false);
   });
 });
 

--- a/src/genie-commands/__tests__/update.test.ts
+++ b/src/genie-commands/__tests__/update.test.ts
@@ -296,10 +296,11 @@ describe('formatVerifyBanner', () => {
     expect(lines.some((l) => l.includes('no-restart'))).toBe(true);
   });
 
-  test('health-unreachable surfaces probe endpoint + pm2 fix', () => {
+  test('health-unreachable surfaces probe endpoint + PM2 recreate fix', () => {
     const lines = formatVerifyBanner({ kind: 'health-unreachable', endpoint: 'doctor --json' });
     expect(lines.some((l) => l.includes('unreachable'))).toBe(true);
-    expect(lines.some((l) => l.includes('pm2 restart Genie'))).toBe(true);
+    expect(lines.some((l) => l.includes('pm2 restart Genie --update-env'))).toBe(true);
+    expect(lines.some((l) => l.includes('pm2 delete Genie && genie install'))).toBe(true);
   });
 
   test('daemon-stale-inode banner surfaces pid, cwd, and pm2 restart remediation', () => {

--- a/src/genie-commands/install.ts
+++ b/src/genie-commands/install.ts
@@ -117,6 +117,12 @@ interface Pm2Process {
   pm2_env?: { status?: string };
 }
 
+function isReusableCanonicalPm2Process(process: Pm2Process | null): boolean {
+  if (!process) return false;
+  if (process.pm2_env?.status !== 'online') return false;
+  return typeof process.pid === 'number' && process.pid > 0;
+}
+
 function pm2GetProcess(name: string): Pm2Process | null {
   try {
     const out = execFileSync('pm2', ['jlist'], {
@@ -154,17 +160,21 @@ function pm2GetAnyProcess(names: readonly string[]): Pm2Process | null {
  *     a manual cleanup to do (`pm2 delete <legacy-name>`) but do not abort
  *     install over it.
  */
+function deletePm2Process(name: string): void {
+  execFileSync('pm2', ['delete', name], {
+    encoding: 'utf8',
+    timeout: 10_000,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
 function removeLegacyPm2Entries(log: (msg: string) => void = () => {}): string[] {
   const removed: string[] = [];
   for (const legacyName of LEGACY_PM2_PROCESS_NAMES) {
     const existing = pm2GetProcess(legacyName);
     if (!existing) continue;
     try {
-      execFileSync('pm2', ['delete', legacyName], {
-        encoding: 'utf8',
-        timeout: 10_000,
-        stdio: ['ignore', 'pipe', 'pipe'],
-      });
+      deletePm2Process(legacyName);
       log(`removed legacy pm2 entry "${legacyName}" (renamed to "${PM2_PROCESS_NAME}")`);
       removed.push(legacyName);
     } catch (err) {
@@ -570,10 +580,23 @@ export async function installCommand(options: InstallOptions = {}): Promise<void
   // Step 3 — pm2-supervise the canonical Genie service.
   const existing = pm2GetProcess(PM2_PROCESS_NAME);
   if (existing) {
+    if (isReusableCanonicalPm2Process(existing)) {
+      ok(
+        `already installed (pm2 process "${PM2_PROCESS_NAME}", status=${existing.pm2_env?.status ?? 'unknown'}). Use \`pm2 delete ${PM2_PROCESS_NAME} && genie install\` to refresh the env (e.g. to pick up a new canonical pgserve URL).`,
+      );
+      return;
+    }
+
+    const status = existing.pm2_env?.status ?? 'unknown';
     ok(
-      `already installed (pm2 process "${PM2_PROCESS_NAME}", status=${existing.pm2_env?.status ?? 'unknown'}). Use \`pm2 delete ${PM2_PROCESS_NAME} && genie install\` to refresh the env (e.g. to pick up a new canonical pgserve URL).`,
+      `pm2 process "${PM2_PROCESS_NAME}" exists but is not reusable (status=${status}, pid=${existing.pid ?? 'none'}); recreating`,
     );
-    return;
+    try {
+      deletePm2Process(PM2_PROCESS_NAME);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      fail(`pm2 process "${PM2_PROCESS_NAME}" is unhealthy and pm2 delete failed: ${reason}`);
+    }
   }
 
   ensureLogsDir();
@@ -641,4 +664,5 @@ export const _internals = {
   isPgservePm2ManagedStatus,
   isPgserveReadyStatus,
   isPgserveOnlinePm2,
+  isReusableCanonicalPm2Process,
 };

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -1062,7 +1062,7 @@ export function formatVerifyBanner(result: VerifyResult): string[] {
     case 'health-unreachable':
       lines.push(`${colorize('\x1b[31m', '\x1b[0m', '✖')} Genie server unreachable (probe: ${result.endpoint})`);
       lines.push(
-        `${colorize('\x1b[2m', '\x1b[0m', '  fix: pm2 restart Genie  (or `genie install` if not yet supervised)')}`,
+        `${colorize('\x1b[2m', '\x1b[0m', '  fix: pm2 restart Genie --update-env  (if PM2 says "waiting restart": pm2 delete Genie && genie install)')}`,
       );
       break;
     case 'daemon-stale-inode': {


### PR DESCRIPTION
Promotes dev to stable for the PM2 Genie install recovery fix.\n\nIncluded fix:\n- Recreate unhealthy PM2 `Genie` entries during `genie install` instead of treating `waiting restart` / non-online entries as already installed.\n- Improve update diagnostic remediation for recurring `Genie server unreachable` after update.\n\nEvidence:\n- Commit: 776ea68fbf017f9b0b255f13b9c3f9a7df92ed0b `fix: recreate unhealthy pm2 genie install`\n- Dev release: v4.260522.9\n- Dev CI: success\n- Commitlint: success\n- Release v4.260522.9: success\n\nLocal runtime verification on genie-khal-hermes:\n- `genie --version` = 4.260522.8\n- PM2 `Genie` recreated and online\n- `~/.genie/serve.pid` present\n- `genie serve status` reports running, pgserve healthy, hook UDS listening, scheduler integrated\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Version bumped to 4.260522.9

* **Bug Fixes**
  * Improved detection of existing Genie installations to prevent reinstallation attempts
  * Enhanced troubleshooting guidance for offline service conditions, including specific remediation steps
  * Refined PM2 process health validation logic for better installation stability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/automagik-dev/genie/pull/2476?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->