### PR TITLE
fix(ci): rolling-pr treats dev==main as healthy no-op

### DIFF
--- a/.github/workflows/rolling-pr.yml
+++ b/.github/workflows/rolling-pr.yml
@@ -55,8 +55,10 @@ jobs:
           # requests" disabled, so github.token cannot create PRs.
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
-          # Create new rolling PR
-          gh pr create --repo ${{ github.repository }} \
+          # Create new rolling PR. dev == main (no commits to promote) is a
+          # healthy state, not a failure — tolerate exactly that error.
+          set +e
+          OUT=$(gh pr create --repo ${{ github.repository }} \
             --base main --head dev \
             --title "chore: rolling promotion dev -> main" \
             --body "$(cat <<'BODY'
@@ -75,5 +77,17 @@ jobs:
 
           > Human approval required for merge to production.
           BODY
-          )"
-          echo "Created new rolling PR"
+          )" 2>&1)
+          RC=$?
+          set -e
+          if [ $RC -ne 0 ]; then
+            if echo "$OUT" | grep -q "No commits between"; then
+              echo "dev == main — nothing to promote; healthy no-op"
+            else
+              echo "$OUT" >&2
+              exit $RC
+            fi
+          else
+            echo "$OUT"
+            echo "Created new rolling PR"
+          fi


### PR DESCRIPTION
Follow-up to #2528: with the refreshed PAT, the run now reaches createPullRequest successfully; the only remaining failure mode is `No commits between main and dev` — a healthy state that kept the hourly run red. Tolerate exactly that error (all other create failures still fail loudly). YAML + step-script bash syntax validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N1FLEV2Qse3jbX5Wz1sjWE