### PR TITLE
fix(resource-shipping): close LOW follow-ups

### DIFF
--- a/.genie/wishes/plugin-resource-shipping/WISH.md
+++ b/.genie/wishes/plugin-resource-shipping/WISH.md
@@ -92,7 +92,11 @@ test ! -e templates/wish-template.md || { echo "repo-root template still present
 grep -q 'CLAUDE_SKILL_DIR}/templates/wish-template.md' skills/wish/SKILL.md || { echo "scaffold not CLAUDE_SKILL_DIR-addressed"; exit 1; }
 grep -nE '^\s*(bash )?bun run wishes:lint' skills/wish/SKILL.md skills/brainstorm/SKILL.md skills/README.md | grep -v 'grep -q' && { echo "unguarded executable lint invocation remains"; exit 1; }
 grep -q 'cp templates/wish-template.md' skills/wish/SKILL.md && { echo "old bare cp form survives in wish skill"; exit 1; }
-grep -rn 'templates/wish-template.md' . 2>/dev/null | grep -v 'skills/wish/templates/wish-template.md' | grep -v 'CLAUDE_SKILL_DIR}/templates/wish-template.md' | grep -v '^\./\.genie/' | grep -v '^\./node_modules/' | grep -v '^\./\.docs-vendor/' | grep -v '^\./\.git/' && { echo "stale old-path reference (any extension)"; exit 1; }
+# git grep is tracked-only (auto-skips node_modules/.git and the .docs-vendor submodule);
+# :(exclude) drops .genie history docs and the lint rule's own negative fixtures
+# (skills-lint.test.ts intentionally ships bare `cp templates/...` strings) so the
+# sweep stays replay-safe post-G2 while still catching a real stale old-path reference.
+git grep -In 'templates/wish-template\.md' -- ':(exclude).genie/' ':(exclude)scripts/skills-lint.test.ts' | grep -v 'skills/wish/templates/wish-template.md' | grep -v 'CLAUDE_SKILL_DIR}/templates/wish-template.md' && { echo "stale old-path reference (any extension)"; exit 1; }
 grep -rn 'REPO_ROOT/templates' tests/ && { echo "e2e still reads repo-root template"; exit 1; }
 bun run wishes:lint || exit 1
 bun run check || exit 1

--- a/scripts/fresh-install-smoke.test.ts
+++ b/scripts/fresh-install-smoke.test.ts
@@ -1,9 +1,17 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 const SMOKE_SCRIPT = join(import.meta.dir, 'fresh-install-smoke.ts');
+
+// Internal work dirs the script mkdtemps in runWishScaffoldSmoke. A survivor
+// with this prefix (and NOT this test's own '-fixture-' dirs) means the phase-b
+// cleanup was skipped.
+const WORKDIR_PREFIX = 'genie-fresh-install-';
+function scaffoldWorkDirs(): Set<string> {
+  return new Set(readdirSync(tmpdir()).filter((n) => n.startsWith(WORKDIR_PREFIX) && !n.includes('-fixture-')));
+}
 
 function runSmoke(args: string[] = []): { code: number; stdout: string; stderr: string } {
   const result = Bun.spawnSync(['bun', SMOKE_SCRIPT, ...args], {
@@ -46,6 +54,67 @@ describe('fresh-install-smoke', () => {
       const result = runSmoke(['--skills-dir', skillsDir]);
       expect(result.code).not.toBe(0);
       expect(result.stderr).toContain('does not resolve to a real file');
+    });
+  });
+
+  // Phase-b failures create a scaffold work dir BEFORE the assertion trips, so
+  // they are the path where the old process.exit() bypassed cleanup. Induce one
+  // and prove the temp dir is gone regardless.
+  describe('phase-b failure cleanup', () => {
+    let skillsDir: string;
+
+    // Wish skill whose SKILL.md references its in-skill template (phase-a
+    // passes) but whose template omits `## Execution Groups`, so the phase-b
+    // structural check fails after the work dir already exists.
+    function writeWishFixture(templateBody: string): void {
+      const wishDir = join(skillsDir, 'wish');
+      mkdirSync(join(wishDir, 'templates'), { recursive: true });
+      writeFileSync(
+        join(wishDir, 'SKILL.md'),
+        ['# wish', '', '```bash', 'cp "${CLAUDE_SKILL_DIR}/templates/wish-template.md" out.md', '```', ''].join('\n'),
+      );
+      writeFileSync(join(wishDir, 'templates', 'wish-template.md'), templateBody);
+    }
+
+    const FULL_SECTIONS = [
+      '## Summary',
+      '## Scope',
+      '### IN',
+      '### OUT',
+      '## Success Criteria',
+      '## Execution Strategy',
+    ];
+
+    beforeEach(() => {
+      skillsDir = mkdtempSync(join(tmpdir(), 'phaseb-fixture-'));
+    });
+    afterEach(() => {
+      rmSync(skillsDir, { recursive: true, force: true });
+    });
+
+    test('a phase-b failure exits non-zero and leaves no scaffold temp dir behind', () => {
+      writeWishFixture(`${FULL_SECTIONS.join('\n')}\n`); // no '## Execution Groups'
+      const before = scaffoldWorkDirs();
+
+      const result = runSmoke(['--skills-dir', skillsDir]);
+
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toContain('fresh-install-smoke: FAIL');
+      expect(result.stderr).toContain('## Execution Groups');
+
+      const leaked = [...scaffoldWorkDirs()].filter((n) => !before.has(n));
+      expect(leaked).toEqual([]);
+    });
+
+    test('a clean phase-b run exits 0 and leaves no scaffold temp dir behind', () => {
+      writeWishFixture(`${[...FULL_SECTIONS, '## Execution Groups'].join('\n')}\n`);
+      const before = scaffoldWorkDirs();
+
+      const result = runSmoke(['--skills-dir', skillsDir]);
+
+      expect(result.code).toBe(0);
+      const leaked = [...scaffoldWorkDirs()].filter((n) => !before.has(n));
+      expect(leaked).toEqual([]);
     });
   });
 });

