### PR TITLE
fix(hermes): dogfood follow-ups — nested external_dirs merge + auto-version plugin.yaml staging

### DIFF
--- a/.genie/wishes/hermes-homogeneous-integration/reports/d2-workflow-patch.diff
+++ b/.genie/wishes/hermes-homogeneous-integration/reports/d2-workflow-patch.diff
@@ -1,0 +1,19 @@
+commit 8e4726364d9e12004c2753aa82f7107f4db4722c
+Author: Felipe Rosa <felipe@namastex.io>
+Date:   Mon Jul 13 06:25:39 2026 -0300
+
+    fix(ci): stage plugin.yaml in auto-version commit (D2)
+
+diff --git a/.github/workflows/version.yml b/.github/workflows/version.yml
+index d0e9741f..3e3b80bc 100644
+--- a/.github/workflows/version.yml
++++ b/.github/workflows/version.yml
+@@ -198,7 +198,7 @@ jobs:
+           VERSION="${{ steps.version.outputs.version }}"
+           BRANCH="${{ steps.context.outputs.branch }}"
+ 
+-          git add -A '*.json' 'src/lib/version.ts'
++          git add -A '*.json' 'src/lib/version.ts' 'plugins/hermes-genie/plugin.yaml'
+           if git diff --cached --quiet; then
+             echo "No version changes to commit"
+           else

