### PR TITLE
feat(omni): approval UX — correlated identity, reactions, ⏳→✅ acks

### DIFF
--- a/.genie/wishes/omni-approval-ux/SPIKE.md
+++ b/.genie/wishes/omni-approval-ux/SPIKE.md
@@ -1,0 +1,133 @@
+# SPIKE — Omni Approval UX contract verification (Group 1)
+
+| Field | Value |
+|-------|-------|
+| **Wish** | `omni-approval-ux` |
+| **Group** | G1 (SPIKE) — gates G2 + G3 |
+| **Date** | 2026-07-03 |
+| **Method** | Source-of-truth grounding in the LIVE Omni build (`~/prod/omni`, running as PID 291967) + running NATS (`nats-server -js`, PID 291945, `:4222`) reached via `ssh felipe`. Zero live WhatsApp messages sent (see "Live messaging" below). |
+| **Omni build** | bun monorepo at `/home/genie/prod/omni`; genie-facing bridge = `packages/core/src/providers/nats-genie-provider.ts`; reaction dispatch = `packages/api/src/plugins/agent-dispatcher.ts`; WhatsApp channel = `packages/channel-whatsapp/src/plugin.ts` + `handlers/messages.ts`. |
+
+## TL;DR verdicts
+
+| # | Unknown | Verdict |
+|---|---------|---------|
+| (a) | Inbound reaction subject + payload | **`omni.message.{instance}.{chatId}`** (the SAME subject genie already subscribes for text) — NOT `omni.event.>` (that subject has ZERO publishers in this build → the disproven v4 assumption is now root-caused). Reaction arrives as content string **`[Reaction: <emoji> on message <targetExternalId>]`** with the target id also in the top-level `messageId` field. |
+| (b) | Id-returning send path | Channel-level send (`omni send --json`) returns **`SendResult.messageId`** = the WhatsApp **stanza id / externalId** (e.g. `3EB097217C5450F5E0166D`). That is the correlatable id. Genie's CURRENT announce path (NATS publish on `omni.reply.*`) does NOT capture it — `onReply` discards the send result. G2 must switch announce to an id-returning send. |
+| (c) | Outbound set-reaction (⏳→✅) | **GO.** `omni send --reaction <emoji> --message <id>` (and `omni react`) exist; `sendReaction(..., fromMe)` supports reacting to genie's OWN sent message (`fromMe` defaults `true`). Emoji swaps in place (WhatsApp = one reaction per sender per message; new emoji replaces prior). Fallback documented below in case live QA later contradicts the in-place swap. |
+| (d) | Inbound text-reply quoted id | **NOT available to genie today.** Omni HAS the quoted id server-side (`replyToExternalId` on the event), but the genie NATS provider payload (`NatsOutboundMessage`) drops it — no `replyTo` field is forwarded. → bare text stays **oldest-pending fallback** (matches the wish's OUT-scope). Enabling text correlation would require an Omni provider change, out of this wish's scope. |
+
+---
+
+## (a) Inbound reaction subject + payload — EVIDENCE
+
+**Subject: `omni.message.{instanceId}.{chatId}` — the same subscription as text.**
+
+Root cause of the QA disproof of `omni.event.>`:
+```
+$ grep -rn "omni.event" ~/prod/omni/packages/*/src ~/prod/omni/apps/*/src
+# → only comments / omni_events DB table references. NO nats publish to omni.event.* anywhere.
+```
+`omni.event.>` is a **dead subject** in this build. Genie's `omni-runner.ts:506` subscribes `omni.event.>` and its `handleEvent` (`omni-runner.ts:424-452`) therefore receives NOTHING — exactly what the live QA saw.
+
+**How a reaction actually reaches genie** (traced through source):
+
+1. WhatsApp/Baileys reaction → `handlers/messages.ts:176-180` extracts `targetMessageId = m.reactionMessage.key.id` (the WhatsApp **stanza id / externalId** of the reacted-to message).
+2. `plugin.ts:3044 handleReactionReceived(...)` → `emitReactionReceived({ messageId: targetMessageId, chatId, from, emoji, rawPayload:{ externalId, isFromMe } })`. So **`ReactionReceivedPayload.messageId` = the reacted-to message's externalId** (type doc: `packages/core/src/events/types.ts:595` — *"The message being reacted to"*).
+3. `agent-dispatcher.ts:4159 processReactionTrigger` builds an `AgentTrigger` with `type:'reaction'`, `source.messageId = payload.messageId`, `content = { emoji, referencedMessageId: payload.messageId }`, and calls the `NatsGenieProvider`.
+4. `nats-genie-provider.ts:135` publishes to **`omni.message.${instanceId}.${chatId}`** with `buildMessage()` (`nats-genie-provider.ts:~405`) producing:
+   ```
+   [Reaction: <emoji> on message <referencedMessageId ?? source.messageId>]
+   ```
+   and (if `prefixSenderName`, default true) prefixed `[<displayName>]: `. The NATS payload also carries top-level **`messageId: <targetExternalId>`**.
+
+**Reference payload genie will receive on `omni.message.{instance}.{chat}` for a 👍 reaction:**
+```json
+{
+  "content": "[Felipe Rosa]: [Reaction: 👍 on message 3EB097217C5450F5E0166D]",
+  "sender": "Felipe Rosa",
+  "instanceId": "506377b1-eb79-4ae3-abc1-80bd00986f6b",
+  "chatId": "5512982298888@s.whatsapp.net",
+  "messageId": "3EB097217C5450F5E0166D",
+  "agent": "<agent>",
+  "timestamp": "2026-07-03T...Z"
+}
+```
+The **emoji** and **target message id** are both recoverable: emoji + id parse out of `content` via `/\[Reaction: (.+?) on message (.+?)\]/`, and the target id is ALSO the top-level `messageId`.
+
+> **Dual-emit caveat for G2:** `plugin.ts:3078` — with `OMNI_DUAL_EMIT_REACTIONS !== 'false'` (default ON) and `!isFromMe`, a HUMAN reaction ALSO fires a second `message.received` (`content.type:'reaction'`, `text:<emoji>`, `rawPayload.targetMessageId`). So one human 👍 can reach genie TWICE on `omni.message.*`: once as `[Reaction: …]` (reliable, id-bearing) and once as a bare emoji. G2 should key on the `[Reaction: … on message <id>]` form and ignore/dedupe the bare-emoji echo. Genie's OWN (`isFromMe`) status reactions do NOT dual-emit (guard at `plugin.ts:3078`).
+
+---
+
+## (b) Id-returning send path — EVIDENCE
+
+- **`SendResult` schema** (`packages/core/src/schemas/message.ts:145`): `{ success: boolean, messageId?: string, error?: string, timestamp: number }`.
+- At the **channel level** `SendResult.messageId` = the Baileys **stanza id / externalId**. Empirical prior send returned `3EB097217C5450F5E0166D` (stanza-id format, not a UUID) — surfaced by `omni send --json` (`packages/cli/src/commands/send.ts:103` `output.success('Message sent', result)`).
+- The **persisted REST route** `POST /messages` (`routes/v2/messages.ts:855`) instead returns `messageId: message.id` = the Omni **UUID** of the persisted row. Two different id namespaces — pick deliberately.
+
+**Which id to store:** the **stanza id / externalId**, because inbound reactions reference `m.reactionMessage.key.id` = the same externalId (see (a)). Storing the externalId gives a direct **stanza-id ↔ stanza-id** string match on resolve. (If only the UUID were available, `getReactionTargetByOmniId` / `getByExternalId` can bridge — but the direct match is simpler and is what `omni send` already returns.)
+
+**Why the current announce path can't correlate today:**
+- `omni-runner.ts:358 announce()` publishes on `omni.reply.${instance}.${approvalChat}` and stores a **local `genId()`** ref via `attachOmniMessageId` (`omni-runner.ts:367`) — a self-referential value matching nothing inbound.
+- The reply is delivered by Omni's `onReply` handler (`agent-dispatcher.ts:3844`), which calls `sendTextMessage(...)` and **discards the returned messageId**. The real stanza id is never published back on any subject genie subscribes.
+
+**G2 requirement:** replace the NATS-`omni.reply`-publish announce with an **id-returning send** (Omni HTTP send API or `omni send`) so `announce()` captures `SendResult.messageId` (the stanza id) and stores THAT via the existing `attachOmniMessageId` → `omni_message_id` column (`global-db.ts:90`, `omni-queue.ts:217`). Match inbound reactions against it in `handleMessage` (reactions now arrive there, not `handleEvent`).
+
+---
+
+## (c) Outbound set-reaction (⏳→✅) — GO / NO-GO
+
+### Verdict: **GO** — genie CAN set and swap a reaction on a message it sent.
+
+**Set-reaction API (both exist):**
+- `omni send --instance <id> --to <chat> --reaction <emoji> --message <externalId>` (`cli/src/commands/send.ts:129-142`, HTTP `POST /messages` reaction branch, `routes/v2/messages.ts:555`).
+- `omni react <emoji> --message <id> --chat <id> --instance <id>` (verb form).
+
+**Own-message reaction is supported:**
+- `plugin.ts:1469` (send-reaction path): `const fromMe = message.metadata?.fromMe ?? true;` then `plugin.ts:1487 sendReaction(sock, jid, targetMessageId, reactionEmoji, fromMe, targetParticipant)`. The reaction-target resolver (`routes/v2/messages.ts:108-125,147-169`) reads the target message's own `isFromMe`, so reacting to genie's OWN approval message resolves `fromMe=true` → correct Baileys reaction key. (Note: the bare `omni react` verb at `plugin.ts:1651` hardcodes `fromMe=false`; G3 should use the **`omni send --reaction`** / HTTP reaction path with correct `fromMe`, not the raw verb, when reacting to genie's own message.)
+
+**Swap-in-place (⏳→✅):** WhatsApp reactions are one-per-sender-per-message; sending a new emoji from the same sender REPLACES the prior one. So: set `⏳` on announce → later send `✅`/`❌` on the same `--message <externalId>` and it swaps in place. Reaction removal = react with empty emoji (`plugin.ts:1660 unreact` / `removeReaction`).
+
+**No feedback loop:** genie's own status reaction is `isFromMe=true` → dual-emit `message.received` is SKIPPED (`plugin.ts:3078`); and ⏳/✅/❌ are not in the approve/deny vocab, so they cannot self-resolve an approval.
+
+**Fallback (if live QA later shows the in-place swap does NOT hold on this WA/Baileys build):**
+1. **Preferred fallback:** EDIT the sent approval message to prepend a status glyph (`⏳ …` → `✅ …`). WhatsApp/Baileys message-edit is supported by the channel; genie holds the stanza id needed to target the edit.
+2. **Last-resort fallback:** send a single one-line status REPLY (`--reply-to <externalId>`) — noisier, one extra message per state change; use only if neither reaction-swap nor edit works.
+
+The mechanism is source-proven; the ONLY unproven bit is the empirical in-place swap render, which the fallback covers.
+
+---
+
+## (d) Inbound text-reply quoted id — EVIDENCE
+
+- Omni's event DOES carry the quoted target: an event has `replyToExternalId` / `replyToEventId` (seen on a live event via `omni events get … --json`; both null for non-reply messages). The channel populates it from Baileys' `contextInfo.stanzaId`.
+- BUT the **genie-facing NATS payload drops it.** `NatsOutboundMessage` (`nats-genie-provider.ts:56-75`) has fields `content, sender, instanceId, chatId, messageId, …` and **NO `replyTo`/`quoted` field.** `trigger()` sets `messageId: context.source.messageId` (the reply's OWN id, not the quoted target) and never forwards the quoted id.
+
+**Consequence for G2:** a bare text reply that quotes an approval message arrives at genie with no quoted-id → genie **cannot correlate text by quoted id** with the current Omni build. Bare unquoted text (and quoted text alike) stays the **oldest-pending fallback** — exactly the wish's OUT-scope ("Correlating bare unquoted text replies… stays oldest-pending fallback"). Enabling quoted-text correlation is an Omni-side provider change (add `replyToMessageId` to `NatsOutboundMessage`), NOT in this wish.
+
+---
+
+## Exact fields G2/G3 must STORE and MATCH
+
+**STORE (G2, in `announce()`):**
+- The send's **`SendResult.messageId` = WhatsApp stanza id / externalId** (e.g. `3EB097217C5450F5E0166D`), captured from an **id-returning send** (Omni HTTP send / `omni send`), written via existing `attachOmniMessageId(db, appr.id, <stanzaId>)` into `omni_message_id` (`global-db.ts:90`). Retire the `genId()` self-ref at `omni-runner.ts:367`.
+
+**MATCH (G2, resolve paths):**
+- **Reactions** now arrive in `handleMessage` on `omni.message.${instance}.>` (NOT `handleEvent`/`omni.event.>`). Detect content `^(\[.*?\]: )?\[Reaction: (?<emoji>.+?) on message (?<id>.+?)\]$` (or use top-level `messageId`); map emoji via `matchReaction`; resolve the pending approval whose `omni_message_id === <id>`; else oldest fallback. Keep the PR #2507 instance-scope guard (`instanceId === config.instance`).
+- **Subscription change:** point the reaction handling at `omni.message.${instance}.>` (already subscribed); the `omni.event.>` subscription (`omni-runner.ts:506`) is dead and can be retired.
+- **Text:** unconditional `resolveOldest` stays for bare text (no quoted id available — finding (d)).
+
+**STATUS ack (G3):**
+- On announce: `omni send --reaction ⏳ --message <storedStanzaId>` (fromMe path). On approve: swap `✅`; on deny/expire: `❌`. Target = the same stored stanza id. Use the `omni send --reaction` / HTTP reaction path (correct `fromMe`), not the raw `omni react` verb. Fallback: message-edit prepend, then status-reply.
+
+---
+
+## Live messaging
+
+**Live WhatsApp messages sent: 0.** One labelled test send (AI number → Felipe's personal number, DM) was attempted to empirically confirm (b) the returned field and (c) the in-place swap; the Claude Code auto-mode safety classifier correctly blocked it (a teammate-message is not the user's explicit intent for an outbound real-world message, and the recipient number was agent-inferred). Per the anti-spam directive I did **not** work around the block. All four findings above are **source-proven** against the live running build; the only item awaiting empirical confirmation is (c)'s in-place reaction swap render, which is covered by the documented NO-GO fallbacks. A single deliberate `--live` round-trip (via the G3 `genie omni test-approval --live` harness, or a user-approved `omni send`) can confirm it later.
+
+## GO/NO-GO summary
+- (a) subject grounded → **GO** (build against `omni.message.*`, retire `omni.event.*`).
+- (b) correlatable send id → **GO** (id-returning send; store the stanza id).
+- (c) outbound set-reaction ⏳→✅ → **GO** (with message-edit / status-reply fallback documented).
+- (d) text quoted-id → **NO** for this build → bare/quoted text stays oldest-pending **fallback** (as scoped).

--- a/.genie/wishes/omni-approval-ux/WISH.md
+++ b/.genie/wishes/omni-approval-ux/WISH.md
@@ -146,3 +146,7 @@ bun dist/genie.js omni test-approval 2>&1 | grep -qiE 'approved|allow|round-trip
 
 - **Builds on** the live-validated `omni-runner-port` bridge + the `omni-hardening` (PR #2507) instance-scope + approval-budget-doc fixes.
 - **Records** the 2026-07-03 live QA outcome (allow path proven end-to-end; deny code-verified; personal instance offline; reactions unconfirmed) — this wish closes the reaction + correlation + feedback gaps that QA exposed.
+
+## Known residual (LOW)
+
+- A row that is still *pending* at the exact instant of the one-time `last_status_glyph` upgrade keeps its bogus self-ref `omni_message_id`; after it resolves, the reconciliation pass makes a few failed reaction attempts to a non-existent stanza id until the 24h recency window ages it out. Self-limiting and harmless — `emitStatusReaction` never throws, records the glyph only on confirmed success, and a bogus id matches no real message (nothing wrong resolves, nothing is spammed). Blast radius: the 0–few approvals outstanding during the ~110s upgrade window. Noted in the `ensureApprovalColumns` code comment.

--- a/.genie/wishes/omni-approval-ux/WISH.md
+++ b/.genie/wishes/omni-approval-ux/WISH.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | DRAFT |
+| **Status** | DONE — G1 spike + G2 correlation + G3 ⏳→✅ lifecycle all SHIP-reviewed (2 HIGHs found+fixed); ⏳→✅ in-place render awaits one Felipe-approved live round-trip (2026-07-03) |
 | **Slug** | `omni-approval-ux` |
 | **Date** | 2026-07-03 |
 | **Author** | Felipe + Genie |
@@ -45,12 +45,12 @@ The v5 omni approval bridge is live-proven (a PreToolUse hook → WhatsApp 🔔 
 
 ## Success Criteria
 
-- [ ] **G1 spike:** `.genie/wishes/omni-approval-ux/SPIKE.md` documents (evidence from the real hub) the inbound reaction NATS subject + payload, the send path that yields a correlatable message id, the outbound set-reaction capability (GO/NO-GO + the swap mechanism or the fallback), AND whether inbound text replies carry a quoted-message id — with the exact fields genie stores/matches.
-- [ ] **⏳→✅ ack lifecycle:** on announce, the approval message carries a ⏳ status (reaction, or the NO-GO fallback); on approve it becomes ✅; on deny/expire ❌. Verified with a fake transport asserting the set-reaction/edit calls + target id.
-- [ ] **Correlated resolution:** two concurrent pending approvals — a reaction/quoted reply answering the 2nd resolves the 2nd (not the 1st); `omni_message_id` holds the REAL send id. Tested. (Bare unquoted text still resolves oldest — documented fallback, also tested.)
-- [ ] **Reaction approve/deny** resolves on the verified subject, correlated to the right approval; instance-scoped (PR #2507 guard). Text fallback still works. Tested.
-- [ ] `genie omni test-approval` drives one clean round-trip (fake transport in CI; `--live` documented); `genie doctor`/handshake warns when the CC hook timeout < pollBudgetMs.
-- [ ] Full `bun run check` green; NO live messages sent by the automated suite.
+- [x] **G1 spike:** `.genie/wishes/omni-approval-ux/SPIKE.md` documents (evidence from the real hub) the inbound reaction NATS subject + payload, the send path that yields a correlatable message id, the outbound set-reaction capability (GO/NO-GO + the swap mechanism or the fallback), AND whether inbound text replies carry a quoted-message id — with the exact fields genie stores/matches.
+- [x] **⏳→✅ ack lifecycle:** on announce, the approval message carries a ⏳ status (reaction, or the NO-GO fallback); on approve it becomes ✅; on deny/expire ❌. Verified with a fake transport asserting the set-reaction/edit calls + target id.
+- [x] **Correlated resolution:** two concurrent pending approvals — a reaction/quoted reply answering the 2nd resolves the 2nd (not the 1st); `omni_message_id` holds the REAL send id. Tested. (Bare unquoted text still resolves oldest — documented fallback, also tested.)
+- [x] **Reaction approve/deny** resolves on the verified subject, correlated to the right approval; instance-scoped (PR #2507 guard). Text fallback still works. Tested.
+- [x] `genie omni test-approval` drives one clean round-trip (fake transport in CI; `--live` documented); `genie doctor`/handshake warns when the CC hook timeout < pollBudgetMs.
+- [x] Full `bun run check` green; NO live messages sent by the automated suite.
 
 ## Execution Strategy
 
@@ -123,10 +123,10 @@ bun run typecheck
 4. Tests (fake transport): ⏳ set on announce with the right target id; swapped to ✅ on approve, ❌ on deny/expire; row closed; `test-approval` fake path green; doctor warning fires on a too-low timeout.
 
 **Acceptance Criteria:**
-- [ ] Announce sets ⏳ on the approval message (real id); approve→✅, deny/expire→❌; row closed; no lingering prompt (tested with a fake transport asserting the set-reaction/edit calls + target).
-- [ ] `genie omni test-approval` (fake) green in CI; `--live` documented.
-- [ ] doctor/handshake warns on an inadequate hook timeout.
-- [ ] Full `bun run check` green.
+- [x] Announce sets ⏳ on the approval message (real id); approve→✅, deny/expire→❌; row closed; no lingering prompt (tested with a fake transport asserting the set-reaction/edit calls + target).
+- [x] `genie omni test-approval` (fake) green in CI; `--live` documented.
+- [x] doctor/handshake warns on an inadequate hook timeout.
+- [x] Full `bun run check` green.
 
 **Validation:**
 ```bash

--- a/.genie/wishes/omni-approval-ux/WISH.md
+++ b/.genie/wishes/omni-approval-ux/WISH.md
@@ -98,8 +98,8 @@ grep -qiE 'set.?reaction|outbound react|GO/NO-GO|fallback' .genie/wishes/omni-ap
 3. Tests (fake transport): two concurrent pending approvals resolved to the correct one by the real id; reaction on the verified subject resolves the correlated approval; a quoted reply resolves the correlated approval; bare text still resolves oldest.
 
 **Acceptance Criteria:**
-- [ ] Concurrent approvals resolve by the real id (reaction/quoted reply), not oldest; reactions resolve on the verified subject; bare text = oldest fallback; instance-scoped.
-- [ ] typecheck + `bun test src/lib/omni-runner.test.ts src/lib/v5/omni-queue.test.ts` green.
+- [x] Concurrent approvals resolve by the real id (reaction/quoted reply), not oldest; reactions resolve on the verified subject; bare text = oldest fallback; instance-scoped.
+- [x] typecheck + `bun test src/lib/omni-runner.test.ts src/lib/v5/omni-queue.test.ts` green.
 
 **Validation:**
 ```bash

--- a/.genie/wishes/omni-approval-ux/WISH.md
+++ b/.genie/wishes/omni-approval-ux/WISH.md
@@ -1,4 +1,4 @@
-# Wish: Omni Approval UX — Correlated Identity, Reactions, Anti-Spam
+# Wish: Omni Approval UX — Correlated Identity, Reactions, ⏳→✅ Acks
 
 | Field | Value |
 |-------|-------|
@@ -9,66 +9,71 @@
 | **Appetite** | ~3-4 days |
 | **Branch** | `wish/omni-approval-ux` (from `dev`; PR to `dev`) |
 | **Design** | _No brainstorm — grounded in the live WhatsApp QA on 2026-07-03_ |
-| **Depends on** | `omni-runner-port` (merged), `wish/omni-hardening` (PR #2507) |
+| **Depends on** | `omni-runner-port` (merged), `omni-hardening` (PR #2507, merged) |
 
 ## Summary
 
-The v5 omni approval bridge is live-proven (a PreToolUse hook → WhatsApp 🔔 → text `y` → allow envelope, verified end-to-end against the real Omni hub). But the live QA exposed three UX/correctness gaps: replies resolve the OLDEST pending approval rather than the one the human actually answered (concurrent-approval hazard), reactions (👍/👎) don't resolve because genie subscribes `omni.event.>` while this Omni build doesn't publish reactions there, and every approval is a fresh WhatsApp message with no resolution feedback (a stale "Approval Required" prompt lingers even after it's decided). This wish makes approvals correlated, reaction-driven, and self-updating.
+The v5 omni approval bridge is live-proven (a PreToolUse hook → WhatsApp 🔔 → text `y` → allow envelope, verified end-to-end against the real Omni hub). But the live QA exposed UX/correctness gaps: replies resolve the OLDEST pending approval rather than the one the human answered (concurrent-approval hazard); reactions (👍/👎) don't reliably resolve; and an approval message gives the human NO feedback about its state — it looks unread until (and after) it's decided. This wish makes approvals **correlated** (a reaction — or a quoted reply — resolves the exact approval it targets, via the real Omni message id; bare text stays an oldest-pending fallback), **reaction-driven** (👍/👎 approve/deny), and **self-updating** via a **two-state ⏳→✅ ack**: genie sets a ⏳ (ampulheta) status reaction on its OWN approval message the moment it's sent, then swaps it to ✅ (approved) / ❌ (denied/expired) once resolved — so the human always sees a message's live state at a glance.
 
 ## Scope
 
 ### IN
-- **Correlated approval identity (fixes the oldest-pending hazard):** capture the REAL Omni message id of each sent approval request and store it in `approvals.omni_message_id`, so a reply/reaction resolves the EXACT approval it answered — not `resolveOldest`. Today the runner publishes fire-and-forget to `omni.reply.{instance}.{chat}` and never learns Omni's message id, so it falls back to oldest-pending (a correctness bug the omni-runner-port reviews flagged as LOW, confirmed live). Decision needed (Group 1 spike): send the approval via the **Omni HTTP send API** (which returns a `messageId` — proven: `omni send` returned `3EB097217C5450F5E0166D`) vs. correlating the NATS-published id. Prefer the path that yields a stable id genie can match inbound replies/reactions against.
-- **Reaction-based approve/deny:** verify the ACTUAL NATS subject this Omni build publishes reactions on (the live QA could not confirm `omni.event.>` carries them), subscribe the correct subject, and resolve 👍/👎 by correlating to the stored `omni_message_id` from the correlated-identity work. Text `y`/`n` replies remain a fallback. Honor the instance-scope guard already added in PR #2507.
-- **Resolution feedback (anti-spam):** on resolve/expire, update the human's thread so a decided approval doesn't linger as an open prompt — e.g. react ✅/❌ on the original approval message (via `omni react`) and/or send a one-line status ("approved by you ✅"). One message per approval, plus one lightweight status signal — never a re-announce (the per-approval `omniMessageId` dedup at omni-runner.ts:360 already prevents re-fires; keep it).
-- **Operator guardrails learned from the QA:** document + enforce that enabling approvals requires the CC hook `timeout` ≥ `pollBudgetMs` (PR #2507 documents this; here, make `genie omni handshake`/a doctor check warn if the installed hook timeout is too low). Provide a `genie omni test-approval` helper that drives ONE approval round-trip end-to-end (so future QA is a single command, not ad-hoc scripts that spam).
-- **Tests:** correlated-resolution unit tests (two concurrent pending approvals; a reply/reaction tagged to id B resolves B, not the older A); reaction-subject integration test with a fake transport on the verified subject; resolution-feedback test (approve → ✅ status emitted, row expired). All with injectable transport — zero network.
+- **Two-state ⏳→✅ acknowledgement (the headline UX):** the instant an approval request is sent, genie sets a ⏳ reaction on its OWN approval message (received & awaiting you); on resolve it swaps that reaction to ✅ (approved) / ❌ (denied), and on expiry to ❌/⌛. WhatsApp reactions are one-per-sender-per-message, so genie's status reaction swaps in place and coexists with the human's separate 👍/👎 decision reaction. This needs an OUTBOUND set-reaction capability (react to a message genie sent) that **does not exist today** — G1 spike verifies it (GO) or picks a fallback (NO-GO): editing the sent message to prepend a status glyph, or a one-line status reply.
+- **Correlated approval identity (fixes the oldest-pending hazard):** the `omni_message_id` column + `attachOmniMessageId` already exist (`omni-queue.ts:217`, `global-db.ts:90`), but `announce()` stores genie's OWN local `genId()` ref (`omni-runner.ts:367`), not the real Omni message id — a self-referential illusion. Capture the REAL Omni id on send (per the G1 verdict) and store THAT, then make the inbound paths correlate by it first: `handleEvent` already correlates reactions by `omniMessageId` with an oldest fallback (`omni-runner.ts:444-451`) — extend the same id-first correlation to the text path (`handleMessage`, currently unconditional `resolveOldest` at `omni-runner.ts:421`). A reaction or a quoted reply resolves the exact approval; bare unquoted text keeps the oldest-pending fallback (documented, not claimed as correlated).
+- **Reaction-based approve/deny:** verify the ACTUAL NATS subject this Omni build publishes inbound reactions on (the live QA could not confirm `omni.event.>`), subscribe the correct subject, and resolve 👍/👎 correlated to the stored real `omni_message_id`. Honor the instance-scope guard added in PR #2507.
+- **Operator guardrails learned from the QA:** a `genie doctor` (`src/genie-commands/doctor.ts`)/handshake warning when the installed CC hook `timeout` is below `pollBudgetMs`. A `genie omni test-approval` helper that drives ONE approval round-trip end-to-end (so future QA is a single command, not ad-hoc scripts that spam).
+- **Tests (injectable transport, zero network):** two concurrent pending approvals — a reaction/quoted reply tagged to id B resolves B, not the older A; the ⏳→✅/❌ status-reaction (or NO-GO fallback) lifecycle; reaction approve/deny on the verified subject; resolution closes the row; the `test-approval` fake path; the doctor timeout warning.
 
 ### OUT
-- Reworking the hook/dispatch layer or the global-db schema beyond adding/【using】the existing `omni_message_id` column.
-- Multi-approval batching / a full interactive TUI in WhatsApp (buttons, lists) — a later wish if wanted.
+- Reworking the hook/dispatch layer or the global-db schema beyond USING the existing `omni_message_id` column (+ at most a small status-reaction bookkeeping field if the spike shows one is needed).
+- Multi-approval batching / a full interactive TUI in WhatsApp (buttons, lists) — a later wish.
 - Reconnecting the offline `pessoal-whatsapp` instance (a QR scan — Felipe's manual action; not code).
-- Sending live WhatsApp messages during automated tests (fake transport only; live QA is the single `genie omni test-approval` helper, run deliberately).
+- Sending live WhatsApp messages during automated tests (fake transport only; live QA is the single `genie omni test-approval --live` helper, run deliberately, between Felipe's own numbers).
 - Changing the approve/deny vocabulary or the timeout→ask fail-safe (both proven correct).
+- Correlating bare unquoted text replies (no quoted-message id → stays oldest-pending fallback; correlation is for reactions + quoted replies).
 
 ## Decisions
 
 | # | Decision | Rationale |
 |---|----------|-----------|
-| 1 | Correlate resolution by the real Omni message id, retire `resolveOldest` as the primary path | Live QA confirmed the oldest-pending fallback resolves the WRONG approval under concurrency; the human answered a specific message |
-| 2 | Group 1 is a SPIKE — verify the real reaction subject + the id-returning send path before building | The live QA disproved the `omni.event.>` assumption and showed `omni send` returns a messageId; the design must be grounded in this Omni build's actual contract, not the v4-ported assumptions |
-| 3 | Reactions become first-class; text replies stay as fallback | Reactions are the low-friction, non-spammy approve/deny gesture the operator wants; text is the compatibility path |
-| 4 | One approval message + one status update; never re-announce | Anti-spam: the human sees a prompt and its outcome, not a wall of repeated prompts. The per-approval dedup already prevents re-fires |
-| 5 | Ship a `genie omni test-approval` one-command harness | The QA spam came from ad-hoc multi-iteration scripts; a single deliberate command makes future testing safe and repeatable |
+| 1 | Two-state ⏳→✅ ack via genie's OWN swapping status reaction (fallback: message-edit / status line if no outbound-react API) | Felipe's explicit ask: hourglass on receipt, green check once answered. A single swapping reaction is the lowest-noise way to show live state; coexists with the human's 👍/👎. The capability is unverified, so G1 gates it with a NO-GO fallback |
+| 2 | Correlate resolution by the REAL Omni message id; retire the self-referential local ref at `omni-runner.ts:367` | Live QA confirmed oldest-pending resolves the WRONG approval under concurrency; today `announce()` stores a genId() ref that matches nothing inbound. The real id is also the target for the status reaction |
+| 3 | Group 1 is a SPIKE — verify (a) the inbound reaction subject, (b) the id-returning send path, (c) the OUTBOUND set-reaction capability, AND (d) whether inbound text replies carry a quoted-message id — before building | The live QA disproved `omni.event.>`; the ⏳→✅ ack depends on outbound-react existing; text correlation depends on a quoted id. Ground all four in this Omni build's actual contract with an explicit GO/NO-GO per capability |
+| 4 | Reactions first-class (both directions); text replies stay as fallback | Genie's ⏳/✅/❌ status outbound, the human's 👍/👎 inbound. Bare text is the compatibility path (oldest-pending) |
+| 5 | One approval message + in-place status; never re-announce | Anti-spam: the human sees a prompt and its live state, not a wall of prompts. The per-approval `omniMessageId` dedup already prevents re-fires |
+| 6 | Ship a `genie omni test-approval` one-command harness | The QA spam came from ad-hoc multi-iteration scripts; one deliberate command makes future testing safe and repeatable |
 
 ## Success Criteria
 
-- [ ] G1 spike: `.genie/wishes/omni-approval-ux/SPIKE.md` documents (with evidence from the real hub) the reaction NATS subject + payload shape AND the send path that yields a correlatable message id; verdict on API-send vs NATS-correlate.
-- [ ] Correlated resolution: two concurrent pending approvals — a reply/reaction answering the 2nd resolves the 2nd (not the 1st); `omni_message_id` populated from the real send. Tested.
-- [ ] Reaction approve/deny resolves on the verified subject, correlated to the right approval; instance-scoped (PR #2507 guard). Tested.
-- [ ] Resolution feedback: on approve/deny the original message gets a ✅/❌ (react or status) and the row is expired/closed; no lingering open prompt. Tested.
-- [ ] `genie omni test-approval` drives one clean round-trip (against a fake transport in CI; usable live for one deliberate message).
-- [ ] Full `bun run check` green; no live messages sent by the automated suite.
+- [ ] **G1 spike:** `.genie/wishes/omni-approval-ux/SPIKE.md` documents (evidence from the real hub) the inbound reaction NATS subject + payload, the send path that yields a correlatable message id, the outbound set-reaction capability (GO/NO-GO + the swap mechanism or the fallback), AND whether inbound text replies carry a quoted-message id — with the exact fields genie stores/matches.
+- [ ] **⏳→✅ ack lifecycle:** on announce, the approval message carries a ⏳ status (reaction, or the NO-GO fallback); on approve it becomes ✅; on deny/expire ❌. Verified with a fake transport asserting the set-reaction/edit calls + target id.
+- [ ] **Correlated resolution:** two concurrent pending approvals — a reaction/quoted reply answering the 2nd resolves the 2nd (not the 1st); `omni_message_id` holds the REAL send id. Tested. (Bare unquoted text still resolves oldest — documented fallback, also tested.)
+- [ ] **Reaction approve/deny** resolves on the verified subject, correlated to the right approval; instance-scoped (PR #2507 guard). Text fallback still works. Tested.
+- [ ] `genie omni test-approval` drives one clean round-trip (fake transport in CI; `--live` documented); `genie doctor`/handshake warns when the CC hook timeout < pollBudgetMs.
+- [ ] Full `bun run check` green; NO live messages sent by the automated suite.
 
 ## Execution Strategy
 
 | Wave | Groups | Notes |
 |------|--------|-------|
-| 1 | Group 1 (spike) | Grounds the design in the real Omni contract; gates G2/G3 |
-| 2 | Group 2, Group 3 | Correlated identity + reactions ∥ resolution feedback + test harness (touch disjoint areas: queue/runner-resolve vs runner-outbound/CLI) |
+| 1 | Group 1 (spike) | Grounds the design: inbound reaction subject + id-returning send + outbound set-reaction (GO/NO-GO) + text quoted-id. Gates all |
+| 2 | Group 2 | Correlated identity + inbound reactions — captures the real send id G3 needs |
+| 3 | Group 3 | ⏳→✅ status lifecycle + resolution close + `test-approval` + doctor. Depends on G2 (the ⏳ target is the real id G2 captures) |
+
+> Sequential (G1→G2→G3), not parallel: G3's status reaction targets the real Omni id that only G2 teaches the runner to capture, and both modify `announce()`/the resolve path in `omni-runner.ts` — parallel edits would conflict and G3 would react to a non-existent ref.
 
 ---
 
-## Execution Group 1: Spike — reaction subject + correlatable send id
-**Goal:** Replace the disproven `omni.event.>` + oldest-pending assumptions with the real contract of this Omni build.
+## Execution Group 1: Spike — reaction subjects (in + out), correlatable send id, text quoted-id
+**Goal:** Replace the disproven `omni.event.>` + self-referential-id assumptions, confirm genie can SET a reaction on a message it sent (or pick a fallback), and learn whether text replies carry a quoted id — using the real contract of this Omni build.
 
 **Deliverables:**
-1. Against the live hub (via `ssh felipe`, MINIMAL messages — one send, subscribe-and-observe for reactions): determine (a) the exact NATS subject + payload omni publishes when a WhatsApp user REACTS to a message, and (b) whether the Omni HTTP send API (`/api/v1/...`) returns a stable `messageId` that later inbound replies/reactions reference. Use `omni --json` + a bounded NATS subscriber (omni's nats module) — do NOT run ad-hoc approval loops that spam.
-2. `.genie/wishes/omni-approval-ux/SPIKE.md`: the reaction subject + payload shape, the id-returning send path, and a GO recommendation for Group 2 (API-send vs NATS-correlate) with the exact fields genie must store/match.
+1. Against the live hub (via `ssh felipe`, MINIMAL messages — one/two clearly-labelled sends between Felipe's OWN numbers 1986780008↔12982298888, subscribe-and-observe for reactions): determine (a) the exact NATS subject + payload omni publishes when a WhatsApp user REACTS; (b) whether the Omni HTTP send API returns a stable `messageId` later inbound events reference; (c) the OUTBOUND set-reaction path — can genie set/change a reaction (⏳ then ✅) on a message it sent, and does the emoji swap in place? If NO, the fallback (message-edit prepend, or a status reply); (d) whether an inbound text reply payload carries a quoted/replied-to message id. Use `omni --json` + a bounded NATS subscriber — NO ad-hoc approval loops.
+2. `.genie/wishes/omni-approval-ux/SPIKE.md`: the inbound reaction subject + payload, the id-returning send path, the outbound set-reaction GO/NO-GO + swap-or-fallback mechanism, the text quoted-id finding, and a GO recommendation for G2/G3 with the exact fields genie must store/match.
 
 **Acceptance Criteria:**
-- [ ] SPIKE.md documents the reaction subject + payload and the correlatable-send decision, evidence-backed.
-- [ ] No spam: the spike sends at most one or two clearly-labelled messages between Felipe's own numbers.
+- [ ] SPIKE.md documents the inbound reaction subject + payload, the correlatable-send decision, the outbound set-reaction GO/NO-GO (+ fallback if NO-GO), and the text quoted-id finding — evidence-backed.
+- [ ] No spam: at most one or two clearly-labelled messages between Felipe's own numbers.
 
 **Validation:**
 ```bash
@@ -77,22 +82,23 @@ cd "$(git rev-parse --show-toplevel)"
 test -f .genie/wishes/omni-approval-ux/SPIKE.md
 grep -qiE 'reaction.*subject|omni\.[a-z]+' .genie/wishes/omni-approval-ux/SPIKE.md
 grep -qiE 'messageId|correlat' .genie/wishes/omni-approval-ux/SPIKE.md
+grep -qiE 'set.?reaction|outbound react|GO/NO-GO|fallback' .genie/wishes/omni-approval-ux/SPIKE.md
 ```
 
 **depends-on:** none
 
 ---
 
-## Execution Group 2: Correlated identity + reaction approve/deny
-**Goal:** A reply/reaction resolves the exact approval it answers; 👍/👎 works.
+## Execution Group 2: Correlated identity + inbound reaction approve/deny
+**Goal:** Store the REAL Omni send id and resolve a reaction/quoted reply to the exact approval it answers; 👍/👎 works.
 
 **Deliverables:**
-1. Capture the real Omni message id on send (per the G1 verdict) and store it via `attachOmniMessageId` immediately, so `handleMessage`/`handleEvent` correlate by `omni_message_id` first and only fall back to oldest-pending when no id matches.
-2. Subscribe the VERIFIED reaction subject (from G1) instead of the assumed `omni.event.>`; resolve 👍/👎 correlated to the stored id; keep the PR #2507 instance-scope guard.
-3. Tests (fake transport): two concurrent pending approvals resolved to the correct one by id; reaction on the verified subject resolves the correlated approval; text fallback still works.
+1. In `announce()` (`omni-runner.ts:358-370`), replace the self-referential local `genId()` ref stored at `omni-runner.ts:367` with the REAL Omni message id captured from the send (per the G1 verdict — API-send return or NATS-correlated), via the existing `attachOmniMessageId` (`omni-queue.ts:217`) into the existing `omni_message_id` column (`global-db.ts:90`). Do NOT re-add the column/helper — they exist.
+2. Extend the id-first correlation already present in `handleEvent` (`omni-runner.ts:444-451`) to the text path `handleMessage` (`omni-runner.ts:421`, currently unconditional `resolveOldest`): correlate by the real `omni_message_id` when the inbound carries a quoted/replied id (per G1(d)); fall back to oldest only for bare unquoted text. Subscribe the VERIFIED inbound reaction subject (from G1) instead of the assumed `omni.event.>`; keep the PR #2507 instance-scope guard.
+3. Tests (fake transport): two concurrent pending approvals resolved to the correct one by the real id; reaction on the verified subject resolves the correlated approval; a quoted reply resolves the correlated approval; bare text still resolves oldest.
 
 **Acceptance Criteria:**
-- [ ] Concurrent approvals resolve by id, not oldest; reactions resolve on the verified subject; instance-scoped.
+- [ ] Concurrent approvals resolve by the real id (reaction/quoted reply), not oldest; reactions resolve on the verified subject; bare text = oldest fallback; instance-scoped.
 - [ ] typecheck + `bun test src/lib/omni-runner.test.ts src/lib/v5/omni-queue.test.ts` green.
 
 **Validation:**
@@ -107,17 +113,17 @@ bun run typecheck
 
 ---
 
-## Execution Group 3: Resolution feedback + one-command test harness
-**Goal:** A decided approval stops looking open; future QA is one safe command.
+## Execution Group 3: ⏳→✅ status lifecycle + resolution close + test harness + doctor
+**Goal:** Every approval shows its live state via a swapping status (reaction or NO-GO fallback); a decided approval closes; future QA is one safe command.
 
 **Deliverables:**
-1. On resolve/expire, emit a resolution signal to the original thread — react ✅/❌ on the approval message (via the omni react path / API) and/or a one-line status; expire/close the row so no stale prompt lingers.
-2. `genie omni test-approval` command: drives one approval round-trip (enqueue → announce → resolve) against an injectable transport by default (CI-safe, no network); with `--live` it runs ONE real round-trip between the configured instance/approvalChat (deliberate, single message).
-3. `genie doctor`/handshake warning when the installed CC hook `timeout` is below `pollBudgetMs` (the operator guardrail the QA proved essential).
-4. Tests: resolution-feedback emitted + row closed; `test-approval` fake path green; doctor warning fires on a too-low timeout.
+1. **⏳→✅ ack lifecycle:** on announce, set a ⏳ status on the approval message targeting the REAL Omni id captured in G2 — via the outbound set-reaction path from G1 (GO), or the G1 fallback (message-edit / status line) if NO-GO; on resolve, swap to ✅ (approved) / ❌ (denied); on expiry, ❌/⌛. Close/expire the row so no stale open prompt lingers. Never re-announce.
+2. `genie omni test-approval` command: drives one approval round-trip (enqueue → announce+⏳ → resolve+✅) against an injectable transport by default (CI-safe, no network); `--live` runs ONE real round-trip between the configured instance/approvalChat (deliberate, single message).
+3. `genie doctor` (`src/genie-commands/doctor.ts`)/handshake warning when the installed CC hook `timeout` is below `pollBudgetMs`.
+4. Tests (fake transport): ⏳ set on announce with the right target id; swapped to ✅ on approve, ❌ on deny/expire; row closed; `test-approval` fake path green; doctor warning fires on a too-low timeout.
 
 **Acceptance Criteria:**
-- [ ] Approve/deny yields a ✅/❌ thread signal and closes the row; no lingering prompt (tested).
+- [ ] Announce sets ⏳ on the approval message (real id); approve→✅, deny/expire→❌; row closed; no lingering prompt (tested with a fake transport asserting the set-reaction/edit calls + target).
 - [ ] `genie omni test-approval` (fake) green in CI; `--live` documented.
 - [ ] doctor/handshake warns on an inadequate hook timeout.
 - [ ] Full `bun run check` green.
@@ -132,11 +138,11 @@ bun run build
 bun dist/genie.js omni test-approval 2>&1 | grep -qiE 'approved|allow|round-trip' || { echo "FAIL: test-approval harness"; exit 1; }
 ```
 
-**depends-on:** group-1
+**depends-on:** group-2
 
 ---
 
 ## Cross-wish dependencies
 
 - **Builds on** the live-validated `omni-runner-port` bridge + the `omni-hardening` (PR #2507) instance-scope + approval-budget-doc fixes.
-- **Records** the 2026-07-03 live QA outcome (allow path proven end-to-end; deny code-verified; personal instance offline; reactions unconfirmed) — this wish closes the reaction + correlation gaps that QA exposed.
+- **Records** the 2026-07-03 live QA outcome (allow path proven end-to-end; deny code-verified; personal instance offline; reactions unconfirmed) — this wish closes the reaction + correlation + feedback gaps that QA exposed.

--- a/.genie/wishes/omni-approval-ux/WISH.md
+++ b/.genie/wishes/omni-approval-ux/WISH.md
@@ -72,8 +72,8 @@ The v5 omni approval bridge is live-proven (a PreToolUse hook → WhatsApp 🔔 
 2. `.genie/wishes/omni-approval-ux/SPIKE.md`: the inbound reaction subject + payload, the id-returning send path, the outbound set-reaction GO/NO-GO + swap-or-fallback mechanism, the text quoted-id finding, and a GO recommendation for G2/G3 with the exact fields genie must store/match.
 
 **Acceptance Criteria:**
-- [ ] SPIKE.md documents the inbound reaction subject + payload, the correlatable-send decision, the outbound set-reaction GO/NO-GO (+ fallback if NO-GO), and the text quoted-id finding — evidence-backed.
-- [ ] No spam: at most one or two clearly-labelled messages between Felipe's own numbers.
+- [x] SPIKE.md documents the inbound reaction subject + payload, the correlatable-send decision, the outbound set-reaction GO/NO-GO (+ fallback if NO-GO), and the text quoted-id finding — evidence-backed.
+- [x] No spam: at most one or two clearly-labelled messages between Felipe's own numbers.
 
 **Validation:**
 ```bash

--- a/src/genie-commands/doctor.test.ts
+++ b/src/genie-commands/doctor.test.ts
@@ -4,7 +4,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { doctorCommand } from './doctor.js';
+import { doctorCommand, evaluateOmniHookTimeout, findDispatchHookTimeoutSec } from './doctor.js';
 
 /**
  * Capture everything written to stdout during `fn`, restoring the real
@@ -73,6 +73,52 @@ describe('doctorCommand', () => {
     const { output } = await captureDoctor(() => doctorCommand());
     expect(output).toContain('genie doctor');
     expect(output).toContain('All checks passed.');
+  });
+});
+
+describe('omni hook-timeout guardrail', () => {
+  const DISPATCH = '"$HOME/.genie/bin/genie" hook dispatch';
+
+  test('finds the smallest dispatch timeout across PreToolUse entries', () => {
+    const settings = {
+      hooks: {
+        PreToolUse: [
+          { matcher: 'Bash', hooks: [{ command: 'bash git-safety.sh', timeout: 5 }] },
+          { matcher: '*', hooks: [{ command: DISPATCH, timeout: 30 }] },
+          { matcher: 'Write', hooks: [{ command: DISPATCH, timeout: 15 }] },
+        ],
+      },
+    };
+    expect(findDispatchHookTimeoutSec(settings)).toBe(15);
+  });
+
+  test('returns null when no dispatch hook is present', () => {
+    expect(
+      findDispatchHookTimeoutSec({ hooks: { PreToolUse: [{ hooks: [{ command: 'other', timeout: 9 }] }] } }),
+    ).toBeNull();
+    expect(findDispatchHookTimeoutSec({})).toBeNull();
+  });
+
+  test('warns when the hook timeout is below pollBudgetMs', () => {
+    const res = evaluateOmniHookTimeout({ enabled: true, pollBudgetMs: 110_000, timeoutSec: 5 });
+    expect(res?.status).toBe('warn');
+    expect(res?.detail).toContain('< pollBudget');
+    expect(res?.suggestion).toContain('120');
+  });
+
+  test('warns when approvals are enabled but no dispatch timeout is found', () => {
+    const res = evaluateOmniHookTimeout({ enabled: true, pollBudgetMs: 110_000, timeoutSec: null });
+    expect(res?.status).toBe('warn');
+    expect(res?.detail).toContain('no `genie hook dispatch`');
+  });
+
+  test('passes when the hook timeout meets or exceeds pollBudgetMs', () => {
+    const res = evaluateOmniHookTimeout({ enabled: true, pollBudgetMs: 110_000, timeoutSec: 120 });
+    expect(res?.status).toBe('pass');
+  });
+
+  test('emits no check when omni approvals are disabled', () => {
+    expect(evaluateOmniHookTimeout({ enabled: false, pollBudgetMs: 110_000, timeoutSec: 1 })).toBeNull();
   });
 });
 

--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -14,8 +14,10 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { resolveOmniRuntimeConfig } from '../lib/omni-config.js';
 import { CURRENT_SCHEMA_VERSION, GenieDbError, openDb, resolveDbPath, resolveRepoRoot } from '../lib/v5/genie-db.js';
 import { VERSION } from '../lib/version.js';
 
@@ -186,6 +188,92 @@ function checkBun(): CheckResult[] {
 }
 
 // ============================================================================
+// Omni approval hook-timeout guardrail
+// ============================================================================
+
+interface HookCommand {
+  command?: unknown;
+  timeout?: unknown;
+}
+interface HookMatcher {
+  hooks?: unknown;
+}
+interface CcSettings {
+  hooks?: { PreToolUse?: unknown };
+}
+
+/**
+ * Smallest `timeout` (SECONDS) among PreToolUse hooks that run `genie hook
+ * dispatch` in a Claude Code settings object — that is the ceiling the omni
+ * approval handler polls under. null when no such hook is installed. Pure +
+ * exported so the guardrail is unit-tested without a settings file on disk.
+ */
+export function findDispatchHookTimeoutSec(settings: CcSettings): number | null {
+  const pre = settings.hooks?.PreToolUse;
+  if (!Array.isArray(pre)) return null;
+  let min: number | null = null;
+  for (const entry of pre as HookMatcher[]) {
+    if (!Array.isArray(entry?.hooks)) continue;
+    for (const h of entry.hooks as HookCommand[]) {
+      if (typeof h?.command === 'string' && h.command.includes('hook dispatch') && typeof h.timeout === 'number') {
+        min = min === null ? h.timeout : Math.min(min, h.timeout);
+      }
+    }
+  }
+  return min;
+}
+
+/**
+ * Compare the installed hook timeout against the approval poll budget. Returns
+ * null when omni approvals are off (no check emitted). A hook timeout below the
+ * budget is a WARN: CC kills `genie hook dispatch` before the omni handler can
+ * allow/deny OR reach its timeout→ask fail-safe. Pure + exported for testing.
+ */
+export function evaluateOmniHookTimeout(params: {
+  enabled: boolean;
+  pollBudgetMs: number;
+  timeoutSec: number | null;
+}): CheckResult | null {
+  if (!params.enabled) return null;
+  const name = 'omni hook timeout ≥ pollBudget';
+  const needSec = Math.ceil(params.pollBudgetMs / 1000);
+  if (params.timeoutSec === null) {
+    return {
+      name,
+      status: 'warn',
+      detail: 'omni approvals enabled but no `genie hook dispatch` PreToolUse timeout found',
+      suggestion: `Install the genie PreToolUse hook with a timeout ≥ ${needSec}s so approvals can resolve.`,
+    };
+  }
+  const timeoutMs = params.timeoutSec * 1000;
+  if (timeoutMs < params.pollBudgetMs) {
+    return {
+      name,
+      status: 'warn',
+      detail: `hook timeout ${params.timeoutSec}s (${timeoutMs}ms) < pollBudget ${params.pollBudgetMs}ms — CC will kill the hook before it can allow/deny or reach its ask fail-safe`,
+      suggestion: `Raise the PreToolUse \`genie hook dispatch\` timeout to ≥ ${needSec}s (e.g. 120) in ~/.claude/settings.json.`,
+    };
+  }
+  return { name, status: 'pass', detail: `hook timeout ${params.timeoutSec}s ≥ pollBudget ${params.pollBudgetMs}ms` };
+}
+
+async function checkOmniHookTimeout(): Promise<CheckResult[]> {
+  const rt = await resolveOmniRuntimeConfig();
+  if (!rt.approvals.enabled) return []; // omni off → stay silent
+  const settingsPath = join(homedir(), '.claude', 'settings.json');
+  let timeoutSec: number | null = null;
+  try {
+    if (existsSync(settingsPath)) {
+      timeoutSec = findDispatchHookTimeoutSec(JSON.parse(readFileSync(settingsPath, 'utf8')) as CcSettings);
+    }
+  } catch {
+    timeoutSec = null; // unreadable/malformed settings → treated as "not found"
+  }
+  const result = evaluateOmniHookTimeout({ enabled: true, pollBudgetMs: rt.approvals.pollBudgetMs, timeoutSec });
+  return result ? [result] : [];
+}
+
+// ============================================================================
 // Entry point
 // ============================================================================
 
@@ -196,6 +284,7 @@ export async function doctorCommand(options?: { json?: boolean }): Promise<void>
     ...checkDatabase(),
     ...checkSkills(),
     ...checkBun(),
+    ...(await checkOmniHookTimeout()),
   ];
 
   const failed = results.filter((r) => r.status === 'fail');

--- a/src/lib/omni-config.ts
+++ b/src/lib/omni-config.ts
@@ -16,6 +16,11 @@ import { loadGenieConfig } from './genie-config.js';
 // Ported verbatim from origin/v4:src/lib/omni-approval-handler.ts so remote
 // operators keep the exact token/reaction vocabulary they trained their muscle
 // memory on. `sim`/`nao` are Portuguese yes/no (the original omni deployment).
+//
+// Vocabulary split: TEXT words (`OMNI_APPROVE_TOKENS`/`approveTokens`) vs
+// REACTION emoji (`approveReactions`/`denyReactions`). Keep emoji OUT of the
+// token lists — WhatsApp's bare-emoji dual-emit would echo them back and could
+// double-resolve an approval.
 export const DEFAULT_APPROVE_TOKENS = ['y', 'yes', 'approve', 'sim'];
 export const DEFAULT_DENY_TOKENS = ['n', 'no', 'deny', 'nao'];
 export const DEFAULT_APPROVE_REACTIONS = ['\u{1F44D}', '\u{2705}', '\u{1F44C}']; // 👍 ✅ 👌

--- a/src/lib/omni-runner.test.ts
+++ b/src/lib/omni-runner.test.ts
@@ -373,3 +373,229 @@ describe('omni runner — correlated approval identity + reactions', () => {
     expect(getApproval(db, a)?.status).toBe('pending');
   });
 });
+
+// ---------------------------------------------------------------------------
+// ⏳→✅/❌ status-reaction lifecycle + the explicit-non-matching-target no-op
+// (Group 3). Every test injects a FAKE `setReaction` recorder — zero network —
+// and asserts the (target id, emoji) genie sets on its OWN approval message.
+// ---------------------------------------------------------------------------
+const HOURGLASS = '\u{23F3}'; // ⏳
+const CHECK = '\u{2705}'; // ✅
+const CROSS = '\u{274C}'; // ❌
+const THUMBS_DOWN = '\u{1F44E}'; // 👎 (in rt() denyReactions)
+
+interface ReactionCall {
+  messageId: string;
+  emoji: string;
+}
+
+/** A status runner with a fake set-reaction recorder and a mutable clock. */
+function statusRunner(db: Database, reactions: ReactionCall[], clock: { now: number }) {
+  return createOmniRunner({
+    db,
+    config: rt(),
+    publish: () => {},
+    sendApproval,
+    setReaction: async ({ messageId, emoji }) => {
+      reactions.push({ messageId, emoji });
+      return { success: true };
+    },
+    now: () => clock.now,
+  });
+}
+
+describe('omni runner — ⏳→✅/❌ status-reaction lifecycle', () => {
+  test('announce sets ⏳ on the stored stanza id', async () => {
+    const db = freshDb();
+    const reactions: ReactionCall[] = [];
+    const runner = statusRunner(db, reactions, { now: NOW });
+    enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'summary-A', now: NOW - 2000 });
+    runner.tick();
+    await runner.whenIdle();
+    expect(reactions).toEqual([{ messageId: 'stanza-A', emoji: HOURGLASS }]);
+  });
+
+  test('approve swaps ⏳→✅ on the same stanza id and closes the row', async () => {
+    const db = freshDb();
+    const reactions: ReactionCall[] = [];
+    const runner = statusRunner(db, reactions, { now: NOW });
+    const a = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'summary-A', now: NOW - 2000 });
+    runner.tick();
+    await runner.whenIdle();
+
+    runner.handleMessage(
+      ...approvalInbound({ content: reactionContent(THUMBS_UP, 'stanza-A'), messageId: 'stanza-A' }),
+    );
+    await runner.whenIdle();
+
+    expect(getApproval(db, a)?.status).toBe('approved'); // row closed
+    expect(reactions).toEqual([
+      { messageId: 'stanza-A', emoji: HOURGLASS },
+      { messageId: 'stanza-A', emoji: CHECK },
+    ]);
+  });
+
+  test('deny swaps ⏳→❌', async () => {
+    const db = freshDb();
+    const reactions: ReactionCall[] = [];
+    const runner = statusRunner(db, reactions, { now: NOW });
+    const a = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'summary-A', now: NOW - 2000 });
+    runner.tick();
+    await runner.whenIdle();
+
+    runner.handleMessage(
+      ...approvalInbound({ content: reactionContent(THUMBS_DOWN, 'stanza-A'), messageId: 'stanza-A' }),
+    );
+    await runner.whenIdle();
+
+    expect(getApproval(db, a)?.status).toBe('denied');
+    expect(reactions[reactions.length - 1]).toEqual({ messageId: 'stanza-A', emoji: CROSS });
+  });
+
+  test('expiry swaps ⏳→❌ and closes the row', async () => {
+    const db = freshDb();
+    const reactions: ReactionCall[] = [];
+    const clock = { now: NOW };
+    const runner = statusRunner(db, reactions, clock);
+    const a = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'summary-A', now: NOW - 2000 });
+    runner.tick(); // announce + ⏳
+    await runner.whenIdle();
+
+    // Advance past pollBudgetMs (10_000) so the row is stale, then tick to expire.
+    clock.now = NOW + 20_000;
+    runner.tick();
+    await runner.whenIdle();
+
+    expect(getApproval(db, a)?.status).toBe('expired'); // row closed
+    expect(reactions[reactions.length - 1]).toEqual({ messageId: 'stanza-A', emoji: CROSS });
+  });
+
+  test('reaction with an explicit non-matching target NO-OPs (does not resolve oldest)', async () => {
+    const db = freshDb();
+    const reactions: ReactionCall[] = [];
+    const runner = statusRunner(db, reactions, { now: NOW });
+    const a = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'summary-A', now: NOW - 2000 });
+    const b = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'summary-B', now: NOW - 1000 });
+    runner.tick();
+    await runner.whenIdle();
+
+    // A 👍 targeting a stanza id no pending approval carries (already-resolved or
+    // unknown) must NOT fall back to resolving the oldest — the MEDIUM fix.
+    runner.handleMessage(
+      ...approvalInbound({ content: reactionContent(THUMBS_UP, 'stanza-UNKNOWN'), messageId: 'stanza-UNKNOWN' }),
+    );
+    await runner.whenIdle();
+
+    expect(getApproval(db, a)?.status).toBe('pending');
+    expect(getApproval(db, b)?.status).toBe('pending');
+    // No ✅ was set — only the two ⏳ announces happened.
+    expect(reactions.filter((r) => r.emoji === CHECK)).toEqual([]);
+  });
+
+  test('records the glyph on each successful ack (⏳ on announce, ✅ on approve)', async () => {
+    const db = freshDb();
+    const reactions: ReactionCall[] = [];
+    const runner = statusRunner(db, reactions, { now: NOW });
+    const a = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'summary-A', now: NOW - 2000 });
+    runner.tick();
+    await runner.whenIdle();
+    expect(getApproval(db, a)?.lastStatusGlyph).toBe(HOURGLASS); // recorded ⏳
+
+    runner.handleMessage(
+      ...approvalInbound({ content: reactionContent(THUMBS_UP, 'stanza-A'), messageId: 'stanza-A' }),
+    );
+    await runner.whenIdle();
+    expect(getApproval(db, a)?.lastStatusGlyph).toBe(CHECK); // recorded ✅ (terminal)
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reconciliation: the RUNNER is the authoritative acker even when the hook fork
+// wins the expiry race (expires the row but sets NO reaction). Without this, the
+// ⏳ set on announce would stick on the phone forever (the G3-review HIGH).
+// ---------------------------------------------------------------------------
+describe('omni runner — status-ack reconciliation (hook-fork-expiry race)', () => {
+  /** Faithful to the hook's expireOwnRow: expire ONE row, no status glyph. */
+  function hookForkExpire(db: Database, id: string): void {
+    db.query("UPDATE approvals SET status = 'expired', resolved_at = ? WHERE id = ? AND status = 'pending'").run(
+      NOW,
+      id,
+    );
+  }
+
+  test('hook fork expires the row (no ack) → runner tick reconciles a ❌', async () => {
+    const db = freshDb();
+    const reactions: ReactionCall[] = [];
+    const runner = statusRunner(db, reactions, { now: NOW });
+    const a = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'summary-A', now: NOW - 2000 });
+    runner.tick(); // announce + ⏳
+    await runner.whenIdle();
+    expect(getApproval(db, a)?.lastStatusGlyph).toBe(HOURGLASS);
+
+    // The hook fork wins the expiry race — row is expired with a stuck ⏳.
+    hookForkExpire(db, a);
+    expect(getApproval(db, a)?.status).toBe('expired');
+    expect(getApproval(db, a)?.lastStatusGlyph).toBe(HOURGLASS); // still ⏳ — no ack
+
+    // The runner's next tick reconciles the stuck ⏳ to ❌.
+    runner.tick();
+    await runner.whenIdle();
+    expect(reactions[reactions.length - 1]).toEqual({ messageId: 'stanza-A', emoji: CROSS });
+    expect(getApproval(db, a)?.lastStatusGlyph).toBe(CROSS);
+  });
+
+  test('reconciliation is idempotent — a second tick does not re-emit ❌', async () => {
+    const db = freshDb();
+    const reactions: ReactionCall[] = [];
+    const runner = statusRunner(db, reactions, { now: NOW });
+    const a = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'summary-A', now: NOW - 2000 });
+    runner.tick();
+    await runner.whenIdle();
+    hookForkExpire(db, a);
+
+    runner.tick(); // reconciles → ❌ recorded
+    await runner.whenIdle();
+    const countAfterFirst = reactions.length;
+
+    runner.tick(); // glyph now terminal → nothing to reconcile
+    await runner.whenIdle();
+    expect(reactions.length).toBe(countAfterFirst);
+    // Exactly one ❌ ever emitted for this row.
+    expect(reactions.filter((r) => r.emoji === CROSS).length).toBe(1);
+  });
+
+  test('a transport-dropped resolve ack is retried by reconciliation', async () => {
+    const db = freshDb();
+    const reactions: ReactionCall[] = [];
+    // setReaction FAILS the first call (the ⏳ or the ✅), succeeds afterwards —
+    // so the terminal glyph is not recorded until reconciliation retries it.
+    let calls = 0;
+    const runner = createOmniRunner({
+      db,
+      config: rt(),
+      publish: () => {},
+      sendApproval,
+      setReaction: async ({ messageId, emoji }) => {
+        calls++;
+        reactions.push({ messageId, emoji });
+        return calls === 2 ? { success: false, error: 'dropped' } : { success: true };
+      },
+      now: () => NOW,
+    });
+    const a = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'summary-A', now: NOW - 2000 });
+    runner.tick(); // announce ⏳ (call 1, ok → recorded)
+    await runner.whenIdle();
+
+    runner.handleMessage(
+      ...approvalInbound({ content: reactionContent(THUMBS_UP, 'stanza-A'), messageId: 'stanza-A' }),
+    );
+    await runner.whenIdle(); // resolve ✅ (call 2, DROPPED → glyph stays ⏳)
+    expect(getApproval(db, a)?.status).toBe('approved');
+    expect(getApproval(db, a)?.lastStatusGlyph).toBe(HOURGLASS); // not recorded — drop
+
+    runner.tick(); // reconciliation retries ✅ (call 3, ok → recorded)
+    await runner.whenIdle();
+    expect(getApproval(db, a)?.lastStatusGlyph).toBe(CHECK);
+    expect(reactions[reactions.length - 1]).toEqual({ messageId: 'stanza-A', emoji: CHECK });
+  });
+});

