### PR TITLE
fix: flag errored agents in observe health

### DIFF
--- a/src/lib/agent-observability.test.ts
+++ b/src/lib/agent-observability.test.ts
@@ -123,6 +123,30 @@ describe('assessHealth (pure)', () => {
     expect(assessHealth(row, now).flags).not.toContain('stale_executor');
   });
 
+  test('agent_error fires for errored agent lifecycle even without recent tool errors', () => {
+    const row = baseRow();
+    row.agentState = 'error';
+    row.executorState = 'terminated';
+    row.recentErrorCount = 0;
+
+    const h = assessHealth(row);
+
+    expect(h.flags).toContain('agent_error');
+    expect(h.degraded).toBe(true);
+  });
+
+  test('agent_error fires for errored executor lifecycle even when agent row has not caught up', () => {
+    const row = baseRow();
+    row.agentState = 'working';
+    row.executorState = 'error';
+    row.recentErrorCount = 0;
+
+    const h = assessHealth(row);
+
+    expect(h.flags).toContain('agent_error');
+    expect(h.degraded).toBe(true);
+  });
+
   test('missing_session fires when current executor has no session linkage or claude_session_id anchor', () => {
     const row = baseRow();
     row.sessionId = null;

--- a/src/lib/agent-observability.ts
+++ b/src/lib/agent-observability.ts
@@ -12,8 +12,8 @@
  * the join + 24h tool/usage aggregates server-side; this module:
  *
  *   1. Casts row types into a stable TS shape (camelCase, typed).
- *   2. Computes derived health flags (`stale_executor`, `missing_session`,
- *      `missing_attribution`, `recent_failure`, `cost_spike`,
+ *   2. Computes derived health flags (`agent_error`, `stale_executor`,
+ *      `missing_session`, `missing_attribution`, `recent_failure`, `cost_spike`,
  *      `high_hook_latency`).
  *   3. Provides classifier filters (`agent` vs `harness`).
  *
@@ -41,6 +41,7 @@ export const AGENT_OBSERVABILITY_SCHEMA_VERSION = 1;
 export type AgentClassification = 'agent' | 'harness';
 
 export type HealthFlag =
+  | 'agent_error'
   | 'stale_executor'
   | 'missing_session'
   | 'missing_attribution'
@@ -172,6 +173,14 @@ function latestScopedActivity(row: AgentObservabilityRow): number {
  */
 export function assessHealth(row: AgentObservabilityRow, now: number = Date.now()): HealthAssessment {
   const flags: HealthFlag[] = [];
+
+  // agent_error: the lifecycle itself is terminal/failed. Do not rely only on
+  // recent tool-event errors: many harness failures transition the agent or
+  // executor to `error` without a scoped tool_events row, and observe surfaces
+  // must still report the row as degraded.
+  if (row.agentState === 'error' || row.executorState === 'error') {
+    flags.push('agent_error');
+  }
 
   // stale_executor: live state but no heartbeat in the staleness window.
   // Prefer the freshest activity signal available. Executor rows may miss

--- a/src/term-commands/agent/observe.ts
+++ b/src/term-commands/agent/observe.ts
@@ -35,6 +35,7 @@ interface ObserveOptions {
 }
 
 const FLAG_LABELS: Record<HealthFlag, string> = {
+  agent_error: 'agent/executor lifecycle is error',
   stale_executor: 'stale executor (no recent heartbeat)',
   missing_session: 'missing session linkage',
   missing_attribution: 'missing attribution (no name/role)',

--- a/src/term-commands/observe.ts
+++ b/src/term-commands/observe.ts
@@ -30,6 +30,7 @@ interface ObserveAgentsOptions {
 }
 
 const FLAG_LABELS: Record<HealthFlag, string> = {
+  agent_error: 'ERROR',
   stale_executor: 'STALE',
   missing_session: 'NO-SESSION',
   missing_attribution: 'UNATTRIBUTED',


### PR DESCRIPTION
## Summary
- Add `agent_error` observe health flag for rows whose agent or current executor lifecycle is `error`
- Update both single-agent and fleet observe render labels for the new health flag
- Add pure regression coverage for agent-state and executor-state error paths without relying on recent tool errors

## Verification
- `GENIE_TEST_SKIP_PGSERVE=1 bun test src/lib/agent-observability.test.ts`
- `bunx biome check src/lib/agent-observability.ts src/lib/agent-observability.test.ts src/term-commands/agent/observe.ts src/term-commands/observe.ts`
- `bun run build`
- `GENIE_TEST_SKIP_PGSERVE=1 bun run check:fast`
- `./dist/genie.js observe agents --json` smoke: parsed successfully; current local DB had 1 agent row and 0 degraded rows

## Known baseline/environment failures
- Full `GENIE_TEST_SKIP_PGSERVE=1 bun test` still fails outside this diff with 41 failures / 1 error tied to local pgserve/test-preload, docs submodule missing files, tmux missing, occupied otel port, and existing unrelated assertions. The touched focused suite and non-PG quality gate pass.

## Review
- Independent reviewer passed the diff with no security concerns or logic errors; suggestion to cover both sides of the OR was applied.
