### PR TITLE
fix: reduce Genie DX false positives

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "4.260522.19",
+      "version": "4.260522.20",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/genie",
-  "version": "4.260522.19",
+  "version": "4.260522.20",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
   "type": "module",
   "bin": {

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "4.260522.19",
+  "version": "4.260522.20",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "4.260522.19",
+  "version": "4.260522.20",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "type": "module",

--- a/src/genie-commands/__tests__/doctor.test.ts
+++ b/src/genie-commands/__tests__/doctor.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { resolveBinaryInteractive, resolveBinaryNonInteractive } from '../doctor.js';
+import { isSetupEffectivelyComplete, resolveBinaryInteractive, resolveBinaryNonInteractive } from '../doctor.js';
 
 const tmpDirs: string[] = [];
 
@@ -35,5 +35,16 @@ describe('doctor PATH detection', () => {
 
     await expect(resolveBinaryInteractive('missing-genie-bin', env)).resolves.toBeNull();
     await expect(resolveBinaryNonInteractive('bad;name', env)).resolves.toBeNull();
+  });
+});
+
+describe('setup completion diagnostics', () => {
+  test('treats an existing modern v2 config as effectively complete even if the legacy setup flag is false', () => {
+    expect(isSetupEffectivelyComplete(false, { version: 2 })).toBe(true);
+  });
+
+  test('still honors explicit setup completion and missing configs', () => {
+    expect(isSetupEffectivelyComplete(true, { version: 2 })).toBe(true);
+    expect(isSetupEffectivelyComplete(false, null)).toBe(false);
   });
 });

--- a/src/genie-commands/__tests__/doctor.test.ts
+++ b/src/genie-commands/__tests__/doctor.test.ts
@@ -45,6 +45,12 @@ describe('setup completion diagnostics', () => {
 
   test('still honors explicit setup completion and missing configs', () => {
     expect(isSetupEffectivelyComplete(true, { version: 2 })).toBe(true);
+    expect(isSetupEffectivelyComplete(true, null)).toBe(true);
     expect(isSetupEffectivelyComplete(false, null)).toBe(false);
+  });
+
+  test('rejects pre-v2 and missing-version configs', () => {
+    expect(isSetupEffectivelyComplete(false, { version: 1 })).toBe(false);
+    expect(isSetupEffectivelyComplete(false, {})).toBe(false);
   });
 });

--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -24,7 +24,13 @@ import type { BridgeStatusResult, PingOptions } from '../lib/bridge-status.js';
 import { contractClaudePath, getClaudeSettingsPath } from '../lib/claude-settings.js';
 import { getConnection, isAvailable as isRuntimePgAvailable, resolveDatabaseName } from '../lib/db.js';
 import { tmuxBin } from '../lib/ensure-tmux.js';
-import { genieConfigExists, getGenieConfigPath, isSetupComplete, loadGenieConfig } from '../lib/genie-config.js';
+import {
+  genieConfigExists,
+  getGenieConfigPath,
+  isSetupComplete,
+  loadGenieConfig,
+  loadGenieConfigSync,
+} from '../lib/genie-config.js';
 import { respawnInvocation } from '../lib/respawn.js';
 import { type RoleCutoverInspection, inspectRoleCutover } from '../lib/role-cutover.js';
 import { checkCommand } from '../lib/system-detect.js';
