### PR TITLE
feat: v5 completion — CLAUDE.md truth, Codex launch target, 5.x distribution

### DIFF
--- a/.genie/wishes/v5-completion/WISH.md
+++ b/.genie/wishes/v5-completion/WISH.md
@@ -66,9 +66,9 @@ Close out the v5 lightweight body with the three remaining independent tracks, b
 2. Drift-guard: a test or e2e grep gate asserting `CLAUDE.md` contains none of the retired-fossil tokens.
 
 **Acceptance Criteria:**
-- [ ] Zero stale-v4 fossils (grep gate incl. the native-teams tokens); real 12-command surface + genie.db + in-process hooks documented; still-true sections preserved; OTel relay reference (if any) untouched.
-- [ ] Drift-guard gate fails hard if a fossil returns.
-- [ ] `bun run check` green.
+- [x] Zero stale-v4 fossils (grep gate incl. the native-teams tokens); real 12-command surface + genie.db + in-process hooks documented; still-true sections preserved; OTel relay reference (if any) untouched.
+- [x] Drift-guard gate fails hard if a fossil returns.
+- [x] `bun run check` green.
 
 **Validation:**
 ```bash

--- a/.genie/wishes/v5-completion/WISH.md
+++ b/.genie/wishes/v5-completion/WISH.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | DRAFT |
+| **Status** | DONE — all 3 groups SHIP-reviewed (2026-07-02); 3 commits |
 | **Slug** | `v5-completion` |
 | **Date** | 2026-07-02 |
 | **Author** | Felipe + Genie |
@@ -44,10 +44,10 @@ Close out the v5 lightweight body with the three remaining independent tracks, b
 
 ## Success Criteria
 
-- [ ] G1: `CLAUDE.md` has zero references to the retired v4 surface (`genie agent`/`genie team`/`genie exec` namespaces, pgserve/PostgreSQL, `GENIE_OTEL_PORT`, tmux orchestration, native-teams/`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`/`workers.json`/`GENIE_IDLE_TIMEOUT_MS`/mailbox, "~305KB" bundle); it documents the real 12 commands + genie.db + in-process hooks; a drift-guard grep gate fails if any fossil returns; the still-true sections are preserved; `bun run check` green.
-- [ ] G2: `genie launch <slug> --agent codex --dry-run` emits a pane command of the form `codex exec "$(cat …)"` against the worktree prompt (asserted in the YAML); `--agent claude` (default) output is byte-identical to today; an invalid `--agent` value → typed error; the Hermes decision doc exists under `.genie/` with a clear recommendation; launch tests green.
-- [ ] G3: `package.json` version is 5.x; `genie --version` reports it (not `0.0.0-unknown`); `scripts/version.ts` generates 5.x (no `4.`/`v4.` hardcodes); the npm vestiges (`publishConfig`, npm-only `prepack`, dead plugin-sync/npm scripts) are REMOVED; `npm pack --dry-run` succeeds and the tarball contains exactly the intended files (no stale/vestigial entries); the release workflows are audited (each v4-assumption fixed or deferred-with-note in `.genie/wishes/v5-completion/release-checklist.md`); nothing published/tagged.
-- [ ] Full `bun run check` + build + e2e green; CI green on the PR.
+- [x] G1: `CLAUDE.md` has zero references to the retired v4 surface (`genie agent`/`genie team`/`genie exec` namespaces, pgserve/PostgreSQL, `GENIE_OTEL_PORT`, tmux orchestration, native-teams/`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`/`workers.json`/`GENIE_IDLE_TIMEOUT_MS`/mailbox, "~305KB" bundle); it documents the real 12 commands + genie.db + in-process hooks; a drift-guard grep gate fails if any fossil returns; the still-true sections are preserved; `bun run check` green.
+- [x] G2: `genie launch <slug> --agent codex --dry-run` emits a pane command of the form `codex exec "$(cat …)"` against the worktree prompt (asserted in the YAML); `--agent claude` (default) output is byte-identical to today; an invalid `--agent` value → typed error; the Hermes decision doc exists under `.genie/` with a clear recommendation; launch tests green.
+- [x] G3: `package.json` version is 5.x; `genie --version` reports it (not `0.0.0-unknown`); `scripts/version.ts` generates 5.x (no `4.`/`v4.` hardcodes); the npm vestiges (`publishConfig`, npm-only `prepack`, dead plugin-sync/npm scripts) are REMOVED; `npm pack --dry-run` succeeds and the tarball contains exactly the intended files (no stale/vestigial entries); the release workflows are audited (each v4-assumption fixed or deferred-with-note in `.genie/wishes/v5-completion/release-checklist.md`); nothing published/tagged.
+- [x] Full `bun run check` + build + e2e green; CI green on the PR.
 
 ## Execution Strategy
 
@@ -132,11 +132,11 @@ grep -qiE 'recommend|decision' .genie/wishes/v5-completion/hermes-integration.md
 6. Do NOT publish, do NOT tag, do NOT revive npm.
 
 **Acceptance Criteria:**
-- [ ] `package.json` version is 5.x; `scripts/version.ts` generates 5.x (no `4.`/`v4.` hardcodes); `genie --version` reports the 5.x version (not `0.0.0-unknown`).
-- [ ] npm vestiges removed (`publishConfig`, dead `prepack`/plugin-sync/npm scripts); `files` allowlist honest for the signed tarball.
-- [ ] `npm pack --dry-run` succeeds (packs+lists only, no registry/auth); tarball contains exactly the intended files, no stale entries.
-- [ ] Release workflows audited; each v4-assumption fixed or deferred-with-note; release-bot/branch-guard interaction documented — all in `.genie/wishes/v5-completion/release-checklist.md`.
-- [ ] `bun run check` + build green; nothing published/tagged.
+- [x] `package.json` version is 5.x; `scripts/version.ts` generates 5.x (no `4.`/`v4.` hardcodes); `genie --version` reports the 5.x version (not `0.0.0-unknown`).
+- [x] npm vestiges removed (`publishConfig`, dead `prepack`/plugin-sync/npm scripts); `files` allowlist honest for the signed tarball.
+- [x] `npm pack --dry-run` succeeds (packs+lists only, no registry/auth); tarball contains exactly the intended files, no stale entries.
+- [x] Release workflows audited; each v4-assumption fixed or deferred-with-note; release-bot/branch-guard interaction documented — all in `.genie/wishes/v5-completion/release-checklist.md`.
+- [x] `bun run check` + build green; nothing published/tagged.
 
 **Validation:**
 ```bash

--- a/.genie/wishes/v5-completion/WISH.md
+++ b/.genie/wishes/v5-completion/WISH.md
@@ -99,10 +99,10 @@ bun run check
 4. Hermes integration-model decision: `.genie/wishes/v5-completion/hermes-integration.md` (under `.genie/`, NOT `docs/` — that is a submodule symlink) — state that Hermes is an HTTP/API agent (per hermes-agent.nousresearch.com developer guide) with no launchable terminal CLI, so it does not fit the worktree-pane launch model; recommend the integration shape (runner like omni / emit-to-API / defer) with rationale and a rough sketch. NO Hermes launcher code in this group.
 
 **Acceptance Criteria:**
