### PR TITLE
fix: close version-race, purge dead v4 verbs from nudges + soul template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,15 +28,18 @@ on:
         required: true
         type: string
       channel:
-        description: 'Release channel — stable publishes to @latest; homolog + dev are prereleases with their own .well-known/<channel>.json pointer'
+        description: 'Release channel — stable publishes to @latest; homolog + dev are prereleases. All channel manifests live on MAIN (.well-known/); the channel only selects which file is written'
         required: false
         type: choice
         default: stable
         # Canonical channel taxonomy (Felipe directive 2026-05-12,
         # unified across the automagik sibling projects):
-        #   stable  → main branch    → .well-known/latest.json
-        #   homolog → homolog branch → .well-known/homolog.json
-        #   dev     → dev branch     → .well-known/dev.json
+        # ALL channel manifests are committed to MAIN — matching
+        # install.sh's MANIFEST_BASE=.../main/.well-known for every
+        # channel. The channel selects WHICH file, never the branch:
+        #   stable  → main:.well-known/latest.json
+        #   homolog → main:.well-known/homolog.json
+        #   dev     → main:.well-known/dev.json
         # beta + canary retired. genie may not have an active homolog
         # branch yet (omni does); the channel surface is kept for
         # cross-repo taxonomy parity + future operator dispatch.

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -24,9 +24,9 @@ name: Version
 #
 # SHA-pin invariant (Invariant A — correctness over completeness):
 # Version always tags the commit that passed CI, never branch HEAD.
-# Per-branch concurrency with cancel-in-progress means older runs
-# supersede when dev advances during a Version run (back-to-back
-# merges). When dev advances past the SHA we checked out, the
+# Concurrent runs QUEUE per branch+event (no cancellation — see the
+# concurrency block below). When dev advances past the SHA a queued
+# run checked out, the
 # `git push --atomic` rejects rather than mis-tag — emitting
 # `release-race.next-tag-pin-skipped.detected` in the CI log. The
 # next merge's run catches up.
@@ -42,9 +42,15 @@ permissions:
   contents: write          # commit + push version bump + tag
   actions: write           # `gh workflow run` to dispatch Build Tarballs after tag push
 
+# RACE (observed 2026-07-04T23:11:46Z, missed dev release): CI completes twice
+# per dev merge (push-event run + pull_request-event run); both trigger this
+# workflow. The PR-event run always fails the job `if` (event=='push') and shows
+# "skipped" — but in a shared group with cancel-in-progress it CANCELLED the
+# in-flight push-event bump. Scope the group by triggering event, and never
+# cancel: killing a version bump mid-tag-push is unsafe regardless — queue instead.
 concurrency:
