### PR TITLE
fix(hooks): de-shell file-path git calls to close command injection

### DIFF
--- a/src/genie.ts
+++ b/src/genie.ts
@@ -31,20 +31,6 @@ import { registerOmniCommands } from './term-commands/omni.js';
 import { registerV5BoardCommands } from './term-commands/v5-board.js';
 import { registerV5TaskCommands } from './term-commands/v5-task.js';
 
-// Safety net: ensure git repo is never in bare mode.
-// This should no longer trigger now that we use `git clone --shared` instead of
-// `git worktree` (which could flip core.bare=true on the parent repo). Kept as
-// a last-resort guard for repos previously corrupted by the old worktree approach.
-try {
-  const { execSync: execSyncStartup } = require('node:child_process');
-  const isBare = execSyncStartup('git config core.bare', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
-  if (isBare === 'true') {
-    execSyncStartup('git config core.bare false', { stdio: ['pipe', 'pipe', 'pipe'] });
-  }
-} catch {
-  // Not in a git repo — that's fine
-}
-
 const program = new Command();
 
 program.name('genie').description('Genie CLI - AI-assisted development').version(VERSION);

--- a/src/hooks/handlers/__tests__/audit-context.test.ts
+++ b/src/hooks/handlers/__tests__/audit-context.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { execSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { HookPayload } from '../../types.js';
@@ -110,5 +110,22 @@ describe('audit-context handler', () => {
     const result = await auditContext(payload);
     expect(result).toBeUndefined();
     execSync(`rm -rf ${nonGitDir}`);
+  });
+
+  test('does not execute a shell-injection file_path (no shell, execFileSync)', async () => {
+    // A file_path crafted to run `touch PWNED` under a shell. audit-context has
+    // no on-disk existence gate — it hands the path straight to git — so this is
+    // the primary injection vector. execFileSync passes the path literally to git
+    // with no shell, so `$(...)` is never evaluated and PWNED is never created.
+    const payload: HookPayload = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Edit',
+      tool_input: { file_path: '$(touch PWNED)' },
+      cwd: repoDir,
+    };
+
+    await auditContext(payload);
+
+    expect(existsSync(join(repoDir, 'PWNED'))).toBe(false);
   });
 });

--- a/src/hooks/handlers/__tests__/freshness.test.ts
+++ b/src/hooks/handlers/__tests__/freshness.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { execSync } from 'node:child_process';
 // CI-tolerant: handler assertions are conditional (git log/status may return empty in CI)