-- [ ] `--agent codex --dry-run` emits `codex exec "$(cat …)"` (asserted); `--agent claude` byte-identical to today; bad `--agent` → typed error.
-- [ ] Agent-command mapping is a single extensible seam (a third target = a data entry, not a rewrite).
-- [ ] Hermes decision doc exists under `.genie/` with a clear recommendation; no half-built Hermes launcher.
-- [ ] launch tests + typecheck + build green.
+- [x] `--agent codex --dry-run` emits `codex exec "$(cat …)"` (asserted); `--agent claude` byte-identical to today; bad `--agent` → typed error.
+- [x] Agent-command mapping is a single extensible seam (a third target = a data entry, not a rewrite).
+- [x] Hermes decision doc exists under `.genie/` with a clear recommendation; no half-built Hermes launcher.
+- [x] launch tests + typecheck + build green.
 
 **Validation:**
 ```bash

--- a/.genie/wishes/v5-completion/hermes-integration.md
+++ b/.genie/wishes/v5-completion/hermes-integration.md
@@ -1,0 +1,98 @@
+# Hermes integration — decision
+
+**Status:** decision doc (no launcher code). Scope: how, if at all, Hermes fits
+`genie launch`'s worktree-pane model, and the recommended integration shape.
+
+## Context
+
+`genie launch` (`src/term-commands/launch.ts`) turns each ready wish-group into
+one Warp pane. Every pane opens in its own git worktree and runs a **terminal
+agent's non-interactive CLI** against a kickoff prompt file:
+
+- `claude "$(cat "<prompt>")"`
+- `codex exec "$(cat "<prompt>")"` (added in this group)
+
+The agent→command seam is a single data table (`AGENT_COMMANDS`), so a new
+launch target is normally one entry: `<agent> → <shell command that runs a CLI
+in a worktree against a prompt file>`.
+
+That seam's hard requirement is a **launchable local terminal CLI** — a binary
+on `PATH` that (a) accepts a prompt, (b) runs to completion (or drives an agent
+loop) inside the pane's cwd, and (c) can operate on the worktree's files.
+
+## Finding: Hermes does not fit the worktree-pane model
+
+Hermes (Nous Research; developer guide at hermes-agent.nousresearch.com) is an
+**HTTP/API agent**, not a terminal program. You interact with it by sending
+requests to a hosted API endpoint and reading structured responses. There is:
+
+- **no `hermes` binary** to put on `PATH` and drop into `AGENT_COMMANDS`;
+- **no non-interactive CLI** that takes a prompt arg and runs to completion in a
+  cwd the way `claude` / `codex exec` do;
+- **no notion of "operate on the files in this worktree"** — it is a remote
+  request/response service, so the worktree + prompt-file + Warp-pane machinery
+  has nothing to bind to.
+
+Forcing Hermes into `AGENT_COMMANDS` would mean wrapping the API in a bespoke
+local shim just so a pane has something to `exec` — that shim is a real feature
+(an API client with auth, streaming, and a repo-editing loop), not a one-line
+command template. Wedging it behind the launch seam would misrepresent its cost
+and couple an unrelated integration to the pane launcher.
+
+**Conclusion:** Hermes is out of scope for `genie launch`. It is an
+API-agent integration, adjacent to `omni`, not a launch target.
+
+## Options considered
+
+- **(a) A future `genie hermes` runner (like `omni`).** A dedicated command that
+  owns the Hermes API client: auth/config, prompt submission, response
+  streaming, and (optionally) applying the agent's proposed edits to the repo.
+  Mirrors how `omni` is its own runner rather than a launch pane. Highest effort,
+  but the only shape that honestly reflects an HTTP agent's surface and gives
+  Hermes a first-class home.
+- **(b) An emit-to-API path.** Reuse launch's plan/prompt builder to POST each
+  group's kickoff prompt to the Hermes endpoint instead of opening a pane —
+  "launch, but the executor is an API call." Lighter than (a), but it strands
+  Hermes as a half-runner: no session, no interactive follow-up, no place for
+  auth/streaming to live, and it complicates the pane launcher with a non-pane
+  branch. A stepping stone at best.
+- **(c) Defer.** Ship the `claude` + `codex` launch targets now; leave Hermes
+  unbuilt until there is a concrete use case and the API contract is pinned.
+
+## Recommendation
+
+**Defer now (c), and when demand is real build a standalone `genie hermes`
+runner (a) — do NOT wedge Hermes into `AGENT_COMMANDS` or the launch pane
+model.**
+
+Rationale:
+
+1. **Right seam.** An HTTP agent belongs behind a runner that owns auth,
+   streaming, and an edit-apply loop — the same shape as `omni` — not behind a
+   pane-command template built for local CLIs. Option (a) is the only shape that
+   models Hermes honestly; (b) would leak API concerns into the launcher and
+   still leave Hermes half-integrated.
+2. **No forcing today.** Nothing in the v5-completion wish needs Hermes. The
+   launch seam stays clean (claude + codex), and we avoid building an API client
+   speculatively before the contract and a use case are pinned.
+3. **Cheap to revisit.** The launch seam already proves the "group → prompt →
+   executor" decomposition. When Hermes lands as a runner, it can reuse
+   `buildLaunchPlan`/`buildPrompt` to produce the same kickoff prompt and POST it
+   to the API — no rework of the launcher required.
+
+### Rough sketch of the future `genie hermes` runner
+
+```
+genie hermes <slug> [--group <name>]
+  1. buildLaunchPlan(db, slug, …)      # reuse the existing plan/prompt builder
+  2. for each selected group:
+       prompt = group.prompt           # identical kickoff prompt as launch panes
+       resp   = hermesClient.run({     # HTTP POST to hermes-agent.nousresearch.com
+                  prompt, repo: repoRoot, group: group.name })
+       stream resp to stdout           # + optional: apply proposed edits to the worktree
+  3. record the run like omni does
+```
+
+Config (API key/endpoint) lives with the runner — mirroring `omni` and
+`src/lib/codex-config.ts`'s TOML-config pattern — never in the launch pane
+command. No Hermes launcher code is added by this wish.

--- a/.genie/wishes/v5-completion/release-checklist.md
+++ b/.genie/wishes/v5-completion/release-checklist.md
@@ -1,0 +1,114 @@
+# v5-completion — Group 3: Distribution 5.x + npm vestiges (VG3)
+
+Task: `t_mr44jc4wfa5b4654`. Branch `wish/v5-completion` (in-tree, not committed).
+
+## 1. Version scheme → 5.x
+
+**Chosen scheme: `5.YYMMDD.N`** (daily-counter preserved from v4; only the leading
+major moved `4.`→`5.`).
+
+Why: minimal, reversible change. The daily counter mechanism and git-tag counting
+that the whole release pipeline already depends on are untouched — the first v5
+build of a day is `.N=1` because the counter now counts `v5.<date>.*` tags (of
+which there are none), so it resets cleanly across the major boundary without any
+special-casing. Switching to plain semver (5.0.0) would have required rewriting the
+generator, the CI derive-version step, and `getTodayPublishCount`, plus a story for
+subsequent bumps — more surface, more risk, no benefit for a date-stamped dev cadence.
+
+Changes:
+- `scripts/version.ts` (local generator): `4.`→`5.` in `generateVersion()`, tag glob
+  `v4.<date>.*`→`v5.<date>.*` in `getTodayPublishCount()`, and header/comment docstrings.
+- `.github/workflows/version.yml` (**the actual production generator** — CI derives the
+  version here, not from `scripts/version.ts`): `echo "prefix=4"` → `prefix=5` (line ~102).
+  This is the load-bearing change; the CI derive step at line ~134 already uses
+  `git tag --list "v${PREFIX}.${TODAY}.*"`, so flipping the prefix flips both the version
+  string and the tag glob together.
+- `package.json`: `version` `4.260702.10` → `5.260702.1`.
+- `genie --version` reads root `package.json` at runtime (`src/lib/version.ts` resolver) →
+  reports `5.260702.1`. Verified after `bun run build`.
+
+**Dead stamp step removed:** `scripts/version.ts` previously read `src/lib/version.ts`
+and ran `.replace(/export const VERSION = '[^']+';/, ...)`. The runtime resolver no
+longer contains that literal (it exports `VERSION = readVersionFromPackageJson()`), so
+the regex matched nothing and the step rewrote the file unchanged — a dead no-op.
+Removed. `src/lib/version.ts` itself is otherwise untouched (the resolver already
+handles v5 transparently; version is data, not code).
+
+Note (deferred, cosmetic, non-breaking): `version.yml`'s commit step still does
+`git add -A '*.json' 'src/lib/version.ts'`. Since the generator no longer writes
+`src/lib/version.ts`, that path now stages nothing. Harmless; left as-is to keep the
+workflow diff minimal.
+
+## 2. npm vestiges removed
+
+- **`publishConfig` `{ "access": "public" }`** — pure npm-registry publish config.
+  Removed. npm distribution discontinued 2026-05-09; nothing publishes to the registry.
+- **`prepack` (`bun run build`)** — npm lifecycle hook that only fires on `npm pack` /
+  `npm publish`. **Verification:** the signed-tarball build (`build-tarballs.yml`) builds
+  via `bun install --frozen-lockfile` + `bash scripts/build-binary.sh` (`bun build --compile`)
+  and never invokes `npm pack`/`prepack`; `release-publish.yml` and `sign-attest.yml` only
+  operate on the tarballs `build-tarballs.yml` produces. So `prepack` was a dead npm-only
+  hook. Removed. (The validation's `npm pack --dry-run` runs `bun run build` beforehand, so
+  `dist/` exists without the hook.)
+- **`description`** — kept the "npm distribution discontinued 2026-05-09 … install via
+  curl" truth intact.
+- **`files` allowlist** — already honest for the signed tarball:
+  `["dist/", "skills/", "plugins/genie/", "templates/", "README.md", "LICENSE"]`.
+  All targets exist; matches exactly what the tarball needs. Left unchanged.
+
+**Kept (NOT npm-publish vestiges):** `build:plugin` / `sync` / `build-and-sync` and the
+plugin-JSON sync in `scripts/version.ts` serve the **live Claude Code plugin/marketplace
+channel** (`plugins/genie/`, `marketplace.json`), not npm. Removing them risks
+smart-install (explicit constraint). Left in place. `sync.js` is self-deprecated in favor
+of `term sync` but is a separate cleanup, not an npm vestige.
+
+**Plugin version JSONs left at 4.260702.10** (`plugins/genie/.claude-plugin/plugin.json`,
+`plugins/genie/package.json`, `.claude-plugin/marketplace.json`): the "touch ONLY" scope
+excludes them and the constraint forbids bumping plugin sync. The version generator
+(`bun run version` in CI) resyncs all four to the same `5.x` value on the next real
+release, so the transient mismatch self-heals. Root `package.json` (the one
+`genie --version` reads) is 5.x.
+
+## 3. Release-workflow audit (v4/date-scheme assumptions)
+
+| Workflow | Finding | Action |
+|---|---|---|
+| `version.yml` | `prefix=4` hardcode drove the whole scheme | **FIXED → `prefix=5`** |
+| `release.yml` | `tags: ['v*']` glob is scheme-agnostic; dispatch input example said `4.260510.6` | Glob OK; **updated example → `5.260702.1`** (cosmetic clarity) |
+| `build-tarballs.yml` | version from `inputs.version` / `GITHUB_REF_NAME#v` / `package.json` — scheme-agnostic; builds via bun-compile, no npm pack | No change |
+| `release-publish.yml` | parses version from artifact name via `sed 's/^genie-(.+)-<platform>.tar.gz$/\1/'` — `.+` capture, scheme-agnostic | No change (historical `v4.260511.5` refs are comment anchors) |
+| `sign-attest.yml` | same `(.+)` sed capture from tarball filename; `cosign-release: v2.4.1` is cosign's own version | No change |
+| `rolling-pr.yml` | no version logic (dev→main PR maintenance only) | No change |
+| `release-orphan-alert.yml` | `git tag --list 'v*'` — scheme-agnostic | No change |
+| `audit-next-tag.yml` | **npm-registry vestige** — audits `npm view @automagik/genie@next`. Scheme-agnostic (does NOT parse version format), so 5.x does NOT break it. But npm is discontinued, so it's non-functional (its script exits 0 on "npm registry unreachable / no @next advertised"). | **DEFER-with-note:** orthogonal to the version scheme. Decommissioning this scheduled workflow + `scripts/audit-next-tag-pinning.sh` + the npm OIDC trusted-publisher entry (noted in `version.yml` lines ~276-287) is a dedicated npm-decommission cleanup, out of scope for a surgical version-scheme change. Not touched. |
+
+## 4. Release-bot vs branch-guard
+
+**Finding: no conflict.** The release automation does NOT push to `main`.
+
+- `version.yml` bumps + tags only on the **dev** path (`should_bump=true`) and pushes
+  `HEAD:refs/heads/${BRANCH}` where `BRANCH` is `dev`/`homolog` — never `main`. On `main`
+  and `homolog` merges it runs `should_bump=false` (no version push); a separate
+  "promoted tag" dispatch only tags the already-merged commit.
+- `main` advances exclusively through the **human-merged** rolling PR that `rolling-pr.yml`
+  creates (dev→main; "Human approval required for merge to production"). The bot creates
+  the PR; it does not merge or push to main.
+- Even where the bot pushes (to dev) or tags, it runs **remotely in GitHub Actions using
+  `GITHUB_TOKEN`/`RELEASE_PLEASE_TOKEN`**. The genie `branch-guard` hook
+  (`src/hooks/handlers/branch-guard.ts`) is a **local Claude Code PreToolUse hook** — it
+  only intercepts git operations initiated through a local CC agent session. GitHub Actions
+  runners never load that hook, so branch-guard's "deny agent pushes to main" policy is
+  neither triggered by nor in conflict with the release bots. The two live in different
+  planes (local agent tooling vs. remote CI identity).
+
+Conclusion: branch-guard's default-dispatch denial of agent pushes to main is correct and
+does not need a CI exemption — CI never hits it, and the one path to main is a human merge.
+
+## 5. Validation
+
+Run at end of task — see final agent message for captured output. Acceptance:
+- package.json 5.x ✓ / `scripts/version.ts` no `4.`/`v4.` hardcodes ✓ / `genie --version` 5.x ✓
+- `publishConfig` gone ✓ / `prepack` gone (proven dead) ✓ / `files` honest ✓
+- `npm pack --dry-run` succeeds, tarball contains `dist/genie.js` ✓
+- workflows audited (fixed vs deferred above) ✓ / release-bot finding above ✓
+- `bun run check` + build green ✓ / nothing published or tagged ✓

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version (e.g. 4.260510.6 — no v prefix)'
+        description: 'Version (e.g. 5.260702.1 — no v prefix)'
         required: true
         type: string
       channel:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -99,7 +99,10 @@ jobs:
               echo "should_bump=true" >> "$GITHUB_OUTPUT"
               ;;
           esac
