### PR TITLE
fix(config): resolve genie config dir via GENIE_HOME, lazily

### DIFF
--- a/src/hooks/__tests__/dispatch-fail-closed-regression.test.ts
+++ b/src/hooks/__tests__/dispatch-fail-closed-regression.test.ts
@@ -30,21 +30,30 @@
  * the plugin should route additional events is a separate registration concern,
  * not this gate's subject.
  */
-import { beforeAll, describe, expect, test } from 'bun:test';
-import { existsSync } from 'node:fs';
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 const REPO_ROOT = join(import.meta.dir, '..', '..', '..');
 const DIST = join(REPO_ROOT, 'dist', 'genie.js');
 
+// Isolated global state so "default path" means default CONFIG on every host —
+// a real ~/.genie/config.json (e.g. omni approvals enabled) would otherwise
+// change the dispatcher's registry and this gate would no longer test the default.
+const ISOLATED_HOME = mkdtempSync(join(tmpdir(), 'genie-dispatch-regression-'));
+afterAll(() => rmSync(ISOLATED_HOME, { recursive: true, force: true }));
+
 /**
  * Drive the built CLI's real hook-dispatch entry point as a subprocess and
- * return its stdout. No GENIE_* flags are set — this is the default path CC
+ * return its stdout. No behavior flags are set — this is the default path CC
  * uses, so a fall-open default would show up here as an empty (allow) decision.
+ * GENIE_HOME only relocates global state, keeping the run host-independent.
  */
 async function driveDispatch(payload: unknown): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   const proc = Bun.spawn(['bun', DIST, 'hook', 'dispatch'], {
     cwd: REPO_ROOT,
+    env: { ...process.env, GENIE_HOME: ISOLATED_HOME },
     stdin: Buffer.from(JSON.stringify(payload)),
     stdout: 'pipe',
     stderr: 'pipe',

--- a/src/hooks/__tests__/omni-dispatch.test.ts
+++ b/src/hooks/__tests__/omni-dispatch.test.ts
@@ -10,6 +10,9 @@
  *      byte-identical to a build with no Omni.
  */
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { orchestrationGuard } from '../handlers/orchestration-guard.js';
 import { buildOmniRegistry, dispatch, getRegistry, installDispatchRegistry, setRegistry } from '../index.js';
 import type { Handler, HandlerResult } from '../types.js';
@@ -67,19 +70,27 @@ describe('config-gated omni-approval registry', () => {
 describe('installDispatchRegistry — config-gated boot seam', () => {
   let original: ReadonlyArray<Handler>;
   let prev: Record<string, string | undefined>;
+  let isolatedHome: string;
   beforeEach(() => {
     original = getRegistry();
     prev = {
       enabled: process.env.OMNI_APPROVALS_ENABLED,
       instance: process.env.OMNI_INSTANCE,
       chat: process.env.OMNI_APPROVAL_CHAT,
+      home: process.env.GENIE_HOME,
     };
+    // Isolate global state: "default config" must not mean the host's real
+    // ~/.genie/config.json, which may have omni approvals enabled.
+    isolatedHome = mkdtempSync(join(tmpdir(), 'genie-omni-dispatch-'));
+    process.env.GENIE_HOME = isolatedHome;
   });
   afterEach(() => {
     setRegistry(original);
     restoreEnv('OMNI_APPROVALS_ENABLED', prev.enabled);
     restoreEnv('OMNI_INSTANCE', prev.instance);
     restoreEnv('OMNI_APPROVAL_CHAT', prev.chat);
+    restoreEnv('GENIE_HOME', prev.home);
+    rmSync(isolatedHome, { recursive: true, force: true });
   });
 
   test('disabled (no env, default config) → registry has NO omni-approval handler', async () => {

--- a/src/lib/genie-config.test.ts
+++ b/src/lib/genie-config.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  genieConfigExists,
+  getGenieConfigPath,
+  getGenieDir,
+  loadGenieConfig,
+  saveGenieConfig,
+} from './genie-config.js';
+
+describe('genie-config GENIE_HOME resolution', () => {
+  let dir: string;
+  let prevGenieHome: string | undefined;
+
+  beforeEach(() => {
+    prevGenieHome = process.env.GENIE_HOME;
+    dir = mkdtempSync(join(tmpdir(), 'genie-config-'));
+    process.env.GENIE_HOME = dir;
+  });
+
+  afterEach(() => {
+    if (prevGenieHome === undefined) {
+      Reflect.deleteProperty(process.env, 'GENIE_HOME');
+    } else {
+      process.env.GENIE_HOME = prevGenieHome;
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('config dir and path honor GENIE_HOME lazily (set after import)', () => {
+    expect(getGenieDir()).toBe(dir);
+    expect(getGenieConfigPath()).toBe(join(dir, 'config.json'));
+  });
+
+  test('load returns isolated defaults, save/load round-trips inside GENIE_HOME', async () => {
+    expect(genieConfigExists()).toBe(false);
+    const config = await loadGenieConfig();
+    config.setupComplete = true;
+    await saveGenieConfig(config);
+    expect(genieConfigExists()).toBe(true);
+    const reloaded = await loadGenieConfig();
+    expect(reloaded.setupComplete).toBe(true);
+  });
+
+  test('falls back to ~/.genie when GENIE_HOME is unset', () => {
+    Reflect.deleteProperty(process.env, 'GENIE_HOME');
+    expect(getGenieDir()).toBe(join(homedir(), '.genie'));
+    expect(getGenieConfigPath()).toBe(join(homedir(), '.genie', 'config.json'));
+  });
+});

--- a/src/lib/genie-config.ts
+++ b/src/lib/genie-config.ts
@@ -2,37 +2,38 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { type GenieConfig, GenieConfigSchema, type ShortcutsConfig } from '../types/genie-config.js';
-
-const GENIE_DIR = join(homedir(), '.genie');
-const GENIE_CONFIG_FILE = join(GENIE_DIR, 'config.json');
+import { genieHome } from './workspace.js';
 
 /**
- * Get the path to the genie config directory
+ * Get the path to the genie config directory.
+ * Honors GENIE_HOME (which relocates ALL global state) and resolves lazily so
+ * env overrides in tests and spawned subprocesses take effect.
  */
 export function getGenieDir(): string {
-  return GENIE_DIR;
+  return genieHome();
 }
 
 /**
  * Get the path to the genie config file
  */
 export function getGenieConfigPath(): string {
-  return GENIE_CONFIG_FILE;
+  return join(genieHome(), 'config.json');
 }
 
 /**
  * Check if genie config exists
  */
 export function genieConfigExists(): boolean {
-  return existsSync(GENIE_CONFIG_FILE);
+  return existsSync(getGenieConfigPath());
 }
 
 /**
  * Ensure the genie config directory exists
  */
 function ensureGenieDir(): void {
-  if (!existsSync(GENIE_DIR)) {
-    mkdirSync(GENIE_DIR, { recursive: true });
+  const dir = getGenieDir();
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
   }
 }
 
@@ -40,12 +41,13 @@ function ensureGenieDir(): void {
  * Load genie config, returning defaults if not found
  */
 export async function loadGenieConfig(): Promise<GenieConfig> {
-  if (!existsSync(GENIE_CONFIG_FILE)) {
+  const configPath = getGenieConfigPath();
+  if (!existsSync(configPath)) {
     return GenieConfigSchema.parse({});
   }
 
   try {
-    const content = readFileSync(GENIE_CONFIG_FILE, 'utf-8');
+    const content = readFileSync(configPath, 'utf-8');
     const data = JSON.parse(content);
     return GenieConfigSchema.parse(data);
   } catch (error) {
@@ -64,7 +66,7 @@ export async function saveGenieConfig(config: GenieConfig): Promise<void> {
   try {
     const validated = GenieConfigSchema.parse(config);
     const content = JSON.stringify(validated, null, 2);
-    writeFileSync(GENIE_CONFIG_FILE, content, 'utf-8');
+    writeFileSync(getGenieConfigPath(), content, 'utf-8');
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to save genie config: ${message}`);


### PR DESCRIPTION
## Problem

`src/lib/genie-config.ts` computed `~/.genie` once from `homedir()` at import time, ignoring `GENIE_HOME` — the env var CLAUDE.md documents as relocating ALL global state. On any host with a real `~/.genie/config.json`, that config leaked into tests and subprocesses that believed they were isolated. Concrete symptom (root-caused during wish `hermes-khaw-native-surface` QA): with omni approvals enabled in the host config, `dispatch-fail-closed-regression.test.ts` (5s timeout while the dispatcher polled for approval) and `omni-dispatch.test.ts` (default-config assertion) failed on every branch on that host.

## Fix

- Config dir/path resolve through the existing lazily-evaluated `workspace.ts genieHome()` (`GENIE_HOME ?? ~/.genie`) per call — same pattern as `omni-signature.ts`, no import cycle.
- The two dispatcher tests now genuinely isolate global state per the repo's own testing convention: the boot-seam suite sets `GENIE_HOME` to a tmpdir, and the regression gate spawns `dist/genie.js` with an isolated `GENIE_HOME` (its docstring updated: no *behavior* flags — GENIE_HOME only relocates state so "default path" means default config on every host).
- New `src/lib/genie-config.test.ts`: lazy GENIE_HOME honoring (set after import), round-trip inside GENIE_HOME, fallback to `~/.genie` when unset.

## Verification

- `bun test src/hooks/__tests__/dispatch-fail-closed-regression.test.ts src/hooks/__tests__/omni-dispatch.test.ts src/lib/genie-config.test.ts` → **19 pass / 0 fail** on the host that previously failed both files
- `bun run typecheck` clean, `bun run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEJCsZTjxLyrM8BQKjGEVs