@@ -44,6 +50,14 @@ interface CheckResult {
   status: 'pass' | 'fail' | 'warn';
   message?: string;
   suggestion?: string;
+}
+
+export function isSetupEffectivelyComplete(
+  explicitSetupComplete: boolean,
+  config: { version?: number } | null,
+): boolean {
+  if (explicitSetupComplete) return true;
+  return (config?.version ?? 0) >= 2;
 }
 
 /**
@@ -253,8 +267,15 @@ async function checkConfiguration(): Promise<CheckResult[]> {
     });
   }
 
-  // Check if setup is complete
-  if (isSetupComplete()) {
+  // Check if setup is complete. Older config files can carry
+  // setupComplete=false even though the v2 runtime config exists and has
+  // already been used successfully; treat that as a pass to avoid a stale
+  // wizard-warning in otherwise healthy local/dev installs.
+  const setupComplete = isSetupEffectivelyComplete(
+    isSetupComplete(),
+    genieConfigExists() ? loadGenieConfigSync() : null,
+  );
+  if (setupComplete) {
     results.push({
       name: 'Setup complete',
       status: 'pass',

--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -271,10 +271,15 @@ async function checkConfiguration(): Promise<CheckResult[]> {
   // setupComplete=false even though the v2 runtime config exists and has
   // already been used successfully; treat that as a pass to avoid a stale
   // wizard-warning in otherwise healthy local/dev installs.
-  const setupComplete = isSetupEffectivelyComplete(
-    isSetupComplete(),
-    genieConfigExists() ? loadGenieConfigSync() : null,
-  );
+  let loadedConfig: { version?: number } | null = null;
+  if (genieConfigExists()) {
+    try {
+      loadedConfig = loadGenieConfigSync();
+    } catch {
+      loadedConfig = null;
+    }
+  }
+  const setupComplete = isSetupEffectivelyComplete(isSetupComplete(), loadedConfig);
   if (setupComplete) {
     results.push({
       name: 'Setup complete',

--- a/src/genie-commands/installer-resolution.test.ts
+++ b/src/genie-commands/installer-resolution.test.ts
@@ -79,6 +79,17 @@ describe('classifyInstallerResolution', () => {
     expect(rows[0].message).toContain('Genie managed binary');
   });
 
+  test('passes when realPath is Genie-managed but path is a symlink elsewhere', () => {
+    const rows = classifyInstallerResolution({
+      resolved: resolved('/usr/local/bin/genie', '/home/alice/.genie/bin/genie'),
+      installers: [],
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe('pass');
+    expect(rows[0].message).toContain('Genie managed binary');
+  });
+
   test('warns on duplicate installs and labels the older one stale', () => {
     const npmBin = '/virtual/npm/bin/genie';
     const bunBin = '/virtual/bun/bin/genie';

--- a/src/genie-commands/installer-resolution.test.ts
+++ b/src/genie-commands/installer-resolution.test.ts
@@ -68,6 +68,17 @@ describe('classifyInstallerResolution', () => {
     expect(rows[1].name).toContain('npm');
   });
 
+  test('passes when resolver is the Genie self-managed binary under ~/.genie/bin', () => {
+    const rows = classifyInstallerResolution({
+      resolved: resolved('/home/alice/.genie/bin/genie'),
+      installers: [],
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe('pass');
+    expect(rows[0].message).toContain('Genie managed binary');
+  });
+
   test('warns on duplicate installs and labels the older one stale', () => {
     const npmBin = '/virtual/npm/bin/genie';
     const bunBin = '/virtual/bun/bin/genie';

--- a/src/genie-commands/installer-resolution.ts
+++ b/src/genie-commands/installer-resolution.ts
@@ -113,8 +113,10 @@ function safeRealpath(p: string): string {
   }
 }
 
+const GENIE_MANAGED_BIN_PATTERN = /(^|\/)\.genie\/bin\/genie$/;
+
 function isGenieManagedBinary(resolved: ResolvedBinary): boolean {
-  return /(^|\/)\.genie\/bin\/genie$/.test(resolved.path) || /(^|\/)\.genie\/bin\/genie$/.test(resolved.realPath);
+  return GENIE_MANAGED_BIN_PATTERN.test(resolved.path) || GENIE_MANAGED_BIN_PATTERN.test(resolved.realPath);
 }
 
 async function probeOne(installer: InstallerId, binDir: string | null): Promise<InstallerEntry | null> {

--- a/src/genie-commands/installer-resolution.ts
+++ b/src/genie-commands/installer-resolution.ts
@@ -113,6 +113,10 @@ function safeRealpath(p: string): string {
   }
 }
 
+function isGenieManagedBinary(resolved: ResolvedBinary): boolean {
+  return /(^|\/)\.genie\/bin\/genie$/.test(resolved.path) || /(^|\/)\.genie\/bin\/genie$/.test(resolved.realPath);
+}
+
 async function probeOne(installer: InstallerId, binDir: string | null): Promise<InstallerEntry | null> {
   if (!binDir) return null;
   const binPath = join(binDir, 'genie');
@@ -238,6 +242,15 @@ export function classifyInstallerResolution(state: InstallerResolutionState): Ch
   const rows: CheckResult[] = [];
 
   if (!owner) {
+    if (isGenieManagedBinary(resolved)) {
+      rows.push({
+        name: 'Resolved binary',
+        status: 'pass',
+        message: `${resolved.path} (Genie managed binary)`,
+      });
+      return rows;
+    }
+
     rows.push({
       name: 'Resolved binary',
       status: 'warn',

--- a/src/lib/agent-observability.test.ts
+++ b/src/lib/agent-observability.test.ts
@@ -85,9 +85,27 @@ describe('assessHealth (pure)', () => {
     expect(h.degraded).toBe(true);
   });
 
+  test('stale_executor does NOT fire when recent tool activity proves the executor is alive', () => {
+    const now = Date.now();
+    const row = baseRow();
+    row.executorState = 'running';
+    row.executorUpdatedAt = new Date(now - STALE_EXECUTOR_WINDOW_MS - 60_000).toISOString();
+    row.recentLastToolAt = new Date(now - 60_000).toISOString();
+
+    expect(assessHealth(row, now).flags).not.toContain('stale_executor');
+  });
+
   test('stale_executor does NOT fire for terminal executor states', () => {
     const row = baseRow();
     row.executorState = 'terminated';
+    row.executorUpdatedAt = new Date(Date.now() - STALE_EXECUTOR_WINDOW_MS - 60_000).toISOString();
+    expect(assessHealth(row).flags).not.toContain('stale_executor');
+  });
+
+  test('stale_executor does NOT fire for idle agent rows even if a historical executor row is running', () => {
+    const row = baseRow();
+    row.agentState = 'idle';
+    row.executorState = 'running';
     row.executorUpdatedAt = new Date(Date.now() - STALE_EXECUTOR_WINDOW_MS - 60_000).toISOString();
     expect(assessHealth(row).flags).not.toContain('stale_executor');
   });

--- a/src/lib/agent-observability.test.ts
+++ b/src/lib/agent-observability.test.ts
@@ -89,10 +89,22 @@ describe('assessHealth (pure)', () => {
     const now = Date.now();
     const row = baseRow();
     row.executorState = 'running';
+    row.executorStartedAt = new Date(now - STALE_EXECUTOR_WINDOW_MS).toISOString();
     row.executorUpdatedAt = new Date(now - STALE_EXECUTOR_WINDOW_MS - 60_000).toISOString();
     row.recentLastToolAt = new Date(now - 60_000).toISOString();
 
     expect(assessHealth(row, now).flags).not.toContain('stale_executor');
+  });
+
+  test('stale_executor still fires when recent tool activity predates the current executor', () => {
+    const now = Date.now();
+    const row = baseRow();
+    row.executorState = 'running';
+    row.executorStartedAt = new Date(now - 5 * 60_000).toISOString();
+    row.executorUpdatedAt = new Date(now - STALE_EXECUTOR_WINDOW_MS - 60_000).toISOString();
+    row.recentLastToolAt = new Date(now - 10 * 60_000).toISOString();
+
+    expect(assessHealth(row, now).flags).toContain('stale_executor');
   });
 
   test('stale_executor does NOT fire for terminal executor states', () => {
@@ -103,11 +115,12 @@ describe('assessHealth (pure)', () => {
   });
 
   test('stale_executor does NOT fire for idle agent rows even if a historical executor row is running', () => {
+    const now = Date.now();
     const row = baseRow();
     row.agentState = 'idle';
     row.executorState = 'running';
-    row.executorUpdatedAt = new Date(Date.now() - STALE_EXECUTOR_WINDOW_MS - 60_000).toISOString();
-    expect(assessHealth(row).flags).not.toContain('stale_executor');
+    row.executorUpdatedAt = new Date(now - STALE_EXECUTOR_WINDOW_MS - 60_000).toISOString();
+    expect(assessHealth(row, now).flags).not.toContain('stale_executor');
   });
 
   test('missing_session fires when current executor has no session linkage or claude_session_id anchor', () => {

--- a/src/lib/agent-observability.ts
+++ b/src/lib/agent-observability.ts
@@ -146,6 +146,26 @@ const HEARTBEAT_EXPECTED_AGENT_STATES = new Set(['spawning', 'working', 'permiss
 // Health flag computation
 // ============================================================================
 
+function finiteTime(value: string | null): number {
+  if (!value) return Number.NaN;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : Number.NaN;
+}
+
+function latestScopedActivity(row: AgentObservabilityRow): number {
+  const executorUpdated = finiteTime(row.executorUpdatedAt);
+  const recentToolAt = finiteTime(row.recentLastToolAt);
+  const activityFloor = Math.max(
+    finiteTime(row.executorStartedAt) || Number.NEGATIVE_INFINITY,
+    finiteTime(row.sessionStartedAt) || Number.NEGATIVE_INFINITY,
+  );
+  const scopedRecentToolAt =
+    Number.isFinite(recentToolAt) && Number.isFinite(activityFloor) && recentToolAt >= activityFloor
+      ? recentToolAt
+      : Number.NEGATIVE_INFINITY;
+  return Math.max(Number.isFinite(executorUpdated) ? executorUpdated : Number.NEGATIVE_INFINITY, scopedRecentToolAt);
+}
+
 /**
  * Compute derived health flags from a row.
  * Pure function — no IO; safe to call inside list iterators.
@@ -155,9 +175,9 @@ export function assessHealth(row: AgentObservabilityRow, now: number = Date.now(
 
   // stale_executor: live state but no heartbeat in the staleness window.
   // Prefer the freshest activity signal available. Executor rows may miss
-  // heartbeat writes while Claude is still actively emitting tool events; in
-  // that case recentLastToolAt is a stronger liveness proof than the stale
-  // executor.updated_at timestamp and should not scare operators.
+  // heartbeat writes while Claude is still actively emitting tool events. Since
+  // recentLastToolAt is currently aggregated by agent, only use it as liveness
+  // proof when it is newer than the current executor/session start boundary.
   if (
     row.executorId &&
     row.executorState &&
@@ -165,12 +185,7 @@ export function assessHealth(row: AgentObservabilityRow, now: number = Date.now(
     row.agentState &&
     HEARTBEAT_EXPECTED_AGENT_STATES.has(row.agentState)
   ) {
-    const executorUpdated = row.executorUpdatedAt ? Date.parse(row.executorUpdatedAt) : Number.NaN;
-    const recentToolAt = row.recentLastToolAt ? Date.parse(row.recentLastToolAt) : Number.NaN;
-    const latestActivity = Math.max(
-      Number.isFinite(executorUpdated) ? executorUpdated : Number.NEGATIVE_INFINITY,
-      Number.isFinite(recentToolAt) ? recentToolAt : Number.NEGATIVE_INFINITY,
-    );
+    const latestActivity = latestScopedActivity(row);
     if (Number.isFinite(latestActivity) && now - latestActivity > STALE_EXECUTOR_WINDOW_MS) {
       flags.push('stale_executor');
     }

--- a/src/lib/agent-observability.ts
+++ b/src/lib/agent-observability.ts
@@ -130,10 +130,17 @@ export const STALE_EXECUTOR_WINDOW_MS = 30 * 60 * 1000; // 30 minutes
 export const COST_SPIKE_USD_24H = 50;
 
 /**
- * Live executor states — anything in this set is expected to keep
- * heartbeating, so missing recent updates count as `stale_executor`.
+ * Executor states that are capable of emitting heartbeats when the owning
+ * agent is in an active turn state.
  */
 const LIVE_EXECUTOR_STATES = new Set(['spawning', 'running', 'idle', 'working', 'permission', 'question']);
