### PR TITLE
fix(hermes): skip comment-only lines when deriving child indent in Hermes YAML merge

### DIFF
--- a/src/lib/hermes-mcp-config.test.ts
+++ b/src/lib/hermes-mcp-config.test.ts
@@ -269,4 +269,120 @@ describe('mergeMcpServersGenie', () => {
     };
     expect(parsed.mcp_servers.genie.env.GENIE_HOME).toBe(root);
   });
+
+  // A YAML comment is valid at ANY indentation, including one deeper than the
+  // real children. Before the fix, `childIndentOf` picked the comment's indent
+  // as the block's child indent, `findChildRange` then missed the real `genie`/
+  // sibling lines at the true indent, and a duplicate mis-indented `genie` block
+  // was appended — producing output `Bun.YAML.parse` rejects. These cases lock
+  // that class of bug down for good.
+  describe('comment-line indentation (regression)', () => {
+    test('repro: comment deeper-indented than the real sibling child still merges cleanly, output parses', () => {
+      const root = tmp();
+      const configPath = join(root, 'config.yaml');
+      const original = 'mcp_servers:\n      # my servers\n  other:\n    command: x\n';
+      writeFileSync(configPath, original);
+
+      const result = mergeMcpServersGenie({
+        configPath,
+        binaryPath: bin(root),
+        genieHome: root,
+        fsExists: () => false,
+      });
+      expect(result.status).toBe('created');
+
+      const text = readFileSync(configPath, 'utf8');
+      // Exactly one genie child — no duplicate mis-indented append.
+      expect(text.match(/^\s*genie:\s*$/gm)?.length).toBe(1);
+      expect(text).toContain('      # my servers\n');
+
+      const parsed = Bun.YAML.parse(text) as {
+        mcp_servers: { other: { command: string }; genie: { command: string } };
+      };
+      expect(parsed.mcp_servers.other.command).toBe('x');
+      expect(parsed.mcp_servers.genie.command).toBe(bin(root));
+    });
+
+    test('comment at a smaller indent than the genie child is skipped when deriving child indent', () => {
+      const root = tmp();
+      const configPath = join(root, 'config.yaml');
+      const original =
+        'mcp_servers:\n# top-level-ish comment\n  genie:\n    command: /old/genie\n    args:\n      - mcp\n';
+      writeFileSync(configPath, original);
+
+      const command = bin(root);
+      const result = mergeMcpServersGenie({ configPath, binaryPath: command, genieHome: root, fsExists: () => false });
+      expect(result.status).toBe('updated');
+
+      const text = readFileSync(configPath, 'utf8');
+      expect(text.match(/^\s*genie:\s*$/gm)?.length).toBe(1);
+
+      const parsed = Bun.YAML.parse(text) as { mcp_servers: { genie: { command: string } } };
+      expect(parsed.mcp_servers.genie.command).toBe(command);
+    });
+
+    test('a comment sitting between the genie child and a later sibling does not swallow the sibling', () => {
+      const root = tmp();
+      const configPath = join(root, 'config.yaml');
+      const original =
+        'mcp_servers:\n' +
+        '  genie:\n' +
+        '    command: /old/genie\n' +
+        '    args:\n' +
+        '      - mcp\n' +
+        '  # comment between children\n' +
+        '  other:\n' +
+        '    command: /usr/bin/other\n';
+      writeFileSync(configPath, original);
+
+      const command = bin(root);
+      const result = mergeMcpServersGenie({ configPath, binaryPath: command, genieHome: root, fsExists: () => false });
+      expect(result.status).toBe('updated');
+
+      const text = readFileSync(configPath, 'utf8');
+      expect(text).toContain('  # comment between children\n');
+
+      const parsed = Bun.YAML.parse(text) as {
+        mcp_servers: { genie: { command: string }; other: { command: string } };
+      };
+      expect(parsed.mcp_servers.genie.command).toBe(command);
+      expect(parsed.mcp_servers.other.command).toBe('/usr/bin/other');
+    });
+
+    test('a comment-only mcp_servers body (no real children yet) still derives a sane child indent and merges cleanly', () => {
+      const root = tmp();
+      const configPath = join(root, 'config.yaml');
+      const original = 'mcp_servers:\n  # nothing configured yet\nother: 1\n';
+      writeFileSync(configPath, original);
+
+      const result = mergeMcpServersGenie({
+        configPath,
+        binaryPath: bin(root),
+        genieHome: root,
+        fsExists: () => false,
+      });
+      expect(result.status).toBe('created');
+
+      const text = readFileSync(configPath, 'utf8');
+      const parsed = Bun.YAML.parse(text) as { mcp_servers: { genie: { command: string } }; other: number };
+      expect(parsed.mcp_servers.genie.command).toBe(bin(root));
+      expect(parsed.other).toBe(1);
+    });
+
+    test('repro layout is idempotent: a second merge is unchanged and stays parseable', () => {
+      const root = tmp();
+      const configPath = join(root, 'config.yaml');
+      writeFileSync(configPath, 'mcp_servers:\n      # my servers\n  other:\n    command: x\n');
+      const command = bin(root);
+
+      const first = mergeMcpServersGenie({ configPath, binaryPath: command, genieHome: root, fsExists: () => false });
+      expect(first.status).toBe('created');
+      const afterFirst = readFileSync(configPath, 'utf8');
+      Bun.YAML.parse(afterFirst); // still parses
+
+      const second = mergeMcpServersGenie({ configPath, binaryPath: command, genieHome: root, fsExists: () => false });
+      expect(second.status).toBe('unchanged');
+      expect(readFileSync(configPath, 'utf8')).toBe(afterFirst);
+    });
+  });
 });