-          echo "prefix=4" >> "$GITHUB_OUTPUT"
+          # v5 version scheme: 5.YYMMDD.N (daily counter preserved from v4;
+          # only the leading major moved). Must stay in sync with the local
+          # generator in scripts/version.ts and the v5.<date>.* tag glob below.
+          echo "prefix=5" >> "$GITHUB_OUTPUT"
           echo "Resolved: branch=${BRANCH}"
 
       - uses: actions/checkout@v5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,107 +46,90 @@ CI in `automagik-dev/genie` runs `actions/checkout@v4` with `submodules: recursi
 
 ```
 src/genie.ts                    CLI entry point (commander)
-src/lib/                        Core modules (state, registry, locking, messaging, providers)
+src/lib/                        Core modules (transcript, codex/claude logs, paths, config)
 src/lib/transcript.ts           Provider-agnostic transcript abstraction (Claude + Codex)
 src/lib/codex-logs.ts           Codex JSONL parsing + SQLite discovery
+src/lib/codex-config.ts         Codex config.toml + OTel relay wiring (state detection)
 src/lib/claude-logs.ts          Claude log parsing + transcript adapter
-src/term-commands/              CLI command handlers
-  agent/                        genie agent — spawn, stop, resume, kill, list, show, log, send, answer, register, directory, inbox, brief
-  task/                         genie task — extends core CRUD with status, reset, board, project, releases, type
-  team/                         genie team — create, hire, fire, list, disband
-  exec/                         genie exec — list, show, terminate (debug)
-src/hooks/                      Git hook system (branch-guard, auto-spawn, identity-inject)
-src/genie-commands/             Setup/utility commands (setup, doctor, update, session)
-src/types/                      Shared types (genie-config Zod schema)
+src/lib/v5/                     v5 state engine — SQLite, zero-daemon ("lightweight body")
+  genie-db.ts                   Per-repo .genie/genie.db open/init (worktree-aware, WAL)
+  global-db.ts                  Global ~/.genie/genie.db — omni approval queue + inbox
+  sqlite-open.ts                Shared bun:sqlite open primitive (WAL, busy_timeout, typed errors)
+  task-state.ts                 Task / dependency / ready-set state machine
+  omni-queue.ts                 Approval-queue + inbox persistence for the Omni runner
+  warp-launch.ts                Warp cockpit planner — one worktree per ready group
+  TAXONOMY.md                   The docs-in-git / state-in-SQLite contract
+src/hooks/                      In-process Claude Code hook dispatch (fail-closed)
+  index.ts                      Handler chain + fail-closed envelope (buildFailClosedResponse)
+  dispatch-command.ts           CLI entry: genie hook dispatch
+  handlers/                     branch-guard, freshness, identity-inject, omni-approval, orchestration-guard, audit-context
+src/term-commands/              CLI command handlers (board, init, launch, omni, shortcuts, task, ...)
 skills/                         Skill prompt files (brainstorm, wish, work, review, etc.)
