### PR TITLE
fix(spawn): suppress bare --agent for native-team workers (Claude Code 2.1.191)

### DIFF
--- a/src/lib/provider-adapters.test.ts
+++ b/src/lib/provider-adapters.test.ts
@@ -192,6 +192,25 @@ describe('buildClaudeCommand', () => {
     expect(result.command).toContain("--agent 'engineer'");
   });
 
+  // CC 2.1.191 regression: native-team workers must NOT receive a bare
+  // `--agent <name>` flag. 2.1.191 hard-rejects `--agent <unregistered-name>`
+  // ("agent '<name>' not found"), killing the worker before the readiness
+  // probe. Identity is carried by --agent-id/--agent-name/--agent-type instead.
+  it('suppresses bare --agent when nativeTeam is enabled', () => {
+    const result = buildClaudeCommand({
+      provider: 'claude',
+      team: 'work',
+      role: 'genie-nodra',
+      systemPromptFile: '/path/to/AGENTS.md',
+      nativeTeam: { enabled: true, agentName: 'genie-nodra', agentType: 'genie-nodra' },
+    });
+    // Native-team identity flags ARE present...
+    expect(result.command).toContain("--agent-name 'genie-nodra'");
+    expect(result.command).toContain("--agent-type 'genie-nodra'");
+    // ...but the bare `--agent '<name>'` flag is NOT.
+    expect(result.command).not.toContain("--agent '");
+  });
+
   it('does not include hidden teammate flags', () => {
     const result = buildClaudeCommand({ provider: 'claude', team: 'work', role: 'implementor' });
     expect(result.command).not.toContain('--teammate');

--- a/src/lib/provider-adapters.ts
+++ b/src/lib/provider-adapters.ts
@@ -416,7 +416,15 @@ function appendSessionFlags(parts: string[], params: SpawnParams): void {
   // the agents.ts:buildSpawnParams call site is now responsible for
   // setting agentTemplate to the verified template name so the right
   // value reaches Claude's template lookup.
-  const claudeAgentFlag = params.agentTemplate ?? params.role;
+  // Claude Code >=2.1.191 hard-rejects `--agent <name>` unless <name> is a
+  // registered subagent definition ("agent '<name>' not found"), which kills
+  // the spawn ~immediately. Native-team workers establish identity via
+  // --agent-id/--agent-name/--agent-type and carry their own system prompt
+  // (AGENTS.md), so they neither need nor want a subagent definition. Only
+  // emit --agent for non-native-team spawns. (Empirically verified on 2.1.191:
+  // the native-team flag set launches cleanly without --agent; adding --agent
+  // <unregistered-name> makes it exit before the readiness probe.)
+  const claudeAgentFlag = params.nativeTeam?.enabled ? undefined : (params.agentTemplate ?? params.role);
   if (claudeAgentFlag) parts.push('--agent', escapeShellArg(claudeAgentFlag));
   if (params.model) parts.push('--model', escapeShellArg(params.model));
   // NOTE: --name intentionally NOT emitted. CC stores --name as `customTitle`

--- a/src/services/executors/claude-code.test.ts
+++ b/src/services/executors/claude-code.test.ts
@@ -129,6 +129,15 @@ describe('buildOmniSpawnParams', () => {
     expect(params.nativeTeam?.color).toBe('pink');
   });
 
+  test('sets nativeTeam.agentType so the launch command emits --agent-type', () => {
+    // Regression: Claude Code >=2.1.191 rejects `--agent <name>` when the type
+    // was never declared, killing every freshly-spawned omni turn-handler ~15s
+    // after launch. agentType must match the agent name (mirrors the base/dir
+    // spawn path which sets it from template.role).
+    const params = buildOmniSpawnParams('simone', 'chat123', fakeEntry, {});
+    expect(params.nativeTeam?.agentType).toBe('simone');
+  });
+
   test('passes model from directory entry', () => {
     const params = buildOmniSpawnParams('simone', 'chat123', fakeEntry, {});
     expect(params.model).toBe('opus');

--- a/src/services/executors/claude-code.ts
+++ b/src/services/executors/claude-code.ts
@@ -201,6 +201,13 @@ export function buildOmniSpawnParams(
     nativeTeam: {
       enabled: true,
       agentName,
+      // Register the agent type so the launch command emits `--agent-type <name>`
+      // alongside `--agent <name>`. Claude Code >=2.1.191 rejects `--agent <name>`
+      // when the type was never declared ("agent '<name>' not found"), which kills
+      // every freshly-spawned omni turn-handler ~15s after launch. The base/dir
+      // spawn path already sets this via protocol-router-spawn (template.role);
+      // the omni bridge path was missing it.
+      agentType: agentName,
       color: (entry.color as 'blue' | undefined) ?? undefined,
     },
   };


### PR DESCRIPTION
## Problem

**Claude Code 2.1.191** hard-rejects `--agent <name>` unless `<name>` is a registered subagent definition:

```
--agent 'genie-nodra' not found. Available agents: claude, claude-code-guide, Explore, general-purpose, Plan, statusline-setup
```

Genie's launch builder emits a bare `--agent <role>` for **every** native-team spawn. On 2.1.191 this kills the worker before the readiness probe — breaking **all** fresh spawns:

- **omni turn-handlers** (Telegram/WhatsApp bots): `Session active` → `Dead session detected` ~15s later, on a loop, one cycle per inbound message. Bots silently stop replying.
- **`genie agent spawn`** (team leads): `worker process exited before the readiness probe succeeded`.

Agents only survive if they had a live tmux session predating the Claude update.

## Root cause

`appendSessionFlags` (`src/lib/provider-adapters.ts`) always emits `--agent <agentTemplate ?? role>`. Native-team workers establish identity via `--agent-id`/`--agent-name`/`--agent-type` and carry their own system prompt (AGENTS.md) — they neither need nor want a claude subagent definition. The bare `--agent` is redundant and, on 2.1.191, fatal.

## Fix

Suppress the bare `--agent` flag whenever `nativeTeam.enabled`. Non-native-team spawns are unchanged (Group 21 template-resolution preserved). Also sets `nativeTeam.agentType` for omni spawns so `--agent-type` is emitted (was missing).

## Verification

Empirical, on Claude Code 2.1.191:
- `claude --agent-id … --agent-name … --team-name … --agent-type … --session-id … --agent xtest --print 'OK'` → **`--agent 'xtest' not found`**
- same command **without** `--agent` → **`OK`** (launches cleanly)

Tests: `bun test src/lib/provider-adapters.test.ts src/services/executors/claude-code.test.ts` → **125 pass / 0 fail**. Typecheck + lint clean. New regression test asserts bare `--agent` is suppressed under `nativeTeam`.

## Deploy note

The running server had this bug in two separate binaries (the omni bridge `dist/genie.js` and the standalone CLI). Both need the released fix via `genie update` once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)