### PR TITLE
Promote v4.260522.17 stable: Brain control surface fix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "4.260522.16",
+      "version": "4.260522.17",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/genie",
-  "version": "4.260522.16",
+  "version": "4.260522.17",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
   "type": "module",
   "bin": {

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "4.260522.16",
+  "version": "4.260522.17",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "4.260522.16",
+  "version": "4.260522.17",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "type": "module",


### PR DESCRIPTION
## Summary\n- Promote v4.260522.17 from dev to main/stable.\n- Includes merged Brain control surface fix from PR #2478 plus fresh version tag that actually contains it.\n- This makes stable 
  Brain is an enterprise knowledge graph engine.
  It is not installed.

  Quick install:

    genie brain install

  Requires GitHub org membership (khal-os). recognize standalone Brain installs and 
Genie Serve
──────────────────────────────────────────────────
  Status:     running
  PID:        2622546
  pgserve:    healthy (port 8432)
  hook UDS:   listening at /home/genie/.genie/hook.sock
  brain:      not installed
  tmux -L genie: running (2 sessions)
              genie, khal-os
  tmux -L genie-tui: stopped
  scheduler:  integrated (in-process)
  inbox:      watching (poll 30s)
  omni-bridge: running (pid 2622546, uptime 3614s, ping 18ms)
  PID file:   /home/genie/.genie/serve.pid show active Brain daemon state.\n\n## Verification\n- main CI for #2478 merge passed\n- manual dev Version minted v4.260522.17 at commit aba7a5ca containing fb866331\n- v4.260522.17 release pipeline passed (build, sign/attest, publish)\n- local dev smoke: 1.61.1 → 1.61.1\n- local dev smoke: 
Confidence: HIGH (0.91)
Strategy: rag | 2 results | 154ms

  0.913 | raw/legacy-genie-khal-os/brain/memory/project_app_studio.md
         # App Studio

The next major product initiative for khal-os. A Lovable/V0-style app builder that is:
  0.607 | dspy-telemetry/raw-claude-code/manual-probe-failure-sessions-20260521.txt
         
### FILE /home/genie/.claude/projects/-home-genie-workspace-agents-khal-os/cbeb7888-8297-4153-af23- returned HIGH confidence\n- local dev smoke: 
Genie Serve
──────────────────────────────────────────────────
  Status:     running
  PID:        2622546
  pgserve:    healthy (tcp 127.0.0.1:8432)
  hook UDS:   listening at /home/genie/.genie/hook.sock
  brain:      running (khal_knowledge, port 3847)
  tmux -L genie: running (2 sessions)
              genie, khal-os
  tmux -L genie-tui: stopped
  scheduler:  integrated (in-process)
  inbox:      watching (poll 30s)
  omni-bridge: running (pid 2622546, uptime 3623s, ping 20ms)
  PID file:   /home/genie/.genie/serve.pid shows brain running (khal_knowledge, port 3847)