### PR TITLE
fix(doctor): enforce strictly-below hook-timeout contract at the boundary

### DIFF
--- a/src/genie-commands/doctor.test.ts
+++ b/src/genie-commands/doctor.test.ts
@@ -102,8 +102,16 @@ describe('omni hook-timeout guardrail', () => {
   test('warns when the hook timeout is below pollBudgetMs', () => {
     const res = evaluateOmniHookTimeout({ enabled: true, pollBudgetMs: 110_000, timeoutSec: 5 });
     expect(res?.status).toBe('warn');
-    expect(res?.detail).toContain('< pollBudget');
+    expect(res?.detail).toContain('≤ pollBudget');
     expect(res?.suggestion).toContain('120');
+  });
+
+  test('warns at the exact boundary (timeoutMs === pollBudgetMs — strictly-below contract)', () => {
+    // 110s → 110_000ms === pollBudget: no margin, so the strict contract must warn.
+    const res = evaluateOmniHookTimeout({ enabled: true, pollBudgetMs: 110_000, timeoutSec: 110 });
+    expect(res?.status).toBe('warn');
+    // smallest safe whole-second timeout strictly exceeds the budget → 111s.
+    expect(res?.suggestion).toContain('111');
   });
 
   test('warns when approvals are enabled but no dispatch timeout is found', () => {
@@ -112,9 +120,10 @@ describe('omni hook-timeout guardrail', () => {
     expect(res?.detail).toContain('no `genie hook dispatch`');
   });
 
-  test('passes when the hook timeout meets or exceeds pollBudgetMs', () => {
+  test('passes when the hook timeout strictly exceeds pollBudgetMs', () => {
     const res = evaluateOmniHookTimeout({ enabled: true, pollBudgetMs: 110_000, timeoutSec: 120 });
     expect(res?.status).toBe('pass');
+    expect(res?.detail).toContain('> pollBudget');
   });
 
   test('emits no check when omni approvals are disabled', () => {

--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -235,8 +235,10 @@ export function evaluateOmniHookTimeout(params: {
   timeoutSec: number | null;
 }): CheckResult | null {
   if (!params.enabled) return null;
-  const name = 'omni hook timeout ≥ pollBudget';
-  const needSec = Math.ceil(params.pollBudgetMs / 1000);
+  const name = 'omni hook timeout > pollBudget';
+  // pollBudgetMs MUST stay STRICTLY below the hook timeout (genie-config.ts), so
+  // the smallest safe whole-second timeout is the first that exceeds pollBudgetMs.
+  const needSec = Math.floor(params.pollBudgetMs / 1000) + 1;
   if (params.timeoutSec === null) {
     return {
       name,
@@ -246,15 +248,21 @@ export function evaluateOmniHookTimeout(params: {
     };
   }
   const timeoutMs = params.timeoutSec * 1000;
-  if (timeoutMs < params.pollBudgetMs) {
+  // At timeoutMs === pollBudgetMs there is no margin — CC can kill the hook the
+  // instant the poll budget expires — so the strict contract warns on equal too.
+  if (timeoutMs <= params.pollBudgetMs) {
     return {
       name,
       status: 'warn',
-      detail: `hook timeout ${params.timeoutSec}s (${timeoutMs}ms) < pollBudget ${params.pollBudgetMs}ms — CC will kill the hook before it can allow/deny or reach its ask fail-safe`,
+      detail: `hook timeout ${params.timeoutSec}s (${timeoutMs}ms) ≤ pollBudget ${params.pollBudgetMs}ms — CC may kill the hook before it can allow/deny or reach its ask fail-safe`,
       suggestion: `Raise the PreToolUse \`genie hook dispatch\` timeout to ≥ ${needSec}s (e.g. 120) in ~/.claude/settings.json.`,
     };
   }
-  return { name, status: 'pass', detail: `hook timeout ${params.timeoutSec}s ≥ pollBudget ${params.pollBudgetMs}ms` };
+  return {
+    name,
+    status: 'pass',
+    detail: `hook timeout ${params.timeoutSec}s (${timeoutMs}ms) > pollBudget ${params.pollBudgetMs}ms`,
+  };
 }
 
 async function checkOmniHookTimeout(): Promise<CheckResult[]> {


### PR DESCRIPTION
## Finding (CodeRabbit on #2510)

`src/genie-commands/doctor.ts` — the omni hook-timeout guardrail warned only when `timeoutMs < pollBudgetMs` and **passed** at `timeoutMs === pollBudgetMs`. But `src/types/genie-config.ts` documents that `pollBudgetMs` **MUST stay strictly below** the hook timeout: at exactly equal there is **no margin** — Claude Code can kill the hook the instant the poll budget expires, before it can allow/deny or reach its ask fail-safe.

## Fix

- Warn on `timeoutMs <= pollBudgetMs` (equal now warns); reword `<`/`≥` → `≤`/`>`.
- `needSec = floor(pollBudgetMs/1000) + 1` — the smallest whole-second timeout that **strictly** exceeds the budget (was `ceil`, which for the default 110 000 ms suggested `110s` that still *equals* it).

## Test

Added the exact-boundary case CodeRabbit flagged as missing (`timeoutSec: 110`, `pollBudgetMs: 110_000` → warn, suggests `111s`); the pass test now requires strict `>`.

Gates: 14 doctor tests pass; `bun run check` + build green.