### PR TITLE
fix(release): verify main promotions by content, not merge-commit message

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -63,16 +63,16 @@ jobs:
        github.event.workflow_run.event == 'push' &&
        !contains(github.event.workflow_run.head_commit.message, '[auto-version]') &&
        (
-         (github.event.workflow_run.head_branch == 'main' &&
-          startsWith(github.event.workflow_run.head_commit.message, 'Merge pull request') &&
-          contains(github.event.workflow_run.head_commit.message, '/dev'))
-         ||
-         (github.event.workflow_run.head_branch == 'homolog' &&
-          startsWith(github.event.workflow_run.head_commit.message, 'Merge pull request') &&
-          contains(github.event.workflow_run.head_commit.message, '/dev'))
-         ||
+         (github.event.workflow_run.head_branch == 'main') ||
+         (github.event.workflow_run.head_branch == 'homolog') ||
          (github.event.workflow_run.head_branch == 'dev')
        ))
+    # main/homolog promotion is verified by the "Verify dev promotion" STEP
+    # below (merge-commit message OR content match against dev), not by a
+    # message-only expression here. Message-only gating silently skipped the
+    # stable release whenever a dev→main PR was rebase- or squash-merged
+    # (observed #2537 2026-07-09 and #2542 2026-07-10: main advanced, stable
+    # .well-known stayed stale, clients downgraded).
 
     steps:
       - name: Determine branch and version prefix
@@ -120,6 +120,40 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Promotion gate for the no-bump (main/homolog) path. A promotion is a
+      # push whose head commit is a dev merge commit ("Merge pull request …
+      # /dev") OR whose content equals dev's tip — the latter is what a
+      # rebase- or squash-merged dev→main PR produces (no merge commit, so
+      # message checks can never see it). `.well-known` is excluded from the
+      # content diff: release-publish commits channel manifests to main only,
+      # so a rebased promotion's tree always differs from dev exactly there.
+      # If dev advanced past the PR head before this runs, the content check
+      # misses and we skip with a notice — the next promotion catches up
+      # (same posture as the atomic tag-push race below).
+      - name: Verify dev promotion (main/homolog no-bump path)
+        id: promotion
+        if: steps.context.outputs.should_bump == 'false'
+        run: |
+          SUBJECT="$(git show -s --format=%s HEAD)"
+          PROMOTED=false
+          REASON="not a dev promotion"
+          if printf '%s' "${SUBJECT}" | grep -q '^Merge pull request' && printf '%s' "${SUBJECT}" | grep -q '/dev'; then
+            PROMOTED=true
+            REASON="dev merge commit"
+          else
+            git fetch origin dev --quiet
+            if git diff --quiet origin/dev HEAD -- ':(exclude).well-known'; then
+              PROMOTED=true
+              REASON="content matches dev tip (rebase/squash promotion)"
+            fi
+          fi
+          echo "promoted=${PROMOTED}" >> "$GITHUB_OUTPUT"
+          if [ "${PROMOTED}" = "true" ]; then
+            echo "Promotion verified: ${REASON}"
+          else
+            echo "::notice ::release-trigger.promotion_unverified head commit is neither a dev merge commit nor content-identical to dev — stable/homolog dispatch skipped"
+          fi
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -249,7 +283,7 @@ jobs:
       # advances. This is the ONLY code path that publishes the stable
       # channel; without it a main merge produces no stable release.
       - name: Trigger release pipeline for the promoted tag (stable/homolog)
-        if: steps.context.outputs.should_bump == 'false'
+        if: steps.context.outputs.should_bump == 'false' && steps.promotion.outputs.promoted == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/plugins/genie/.codex-plugin/plugin.json
+++ b/plugins/genie/.codex-plugin/plugin.json
@@ -9,21 +9,13 @@
   "homepage": "https://github.com/automagik-dev/genie",
   "repository": "https://github.com/automagik-dev/genie",
   "license": "MIT",
-  "keywords": [
-    "workflow",
-    "orchestration",
-    "codex",
-    "skills",
-    "agents"
-  ],
+  "keywords": ["workflow", "orchestration", "codex", "skills", "agents"],
   "skills": "./skills/",
   "hooks": "./hooks/codex-hooks.json",
   "mcpServers": {
     "genie": {
       "command": "genie",
-      "args": [
-        "mcp"
-      ]
+      "args": ["mcp"]
     }
   },
   "interface": {
@@ -32,12 +24,7 @@
     "longDescription": "First-class Genie workflows for Codex, including shared skills, lifecycle hooks, MCP task state, and role-specific subagents.",
     "developerName": "Namastex Labs",
     "category": "Developer Tools",
-    "capabilities": [
-      "Skills",
-      "Hooks",
-      "MCP",
-      "Subagents"
-    ],
+    "capabilities": ["Skills", "Hooks", "MCP", "Subagents"],
     "websiteURL": "https://github.com/automagik-dev/genie",
     "defaultPrompt": [
       "Use $wish to turn this request into an executable plan.",


### PR DESCRIPTION
Goal-loop structural fix: version.yml gated the stable/homolog release on the head commit message starting with 'Merge pull request … /dev'. A rebase- or squash-merged dev→main PR produces no such commit, so the stable release silently never fired — observed on #2537 (2026-07-09) and #2542 (2026-07-10): main advanced, .well-known/latest.json stayed stale, and pre-guard clients downgraded (reproduced live on the reference machine).

Fix: job-level message conditions replaced by a 'Verify dev promotion' step on the no-bump path — promoted when the head commit IS a dev merge commit (legacy fast path) OR when the pushed content equals dev's tip excluding .well-known (what rebase/squash promotions produce; manifests land on main only, which is exactly where a rebased tree always differs). Non-promotions skip the dispatch with a ::notice. If dev advanced past the PR head, the content check misses and the next promotion catches up — same posture as the existing atomic tag-push race.

Effect: the pending #2545 promotion publishes stable regardless of which merge button gets clicked.