### PR TITLE
fix(release): repair curl|bash install path — unblock the v5 5.x tag

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "4.260702.10",
+      "version": "5.260702.1",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/.genie/release-readiness-5x.md
+++ b/.genie/release-readiness-5x.md
@@ -1,0 +1,160 @@
+# v5 Release-Readiness Audit — genie 5.260702.1
+
+**Date:** 2026-07-02 · **Branch:** dev · **Auditor pass:** read/verify + local artifact build
+**Distribution model:** cosign/SLSA-signed tarballs → GitHub Releases, installed via `curl … install.sh` (NOT npm).
+
+## Verdict
+
+**DO NOT TAG AS-IS.** The signed-tarball build/sign/publish chain and `install.sh`
+download+verify path are coherent and were exercised locally end-to-end, but **the
+installer's final handoff calls a command that no longer exists in v5**, so a fresh
+`curl | bash` install ends in an error and exit 1 (BLOCKER 1). A second install path
+(Claude Code plugin marketplace) still auto-installs genie from the discontinued npm
+channel (BLOCKER 2). Both are one-line-ish fixes. Version drift (SHOULD 3) auto-heals
+if the release goes through the normal dev-bump pipeline but ships a wrong plugin
+version if tagged directly from this commit.
+
+---
+
+## What I exercised (evidence)
+
+### Multi-platform build — ALL 4 built locally ✅
+Ran `bash scripts/build-binary.sh --platform <p>` for each entry in the PLATFORMS list.
+`bun --compile --target=…` cross-compiles cleanly on this darwin-arm64 host:
+
+| Platform | Built here? | Tarball | Size |
+|---|---|---|---|
+| darwin-arm64 | ✅ native | genie-5.260702.1-darwin-arm64.tar.gz | 21.6 MB |
+| linux-x64-glibc | ✅ cross | genie-5.260702.1-linux-x64-glibc.tar.gz | 37.6 MB |
+| linux-x64-musl | ✅ cross | genie-5.260702.1-linux-x64-musl.tar.gz | 35.3 MB |
+| linux-arm64 | ✅ cross | genie-5.260702.1-linux-arm64.tar.gz | 37.1 MB |
+
+All well under the 80 MB budget. Cross-compiled linux binaries embed the local bun
+runtime (1.3.9); I could not execute them on macOS but the darwin binary ran correctly
+(below). CI builds these on native runners with bun 1.3.11 (build-tarballs.yml matrix).
+
+**Contents per tarball (verified on darwin-arm64):** `genie` (Mach-O arm64, +x),
+`VERSION`=`5.260702.1`, `plugins/`, `skills/` (18), `templates/` (2). Extracted
+`./genie --version` → **`5.260702.1`** (NOT `0.0.0-unknown`). The version.ts VERSION-file
+stamp path (execDir/VERSION) works for compiled binaries. ✅
+
+### Shipped-surface smoke (compiled darwin binary) ✅
+- `genie --help` → 12 commands: board, doctor, help, hook, init, launch, omni, setup,
+  shortcuts, task, uninstall, update. Exit 0.
+- `genie doctor` → all checks pass, correctly reports version 5.260702.1; only warning is
+  "genie on PATH — not found" (expected, ran from /tmp). Exit 0.
+- `genie init` in a fresh `/tmp` git repo → scaffolds `.genie/INDEX.md` + `.gitignore`;
+  idempotent on second run (exit 0). `genie task list` and `genie board` both work. ✅
+
+### Release-workflow chain — coherent ✅
+`version.yml` (derives `5.YYMMDD.N`, `bun run version` syncs all 4 JSONs, commits + pushes
+tag `v<version>`) → tag `v*` fires `release.yml` orchestrator → `build-tarballs.yml`
+(matrix, native runners) → `sign-attest.yml` (cosign keyless + SLSA L3) →
+`release-publish.yml` (gh release + 12 assets + `.well-known/*.json`). Single run via
+`workflow_call`; no `workflow_run` recursion. Tag glob `v5.*` matches the version scheme.
+
+**Naming contract is consistent end-to-end:**
+`genie-<v>-<platform>.tar.gz` (build) → `+.bundle` `+.intoto.jsonl` (sign) → upload
+`dist/*` = 12 assets (publish) → `install.sh` downloads `genie-<v>-<platform>.tar.gz` +
+`.bundle` and runs `cosign verify-blob` / `gh attestation verify` with cert-identity
+pinned to `^https://github.com/automagik-dev/genie/.github/workflows/sign-attest.yml@`
++ github OIDC issuer — matches the workflow that physically holds the cosign step.
+
+**Manifest chain consistent:** publish writes `.well-known/{latest,homolog,dev}.json`
+with `version` + `tarball_base=…/releases/download/v<version>`; install.sh reads
+`latest.json` (stable) → `version` + `tarball_base`, then fetches the platform tarball
+from it. Platform detection in install.sh (linux-x64-{glibc,musl}, linux-arm64,
+darwin-arm64; Intel-Mac rejected) matches the 4 built platforms exactly. Channel taxonomy
+(stable/homolog/dev) is consistent across install.sh, release.yml, release-publish.yml.
+
+---
+
+## Blockers (prioritized)
+
+### 🔴 BLOCKER 1 — install.sh execs a command that doesn't exist in v5
+`install.sh:311-315` `handoff_to_subcommand()` runs `exec "$LOCAL_BIN/genie" install`
+as the final step. **v5 has no top-level `install` command.** The only `install` is
+`shortcuts install` (src/genie.ts:110, a subcommand of `shortcuts`). Verified on the
+compiled binary:
+```
+$ genie install
+Error (genie): error: unknown command 'install' (Did you mean uninstall?)
+$ echo $?  → 1
+```
+Impact: `curl … install.sh | bash` extracts + symlinks the binary successfully (that
+happens before the handoff), then dies with `unknown command 'install'` and **exit 1**.
+The "shell-rc + completions wiring" that `genie install` was supposed to do never runs —
+so on any box where `~/.local/bin` is not already on PATH (common fresh macOS/Linux), a
+new shell can't find `genie` and the install *looks* failed.
+**Fix:** repoint the handoff at a command that exists (e.g. `genie setup --quick`, which
+does shell-rc/shortcut wiring) or reintroduce a top-level `genie install`; and/or make the
+handoff non-fatal (`exec … || true` won't work with exec — guard it) so a missing setup
+step never fails the whole install.
+
+### 🔴 BLOCKER 2 — Claude Code plugin path still auto-installs genie from discontinued npm
+`plugins/genie/scripts/smart-install.js:428` (wired as a **SessionStart** hook in
+`plugins/genie/hooks/hooks.json:10`) runs `bun add -g @automagik/genie@latest` whenever
+`genieCliNeedsInstall()` is true (no genie binary present). npm distribution was
+**discontinued 2026-05-09** (per package.json description). A fresh user who installs the
+`genie` plugin via the Claude Code marketplace therefore gets a stale last-published npm
+build (≤4.x) or a hard failure — never v5, and never the signed-tarball path.
+**Fix:** rewrite `installGenieCli()` to bootstrap via `install.sh` / GitHub Releases, or
+drop the auto-install and print the `curl … install.sh` one-liner. Decide whether the
+plugin marketplace is a supported v5 install path at all; if not, deprecate it loudly.
+
+---
+
+## Should-fix
+
+### 🟡 SHOULD 3 — plugin/marketplace version files stranded at 4.x
+Root `package.json`=**5.260702.1**, but:
+- `plugins/genie/package.json` = `4.260702.10`
+- `plugins/genie/.claude-plugin/plugin.json` = `4.260702.10`
+- `.claude-plugin/marketplace.json` plugins[0].version = `4.260702.10`
+
+The **shipped tarball** carries `plugins/genie/.claude-plugin/plugin.json` = 4.260702.10
+inside it (verified in the extracted darwin tarball). Cause: commit `e92ad2f1`
+("chore(v5)!: 5.x version scheme…") hand-set the root version without running
+`bun run version` — `scripts/version.ts` is the thing that syncs all four files (lines
+80-101) and it wasn't run.
+Severity depends on the release route:
+- **Normal dev-bump route (auto-heals):** a real release is derived on a dev CI push
+  where `version.yml` runs `bun run version` → all 4 files rewritten to `5.YYMMDD.N`,
+  committed, tagged. The drift disappears. Cosmetic.
+- **Direct tag from this commit (real mismatch):** the release ships a plugin advertising
+  4.260702.10 while the CLI reports 5.260702.1 — marketplace listing + in-tarball
+  plugin.json disagree with the binary. Confusing on a fresh plugin install.
+`smart-install.js` compares its own plugin `package.json` version against a marker for
+dep-reinstall (not against the CLI), so it won't hard-fail on the drift — but the
+user-visible version in the marketplace is wrong.
+**Fix:** run `bun run version` (or manually bump the 3 plugin JSONs to 5.260702.1) before
+tagging, OR guarantee the release goes through the dev-bump pipeline rather than a manual
+tag of e92ad2f1.
+
+---
+
+## Notes (fine / low-priority)
+
+- **NOTE 4 — dead build define.** `scripts/build-binary.sh:61` passes
+  `--define GENIE_BUILD_VERSION='<v>'`, but nothing in `src/` reads `GENIE_BUILD_VERSION`
+  (version resolves from the `VERSION` file stamp, which works). Harmless no-op; remove
+  for clarity.
+- **NOTE 5 — CI smoke test no longer asserts anything.** `build-tarballs.yml` smoke steps
+  run `genie /work --help` (lines 125/148/167). `/work` is a Claude Code slash command,
+  not a genie CLI subcommand in v5; genie prints top-level help and **exits 0**, so the
+  step passes but verifies nothing. Not fatal. Swap for `genie doctor` or `genie --help`
+  to make the smoke test meaningful again.
+- **NOTE 6 — local bun below engine floor.** This host has bun 1.3.9; `package.json`
+  engines requires `>=1.3.10` and CI uses 1.3.11 (build) / 1.3.10 (version). Local builds
+  still succeeded and produced correct binaries — no release impact, CI is source of truth.
+
+---
+
+## Bottom line for tagging
+Fix **BLOCKER 1** (install.sh handoff) before cutting — it breaks the primary
+`curl | bash` install on the most common first-run environment. Resolve **BLOCKER 2**
+(or explicitly deprecate the plugin-marketplace install) so the two install paths don't
+diverge to different major versions. Ensure the release is cut via the **dev-bump
+pipeline** (not a manual tag of the current commit) so **SHOULD 3** auto-heals, or bump
+the plugin JSONs by hand first. The signing/attestation/publish/verify machinery and the
+tarball artifacts themselves are sound.

--- a/.github/workflows/build-tarballs.yml
+++ b/.github/workflows/build-tarballs.yml
@@ -122,8 +122,8 @@ jobs:
             echo "::error::genie --version mismatch: expected '${VERSION}', got '${ACTUAL}'"
             exit 1
           fi
-          "${STAGE}/genie" /work --help >/dev/null
-          echo "smoke ok: --version=${ACTUAL}; /work --help exit 0"
+          "${STAGE}/genie" --help >/dev/null
+          echo "smoke ok: --version=${ACTUAL}; --help exit 0"
 
       - name: Smoke test (musl binary in alpine container)
         if: matrix.platform == 'linux-x64-musl'
@@ -145,8 +145,8 @@ jobs:
               echo "::error::genie --version mismatch: expected ${VERSION}, got ${ACTUAL}"
               exit 1
             fi
-            /app/genie /work --help >/dev/null
-            echo "smoke ok (alpine): --version=${ACTUAL}; /work --help exit 0"
+            /app/genie --help >/dev/null
+            echo "smoke ok (alpine): --version=${ACTUAL}; --help exit 0"
           '
 
       - name: Smoke test (extract + --version on macOS runners)
@@ -164,8 +164,8 @@ jobs:
             echo "::error::genie --version mismatch: expected '${VERSION}', got '${ACTUAL}'"
             exit 1
           fi
-          "${STAGE}/genie" /work --help >/dev/null
-          echo "smoke ok: --version=${ACTUAL}; /work --help exit 0"
+          "${STAGE}/genie" --help >/dev/null
+          echo "smoke ok: --version=${ACTUAL}; --help exit 0"
 
       - name: Verify size budget (≤80 MB compressed)
         shell: bash

--- a/install.sh
+++ b/install.sh
@@ -308,10 +308,56 @@ detect_legacy_install() {
   fi
 }
 
-handoff_to_subcommand() {
-  log "handing off to: genie install (shell-rc + completions wiring)"
-  rm -rf "$TMP_DIR"
-  exec "$LOCAL_BIN/genie" install
+# Post-install PATH wiring. v5 exposes no install subcommand on the genie CLI —
+# the shell-rc PATH wiring lives here in the installer (mirroring how `genie init`
+# idempotently manages .gitignore). If $LOCAL_BIN is already resolvable on PATH
+# there is nothing to do; otherwise append a single export line to the login
+# shell's rc file, guarded so re-runs never duplicate it.
+path_contains_local_bin() {
+  case ":${PATH}:" in
+    *":${LOCAL_BIN}:"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Pick the rc file for the user's login shell. Fall back to ~/.profile, which
+# POSIX login shells source.
+shell_rc_file() {
+  case "$(basename "${SHELL:-}")" in
+    zsh) echo "$HOME/.zshrc" ;;
+    bash)
+      # macOS bash login shells read ~/.bash_profile; Linux reads ~/.bashrc.
+      # Prefer an existing file, else default per-OS.
+      if [[ -f "$HOME/.bashrc" ]]; then echo "$HOME/.bashrc"
+      elif [[ -f "$HOME/.bash_profile" ]]; then echo "$HOME/.bash_profile"
+      elif [[ "$(uname -s)" == "Darwin" ]]; then echo "$HOME/.bash_profile"
+      else echo "$HOME/.bashrc"; fi ;;
+    *) echo "$HOME/.profile" ;;
+  esac
+}
+
+ensure_path_wired() {
+  if path_contains_local_bin; then
+    log "PATH already includes $LOCAL_BIN — genie is ready"
+    return 0
+  fi
+  local rc
+  rc="$(shell_rc_file)"
+  # Idempotent: if any line already puts ~/.local/bin on PATH (ours or the
+  # user's own), don't append a duplicate. The written line uses the literal
+  # $HOME form, so match on the shared ".local/bin" substring.
+  if [[ -f "$rc" ]] && grep -qF '.local/bin' "$rc" 2>/dev/null; then
+    log "PATH wiring already present in ${rc/#$HOME/\~}"
+  else
+    mkdir -p "$(dirname "$rc")"
+    {
+      printf '\n# genie: put ~/.local/bin on PATH\n'
+      printf 'export PATH="$HOME/.local/bin:$PATH"\n'
+    } >> "$rc"
+    log "added $LOCAL_BIN to PATH in ${rc/#$HOME/\~}"
+  fi
+  warn "genie is installed but $LOCAL_BIN is not on your PATH yet."
+  warn "  open a new shell, or run:  export PATH=\"$LOCAL_BIN:\$PATH\" && hash -r"
 }
 
 main() {
@@ -329,7 +375,8 @@ main() {
   tarball="$(download_and_verify "$version" "$platform" "$tarball_base")"
   extract_and_link "$tarball"
   detect_legacy_install
-  handoff_to_subcommand
+  ensure_path_wired
+  log "genie v${version} installed"
 }
 
 main "$@"

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "4.260702.10",
+  "version": "5.260702.1",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "4.260702.10",
+  "version": "5.260702.1",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "type": "module",

--- a/plugins/genie/scripts/smart-install.js
+++ b/plugins/genie/scripts/smart-install.js
@@ -414,24 +414,25 @@ function configureTmux() {
 }
 
 /**
- * Install or upgrade genie CLI globally via bun
+ * genie CLI is missing — advise the canonical v5 install path.
+ *
+ * v5 ships as cosign/SLSA-signed tarballs via GitHub Releases + install.sh.
+ * The old npm/bun-global path (`bun add -g` of the @automagik package) was
+ * discontinued 2026-05-09 and no longer resolves a current build.
+ *
+ * We deliberately do NOT run the network installer from this SessionStart hook:
+ * `curl | bash` downloads, cosign-verifies, extracts, and rewrites the user's
+ * shell rc — too heavy and intrusive to do silently while a Claude Code session
+ * is starting, and it would block startup on the network. Instead we print the
+ * one canonical command and let the user run it deliberately. The hook stays
+ * fast and never hard-fails on a missing CLI.
  */
-function installGenieCli() {
-  const bunPath = getBunPath();
-  if (!bunPath) {
-    throw new Error('Bun executable not found — cannot install genie CLI');
-  }
-
-  console.error('Installing genie CLI globally via bun...');
-
-  const bunCmd = IS_WINDOWS && bunPath.includes(' ') ? `"${bunPath}"` : bunPath;
-  execSync(`${bunCmd} add -g @automagik/genie@latest`, { stdio: ['pipe', 'pipe', 'pipe'], shell: IS_WINDOWS });
-
-  const newVersion = getGenieVersion();
-  if (!newVersion) {
-    throw new Error('genie CLI installation completed but binary not found. Restart your terminal.');
-  }
-  console.error(`genie CLI ${newVersion} installed`);
+function adviseGenieCliInstall() {
+  console.error('');
+  console.error('genie CLI is not installed.');
+  console.error('Install it (cosign + SLSA verified) with:');
+  console.error('  curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash');
+  console.error('');
 }
 
 // Main execution
@@ -503,14 +504,9 @@ try {
     console.error(`Warning: Could not configure tmux TUI: ${e.message}`);
   }
 
-  // 4. Install or upgrade genie CLI via bun global (non-fatal)
+  // 4. Advise on genie CLI install if missing (non-fatal, no network in-hook)
   if (genieCliNeedsInstall()) {
-    try {
-      installGenieCli();
-    } catch (e) {
-      console.error(`Warning: genie CLI install/upgrade failed: ${e.message}`);
-      console.error('The plugin will still work. Install genie CLI manually later.');
-    }
+    adviseGenieCliInstall();
   }
 } catch (e) {
   // Only Bun install failure reaches here — everything else is graceful.

--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -58,7 +58,6 @@ mkdir -p "$STAGE"
 echo "==> [${PLATFORM}] bun build --compile --target=${TARGET}  (v${VERSION})"
 bun build --compile \
   --target="${TARGET}" \
-  --define GENIE_BUILD_VERSION="'${VERSION}'" \
   "${ENTRY_POINT}" \
   --outfile "${STAGE}/genie"
 


### PR DESCRIPTION
## Summary

A release-readiness audit of the just-completed v5 umbrella found **2 blockers that would ship a broken v5** — a fresh `curl | bash` install dies before it works. This PR fixes both plus three follow-ups, clearing the path to tag a real 5.x release. Full audit in [`.genie/release-readiness-5x.md`](.genie/release-readiness-5x.md).

## Blockers fixed

**🔴 install.sh handed off to a removed command.** After downloading + cosign-verifying + symlinking the binary, `install.sh` did `exec genie install` for PATH/shell-rc wiring — but `genie install` was removed in the warp-integration PR (11→12 commands). So `curl | bash` extracted, symlinked, then died exit 1; PATH never got wired → genie unusable on any box where `~/.local/bin` isn't already on PATH. **Fix:** inlined idempotent shell-rc PATH wiring directly into install.sh (v4's `genie install` was a pm2/pgserve daemon installer, irrelevant to v5, and no v5 command owns this) — appends `export PATH=…` under a `# genie:` marker to the login shell's rc, guarded so a second run (or a user's pre-existing line) never double-appends. Idempotency proven at byte level in review.

