### PR TITLE
fix(omni): address PR #2506 review — 3 Codex P2s

### DIFF
--- a/src/lib/omni-runner.ts
+++ b/src/lib/omni-runner.ts
@@ -429,6 +429,11 @@ export function createOmniRunner(deps: OmniRunnerDeps): OmniRunner {
         return;
       }
       if (evt.type !== 'reaction' || !evt.emoji) return;
+      // Scope to our own instance — text replies are already subject-scoped to
+      // `omni.message.${config.instance}.>`, but reactions arrive on a shared
+      // `omni.event.>` bus where approvalChat JIDs can repeat across instances.
+      // Without this, another instance's 👍/👎 could resolve our approval.
+      if (evt.instanceId && config.instance && evt.instanceId !== config.instance) return;
       const chatId = evt.chatId ?? chatIdFromSubject(subject);
       if (!chatId || chatId !== config.approvalChat) return;
       const decision = matchReaction(evt.emoji, vocab);

--- a/src/lib/v5/task-state.test.ts
+++ b/src/lib/v5/task-state.test.ts
@@ -8,6 +8,7 @@ import {
   CheckoutConflictError,
   CycleError,
   DEFAULT_STALE_MS,
+  TaskNotReadyError,
   UnknownTaskError,
   WishGroupDriftError,
   WishGroupStateError,
@@ -139,6 +140,19 @@ describe('ready-set recompute (idempotent + monotonic)', () => {
     const a = createTask(db, { title: 'a' });
     createTask(db, { title: 'b', dependsOn: [a.id] });
     expect(readyTasks(db).map((t) => t.title)).toEqual(['a']);
+  });
+
+  test('completing a blocked task is rejected (no dependency-gate bypass)', () => {
+    const a = createTask(db, { title: 'a' });
+    const b = createTask(db, { title: 'b', dependsOn: [a.id] });
+    expect(getTask(db, b.id)!.status).toBe('blocked');
+    expect(() => completeTask(db, b.id)).toThrow(TaskNotReadyError);
+    // a's dependency gate is intact — b never went done, nothing downstream moved.
+    expect(getTask(db, b.id)!.status).toBe('blocked');
+    // Once the dep is done, b promotes to ready and completes normally.
+    completeTask(db, a.id);
+    expect(getTask(db, b.id)!.status).toBe('ready');
+    expect(completeTask(db, b.id).status).toBe('done');
   });
 });
 

--- a/src/lib/v5/task-state.ts
+++ b/src/lib/v5/task-state.ts
@@ -132,6 +132,16 @@ export class CheckoutConflictError extends Error {
   }
 }
 
+/** A `blocked` task (unmet dependencies) cannot be completed. */
+export class TaskNotReadyError extends Error {
+  readonly taskId: string;
+  constructor(taskId: string) {
+    super(`Task ${taskId} is blocked — its dependencies are not all done; cannot complete`);
+    this.name = 'TaskNotReadyError';
+    this.taskId = taskId;
+  }
+}
+
 /** An invalid wish-group transition was attempted. */
 export class WishGroupStateError extends Error {
   constructor(message: string) {
@@ -431,6 +441,11 @@ export function claimTask(db: Database, taskId: string, worker: string, opts: Cl
 export function completeTask(db: Database, taskId: string): TaskRow {
   const task = getTask(db, taskId);
   if (!task) throw new UnknownTaskError(taskId);
+  // A `blocked` task's dependencies are not all `done`; completing it would let
+  // recomputeReady() promote downstream tasks whose real prerequisites were
+  // skipped. Reject so a mistaken id can't bypass the dependency gate. Ready
+  // and in_progress remain completable (direct completion + the checkout path).
+  if (task.status === 'blocked') throw new TaskNotReadyError(taskId);
   const now = Date.now();
   const done = db.transaction(() => {
     db.query("UPDATE tasks SET status = 'done', updated_at = ? WHERE id = ?").run(now, taskId);

--- a/src/types/genie-config.ts
+++ b/src/types/genie-config.ts
@@ -77,7 +77,16 @@ const OmniApprovalsConfigSchema = z.object({
   enabled: z.boolean().default(false),
   /** Regex source matched against tool_name to decide which calls to gate. */
   tools: z.string().default('^(Bash|Write|Edit|NotebookEdit)$'),
-  /** Hook self-timeout budget (ms). MUST stay < the CC hook `timeout` (seconds). */
+  /**
+   * Hook self-timeout budget (ms) — how long the PreToolUse handler polls for a
+   * remote resolution before falling back to `ask`. MUST stay strictly below the
+   * Claude Code hook `timeout` (SECONDS) wherever `genie hook dispatch` is
+   * installed, or CC kills the hook before it can allow/deny OR reach its
+   * timeout→ask fail-safe. The shipped dispatch entries default to 5s/15s, which
+   * is far below this 110s default: enabling approvals REQUIRES raising the hook
+   * `timeout` (e.g. 120s) on the PreToolUse dispatch entry — see
+   * `.claude/settings.json` / `plugins/genie/hooks/hooks.json`.
+   */
   pollBudgetMs: z.number().default(110_000),
   /** Poll interval while waiting for a resolution (ms). */
   pollIntervalMs: z.number().default(400),


### PR DESCRIPTION
Addresses the three Codex P2 comments on the cutover PR #2506 (fixes land on dev, flow to main via the cutover).

- **Approval budget vs hook timeout** (`genie-config.ts`): documented that `pollBudgetMs` (110s) MUST stay under the Claude Code hook `timeout` wherever `genie hook dispatch` is installed — the shipped 5s/15s entries kill the approval hook before it can allow/deny or reach its timeout→ask fail-safe. Enabling approvals requires raising the hook timeout (e.g. 120s). *Being validated live in the omni WhatsApp QA.*
- **Task-done dependency guard** (`task-state.ts`): `completeTask` now rejects a `blocked` task (`TaskNotReadyError`) so a mistaken id can't complete it and let `recomputeReady` promote downstream tasks whose prerequisites were skipped. `ready`/`in_progress` stay completable. Tested.
- **Reaction instance scope** (`omni-runner.ts`): `handleEvent` scopes reactions to `config.instance`, mirroring the instance-scoped text-reply subject, so another instance's 👍/👎 on a shared event bus can't resolve this host's approval.

**Declined**: Gemini MEDIUM (Portuguese table headers in `DESIGN.md`) — a historical brainstorm doc, cosmetic, not worth churning.

579 tests green. Merge → Felipe.