### PR TITLE
fix(update): tolerate already-disabled claude plugin and reconcile stale refresh intent

### DIFF
--- a/.genie/agents/metrics-updater/runs.jsonl
+++ b/.genie/agents/metrics-updater/runs.jsonl
@@ -1,1 +1,0 @@
-{"timestamp":"2026-07-12T07:00:00Z","duration_ms":45000,"api_calls":2,"tools_generated":0,"errors":0,"metrics":{"releases_24h":5,"avg_merge_time_h":3.7,"ship_rate_pct":100,"merged_prs_7d":39}}

--- a/.genie/agents/metrics-updater/state.json
+++ b/.genie/agents/metrics-updater/state.json
@@ -1,9 +1,0 @@
-{
-  "last_run": "2026-07-12",
-  "last_metrics": {
-    "releases_24h": 5,
-    "avg_merge_time_h": 3.7,
-    "ship_rate_pct": 100,
-    "merged_prs_7d": 39
-  }
-}

--- a/README.md
+++ b/README.md
@@ -11,19 +11,6 @@
   <a href="https://discord.gg/xcW8c7fF3R"><img alt="discord" src="https://img.shields.io/discord/1095114867012292758?style=flat-square&color=00D9FF&label=discord" /></a>
 </p>
 
-<!-- METRICS:START -->
-<p align="center">
-
-| Metric | Value |
-|--------|-------|
-| Releases (24h) | 5 |
-| Avg merge time (7d) | 3.7h |
-| SHIP rate (7d) | 100% |
-
-<sub>Last updated: 2026-07-12</sub>
-</p>
-<!-- METRICS:END -->
-
 <br />
 
 Genie is a planning-and-execution layer for AI coding agents. You describe what you want in one sentence; Genie interviews you into a plan, dispatches agents to build it in parallel, reviews the result against acceptance criteria, and hands you something ready to merge.

--- a/src/lib/runtime-integrations.test.ts
+++ b/src/lib/runtime-integrations.test.ts
@@ -592,6 +592,126 @@ describe('durable integration consent and Claude payload provenance', () => {
     expect(retry).toBeNull();
     expect(retryCalls).toEqual(['claude plugin list --json']);
   });