--- a/src/lib/hermes-mcp-config.ts
+++ b/src/lib/hermes-mcp-config.ts
@@ -155,6 +155,7 @@ export function mergeMcpServersGenie(opts: MergeMcpGenieOptions): MergeMcpGenieR
 
   const status: 'created' | 'updated' = existingGenie ? 'updated' : 'created';
   const nextText = spliceGenieEntry(original, entry);
+  assertMergedGenieEntryInvariant(nextText, entry);
 
   let backupPath: string | undefined;
   if (exists && original.length > 0) {
@@ -197,6 +198,34 @@ function entrySatisfies(existing: McpGenieEntry, desired: McpGenieEntry): boolea
     }
   }
   return true;
+}
+
+/**
+ * Final fail-closed safety net: the line-level splice above handles every
+ * documented shape (marker region, unmarked child, no genie child, no
+ * mcp_servers key, comment lines interleaved among siblings), but a
+ * sufficiently pathological comment layout could still slip past the matchers
+ * undetected. Rather than trust that no such layout exists, verify the actual
+ * output before it is ever written: it must parse as YAML and it must contain
+ * exactly the expected `mcp_servers.genie` entry (the never-clobber invariant —
+ * refusal is always acceptable, corruption never is).
+ */
+function assertMergedGenieEntryInvariant(nextText: string, entry: McpGenieEntry): void {
+  try {
+    Bun.YAML.parse(nextText);
+  } catch (err) {
+    throw new HermesConfigError(
+      'unparseable-merge-result',
+      `refusing to write: merged config would not parse as YAML (${err instanceof Error ? err.message : String(err)})`,
+    );
+  }
+  const written = readGenieEntry(nextText);
+  if (!written || !entrySatisfies(written, entry)) {
+    throw new HermesConfigError(
+      'unverified-merge',
+      'refusing to write: merged config would not contain the expected mcp_servers.genie entry',
+    );
+  }
 }
 
 /** Produce the next config text with the genie entry merged in via targeted surgery. */
@@ -291,6 +320,21 @@ function isBlank(line: string): boolean {
   return line.trim() === '';
 }
 
+/**
+ * A YAML comment-only line is valid at ANY indentation and carries no structural
+ * weight. Every boundary-detection helper below must treat it exactly like a
+ * blank line: it never terminates a block and it is never mistaken for "the
+ * first real child" when deriving a block's child indent.
+ */
+function isCommentOnly(line: string): boolean {
+  return line.trim().startsWith('#');
+}
+
+/** True for a line with no structural weight: blank or comment-only. */
+function isSkippable(line: string): boolean {
+  return isBlank(line) || isCommentOnly(line);
+}
+
 function indentOf(line: string): number {
   return line.match(/^ */)?.[0].length ?? 0;
 }
