### PR TITLE
fix(plugin): anchor Claude Code MCP launcher via CLAUDE_PLUGIN_ROOT

### DIFF
--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -7,5 +7,11 @@
   },
   "repository": "https://github.com/automagik-dev/genie",
   "license": "MIT",
-  "keywords": ["workflow", "orchestration", "collaboration", "claude-code", "tmux", "agents"]
+  "keywords": ["workflow", "orchestration", "collaboration", "claude-code", "tmux", "agents"],
+  "mcpServers": {
+    "genie": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/mcp-launcher.cjs"]
+    }
+  }
 }

--- a/scripts/fresh-install-smoke.test.ts
+++ b/scripts/fresh-install-smoke.test.ts
@@ -317,6 +317,30 @@ describe('fresh-install-smoke', () => {
     }
   });
 
+  test('rejects a Claude manifest whose MCP entry is not plugin-root-anchored', () => {
+    const root = mkdtempSync(join(tmpdir(), 'genie-plugin-claude-mcp-fixture-'));
+    try {
+      const pluginRoot = join(root, 'plugin');
+      cpSync(join(REPO_ROOT, 'plugins', 'genie'), pluginRoot, {
+        recursive: true,
+        dereference: false,
+        verbatimSymlinks: true,
+      });
+      const manifestPath = join(pluginRoot, '.claude-plugin', 'plugin.json');
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as Record<string, unknown>;
+      manifest.mcpServers = {
+        genie: { command: 'node', args: ['./scripts/mcp-launcher.cjs'], cwd: '.' },
+      };
+      writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+      const result = runSmoke(['--skills-dir', join(REPO_ROOT, 'skills'), '--plugin-root', pluginRoot]);
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toContain('${CLAUDE_PLUGIN_ROOT}/scripts/mcp-launcher.cjs');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   for (const fixture of [
     {
       label: 'renamed Codex role profile',

--- a/scripts/fresh-install-smoke.ts
+++ b/scripts/fresh-install-smoke.ts
@@ -468,6 +468,37 @@ function checkPluginMcpLayout(pluginRoot: string, manifest: Record<string, unkno
   }
 }
 
+// Claude Code spawns plugin MCP servers from the project cwd (the root
+// .mcp.json's relative launcher path only works for Codex), so the Claude
+// manifest must carry its own ${CLAUDE_PLUGIN_ROOT}-anchored entry that
+// overrides the shared root config.
+function checkClaudePluginMcpLayout(pluginRoot: string): void {
+  const manifestPath = join(pluginRoot, '.claude-plugin', 'plugin.json');
+  if (!existsSync(manifestPath)) fail(`Claude plugin manifest missing: ${manifestPath}`);
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as Record<string, unknown>;
+  const servers = manifest.mcpServers;
+  const serverMap =
+    typeof servers === 'object' && servers !== null && !Array.isArray(servers)
+      ? (servers as Record<string, unknown>)
+      : undefined;
+  const rawEntry = serverMap?.genie;
+  const entry =
+    typeof rawEntry === 'object' && rawEntry !== null && !Array.isArray(rawEntry)
+      ? (rawEntry as { command?: unknown; args?: unknown; cwd?: unknown })
+      : undefined;
+  if (
+    entry?.command !== 'node' ||
+    !Array.isArray(entry.args) ||
+    entry.args.length !== 1 ||
+    entry.args[0] !== '${CLAUDE_PLUGIN_ROOT}/scripts/mcp-launcher.cjs' ||
+    'cwd' in entry
+  ) {
+    fail(
+      'Claude plugin manifest must declare an inline genie MCP server running node ${CLAUDE_PLUGIN_ROOT}/scripts/mcp-launcher.cjs',
+    );
+  }
+}
+
 function checkPluginLayout(pluginRoot: string, canonicalSkills: string, expectedNames: string[]): void {
   const { skillsDir, manifest } = resolvePluginSkills(pluginRoot);
   const actual = listSkillNames(skillsDir);
@@ -481,6 +512,7 @@ function checkPluginLayout(pluginRoot: string, canonicalSkills: string, expected
   });
   checkStarterPrompts(manifest, expectedNames);
   checkPluginMcpLayout(pluginRoot, manifest);
+  checkClaudePluginMcpLayout(pluginRoot);
   try {
     assertHookContentBinding(
       join(pluginRoot, 'hooks', 'codex-hooks.json'),


### PR DESCRIPTION
## Problem

The genie plugin's MCP server fails in Claude Code with `MCP error -32000: Connection closed`. The spawn log shows the real error:

```
Error: Cannot find module '/home/<user>/<project>/scripts/mcp-launcher.cjs'
```

Claude Code spawns plugin MCP servers from the **project** cwd and does not honor the `"cwd": "."` field, so the shared root `.mcp.json`'s relative `./scripts/mcp-launcher.cjs` resolves against the user's project and node exits with MODULE_NOT_FOUND within ~30ms. Codex resolves the same file against the plugin root, which is why only the Claude host was broken.

## Fix

- Keep `plugins/genie/.mcp.json` untouched — it stays the canonical Codex contract, pinned by `inspectCodexPluginMcpUsability` and `checkPluginMcpLayout` (both fail-closed).
- Add an inline `mcpServers` entry to `plugins/genie/.claude-plugin/plugin.json` using `${CLAUDE_PLUGIN_ROOT}/scripts/mcp-launcher.cjs`. Claude Code loads the root `.mcp.json` first and then merges manifest `mcpServers` entries over it, so the manifest entry wins for the same `genie` server name — each host now gets its native path form from a single plugin payload.
- Extend `fresh-install-smoke` with `checkClaudePluginMcpLayout`, which fails closed if the Claude manifest entry is ever missing, relative, or carrying a `cwd` again, plus a mutation test.

## Verification

- Manually completed an MCP `initialize` handshake against the launcher via the absolute path from a foreign cwd (returns `serverInfo: genie`), and reproduced the MODULE_NOT_FOUND crash with the old relative form.
- `bun test scripts/fresh-install-smoke.test.ts src/lib/codex-project-mcp.test.ts` — 48 pass, 0 fail.
- `bun scripts/fresh-install-smoke.ts --skills-dir skills --plugin-root plugins/genie` — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)