### PR TITLE
feat(doctor): v4 home-residue detection + --fix, diagnostics age filter

### DIFF
--- a/.genie/wishes/v4-home-residue-doctor/WISH.md
+++ b/.genie/wishes/v4-home-residue-doctor/WISH.md
@@ -1,0 +1,109 @@
+# Wish: v4 Home Residue — Manifest + Doctor Check/Fix + Diagnostics Age Filter
+
+| Field | Value |
+|-------|-------|
+| **Status** | DRAFT |
+| **Slug** | `v4-home-residue-doctor` |
+| **Date** | 2026-07-05 |
+| **Author** | Felipe (directive: "find and clean all stale genie v4 shit… genie doctor should do that") |
+| **Appetite** | small |
+| **Branch** | `wish/v4-home-residue-doctor` |
+| **Repos touched** | `automagik-dev/genie` → `/home/feliperosa/vm-home/workspace/worktrees/genie-skills-revamp` |
+| **Design** | _No brainstorm — direct wish_ |
+
+## Summary
+
+**Problem:** the v4→v5 cutover left daemon-era residue in `~/.genie` on upgraded machines (scheduler/serve/relay/spawn artifacts, megabyte logs), and `genie update`'s diagnostics tail `logs/scheduler.log` with no age filter — a June-22 disk-full incident just resurfaced as "Recent scheduler signals" on a healthy machine. The existing `legacy-v4` cleanup only covers `~/.claude` (rules file, plugin caches). Extend it to `~/.genie` home residue, surface detection in `genie doctor` with an opt-in `--fix`, and age-filter the diagnostics tail — so every upgraded user gets the same cleanup, not just this machine.
+
+## Scope
+
+### IN
+
+- Extend `src/genie-commands/legacy-v4.ts` manifest with `~/.genie` v4 residue, **each entry verified dead against v5 src** (nothing in `src/` reads/writes it) before inclusion. Candidates observed on a real v4-upgraded machine (mtimes May/June vs v5-live today): `serve.pid`, `genie-serve.config.cjs`, `relay/`, `spawn-scripts/`, `hook-fallback.log`, `role-cutover-events.jsonl`, `.role-cutover-*.json`, `config.json.bak-pre-omni`, `state/` (v4 wish-state JSONs; v5 state = genie.db), `logs/scheduler.log`, `Genie.config.cjs`, `model-a/`, `data/`, `tmux.conf.bak`, `tui-tmux.conf.bak`. Engineer classifies each keep/delete from src evidence; uncertain → KEEP (log-only report).
+- `genie doctor`: new check "v4 residue" — reports found relics (count + total size, per-path list); `genie doctor --fix` runs the same backup-first cleanup path (`cleanupV4`-family: backup to `~/.genie/state-backups/v4-cleanup-<ts>/`, logged, idempotent). Without `--fix`, detection only, exit code unchanged.
+- `src/genie-commands/update.ts` diagnostics: `summarizeJsonlSignals(schedulerLog)` gains an age filter (default: signals older than 48h excluded; if everything is older, print "no recent signals; last entry <date>" instead of resurfacing stale errors).
+- Tests (pgserve-free, fixture homes): manifest classification, doctor detect vs --fix behavior, backup-first ordering reuse, age-filter boundary.
+
+### OUT
+
+- No deletion of anything v5 reads/writes (bin/, worktrees/, state-backups/, logs/ other than scheduler.log, genie.db*, config.json, keys/, plugins/skills/templates/, scripts/ + tmux/TUI confs — smart-install still manages those).
+- No changes to `~/.claude` handling (already shipped); no doctor UX redesign beyond the one check + flag.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | Doctor is detect-by-default, `--fix` opt-in | Doctor is a diagnostic surface users run casually; destructive action needs explicit intent. install/update keep auto-cleaning (already-shipped behavior) but gain the extended manifest |
+| 2 | Uncertain classification → KEEP + report | Deleting user home data on a guess is the one unforgivable failure; the manifest only ever lists provably-dead paths |
+| 3 | Age-filter in the reporter, not log deletion alone | scheduler.log is also in the delete manifest, but the reporter must be robust for users who never run --fix |
+
+## Success Criteria
+
+- [ ] Every manifest addition justified by a src-grep proof (path absent from v5 read/write surfaces), stated in code comment or test.
+- [ ] `genie doctor` on a residue-laden fixture home reports the relics; `--fix` backs up + removes exactly the manifest entries; second run reports clean; non-manifest files untouched (test-proven).
+- [ ] Update diagnostics on a fixture scheduler.log with only June entries prints the no-recent-signals line, not the errors.
+- [ ] `bun run check:fast` green; existing v4-cleanup tests still green; field run on THIS machine (post-merge): `genie doctor` reports the real residue, `genie doctor --fix` cleans it, backups verified.
+
+## Execution Strategy
+
+### Wave 1 (single group)
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| residue | engineer | Manifest extension + doctor check/--fix + diagnostics age filter + tests |
+
+## Execution Groups
+
+### Group residue
+
+**Goal:** Every upgraded machine can find and clean its v4 home residue via genie itself.
+
+**Deliverables:**
+1. Manifest extension in `legacy-v4.ts` (src-proof per entry; uncertain → excluded, listed in report only).
+2. Doctor check + `--fix` flag wiring (follow the existing doctor check patterns).
+3. `summarizeJsonlSignals` age filter (48h default) with stale-summary line.
+4. Tests per Success Criteria.
+
+**Acceptance Criteria:**
+- [ ] Detect/fix/idempotency/non-manifest-untouched all test-locked.
+- [ ] Doctor without --fix mutates nothing (test-proven).
+- [ ] tsc, biome, check:fast green.
+
+**Validation:**
+```bash
+cd "$(git rev-parse --show-toplevel)" && bunx tsc --noEmit && \
+  bun test $(ls src/genie-commands/*v4*.test.ts src/genie-commands/install.test.ts 2>/dev/null) && echo RESIDUE-OK
+```
+
+**depends-on:** none
+
+---
+
+## QA Criteria
+
+- [ ] Post-merge on this machine: `genie doctor` lists the real residue (~2MB: hook-fallback.log 1MB, role-cutover-events.jsonl 0.9MB, + small files); `--fix` cleans with backup; `genie update` diagnostics no longer show June signals.
+
+---
+
+## Assumptions / Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| A "dead" path is live for some user workflow (TUI/scripts) | High | Decision 2: src-proof required; uncertain → KEEP; backup-first makes mistakes reversible |
+
+---
+
+## Review Results
+
+_Populated by /review._
+
+---
+
+## Files to Create/Modify
+
+```
+src/genie-commands/legacy-v4.ts        (manifest extension + home-residue support)
+src/genie-commands/legacy-v4.test.ts   (new scenarios)
+<doctor command file>                   (v4-residue check + --fix)
+src/genie-commands/update.ts            (summarizeJsonlSignals age filter)
+```

--- a/src/genie-commands/__tests__/update.test.ts
+++ b/src/genie-commands/__tests__/update.test.ts
@@ -37,6 +37,7 @@ import {
   runVerifyProbe,
   shortCircuitIfCurrent,
   shouldEmitPathDivergenceWarning,
+  summarizeJsonlSignals,
   syncBinaryVersionStamp,
   verifySwappedBinary,
 } from '../update.js';
