### PR TITLE
chore: promote dev → main (genie mcp registration + rules-ghost fix, v5.260705.5)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "5.260705.4",
+      "version": "5.260705.5",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/genie",
-  "version": "5.260705.4",
+  "version": "5.260705.5",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
   "type": "module",
   "bin": {

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260705.4",
+  "version": "5.260705.5",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/.mcp.json
+++ b/plugins/genie/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "genie": {
+      "command": "genie",
+      "args": ["mcp"]
+    }
+  }
+}

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "5.260705.4",
+  "version": "5.260705.5",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "type": "module",

--- a/plugins/genie/references/review-criteria.md
+++ b/plugins/genie/references/review-criteria.md
@@ -60,8 +60,8 @@ For PASS criteria, evidence includes:
 
 ```
 /wish → creates plan
-/plan-review → validates plan structure
-/make → executes plan
+/review (plan mode) → validates plan structure
+/work → executes plan
 /review → final validation → SHIP / FIX-FIRST / BLOCKED
 ```
 

--- a/plugins/genie/rules/genie-orchestration.md
+++ b/plugins/genie/rules/genie-orchestration.md
@@ -1,59 +1,20 @@
-# Genie CLI — Agent Orchestration
+# Genie — Agent Orchestration (v5)
+Genie is zero-daemon: docs live in git, task state in SQLite. Load `/genie` for full guidance.
 
-Automagik Genie is installed. Load `/genie` to activate full orchestration guidance.
+## Dispatch — native teams
+- Spawn workers with the **Agent tool**: one call per execution group, all groups in a single message for parallel waves; workers run in the background and notify on completion.
+- Follow-ups via **SendMessage**; each worker's final report returns as its Agent tool result. Push, not poll.
+- Multi-session cockpit: `genie launch <slug> [--groups <csv>]` — one pane per ready group.
 
-## Essential Commands
-
+## Task DB — the shared truth
 ```bash
-genie team create <name> --repo <path> --wish <slug>  # Launch autonomous team
-genie spawn <role>                                     # Spawn agent (engineer, reviewer, qa, fix)
-genie send '<msg>' --to <agent>                        # Message cross-session agent
-genie wish status <slug>                               # Check wish progress
-genie events list --since 5m                           # Recent structured events
-genie events timeline <entity-id>                      # Full entity event history
-genie ls --json                                        # Agent state from PG
+genie task checkout <id> --worker <name>  # worker atomically claims its task
+genie task status <id>                    # task detail + stage log
+genie task list --json                    # all task state
+genie board --wish <slug> --json          # wish progress
+genie task done <id>                      # ORCHESTRATOR marks done, after review + validation
 ```
 
-## Tool Restrictions
-
-NEVER use `Agent` to spawn agents — use `genie spawn` instead.
-NEVER use `TeamCreate` or `TeamDelete` — use `genie team create` / `genie team disband` instead.
-
-## Spawn Session Rule
-
-NEVER pass `--session <team-name>` to `genie spawn`. The team config already stores the correct `tmuxSessionName` (resolved at team creation from the parent session). Passing `--session` overrides this and creates a separate tmux session, breaking the topology.
-
-```bash
-# WRONG — creates separate session
-genie spawn reviewer --team my-team --session my-team
-
-# CORRECT — uses team's configured session
-genie spawn reviewer --team my-team
-```
-
-The `--session` flag is for rare manual overrides only. When `--team` is set, let genie resolve the session from the team config.
-
-## Post-Dispatch Monitoring
-
-After `genie team create` or `genie spawn`, use ONLY structured primitives. A hook enforces this automatically.
-
-### DO — Structured monitoring
-| Need | Command |
-|------|---------|
-| Wish progress | `genie wish status <slug>` |
-| Worker state | `genie ls --json` |
-| Send instructions | `genie send '<msg>' --to <agent>` |
-| Event timeline | `genie events timeline <id>` |
-| Error patterns | `genie events errors` |
-
-### NEVER — Terminal scraping
-- `tmux capture-pane` to check worker progress (BLOCKED by hook)
-- `sleep` + poll loops to watch terminal output (BLOCKED by hook)
-- Raw terminal text parsing for workflow decisions
-
-### Post-dispatch flow
-1. **Dispatch** — `genie team create` or `genie spawn`
-2. **Trust** — workers execute autonomously, report via PG events
-3. **Check** — `genie wish status <slug>` for progress
-4. **Communicate** — `genie send` for instructions
-5. **Review** — when workers report done, review output
+## Never
+- Terminal-scrape (`tmux capture-pane`) or sleep-poll workers — use the primitives above; a hook nudges this.
+- Workers marking their own tasks done — `done` is the orchestrator's verb, post-review.

--- a/plugins/genie/scripts/smart-install.js
+++ b/plugins/genie/scripts/smart-install.js
@@ -239,60 +239,10 @@ function genieCliNeedsInstall() {
 }
 
 
