### PR TITLE
fix(codex): setup repair converges marketplace root and plugin version

### DIFF
--- a/src/lib/runtime-integrations.test.ts
+++ b/src/lib/runtime-integrations.test.ts
@@ -10,6 +10,7 @@ import {
   resolveBundleRoot,
   setCodexPluginEnabled,
 } from './runtime-integrations.js';
+import { VERSION } from './version.js';
 
 const MANAGED_TOML = '# Managed by Genie. Remove with `genie uninstall`.\nname = "genie_reviewer"\n';
 
@@ -125,6 +126,90 @@ describe('resolveBundleRoot', () => {
     expect(resolveBundleRoot('/nonexistent/explicit')).toBe('/nonexistent/explicit');
     process.env.GENIE_BUNDLE_ROOT = '/nonexistent/env';
     expect(resolveBundleRoot()).toBe('/nonexistent/env');
+  });
+});
+
+describe('codex repair convergence (stale marketplace root / stale installed plugin)', () => {
+  const staleList = JSON.stringify({
+    installed: [{ pluginId: 'genie@automagik', enabled: true, version: '5.260710.9' }],
+  });
+  const currentList = JSON.stringify({
+    installed: [{ pluginId: 'genie@automagik', enabled: true, version: VERSION }],
+  });
+
+  function makeCodexHome(): string {
+    return mkdtempSync(join(tmpdir(), 'genie-codex-home-'));
+  }
+
+  test('marketplace registered from a different source is repointed at the bundle root', () => {
+    const bundleRoot = join(import.meta.dir, '..', '..');
+    const calls: string[] = [];
+    let marketplaceAdds = 0;
+    const results = installRuntimeIntegrations({
+      selection: 'codex',
+      bundleRoot,
+      codexHome: makeCodexHome(),
+      detected: { codex: true },
+      runner(command, args) {
+        const call = [command, ...args].join(' ');
+        calls.push(call);
+        if (args.join(' ') === `plugin marketplace add ${bundleRoot} --json`) {
+          marketplaceAdds += 1;
+          if (marketplaceAdds === 1) {
+            return {
+              exitCode: 1,
+              stdout: '',
+              stderr:
+                "Error: marketplace 'automagik' is already added from a different source; remove it before adding this source",
+            };
+          }
+        }
+        return { exitCode: 0, stdout: args.join(' ') === 'plugin list --json' ? currentList : '{}', stderr: '' };
+      },
+    });
+    expect(results[0].ok).toBe(true);
+    expect(calls).toContain('codex plugin marketplace remove automagik --json');
+    expect(marketplaceAdds).toBe(2);
+  });
+
+  test('installed plugin pinned to a stale root is reinstalled until version-matched', () => {
+    const bundleRoot = join(import.meta.dir, '..', '..');
+    const calls: string[] = [];
+    let lists = 0;
+    const results = installRuntimeIntegrations({
+      selection: 'codex',
+      bundleRoot,
+      codexHome: makeCodexHome(),
+      detected: { codex: true },
+      runner(command, args) {
+        calls.push([command, ...args].join(' '));
+        if (args.join(' ') === 'plugin list --json') {
+          lists += 1;
+          // before-state and first verify see the stale install; after the
+          // reinstall the registry reports the version-matched plugin.
+          return { exitCode: 0, stdout: lists <= 2 ? staleList : currentList, stderr: '' };
+        }
+        return { exitCode: 0, stdout: '{}', stderr: '' };
+      },
+    });
+    expect(results[0].ok).toBe(true);
+    expect(calls).toContain('codex plugin remove genie@automagik --json');
+    expect(calls.filter((call) => call === 'codex plugin add genie@automagik --json').length).toBe(2);
+  });
+
+  test('a repair that cannot converge fails loudly instead of reporting refreshed', () => {
+    const bundleRoot = join(import.meta.dir, '..', '..');
+    const results = installRuntimeIntegrations({
+      selection: 'codex',
+      bundleRoot,
+      codexHome: makeCodexHome(),
+      detected: { codex: true },
+      runner(_command, args) {
+        return { exitCode: 0, stdout: args.join(' ') === 'plugin list --json' ? staleList : '{}', stderr: '' };
+      },
+    });
+    expect(results[0].ok).toBe(false);
+    expect(results[0].detail).toMatch(/stuck at v5\.260710\.9/);
   });
 });
 

--- a/src/lib/runtime-integrations.ts
+++ b/src/lib/runtime-integrations.ts
@@ -11,6 +11,7 @@ import {
 import { dirname, join, resolve } from 'node:path';
 import { getCodexConfigPath, getCodexHome, migrateDeadGenieOtel } from './codex-config.js';
 import { resolveGenieHome } from './genie-home.js';
+import { VERSION } from './version.js';
 
 export type IntegrationSelection = 'auto' | 'codex' | 'claude' | 'all' | 'none';
 export type RuntimeName = 'codex' | 'claude';
@@ -228,14 +229,56 @@ export function installRuntimeIntegrations(options: InstallIntegrationsOptions =
   });
 }
 