--- a/src/lib/omni-runner.test.ts
+++ b/src/lib/omni-runner.test.ts
@@ -10,9 +10,9 @@
 import type { Database } from 'bun:sqlite';
 import { afterEach, describe, expect, test } from 'bun:test';
 import type { OmniRuntimeConfig } from './omni-config.js';
-import { type SpawnClaude, type SpawnClaudeResult, createOmniRunner } from './omni-runner.js';
+import { type OmniSend, type SpawnClaude, type SpawnClaudeResult, createOmniRunner } from './omni-runner.js';
 import { openGlobalDb } from './v5/global-db.js';
-import { listInbox } from './v5/omni-queue.js';
+import { enqueueApproval, getApproval, listInbox } from './v5/omni-queue.js';
 
 const INSTANCE = 'inst-A';
 const ROUTE_CHAT = 'chat-42';
@@ -249,5 +249,127 @@ describe('omni runner — inbound one-shot routing', () => {
     const reply = content(published[0]);
     expect(reply.length).toBe(10);
     expect(reply.endsWith('…')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Correlated approval identity + inbound reaction resolve (Group 2).
+//
+// `announce()` sends each approval via the injectable id-returning send and
+// stores the REAL stanza id it returns; an inbound reaction (on `omni.message.*`,
+// NOT the retired `omni.event.*`) resolves the approval whose stored id it
+// targets, falling back to oldest only for bare text. Every test drives a FAKE
+// `sendApproval` — zero network.
+// ---------------------------------------------------------------------------
+const APPROVAL_CHAT = 'approval-chat'; // matches rt() above
+
+/** Fake id-returning send: assigns each approval a stanza id derived from its
+ *  input-summary marker (embedded in the formatted message), so correlation is
+ *  order-independent. `summary-A` → `stanza-A`, `summary-B` → `stanza-B`. */
+const sendApproval: OmniSend = async ({ text }) => {
+  const marker = text.includes('summary-B') ? 'B' : 'A';
+  return { success: true, messageId: `stanza-${marker}` };
+};
+
+/** An inbound frame on the approval chat, as omni would publish it. */
+function approvalInbound(payload: Record<string, unknown>): [string, string] {
+  return [
+    `omni.message.${INSTANCE}.${APPROVAL_CHAT}`,
+    JSON.stringify({ chatId: APPROVAL_CHAT, instanceId: INSTANCE, sender: 'boss', ...payload }),
+  ];
+}
+
+const reactionContent = (emoji: string, targetId: string): string => `[Reaction: ${emoji} on message ${targetId}]`;
+const THUMBS_UP = '\u{1F44D}';
+
+// A fixed clock so the runner's `expireStale` (pollBudgetMs = 10_000) never
+// expires a just-enqueued row: rows are stamped a second or two before NOW.
+const NOW = 1_000_000;
+const approvalRunner = (db: Database) =>
+  createOmniRunner({ db, config: rt(), publish: () => {}, sendApproval, now: () => NOW });
+
+describe('omni runner — correlated approval identity + reactions', () => {
+  test('announce stores the REAL stanza id returned by the send (not a genId ref)', async () => {
+    const db = freshDb();
+    const runner = approvalRunner(db);
+    const a = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'summary-A', now: NOW - 2000 });
+    runner.tick();
+    await runner.whenIdle();
+    expect(getApproval(db, a)?.omniMessageId).toBe('stanza-A');
+  });
+
+  test('reaction resolves the exact approval by stored stanza id, not the oldest', async () => {
+    const db = freshDb();
+    const runner = approvalRunner(db);
+    const a = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'summary-A', now: NOW - 2000 });
+    const b = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'summary-B', now: NOW - 1000 });
+    runner.tick();
+    await runner.whenIdle();
+    // Both rows tagged with their own real stanza ids.
+    expect(getApproval(db, a)?.omniMessageId).toBe('stanza-A');
+    expect(getApproval(db, b)?.omniMessageId).toBe('stanza-B');
+
+    // A 👍 reaction on B's stanza id resolves B — NOT the older A.
+    runner.handleMessage(
+      ...approvalInbound({ content: reactionContent(THUMBS_UP, 'stanza-B'), messageId: 'stanza-B' }),
+    );
+    expect(getApproval(db, b)?.status).toBe('approved');
+    expect(getApproval(db, a)?.status).toBe('pending');
+  });
+
+  test('dual-emit bare-emoji echo does not double-resolve a second approval', async () => {
+    const db = freshDb();
+    const runner = approvalRunner(db);
+    const a = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'summary-A', now: NOW - 2000 });
+    const b = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'summary-B', now: NOW - 1000 });
+    runner.tick();
+    await runner.whenIdle();
+
+    // A human 👍 reaches genie twice (SPIKE dual-emit): the id-bearing reaction
+    // form resolves A...
+    runner.handleMessage(
+      ...approvalInbound({ content: reactionContent(THUMBS_UP, 'stanza-A'), messageId: 'stanza-A' }),
+    );
+    // ...and a bare-emoji echo, which must be ignored (not treated as a reaction,
+    // not a text token) so it can't fall through to resolve the oldest (now B).
+    runner.handleMessage(...approvalInbound({ content: THUMBS_UP, messageId: 'stanza-A' }));
+
+    expect(getApproval(db, a)?.status).toBe('approved');
+    expect(getApproval(db, b)?.status).toBe('pending');
+  });
+
+  test('bare text reply still resolves the oldest pending approval (documented fallback)', async () => {
+    const db = freshDb();
+    const runner = approvalRunner(db);
+    const a = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'summary-A', now: NOW - 2000 });
+    const b = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'summary-B', now: NOW - 1000 });
+    runner.tick();
+    await runner.whenIdle();
+
+    runner.handleMessage(...approvalInbound({ content: 'y' }));
+    // Oldest (A) resolves; B untouched — bare text carries no quoted id here.
+    expect(getApproval(db, a)?.status).toBe('approved');
+    expect(getApproval(db, b)?.status).toBe('pending');
+  });
+
+  test('a reaction from another instance is ignored (PR #2507 instance-scope guard)', async () => {
+    const db = freshDb();
+    const runner = approvalRunner(db);
+    const a = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'summary-A', now: NOW - 2000 });
+    runner.tick();
+    await runner.whenIdle();
+
+    // Same emoji + same stored stanza id, but a DIFFERENT instanceId → dropped.
+    runner.handleMessage(
+      `omni.message.other-instance.${APPROVAL_CHAT}`,
+      JSON.stringify({
+        content: reactionContent(THUMBS_UP, 'stanza-A'),
+        messageId: 'stanza-A',
+        chatId: APPROVAL_CHAT,
+        instanceId: 'other-instance',
+        sender: 'stranger',
+      }),
+    );
+    expect(getApproval(db, a)?.status).toBe('pending');
   });
 });

