### PR TITLE
fix(update): never clobber config, refuse silent downgrades, doctor exclusion-aware

### DIFF
--- a/src/genie-commands/__tests__/update.test.ts
+++ b/src/genie-commands/__tests__/update.test.ts
@@ -21,6 +21,8 @@ import {
   type VerifyResult,
   _resetNextDeprecationLatchForTest,
   atomicBinarySwap,
+  compareVersions,
+  decideDowngrade,
   decideVerify,
   downloadAndVerifyTarball,
   ensureCanonicalInstall,
@@ -173,6 +175,123 @@ describe('shortCircuitIfCurrent', () => {
 
   test('different versions return false', () => {
     expect(shortCircuitIfCurrent('1.0.0', '1.0.1')).toBe(false);
+  });
+});
+
+// ============================================================================
+// Downgrade guard (BUG B) — numeric version comparison + the pure decision
+// function that refuses a silent backward swap. `shortCircuitIfCurrent` only
+// covers the EQUAL case; these cover installed > latest.
+// ============================================================================
+
+describe('compareVersions', () => {
+  test('older < newer across each MAJOR.YYMMDD.N component', () => {
+    expect(compareVersions('5.260710.2', '5.260710.10')).toBe(-1);
+    expect(compareVersions('5.260709.9', '5.260710.1')).toBe(-1);
+    expect(compareVersions('4.999999.9', '5.000000.0')).toBe(-1);
+  });
+
+  test('newer > older is the inverse', () => {
+    expect(compareVersions('5.260710.10', '5.260710.2')).toBe(1);
+    expect(compareVersions('5.260710.1', '5.260709.9')).toBe(1);
+  });
+
+  test('equal versions compare 0', () => {
+    expect(compareVersions('5.260710.11', '5.260710.11')).toBe(0);
+  });
+
+  test('build metadata is stripped before comparing', () => {
+    expect(compareVersions('5.260710.11+abc1234', '5.260710.11')).toBe(0);
+    expect(compareVersions('5.260710.10+deadbee', '5.260710.2')).toBe(1);
+  });
+
+  test('N is compared numerically, not lexically (10 > 2)', () => {
+    // The core of the live bug: string compare would rank "2" above "10".
+    expect(compareVersions('5.260710.10', '5.260710.2')).toBe(1);
+  });
+
+  test('missing / non-numeric components degrade to 0 (never spuriously newer)', () => {
+    expect(compareVersions('5.260710', '5.260710.0')).toBe(0);
+    expect(compareVersions('garbage', '5.260710.1')).toBe(-1);
+    expect(compareVersions('5.260710.1', '')).toBe(1);
+  });
+});
+
+describe('decideDowngrade', () => {
+  test('installed older → upgrade (proceed normally)', () => {
+    expect(
+      decideDowngrade({ installedVersion: '5.260710.2', latestVersion: '5.260710.10', explicitChannel: false }).kind,
+    ).toBe('upgrade');
+  });
+
+  test('installed equal → current (short-circuit)', () => {
+    expect(
+      decideDowngrade({ installedVersion: '5.260710.11', latestVersion: '5.260710.11', explicitChannel: false }).kind,
+    ).toBe('current');
+  });
+
+  test('installed newer + NO explicit flag → block-downgrade with both versions', () => {
+    const d = decideDowngrade({
+      installedVersion: '5.260710.10',
+      latestVersion: '5.260710.2',
+      explicitChannel: false,
+    });
+    expect(d.kind).toBe('block-downgrade');
+    if (d.kind === 'block-downgrade') {
+      expect(d.installed).toBe('5.260710.10');
+      expect(d.latest).toBe('5.260710.2');
+    }
+  });
+
+  test('installed newer + explicit channel flag → allow-downgrade (operator intent)', () => {
+    const d = decideDowngrade({
+      installedVersion: '5.260710.10',
+      latestVersion: '5.260710.2',
+      explicitChannel: true,
+    });
+    expect(d.kind).toBe('allow-downgrade');
+    if (d.kind === 'allow-downgrade') {
+      expect(d.installed).toBe('5.260710.10');
+      expect(d.latest).toBe('5.260710.2');
+    }
+  });
+
+  test('null/undefined latest → upgrade (defers to the manifest-unavailable abort)', () => {
+    expect(decideDowngrade({ installedVersion: '5.260710.10', latestVersion: null, explicitChannel: false }).kind).toBe(
+      'upgrade',
+    );
+    expect(
+      decideDowngrade({ installedVersion: '5.260710.10', latestVersion: undefined, explicitChannel: true }).kind,
+    ).toBe('upgrade');
+  });
+});
+
+describe('updateCommand downgrade wiring (BUG B source-shape lock)', () => {
+  test('updateCommand runs the downgrade guard before download', () => {
+    const source = readFileSync(join(__dirname, '..', 'update.ts'), 'utf-8');
+    const cmdStart = source.indexOf('export async function updateCommand');
+    const cmdBody = source.slice(cmdStart);
+    const guardIdx = cmdBody.indexOf('applyDowngradeGuard(');
+    const downloadIdx = cmdBody.indexOf('await downloadAndVerifyTarball(');
+    // The guard must run BEFORE any tarball is fetched.
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(guardIdx).toBeLessThan(downloadIdx);
+    // A refused downgrade still converges agents (parity with already-current).
+    const afterGuard = cmdBody.slice(guardIdx);
+    expect(afterGuard).toContain('runAgentSyncSafe()');
+  });
+
+  test('the guard consults decideDowngrade and honors both refusal and explicit-intent paths', () => {
+    const source = readFileSync(join(__dirname, '..', 'update.ts'), 'utf-8');
+    expect(source).toContain('decideDowngrade({');
+    // block-downgrade path: refuse loudly.
+    expect(source).toContain("downgrade.kind === 'block-downgrade'");
+    expect(source).toContain('refusing automatic downgrade');
+    // allow-downgrade path: loud one-liner honoring explicit operator intent.
+    expect(source).toContain("downgrade.kind === 'allow-downgrade'");
+    expect(source).toContain('DOWNGRADE v');
+    // An explicit channel flag is what authorizes the backward move.
+    expect(source).toContain('const explicitChannel = Boolean(');
   });
 });
 
@@ -501,6 +620,118 @@ describe('persistChannel — sticky channel persistence (release-channel-dev)', 
 
   test('persistChannel("stable") does not throw', async () => {
     await expect(persistChannel('stable')).resolves.toBeUndefined();
+  });
+});
+
+// ============================================================================
+// Channel persistence never clobbers the config (BUG A). A transient config
+// read failure between two `genie update` runs must NOT (a) silently reset a
+// persisted channel to stable, nor (b) rewrite the whole file from defaults.
+// Isolated under a tmp GENIE_HOME so a real ~/.genie/config.json is never read
+// or written; stderr is captured so the advisory lines are asserted, not leaked.
+// ============================================================================
+
+describe('resolveChannel + persistChannel — config preservation (BUG A)', () => {
+  let dir: string;
+  let configPath: string;
+  let prevGenieHome: string | undefined;
+  let stderrCapture: string;
+  const realStderrWrite = process.stderr.write.bind(process.stderr);
+
+  beforeEach(() => {
+    prevGenieHome = process.env.GENIE_HOME;
+    dir = mkdtempSync(join(tmpdir(), 'update-channel-'));
+    process.env.GENIE_HOME = dir;
+    configPath = join(dir, 'config.json');
+    stderrCapture = '';
+    (process.stderr.write as unknown) = ((chunk: string | Uint8Array): boolean => {
+      stderrCapture += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8');
+      return true;
+    }) as typeof process.stderr.write;
+  });
+
+  afterEach(() => {
+    (process.stderr.write as unknown) = realStderrWrite as typeof process.stderr.write;
+    if (prevGenieHome === undefined) {
+      Reflect.deleteProperty(process.env, 'GENIE_HOME');
+    } else {
+      process.env.GENIE_HOME = prevGenieHome;
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('valid persisted channel resolves back and persist preserves sibling keys', async () => {
+    writeFileSync(configPath, JSON.stringify({ updateChannel: 'homolog', setupComplete: true }, null, 2), 'utf-8');
+    expect(await resolveChannel({})).toBe('homolog');
+    expect(stderrCapture).toBe(''); // happy path is silent
+    await persistChannel('homolog');
+    const saved = JSON.parse(readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
+    expect(saved.updateChannel).toBe('homolog');
+    expect(saved.setupComplete).toBe(true);
+  });
+
+  test('valid config with unknown/extra fields survives persistChannel byte-for-byte except updateChannel', async () => {
+    // Unknown keys (myTool) are stripped by the schema on parse — proving that even
+    // the happy path must NOT round-trip through saveGenieConfig, or they vanish.
+    const original = {
+      updateChannel: 'dev',
+      setupComplete: true,
+      promptMode: 'system',
+      myTool: { foo: 1, list: ['a', 'b'] },
+    };
+    writeFileSync(configPath, JSON.stringify(original, null, 2), 'utf-8');
+
+    await persistChannel('stable'); // dev → latest
+
+    const after = readFileSync(configPath, 'utf-8');
+    // Byte-for-byte identical except updateChannel flipped to its canonical token.
+    expect(after).toBe(JSON.stringify({ ...original, updateChannel: 'latest' }, null, 2));
+    const saved = JSON.parse(after) as Record<string, unknown>;
+    expect(saved.updateChannel).toBe('latest');
+    expect(saved.setupComplete).toBe(true);
+    expect(saved.promptMode).toBe('system');
+    expect(saved.myTool).toEqual({ foo: 1, list: ['a', 'b'] });
+    expect(stderrCapture).toBe('');
+  });
+
+  test('schema-invalid-but-parseable config keeps its channel on resolve and is NOT clobbered on persist', async () => {
+    // omni present but missing its required apiUrl → the full schema rejects this,
+    // but the file is valid JSON, so the channel is still recoverable.
+    const invalid = { updateChannel: 'dev', setupComplete: true, omni: { instance: 'x' } };
+    writeFileSync(configPath, JSON.stringify(invalid, null, 2), 'utf-8');
+
+    // resolve: recovers 'dev' from the raw key rather than silently → stable.
+    expect(await resolveChannel({})).toBe('dev');
+    expect(stderrCapture).toContain('keeping channel dev');
+
+    // persist: raw read-modify-write; the invalid-but-present siblings survive.
+    await persistChannel('dev');
+    const saved = JSON.parse(readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
+    expect(saved.updateChannel).toBe('dev');
+    expect(saved.setupComplete).toBe(true); // NOT reset to the default (false)
+    expect(saved.omni).toEqual({ instance: 'x' }); // NOT dropped
+  });
+
+  test('unparseable config → advisory + no write on persist, stated stable fallback on resolve', async () => {
+    const garbage = '{ this is not valid json ,,, ';
+    writeFileSync(configPath, garbage, 'utf-8');
+
+    // resolve: falls back to stable, and says so.
+    expect(await resolveChannel({})).toBe('stable');
+    expect(stderrCapture).toContain('could not read');
+    expect(stderrCapture).toContain('falling back to stable channel');
+
+    // persist: leaves the file untouched rather than clobbering it.
+    await persistChannel('dev');
+    expect(readFileSync(configPath, 'utf-8')).toBe(garbage);
+    expect(stderrCapture).toContain('unparseable');
+    expect(stderrCapture).toContain('not persisted');
+  });
+
+  test('valid config with no updateChannel key resolves to stable silently (schema default)', async () => {
+    writeFileSync(configPath, JSON.stringify({ setupComplete: true }, null, 2), 'utf-8');
+    expect(await resolveChannel({})).toBe('stable');
+    expect(stderrCapture).toBe('');
   });
 });
 

--- a/src/genie-commands/doctor.test.ts
+++ b/src/genie-commands/doctor.test.ts
@@ -544,6 +544,24 @@ describe('checkAgentSync', () => {
     expect(hermes?.detail).toContain('linked');
   });
 
+  test('claude excludes council: expected set is source minus exclusions → pass, no advisory (BUG C)', () => {
+    // `council` is a source skill the native /council workflow owns, so claude
+    // legitimately never receives it. Doctor must subtract it from claude's
+    // expected source set — otherwise it reports "2/3 current" and advises
+    // `genie update` forever even though claude is fully converged.
+    writeSourceSkill('council', '# council\n');
+    seedManaged(join(pluginRoot, 'skills', 'wish'), join(claudeDir, 'skills', 'wish'));
+    seedManaged(join(pluginRoot, 'skills', 'review'), join(claudeDir, 'skills', 'review'));
+    stampCouncil(pluginRoot);
+
+    const claude = find(checkAgentSync(paths()), 'agent sync: claude');
+    expect(claude?.status).toBe('pass');
+    // 3 source skills, council excluded → expected 2, both present → 2/2 current.
+    expect(claude?.detail).toContain('2/2 source skills current');
+    expect(claude?.detail).toContain('council.js current');
+    expect(claude?.suggestion).toBeUndefined();
+  });
+
   test('stale managed skill + wrong council stamp → warn + genie-update advice', () => {
     seedManaged(join(pluginRoot, 'skills', 'wish'), join(claudeDir, 'skills', 'wish'));
     seedManaged(join(pluginRoot, 'skills', 'review'), join(claudeDir, 'skills', 'review'), 'deadbeef');

--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -17,7 +17,14 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, lstatSync, readFileSync, readdirSync, readlinkSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
-import { MANAGED_BY, MANIFEST_NAME, TARGET_NAME, computeDirDigest, resolveGenieSource } from '../lib/agent-sync.js';
+import {
+  CLAUDE_EXCLUDED_SKILLS,
+  MANAGED_BY,
+  MANIFEST_NAME,
+  TARGET_NAME,
+  computeDirDigest,
+  resolveGenieSource,
+} from '../lib/agent-sync.js';
 import { DEAD_GENIE_OTEL_EXPORTER, getCodexConfigPath, getCodexHome } from '../lib/codex-config.js';
 import { loadGenieConfig } from '../lib/genie-config.js';
 import {
@@ -595,9 +602,18 @@ function sourceSkillDigests(pluginRoot: string): Map<string, string> {
  * `unchanged`: manifest present, on-disk content matches its manifest, and the
  * manifest matches the current source digest. Unmanaged dirs are ignored — genie
  * only speaks for what it provably shipped.
+ *
+ * `excluded` names are dropped from the EXPECTED source set so an agent that
+ * legitimately never receives a skill (e.g. Claude excludes `council`, whose name
+ * the native /council workflow owns) is not reported as one skill short of source.
  */
-function summarizeManagedSkills(pluginRoot: string, targetParent: string): ManagedSkillsSummary {
+function summarizeManagedSkills(
+  pluginRoot: string,
+  targetParent: string,
+  excluded?: Set<string>,
+): ManagedSkillsSummary {
   const source = sourceSkillDigests(pluginRoot);
+  if (excluded) for (const name of excluded) source.delete(name);
   let current = 0;
   let stale = 0;
   for (const name of listSubdirs(targetParent)) {
@@ -637,7 +653,10 @@ function councilStampState(councilPath: string, pluginRoot: string): { stale: bo
 
 function checkClaudeSync(pluginRoot: string, claudeDir: string): CheckResult[] {
   if (!existsSync(claudeDir)) return [{ name: 'agent sync: claude', status: 'pass', detail: 'not detected' }];
-  const skills = skillsFreshness(summarizeManagedSkills(pluginRoot, join(claudeDir, 'skills')));
+  // Claude legitimately excludes `council` (the /council native workflow owns
+  // that name), so its expected source set is source minus CLAUDE_EXCLUDED_SKILLS
+  // — otherwise doctor reports "N-1/N current" and advises `genie update` forever.
+  const skills = skillsFreshness(summarizeManagedSkills(pluginRoot, join(claudeDir, 'skills'), CLAUDE_EXCLUDED_SKILLS));
   const council = councilStampState(join(claudeDir, 'workflows', COUNCIL_WORKFLOW_FILE), pluginRoot);
   const stale = skills.stale || council.stale;
   return [

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -19,8 +19,9 @@ import {
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { type AgentSyncReport, runAgentSync } from '../lib/agent-sync.js';
-import { genieConfigExists, loadGenieConfig, saveGenieConfig } from '../lib/genie-config.js';
+import { contractPath, genieConfigExists, getGenieConfigPath, saveGenieConfig } from '../lib/genie-config.js';
 import { VERSION } from '../lib/version.js';
+import { GenieConfigSchema } from '../types/genie-config.js';
 import { cleanupV4 } from './legacy-v4.js';
 
 const GENIE_HOME = process.env.GENIE_HOME || join(homedir(), '.genie');
@@ -123,6 +124,61 @@ export function decideVerify(args: DecideVerifyArgs): VerifyResult {
 export function shortCircuitIfCurrent(currentVersion: string, latestVersion: string | null | undefined): boolean {
   if (!latestVersion) return false;
   return normalizeVersion(currentVersion) === normalizeVersion(latestVersion);
+}
+
+/**
+ * Compare two genie versions (`MAJOR.YYMMDD.N`, build metadata stripped) numerically,
+ * component by component. Returns -1 when `a` is older than `b`, 0 when equal, 1 when
+ * `a` is newer. Missing or non-numeric components are treated as 0 so a malformed
+ * version string degrades to "older-or-equal" and never spuriously blocks an update.
+ */
+export function compareVersions(a: string, b: string): number {
+  const pa = normalizeVersion(a).split('.');
+  const pb = normalizeVersion(b).split('.');
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const x = Number.parseInt(pa[i] ?? '', 10);
+    const y = Number.parseInt(pb[i] ?? '', 10);
+    const xv = Number.isNaN(x) ? 0 : x;
+    const yv = Number.isNaN(y) ? 0 : y;
+    if (xv < yv) return -1;
+    if (xv > yv) return 1;
+  }
+  return 0;
+}
+
+/**
+ * Direction of a resolved update relative to the installed binary.
+ * - `upgrade`         — installed is older (or the manifest version is unknown); proceed.
+ * - `current`         — installed equals the manifest version; short-circuit.
+ * - `block-downgrade` — installed is NEWER and no explicit channel flag authorized it; refuse.
+ * - `allow-downgrade` — installed is NEWER but an explicit `--stable/--dev/--homolog`
+ *   signalled operator intent; proceed with a loud notice.
+ */
+export type DowngradeDecision =
+  | { kind: 'upgrade' }
+  | { kind: 'current' }
+  | { kind: 'block-downgrade'; installed: string; latest: string }
+  | { kind: 'allow-downgrade'; installed: string; latest: string };
+
+/**
+ * Decide whether `genie update` should proceed, short-circuit, refuse, or force a
+ * version move. Pure so the operator-facing branch is unit-tested without any network
+ * or binary swap. A null/empty `latestVersion` yields `upgrade` so the caller's
+ * existing "manifest unavailable" abort runs unchanged.
+ */
+export function decideDowngrade(args: {
+  installedVersion: string;
+  latestVersion: string | null | undefined;
+  explicitChannel: boolean;
+}): DowngradeDecision {
+  if (!args.latestVersion) return { kind: 'upgrade' };
+  const cmp = compareVersions(args.installedVersion, args.latestVersion);
+  if (cmp === 0) return { kind: 'current' };
+  if (cmp < 0) return { kind: 'upgrade' };
+  return args.explicitChannel
+    ? { kind: 'allow-downgrade', installed: args.installedVersion, latest: args.latestVersion }
+    : { kind: 'block-downgrade', installed: args.installedVersion, latest: args.latestVersion };
 }
 
 // ============================================================================
@@ -1298,6 +1354,60 @@ export function _resetNextDeprecationLatchForTest(): void {
   nextDeprecationEmitted = false;
 }
 
+/** Map a raw `updateChannel` token (including the legacy 'next' alias) to a
+ *  ReleaseChannel, or null when the token is absent or unrecognized. */
+function channelFromToken(token: unknown): ReleaseChannel | null {
+  if (token === 'dev' || token === 'next') return 'dev';
+  if (token === 'homolog') return 'homolog';
+  if (token === 'latest') return 'stable';
+  return null;
+}
+
+/** Map a ReleaseChannel back to its canonical persisted token. We always write
+ *  one of the three canonical tokens ('latest' / 'homolog' / 'dev'); the legacy
+ *  'next' alias is read-only and never round-trips to disk. */
+function channelToken(channel: ReleaseChannel): 'latest' | 'homolog' | 'dev' {
+  if (channel === 'dev') return 'dev';
+  if (channel === 'homolog') return 'homolog';
+  return 'latest';
+}
+
+/** Outcome of a tolerant config read. `ok` means the file parsed as a JSON
+ *  object (recoverable — the updateChannel key is readable even when the full
+ *  schema rejects the config); `unreadable` means it could not be parsed at all. */
+type RawConfigRead =
+  | { kind: 'ok'; raw: Record<string, unknown>; schemaValid: boolean }
+  | { kind: 'unreadable'; reason: string };
+
+/**
+ * Read the genie config leniently — never throws, never returns defaults. Unlike
+ * `loadGenieConfig`, this distinguishes a JSON-parseable-but-schema-invalid file
+ * (from which the channel can still be recovered) from a truly unparseable one, and
+ * it never manufactures a defaults object that a caller could mistake for the real
+ * config and persist over the top of it. `schemaValid` is true only when the WHOLE
+ * config satisfies GenieConfigSchema.
+ */
+function readConfigTolerant(): RawConfigRead {
+  const path = getGenieConfigPath();
+  let text: string;
+  try {
+    text = readFileSync(path, 'utf-8');
+  } catch (err) {
+    return { kind: 'unreadable', reason: err instanceof Error ? err.message : String(err) };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    return { kind: 'unreadable', reason: err instanceof Error ? err.message : String(err) };
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { kind: 'unreadable', reason: 'config root is not a JSON object' };
+  }
+  const raw = parsed as Record<string, unknown>;
+  return { kind: 'ok', raw, schemaValid: GenieConfigSchema.safeParse(raw).success };
+}
+
 export async function resolveChannel(options: {
   dev?: boolean;
   homolog?: boolean;
@@ -1327,37 +1437,76 @@ export async function resolveChannel(options: {
     emitNextDeprecationOnce();
     return 'dev';
   }
-  if (genieConfigExists()) {
-    try {
-      const config = await loadGenieConfig();
-      // The zod schema's `.transform` already normalizes the legacy 'next'
-      // token to 'dev' at parse time. Post-2026-05-12 the schema also
-      // accepts 'homolog'; only 'latest' | 'homolog' | 'dev' can land here.
-      if (config.updateChannel === 'dev') return 'dev';
-      if (config.updateChannel === 'homolog') return 'homolog';
-      if (config.updateChannel === 'latest') return 'stable';
-    } catch {
-      // ignore
-    }
+  if (genieConfigExists()) return resolveChannelFromConfig();
+  return 'stable';
+}
+
+/**
+ * Resolve the sticky channel from an EXISTING config file, degrading loudly — never
+ * silently — when the file can't be fully read. A transient corruption (a truncated
+ * concurrent write, or a schema-rejecting field written by another session) must NOT
+ * silently reset a persisted 'dev'/'homolog' channel to stable: we recover the channel
+ * from the raw updateChannel key first, and only fall back to stable when even that is
+ * impossible — saying so on stderr either way.
+ */
+function resolveChannelFromConfig(): ReleaseChannel {
+  const path = getGenieConfigPath();
+  const read = readConfigTolerant();
+  if (read.kind === 'unreadable') {
+    process.stderr.write(
+      `warning: could not read ${contractPath(path)} (${read.reason}); falling back to stable channel\n`,
+    );
+    return 'stable';
   }
+  const channel = channelFromToken(read.raw.updateChannel);
+  if (read.schemaValid) {
+    // Valid config; an absent updateChannel means the schema default (stable).
+    return channel ?? 'stable';
+  }
+  // JSON-parseable but schema-invalid — recover the channel from the raw key
+  // rather than silently resetting to stable.
+  if (channel) {
+    process.stderr.write(
+      `warning: could not fully read ${contractPath(path)} (invalid config); keeping channel ${channel} from updateChannel\n`,
+    );
+    return channel;
+  }
+  process.stderr.write(
+    `warning: could not fully read ${contractPath(path)} (invalid config, no usable updateChannel); falling back to stable channel\n`,
+  );
   return 'stable';
 }
 
 export async function persistChannel(channel: ReleaseChannel): Promise<void> {
-  try {
-    const config = await loadGenieConfig();
-    // Map ReleaseChannel → genie-config schema enum. The schema accepts
-    // 'next' as a read-time alias but we always write a canonical token
-    // ('latest' / 'homolog' / 'dev') so the user's config converges to
-    // the current naming on their next update.
-    if (channel === 'dev') {
-      config.updateChannel = 'dev';
-    } else if (channel === 'homolog') {
-      config.updateChannel = 'homolog';
-    } else {
-      config.updateChannel = 'latest';
+  const token = channelToken(channel);
+  // Fresh install (no config yet): write a proper default config carrying the
+  // channel. There is nothing on disk to preserve.
+  if (!genieConfigExists()) {
+    try {
+      const config = GenieConfigSchema.parse({});
+      config.updateChannel = token;
+      await saveGenieConfig(config);
+    } catch {
+      // non-fatal — channel preference lost but update still works.
     }
-    await saveGenieConfig(config);
+    return;
+  }
+  // Existing config: NEVER round-trip through the schema. `saveGenieConfig` strips
+  // unknown keys and, when the load fails, `loadGenieConfig` returns DEFAULTS — so
+  // the old load→save path rewrote the whole file from defaults on any transient
+  // read failure, the exact side effect that silently reset users' configs during
+  // `genie update`. A tolerant raw read-modify-write touches only updateChannel and
+  // preserves every other key verbatim; an unparseable file is left untouched.
+  const read = readConfigTolerant();
+  if (read.kind === 'unreadable') {
+    process.stderr.write(
+      `warning: ${contractPath(getGenieConfigPath())} is unparseable (${read.reason}); leaving it untouched — channel ${channel} not persisted\n`,
+    );
+    return;
+  }
+  read.raw.updateChannel = token;
+  try {
+    writeFileSync(getGenieConfigPath(), JSON.stringify(read.raw, null, 2), 'utf-8');
   } catch {
     // non-fatal — channel preference lost but update still works.
   }
@@ -1397,6 +1546,36 @@ export interface UpdateCommandOptions {
    *  the unknown flag and exits immediately (zero network) instead of silently
    *  running a full unattended update. */
   syncOnly?: boolean;
+}
+
+/**
+ * Downgrade policy gate. Returns true when the caller MUST short-circuit — a
+ * backward-pointing manifest with no explicit operator intent — after emitting the
+ * refusal line. Returns false to proceed with the swap: for an explicitly-authorized
+ * downgrade it first prints a loud one-line notice so the backward move is never
+ * silent. An explicit `--stable/--homolog/--dev/--next` on the command line is what
+ * counts as operator intent.
+ */
+function applyDowngradeGuard(
+  installedVersion: string,
+  latestVersion: string | null,
+  channel: ReleaseChannel,
+  options: UpdateCommandOptions,
+): boolean {
+  const explicitChannel = Boolean(options.stable || options.homolog || options.dev || options.next);
+  const downgrade = decideDowngrade({ installedVersion, latestVersion, explicitChannel });
+  if (downgrade.kind === 'block-downgrade') {
+    log(
+      `Installed v${normalizeVersion(downgrade.installed)} is NEWER than ${channel} manifest v${normalizeVersion(downgrade.latest)} — refusing automatic downgrade (switch channels or reinstall explicitly to downgrade)`,
+    );
+    return true;
+  }
+  if (downgrade.kind === 'allow-downgrade') {
+    log(
+      `DOWNGRADE v${normalizeVersion(downgrade.installed)} → v${normalizeVersion(downgrade.latest)} (channel ${channel})`,
+    );
+  }
+  return false;
 }
 
 export async function updateCommand(options: UpdateCommandOptions = {}): Promise<void> {
@@ -1445,6 +1624,17 @@ export async function updateCommand(options: UpdateCommandOptions = {}): Promise
     success(`Already up to date (v${normalizeVersion(installedVersion)}, channel ${channel})`);
     // Update = converge everything, not just the binary: sync agents even when
     // the installed binary is already at the latest version.
+    runAgentSyncSafe();
+    console.log();
+    return;
+  }
+
+  // Downgrade guard. `shortCircuitIfCurrent` only catches the EQUAL case; without
+  // this a manifest that points BACKWARD (a channel rollback, or a stale
+  // .well-known pin) would swap the binary to an OLDER build via the normal
+  // "Update available" flow.
+  if (applyDowngradeGuard(installedVersion, latestVersion, channel, options)) {
+    // Refused downgrade — still converge agents, exactly like the already-current path.
     runAgentSyncSafe();
     console.log();
     return;

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -62,8 +62,12 @@ export const MANAGED_BY = 'genie-agent-sync';
  * the exact collision council-workflow Decision 8 forbids. Excluded names are
  * also dropped from the orphan-protection set, so an already-synced managed
  * copy is backed up and removed on the next sync.
+ *
+ * Exported as the single source of truth for the excluded set: doctor's
+ * freshness check subtracts these from Claude's expected source skills so it
+ * never reports a legitimately-excluded skill as "missing/stale".
  */
-const CLAUDE_EXCLUDED_SKILLS = new Set(['council']);
+export const CLAUDE_EXCLUDED_SKILLS = new Set(['council']);
 /** Skill actions that represent an actual write to the target. */
 const WRITE_ACTIONS = new Set<SkillAction>(['created', 'updated', 'adopted', 'removed']);
 /**


### PR DESCRIPTION
Live-dogfood findings (goal loop, iteration 2):

**A — config clobber / channel loss (HIGH):** `loadGenieConfig` returns fabricated defaults on ANY read failure (genie-config.ts:55-59); `persistChannel` wrote them back — destroying the user's config and silently flipping dev→stable. Observed live: persisted dev channel lost 17min after being set; config rewritten with setupComplete:false. Fix: tolerant channel read (schema-invalid → recover raw updateChannel key with warning; unparseable → stated stable fallback) + raw read-modify-write persisting ONLY updateChannel (unknown keys preserved byte-for-byte; unparseable file left untouched with advisory).
**B — silent downgrade (HIGH):** installed 5.260710.10 + stable manifest .2 swapped BACKWARD via the normal flow. Fix: numeric version compare + downgrade guard — refuses without an explicit channel flag (exit 0, agent-sync still runs); explicit flag allows with a loud DOWNGRADE notice.
**C — doctor false-stale (LOW):** doctor counted council against claude forever (22/23 + perpetual advisory). Fix: per-agent expected set subtracts exported CLAUDE_EXCLUDED_SKILLS.

19 new tests; 875 pass / 1 skip; g2-wiring gate green. Residual (follow-up wish): make saveGenieConfig atomic + surface load failures to markSetupComplete/updateShortcutsConfig callers.