**🔴 plugin auto-install used discontinued npm.** The genie plugin's SessionStart hook (`smart-install.js`) auto-installed via `bun add -g @automagik/genie@latest` — npm was discontinued 2026-05-09. Fresh plugin users got stale/failed installs, never v5. **Fix:** replaced with a non-throwing advisory that prints the canonical `curl … install.sh` command; the hook can never hard-fail a Claude Code session.

## Follow-ups

- Synced the stranded plugin JSONs (`plugin.json`, plugin `package.json`, `marketplace.json`) 4.260702.10 → 5.260702.1
- Removed a dead `--define GENIE_BUILD_VERSION` from build-binary.sh
- Fixed the CI smoke test (`genie /work --help` → `genie --help` — `/work` isn't a v5 command)

## Verification

Full `bun run check` (578 tests) green; the real compiled binary (`build-binary.sh --platform darwin-arm64`) reports `5.260702.1`; install flow exercised in an isolated `$HOME` harness (verify → extract → symlink → idempotent PATH wire).

## After this merges

Per the audit, the signing/attestation/publish machinery and the tarball artifacts are already sound — these two install-path fixes were the last things between a fresh box and a working `curl | bash`. **v5 becomes tag-ready.** Cut the release through the normal dev-bump pipeline (which also re-syncs versions).

Merge decision: Felipe.