### PR TITLE
fix(migrations): 002 discovers canonical pgserve port instead of hardcoding 8432

### DIFF
--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -20,6 +20,7 @@ import {
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { genieConfigExists, loadGenieConfig, saveGenieConfig } from '../lib/genie-config.js';
+import { extractPgservePortFromStatus } from '../lib/pgserve-status.js';
 import { VERSION } from '../lib/version.js';
 import { pm2ProcessNameCandidates, regenerateEcosystemConfig } from './install.js';
 import { type CleanupReport, cleanupLegacyArtifacts, parseSkipCleanupFlag } from './legacy-cleanup.js';
@@ -1259,21 +1260,10 @@ export function extractPgserveSocketDirFromStatus(output: string): string | null
   return null;
 }
 
-export function extractPgservePortFromStatus(output: string): string | null {
-  try {
-    const parsed = JSON.parse(output) as {
-      port?: unknown;
-      instance?: { port?: unknown };
-      runtime?: { port?: unknown };
-    };
-    const rawPort = parsed.port ?? parsed.instance?.port ?? parsed.runtime?.port;
-    if (typeof rawPort === 'number' && Number.isFinite(rawPort)) return String(rawPort);
-    if (typeof rawPort === 'string' && rawPort.trim()) return rawPort.trim();
-  } catch {
-    // best-effort diagnostics only; callers fall back to null.
-  }
-  return null;
-}
+// Moved to ../lib/pgserve-status.js so migration 002 can share the same
+// nested-shape-tolerant parser. Re-exported here to preserve the public API
+// (and existing update.test.ts import path).
+export { extractPgservePortFromStatus };
 
 function collectGenieProcessSnapshot(): string | null {
   const snapshot = safeExec('ps -axo pid,ppid,pgid,stat,pcpu,pmem,etime,command -r', 2000)

--- a/src/lib/pgserve-status.ts
+++ b/src/lib/pgserve-status.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared parser for `<autopg|pgserve> status --json` output.
+ *
+ * The port can appear at the top level (`port`) or nested under `instance.port`
+ * / `runtime.port` depending on the binary version. Consumers MUST tolerate all
+ * three shapes — reading only top-level `.port` silently null-resolves on hosts
+ * emitting the nested shape. Extracted here so both `genie update` diagnostics
+ * and migration 002 (canonical-port discovery) share one implementation.
+ */
+export function extractPgservePortFromStatus(output: string): string | null {
+  try {
+    const parsed = JSON.parse(output) as {
+      port?: unknown;
+      instance?: { port?: unknown };
+      runtime?: { port?: unknown };
+    };
+    const rawPort = parsed.port ?? parsed.instance?.port ?? parsed.runtime?.port;
+    if (typeof rawPort === 'number' && Number.isFinite(rawPort)) return String(rawPort);
+    if (typeof rawPort === 'string' && rawPort.trim()) return rawPort.trim();
+  } catch {
+    // best-effort diagnostics only; callers fall back to null.
+  }
+  return null;
+}

--- a/src/migrations/steps/002-kill-embedded-pgserve-legacy.ts
+++ b/src/migrations/steps/002-kill-embedded-pgserve-legacy.ts
@@ -1,27 +1,71 @@
 /**
  * Migration 002 — kill legacy embedded pgserve listening on a non-canonical port.
  *
- * Detection: a postgres process owned by the current user is listening on
- * a port other than canonical 8432, AND canonical pgserve responds on
- * 8432, AND no obvious user-intent override (env var GENIE_KEEP_LEGACY_PG=1).
+ * Detection: a postgres process owned by the current user is listening on a
+ * port OTHER than the one the canonical pgserve actually binds, AND that
+ * canonical pgserve is reachable, AND no user-intent override
+ * (env var GENIE_KEEP_LEGACY_PG=1).
+ *
+ * The canonical port is DISCOVERED from the autopg/pgserve binary at runtime —
+ * never hardcoded. The canonical backbone moved 8432 → 5432 in the
+ * autopg-v3 / socket-singleton cutover; a hardcoded 8432 here would (a) be a
+ * no-op on healthy 5432 hosts and, worse, (b) during a mixed window where a
+ * stray legacy postmaster is still live on 8432 alongside canonical 5432,
+ * mistake 8432 for canonical and STOP the real 5432 backbone. Discovering the
+ * port fixes both. When no canonical binary is installed / it can't report a
+ * port, this migration is a safe no-op: we never stop a postmaster we cannot
+ * positively distinguish from canonical.
  *
  * Fix: send graceful pg_ctl stop to the legacy process; if that fails,
  * SIGTERM. Migration 001 (must run first) ensures genie-serve no longer
  * spawns it, so it stays dead.
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 
+import { resolvePgserveBinary } from '../../lib/canonical-pgserve-binary.js';
 import type { MigrationContext } from '../discover.js';
 
 export const id = '002-kill-embedded-pgserve-legacy';
 export const description = 'Stop legacy embedded pgserve on non-canonical ports when canonical is healthy';
 
-const CANONICAL_PORT = 8432;
-
 interface ListeningPg {
   pid: number;
   port: number;
+}
+
+let canonicalPortCache: number | null | undefined;
+
+/**
+ * Resolve the port the canonical pgserve actually binds by asking the
+ * autopg/pgserve binary (`<bin> status --json` → `.port`). Memoized for the
+ * duration of the migration run. Returns null when no canonical binary is
+ * installed or it doesn't report a numeric port.
+ */
+function resolveCanonicalPort(): number | null {
+  if (canonicalPortCache !== undefined) return canonicalPortCache;
+  const bin = resolvePgserveBinary();
+  if (!bin) {
+    canonicalPortCache = null;
+    return null;
+  }
+  try {
+    const out = execFileSync(bin, ['status', '--json'], {
+      encoding: 'utf8',
+      timeout: 5000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const port = Number((JSON.parse(out) as { port?: unknown }).port);
+    canonicalPortCache = Number.isFinite(port) ? port : null;
+  } catch {
+    canonicalPortCache = null;
+  }
+  return canonicalPortCache;
+}
+
+/** Test-only: clear the memoized canonical port. */
+export function _resetCanonicalPortCache(): void {
+  canonicalPortCache = undefined;
 }
 
 function listListeningPgserve(): ListeningPg[] {
@@ -49,19 +93,32 @@ function listListeningPgserve(): ListeningPg[] {
   }
 }
 
-function canonicalReachable(): boolean {
+function canonicalReachable(port: number): boolean {
   try {
-    execSync(`pg_isready -h 127.0.0.1 -p ${CANONICAL_PORT}`, { stdio: 'pipe' });
+    execSync(`pg_isready -h 127.0.0.1 -p ${port}`, { stdio: 'pipe' });
     return true;
   } catch {
     return false;
   }
 }
 
+/**
+ * Pure selection: given the discovered canonical port and the set of listening
+ * postmasters, return the legacy one to stop (any port that is NOT canonical),
+ * or undefined. A null canonical port means "cannot identify canonical" → never
+ * select anything. Extracted for deterministic unit testing.
+ */
+export function selectLegacyEmbedded(canonicalPort: number | null, listening: ListeningPg[]): ListeningPg | undefined {
+  if (canonicalPort === null) return undefined;
+  return listening.find((p) => p.port !== canonicalPort);
+}
+
 function findLegacyEmbedded(): ListeningPg | undefined {
   if (process.env.GENIE_KEEP_LEGACY_PG === '1') return undefined;
-  if (!canonicalReachable()) return undefined;
-  return listListeningPgserve().find((p) => p.port !== CANONICAL_PORT);
+  const canonicalPort = resolveCanonicalPort();
+  if (canonicalPort === null) return undefined;
+  if (!canonicalReachable(canonicalPort)) return undefined;
+  return selectLegacyEmbedded(canonicalPort, listListeningPgserve());
 }
 
 export async function check(_ctx: MigrationContext): Promise<boolean> {

--- a/src/migrations/steps/002-kill-embedded-pgserve-legacy.ts
+++ b/src/migrations/steps/002-kill-embedded-pgserve-legacy.ts
@@ -24,6 +24,7 @@
 import { execFileSync, execSync } from 'node:child_process';
 
 import { resolvePgserveBinary } from '../../lib/canonical-pgserve-binary.js';
+import { extractPgservePortFromStatus } from '../../lib/pgserve-status.js';
 import type { MigrationContext } from '../discover.js';
 
 export const id = '002-kill-embedded-pgserve-legacy';
@@ -55,8 +56,13 @@ function resolveCanonicalPort(): number | null {
       timeout: 5000,
       stdio: ['ignore', 'pipe', 'ignore'],
     });
-    const port = Number((JSON.parse(out) as { port?: unknown }).port);
-    canonicalPortCache = Number.isFinite(port) ? port : null;
+    // Tolerate top-level `port` AND nested `instance.port` / `runtime.port`
+    // shapes (shared with `genie update` diagnostics). Reading only `.port`
+    // would null-resolve on hosts emitting the nested shape, making this
+    // migration a permanent no-op there.
+    const portStr = extractPgservePortFromStatus(out);
+    const port = portStr === null ? Number.NaN : Number.parseInt(portStr, 10);
+    canonicalPortCache = Number.isFinite(port) && port > 0 ? port : null;
   } catch {
     canonicalPortCache = null;
   }
@@ -104,33 +110,30 @@ function canonicalReachable(port: number): boolean {
 
 /**
  * Pure selection: given the discovered canonical port and the set of listening
- * postmasters, return the legacy one to stop (any port that is NOT canonical),
- * or undefined. A null canonical port means "cannot identify canonical" → never
- * select anything. Extracted for deterministic unit testing.
+ * postmasters, return ALL legacy ones to stop (every port that is NOT
+ * canonical). A null canonical port means "cannot identify canonical" → never
+ * select anything. Returning every match (not just the first) ensures `apply`
+ * stops all strays in one pass; otherwise `validate` fails after 5s because
+ * the un-stopped siblings are still listening. Extracted for unit testing.
  */
-export function selectLegacyEmbedded(canonicalPort: number | null, listening: ListeningPg[]): ListeningPg | undefined {
-  if (canonicalPort === null) return undefined;
-  return listening.find((p) => p.port !== canonicalPort);
+export function selectLegacyEmbedded(canonicalPort: number | null, listening: ListeningPg[]): ListeningPg[] {
+  if (canonicalPort === null) return [];
+  return listening.filter((p) => p.port !== canonicalPort);
 }
 
-function findLegacyEmbedded(): ListeningPg | undefined {
-  if (process.env.GENIE_KEEP_LEGACY_PG === '1') return undefined;
+function findLegacyEmbedded(): ListeningPg[] {
+  if (process.env.GENIE_KEEP_LEGACY_PG === '1') return [];
   const canonicalPort = resolveCanonicalPort();
-  if (canonicalPort === null) return undefined;
-  if (!canonicalReachable(canonicalPort)) return undefined;
+  if (canonicalPort === null) return [];
+  if (!canonicalReachable(canonicalPort)) return [];
   return selectLegacyEmbedded(canonicalPort, listListeningPgserve());
 }
 
 export async function check(_ctx: MigrationContext): Promise<boolean> {
-  return findLegacyEmbedded() !== undefined;
+  return findLegacyEmbedded().length > 0;
 }
 
-export async function apply(ctx: MigrationContext): Promise<void> {
-  const target = findLegacyEmbedded();
-  if (!target) {
-    ctx.log('no legacy embedded found at apply time (race resolved)');
-    return;
-  }
+function stopLegacy(ctx: MigrationContext, target: ListeningPg): void {
   ctx.log(`stopping legacy embedded pgserve PID ${target.pid} (port ${target.port})`);
   // Try pg_ctl stop via discovered data dir from the process
   try {
@@ -145,7 +148,7 @@ export async function apply(ctx: MigrationContext): Promise<void> {
       return;
     }
   } catch (err) {
-    ctx.warn(`pg_ctl stop failed: ${(err as Error).message} — falling back to SIGTERM`);
+    ctx.warn(`pg_ctl stop failed for PID ${target.pid}: ${(err as Error).message} — falling back to SIGTERM`);
   }
   // Fallback: SIGTERM the master process
   try {
@@ -156,16 +159,28 @@ export async function apply(ctx: MigrationContext): Promise<void> {
   }
 }
 
+export async function apply(ctx: MigrationContext): Promise<void> {
+  const targets = findLegacyEmbedded();
+  if (targets.length === 0) {
+    ctx.log('no legacy embedded found at apply time (race resolved)');
+    return;
+  }
+  for (const target of targets) {
+    stopLegacy(ctx, target);
+  }
+}
+
 export async function validate(_ctx: MigrationContext): Promise<void> {
-  // Allow up to 5s for shutdown
+  // Allow up to 5s for all strays to shut down
   const deadline = Date.now() + 5000;
   while (Date.now() < deadline) {
-    if (findLegacyEmbedded() === undefined) return;
+    if (findLegacyEmbedded().length === 0) return;
     // small sleep
     Bun.sleepSync(200);
   }
   const remaining = findLegacyEmbedded();
-  if (remaining) {
-    throw new Error(`legacy embedded still listening on port ${remaining.port} (PID ${remaining.pid}) after 5s`);
+  if (remaining.length > 0) {
+    const desc = remaining.map((p) => `port ${p.port} (PID ${p.pid})`).join(', ');
+    throw new Error(`legacy embedded still listening after 5s: ${desc}`);
   }
 }

--- a/test/migrations/002-kill-embedded-pgserve-legacy.test.ts
+++ b/test/migrations/002-kill-embedded-pgserve-legacy.test.ts
@@ -3,29 +3,40 @@ import { expect, test } from 'bun:test';
 import { selectLegacyEmbedded } from '../../src/migrations/steps/002-kill-embedded-pgserve-legacy.js';
 
 // Regression guard for the canonical-port-discovery fix: the legacy selector
-// must compare against the DISCOVERED canonical port, never a hardcoded 8432.
+// must compare against the DISCOVERED canonical port, never a hardcoded 8432,
+// and must return EVERY stray (not just the first) so apply stops them all.
 
 test('never selects the canonical postmaster (5432-only healthy host)', () => {
-  expect(selectLegacyEmbedded(5432, [{ pid: 100, port: 5432 }])).toBeUndefined();
+  expect(selectLegacyEmbedded(5432, [{ pid: 100, port: 5432 }])).toEqual([]);
 });
 
 test('selects the stray 8432, NOT the canonical 5432 (mixed migration window)', () => {
-  const got = selectLegacyEmbedded(5432, [
-    { pid: 100, port: 5432 },
+  expect(
+    selectLegacyEmbedded(5432, [
+      { pid: 100, port: 5432 },
+      { pid: 200, port: 8432 },
+    ]),
+  ).toEqual([{ pid: 200, port: 8432 }]);
+});
+
+test('selects ALL strays, not just the first (multiple legacy postmasters)', () => {
+  expect(
+    selectLegacyEmbedded(5432, [
+      { pid: 100, port: 5432 },
+      { pid: 200, port: 8432 },
+      { pid: 300, port: 9432 },
+    ]),
+  ).toEqual([
     { pid: 200, port: 8432 },
+    { pid: 300, port: 9432 },
   ]);
-  expect(got).toEqual({ pid: 200, port: 8432 });
 });
 
 test('legacy-era host: canonical on 8432, nothing stray → no-op', () => {
-  expect(selectLegacyEmbedded(8432, [{ pid: 100, port: 8432 }])).toBeUndefined();
+  expect(selectLegacyEmbedded(8432, [{ pid: 100, port: 8432 }])).toEqual([]);
 });
 
 test('canonical port unidentifiable (null) → never selects anything', () => {
-  expect(selectLegacyEmbedded(null, [{ pid: 100, port: 5432 }])).toBeUndefined();
-  expect(selectLegacyEmbedded(null, [])).toBeUndefined();
-});
-
-test('selects a single legacy when canonical is elsewhere', () => {
-  expect(selectLegacyEmbedded(5432, [{ pid: 300, port: 9432 }])).toEqual({ pid: 300, port: 9432 });
+  expect(selectLegacyEmbedded(null, [{ pid: 100, port: 5432 }])).toEqual([]);
+  expect(selectLegacyEmbedded(null, [])).toEqual([]);
 });

--- a/test/migrations/002-kill-embedded-pgserve-legacy.test.ts
+++ b/test/migrations/002-kill-embedded-pgserve-legacy.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from 'bun:test';
+
+import { selectLegacyEmbedded } from '../../src/migrations/steps/002-kill-embedded-pgserve-legacy.js';
+
+// Regression guard for the canonical-port-discovery fix: the legacy selector
+// must compare against the DISCOVERED canonical port, never a hardcoded 8432.
+
+test('never selects the canonical postmaster (5432-only healthy host)', () => {
+  expect(selectLegacyEmbedded(5432, [{ pid: 100, port: 5432 }])).toBeUndefined();
+});
+
+test('selects the stray 8432, NOT the canonical 5432 (mixed migration window)', () => {
+  const got = selectLegacyEmbedded(5432, [
+    { pid: 100, port: 5432 },
+    { pid: 200, port: 8432 },
+  ]);
+  expect(got).toEqual({ pid: 200, port: 8432 });
+});
+
+test('legacy-era host: canonical on 8432, nothing stray → no-op', () => {
+  expect(selectLegacyEmbedded(8432, [{ pid: 100, port: 8432 }])).toBeUndefined();
+});
+
+test('canonical port unidentifiable (null) → never selects anything', () => {
+  expect(selectLegacyEmbedded(null, [{ pid: 100, port: 5432 }])).toBeUndefined();
+  expect(selectLegacyEmbedded(null, [])).toBeUndefined();
+});
+
+test('selects a single legacy when canonical is elsewhere', () => {
+  expect(selectLegacyEmbedded(5432, [{ pid: 300, port: 9432 }])).toEqual({ pid: 300, port: 9432 });
+});


### PR DESCRIPTION
## Problem
Migration `002-kill-embedded-pgserve-legacy` hardcoded `CANONICAL_PORT = 8432` and stops any postgres listening on a *different* port. After the autopg-v3 socket-singleton cutover the canonical backbone binds **5432**, which makes this migration:

1. **Inert** on a healthy 5432 host (it probes 8432 for "canonical", finds nothing, no-ops); and worse
2. **Actively dangerous** in the mixed window where a stray legacy postmaster is still live on 8432 alongside canonical 5432 — it treats 8432 as canonical and **stops the real 5432 backbone** as "legacy".

This affects any user upgrading across the 8432→5432 cutover, not just one host.

## Fix
Discover the canonical port from the autopg/pgserve binary at runtime (`<bin> status --json` → `.port`), never hardcode it. When no canonical binary is installed or it can't report a port, the migration is a **safe no-op** — we never stop a postmaster we can't positively distinguish from canonical.

- Extracted `selectLegacyEmbedded(canonicalPort, listening)` as a pure, unit-tested helper.
- Memoized port resolution for the migration run.

## Tests
`test/migrations/002-kill-embedded-pgserve-legacy.test.ts` (5 cases): never selects canonical on a 5432-only host; selects the stray 8432 (not 5432) in the mixed window; no-op when canonical port is unidentifiable (null); legacy-era 8432 no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)