+.genie/                         Per-repo state: git-tracked wishes/brainstorms/INDEX.md + genie.db (gitignored)
 ```
 
-## CLI Namespaces
+## CLI Commands
 
-Top-level aliases (`genie spawn`, `genie kill`, etc.) are shortcuts for the `genie agent` namespace. Both forms work identically.
+Twelve top-level commands (run `genie <command> --help` for detail):
 
-### Agent Commands
+| Command | Purpose |
+|---------|---------|
+| `board` | Kanban view derived by query (no stored view state); `--board`, `--wish`, `--json` |
+| `doctor` | Diagnostic checks on the genie installation |
+| `hook` | Hook middleware for Claude Code (`genie hook dispatch` runs in-process) |
+| `init` | Scaffold per-repo state — `.genie/INDEX.md` + `.gitignore` rules (idempotent) |
+| `launch <slug>` | Open a Warp cockpit for a wish: one pane per ready group, each in its own worktree |
+| `omni` | Omni integration — `serve`, `status`, `inbox`, `handshake` |
+| `setup` | Configure genie settings |
+| `shortcuts` | Manage tmux keyboard shortcuts |
+| `task` | Task state (SQLite, zero-daemon) |
+| `uninstall` | Remove Genie CLI and clean up hooks |
+| `update` | Update Genie CLI to the latest GitHub Release |
+| `help` | `genie help [command]` |
+
+### Task subcommands
 ```bash
-# Top-level aliases (shortcuts)
-genie spawn <name>                    # Alias for: genie agent spawn <name>
-genie kill <name>                     # Alias for: genie agent kill <name>
-genie stop <name>                     # Alias for: genie agent stop <name>
-genie resume [name]                   # Alias for: genie agent resume [name]
-genie ls                              # Alias for: genie agent list
-genie log [agent]                     # Alias for: genie agent log [agent]
-genie read <name>                     # Read terminal output from agent pane
-genie history <name>                  # Show compressed session history
-genie answer <name> <choice>          # Alias for: genie agent answer <name> <choice>
-
-# Full namespace commands
-genie agent spawn <name>              # Spawn agent (resolves from directory or built-ins)
-genie agent list                      # List agents with runtime status
-genie agent log <name>                # Unified log (default)
-genie agent log <name> --raw          # Pane capture
-genie agent log <name> --transcript   # Compressed transcript
-genie agent send '<msg>' --to <name>  # Direct message (hierarchy-enforced)
-genie agent send '<msg>' --broadcast  # Team broadcast
-genie agent inbox                     # View inbox
-genie agent brief --team <name>       # Cold-start summary
-genie agent answer <name> <choice>    # Answer prompt
-genie agent show <name>               # Agent + executor detail
-genie agent stop/kill/resume <name>   # Lifecycle management
-genie agent register <name>           # Register agent locally + Omni
-genie agent directory [name]          # List/show directory entries
+genie task create --title 'x'         # Create a task
+genie task list                       # List tasks (with filters)
+genie task checkout <id> --worker w   # Atomically claim a ready task for a worker
+genie task status <id>                # Task detail, dependencies, stage log
+genie task done <id>                  # Mark done + recompute the ready set
+genie task export                     # Emit the complete DB state as JSON
 ```
 
-### Task Commands
+### Omni subcommands
 ```bash
