### PR TITLE
Promote dev to stable: update diagnostics cleanup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "4.260522.13",
+      "version": "4.260522.14",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "4.260522.9",
+      "version": "4.260522.10",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "4.260522.11",
+      "version": "4.260522.12",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "4.260522.10",
+      "version": "4.260522.11",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "4.260522.12",
+      "version": "4.260522.13",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/.github/workflows/audit-next-tag.yml
+++ b/.github/workflows/audit-next-tag.yml
@@ -46,7 +46,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node (for npm)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
 

--- a/.github/workflows/audit-next-tag.yml
+++ b/.github/workflows/audit-next-tag.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout (with tags)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/binary-sha-drift.yml
+++ b/.github/workflows/binary-sha-drift.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Verify pinned SHA-256 against upstream
         shell: bash

--- a/.github/workflows/build-tarballs.yml
+++ b/.github/workflows/build-tarballs.yml
@@ -73,7 +73,7 @@ jobs:
             runner:   macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/build-tarballs.yml
+++ b/.github/workflows/build-tarballs.yml
@@ -81,7 +81,7 @@ jobs:
           bun-version: 1.3.11
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
 
@@ -179,7 +179,7 @@ jobs:
           fi
 
       - name: Upload tarball artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: genie-${{ steps.ver.outputs.version }}-${{ matrix.platform }}-tarball
           path: dist/genie-${{ steps.ver.outputs.version }}-${{ matrix.platform }}.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/release-orphan-alert.yml
+++ b/.github/workflows/release-orphan-alert.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Scan tags vs releases
         env:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Resolve upstream sign-attest run-id
         id: src

--- a/.github/workflows/sign-attest.yml
+++ b/.github/workflows/sign-attest.yml
@@ -195,7 +195,7 @@ jobs:
           - darwin-arm64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download tarball artifact (${{ matrix.platform }})
         uses: actions/download-artifact@v4

--- a/.github/workflows/sign-attest.yml
+++ b/.github/workflows/sign-attest.yml
@@ -390,7 +390,7 @@ jobs:
           rm -f "${MUTATED}"
 
       - name: Upload signed artifact (${{ matrix.platform }})
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: genie-${{ needs.prepare.outputs.version }}-${{ matrix.platform }}-signed
           path: |

--- a/biome.json
+++ b/biome.json
@@ -52,7 +52,9 @@
       ".worktrees",
       ".claude",
       "plugins/genie/scripts",
-      ".docs-vendor"
+      ".docs-vendor",
+      "docs",
+      "test-fixtures/symlink-cycle/real/cycle"
     ]
   },
   "overrides": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/genie",
