### PR TITLE
Promote v4.260522.19 stable: doctor PATH fidelity

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "4.260522.18",
+      "version": "4.260522.19",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "4.260522.17",
+      "version": "4.260522.18",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/genie",
-  "version": "4.260522.18",
+  "version": "4.260522.19",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/genie",
-  "version": "4.260522.17",
+  "version": "4.260522.18",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
   "type": "module",
   "bin": {

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "4.260522.18",
+  "version": "4.260522.19",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "4.260522.17",
+  "version": "4.260522.18",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "4.260522.18",
+  "version": "4.260522.19",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "type": "module",

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "4.260522.17",
+  "version": "4.260522.18",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "type": "module",

--- a/src/genie-commands/__tests__/doctor.test.ts
+++ b/src/genie-commands/__tests__/doctor.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveBinaryInteractive, resolveBinaryNonInteractive } from '../doctor.js';
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeFakeBin(name: string): { dir: string; path: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'genie-doctor-path-'));
+  tmpDirs.push(dir);
+  const path = join(dir, name);
+  writeFileSync(path, '#!/bin/sh\nexit 0\n');
+  chmodSync(path, 0o755);
+  return { dir, path };
+}
+
+describe('doctor PATH detection', () => {
+  test('resolves binaries through a POSIX shell builtin instead of Bun shell external command lookup', async () => {
+    const fake = makeFakeBin('fake-genie-bin');
+    const env = { PATH: fake.dir };
+
+    await expect(resolveBinaryInteractive('fake-genie-bin', env)).resolves.toBe(fake.path);
+    await expect(resolveBinaryNonInteractive('fake-genie-bin', env)).resolves.toBe(fake.path);
+  });
+
+  test('returns null for invalid binary names and missing PATH entries', async () => {
+    const env = { PATH: tmpdir() };
+
+    await expect(resolveBinaryInteractive('missing-genie-bin', env)).resolves.toBeNull();
+    await expect(resolveBinaryNonInteractive('bad;name', env)).resolves.toBeNull();
+  });
+});

--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -195,26 +195,36 @@ async function checkNonInteractivePath(bin: string): Promise<CheckResult | null>
  * is running `genie doctor` from). Uses Bun's `$` which inherits the
  * parent process environment.
  */
