### PR TITLE
feat: genie mcp server — Warp + Claude Code consume genie state

### DIFF
--- a/.genie/wishes/genie-mcp/SPIKE.md
+++ b/.genie/wishes/genie-mcp/SPIKE.md
@@ -1,0 +1,123 @@
+# G1 Spike — MCP transport + Warp/Claude Code config schema
+
+Date: 2026-07-03 · Worker: g1-spike · Gates: G2, G3
+
+## Verdict: hand-rolled
+
+A hand-rolled newline-delimited JSON-RPC 2.0 stdio server (zero deps) satisfied a **real Claude Code** client end-to-end (`initialize` → `tools/list` → `tools/call`) on two boxes, and speaks the exact MCP protocol (`2024-11-05`) Warp uses. Genie stays 4-runtime-deps-lean — no 5th dep (`@modelcontextprotocol/sdk`) required. The SDK remains the documented fallback (dynamic-imported like `nats` in `omni.ts`) **only if** Warp's live UI later reveals a framing/handshake quirk during Felipe's eyeball check (see Warp evidence below) — nothing observed suggests it will.
+
+Throwaway server: `.genie/wishes/genie-mcp/spike/server.mjs` (runs under both `node` and `bun`; NOT in `src/`).
+
+## Framing
+
+**Newline-delimited JSON** — one JSON-RPC 2.0 object per line on stdin/stdout, no embedded newlines, no `Content-Length` headers. This is the MCP stdio transport (Content-Length framing is LSP, not MCP). Confirmed: real Claude Code connected and invoked a tool against the newline-delimited server with no framing negotiation.
+
+Handshake contract:
+- Client → `initialize` (`params.protocolVersion: "2024-11-05"`, `capabilities`, `clientInfo`).
+- Server → result envelope `{ protocolVersion, capabilities: { tools: {...} }, serverInfo: { name, version } }`.
+- Client → `notifications/initialized` (a notification — **no `id`, no response**; the server must not reply).
+- Then `tools/list`, `tools/call`, (optional `ping`, `resources/list`, `resources/read`).
+- Notifications (messages with no `id`) get NO response. Unknown method with an `id` → JSON-RPC error `-32601`.
+- **Flush before exit:** on stdin `end`, drain stdout before `process.exit(0)` or the last response truncates (mirrors the WISH G2 impl note).
+
+## Evidence per client
+
+### Claude Code — CONFIRMED end-to-end (both Mac + Linux)
+
+- **Mac (local):** project `.mcp.json` was auto-discovered and listed by `claude mcp list` as `⏸ Pending approval` (the expected project-scope security gate — project servers require workspace trust before connecting). Adding the identical server at `--scope local` (auto-approved) health-checked to **`✔ Connected`** (a real `initialize` handshake). A headless `claude -p "...call the echo tool..." --allowedTools mcp__genie-spike__echo` returned the tool's exact output `echo: spike-ok-12345` → proves `initialize` + `tools/list` + `tools/call` through the real client.
+- **Linux box `felipe` (where Warp-over-SSH would spawn the server):** the same hand-rolled server health-checked to **`✔ Connected`** under Claude Code `2.1.199`.
+- Both registrations were removed after testing.
+
+Claude Code `.mcp.json` notes for G3:
+- `type: "stdio"` is **optional** — a server object with `command` present defaults to stdio.
+- Project `.mcp.json` servers are **pending approval** until the user trusts the workspace (runs `claude` interactively and accepts the trust dialog) — expected, not a bug; document it.
+- Supports `${VAR}` env expansion and an optional per-server `"timeout"` (ms).
+
+### Warp — schema + protocol CONFIRMED; live UI connection NEEDS FELIPE'S EYES
+
+`felipe` is a **Linux** dev box (`warp-terminal` Linux build) that Felipe reaches **via Warp's SSH remote feature** — the Warp GUI runs on Felipe's Mac and drives a `~/.warp/remote-server/` component on `felipe`. Warp opens the repo on the remote, so it discovers `<repo>/.warp/.mcp.json` **on `felipe`** and spawns the stdio server **on `felipe`**.
+
+Confirmed without the GUI:
+- **Authoritative schema** — Warp's own bundled skill on the box: `~/.warp/remote-server/bundled_resources/bundled/skills/add-mcp-server/SKILL.md` (see Config Schema below). This is Warp's shipped source of truth, not a third-party doc.
+- **Warp's MCP subsystem is live on the remote** — `~/.local/state/warp-terminal/oz/warp.log`: `mcp_static_config: Some(McpStaticConfig{...})` and `Converting 0 legacy MCP servers into templatable MCP servers` (0 because the scratch repo hasn't been opened in a Warp session yet).
+- **The server runs where Warp spawns it** — the raw `initialize`/`tools/list` handshake was replayed with `node` on `felipe` and returned correct envelopes.
+- **Config staged for eyeball** — `~/genie-mcp-spike/scratch-repo/.warp/.mcp.json` (+ `.mcp.json`) on `felipe`, pointing at `~/genie-mcp-spike/server.mjs`.
+
+**What needs Felipe's eyes (cannot be driven over ssh — Warp is a GUI):** open Warp on the Mac → SSH into `felipe` → `cd ~/genie-mcp-spike/scratch-repo` → check **Settings → AI/Agents → MCP servers**. Expect `genie-spike` listed **"Detected from Warp"** and a green/connected status; optionally ask Warp's agent to call the `echo` tool. Warp auto-detects `.mcp.json` changes on save (no restart). Since Warp speaks the same MCP `2024-11-05` JSON-RPC that Claude Code accepted against this exact server, the risk is low; the only unproven bit is Warp's client-side connect, not the protocol.
+
+## Config schema (both files)
+
+**Identical shape for both clients.** Both use the top-level `mcpServers` key and the stdio `{ command, args, env?, working_directory? }` per-server object — a single JSON body satisfies both files. `type: "stdio"` is optional (omit it).
+
+Locations (PROJECT scope — what G3 writes; distinct from the GLOBAL launch-config path):
+- Warp project: `<repo>/.warp/.mcp.json` — spawns from repo root by default. (Global would be `~/.warp/.mcp.json`.) **Distinct from** the launch-config emitter's global `~/.warp/launch_configurations/`.
+- Claude Code project: `<repo>/.mcp.json` — checked into version control; team-shared.
+- (Warp also reads `~/.claude.json` as a *global* config, per its bundled skill — not used by this wish.)
+
+Warp recognizes these wrapper keys, in order of preference: `mcpServers` (preferred), `mcp_servers`, `servers`, nested `mcp.servers`, or a flat map. G3 writes/merges under **`mcpServers`** and preserves whichever wrapper key an existing file already uses. Never remove existing server entries — add/update only the `genie` entry.
+
+Concrete genie block (what G3 writes to BOTH `<repo>/.warp/.mcp.json` and `<repo>/.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "genie": {
+      "command": "/absolute/path/to/genie",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+## Spawn `command` form (pinned)
+
+**Use an ABSOLUTE path to the genie binary — NOT bare `"genie"`.** `{"command":"genie","args":["mcp"]}` assumes `genie` is on the spawning process's PATH, which is NOT reliable:
+- **Mac (this install):** `genie` is **not** on PATH — it lives only at `~/.genie/bin/genie` (a 59 MB bun-compiled single-file binary). Bare `genie` would fail to spawn.
+- **`felipe` (Linux):** `genie` IS on PATH (`/home/genie/.local/bin/genie`, also `~/.genie/bin/genie`).
+
+Recommendation for G3: at `genie init`/`launch` time, resolve the **absolute path of the currently-running genie executable** (for the bun-compiled binary that is `process.execPath`) and write that as `command`, with `args: ["mcp"]`. Fallback: `~/.genie/bin/genie` expanded to an absolute path. This is self-consistent under Warp-over-SSH: `genie init` runs on the box that owns the repo (e.g. `felipe`), so it writes that box's genie path, and Warp spawns the server on that same box. Warp supports `${VAR}` substitution, but a resolved absolute path is simpler and avoids PATH ambiguity.
+
+## Tools contract for G2 (the 5 read-only tools)
+
+All backed by the existing read layer in `src/lib/v5/task-state.ts` (`getBoardByName`, `getTask`, `listTasks{status,wish,boardId}`, `getWishGroups`) over a **net-new `new Database(resolveDbPath(cwd), { readonly: true })`** open (NOT `openSqlite()`); degrade to an empty board when the db file is absent. `resolveDbPath()` (in `src/lib/v5/genie-db.ts`) yields the worktree-shared `.genie/genie.db`.
+
+`tools/call` result envelope (MCP standard): `{ "content": [{ "type": "text", "text": "<JSON.stringify(payload)>" }], "isError": false }`. Optionally also set `structuredContent` to the payload object. Payload shapes below (from `TaskRow`/`WishGroupRow`/`BoardRow`).
+
+Reference types (`task-state.ts`): `TaskStatus = 'blocked'|'ready'|'in_progress'|'done'`; `TaskRow = { id, boardId, title, status, claimedBy, claimedAt, wish, group, createdAt, updatedAt }`; `WishGroupRow = { wish, name, status, dependsOn:string[], assignee, startedAt, completedAt }`; `BoardRow = { id, name, createdAt }`.
+
+1. **`genie_board`** — board counts + tasks, optional wish filter.
+   - inputSchema: `{ type:"object", properties:{ board:{type:"string", description:"board name; default repo board"}, wish:{type:"string", description:"filter to a wish slug"} }, required:[] }`
+   - payload: `{ board: string|null, counts: { blocked:number, ready:number, in_progress:number, done:number, total:number }, tasks: TaskSummary[] }` where `TaskSummary = { id, title, status, claimedBy, wish, group }`.
+   - impl: `getBoardByName(db, board)` → `listTasks(db, { boardId, wish? })`; tally counts.
+
+2. **`genie_wish_status`** — a wish's group/DAG progress.
+   - inputSchema: `{ type:"object", properties:{ wish:{type:"string", description:"wish slug"} }, required:["wish"] }`
+   - payload: `{ wish: string, groups: { name, status, dependsOn:string[], assignee, startedAt, completedAt }[], tasks: TaskSummary[] }`.
+   - impl: `getWishGroups(db, wish)` + `listTasks(db, { wish })`.
+
+3. **`genie_worktree_context`** — resolve the caller's git BRANCH `wish/<slug>-<group>` → its wish/group/tasks (the per-pane "what am I here for").
+   - inputSchema: `{ type:"object", properties:{ branch:{type:"string", description:"override; default = current git branch"} }, required:[] }`
+   - payload: `{ branch: string|null, resolved: boolean, wish: string|null, group: string|null, tasks: TaskSummary[] }`.
+   - impl: read the current branch (`git rev-parse --abbrev-ref HEAD` / `git symbolic-ref`); parse `wish/<slug>-<group>`; on match → `listTasks(db, { wish })` filtered to the group (`resolved:true`); on no match → `resolved:false` with the repo-level board tasks as fallback. Resolve by BRANCH, not path (worktree base dir is configurable via `GENIE_WORKTREES_DIR`).
+
+4. **`genie_task`** — full detail by id.
+   - inputSchema: `{ type:"object", properties:{ id:{type:"string", description:"task id, e.g. t_..."} }, required:["id"] }`
+   - payload: the full `TaskRow` (`{ id, boardId, title, status, claimedBy, claimedAt, wish, group, createdAt, updatedAt }`) or `{ error: "not_found", id }` (surface a not-found result, not a protocol error).
+   - impl: `getTask(db, id)`.
+
+5. **`genie_active`** — all in-progress tasks + who claimed what.
+   - inputSchema: `{ type:"object", properties:{}, required:[] }`
+   - payload: `{ tasks: { id, title, status, claimedBy, claimedAt, wish, group }[] }`.
+   - impl: `listTasks(db, { status: 'in_progress' })`.
+
+Also implement `initialize` (advertise `capabilities.tools`), `tools/list` (the 5 above), and `ping`. `resources/list`/`resources/read` are optional for G2 (the wish lists them but the 5 tools are the required contract); if included, expose the board/wishes as resources mirroring the same payloads.
+
+## Non-MCP startup probe (for G2)
+
+The MCP transport must not load on `genie board`/`task`/`--help`. Because the hand-rolled server is plain stdin/stdout JSON with zero imports, this is trivially satisfied by keeping the server module lazy (only reached inside the `genie mcp` command body). If the SDK fallback is ever taken, dynamic-import it inside `genie mcp` only (nats precedent, `omni.ts`).
+
+## Cleanup done
+
+- Removed both Claude Code registrations (Mac local-scope + felipe local-scope).
+- Left intentionally for Felipe's Warp eyeball: `~/genie-mcp-spike/` on `felipe` (server.mjs + scratch-repo with `.warp/.mcp.json` + `.mcp.json`). Safe to `rm -rf ~/genie-mcp-spike` after the Warp check.
+- Local Mac scratch repo is under `/var/folders/.../T/` (OS-cleaned tmp).

--- a/.genie/wishes/genie-mcp/WISH.md
+++ b/.genie/wishes/genie-mcp/WISH.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | DRAFT |
+| **Status** | DONE — G1 spike (hand-rolled) + G2 server + G3 auto-register all SHIP-reviewed (2026-07-03); Warp live-UI QA awaits Felipe |
 | **Slug** | `genie-mcp` |
 | **Date** | 2026-07-03 |
 | **Author** | Felipe + Genie |
@@ -44,11 +44,11 @@ Genie's live state (wishes, tasks, board, what each worktree/pane is working on)
 
 ## Success Criteria
 
-- [ ] `genie mcp` answers MCP `initialize` + `tools/list` + `tools/call` over stdio and returns real genie.db state (board / wish_status / worktree_context) — automated protocol test; opens the db read-only and degrades to an empty board when absent.
-- [ ] `genie init` JSON-merge-writes idempotent `<repo>/.warp/.mcp.json` + `<repo>/.mcp.json` registering `genie mcp` (byte-identical on rerun; a pre-existing MCP server is preserved).
+- [x] `genie mcp` answers MCP `initialize` + `tools/list` + `tools/call` over stdio and returns real genie.db state (board / wish_status / worktree_context) — automated protocol test; opens the db read-only and degrades to an empty board when absent.
+- [x] `genie init` JSON-merge-writes idempotent `<repo>/.warp/.mcp.json` + `<repo>/.mcp.json` registering `genie mcp` (byte-identical on rerun; a pre-existing MCP server is preserved).
 - [ ] A real Warp AND a real Claude Code session connect to `genie mcp` and read genie state (manual QA recorded in qa.md).
-- [ ] Non-mcp paths (`genie board`/`task`/`--help`) do not initialize the MCP transport/dep (startup probe).
-- [ ] Full `bun run check` + build green; CI green on the PR.
+- [x] Non-mcp paths (`genie board`/`task`/`--help`) do not initialize the MCP transport/dep (startup probe).
+- [x] Full `bun run check` + build green; CI green on the PR.
 
 ## Execution Strategy
 
@@ -94,9 +94,9 @@ grep -qiE 'command' .genie/wishes/genie-mcp/SPIKE.md
 4. Tests: an MCP-protocol test (spawn `genie mcp`, drive initialize → tools/list → tools/call, assert real genie.db state); a readonly + absent-db test; a non-mcp init probe (the MCP transport/dep is NOT loaded on `board`/`task`/`--help`).
 
 **Acceptance Criteria:**
-- [ ] `genie mcp` answers initialize/tools/list/tools/call over stdio with real genie.db state; opens read-only; degrades to empty board on absent db.
-- [ ] Non-mcp paths don't initialize the MCP transport/dep (probe test).
-- [ ] typecheck + `bun test` for the mcp module + build green; `--help` lists `mcp`.
+- [x] `genie mcp` answers initialize/tools/list/tools/call over stdio with real genie.db state; opens read-only; degrades to empty board on absent db.
+- [x] Non-mcp paths don't initialize the MCP transport/dep (probe test).
+- [x] typecheck + `bun test` for the mcp module + build green; `--help` lists `mcp`.
 
 **Validation:**
 ```bash

--- a/.genie/wishes/genie-mcp/WISH.md
+++ b/.genie/wishes/genie-mcp/WISH.md
@@ -67,8 +67,8 @@ Genie's live state (wishes, tasks, board, what each worktree/pane is working on)
 2. `.genie/wishes/genie-mcp/SPIKE.md`: verdict (hand-rolled | SDK), the exact `.warp/.mcp.json` + `.mcp.json` schema (keys, the `command`/`args` shape, project vs global location), the spawn `command` form that actually runs on this install (global `genie` vs the dist/bun path), and the tools/resources JSON contract Group 2 must implement.
 
 **Acceptance Criteria:**
-- [ ] SPIKE.md documents the transport verdict + the confirmed config schema + command form, with evidence from BOTH real clients.
-- [ ] The scratch config uses the PROJECT `<repo>/.warp/.mcp.json` (confirmed distinct from the global `~/.warp/launch_configurations/`).
+- [x] SPIKE.md documents the transport verdict + the confirmed config schema + command form, with evidence from BOTH real clients.
+- [x] The scratch config uses the PROJECT `<repo>/.warp/.mcp.json` (confirmed distinct from the global `~/.warp/launch_configurations/`).
 
 **Validation:**
 ```bash

--- a/.genie/wishes/genie-mcp/WISH.md
+++ b/.genie/wishes/genie-mcp/WISH.md
@@ -128,9 +128,9 @@ echo "$OUT" | grep -q '"result"' || { echo "FAIL: mcp initialize no result"; exi
 3. Tests: idempotent merge test — empty case AND a pre-populated `.mcp.json` with ANOTHER server (assert the other server survives + byte-identical rerun); `genie init` in a fixture repo registers `genie mcp` in both files.
 
 **Acceptance Criteria:**
-- [ ] `genie init` writes/merges both files registering `genie mcp`; a pre-existing MCP server is preserved; rerun is byte-identical.
-- [ ] Docs updated; the tab-info limitation stated honestly.
-- [ ] Full `bun run check` green.
+- [x] `genie init` writes/merges both files registering `genie mcp`; a pre-existing MCP server is preserved; rerun is byte-identical.
+- [x] Docs updated; the tab-info limitation stated honestly.
+- [x] Full `bun run check` green.
 
 **Validation:**
 ```bash

--- a/.genie/wishes/genie-mcp/spike/server.mjs
+++ b/.genie/wishes/genie-mcp/spike/server.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+// THROWAWAY G1 spike: hand-rolled JSON-RPC 2.0 MCP server over stdio.
+// Newline-delimited framing (one JSON object per line) — MCP stdio transport.
+// Implements just: initialize, tools/list, tools/call (echo). No deps.
+// Runs under both `bun` and `node`.
+
+const PROTOCOL_VERSION = '2024-11-05';
+const SERVER_INFO = { name: 'genie-spike', version: '0.0.1' };
+
+const TOOLS = [
+  {
+    name: 'echo',
+    description: 'Echo back the provided text (spike smoke tool).',
+    inputSchema: {
+      type: 'object',
+      properties: { text: { type: 'string', description: 'Text to echo' } },
+      required: ['text'],
+    },
+  },
+];
+
+function send(msg) {
+  process.stdout.write(JSON.stringify(msg) + '\n');
+}
+
+function reply(id, result) {
+  send({ jsonrpc: '2.0', id, result });
+}
+
+function replyError(id, code, message) {
+  send({ jsonrpc: '2.0', id, error: { code, message } });
+}
+
+function handle(msg) {
+  const { id, method, params } = msg;
+  // Notifications (no id) — e.g. notifications/initialized — need no response.
+  if (method === 'notifications/initialized' || method === 'initialized') return;
+
+  switch (method) {
+    case 'initialize':
+      reply(id, {
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: { tools: { listChanged: false } },
+        serverInfo: SERVER_INFO,
+      });
+      return;
+    case 'ping':
+      reply(id, {});
+      return;
+    case 'tools/list':
+      reply(id, { tools: TOOLS });
+      return;
+    case 'tools/call': {
+      const name = params?.name;
+      const args = params?.arguments ?? {};
+      if (name === 'echo') {
+        reply(id, {
+          content: [{ type: 'text', text: `echo: ${args.text ?? ''}` }],
+          isError: false,
+        });
+        return;
+      }
+      replyError(id, -32602, `Unknown tool: ${name}`);
+      return;
+    }
+    default:
+      if (id !== undefined) replyError(id, -32601, `Method not found: ${method}`);
+  }
+}
+
+let buf = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => {
+  buf += chunk;
+  let nl;
+  while ((nl = buf.indexOf('\n')) >= 0) {
+    const line = buf.slice(0, nl).trim();
+    buf = buf.slice(nl + 1);
+    if (!line) continue;
+    try {
+      handle(JSON.parse(line));
+    } catch (e) {
+      replyError(null, -32700, `Parse error: ${e.message}`);
+    }
+  }
+});
+// Do NOT exit on stdin end until stdout drains, or clients truncate responses.
+process.stdin.on('end', () => {
+  process.stdout.write('', () => process.exit(0));
+});