--- a/scripts/version-ci-staging.test.ts
+++ b/scripts/version-ci-staging.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { synchronizeVersionFiles } from './version.ts';
+
+/**
+ * D2: `synchronizeVersionFiles` owns the version-carrying file list, so it must
+ * `git add` every file it rewrote when running in CI — otherwise the release
+ * workflow's own (stale) `git add` list omits plugins/hermes-genie/plugin.yaml
+ * and ships a bump with a stale Hermes manifest.
+ */
+describe('synchronizeVersionFiles CI staging', () => {
+  const roots: string[] = [];
+  const savedGithubActions = process.env.GITHUB_ACTIONS;
+
+  afterEach(() => {
+    if (savedGithubActions === undefined) Reflect.deleteProperty(process.env, 'GITHUB_ACTIONS');
+    else process.env.GITHUB_ACTIONS = savedGithubActions;
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  function versionFixture(): string {
+    const root = mkdtempSync(join(tmpdir(), 'genie-version-ci-'));
+    roots.push(root);
+    const writeJson = (relativePath: string, value: unknown) => {
+      const path = join(root, relativePath);
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+    };
+    for (const path of [
+      'package.json',
+      'plugins/genie/.claude-plugin/plugin.json',
+      'plugins/genie/.codex-plugin/plugin.json',
+      'plugins/genie/package.json',
+    ]) {
+      writeJson(path, { name: 'genie', version: '5.000000.0' });
+    }
+    writeJson('.claude-plugin/marketplace.json', { plugins: [{ name: 'genie', version: '5.000000.0' }] });
+    const yamlPath = join(root, 'plugins/hermes-genie/plugin.yaml');
+    mkdirSync(dirname(yamlPath), { recursive: true });
+    writeFileSync(yamlPath, 'name: genie\nversion: 5.000000.0\ndescription: "Native surface"\n');
+    return root;
+  }
+
+  function initGitRepo(root: string): void {
+    const opts = { cwd: root, stdio: 'pipe' as const };
+    execFileSync('git', ['init', '-q'], opts);
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], opts);
+    execFileSync('git', ['config', 'user.name', 'Test'], opts);
+    execFileSync('git', ['add', '-A'], opts);
+    execFileSync('git', ['commit', '-q', '-m', 'initial'], opts);
+  }
+
+  function stagedPaths(root: string): string[] {
+    return execFileSync('git', ['diff', '--cached', '--name-only'], { cwd: root, encoding: 'utf-8' })
+      .split('\n')
+      .filter(Boolean);
+  }
+
+  test('stages the rewritten plugin.yaml when GITHUB_ACTIONS=true', async () => {
+    const root = versionFixture();
+    initGitRepo(root);
+    process.env.GITHUB_ACTIONS = 'true';
+
+    await synchronizeVersionFiles(root, '5.260713.3');
+
+    const staged = stagedPaths(root);
+    expect(staged).toContain('plugins/hermes-genie/plugin.yaml');
+    expect(staged).toContain('package.json');
+    expect(staged).toContain('.claude-plugin/marketplace.json');
+    // The rewritten value is actually on disk (staging did not mask a no-op).
+    expect(readFileSync(join(root, 'plugins/hermes-genie/plugin.yaml'), 'utf8')).toContain('version: 5.260713.3');
+  });
+
+  test('stages nothing when GITHUB_ACTIONS is unset', async () => {
+    const root = versionFixture();
+    initGitRepo(root);
+    Reflect.deleteProperty(process.env, 'GITHUB_ACTIONS');
+
+    await synchronizeVersionFiles(root, '5.260713.4');
+
+    expect(stagedPaths(root)).toEqual([]);
+    // Files were still rewritten locally — only the staging is CI-gated.
+    expect(readFileSync(join(root, 'plugins/hermes-genie/plugin.yaml'), 'utf8')).toContain('version: 5.260713.4');
+  });
+
+  test('warns but exits 0 when git add fails (not a git repo)', async () => {
+    const root = versionFixture(); // deliberately NOT a git repo
+    process.env.GITHUB_ACTIONS = 'true';
+
+    // Best-effort staging: the git failure must not reject the sync.
+    await expect(synchronizeVersionFiles(root, '5.260713.5')).resolves.toBeUndefined();
+    // The version files are still fully rewritten despite the staging failure.
+    expect(readFileSync(join(root, 'plugins/hermes-genie/plugin.yaml'), 'utf8')).toContain('version: 5.260713.5');
+    expect(JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')).version).toBe('5.260713.5');
+  });
+});

--- a/scripts/version.ts
+++ b/scripts/version.ts
@@ -17,9 +17,21 @@
  * - plugins/genie/package.json (runtime payload metadata)
  * - .claude-plugin/marketplace.json (marketplace listing)
  * - plugins/hermes-genie/plugin.yaml (Hermes native surface, YAML manifest)
+ *
+ * CI staging (GITHUB_ACTIONS only): after rewriting, this script `git add`s every
+ * file it actually touched. This exists because the release workflow's own
+ * `git add -A '*.json' 'src/lib/version.ts'` list predates the YAML manifests —
+ * it re-guesses the version-carrying file set and silently omitted plugin.yaml,
+ * so a bump could ship with a stale Hermes manifest (defect D2). The list of
+ * version files lives here, not in the workflow, so this is the one place that
+ * always knows the full set. Keeping the fix here (rather than in the workflow)
+ * matters because `.github/workflows/**` can't always be updated in the same
+ * change — some environments lack workflow-scoped push credentials. Staging is
+ * best-effort: a git failure warns but never fails the sync, and the workflow's
+ * own `git add` still covers the JSON files as belt-and-suspenders.
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { readFile, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
@@ -163,6 +175,22 @@ async function assertClaudeMarketplaceShape(filePath: string): Promise<void> {
   }
 }
 
+/**
+ * In CI only, stage the files this sync actually rewrote so the auto-version
+ * commit ships them. Best-effort: a git failure logs a warning and returns —
+ * it must never fail the version sync (the workflow's own `git add` still covers
+ * the JSON files). Uses an arg-array (never a shell string) so paths can't be
+ * interpolated into a command line.
+ */
+function stageRewrittenFilesInCi(rootDir: string, paths: string[]): void {
+  if (process.env.GITHUB_ACTIONS !== 'true' || paths.length === 0) return;
+  try {
+    execFileSync('git', ['add', '--', ...paths], { cwd: rootDir, stdio: 'pipe' });
+  } catch (err) {
+    console.warn(`  ⚠ CI staging skipped (git add failed): ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
 /** Update every authoritative version file and fail the command on any partial write. */
 export async function synchronizeVersionFiles(rootDir: string, version: string): Promise<void> {
   const paths = [
@@ -202,6 +230,13 @@ export async function synchronizeVersionFiles(rootDir: string, version: string):
 
   outcomes.push({ path: marketplacePath, ok: await updateClaudeMarketplaceVersion(marketplacePath, version) });
   for (const path of yamlPaths) outcomes.push({ path, ok: await updateYamlVersion(path, version) });
+
+  // Stage every file we actually rewrote so CI commits the full set (incl. YAML).
+  stageRewrittenFilesInCi(
+    rootDir,
+    outcomes.filter((outcome) => outcome.ok).map((outcome) => outcome.path),
+  );
+
   const failed = outcomes.filter((outcome) => !outcome.ok).map((outcome) => outcome.path);
   if (failed.length > 0) throw new Error(`version synchronization failed for: ${failed.join(', ')}`);
 }

--- a/src/lib/hermes-skills-config.test.ts
+++ b/src/lib/hermes-skills-config.test.ts
@@ -225,6 +225,92 @@ describe('mergeSkillsExternalDir', () => {
     // Exactly one managed entry — old genie root replaced, not accumulated.
     expect(parsed.skills.external_dirs).toEqual([newRoot]);
   });
+
+  // Nested inline child inside a block-style `skills:` — the real isit profile shape.
+  // An inline empty `external_dirs: []` child must be merged IN PLACE (replaced with
+  // the managed block), never appended as a second `external_dirs` key.
+  test('isit shape: inline empty external_dirs child merged in place → exactly one key, siblings byte-identical', () => {
+    const root = tmp();
+    const skillsRoot = makeSkillsRoot(join(root, 'skills'));
+    const configPath = join(root, 'config.yaml');
+    const original =
+      'skills:\n' +
+      '  external_dirs: []\n' +
+      '  template_vars: true\n' +
+      '  inline_shell: false\n' +
+      '  inline_shell_timeout: 10\n';
+    writeFileSync(configPath, original);
+
+    const result = mergeSkillsExternalDir({ configPath, skillsRoot, now: new Date('2026-07-13T00:00:00Z') });
+    expect(result.status).toBe('updated');
+    expect(result.backupPath).toBeDefined();
+    expect(readFileSync(result.backupPath as string, 'utf8')).toBe(original);
+
+    const text = readFileSync(configPath, 'utf8');
+    // Exactly ONE external_dirs key inside the skills mapping (no spec-invalid duplicate).
+    expect(text.match(/external_dirs:/g)?.length).toBe(1);
+    // Siblings preserved byte-for-byte.
+    expect(text).toContain('  template_vars: true\n');
+    expect(text).toContain('  inline_shell: false\n');
+    expect(text).toContain('  inline_shell_timeout: 10\n');
+
+    const parsed = Bun.YAML.parse(text) as {
+      skills: {
+        external_dirs: string[];
+        template_vars: boolean;
+        inline_shell: boolean;
+        inline_shell_timeout: number;
+      };
+    };
+    expect(parsed.skills.external_dirs).toEqual([skillsRoot]);
+    expect(parsed.skills.template_vars).toBe(true);
+    expect(parsed.skills.inline_shell).toBe(false);
+    expect(parsed.skills.inline_shell_timeout).toBe(10);
+  });
+
+  test('inline NON-empty external_dirs child → typed refusal, file + backup untouched', () => {
+    const root = tmp();
+    const skillsRoot = makeSkillsRoot(join(root, 'skills'));
+    const configPath = join(root, 'config.yaml');
+    const original = 'skills:\n  external_dirs: [/home/u/mine]\n  template_vars: true\n';
+    writeFileSync(configPath, original);
+
+    expect(() => mergeSkillsExternalDir({ configPath, skillsRoot })).toThrow(HermesConfigError);
+    // The user's inline entry is never deleted: the file is left byte-for-byte.
+    expect(readFileSync(configPath, 'utf8')).toBe(original);
+    expect(hasBackup(root)).toBe(false);
+  });
+
+  test('the inline non-empty nested refusal carries the distinct inline-nested-key code', () => {
+    const root = tmp();
+    const skillsRoot = makeSkillsRoot(join(root, 'skills'));
+    const configPath = join(root, 'config.yaml');
+    writeFileSync(configPath, 'skills:\n  external_dirs: [/home/u/mine]\n');
+
+    try {
+      mergeSkillsExternalDir({ configPath, skillsRoot });
+      throw new Error('expected a HermesConfigError to be thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(HermesConfigError);
+      expect((err as HermesConfigError).code).toBe('inline-nested-key');
+    }
+  });
+
+  test('isit shape merge is idempotent: second run is unchanged', () => {
+    const root = tmp();
+    const skillsRoot = makeSkillsRoot(join(root, 'skills'));
+    const configPath = join(root, 'config.yaml');
+    const original = 'skills:\n  external_dirs: []\n  template_vars: true\n';
+    writeFileSync(configPath, original);
+
+    const first = mergeSkillsExternalDir({ configPath, skillsRoot });
+    expect(first.status).toBe('updated');
+    const afterFirst = readFileSync(configPath, 'utf8');
+
+    const second = mergeSkillsExternalDir({ configPath, skillsRoot });
+    expect(second.status).toBe('unchanged');
+    expect(readFileSync(configPath, 'utf8')).toBe(afterFirst);
+  });
 });
 
 describe('copyProductSkillsDigestManaged (older-Hermes fallback)', () => {

--- a/src/lib/hermes-skills-config.ts
+++ b/src/lib/hermes-skills-config.ts
@@ -37,8 +37,18 @@
  * *not* merged: merging into a flow value would require re-serializing user bytes,
  * and blindly appending a second `skills:` key produces spec-invalid duplicate-key
  * YAML or silently drops the user's siblings on last-wins. Such a config is refused
- * with a typed `HermesConfigError` before any backup or write, so the original file
- * survives byte-for-byte.
+ * with a typed `HermesConfigError('inline-top-level-key')` before any backup or
+ * write, so the original file survives byte-for-byte.
+ *
+ * The same fail-closed philosophy extends one level down. Inside a block-style
+ * `skills:`, a nested `external_dirs` child is merged **in place** — never appended
+ * as a second key:
+ *   - a block-style child gets the single managed entry merged/replaced inside it;
+ *   - an inline **empty** child (`external_dirs: []`) is rewritten to the managed
+ *     block, leaving every surrounding sibling byte-for-byte;
+ *   - an inline **non-empty** child (`external_dirs: [/x]`) cannot be merged without
+ *     re-serializing user bytes, so it is refused with a typed
+ *     `HermesConfigError('inline-nested-key')` before any backup or write.
  *
  * ## Older-Hermes fallback
  *
@@ -212,6 +222,19 @@ function spliceExternalDir(original: string, skillsRoot: string): string {
   const extHeader = findChildKeyLine(lines, skillsHeader + 1, skillsEnd, childIndent, 'external_dirs');
 
   if (extHeader < 0) {
+    const inline = findInlineChildKeyLine(lines, skillsHeader + 1, skillsEnd, childIndent, 'external_dirs');
+    if (inline.index >= 0) {
+      if (!inline.empty) {
+        throw new HermesConfigError(
+          'inline-nested-key',
+          `cannot merge: nested "skills.external_dirs" has an inline non-empty value on the same line (${lines[inline.index].trim()}); rewrite it as a block list so genie can merge without deleting your entries`,
+        );
+      }
+      // Inline empty `external_dirs: []` → replace that single line with the managed
+      // block entry in place, preserving every surrounding sibling byte-for-byte.
+      lines.splice(inline.index, 1, `${' '.repeat(childIndent)}external_dirs:`, managedItem(childIndent + 2));
+      return fromLines(lines, trailingNewline);
+    }
     lines.splice(skillsEnd, 0, `${' '.repeat(childIndent)}external_dirs:`, managedItem(childIndent + 2));
     return fromLines(lines, trailingNewline);
   }
@@ -350,6 +373,31 @@ function findChildKeyLine(lines: string[], start: number, blockEnd: number, chil
     if (indentOf(lines[i]) === childIndent && re.test(lines[i])) return i;
   }
   return -1;
+}
+
+/**
+ * Locate a nested child key that carries an inline/flow value on the same line
+ * (e.g. `external_dirs: []`, `external_dirs: [/x]`) rather than a bare block
+ * header. Block-style headers are handled by `findChildKeyLine`; this covers the
+ * inline sibling class. `empty` is true only for an empty flow list (`[]`/`[ ]`),
+ * which can be replaced in place; any other inline value is unmergeable.
+ */
+function findInlineChildKeyLine(
+  lines: string[],
+  start: number,
+  blockEnd: number,
+  childIndent: number,
+  name: string,
+): { index: number; empty: boolean } {
+  const prefix = new RegExp(`^ {${childIndent}}${name}:(?:\\s|$)`);
+  const bare = new RegExp(`^ {${childIndent}}${name}:\\s*(#.*)?$`);
+  const empty = new RegExp(`^ {${childIndent}}${name}:\\s+\\[\\s*\\]\\s*(#.*)?$`);
+  for (let i = start; i < blockEnd; i++) {
+    if (indentOf(lines[i]) !== childIndent) continue;
+    if (!prefix.test(lines[i]) || bare.test(lines[i])) continue;
+    return { index: i, empty: empty.test(lines[i]) };
+  }
+  return { index: -1, empty: false };
 }
 
 /** Indentation of the first list item, defaulting to childIndent + 2. */


### PR DESCRIPTION
## Summary

Fixes the two MEDIUM defects found by the live isit-profile dogfood of PR #2565 (evidence: `.genie/wishes/hermes-homogeneous-integration/qa/live-dogfood-20260713.md`).

### D1 — duplicate nested `external_dirs` key (`src/lib/hermes-skills-config.ts`)

A block-style `skills:` with an inline `external_dirs: []` child (the operator's real profile shape) caused `mergeSkillsExternalDir` to append a **second** `external_dirs:` key — spec-invalid duplicate-key YAML that only works via PyYAML last-wins. Now:

- inline empty `[]` child → replaced in place with the managed block entry; sibling lines byte-identical
- inline non-empty child → typed `HermesConfigError('inline-nested-key')` raised **before** any backup/write (fail-closed, file untouched)
- block-style child path unchanged

4 failing-first regression tests, including the exact live-config shape and second-run idempotency. Reviewer independently live-probed the fix and confirmed the sibling `hermes-mcp-config.ts` is structurally immune to the same class.

### D2 — auto-version drops the plugin.yaml bump (`scripts/version.ts`)

`bun run version` rewrites `plugins/hermes-genie/plugin.yaml` (wired in #2565), but the workflow's `git add -A '*.json' 'src/lib/version.ts'` list predates YAML manifests and silently discarded the rewrite — release `a4a8793d` shipped plugin `5.260712.2` vs genie `5.260713.2`. Root cause is duplicated knowledge: `version.ts` owns the version-file list; the workflow re-guessed it and drifted.

Fix at the source: `synchronizeVersionFiles` now stages every file it actually rewrote (`git add` via arg-array, best-effort) — **only when `GITHUB_ACTIONS=true`**, never on local runs. Reviewer verified end-to-end in a real-git simulation: the pre-staged YAML survives the workflow's later `git add`, passes the `diff --cached` guard, and lands in the auto-version commit; a full test run under `GITHUB_ACTIONS=true` leaves `git status` clean (no side effects in CI test jobs). Version parity self-heals on the first auto-version run after this merges.

Note: the equivalent one-line workflow fix is preserved at `.genie/wishes/hermes-homogeneous-integration/reports/d2-workflow-patch.diff` for a maintainer with `workflow`-scoped credentials to apply as belt-and-suspenders (this environment's OAuth token cannot push `.github/workflows/**`; applying both is idempotent).

## Validation

- `bun test scripts/`: 154 pass / 0 fail; `bun test src/lib/hermes-skills-config.test.ts src/lib/hermes-mcp-config.test.ts`: 38 pass / 0 fail (re-run by orchestrator and reviewer)
- `bun run typecheck` + `bun run lint`: clean
- Independent review: SHIP on both commits (LOWs accepted: trailing comment on genie's own managed line dropped on rewrite; cosmetic `not a git repository` warn from one legacy test fixture under CI; version string self-heals next bump)

Board: follow-up tasks `t_mrizrcnhbc78b176` / `t_mrizrcp6e2344abf` done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)