### PR TITLE
fix: use script-based tmux launch to prevent Omni spawn corruption

### DIFF
--- a/.well-known/dev.json
+++ b/.well-known/dev.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "channel": "dev",
-  "version": "4.260525.1",
-  "released_at": "2026-05-25T01:24:55Z",
-  "tarball_base": "https://github.com/automagik-dev/genie/releases/download/v4.260525.1",
+  "version": "4.260525.2",
+  "released_at": "2026-05-25T12:19:49Z",
+  "tarball_base": "https://github.com/automagik-dev/genie/releases/download/v4.260525.2",
   "platforms": ["linux-x64-glibc", "linux-x64-musl", "linux-arm64", "darwin-arm64"]
 }

--- a/scripts/tests/omni-spawn-smoke.ts
+++ b/scripts/tests/omni-spawn-smoke.ts
@@ -1,0 +1,162 @@
+#!/usr/bin/env bun
+/**
+ * Smoke test for issue #2486 — Omni-Bridge spawn command corruption.
+ *
+ * Validates that the NEW script-based path (writeTmuxLaunchScript + source)
+ * works reliably with long commands containing backticks, emojis, parentheses,
+ * and nested quotes.
+ *
+ * Run with:
+ *   bun run scripts/tests/omni-spawn-smoke.ts
+ */
+
+import { execSync } from 'node:child_process';
+import { readFileSync, unlinkSync } from 'node:fs';
+import { writeTmuxLaunchScript } from '../../src/lib/tmux-launch-script.js';
+
+const MARKER = 'OMNI_SPAWN_SUCCESS_2486';
+const RESULT_FILE = `/tmp/${MARKER}`;
+
+// Build a deliberately nasty payload with all the problematic chars.
+// We wrap everything in a single 'sh -c' so writeTmuxLaunchScript's
+// leading 'exec' works correctly (the real Genie launches 'claude',
+// a long-running process; here we use 'sleep' to keep the pane alive
+// long enough for capture).
+const nastyPayload = '👍 `backticks` (instance: alpha) (ALWAYS your last action)';
+const innerCommand = [
+  `echo '${MARKER}'`,
+  `export TEST_VAR='${nastyPayload}'`,
+  `export JSON='{"emoji":"👍","nested":"(instance: alpha)"}'`,
+  `export LONG='${'A'.repeat(1800)}'`,
+  `touch ${RESULT_FILE}`,
+  'sleep 1',
+].join(' && ');
+
+// The full command that Genie would pass to writeTmuxLaunchScript
+const nastyCommand = `sh -c '${innerCommand.replace(/'/g, "'\\''")}'`;
+
+function killServer(socket: string) {
+  try {
+    execSync(`tmux -L ${socket} kill-server 2>/dev/null`, { stdio: 'ignore' });
+  } catch {
+    // ignore
+  }
+}
+
+function cleanup(socket: string, scriptPath?: string) {
+  killServer(socket);
+  try {
+    unlinkSync(RESULT_FILE);
+  } catch {
+    // ignore
+  }
+  if (scriptPath) {
+    try {
+      unlinkSync(scriptPath);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+function createPane(socket: string): string {
+  execSync(`tmux -L ${socket} new-session -d -e LC_ALL=C.UTF-8 -e LANG=C.UTF-8`, { stdio: 'ignore' });
+  execSync('sleep 0.3');
+  const paneId = execSync(`tmux -L ${socket} list-panes -F '#{pane_id}'`, { encoding: 'utf-8' }).trim();
+  return paneId;
+}
+
+function capturePane(socket: string, paneId: string): string {
+  try {
+    return execSync(`tmux -L ${socket} capture-pane -p -t '${paneId}' -S -10`, { encoding: 'utf-8' });
+  } catch {
+    return '';
+  }
+}
+
+function waitForResult(socket: string, paneId: string, timeoutMs = 5000): boolean {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const content = capturePane(socket, paneId);
+    if (content.includes(MARKER)) return true;
+    if (content.includes('parse error')) return false;
+    execSync('sleep 0.2');
+  }
+  return false;
+}
+
+console.log('=== Omni-Bridge Spawn Smoke Test (#2486) ===\n');
+
+// ---------------------------------------------------------------------------
+// TEST 1: OLD inline path (replicates executeTmux -> send-keys without -l)
+// ---------------------------------------------------------------------------
+const socket1 = 'genie-smoke-old';
+console.log('TEST 1: Inline send-keys (old path)');
+cleanup(socket1);
+const pane1 = createPane(socket1);
+
+// Replicate the OLD Genie path exactly:
+// executeTmux(`send-keys -t '${paneId}' ${shellQuote(cmd)} Enter`)
+const quotedOld = `'${nastyCommand.replace(/'/g, "'\\''")}'`;
+try {
+  execSync(`tmux -L ${socket1} send-keys -t '${pane1}' ${quotedOld} Enter`);
+} catch (e) {
+  console.log(`  tmux send-keys itself failed: ${e instanceof Error ? e.message : e}`);
+}
+
+const oldOk = waitForResult(socket1, pane1);
+const oldContent = capturePane(socket1, pane1);
+const oldHasParseError = oldContent.includes('parse error');
+console.log(`  Parse error visible: ${oldHasParseError}`);
+console.log(`  Marker detected: ${oldOk}`);
+console.log(`  Result: ${oldOk ? 'PASS' : 'FAIL / FLAKY'}\n`);
+
+killServer(socket1);
+
+// ---------------------------------------------------------------------------
+// TEST 2: NEW script-based path
+// ---------------------------------------------------------------------------
+const socket2 = 'genie-smoke-new';
+console.log('TEST 2: Script-based send-keys (writeTmuxLaunchScript + source)');
+cleanup(socket2);
+const pane2 = createPane(socket2);
+
+const scriptPath = writeTmuxLaunchScript('smoke-2486', nastyCommand);
+// Replicate the NEW Genie path:
+// executeTmux(`send-keys -t '${paneId}' "source ${scriptPath}" Enter`)
+execSync(`tmux -L ${socket2} send-keys -t '${pane2}' "source ${scriptPath}" Enter`);
+
+const newOk = waitForResult(socket2, pane2);
+const newContent = capturePane(socket2, pane2);
+const newHasParseError = newContent.includes('parse error');
+let markerOnDisk = false;
+try {
+  markerOnDisk = readFileSync(RESULT_FILE).toString().trim() === '';
+} catch {
+  markerOnDisk = false;
+}
+console.log(`  Parse error visible: ${newHasParseError}`);
+console.log(`  Marker in pane: ${newContent.includes(MARKER)}`);
+console.log(`  Marker file created: ${markerOnDisk}`);
+console.log(`  Result: ${newOk ? 'PASS' : 'FAIL'}\n`);
+
+cleanup(socket2, scriptPath);
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log('=== Summary ===');
+if (!oldOk && newOk) {
+  console.log('✅ Fix validated: inline path fails, script path is stable.');
+  process.exit(0);
+} else if (oldOk && newOk) {
+  console.log('⚠️  Both paths passed on this machine (tmux/zsh may be tolerant for this payload).');
+  console.log('   The script path is still the safer architectural choice for 1968+ char payloads.');
+  process.exit(0);
+} else if (!newOk) {
+  console.log('❌ New script path failed — investigate.');
+  process.exit(1);
+} else {
+  console.log('❓ Unexpected state — review output above.');
+  process.exit(1);
+}

--- a/src/lib/__tests__/tmux-launch-script.test.ts
+++ b/src/lib/__tests__/tmux-launch-script.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for tmux-launch-script.ts
+ */
+
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { writeTmuxLaunchScript } from '../tmux-launch-script.js';
+
+const SPAWN_DIR = join(homedir(), '.genie', 'spawn-scripts');
+
+describe('writeTmuxLaunchScript', () => {
+  beforeEach(() => {
+    // Clean up any leftover test scripts
+    try {
+      const files = require('node:fs').readdirSync(SPAWN_DIR);
+      for (const f of files) {
+        if (f.startsWith('test-') || f.startsWith('omni-')) {
+          rmSync(join(SPAWN_DIR, f));
+        }
+      }
+    } catch {
+      // dir may not exist yet
+    }
+  });
+
+  test('creates a script with shebang and exec command', () => {
+    const path = writeTmuxLaunchScript('test-worker', 'echo hello');
+    expect(existsSync(path)).toBe(true);
+
+    const content = readFileSync(path, 'utf-8');
+    expect(content).toStartWith('#!/bin/sh\n');
+    expect(content).toInclude('exec echo hello\n');
+  });
+
+  test('sanitizes workerId in filename', () => {
+    const path = writeTmuxLaunchScript('worker/with:bad@chars', 'echo hello');
+    const basename = path.split('/').pop()!;
+    expect(basename).toMatch(/^worker-with-bad-chars-/);
+    expect(basename).toEndWith('.sh');
+  });
+
+  test('creates script in ~/.genie/spawn-scripts', () => {
+    const path = writeTmuxLaunchScript('test-worker', 'echo hello');
+    expect(path).toStartWith(SPAWN_DIR);
+  });
+
+  test('sets executable permissions', () => {
+    const path = writeTmuxLaunchScript('test-worker', 'echo hello');
+    const stats = require('node:fs').statSync(path);
+    // Check owner-execute bit
+    expect(stats.mode & 0o100).toBe(0o100);
+  });
+
+  test('preserves complex commands with quotes and backticks', () => {
+    const cmd = `OMNI_API_KEY='sk-123' claude --permission-mode 'auto' --system-prompt 'Use \`git\` (👍) for (instance: x)'`;
+    const path = writeTmuxLaunchScript('omni-chat-123', cmd);
+    const content = readFileSync(path, 'utf-8');
+    expect(content).toInclude(`exec ${cmd}\n`);
+  });
+});

--- a/src/lib/tmux-launch-script.ts
+++ b/src/lib/tmux-launch-script.ts
@@ -1,0 +1,29 @@
+/**
+ * Tmux Launch Script — Write a temporary shell script for complex tmux spawns.
+ *
+ * Long commands with nested quotes, backticks, emojis, and JSON escapes corrupt
+ * when passed through `tmux send-keys`. Writing the command to a script file and
+ * sourcing it from the pane removes the escaping surface and keeps the launch
+ * stable.
+ */
+
+import { chmodSync, mkdirSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Write a temporary launch script for complex tmux spawns.
+ *
+ * @param workerId — identifier used in the filename (e.g. agent or chat id)
+ * @param fullCommand — the complete shell command to execute
+ * @returns absolute path to the written script
+ */
+export function writeTmuxLaunchScript(workerId: string, fullCommand: string): string {
+  const dir = join(homedir(), '.genie', 'spawn-scripts');
+  mkdirSync(dir, { recursive: true });
+  const safeId = workerId.replace(/[^a-zA-Z0-9._-]/g, '-');
+  const scriptPath = join(dir, `${safeId}-${Date.now().toString(36)}.sh`);
+  writeFileSync(scriptPath, `#!/bin/sh\n${fullCommand}\n`, { mode: 0o700 });
+  chmodSync(scriptPath, 0o700);
+  return scriptPath;
+}

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -664,7 +664,7 @@ export async function isPaneProcessRunning(
     const exec: ExecSyncFn = execSyncFn ?? ((await import('node:child_process')).execSync as ExecSyncFn);
     // Check direct children and grandchildren for the target process name
     const output = exec(
-      `pgrep -la -P ${panePid} 2>/dev/null; for cpid in $(pgrep -P ${panePid} 2>/dev/null); do pgrep -la -P "$cpid" 2>/dev/null; done; true`,
+      `pgrep -la -P ${panePid} 2>/dev/null; for cpid in $(pgrep -P ${panePid} 2>/dev/null); do pgrep -la -P "$cpid" 2>/dev/null; ps -p "$cpid" -o comm= 2>/dev/null; done; true`,
       { encoding: 'utf-8', timeout: 5000 },
     );
     return output.toLowerCase().includes(processName.toLowerCase());

--- a/src/services/executors/claude-code.ts
+++ b/src/services/executors/claude-code.ts
@@ -18,6 +18,7 @@ import { signOmniRequest } from '../../lib/omni-signature.js';
 import { buildLaunchCommand } from '../../lib/provider-adapters.js';
 import type { SpawnParams } from '../../lib/provider-adapters.js';
 import { shellQuote } from '../../lib/team-lead-command.js';
+import { writeTmuxLaunchScript } from '../../lib/tmux-launch-script.js';
 import {
   capturePaneContent,
   ensureTeamWindow,
@@ -255,7 +256,8 @@ export class ClaudeCodeOmniExecutor implements IExecutor {
       .map(([k, v]) => `${k}=${shellQuote(v)}`)
       .join(' ');
     const cmd = envPrefix ? `${envPrefix} ${launch.command}` : launch.command;
-    await executeTmux(`send-keys -t '${paneId}' ${shellQuote(cmd)} Enter`);
+    const scriptPath = writeTmuxLaunchScript(`omni-${chatId}`, cmd);
+    await executeTmux(`send-keys -t '${paneId}' "source ${scriptPath}" Enter`);
     return claudeSessionId;
   }
 

--- a/src/term-commands/agents.ts
+++ b/src/term-commands/agents.ts
@@ -45,6 +45,7 @@ import {
   resolveTeamForSpawn,
   resolveTeamForSpawnWithDeps,
 } from '../lib/team-resolver.js';
+import { writeTmuxLaunchScript } from '../lib/tmux-launch-script.js';
 import { genieTmuxCmd, prependEnvVars } from '../lib/tmux-wrapper.js';
 import * as tmux from '../lib/tmux.js';
 import { TmuxUnreachableError, executeTmux, isPaneAlive } from '../lib/tmux.js';
@@ -795,28 +796,6 @@ type TeamWindowInfo = {
 
 function shellQuote(arg: string): string {
   return `'${arg.replace(/'/g, "'\\''")}'`;
-}
-
-/**
- * Write a temporary launch script for complex tmux spawns.
- *
- * Native Claude team launches carry many quoted flags and prompt-file args. In
- * some shells that last outer-shell → tmux → inner-shell hop can mangle argv.
- * Executing a script path removes one parsing layer and keeps the worker launch
- * stable.
- */
-function writeTmuxLaunchScript(workerId: string, fullCommand: string): string {
-  const { chmodSync, mkdirSync, writeFileSync } = require('node:fs');
-  const { join } = require('node:path');
-  const { homedir } = require('node:os');
-
-  const dir = join(homedir(), '.genie', 'spawn-scripts');
-  mkdirSync(dir, { recursive: true });
-  const safeId = workerId.replace(/[^a-zA-Z0-9._-]/g, '-');
-  const scriptPath = join(dir, `${safeId}-${Date.now().toString(36)}.sh`);
-  writeFileSync(scriptPath, `#!/bin/sh\nexec ${fullCommand}\n`, { mode: 0o700 });
-  chmodSync(scriptPath, 0o700);
-  return scriptPath;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fix Omni-Bridge spawn corruption for commands containing backticks, emojis, parentheses, and nested quotes by switching from inline `tmux send-keys` to a script-based launch path
- Extract `writeTmuxLaunchScript` into its own module so both `agents.ts` (agent spawn) and `claude-code.ts` (Omni bridge) share the same stable launch mechanism
- Fix grandchild process detection in `isPaneProcessRunning` by checking the process name directly via `ps`

## Details

Long commands with shell-special characters (backticks, emojis, JSON, nested quotes) would corrupt when passed through `tmux send-keys` — the extra shell hop mangled argv boundaries. By writing the command to a temp script and `source`-ing it from the pane, we eliminate the escaping surface entirely.

The `writeTmuxLaunchScript` helper was previously defined inline in `agents.ts`. This PR promotes it to `src/lib/tmux-launch-script.ts` so the Claude Code Omni executor can use the same mechanism, and adds unit tests for script creation, permissions, worker-id sanitization, and complex command preservation.

The smoke test (`scripts/tests/omni-spawn-smoke.ts`) validates both paths side-by-side in real tmux sessions.

Closes #2486

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tmux command execution to better handle special characters, quotes, and complex payloads.
  * Enhanced process-name detection in tmux pane monitoring.

* **Chores**
  * Updated dev channel release to version 4.260525.2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/automagik-dev/genie/pull/2487?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->