+
+  test('Claude disabled-state restore tolerates an already-disabled plugin', () => {
+    const root = mkdtempSync(join(tmpdir(), 'genie-claude-already-disabled-'));
+    const statePath = join(root, 'refresh.json');
+    const result = convergeClaudePlugin({
+      command: 'claude',
+      bundleRoot: root,
+      expectedVersion: VERSION,
+      installIfAbsent: false,
+      statePath,
+      verifyClaudePayload: () => undefined,
+      runner(_command, args) {
+        const call = args.join(' ');
+        if (call === 'plugin list --json') {
+          return {
+            exitCode: 0,
+            stdout: JSON.stringify([{ id: 'genie@automagik', enabled: false, version: VERSION }]),
+            stderr: '',
+          };
+        }
+        if (call === 'plugin disable genie@automagik') {
+          return {
+            exitCode: 1,
+            stdout: '',
+            stderr: '✘ Failed to disable plugin "genie@automagik": Plugin "genie@automagik" is already disabled',
+          };
+        }
+        return { exitCode: 0, stdout: '{}', stderr: '' };
+      },
+    });
+
+    expect(result?.ok).toBe(true);
+    expect(result?.preservedDisabled).toBe(true);
+    expect(existsSync(statePath)).toBe(false);
+  });
+
+  test('Claude stale planned intent defers to a live enabled plugin instead of re-disabling it', () => {
+    const root = mkdtempSync(join(tmpdir(), 'genie-claude-stale-planned-intent-'));
+    const statePath = join(root, 'refresh.json');
+    writeFileSync(
+      statePath,
+      `${JSON.stringify({
+        schemaVersion: 4,
+        runtime: 'claude',
+        installed: true,
+        enabled: false,
+        createdAt: new Date().toISOString(),
+        phase: 'planned',
+      })}\n`,
+    );
+    const calls: string[] = [];
+    const result = convergeClaudePlugin({
+      command: 'claude',
+      bundleRoot: root,
+      expectedVersion: VERSION,
+      installIfAbsent: false,
+      statePath,
+      verifyClaudePayload: () => undefined,
+      runner(_command, args) {
+        const call = args.join(' ');
+        calls.push(call);
+        if (call === 'plugin list --json') {
+          return {
+            exitCode: 0,
+            stdout: JSON.stringify([{ id: 'genie@automagik', enabled: true, version: VERSION }]),
+            stderr: '',
+          };
+        }
+        return { exitCode: 0, stdout: '{}', stderr: '' };
+      },
+    });
+
+    expect(result?.ok).toBe(true);
+    expect(result?.preservedDisabled).toBe(false);
+    expect(calls).not.toContain('plugin disable genie@automagik');
+    expect(existsSync(statePath)).toBe(false);
+  });
+
+  test('Codex stale planned intent defers to a live enabled plugin instead of re-disabling it', () => {
+    const root = mkdtempSync(join(tmpdir(), 'genie-codex-stale-planned-intent-'));
+    const statePath = join(root, 'refresh.json');
+    const configPath = join(root, 'config.toml');
+    writeFileSync(configPath, '[plugins."genie@automagik"]\nenabled = true\n');
+    writeFileSync(
+      statePath,
+      `${JSON.stringify({
+        schemaVersion: 4,
+        runtime: 'codex',
+        installed: true,
+        enabled: false,
+        createdAt: new Date().toISOString(),
+        phase: 'planned',
+      })}\n`,
+    );
+    const result = convergeCodexPlugin({
+      command: 'codex',
+      bundleRoot: root,
+      expectedVersion: VERSION,
+      installIfAbsent: false,
+      statePath,
+      configPath,
+      codexHome: root,
+      verifyCodexPayload: () => undefined,
+      runner(_command, args) {
+        if (args.join(' ') === 'plugin list --json') {
+          return {
+            exitCode: 0,
+            stdout: JSON.stringify({ installed: [{ pluginId: 'genie@automagik', enabled: true, version: VERSION }] }),
+            stderr: '',
+          };
+        }
+        return { exitCode: 0, stdout: '{}', stderr: '' };
+      },
+    });
+
+    expect(result?.ok).toBe(true);
+    expect(result?.preservedDisabled).toBe(false);
+    expect(readFileSync(configPath, 'utf8')).toContain('enabled = true');
+    expect(existsSync(statePath)).toBe(false);
+  });
 });
 
 describe('codex repair convergence (stale marketplace root / stale installed plugin)', () => {

--- a/src/lib/runtime-integrations.ts
+++ b/src/lib/runtime-integrations.ts
@@ -2167,6 +2167,22 @@ function settleFailedRefreshIntent(
   return markRefreshAmbiguous(options.statePath, intent);
 }
 
+/**
+ * A leftover planned-phase intent means the previous run settled with the
+ * plugin installed, so the live enabled state — which the user may have
+ * changed since — is authoritative, not the file's snapshot. Later phases
+ * keep the file's word: mid-recovery the plugin can be legitimately absent
+ * or transiently misconfigured, and only the intent knows the user's state.
+ */
+function reconcilePlannedIntentWithLiveState(
+  intent: RefreshIntent | null,
+  before: RuntimePluginState,
+): RefreshIntent | null {
+  if (intent === null || intent.phase !== 'planned' || !before.installed) return intent;
+  const liveEnabled = before.enabled === true;
+  return intent.enabled === liveEnabled ? intent : { ...intent, enabled: liveEnabled };
+}
+
 function integrationFailure(runtime: RuntimeName, error: unknown): IntegrationResult {
   return {
     runtime,
@@ -2273,6 +2289,8 @@ function performCodexPluginConvergence(
     if (progress.intent !== null) clearRefreshIntent(options.statePath);
     return false;
   }
+  progress.intent = reconcilePlannedIntentWithLiveState(progress.intent, before);
+  progress.desiredEnabled = progress.intent?.enabled ?? null;
 
   progress.hookReviewRequired = codexHookReviewRequired(options, before);
 
@@ -2464,6 +2482,8 @@ export function convergeClaudePlugin(options: ConvergePluginOptions): Integratio
       if (intent !== null) clearRefreshIntent(options.statePath);
       return null;
     }
+    intent = reconcilePlannedIntentWithLiveState(intent, before);
+    desiredEnabled = intent?.enabled ?? null;
     intent ??= plannedRefreshIntent('claude', before.installed ? before.enabled === true : true);
     desiredEnabled = intent.enabled;
     writeRefreshIntent(options.statePath, intent);
@@ -2520,7 +2540,9 @@ export function convergeClaudePlugin(options: ConvergePluginOptions): Integratio
 
   if (desiredEnabled === false) {
     try {
-      runChecked(options.runner, options.command, ['plugin', 'disable', 'genie@automagik'], false, timeoutMs);
+      // "already disabled" is the desired end state, not a failure; the list
+      // check below verifies the restore either way.
+      runChecked(options.runner, options.command, ['plugin', 'disable', 'genie@automagik'], true, timeoutMs);
       const restored = requireClaudePluginState(
         runChecked(options.runner, options.command, ['plugin', 'list', '--json'], false, timeoutMs).stdout,
         'after restoring disabled state',


### PR DESCRIPTION
## Problem

`genie update` reports `integration refresh: claude — FAILED: ... Plugin "genie@automagik" is already disabled` on every run when the Claude plugin is disabled at update time. Reproduced live on v5.260712.1 (stable).

Three coupled defects in `src/lib/runtime-integrations.ts`:

1. **Non-idempotent restore** — the disabled-state restore shells `claude plugin disable` with `allowAlready=false`. `plugin update` never re-enables a disabled plugin, so the target is already disabled, the CLI exits non-zero, and the refresh reports FAILED. (Codex is unaffected — its restore writes config atomically.)
2. **Self-perpetuating loop** — the failure keeps `~/.genie/.integration-refresh-claude.json` (phase `planned`, `enabled:false`), so every subsequent update re-reads it and fails identically.
3. **Stale intent outranks live state** — `desiredEnabled` trusts the leftover file over `plugin list`; a user who manually re-enables the plugin gets silently re-disabled by the next update, which then reports success.

## Fix

- Pass `allowAlready=true` on the `plugin disable` restore call — "already disabled" is the desired end state; the existing `plugin list` + `requireExpectedState` verification still confirms it.
- New `reconcilePlannedIntentWithLiveState`: a leftover **planned**-phase intent (previous run settled with the plugin installed) adopts the live enabled state. Later phases (`command-started`, `removal-observed`, `ambiguous-absent`) keep trusting the file — crash recovery semantics unchanged (locked by existing tests).
- Applied to both `convergeClaudePlugin` and `performCodexPluginConvergence`.

## Tests

Three new regression tests (all fail on unpatched source, verified):
- Claude restore tolerates an already-disabled plugin (`ok:true`, `preservedDisabled:true`, intent cleared) — previously an untested gap; every existing test returned exit 0 for `plugin disable`.
- Claude stale planned intent + live-enabled plugin → no `plugin disable` issued, plugin stays enabled, intent cleared.
- Codex parity for the planned-intent reconcile.

## Also in this PR

Second commit re-retires the resurrected metrics bot output (README `METRICS` block + `.genie/agents/metrics-updater` state, pushed by a scheduled cloud session at 12:12 UTC today after their retirement). That commit broke the `release-docs` guard test and has held **dev CI red since** — blocking the release pipeline this fix needs to ship through. The still-live scheduled session needs separate attention or it will re-push.

## Validation

- `bun run check` exit 0 (typecheck, lint, dead-code, 1399 tests pass / 1 skip).
- New tests watched failing for the right reason on unpatched source before the fix.