@@ -1385,6 +1386,7 @@ describe('shouldEmitPathDivergenceWarning (self-symlink suppression)', () => {
 describe('runV4CleanupSafe', () => {
   const stubResult = {
     report: { rulesFile: { path: '/fixture', status: 'absent' as const }, cacheDirs: [], hasRelics: false },
+    homeResidue: [],
     actions: [],
     backupDir: null,
     logFile: null,
@@ -1418,5 +1420,70 @@ describe('runV4CleanupSafe', () => {
     expect(callIdx).toBeGreaterThan(-1);
     expect(verifyIdx).toBeGreaterThan(-1);
     expect(callIdx).toBeLessThan(verifyIdx);
+  });
+});
+
+// ============================================================================
+// Scheduler-signal age filter (wish v4-home-residue-doctor): a June disk-full
+// incident must not resurface as "Recent scheduler signals" weeks later.
+// ============================================================================
+
+describe('summarizeJsonlSignals age filter', () => {
+  const HOUR = 60 * 60 * 1000;
+  const NOW = Date.parse('2026-07-05T12:00:00.000Z');
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'sched-age-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeLog(entries: Array<{ level: string; event: string; ageHours?: number; error?: string }>): string {
+    const path = join(dir, 'scheduler.log');
+    const lines = entries.map((e) => {
+      const timestamp = e.ageHours === undefined ? undefined : new Date(NOW - e.ageHours * HOUR).toISOString();
+      return JSON.stringify({ level: e.level, event: e.event, timestamp, error: e.error });
+    });
+    writeFileSync(path, `${lines.join('\n')}\n`, 'utf-8');
+    return path;
+  }
+
+  test('only-stale log → zero signals, newest stale timestamp reported', () => {
+    const path = writeLog([
+      { level: 'error', event: 'disk.full', ageHours: 320, error: 'ENOSPC' },
+      { level: 'error', event: 'disk.full', ageHours: 313, error: 'ENOSPC' },
+    ]);
+    const summary = summarizeJsonlSignals(path, NOW);
+    expect(summary.signals).toHaveLength(0);
+    expect(summary.newestStaleTimestamp).toBe(new Date(NOW - 313 * HOUR).toISOString());
+  });
+
+  test('mixed log → only fresh entries summarized', () => {
+    const path = writeLog([
+      { level: 'error', event: 'disk.full', ageHours: 320, error: 'ENOSPC' },
+      { level: 'warn', event: 'queue.slow', ageHours: 3 },
+    ]);
+    const summary = summarizeJsonlSignals(path, NOW);
+    expect(summary.signals.map((s) => s.event)).toEqual(['queue.slow']);
+    expect(summary.newestStaleTimestamp).toBe(new Date(NOW - 320 * HOUR).toISOString());
+  });
+
+  test('48h boundary: exactly 48h kept, just past excluded', () => {
+    const path = writeLog([
+      { level: 'error', event: 'at.boundary', ageHours: 48 },
+      { level: 'error', event: 'past.boundary', ageHours: 48.001 },
+    ]);
+    const summary = summarizeJsonlSignals(path, NOW);
+    expect(summary.signals.map((s) => s.event)).toEqual(['at.boundary']);
+    expect(summary.newestStaleTimestamp).not.toBeNull();
+  });
+
+  test('entries without a parseable timestamp are kept — staleness must be proven', () => {
+    const path = writeLog([{ level: 'error', event: 'no.timestamp' }]);
+    const summary = summarizeJsonlSignals(path, NOW);
+    expect(summary.signals.map((s) => s.event)).toEqual(['no.timestamp']);
+    expect(summary.newestStaleTimestamp).toBeNull();
   });
 });

--- a/src/genie-commands/doctor.test.ts
+++ b/src/genie-commands/doctor.test.ts
@@ -1,10 +1,20 @@
 import { Database } from 'bun:sqlite';
 import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { doctorCommand, evaluateOmniHookTimeout, findDispatchHookTimeoutSec } from './doctor.js';
+import { checkV4Residue, doctorCommand, evaluateOmniHookTimeout, findDispatchHookTimeoutSec } from './doctor.js';
+import { cleanupV4 } from './legacy-v4.js';
 
 /**
  * Capture everything written to stdout during `fn`, restoring the real
@@ -187,5 +197,195 @@ describe('doctorCommand — genie.db check branches', () => {
     expect(db?.status).toBe('fail');
     expect(json.ok).toBe(false);
     expect(exitCode).toBe(1);
+  });
+});
+
+// ============================================================================
+// v4 residue check (wish v4-home-residue-doctor)
+// ============================================================================
+
+describe('checkV4Residue', () => {
+  let residueHome: string;
+  let residueGenieHome: string;
+  let savedGenieHomeEnv: string | undefined;
+
+  beforeEach(() => {
+    residueHome = mkdtempSync(join(tmpdir(), 'doctor-v4-'));
+    residueGenieHome = join(residueHome, '.genie');
+    savedGenieHomeEnv = process.env.GENIE_HOME;
+  });
+
+  afterEach(() => {
+    rmSync(residueHome, { recursive: true, force: true });
+    if (savedGenieHomeEnv === undefined) {
+      // biome-ignore lint/performance/noDelete: process.env assignment coerces undefined→"undefined"; delete is the only correct unset
+      delete process.env.GENIE_HOME;
+    } else process.env.GENIE_HOME = savedGenieHomeEnv;
+  });
+
+  function seed(): string[] {
+    mkdirSync(join(residueGenieHome, 'spawn-scripts'), { recursive: true });
+    writeFileSync(join(residueGenieHome, 'spawn-scripts', 'run.sh'), '#!/bin/sh\n', 'utf-8');
+    writeFileSync(join(residueGenieHome, 'serve.pid'), '999\n', 'utf-8');
+    writeFileSync(join(residueGenieHome, 'config.json'), '{"version":2}\n', 'utf-8'); // live
+    return [join(residueGenieHome, 'spawn-scripts'), join(residueGenieHome, 'serve.pid')];
+  }
+
+  /** Recursive (path, size, mtimeMs) snapshot — proves detection mutates nothing. */
+  function snapshot(dir: string): string[] {
+    const out: string[] = [];
+    const walk = (d: string): void => {
+      for (const entry of readdirSync(d, { withFileTypes: true })) {
+        const p = join(d, entry.name);
+        const s = statSync(p);
+        out.push(`${p}|${s.size}|${s.mtimeMs}`);
+        if (entry.isDirectory()) walk(p);
+      }
+    };
+    walk(dir);
+    return out.sort();
+  }
+
+  test('clean home → single pass line', () => {
+    const results = checkV4Residue(residueHome, residueGenieHome);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ name: 'v4 residue', status: 'pass' });
+  });
+
+  test('residue → warn summary (count + size) plus per-path list; detection is a pure read', () => {
+    seed();
+    const before = snapshot(residueHome);
+
+    const results = checkV4Residue(residueHome, residueGenieHome);
+
+    expect(snapshot(residueHome)).toEqual(before); // zero mutation
+    const summary = results[0];
+    expect(summary.status).toBe('warn');
+    expect(summary.detail).toContain('2 reclaimable item(s) (2 genie-home, 0 claude)');
+    expect(summary.suggestion).toContain('--fix');
+    const paths = results
+      .slice(1)
+      .map((r) => r.name)
+      .sort();
+    expect(paths).toEqual(['v4 residue: serve.pid', 'v4 residue: spawn-scripts']);
+  });
+
+  test('--fix path (cleanupV4) clears the check; live config.json untouched', () => {
+    seed();
+    expect(checkV4Residue(residueHome, residueGenieHome)[0].status).toBe('warn');
+
+    cleanupV4({ home: residueHome, genieHome: residueGenieHome });
+
+    const after = checkV4Residue(residueHome, residueGenieHome);
+    expect(after).toHaveLength(1);
+    expect(after[0].status).toBe('pass');
+    expect(readFileSync(join(residueGenieHome, 'config.json'), 'utf-8')).toBe('{"version":2}\n');
+  });
+
+  test('doctorCommand without --fix mutates nothing (GENIE_HOME fixture)', async () => {
+    seed();
+    process.env.GENIE_HOME = residueGenieHome;
+    const before = snapshot(residueHome);
+
+    const { output } = await captureDoctor(() => doctorCommand({ json: true }));
+
+    expect(snapshot(residueHome)).toEqual(before); // no fix flag → zero disk change
+    const parsed = JSON.parse(output) as { checks: Array<{ name: string; status: string }> };
+    const relicChecks = parsed.checks.filter((c) => c.name.startsWith('v4 residue:'));
+    expect(relicChecks.map((c) => c.name)).toContain('v4 residue: serve.pid');
+  });
+
+  test('doctorCommand wires cleanup strictly behind the fix flag (source lock)', () => {
+    const source = readFileSync(join(import.meta.dir, 'doctor.ts'), 'utf-8');
+    expect(source).toMatch(/if \(options\?\.fix\) \{\s*\n\s*cleanupV4\(/);
+  });
+});
+
+describe('checkV4Residue — accounting + uncertain keeps + json fix', () => {
+  let fxHome: string;
+  let fxGenieHome: string;
+  let savedGenieHomeEnv: string | undefined;
+  let savedHomeEnv: string | undefined;
+
+  beforeEach(() => {
+    fxHome = mkdtempSync(join(tmpdir(), 'doctor-v4b-'));
+    fxGenieHome = join(fxHome, '.genie');
+    savedGenieHomeEnv = process.env.GENIE_HOME;
+    savedHomeEnv = process.env.HOME;
+  });
+
+  afterEach(() => {
+    if (savedHomeEnv === undefined) {
+      // biome-ignore lint/performance/noDelete: process.env assignment coerces undefined→"undefined"; delete is the only correct unset
+      delete process.env.HOME;
+    } else process.env.HOME = savedHomeEnv;
+    if (savedGenieHomeEnv === undefined) {
+      // biome-ignore lint/performance/noDelete: same env-unset contract as above
+      delete process.env.GENIE_HOME;
+    } else process.env.GENIE_HOME = savedGenieHomeEnv;
+    rmSync(fxHome, { recursive: true, force: true });
+  });
+
+  test('user-modified rules file: kept, labeled, never counted as reclaimable', () => {
+    mkdirSync(join(fxHome, '.claude', 'rules'), { recursive: true });
+    writeFileSync(join(fxHome, '.claude', 'rules', 'genie-orchestration.md'), '# my own rules\n', 'utf-8');
+    mkdirSync(fxGenieHome, { recursive: true });
+    writeFileSync(join(fxGenieHome, 'serve.pid'), '1\n', 'utf-8');
+
+    const results = checkV4Residue(fxHome, fxGenieHome);
+
+    const summary = results[0];
+    expect(summary.detail).toContain('1 reclaimable item(s) (1 genie-home, 0 claude)');
+    const rulesRow = results.find((r) => r.name === 'v4 residue: ~/.claude rules file');
+    expect(rulesRow?.detail).toContain('kept (user-modified)');
+    // still kept on disk after a fix run
+    cleanupV4({ home: fxHome, genieHome: fxGenieHome });
+    expect(readFileSync(join(fxHome, '.claude', 'rules', 'genie-orchestration.md'), 'utf-8')).toBe('# my own rules\n');
+  });
+
+  test('marker rules file is counted and byte-sized in the claude bucket', () => {
+    mkdirSync(join(fxHome, '.claude', 'rules'), { recursive: true });
+    writeFileSync(join(fxHome, '.claude', 'rules', 'genie-orchestration.md'), 'genie spawn everything\n', 'utf-8');
+
+    const results = checkV4Residue(fxHome, fxGenieHome);
+
+    expect(results[0].detail).toContain('1 reclaimable item(s) (0 genie-home, 1 claude)');
+    expect(results.find((r) => r.name === 'v4 residue: ~/.claude rules file')?.detail).toMatch(/\d+ B/);
+  });
+
+  test('uncertain keeps are report-only rows and survive --fix', () => {
+    mkdirSync(join(fxGenieHome, '.genie'), { recursive: true });
+    writeFileSync(join(fxGenieHome, 'tmux.conf.bak'), 'old tmux\n', 'utf-8');
+    writeFileSync(join(fxGenieHome, 'serve.pid'), '1\n', 'utf-8');
+
+    const results = checkV4Residue(fxHome, fxGenieHome);
+    const keptNames = results.filter((r) => r.name.startsWith('kept (uncertain):')).map((r) => r.name);
+    expect(keptNames.sort()).toEqual(['kept (uncertain): .genie', 'kept (uncertain): tmux.conf.bak']);
+    for (const r of results.filter((x) => x.name.startsWith('kept (uncertain):'))) expect(r.status).toBe('pass');
+
+    cleanupV4({ home: fxHome, genieHome: fxGenieHome });
+    expect(existsSync(join(fxGenieHome, 'tmux.conf.bak'))).toBe(true);
+    expect(existsSync(join(fxGenieHome, '.genie'))).toBe(true);
+    expect(existsSync(join(fxGenieHome, 'serve.pid'))).toBe(false);
+  });
+
+  test('doctor --fix --json: stdout is valid JSON, relic removed (chatter on stderr)', () => {
+    // Subprocess drive: bun's homedir() does not re-read a runtime HOME change,
+    // so the fixture home must be injected at process spawn — which also tests
+    // the CLI exactly as a user invokes it.
+    mkdirSync(fxGenieHome, { recursive: true });
+    writeFileSync(join(fxGenieHome, 'serve.pid'), '77\n', 'utf-8');
+    const repoRoot = join(import.meta.dir, '..', '..');
+
+    const proc = Bun.spawnSync([process.execPath, join(repoRoot, 'src', 'genie.ts'), 'doctor', '--fix', '--json'], {
+      cwd: repoRoot,
+      env: { ...process.env, HOME: fxHome, GENIE_HOME: fxGenieHome },
+    });
+
+    const stdout = proc.stdout.toString();
+    const parsed = JSON.parse(stdout) as { checks: Array<{ name: string; status: string }> }; // whole stdout is the document
+    expect(existsSync(join(fxGenieHome, 'serve.pid'))).toBe(false);
+    expect(parsed.checks.find((c) => c.name === 'v4 residue')?.status).toBe('pass'); // post-fix state
+    expect(proc.stderr.toString()).toContain('Removed v4 residue'); // chatter rerouted, not lost
   });
 });

