### PR TITLE
fix(agent-sync): preserve dangling skill symlinks instead of failing the sync

### DIFF
--- a/src/lib/agent-sync.test.ts
+++ b/src/lib/agent-sync.test.ts
@@ -409,6 +409,19 @@ describe('same-name collision preservation', () => {
     expect(readFileSync(join(outside, 'SKILL.md'), 'utf8')).toBe('# personal symlink target\n');
   });
 
+  test('a same-name dangling skill symlink is preserved instead of failing the sync', () => {
+    present(fixture.claudeDir);
+    const alphaDir = join(fixture.claudeDir, 'skills', 'alpha');
+    mkdirSync(dirname(alphaDir), { recursive: true });
+    symlinkSync(join(fixture.root, 'target-that-does-not-exist'), alphaDir);
+
+    const report = agentReport(run(), 'claude');
+
+    expect(skillAction(report, 'alpha')).toBe('skipped-unmanaged-kept');
+    expect(report.failures ?? []).toEqual([]);
+    expect(lstatSync(alphaDir).isSymbolicLink()).toBe(true);
+  });
+
   test('a dir genie never shipped is left completely untouched', () => {
     present(fixture.claudeDir);
     const customDir = join(fixture.claudeDir, 'skills', 'my-custom-skill');

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -1224,11 +1224,15 @@ function syncOneSkill(ctx: RunContext, skill: SourceSkill, targetParent: string)
   recoverLegacyManagedDirSwap(destDir);
   const sourceDigest = computeDirDigest(skill.dir);
   const manifest = buildManifest(ctx, sourceDigest);
-  if (!existsSync(destDir)) {
+  // lstat, not existsSync: a dangling symlink is absent to existsSync but present to the
+  // lstat-based identity check that guards promotion. Treating it as absent would stage a
+  // create, then abort on the "changed before promotion" conflict it can never satisfy.
+  const destStat = lstatSafe(destDir);
+  if (destStat === null) {
     writeManagedDir(ctx, skill.dir, destDir, manifest, { contentDigest: null, manifestDigest: null });
     return { action: 'created' };
   }
-  if (lstatSafe(destDir)?.isSymbolicLink()) {
+  if (destStat.isSymbolicLink()) {
     return { action: 'skipped-unmanaged-kept', detail: 'same-name symlink preserved and never followed' };
   }
   const existing = readManifest(destDir);


### PR DESCRIPTION
A dangling symlink at a skill destination aborts the entire post-install agent sync. Hit in the wild on a real machine: a leftover `~/.agents/skills/genie -> .../.bun/install/global/node_modules/@automagik/genie/skills` from an old bun-global install, whose target no longer existed.

```
▸ codex: skill genie (codex) failed: managed skill changed before promotion;
  kept live and incoming versions for review at .../.conflict-67656e6965-...
▸ agent sync failed: ...
xx genie install finishing failed; installation remains incomplete and retryable
```

## Root cause

An `existsSync` / `lstat` mismatch in `syncOneSkill`:

```ts
if (!existsSync(destDir)) {            // follows symlinks → dangling link reads as ABSENT
  writeManagedDir(..., { contentDigest: null, ... });   // stages a "create"
  return { action: "created" };
}
if (lstatSafe(destDir)?.isSymbolicLink()) {   // unreachable for a *broken* link
  return { action: "skipped-unmanaged-kept", ... };
}
```

`existsSync` follows symlinks, so a **dangling** link reports absent and takes the create branch — with an expected identity of *absent*. The symlink guard immediately below only ever catches *resolvable* links.

`writeManagedDir` then re-verifies the destination with `matchesExpectedManagedDirIdentity`, which is **lstat**-based and does not follow symlinks. It sees the link as present, the "absent" expectation can never be satisfied, and promotion aborts with `managed skill changed before promotion`.

Because agent-sync runs `strict` during `genie install`, that single unsatisfiable conflict failed the whole sync — leaving every *other* skill stranded on the previous version (observed: 22 skills stuck at 5.260711.3 while the binary was 5.260712.1).

## Fix

Probe with `lstat` so absence and symlink detection agree with the lstat-based identity check that actually guards promotion. A dangling symlink now takes the **existing** `skipped-unmanaged-kept` path — preserved, never followed, reported as an advisory — instead of crashing the sync. No change to the never-clobber policy: genie still refuses to touch a symlink it did not create.

## Testing

- New regression test: `a same-name dangling skill symlink is preserved instead of failing the sync`. It fails on `main` with the exact production error (`managed skill changed before promotion; kept live and incoming versions for review at ...`) and passes with the fix.
- `bun test` — 1397 pass, 0 fail
- `tsc --noEmit` clean, `biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved same-name dangling symbolic links during skill synchronization instead of treating them as missing.
  - Prevented synchronization failures and correctly reported preserved unmanaged links as skipped.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->