--- a/.genie/wishes/omni-approval-ux/WISH.md
+++ b/.genie/wishes/omni-approval-ux/WISH.md
@@ -1,0 +1,142 @@
+# Wish: Omni Approval UX — Correlated Identity, Reactions, Anti-Spam
+
+| Field | Value |
+|-------|-------|
+| **Status** | DRAFT |
+| **Slug** | `omni-approval-ux` |
+| **Date** | 2026-07-03 |
+| **Author** | Felipe + Genie |
+| **Appetite** | ~3-4 days |
+| **Branch** | `wish/omni-approval-ux` (from `dev`; PR to `dev`) |
+| **Design** | _No brainstorm — grounded in the live WhatsApp QA on 2026-07-03_ |
+| **Depends on** | `omni-runner-port` (merged), `wish/omni-hardening` (PR #2507) |
+
+## Summary
+
+The v5 omni approval bridge is live-proven (a PreToolUse hook → WhatsApp 🔔 → text `y` → allow envelope, verified end-to-end against the real Omni hub). But the live QA exposed three UX/correctness gaps: replies resolve the OLDEST pending approval rather than the one the human actually answered (concurrent-approval hazard), reactions (👍/👎) don't resolve because genie subscribes `omni.event.>` while this Omni build doesn't publish reactions there, and every approval is a fresh WhatsApp message with no resolution feedback (a stale "Approval Required" prompt lingers even after it's decided). This wish makes approvals correlated, reaction-driven, and self-updating.
+
+## Scope
+
+### IN
+- **Correlated approval identity (fixes the oldest-pending hazard):** capture the REAL Omni message id of each sent approval request and store it in `approvals.omni_message_id`, so a reply/reaction resolves the EXACT approval it answered — not `resolveOldest`. Today the runner publishes fire-and-forget to `omni.reply.{instance}.{chat}` and never learns Omni's message id, so it falls back to oldest-pending (a correctness bug the omni-runner-port reviews flagged as LOW, confirmed live). Decision needed (Group 1 spike): send the approval via the **Omni HTTP send API** (which returns a `messageId` — proven: `omni send` returned `3EB097217C5450F5E0166D`) vs. correlating the NATS-published id. Prefer the path that yields a stable id genie can match inbound replies/reactions against.
+- **Reaction-based approve/deny:** verify the ACTUAL NATS subject this Omni build publishes reactions on (the live QA could not confirm `omni.event.>` carries them), subscribe the correct subject, and resolve 👍/👎 by correlating to the stored `omni_message_id` from the correlated-identity work. Text `y`/`n` replies remain a fallback. Honor the instance-scope guard already added in PR #2507.
+- **Resolution feedback (anti-spam):** on resolve/expire, update the human's thread so a decided approval doesn't linger as an open prompt — e.g. react ✅/❌ on the original approval message (via `omni react`) and/or send a one-line status ("approved by you ✅"). One message per approval, plus one lightweight status signal — never a re-announce (the per-approval `omniMessageId` dedup at omni-runner.ts:360 already prevents re-fires; keep it).
+- **Operator guardrails learned from the QA:** document + enforce that enabling approvals requires the CC hook `timeout` ≥ `pollBudgetMs` (PR #2507 documents this; here, make `genie omni handshake`/a doctor check warn if the installed hook timeout is too low). Provide a `genie omni test-approval` helper that drives ONE approval round-trip end-to-end (so future QA is a single command, not ad-hoc scripts that spam).
+- **Tests:** correlated-resolution unit tests (two concurrent pending approvals; a reply/reaction tagged to id B resolves B, not the older A); reaction-subject integration test with a fake transport on the verified subject; resolution-feedback test (approve → ✅ status emitted, row expired). All with injectable transport — zero network.
+
+### OUT
+- Reworking the hook/dispatch layer or the global-db schema beyond adding/【using】the existing `omni_message_id` column.
+- Multi-approval batching / a full interactive TUI in WhatsApp (buttons, lists) — a later wish if wanted.
+- Reconnecting the offline `pessoal-whatsapp` instance (a QR scan — Felipe's manual action; not code).
+- Sending live WhatsApp messages during automated tests (fake transport only; live QA is the single `genie omni test-approval` helper, run deliberately).
+- Changing the approve/deny vocabulary or the timeout→ask fail-safe (both proven correct).
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | Correlate resolution by the real Omni message id, retire `resolveOldest` as the primary path | Live QA confirmed the oldest-pending fallback resolves the WRONG approval under concurrency; the human answered a specific message |
+| 2 | Group 1 is a SPIKE — verify the real reaction subject + the id-returning send path before building | The live QA disproved the `omni.event.>` assumption and showed `omni send` returns a messageId; the design must be grounded in this Omni build's actual contract, not the v4-ported assumptions |
+| 3 | Reactions become first-class; text replies stay as fallback | Reactions are the low-friction, non-spammy approve/deny gesture the operator wants; text is the compatibility path |
+| 4 | One approval message + one status update; never re-announce | Anti-spam: the human sees a prompt and its outcome, not a wall of repeated prompts. The per-approval dedup already prevents re-fires |
+| 5 | Ship a `genie omni test-approval` one-command harness | The QA spam came from ad-hoc multi-iteration scripts; a single deliberate command makes future testing safe and repeatable |
+
+## Success Criteria
+
+- [ ] G1 spike: `.genie/wishes/omni-approval-ux/SPIKE.md` documents (with evidence from the real hub) the reaction NATS subject + payload shape AND the send path that yields a correlatable message id; verdict on API-send vs NATS-correlate.
+- [ ] Correlated resolution: two concurrent pending approvals — a reply/reaction answering the 2nd resolves the 2nd (not the 1st); `omni_message_id` populated from the real send. Tested.
+- [ ] Reaction approve/deny resolves on the verified subject, correlated to the right approval; instance-scoped (PR #2507 guard). Tested.
+- [ ] Resolution feedback: on approve/deny the original message gets a ✅/❌ (react or status) and the row is expired/closed; no lingering open prompt. Tested.
+- [ ] `genie omni test-approval` drives one clean round-trip (against a fake transport in CI; usable live for one deliberate message).
+- [ ] Full `bun run check` green; no live messages sent by the automated suite.
+
+## Execution Strategy
+
+| Wave | Groups | Notes |
+|------|--------|-------|
+| 1 | Group 1 (spike) | Grounds the design in the real Omni contract; gates G2/G3 |
+| 2 | Group 2, Group 3 | Correlated identity + reactions ∥ resolution feedback + test harness (touch disjoint areas: queue/runner-resolve vs runner-outbound/CLI) |
+
+---
+
+## Execution Group 1: Spike — reaction subject + correlatable send id
+**Goal:** Replace the disproven `omni.event.>` + oldest-pending assumptions with the real contract of this Omni build.
+
+**Deliverables:**
+1. Against the live hub (via `ssh felipe`, MINIMAL messages — one send, subscribe-and-observe for reactions): determine (a) the exact NATS subject + payload omni publishes when a WhatsApp user REACTS to a message, and (b) whether the Omni HTTP send API (`/api/v1/...`) returns a stable `messageId` that later inbound replies/reactions reference. Use `omni --json` + a bounded NATS subscriber (omni's nats module) — do NOT run ad-hoc approval loops that spam.
+2. `.genie/wishes/omni-approval-ux/SPIKE.md`: the reaction subject + payload shape, the id-returning send path, and a GO recommendation for Group 2 (API-send vs NATS-correlate) with the exact fields genie must store/match.
+
+**Acceptance Criteria:**
+- [ ] SPIKE.md documents the reaction subject + payload and the correlatable-send decision, evidence-backed.
+- [ ] No spam: the spike sends at most one or two clearly-labelled messages between Felipe's own numbers.
+
+**Validation:**
+```bash
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+test -f .genie/wishes/omni-approval-ux/SPIKE.md
+grep -qiE 'reaction.*subject|omni\.[a-z]+' .genie/wishes/omni-approval-ux/SPIKE.md
+grep -qiE 'messageId|correlat' .genie/wishes/omni-approval-ux/SPIKE.md
+```
+
+**depends-on:** none
+
+---
+
+## Execution Group 2: Correlated identity + reaction approve/deny
+**Goal:** A reply/reaction resolves the exact approval it answers; 👍/👎 works.
+
+**Deliverables:**
+1. Capture the real Omni message id on send (per the G1 verdict) and store it via `attachOmniMessageId` immediately, so `handleMessage`/`handleEvent` correlate by `omni_message_id` first and only fall back to oldest-pending when no id matches.
+2. Subscribe the VERIFIED reaction subject (from G1) instead of the assumed `omni.event.>`; resolve 👍/👎 correlated to the stored id; keep the PR #2507 instance-scope guard.
+3. Tests (fake transport): two concurrent pending approvals resolved to the correct one by id; reaction on the verified subject resolves the correlated approval; text fallback still works.
+
+**Acceptance Criteria:**
+- [ ] Concurrent approvals resolve by id, not oldest; reactions resolve on the verified subject; instance-scoped.
+- [ ] typecheck + `bun test src/lib/omni-runner.test.ts src/lib/v5/omni-queue.test.ts` green.
+
+**Validation:**
+```bash
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+bun test src/lib/omni-runner.test.ts src/lib/v5/omni-queue.test.ts
+bun run typecheck
+```
+
+**depends-on:** group-1
+
+---
+
+## Execution Group 3: Resolution feedback + one-command test harness
+**Goal:** A decided approval stops looking open; future QA is one safe command.
+
+**Deliverables:**
+1. On resolve/expire, emit a resolution signal to the original thread — react ✅/❌ on the approval message (via the omni react path / API) and/or a one-line status; expire/close the row so no stale prompt lingers.
+2. `genie omni test-approval` command: drives one approval round-trip (enqueue → announce → resolve) against an injectable transport by default (CI-safe, no network); with `--live` it runs ONE real round-trip between the configured instance/approvalChat (deliberate, single message).
+3. `genie doctor`/handshake warning when the installed CC hook `timeout` is below `pollBudgetMs` (the operator guardrail the QA proved essential).
+4. Tests: resolution-feedback emitted + row closed; `test-approval` fake path green; doctor warning fires on a too-low timeout.
+
+**Acceptance Criteria:**
+- [ ] Approve/deny yields a ✅/❌ thread signal and closes the row; no lingering prompt (tested).
+- [ ] `genie omni test-approval` (fake) green in CI; `--live` documented.
+- [ ] doctor/handshake warns on an inadequate hook timeout.
+- [ ] Full `bun run check` green.
+
+**Validation:**
+```bash
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+bun test src/lib/omni-runner.test.ts src/term-commands/omni.test.ts
+bun run check
+bun run build
+bun dist/genie.js omni test-approval 2>&1 | grep -qiE 'approved|allow|round-trip' || { echo "FAIL: test-approval harness"; exit 1; }
+```
+
+**depends-on:** group-1
+
+---
+
+## Cross-wish dependencies
+
+- **Builds on** the live-validated `omni-runner-port` bridge + the `omni-hardening` (PR #2507) instance-scope + approval-budget-doc fixes.
+- **Records** the 2026-07-03 live QA outcome (allow path proven end-to-end; deny code-verified; personal instance offline; reactions unconfirmed) — this wish closes the reaction + correlation gaps that QA exposed.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,27 @@ All linked worktrees of a repository share one `genie.db`, resolved from the git
 - Approval-gated agents launched with `--permission-mode default`. Under `auto` mode a passthrough `ask` can auto-resolve to allow, which defeats the timeout→ask fail-safe.
 - `genie omni serve` running as the one resident process. It is the *only* NATS client — `--help`, `task`, `board`, and every other command stay transport-free (`nats` never initializes on those paths).
 
+## MCP server (Warp + Claude Code)
+
+`genie mcp` is a zero-dependency, read-only [MCP](https://modelcontextprotocol.io) server over stdio. It lets the AI agent inside a Warp pane or Claude Code session query live board and wish state without shelling out to the CLI.
+
+**How it gets picked up.** `genie init` registers the server into two project-scope config files, and `genie launch` writes the same pair into every worktree it opens:
+
+- `.mcp.json` — Claude Code's project MCP config. Project-scope servers are *pending approval* until you trust the workspace (accept the trust dialog in an interactive `claude` session) — expected, not a bug.
+- `.warp/.mcp.json` — Warp auto-detects this on save (no restart) and lists `genie` under Settings → AI/Agents → MCP servers.
+
+Both files use the identical `mcpServers` shape and are merged idempotently: re-running `genie init` preserves every other server and top-level key and rewrites byte-identical. The registered `command` is the **absolute path to the running genie binary** (resolved from `process.execPath`), not bare `genie` — genie is not reliably on PATH (on macOS it lives only at `~/.genie/bin/genie`). Because `genie init`/`launch` run on the box that owns the repo, the recorded path is correct even under Warp's SSH-remote feature, where Warp spawns the server on that same box.
+
+**What it exposes** — five read-only tools backed by the per-repo `.genie/genie.db`:
+
+- `genie_board` — board counts + tasks (optional wish filter)
+- `genie_wish_status` — a wish's group/DAG progress
+- `genie_worktree_context` — resolves the pane's `wish/<slug>-<group>` branch to its wish, group, and tasks (the per-pane "what am I here for")
+- `genie_task` — full task detail by id
+- `genie_active` — every in-progress task and who claimed it
+
+**Honest limitation — genie does not push into your tabs.** Warp exposes no external tab-push API, so genie cannot inject state into a pane. The flow is pull, not push: the pane's agent *asks* genie over MCP (`genie_worktree_context`, `genie_board`, …) when it wants to know the board state. `genie launch` still seeds each pane with a kickoff prompt at open time, but ongoing awareness is the agent querying the MCP server, not genie writing into the tab.
+
 ## Roadmap
 
 No dates — direction, not promises:

--- a/src/genie.ts
+++ b/src/genie.ts
@@ -25,6 +25,7 @@ import { installWorkspaceCheck } from './lib/interactivity.js';
 import { VERSION } from './lib/version.js';
 import { registerInitCommand } from './term-commands/init.js';
 import { registerLaunchCommand } from './term-commands/launch.js';
+import { registerMcpCommand } from './term-commands/mcp.js';
 import { registerOmniCommands } from './term-commands/omni.js';
 import { registerV5BoardCommands } from './term-commands/v5-board.js';
 import { registerV5TaskCommands } from './term-commands/v5-task.js';
@@ -124,6 +125,7 @@ registerHookNamespace(program);
 
 registerInitCommand(program);
 registerLaunchCommand(program);
+registerMcpCommand(program);
 registerV5TaskCommands(program);
 registerV5BoardCommands(program);
 registerOmniCommands(program);

--- a/src/lib/interactivity.ts
+++ b/src/lib/interactivity.ts
@@ -70,6 +70,10 @@ const WORKSPACE_EXEMPT = new Set([
   // `task`/`board` it self-resolves the global genie.db and never reads the
   // v4 workspace.json, so gating it on the legacy workspace concept is wrong.
   'omni',
+  // `mcp` is the read-only stdio MCP server. It opens the shared genie.db
+  // read-only and DEGRADES to an empty board when the file is absent, so the
+  // legacy workspace gate must not exit 2 before the JSON-RPC loop even starts.
+  'mcp',
 ]);
 
 /**

--- a/src/lib/v5/mcp-tools.ts
+++ b/src/lib/v5/mcp-tools.ts
@@ -1,0 +1,280 @@
+/**
+ * Genie v5 MCP tools — the read-only projection of `.genie/genie.db` exposed
+ * over the hand-rolled stdio MCP server (see `src/term-commands/mcp.ts`).
+ *
+ * This module is intentionally LAZY-LOADED: `genie mcp` dynamic-imports it
+ * inside the command body so that non-mcp code paths (`genie board`, `genie
+ * task`, `genie --help`) never touch the read-only `bun:sqlite` open here. The
+ * import-graph probe in `mcp.test.ts` locks that contract.
+ *
+ * The DB is opened NET-NEW and READ-ONLY (`new Database(path, {readonly:true})`)
+ * — deliberately NOT `openSqlite()`/`openDb()`, which force-create the file and
+ * run write pragmas. An absent db (readonly open throws) degrades to `null`, and
+ * every tool renders an empty board rather than erroring.
+ */
+
+import { Database } from 'bun:sqlite';
+import { execFileSync } from 'node:child_process';
+import { resolveDbPath } from './genie-db.js';
+import {
+  type TaskFilter,
+  type TaskRow,
+  type WishGroupRow,
+  getBoardByName,
+  getTask,
+  getWishGroups,
+  listTasks,
+} from './task-state.js';
+
+// ============================================================================
+// Read-only DB open (net-new; degrade to null when the file is absent)
+// ============================================================================
+
+/**
+ * Open the repo's shared `.genie/genie.db` READ-ONLY. Returns `null` when the
+ * file does not exist (readonly open of a missing file throws) so callers can
+ * degrade to an empty board instead of crashing the server. The handle is the
+ * caller's to close.
+ */
+export function openReadonlyDb(cwd?: string): Database | null {
+  try {
+    return new Database(resolveDbPath(cwd), { readonly: true });
+  } catch {
+    return null;
+  }
+}
+
+// ============================================================================
+// Payload shapes
+// ============================================================================
+
+export interface TaskSummary {
+  id: string;
+  title: string;
+  status: TaskRow['status'];
+  claimedBy: string | null;
+  wish: string | null;
+  group: string | null;
+}
+
+function toSummary(t: TaskRow): TaskSummary {
+  return { id: t.id, title: t.title, status: t.status, claimedBy: t.claimedBy, wish: t.wish, group: t.group };
+}
+
+interface StatusCounts {
+  blocked: number;
+  ready: number;
+  in_progress: number;
+  done: number;
+  total: number;
+}
+
+function tally(tasks: TaskRow[]): StatusCounts {
+  const counts: StatusCounts = { blocked: 0, ready: 0, in_progress: 0, done: 0, total: 0 };
+  for (const t of tasks) {
+    counts[t.status]++;
+    counts.total++;
+  }
+  return counts;
+}
+
+// ============================================================================
+// Git branch resolution (for genie_worktree_context)
+// ============================================================================
+
+/** Current git branch of `cwd`, or `null` when unavailable (detached / not a repo). */
+function currentBranch(cwd: string): string | null {
+  try {
+    const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    return branch && branch !== 'HEAD' ? branch : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse a `wish/<slug>-<group>` branch into `{ wish, group }`. The group is the
+ * final `-`-delimited segment; the slug is everything before it (slugs may
+ * themselves contain hyphens, e.g. `wish/genie-mcp-g2` → `genie-mcp` / `g2`).
+ * Returns `null` when the branch is not a wish worktree branch.
+ */
+function parseWishBranch(branch: string): { wish: string; group: string } | null {
+  const rest = branch.startsWith('wish/') ? branch.slice('wish/'.length) : null;
+  if (!rest) return null;
+  const dash = rest.lastIndexOf('-');
+  if (dash <= 0 || dash === rest.length - 1) return null;
+  return { wish: rest.slice(0, dash), group: rest.slice(dash + 1) };
+}
+
+// ============================================================================
+// Tool context + registry
+// ============================================================================
+
+export interface ToolContext {
+  /** Read-only handle, or `null` when the db is absent (degrade to empty). */
+  db: Database | null;
+  /** Working directory for git branch resolution. Defaults to `process.cwd()`. */
+  cwd: string;
+}
+
+export interface McpTool {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  handler(ctx: ToolContext, args: Record<string, unknown>): unknown;
+}
+
+function argString(args: Record<string, unknown>, key: string): string | undefined {
+  const v = args[key];
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+// --- genie_board -----------------------------------------------------------
+
+interface BoardPayload {
+  board: string | null;
+  counts: StatusCounts;
+  tasks: TaskSummary[];
+}
+
+function genieBoard(ctx: ToolContext, args: Record<string, unknown>): BoardPayload {
+  const emptyCounts: StatusCounts = { blocked: 0, ready: 0, in_progress: 0, done: 0, total: 0 };
+  const boardArg = argString(args, 'board');
+  const wishArg = argString(args, 'wish');
+  if (!ctx.db) return { board: boardArg ?? null, counts: emptyCounts, tasks: [] };
+
+  const filter: TaskFilter = {};
+  let boardName: string | null = null;
+  if (boardArg) {
+    const board = getBoardByName(ctx.db, boardArg);
+    // Unknown board name → empty projection (read-only; never throws at caller).
+    if (!board) return { board: boardArg, counts: emptyCounts, tasks: [] };
+    boardName = board.name;
+    filter.boardId = board.id;
+  }
+  if (wishArg) filter.wish = wishArg;
+
+  const tasks = listTasks(ctx.db, filter);
+  return { board: boardName, counts: tally(tasks), tasks: tasks.map(toSummary) };
+}
+
+// --- genie_wish_status -----------------------------------------------------
+
+interface WishStatusPayload {
+  wish: string;
+  groups: Array<Omit<WishGroupRow, 'wish'>>;
+  tasks: TaskSummary[];
+}
+
+function genieWishStatus(ctx: ToolContext, args: Record<string, unknown>): WishStatusPayload {
+  const wish = argString(args, 'wish') ?? '';
+  if (!ctx.db) return { wish, groups: [], tasks: [] };
+  const groups = getWishGroups(ctx.db, wish).map(({ wish: _w, ...rest }) => rest);
+  const tasks = listTasks(ctx.db, { wish });
+  return { wish, groups, tasks: tasks.map(toSummary) };
+}
+
+// --- genie_worktree_context ------------------------------------------------
+
+interface WorktreeContextPayload {
+  branch: string | null;
+  resolved: boolean;
+  wish: string | null;
+  group: string | null;
+  tasks: TaskSummary[];
+}
+
+function genieWorktreeContext(ctx: ToolContext, args: Record<string, unknown>): WorktreeContextPayload {
+  const branch = argString(args, 'branch') ?? currentBranch(ctx.cwd);
+  const parsed = branch ? parseWishBranch(branch) : null;
+
+  if (parsed) {
+    const tasks = ctx.db ? listTasks(ctx.db, { wish: parsed.wish }).filter((t) => t.group === parsed.group) : [];
+    return { branch, resolved: true, wish: parsed.wish, group: parsed.group, tasks: tasks.map(toSummary) };
+  }
+
+  // Non-wish branch (or none) → repo-board fallback: all tasks, unresolved.
+  const tasks = ctx.db ? listTasks(ctx.db, {}) : [];
+  return { branch, resolved: false, wish: null, group: null, tasks: tasks.map(toSummary) };
+}
+
+// --- genie_task ------------------------------------------------------------
+
+function genieTask(ctx: ToolContext, args: Record<string, unknown>): TaskRow | { error: 'not_found'; id: string } {
+  const id = argString(args, 'id') ?? '';
+  const task = ctx.db ? getTask(ctx.db, id) : null;
+  return task ?? { error: 'not_found', id };
+}
+
+// --- genie_active ----------------------------------------------------------
+
+interface ActiveTask extends TaskSummary {
+  claimedAt: number | null;
+}
+
+function genieActive(ctx: ToolContext): { tasks: ActiveTask[] } {
+  if (!ctx.db) return { tasks: [] };
+  const tasks = listTasks(ctx.db, { status: 'in_progress' });
+  return { tasks: tasks.map((t) => ({ ...toSummary(t), claimedAt: t.claimedAt })) };
+}
+
+// ============================================================================
+// The 5 read-only tools
+// ============================================================================
+
+export const MCP_TOOLS: McpTool[] = [
+  {
+    name: 'genie_board',
+    description: 'Board status counts and tasks; optional board name and wish-slug filters.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        board: { type: 'string', description: 'board name; default repo board' },
+        wish: { type: 'string', description: 'filter to a wish slug' },
+      },
+      required: [],
+    },
+    handler: genieBoard,
+  },
+  {
+    name: 'genie_wish_status',
+    description: "A wish's execution groups (DAG progress) and its tasks.",
+    inputSchema: {
+      type: 'object',
+      properties: { wish: { type: 'string', description: 'wish slug' } },
+      required: ['wish'],
+    },
+    handler: genieWishStatus,
+  },
+  {
+    name: 'genie_worktree_context',
+    description:
+      "Resolve a wish/<slug>-<group> git branch to its wish, group, and tasks (the pane's 'what am I here for').",
+    inputSchema: {
+      type: 'object',
+      properties: { branch: { type: 'string', description: 'override; default = current git branch' } },
+      required: [],
+    },
+    handler: genieWorktreeContext,
+  },
+  {
+    name: 'genie_task',
+    description: 'Full detail for a single task by id.',
+    inputSchema: {
+      type: 'object',
+      properties: { id: { type: 'string', description: 'task id, e.g. t_...' } },
+      required: ['id'],
+    },
+    handler: genieTask,
+  },
+  {
+    name: 'genie_active',
+    description: 'All in-progress tasks and who claimed each.',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    handler: (ctx) => genieActive(ctx),
+  },
+];

--- a/src/term-commands/init.test.ts
+++ b/src/term-commands/init.test.ts
@@ -154,4 +154,85 @@ describe('genie init', () => {
     expect(second.gitignore).toBe('skipped');
     expect(second.rulesAdded).toEqual([]);
   });
+
+  describe('MCP server registration', () => {
+    const mcpPath = (root: string) => join(root, '.mcp.json');
+    const warpMcpPath = (root: string) => join(root, '.warp', '.mcp.json');
+
+    test('fresh repo: writes both .mcp.json and .warp/.mcp.json with the genie entry', () => {
+      initGitRepo(dir);
+      expect(runInit(dir).code).toBe(0);
+
+      for (const path of [mcpPath(dir), warpMcpPath(dir)]) {
+        expect(existsSync(path)).toBe(true);
+        const servers = JSON.parse(readFileSync(path, 'utf-8')).mcpServers;
+        expect(servers.genie).toBeDefined();
+        expect(servers.genie.args).toEqual(['mcp']);
+        // Absolute command resolved from the running executable — never bare "genie".
+        expect(servers.genie.command).not.toBe('genie');
+        expect(servers.genie.command.startsWith('/')).toBe(true);
+      }
+    });
+
+    test('pre-populated .mcp.json: preserves the other server and adds genie', () => {
+      initGitRepo(dir);
+      writeFileSync(mcpPath(dir), '{"mcpServers":{"other":{"command":"x"}}}');
+
+      expect(runInit(dir).code).toBe(0);
+
+      const servers = JSON.parse(readFileSync(mcpPath(dir), 'utf-8')).mcpServers;
+      expect(servers.other).toEqual({ command: 'x' });
+      expect(servers.genie).toBeDefined();
+      expect(servers.genie.args).toEqual(['mcp']);
+    });
+
+    test('preserves other top-level keys and an alternate wrapper key', () => {
+      initGitRepo(dir);
+      // Existing file uses the `servers` wrapper + carries an unrelated top-level key.
+      writeFileSync(mcpPath(dir), '{"$schema":"./s.json","servers":{"other":{"command":"x"}}}');
+
+      expect(runInit(dir).code).toBe(0);
+
+      const parsed = JSON.parse(readFileSync(mcpPath(dir), 'utf-8'));
+      expect(parsed.$schema).toBe('./s.json');
+      // Whichever wrapper key already held servers is preserved — no new mcpServers key.
+      expect(parsed.mcpServers).toBeUndefined();
+      expect(parsed.servers.other).toEqual({ command: 'x' });
+      expect(parsed.servers.genie).toBeDefined();
+    });
+
+    test('rerun is byte-identical for both fresh and pre-populated configs', () => {
+      initGitRepo(dir);
+      writeFileSync(mcpPath(dir), '{"mcpServers":{"other":{"command":"x"}}}');
+      expect(runInit(dir).code).toBe(0);
+
+      const mcpBefore = readFileSync(mcpPath(dir));
+      const warpBefore = readFileSync(warpMcpPath(dir));
+
+      expect(runInit(dir).code).toBe(0);
+
+      expect(readFileSync(mcpPath(dir)).equals(mcpBefore)).toBe(true);
+      expect(readFileSync(warpMcpPath(dir)).equals(warpBefore)).toBe(true);
+    });
+
+    test('--json reports the mcp config writes as created then skipped', () => {
+      initGitRepo(dir);
+      const first = JSON.parse(runInit(dir, ['--json']).stdout);
+      const actions = first.mcp.map((c: { path: string; action: string }) => c.action);
+      expect(actions).toEqual(['created', 'created']);
+
+      const second = JSON.parse(runInit(dir, ['--json']).stdout);
+      expect(second.mcp.map((c: { action: string }) => c.action)).toEqual(['skipped', 'skipped']);
+    });
+
+    test('malformed .mcp.json is surfaced, not clobbered', () => {
+      initGitRepo(dir);
+      writeFileSync(mcpPath(dir), 'not json {');
+      const { code, stderr } = runInit(dir);
+      expect(code).toBe(1);
+      expect(stderr).toContain('.mcp.json');
+      // The bad file is left untouched.
+      expect(readFileSync(mcpPath(dir), 'utf-8')).toBe('not json {');
+    });
+  });
 });

--- a/src/term-commands/init.ts
+++ b/src/term-commands/init.ts
@@ -1,10 +1,12 @@
 /**
  * genie init — idempotent per-repo scaffold.
  *
- * Bootstraps the two things a fresh repo needs before the genie lifecycle can
- * run: the plans jar (`.genie/INDEX.md`) and the `.gitignore` rules that keep
- * the SQLite state files out of version control. Both steps are idempotent —
- * re-running `genie init` on an already-scaffolded repo produces zero diff.
+ * Bootstraps the things a fresh repo needs before the genie lifecycle can run:
+ * the plans jar (`.genie/INDEX.md`), the `.gitignore` rules that keep the
+ * SQLite state files out of version control, and the MCP server registration
+ * that lets Warp + Claude Code discover the read-only `genie mcp` server. Every
+ * step is idempotent — re-running `genie init` on an already-scaffolded repo
+ * produces zero diff.
  *
  * No network, no daemon, no database. Refuses politely outside a git repo.
  */
@@ -95,6 +97,7 @@ interface InitResult {
   index: ArtifactAction;
   gitignore: ArtifactAction;
   rulesAdded: string[];
+  mcp: McpConfigResult[];
 }
 
 /** Create `.genie/INDEX.md` with the jar skeleton if it does not exist. */
@@ -127,11 +130,133 @@ function scaffoldGitignore(root: string): { action: ArtifactAction; added: strin
 }
 
 // ============================================================================
+// MCP server registration (.mcp.json + .warp/.mcp.json)
+// ============================================================================
+
+/**
+ * A stdio MCP server entry, as both Warp and Claude Code read it. `type:"stdio"`
+ * is optional (a `command` present defaults to stdio), so it is omitted.
+ */
+interface McpServerEntry {
+  command: string;
+  args: string[];
+}
+
+/** Arbitrary JSON object (an already-parsed config we merge into). */
+type JsonObject = Record<string, unknown>;
+
+/**
+ * Wrapper keys Warp recognizes for the server map, in order of preference.
+ * `mcpServers` is what we write for a fresh file; if an existing file already
+ * holds its servers under one of the alternates, that key is preserved.
+ */
+const MCP_WRAPPER_KEYS = ['mcpServers', 'mcp_servers', 'servers'] as const;
+
+/**
+ * The genie server entry written under the `genie` key. The command is the
+ * ABSOLUTE path to the currently-running genie executable — for the shipped
+ * bun-compiled single-file binary that is {@link process.execPath}. Bare
+ * `"genie"` is NOT used: genie is not reliably on the spawning process's PATH
+ * (on macOS it lives only at `~/.genie/bin/genie`). Resolving at write time is
+ * self-consistent under Warp-over-SSH — `genie init` runs on the box that owns
+ * the repo, so it records that box's genie path, and Warp spawns there too.
+ */
+function genieMcpEntry(): McpServerEntry {
+  return { command: process.execPath, args: ['mcp'] };
+}
+
+/** True for a plain (non-array) JSON object. */
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Parse an existing config's raw bytes into an object, or start from `{}` when
+ * the file is absent. A file that exists but is not a JSON object is a real
+ * problem worth surfacing (we must not silently clobber it), so it throws.
+ */
+function parseMcpConfig(raw: string | null, path: string): JsonObject {
+  if (raw === null || raw.trim() === '') return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`Cannot register genie MCP server: ${path} is not valid JSON.`);
+  }
+  if (!isJsonObject(parsed)) {
+    throw new Error(`Cannot register genie MCP server: ${path} is not a JSON object.`);
+  }
+  return parsed;
+}
+
+/**
+ * Locate the server map inside a parsed config, preserving whatever wrapper key
+ * an existing file already uses (`mcpServers`, `mcp_servers`, `servers`, or a
+ * nested `mcp.servers`). When none is present the `mcpServers` key is created —
+ * the preferred shape for a new file.
+ */
+function locateServerMap(config: JsonObject): JsonObject {
+  for (const key of MCP_WRAPPER_KEYS) {
+    const existing = config[key];
+    if (isJsonObject(existing)) return existing;
+  }
+  const nested = config.mcp;
+  if (isJsonObject(nested) && isJsonObject(nested.servers)) return nested.servers;
+
+  const created: JsonObject = {};
+  config.mcpServers = created;
+  return created;
+}
+
+/**
+ * Merge the genie MCP server entry into the config at `configPath`, creating the
+ * file (and its parent dir) when absent. Only the `genie` key under the server
+ * map is added/updated — every other server AND every other top-level key is
+ * preserved. Serialization is deterministic (2-space JSON + trailing newline)
+ * so a rerun that changes nothing is byte-identical and reports `skipped`.
+ */
+function mergeMcpConfig(configPath: string, entry: McpServerEntry): ArtifactAction {
+  const raw = existsSync(configPath) ? readFileSync(configPath, 'utf-8') : null;
+  const config = parseMcpConfig(raw, configPath);
+  const servers = locateServerMap(config);
+  servers.genie = entry;
+
+  const serialized = `${JSON.stringify(config, null, 2)}\n`;
+  if (raw !== null && raw === serialized) return 'skipped';
+
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeFileSync(configPath, serialized);
+  return raw === null ? 'created' : 'updated';
+}
+
+interface McpConfigResult {
+  path: string;
+  action: ArtifactAction;
+}
+
+/**
+ * Register the `genie mcp` server into both project-scope config files under
+ * `root`: `<root>/.mcp.json` (Claude Code) and `<root>/.warp/.mcp.json` (Warp).
+ * Both get the identical entry; the merge is idempotent and preserves existing
+ * servers. Exported so `genie launch` can register the same server per worktree.
+ */
+export function registerMcpConfigs(root: string): McpConfigResult[] {
+  const entry = genieMcpEntry();
+  const targets = [join(root, '.mcp.json'), join(root, '.warp', '.mcp.json')];
+  return targets.map((path) => ({ path, action: mergeMcpConfig(path, entry) }));
+}
+
+// ============================================================================
 // Reporting
 // ============================================================================
 
 function actionLabel(action: ArtifactAction): string {
   return action === 'skipped' ? 'already present' : action;
+}
+
+/** Short, repo-relative label for an MCP config path (`.mcp.json`, `.warp/.mcp.json`). */
+function mcpConfigLabel(configPath: string): string {
+  return configPath.endsWith(join('.warp', '.mcp.json')) ? '.warp/.mcp.json' : '.mcp.json';
 }
 
 function printHumanReport(result: InitResult): void {
@@ -143,6 +268,11 @@ function printHumanReport(result: InitResult): void {
   } else {
     out(`  .gitignore        ${actionLabel(result.gitignore)}`);
   }
+  for (const cfg of result.mcp) {
+    out(`  ${mcpConfigLabel(cfg.path)}        ${actionLabel(cfg.action)}`);
+  }
+  out('');
+  out('Warp + Claude Code will discover the read-only `genie mcp` server from those files.');
   out('');
   out('Next steps — the plan/work lifecycle (run inside Claude Code):');
   out('  /brainstorm   Explore a fuzzy idea into a DESIGN.md');
@@ -168,7 +298,8 @@ function handleInit(opts: InitOptions): void {
 
     const index = scaffoldIndex(root);
     const gitignore = scaffoldGitignore(root);
-    const result: InitResult = { root, index, gitignore: gitignore.action, rulesAdded: gitignore.added };
+    const mcp = registerMcpConfigs(root);
+    const result: InitResult = { root, index, gitignore: gitignore.action, rulesAdded: gitignore.added, mcp };
 
     if (opts.json) {
       out(JSON.stringify(result, null, 2));

--- a/src/term-commands/launch.ts
+++ b/src/term-commands/launch.ts
@@ -26,6 +26,7 @@ import { openDb } from '../lib/v5/genie-db.js';
 import { type TaskRow, listTasks } from '../lib/v5/task-state.js';
 import { type PaneSpec, buildLaunchConfigYaml, launchUri, writeLaunchConfig } from '../lib/v5/warp-launch.js';
 import { genieHome } from '../lib/workspace.js';
+import { registerMcpConfigs } from './init.js';
 
 // ============================================================================
 // Typed errors
@@ -524,6 +525,9 @@ function materialize(plan: LaunchPlan, deps: LaunchDeps, write: (line: string) =
     const action = ensureWorktree(plan.repoRoot, group, write);
     mkdirSync(dirname(group.promptPath), { recursive: true });
     writeFileSync(group.promptPath, group.prompt, 'utf-8');
+    // Register the read-only `genie mcp` server in this worktree so the pane's
+    // agent (Warp/Claude Code) can query board + wish state. Idempotent + merges.
+    registerMcpConfigs(group.worktree);
     write(`  ${group.name}  →  ${group.worktree}  [${action}]`);
   }
 

--- a/src/term-commands/mcp.test.ts
+++ b/src/term-commands/mcp.test.ts
@@ -1,0 +1,369 @@
+/**
+ * genie mcp — CLI-level tests. Drives the real `genie.ts mcp` stdio server as a
+ * subprocess (as an MCP client would), speaking newline-delimited JSON-RPC 2.0,
+ * against throwaway git-repo fixtures seeded via the real v5 state layer.
+ *
+ * Also asserts the LAZY-LOAD contract with a static import-graph probe: the
+ * read-only `bun:sqlite` open in `mcp-tools.ts` must NOT be reachable from
+ * `genie.ts` except through the dynamic `import()` inside the `mcp` action.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { openDb } from '../lib/v5/genie-db.js';
+import { createBoard, createTask, createWishGroups } from '../lib/v5/task-state.js';
+
+const GENIE = join(import.meta.dir, '..', 'genie.ts');
+const SRC_ROOT = resolve(import.meta.dir, '..');
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+let repo: string;
+
+function git(cwd: string, ...args: string[]): void {
+  execFileSync('git', args, {
+    cwd,
+    stdio: 'ignore',
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'Test',
+      GIT_AUTHOR_EMAIL: 'test@example.com',
+      GIT_COMMITTER_NAME: 'Test',
+      GIT_COMMITTER_EMAIL: 'test@example.com',
+    },
+  });
+}
+
+beforeEach(() => {
+  repo = mkdtempSync(join(tmpdir(), 'genie-mcp-'));
+  git(repo, 'init', '-b', 'main');
+  git(repo, 'commit', '--allow-empty', '-m', 'init');
+});
+
+afterEach(() => {
+  rmSync(repo, { recursive: true, force: true });
+});
+
+// ============================================================================
+// JSON-RPC driver — write all requests, close stdin, collect response lines.
+// ============================================================================
+
+interface RpcResponse {
+  jsonrpc: '2.0';
+  id: number | string | null;
+  result?: Record<string, unknown>;
+  error?: { code: number; message: string };
+}
+
+async function driveMcp(cwd: string, requests: Record<string, unknown>[]): Promise<RpcResponse[]> {
+  const proc = Bun.spawn(['bun', GENIE, 'mcp'], {
+    cwd,
+    stdin: 'pipe',
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: { ...process.env, NO_COLOR: '1', GENIE_TEST_SKIP_PGSERVE: '1' },
+  });
+  const payload = `${requests.map((r) => JSON.stringify(r)).join('\n')}\n`;
+  proc.stdin.write(payload);
+  await proc.stdin.end();
+  const stdout = await new Response(proc.stdout).text();
+  await proc.exited;
+  return stdout
+    .split('\n')
+    .filter((l) => l.trim().length > 0)
+    .map((l) => JSON.parse(l) as RpcResponse);
+}
+
+const INIT = {
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'initialize',
+  params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 't', version: '0' } },
+};
+const INITIALIZED = { jsonrpc: '2.0', method: 'notifications/initialized' };
+
+/** Parse the JSON text payload out of a tools/call result envelope. */
+function toolPayload<T>(res: RpcResponse): T {
+  const content = (res.result?.content as Array<{ type: string; text: string }>) ?? [];
+  return JSON.parse(content[0].text) as T;
+}
+
+function seed(cwd: string): { taskId: string } {
+  const db = openDb({ cwd });
+  const board = createBoard(db, 'repo');
+  const t = createTask(db, { title: 'seed task', boardId: board.id, wish: 'genie-mcp', group: 'g2' });
+  createTask(db, { title: 'other', boardId: board.id });
+  createWishGroups(db, 'genie-mcp', [{ name: 'g1' }, { name: 'g2', dependsOn: ['g1'] }]);
+  db.close();
+  return { taskId: t.id };
+}
+
+// ============================================================================
+// Handshake
+// ============================================================================
+
+describe('mcp handshake', () => {
+  test('initialize replies with protocolVersion, tools capability, and serverInfo', async () => {
+    const [res] = await driveMcp(repo, [INIT]);
+    expect(res.id).toBe(1);
+    expect(res.result?.protocolVersion).toBe('2024-11-05');
+    expect(res.result?.capabilities).toEqual({ tools: {} });
+    const serverInfo = res.result?.serverInfo as { name: string; version: string };
+    expect(serverInfo.name).toBe('genie');
+    expect(typeof serverInfo.version).toBe('string');
+  });
+
+  test('notifications/initialized gets NO reply', async () => {
+    // Two ids (init, ping) + the notification → exactly two responses.
+    const responses = await driveMcp(repo, [INIT, INITIALIZED, { jsonrpc: '2.0', id: 2, method: 'ping' }]);
+    expect(responses.map((r) => r.id)).toEqual([1, 2]);
+  });
+
+  test('unknown method with an id → JSON-RPC -32601', async () => {
+    const responses = await driveMcp(repo, [INIT, { jsonrpc: '2.0', id: 9, method: 'bogus/method' }]);
+    const bogus = responses.find((r) => r.id === 9);
+    expect(bogus?.error?.code).toBe(-32601);
+  });
+});
+
+// ============================================================================
+// tools/list
+// ============================================================================
+
+describe('mcp tools/list', () => {
+  test('lists exactly the 5 read-only tools with input schemas', async () => {
+    const responses = await driveMcp(repo, [INIT, INITIALIZED, { jsonrpc: '2.0', id: 2, method: 'tools/list' }]);
+    const list = responses.find((r) => r.id === 2);
+    const tools = list?.result?.tools as Array<{ name: string; inputSchema: unknown }>;
+    expect(tools.map((t) => t.name).sort()).toEqual([
+      'genie_active',
+      'genie_board',
+      'genie_task',
+      'genie_wish_status',
+      'genie_worktree_context',
+    ]);
+    for (const t of tools) expect(t.inputSchema).toBeDefined();
+  });
+});
+
+// ============================================================================
+// tools/call — real state
+// ============================================================================
+
+describe('mcp tools/call', () => {
+  test('genie_board reflects real seeded db state', async () => {
+    seed(repo);
+    const responses = await driveMcp(repo, [
+      INIT,
+      INITIALIZED,
+      { jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'genie_board', arguments: {} } },
+    ]);
+    const res = responses.find((r) => r.id === 3);
+    expect(res?.result?.isError).toBe(false);
+    const payload = toolPayload<{ counts: { total: number; ready: number }; tasks: Array<{ wish: string }> }>(res!);
+    expect(payload.counts.total).toBe(2);
+    expect(payload.counts.ready).toBe(2);
+    expect(payload.tasks.some((t) => t.wish === 'genie-mcp')).toBe(true);
+  });
+
+  test('genie_wish_status returns the group DAG and tasks', async () => {
+    seed(repo);
+    const responses = await driveMcp(repo, [
+      INIT,
+      INITIALIZED,
+      {
+        jsonrpc: '2.0',
+        id: 4,
+        method: 'tools/call',
+        params: { name: 'genie_wish_status', arguments: { wish: 'genie-mcp' } },
+      },
+    ]);
+    const payload = toolPayload<{ wish: string; groups: Array<{ name: string; status: string; dependsOn: string[] }> }>(
+      responses.find((r) => r.id === 4)!,
+    );
+    expect(payload.wish).toBe('genie-mcp');
+    expect(payload.groups.map((g) => g.name).sort()).toEqual(['g1', 'g2']);
+    const g2 = payload.groups.find((g) => g.name === 'g2');
+    expect(g2?.dependsOn).toEqual(['g1']);
+    expect(g2?.status).toBe('blocked');
+  });
+
+  test('genie_task returns full detail by id, or not_found', async () => {
+    const { taskId } = seed(repo);
+    const responses = await driveMcp(repo, [
+      INIT,
+      INITIALIZED,
+      { jsonrpc: '2.0', id: 5, method: 'tools/call', params: { name: 'genie_task', arguments: { id: taskId } } },
+      { jsonrpc: '2.0', id: 6, method: 'tools/call', params: { name: 'genie_task', arguments: { id: 't_nope' } } },
+    ]);
+    const found = toolPayload<{ id: string; title: string }>(responses.find((r) => r.id === 5)!);
+    expect(found.id).toBe(taskId);
+    expect(found.title).toBe('seed task');
+    const missing = toolPayload<{ error: string; id: string }>(responses.find((r) => r.id === 6)!);
+    expect(missing).toEqual({ error: 'not_found', id: 't_nope' });
+  });
+
+  test('genie_worktree_context resolves a wish/<slug>-<group> branch', async () => {
+    seed(repo);
+    const responses = await driveMcp(repo, [
+      INIT,
+      INITIALIZED,
+      {
+        jsonrpc: '2.0',
+        id: 7,
+        method: 'tools/call',
+        params: { name: 'genie_worktree_context', arguments: { branch: 'wish/genie-mcp-g2' } },
+      },
+    ]);
+    const payload = toolPayload<{ resolved: boolean; wish: string; group: string; tasks: Array<{ group: string }> }>(
+      responses.find((r) => r.id === 7)!,
+    );
+    expect(payload.resolved).toBe(true);
+    expect(payload.wish).toBe('genie-mcp');
+    expect(payload.group).toBe('g2');
+    expect(payload.tasks.every((t) => t.group === 'g2')).toBe(true);
+  });
+
+  test('genie_worktree_context falls back to unresolved on a non-wish branch', async () => {
+    seed(repo);
+    const responses = await driveMcp(repo, [
+      INIT,
+      INITIALIZED,
+      {
+        jsonrpc: '2.0',
+        id: 8,
+        method: 'tools/call',
+        params: { name: 'genie_worktree_context', arguments: { branch: 'main' } },
+      },
+    ]);
+    const payload = toolPayload<{ resolved: boolean; wish: null; tasks: unknown[] }>(
+      responses.find((r) => r.id === 8)!,
+    );
+    expect(payload.resolved).toBe(false);
+    expect(payload.wish).toBeNull();
+    expect(payload.tasks.length).toBe(2); // repo-board fallback: all tasks
+  });
+
+  test('genie_active lists in-progress tasks with claimant', async () => {
+    const { taskId } = seed(repo);
+    // Claim the seed task so it becomes in_progress.
+    const db = openDb({ cwd: repo });
+    db.query("UPDATE tasks SET status='in_progress', claimed_by='worker-1', claimed_at=? WHERE id=?").run(
+      Date.now(),
+      taskId,
+    );
+    db.close();
+    const responses = await driveMcp(repo, [
+      INIT,
+      INITIALIZED,
+      { jsonrpc: '2.0', id: 10, method: 'tools/call', params: { name: 'genie_active', arguments: {} } },
+    ]);
+    const payload = toolPayload<{ tasks: Array<{ id: string; claimedBy: string; status: string }> }>(
+      responses.find((r) => r.id === 10)!,
+    );
+    expect(payload.tasks).toHaveLength(1);
+    expect(payload.tasks[0].id).toBe(taskId);
+    expect(payload.tasks[0].claimedBy).toBe('worker-1');
+    expect(payload.tasks[0].status).toBe('in_progress');
+  });
+
+  test('unknown tool name → isError result (not a protocol error)', async () => {
+    const responses = await driveMcp(repo, [
+      INIT,
+      INITIALIZED,
+      { jsonrpc: '2.0', id: 11, method: 'tools/call', params: { name: 'genie_nope', arguments: {} } },
+    ]);
+    const res = responses.find((r) => r.id === 11);
+    expect(res?.error).toBeUndefined();
+    expect(res?.result?.isError).toBe(true);
+    const payload = toolPayload<{ error: string; name: string }>(res!);
+    expect(payload).toEqual({ error: 'unknown_tool', name: 'genie_nope' });
+  });
+});
+
+// ============================================================================
+// Absent-db degrade
+// ============================================================================
+
+describe('mcp absent-db degrade', () => {
+  test('genie_board degrades to an empty board when genie.db is absent', async () => {
+    // Fresh repo, never seeded → no .genie/genie.db. Readonly open throws → null.
+    const responses = await driveMcp(repo, [
+      INIT,
+      INITIALIZED,
+      { jsonrpc: '2.0', id: 12, method: 'tools/call', params: { name: 'genie_board', arguments: {} } },
+    ]);
+    const res = responses.find((r) => r.id === 12);
+    expect(res?.result?.isError).toBe(false);
+    const payload = toolPayload<{ board: null; counts: { total: number }; tasks: unknown[] }>(res!);
+    expect(payload.counts.total).toBe(0);
+    expect(payload.tasks).toEqual([]);
+  });
+});
+
+// ============================================================================
+// Lazy-load probe — mcp-tools (the readonly bun:sqlite open) must NOT be in the
+// STATIC import graph reachable from genie.ts. It is only `await import`-ed
+// inside the `mcp` action, so non-mcp paths (board/task/--help) never load it.
+// ============================================================================
+
+/** Value (non-type) static import/re-export specifiers in a source file. */
+function staticValueImports(file: string): string[] {
+  const src = readFileSync(file, 'utf-8');
+  const specs: string[] = [];
+  // `import ... from '<spec>'` and `export ... from '<spec>'`, skipping the
+  // type-only forms (`import type` / `export type`) which are erased at runtime.
+  const re = /(?:^|\n)\s*(?:import|export)\s+(type\s+)?[^;'"]*?from\s+['"]([^'"]+)['"]/g;
+  let m: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop
+  while ((m = re.exec(src)) !== null) {
+    if (m[1]) continue; // `type` import — erased, no runtime load
+    specs.push(m[2]);
+  }
+  // Bare side-effect imports: `import '<spec>'`.
+  const sideEffect = /(?:^|\n)\s*import\s+['"]([^'"]+)['"]/g;
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop
+  while ((m = sideEffect.exec(src)) !== null) specs.push(m[1]);
+  return specs;
+}
+
+/** Files transitively reachable via STATIC value imports from `entry`. */
+function reachableFrom(entry: string): Set<string> {
+  const seen = new Set<string>();
+  const stack = [entry];
+  while (stack.length > 0) {
+    const file = stack.pop() as string;
+    if (seen.has(file)) continue;
+    seen.add(file);
+    for (const spec of staticValueImports(file)) {
+      if (!spec.startsWith('.')) continue; // external / node: — not our source graph
+      const target = resolve(dirname(file), spec.replace(/\.js$/, '.ts'));
+      stack.push(target);
+    }
+  }
+  return seen;
+}
+
+describe('mcp lazy-load probe', () => {
+  test('mcp-tools.ts is NOT statically reachable from genie.ts', () => {
+    const reachable = reachableFrom(join(SRC_ROOT, 'genie.ts'));
+    const mcpTools = join(SRC_ROOT, 'lib', 'v5', 'mcp-tools.ts');
+    expect(reachable.has(mcpTools)).toBe(false);
+    // Sanity: the lightweight registration module IS eagerly loaded (expected).
+    expect(reachable.has(join(SRC_ROOT, 'term-commands', 'mcp.ts'))).toBe(true);
+  });
+
+  test('mcp.ts loads bun:sqlite / mcp-tools only via dynamic import()', () => {
+    const src = readFileSync(join(SRC_ROOT, 'term-commands', 'mcp.ts'), 'utf-8');
+    // No static value import of the tools module or bun:sqlite.
+    expect(src).not.toMatch(/(?:^|\n)\s*import\s+\{[^}]*\}\s+from\s+['"]\.\.\/lib\/v5\/mcp-tools/);
+    expect(src).not.toMatch(/from\s+['"]bun:sqlite['"]/);
+    // The tools ARE reached, via a dynamic import inside the action.
+    expect(src).toMatch(/await import\(['"]\.\.\/lib\/v5\/mcp-tools\.js['"]\)/);
+  });
+});

--- a/src/term-commands/mcp.ts
+++ b/src/term-commands/mcp.ts
@@ -1,0 +1,180 @@
+/**
+ * genie mcp — a hand-rolled, zero-dependency stdio MCP server exposing the v5
+ * `.genie/genie.db` state READ-ONLY.
+ *
+ * Transport (per SPIKE.md, verdict "hand-rolled"): newline-delimited JSON-RPC
+ * 2.0 — one JSON object per line on stdin/stdout. NOT LSP `Content-Length`
+ * framing. Speaks MCP protocol `2024-11-05`, confirmed against real Claude Code
+ * and Warp's bundled schema.
+ *
+ * LAZY-LOAD contract: this module statically imports ONLY commander types and
+ * the version string. The `bun:sqlite` read-only open and the tool
+ * implementations live in `../lib/v5/mcp-tools.js`, which is `await import`-ed
+ * inside the command action — so `genie board`/`task`/`--help` never load it.
+ * `mcp.test.ts` locks this via an import-graph probe.
+ *
+ * The stdio protocol writes (`process.stdout.write`) ARE the server's output by
+ * design — not stray logging — so they satisfy biome's no-console rule.
+ */
+
+import { createInterface } from 'node:readline';
+import type { Command } from 'commander';
+// Type-only import: erased at compile time, so it does NOT load mcp-tools (and
+// its bun:sqlite open) at genie startup — the runtime load stays in the action.
+import type { ToolContext } from '../lib/v5/mcp-tools.js';
+import { VERSION } from '../lib/version.js';
+
+// ============================================================================
+// JSON-RPC 2.0 message shapes
+// ============================================================================
+
+interface JsonRpcRequest {
+  jsonrpc: '2.0';
+  id?: number | string | null;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: '2.0';
+  id: number | string | null;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+const PROTOCOL_VERSION = '2024-11-05';
+
+// JSON-RPC standard error codes.
+const METHOD_NOT_FOUND = -32601;
+const INTERNAL_ERROR = -32603;
+
+function writeMessage(msg: JsonRpcResponse): void {
+  // Newline-delimited: exactly one JSON object per line, no embedded newlines.
+  process.stdout.write(`${JSON.stringify(msg)}\n`);
+}
+
+function ok(id: number | string | null, result: unknown): void {
+  writeMessage({ jsonrpc: '2.0', id, result });
+}
+
+function err(id: number | string | null, code: number, message: string): void {
+  writeMessage({ jsonrpc: '2.0', id, error: { code, message } });
+}
+
+// ============================================================================
+// Server run loop
+// ============================================================================
+
+/**
+ * Drive the stdio MCP server until stdin closes. Opens a NET-NEW read-only db
+ * handle (degrading to an empty board when the file is absent) and dispatches
+ * each newline-delimited JSON-RPC message.
+ */
+export async function runMcpServer(): Promise<void> {
+  // Lazy: the read-only bun:sqlite open + tools load here, not at genie startup.
+  const { MCP_TOOLS, openReadonlyDb } = await import('../lib/v5/mcp-tools.js');
+  const cwd = process.cwd();
+  const db = openReadonlyDb(cwd);
+  const ctx: ToolContext = { db, cwd };
+
+  const toolByName = new Map(MCP_TOOLS.map((t) => [t.name, t] as const));
+
+  function handleToolsCall(id: number | string | null, params: Record<string, unknown> | undefined): void {
+    const name = typeof params?.name === 'string' ? params.name : '';
+    const args = (params?.arguments as Record<string, unknown> | undefined) ?? {};
+    const tool = toolByName.get(name);
+    if (!tool) {
+      // Surface as an isError tool result (not a protocol error) per MCP.
+      ok(id, {
+        content: [{ type: 'text', text: JSON.stringify({ error: 'unknown_tool', name }) }],
+        isError: true,
+      });
+      return;
+    }
+    const payload = tool.handler(ctx, args);
+    ok(id, {
+      content: [{ type: 'text', text: JSON.stringify(payload) }],
+      structuredContent: payload,
+      isError: false,
+    });
+  }
+
+  function dispatch(req: JsonRpcRequest): void {
+    // A message with no id (or null id) is a notification: process side effects
+    // but send NO reply (e.g. notifications/initialized).
+    const isNotification = req.id === undefined || req.id === null;
+    const id = req.id ?? null;
+
+    switch (req.method) {
+      case 'initialize':
+        ok(id, {
+          protocolVersion: PROTOCOL_VERSION,
+          capabilities: { tools: {} },
+          serverInfo: { name: 'genie', version: VERSION },
+        });
+        return;
+      case 'ping':
+        if (!isNotification) ok(id, {});
+        return;
+      case 'tools/list':
+        if (!isNotification) {
+          ok(id, {
+            tools: MCP_TOOLS.map((t) => ({ name: t.name, description: t.description, inputSchema: t.inputSchema })),
+          });
+        }
+        return;
+      case 'tools/call':
+        if (!isNotification) handleToolsCall(id, req.params);
+        return;
+      default:
+        // Notifications (e.g. notifications/initialized, notifications/*) get no
+        // reply. An unknown method WITH an id is a JSON-RPC method-not-found.
+        if (!isNotification) err(id, METHOD_NOT_FOUND, `Method not found: ${req.method}`);
+        return;
+    }
+  }
+
+  function handleLine(line: string): void {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+    let req: JsonRpcRequest;
+    try {
+      req = JSON.parse(trimmed) as JsonRpcRequest;
+    } catch {
+      // Unparseable line → cannot attribute an id; drop it (no id to reply to).
+      return;
+    }
+    try {
+      dispatch(req);
+    } catch (e) {
+      const id = req.id ?? null;
+      if (id !== null) err(id, INTERNAL_ERROR, e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  const rl = createInterface({ input: process.stdin, crlfDelay: Number.POSITIVE_INFINITY });
+  rl.on('line', handleLine);
+
+  await new Promise<void>((resolve) => {
+    rl.on('close', () => {
+      db?.close();
+      // Flush stdout BEFORE exiting: the empty-write callback fires after the
+      // stream's buffer (including all prior response writes) drains to the OS,
+      // so the final response is never truncated. See SPIKE.md flush note.
+      process.stdout.write('', () => resolve());
+    });
+  });
+}
+
+// ============================================================================
+// Registration (the single line in genie.ts calls this)
+// ============================================================================
+
+export function registerMcpCommand(program: Command): void {
+  program
+    .command('mcp')
+    .description('Run a read-only stdio MCP server exposing genie.db task/board state')
+    .action(async () => {
+      await runMcpServer();
+    });
+}


### PR DESCRIPTION
## Summary

Genie's live state (wishes, tasks, board, what each worktree is working on) was invisible to Warp and to the agents running inside it. This adds a `genie mcp` stdio MCP server that exposes `genie.db` **read-only** as MCP tools, auto-registered into the project `.warp/.mcp.json` + `.mcp.json` by `genie init`/`launch` — so **Warp and Claude Code (any MCP client) can read genie's live state**, and each Warp pane's agent can ask "what wish/group am I here for." Executes wish [`genie-mcp`](.genie/wishes/genie-mcp/WISH.md) — brainstorm → design → wish, each independently reviewed.

## The correction behind this

The original "richer Warp integration" ask assumed a Warp plugin with stateful tabs. The real answer (from Warp's docs): **Warp's plugin surface *is* MCP**, and it's *pull, not push* — Warp has no external API to write tab titles. So genie exposes state via MCP and the pane's agent *asks*. Bigger than Warp: the same server gives **every Claude Code session** live genie state.

## What shipped (3 groups, spike-first)

- **G1 spike** — verdict **hand-rolled**: a zero-dep newline-delimited JSON-RPC 2.0 stdio server satisfies real Claude Code end-to-end and speaks MCP 2024-11-05 (Warp's protocol). genie stays 4-deps-lean — no MCP SDK. Pinned the `.warp/.mcp.json`/`.mcp.json` schema + the `process.execPath` command form.
- **G2** — `genie mcp`: the hand-rolled server + 5 read-only tools (`genie_board`, `genie_wish_status`, `genie_worktree_context` (resolves branch `wish/<slug>-<group>`), `genie_task`, `genie_active`). Net-new `new Database(readonly)` open degrades to an empty board on absent db; `mcp-tools` is `await import`-ed so non-mcp paths never load `bun:sqlite` (real graph-walk probe).
- **G3** — `init`/`launch` JSON-merge-register the server into both config files, preserving existing servers/keys, byte-identical rerun, malformed-JSON-safe; absolute command via `process.execPath`.

## Needs your eyes — Warp live-UI connect

The spike confirmed the schema, the MCP protocol, and Claude Code end-to-end (both boxes), but Warp's GUI can't be driven over ssh. To close the last criterion: open Warp on your Mac → SSH `felipe` → a genie-init'd repo → **Settings → Agents → MCP servers** → expect `genie` detected + green. A scratch repo is staged at `~/genie-mcp-spike/` on felipe (safe to `rm -rf` after).

## Gates

Full `bun run check` (599 tests) + build green; the dist server's protocol verified end-to-end (initialize → tools/list → tools/call); the full init→register→serve loop proven.

## Follow-ups (noted, non-blocking)

- Dev-mode `process.execPath` resolves to `bun` (correct for the shipped compiled binary; self-evident in dev) — optional `Bun.main` hardening.
- MCP WRITE tools + Codex TOML wiring are later wishes (this is read-only, Warp + Claude Code).

Merge decision: Felipe.