+
+/**
+ * Agent states where a missing heartbeat is operator-actionable. Idle/error
+ * rows can retain historical executor pointers; those should not scare users
+ * unless the agent is actually in a D3 turn state.
+ */
+const HEARTBEAT_EXPECTED_AGENT_STATES = new Set(['spawning', 'working', 'permission', 'question']);
 
 // ============================================================================
 // Health flag computation
@@ -147,9 +154,24 @@ export function assessHealth(row: AgentObservabilityRow, now: number = Date.now(
   const flags: HealthFlag[] = [];
 
   // stale_executor: live state but no heartbeat in the staleness window.
-  if (row.executorId && row.executorState && LIVE_EXECUTOR_STATES.has(row.executorState)) {
-    const updated = row.executorUpdatedAt ? Date.parse(row.executorUpdatedAt) : Number.NaN;
-    if (Number.isFinite(updated) && now - updated > STALE_EXECUTOR_WINDOW_MS) {
+  // Prefer the freshest activity signal available. Executor rows may miss
+  // heartbeat writes while Claude is still actively emitting tool events; in
+  // that case recentLastToolAt is a stronger liveness proof than the stale
+  // executor.updated_at timestamp and should not scare operators.
+  if (
+    row.executorId &&
+    row.executorState &&
+    LIVE_EXECUTOR_STATES.has(row.executorState) &&
+    row.agentState &&
+    HEARTBEAT_EXPECTED_AGENT_STATES.has(row.agentState)
+  ) {
+    const executorUpdated = row.executorUpdatedAt ? Date.parse(row.executorUpdatedAt) : Number.NaN;
+    const recentToolAt = row.recentLastToolAt ? Date.parse(row.recentLastToolAt) : Number.NaN;
+    const latestActivity = Math.max(
+      Number.isFinite(executorUpdated) ? executorUpdated : Number.NEGATIVE_INFINITY,
+      Number.isFinite(recentToolAt) ? recentToolAt : Number.NEGATIVE_INFINITY,
+    );
+    if (Number.isFinite(latestActivity) && now - latestActivity > STALE_EXECUTOR_WINDOW_MS) {
       flags.push('stale_executor');
     }
   }

--- a/src/lib/scheduler-daemon.test.ts
+++ b/src/lib/scheduler-daemon.test.ts
@@ -2668,7 +2668,7 @@ describe('runAgentRecoveryPass — turn-aware D1 / D3 routing', () => {
     },
   );
 
-  test('flag ON: state=error + dead pane → skipped, no resume (prevents post-D1 ghost loop)', async () => {
+  test('flag ON: state=error + dead pane → silently skipped, no resume (prevents post-D1 ghost-loop log flicker)', async () => {
     process.env[TURN_AWARE_RECONCILER_FLAG] = '1';
     const w = makeWorker('error', 'agent-err');
     let resumeCalls = 0;
@@ -2688,7 +2688,7 @@ describe('runAgentRecoveryPass — turn-aware D1 / D3 routing', () => {
 
     expect(resumeCalls).toBe(0);
     expect(res.terminalized).toBe(0);
-    expect(logs.some((l) => l.event === 'agent_resume_skipped_turn_aware' && l.state === 'error')).toBe(true);
+    expect(logs.some((l) => l.event === 'agent_resume_skipped_turn_aware' && l.state === 'error')).toBe(false);
   });
 
   test('C20 regression: ghost-loop cannot replay across multiple ticks when idle+dead (flag ON)', async () => {

--- a/src/lib/scheduler-daemon.ts
+++ b/src/lib/scheduler-daemon.ts
@@ -1084,15 +1084,6 @@ async function handleDeadPane(
     return 'skipped';
   }
   if (turnAware && !TURN_AWARE_RESUMABLE_STATES.has(worker.state as AgentState)) {
-    deps.log({
-      timestamp: deps.now().toISOString(),
-      level: 'debug',
-      event: 'agent_resume_skipped_turn_aware',
-      daemon_id: daemonId,
-      agent_id: worker.id,
-      state: worker.state,
-      reason: 'state_not_in_d3',
-    });
     return 'skipped';
   }
   const result = await attemptAgentResume(deps, config, worker);
@@ -1230,6 +1221,15 @@ export async function runAgentRecoveryPass(
       // which has its own guards.
       const decision = await shouldResume(worker.id);
       if (mode === 'boot' && !decision.resume && decision.reason !== 'unknown_agent') continue;
+
+      if (
+        mode !== 'boot' &&
+        turnAware &&
+        worker.state !== 'idle' &&
+        !TURN_AWARE_RESUMABLE_STATES.has(worker.state as AgentState)
+      ) {
+        continue;
+      }
 
       let enriched = worker;
       if (!enriched.currentSessionId && decision.resume && decision.sessionId) {

--- a/src/lib/scheduler-daemon.ts
+++ b/src/lib/scheduler-daemon.ts
@@ -1083,9 +1083,6 @@ async function handleDeadPane(
     }
     return 'skipped';
   }
-  if (turnAware && !TURN_AWARE_RESUMABLE_STATES.has(worker.state as AgentState)) {
-    return 'skipped';
-  }
   const result = await attemptAgentResume(deps, config, worker);
   return result === 'resumed' ? 'resumed' : 'skipped';
 }


### PR DESCRIPTION
## Summary
- suppresses false `stale_executor` alerts when the agent is idle or recent tool activity proves liveness
- silences turn-aware scheduler `state_not_in_d3` lifecycle flicker for non-D3 states
- treats valid modern v2 configs and `~/.genie/bin/genie` managed binaries as healthy in doctor

## Verification
- `GENIE_TEST_SKIP_PGSERVE=1 bun test src/genie-commands/__tests__/doctor.test.ts src/lib/agent-observability.test.ts src/lib/scheduler-daemon.test.ts src/genie-commands/installer-resolution.test.ts --timeout 20000` → 127 pass, 13 skip, 0 fail
- `bun run typecheck` → pass
- `bun run lint` → pass
- `bun run build` → pass
- pre-push hook: `typecheck`, `lint`, `dead-code`, `skills:lint`, `wishes:lint`, `lint:emit` → pass
- dogfood: doctor 0 warn/fail rows; observe 0 flagged rows; scheduler flicker scan 0 `state_not_in_d3`, 0 `agent_resume_skipped_turn_aware`, 0 `stale_executor` after removing stale duplicate foreground serve
- independent reviewer: passed; no security concerns or logic errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recognizes modern v2 setups as complete even when legacy flags are unset
  * Better detects Genie-managed binaries and classifies them as pass to reduce false installer warnings
  * Fewer false "stale executor" alerts by considering recent activity and heartbeat-expected states
  * Silently skips non-resumable workers during turn-aware recovery to avoid noisy error handling

* **Tests**
  * Added and adjusted tests for setup detection, installer resolution, health assessment, and scheduler behavior

* **Chores**
  * Bumped package and plugin versions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/automagik-dev/genie/pull/2481?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->