--- a/scripts/fresh-install-smoke.ts
+++ b/scripts/fresh-install-smoke.ts
@@ -26,9 +26,14 @@ import { dirname, join, resolve, sep } from 'node:path';
 
 const REPO_ROOT = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
 
+// A checked smoke violation. Thrown (not process.exit'd) so any `finally`
+// cleanup on the call stack — notably the tmp-dir removal in
+// runWishScaffoldSmoke — runs before we translate it to the exit-1 contract in
+// main(). process.exit() would skip those finalizers and orphan the temp dir.
+class SmokeFailure extends Error {}
+
 function fail(message: string): never {
-  console.error(`fresh-install-smoke: FAIL — ${message}`);
-  process.exit(1);
+  throw new SmokeFailure(message);
 }
 
 function parseArgs(argv: string[]): { skillsDir: string } {
@@ -143,12 +148,20 @@ function runWishScaffoldSmoke(skillsDir: string): void {
 }
 
 function main(): void {
-  const { skillsDir } = parseArgs(process.argv.slice(2));
-  if (!existsSync(skillsDir)) fail(`skills dir not found: ${skillsDir}`);
-  const refs = checkSkillDirReferences(skillsDir);
-  runWishScaffoldSmoke(skillsDir);
-  const summary = `${refs} \${CLAUDE_SKILL_DIR} reference(s) resolved, wish scaffold works with no genie on PATH`;
-  console.log(`fresh-install-smoke: OK (${summary})`);
+  try {
+    const { skillsDir } = parseArgs(process.argv.slice(2));
+    if (!existsSync(skillsDir)) fail(`skills dir not found: ${skillsDir}`);
+    const refs = checkSkillDirReferences(skillsDir);
+    runWishScaffoldSmoke(skillsDir);
+    const summary = `${refs} \${CLAUDE_SKILL_DIR} reference(s) resolved, wish scaffold works with no genie on PATH`;
+    console.log(`fresh-install-smoke: OK (${summary})`);
+  } catch (err) {
+    // Checked violations become the exit-1 contract CI depends on; any other
+    // error propagates untouched (non-zero exit + stack trace).
+    if (!(err instanceof SmokeFailure)) throw err;
+    console.error(`fresh-install-smoke: FAIL — ${err.message}`);
+    process.exit(1);
+  }
 }
 
-main();
+if (import.meta.main) main();

--- a/scripts/skills-lint.test.ts
+++ b/scripts/skills-lint.test.ts
@@ -34,6 +34,26 @@ describe('checkResourceLine — imperative discriminators', () => {
     expect(checkResourceLine(guarded)).toEqual([]);
   });
 
+  test('passes other short-circuit package.json probe shapes', () => {
+    expect(checkResourceLine('test -f package.json && bun run skills:lint')).toEqual([]);
+    expect(checkResourceLine('[ -f package.json ] && bun run wishes:lint')).toEqual([]);
+  });
+
+  test('flags a line that only mentions package.json incidentally', () => {
+    // Trailing comment — the probe does not gate the command.
+    expect(checkResourceLine('bun run skills:lint  # regenerates package.json entries').map((v) => v.rule)).toEqual([
+      'unguarded-repo-lint',
+    ]);
+    // package.json referenced AFTER the command — no short-circuit guard.
+    expect(checkResourceLine('bun run wishes:lint && cat package.json').map((v) => v.rule)).toEqual([
+      'unguarded-repo-lint',
+    ]);
+    // Mention in a `;`-joined prose segment is not a short-circuit guard.
+    expect(checkResourceLine('echo "see package.json"; bun run skills:lint').map((v) => v.rule)).toEqual([
+      'unguarded-repo-lint',
+    ]);
+  });
+
   test('flags an imperative repo-script invocation but not a descriptive mention', () => {
     expect(checkResourceLine('bun run scripts/skills-lint.ts').map((v) => v.rule)).toEqual(['repo-script-invocation']);
     expect(checkResourceLine('node scripts/foo.ts').map((v) => v.rule)).toEqual(['repo-script-invocation']);

--- a/scripts/skills-lint.ts
+++ b/scripts/skills-lint.ts
@@ -170,10 +170,18 @@ export function checkResourceLine(line: string): ResourceViolation[] {
   }
 
   // (b) Repo-only lint invocation without the SAME-LINE package.json guard.
-  // A split-line guard (probe on the previous line) does not count — the probe
-  // must sit on the same line as the command it protects.
-  if (/\bbun run (?:wishes|skills):lint\b/.test(line) && !line.includes('package.json')) {
-    violations.push({ rule: 'unguarded-repo-lint', snippet });
+  // The guard must be a package.json probe that short-circuits (`&&`) INTO the
+  // command, e.g. `grep -q '"wishes:lint"' package.json 2>/dev/null && bun run
+  // wishes:lint` or `test -f package.json && bun run skills:lint`. A bare
+  // mention of package.json elsewhere on the line — a trailing comment, an echo
+  // arg, or a reference AFTER the command — does not gate the run, so it must
+  // NOT exempt it. A split-line guard (probe on the previous line) also fails:
+  // the probe must sit on the same line, ahead of the command it protects.
+  const lintMatch = /\bbun run (?:wishes|skills):lint\b/.exec(line);
+  if (lintMatch) {
+    const guard = line.slice(0, lintMatch.index);
+    const guarded = /\bpackage\.json\b[^&|;]*&&/.test(guard);
+    if (!guarded) violations.push({ rule: 'unguarded-repo-lint', snippet });
   }
 
   // (c) Imperative execution of a repo-root script — scripts/*.ts is repo-only.


### PR DESCRIPTION
Closes the three LOW follow-ups recorded at ship time of wish **plugin-resource-shipping** (merged to dev via PR #2540, commits `ecbb67fc`/`203c97df`/`bbd6439e`). Each was verified against the actual code before fixing; all three were real.

## 1. `scripts/fresh-install-smoke.ts` — temp-dir cleanup bypassed on phase-b failure
`fail()` called `process.exit(1)`, which does **not** run `finally` blocks, so the `try/finally` tmp-dir removal in `runWishScaffoldSmoke` was skipped on any phase-b failure — orphaning a `genie-fresh-install-*` dir despite the header comment claiming cleanup on failure.

**Fix:** `fail()` now throws a `SmokeFailure`; `main()` catches it and translates to the **same** exit-1 + `fresh-install-smoke: FAIL — …` stderr contract CI depends on. The existing `finally` now runs on every exit path. Any non-`SmokeFailure` error still propagates untouched. Guarded `main()` behind `import.meta.main` so the module is importable/testable.

**Verified:** ran the pre-fix script vs the fixed script against an induced phase-b failure in an isolated `TMPDIR` — original left **1** orphaned temp dir, fixed left **0**, both exit 1 with identical stderr. Colocated test (`phase-b failure cleanup`) asserts non-zero exit + no surviving scaffold temp dir.

## 2. `scripts/skills-lint.ts` — substring-based same-line guard
The `unguarded-repo-lint` rule exempted a repo-only `bun run wishes:lint`/`skills:lint` whenever the literal `package.json` appeared **anywhere** on the line (`!line.includes('package.json')`) — a trailing comment, an echo arg, or a mention *after* the command all falsely exempted it.

**Fix:** the exemption now requires a `package.json` probe that short-circuits (`&&`) **into** the command (`/\bpackage\.json\b[^&|;]*&&/` over the segment before the invocation). Existing positive/negative fixtures still pass; added fixtures for the false-exemption cases (trailing comment, ref-after-command, `;`-joined prose) and for broader probe shapes (`test -f package.json &&`, `[ -f package.json ] &&`).

## 3. `plugin-resource-shipping` WISH.md G1 validation sweep — not replay-safe post-G2
Note: there is **no** `validate/` dir for this wish; the G1 sweep lives inline in `WISH.md` (Group 1 → Validation). The recursive `grep -rn 'templates/wish-template.md' .` tripped on the lint rule's own negative fixtures in `scripts/skills-lint.test.ts` (bare `cp templates/wish-template.md` strings), which are intentional test data.

**Fix:** switched that sweep line to `git grep -In` (tracked-only; auto-skips node_modules/.git and the `.docs-vendor` submodule) with `:(exclude)` pathspecs for `.genie/` history docs and the fixture file. Still catches real regressions.

**Verified:** on the current tree the sweep passes clean (exit 0); injecting a stale `templates/wish-template.md` ref into a tracked decoy file fires it (exit 1); the full G1 validation block runs green end-to-end.

## Gates (all green)
Run from `scratchpad/gates.sh` (script file — inline multi-line bash false-PASSES in this env):
- `bun run check` — exit 0 (typecheck + lint + dead-code + skills:lint + wishes:lint + council-workflow lint + full suite, 810 pass / 1 skip / 0 fail)
- `bun run skills:lint` — exit 0 (31 files, 0 violations)
- `bun run lint:complexity-budget` — exit 0
- `bun test scripts/fresh-install-smoke.test.ts scripts/skills-lint.test.ts` — 21 pass / 0 fail

No items skipped — all three follow-ups were real and are fixed.