+/**
+ * Register the canonical marketplace root. `plugin marketplace add` refuses when
+ * the `automagik` marketplace already points at a DIFFERENT source — live case:
+ * a deleted live-test worktree kept feeding every install/repair a stale plugin
+ * — and that refusal matches the generic `already` tolerance, so it must be
+ * handled first: repoint the marketplace instead of keeping the stale root.
+ */
+function addCodexMarketplace(runner: CommandRunner, bundleRoot: string): void {
+  const result = runner('codex', ['plugin', 'marketplace', 'add', bundleRoot, '--json']);
+  if (result.exitCode === 0) return;
+  const output = `${result.stdout}\n${result.stderr}`;
+  if (/different source/i.test(output)) {
+    runChecked(runner, 'codex', ['plugin', 'marketplace', 'remove', 'automagik', '--json'], true);
+    runChecked(runner, 'codex', ['plugin', 'marketplace', 'add', bundleRoot, '--json']);
+    return;
+  }
+  if (!/already|exists|configured/i.test(output)) {
+    throw new Error(
+      `codex plugin marketplace add ${bundleRoot} --json failed: ${(result.stderr || result.stdout).trim()}`,
+    );
+  }
+}
+
+/**
+ * `plugin add` is a no-op when the id is already installed, so a plugin that
+ * came from a previous marketplace root stays pinned to that root's version
+ * forever. When the installed version disagrees with the CLI, reinstall once
+ * from the (now canonical) marketplace and re-verify — a repair that cannot
+ * converge fails loudly instead of reporting "refreshed".
+ */
+function verifyCodexPluginCurrent(runner: CommandRunner): void {
+  let state = codexPluginState(runChecked(runner, 'codex', ['plugin', 'list', '--json']).stdout);
+  if (!state.installed || state.version === VERSION) return;
+  runChecked(runner, 'codex', ['plugin', 'remove', 'genie@automagik', '--json'], true);
+  runChecked(runner, 'codex', ['plugin', 'add', 'genie@automagik', '--json']);
+  state = codexPluginState(runChecked(runner, 'codex', ['plugin', 'list', '--json']).stdout);
+  if (state.installed && state.version !== VERSION) {
+    throw new Error(`codex plugin stuck at v${state.version} (CLI v${VERSION}) — marketplace root may be stale`);
+  }
+}
+
 function installCodexIntegration(runner: CommandRunner, bundleRoot: string, codexHome?: string): IntegrationResult {
   const configPath = join(codexHome ?? getCodexHome(), 'config.toml');
   const migration = migrateDeadGenieOtel(configPath);
   if (migration.status === 'error') throw new Error(`Codex config migration failed: ${migration.error}`);
   const agents = installCodexAgents(bundleRoot, codexHome);
   const before = codexPluginState(runChecked(runner, 'codex', ['plugin', 'list', '--json']).stdout);
-  runChecked(runner, 'codex', ['plugin', 'marketplace', 'add', bundleRoot, '--json'], true);
+  addCodexMarketplace(runner, bundleRoot);
   runChecked(runner, 'codex', ['plugin', 'add', 'genie@automagik', '--json']);
+  verifyCodexPluginCurrent(runner);
   if (before.installed && before.enabled === false) setCodexPluginEnabled(false, configPath);
   const notes = [`${agents.installed} role agents installed`];
   if (agents.backedUp.length > 0) notes.push(`${agents.backedUp.length} user-tuned backed up (*.genie-backup)`);


### PR DESCRIPTION
## Why (live-reproduced during the stable-release dogfood)

`genie doctor` warned `Codex Genie plugin — v5.260710.9 (CLI v5.260711.3)` and pointed at `genie setup --codex`. Running it reported **"plugin refreshed"** — but the plugin stayed at v5.260710.9, sending the user in a loop.

Root cause, two layers in `installCodexIntegration`:

1. **Stale marketplace root, silently kept.** Codex had the `automagik` marketplace registered from a live-test worktree (`~/.codex/worktrees/79e0/genie`). `codex plugin marketplace add ~/.genie` refuses with *"marketplace 'automagik' is already added from a different source; remove it before adding this source"* — which matches the generic `allowAlready` tolerance (`/already|exists|configured/`), so the refusal was swallowed and every install kept feeding from the dead worktree.
2. **`plugin add` no-ops on an installed id, and nothing verifies the result.** The plugin stayed pinned to the old root's version while setup reported success.

## What

- `addCodexMarketplace`: the *different source* answer is now handled before the `already` tolerance — `plugin marketplace remove automagik` + re-add (checked) repoints Codex at the canonical bundle root. Same-source "already added" stays tolerated; other failures still throw.
- `verifyCodexPluginCurrent`: after `plugin add`, re-read `codex plugin list --json`; on version mismatch with the CLI, reinstall once (`plugin remove` + `plugin add`) and re-verify. A repair that cannot converge now **fails loudly** (`codex plugin stuck at vX — marketplace root may be stale`) instead of reporting "refreshed".
- 3 regression tests with the injectable runner: marketplace repoint, stale-plugin reinstall-until-matched, and loud failure on non-convergence. Existing green paths (fresh install, preserved-disabled) unchanged.

## Validation

- `bun test src/lib/runtime-integrations.test.ts` — 14 pass (11 existing + 3 new).
- `bun run check` — 921 pass / 1 skip / 0 fail.
- The exact remove→re-add sequence the fix automates was executed manually on the reference machine and converged it: `genie@automagik 5.260711.3` from `~/.genie/plugins/genie`, doctor all-green.

Out of scope (candidate follow-up): `installClaudeIntegration` tolerates the same *different source* refusal for the Claude marketplace; not live-reproduced there, left untouched.