### PR TITLE
fix(mcp): a bare 'null' JSON-RPC line must not crash the server

### DIFF
--- a/src/term-commands/mcp.test.ts
+++ b/src/term-commands/mcp.test.ts
@@ -79,6 +79,25 @@ async function driveMcp(cwd: string, requests: Record<string, unknown>[]): Promi
     .map((l) => JSON.parse(l) as RpcResponse);
 }
 
+/** Like driveMcp but sends raw (already-serialized) lines — for malformed input. */
+async function driveMcpRaw(cwd: string, rawLines: string[]): Promise<RpcResponse[]> {
+  const proc = Bun.spawn(['bun', GENIE, 'mcp'], {
+    cwd,
+    stdin: 'pipe',
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: { ...process.env, NO_COLOR: '1', GENIE_TEST_SKIP_PGSERVE: '1' },
+  });
+  proc.stdin.write(`${rawLines.join('\n')}\n`);
+  await proc.stdin.end();
+  const stdout = await new Response(proc.stdout).text();
+  await proc.exited;
+  return stdout
+    .split('\n')
+    .filter((l) => l.trim().length > 0)
+    .map((l) => JSON.parse(l) as RpcResponse);
+}
+
 const INIT = {
   jsonrpc: '2.0',
   id: 1,
@@ -108,6 +127,14 @@ function seed(cwd: string): { taskId: string } {
 // ============================================================================
 
 describe('mcp handshake', () => {
+  test('a bare `null` / primitive line is dropped and does not crash the server', async () => {
+    // `JSON.parse('null')` is valid JSON but not a JSON-RPC object; without the
+    // non-object guard, dispatch(null) throws on null.id and the server crashes.
+    const res = await driveMcpRaw(repo, ['null', '5', 'true', '"str"', JSON.stringify(INIT)]);
+    // The malformed lines are silently dropped; the server survives + answers initialize.
+    expect(res.some((r) => r.id === 1 && (r.result as { serverInfo?: unknown })?.serverInfo)).toBe(true);
+  });
+
   test('initialize replies with protocolVersion, tools capability, and serverInfo', async () => {
     const [res] = await driveMcp(repo, [INIT]);
     expect(res.id).toBe(1);

--- a/src/term-commands/mcp.ts
+++ b/src/term-commands/mcp.ts
@@ -144,6 +144,11 @@ export async function runMcpServer(): Promise<void> {
       // Unparseable line → cannot attribute an id; drop it (no id to reply to).
       return;
     }
+    // A JSON-RPC request must be a non-null object. `JSON.parse('null')` and bare
+    // primitives are valid JSON but carry no id to attribute — drop them like an
+    // unparseable line. Without this, `dispatch(null)` (and the catch below) throw
+    // on `null.id`, and the uncaught error crashes the server on a `null` line.
+    if (req === null || typeof req !== 'object') return;
     try {
       dispatch(req);
     } catch (e) {


### PR DESCRIPTION
## Finding (Gemini review on #2510, HIGH)

`src/term-commands/mcp.ts` — the newline JSON-RPC loop parses each line with `JSON.parse`, catching only *parse* errors. But `JSON.parse('null')` is **valid JSON** returning `null`: `req` becomes `null`, `dispatch(null)` throws accessing `null.id` (mcp.ts:105), and the `catch (e)` handler *also* reads `req.id` on `null` → a second, **uncaught** TypeError → the stdio MCP server crashes on a single `null` line. (Bare primitives like `5`/`true` reach `dispatch` harmlessly — only `null` crashes — but the guard covers all non-objects.)

## Fix

After a successful parse, drop any value that isn't a non-null object — it can't be a JSON-RPC request and carries no id to attribute, exactly like an unparseable line:

```ts
if (req === null || typeof req !== 'object') return;
```

## Test

New regression drives raw `null` / `5` / `true` / `"str"` lines followed by a valid `initialize` and asserts the server **survives + answers initialize** (previously it crashed on the `null` line). Verified against the built `dist/genie.js` too.

Gates: `bun run check` green; typecheck clean; 15 mcp tests pass.