### PR TITLE
fix(agent-sync): claude gets the /council workflow, not the portable council skill

### DIFF
--- a/src/lib/agent-sync.test.ts
+++ b/src/lib/agent-sync.test.ts
@@ -376,6 +376,64 @@ describe('managed orphan handling', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Claude council exclusion (skill-vs-workflow collision, Decision 8)
+// ---------------------------------------------------------------------------
+
+describe('claude council exclusion', () => {
+  const councilFiles = { 'SKILL.md': '# council (portable, non-workflow runtimes)\n' };
+
+  test('council is synced to codex but never to claude (workflow owns the name there)', () => {
+    rmSync(fixture.root, { recursive: true, force: true });
+    fixture = setup({ skills: { alpha: { 'SKILL.md': '# alpha\n' }, council: councilFiles } });
+    present(fixture.claudeDir);
+    present(fixture.codexDir);
+
+    const report = run();
+    const claude = agentReport(report, 'claude');
+    const codex = agentReport(report, 'codex');
+    expect(skillAction(claude, 'council')).toBeUndefined();
+    expect(existsSync(join(fixture.claudeDir, 'skills', 'council'))).toBe(false);
+    expect(skillAction(claude, 'alpha')).toBe('created');
+    expect(skillAction(codex, 'council')).toBe('created');
+    expect(existsSync(join(fixture.codexDir, 'skills', '.curated', 'council', 'SKILL.md'))).toBe(true);
+  });
+
+  test('a managed council already synced to claude (pre-exclusion release) is backed up and removed', () => {
+    rmSync(fixture.root, { recursive: true, force: true });
+    fixture = setup({ skills: { alpha: { 'SKILL.md': '# alpha\n' }, council: councilFiles } });
+    present(fixture.claudeDir);
+    // Simulate the pre-exclusion release: a digest-clean managed council in the claude target.
+    const destDir = join(fixture.claudeDir, 'skills', 'council');
+    writeFile(join(destDir, 'SKILL.md'), councilFiles['SKILL.md']);
+    const digest = computeDirDigest(destDir);
+    writeFile(
+      join(destDir, MANIFEST_NAME),
+      JSON.stringify({ managedBy: 'genie-agent-sync', version: '9.9.8', digest, syncedAt: '2026-07-10T00:00:00.000Z' }),
+    );
+
+    const report = run();
+    const claude = agentReport(report, 'claude');
+    expect(skillAction(claude, 'council')).toBe('removed');
+    expect(existsSync(destDir)).toBe(false);
+    const backup = join(report.backupsDir as string, 'claude', 'council', 'SKILL.md');
+    expect(readFileSync(backup, 'utf8')).toBe(councilFiles['SKILL.md']);
+  });
+
+  test('a user-created unmanaged council dir in claude is never touched', () => {
+    rmSync(fixture.root, { recursive: true, force: true });
+    fixture = setup({ skills: { alpha: { 'SKILL.md': '# alpha\n' }, council: councilFiles } });
+    present(fixture.claudeDir);
+    const userDir = join(fixture.claudeDir, 'skills', 'council');
+    writeFile(join(userDir, 'SKILL.md'), '# my own council launcher\n');
+
+    const report = run();
+    const claude = agentReport(report, 'claude');
+    expect(skillAction(claude, 'council')).toBeUndefined();
+    expect(readFileSync(join(userDir, 'SKILL.md'), 'utf8')).toBe('# my own council launcher\n');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Missing agents
 // ---------------------------------------------------------------------------
 

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -54,6 +54,16 @@ export const TARGET_NAME = 'council.js';
 export const MANIFEST_NAME = '.genie-sync.json';
 /** `managedBy` value that certifies a dir as one this engine owns. Exported: single source of truth. */
 export const MANAGED_BY = 'genie-agent-sync';
+/**
+ * Skills NOT synced to Claude Code. On CC, `/council` is the stamped native
+ * WORKFLOW (council.js); the portable `council` SKILL exists for runtimes
+ * without the workflow engine (Codex, Hermes). Shipping both to CC would
+ * register a skill and a workflow under one name — undocumented precedence,
+ * the exact collision council-workflow Decision 8 forbids. Excluded names are
+ * also dropped from the orphan-protection set, so an already-synced managed
+ * copy is backed up and removed on the next sync.
+ */
+const CLAUDE_EXCLUDED_SKILLS = new Set(['council']);
 /** Skill actions that represent an actual write to the target. */
 const WRITE_ACTIONS = new Set<SkillAction>(['created', 'updated', 'adopted', 'removed']);
 /**
@@ -323,8 +333,14 @@ function enumerateSourceSkills(pluginRoot: string): SourceSkill[] {
  * Sync every source skill into `targetParent`, then remove managed orphans.
  * Each skill is guarded independently so one failure cannot sink the rest.
  */
-function syncSkillDirsInto(ctx: RunContext, agent: string, targetParent: string, report: AgentReport): void {
-  const sourceSkills = enumerateSourceSkills(ctx.pluginRoot);
+function syncSkillDirsInto(
+  ctx: RunContext,
+  agent: string,
+  targetParent: string,
+  report: AgentReport,
+  exclude?: Set<string>,
+): void {
+  const sourceSkills = enumerateSourceSkills(ctx.pluginRoot).filter((skill) => !exclude?.has(skill.name));
   const sourceNames = new Set(sourceSkills.map((skill) => skill.name));
   mkdirSync(targetParent, { recursive: true });
   for (const skill of sourceSkills) {
@@ -426,7 +442,7 @@ function syncClaude(ctx: RunContext, report: AgentReport): void {
   const claudeDir = ctx.targets.claude;
   if (!existsSync(claudeDir)) return;
   report.detected = true;
-  syncSkillDirsInto(ctx, 'claude', join(claudeDir, 'skills'), report);
+  syncSkillDirsInto(ctx, 'claude', join(claudeDir, 'skills'), report, CLAUDE_EXCLUDED_SKILLS);
   stampClaudeWorkflow(ctx, claudeDir, report);
 }
 


### PR DESCRIPTION
Live-dogfood finding (goal loop, first agent-sync run on the reference machine): the codex-first-class commit e9d7d108 recreated `skills/council` as a portable deliberation skill for runtimes without the Workflow engine — correct for Codex/Hermes, but agent-sync also synced it to `~/.claude/skills/council`, registering a SKILL and a WORKFLOW under the same `/council` name on Claude Code (undocumented precedence — the exact collision council-workflow Decision 8 forbids).

Fix: `CLAUDE_EXCLUDED_SKILLS` in the engine — the claude adapter skips `council` AND drops it from the orphan-protection set, so machines synced by the pre-exclusion release get their managed copy backed up + removed on the next `genie update`. Codex/Hermes keep the portable skill; unmanaged user-created `council` dirs are never touched.

Locks: 3 new engine tests (codex-yes/claude-no; pre-exclusion managed copy removed with backup; unmanaged user dir untouched). `bun run check`: 855 pass / 1 skip.