### PR TITLE
chore: promote dev → main (rolling-pr auth hardening, v5.260705.6)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "5.260705.5",
+      "version": "5.260705.6",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/.genie/wishes/rolling-pr-auth-hardening/WISH.md
+++ b/.genie/wishes/rolling-pr-auth-hardening/WISH.md
@@ -1,0 +1,103 @@
+# Wish: Harden rolling-pr.yml Auth (Fail-Fast + Token Split)
+
+| Field | Value |
+|-------|-------|
+| **Status** | DRAFT |
+| **Slug** | `rolling-pr-auth-hardening` |
+| **Date** | 2026-07-05 |
+| **Author** | Felipe (dogfooding the revamped v5 lifecycle) |
+| **Appetite** | small |
+| **Branch** | `wish/rolling-pr-auth-hardening` |
+| **Repos touched** | `automagik-dev/genie` → `/home/feliperosa/vm-home/workspace/worktrees/genie-skills-revamp` |
+| **Design** | _No brainstorm — direct wish_ |
+
+## Summary
+
+**Problem:** `rolling-pr.yml` fails every hour with a raw unauthenticated-gh error ("Try authenticating with: gh auth login") because `secrets.RELEASE_PLEASE_TOKEN` is present but dead — runs show `HTTP 401: Bad credentials` with the token masked `***` (expired/revoked PAT), verified in run logs; the failure forced two manual promotion-PR creations tonight. Repo workflow permissions are `read`-only with PR-approval disabled, so `github.token` genuinely cannot create PRs — the PAT is required for creation, but the workflow should say so instead of dying cryptically.
+
+Harden the workflow: fail fast with an actionable `::error` when the secret is absent, and scope the PAT to the one step that needs it (PR creation) so the read-only existence check runs on `github.token`.
+
+## Scope
+
+### IN
+
+- `.github/workflows/rolling-pr.yml` only: explicit guard step that fails when the secret is empty OR fails a cheap validity probe (`gh api user` with the PAT, read-only, ~1s), with `::error::RELEASE_PLEASE_TOKEN missing or invalid (HTTP 401) — mint a PAT with contents:read + pull-requests:write and add it to repo secrets` when the secret is empty; `gh pr list` (read-only) runs with `GH_TOKEN: ${{ github.token }}`; only `gh pr create` uses the PAT; cadence, concurrency, and PR body preserved.
+
+### OUT
+
+- Minting/refreshing the PAT itself — human action item for Felipe (repo Settings → Secrets → `RELEASE_PLEASE_TOKEN`).
+- Any other workflow; any change to the rolling-PR cadence or merge policy (§19 humans-only main merges unchanged).
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | Fail-fast guard instead of silent PAT fallback to `github.token` for creation | Repo setting `default_workflow_permissions: read`, `can_approve_pull_request_reviews: false` (verified via API) — creation with `github.token` would fail anyway; a loud, actionable error beats an hourly cryptic one |
+| 2 | Split tokens: `github.token` for list, PAT for create | Least privilege; the workflow keeps working read-only (and reports clearly) even while the secret is dead |
+
+## Success Criteria
+
+- [ ] With the secret absent or dead (current reality: present, 401): `workflow_dispatch` run fails in seconds with the actionable `::error` text, not a raw gh auth message.
+- [ ] `gh pr list` step authenticates via `github.token` (no PAT dependency on the read path).
+- [ ] YAML parses; workflow diff touches only `rolling-pr.yml`.
+- [ ] Once Felipe refreshes the PAT: the hourly run creates/confirms the rolling PR again (post-merge QA item).
+
+## Execution Strategy
+
+### Wave 1 (single group, sequential)
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| harden | engineer | Guard + token split in rolling-pr.yml |
+
+## Execution Groups
+
+### Group harden: Guard + token split
+
+**Goal:** The workflow self-diagnoses a missing PAT and needs it only where GitHub policy requires it.
+
+**Deliverables:**
+1. Guard step (first): if `secrets.RELEASE_PLEASE_TOKEN` is empty OR the validity probe (`gh api user` under the PAT) fails → same actionable `::error` mint/refresh text → exit 1.
+2. Existence check (`gh pr list`) on `GH_TOKEN: ${{ github.token }}`; creation step keeps the PAT env; stale comment updated to explain the split + the verified repo policy.
+
+**Acceptance Criteria:**
+- [ ] YAML valid; only rolling-pr.yml modified.
+- [ ] Guard precedes any gh call; error text names the secret, required scopes, and where to add it.
+- [ ] PR body/title/cadence/concurrency byte-preserved.
+
+**Validation:**
+```bash
+cd "$(git rev-parse --show-toplevel)" && python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/rolling-pr.yml')); print('yaml-ok')" && \
+  grep -q "::error" .github/workflows/rolling-pr.yml && grep -q "api user" .github/workflows/rolling-pr.yml && grep -q "github.token" .github/workflows/rolling-pr.yml && echo HARDEN-OK
+```
+
+**depends-on:** none
+
+---
+
+## QA Criteria
+
+- [ ] Post-merge `workflow_dispatch` (secret still absent) → clear actionable failure in the Actions UI.
+- [ ] After Felipe adds the PAT → next hourly run green, rolling PR exists.
+
+---
+
+## Assumptions / Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Org policy also blocks PAT-created PRs from Actions | Low | Tonight's evidence: PRs #2516/#779 previously auto-created via the same secret when it was valid |
+
+---
+
+## Review Results
+
+_Populated by `/review`._
+
+---
+
+## Files to Create/Modify
+
+```
+.github/workflows/rolling-pr.yml   (modify — guard + token split + comment)
+```

