### PR TITLE
fix(release): version stamp self-formats with biome so bumps never break lint

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -190,7 +190,7 @@ jobs:
       - name: Format versioned JSON (Biome)
         if: steps.context.outputs.should_bump == 'true'
         run: |
-          bunx biome format --write package.json plugins/genie/.claude-plugin/plugin.json plugins/genie/package.json .claude-plugin/marketplace.json 2>/dev/null || true
+          bunx biome format --write package.json plugins/genie/.claude-plugin/plugin.json plugins/genie/.codex-plugin/plugin.json plugins/genie/package.json .claude-plugin/marketplace.json 2>/dev/null || true
 
       - name: Commit and tag
         if: steps.context.outputs.should_bump == 'true'

--- a/plugins/genie/.codex-plugin/plugin.json
+++ b/plugins/genie/.codex-plugin/plugin.json
@@ -9,21 +9,13 @@
   "homepage": "https://github.com/automagik-dev/genie",
   "repository": "https://github.com/automagik-dev/genie",
   "license": "MIT",
-  "keywords": [
-    "workflow",
-    "orchestration",
-    "codex",
-    "skills",
-    "agents"
-  ],
+  "keywords": ["workflow", "orchestration", "codex", "skills", "agents"],
   "skills": "./skills/",
   "hooks": "./hooks/codex-hooks.json",
   "mcpServers": {
     "genie": {
       "command": "genie",
-      "args": [
-        "mcp"
-      ]
+      "args": ["mcp"]
     }
   },
   "interface": {
@@ -32,12 +24,7 @@
     "longDescription": "First-class Genie workflows for Codex, including shared skills, lifecycle hooks, MCP task state, and role-specific subagents.",
     "developerName": "Namastex Labs",
     "category": "Developer Tools",
-    "capabilities": [
-      "Skills",
-      "Hooks",
-      "MCP",
-      "Subagents"
-    ],
+    "capabilities": ["Skills", "Hooks", "MCP", "Subagents"],
     "websiteURL": "https://github.com/automagik-dev/genie",
     "defaultPrompt": [
       "Use $wish to turn this request into an executable plan.",

--- a/scripts/version.ts
+++ b/scripts/version.ts
@@ -67,6 +67,27 @@ async function updateJsonVersion(filePath: string, version: string): Promise<boo
   }
 }
 
+// JSON.stringify(_, null, 2) expands short arrays that Biome (120 width)
+// collapses, so a raw stamp leaves the tree lint-red until the next manual
+// format. Re-format every stamped file so a version bump can never break
+// `biome check`. Non-fatal: without Biome the stamp still lands.
+function formatStampedFiles(rootDir: string, files: string[]): void {
+  const targets = files.filter((file) => existsSync(file));
+  if (targets.length === 0) {
+    return;
+  }
+  try {
+    execSync(`bunx biome format --write ${targets.map((file) => `"${file}"`).join(' ')}`, {
+      cwd: rootDir,
+      stdio: 'pipe',
+      timeout: 60000,
+    });
+    console.log('  ✓ biome format applied to stamped files');
+  } catch {
+    console.warn('  ⚠ biome format unavailable — run `bunx biome format --write` on the stamped files');
+  }
+}
+
 async function main() {
   const version = generateVersion();
   const rootDir = join(dirname(import.meta.path), '..');
@@ -103,6 +124,14 @@ async function main() {
       console.error(`  ✗ Failed: ${marketplacePath}`, err);
     }
   }
+
+  formatStampedFiles(rootDir, [
+    join(rootDir, 'package.json'),
+    join(rootDir, 'plugins/genie/.claude-plugin/plugin.json'),
+    join(rootDir, 'plugins/genie/.codex-plugin/plugin.json'),
+    join(rootDir, 'plugins/genie/package.json'),
+    marketplacePath,
+  ]);
 
   console.log('\n✅ All versions synchronized');
 }


### PR DESCRIPTION
## Why

Every auto-version bump was re-breaking `bunx biome check .` on dev — which is what just turned PR #2545's Quality Gate red.

Chain:
1. `scripts/version.ts` stamps manifests via `JSON.parse` → `JSON.stringify(json, null, 2)`, which expands short arrays multi-line.
2. Biome (120 line width) wants those arrays collapsed — so the stamped `plugins/genie/.codex-plugin/plugin.json` comes out unformatted.
3. version.yml's "Format versioned JSON (Biome)" step re-formats the stamped files, but its list was never updated to include the codex manifest (added to stamping later).
4. Result: bump commit `c287bfda` (5.260711.2) undid the earlier format fix (`07734b3c`) — the third occurrence of this exact lint break.

Extra twist: version.yml runs from **main** on `workflow_run`, so patching only the yml on dev wouldn't take effect until promotion. `scripts/version.ts` runs from the checked-out SHA, so fixing it there stops the ping-pong on the very next dev bump.

## What

- `scripts/version.ts`: after stamping, `formatStampedFiles` runs `bunx biome format --write` on all five stamped files (non-fatal if biome is absent). A version bump can no longer produce a lint-red tree, regardless of which workflow definition invoked it.
- `.github/workflows/version.yml`: the existing format step's file list gains `plugins/genie/.codex-plugin/plugin.json` (belt-and-suspenders; activates once this reaches main).
- `plugins/genie/.codex-plugin/plugin.json`: re-formatted (fixes the current breakage; version value untouched at 5.260711.2).

## Validation

- Behavioral gate (script): format broken manifest → run patched `bun scripts/version.ts` → `bunx biome check .` still clean after stamping (previously failed) → stamp reverted, only the fix remains.
- `bun run check`: 918 pass / 1 skip / 0 fail.

Unblocks #2545 (dev→main): once this merges, dev goes lint-green and the promotion PR's checks re-run against the new head.