-import { mkdtempSync, utimesSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, realpathSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { HookPayload } from '../../types.js';
@@ -187,5 +187,104 @@ describe('freshness handler', () => {
     const result = await freshness(payload);
     // Should not warn because the current agent made the commit
     expect(result).toBeUndefined();
+  });
+
+  test('does not execute injection via committed file_path (getLastCommitInfo, no shell)', async () => {
+    // A file whose literal name is a shell-injection payload. When getLastCommitInfo
+    // runs `git log` against it, a shell would evaluate `$(touch PWNED)`;
+    // execFileSync hands the path to git literally, so it never runs. The OLD
+    // vulnerable execSync form would run `$(touch PWNED)` via the shell BEFORE git
+    // is even invoked, so this assertion is meaningful even when git is absent — no
+    // repoReady gate (mirrors audit-context's injection test).
+    const evilPath = join(repoDir, '$(touch PWNED)');
+    writeFileSync(evilPath, 'const x = 1;\n');
+    // Best-effort commit so getLastCommitInfo has a commit to read; its failure
+    // must NOT skip the sentinel assertion below.
+    try {
+      execSync('git add . && git commit -m "add evil"', { cwd: repoDir, stdio: 'pipe' });
+    } catch {
+      // git unavailable/failed — the injection assertion still runs below
+    }
+    // Fresh mtime (set regardless of git) so freshness passes the disk-age gate
+    // into the injectable git call.
+    const now = new Date();
+    utimesSync(evilPath, now, now);
+
+    const payload: HookPayload = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Read',
+      tool_input: { file_path: evilPath },
+      cwd: repoDir,
+    };
+
+    await freshness(payload);
+
+    expect(existsSync(join(repoDir, 'PWNED'))).toBe(false);
+  });
+
+  test('does not execute injection via uncommitted file_path (checkUncommittedChanges, no shell)', async () => {
+    // GENIE_AGENT_NAME is set in beforeEach. The file is left UNCOMMITTED so
+    // getLastCommitInfo returns null and the currentAgent branch falls through to
+    // checkUncommittedChanges (`git status`). A shell would evaluate the name; the
+    // de-shelled execFileSync passes it to git literally. The OLD vulnerable
+    // execSync form would run `$(touch PWNED2)` via the shell before git is
+    // invoked, so this assertion is meaningful even when git is absent — no
+    // repoReady gate (mirrors audit-context's injection test).
+    const evilPath = join(repoDir, '$(touch PWNED2)');
+    writeFileSync(evilPath, 'const x = 1;\n');
+    // Fresh mtime so freshness passes the disk-age gate.
+    const now = new Date();
+    utimesSync(evilPath, now, now);
+
+    const payload: HookPayload = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Read',
+      tool_input: { file_path: evilPath },
+      cwd: repoDir,
+    };
+
+    await freshness(payload);
+
+    expect(existsSync(join(repoDir, 'PWNED2'))).toBe(false);
+  });
+
+  test('still warns for a recent commit by another agent (--format parse intact after de-shell)', async () => {
+    if (!repoReady) return; // Skip in CI when git setup fails
+
+    // Canonicalize the repo path so `git log -- <abs path>` matches git's own
+    // canonical view (macOS /var -> /private/var). This removes the one confound
+    // that could make this STRICT assertion flake for a reason unrelated to parsing.
+    const realRepo = realpathSync(repoDir);
+    const testFile = join(realRepo, 'recent.ts');
+    writeFileSync(testFile, 'const y = 1;\n');
+    try {
+      execSync('git add . && git commit -m "recent change"', { cwd: realRepo, stdio: 'pipe' });
+    } catch {
+      return; // git commit failed in CI — skip test
+    }
+    // Fresh mtime so the disk-age gate passes.
+    const now = new Date();
+    utimesSync(testFile, now, now);
+
+    const payload: HookPayload = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Read',
+      tool_input: { file_path: testFile },
+      cwd: realRepo,
+    };
+
+    const result = await freshness(payload);
+
+    // STRICT: the commit is < 120s old and authored by "other-agent" (not the
+    // "test-agent" in GENIE_AGENT_NAME), so a warning MUST fire. If the `--format`
+    // element had kept its shell quotes, git would emit a leading `"`, the
+    // timestamp would parse to NaN, getLastCommitInfo would return null, and this
+    // would be undefined. A passing warning proves the de-shell kept the parse.
+    expect(result).toBeDefined();
+    expect(result!.hookSpecificOutput).toBeDefined();
+    expect(result!.hookSpecificOutput!.additionalContext).toContain('[freshness]');
+    expect(result!.hookSpecificOutput!.additionalContext).toContain('was modified');
+    expect(result!.hookSpecificOutput!.additionalContext).toContain('other-agent');
+    expect(result!.hookSpecificOutput!.permissionDecision).toBe('allow');
   });
 });

--- a/src/hooks/handlers/audit-context.ts
+++ b/src/hooks/handlers/audit-context.ts
@@ -8,7 +8,7 @@
  * Priority: 8 (runs before identity-inject, after brain-inject)
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import type { HandlerResult, HookPayload } from '../types.js';
 
 /** Max number of recent commits to show per file. */
