### PR TITLE
feat(omni): Model A — persona + session + streaming + ⏳→✅ ack for genie omni serve

### DIFF
--- a/src/lib/omni-config.ts
+++ b/src/lib/omni-config.ts
@@ -38,6 +38,12 @@ export interface OmniRoute {
   instance: string;
   chat: string;
   repo: string;
+  /**
+   * Absolute path to a persona / AGENTS.md file appended to the agent's system
+   * prompt for this route's runs. Omitted → the runner falls back to
+   * `<repo>/AGENTS.md` if it exists, else no persona.
+   */
+  persona?: string;
 }
 
 /**

--- a/src/lib/omni-runner.test.ts
+++ b/src/lib/omni-runner.test.ts
@@ -15,12 +15,14 @@ import { join } from 'node:path';
 import type { OmniRuntimeConfig } from './omni-config.js';
 import {
   type OmniSend,
+  type RawClaudeSpawn,
   type SpawnClaude,
   type SpawnClaudeResult,
   buildClaudeArgs,
   createOmniRunner,
   deterministicSessionId,
   extractStreamJsonReply,
+  runClaudeSession,
 } from './omni-runner.js';
 import { openGlobalDb } from './v5/global-db.js';
 import { enqueueApproval, getApproval, listInbox } from './v5/omni-queue.js';
@@ -616,8 +618,13 @@ describe('omni runner — status-ack reconciliation (hook-fork-expiry race)', ()
 // session-id derivation. Pure functions, no runner / fork / HTTP.
 // ---------------------------------------------------------------------------
 describe('buildClaudeArgs — Model A argv contract', () => {
-  test('streams stream-json under a session id, appends the persona when present', () => {
-    const args = buildClaudeArgs({ message: 'hi', sessionId: 'sess-1', personaFile: '/repo/AGENTS.md' });
+  test('create mode binds --session-id, streams stream-json, appends the persona', () => {
+    const args = buildClaudeArgs({
+      message: 'hi',
+      sessionId: 'sess-1',
+      personaFile: '/repo/AGENTS.md',
+      mode: 'create',
+    });
     expect(args).toEqual([
       '-p',
       '--output-format',
@@ -631,8 +638,15 @@ describe('buildClaudeArgs — Model A argv contract', () => {
     ]);
   });
 
+  test('resume mode binds --resume (not --session-id)', () => {
+    const args = buildClaudeArgs({ message: 'again', sessionId: 'sess-1', mode: 'resume' });
+    expect(args).toContain('--resume');
+    expect(args).not.toContain('--session-id');
+    expect(args[args.indexOf('--resume') + 1]).toBe('sess-1');
+  });
+
   test('omits the persona flag when no persona file is resolved; message stays last', () => {
-    const args = buildClaudeArgs({ message: 'hello there', sessionId: 'sess-2' });
+    const args = buildClaudeArgs({ message: 'hello there', sessionId: 'sess-2', mode: 'create' });
     expect(args).not.toContain('--append-system-prompt-file');
     expect(args).toContain('--session-id');
     expect(args).toContain('stream-json');
@@ -645,9 +659,9 @@ describe('extractStreamJsonReply — stream-json parsing', () => {
     const nd = [
       JSON.stringify({ type: 'system', subtype: 'init', session_id: 'x' }),
       JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'thinking…' }] } }),
-      JSON.stringify({ type: 'result', subtype: 'success', result: 'THE FINAL ANSWER' }),
+      JSON.stringify({ type: 'result', subtype: 'success', is_error: false, result: 'THE FINAL ANSWER' }),
     ].join('\n');
-    expect(extractStreamJsonReply(nd)).toBe('THE FINAL ANSWER');
+    expect(extractStreamJsonReply(nd)).toEqual({ reply: 'THE FINAL ANSWER', isError: false });
   });
 
   test('falls back to concatenated assistant text when there is no success result', () => {
@@ -655,11 +669,90 @@ describe('extractStreamJsonReply — stream-json parsing', () => {
       JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'Hello ' }] } }),
       JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'world' }] } }),
     ].join('\n');
-    expect(extractStreamJsonReply(nd)).toBe('Hello world');
+    expect(extractStreamJsonReply(nd)).toEqual({ reply: 'Hello world', isError: false });
   });
 
   test('falls back to the raw stdout when the output is not stream-json at all', () => {
-    expect(extractStreamJsonReply('plain non-json output')).toBe('plain non-json output');
+    expect(extractStreamJsonReply('plain non-json output')).toEqual({ reply: 'plain non-json output', isError: false });
+  });
+
+  test('flags is_error on an error terminal result and never returns the raw NDJSON blob', () => {
+    const nd = [
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'partial' }] } }),
+      JSON.stringify({ type: 'result', subtype: 'error_max_turns', is_error: true, result: 'hit max turns' }),
+    ].join('\n');
+    const parsed = extractStreamJsonReply(nd);
+    expect(parsed.isError).toBe(true);
+    expect(parsed.reply).not.toContain('"type":"result"'); // never the raw blob
+  });
+
+  test('flags an empty success result as an error (no happy blank reply)', () => {
+    const nd = JSON.stringify({ type: 'result', subtype: 'success', is_error: false, result: '' });
+    expect(extractStreamJsonReply(nd).isError).toBe(true);
+  });
+});
+
+describe('runClaudeSession — resume-first session continuity', () => {
+  const noSignal = () => new AbortController().signal;
+  const successNd = (text: string) =>
+    JSON.stringify({ type: 'result', subtype: 'success', is_error: false, result: text });
+  const base = { message: 'm', cwd: '/repo', sessionId: 'sess-x' };
+
+  test('turn 2+ (session exists): resume succeeds in ONE spawn, no create', async () => {
+    const calls: string[][] = [];
+    const rawSpawn: RawClaudeSpawn = async (args) => {
+      calls.push(args);
+      return { stdout: successNd('RESUMED'), stderr: '', exitCode: 0 };
+    };
+    const res = await runClaudeSession({ ...base, signal: noSignal() }, rawSpawn);
+    expect(res).toEqual({ stdout: 'RESUMED', exitCode: 0, isError: false });
+    expect(calls.length).toBe(1);
+    expect(calls[0]).toContain('--resume');
+  });
+
+  test('turn 1 (no session): resume reports missing → falls back to --session-id create', async () => {
+    const calls: string[][] = [];
+    const rawSpawn: RawClaudeSpawn = async (args) => {
+      calls.push(args);
+      if (args.includes('--resume')) {
+        return { stdout: '', stderr: 'No conversation found with session ID: sess-x', exitCode: 1 };
+      }
+      return { stdout: successNd('CREATED'), stderr: '', exitCode: 0 };
+    };
+    const res = await runClaudeSession({ ...base, signal: noSignal() }, rawSpawn);
+    expect(res.stdout).toBe('CREATED');
+    expect(res.exitCode).toBe(0);
+    expect(calls.length).toBe(2);
+    expect(calls[0]).toContain('--resume');
+    expect(calls[1]).toContain('--session-id');
+  });
+
+  test('regression: resume-first never re-triggers "already in use" (session-id would fail, resume wins)', async () => {
+    // Models the LIVE-verified CRITICAL: a second --session-id on an existing id
+    // exits 1 "already in use". Resume-first must reach the session via --resume
+    // and NEVER re-issue --session-id.
+    const calls: string[][] = [];
+    const rawSpawn: RawClaudeSpawn = async (args) => {
+      calls.push(args);
+      if (args.includes('--session-id')) {
+        return { stdout: '', stderr: 'Error: Session ID sess-x is already in use.', exitCode: 1 };
+      }
+      return { stdout: successNd('RESUMED'), stderr: '', exitCode: 0 };
+    };
+    const res = await runClaudeSession({ ...base, signal: noSignal() }, rawSpawn);
+    expect(res.stdout).toBe('RESUMED');
+    expect(calls.every((a) => !a.includes('--session-id'))).toBe(true);
+  });
+
+  test('a resume failure that is NOT a missing session is surfaced as-is (no create fallback)', async () => {
+    const calls: string[][] = [];
+    const rawSpawn: RawClaudeSpawn = async (args) => {
+      calls.push(args);
+      return { stdout: '', stderr: 'Error: something else entirely', exitCode: 1 };
+    };
+    const res = await runClaudeSession({ ...base, signal: noSignal() }, rawSpawn);
+    expect(res.exitCode).toBe(1);
+    expect(calls.length).toBe(1); // never fell back to create
   });
 });
 
@@ -778,6 +871,29 @@ describe('omni runner — Model A route-scoped run acks (⏳→✅/❌)', () => 
     expect(reactions.map((r) => r.emoji)).toEqual([HOURGLASS, CROSS]);
   });
 
+  test('a soft-error result (exit 0 but isError) publishes an error notice + ❌, not the reply + ✅', async () => {
+    const db = freshDb();
+    const published: Published[] = [];
+    const reactions: RouteReactionCall[] = [];
+    const runner = createOmniRunner({
+      db,
+      config: rt(),
+      publish: (subject, payload) => published.push({ subject, payload }),
+      // exit 0 but the terminal result was an error — must NOT publish `stdout` as ✅.
+      spawnClaude: async () => ({ stdout: 'hit max turns', exitCode: 0, isError: true }),
+      setReaction: async ({ instance, chat, messageId, emoji }) => {
+        reactions.push({ instance, chat, messageId, emoji });
+        return { success: true };
+      },
+    });
+
+    runner.handleMessage(...mappedInboundWithId('soft-error', 'wamid-e'));
+    await runner.whenIdle();
+
+    expect(content(published[0])).toContain('failed'); // errorNotice, not the raw reply
+    expect(reactions.map((r) => r.emoji)).toEqual([HOURGLASS, CROSS]);
+  });
+
   test('sets NO reaction when the inbound carries no messageId', async () => {
     const db = freshDb();
     const reactions: RouteReactionCall[] = [];
@@ -839,21 +955,41 @@ describe('omni runner — Model A persona + session threading', () => {
   }
 
   test('threads a stable session id (same across messages) and the explicit route persona', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'genie-omni-explicit-'));
+    try {
+      const persona = join(dir, 'persona-A.md');
+      writeFileSync(persona, '# persona A');
+      const db = freshDb();
+      const seen: SeenSpawn[] = [];
+      const runner = threadingRunner(db, seen, [{ instance: INSTANCE, chat: ROUTE_CHAT, repo: ROUTE_REPO, persona }]);
+
+      runner.handleMessage(...mappedInboundWithId('m1', 'id1'));
+      await runner.whenIdle();
+      runner.handleMessage(...mappedInboundWithId('m2', 'id2'));
+      await runner.whenIdle();
+
+      expect(seen.length).toBe(2);
+      expect(seen[0].personaFile).toBe(persona);
+      expect(seen[0].sessionId).toBe(deterministicSessionId(INSTANCE, ROUTE_CHAT));
+      // Stable session id ⇒ the conversation resumes across messages.
+      expect(seen[1].sessionId).toBe(seen[0].sessionId);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('drops a typo’d explicit route.persona that does not exist (never passes it to claude)', async () => {
     const db = freshDb();
     const seen: SeenSpawn[] = [];
-    const persona = '/tmp/persona-A.md';
-    const runner = threadingRunner(db, seen, [{ instance: INSTANCE, chat: ROUTE_CHAT, repo: ROUTE_REPO, persona }]);
+    const missing = join(tmpdir(), 'genie-omni-does-not-exist', 'persona.md');
+    const runner = threadingRunner(db, seen, [
+      { instance: INSTANCE, chat: ROUTE_CHAT, repo: ROUTE_REPO, persona: missing },
+    ]);
 
-    runner.handleMessage(...mappedInboundWithId('m1', 'id1'));
-    await runner.whenIdle();
-    runner.handleMessage(...mappedInboundWithId('m2', 'id2'));
+    runner.handleMessage(...mappedInboundWithId('m', 'id'));
     await runner.whenIdle();
 
-    expect(seen.length).toBe(2);
-    expect(seen[0].personaFile).toBe(persona);
-    expect(seen[0].sessionId).toBe(deterministicSessionId(INSTANCE, ROUTE_CHAT));
-    // Stable session id ⇒ the conversation resumes across messages.
-    expect(seen[1].sessionId).toBe(seen[0].sessionId);
+    expect(seen[0].personaFile).toBeUndefined();
   });
 
   test('falls back to <repo>/AGENTS.md when route.persona is unset', async () => {

--- a/src/lib/omni-runner.test.ts
+++ b/src/lib/omni-runner.test.ts
@@ -9,8 +9,19 @@
  */
 import type { Database } from 'bun:sqlite';
 import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { OmniRuntimeConfig } from './omni-config.js';
