### PR TITLE
chore(release): promote dev → main — stable release of v5.260710.1 (hook injection fix)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "5.260709.2",
+      "version": "5.260710.1",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/genie",
-  "version": "5.260709.2",
+  "version": "5.260710.1",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
   "type": "module",
   "bin": {

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260709.2",
+  "version": "5.260710.1",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "5.260709.2",
+  "version": "5.260710.1",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "type": "module",


### PR DESCRIPTION
## Promote dev → main — stable release of v5.260710.1

Brings the dev-channel version bump to `main` so the stable-release automation mints **v5.260710.1** on the stable channel (`.well-known/latest.json`).

**What this carries:** `7fd739f7 chore(version): bump to 5.260710.1 [auto-version]` (derived on dev when the dev release was cut). The fix code itself — `f61aaf13`, the hook command-injection de-shelling — is **already on main** via #2536; this promotion is what advances the **stable channel pointer** and cuts the **stable** GitHub release for it. Stable/latest is currently still `5.260709.2`.

## ⚠️ Merge with a MERGE COMMIT — not squash, not rebase

`version.yml` cuts the stable release only when the merge commit on `main` matches `startsWith('Merge pull request') && contains('/dev')`. A **squash or rebase** merge produces a different message and would **silently skip the stable release** — the exact failure this PR exists to correct. Use **"Create a merge commit."**

## After merge (automatic)
`main` merge → CI → `version.yml` (no-bump, branch=main) → dispatches `release.yml` with `channel=stable` for the existing `v5.260710.1` tag → publishes the stable release and advances `latest.json` to `5.260710.1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the Genie plugin and package to version **5.260710.1**.
  * Synchronized version information across marketplace, plugin, and package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->