### PR TITLE
Promote dev to stable: socket transport diagnostics

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "4.260522.14",
+      "version": "4.260522.15",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "4.260522.15",
+      "version": "4.260522.16",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/genie",
-  "version": "4.260522.14",
+  "version": "4.260522.15",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/genie",
-  "version": "4.260522.15",
+  "version": "4.260522.16",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
   "type": "module",
   "bin": {

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "4.260522.14",
+  "version": "4.260522.15",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "4.260522.15",
+  "version": "4.260522.16",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "4.260522.15",
+  "version": "4.260522.16",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "type": "module",

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "4.260522.14",
+  "version": "4.260522.15",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "type": "module",

--- a/src/genie-commands/__tests__/update.test.ts
+++ b/src/genie-commands/__tests__/update.test.ts
@@ -24,6 +24,7 @@ import {
   downloadAndVerifyTarball,
   ensureCanonicalInstall,
   extractPgservePortFromStatus,
+  extractPgserveSocketDirFromStatus,
   fetchLatestManifest,
   formatVerifyBanner,
   isGenieProcessSnapshotLine,
@@ -893,6 +894,18 @@ describe('Diagnostics schema (G5)', () => {
     expect(extractPgservePortFromStatus('not-json')).toBe(null);
   });
 
+  test('diagnostics derives pgserve socket dir from live pgserve runtime status json', () => {
+    const liveStatus = JSON.stringify({
+      installed: true,
+      status: 'online',
+      port: 8432,
+      socketDir: '/run/user/1000/pgserve',
+      runtime: { socketDir: '/run/user/1000/pgserve', port: 8432, live: true },
+    });
+
+    expect(extractPgserveSocketDirFromStatus(liveStatus)).toBe('/run/user/1000/pgserve');
+  });
+
   test('diagnostics derives pgserve port from live pgserve runtime status json', () => {
     const liveStatus = JSON.stringify({
       installed: true,
@@ -902,6 +915,18 @@ describe('Diagnostics schema (G5)', () => {
     });
 
     expect(extractPgservePortFromStatus(liveStatus)).toBe('8432');
+  });
+
+  test('serve status reports pgserve transport from resolver instead of stale active port', () => {
+    const source = readFileSync(join(__dirname, '..', '..', 'term-commands', 'serve.ts'), 'utf-8');
+    const fnStart = source.indexOf('async function printPgserveHealth');
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnBody = source.slice(fnStart, source.indexOf('/**', fnStart + 1));
+
+    expect(fnBody).toContain('resolvePgserveTransport');
+    expect(fnBody).toContain("transport?.kind === 'unix'");
+    expect(fnBody).not.toContain('isSocketMode()');
+    expect(fnBody).not.toContain('getActivePort()');
   });
 
   test('NO_COLOR honored via colorEnabled() helper', () => {

--- a/src/genie-commands/__tests__/update.test.ts
+++ b/src/genie-commands/__tests__/update.test.ts
@@ -893,6 +893,17 @@ describe('Diagnostics schema (G5)', () => {
     expect(extractPgservePortFromStatus('not-json')).toBe(null);
   });
 
+  test('diagnostics derives pgserve port from live pgserve runtime status json', () => {
+    const liveStatus = JSON.stringify({
+      installed: true,
+      status: 'online',
+      port: null,
+      runtime: { port: 8432, live: true },
+    });
+
+    expect(extractPgservePortFromStatus(liveStatus)).toBe('8432');
+  });
+
   test('NO_COLOR honored via colorEnabled() helper', () => {
     const source = readFileSync(join(__dirname, '..', 'update.ts'), 'utf-8');
     expect(source).toContain('process.env.NO_COLOR');

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -1245,6 +1245,20 @@ export function isGenieProcessSnapshotLine(line: string): boolean {
   );
 }
 
+export function extractPgserveSocketDirFromStatus(output: string): string | null {
+  try {
+    const parsed = JSON.parse(output) as {
+      socketDir?: unknown;
+      runtime?: { socketDir?: unknown };
+    };
+    const rawSocketDir = parsed.runtime?.socketDir ?? parsed.socketDir;
+    if (typeof rawSocketDir === 'string' && rawSocketDir.trim()) return rawSocketDir.trim();
+  } catch {
+    // best-effort diagnostics only; callers fall back to null.
+  }
+  return null;
+}
+
 export function extractPgservePortFromStatus(output: string): string | null {
   try {
     const parsed = JSON.parse(output) as {
@@ -1291,7 +1305,9 @@ async function collectUpdateDiagnostics(
   const signals = summarizeJsonlSignals(schedulerLog);
   const pgservePortFromFile = safeRead(join(GENIE_HOME, 'pgserve.port'), 200);
   const pgserveStatusJson = (await runCommandSilent('pgserve', ['status', '--json'], undefined, 2000)).output.trim();
+  const pgserveSocketDir = extractPgserveSocketDirFromStatus(pgserveStatusJson);
   const pgservePort = pgservePortFromFile ?? extractPgservePortFromStatus(pgserveStatusJson);
+  const pgserveTransport = pgserveSocketDir ? 'unix-socket' : pgservePort ? 'tcp' : null;
 
   const diagnostics = {
     schemaVersion: UPDATE_DIAGNOSTIC_SCHEMA_VERSION,
@@ -1331,6 +1347,8 @@ async function collectUpdateDiagnostics(
       genieBinPrevious: GENIE_BIN_PREVIOUS,
       logsDir,
       servePid: safeRead(join(GENIE_HOME, 'serve.pid'), 200),
+      pgserveTransport,
+      pgserveSocketDir,
       pgservePort,
       schedulerLog,
       tuiCrashLog,

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -1247,8 +1247,12 @@ export function isGenieProcessSnapshotLine(line: string): boolean {
 
 export function extractPgservePortFromStatus(output: string): string | null {
   try {
-    const parsed = JSON.parse(output) as { port?: unknown; instance?: { port?: unknown } };
-    const rawPort = parsed.port ?? parsed.instance?.port;
+    const parsed = JSON.parse(output) as {
+      port?: unknown;
+      instance?: { port?: unknown };
+      runtime?: { port?: unknown };
+    };
+    const rawPort = parsed.port ?? parsed.instance?.port ?? parsed.runtime?.port;
     if (typeof rawPort === 'number' && Number.isFinite(rawPort)) return String(rawPort);
     if (typeof rawPort === 'string' && rawPort.trim()) return rawPort.trim();
   } catch {

--- a/src/term-commands/brain.ts
+++ b/src/term-commands/brain.ts
@@ -351,6 +351,10 @@ async function showVersion(): Promise<void> {
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     if (isModuleNotFound(msg)) {
+      if (canRunStandaloneBrain()) {
+        executeStandaloneBrain(['--version']);
+        return;
+      }
       console.log('  Brain is not installed. Run: genie brain install');
       return;
     }
@@ -492,6 +496,24 @@ function isModuleNotFound(msg: string): boolean {
   return msg.includes('Cannot find') || msg.includes('not found') || msg.includes('MODULE_NOT_FOUND');
 }
 
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function canRunStandaloneBrain(): boolean {
+  try {
+    execSync('command -v brain', { stdio: 'ignore', shell: '/bin/bash' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function executeStandaloneBrain(args: string[]): void {
+  const quotedArgs = args.map(shellQuote).join(' ');
+  execSync(`brain ${quotedArgs}`, { stdio: 'inherit', env: process.env, shell: '/bin/bash' });
+}
+
 function printNotInstalledMessage(): void {
   console.log('');
   console.log('  Brain is an enterprise knowledge graph engine.');
@@ -524,6 +546,10 @@ async function executeBrainCommand(args: string[]): Promise<void> {
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     if (isModuleNotFound(msg)) {
+      if (canRunStandaloneBrain()) {
+        executeStandaloneBrain(args);
+        return;
+      }
       printNotInstalledMessage();
       process.exit(1);
     } else {

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -1475,9 +1475,15 @@ async function stopServe(): Promise<void> {
 /** Check pgserve health and print status */
 async function printPgserveHealth(): Promise<void> {
   try {
-    const { isAvailable, getActivePort, isSocketMode, resolvePgserveSocketDir } = await import('../lib/db.js');
+    const { isAvailable, resolvePgserveTransport } = await import('../lib/db.js');
     const dbOk = await isAvailable();
-    const where = isSocketMode() ? `socket ${resolvePgserveSocketDir()}` : `port ${getActivePort()}`;
+    const transport = dbOk ? await resolvePgserveTransport() : null;
+    const where =
+      transport?.kind === 'unix'
+        ? `socket ${transport.socketDir}`
+        : transport
+          ? `tcp ${transport.host}:${transport.port}`
+          : null;
     console.log(`  pgserve:    ${dbOk ? `healthy (${where})` : 'unreachable'}`);
   } catch {
     console.log('  pgserve:    unavailable');

--- a/src/term-commands/serve.ts
+++ b/src/term-commands/serve.ts
@@ -1558,6 +1558,43 @@ async function probeBrainHealth(brainPort: number): Promise<void> {
   }
 }
 
+interface ActiveBrainConfigFile {
+  brainSlug?: string;
+  database?: string;
+  pid?: number;
+  port?: number;
+}
+
+function readActiveBrainConfigFile(): ActiveBrainConfigFile | null {
+  try {
+    const configPath = join(homedir(), '.brain', 'config.json');
+    if (!existsSync(configPath)) return null;
+    const config = JSON.parse(readFileSync(configPath, 'utf-8')) as ActiveBrainConfigFile;
+    if (!config.pid || !isProcessAlive(config.pid) || !config.port) return null;
+    return config;
+  } catch {
+    return null;
+  }
+}
+
+async function printStandaloneBrainStatus(): Promise<boolean> {
+  const config = readActiveBrainConfigFile();
+  if (!config?.port) return false;
+  try {
+    const resp = await fetch(`http://127.0.0.1:${config.port}/healthz`);
+    const label = config.brainSlug ?? config.database ?? `port ${config.port}`;
+    console.log(
+      resp.ok
+        ? `  brain:      running (${label}, port ${config.port})`
+        : `  brain:      unhealthy (${label}, status ${resp.status})`,
+    );
+    return true;
+  } catch {
+    console.log(`  brain:      stopped (port ${config.port} unreachable)`);
+    return true;
+  }
+}
+
 async function printBrainStatus(): Promise<void> {
   try {
     // @ts-expect-error — brain is enterprise-only, not in genie's deps
@@ -1575,6 +1612,7 @@ async function printBrainStatus(): Promise<void> {
       console.log('  brain:      stopped');
     }
   } catch {
+    if (await printStandaloneBrainStatus()) return;
     console.log('  brain:      not installed');
   }
 }


### PR DESCRIPTION
## Summary\n- report pgserve Unix socket transport in update diagnostics\n- include pgserve socketDir while keeping port only as legacy metadata\n- make serve status use resolvePgserveTransport() instead of stale active-port state\n- includes prior pgserve runtime.port diagnostics fix\n\n## Verification\n- GENIE_TEST_SKIP_PGSERVE=1 bun test src/genie-commands/__tests__/update.test.ts\n- bun run typecheck\n- bun run lint\n- bun run dead-code\n- bun run skills:lint\n- bun run wishes:lint\n- bun run lint:emit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved pgserve diagnostics with unified transport detection (socket vs TCP) and richer connection metadata extraction.
  * Enhanced service status reporting for the brain, including standalone discovery and direct CLI probing when available.

* **Chores**
  * Version bump to 4.260522.16

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/automagik-dev/genie/pull/2478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->