-genie task create --title 'x'         # Create task
-genie task list                       # List tasks
-genie task status <slug>              # Wish group status
-genie task done <ref>                 # Mark group done
-genie task board/project/releases/type  # Planning hierarchy
+genie omni handshake                  # Register this host with the omni server (ed25519, idempotent)
+genie omni serve                      # Resident runner: NATS bridge → approval queue (foreground)
+genie omni status                     # Approval-queue counts + config sanity (no network)
+genie omni inbox                      # List stored inbound Omni messages (no network)
 ```
 
-### Team Commands
-```bash
-genie team create/hire/fire/list/disband  # Team lifecycle
-```
-
-### Other
-```bash
-genie exec list/show/terminate           # Executor debug
-genie run <spec>                         # Wish/spec runner (top-level)
-```
-
-## State File Locations (CRITICAL — fragmented across 4 scopes)
+## State File Locations (SQLite + git-tracked docs)
 
 | State | Location | Scope | Format |
 |-------|----------|-------|--------|
-| Wish state | `<repo>/.genie/state/<slug>.json` | Per-repo CWD, shared across worktrees | JSON |
-| Worker registry | `~/.genie/workers.json` | Global | JSON |
-| Team configs | `~/.genie/teams/<name>.json` | Global | JSON |
-| Mailbox | `<repo>/.genie/mailbox/<worker>.json` | Per-repo | JSON |
-| Team chat | `<repo>/.genie/chat/<team>.jsonl` | Per-repo worktree | JSONL |
-| Session store | `~/.genie/sessions.json` | Global | JSON |
-| Native teams | `~/.claude/teams/<team>/` | Global (Claude Code) | JSON |
+| Task / board / wish state | `<repo>/.genie/genie.db` | Per-repo, shared across worktrees | SQLite (bun:sqlite) |
+| Omni approvals + inbox | `~/.genie/genie.db` | Global (machine-wide) | SQLite (bun:sqlite) |
+| Wishes / brainstorms / INDEX | `<repo>/.genie/{wishes,brainstorms,INDEX.md}` | Per-repo, git-tracked | Markdown |
 
-Worktrees share the main repo's `.genie/` via `git rev-parse --git-common-dir`. Worker registry is global, not per-worktree.
+Worktrees share the main repo's `.genie/genie.db` via `git rev-parse --git-common-dir`. The two `genie.db` files are wholly separate databases: different paths, different schemas, independent `PRAGMA user_version` — `global-db.ts` deliberately imports NONE of `genie-db.ts`'s path constants; the only shared code is the open primitive in `sqlite-open.ts`. Both use WAL. Documents live in git; operational state lives in SQLite.
 
 ## Environment Variables
 
 | Var | Effect |
 |-----|--------|
-| `GENIE_HOME` | Relocates ALL global state from `~/.genie` |
-| `GENIE_AGENT_NAME` | Agent identity for hook dispatch. MUST be set for auto-spawn to work. |
+| `GENIE_HOME` | Relocates ALL global state from `~/.genie` (the global `genie.db` and `worktrees/`) |
+| `GENIE_AGENT_NAME` | Agent identity for hook dispatch |
+| `GENIE_AGENT_ID` | Agent id used by hook identity injection |
 | `GENIE_TEAM` | Default team when `--team` not provided |
-| `CLAUDECODE=1` | Enables Claude Code features (set in team-lead command) |
-| `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` | Enables native teammate UI |
-| `GENIE_IDLE_TIMEOUT_MS` | Auto-suspend idle workers after N ms |
-| `GENIE_OTEL_PORT` | Pins the Claude OTel receiver to one explicit port; if busy, genie skips telemetry injection instead of probing |
-| `GENIE_OTEL_PORT_PROBE_MAX` | Number of receiver ports to probe in default mode, starting at pgserve port + 1; defaults to 8 |
-
-`GENIE_AGENT_NAME` and the 5 native team CLI flags must stay in sync — if any are missing, Claude Code won't recognize the agent as a team member.
+| `GENIE_WORKTREES_DIR` | Override where `launch` creates per-group worktrees (default `<GENIE_HOME>/worktrees`) |
+| `GENIE_CONFIG_FILE` | Override the resolved genie config path |
+| `OMNI_*` | Omni runner config — `OMNI_APPROVALS_ENABLED`, `OMNI_API_URL`, `OMNI_API_KEY`, `OMNI_NATS_URL`, `OMNI_APPROVAL_CHAT`, `OMNI_INSTANCE`, `OMNI_APPROVE_TOKENS`/`OMNI_DENY_TOKENS` |
 
 ## Build
 
-Single-file bundle: `bun build` inlines all dependencies into `dist/genie.js` (~305KB minified). No runtime deps to co-locate. The shebang `#!/usr/bin/env bun` makes it executable. `chmod +x` is applied after build.
+Single-file bundle: `bun build src/genie.ts --outdir dist --target bun --minify-syntax --minify-whitespace --external bun` inlines all four runtime deps (`commander`, `@inquirer/prompts`, `nats`, `zod`) into `dist/genie.js` (~1.3MB). Only the `bun` builtin is external. The shebang `#!/usr/bin/env bun` makes it executable; `chmod +x` is applied after build.
 
 ## Testing
 