--- a/.github/workflows/rolling-pr.yml
+++ b/.github/workflows/rolling-pr.yml
@@ -18,21 +18,48 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 5
     steps:
-      - name: Check/Create Rolling PR
+      - name: Guard — RELEASE_PLEASE_TOKEN must be valid
         env:
-          # GITHUB_TOKEN cannot create PRs (org restriction).
-          # Use a PAT with contents:read + pull-requests:write scopes.
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          # Fail loudly up front instead of hourly-cryptically at create time:
+          # observed 2026-07-05, the secret was PRESENT but returned HTTP 401
+          # Bad credentials (expired/revoked PAT). Cheap read-only probe; the
+          # PAT itself is only needed for PR creation (see the create step).
+          if [ -z "$GH_TOKEN" ] || ! gh api user >/dev/null 2>&1; then
+            echo "::error::RELEASE_PLEASE_TOKEN missing or invalid (HTTP 401) — mint a PAT with contents:read + pull-requests:write and add it to repo secrets"
+            exit 1
+          fi
+
+      - name: Check for existing Rolling PR
+        id: check
+        env:
+          # Read path is PAT-free: listing PRs needs only read access, which
+          # github.token retains even under this repo's Actions policy
+          # (workflow permissions read-only, "create and approve pull
+          # requests" disabled).
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Check if open PR exists (dev -> main)
           PR=$(gh pr list --repo ${{ github.repository }} --base main --head dev --state open --json number --jq '.[0].number')
+          echo "pr=$PR" >> "$GITHUB_OUTPUT"
+          if [ -n "$PR" ]; then
+            echo "Rolling PR #$PR exists and is up to date"
+          fi
 
-          if [ -z "$PR" ]; then
-            # Create new rolling PR
-            gh pr create --repo ${{ github.repository }} \
-              --base main --head dev \
-              --title "chore: rolling promotion dev -> main" \
-              --body "$(cat <<'BODY'
+      - name: Create Rolling PR
+        if: steps.check.outputs.pr == ''
+        env:
+          # Creation is the ONLY step that needs the PAT: verified repo policy
+          # is read-only workflow permissions with "create and approve pull
+          # requests" disabled, so github.token cannot create PRs.
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          # Create new rolling PR
+          gh pr create --repo ${{ github.repository }} \
+            --base main --head dev \
+            --title "chore: rolling promotion dev -> main" \
+            --body "$(cat <<'BODY'
           ## Rolling Promotion PR
 
           Auto-maintained rolling promotion PR from `dev` to `main`.
@@ -49,7 +76,4 @@ jobs:
           > Human approval required for merge to production.
           BODY
           )"
-            echo "Created new rolling PR"
-          else
-            echo "Rolling PR #$PR exists and is up to date"
-          fi
+          echo "Created new rolling PR"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/genie",
-  "version": "5.260705.5",
+  "version": "5.260705.6",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
   "type": "module",
   "bin": {

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260705.5",
+  "version": "5.260705.6",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "5.260705.5",
+  "version": "5.260705.6",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "type": "module",


### PR DESCRIPTION
## Promotion: 2 commits — the dogfood lap of the revamped v5 lifecycle

1. **#2528** (plan-reviewed FIX-FIRST→amended→execution-reviewed SHIP): `rolling-pr.yml` fail-fast guard on dead/missing `RELEASE_PLEASE_TOKEN` (probe: `gh api user`; actionable `::error` with scopes + location) + read/create token split (`github.token` for list, PAT solely for create per verified read-only repo Actions policy). Title/body/cron/concurrency byte-preserved.
2. `chore(version): bump to 5.260705.6 [auto-version]` — second consecutive fully-autonomous release since the race fix.

**Human action item (unblocks the hourly rolling PR):** refresh the `RELEASE_PLEASE_TOKEN` repo secret — PAT with `contents:read + pull-requests:write`. Until then the workflow fails loudly with those exact instructions.

Lifecycle exercised end-to-end with the revamped skills (plugin 5.260705.5), genie MCP tools, and the task DB — full trail in `.genie/wishes/rolling-pr-auth-hardening/WISH.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N1FLEV2Qse3jbX5Wz1sjWE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved rolling PR automation with a clearer, safer authentication flow.
  * Added an early validation check that surfaces a fast, actionable error when the required token is missing or invalid.

* **Bug Fixes**
  * Split PR checking and PR creation into separate steps so read-only checks use limited access and creation only runs when needed.

* **Chores**
  * Bumped the package and plugin versions to `5.260705.6`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->