### PR TITLE
fix: fail closed when test DB isolation is unavailable

### DIFF
--- a/src/lib/isolation-guard.test.ts
+++ b/src/lib/isolation-guard.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('isolated database setup fail-closed guard', () => {
+  test('does not return no-op cleanup when isolated DB setup fails', () => {
+    const source = readFileSync(join(process.cwd(), 'src/lib', `test-${'db'}.ts`), 'utf8');
+
+    expect(source).toContain('Unable to prepare isolated Genie test database');
+    expect(source).toContain('Unable to create isolated Genie test database');
+    expect(source).not.toContain('return async () => {};');
+  });
+});

--- a/src/lib/test-db.ts
+++ b/src/lib/test-db.ts
@@ -87,12 +87,16 @@ async function warmTestConnection(): Promise<void> {
  */
 export async function setupTestDatabase(): Promise<() => Promise<void>> {
   // Under concurrent test load, pgserve may have died unexpectedly. If that
-  // happens, fall back to a no-op cleanup so describe.skipIf(!DB_AVAILABLE)
-  // can still make progress.
+  // happens, fail closed instead of returning a no-op cleanup: many tests run
+  // destructive setup such as `DELETE FROM agents` immediately after this
+  // helper returns. Continuing without a guaranteed isolated database can wipe
+  // the operator's live Genie registry.
   try {
     await ensurePgserve();
-  } catch {
-    return async () => {};
+  } catch (error) {
+    throw new Error(
+      `Unable to prepare isolated Genie test database: pgserve unavailable (${error instanceof Error ? error.message : String(error)})`,
+    );
   }
 
   // Quiesce the emit.ts background flusher BEFORE we swap databases.
@@ -109,15 +113,14 @@ export async function setupTestDatabase(): Promise<() => Promise<void>> {
 
   try {
     await createTestDatabase(dbName);
-  } catch {
+  } catch (error) {
     // createTestDatabase failed (e.g. pgserve died, template DB missing).
-    // shutdownEmitter() already latched `shuttingDown = true`; if we return
-    // without resumeEmitter() the emitter stays quiesced for the remainder
-    // of this process, silently dropping every emit from every subsequent
-    // test file. Re-open admits before bailing so fallback no-op cleanup is
-    // truly side-effect free.
+    // Fail closed: returning a no-op cleanup here leaves GENIE_TEST_DB_NAME
+    // unset, so destructive test setup can run against the operator's live DB.
     resumeEmitter();
-    return async () => {};
+    throw new Error(
+      `Unable to create isolated Genie test database ${dbName}: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
 
   // Point db.ts at the new database and force a rebuild.


### PR DESCRIPTION
## Summary
- abandon the alias approach: Genie already has team/member addressing; the missing khal-os rows were evidence of registry clobbering, not a naming feature gap
- make setupTestDatabase fail closed when pgserve or DB clone setup fails
- add a lightweight regression guard to prevent reintroducing the no-op cleanup fallback

## Root cause
setupTestDatabase previously returned a no-op cleanup if pgserve or CREATE DATABASE ... TEMPLATE failed. That allowed tests to continue with GENIE_TEST_DB_NAME unset, so destructive test setup could hit the operator/live Genie DB instead of an isolated test DB. That explains why team khal-os still had members while agents rows disappeared, making native CLI resolution look broken.

## Verification
- bun test src/lib/isolation-guard.test.ts
- bunx biome check --write src/lib/test-db.ts src/lib/isolation-guard.test.ts
- bunx biome check src/lib/test-db.ts src/lib/isolation-guard.test.ts
- bun run typecheck
- bun run build
- pre-push hook: typecheck, lint, dead-code, skills:lint, wishes:lint, lint:emit

## Notes
- No alias command in this PR. The earlier alias branch was the wrong product fix.
- Normal full-suite health remains subject to the existing local test pgserve port issue; this PR prevents that kind of infrastructure failure from silently touching live state.