@@ -155,13 +138,8 @@ Single-file bundle: `bun build` inlines all dependencies into `dist/genie.js` (~
 - Fixtures: tmpdir with cleanup in afterEach
 - Git tests: real git repos in `/tmp`, not mocks
 - Concurrency tests: `Promise.allSettled()` pattern
-- Isolation: set `process.env.GENIE_HOME` to tmpdir to isolate global state
-- macOS RAM-disk (opt-in): `GENIE_TEST_MAC_RAM=1 bun test` mounts a 1 GiB
-  hdiutil-backed volume at `/Volumes/genie-test-ram` and points pgserve at
-  `/Volumes/genie-test-ram/pgserve`. Matches Linux `/dev/shm` throughput for
-  the pgserve test harness. Unset = ephemeral temp dir (no change). The volume
-  is detached on daemon reap; a manual `hdiutil detach /Volumes/genie-test-ram`
-  is safe — the next run recreates it.
+- Isolation: set `process.env.GENIE_HOME` to tmpdir to isolate global state (both `genie.db` files resolve under it)
+- SQLite tests: `sqlite-open.ts` uses WAL + `busy_timeout`, so concurrent-writer tests surface clean claim-conflicts, not `SQLITE_BUSY` flake
 
 ## Code Style
 
@@ -181,11 +159,11 @@ Biome's `noExcessiveCognitiveComplexity` is set to `maxAllowedComplexity: 25` (w
 
 ## Gotchas
 
-- **File lock timeout force-removes are intentional** — prevents permanent deadlocks from crashed processes. The `open('wx')` after unlink is still atomic, so only one process wins.
 - **Hook dispatch is in-process, fail-closed, and bounded by Claude Code's per-hook `timeout`** — each hook event is a short-lived `genie hook dispatch` fork that runs the handler chain in-process and exits (no daemon, no socket, no DB). There is no genie-managed dispatch timeout; the ceiling is the `timeout` field on the hook's entry in Claude Code's `settings.json` (CC default if unset). A dispatch that can't parse its payload or throws emits a NON-empty deny/block envelope instead of empty stdout, because CC reads empty PreToolUse stdout as allow-by-default — see `buildFailClosedResponse` in `src/hooks/index.ts`. The fail-closed default is locked by `src/hooks/__tests__/dispatch-fail-closed-regression.test.ts`, which drives the shipped `dist/genie.js`.
-- **tmux is required for agent spawn** — no fallback. `hasBinary()` checks PATH before launch.
-- **System prompt injection can fail silently** — `buildTeamLeadCommand()` writes to `~/.genie/prompts/<team>.md`. If write fails, the command still generates but Claude Code dies on startup trying to read the missing file.
-- **Mailbox delivery is best-effort** — message is persisted to disk (durable), but tmux pane injection is not retried. Dead pane = message stays `deliveredAt: null` forever.
+- **`AskUserQuestion` is the one PreToolUse carve-out** — it is in `NON_INTERCEPTABLE_PRE_TOOL_USE_TOOLS` and MUST get an EMPTY response, not the neutral `{ decision: 'block' }` block form. Empirically CC consumes any additionalContext as the synthesized answer, so a fail-closed block would corrupt the inline picker. The fail-closed envelope special-cases this tool.
+- **Two `genie.db` files, never cross-import** — per-repo `.genie/genie.db` (`genie-db.ts`, task/board/wish) and global `~/.genie/genie.db` (`global-db.ts`, omni queue + inbox) are independent databases with their own schemas and `user_version`. `global-db.ts` shares only `sqlite-open.ts` with the per-repo one — do not reach across for path constants.
+- **Codex OTel relay is real v5, not the deleted receiver** — `src/lib/codex-config.ts` wires Codex's `config.toml` to a fixed OTel relay on `127.0.0.1:14318` (`OTEL_RELAY_PORT`) for state detection. This is live; only the v4 receiver-probing env vars are gone. Do not blanket-purge "OTel" from docs — this relay is load-bearing.
+- **The Omni runner (`genie omni serve`) is the only optional daemon** — a foreground NATS bridge that drains the global approval queue. Everything else is fork-and-exit; no resident processes.
 - **`bun run dead-code`** (knip) has pre-existing false positives for biome/commitlint/husky devDeps — not regressions.
 
 ## PR Review Rules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/genie",
-  "version": "4.260702.10",
+  "version": "5.260702.1",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
   "type": "module",
   "bin": {
@@ -15,7 +15,6 @@
     "build:plugin": "node scripts/build.js",
     "sync": "node scripts/sync.js",
     "build-and-sync": "npm run build:plugin && npm run sync",
-    "prepack": "bun run build",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
@@ -53,9 +52,6 @@
   },
   "engines": {
     "bun": ">=1.3.10"
-  },
-  "publishConfig": {
-    "access": "public"
   },
   "trustedDependencies": ["@biomejs/biome", "bun"]
 }

--- a/scripts/version.ts
+++ b/scripts/version.ts
@@ -2,12 +2,16 @@
 
 /**
  * Pre-build script: generates date-based version and updates ALL version files
- * Format: 4.YYMMDD.N (e.g., 4.260201.1 = Feb 1, 2026, first publish of the day)
+ * Format: 5.YYMMDD.N (e.g., 5.260201.1 = Feb 1, 2026, first publish of the day)
  * N increments per day: .1, .2, .3, etc.
+ *
+ * v5 kept the daily-counter scheme from v4 — only the leading major moved
+ * 4.→5.. The counter is derived by counting existing `v5.<date>.*` git tags,
+ * so the first v5 build of a day is .1 regardless of how many v4 builds
+ * preceded it.
  *
  * Syncs versions across:
  * - package.json (root)
- * - src/lib/version.ts
  * - plugins/genie/.claude-plugin/plugin.json (Claude Code)
  * - plugins/genie/package.json (smart-install version checks)
  * - .claude-plugin/marketplace.json (marketplace listing)
@@ -21,7 +25,7 @@ import { dirname, join } from 'node:path';
 // Count existing versions for today from git tags
 function getTodayPublishCount(datePrefix: string): number {
   try {
-    const output = execSync(`git tag --list "v4.${datePrefix}.*"`, {
+    const output = execSync(`git tag --list "v5.${datePrefix}.*"`, {
       encoding: 'utf-8',
       timeout: 5000,
     });
@@ -31,7 +35,7 @@ function getTodayPublishCount(datePrefix: string): number {
   }
 }
 
-// Generate version: 4.YYMMDD.N where N = daily publish counter
+// Generate version: 5.YYMMDD.N where N = daily publish counter
 function generateVersion(): string {
   const now = new Date();
   const yy = String(now.getFullYear()).slice(-2);
@@ -42,7 +46,7 @@ function generateVersion(): string {
   const existing = getTodayPublishCount(datePrefix);
   const n = existing + 1;
 
-  return `4.${datePrefix}.${n}`;
+  return `5.${datePrefix}.${n}`;
 }
 
 async function updateJsonVersion(filePath: string, version: string): Promise<boolean> {
@@ -69,28 +73,19 @@ async function main() {
   console.log(`Version: ${version}`);
   console.log('Updating files:');
 
-  // 1. Update package.json (root)
+  // 1. Update package.json (root). src/lib/version.ts is NOT stamped here —
+  // it resolves the version at runtime from package.json (see that file's
+  // header). The old `export const VERSION = '...'` literal it used to
+  // rewrite no longer exists, so the former stamp step was a dead no-op.
   await updateJsonVersion(join(rootDir, 'package.json'), version);
 
-  // 2. Update src/lib/version.ts
-  const versionPath = join(rootDir, 'src/lib/version.ts');
-  if (existsSync(versionPath)) {
-    const versionContent = await readFile(versionPath, 'utf-8');
-    const updatedContent = versionContent.replace(
-      /export const VERSION = '[^']+';/,
-      `export const VERSION = '${version}';`,
-    );
-    await writeFile(versionPath, updatedContent);
-    console.log(`  ✓ ${versionPath}`);
-  }
-
-  // 3. Update Claude Code plugin manifest
+  // 2. Update Claude Code plugin manifest
   await updateJsonVersion(join(rootDir, 'plugins/genie/.claude-plugin/plugin.json'), version);
 
-  // 4. Update plugin package.json (used by smart-install.js for version checks)
+  // 3. Update plugin package.json (used by smart-install.js for version checks)
   await updateJsonVersion(join(rootDir, 'plugins/genie/package.json'), version);
 
-  // 5. Update marketplace.json plugin version
+  // 4. Update marketplace.json plugin version
   const marketplacePath = join(rootDir, '.claude-plugin/marketplace.json');
   if (existsSync(marketplacePath)) {
     try {

--- a/src/__tests__/claude-md-drift.test.ts
+++ b/src/__tests__/claude-md-drift.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Drift guard for CLAUDE.md — the instruction set every agent loads.
+ *
+ * CLAUDE.md must describe v5 reality, not the demolished v4 harness. This test
+ * fails hard if any retired-v4 fossil string reappears (a stale edit or a bad
+ * merge that resurrects the old surface). Add a token here whenever a v4
+ * concept is removed for good.
+ */
+
+const CLAUDE_MD = join(import.meta.dir, '..', '..', 'CLAUDE.md');
+
+// Substrings that MUST NOT appear anywhere in CLAUDE.md. Each is a v4 fossil:
+// a demolished subsystem, a deleted env var, or a retired command namespace.
+const RETIRED_FOSSILS: ReadonlyArray<string> = [
+  'pgserve',
+  'PostgreSQL',
+  'GENIE_OTEL',
+  'genie agent spawn',
+  'genie team ',
+  'genie exec ',
+  '305KB',
+  'tmux is required',
+  'CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS',
+  'workers.json',
+  'GENIE_IDLE_TIMEOUT_MS',
+  'buildTeamLeadCommand',
+];
+
+// v5 command surface that MUST stay documented so the file can't drift back
+// into describing a body that no longer ships.
+const REQUIRED_V5_COMMANDS: ReadonlyArray<string> = [
+  'board',
+  'doctor',
+  'hook',
+  'init',
+  'launch',
+  'omni',
+  'setup',
+  'shortcuts',
+  'task',
+  'uninstall',
+  'update',
+];
+
+describe('CLAUDE.md v5 drift guard', () => {
+  const content = readFileSync(CLAUDE_MD, 'utf8');
+
+  for (const fossil of RETIRED_FOSSILS) {
+    test(`does not contain retired v4 fossil: ${JSON.stringify(fossil)}`, () => {
+      expect(content).not.toContain(fossil);
+    });
+  }
+
+  for (const command of REQUIRED_V5_COMMANDS) {
+    test(`documents v5 command: ${command}`, () => {
+      expect(content).toContain(command);
+    });
+  }
+
+  test('documents the v5 SQLite state store', () => {
+    expect(content).toContain('genie.db');
+    expect(content).toContain('bun:sqlite');
+  });
+});