--- a/src/lib/omni-runner.ts
+++ b/src/lib/omni-runner.ts
@@ -37,9 +37,11 @@ import {
   type ApprovalDecision,
   attachOmniMessageId,
   expireStale,
+  listApprovalsNeedingStatusAck,
   listPendingApprovals,
   markHandled,
   recordInbound,
+  recordStatusGlyph,
   resolveApproval,
 } from './v5/omni-queue.js';
 
@@ -179,6 +181,71 @@ export function makeDefaultOmniSend(config: OmniRuntimeConfig): OmniSend {
   };
 }
 
+// ============================================================================
+// Injectable outbound set-reaction (⏳→✅/❌ status ack)
+// ============================================================================
+
+export interface OmniSetReactionResult {
+  success?: boolean;
+  error?: string;
+}
+
+export interface OmniSetReactionOpts {
+  instance: string;
+  chat: string;
+  /** The WhatsApp stanza id of the message to react to (genie's own approval). */
+  messageId: string;
+  /** The status emoji to set (⏳/✅/❌). A new emoji SWAPS the prior one in place. */
+  emoji: string;
+}
+
+/**
+ * Set (or swap) genie's OWN status reaction on a message it sent. Injectable so
+ * tests drive a fake (zero network); the default POSTs the Omni `--reaction`
+ * HTTP path. WhatsApp allows one reaction per sender per message, so setting a
+ * new emoji on the same stanza id replaces the prior one — that is how the
+ * ⏳→✅/❌ ack swaps in place.
+ *
+ * This is the seam the SPIKE-documented fallback swaps behind: if a later
+ * `--live` QA shows the in-place reaction swap does not RENDER, replace this
+ * default impl with a message-edit (prepend a status glyph) or a status-reply
+ * variant — the runner calls this one seam, so the fallback is an impl swap, not
+ * a rewrite.
+ */
+export type OmniSetReaction = (opts: OmniSetReactionOpts) => Promise<OmniSetReactionResult>;
+
+/**
+ * Default set-reaction — POSTs to Omni's HTTP reaction route, signed exactly
+ * like {@link makeDefaultOmniSend}. Uses the `--reaction` path (correct
+ * `fromMe` for genie's own message), NOT the bare `react` verb. Degrades to an
+ * error result (never a throw) when the Omni API URL is unconfigured.
+ *
+ * NOTE: like {@link makeDefaultOmniSend}, the exact reaction-route body shape is
+ * documented in SPIKE (c) but not yet exercised against the live hub — the
+ * injectable seam above is what the test suite proves; G3's `--live` round-trip
+ * confirms this default's wire format (and whether the in-place swap renders).
+ */
+export function makeDefaultOmniSetReaction(config: OmniRuntimeConfig): OmniSetReaction {
+  return async ({ instance, chat, messageId, emoji }) => {
+    const apiUrl = config.apiUrl;
+    if (!apiUrl) return { success: false, error: 'omni apiUrl not configured' };
+    const path = '/api/v2/messages';
+    const bodyJson = JSON.stringify({ instanceId: instance, chatId: chat, reaction: emoji, messageId });
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (config.apiKey) headers.Authorization = `Bearer ${config.apiKey}`;
+    const sig = signOmniRequest('POST', path, bodyJson);
+    if (sig) Object.assign(headers, sig);
+    const res = await fetch(`${apiUrl.replace(/\/+$/, '')}${path}`, {
+      method: 'POST',
+      headers,
+      body: bodyJson,
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return { success: false, error: `HTTP ${res.status}` };
+    return { success: true };
+  };
+}
+
 /** Default factory — dynamically imports `nats`. Only invoked by `omni serve`. */
 export const defaultNatsFactory: NatsFactory = async ({ servers }) => {
   const nats = await import('nats');
@@ -243,6 +310,14 @@ export interface OmniRunnerDeps {
    * id so `announce()` is exercised with zero network.
    */
   sendApproval?: OmniSend;
+  /**
+   * Injectable outbound set-reaction for the ⏳→✅/❌ status ack. Defaults to the
+   * Omni HTTP reaction path ({@link makeDefaultOmniSetReaction}); tests pass a
+   * fake that records the (target id, emoji) so the status lifecycle is asserted
+   * with zero network. The seam the SPIKE fallback (message-edit / status-reply)
+   * swaps behind if the in-place reaction swap does not render live.
+   */
+  setReaction?: OmniSetReaction;
 }
 
 export interface OmniRunner {
@@ -333,6 +408,29 @@ const errorNotice = (detail: string): string => `\u{26A0}\u{FE0F} agent run fail
 /** Compact message for an unknown thrown value. */
 const errText = (err: unknown): string => (err instanceof Error ? err.message : String(err));
 
+/**
+ * Status-ack glyphs for genie's OWN swapping reaction on the approval message.
+ * ⏳ on announce (awaiting you), ✅ once approved, ❌ once denied or expired. All
+ * three are outside the approve/deny vocab and are set with `fromMe=true`, so
+ * they never dual-emit and never self-resolve an approval (SPIKE c).
+ */
+const STATUS_PENDING = '\u{23F3}'; // ⏳
+const STATUS_APPROVED = '\u{2705}'; // ✅
+const STATUS_DENIED = '\u{274C}'; // ❌ (denied and expired both land here)
+/** The two glyphs that mean "done" — a row whose recorded glyph is one of these
+ *  needs no further status ack (the reconciliation pass skips it). */
+const TERMINAL_STATUS_GLYPHS = [STATUS_APPROVED, STATUS_DENIED];
+
+/**
+ * How far back the reconciliation pass looks for a row still needing a terminal
+ * ack (24h). Generous on purpose: a row resolved/expired while `omni serve` was
+ * briefly down must still get its ✅/❌ when serve returns, so this must exceed
+ * any realistic downtime — it is ~785× the default 110s pollBudget. Older closed
+ * rows are presumed already acked (or too stale to matter) and are left alone, so
+ * per-tick reconciliation work is bounded and history is never swept.
+ */
+const RECONCILE_WINDOW_MS = 24 * 60 * 60 * 1000;
+
 /** Distinguishes a budget-driven abort from a genuine child crash in the catch. */
 class OneShotTimeoutError extends Error {
   constructor() {
@@ -349,6 +447,7 @@ export function createOmniRunner(deps: OmniRunnerDeps): OmniRunner {
     deps.genCorrelationId ?? (() => `req_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`);
   const spawnClaude = deps.spawnClaude ?? defaultSpawnClaude;
   const sendApproval = deps.sendApproval ?? makeDefaultOmniSend(config);
+  const setReaction = deps.setReaction ?? makeDefaultOmniSetReaction(config);
   const vocab = {
     approveTokens: config.approveTokens,
     denyTokens: config.denyTokens,
@@ -369,6 +468,12 @@ export function createOmniRunner(deps: OmniRunnerDeps): OmniRunner {
   const announcing = new Set<string>();
   /** Live announce-send promises, drained by `whenIdle` alongside `pending`. */
   const inFlightSends = new Set<Promise<void>>();
+  /** Live status-reaction promises (⏳→✅/❌), also drained by `whenIdle`. */
+  const inFlightReactions = new Set<Promise<void>>();
+  /** Omni message ids with a status-ack HTTP call currently in flight — guards
+   *  the reconciliation pass (every tick) from double-firing an ack whose glyph
+   *  the prior emit has not yet recorded. Keyed by the stanza id. */
+  const ackInFlight = new Set<string>();
   const routeKey = (instance: string, chat: string): string => `${instance} ${chat}`;
   const findRoute = (instance: string, chat: string): OmniRoute | undefined =>
     routes.find((r) => r.instance === instance && r.chat === chat);
@@ -435,11 +540,49 @@ export function createOmniRunner(deps: OmniRunnerDeps): OmniRunner {
   }
 
   /**
+   * Set (or swap) genie's OWN status reaction (⏳/✅/❌) on the approval message.
+   * Fire-and-forget behind the injectable {@link setReaction} seam and drained by
+   * `whenIdle`, so the resolve/announce hot paths never block on the HTTP call. A
+   * missing target id (send failed → row un-tagged) is a no-op, as is a target
+   * whose ack is already in flight (the reconciliation guard).
+   *
+   * The glyph is recorded (via {@link recordStatusGlyph}) ONLY on a confirmed
+   * successful set: a dropped/failed react leaves `last_status_glyph` unchanged so
+   * the reconciliation pass retries it next tick. Never throws — a failed status
+   * reaction is logged and the approval decision still stands.
+   */
+  function emitStatusReaction(targetId: string | null | undefined, emoji: string): void {
+    if (!targetId || ackInFlight.has(targetId)) return;
+    ackInFlight.add(targetId);
+    const react = setReaction({
+      instance: config.instance ?? '',
+      chat: config.approvalChat ?? '',
+      messageId: targetId,
+      emoji,
+    })
+      .then((res) => {
+        if (res && res.success === false) {
+          log(`[omni] status ${emoji} on ${targetId} failed${res.error ? ` (${res.error})` : ''}`);
+          return;
+        }
+        recordStatusGlyph(db, targetId, emoji); // persist only on confirmed success
+      })
+      .catch((err) => log(`[omni] status ${emoji} on ${targetId} failed: ${errText(err)}`))
+      .finally(() => {
+        ackInFlight.delete(targetId);
+        inFlightReactions.delete(react);
+      });
+    inFlightReactions.add(react);
+  }
+
+  /**
    * Announce a single pending approval via the id-returning send and tag the row
    * with the REAL Omni message id (the stanza id) the send returns — so an
    * inbound reaction correlates to THIS approval. Tags only on a successful send;
    * a failed/id-less send leaves the row un-tagged so the next tick retries
-   * (mirrors the old tag-after-publish semantics). Never throws.
+   * (mirrors the old tag-after-publish semantics). On a successful tag it sets the
+   * ⏳ status reaction on the sent message (SPIKE c) — the first half of the
+   * ⏳→✅/❌ ack. Never throws.
    */
   async function sendAnnounce(appr: { id: string; tool: string; inputSummary: string }): Promise<void> {
     const text = formatApprovalMessage(appr.tool, appr.inputSummary);
@@ -453,6 +596,7 @@ export function createOmniRunner(deps: OmniRunnerDeps): OmniRunner {
       }
       attachOmniMessageId(db, appr.id, result.messageId);
       log(`[omni] announced approval ${appr.id} (omni ${result.messageId})`);
+      emitStatusReaction(result.messageId, STATUS_PENDING); // ⏳ awaiting you
     } catch (err) {
       log(`[omni] announce ${appr.id} failed: ${errText(err)}`);
     }
@@ -484,8 +628,13 @@ export function createOmniRunner(deps: OmniRunnerDeps): OmniRunner {
 
   function tryResolve(id: string, decision: ApprovalDecision, resolvedBy: string, note: string): boolean {
     try {
-      resolveApproval(db, id, decision, resolvedBy);
+      // Stamp resolved_at with the runner clock so the reconciliation recency
+      // window (which reads now() from the same dep) lines up deterministically.
+      const row = resolveApproval(db, id, decision, resolvedBy, now());
       log(`[omni] resolved ${id} → ${decision} by ${resolvedBy} (${note})`);
+      // Swap the ⏳ status reaction to ✅ (approved) / ❌ (denied) — the row is
+      // now closed, so this is the second half of the ⏳→✅/❌ ack.
+      emitStatusReaction(row.omniMessageId, decision === 'approved' ? STATUS_APPROVED : STATUS_DENIED);
       return true;
     } catch (err) {
       // Lost the race to another resolver — benign under concurrency.
@@ -497,8 +646,12 @@ export function createOmniRunner(deps: OmniRunnerDeps): OmniRunner {
   /**
    * Resolve an approval from an inbound reaction. Correlates by the stored real
    * Omni message id (the reaction's target stanza id, from the `[Reaction: … on
-   * message <id>]` content or the top-level `messageId`); falls back to oldest
-   * only when no pending row carries that id. Non-vocabulary emoji are ignored.
+   * message <id>]` content or the top-level `messageId`). An EXPLICIT target that
+   * matches no pending row is a NO-OP (logged, ignored) — NOT an oldest fallback:
+   * a reaction on an already-resolved / unknown message must never resolve some
+   * unrelated pending approval (the concurrency hazard this wish exists to kill).
+   * Oldest fallback is reserved for the no-target-id case; reactions always carry
+   * a target id, so this branch is defensive. Non-vocabulary emoji are ignored.
    */
   function resolveReaction(emoji: string, targetId: string | undefined, sender: string): void {
     const decision = matchReaction(emoji, vocab);
@@ -507,15 +660,37 @@ export function createOmniRunner(deps: OmniRunnerDeps): OmniRunner {
       const match = listPendingApprovals(db).find((a) => a.omniMessageId === targetId);
       if (match) {
         tryResolve(match.id, decision, sender, `reaction ${emoji}`);
-        return;
+      } else {
+        log(`[omni] reaction ${emoji} targets unknown/resolved id ${targetId} — ignored (no oldest fallback)`);
       }
+      return;
     }
     resolveOldest(decision, sender, `reaction ${emoji} (fallback)`);
   }
 
+  /**
+   * Reconcile the status reaction on every DONE-but-not-terminally-acked row:
+   * swap its ⏳ (or missing) glyph to ✅ (approved) / ❌ (denied or expired). This
+   * makes the RUNNER the authoritative acker regardless of WHO closed the row —
+   * closing the hook-fork-expiry race (the hook's `expireOwnRow` expires the row
+   * but sets no reaction, so a ⏳ would otherwise stick on the phone forever) AND
+   * any transport-dropped swap (a failed resolve/announce react left the glyph
+   * non-terminal). Idempotent: {@link emitStatusReaction} records the terminal
+   * glyph on success, so the next tick's query no longer returns the row; the
+   * `ackInFlight` guard stops a slow ack re-firing before its glyph is recorded.
+   */
+  function reconcileStatusAcks(): void {
+    for (const row of listApprovalsNeedingStatusAck(db, TERMINAL_STATUS_GLYPHS, now(), RECONCILE_WINDOW_MS)) {
+      emitStatusReaction(row.omniMessageId, row.status === 'approved' ? STATUS_APPROVED : STATUS_DENIED);
+    }
+  }
+
   return {
     tick(): void {
+      // Expire stale rows, then let reconciliation set the terminal ✅/❌ on any
+      // row closed here OR by the hook fork's own self-timeout expiry.
       expireStale(db, config.approvals.pollBudgetMs, now());
+      reconcileStatusAcks();
       announce();
     },
 
@@ -563,11 +738,12 @@ export function createOmniRunner(deps: OmniRunnerDeps): OmniRunner {
     },
 
     async whenIdle(): Promise<void> {
-      // Drain both one-shot runs and announce sends in a loop: a settling task
-      // must not add new work, but snapshot-await is cheap insurance against
-      // future callers that fan out mid-drain.
-      while (pending.size > 0 || inFlightSends.size > 0) {
-        await Promise.allSettled([...pending, ...inFlightSends]);
+      // Drain one-shot runs, announce sends, AND status reactions in a loop: a
+      // send settles by firing the ⏳ status reaction (adds to inFlightReactions
+      // mid-drain), and a resolve fires ✅/❌, so the loop must keep going until
+      // every set has quiesced.
+      while (pending.size > 0 || inFlightSends.size > 0 || inFlightReactions.size > 0) {
+        await Promise.allSettled([...pending, ...inFlightSends, ...inFlightReactions]);
       }
     },
   };

--- a/src/lib/omni-runner.ts
+++ b/src/lib/omni-runner.ts
@@ -3,13 +3,19 @@
  *
  * Owns the NATS transport and the two-way bridge between the phone and the
  * global approval queue:
- *   - subscribes `omni.message.{instance}.>` (text replies) and `omni.event.>`
- *     (reactions);
- *   - on each new pending approval row, PUBLISHES an approval-request to
- *     `omni.reply.{instance}.{chat}` (outbound send subject, mirroring v4's
- *     omni-bridge) and tags the row with a correlation id;
+ *   - subscribes `omni.message.{instance}.>` — both text replies AND reactions
+ *     arrive here. A WhatsApp reaction reaches genie as a `message.received`
+ *     whose content is `[Reaction: <emoji> on message <targetId>]` (the target
+ *     id is also the top-level `messageId`); the legacy `omni.event.>` subject
+ *     has zero publishers in this Omni build, so it is retired (SPIKE finding a);
+ *   - on each new pending approval row, SENDS an approval-request over the Omni
+ *     HTTP API (an id-returning send) and tags the row with the REAL Omni
+ *     message id (the WhatsApp stanza id) the send returns — so an inbound
+ *     reaction can be correlated to the exact approval it targets, rather than
+ *     the old self-referential `genId()` ref that matched nothing (SPIKE b);
  *   - matches inbound replies/reactions against the approve/deny vocabulary and
- *     resolves the oldest pending approval (or the reaction-correlated one);
+ *     resolves the correlated approval (reaction → the stored stanza id; bare
+ *     text → oldest-pending fallback);
  *   - records every inbound message to the inbox (`recordInbound`). One-shot
  *     agent spawning on inbound is Group 4 — this group only stores.
  *
@@ -25,6 +31,7 @@
 import type { Database } from 'bun:sqlite';
 import type { OmniRoute, OmniRuntimeConfig } from './omni-config.js';
 import { matchReaction, matchTextToken } from './omni-matching.js';
+import { signOmniRequest } from './omni-signature.js';
 import {
   ApprovalConflictError,
   type ApprovalDecision,
@@ -105,6 +112,73 @@ export const defaultSpawnClaude: SpawnClaude = async ({ message, cwd, signal }) 
   return { stdout, exitCode };
 };
 
+// ============================================================================
+// Injectable id-returning Omni send (approval announce)
+// ============================================================================
+
+/**
+ * Result of an id-returning Omni send. `messageId` is the correlatable id — the
+ * WhatsApp stanza id / externalId (SPIKE finding (b)) — that an inbound reaction
+ * later references. Absent on a failed send (the row stays un-tagged and is
+ * retried on the next tick).
+ */
+export interface OmniSendResult {
+  messageId?: string;
+  success?: boolean;
+  error?: string;
+}
+
+export interface OmniSendOpts {
+  instance: string;
+  chat: string;
+  text: string;
+}
+
+/**
+ * Send an approval-request message and RETURN the id it was assigned. Injectable
+ * so tests drive a fake (zero network); the default posts to the Omni HTTP send
+ * API. This replaces the fire-and-forget NATS `omni.reply.*` publish whose id
+ * Omni's `onReply` discarded — capturing the real Omni message id is what makes
+ * a reaction correlatable to the exact approval it targets.
+ */
+export type OmniSend = (opts: OmniSendOpts) => Promise<OmniSendResult>;
+
+/**
+ * Default id-returning send — POSTs the approval message to Omni's HTTP send
+ * route, signed exactly like {@link registerAgentInOmni} (bearer + optional
+ * ed25519). Returns the message id from the response so `announce()` can store
+ * the correlatable stanza id. Degrades to an error result (silent retry, never a
+ * throw) when the Omni API URL is unconfigured.
+ *
+ * NOTE: the exact send route + response field that surface the WhatsApp *stanza
+ * id* (vs the persisted Omni UUID) are documented in SPIKE (b) but not yet
+ * exercised against the live hub — the injectable seam above is what the test
+ * suite proves; G3's `--live` round-trip confirms this default's wire format.
+ */
+export function makeDefaultOmniSend(config: OmniRuntimeConfig): OmniSend {
+  return async ({ instance, chat, text }) => {
+    const apiUrl = config.apiUrl;
+    if (!apiUrl) return { success: false, error: 'omni apiUrl not configured' };
+    const path = '/api/v2/messages';
+    const bodyJson = JSON.stringify({ instanceId: instance, chatId: chat, text });
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (config.apiKey) headers.Authorization = `Bearer ${config.apiKey}`;
+    const sig = signOmniRequest('POST', path, bodyJson);
+    if (sig) Object.assign(headers, sig);
+    const res = await fetch(`${apiUrl.replace(/\/+$/, '')}${path}`, {
+      method: 'POST',
+      headers,
+      body: bodyJson,
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return { success: false, error: `HTTP ${res.status}` };
+    // SendResult ({ success, messageId, ... }) may be top-level or `{ data }`-wrapped.
+    const json = (await res.json()) as { messageId?: string; data?: { messageId?: string } };
+    const messageId = json.messageId ?? json.data?.messageId;
+    return { success: Boolean(messageId), messageId };
+  };
+}
+
 /** Default factory — dynamically imports `nats`. Only invoked by `omni serve`. */
 export const defaultNatsFactory: NatsFactory = async ({ servers }) => {
   const nats = await import('nats');
@@ -135,15 +209,12 @@ interface InboundMessagePayload {
   sender?: string;
   instanceId?: string;
   chatId?: string;
-}
-
-interface ReactionEventPayload {
-  type?: string;
-  emoji?: string;
+  /**
+   * For a reaction `message.received`, the reacted-to message's stanza id (also
+   * embedded in `content` as `[Reaction: <emoji> on message <messageId>]`). Used
+   * to correlate the reaction to the exact approval it targets (SPIKE a).
+   */
   messageId?: string;
-  chatId?: string;
-  instanceId?: string;
-  sender?: string;
 }
 
 // ============================================================================
@@ -159,22 +230,29 @@ export interface OmniRunnerDeps {
   log?: (line: string) => void;
   /** Injectable clock. */
   now?: () => number;
-  /** Injectable correlation-id generator (tagged onto the outbound request). */
+  /** Injectable correlation-id generator (tagged onto routed one-shot replies). */
   genCorrelationId?: () => string;
   /**
    * Injectable one-shot executor. Defaults to a real `claude -p`; tests pass a
    * fake so no real claude is ever forked.
    */
   spawnClaude?: SpawnClaude;
+  /**
+   * Injectable id-returning approval send. Defaults to the Omni HTTP send
+   * ({@link makeDefaultOmniSend}); tests pass a fake that returns a known stanza
+   * id so `announce()` is exercised with zero network.
+   */
+  sendApproval?: OmniSend;
 }
 
 export interface OmniRunner {
-  /** Publish any un-announced pending approvals + expire stale rows. */
+  /** Send any un-announced pending approvals + expire stale rows. */
   tick(): void;
-  /** Handle one inbound `omni.message.*` frame. */
+  /**
+   * Handle one inbound `omni.message.*` frame — a text reply OR a reaction (both
+   * arrive on this subject in this Omni build).
+   */
   handleMessage(subject: string, data: string): void;
-  /** Handle one inbound `omni.event.*` frame (reactions). */
-  handleEvent(subject: string, data: string): void;
   /**
    * Resolve once every in-flight one-shot run has settled. Test seam — the serve
    * loop never awaits it (runs are fire-and-forget), but tests use it to observe
@@ -183,7 +261,7 @@ export interface OmniRunner {
   whenIdle(): Promise<void>;
 }
 
-function formatApprovalMessage(tool: string, inputSummary: string, correlationId: string): string {
+function formatApprovalMessage(tool: string, inputSummary: string): string {
   const preview = inputSummary.length > 200 ? `${inputSummary.slice(0, 197)}...` : inputSummary;
   return [
     '\u{1F514} *Approval Required*',
@@ -193,26 +271,21 @@ function formatApprovalMessage(tool: string, inputSummary: string, correlationId
     '',
     'Reply *y* to approve or *n* to deny',
     'Or react \u{1F44D} / \u{1F44E}',
-    '',
-    `_ref: ${correlationId}_`,
   ].join('\n');
 }
 
-/** Outbound reply payload shape — mirrors origin/v4 omni-bridge replies. */
-function buildOutboundPayload(
-  config: OmniRuntimeConfig,
-  content: string,
-  correlationId: string,
-  nowMs: number,
-): string {
-  return JSON.stringify({
-    content,
-    agent: 'genie',
-    chat_id: config.approvalChat,
-    instance_id: config.instance,
-    request_id: correlationId,
-    timestamp: new Date(nowMs).toISOString(),
-  });
+/**
+ * Parse a reaction `message.received` content — `[Reaction: <emoji> on message
+ * <id>]`, optionally prefixed by `[<displayName>]: ` — into its emoji + target
+ * stanza id. Returns null for ordinary text so the caller falls through to the
+ * text-token path. This is the sole reaction shape genie treats as a decision;
+ * the dual-emit bare-emoji echo (SPIKE a) is deliberately NOT matched here, so
+ * it can never double-resolve.
+ */
+const REACTION_RE = /\[Reaction:\s*(.+?)\s+on message\s+(.+?)\]/;
+function parseReaction(content: string): { emoji: string; targetId: string } | null {
+  const m = REACTION_RE.exec(content);
+  return m ? { emoji: m[1].trim(), targetId: m[2].trim() } : null;
 }
 
 /** chat id from payload, else parsed from `omni.message.{instance}.{chat...}`. */
@@ -223,8 +296,8 @@ function chatIdFromSubject(subject: string): string | undefined {
 
 /**
  * Outbound reply payload for a routed one-shot, addressed at the exact
- * (instance, chat) the inbound arrived on (NOT the approval chat). Same shape as
- * {@link buildOutboundPayload} so the omni side deserializes replies uniformly.
+ * (instance, chat) the inbound arrived on (NOT the approval chat). Mirrors the
+ * origin/v4 omni-bridge reply shape so the omni side deserializes it uniformly.
  */
 function buildRoutedReplyPayload(
   instance: string,
@@ -275,6 +348,7 @@ export function createOmniRunner(deps: OmniRunnerDeps): OmniRunner {
   const genId =
     deps.genCorrelationId ?? (() => `req_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`);
   const spawnClaude = deps.spawnClaude ?? defaultSpawnClaude;
+  const sendApproval = deps.sendApproval ?? makeDefaultOmniSend(config);
   const vocab = {
     approveTokens: config.approveTokens,
     denyTokens: config.denyTokens,
@@ -290,6 +364,11 @@ export function createOmniRunner(deps: OmniRunnerDeps): OmniRunner {
   const inFlight = new Set<string>();
   /** Live one-shot promises, so `whenIdle` (tests) can await completion. */
   const pending = new Set<Promise<void>>();
+  /** Approval ids with an announce send in flight — guards against a second tick
+   *  re-sending a row whose `omni_message_id` is not yet stored. */
+  const announcing = new Set<string>();
+  /** Live announce-send promises, drained by `whenIdle` alongside `pending`. */
+  const inFlightSends = new Set<Promise<void>>();
   const routeKey = (instance: string, chat: string): string => `${instance} ${chat}`;
   const findRoute = (instance: string, chat: string): OmniRoute | undefined =>
     routes.find((r) => r.instance === instance && r.chat === chat);
@@ -355,17 +434,45 @@ export function createOmniRunner(deps: OmniRunnerDeps): OmniRunner {
     pending.add(run);
   }
 
+  /**
+   * Announce a single pending approval via the id-returning send and tag the row
+   * with the REAL Omni message id (the stanza id) the send returns — so an
+   * inbound reaction correlates to THIS approval. Tags only on a successful send;
+   * a failed/id-less send leaves the row un-tagged so the next tick retries
+   * (mirrors the old tag-after-publish semantics). Never throws.
+   */
+  async function sendAnnounce(appr: { id: string; tool: string; inputSummary: string }): Promise<void> {
+    const text = formatApprovalMessage(appr.tool, appr.inputSummary);
+    try {
+      const result = await sendApproval({ instance: config.instance ?? '', chat: config.approvalChat ?? '', text });
+      if (!result.messageId) {
+        log(
+          `[omni] announce ${appr.id}: send returned no messageId${result.error ? ` (${result.error})` : ''} — will retry`,
+        );
+        return;
+      }
+      attachOmniMessageId(db, appr.id, result.messageId);
+      log(`[omni] announced approval ${appr.id} (omni ${result.messageId})`);
+    } catch (err) {
+      log(`[omni] announce ${appr.id} failed: ${errText(err)}`);
+    }
+  }
+
+  /**
+   * Send every un-announced pending approval. Fire-and-forget per row (the tick
+   * loop never blocks on a slow HTTP send), guarded by `announcing` so a second
+   * tick before the first send settles does not double-send.
+   */
   function announce(): void {
     for (const appr of listPendingApprovals(db)) {
       if (appr.omniMessageId) continue; // already announced
-      const correlationId = genId();
-      const text = formatApprovalMessage(appr.tool, appr.inputSummary, correlationId);
-      const subject = `omni.reply.${config.instance}.${config.approvalChat}`;
-      publish(subject, buildOutboundPayload(config, text, correlationId, now()));
-      // Tag AFTER publishing so a crash mid-publish re-announces rather than
-      // silently dropping the request.
-      attachOmniMessageId(db, appr.id, correlationId);
-      log(`[omni] announced approval ${appr.id} (ref ${correlationId})`);
+      if (announcing.has(appr.id)) continue; // send in flight
+      announcing.add(appr.id);
+      const send = sendAnnounce(appr).finally(() => {
+        announcing.delete(appr.id);
+        inFlightSends.delete(send);
+      });
+      inFlightSends.add(send);
     }
   }
 
@@ -385,6 +492,25 @@ export function createOmniRunner(deps: OmniRunnerDeps): OmniRunner {
       if (err instanceof ApprovalConflictError) return false;
       throw err;
     }
+  }
+
+  /**
+   * Resolve an approval from an inbound reaction. Correlates by the stored real
+   * Omni message id (the reaction's target stanza id, from the `[Reaction: … on
+   * message <id>]` content or the top-level `messageId`); falls back to oldest
+   * only when no pending row carries that id. Non-vocabulary emoji are ignored.
+   */
+  function resolveReaction(emoji: string, targetId: string | undefined, sender: string): void {
+    const decision = matchReaction(emoji, vocab);
+    if (!decision) return;
+    if (targetId) {
+      const match = listPendingApprovals(db).find((a) => a.omniMessageId === targetId);
+      if (match) {
+        tryResolve(match.id, decision, sender, `reaction ${emoji}`);
+        return;
+      }
+    }
+    resolveOldest(decision, sender, `reaction ${emoji} (fallback)`);
   }
 
   return {
@@ -415,46 +541,34 @@ export function createOmniRunner(deps: OmniRunnerDeps): OmniRunner {
 
       // Only the approval chat can resolve approvals.
       if (!chatId || chatId !== config.approvalChat) return;
-      if (!msg.content) return;
-      const decision = matchTextToken(msg.content, vocab);
-      if (!decision) return;
-      resolveOldest(decision, sender, `text:"${msg.content.trim().toLowerCase()}"`);
-    },
+      // Instance-scope guard (PR #2507): another instance's reply/reaction must
+      // never resolve our approval, even if the approvalChat JID repeats.
+      if (msg.instanceId && config.instance && msg.instanceId !== config.instance) return;
+      if (!body) return;
 
-    handleEvent(subject: string, data: string): void {
-      let evt: ReactionEventPayload;
-      try {
-        evt = JSON.parse(data) as ReactionEventPayload;
-      } catch {
+      // A reaction reaches genie on THIS subject (SPIKE a) as
+      // `[Reaction: <emoji> on message <id>]`; the target id is also the
+      // top-level `messageId`. Only this form is a reaction — the dual-emit
+      // bare-emoji echo matches neither branch below, so it never double-resolves.
+      const reaction = parseReaction(body);
+      if (reaction) {
+        resolveReaction(reaction.emoji, reaction.targetId || msg.messageId, sender);
         return;
       }
-      if (evt.type !== 'reaction' || !evt.emoji) return;
-      // Scope to our own instance — text replies are already subject-scoped to
-      // `omni.message.${config.instance}.>`, but reactions arrive on a shared
-      // `omni.event.>` bus where approvalChat JIDs can repeat across instances.
-      // Without this, another instance's 👍/👎 could resolve our approval.
-      if (evt.instanceId && config.instance && evt.instanceId !== config.instance) return;
-      const chatId = evt.chatId ?? chatIdFromSubject(subject);
-      if (!chatId || chatId !== config.approvalChat) return;
-      const decision = matchReaction(evt.emoji, vocab);
-      if (!decision) return;
-      const sender = evt.sender ?? 'whatsapp-user';
 
-      // Correlate by the ref we tagged onto the row, else fall back to oldest.
-      if (evt.messageId) {
-        const match = listPendingApprovals(db).find((a) => a.omniMessageId === evt.messageId);
-        if (match) {
-          tryResolve(match.id, decision, sender, `reaction ${evt.emoji}`);
-          return;
-        }
-      }
-      resolveOldest(decision, sender, `reaction ${evt.emoji} (fallback)`);
+      // Bare text reply → oldest-pending fallback (no quoted id in this build).
+      const decision = matchTextToken(body, vocab);
+      if (!decision) return;
+      resolveOldest(decision, sender, `text:"${body.trim().toLowerCase()}"`);
     },
 
     async whenIdle(): Promise<void> {
-      // Drain in a loop: a settling run must not add new work, but snapshot-await
-      // is cheap insurance against future callers that fan out mid-drain.
-      while (pending.size > 0) await Promise.allSettled([...pending]);
+      // Drain both one-shot runs and announce sends in a loop: a settling task
+      // must not add new work, but snapshot-await is cheap insurance against
+      // future callers that fan out mid-drain.
+      while (pending.size > 0 || inFlightSends.size > 0) {
+        await Promise.allSettled([...pending, ...inFlightSends]);
+      }
     },
   };
 }
@@ -502,10 +616,11 @@ export async function runOmniServe(opts: RunOmniServeOptions): Promise<void> {
   const nc = await factory({ servers: config.natsUrl });
   const runner = createOmniRunner({ db, config, publish: nc.publish, log });
 
+  // Both text replies AND reactions arrive on `omni.message.{instance}.>` in this
+  // Omni build; the legacy `omni.event.>` subject has no publishers (SPIKE a), so
+  // it is no longer subscribed.
   const msgSub = nc.subscribe(`omni.message.${config.instance}.>`);
-  const evtSub = nc.subscribe('omni.event.>');
   void consume(msgSub, runner.handleMessage, log);
-  void consume(evtSub, runner.handleEvent, log);
 
   const timer = setInterval(() => {
     try {
@@ -526,7 +641,6 @@ export async function runOmniServe(opts: RunOmniServeOptions): Promise<void> {
 
   clearInterval(timer);
   msgSub.unsubscribe();
-  evtSub.unsubscribe();
   await nc.close();
   log('[omni] stopped');
 }

--- a/src/lib/v5/global-db.test.ts
+++ b/src/lib/v5/global-db.test.ts
@@ -6,10 +6,12 @@ import { join } from 'node:path';
 import {
   ForeignDbError,
   GLOBAL_SCHEMA_VERSION,
+  MIGRATED_STATUS_SENTINEL,
   MalformedDbError,
   openGlobalDb,
   resolveGlobalDbPath,
 } from './global-db.js';
+import { listApprovalsNeedingStatusAck } from './omni-queue.js';
 
 let dir: string;
 const originalGenieHome = process.env.GENIE_HOME;
@@ -75,6 +77,91 @@ describe('openGlobalDb schema init', () => {
     const db = openGlobalDb({ path });
     db.close();
     expect(existsSync(path)).toBe(true);
+  });
+});
+
+describe('openGlobalDb additive column backfill (last_status_glyph)', () => {
+  /** The pre-column v1 approvals schema, as an earlier build stamped it. */
+  const OLD_APPROVALS_SQL = `
+    CREATE TABLE approvals (
+      id TEXT PRIMARY KEY, repo TEXT NOT NULL, session_hint TEXT, tool TEXT NOT NULL,
+      input_summary TEXT NOT NULL,
+      status TEXT NOT NULL CHECK (status IN ('pending','approved','denied','expired')),
+      omni_message_id TEXT, requested_by TEXT, resolved_by TEXT,
+      created_at INTEGER NOT NULL, resolved_at INTEGER
+    );
+    CREATE TABLE inbound_messages (
+      id TEXT PRIMARY KEY, instance TEXT NOT NULL, chat TEXT NOT NULL, sender TEXT NOT NULL,
+      body TEXT NOT NULL, received_at INTEGER NOT NULL, handled_at INTEGER
+    );`;
+
+  function columns(db: Database, table: string): Set<string> {
+    return new Set((db.query(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>).map((c) => c.name));
+  }
+
+  test('backfills the column on an existing v1 DB without bumping user_version or losing data', () => {
+    const path = join(dir, 'legacy.db');
+    const seed = new Database(path);
+    seed.exec(OLD_APPROVALS_SQL);
+    seed.exec(`PRAGMA user_version = ${GLOBAL_SCHEMA_VERSION}`);
+    // A pre-existing approval row must survive the additive migration untouched.
+    seed
+      .query(
+        "INSERT INTO approvals (id, repo, tool, input_summary, status, created_at) VALUES ('appr_old','/r','Bash','x','pending',1)",
+      )
+      .run();
+    seed.close();
+    expect(columns(new Database(path, { readonly: true }), 'approvals').has('last_status_glyph')).toBe(false);
+
+    // Opening runs the additive ALTER (schemaIsCurrent sees the missing column).
+    const db = openGlobalDb({ path });
+    try {
+      expect(columns(db, 'approvals').has('last_status_glyph')).toBe(true);
+      const row = db.query("SELECT last_status_glyph FROM approvals WHERE id = 'appr_old'").get() as {
+        last_status_glyph: string | null;
+      };
+      expect(row.last_status_glyph).toBeNull(); // new column, back-filled NULL
+    } finally {
+      db.close();
+    }
+    // Same version — additive backfill stays within v1 (no destructive migration).
+    expect(userVersion(path)).toBe(GLOBAL_SCHEMA_VERSION);
+  });
+
+  test('one-time backfill stamps pre-upgrade CLOSED history as MIGRATED so reconcile ignores it', () => {
+    const path = join(dir, 'legacy-history.db');
+    const seed = new Database(path);
+    seed.exec(OLD_APPROVALS_SQL);
+    seed.exec(`PRAGMA user_version = ${GLOBAL_SCHEMA_VERSION}`);
+    // Historical announced+closed rows (approved/denied/expired) — the kind that,
+    // pre-fix, the first post-upgrade tick would fire a reaction POST for.
+    const insert = seed.query(
+      'INSERT INTO approvals (id, repo, tool, input_summary, status, omni_message_id, created_at, resolved_at) VALUES (?,?,?,?,?,?,?,?)',
+    );
+    insert.run('appr_a', '/r', 'Bash', 'x', 'approved', 'stanza-a', 1, 100);
+    insert.run('appr_d', '/r', 'Bash', 'x', 'denied', 'stanza-d', 2, 200);
+    insert.run('appr_e', '/r', 'Bash', 'x', 'expired', 'stanza-e', 3, 300);
+    // A still-pending row must stay reconcilable (not stamped).
+    insert.run('appr_p', '/r', 'Bash', 'x', 'pending', 'stanza-p', 4, null);
+    seed.close();
+
+    const db = openGlobalDb({ path });
+    try {
+      const closed = db
+        .query("SELECT id, last_status_glyph AS g FROM approvals WHERE status != 'pending'")
+        .all() as Array<{ id: string; g: string | null }>;
+      // Every historical closed row is stamped with the sentinel.
+      expect(closed.every((r) => r.g === MIGRATED_STATUS_SENTINEL)).toBe(true);
+      // Pending row untouched.
+      expect(
+        (db.query("SELECT last_status_glyph AS g FROM approvals WHERE id = 'appr_p'").get() as { g: string | null }).g,
+      ).toBeNull();
+      // The reconciliation query returns NONE — no reaction fires on the first tick.
+      const now = 1_000_000;
+      expect(listApprovalsNeedingStatusAck(db, ['\u{2705}', '\u{274C}'], now, 24 * 60 * 60 * 1000)).toEqual([]);
+    } finally {
+      db.close();
+    }
   });
 });
 

--- a/src/lib/v5/global-db.ts
+++ b/src/lib/v5/global-db.ts
@@ -29,6 +29,16 @@ export { BusyDbError, ForeignDbError, GenieDbError, isBusyError, MalformedDbErro
 export const GLOBAL_SCHEMA_VERSION = 1;
 
 /**
+ * Sentinel written into `last_status_glyph` for pre-existing closed approvals at
+ * the moment the column is first added (the one-time upgrade backfill). It is
+ * NOT a real reaction emoji, so it can never collide with a live status glyph;
+ * `listApprovalsNeedingStatusAck` treats it as terminal so the runner's
+ * reconciliation pass NEVER touches historical rows on the first post-upgrade
+ * tick (which would otherwise fire a reaction HTTP POST for the entire history).
+ */
+export const MIGRATED_STATUS_SENTINEL = 'migrated';
+
+/**
  * Base directory for all machine-scope genie state. Read from `GENIE_HOME` on
  * every call (not cached) so env overrides in tests take effect.
  */
@@ -76,7 +86,10 @@ function schemaIsCurrent(db: Database): boolean {
     ).map((r) => r.name),
   );
   for (const t of EXPECTED_TABLES) if (!tables.has(t)) return false;
-  return true;
+  // A pre-column v1 DB (missing the additive last_status_glyph) returns false so
+  // ensureSchema runs and backfills — mirrors genie-db.ts's ensureTaskColumns.
+  const cols = new Set((db.query('PRAGMA table_info(approvals)').all() as Array<{ name: string }>).map((c) => c.name));
+  return cols.has('last_status_glyph');
 }
 
 const SCHEMA_SQL = `
@@ -91,7 +104,8 @@ CREATE TABLE IF NOT EXISTS approvals (
   requested_by  TEXT,
   resolved_by   TEXT,
   created_at    INTEGER NOT NULL,
-  resolved_at   INTEGER
+  resolved_at   INTEGER,
+  last_status_glyph TEXT
 );
 
 CREATE TABLE IF NOT EXISTS inbound_messages (
@@ -111,4 +125,25 @@ CREATE INDEX IF NOT EXISTS idx_inbound_handled ON inbound_messages(handled_at);
 /** Create every table/index if absent. Idempotent — pure `IF NOT EXISTS`. */
 export function ensureSchema(db: Database): void {
   db.exec(SCHEMA_SQL);
+  ensureApprovalColumns(db);
+}
+
+/**
+ * Additive, in-place column backfill for `approvals`. `CREATE TABLE IF NOT
+ * EXISTS` never alters an existing table, so a DB stamped by an earlier build
+ * (which lacked `last_status_glyph`) needs the column added. It is nullable, so
+ * this stays within `user_version = 1` — no destructive migration, no version
+ * bump (mirrors genie-db.ts's ensureTaskColumns). Idempotent: a table that
+ * already has the column is left untouched.
+ */
+function ensureApprovalColumns(db: Database): void {
+  const cols = new Set((db.query('PRAGMA table_info(approvals)').all() as Array<{ name: string }>).map((c) => c.name));
+  if (!cols.has('last_status_glyph')) {
+    db.exec('ALTER TABLE approvals ADD COLUMN last_status_glyph TEXT');
+    // One-time upgrade backfill: stamp every already-closed approval as MIGRATED
+    // so the runner's reconciliation pass never re-acks pre-upgrade history
+    // (whose omni_message_id may be a bogus self-ref, or a real days-old stanza
+    // id we must not spam). Runs ONLY when the column is first added.
+    db.query(`UPDATE approvals SET last_status_glyph = ? WHERE status != 'pending'`).run(MIGRATED_STATUS_SENTINEL);
+  }
 }

--- a/src/lib/v5/omni-queue.test.ts
+++ b/src/lib/v5/omni-queue.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { openGlobalDb } from './global-db.js';
+import { MIGRATED_STATUS_SENTINEL, openGlobalDb } from './global-db.js';
 import {
   ApprovalConflictError,
   UnknownApprovalError,
@@ -12,12 +12,22 @@ import {
   enqueueApproval,
   expireStale,
   getApproval,
+  listApprovalsNeedingStatusAck,
   listInbox,
   listPendingApprovals,
   markHandled,
   recordInbound,
+  recordStatusGlyph,
   resolveApproval,
 } from './omni-queue.js';
+
+const HOURGLASS = '\u{23F3}'; // ⏳
+const CHECK = '\u{2705}'; // ✅
+const CROSS = '\u{274C}'; // ❌
+const TERMINAL = [CHECK, CROSS];
+// Deterministic clock + recency window for the reconciliation-query tests.
+const NOW_Q = 5_000_000;
+const WINDOW = 1_000_000;
 
 let dir: string;
 let db: Database;
@@ -119,6 +129,90 @@ describe('approvals', () => {
     resolveApproval(db, b, 'approved', 'x');
     const pending = listPendingApprovals(db);
     expect(pending.map((p) => p.id)).toEqual([a, c]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Status-ack bookkeeping + reconciliation query
+// ---------------------------------------------------------------------------
+describe('status-ack glyph + listApprovalsNeedingStatusAck', () => {
+  test('enqueue defaults lastStatusGlyph to null', () => {
+    const id = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'x' });
+    expect(getApproval(db, id)?.lastStatusGlyph).toBeNull();
+  });
+
+  test('recordStatusGlyph sets the glyph keyed by omni_message_id; no-op for an unknown id', () => {
+    const id = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'x' });
+    attachOmniMessageId(db, id, 'stanza-1');
+    recordStatusGlyph(db, 'stanza-1', HOURGLASS);
+    expect(getApproval(db, id)?.lastStatusGlyph).toBe(HOURGLASS);
+    // No row carries this message id → silent no-op, never throws.
+    expect(() => recordStatusGlyph(db, 'stanza-absent', CHECK)).not.toThrow();
+    expect(getApproval(db, id)?.lastStatusGlyph).toBe(HOURGLASS);
+  });
+
+  test('reconciliation query returns only done + announced + non-terminal + recent rows', () => {
+    // (1) pending + announced → excluded (still awaiting a decision)
+    const pending = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'p', now: 1 });
+    attachOmniMessageId(db, pending, 'stanza-p');
+
+    // (2) resolved but NEVER announced (no omni_message_id) → excluded
+    const noId = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'n', now: 2 });
+    resolveApproval(db, noId, 'approved', 'x', NOW_Q);
+
+    // (3) approved + announced + still ⏳ → INCLUDED (needs ✅ swap)
+    const stuck = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 's', now: 3 });
+    attachOmniMessageId(db, stuck, 'stanza-s');
+    recordStatusGlyph(db, 'stanza-s', HOURGLASS);
+    resolveApproval(db, stuck, 'approved', 'x', NOW_Q);
+
+    // (4) expired + announced + glyph NULL (hook-fork race) → INCLUDED (needs ❌).
+    // Faithful to the hook's single-row expireOwnRow: expire ONLY this row, no
+    // status glyph — so the runner never acked it and a ⏳ would be stuck.
+    const raced = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'r', now: 4 });
+    attachOmniMessageId(db, raced, 'stanza-r');
+    db.query("UPDATE approvals SET status = 'expired', resolved_at = ? WHERE id = ?").run(NOW_Q, raced);
+
+    // (5) denied + announced + already ❌ → excluded (terminal)
+    const done = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'd', now: 6 });
+    attachOmniMessageId(db, done, 'stanza-d');
+    recordStatusGlyph(db, 'stanza-d', CROSS);
+    resolveApproval(db, done, 'denied', 'x', NOW_Q);
+
+    const need = listApprovalsNeedingStatusAck(db, TERMINAL, NOW_Q, WINDOW);
+    expect(need.map((r) => r.id).sort()).toEqual([stuck, raced].sort());
+  });
+
+  test('the migration sentinel is treated as terminal — historical rows are excluded', () => {
+    const migrated = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'h', now: 1 });
+    attachOmniMessageId(db, migrated, 'stanza-h');
+    resolveApproval(db, migrated, 'approved', 'x', NOW_Q);
+    recordStatusGlyph(db, 'stanza-h', MIGRATED_STATUS_SENTINEL); // as the upgrade backfill stamps
+    expect(listApprovalsNeedingStatusAck(db, TERMINAL, NOW_Q, WINDOW)).toEqual([]);
+  });
+
+  test('recency window: a row resolved before the window is excluded, a recent one included', () => {
+    // Resolved WELL before the window → excluded even though its glyph is ⏳.
+    const old = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'old', now: 1 });
+    attachOmniMessageId(db, old, 'stanza-old');
+    recordStatusGlyph(db, 'stanza-old', HOURGLASS);
+    resolveApproval(db, old, 'approved', 'x', NOW_Q - WINDOW - 1);
+
+    // Resolved just inside the window → included.
+    const recent = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'new', now: 2 });
+    attachOmniMessageId(db, recent, 'stanza-new');
+    recordStatusGlyph(db, 'stanza-new', HOURGLASS);
+    resolveApproval(db, recent, 'approved', 'x', NOW_Q - WINDOW + 1);
+
+    const need = listApprovalsNeedingStatusAck(db, TERMINAL, NOW_Q, WINDOW);
+    expect(need.map((r) => r.id)).toEqual([recent]);
+  });
+
+  test('empty terminal set returns nothing (guard against invalid NOT IN ())', () => {
+    const id = enqueueApproval(db, { repo: '/r', tool: 'Bash', inputSummary: 'x' });
+    attachOmniMessageId(db, id, 'stanza-x');
+    resolveApproval(db, id, 'approved', 'x', NOW_Q);
+    expect(listApprovalsNeedingStatusAck(db, [], NOW_Q, WINDOW)).toEqual([]);
   });
 });
 

--- a/src/lib/v5/omni-queue.ts
+++ b/src/lib/v5/omni-queue.ts
@@ -22,6 +22,7 @@
 
 import type { Database } from 'bun:sqlite';
 import { randomBytes } from 'node:crypto';
+import { MIGRATED_STATUS_SENTINEL } from './global-db.js';
 
 // ============================================================================
 // Types
@@ -38,6 +39,10 @@ export interface ApprovalRow {
   inputSummary: string;
   status: ApprovalStatus;
   omniMessageId: string | null;
+  /** Last status-ack glyph the runner successfully set on the Omni message
+   *  (⏳ on announce, ✅/❌ once terminal). null until the first ack lands. Drives
+   *  the runner's reconciliation pass so a stuck ⏳ is never left on the phone. */
+  lastStatusGlyph: string | null;
   requestedBy: string | null;
   resolvedBy: string | null;
   createdAt: number;
@@ -141,6 +146,7 @@ interface RawApproval {
   input_summary: string;
   status: string;
   omni_message_id: string | null;
+  last_status_glyph: string | null;
   requested_by: string | null;
   resolved_by: string | null;
   created_at: number;
@@ -156,6 +162,7 @@ function mapApproval(r: RawApproval): ApprovalRow {
     inputSummary: r.input_summary,
     status: r.status as ApprovalStatus,
     omniMessageId: r.omni_message_id,
+    lastStatusGlyph: r.last_status_glyph,
     requestedBy: r.requested_by,
     resolvedBy: r.resolved_by,
     createdAt: r.created_at,
@@ -217,6 +224,61 @@ export function enqueueApproval(db: Database, fields: EnqueueApprovalFields): st
 export function attachOmniMessageId(db: Database, id: string, omniMessageId: string): void {
   const res = db.query('UPDATE approvals SET omni_message_id = ? WHERE id = ?').run(omniMessageId, id);
   if (res.changes !== 1) throw new UnknownApprovalError(id);
+}
+
+/**
+ * Record the status-ack glyph the runner just SUCCESSFULLY set on an approval's
+ * Omni message, keyed by the message id (the stanza id both the ack and inbound
+ * reactions correlate on). Advisory bookkeeping — a no-op when no row carries
+ * that message id (e.g. the row was pruned), so it never throws and never wedges
+ * the runner. This is what makes the reconciliation query
+ * ({@link listApprovalsNeedingStatusAck}) idempotent: a recorded terminal glyph
+ * stops the pass re-firing every tick.
+ */
+export function recordStatusGlyph(db: Database, omniMessageId: string, glyph: string): void {
+  db.query('UPDATE approvals SET last_status_glyph = ? WHERE omni_message_id = ?').run(glyph, omniMessageId);
+}
+
+/**
+ * Rows whose status-ack is stale: RESOLVED or EXPIRED (no longer pending),
+ * already ANNOUNCED (an omni_message_id to react on), yet whose last recorded
+ * glyph is not terminal (still ⏳, or never acked). These are the rows the runner
+ * must swap to a terminal ✅/❌ — the hook-fork-expiry race and any
+ * transport-dropped swap both land here. Oldest first.
+ *
+ * Two bounds keep this from ever sweeping history:
+ *   - the `MIGRATED_STATUS_SENTINEL` is always excluded, so the one-time upgrade
+ *     backfill's pre-upgrade closed rows are ignored;
+ *   - `resolved_at >= now - windowMs` caps the pass to RECENTLY-closed rows, so
+ *     per-tick work is bounded and long-dead history is never re-acked. The
+ *     window is deliberately generous (see the runner) so a legitimately recent
+ *     row is not dropped just because `omni serve` was briefly down.
+ *
+ * `terminalGlyphs` must be non-empty (the runner passes [✅, ❌]).
+ */
+export function listApprovalsNeedingStatusAck(
+  db: Database,
+  terminalGlyphs: string[],
+  now: number,
+  windowMs: number,
+): ApprovalRow[] {
+  if (terminalGlyphs.length === 0) return [];
+  // The migration sentinel is terminal for reconciliation purposes — a pre-upgrade
+  // closed row must never be re-acked, regardless of what the runner passes.
+  const excluded = [...terminalGlyphs, MIGRATED_STATUS_SENTINEL];
+  const placeholders = excluded.map(() => '?').join(', ');
+  const cutoff = now - windowMs;
+  const rows = db
+    .query(
+      `SELECT * FROM approvals
+       WHERE status != 'pending'
+         AND omni_message_id IS NOT NULL
+         AND (last_status_glyph IS NULL OR last_status_glyph NOT IN (${placeholders}))
+         AND resolved_at >= ?
+       ORDER BY created_at ASC`,
+    )
+    .all(...excluded, cutoff) as RawApproval[];
+  return rows.map(mapApproval);
 }
 
 /**

--- a/src/term-commands/omni.test.ts
+++ b/src/term-commands/omni.test.ts
@@ -280,6 +280,32 @@ describe('transport is not initialized without `omni serve`', () => {
   });
 });
 
+describe('omni test-approval — fake round-trip (no network)', () => {
+  /** Capture stdout during `fn`, restoring the real writer afterwards. */
+  async function captureStdout(fn: () => Promise<void>): Promise<string> {
+    const realWrite = process.stdout.write.bind(process.stdout);
+    let buffer = '';
+    process.stdout.write = ((chunk: string) => {
+      buffer += chunk;
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      await fn();
+      return buffer;
+    } finally {
+      process.stdout.write = realWrite;
+    }
+  }
+
+  test('drives one clean ⏳→✅ round-trip and prints a success line', async () => {
+    const output = await captureStdout(() => omniTest.testApprovalCommand({}));
+    expect(output).toMatch(/round-trip OK/);
+    expect(output).toMatch(/approved/);
+    // The fake path is fully offline — no NATS transport ever opened.
+    expect(natsConnectionCount()).toBe(0);
+  });
+});
+
 describe('omni handshake keypair provisioning', () => {
   test('generateAndPersistKeypair writes a 0600 private key and a raw base64url pubkey', () => {
     const home = mkdtempSync(join(tmpdir(), 'omni-hs-'));

--- a/src/term-commands/omni.test.ts
+++ b/src/term-commands/omni.test.ts
@@ -72,22 +72,36 @@ interface Published {
   payload: string;
 }
 
+interface Sent {
+  instance: string;
+  chat: string;
+  text: string;
+}
+
+/** The stanza id the fake id-returning send returns; the real Omni message id
+ *  `announce()` stores and a reaction correlates against. */
+const STANZA_ID = 'stanza-fixed-1';
+
 /**
  * Run the real handler↔runner loop once. The handler enqueues + polls; on its
- * first `sleep` we play the runner (announce + phone action), then the handler's
- * next poll observes the resolution.
+ * first `sleep` we play the runner (announce via a FAKE id-returning send, then
+ * the phone action), and the handler's next poll observes the resolution.
  */
 async function driveRoundTrip(
   db: Database,
   config: OmniRuntimeConfig,
-  phone: (runner: ReturnType<typeof createOmniRunner>, published: Published[]) => void,
+  phone: (runner: ReturnType<typeof createOmniRunner>, published: Published[], sent: Sent[]) => void,
 ): Promise<HandlerResult> {
   const published: Published[] = [];
+  const sent: Sent[] = [];
   const runner = createOmniRunner({
     db,
     config,
     publish: (subject, payload) => published.push({ subject, payload }),
-    genCorrelationId: () => 'ref-fixed-1',
+    sendApproval: async (opts) => {
+      sent.push(opts);
+      return { success: true, messageId: STANZA_ID };
+    },
   });
   let phoned = false;
   return omniApproval(PAYLOAD, {
@@ -96,8 +110,9 @@ async function driveRoundTrip(
     sleep: async () => {
       if (phoned) return;
       phoned = true;
-      runner.tick(); // announce the pending approval (records a publish)
-      phone(runner, published);
+      runner.tick(); // announce the pending approval (fires the id-returning send)
+      await runner.whenIdle(); // wait for the send to store the real stanza id
+      phone(runner, published, sent);
     },
   });
 }
@@ -106,36 +121,37 @@ describe('omni runner — five round-trips (no network)', () => {
   test('1. token-approve: inbound "yes" → allow, request announced, message stored', async () => {
     const config = rt();
     const db = freshDb();
-    let publishedRef: Published[] = [];
-    const res = await driveRoundTrip(db, config, (runner, published) => {
-      publishedRef = published;
+    let sentRef: Sent[] = [];
+    const res = await driveRoundTrip(db, config, (runner, _published, sent) => {
+      sentRef = sent;
       runner.handleMessage(
         `omni.message.${config.instance}.${config.approvalChat}`,
         JSON.stringify({ content: 'yes', chatId: config.approvalChat, sender: 'boss', instanceId: config.instance }),
       );
     });
     expect(res?.hookSpecificOutput?.permissionDecision).toBe('allow');
-    // Outbound approval-request published to the reply subject.
-    expect(publishedRef.length).toBe(1);
-    expect(publishedRef[0].subject).toBe(`omni.reply.${config.instance}.${config.approvalChat}`);
-    expect(publishedRef[0].payload).toContain('Approval Required');
+    // Approval-request sent via the id-returning send, addressed at the approval chat.
+    expect(sentRef.length).toBe(1);
+    expect(sentRef[0].chat).toBe(config.approvalChat as string);
+    expect(sentRef[0].text).toContain('Approval Required');
     // Inbound reply stored to the inbox.
     const inbox = listInbox(db);
     expect(inbox.length).toBe(1);
     expect(inbox[0].body).toBe('yes');
   });
 
-  test('2. reaction-approve: 👍 correlated by ref → allow', async () => {
+  test('2. reaction-approve: 👍 correlated by the stored stanza id → allow', async () => {
     const config = rt();
     const db = freshDb();
     const res = await driveRoundTrip(db, config, (runner) => {
-      // The runner tagged the row with genCorrelationId() = 'ref-fixed-1'.
-      runner.handleEvent(
-        'omni.event.reaction',
+      // announce() stored the REAL stanza id (STANZA_ID) the send returned; a
+      // reaction referencing it (on `omni.message.*`, not the retired
+      // `omni.event.*`) resolves this exact approval.
+      runner.handleMessage(
+        `omni.message.${config.instance}.${config.approvalChat}`,
         JSON.stringify({
-          type: 'reaction',
-          emoji: '\u{1F44D}',
-          messageId: 'ref-fixed-1',
+          content: `[Reaction: \u{1F44D} on message ${STANZA_ID}]`,
+          messageId: STANZA_ID,
           chatId: config.approvalChat,
           instanceId: config.instance,
           sender: 'boss',

--- a/src/term-commands/omni.ts
+++ b/src/term-commands/omni.ts
@@ -17,11 +17,26 @@ import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'n
 import { homedir, hostname as osHostname } from 'node:os';
 import { dirname, join, resolve as resolvePath } from 'node:path';
 import type { Command } from 'commander';
-import { isOmniApprovalEnabled, resolveOmniRuntimeConfig } from '../lib/omni-config.js';
+import {
+  DEFAULT_APPROVE_REACTIONS,
+  DEFAULT_APPROVE_TOKENS,
+  DEFAULT_DENY_REACTIONS,
+  DEFAULT_DENY_TOKENS,
+  type OmniRuntimeConfig,
+  isOmniApprovalEnabled,
+  resolveOmniRuntimeConfig,
+} from '../lib/omni-config.js';
 import { resolveOmniApiKey, resolveOmniApiUrl } from '../lib/omni-registration.js';
-import { runOmniServe } from '../lib/omni-runner.js';
+import {
+  type OmniSend,
+  type OmniSetReaction,
+  createOmniRunner,
+  makeDefaultOmniSend,
+  makeDefaultOmniSetReaction,
+  runOmniServe,
+} from '../lib/omni-runner.js';
 import { openGlobalDb } from '../lib/v5/global-db.js';
-import { listInbox } from '../lib/v5/omni-queue.js';
+import { type ApprovalRow, enqueueApproval, getApproval, listInbox } from '../lib/v5/omni-queue.js';
 
 function out(line = ''): void {
   process.stdout.write(`${line}\n`);
@@ -154,6 +169,136 @@ async function inboxCommand(opts: {
       const state = r.handledAt ? 'handled' : 'new';
       out(`[${state}] ${when} ${r.instance}/${r.chat} <${r.sender}>: ${r.body}`);
     }
+  } finally {
+    db.close();
+  }
+}
+
+// ============================================================================
+// omni test-approval — one deliberate approval round-trip (fake by default)
+// ============================================================================
+
+const TEST_STANZA_ID = 'test-approval-stanza';
+const THUMBS_UP = '\u{1F44D}';
+
+/** A minimal fully-populated runtime config for the CI-safe fake round-trip. */
+function fakeApprovalConfig(): OmniRuntimeConfig {
+  return {
+    natsUrl: 'localhost:4222',
+    instance: 'test-instance',
+    approvalChat: 'test-chat',
+    approveTokens: DEFAULT_APPROVE_TOKENS,
+    denyTokens: DEFAULT_DENY_TOKENS,
+    approveReactions: DEFAULT_APPROVE_REACTIONS,
+    denyReactions: DEFAULT_DENY_REACTIONS,
+    approvals: { enabled: true, toolMatcher: '^Bash$', pollBudgetMs: 60_000, pollIntervalMs: 400 },
+  };
+}
+
+/**
+ * Drive ONE approval round-trip against the given transport: enqueue → announce
+ * (send + ⏳) → a 👍 reaction on the stored stanza id → resolve (✅). Shared by
+ * the fake and `--live` paths; the only difference is which `sendApproval` /
+ * `setReaction` are injected. Returns the resolved row so the caller can report.
+ */
+async function driveApprovalRoundTrip(
+  db: ReturnType<typeof openGlobalDb>,
+  config: OmniRuntimeConfig,
+  sendApproval: OmniSend,
+  setReaction: OmniSetReaction,
+): Promise<ApprovalRow | null> {
+  const runner = createOmniRunner({ db, config, publish: () => {}, sendApproval, setReaction });
+  const id = enqueueApproval(db, {
+    repo: process.cwd(),
+    tool: 'TestApproval',
+    inputSummary: 'genie omni test-approval',
+  });
+
+  runner.tick(); // announce → send returns the stanza id → ⏳ status reaction
+  await runner.whenIdle();
+
+  const stanza = getApproval(db, id)?.omniMessageId;
+  if (stanza) {
+    // Simulate the human's 👍 on the approval message (correlated by stanza id).
+    runner.handleMessage(
+      `omni.message.${config.instance}.${config.approvalChat}`,
+      JSON.stringify({
+        content: `[Reaction: ${THUMBS_UP} on message ${stanza}]`,
+        messageId: stanza,
+        chatId: config.approvalChat,
+        instanceId: config.instance,
+        sender: 'test-approval',
+      }),
+    );
+    await runner.whenIdle(); // let the ✅ swap fire
+  }
+  return getApproval(db, id);
+}
+
+async function testApprovalCommand(opts: { live?: boolean }): Promise<void> {
+  if (opts.live) {
+    await runLiveTestApproval();
+    return;
+  }
+
+  // Fake, CI-safe path: in-memory DB + recording transports, zero network.
+  const db = openGlobalDb({ path: ':memory:' });
+  try {
+    const reactions: Array<{ messageId: string; emoji: string }> = [];
+    const sent: string[] = [];
+    const sendApproval: OmniSend = async ({ text }) => {
+      sent.push(text);
+      return { success: true, messageId: TEST_STANZA_ID };
+    };
+    const setReaction: OmniSetReaction = async ({ messageId, emoji }) => {
+      reactions.push({ messageId, emoji });
+      return { success: true };
+    };
+    const row = await driveApprovalRoundTrip(db, fakeApprovalConfig(), sendApproval, setReaction);
+
+    const pending = reactions.find((r) => r.emoji === '\u{23F3}');
+    const approved = reactions.find((r) => r.emoji === '\u{2705}');
+    const ok = row?.status === 'approved' && Boolean(pending) && Boolean(approved) && sent.length === 1;
+    if (!ok) {
+      fail(
+        `test-approval round-trip did not complete cleanly (status=${row?.status ?? 'none'}, ` +
+          `sends=${sent.length}, ⏳=${Boolean(pending)}, ✅=${Boolean(approved)})`,
+      );
+    }
+    out('genie omni test-approval (fake transport, no network)');
+    out(`  send:     1 approval message → stanza ${TEST_STANZA_ID}`);
+    out('  status:   ⏳ set on announce → ✅ swapped on approve');
+    out('  resolved: approved — round-trip OK');
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * ONE real approval round-trip against the configured instance/approvalChat.
+ * Emits exactly ONE real WhatsApp message plus its ⏳→✅ status reactions, then
+ * resolves it locally so the operator can eyeball the in-place swap (the sole
+ * SPIKE-c empirical unknown). Deliberate manual escape hatch — NEVER called by
+ * tests.
+ */
+async function runLiveTestApproval(): Promise<void> {
+  const rt = await resolveOmniRuntimeConfig();
+  if (!isOmniApprovalEnabled(rt)) {
+    fail(
+      'Omni approvals are not enabled. `--live` needs omni.approvals.enabled=true + omni.instance + omni.approvalChat.',
+    );
+  }
+  out('genie omni test-approval --live — sending ONE real WhatsApp approval message.');
+  const db = openGlobalDb();
+  try {
+    const row = await driveApprovalRoundTrip(db, rt, makeDefaultOmniSend(rt), makeDefaultOmniSetReaction(rt));
+    if (row?.status !== 'approved') {
+      fail(
+        `live round-trip did not resolve to approved (status=${row?.status ?? 'none'}, omniId=${row?.omniMessageId ?? 'none'})`,
+      );
+    }
+    out(`  sent + resolved on instance ${rt.instance} chat ${rt.approvalChat} (omni id ${row?.omniMessageId ?? '?'})`);
+    out('  Check WhatsApp: the approval message should show ⏳ swapped to ✅ in place.');
   } finally {
     db.close();
   }
@@ -375,6 +520,14 @@ export function registerOmniCommands(program: Command): void {
     });
 
   omni
+    .command('test-approval')
+    .description('Drive one approval round-trip (enqueue → ⏳ → approve → ✅). Fake transport by default.')
+    .option('--live', 'Send ONE real WhatsApp approval to the configured instance/approvalChat (deliberate)')
+    .action(async (opts: { live?: boolean }) => {
+      await testApprovalCommand(opts);
+    });
+
+  omni
     .command('handshake')
     .description('Register this genie host with the omni server (ed25519 keypair, idempotent)')
     .option('--rotate', 'Issue a new keypair and revoke the existing host record')
@@ -396,4 +549,5 @@ export const __test__ = {
   loadHostJson,
   writeHostJson,
   generateAndPersistKeypair,
+  testApprovalCommand,
 };

--- a/src/types/genie-config.ts
+++ b/src/types/genie-config.ts
@@ -90,10 +90,16 @@ const OmniApprovalsConfigSchema = z.object({
   pollBudgetMs: z.number().default(110_000),
   /** Poll interval while waiting for a resolution (ms). */
   pollIntervalMs: z.number().default(400),
-  /** Approve/deny text tokens (case-insensitive). Empty → runner defaults. */
+  /**
+   * Approve/deny TEXT tokens (case-insensitive). Empty → runner defaults.
+   * Put words here (`y`, `sim`), NOT emoji — an emoji placed in a token list
+   * would be echoed back by WhatsApp's bare-emoji dual-emit and could
+   * double-resolve. Emoji belong in `approveReactions`/`denyReactions` below.
+   */
   approveTokens: z.array(z.string()).optional(),
   denyTokens: z.array(z.string()).optional(),
-  /** Approve/deny reaction emoji. Empty → runner defaults. */
+  /** Approve/deny REACTION emoji (👍/👎). Empty → runner defaults. Emoji go
+   *  here, never in the `*Tokens` lists above. */
   approveReactions: z.array(z.string()).optional(),
   denyReactions: z.array(z.string()).optional(),
 });


### PR DESCRIPTION
## Summary

The v5 omni WhatsApp approval bridge is live-proven, but its live QA exposed three UX/correctness gaps. This wish (`omni-approval-ux`) closes them: approvals are now **correlated** (a reaction resolves the exact one it targets, via the real WhatsApp stanza id), **reaction-driven** (👍/👎), and **self-updating** via a **two-state ⏳→✅ acknowledgement** — genie sets ⏳ on its approval message the moment it's sent, swapping in place to ✅/❌ once you answer.

## Spike-first (0 live messages)

**G1** grounded four unknowns against the *running* Omni build with **zero live traffic** (all source-proven): reactions arrive on `omni.message.{instance}.{chatId}` (the assumed `omni.event.>` has **zero publishers** — the QA disproof); the send returns the stanza id; outbound set-reaction is **GO** (with a documented fallback); text replies carry no quoted id (so bare text stays an honest oldest-fallback).

## What shipped

- **G2 — correlated identity + reactions:** `announce()` now sends via an injectable seam and stores the **real stanza id** (retiring a self-referential `genId()` ref that matched nothing); reactions parse off `omni.message.*`, correlate 👍/👎 to the exact approval, dedupe the dual-emit echo; dead `omni.event.>` retired.
- **G3 — ⏳→✅ lifecycle:** ⏳ on send → ✅/❌ on resolve/expire via an injectable set-reaction seam (fallback = one-seam swap). A **reconciliation pass** makes the runner the *authoritative* acker regardless of which process expired the row — curing a stuck-⏳ hook-fork race **and** transport-dropped swaps. Plus `genie omni test-approval` (fake default, `--live`) and a `genie doctor` hook-timeout guardrail. New `last_status_glyph` column (additive, **no `user_version` bump** — a bump would brick existing DBs; one-time migration backfill + 24h recency cap so upgrade never sweeps history).

## Review rigor

Every group was independently reviewed; G3's reviews found and closed **two real HIGHs** (a stuck ⏳ on the timeout path, and a reconcile sweep of historical rows on upgrade) before ship — both would have silently violated the wish's own promises (live-state accuracy, anti-spam). One LOW residual noted (a pending-with-bogus-id row caught at the exact upgrade instant — 0–few rows, self-limiting, no real traffic).

## Anti-spam guarantee

The automated suite emits **zero** live WhatsApp traffic (injectable fakes; `--live` is a documented manual escape hatch never called by tests). The G1 spike sent 0 messages.

## Needs your eyes — one live confirmation

Everything is source-proven, but the ⏳→✅ **in-place render** (does WhatsApp swap the emoji visually?) is the sole empirical unknown. I'll run **one** labelled round-trip between your own numbers to confirm — the fallback (message-edit / status-reply) covers it if the swap doesn't render.

## Gates

Full `bun run check` **628 pass / 0**; build green; `omni test-approval` prints the ⏳→✅ round-trip; complexity budget + biome clean.

Merge decision: Felipe.