-  group: version-${{ github.event.workflow_run.head_branch || 'manual' }}
-  cancel-in-progress: true
+  group: version-${{ github.event.workflow_run.head_branch || 'manual' }}-${{ github.event.workflow_run.event || 'dispatch' }}
+  cancel-in-progress: false
 
 jobs:
   auto-version:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ skills/                         Skill prompt files (brainstorm, wish, work, revi
 
 ## CLI Commands
 
-Twelve top-level commands (run `genie <command> --help` for detail):
+Fourteen top-level commands (run `genie <command> --help` for detail):
 
 | Command | Purpose |
 |---------|---------|
@@ -78,7 +78,9 @@ Twelve top-level commands (run `genie <command> --help` for detail):
 | `doctor` | Diagnostic checks on the genie installation |
 | `hook` | Hook middleware for Claude Code (`genie hook dispatch` runs in-process) |
 | `init` | Scaffold per-repo state — `.genie/INDEX.md` + `.gitignore` rules (idempotent) |
+| `install` | Post-install finisher — v4 legacy cleanup (`--skip-v4-cleanup`) |
 | `launch <slug>` | Open a Warp cockpit for a wish: one pane per ready group, each in its own worktree |
+| `mcp` | Read-only stdio MCP server exposing genie.db task/board state |
 | `omni` | Omni integration — `serve`, `status`, `inbox`, `handshake` |
 | `setup` | Configure genie settings |
 | `shortcuts` | Manage tmux keyboard shortcuts |

--- a/src/hooks/handlers/orchestration-guard.ts
+++ b/src/hooks/handlers/orchestration-guard.ts
@@ -22,25 +22,25 @@ const NUDGE_PATTERNS: NudgePattern[] = [
   {
     test: /tmux\s+capture-pane/,
     message:
-      "If you're checking genie agent progress, use structured monitoring instead:\n" +
-      '  genie task status <slug>   — wish progress\n' +
-      '  genie agent list --json    — executor state machine\n' +
-      '  genie events timeline <id> — structured event log\n' +
-      '  genie agent send --to <a>  — direct messaging',
+      "If you're checking genie worker progress, use structured monitoring instead:\n" +
+      '  genie board --wish <slug> --json — wish progress\n' +
+      '  genie task list --json           — task state\n' +
+      '  genie task status <id>           — structured task detail + stage log\n' +
+      '  SendMessage tool (native team)   — direct messaging',
   },
   {
     test: /sleep\s+\d+\s*&&\s*tmux/,
     message:
-      'Workers report via structured events — polling terminals is not needed.\n' +
-      '  genie task status <slug>   — check progress\n' +
-      '  genie agent send --to <a>  — communicate directly',
+      'Workers report via structured task state — polling terminals is not needed.\n' +
+      '  genie task status <id>          — check progress\n' +
+      '  SendMessage tool (native team)  — communicate directly',
   },
   {
     test: /sleep\s+\d+\s*&&\s*.*(?:capture-pane|tmux\s+list)/,
     message:
       'Consider using genie primitives instead of terminal polling:\n' +
-      '  genie task status <slug>\n' +
-      '  genie events list --since 5m',
+      '  genie task status <id>\n' +
+      '  genie task list --json',
   },
 ];
 

--- a/src/templates/genie-soul.md
+++ b/src/templates/genie-soul.md
@@ -18,59 +18,59 @@ brainstorm → wish → work → review → ship
 
 ## Genie Commands Reference
 
-### Agent Management
+### Worker Dispatch (native teams)
+Workers are not CLI processes. Spawn them with the **Agent tool** — they run in
+the background and notify you on completion. Send follow-ups with **SendMessage**;
+each worker's final report comes back as its Agent tool result. Worker state
+lives in the task engine:
 ```bash
-genie spawn <name>              # Start an agent (resolves from directory or built-ins)
-genie kill <name>               # Force kill an agent
-genie stop <name>               # Stop (preserves session for resume)
-genie resume [name]             # Resume a suspended agent
-genie ls                        # List agents with runtime status
-genie log [agent]               # Unified observability feed
-genie read <name>               # Read terminal output from agent pane
-genie history <name>            # Compressed session history
-genie answer <name> <choice>    # Answer a prompt for an agent
+genie task list --json                # Worker/task state
+genie task status <id>                # One task's detail + stage log
+genie launch <slug> [--groups <csv>]  # Multi-session cockpit: one pane per ready group
 ```
 
 ### Agent Communication
+Direct teammate messaging is native, not a CLI verb: use the **SendMessage tool**
+with the agent's ID or name (context preserved); each agent's final report returns
+to you as its Agent tool result. For state visibility, use the task engine:
 ```bash
-genie agent send '<msg>' --to <name>    # Direct message
-genie agent send '<msg>' --broadcast    # Team broadcast
-genie agent inbox                       # View inbox
-genie agent brief --team <name>         # Cold-start summary
+genie task list --json            # Task state across workers
+genie board --wish <slug> --json  # Wish progress board
 ```
 
-### Team Orchestration
+### Wave Orchestration
+Execution follows /work's wave model: one Agent-tool call per execution group,
+all in a single message, so groups run in parallel. The task DB keeps everyone
+honest:
 ```bash
-genie team create <name> --repo <path> --wish <slug>   # Launch autonomous team
-genie team hire <name> --team <team>                    # Add agent to team
-genie team fire <name> --team <team>                    # Remove agent from team
-genie team list                                         # List teams
-genie team disband <name>                               # Disband team
+genie task checkout <id> --worker <name>  # Worker atomically claims its task
+genie task done <id>                      # Orchestrator marks done after review + validation
 ```
 
-### Task & Wish Management
+### Task & Wish State
 ```bash
-genie task create --title 'x'     # Create task
-genie task list                   # List tasks
-genie task status <slug>          # Wish group status
-genie task done <ref>             # Mark done
-genie task board                  # Planning board
+genie task create --title 'x'     # Create a task
+genie task list                   # List tasks (filters available)
+genie task status <id>            # Task detail, dependencies, stage log
+genie board --wish <slug> --json  # Kanban view of wish progress
 ```
+Plans themselves are born through the skills: /wish structures them, /work runs them.
 
 ### Workspace
 ```bash
-genie init                        # Initialize workspace
-genie init agent <name>           # Scaffold new agent
-genie serve                       # Start infrastructure (pgserve + tmux + scheduler)
+genie init                        # Initialize per-repo state (idempotent)
 genie doctor                      # Diagnostic checks
 ```
+There is no infrastructure daemon to start — genie is zero-daemon. The only
+optional resident is `genie omni serve` (Omni channel bridge). Agent identity
+scaffolding is guided, not a CLI verb: use the /wizard skill.
 
 ## Concierge → Orchestrator Transition
 
 Detect workspace maturity and adapt:
 
 **Concierge mode** activates when:
-- Workspace has 0-1 agents (just the default genie agent)
+- Workspace has 0-1 agents (just the default genie itself)
 - No wishes exist yet
 - User appears new to genie (asking "how do I..." questions)
 
@@ -117,6 +117,6 @@ Missing:
   - [ ] HEARTBEAT.md — autonomous checklist
   - [ ] frontmatter.model — which model to use
 Suggestions:
-  - Run `genie init agent <name>` to scaffold missing files
+  - Run the /wizard skill to scaffold missing files
   - Run mini-wizard to complete frontmatter
 ```


### PR DESCRIPTION
## Bugs found during the skills-fable5-revamp release/E2E run

1. **version.yml race (functional — caused a missed dev release):** CI completes twice per dev merge (push + pull_request events). The PR-event `workflow_run` run always skips its job, but it shared concurrency group `version-<branch>` with `cancel-in-progress: true` and cancelled the in-flight push-event bump (observed 2026-07-04T23:11:46Z: cancelled+skipped pair → no release). Group is now event-scoped and bumps queue instead of cancelling (cancelling mid-tag-push was unsafe regardless; `git push --atomic` remains the stale-SHA guard).
2. **release.yml misleading comments:** claimed per-branch manifest homes; implementation (correctly) commits all channel manifests to MAIN, matching install.sh's `MANIFEST_BASE`. Comments/input description fixed — zero behavior change.
3. **CLAUDE.md CLI table stale:** 12 → 14 commands (adds `install`, `mcp`), verified against live `genie --help` v5.260705.3.
4. **orchestration-guard nudges taught dead v4 verbs** (`genie agent list/send`, `genie events ...`) → now recommend live v5 primitives (`genie task list --json`, `genie board --wish --json`, `genie task status <id>`, SendMessage tool). Nudge semantics unchanged (informational allow).
5. **genie-soul.md template shipped ~15 dead v4 commands** across dispatch/orchestration sections → full v5 native-team rewrite; strict dead-verb grep returns zero; dead `genie init agent` removed in favor of /wizard.

### Gates
`bun run check:fast` exit 0 (typecheck, biome, knip, skills:lint full-strict 28 files, wishes:lint); `bun test src/hooks/` 167 pass / 0 fail (dist rebuilt from branch); both YAMLs parse; independently reviewed — SHIP ×2 rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N1FLEV2Qse3jbX5Wz1sjWE