-/**
- * Read the current marker version (before installDeps overwrites it).
- * Returns the version string or null if not found.
- */
-function getMarkerVersion() {
-  try {
-    if (existsSync(MARKER)) {
-      const marker = JSON.parse(readFileSync(MARKER, 'utf-8'));
-      return marker.version || null;
-    }
-  } catch {
-    // Ignore
-  }
-  return null;
-}
-
-/**
- * Inject the orchestration prompt into ~/.claude/rules/genie-orchestration.md
- * Reads from the rules file in the plugin directory.
- * Only writes/rewrites if the plugin version changed.
- * @param {string|null} oldVersion - marker version captured before installDeps ran
- */
-function injectOrchestrationPrompt(oldVersion) {
-  const rulesDir = join(homedir(), '.claude', 'rules');
-  const destFile = join(rulesDir, 'genie-orchestration.md');
-
-  if (!existsSync(rulesDir)) {
-    mkdirSync(rulesDir, { recursive: true });
-  }
-
-  let pluginVersion = null;
-  try {
-    const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf-8'));
-    pluginVersion = pkg.version || null;
-  } catch {
-    // Ignore
-  }
-
-  const fileExists = existsSync(destFile);
-  const versionChanged = !fileExists || oldVersion !== pluginVersion;
-
-  if (versionChanged) {
-    const sourceFile = join(ROOT, 'rules', 'genie-orchestration.md');
-    if (existsSync(sourceFile)) {
-      const content = readFileSync(sourceFile, 'utf-8');
-      writeFileSync(destFile, content, 'utf-8');
-      console.error(`Orchestration rules installed: ${destFile}`);
-    } else {
-      // Fallback: write minimal inline message
-      writeFileSync(destFile, '# Genie CLI\n\nUse `genie` CLI for all agent operations. Never use native Agent/SendMessage tools.\n', 'utf-8');
-      console.error(`Orchestration rules installed (fallback): ${destFile}`);
-    }
-  }
-}
+// NOTE: this script used to copy rules/genie-orchestration.md into
+// ~/.claude/rules/ on version change. That injection is gone: the rules file
+// is plugin-native (loaded from the plugin itself), and the copy kept
+// resurrecting a file that `genie install`'s v4 cleanup deletes.
 
 /**
  * Create default ~/.genie/config.json with schema v2 defaults if missing.
@@ -456,7 +406,7 @@ try {
   if (!isTmuxInstalled()) {
     console.error('');
     console.error('WARNING: tmux is not installed.');
-    console.error('tmux is required for agent orchestration (genie spawn, teams, etc.).');
+    console.error('tmux is required for the genie launch cockpit and TUI integration.');
     console.error('Non-interactive features still work without it.');
     console.error('');
     console.error('Install tmux:');
@@ -474,30 +424,20 @@ try {
     // Don't exit — let the rest of the chain run
   }
 
-  // Capture marker version BEFORE installDeps overwrites it
-  const oldVersion = getMarkerVersion();
-
   // 3. Install plugin dependencies if needed
   if (needsInstall()) {
     installDeps();
     console.error('Dependencies installed');
   }
 
-  // 3a. Inject orchestration prompt (idempotent — checks version marker)
-  try {
-    injectOrchestrationPrompt(oldVersion);
-  } catch (e) {
-    console.error(`Warning: Could not write orchestration prompt: ${e.message}`);
-  }
-
-  // 3b. Create default config if missing (idempotent — never overwrites)
+  // 3a. Create default config if missing (idempotent — never overwrites)
   try {
     createDefaultConfig();
   } catch (e) {
     console.error(`Warning: Could not create default config: ${e.message}`);
   }
 
-  // 3c. Configure tmux TUI (scripts + config on first run)
+  // 3b. Configure tmux TUI (scripts + config on first run)
   try {
     configureTmux();
   } catch (e) {


### PR DESCRIPTION
## Promotion: 2 commits

1. **#2526** (twice-reviewed SHIP, merged to dev): registers the `genie mcp` stdio server via plugin `.mcp.json` (tools verified live: `genie_board`, `genie_wish_status`, `genie_worktree_context`, `genie_task`, `genie_active`); removes the SessionStart injection of stale v4 orchestration rules into `~/.claude/rules/` (the confirmed ghost-restorer fighting `genie install`'s v4 cleanup); plugin rules rewritten lean-v5 (59→20, zero dead verbs); review-criteria + tmux-string dead names fixed.
2. `chore(version): bump to 5.260705.5 [auto-version]` — **the version-race fix proving itself: this tag/release cut fully autonomously on the natural dev merge** (no manual dispatch, first time tonight).

Diff shape verified: 8 files, +36/−127, all under plugins/genie/ + version-stamped manifests. Release v5.260705.5 publishing now; on merge, the stable channel + marketplace advance and `/plugin` update + restart surfaces the genie MCP server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N1FLEV2Qse3jbX5Wz1sjWE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new MCP server entry for Genie, enabling it to run with the updated command flow.
  * Introduced multi-session cockpit launching and clearer orchestration guidance for managing background work in parallel.

* **Documentation**
  * Updated the Genie review workflow and orchestration reference to reflect the latest command names and status flow.

* **Chores**
  * Bumped the app and plugin version to `5.260705.5`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->