### PR TITLE
docs: remove Severance theme refs + fix /wizard usage (follow-up to #2492)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,8 @@ jobs:
             exit 1
           fi
 
-      # Visual regression — TUI snapshots locked to the Severance Lumon-MDR
-      # palette (Group 6 of the design-system-severance wish). Any palette
+      # Visual regression — TUI snapshots locked to the petrol/mint
+      # palette. Any palette
       # token change without a matching `bun test test/visual/ -u` rerun
       # produces a snapshot diff and fails the build. Runs before knip so a
       # palette regression surfaces with a clean error rather than after

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,7 +130,7 @@ Wish: `wish/tui-native-selection`.
 
 ### Breaking — design system
 
-- **Unified design system on the Severance Lumon-MDR palette.** All color
+- **Unified design system on the petrol/mint palette.** All color
   tokens now live in a single workspace package, `packages/genie-tokens/`,
   consumed by the TUI (`src/tui/theme.ts`), the desktop app
   (`packages/genie-app/lib/theme.ts`), and tmux (via the generated

--- a/README.md
+++ b/README.md
@@ -29,14 +29,15 @@ Genie is a CLI that turns one sentence into a finished pull request. You describ
 curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash
 ```
 
-Every release is cosign-signed with SLSA provenance — the installer verifies the binary before it runs. Then:
+Every release is cosign-signed with SLSA provenance — the installer verifies the binary before it runs.
 
-```bash
-genie
-/wizard      # interviews you, scaffolds your project, walks your first wish
+Then, in Claude Code, Codex, or any AI coding agent, run the onboarding wizard:
+
+```text
+/wizard
 ```
 
-Run `genie doctor` anytime to check your install.
+It interviews you, scaffolds the project, and walks you through your first wish. Prefer the cockpit? `genie` opens the terminal UI; `genie doctor` checks your install.
 
 ## What you get
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ A ground-up rewrite.
 
 ## Design
 
-A single dark-only palette inspired by **Severance** — one source of truth (`packages/genie-tokens/`), three consumers (TUI, desktop app, tmux).
+A single dark-only palette from one source of truth (`packages/genie-tokens/`), shared by three consumers (TUI, desktop app, tmux).
 
 ---
 

--- a/packages/genie-app/lib/theme.ts
+++ b/packages/genie-app/lib/theme.ts
@@ -1,7 +1,7 @@
 /**
  * Genie design tokens — re-export from `@automagik/genie-tokens`.
  *
- * Severance Lumon-MDR palette: petrol bg, mint accent, calm amber/crimson alarms.
+ * Petrol/mint palette: petrol bg, mint accent, calm amber/crimson alarms.
  * All views import `palette`/`tokens` from here; never hard-code hex.
  */
 
@@ -26,7 +26,7 @@ export const radii = {
  * from `genie-tokens`.
  */
 export const theme = {
-  // Accent surface (legacy purple/violet → Severance mint)
+  // Accent surface (legacy purple/violet → mint)
   purple: palette.accentBright,
   violet: palette.accent,
   cyan: palette.info,

--- a/packages/genie-tokens/__tests__/palette.test.ts
+++ b/packages/genie-tokens/__tests__/palette.test.ts
@@ -41,7 +41,7 @@ describe('palette shape', () => {
     }
   });
 
-  test('Severance signature values are exact', () => {
+  test('signature palette values are exact', () => {
     expect(palette.bg).toBe('#0a1d2a');
     expect(palette.accent).toBe('#7fc8a9');
     expect(palette.error).toBe('#a83838');
@@ -59,9 +59,9 @@ describe('semantic tokens', () => {
     'dangerStrong',
     'attention',
     'info',
-    'severed',
-    'outieWarm',
-    'lumonBeige',
+    'muted',
+    'warm',
+    'beige',
   ] as const;
 
   test.each(requiredAliases)('%s is exposed and resolves to a palette value', (alias) => {
@@ -79,9 +79,9 @@ describe('semantic tokens', () => {
     expect(tokens.dangerStrong).toBe(palette.errorBright);
     expect(tokens.attention).toBe(palette.warning);
     expect(tokens.info).toBe(palette.info);
-    expect(tokens.severed).toBe(palette.innieGrey);
-    expect(tokens.outieWarm).toBe(palette.outieAmber);
-    expect(tokens.lumonBeige).toBe(palette.beige);
+    expect(tokens.muted).toBe(palette.mutedGrey);
+    expect(tokens.warm).toBe(palette.warmAmber);
+    expect(tokens.beige).toBe(palette.beige);
   });
 });
 
@@ -103,8 +103,8 @@ describe('WCAG AA contrast', () => {
   });
 
   test('errorBright on bg meets 3:1 — escalated alarm state must be readable', () => {
-    // Note: `palette.error` (#a83838) is intentionally desaturated per the Severance
-    // design ("Red is rare and means alarm — never decorative"). When higher contrast
+    // Note: `palette.error` (#a83838) is intentionally desaturated by design
+    // ("Red is rare and means alarm — never decorative"). When higher contrast
     // is required, surfaces use `errorBright` (the hover/escalation state).
     expect(contrast(palette.errorBright, palette.bg)).toBeGreaterThanOrEqual(3);
   });

--- a/packages/genie-tokens/package.json
+++ b/packages/genie-tokens/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Genie design tokens — Severance Lumon-MDR palette + semantic aliases.",
+  "description": "Genie design tokens — petrol/mint palette + semantic aliases.",
   "main": "index.ts",
   "exports": {
     ".": "./index.ts",

--- a/packages/genie-tokens/palette.ts
+++ b/packages/genie-tokens/palette.ts
@@ -1,14 +1,13 @@
 /**
- * Severance Lumon-MDR palette — primitive hex values.
+ * Genie palette — primitive hex values.
  *
- * Reference: TV show "Severance" (Apple TV+).
- * - MDR terminal: black-petrol bg, mint-green monospace text, desaturated red alarms.
- * - Lumon offices: pale beige walls, deep navy carpet, fluorescent overhead light.
- * - Severed/Innie palette is muted; warmth (amber) reserved for the Outie world.
+ * A dark, calm scheme:
+ * - Terminal surface: black-petrol bg, mint-green monospace text, desaturated red alarms.
+ * - Muted base palette; warm beige/amber reserved for rare highlights.
  * - Red is rare and means alarm — never decorative.
  */
 export const palette = {
-  // Surfaces (Lumon institutional)
+  // Surfaces
   bg: '#0a1d2a',
   bgRaised: '#0f2638',
   bgHover: '#143049',
@@ -23,7 +22,7 @@ export const palette = {
   border: '#2a3f4f',
   borderActive: '#7fc8a9',
 
-  // Accent (MDR terminal text — replaces brand purple)
+  // Accent (mint terminal text — replaces brand purple)
   accent: '#7fc8a9',
   accentDim: '#5a9d82',
   accentBright: '#9eddc1',
@@ -35,10 +34,10 @@ export const palette = {
   errorBright: '#c44a4a',
   info: '#5a8ca8',
 
-  // Severance accents (rare)
+  // Warm accents (rare)
   beige: '#d4c5a9',
-  innieGrey: '#5e6e74',
-  outieAmber: '#d4a574',
+  mutedGrey: '#5e6e74',
+  warmAmber: '#d4a574',
 
   // Scrollbar
   scrollTrack: '#2a3f4f',

--- a/packages/genie-tokens/tokens.ts
+++ b/packages/genie-tokens/tokens.ts
@@ -27,9 +27,9 @@ export const tokens = {
   info: palette.info,
   success: palette.success,
 
-  severed: palette.innieGrey,
-  outieWarm: palette.outieAmber,
-  lumonBeige: palette.beige,
+  muted: palette.mutedGrey,
+  warm: palette.warmAmber,
+  beige: palette.beige,
 } as const;
 
 export type TokenKey = keyof typeof tokens;

--- a/scripts/tmux/generate-theme.ts
+++ b/scripts/tmux/generate-theme.ts
@@ -2,7 +2,7 @@
 /**
  * Generate the tmux theme file from genie-tokens.
  *
- * Reads the Severance Lumon-MDR palette from `packages/genie-tokens` and emits
+ * Reads the petrol/mint palette from `packages/genie-tokens` and emits
  * `scripts/tmux/.generated.theme.conf` with every color-bearing tmux directive:
  * styles (status, pane border, message, mode, clock) and format strings
  * (pane-border-format, status-format[0], status-format[1]).

--- a/scripts/tmux/genie.tmux.conf
+++ b/scripts/tmux/genie.tmux.conf
@@ -1,6 +1,6 @@
 # ============================================================================
 # Genie TUI — tmux configuration
-# Severance Lumon-MDR theme (petrol bg, mint accent).
+# Petrol/mint theme (petrol bg, mint accent).
 # Native tmux 3.3+, zero plugins.
 #
 # Layout:

--- a/src/tui/components/TreeNode.tsx
+++ b/src/tui/components/TreeNode.tsx
@@ -148,7 +148,7 @@ export function getAgentColor(node: TreeNodeType): string {
   // Mirrors getAgentIcon — work-state first, process state fallback.
   switch (node.workState) {
     case 'in_flight':
-      // Was palette.emerald pre design-system rebase. Lumon-MDR migration
+      // Was palette.emerald pre design-system rebase. The palette migration
       // hard-cut emerald/cyan aliases (theme.ts:5); accentBright is the
       // semantic equivalent for "active, attention-getting" without
       // re-introducing the dropped color name.

--- a/src/tui/theme.ts
+++ b/src/tui/theme.ts
@@ -1,5 +1,5 @@
 /**
- * TUI theme — Severance Lumon-MDR palette.
+ * TUI theme — petrol/mint palette.
  *
  * Hard re-export of the workspace `genie-tokens` package. No backward-compat
  * aliases for the old purple/violet/cyan/emerald names; every call site has

--- a/src/tui/widgets/xterm-cell-paint.ts
+++ b/src/tui/widgets/xterm-cell-paint.ts
@@ -121,7 +121,7 @@ export interface PaintOptions {
   cols: number;
   /** Max rows to paint. */
   rows: number;
-  /** Host theme overrides (default ≈ Lumon-MDR palette). */
+  /** Host theme overrides (default ≈ petrol/mint palette). */
   theme?: PaintTheme;
 }
 

--- a/test/visual/tui-snapshot.test.tsx
+++ b/test/visual/tui-snapshot.test.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Visual regression harness for the Severance Lumon-MDR TUI palette.
+ * Visual regression harness for the petrol/mint TUI palette.
  *
  * Renders each major TUI surface to an opentui char-frame and asserts the
  * frame against a committed snapshot. The snapshot encodes both the layout


### PR DESCRIPTION
Follow-up to #2492, which **merged before these two commits landed** — so they didn't make it into `dev`. This PR carries them in.

### 1. Remove Severance/Lumon theme references (codebase-wide)
The palette was branded after the TV show *Severance* (Lumon/MDR). Stripped the brand everywhere shipped/user-facing while keeping the **exact hex values** (TUI/app/tmux render identically):
- **`packages/genie-tokens`** (private pkg): renamed identifiers — tokens `severed→muted`, `outieWarm→warm`, `lumonBeige→beige`; palette keys `innieGrey→mutedGrey`, `outieAmber→warmAmber` — + doc comments. Tokens test 24/0 pass.
- Scrubbed comments/descriptions in `src/tui/*`, `packages/genie-app/lib/theme.ts`, `scripts/tmux/*`, `test/visual/tui-snapshot.test.tsx`, `.github/workflows/ci.yml`, and the `CHANGELOG.md` design-system entry.
- README Design section: dropped "inspired by Severance".
- **Left intact:** the `design-system-severance` wish slug (DB migration `050` matches it to archive legacy rows — renaming breaks the cleanup).

### 2. Fix `/wizard` usage in the README
`genie` (no args) launches the TUI; `/wizard` is a **skill invoked inside Claude Code / Codex**, not a command typed after `genie`. The install snippet wrongly showed it in a `bash` fence after `genie`. Now presented correctly as an AI-agent slash command.

### Companion docs PR
The engineering-internal `design-system.mdx` (Severance prose + old token names) is scrubbed in **automagik-dev/docs#76**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)