@@ -17,7 +17,7 @@ const MAX_COMMITS = 5;
 /** Get recent git log for a specific file. Returns null if git is unavailable or file is untracked. */
 function getRecentGitHistory(filePath: string, cwd: string): string | null {
   try {
-    const log = execSync(`git log --oneline -n ${MAX_COMMITS} -- ${JSON.stringify(filePath)}`, {
+    const log = execFileSync('git', ['log', '--oneline', '-n', String(MAX_COMMITS), '--', filePath], {
       encoding: 'utf-8',
       timeout: 5000,
       cwd,

--- a/src/hooks/handlers/freshness.ts
+++ b/src/hooks/handlers/freshness.ts
@@ -9,7 +9,7 @@
  * Priority: 8 (runs early, informational only)
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { statSync } from 'node:fs';
 import { readEnvAgentId, readEnvAgentName } from '../env-identity.js';
 import type { HandlerResult, HookPayload } from '../types.js';
@@ -21,7 +21,7 @@ const STALENESS_THRESHOLD_SECS = 120; // 2 minutes
 function getLastCommitInfo(filePath: string, cwd: string): { author: string; age: number; message: string } | null {
   try {
     // Get last commit timestamp, author, and subject for the file
-    const output = execSync(`git log -1 --format="%at|%an|%s" -- ${JSON.stringify(filePath)}`, {
+    const output = execFileSync('git', ['log', '-1', '--format=%at|%an|%s', '--', filePath], {
       encoding: 'utf-8',
       timeout: 5000,
       cwd,
@@ -69,7 +69,7 @@ function buildCommitWarning(
 /** Check for uncommitted changes and return a warning result if any exist. */
 function checkUncommittedChanges(filePath: string, cwd: string, diskAge: number): HandlerResult {
   try {
-    const status = execSync(`git status --porcelain -- ${JSON.stringify(filePath)}`, {
+    const status = execFileSync('git', ['status', '--porcelain', '--', filePath], {
       encoding: 'utf-8',
       timeout: 5000,
       cwd,


### PR DESCRIPTION
## What & why

The three PreToolUse file-path hooks (`audit-context`, `freshness` ×2) built shell command strings with the tool's `file_path` interpolated via `JSON.stringify`, which escapes quotes/backslashes but **not** `$` or backticks. Under `sh -c`, a `file_path` of `$(cmd)` executes `cmd` with the running user's privileges. Because this repo's `.claude/settings.json` routes `"*"` to `genie hook dispatch`, any hooked agent induced to Write/Edit/Read a hostile path was a live RCE in a maintainer's checkout.

This was the specialist panel's single **BLOCKED** finding. Landing it flips the audit verdict **BLOCKED → FIX-FIRST**.

## Changes

- **De-shell all three sites** → `execFileSync('git', [...argv, '--', filePath])`. No shell is invoked; git receives the path literally; the `--` pathspec separator also stops a `-`-leading filename from being parsed as a flag.
  - `src/hooks/handlers/audit-context.ts` — `getRecentGitHistory`
  - `src/hooks/handlers/freshness.ts` — `getLastCommitInfo` (dropped the shell double-quotes around `--format`, which carried into an argv element would become literal and corrupt the timestamp parse) + `checkUncommittedChanges`
- **Regression tests** (`src/hooks/handlers/__tests__/`): hostile-filename injection tests for audit-context and **both** freshness sites — gate-free so they cannot silently skip in a git-less CI shard — plus a `--format` parse-survival guard proving the stale-read warning still fires after de-shelling.
- **Remove the `core.bare` startup probe** from `src/genie.ts` (bundled footgun cleanup): it forked git on every invocation for a v4 corruption-recovery guard that no longer triggers (v5 uses `git clone --shared`) and could flip a legitimately-bare repo's `core.bare` to false. New bare-repo corruption is still caught loudly at launch via `BareRepoError`.

## Verification

- **Vector independently reproduced:** the old `execSync` form creates a sentinel from `$(touch PWNED)`; the new `execFileSync` form does not. Mutation testing confirmed the new tests go RED on the pre-fix code and on the `--format`-quote trap.
- `bun test`: **729 pass / 1 skip / 0 fail**.
- `bun run typecheck`, biome lint, knip dead-code, skills:lint: green. `bun run build` + `dist/genie.js --version` from a non-git dir: OK. Fail-closed dispatch regression (drives the rebuilt bundle): green.
- Three independent subagent reviews (two per-group + one whole-wish), all **SHIP**.

Wish plan: `.genie/wishes/hook-injection-hardening/WISH.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security when checking file history and freshness by preventing file paths from being interpreted as shell commands.
  * Preserved existing freshness warnings and git history behavior while handling paths more safely.

* **Tests**
  * Added coverage confirming that potentially malicious file paths cannot execute commands.
  * Added regression coverage for recent-commit freshness warnings and commit history parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->