### PR TITLE
fix(hermes-plugin): install into the active Hermes profile's plugins dir

### DIFF
--- a/plugins/hermes-genie/README.md
+++ b/plugins/hermes-genie/README.md
@@ -17,6 +17,8 @@ mkdir -p "${HERMES_HOME:-$HOME/.hermes}/plugins" && ln -sfn "$(pwd)/plugins/herm
 plugins/hermes-genie/scripts/install-local.sh --copy
 ```
 
+Hermes hosts running a sticky profile (`$HERMES_HOME/active_profile`) load plugins from `$HERMES_HOME/profiles/<name>/plugins/` — the script detects that and installs there as well. Pass `--no-profile` to skip the profile install. Note that Hermes plugins are opt-in: run `hermes plugins enable genie` after the first install.
+
 ## Smoke Test
 
 ```bash

--- a/plugins/hermes-genie/scripts/install-local.sh
+++ b/plugins/hermes-genie/scripts/install-local.sh
@@ -2,26 +2,32 @@
 # Install the Genie Hermes plugin as $HERMES_HOME/plugins/genie.
 #
 # Default mode symlinks the repo checkout (edits are live — tight dev loop);
-# --copy makes a detached, release-style copy instead.
+# --copy makes a detached, release-style copy instead. When the Hermes host
+# runs a sticky profile ($HERMES_HOME/active_profile), plugins load from the
+# profile's own plugins/ dir, so the plugin is installed there as well.
 set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: install-local.sh [--copy]
+Usage: install-local.sh [--copy] [--no-profile]
 
 Installs plugins/hermes-genie as $HERMES_HOME/plugins/genie.
 
-  (default)  symlink the repo checkout — edits are live
-  --copy     copy the plugin files — detached, release-style install
+  (default)     symlink the repo checkout — edits are live
+  --copy        copy the plugin files — detached, release-style install
+  --no-profile  skip the active-profile install (default installs to
+                $HERMES_HOME/profiles/<active>/plugins/genie too)
 
 HERMES_HOME defaults to $HOME/.hermes.
 EOF
 }
 
 mode="symlink"
+profile_install=1
 for arg in "$@"; do
   case "$arg" in
     --copy) mode="copy" ;;
+    --no-profile) profile_install=0 ;;
     -h|--help)
       usage
       exit 0
@@ -39,25 +45,40 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 plugin_src="$(cd "$script_dir/.." && pwd)"
 
 hermes_home="${HERMES_HOME:-$HOME/.hermes}"
-target="$hermes_home/plugins/genie"
 
-mkdir -p "$hermes_home/plugins"
-# Replace a previous install only (a symlink, or a dir that looks like this
-# plugin). Refuse to wipe unrelated content. Without a trailing slash the rm
-# removes a stale symlink itself, never the checkout it points to.
-if [ -e "$target" ] || [ -L "$target" ]; then
-  if [ -L "$target" ] || [ -f "$target/plugin.yaml" ]; then
-    rm -rf "$target"
-  else
-    echo "refusing to replace $target: exists but does not look like a genie plugin install (no plugin.yaml)" >&2
-    exit 1
+# Install one copy/symlink of the plugin at $1/genie, replacing only a
+# previous install (a symlink, or a dir that looks like this plugin) —
+# refuse to wipe unrelated content. Without a trailing slash the rm removes
+# a stale symlink itself, never the checkout it points to.
+install_into() {
+  local plugins_dir="$1"
+  local target="$plugins_dir/genie"
+
+  mkdir -p "$plugins_dir"
+  if [ -e "$target" ] || [ -L "$target" ]; then
+    if [ -L "$target" ] || [ -f "$target/plugin.yaml" ]; then
+      rm -rf "$target"
+    else
+      echo "refusing to replace $target: exists but does not look like a genie plugin install (no plugin.yaml)" >&2
+      exit 1
+    fi
   fi
-fi
 
-if [ "$mode" = "copy" ]; then
-  cp -R "$plugin_src" "$target"
-  echo "installed (copy): $target (from $plugin_src)"
-else
-  ln -s "$plugin_src" "$target"
-  echo "installed (symlink): $target -> $plugin_src"
+  if [ "$mode" = "copy" ]; then
+    cp -R "$plugin_src" "$target"
+    echo "installed (copy): $target (from $plugin_src)"
+  else
+    ln -s "$plugin_src" "$target"
+    echo "installed (symlink): $target -> $plugin_src"
+  fi
+}
+
+install_into "$hermes_home/plugins"
+
+# Profile-based hosts: a sticky active profile loads plugins from its own dir.
+if [ "$profile_install" = "1" ] && [ -f "$hermes_home/active_profile" ]; then
+  active_profile="$(head -n1 "$hermes_home/active_profile" | tr -d '[:space:]')"
+  if [ -n "$active_profile" ] && [ -d "$hermes_home/profiles/$active_profile" ]; then
+    install_into "$hermes_home/profiles/$active_profile/plugins"
+  fi
 fi


### PR DESCRIPTION
Closes the QA follow-up from the wish's live smoke: profile-based Hermes hosts (sticky `$HERMES_HOME/active_profile`) load plugins from `$HERMES_HOME/profiles/<name>/plugins/`, so a default-dir-only install is invisible there.

`install-local.sh` now function-izes the guarded install (same symlink/copy modes, same unrelated-content refusal) and repeats it into the active profile's plugins dir when one exists; `--no-profile` opts out. README documents the behavior plus the `hermes plugins enable genie` opt-in step.

Verified matrix: no-profile host (default only), profile host (both dirs), dangling profile name (skipped cleanly), `--no-profile`, `--copy` over prior symlinks in both dirs, refusal path preserves unrelated content with exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sg8vJv9r2yqmnbtVPqM2vG