@@ -333,22 +377,36 @@ function assertNoInlineTopLevelKey(lines: string[], key: string): void {
   }
 }
 
-/** First line index after a block header where the block's children end. */
+/**
+ * First line index after a block header where the block's children end. A
+ * comment-only line is skipped regardless of its own indentation — YAML
+ * comments are valid at any column and never close a block on their own.
+ */
 function blockEndIndex(lines: string[], header: number): number {
   let end = header + 1;
-  while (end < lines.length && (isBlank(lines[end]) || indentOf(lines[end]) > 0)) end++;
+  while (end < lines.length && (isCommentOnly(lines[end]) || isBlank(lines[end]) || indentOf(lines[end]) > 0)) end++;
   return end;
 }
 
-/** Indentation of the first non-blank child line, defaulting to 2. */
+/** Indentation of the first real (non-blank, non-comment) child line, defaulting to 2. */
 function childIndentOf(lines: string[], header: number, blockEnd: number): number {
   for (let i = header + 1; i < blockEnd; i++) {
-    if (!isBlank(lines[i])) return indentOf(lines[i]);
+    if (!isSkippable(lines[i])) return indentOf(lines[i]);
   }
   return 2;
 }
 
-/** Line range [start, end) of a named child entry at a given indent. */
+/**
+ * Line range [start, end) of a named child entry at a given indent.
+ *
+ * Deliberately NOT comment-skipping here, unlike the search-boundary helpers
+ * above: this range is used to DELETE and replace an existing child's content
+ * wholesale. A deeper-indented line (comment or not) is still genie's own
+ * nested content and is correctly swallowed by `indentOf > childIndent`. But a
+ * comment sitting AT or below `childIndent` — between this child and the next
+ * sibling — belongs to neither and must not be deleted: the module's contract
+ * is that comments outside the managed entry are never touched.
+ */
 function findChildRange(
   lines: string[],
   start: number,

--- a/src/lib/hermes-skills-config.test.ts
+++ b/src/lib/hermes-skills-config.test.ts
@@ -311,6 +311,110 @@ describe('mergeSkillsExternalDir', () => {
     expect(second.status).toBe('unchanged');
     expect(readFileSync(configPath, 'utf8')).toBe(afterFirst);
   });
+
+  // A YAML comment is valid at ANY indentation, including one deeper than the
+  // real children. Before the fix, `childIndentOf` picked the comment's indent
+  // as the block's child indent, the child-key matchers then missed the real
+  // `external_dirs` line at the true indent, and a duplicate mis-indented key
+  // was appended — producing output `Bun.YAML.parse` rejects. These cases lock
+  // that class of bug down for good.
+  describe('comment-line indentation (regression)', () => {
+    test('repro: comment deeper-indented than the real inline-empty child still merges in place, output parses', () => {
+      const root = tmp();
+      const skillsRoot = makeSkillsRoot(join(root, 'skills'));
+      const configPath = join(root, 'config.yaml');
+      const original = 'skills:\n      # my comment\n  external_dirs: []\nother: 1\n';
+      writeFileSync(configPath, original);
+
+      const result = mergeSkillsExternalDir({ configPath, skillsRoot });
+      expect(result.status).toBe('updated');
+
+      const text = readFileSync(configPath, 'utf8');
+      // Exactly one external_dirs key — no duplicate mis-indented append.
+      expect(text.match(/external_dirs:/g)?.length).toBe(1);
+      expect(text).toContain('      # my comment\n');
+
+      const parsed = Bun.YAML.parse(text) as { skills: { external_dirs: string[] }; other: number };
+      expect(parsed.skills.external_dirs).toEqual([skillsRoot]);
+      expect(parsed.other).toBe(1);
+    });
+
+    test('comment at a smaller indent than the block-style child is skipped when deriving child indent', () => {
+      const root = tmp();
+      const skillsRoot = makeSkillsRoot(join(root, 'skills'));
+      const configPath = join(root, 'config.yaml');
+      const original = 'skills:\n# top-level-ish comment\n  external_dirs:\n    - /home/user/mine\nother: 1\n';
+      writeFileSync(configPath, original);
+
+      const result = mergeSkillsExternalDir({ configPath, skillsRoot });
+      expect(result.status).toBe('updated');
+
+      const text = readFileSync(configPath, 'utf8');
+      expect(text.match(/external_dirs:/g)?.length).toBe(1);
+
+      const parsed = Bun.YAML.parse(text) as { skills: { external_dirs: string[] }; other: number };
+      expect(parsed.skills.external_dirs).toEqual(['/home/user/mine', skillsRoot]);
+      expect(parsed.other).toBe(1);
+    });
+
+    test('a comment sitting between the external_dirs child and a later sibling does not swallow the sibling', () => {
+      const root = tmp();
+      const skillsRoot = makeSkillsRoot(join(root, 'skills'));
+      const configPath = join(root, 'config.yaml');
+      const original =
+        'skills:\n' +
+        '  external_dirs:\n' +
+        '    - /home/user/mine\n' +
+        '  # comment between children\n' +
+        '  template_vars: true\n';
+      writeFileSync(configPath, original);
+
+      const result = mergeSkillsExternalDir({ configPath, skillsRoot });
+      expect(result.status).toBe('updated');
+
+      const text = readFileSync(configPath, 'utf8');
+      expect(text).toContain('  # comment between children\n');
+      expect(text).toContain('  template_vars: true\n');
+
+      const parsed = Bun.YAML.parse(text) as {
+        skills: { external_dirs: string[]; template_vars: boolean };
+      };
+      expect(parsed.skills.external_dirs).toEqual(['/home/user/mine', skillsRoot]);
+      expect(parsed.skills.template_vars).toBe(true);
+    });
+
+    test('a comment-only skills body (no real children yet) still derives a sane child indent and merges cleanly', () => {
+      const root = tmp();
+      const skillsRoot = makeSkillsRoot(join(root, 'skills'));
+      const configPath = join(root, 'config.yaml');
+      const original = 'skills:\n  # nothing configured yet\nother: 1\n';
+      writeFileSync(configPath, original);
+
+      const result = mergeSkillsExternalDir({ configPath, skillsRoot });
+      expect(result.status).toBe('updated');
+
+      const text = readFileSync(configPath, 'utf8');
+      const parsed = Bun.YAML.parse(text) as { skills: { external_dirs: string[] }; other: number };
+      expect(parsed.skills.external_dirs).toEqual([skillsRoot]);
+      expect(parsed.other).toBe(1);
+    });
+
+    test('repro layout is idempotent: a second merge is unchanged and stays parseable', () => {
+      const root = tmp();
+      const skillsRoot = makeSkillsRoot(join(root, 'skills'));
+      const configPath = join(root, 'config.yaml');
+      writeFileSync(configPath, 'skills:\n      # my comment\n  external_dirs: []\nother: 1\n');
+
+      const first = mergeSkillsExternalDir({ configPath, skillsRoot });
+      expect(first.status).toBe('updated');
+      const afterFirst = readFileSync(configPath, 'utf8');
+      Bun.YAML.parse(afterFirst); // still parses
+
+      const second = mergeSkillsExternalDir({ configPath, skillsRoot });
+      expect(second.status).toBe('unchanged');
+      expect(readFileSync(configPath, 'utf8')).toBe(afterFirst);
+    });
+  });
 });
 
 describe('copyProductSkillsDigestManaged (older-Hermes fallback)', () => {

--- a/src/lib/hermes-skills-config.ts
+++ b/src/lib/hermes-skills-config.ts
@@ -155,6 +155,7 @@ export function mergeSkillsExternalDir(opts: MergeSkillsExternalDirOptions): Mer
 
   const status: 'created' | 'updated' = exists && original.length > 0 ? 'updated' : 'created';
   const nextText = spliceExternalDir(original, skillsRoot);
+  assertMergedSkillsInvariant(nextText, skillsRoot);
 
   let backupPath: string | undefined;
   if (exists && original.length > 0) {
@@ -199,6 +200,39 @@ function listedExternalDirs(text: string): string[] {
   if (!isRecord(parsed) || !isRecord(parsed.skills)) return [];
   const dirs = parsed.skills.external_dirs;
   return Array.isArray(dirs) ? dirs.filter((d): d is string => typeof d === 'string') : [];
+}
+
+/**
+ * Final fail-closed safety net: the line-level splice above handles every
+ * documented shape (bare block, inline empty/non-empty child, comment lines
+ * interleaved among children), but a sufficiently pathological comment layout
+ * could still slip past the matchers undetected. Rather than trust that no such
+ * layout exists, verify the actual output before it is ever written: it must
+ * parse as YAML, and it must contain exactly one `skills.external_dirs` entry
+ * equal to the resolved root (the never-clobber invariant — refusal is always
+ * acceptable, corruption never is).
+ */
+function assertMergedSkillsInvariant(nextText: string, skillsRoot: string): void {
+  let parsed: unknown;
+  try {
+    parsed = Bun.YAML.parse(nextText);
+  } catch (err) {
+    throw new HermesConfigError(
+      'unparseable-merge-result',
+      `refusing to write: merged config would not parse as YAML (${err instanceof Error ? err.message : String(err)})`,
+    );
+  }
+  const dirs =
+    isRecord(parsed) && isRecord(parsed.skills) && Array.isArray(parsed.skills.external_dirs)
+      ? parsed.skills.external_dirs.filter((d): d is string => typeof d === 'string')
+      : [];
+  const occurrences = dirs.filter((d) => d === skillsRoot).length;
+  if (occurrences !== 1) {
+    throw new HermesConfigError(
+      'unverified-merge',
+      `refusing to write: merged config would contain ${occurrences} occurrence(s) of "${skillsRoot}" in skills.external_dirs instead of exactly 1`,
+    );
+  }
 }
 
 /** Produce the next config text with exactly one managed external_dirs entry. */
@@ -314,6 +348,21 @@ function isBlank(line: string): boolean {
   return line.trim() === '';
 }
 
+/**
+ * A YAML comment-only line is valid at ANY indentation and carries no structural
+ * weight. Every boundary-detection helper below must treat it exactly like a
+ * blank line: it never terminates a block and it is never mistaken for "the
+ * first real child" when deriving a block's child indent.
+ */
+function isCommentOnly(line: string): boolean {
+  return line.trim().startsWith('#');
+}
+
+/** True for a line with no structural weight: blank or comment-only. */
+function isSkippable(line: string): boolean {
+  return isBlank(line) || isCommentOnly(line);
+}
+
 function indentOf(line: string): number {
   return line.match(/^ */)?.[0].length ?? 0;
 }
@@ -346,23 +395,29 @@ function assertNoInlineTopLevelKey(lines: string[], key: string): void {
   }
 }
 
-/** End of a top-level block: first following line at indent 0. */
+/**
+ * End of a top-level block: first following line at indent 0. A comment-only
+ * line is skipped regardless of its own indentation — YAML comments are valid
+ * at any column and never close a block on their own.
+ */
 function blockEndIndex(lines: string[], header: number): number {
   let end = header + 1;
-  while (end < lines.length && (isBlank(lines[end]) || indentOf(lines[end]) > 0)) end++;
+  while (end < lines.length && (isCommentOnly(lines[end]) || isBlank(lines[end]) || indentOf(lines[end]) > 0)) end++;
   return end;
 }
 
-/** End of a nested block whose header sits at `parentIndent`. */
+/** End of a nested block whose header sits at `parentIndent`. Comments never close it. */
 function blockEndIndexFrom(lines: string[], header: number, hardEnd: number, parentIndent: number): number {
   let end = header + 1;
-  while (end < hardEnd && (isBlank(lines[end]) || indentOf(lines[end]) > parentIndent)) end++;
+  while (end < hardEnd && (isCommentOnly(lines[end]) || isBlank(lines[end]) || indentOf(lines[end]) > parentIndent))
+    end++;
   return end;
 }
 
+/** Indentation of the first real (non-blank, non-comment) child line. */
 function childIndentOf(lines: string[], header: number, blockEnd: number): number {
   for (let i = header + 1; i < blockEnd; i++) {
-    if (!isBlank(lines[i])) return indentOf(lines[i]);
+    if (!isSkippable(lines[i])) return indentOf(lines[i]);
   }
   return 2;
 }


### PR DESCRIPTION
## Finding (MEDIUM, review-confirmed)

`childIndentOf` in `src/lib/hermes-skills-config.ts` (~363-368) and its identical twin in `src/lib/hermes-mcp-config.ts` (~344-349) derived a block's child indent from the **first non-blank line** — but a YAML comment is valid at *any* indentation and can legally be that first line. When a comment sat at a different indent than the real child, `childIndentOf` returned the comment's indent instead of the real child's, so `findChildKeyLine` / `findInlineChildKeyLine` / `findChildRange` then missed the real child at its true indent and the merge appended a **duplicate mis-indented key** — producing a `config.yaml` that `Bun.YAML.parse` rejects.

Repro inputs (both now converge correctly):
- A) `"skills:\n      # my comment\n  external_dirs: []\nother: 1"` → previously returned `status: 'updated'` but wrote unparseable output.
- B) `"mcp_servers:\n      # my servers\n  other:\n    command: x"` → same class of bug.