--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -20,6 +20,14 @@ import { join } from 'node:path';
 import { resolveOmniRuntimeConfig } from '../lib/omni-config.js';
 import { CURRENT_SCHEMA_VERSION, GenieDbError, openDb, resolveDbPath, resolveRepoRoot } from '../lib/v5/genie-db.js';
 import { VERSION } from '../lib/version.js';
+import {
+  cleanupV4,
+  detectUncertainKeeps,
+  detectV4HomeResidue,
+  detectV4Install,
+  resolveGenieHome,
+  sizeOfPathTree,
+} from './legacy-v4.js';
 
 type CheckStatus = 'pass' | 'warn' | 'fail';
 
@@ -188,6 +196,94 @@ function checkBun(): CheckResult[] {
 }
 
 // ============================================================================
+// v4 residue check (detect-only; --fix runs the backup-first cleanup)
+// ============================================================================
+
+function prettyBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${bytes} B`;
+}
+
+function safeSizeOf(path: string): number {
+  try {
+    return sizeOfPathTree(path);
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Detect v4 daemon-era residue (genie home + ~/.claude rules/caches). Pure
+ * read — doctor without --fix must mutate nothing. Exported for tests with an
+ * injectable home pair.
+ *
+ * Accounting contract: "reclaimable" counts and bytes cover ONLY what --fix
+ * would actually remove (home residue + marker-matched rules + orphaned
+ * caches). A user-modified rules file is reported as kept, never counted.
+ * Uncertain-keeps are report-only lines (Decision 2) — absent from the
+ * manifest, unreachable by --fix.
+ */
+export function checkV4Residue(home?: string, genieHome?: string): CheckResult[] {
+  const gh = genieHome ?? resolveGenieHome(home ?? homedir());
+  const residue = detectV4HomeResidue(gh);
+  const claude = detectV4Install(home ?? homedir());
+  const orphanedCaches = claude.cacheDirs.filter((d) => d.orphaned);
+  const rulesReclaimable = claude.rulesFile.status === 'v4-markers';
+  const rulesKeptUserModified = claude.rulesFile.status === 'user-modified';
+  const uncertainKeeps = detectUncertainKeeps(gh);
+
+  const results: CheckResult[] = [];
+  const claudeCount = orphanedCaches.length + (rulesReclaimable ? 1 : 0);
+  if (residue.length === 0 && claudeCount === 0 && !rulesKeptUserModified) {
+    results.push({ name: 'v4 residue', status: 'pass', detail: 'none found' });
+  } else if (residue.length + claudeCount > 0) {
+    const totalBytes =
+      residue.reduce((sum, r) => sum + r.sizeBytes, 0) +
+      (rulesReclaimable ? safeSizeOf(claude.rulesFile.path) : 0) +
+      orphanedCaches.reduce((sum, d) => sum + safeSizeOf(d.path), 0);
+    results.push({
+      name: 'v4 residue',
+      status: 'warn',
+      detail: `${residue.length + claudeCount} reclaimable item(s) (${residue.length} genie-home, ${claudeCount} claude), ${prettyBytes(totalBytes)}`,
+      suggestion: 'Run `genie doctor --fix` to back up and remove (backups: ~/.genie/state-backups/).',
+    });
+  }
+  for (const relic of residue) {
+    results.push({ name: `v4 residue: ${relic.relPath}`, status: 'warn', detail: prettyBytes(relic.sizeBytes) });
+  }
+  if (rulesReclaimable) {
+    results.push({
+      name: 'v4 residue: ~/.claude rules file',
+      status: 'warn',
+      detail: prettyBytes(safeSizeOf(claude.rulesFile.path)),
+    });
+  } else if (rulesKeptUserModified) {
+    results.push({
+      name: 'v4 residue: ~/.claude rules file',
+      status: 'warn',
+      detail: 'kept (user-modified) — not counted as reclaimable; --fix will not touch it',
+    });
+  }
+  for (const dir of orphanedCaches) {
+    results.push({
+      name: `v4 residue: plugin cache ${dir.version}`,
+      status: 'warn',
+      detail: `orphaned, ${prettyBytes(safeSizeOf(dir.path))}`,
+    });
+  }
+  // Report-only (Decision 2): uncertain names we deliberately never touch.
+  for (const name of uncertainKeeps) {
+    results.push({
+      name: `kept (uncertain): ${name}`,
+      status: 'pass',
+      detail: 'not provably v4 — never touched by --fix',
+    });
+  }
+  return results;
+}
+
+// ============================================================================
 // Omni approval hook-timeout guardrail
 // ============================================================================
 
@@ -285,13 +381,22 @@ async function checkOmniHookTimeout(): Promise<CheckResult[]> {
 // Entry point
 // ============================================================================
 
-export async function doctorCommand(options?: { json?: boolean }): Promise<void> {
+export async function doctorCommand(options?: { json?: boolean; fix?: boolean }): Promise<void> {
+  // --fix: run the backup-first v4 cleanup BEFORE the checks so the report
+  // below reflects the post-fix state. Without --fix, detection only — the
+  // residue check is a pure read and nothing on disk changes. In --json mode
+  // stdout belongs to the JSON document, so cleanup chatter goes to stderr.
+  if (options?.fix) {
+    cleanupV4(options.json ? { logSink: (line) => process.stderr.write(`${line}\n`) } : {});
+  }
+
   const results: CheckResult[] = [
     ...checkGenieBinary(),
     ...checkGit(),
     ...checkDatabase(),
     ...checkSkills(),
     ...checkBun(),
+    ...checkV4Residue(),
     ...(await checkOmniHookTimeout()),
   ];
 

--- a/src/genie-commands/install.test.ts
+++ b/src/genie-commands/install.test.ts
@@ -17,6 +17,7 @@ function makeCleanupSpy(): { runner: typeof cleanupV4; calls: () => number } {
     count += 1;
     return {
       report: { rulesFile: { path: '/fixture', status: 'absent' }, cacheDirs: [], hasRelics: false },
+      homeResidue: [],
       actions: [],
       backupDir: null,
       logFile: null,

--- a/src/genie-commands/legacy-v4.test.ts
+++ b/src/genie-commands/legacy-v4.test.ts
@@ -7,12 +7,22 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import {
   V4_LEGACY_MANIFEST,
   cleanupV4,
+  detectV4HomeResidue,
   detectV4Install,
   orchestrationRulesPath,
   v4PluginCacheRoot,
@@ -288,5 +298,108 @@ describe('shared manifest — no duplicated legacy-path literals', () => {
     const source = readFileSync(join(import.meta.dir, '..', '..', 'install.sh'), 'utf-8');
     expect(source).toContain('"$LOCAL_BIN/genie" install');
     expect(source).not.toContain('genie-orchestration.md');
+  });
+});
+
+// ============================================================================
+// Genie-home residue (wish v4-home-residue-doctor)
+// ============================================================================
+
+/** Seed a genie home with manifest residue AND known-live files. */
+function seedResidueHome(): { residue: string[]; live: string[] } {
+  mkdirSync(join(genieHome, 'relay', 'nested'), { recursive: true });
+  mkdirSync(join(genieHome, 'logs'), { recursive: true });
+  mkdirSync(join(genieHome, 'bin'), { recursive: true });
+  writeFileSync(join(genieHome, 'serve.pid'), '12345\n', 'utf-8');
+  writeFileSync(join(genieHome, 'hook-fallback.log'), 'x'.repeat(2048), 'utf-8');
+  writeFileSync(join(genieHome, '.role-cutover-abc123.json'), '{}', 'utf-8');
+  writeFileSync(join(genieHome, 'relay', 'nested', 'payload.txt'), 'relay payload\n', 'utf-8');
+  writeFileSync(join(genieHome, 'logs', 'scheduler.log'), '{"level":"error"}\n', 'utf-8');
+  const live = [
+    join(genieHome, 'genie.db'),
+    join(genieHome, 'config.json'),
+    join(genieHome, 'bin', 'genie'),
+    join(genieHome, 'logs', 'update-diagnostics.json'),
+    join(genieHome, 'tmux.conf.bak'), // KNOWN LIVE per constraint: tmux*/tui-* stay
+    join(genieHome, 'role-cutover-other.txt'), // near-miss for the glob
+  ];
+  for (const f of live) writeFileSync(f, `live ${f}\n`, 'utf-8');
+  return {
+    residue: [
+      join(genieHome, 'serve.pid'),
+      join(genieHome, 'hook-fallback.log'),
+      join(genieHome, '.role-cutover-abc123.json'),
+      join(genieHome, 'relay'),
+      join(genieHome, 'logs', 'scheduler.log'),
+    ],
+    live,
+  };
+}
+
+describe('detectV4HomeResidue', () => {
+  test('absent genie home → no residue', () => {
+    expect(detectV4HomeResidue(genieHome)).toHaveLength(0);
+  });
+
+  test('detects exactly the manifest residue, never live files', () => {
+    const { residue } = seedResidueHome();
+    const found = detectV4HomeResidue(genieHome);
+    expect(found.map((r) => r.path).sort()).toEqual([...residue].sort());
+    // per-relic metadata: sizes populated, dir flagged as dir
+    const relay = found.find((r) => r.relPath === 'relay');
+    expect(relay?.kind).toBe('dir');
+    expect(relay?.sizeBytes).toBeGreaterThan(0);
+    expect(found.find((r) => r.relPath === 'hook-fallback.log')?.sizeBytes).toBe(2048);
+    for (const r of found) expect(r.evidence.length).toBeGreaterThan(0);
+  });
+
+  test('kind mismatch is kept: `state` existing as a FILE is not ours', () => {
+    mkdirSync(genieHome, { recursive: true });
+    writeFileSync(join(genieHome, 'state'), 'not a dir\n', 'utf-8');
+    expect(detectV4HomeResidue(genieHome)).toHaveLength(0);
+  });
+
+  test('symlinked residue name is skipped — never follows a link', () => {
+    const outside = join(home, 'outside-target');
+    mkdirSync(outside, { recursive: true });
+    writeFileSync(join(outside, 'precious.txt'), 'keep me\n', 'utf-8');
+    mkdirSync(genieHome, { recursive: true });
+    symlinkSync(outside, join(genieHome, 'model-a'));
+    expect(detectV4HomeResidue(genieHome)).toHaveLength(0);
+    cleanupV4({ home, genieHome });
+    expect(readFileSync(join(outside, 'precious.txt'), 'utf-8')).toBe('keep me\n');
+  });
+});
+
+describe('cleanupV4 — genie-home residue', () => {
+  test('backs up full content, removes residue, leaves live files byte-identical', () => {
+    const { residue, live } = seedResidueHome();
+    const liveContents = live.map((f) => readFileSync(f, 'utf-8'));
+
+    const result = cleanupV4({ home, genieHome });
+
+    for (const path of residue) expect(existsSync(path)).toBe(false);
+    live.forEach((f, i) => expect(readFileSync(f, 'utf-8')).toBe(liveContents[i]));
+
+    // Full-content backup under <backupDir>/genie-home/<relPath>
+    const backup = result.backupDir as string;
+    expect(readFileSync(join(backup, 'genie-home', 'serve.pid'), 'utf-8')).toBe('12345\n');
+    expect(readFileSync(join(backup, 'genie-home', 'relay', 'nested', 'payload.txt'), 'utf-8')).toBe('relay payload\n');
+    expect(readFileSync(join(backup, 'genie-home', 'logs', 'scheduler.log'), 'utf-8')).toBe('{"level":"error"}\n');
+
+    const kinds = result.actions.map((a) => a.kind);
+    expect(kinds.filter((k) => k === 'removed-home-residue')).toHaveLength(5);
+    expect(result.homeResidue).toHaveLength(5);
+    expect(readFileSync(result.logFile as string, 'utf-8')).toContain('removed-home-residue');
+  });
+
+  test('second run is a no-op', () => {
+    seedResidueHome();
+    const first = cleanupV4({ home, genieHome });
+    expect(first.noOp).toBe(false);
+    const second = cleanupV4({ home, genieHome });
+    expect(second.noOp).toBe(true);
+    expect(second.homeResidue).toHaveLength(0);
+    expect(second.actions).toHaveLength(0);
   });
 });

--- a/src/genie-commands/legacy-v4.ts
+++ b/src/genie-commands/legacy-v4.ts
@@ -39,6 +39,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
+import { cpSync, lstatSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, relative } from 'node:path';
 import { contractPath } from '../lib/genie-config.js';
@@ -46,6 +47,21 @@ import { contractPath } from '../lib/genie-config.js';
 // ============================================================================
 // Manifest — the shared source of truth for every v4 legacy path
 // ============================================================================
+
+export type HomeResidueKind = 'file' | 'dir' | 'glob';
+
+/**
+ * A provably-dead v4 artifact under the genie home dir (GENIE_HOME / ~/.genie).
+ * Entries are EXACT paths (or a single-`*` glob over direct children of the
+ * parent dir) — never recursive guesses. Every entry carries its src-proof.
+ */
+export interface HomeResidueEntry {
+  /** Path segments relative to the genie home dir. For `glob`, the last segment holds one `*`. */
+  relPath: readonly string[];
+  kind: HomeResidueKind;
+  /** src-proof: why v5 provably never reads/writes this path. */
+  evidence: string;
+}
 
 export interface V4LegacyManifest {
   /** Home-relative path segments of the v4 global orchestration rules file. */
@@ -58,7 +74,49 @@ export interface V4LegacyManifest {
   orphanMarkerFile: string;
   /** The rules file is provably genie-installed v4 iff its content contains at least one marker. */
   rulesContentMarkers: readonly string[];
+  /** Daemon-era residue under the genie home dir. See each entry's src-proof. */
+  homeResidue: readonly HomeResidueEntry[];
 }
+
+// src-proof method (2026-07-05): `grep -rn <name> src/ scripts/ plugins/genie/scripts/`
+// on the v5 tree. "no refs" = zero hits outside tests. Deliberately EXCLUDED as
+// live or uncertain: bin/, worktrees/, state-backups/, logs/* (except
+// scheduler.log), genie.db*, config.json, keys/, plugins/, skills/, templates/,
+// scripts/, tmux.conf (written by setup.ts:437), tmux*.conf.bak + tui-* +
+// .generated.theme.conf (TUI/smart-install surface — uncertain, KEEP).
+const HOME_RESIDUE: readonly HomeResidueEntry[] = [
+  {
+    relPath: ['serve.pid'],
+    kind: 'file',
+    evidence:
+      'written only by the deleted v4 serve daemon; sole v5 ref is a tolerant diagnostic safeRead (update.ts) whose absent-path is the fresh-install norm',
+  },
+  { relPath: ['genie-serve.config.cjs'], kind: 'file', evidence: 'v4 pm2 serve config; no refs in v5 src' },
+  { relPath: ['Genie.config.cjs'], kind: 'file', evidence: 'v4 daemon config; no refs in v5 src' },
+  { relPath: ['hook-fallback.log'], kind: 'file', evidence: 'v4 hook-fallback writer deleted; no refs in v5 src' },
+  { relPath: ['role-cutover-events.jsonl'], kind: 'file', evidence: 'v4 role-cutover log; no refs in v5 src' },
+  { relPath: ['.role-cutover-*.json'], kind: 'glob', evidence: 'v4 role-cutover state stamps; no refs in v5 src' },
+  {
+    relPath: ['config.json.bak-pre-omni'],
+    kind: 'file',
+    evidence: 'one-shot migration backup of config.json; no refs in v5 src',
+  },
+  {
+    relPath: ['logs', 'scheduler.log'],
+    kind: 'file',
+    evidence:
+      'v4 scheduler daemon log; sole v5 ref is the update diagnostics tail (tolerant of absence, now age-filtered)',
+  },
+  {
+    relPath: ['relay'],
+    kind: 'dir',
+    evidence: 'v4 relay artifacts; v5 OTel relay is port-only (codex-config.ts), no dir',
+  },
+  { relPath: ['spawn-scripts'], kind: 'dir', evidence: 'v4 spawn machinery; no refs in v5 src' },
+  { relPath: ['state'], kind: 'dir', evidence: 'v4 wish-state JSONs; v5 state lives in genie.db (TAXONOMY.md)' },
+  { relPath: ['model-a'], kind: 'dir', evidence: 'v4 experiment dir; no refs in v5 src' },
+  { relPath: ['data'], kind: 'dir', evidence: 'v4 data dir; no refs in v5 src' },
+];
 
 export const V4_LEGACY_MANIFEST: V4LegacyManifest = {
   orchestrationRulesRelPath: ['.claude', 'rules', 'genie-orchestration.md'],
@@ -66,7 +124,13 @@ export const V4_LEGACY_MANIFEST: V4LegacyManifest = {
   v4CacheVersionPrefix: '4.',
   orphanMarkerFile: '.orphaned_at',
   rulesContentMarkers: ['genie spawn', 'genie team create'],
+  homeResidue: HOME_RESIDUE,
 };
+
+/** Resolve the genie home dir the way the cleanup does everywhere. */
+export function resolveGenieHome(home: string = homedir()): string {
+  return process.env.GENIE_HOME ?? join(home, '.genie');
+}
 
 /** Absolute path of the v4 orchestration rules file for the given home dir. */
 export function orchestrationRulesPath(home: string = homedir()): string {
@@ -146,6 +210,108 @@ export function detectV4Install(home: string = homedir()): V4DetectionReport {
 }
 
 // ============================================================================
+// Home-residue detection (GENIE_HOME / ~/.genie)
+// ============================================================================
+
+export interface V4HomeResidueRelic {
+  /** Absolute path of the found artifact. */
+  path: string;
+  /** Genie-home-relative display path, e.g. `logs/scheduler.log`. */
+  relPath: string;
+  kind: 'file' | 'dir';
+  /** Bytes on disk (recursive for dirs; symlinks never followed). */
+  sizeBytes: number;
+  /** The manifest entry's src-proof. */
+  evidence: string;
+}
+
+/** Bytes on disk for a file or tree (recursive; symlinks contribute 0, never followed). */
+export function sizeOfPathTree(path: string): number {
+  const stat = lstatSync(path);
+  if (stat.isSymbolicLink()) return 0;
+  if (!stat.isDirectory()) return stat.size;
+  let total = 0;
+  for (const entry of readdirSync(path, { withFileTypes: true })) {
+    total += sizeOfPathTree(join(path, entry.name));
+  }
+  return total;
+}
+
+/** Expand a single-`*` glob entry against the DIRECT children of its parent dir. */
+function expandGlobEntry(genieHome: string, entry: HomeResidueEntry): string[] {
+  const parent = join(genieHome, ...entry.relPath.slice(0, -1));
+  const pattern = entry.relPath[entry.relPath.length - 1];
+  const [prefix, suffix] = pattern.split('*');
+  try {
+    if (!statSync(parent).isDirectory()) return [];
+  } catch {
+    return []; // parent absent or unreadable — nothing to expand
+  }
+  return readdirSync(parent)
+    .filter((name) => name.startsWith(prefix) && name.endsWith(suffix) && name.length >= prefix.length + suffix.length)
+    .map((name) => join(parent, name));
+}
+
+/**
+ * Detect v4 daemon-era residue under the genie home dir. Read-only — never
+ * creates, writes, or logs anything (doctor without --fix relies on this).
+ */
+export function detectV4HomeResidue(genieHome: string = resolveGenieHome()): V4HomeResidueRelic[] {
+  const relics: V4HomeResidueRelic[] = [];
+  try {
+    if (!statSync(genieHome).isDirectory()) return relics; // absent or not a dir — nothing to scan
+  } catch {
+    return relics;
+  }
+  for (const entry of V4_LEGACY_MANIFEST.homeResidue) {
+    const paths = entry.kind === 'glob' ? expandGlobEntry(genieHome, entry) : [join(genieHome, ...entry.relPath)];
+    for (const path of paths) {
+      let stat: ReturnType<typeof lstatSync>;
+      try {
+        stat = lstatSync(path);
+      } catch {
+        continue; // absent — the v5-normal case
+      }
+      if (stat.isSymbolicLink()) continue; // never follow a link out of the home
+      const isDir = stat.isDirectory();
+      if (entry.kind === 'dir' && !isDir) continue; // shape mismatch → not ours, keep
+      if (entry.kind === 'file' && isDir) continue;
+      relics.push({
+        path,
+        relPath: relative(genieHome, path),
+        kind: isDir ? 'dir' : 'file',
+        sizeBytes: sizeOfPathTree(path),
+        evidence: entry.evidence,
+      });
+    }
+  }
+  return relics;
+}
+
+// ============================================================================
+// Uncertain keeps — observed v4-era names we deliberately NEVER touch
+// (Decision 2: uncertain → KEEP, log-only report). Listed here so doctor can
+// surface them; absent from the residue manifest so --fix cannot reach them.
+// ============================================================================
+
+export const HOME_UNCERTAIN_KEEPS: readonly string[] = [
+  'tmux.conf.bak', // tmux*.conf surface is smart-install/TUI-managed
+  'tui-tmux.conf.bak', // tui-* surface is TUI-managed
+  '.generated.theme.conf', // theme artifact of unknown ownership
+  '.genie', // nested ~/.genie/.genie oddity (possible GENIE_HOME misresolution)
+];
+
+/** Report-only: which uncertain-keep names exist under the genie home. Pure read. */
+export function detectUncertainKeeps(genieHome: string = resolveGenieHome()): string[] {
+  try {
+    if (!statSync(genieHome).isDirectory()) return [];
+  } catch {
+    return [];
+  }
+  return HOME_UNCERTAIN_KEEPS.filter((name) => existsSync(join(genieHome, name)));
+}
+
+// ============================================================================
 // Cleanup
 // ============================================================================
 
@@ -154,6 +320,11 @@ export interface V4CleanupOptions {
   home?: string;
   /** Genie state dir for backups + logs. Default: $GENIE_HOME, else `<home>/.genie`. */
   genieHome?: string;
+  /**
+   * Where progress chatter goes. Default: stdout (console.log). Callers that
+   * own stdout for a document (e.g. `doctor --fix --json`) pass a stderr sink.
+   */
+  logSink?: (line: string) => void;
 }
 
 export type V4CleanupActionKind =
@@ -161,6 +332,7 @@ export type V4CleanupActionKind =
   | 'kept-rules-user-modified'
   | 'removed-cache'
   | 'kept-cache-unmarked'
+  | 'removed-home-residue'
   | 'error';
 
 export interface V4CleanupAction {
@@ -172,6 +344,8 @@ export interface V4CleanupAction {
 
 export interface V4CleanupResult {
   report: V4DetectionReport;
+  /** v4 residue found under the genie home dir this run (removed unless errored). */
+  homeResidue: V4HomeResidueRelic[];
   actions: V4CleanupAction[];
   /** Backup dir for this run, or null when nothing was removed. */
   backupDir: string | null;
@@ -187,6 +361,7 @@ interface CleanupContext {
   backupDirUsed: boolean;
   actions: V4CleanupAction[];
   logLines: string[];
+  emit: (line: string) => void;
 }
 
 function recordAction(ctx: CleanupContext, action: V4CleanupAction): void {
@@ -198,7 +373,7 @@ function recordAction(ctx: CleanupContext, action: V4CleanupAction): void {
 
 function warnFailure(ctx: CleanupContext, path: string, error: unknown): void {
   const message = error instanceof Error ? error.message : String(error);
-  console.log(`  \x1b[33m!\x1b[0m Failed to clean ${contractPath(path)}: ${message}`);
+  ctx.emit(`  \x1b[33m!\x1b[0m Failed to clean ${contractPath(path)}: ${message}`);
   recordAction(ctx, { kind: 'error', path, detail: message });
 }
 
@@ -253,7 +428,7 @@ function cleanupRulesFile(ctx: CleanupContext, relic: RulesFileRelic): void {
   const display = contractPath(relic.path);
 
   if (relic.status === 'user-modified') {
-    console.log(`  \x1b[33m!\x1b[0m Kept ${display} — no v4 markers found (user-modified?); not removing`);
+    ctx.emit(`  \x1b[33m!\x1b[0m Kept ${display} — no v4 markers found (user-modified?); not removing`);
     recordAction(ctx, { kind: 'kept-rules-user-modified', path: relic.path });
     return;
   }
@@ -261,7 +436,7 @@ function cleanupRulesFile(ctx: CleanupContext, relic: RulesFileRelic): void {
   try {
     const backupPath = backupFile(ctx, relic.path);
     unlinkSync(relic.path);
-    console.log(`  \x1b[32m+\x1b[0m Removed ${display} (v4 orchestration rules)`);
+    ctx.emit(`  \x1b[32m+\x1b[0m Removed ${display} (v4 orchestration rules)`);
     recordAction(ctx, { kind: 'removed-rules', path: relic.path, backupPath });
   } catch (error) {
     warnFailure(ctx, relic.path, error);
@@ -272,7 +447,7 @@ function cleanupCacheDirs(ctx: CleanupContext, relics: V4CacheRelic[]): void {
   for (const relic of relics) {
     const display = contractPath(relic.path);
     if (!relic.orphaned) {
-      console.log(
+      ctx.emit(
         `  \x1b[2mKept ${display} — no ${V4_LEGACY_MANIFEST.orphanMarkerFile} marker (not provably orphaned)\x1b[0m`,
       );
       recordAction(ctx, { kind: 'kept-cache-unmarked', path: relic.path });
@@ -281,8 +456,29 @@ function cleanupCacheDirs(ctx: CleanupContext, relics: V4CacheRelic[]): void {
     try {
       const backupPath = backupCacheManifest(ctx, relic);
       rmSync(relic.path, { recursive: true, force: true });
-      console.log(`  \x1b[32m+\x1b[0m Removed orphaned v4 plugin cache ${relic.version}`);
+      ctx.emit(`  \x1b[32m+\x1b[0m Removed orphaned v4 plugin cache ${relic.version}`);
       recordAction(ctx, { kind: 'removed-cache', path: relic.path, backupPath });
+    } catch (error) {
+      warnFailure(ctx, relic.path, error);
+    }
+  }
+}
+
+/**
+ * Remove genie-home residue, backup-first. Unlike plugin caches (re-downloadable,
+ * manifest-only backup), home residue is machine-unique — the FULL content is
+ * copied to `<backupRoot>/genie-home/<relPath>` before removal.
+ */
+function cleanupHomeResidue(ctx: CleanupContext, relics: V4HomeResidueRelic[]): void {
+  for (const relic of relics) {
+    try {
+      const backupPath = join(ctx.backupRoot, 'genie-home', relic.relPath);
+      mkdirSync(dirname(backupPath), { recursive: true });
+      cpSync(relic.path, backupPath, { recursive: true });
+      ctx.backupDirUsed = true;
+      rmSync(relic.path, { recursive: true, force: true });
+      ctx.emit(`  \x1b[32m+\x1b[0m Removed v4 residue ${contractPath(relic.path)}`);
+      recordAction(ctx, { kind: 'removed-home-residue', path: relic.path, backupPath });
     } catch (error) {
       warnFailure(ctx, relic.path, error);
     }
@@ -307,8 +503,9 @@ export function cleanupV4(options: V4CleanupOptions = {}): V4CleanupResult {
   const home = options.home ?? homedir();
   const genieHome = options.genieHome ?? process.env.GENIE_HOME ?? join(home, '.genie');
   const report = detectV4Install(home);
-  if (!report.hasRelics) {
-    return { report, actions: [], backupDir: null, logFile: null, noOp: true };
+  const homeResidue = detectV4HomeResidue(genieHome);
+  if (!report.hasRelics && homeResidue.length === 0) {
+    return { report, homeResidue, actions: [], backupDir: null, logFile: null, noOp: true };
   }
 
   const stamp = new Date().toISOString().replace(/[:.]/g, '-');
@@ -318,11 +515,13 @@ export function cleanupV4(options: V4CleanupOptions = {}): V4CleanupResult {
     backupDirUsed: false,
     actions: [],
     logLines: [],
+    emit: options.logSink ?? ((line: string) => console.log(line)),
   };
 
-  console.log('\x1b[2mCleaning up v4 leftovers...\x1b[0m');
+  ctx.emit('\x1b[2mCleaning up v4 leftovers...\x1b[0m');
   cleanupRulesFile(ctx, report.rulesFile);
   cleanupCacheDirs(ctx, report.cacheDirs);
+  cleanupHomeResidue(ctx, homeResidue);
 
   // An unwritable GENIE_HOME must degrade gracefully (stderr warning, no raw
   // stack) — the cleanup step still reports its actions and exits 0.
@@ -334,14 +533,15 @@ export function cleanupV4(options: V4CleanupOptions = {}): V4CleanupResult {
     console.error(`  \x1b[33m!\x1b[0m Could not write v4-cleanup log under ${contractPath(genieHome)}: ${message}`);
   }
   if (ctx.backupDirUsed) {
-    console.log(`  \x1b[2mBackups: ${contractPath(ctx.backupRoot)}\x1b[0m`);
+    ctx.emit(`  \x1b[2mBackups: ${contractPath(ctx.backupRoot)}\x1b[0m`);
   }
   if (logFile) {
-    console.log(`  \x1b[2mLog: ${contractPath(logFile)}\x1b[0m`);
+    ctx.emit(`  \x1b[2mLog: ${contractPath(logFile)}\x1b[0m`);
   }
 
   return {
     report,
+    homeResidue,
     actions: ctx.actions,
     backupDir: ctx.backupDirUsed ? ctx.backupRoot : null,
     logFile,

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -1039,25 +1039,69 @@ function tailLines(path: string, maxBytes = 64_000, maxLines = 200): string[] {
   }
 }
 
-function summarizeJsonlSignals(path: string): RecentLogSignal[] {
-  const signals = new Map<string, RecentLogSignal>();
-  for (const line of tailLines(path)) {
-    try {
-      const event = JSON.parse(line) as { level?: unknown; event?: unknown; timestamp?: unknown; error?: unknown };
-      const level = typeof event.level === 'string' ? event.level : 'unknown';
-      if (level !== 'error' && level !== 'warn') continue;
-      const name = typeof event.event === 'string' ? event.event : 'unknown';
-      const key = `${level}:${name}`;
-      const existing = signals.get(key) ?? { level, event: name, count: 0 };
-      existing.count++;
-      if (typeof event.timestamp === 'string') existing.lastTimestamp = event.timestamp;
-      if (typeof event.error === 'string') existing.lastError = event.error;
-      signals.set(key, existing);
-    } catch {
-      // non-JSON lines kept in the raw tail, not summarized.
-    }
+/** Signals older than this are noise from a previous era, not "recent". */
+const SCHEDULER_SIGNAL_MAX_AGE_MS = 48 * 60 * 60 * 1000;
+
+export interface JsonlSignalSummary {
+  signals: RecentLogSignal[];
+  /** Newest timestamp among age-excluded entries — null when nothing was excluded. */
+  newestStaleTimestamp: string | null;
+}
+
+/**
+ * Age-filtered (48h default): scheduler.log is a dead v4 artifact on upgraded
+ * machines, and without the filter a June disk-full incident resurfaced as
+ * "Recent scheduler signals" weeks later on a healthy machine. Entries with an
+ * unparseable/missing timestamp are kept — staleness must be proven, not
+ * assumed. Exported (with injectable clock) for boundary tests.
+ */
+interface ParsedSignalLine {
+  level: string;
+  event: string;
+  ts: string | null;
+  tsMs: number;
+  error?: string;
+}
+
+/** Parse one JSONL line into a warn/error signal — null for non-JSON or info-level lines. */
+function parseSignalLine(line: string): ParsedSignalLine | null {
+  try {
+    const event = JSON.parse(line) as { level?: unknown; event?: unknown; timestamp?: unknown; error?: unknown };
+    const level = typeof event.level === 'string' ? event.level : 'unknown';
+    if (level !== 'error' && level !== 'warn') return null;
+    const ts = typeof event.timestamp === 'string' ? event.timestamp : null;
+    return {
+      level,
+      event: typeof event.event === 'string' ? event.event : 'unknown',
+      ts,
+      tsMs: ts ? Date.parse(ts) : Number.NaN,
+      error: typeof event.error === 'string' ? event.error : undefined,
+    };
+  } catch {
+    return null; // non-JSON lines kept in the raw tail, not summarized.
   }
-  return [...signals.values()].sort((a, b) => b.count - a.count).slice(0, 10);
+}
+
+export function summarizeJsonlSignals(path: string, nowMs: number = Date.now()): JsonlSignalSummary {
+  const signals = new Map<string, RecentLogSignal>();
+  let newestStaleTimestamp: string | null = null;
+  for (const line of tailLines(path)) {
+    const parsed = parseSignalLine(line);
+    if (!parsed) continue;
+    if (parsed.ts && !Number.isNaN(parsed.tsMs) && nowMs - parsed.tsMs > SCHEDULER_SIGNAL_MAX_AGE_MS) {
+      if (newestStaleTimestamp === null || Date.parse(newestStaleTimestamp) < parsed.tsMs) {
+        newestStaleTimestamp = parsed.ts;
+      }
+      continue;
+    }
+    const key = `${parsed.level}:${parsed.event}`;
+    const existing = signals.get(key) ?? { level: parsed.level, event: parsed.event, count: 0 };
+    existing.count++;
+    if (parsed.ts) existing.lastTimestamp = parsed.ts;
+    if (parsed.error) existing.lastError = parsed.error;
+    signals.set(key, existing);
+  }
+  return { signals: [...signals.values()].sort((a, b) => b.count - a.count).slice(0, 10), newestStaleTimestamp };
 }
 
 export function isGenieProcessSnapshotLine(line: string): boolean {
@@ -1088,7 +1132,7 @@ async function collectUpdateDiagnostics(
   ctx: UpdateDiagnosticsContext,
   maintenance: { outcome: 'completed' | 'failed'; durationMs: number; lines: string[]; error?: string },
   extras: UpdateDiagnosticsExtras,
-): Promise<{ path: string; signals: RecentLogSignal[] }> {
+): Promise<{ path: string; signals: RecentLogSignal[]; newestStaleTimestamp: string | null }> {
   const logsDir = join(GENIE_HOME, 'logs');
   mkdirSync(logsDir, { recursive: true });
   const generatedAt = new Date().toISOString();
@@ -1096,7 +1140,8 @@ async function collectUpdateDiagnostics(
   const path = join(logsDir, `update-diagnostics-${safeStamp}.json`);
   const schedulerLog = join(logsDir, 'scheduler.log');
   const tuiCrashLog = join(logsDir, 'tui-crash.log');
-  const signals = summarizeJsonlSignals(schedulerLog);
+  const schedulerSummary = summarizeJsonlSignals(schedulerLog);
+  const signals = schedulerSummary.signals;
 
   const diagnostics = {
     schemaVersion: UPDATE_DIAGNOSTIC_SCHEMA_VERSION,
@@ -1160,7 +1205,7 @@ async function collectUpdateDiagnostics(
   };
 
   writeFileSync(path, `${JSON.stringify(diagnostics, null, 2)}\n`);
-  return { path, signals };
+  return { path, signals, newestStaleTimestamp: schedulerSummary.newestStaleTimestamp };
 }
 
 // ============================================================================
@@ -1689,12 +1734,21 @@ function shouldAutoConfirm(opts: { yes?: boolean }): boolean {
 // Post-update maintenance + verify orchestration.
 // ============================================================================
 
-function printDiagnosticsSummary(diagnostics: { path: string; signals: RecentLogSignal[] }): void {
+function printDiagnosticsSummary(diagnostics: {
+  path: string;
+  signals: RecentLogSignal[];
+  newestStaleTimestamp?: string | null;
+}): void {
   log('Post-update diagnostics captured.');
   console.log(`  Report: ${diagnostics.path}`);
   console.log('  Include this file when opening a GitHub issue; it contains install metadata, step output,');
   console.log('  local process state, and recent scheduler/TUI log signals.');
-  if (diagnostics.signals.length === 0) return;
+  if (diagnostics.signals.length === 0) {
+    if (diagnostics.newestStaleTimestamp) {
+      console.log(`  No recent scheduler signals; last entry ${diagnostics.newestStaleTimestamp}`);
+    }
+    return;
+  }
   console.log('  Recent scheduler signals:');
   for (const signal of diagnostics.signals.slice(0, 3)) {
     const errorDetail = signal.lastError ? ` — ${signal.lastError}` : '';

--- a/src/genie.ts
+++ b/src/genie.ts
@@ -87,6 +87,7 @@ program
   .command('doctor')
   .description('Run diagnostic checks on genie installation')
   .option('--json', 'Emit JSON instead of human output')
+  .option('--fix', 'Back up and remove detected v4 residue (backup-first, idempotent)')
   .action(doctorCommand);
 
 program


### PR DESCRIPTION
## Wish: v4-home-residue-doctor

Extends the shipped v4 cleanup to `~/.genie` daemon-era residue and puts it in every user's hands via `genie doctor`.

- **Manifest**: 13 src-proven entries (serve.pid, genie-serve.config.cjs, relay/, spawn-scripts/, state/, model-a/, data/, hook-fallback.log, role-cutover-events.jsonl, .role-cutover-*.json, config.json.bak-pre-omni, logs/scheduler.log, Genie.config.cjs) — each with grep-evidence; uncertain paths are KEPT and reported, never touched. lstat-only, symlinks never followed, full-content backup-first.
- **Doctor**: `v4 residue` check (count/bytes split by genie-home vs claude buckets); `--fix` opt-in runs the backup-first cleanup; `--fix --json` is contract-safe (chatter → stderr via logSink; subprocess test parses stdout as JSON).
- **Diagnostics**: `summarizeJsonlSignals` age-filters at 48h — a June-22 disk-full no longer resurfaces as "Recent scheduler signals" on healthy machines (observed tonight).

Review: FIX-FIRST (json contract) → fixed → all prescriptions verified. 164 tests/0 fail across the 4 suites; destructive surface independently re-proven (symlink attack, byte-identical live files, near-miss globs). check:fast green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N1FLEV2Qse3jbX5Wz1sjWE