-async function resolveBinaryInteractive(bin: string): Promise<string | null> {
-  try {
-    const result = await $`command -v ${bin}`.quiet().text();
-    return result.trim() || null;
-  } catch {
-    return null;
-  }
+export async function resolveBinaryInteractive(
+  bin: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<string | null> {
+  return resolveBinaryWithShell(bin, env);
 }
 
 /**
  * Resolve a binary's path in a *non-interactive* shell — the same
  * environment that `tmux send-keys` + spawn-scripts run under.
  *
- * Uses `sh -c` to ensure ~/.profile loads but ~/.bashrc's interactive-only
- * sections are skipped. This catches the `posix_spawn ENOENT` class of
- * failures BEFORE they break a worker spawn at runtime.
+ * Use node's execFileSync rather than Bun's shell template. Bun's `$` executes
+ * `command` as an external binary instead of a POSIX shell builtin, producing
+ * false "not in non-interactive PATH" warnings even when PATH is healthy.
  */
-async function resolveBinaryNonInteractive(bin: string): Promise<string | null> {
+export async function resolveBinaryNonInteractive(
+  bin: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<string | null> {
+  return resolveBinaryWithShell(bin, env);
+}
+
+function resolveBinaryWithShell(bin: string, env: NodeJS.ProcessEnv): string | null {
+  if (!/^[A-Za-z0-9._+-]+$/.test(bin)) return null;
   try {
-    const result = await $`sh -c "command -v ${bin}"`.quiet().text();
+    const result = execFileSync('/bin/sh', ['-c', `command -v ${bin}`], {
+      encoding: 'utf8',
+      env,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
     return result.trim() || null;
   } catch {
     return null;


### PR DESCRIPTION
## Summary\n- Promote v4.260522.19 from dev to main/stable.\n- Fixes false 
[1mGenie Doctor[0m
[2m────────────────────────────────────────[0m

[1mPrerequisites:[0m
  [32m✓[0m tmux
  [32m✓[0m jq 1.7
  [32m✓[0m bun 1.3.14
  [32m✓[0m Claude Code 2.1.148
  [32m✓[0m Codex CLI 0.130.0
  [33m![0m Non-interactive PATH: genie not in non-interactive PATH
    [2mAdd genie to ~/.profile (not just ~/.bashrc). Some flows (e.g. genie update) shell out to bare 'genie' from non-interactive subprocesses.[0m
  [33m![0m Non-interactive PATH: node not in non-interactive PATH
    [2mAdd node to ~/.profile (not just ~/.bashrc). Some flows (e.g. genie update) shell out to bare 'node' from non-interactive subprocesses.[0m
  [33m![0m Non-interactive PATH: npm not in non-interactive PATH
    [2mAdd npm to ~/.profile (not just ~/.bashrc). Some flows (e.g. genie update) shell out to bare 'npm' from non-interactive subprocesses.[0m
  [33m![0m Non-interactive PATH: git not in non-interactive PATH
    [2mAdd git to ~/.profile (not just ~/.bashrc). Some flows (e.g. genie update) shell out to bare 'git' from non-interactive subprocesses.[0m

[1mInstaller Resolution:[0m
  [33m![0m Resolved binary /home/genie/.local/bin/genie (not owned by a detected installer)
    [2mLikely a dev checkout or manual symlink. Package-manager updates (`npm i -g`, `bun add -g`) will not replace this binary.[0m

[1mConfiguration:[0m
  [32m✓[0m Genie config exists ~/.genie/config.json
  [33m![0m Setup complete not completed
    [2mRun: genie setup[0m
  [32m✓[0m Claude settings exists ~/.claude/settings.json

[1mTmux:[0m
  [32m✓[0m Server running
  [32m✓[0m Session 'genie' exists

[1mTmux Configs:[0m
  [32m✓[0m tmux configs bundled configs unavailable (skipped)

[1mWorker Profiles:[0m
  [32m✓[0m Worker profiles none configured (using defaults)

[1mPgserve (canonical backbone):[0m
  [32m✓[0m pgserve binary canonical port 8432
  [32m✓[0m pgserve under pm2 online — shared backbone for Genie + omni-api on :8432

[1mOmni Bridge:[0m
  [32m✓[0m Bridge running running (pid 2718758, uptime 1208s)
  [32m✓[0m NATS ping pong in 30ms (localhost:4222)
  [32m✓[0m Subjects omni.message.>, omni.turn.open.>, omni.session.reset.>, omni.bridge.ping

[1mAgent Config:[0m
  [32m✓[0m No legacy frontmatter in agents/*/AGENTS.md

[1mGenie Specialist:[0m
  [32m✓[0m agents/genie scaffold up to date

[2m────────────────────────────────────────[0m
[33mSome warnings detected.[0m Everything should still work. Non-interactive PATH warnings caused by Bun shell treating  as an external binary instead of a POSIX shell builtin.\n- Adds focused regression coverage for doctor PATH detection.\n\n## Verification\n- Local: Checked 846 files in 304ms. No fixes applied.\n- Local: \n- Local: bun test v1.3.14 (0d9b296a) (118 pass, 1 skip)\n- Local: 
[1mGenie Doctor[0m
[2m────────────────────────────────────────[0m

[1mPrerequisites:[0m
  [32m✓[0m tmux
  [32m✓[0m jq 1.7
  [32m✓[0m bun 1.3.14
  [32m✓[0m Claude Code 2.1.148
  [32m✓[0m Codex CLI 0.130.0
  [32m✓[0m Non-interactive PATH: genie /home/genie/.local/bin/genie
  [32m✓[0m Non-interactive PATH: bun /home/genie/.bun/bin/bun
  [32m✓[0m Non-interactive PATH: node /home/genie/.local/bin/node
  [32m✓[0m Non-interactive PATH: npm /home/genie/.local/bin/npm
  [32m✓[0m Non-interactive PATH: git /usr/bin/git
  [32m✓[0m Non-interactive PATH: claude /home/genie/.local/bin/claude
  [32m✓[0m Non-interactive PATH: codex /home/genie/.local/bin/codex

[1mInstaller Resolution:[0m
  [33m![0m Resolved binary /home/genie/.local/bin/genie (not owned by a detected installer)
    [2mLikely a dev checkout or manual symlink. Package-manager updates (`npm i -g`, `bun add -g`) will not replace this binary.[0m

[1mConfiguration:[0m
  [32m✓[0m Genie config exists ~/.genie/config.json
  [33m![0m Setup complete not completed
    [2mRun: genie setup[0m
  [32m✓[0m Claude settings exists ~/.claude/settings.json

[1mTmux:[0m
  [32m✓[0m Server running
  [32m✓[0m Session 'genie' exists

[1mTmux Configs:[0m
  [32m✓[0m ~/.genie tmux configs up to date

[1mWorker Profiles:[0m
  [32m✓[0m Worker profiles none configured (using defaults)

[1mPgserve (canonical backbone):[0m
  [32m✓[0m pgserve binary canonical port 8432
  [32m✓[0m pgserve under pm2 online — shared backbone for Genie + omni-api on :8432

[1mOmni Bridge:[0m
  [32m✓[0m Bridge running running (pid 2718758, uptime 1224s)
  [32m✓[0m NATS ping pong in 32ms (localhost:4222)
  [32m✓[0m Subjects omni.message.>, omni.turn.open.>, omni.session.reset.>, omni.bridge.ping

[1mAgent Config:[0m
  [32m✓[0m No legacy frontmatter in agents/*/AGENTS.md

[1mGenie Specialist:[0m
  [32m✓[0m agents/genie scaffold up to date

[2m────────────────────────────────────────[0m
[33mSome warnings detected.[0m Everything should still work. now reports Non-interactive PATH checks as pass\n- Dev CI: https://github.com/automagik-dev/genie/actions/runs/26304669633 passed\n- Dev release v4.260522.19: https://github.com/automagik-dev/genie/actions/runs/26304768895 passed