## Fix

- Comment-only lines (`line.trim().startsWith('#')`) are now treated exactly like blank lines — structurally invisible — in every **search-boundary** helper: `childIndentOf`, `blockEndIndex`, and `blockEndIndexFrom` in both files.
- `findChildRange`'s own **deletion-range** loop in `hermes-mcp-config.ts` is deliberately left untouched. That loop computes a range used to delete-and-replace an existing `genie:` child, and the module's documented contract says comments outside the managed entry are "never touched." Making it skip comments unconditionally (my first pass) caused it to swallow an unrelated trailing comment sitting between the `genie` child and a later sibling during a full-block replace — technically still valid YAML, but a real regression against the stated preservation contract. Reverted to the original, more conservative range computation there; it was never actually broken (the bug was purely in indent *derivation*, which the fix already covers).
- Added a fail-closed safety net (`assertMergedSkillsInvariant` / `assertMergedGenieEntryInvariant`): before any write, the merged text is re-parsed with `Bun.YAML.parse` and checked for exactly one managed entry (`skills.external_dirs` containing the resolved root exactly once / `mcp_servers.genie` matching the desired entry). Any pathological comment layout that still slips past the matchers now raises a typed `HermesConfigError('unparseable-merge-result' | 'unverified-merge')` instead of writing corrupt output. No layout was found that actually needs this fallback in testing — it's a belt-and-suspenders invariant, not a known-unhandled case.

## Tests

Extended `src/lib/hermes-skills-config.test.ts` and `src/lib/hermes-mcp-config.test.ts` with a `comment-line indentation (regression)` describe block in each, covering:
- both documented repro inputs (must converge correctly **and** the output must `Bun.YAML.parse`)
- comment at a smaller indent than the real child
- comment between children (verified the mcp-config case does **not** swallow the trailing comment, per the module's documented contract)
- comment-only block body (no real children yet)
- idempotent re-run on the repro layout

## Evidence

```
bun test src/lib/hermes-skills-config.test.ts src/lib/hermes-mcp-config.test.ts src/lib/agent-sync.test.ts
# 228 pass, 0 fail

bun run typecheck   # clean
bunx biome check src/lib/hermes-skills-config.ts src/lib/hermes-mcp-config.ts \
  src/lib/hermes-skills-config.test.ts src/lib/hermes-mcp-config.test.ts   # clean

bun run check
# 1628 pass, 1 skip, 2 fail — failures are the documented pre-existing
# env-dependent hooks/codex-manifest.test.ts x2, unrelated to this change
```

`bun run check:fast` / `bun run check` both ran cleanly through the git pre-push hook on `git push`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)