-import { type OmniSend, type SpawnClaude, type SpawnClaudeResult, createOmniRunner } from './omni-runner.js';
+import {
+  type OmniSend,
+  type SpawnClaude,
+  type SpawnClaudeResult,
+  buildClaudeArgs,
+  createOmniRunner,
+  deterministicSessionId,
+  extractStreamJsonReply,
+} from './omni-runner.js';
 import { openGlobalDb } from './v5/global-db.js';
 import { enqueueApproval, getApproval, listInbox } from './v5/omni-queue.js';
 
@@ -597,5 +608,284 @@ describe('omni runner — status-ack reconciliation (hook-fork-expiry race)', ()
     await runner.whenIdle();
     expect(getApproval(db, a)?.lastStatusGlyph).toBe(CHECK);
     expect(reactions[reactions.length - 1]).toEqual({ messageId: 'stanza-A', emoji: CHECK });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Model A pure helpers — argv contract, stream-json parsing, and the stable
+// session-id derivation. Pure functions, no runner / fork / HTTP.
+// ---------------------------------------------------------------------------
+describe('buildClaudeArgs — Model A argv contract', () => {
+  test('streams stream-json under a session id, appends the persona when present', () => {
+    const args = buildClaudeArgs({ message: 'hi', sessionId: 'sess-1', personaFile: '/repo/AGENTS.md' });
+    expect(args).toEqual([
+      '-p',
+      '--output-format',
+      'stream-json',
+      '--verbose',
+      '--session-id',
+      'sess-1',
+      '--append-system-prompt-file',
+      '/repo/AGENTS.md',
+      'hi',
+    ]);
+  });
+
+  test('omits the persona flag when no persona file is resolved; message stays last', () => {
+    const args = buildClaudeArgs({ message: 'hello there', sessionId: 'sess-2' });
+    expect(args).not.toContain('--append-system-prompt-file');
+    expect(args).toContain('--session-id');
+    expect(args).toContain('stream-json');
+    expect(args[args.length - 1]).toBe('hello there');
+  });
+});
+
+describe('extractStreamJsonReply — stream-json parsing', () => {
+  test('prefers the terminal result success text over partial assistant deltas', () => {
+    const nd = [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'x' }),
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'thinking…' }] } }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'THE FINAL ANSWER' }),
+    ].join('\n');
+    expect(extractStreamJsonReply(nd)).toBe('THE FINAL ANSWER');
+  });
+
+  test('falls back to concatenated assistant text when there is no success result', () => {
+    const nd = [
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'Hello ' }] } }),
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'world' }] } }),
+    ].join('\n');
+    expect(extractStreamJsonReply(nd)).toBe('Hello world');
+  });
+
+  test('falls back to the raw stdout when the output is not stream-json at all', () => {
+    expect(extractStreamJsonReply('plain non-json output')).toBe('plain non-json output');
+  });
+});
+
+describe('deterministicSessionId — stable per conversation', () => {
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+  test('is stable for the same (instance, chat) and a valid v5-shaped uuid', () => {
+    const a = deterministicSessionId(INSTANCE, ROUTE_CHAT);
+    expect(a).toBe(deterministicSessionId(INSTANCE, ROUTE_CHAT));
+    expect(a).toMatch(UUID_RE);
+  });
+
+  test('differs when the chat (or instance) differs', () => {
+    const base = deterministicSessionId(INSTANCE, ROUTE_CHAT);
+    expect(deterministicSessionId(INSTANCE, 'other-chat')).not.toBe(base);
+    expect(deterministicSessionId('other-instance', ROUTE_CHAT)).not.toBe(base);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Model A route-scoped run acks (⏳→✅/❌) + persona / session threading. Every
+// test injects a FAKE spawnClaude AND a FAKE setReaction — zero fork, zero HTTP.
+// ---------------------------------------------------------------------------
+interface RouteReactionCall {
+  instance: string;
+  chat: string;
+  messageId: string;
+  emoji: string;
+}
+
+/** An inbound frame on the mapped route carrying a WhatsApp stanza id. */
+function mappedInboundWithId(body: string, messageId: string, chat = ROUTE_CHAT): [string, string] {
+  return [
+    `omni.message.${INSTANCE}.${chat}`,
+    JSON.stringify({ content: body, chatId: chat, sender: 'boss', instanceId: INSTANCE, messageId }),
+  ];
+}
+
+describe('omni runner — Model A route-scoped run acks (⏳→✅/❌)', () => {
+  test('sets ⏳ before the spawn and ✅ after a successful reply, route-scoped to the inbound id', async () => {
+    const db = freshDb();
+    const reactions: RouteReactionCall[] = [];
+    const order: string[] = [];
+    const runner = createOmniRunner({
+      db,
+      config: rt(),
+      publish: () => order.push('publish'),
+      spawnClaude: async () => {
+        order.push('spawn');
+        return { stdout: 'agent reply', exitCode: 0 };
+      },
+      setReaction: async ({ instance, chat, messageId, emoji }) => {
+        reactions.push({ instance, chat, messageId, emoji });
+        order.push(`react:${emoji}`);
+        return { success: true };
+      },
+    });
+
+    runner.handleMessage(...mappedInboundWithId('do it', 'wamid-1'));
+    await runner.whenIdle();
+
+    // ⏳ then ✅, both on the INBOUND stanza id and the ROUTE's (instance, chat).
+    expect(reactions.map((r) => r.emoji)).toEqual([HOURGLASS, CHECK]);
+    for (const r of reactions) {
+      expect(r.instance).toBe(INSTANCE);
+      expect(r.chat).toBe(ROUTE_CHAT);
+      expect(r.messageId).toBe('wamid-1');
+    }
+    // ⏳ strictly before the spawn; ✅ strictly after the reply is published.
+    expect(order.indexOf(`react:${HOURGLASS}`)).toBeLessThan(order.indexOf('spawn'));
+    expect(order.indexOf(`react:${CHECK}`)).toBeGreaterThan(order.indexOf('publish'));
+  });
+
+  test('sets ❌ on a non-zero exit', async () => {
+    const db = freshDb();
+    const reactions: RouteReactionCall[] = [];
+    const runner = createOmniRunner({
+      db,
+      config: rt(),
+      publish: () => {},
+      spawnClaude: async () => ({ stdout: 'ignored', exitCode: 2 }),
+      setReaction: async ({ instance, chat, messageId, emoji }) => {
+        reactions.push({ instance, chat, messageId, emoji });
+        return { success: true };
+      },
+    });
+
+    runner.handleMessage(...mappedInboundWithId('bad run', 'wamid-2'));
+    await runner.whenIdle();
+
+    expect(reactions.map((r) => r.emoji)).toEqual([HOURGLASS, CROSS]);
+    expect(reactions[reactions.length - 1].messageId).toBe('wamid-2');
+  });
+
+  test('sets ❌ on a timeout', async () => {
+    const db = freshDb();
+    const reactions: RouteReactionCall[] = [];
+    const runner = createOmniRunner({
+      db,
+      config: rt({ inboundTimeoutMs: 10 }),
+      publish: () => {},
+      // Honour the abort so the timeout wins cleanly.
+      spawnClaude: ({ signal }) =>
+        new Promise<SpawnClaudeResult>((_, reject) => {
+          signal.addEventListener('abort', () => reject(new Error('killed')), { once: true });
+        }),
+      setReaction: async ({ instance, chat, messageId, emoji }) => {
+        reactions.push({ instance, chat, messageId, emoji });
+        return { success: true };
+      },
+    });
+
+    runner.handleMessage(...mappedInboundWithId('slow', 'wamid-3'));
+    await runner.whenIdle();
+
+    expect(reactions.map((r) => r.emoji)).toEqual([HOURGLASS, CROSS]);
+  });
+
+  test('sets NO reaction when the inbound carries no messageId', async () => {
+    const db = freshDb();
+    const reactions: RouteReactionCall[] = [];
+    const runner = createOmniRunner({
+      db,
+      config: rt(),
+      publish: () => {},
+      spawnClaude: async () => ({ stdout: 'ok', exitCode: 0 }),
+      setReaction: async ({ instance, chat, messageId, emoji }) => {
+        reactions.push({ instance, chat, messageId, emoji });
+        return { success: true };
+      },
+    });
+
+    // mappedInbound (no messageId) still spawns + replies, but never reacts.
+    runner.handleMessage(...mappedInbound('no stanza id'));
+    await runner.whenIdle();
+
+    expect(reactions).toEqual([]);
+  });
+
+  test('a failed status reaction never throws or blocks the run/publish', async () => {
+    const db = freshDb();
+    const published: Published[] = [];
+    const runner = createOmniRunner({
+      db,
+      config: rt(),
+      publish: (subject, payload) => published.push({ subject, payload }),
+      spawnClaude: async () => ({ stdout: 'still replies', exitCode: 0 }),
+      setReaction: async () => ({ success: false, error: 'boom' }),
+    });
+
+    runner.handleMessage(...mappedInboundWithId('react-fails', 'wamid-4'));
+    await runner.whenIdle();
+
+    // The reply is published regardless of the reaction outcome.
+    expect(published.length).toBe(1);
+    expect(content(published[0])).toBe('still replies');
+  });
+});
+
+describe('omni runner — Model A persona + session threading', () => {
+  interface SeenSpawn {
+    cwd: string;
+    sessionId?: string;
+    personaFile?: string;
+  }
+
+  function threadingRunner(db: Database, seen: SeenSpawn[], routes?: OmniRuntimeConfig['routes']) {
+    return createOmniRunner({
+      db,
+      config: rt(routes ? { routes } : {}),
+      publish: () => {},
+      spawnClaude: async ({ cwd, sessionId, personaFile }) => {
+        seen.push({ cwd, sessionId, personaFile });
+        return { stdout: 'ok', exitCode: 0 };
+      },
+    });
+  }
+
+  test('threads a stable session id (same across messages) and the explicit route persona', async () => {
+    const db = freshDb();
+    const seen: SeenSpawn[] = [];
+    const persona = '/tmp/persona-A.md';
+    const runner = threadingRunner(db, seen, [{ instance: INSTANCE, chat: ROUTE_CHAT, repo: ROUTE_REPO, persona }]);
+
+    runner.handleMessage(...mappedInboundWithId('m1', 'id1'));
+    await runner.whenIdle();
+    runner.handleMessage(...mappedInboundWithId('m2', 'id2'));
+    await runner.whenIdle();
+
+    expect(seen.length).toBe(2);
+    expect(seen[0].personaFile).toBe(persona);
+    expect(seen[0].sessionId).toBe(deterministicSessionId(INSTANCE, ROUTE_CHAT));
+    // Stable session id ⇒ the conversation resumes across messages.
+    expect(seen[1].sessionId).toBe(seen[0].sessionId);
+  });
+
+  test('falls back to <repo>/AGENTS.md when route.persona is unset', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'genie-omni-persona-'));
+    try {
+      writeFileSync(join(dir, 'AGENTS.md'), '# persona');
+      const db = freshDb();
+      const seen: SeenSpawn[] = [];
+      const runner = threadingRunner(db, seen, [{ instance: INSTANCE, chat: ROUTE_CHAT, repo: dir }]);
+
+      runner.handleMessage(...mappedInboundWithId('m', 'id'));
+      await runner.whenIdle();
+
+      expect(seen[0].personaFile).toBe(join(dir, 'AGENTS.md'));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('resolves no persona when neither route.persona nor <repo>/AGENTS.md exists', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'genie-omni-nopersona-'));
+    try {
+      const db = freshDb();
+      const seen: SeenSpawn[] = [];
+      const runner = threadingRunner(db, seen, [{ instance: INSTANCE, chat: ROUTE_CHAT, repo: dir }]);
+
+      runner.handleMessage(...mappedInboundWithId('m', 'id'));
+      await runner.whenIdle();
+
+      expect(seen[0].personaFile).toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/lib/omni-runner.test.ts
+++ b/src/lib/omni-runner.test.ts
@@ -754,6 +754,20 @@ describe('runClaudeSession — resume-first session continuity', () => {
     expect(res.exitCode).toBe(1);
     expect(calls.length).toBe(1); // never fell back to create
   });
+
+  test('a generic "… not found" resume failure is NOT treated as a missing session', async () => {
+    // The session EXISTS; some other resource is missing. A bare "not found" must
+    // not trigger a --session-id create (which would then error "already in use").
+    const calls: string[][] = [];
+    const rawSpawn: RawClaudeSpawn = async (args) => {
+      calls.push(args);
+      return { stdout: '', stderr: 'Error: model "sonnet-99" not found', exitCode: 1 };
+    };
+    const res = await runClaudeSession({ ...base, signal: noSignal() }, rawSpawn);
+    expect(res.exitCode).toBe(1);
+    expect(calls.length).toBe(1); // resume only — no spurious create
+    expect(calls[0]).toContain('--resume');
+  });
 });
 
 describe('deterministicSessionId — stable per conversation', () => {

--- a/src/lib/omni-runner.ts
+++ b/src/lib/omni-runner.ts
@@ -437,8 +437,8 @@ export function makeDefaultOmniSetReaction(config: OmniRuntimeConfig): OmniSetRe
   return async ({ instance, chat, messageId, emoji }) => {
     const apiUrl = config.apiUrl;
     if (!apiUrl) return { success: false, error: 'omni apiUrl not configured' };
-    const path = '/api/v2/messages';
-    const bodyJson = JSON.stringify({ instanceId: instance, chatId: chat, reaction: emoji, messageId });
+    const path = '/api/v2/messages/send/reaction';
+    const bodyJson = JSON.stringify({ instanceId: instance, to: chat, messageId, emoji });
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
     if (config.apiKey) headers.Authorization = `Bearer ${config.apiKey}`;
     const sig = signOmniRequest('POST', path, bodyJson);

--- a/src/lib/omni-runner.ts
+++ b/src/lib/omni-runner.ts
@@ -256,12 +256,15 @@ export type RawClaudeSpawn = (args: string[], opts: { cwd: string; signal: Abort
 
 /**
  * Does this stderr mean "the session id you tried to resume does not exist"? Claude
- * 2.1.201 says `No conversation found with session ID: <id>` (NOTE: not the "not
- * found" substring the review assumed — verified live), older/other phrasings say
- * `No such session` / `session not found`. Only a missing session triggers the
- * create fallback; any other resume failure is surfaced as-is.
+ * 2.1.201 says `No conversation found with session ID: <id>` (verified live);
+ * older/other phrasings say `No such session` / `session not found`. Each
+ * alternative is SESSION-scoped on purpose — a bare `not found` would also match an
+ * unrelated failure (e.g. "model not found", an MCP "… not found") on a turn whose
+ * session actually exists, wasting a `--session-id` create that then errors
+ * "already in use". Only a genuinely missing session triggers the create fallback;
+ * any other resume failure is surfaced as-is.
  */
-const NO_SESSION_RE = /no conversation found|no such session|session not found|not found/i;
+const NO_SESSION_RE = /no conversation found|no such session|session not found/i;
 
 function toSpawnResult(run: RawClaudeRun): SpawnClaudeResult {
   const { reply, isError } = extractStreamJsonReply(run.stdout);

--- a/src/lib/omni-runner.ts
+++ b/src/lib/omni-runner.ts
@@ -29,6 +29,9 @@
  */
 
 import type { Database } from 'bun:sqlite';
+import { createHash, randomUUID } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import type { OmniRoute, OmniRuntimeConfig } from './omni-config.js';
 import { matchReaction, matchTextToken } from './omni-matching.js';
 import { signOmniRequest } from './omni-signature.js';
@@ -84,10 +87,25 @@ export interface SpawnClaudeOpts {
   cwd: string;
   /** Aborted when the run exceeds its budget; the child MUST be killed on abort. */
   signal: AbortSignal;
+  /**
+   * Absolute path to a persona / AGENTS.md file appended to Claude Code's system
+   * prompt (`--append-system-prompt-file`). Absent → no persona is appended.
+   */
+  personaFile?: string;
+  /**
+   * Stable `--session-id` (UUID) so a conversation RESUMES across messages. The
+   * runner derives it deterministically from (instance, chat); if a caller omits
+   * it the executor generates a fresh one defensively.
+   */
+  sessionId?: string;
 }
 
 export interface SpawnClaudeResult {
-  /** Captured stdout of the run (truncated to the reply cap before publishing). */
+  /**
+   * The FINAL assistant reply text — already parsed out of Claude's stream-json
+   * stdout (truncated to the reply cap before publishing). See
+   * {@link extractStreamJsonReply}.
+   */
   stdout: string;
   /** Process exit code; non-zero is surfaced as a bounded error notice. */
   exitCode: number;
@@ -97,21 +115,93 @@ export interface SpawnClaudeResult {
 export type SpawnClaude = (opts: SpawnClaudeOpts) => Promise<SpawnClaudeResult>;
 
 /**
- * Default executor — a real `claude -p "<message>"` bounded by the caller's
- * abort signal. Never imported at module top-level cost; only invoked once an
- * inbound message actually matches a configured route.
+ * Build the `claude` argv for one bounded one-shot run (Model A). Streams the
+ * turn as NDJSON (`--output-format stream-json`, which requires `-p`/`--print`
+ * AND `--verbose`) under a stable `--session-id` so the conversation resumes,
+ * and appends the persona to the system prompt when one is resolved. Pure +
+ * exported so the arg contract is unit-tested without forking claude.
  */
-export const defaultSpawnClaude: SpawnClaude = async ({ message, cwd, signal }) => {
-  const proc = Bun.spawn(['claude', '-p', message], {
+export function buildClaudeArgs(opts: { message: string; sessionId: string; personaFile?: string }): string[] {
+  return [
+    '-p',
+    '--output-format',
+    'stream-json',
+    '--verbose',
+    '--session-id',
+    opts.sessionId,
+    ...(opts.personaFile ? ['--append-system-prompt-file', opts.personaFile] : []),
+    opts.message,
+  ];
+}
+
+/**
+ * Extract the final assistant reply from Claude's `stream-json` stdout (NDJSON,
+ * one JSON event per line). Preference order:
+ *   1. the terminal `{"type":"result","subtype":"success","result":"<text>"}`
+ *      event — the canonical final answer;
+ *   2. otherwise the concatenation of `assistant` message text blocks (a partial
+ *      or non-success turn still yields the text it produced);
+ *   3. on total parse failure (stdout is not stream-json at all), the raw stdout
+ *      verbatim — never lose the reply just because the wire format shifted.
+ */
+export function extractStreamJsonReply(raw: string): string {
+  let assistantText = '';
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let evt: unknown;
+    try {
+      evt = JSON.parse(trimmed);
+    } catch {
+      continue; // skip a non-JSON line (log noise / partial frame)
+    }
+    if (!evt || typeof evt !== 'object') continue;
+    const o = evt as { type?: string; subtype?: string; result?: unknown; message?: { content?: unknown } };
+    if (o.type === 'result' && o.subtype === 'success' && typeof o.result === 'string' && o.result.length > 0) {
+      return o.result;
+    }
+    if (o.type === 'assistant' && o.message && Array.isArray(o.message.content)) {
+      for (const block of o.message.content as Array<{ type?: string; text?: string }>) {
+        if (block && block.type === 'text' && typeof block.text === 'string') assistantText += block.text;
+      }
+    }
+  }
+  return assistantText || raw;
+}
+
+/**
+ * Derive a STABLE session-id UUID from (instance, chat) so every message on a
+ * conversation resumes the same Claude session. Deterministic (sha256 of the
+ * pair, shaped into a v5-style UUID) — no state to persist, and two hosts
+ * serving the same route converge on the same id.
+ */
+export function deterministicSessionId(instance: string, chat: string): string {
+  const h = createHash('sha256').update(`omni-session:${instance}:${chat}`).digest('hex').slice(0, 32).split('');
+  h[12] = '5'; // version 5 (name-based)
+  h[16] = ((Number.parseInt(h[16], 16) & 0x3) | 0x8).toString(16); // variant 10xx → 8/9/a/b
+  const s = h.join('');
+  return `${s.slice(0, 8)}-${s.slice(8, 12)}-${s.slice(12, 16)}-${s.slice(16, 20)}-${s.slice(20, 32)}`;
+}
+
+/**
+ * Default executor — a real Model A `claude -p` run bounded by the caller's
+ * abort signal, streaming stream-json and parsing out the final reply. Never
+ * imported at module top-level cost; only invoked once an inbound message
+ * actually matches a configured route. A missing `sessionId` is generated
+ * defensively (callers always pass a stable one).
+ */
+export const defaultSpawnClaude: SpawnClaude = async ({ message, cwd, signal, personaFile, sessionId }) => {
+  const args = buildClaudeArgs({ message, sessionId: sessionId ?? randomUUID(), personaFile });
+  const proc = Bun.spawn(['claude', ...args], {
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
     // Bun forwards the AbortSignal: aborting SIGKILLs the child, freeing the route.
     signal,
   });
-  const stdout = await new Response(proc.stdout).text();
+  const raw = await new Response(proc.stdout).text();
   const exitCode = await proc.exited;
-  return { stdout, exitCode };
+  return { stdout: extractStreamJsonReply(raw), exitCode };
 };
 
 // ============================================================================
@@ -484,28 +574,44 @@ export function createOmniRunner(deps: OmniRunnerDeps): OmniRunner {
    * exit path publishes exactly one reply, marks the inbound handled, and clears
    * the in-flight flag — a child crash NEVER escapes this function.
    */
-  async function runOneShot(route: OmniRoute, inboundId: string, message: string, replySubject: string): Promise<void> {
+  async function runOneShot(
+    route: OmniRoute,
+    inboundId: string,
+    message: string,
+    replySubject: string,
+    messageId?: string,
+  ): Promise<void> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
     const aborted = new Promise<never>((_, reject) => {
       controller.signal.addEventListener('abort', () => reject(new OneShotTimeoutError()), { once: true });
     });
+    // ⏳ on the inbound message right before the spawn (route-scoped, no-op if the
+    // inbound carried no stanza id) — the first half of the run's ⏳→✅/❌ ack.
+    emitRouteReaction(route, messageId, STATUS_PENDING);
     try {
       // Wrap so a SYNCHRONOUS throw from the executor becomes a rejection the
       // race can observe — and so `aborted` always gets a handler attached
       // (else a late finally-abort would surface as an unhandled rejection).
       const spawned = Promise.resolve().then(() =>
-        spawnClaude({ message, cwd: route.repo, signal: controller.signal }),
+        spawnClaude({
+          message,
+          cwd: route.repo,
+          signal: controller.signal,
+          personaFile: resolvePersonaFile(route),
+          sessionId: deterministicSessionId(route.instance, route.chat),
+        }),
       );
       const result = await Promise.race([spawned, aborted]);
-      const content =
-        result.exitCode === 0
-          ? truncateReply(result.stdout, maxReplyChars)
-          : errorNotice(`exit code ${result.exitCode}`);
+      const ok = result.exitCode === 0;
+      const content = ok ? truncateReply(result.stdout, maxReplyChars) : errorNotice(`exit code ${result.exitCode}`);
       publish(replySubject, buildRoutedReplyPayload(route.instance, route.chat, content, genId(), now()));
+      // ✅ once a genuine reply is published; ❌ when the run exited non-zero.
+      emitRouteReaction(route, messageId, ok ? STATUS_APPROVED : STATUS_DENIED);
     } catch (err) {
       const content = err instanceof OneShotTimeoutError ? timeoutNotice(timeoutMs) : errorNotice(errText(err));
       publish(replySubject, buildRoutedReplyPayload(route.instance, route.chat, content, genId(), now()));
+      emitRouteReaction(route, messageId, STATUS_DENIED); // ❌ on timeout / crash
     } finally {
       clearTimeout(timer);
       controller.abort(); // ensure a still-running child is killed on every path
@@ -523,7 +629,7 @@ export function createOmniRunner(deps: OmniRunnerDeps): OmniRunner {
    * to `inFlight` SYNCHRONOUSLY before any await so a second message racing the
    * first sees it busy. Fire-and-forget: the serve loop never awaits the run.
    */
-  function startRoutedRun(route: OmniRoute, inboundId: string, message: string): void {
+  function startRoutedRun(route: OmniRoute, inboundId: string, message: string, messageId?: string): void {
     const replySubject = `omni.reply.${route.instance}.${route.chat}`;
     const key = routeKey(route.instance, route.chat);
     if (inFlight.has(key)) {
@@ -533,7 +639,7 @@ export function createOmniRunner(deps: OmniRunnerDeps): OmniRunner {
       return;
     }
     inFlight.add(key);
-    const run = runOneShot(route, inboundId, message, replySubject)
+    const run = runOneShot(route, inboundId, message, replySubject, messageId)
       .catch((err) => log(`[omni] one-shot crashed unexpectedly: ${errText(err)}`))
       .finally(() => pending.delete(run));
     pending.add(run);
@@ -551,28 +657,76 @@ export function createOmniRunner(deps: OmniRunnerDeps): OmniRunner {
    * the reconciliation pass retries it next tick. Never throws — a failed status
    * reaction is logged and the approval decision still stands.
    */
-  function emitStatusReaction(targetId: string | null | undefined, emoji: string): void {
-    if (!targetId || ackInFlight.has(targetId)) return;
-    ackInFlight.add(targetId);
-    const react = setReaction({
-      instance: config.instance ?? '',
-      chat: config.approvalChat ?? '',
-      messageId: targetId,
-      emoji,
-    })
+  function emitReaction(params: {
+    instance: string;
+    chat: string;
+    targetId: string | null | undefined;
+    emoji: string;
+    /** Persist the glyph on `last_status_glyph` (approval rows only). */
+    recordGlyph: boolean;
+    /** Apply the `ackInFlight` double-fire guard (approval reconciliation only). */
+    guard: boolean;
+  }): void {
+    const { instance, chat, targetId, emoji, recordGlyph, guard } = params;
+    if (!targetId) return;
+    if (guard && ackInFlight.has(targetId)) return;
+    if (guard) ackInFlight.add(targetId);
+    const react = setReaction({ instance, chat, messageId: targetId, emoji })
       .then((res) => {
         if (res && res.success === false) {
           log(`[omni] status ${emoji} on ${targetId} failed${res.error ? ` (${res.error})` : ''}`);
           return;
         }
-        recordStatusGlyph(db, targetId, emoji); // persist only on confirmed success
+        if (recordGlyph) recordStatusGlyph(db, targetId, emoji); // persist only on confirmed success
       })
       .catch((err) => log(`[omni] status ${emoji} on ${targetId} failed: ${errText(err)}`))
       .finally(() => {
-        ackInFlight.delete(targetId);
+        if (guard) ackInFlight.delete(targetId);
         inFlightReactions.delete(react);
       });
     inFlightReactions.add(react);
+  }
+
+  /** Approval-scoped ⏳/✅/❌ ack: scoped to the approval chat, glyph-recorded and
+   *  reconciliation-guarded. Unchanged behaviour from before the route path. */
+  function emitStatusReaction(targetId: string | null | undefined, emoji: string): void {
+    emitReaction({
+      instance: config.instance ?? '',
+      chat: config.approvalChat ?? '',
+      targetId,
+      emoji,
+      recordGlyph: true,
+      guard: true,
+    });
+  }
+
+  /**
+   * Route-scoped run ack: ⏳ before the spawn, ✅ once a reply is published, ❌ on
+   * failure/timeout — set on the INBOUND user message (`messageId`), scoped to the
+   * route's own (instance, chat), NOT the approval chat. No glyph is recorded (a
+   * plain inbound has no approval row) and no reconciliation guard applies (the
+   * ⏳→✅/❌ pair fires exactly once, sequentially, per run). A missing messageId is
+   * a no-op. Fire-and-forget, drained by `whenIdle`; never blocks the run.
+   */
+  function emitRouteReaction(route: OmniRoute, messageId: string | undefined, emoji: string): void {
+    emitReaction({
+      instance: route.instance,
+      chat: route.chat,
+      targetId: messageId,
+      emoji,
+      recordGlyph: false,
+      guard: false,
+    });
+  }
+
+  /**
+   * Resolve the persona file for a route: the explicit `route.persona` if set,
+   * else `<repo>/AGENTS.md` when it exists, else none.
+   */
+  function resolvePersonaFile(route: OmniRoute): string | undefined {
+    if (route.persona) return route.persona;
+    const agents = join(route.repo, 'AGENTS.md');
+    return existsSync(agents) ? agents : undefined;
   }
 
   /**
@@ -711,8 +865,9 @@ export function createOmniRunner(deps: OmniRunnerDeps): OmniRunner {
       const inboundId = recordInbound(db, { instance, chat, sender, body, now: now() });
 
       // Mapped (instance, chat) → spawn a bounded one-shot; unmapped is store-only.
+      // Thread the inbound WhatsApp stanza id so the run can ⏳→✅/❌ react on it.
       const route = findRoute(instance, chat);
-      if (route) startRoutedRun(route, inboundId, body);
+      if (route) startRoutedRun(route, inboundId, body, msg.messageId);
 
       // Only the approval chat can resolve approvals.
       if (!chatId || chatId !== config.approvalChat) return;

--- a/src/lib/omni-runner.ts
+++ b/src/lib/omni-runner.ts
@@ -109,64 +109,124 @@ export interface SpawnClaudeResult {
   stdout: string;
   /** Process exit code; non-zero is surfaced as a bounded error notice. */
   exitCode: number;
+  /**
+   * True when the turn is a SOFT failure despite exit 0: the terminal stream-json
+   * result was `is_error` / a non-success subtype / an empty result. `runOneShot`
+   * treats `(exitCode !== 0 || isError)` as failure so such a turn gets an error
+   * notice + ❌ instead of publishing the (possibly raw NDJSON) blob tagged ✅.
+   */
+  isError?: boolean;
 }
 
 /** Bounded one-shot `claude -p` executor. Injectable so tests never fork claude. */
 export type SpawnClaude = (opts: SpawnClaudeOpts) => Promise<SpawnClaudeResult>;
 
 /**
+ * Which session flag to spawn with. `claude --session-id <id>` CREATES a session
+ * (and errors "already in use" if the id exists); `claude --resume <id>` CONTINUES
+ * an existing one. {@link runClaudeSession} tries `resume` first and only falls
+ * back to `create` when the session does not exist yet — verified against claude
+ * 2.1.201.
+ */
+export type ClaudeSessionMode = 'create' | 'resume';
+
+/**
  * Build the `claude` argv for one bounded one-shot run (Model A). Streams the
  * turn as NDJSON (`--output-format stream-json`, which requires `-p`/`--print`
- * AND `--verbose`) under a stable `--session-id` so the conversation resumes,
- * and appends the persona to the system prompt when one is resolved. Pure +
- * exported so the arg contract is unit-tested without forking claude.
+ * AND `--verbose`), binds the stable session id via `--resume` (continue) or
+ * `--session-id` (create), and appends the persona to the system prompt when one
+ * is resolved. Pure + exported so the arg contract is unit-tested without forking.
  */
-export function buildClaudeArgs(opts: { message: string; sessionId: string; personaFile?: string }): string[] {
+export function buildClaudeArgs(opts: {
+  message: string;
+  sessionId: string;
+  personaFile?: string;
+  mode: ClaudeSessionMode;
+}): string[] {
+  const sessionFlag = opts.mode === 'resume' ? ['--resume', opts.sessionId] : ['--session-id', opts.sessionId];
   return [
     '-p',
     '--output-format',
     'stream-json',
     '--verbose',
-    '--session-id',
-    opts.sessionId,
+    ...sessionFlag,
     ...(opts.personaFile ? ['--append-system-prompt-file', opts.personaFile] : []),
     opts.message,
   ];
 }
 
-/**
- * Extract the final assistant reply from Claude's `stream-json` stdout (NDJSON,
- * one JSON event per line). Preference order:
- *   1. the terminal `{"type":"result","subtype":"success","result":"<text>"}`
- *      event — the canonical final answer;
- *   2. otherwise the concatenation of `assistant` message text blocks (a partial
- *      or non-success turn still yields the text it produced);
- *   3. on total parse failure (stdout is not stream-json at all), the raw stdout
- *      verbatim — never lose the reply just because the wire format shifted.
- */
-export function extractStreamJsonReply(raw: string): string {
-  let assistantText = '';
+/** Parsed final reply + whether the turn ended in an error (soft or hard). */
+export interface ParsedReply {
+  reply: string;
+  isError: boolean;
+}
+
+/** One decoded `stream-json` NDJSON event (fields are all optional/loose). */
+type StreamJsonEvent = {
+  type?: string;
+  subtype?: string;
+  is_error?: boolean;
+  result?: unknown;
+  message?: { content?: unknown };
+};
+
+/** Parse NDJSON stdout into its JSON-object events, skipping blank/non-JSON lines. */
+function parseNdjsonEvents(raw: string): StreamJsonEvent[] {
+  const events: StreamJsonEvent[] = [];
   for (const line of raw.split('\n')) {
     const trimmed = line.trim();
     if (!trimmed) continue;
-    let evt: unknown;
     try {
-      evt = JSON.parse(trimmed);
+      const evt = JSON.parse(trimmed);
+      if (evt && typeof evt === 'object') events.push(evt as StreamJsonEvent);
     } catch {
-      continue; // skip a non-JSON line (log noise / partial frame)
-    }
-    if (!evt || typeof evt !== 'object') continue;
-    const o = evt as { type?: string; subtype?: string; result?: unknown; message?: { content?: unknown } };
-    if (o.type === 'result' && o.subtype === 'success' && typeof o.result === 'string' && o.result.length > 0) {
-      return o.result;
-    }
-    if (o.type === 'assistant' && o.message && Array.isArray(o.message.content)) {
-      for (const block of o.message.content as Array<{ type?: string; text?: string }>) {
-        if (block && block.type === 'text' && typeof block.text === 'string') assistantText += block.text;
-      }
+      // skip a non-JSON line (log noise / partial frame)
     }
   }
-  return assistantText || raw;
+  return events;
+}
+
+/** Concatenate the `text` blocks of one `assistant` event's message content. */
+function assistantEventText(o: StreamJsonEvent): string {
+  if (!o.message || !Array.isArray(o.message.content)) return '';
+  let text = '';
+  for (const block of o.message.content as Array<{ type?: string; text?: string }>) {
+    if (block && block.type === 'text' && typeof block.text === 'string') text += block.text;
+  }
+  return text;
+}
+
+/**
+ * Extract the final assistant reply from Claude's `stream-json` stdout (NDJSON,
+ * one JSON event per line). Preference order:
+ *   1. the terminal `{"type":"result","subtype":"success","is_error":false,
+ *      "result":"<text>"}` event with a NON-EMPTY result — the canonical answer;
+ *   2. a terminal result that is `is_error` / a non-success subtype / an empty
+ *      result → `{ isError: true }` with whatever text it carried (or the
+ *      accumulated assistant text), so the caller surfaces ❌ and NEVER publishes
+ *      the raw NDJSON blob as a reply;
+ *   3. no terminal result but some `assistant` text blocks → that text (a partial
+ *      but non-error turn still yields what it produced);
+ *   4. total parse failure (stdout is not stream-json at all) → the raw stdout
+ *      verbatim — never lose the reply just because the wire format shifted.
+ */
+export function extractStreamJsonReply(raw: string): ParsedReply {
+  let assistantText = '';
+  let sawErrorResult = false;
+  let errorResultText = '';
+  for (const o of parseNdjsonEvents(raw)) {
+    if (o.type === 'result') {
+      const result = typeof o.result === 'string' ? o.result : '';
+      if (o.subtype === 'success' && o.is_error !== true && result.length > 0) return { reply: result, isError: false };
+      sawErrorResult = true; // error subtype, is_error, or empty success
+      errorResultText = result;
+      continue;
+    }
+    if (o.type === 'assistant') assistantText += assistantEventText(o);
+  }
+  if (sawErrorResult) return { reply: errorResultText || assistantText, isError: true };
+  if (assistantText) return { reply: assistantText, isError: false };
+  return { reply: raw, isError: false }; // not stream-json at all — last-resort passthrough
 }
 
 /**
@@ -183,26 +243,81 @@ export function deterministicSessionId(instance: string, chat: string): string {
   return `${s.slice(0, 8)}-${s.slice(8, 12)}-${s.slice(12, 16)}-${s.slice(16, 20)}-${s.slice(20, 32)}`;
 }
 
+/** Raw stdout/stderr/exit of ONE `claude` invocation. */
+export interface RawClaudeRun {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/** Fork ONE `claude` process with the given argv. Injectable so the resume/create
+ *  orchestration in {@link runClaudeSession} is tested without a real fork. */
+export type RawClaudeSpawn = (args: string[], opts: { cwd: string; signal: AbortSignal }) => Promise<RawClaudeRun>;
+
 /**
- * Default executor — a real Model A `claude -p` run bounded by the caller's
- * abort signal, streaming stream-json and parsing out the final reply. Never
- * imported at module top-level cost; only invoked once an inbound message
- * actually matches a configured route. A missing `sessionId` is generated
- * defensively (callers always pass a stable one).
+ * Does this stderr mean "the session id you tried to resume does not exist"? Claude
+ * 2.1.201 says `No conversation found with session ID: <id>` (NOTE: not the "not
+ * found" substring the review assumed — verified live), older/other phrasings say
+ * `No such session` / `session not found`. Only a missing session triggers the
+ * create fallback; any other resume failure is surfaced as-is.
  */
-export const defaultSpawnClaude: SpawnClaude = async ({ message, cwd, signal, personaFile, sessionId }) => {
-  const args = buildClaudeArgs({ message, sessionId: sessionId ?? randomUUID(), personaFile });
+const NO_SESSION_RE = /no conversation found|no such session|session not found|not found/i;
+
+function toSpawnResult(run: RawClaudeRun): SpawnClaudeResult {
+  const { reply, isError } = extractStreamJsonReply(run.stdout);
+  return { stdout: reply, exitCode: run.exitCode, isError };
+}
+
+/**
+ * Run one Model A turn with RESUME-FIRST session continuity.
+ *
+ * `claude --session-id <id>` CREATES a session and fails "already in use" on the
+ * SECOND message — the CRITICAL that broke every turn after the first. So we
+ * attempt `--resume <id>` first (continues the existing session in ONE spawn for
+ * turn 2..N AND across `omni serve` restarts, since the session persists on disk)
+ * and only when that reports a MISSING session ({@link NO_SESSION_RE}) do we fall
+ * back to `--session-id <id>` to create it. Net cost: only the very first turn of
+ * a conversation pays the extra (fast, no-op) resume spawn. A resume failure for
+ * any OTHER reason, or an abort, is returned as-is (no create fallback).
+ */
+export async function runClaudeSession(opts: SpawnClaudeOpts, rawSpawn: RawClaudeSpawn): Promise<SpawnClaudeResult> {
+  const base = { message: opts.message, sessionId: opts.sessionId ?? randomUUID(), personaFile: opts.personaFile };
+  const spawnOpts = { cwd: opts.cwd, signal: opts.signal };
+  const resumed = await rawSpawn(buildClaudeArgs({ ...base, mode: 'resume' }), spawnOpts);
+  if (resumed.exitCode === 0 || opts.signal.aborted || !NO_SESSION_RE.test(resumed.stderr)) {
+    return toSpawnResult(resumed);
+  }
+  // Session does not exist yet → create it (this spawn processes the message).
+  const created = await rawSpawn(buildClaudeArgs({ ...base, mode: 'create' }), spawnOpts);
+  return toSpawnResult(created);
+}
+
+/** Default raw fork of one `claude` process. stdin is closed (`ignore`) so claude
+ *  never waits ~3s for piped input in headless one-shot mode. */
+const defaultRawSpawn: RawClaudeSpawn = async (args, { cwd, signal }) => {
   const proc = Bun.spawn(['claude', ...args], {
     cwd,
+    stdin: 'ignore',
     stdout: 'pipe',
     stderr: 'pipe',
     // Bun forwards the AbortSignal: aborting SIGKILLs the child, freeing the route.
     signal,
   });
-  const raw = await new Response(proc.stdout).text();
-  const exitCode = await proc.exited;
-  return { stdout: extractStreamJsonReply(raw), exitCode };
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, exitCode };
 };
+
+/**
+ * Default executor — a real Model A `claude -p` run bounded by the caller's abort
+ * signal, resume-first (see {@link runClaudeSession}), streaming stream-json and
+ * parsing out the final reply. Never imported at module top-level cost; only
+ * invoked once an inbound message actually matches a configured route.
+ */
+export const defaultSpawnClaude: SpawnClaude = (opts) => runClaudeSession(opts, defaultRawSpawn);
 
 // ============================================================================
 // Injectable id-returning Omni send (approval announce)
@@ -603,10 +718,16 @@ export function createOmniRunner(deps: OmniRunnerDeps): OmniRunner {
         }),
       );
       const result = await Promise.race([spawned, aborted]);
-      const ok = result.exitCode === 0;
-      const content = ok ? truncateReply(result.stdout, maxReplyChars) : errorNotice(`exit code ${result.exitCode}`);
+      // A non-zero exit OR a soft-error terminal result (is_error / non-success /
+      // empty) is a failure — never publish the raw NDJSON blob as a happy reply.
+      const ok = result.exitCode === 0 && !result.isError;
+      const content = ok
+        ? truncateReply(result.stdout, maxReplyChars)
+        : errorNotice(
+            result.exitCode !== 0 ? `exit code ${result.exitCode}` : result.stdout || 'agent returned an error',
+          );
       publish(replySubject, buildRoutedReplyPayload(route.instance, route.chat, content, genId(), now()));
-      // ✅ once a genuine reply is published; ❌ when the run exited non-zero.
+      // ✅ once a genuine reply is published; ❌ on a non-zero exit or soft error.
       emitRouteReaction(route, messageId, ok ? STATUS_APPROVED : STATUS_DENIED);
     } catch (err) {
       const content = err instanceof OneShotTimeoutError ? timeoutNotice(timeoutMs) : errorNotice(errText(err));
@@ -721,12 +842,15 @@ export function createOmniRunner(deps: OmniRunnerDeps): OmniRunner {
 
   /**
    * Resolve the persona file for a route: the explicit `route.persona` if set,
-   * else `<repo>/AGENTS.md` when it exists, else none.
+   * else `<repo>/AGENTS.md`. BOTH candidates are existence-checked — a typo'd
+   * `route.persona` would otherwise make claude exit 1 on every run, so a missing
+   * explicit path is logged and dropped rather than passed through.
    */
   function resolvePersonaFile(route: OmniRoute): string | undefined {
-    if (route.persona) return route.persona;
-    const agents = join(route.repo, 'AGENTS.md');
-    return existsSync(agents) ? agents : undefined;
+    const candidate = route.persona ?? join(route.repo, 'AGENTS.md');
+    if (existsSync(candidate)) return candidate;
+    if (route.persona) log(`[omni] route ${route.instance} ${route.chat}: persona file not found: ${route.persona}`);
+    return undefined;
   }
 
   /**

--- a/src/types/genie-config.ts
+++ b/src/types/genie-config.ts
@@ -129,6 +129,12 @@ const OmniConfigSchema = z.object({
         chat: z.string(),
         /** Absolute directory the one-shot runs in (cwd of `claude -p`). */
         repo: z.string(),
+        /**
+         * Absolute path to a persona / AGENTS.md file appended to the agent's
+         * system prompt for this route. Omitted → the runner falls back to
+         * `<repo>/AGENTS.md` if present, else no persona.
+         */
+        persona: z.string().optional(),
       }),
     )
     .optional(),


### PR DESCRIPTION
Model A for `genie omni serve`: spawn `claude -p` with the route persona (`--append-system-prompt-file`), deterministic per-chat `--session-id` (resume-first), stream-json parsing, and a route-scoped ⏳→✅/❌ reaction ack via the correct `/api/v2/messages/send/reaction` endpoint. Replants the 4 commits from #2514 onto dev (PRs to main must come from dev). Verified live end-to-end.