-  "version": "4.260522.12",
+  "version": "4.260522.13",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/genie",
-  "version": "4.260522.13",
+  "version": "4.260522.14",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/genie",
-  "version": "4.260522.10",
+  "version": "4.260522.11",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/genie",
-  "version": "4.260522.9",
+  "version": "4.260522.10",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/genie",
-  "version": "4.260522.11",
+  "version": "4.260522.12",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
   "type": "module",
   "bin": {

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "4.260522.9",
+  "version": "4.260522.10",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "4.260522.13",
+  "version": "4.260522.14",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "4.260522.11",
+  "version": "4.260522.12",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "4.260522.12",
+  "version": "4.260522.13",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "4.260522.10",
+  "version": "4.260522.11",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "4.260522.12",
+  "version": "4.260522.13",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "type": "module",

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "4.260522.11",
+  "version": "4.260522.12",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "type": "module",

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "4.260522.13",
+  "version": "4.260522.14",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "type": "module",

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "4.260522.9",
+  "version": "4.260522.10",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "type": "module",

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "4.260522.10",
+  "version": "4.260522.11",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "type": "module",

--- a/src/genie-commands/__tests__/update.test.ts
+++ b/src/genie-commands/__tests__/update.test.ts
@@ -23,6 +23,7 @@ import {
   decideVerify,
   downloadAndVerifyTarball,
   ensureCanonicalInstall,
+  extractPgservePortFromStatus,
   fetchLatestManifest,
   formatVerifyBanner,
   isGenieProcessSnapshotLine,
@@ -884,6 +885,12 @@ describe('Diagnostics schema (G5)', () => {
       ),
     ).toBe(false);
     expect(isGenieProcessSnapshotLine('2588570 1 2588570 S postgres -D /home/genie/.genie/data/pgserve')).toBe(false);
+  });
+
+  test('diagnostics derives pgserve port from status json when port file is absent', () => {
+    expect(extractPgservePortFromStatus('{"port":8432,"status":"running"}')).toBe('8432');
+    expect(extractPgservePortFromStatus('{"instance":{"port":"8432"}}')).toBe('8432');
+    expect(extractPgservePortFromStatus('not-json')).toBe(null);
   });
 
   test('NO_COLOR honored via colorEnabled() helper', () => {

--- a/src/genie-commands/__tests__/update.test.ts
+++ b/src/genie-commands/__tests__/update.test.ts
@@ -25,6 +25,7 @@ import {
   ensureCanonicalInstall,
   fetchLatestManifest,
   formatVerifyBanner,
+  isGenieProcessSnapshotLine,
   manifestUrlForChannel,
   normalizeVersion,
   persistChannel,
@@ -869,6 +870,20 @@ describe('Diagnostics schema (G5)', () => {
     expect(source).toContain('tarballPath: ctx.tarballPath');
     expect(source).toContain('attestationVerified: ctx.attestationVerified');
     expect(source).toContain('previousBackup: ctx.previousBackup');
+  });
+
+  test('diagnostics process snapshot excludes pgserve/autopg noise and keeps Genie serve lines', () => {
+    expect(
+      isGenieProcessSnapshotLine(
+        '2554274 1 2554274 Ssl 0.0 0.4 00:08:00 /home/genie/.local/bin/genie serve start --daemon',
+      ),
+    ).toBe(true);
+    expect(
+      isGenieProcessSnapshotLine(
+        '2588570 171462 2588570 Rsl 1.0 2.8 3-12:34:22 bun /home/genie/.bun/install/global/node_modules/pgserve/bin/postgres-server.js postmaster --port 8432',
+      ),
+    ).toBe(false);
+    expect(isGenieProcessSnapshotLine('2588570 1 2588570 S postgres -D /home/genie/.genie/data/pgserve')).toBe(false);
   });
 
   test('NO_COLOR honored via colorEnabled() helper', () => {

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -1235,6 +1235,26 @@ function summarizeJsonlSignals(path: string): RecentLogSignal[] {
   return [...signals.values()].sort((a, b) => b.count - a.count).slice(0, 10);
 }
 
+export function isGenieProcessSnapshotLine(line: string): boolean {
+  if (/pgserve|autopg|postgres-server\.js|postgres -D /.test(line)) return false;
+  return (
+    line.includes(' serve start ') ||
+    line.includes('/dist/genie.js') ||
+    line.includes('/src/genie.ts') ||
+    line.includes('tmux -L genie-tui')
+  );
+}
+
+function collectGenieProcessSnapshot(): string | null {
+  const snapshot = safeExec('ps -axo pid,ppid,pgid,stat,pcpu,pmem,etime,command -r', 2000)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter(isGenieProcessSnapshotLine)
+    .join('\n');
+  return snapshot || null;
+}
+
 interface UpdateDiagnosticsExtras {
   verify: VerifyResult;
   cleanups: CleanupReport;
@@ -1297,11 +1317,7 @@ async function collectUpdateDiagnostics(
       tuiCrashLog,
     },
     processSnapshot: {
-      genie:
-        safeExec(
-          "ps -axo pid,ppid,pgid,stat,pcpu,pmem,etime,command -r | rg -i 'dist/genie.js|/src/genie.ts|pgserve|postgres -D .*\\.genie/data/pgserve|tmux -L genie-tui|bun' || true",
-          2000,
-        ) || null,
+      genie: collectGenieProcessSnapshot(),
       tuiTmux: safeExec('tmux -L genie-tui ls 2>/dev/null || true', 1000) || null,
     },
     maintenance: {

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -1245,6 +1245,18 @@ export function isGenieProcessSnapshotLine(line: string): boolean {
   );
 }
 
+export function extractPgservePortFromStatus(output: string): string | null {
+  try {
+    const parsed = JSON.parse(output) as { port?: unknown; instance?: { port?: unknown } };
+    const rawPort = parsed.port ?? parsed.instance?.port;
+    if (typeof rawPort === 'number' && Number.isFinite(rawPort)) return String(rawPort);
+    if (typeof rawPort === 'string' && rawPort.trim()) return rawPort.trim();
+  } catch {
+    // best-effort diagnostics only; callers fall back to null.
+  }
+  return null;
+}
+
 function collectGenieProcessSnapshot(): string | null {
   const snapshot = safeExec('ps -axo pid,ppid,pgid,stat,pcpu,pmem,etime,command -r', 2000)
     .split(/\r?\n/)
@@ -1273,6 +1285,9 @@ async function collectUpdateDiagnostics(
   const schedulerLog = join(logsDir, 'scheduler.log');
   const tuiCrashLog = join(logsDir, 'tui-crash.log');
   const signals = summarizeJsonlSignals(schedulerLog);
+  const pgservePortFromFile = safeRead(join(GENIE_HOME, 'pgserve.port'), 200);
+  const pgserveStatusJson = (await runCommandSilent('pgserve', ['status', '--json'], undefined, 2000)).output.trim();
+  const pgservePort = pgservePortFromFile ?? extractPgservePortFromStatus(pgserveStatusJson);
 
   const diagnostics = {
     schemaVersion: UPDATE_DIAGNOSTIC_SCHEMA_VERSION,
@@ -1312,7 +1327,7 @@ async function collectUpdateDiagnostics(
       genieBinPrevious: GENIE_BIN_PREVIOUS,
       logsDir,
       servePid: safeRead(join(GENIE_HOME, 'serve.pid'), 200),
-      pgservePort: safeRead(join(GENIE_HOME, 'pgserve.port'), 200),
+      pgservePort,
       schedulerLog,
       tuiCrashLog,
     },


### PR DESCRIPTION
## Summary
- Fix update diagnostics process snapshot so `processSnapshot.genie` no longer captures pgserve/autopg/postgres noise.
- Add a regression test for the process snapshot filter.
- Silence Biome broken-symlink warnings for known symlink fixtures/aliases.
- Upgrade GitHub Actions checkout uses from v4 to v5 to remove Node 20 deprecation annotations.

## Verification
- `bun run typecheck`
- `bun run lint`
- `bun test src/genie-commands/__tests__/install.test.ts src/genie-commands/__tests__/update.test.ts`
- Commit hooks: `typecheck && lint && dead-code && skills:lint && wishes:lint && lint:emit`
- GitHub Actions on dev head `9af2e31`: CI ✅, Commitlint ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped project and plugin versions to 4.260522.14 across manifests
  * Updated CI workflows to use newer GitHub Actions (checkout and artifact upload v5)
  * Extended tooling config to ignore additional docs and test fixture paths

* **Tests**
  * Added regression tests improving process-snapshot filtering and port-extraction diagnostics

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/automagik-dev/genie/pull/2477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->