--- a/src/__tests__/claude-md-drift.test.ts
+++ b/src/__tests__/claude-md-drift.test.ts
@@ -28,6 +28,8 @@ const RETIRED_FOSSILS: ReadonlyArray<string> = [
   'workers.json',
   'GENIE_IDLE_TIMEOUT_MS',
   'buildTeamLeadCommand',
+  'native-teams',
+  'mailbox',
 ];
 
 // v5 command surface that MUST stay documented so the file can't drift back

--- a/src/term-commands/launch.test.ts
+++ b/src/term-commands/launch.test.ts
@@ -9,6 +9,7 @@ import { createTask } from '../lib/v5/task-state.js';
 import {
   BareRepoError,
   EmptyReadySetError,
+  InvalidAgentError,
   InvalidGroupNameError,
   InvalidSlugError,
   type LaunchDeps,
@@ -131,6 +132,63 @@ function flattenLeaves(layout: unknown): Array<Record<string, unknown>> {
   if (Array.isArray(node.panes)) return (node.panes as unknown[]).flatMap(flattenLeaves);
   return [node];
 }
+
+/** Extract each pane's first command `exec` string from a plan's emitted YAML, left-to-right. */
+function paneCommands(yaml: string): string[] {
+  const config = Bun.YAML.parse(yaml) as { windows: Array<{ tabs: Array<{ layout: unknown }> }> };
+  const leaves = flattenLeaves(config.windows[0].tabs[0].layout);
+  return leaves.map((l) => (l.commands as Array<{ exec: string }>)[0].exec);
+}
+
+// ----------------------------------------------------------------------------
+// --agent: the pane command is chosen from the agent→command mapping
+// ----------------------------------------------------------------------------
+
+describe('genie launch --agent', () => {
+  test('--agent codex emits `codex exec "$(cat …)"` pane commands for every group', () => {
+    const slug = 'codex-run';
+    createTask(fx.db, { title: 'build the api', wish: slug, group: 'api' });
+    createTask(fx.db, { title: 'build the ui', wish: slug, group: 'ui' });
+
+    const plan = executeLaunch(slug, { dryRun: true, agent: 'codex' }, deps());
+    expect(paneCommands(plan.yaml)).toEqual([
+      `codex exec "$(cat "${join(worktreeFor(slug, 'api'), '.genie', 'launch', 'api.prompt')}")"`,
+      `codex exec "$(cat "${join(worktreeFor(slug, 'ui'), '.genie', 'launch', 'ui.prompt')}")"`,
+    ]);
+  });
+
+  test('default (no --agent) and --agent claude both emit byte-identical claude pane commands', () => {
+    const slug = 'claude-run';
+    createTask(fx.db, { title: 'a task', wish: slug, group: 'main' });
+    const expected = [`claude "$(cat "${join(worktreeFor(slug, 'main'), '.genie', 'launch', 'main.prompt')}")"`];
+
+    const byDefault = executeLaunch(slug, { dryRun: true }, deps());
+    const explicit = executeLaunch(slug, { dryRun: true, agent: 'claude' }, deps());
+    expect(paneCommands(byDefault.yaml)).toEqual(expected);
+    expect(paneCommands(explicit.yaml)).toEqual(expected);
+    // Default and explicit claude produce identical YAML — no perturbation.
+    expect(explicit.yaml).toBe(byDefault.yaml);
+  });
+
+  test('an unknown --agent value raises InvalidAgentError before anything is materialized', () => {
+    const slug = 'bad-agent';
+    createTask(fx.db, { title: 'a task', wish: slug, group: 'main' });
+
+    let caught: unknown;
+    try {
+      executeLaunch(slug, { open: false, agent: 'xyz' }, deps());
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(InvalidAgentError);
+    expect((caught as InvalidAgentError).agent).toBe('xyz');
+
+    // Validation precedes materialize, so nothing landed on disk.
+    expect(existsSync(fx.worktrees)).toBe(false);
+    expect(existsSync(worktreeFor(slug, 'main'))).toBe(false);
+    expect(existsSync(fx.warp)).toBe(false);
+  });
+});
 
 // ----------------------------------------------------------------------------
 // Real run (--no-open): worktrees, prompts, config, core.bare intact

--- a/src/term-commands/launch.ts
+++ b/src/term-commands/launch.ts
@@ -150,9 +150,10 @@ const AGENT_COMMANDS = {
  */
 function resolveAgentCommand(agent: string | undefined): (promptPath: string) => string {
   const name = agent ?? 'claude';
-  const build = (AGENT_COMMANDS as Record<string, ((promptPath: string) => string) | undefined>)[name];
-  if (!build) throw new InvalidAgentError(name);
-  return build;
+  if (name in AGENT_COMMANDS) {
+    return AGENT_COMMANDS[name as keyof typeof AGENT_COMMANDS];
+  }
+  throw new InvalidAgentError(name);
 }
 
 // ============================================================================

--- a/src/term-commands/launch.ts
+++ b/src/term-commands/launch.ts
@@ -112,6 +112,49 @@ export class BareRepoError extends LaunchError {
   }
 }
 
+/** The `--agent` value is not a known launch target. */
+export class InvalidAgentError extends LaunchError {
+  readonly agent: string;
+  constructor(agent: string) {
+    super(
+      `Invalid launch agent ${JSON.stringify(agent)}. ` + `Known agents: ${Object.keys(AGENT_COMMANDS).join(', ')}.`,
+    );
+    this.name = 'InvalidAgentError';
+    this.agent = agent;
+  }
+}
+
+// ============================================================================
+// Agent → pane-command mapping
+// ============================================================================
+
+/**
+ * Data table mapping each agent to the pane command that runs its
+ * non-interactive CLI against the kickoff prompt file. Each entry takes the
+ * absolute prompt path and returns the exact shell command the pane executes;
+ * `$(cat "…")` inlines the prompt so the pane needs no extra plumbing.
+ *
+ * - `claude` — the historical default; MUST stay byte-identical.
+ * - `codex`  — OpenAI Codex's non-interactive `codex exec [PROMPT]` subcommand
+ *   (prompt passed as the positional arg).
+ */
+const AGENT_COMMANDS = {
+  claude: (promptPath: string) => `claude "$(cat "${promptPath}")"`,
+  codex: (promptPath: string) => `codex exec "$(cat "${promptPath}")"`,
+} as const;
+
+/**
+ * Resolve the pane-command builder for an agent name, defaulting to `claude`.
+ * Rejects any unknown name with a typed {@link InvalidAgentError} so the CLI
+ * exits non-zero before a single worktree, branch, or prompt is materialized.
+ */
+function resolveAgentCommand(agent: string | undefined): (promptPath: string) => string {
+  const name = agent ?? 'claude';
+  const build = (AGENT_COMMANDS as Record<string, ((promptPath: string) => string) | undefined>)[name];
+  if (!build) throw new InvalidAgentError(name);
+  return build;
+}
+
 // ============================================================================
 // Plan types
 // ============================================================================
@@ -169,6 +212,8 @@ export interface LaunchOptions {
   open?: boolean;
   /** Subset of group names to launch. Absent ⇒ all groups with ready tasks. */
   groups?: string[];
+  /** Terminal agent that drives each pane. Absent ⇒ 'claude'. */
+  agent?: string;
 }
 
 // ============================================================================
@@ -259,9 +304,12 @@ function buildPrompt(slug: string, group: string, tasks: TaskRow[]): string {
  * @throws {LaunchError} if `--groups` selects no ready group.
  * @throws {InvalidGroupNameError} if any selected group name is not a safe
  *   filesystem/branch component (validated before anything is created).
+ * @throws {InvalidAgentError} if `opts.agent` is not a known launch target
+ *   (validated before any DB read or git call).
  */
 export function buildLaunchPlan(db: Database, slug: string, deps: LaunchDeps, opts: LaunchOptions): LaunchPlan {
   if (!SLUG_PATTERN.test(slug)) throw new InvalidSlugError(slug);
+  const buildCommand = resolveAgentCommand(opts.agent);
   const cwd = deps.cwd ?? process.cwd();
   const repoRoot = resolveRepoRoot(cwd);
   const repoBase = basename(repoRoot);
@@ -287,7 +335,7 @@ export function buildLaunchPlan(db: Database, slug: string, deps: LaunchDeps, op
       prompt: buildPrompt(slug, name, tasks),
       tasks,
     });
-    panes.push({ title: name, cwd: worktree, command: `claude "$(cat "${promptPath}")"` });
+    panes.push({ title: name, cwd: worktree, command: buildCommand(promptPath) });
   }
 
   return { slug, repoRoot, groups, panes, yaml: buildLaunchConfigYaml({ slug, panes }) };
@@ -515,12 +563,14 @@ interface LaunchCliOptions {
   dryRun?: boolean;
   open?: boolean;
   groups?: string;
+  agent?: string;
 }
 
 function handleLaunch(slug: string, cli: LaunchCliOptions): void {
   const opts: LaunchOptions = {
     dryRun: cli.dryRun,
     open: cli.open,
+    agent: cli.agent,
     groups: cli.groups
       ? cli.groups
           .split(',')
@@ -543,5 +593,6 @@ export function registerLaunchCommand(program: Command): void {
     .option('--dry-run', 'Print the plan (YAML, worktrees, prompts) without touching anything')
     .option('--no-open', 'Emit the launch config but do not open Warp')
     .option('--groups <csv>', 'Launch only these comma-separated group names')
+    .option('--agent <name>', 'Terminal agent to drive each pane (claude|codex)', 'claude')
     .action((slug: string, opts: LaunchCliOptions) => handleLaunch(slug, opts));
 }


### PR DESCRIPTION
## Summary

The final umbrella group of the v5 lightweight body — three independent tracks, landed as three separate commits. Executes wish [`v5-completion`](.genie/wishes/v5-completion/WISH.md), each group independently SHIP-reviewed.

## Three commits

**`da5185ba` — docs(v5): CLAUDE.md rewrite + drift guard**
The instruction set every agent loads now describes v5, not the deleted v4 harness. Removed the `agent/team/exec` namespaces, pgserve, `GENIE_OTEL_PORT`, native-teams, tmux, "~305KB"; documented the real 12 commands, per-repo + global `genie.db`, in-process fail-closed hook dispatch, 4 runtime deps (~1.3MB bundle). A drift-guard test (mutation-proven to bite) locks out 12 fossil tokens. OTel *relay* (Codex, `codex-config.ts:14318`) is documented, not purged.

**`cd3c126d` — feat(v5): `genie launch --agent codex` + Hermes decision**
A single `AGENT_COMMANDS` mapper parameterizes the launch pane command: `claude` byte-identical, `codex` → `codex exec "$(cat …)"` (verified non-interactive — emits-and-runs, won't hang). Invalid `--agent` → typed error before any side effect. Hermes decided in a `.genie` doc (defer + future omni-shaped runner; an API agent doesn't fit the terminal-pane model) — no half-built launcher.

**`e92ad2f1` — chore(v5)!: 5.x version scheme + remove npm vestiges**
Corrects a false premise the plan review caught: npm was discontinued 2026-05-09 — v5 ships cosign/SLSA signed tarballs via curl. So: 5.x scheme (`5.YYMMDD.N`) across `scripts/version.ts` + the load-bearing `version.yml` CI derive step; `genie --version` → `5.260702.1`; **removed** the npm vestiges (`publishConfig`, dead `prepack`) per the housekeeping handoff; release workflows audited (fixes + deferrals in release-checklist.md); release-bot and branch-guard confirmed to be different planes (dev-only bot push; the local hook never loads on CI).

## Gates

Full `bun run check` (576 tests) + build + e2e green; dead-code clean; the three tracks touch disjoint files.

## Notes

- Mixed-concerns by design (user requested one wish) — landed as 3 reviewable/revertible commits.
- Follow-up (out of scope, noted): a codex `--sandbox` passthrough so real panes get write access (bare `codex exec` respects user config, defaults may be read-only); plugin-version JSONs resync to 5.x on the next CI release.

This is the last v5 umbrella group — its merge completes the lightweight body end to end.

Merge decision: Felipe.