### PR TITLE
fix(agent-sync): version-agnostic codex fallback ownership proof

### DIFF
--- a/src/lib/agent-sync.test.ts
+++ b/src/lib/agent-sync.test.ts
@@ -2445,6 +2445,34 @@ describe('Codex fallback ownership planning', () => {
     expect(plan.accepted[0]?.ownership).toBe('historical-tuple');
   });
 
+  test('accepts and retires a historical tuple stamped by a later, unlisted release', () => {
+    // Fallback seeding stamps `marker.version` to whatever release happens to
+    // be installed, not the frozen fixture's markerVersion — a pristine tree
+    // seeded by a later, unlisted release (e.g. current stable 5.260713.1)
+    // with byte-identical content must still be recognized and retired.
+    // markerVersion is provenance metadata, never the ownership proof key.
+    const fallback = join(fixture.root, 'historical-version-agnostic');
+    const shippedSkills = frozenHistoricalSkillsRoot('verified-release-version-agnostic');
+    const tuple = historicalCodexFallbackAllowlist[0];
+    if (tuple === undefined) throw new Error('missing historical tuple');
+    const destination = join(fallback, tuple.skillName);
+    cpSync(join(shippedSkills, tuple.skillName), destination, { recursive: true });
+    expect(stampFallback(destination, '5.260713.1')).toBe(tuple.physicalDigest);
+    expect(tuple.markerVersion).not.toBe('5.260713.1');
+
+    const plan = planCodexFallbackRetirement({ fallbackSkillsDir: fallback, skillNames: [tuple.skillName] });
+    expect(plan.preserved).toEqual([]);
+    expect(plan.accepted).toHaveLength(1);
+    expect(plan.accepted[0]?.ownership).toBe('historical-tuple');
+    expect(plan.accepted[0]?.markerVersion).toBe('5.260713.1');
+    expect(plan.accepted[0]?.physicalDigest).toBe(tuple.physicalDigest);
+
+    const result = applyCodexFallbackRetirement(plan);
+    expect(result.status).toBe('committed');
+    expect(result.retired).toEqual([tuple.skillName]);
+    expect(existsSync(destination)).toBe(false);
+  });
+
   test('rejects a symlinked fallback root before planning', () => {
     const physical = join(fixture.root, 'physical-fallback');
     mkdirSync(physical, { recursive: true });

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -931,7 +931,13 @@ export function inspectManagedSkillTree(dir: string): ManagedSkillTreeReport {
 // ============================================================================
 
 export interface CodexFallbackHistoricalTuple {
-  /** Exact-content retirement policy only; this tuple is not authenticated provenance. */
+  /**
+   * Provenance metadata only — not authenticated, and NOT part of the
+   * ownership match key (see {@link historicalTupleKey}). Fallback seeding
+   * stamps `marker.version` to whatever release happens to be installed, so a
+   * byte-identical tree seeded by a later, unlisted release must still match
+   * on (skillName, physicalDigest) alone.
+   */
   markerVersion: string;
   skillName: string;
   physicalDigest: string;
@@ -1056,8 +1062,16 @@ function verifiedTargetDigest(target: VerifiedCodexSkillPayload | null | undefin
   }
 }
 
-function historicalTupleKey(tuple: CodexFallbackHistoricalTuple): string {
-  return `${tuple.markerVersion}\0${tuple.skillName}\0${tuple.physicalDigest}`;
+/**
+ * Ownership proof key: (skillName, physicalDigest) only. `markerVersion` is
+ * self-reported by the untrusted marker file and is retained on the tuple as
+ * provenance metadata, but it adds zero proof value over the exact-content
+ * digest — fallback seeding stamps `marker.version` to whatever release
+ * happened to be installed, so keying on it silently rejects byte-identical
+ * historical content stamped by a later release than the one the fixture froze.
+ */
+function historicalTupleKey(tuple: Pick<CodexFallbackHistoricalTuple, 'skillName' | 'physicalDigest'>): string {
+  return `${tuple.skillName}\0${tuple.physicalDigest}`;
 }
 
 function classifyCodexFallback(
@@ -1090,7 +1104,7 @@ function classifyCodexFallback(
   if (targetDigest === physicalDigest && target?.skillName === skillName) {
     return { ...common, targetDigest, accepted: true, reason: 'verified-target' };
   }
-  if (historical.has(historicalTupleKey({ markerVersion: parsed.marker.version, skillName, physicalDigest }))) {
+  if (historical.has(historicalTupleKey({ skillName, physicalDigest }))) {
     return { ...common, accepted: true, reason: 'historical-tuple' };
   }
   return {

--- a/src/lib/runtime-integrations.test.ts
+++ b/src/lib/runtime-integrations.test.ts
@@ -2430,6 +2430,96 @@ describe('convergeCodexPluginOnly preservedCollisions counts only real on-disk c
     expect(outcome?.result.preservedCollisions).toBe(1);
     expect(outcome?.retired).toEqual([]);
   });
+
+  test('a well-formed but unrecognized marker is preserved distinctly, not counted as a personal collision', () => {
+    const fallback = mkdtempSync(join(tmpdir(), 'genie-fallback-unrecognized-'));
+    // A well-formed genie marker (managedBy/identityVersion/digest all
+    // self-consistent, so the tree was never locally modified) whose
+    // (skillName, digest) is not in the frozen historical allowlist and has
+    // no verified target match. This is unrecognized managed content, not a
+    // personal collision — the fix must not lump it into the collision count.
+    const skillDir = join(fallback, 'wish');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, 'SKILL.md'), '# unrecognized wish content, never shipped by genie\n');
+    stampFallbackSkill(skillDir, 'fixture-vNext');
+    const outcome = convergeCodexPluginOnly(baseConvergeOptions(fallback));
+    expect(outcome?.preservedCollisions).toBe(0);
+    expect(outcome?.result.preservedCollisions).toBe(0);
+    expect(outcome?.preservedUnrecognized).toBe(1);
+    expect(outcome?.result.preservedUnrecognized).toBe(1);
+    expect(outcome?.retired).toEqual([]);
+  });
+});
+
+describe('describeCodexIntegration reports unrecognized fallbacks distinctly from personal collisions', () => {
+  test('install detail text separates "unrecognized managed fallback" from "personal collision"', () => {
+    const fallback = mkdtempSync(join(tmpdir(), 'genie-fallback-unrecognized-detail-'));
+    const skillDir = join(fallback, 'wish');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, 'SKILL.md'), '# unrecognized wish content, never shipped by genie\n');
+    stampFallbackSkill(skillDir, 'fixture-vNext');
+
+    const result = installRuntimeIntegrations({
+      selection: 'codex',
+      bundleRoot: '/fixture/bundle',
+      codexHome: mkdtempSync(join(tmpdir(), 'genie-codex-home-unrecognized-')),
+      detected: { codex: true },
+      codexPluginOnly: {
+        converge: () => healthyPluginResult(),
+        probe: () => healthyCodexProbe(),
+        prove: () => healthyCodexProof(),
+        runSession: () => ({
+          ok: true,
+          detail: 'ok',
+          tools: [...REQUIRED_GENIE_MCP_TOOLS],
+          wishStatusReadOnly: true,
+        }),
+        installAgents: () => ({ installed: 7, skippedUserOwned: [], keptModified: [], removed: [], backedUp: [] }),
+        fallbackSkillsDir: fallback,
+      },
+    })[0];
+
+    expect(result?.ok).toBe(true);
+    expect(result?.preservedUnrecognized).toBe(1);
+    expect(result?.preservedCollisions).toBe(0);
+    expect(result?.detail).toContain('preserved 1 unrecognized managed fallback');
+    expect(result?.detail).not.toContain('personal collision');
+  });
+
+  test('install detail text still reports a genuine collision as "personal collision"', () => {
+    const fallback = mkdtempSync(join(tmpdir(), 'genie-fallback-collision-detail-'));
+    const skillDir = join(fallback, 'wish');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, 'SKILL.md'), '# wish skill\n');
+    stampFallbackSkill(skillDir);
+    writeFileSync(join(skillDir, 'SKILL.md'), '# wish skill (locally modified)\n');
+
+    const result = installRuntimeIntegrations({
+      selection: 'codex',
+      bundleRoot: '/fixture/bundle',
+      codexHome: mkdtempSync(join(tmpdir(), 'genie-codex-home-collision-')),
+      detected: { codex: true },
+      codexPluginOnly: {
+        converge: () => healthyPluginResult(),
+        probe: () => healthyCodexProbe(),
+        prove: () => healthyCodexProof(),
+        runSession: () => ({
+          ok: true,
+          detail: 'ok',
+          tools: [...REQUIRED_GENIE_MCP_TOOLS],
+          wishStatusReadOnly: true,
+        }),
+        installAgents: () => ({ installed: 7, skippedUserOwned: [], keptModified: [], removed: [], backedUp: [] }),
+        fallbackSkillsDir: fallback,
+      },
+    })[0];
+
+    expect(result?.ok).toBe(true);
+    expect(result?.preservedCollisions).toBe(1);
+    expect(result?.preservedUnrecognized).toBe(0);
+    expect(result?.detail).toContain('preserved 1 personal collision');
+    expect(result?.detail).not.toContain('unrecognized managed fallback');
+  });
 });
 
 describe('proveCodexPluginHealth reject-before-retirement matrix (R4)', () => {

--- a/src/lib/runtime-integrations.ts
+++ b/src/lib/runtime-integrations.ts
@@ -1793,6 +1793,8 @@ export interface IntegrationResult {
   retiredFallbacks?: readonly string[];
   /** Count of preserved personal collisions the retirement classifier left in place. */
   preservedCollisions?: number;
+  /** Count of preserved well-formed-but-unrecognized fallback markers (distinct from a personal collision). */
+  preservedUnrecognized?: number;
 }
 
 export interface InstallIntegrationsOptions {
@@ -2916,6 +2918,8 @@ export interface CodexPluginOnlyResult {
   agents: CodexAgentInstallResult;
   retired: readonly string[];
   preservedCollisions: number;
+  /** Well-formed genie markers whose content is not yet in the frozen allowlist and has no verified target match. */
+  preservedUnrecognized: number;
 }
 
 /** Absent fallback tier means a fresh install: nothing to retire, and R2/R7 forbid creating the lane. */
@@ -2943,14 +2947,28 @@ export function convergeCodexPluginOnly(options: ConvergeCodexPluginOnlyOptions)
   const plugin = (deps.converge ?? convergeCodexPlugin)(options);
   if (plugin === null) return null;
   if (!plugin.ok) {
-    return { result: plugin, proof: null, agents: emptyAgentInstallResult(), retired: [], preservedCollisions: 0 };
+    return {
+      result: plugin,
+      proof: null,
+      agents: emptyAgentInstallResult(),
+      retired: [],
+      preservedCollisions: 0,
+      preservedUnrecognized: 0,
+    };
   }
 
   const snapshot = (deps.probe ?? probeCodexGeniePlugin)({ codexHome, cwd: deps.probeCwd ?? process.cwd() });
 
   if (plugin.preservedDisabled === true) {
     const agents = installAgents(options.bundleRoot, codexHome);
-    return { result: { ...plugin, snapshot }, proof: null, agents, retired: [], preservedCollisions: 0 };
+    return {
+      result: { ...plugin, snapshot },
+      proof: null,
+      agents,
+      retired: [],
+      preservedCollisions: 0,
+      preservedUnrecognized: 0,
+    };
   }
 
   const proof = (deps.prove ?? proveCodexPluginHealth)({
@@ -2964,6 +2982,7 @@ export function convergeCodexPluginOnly(options: ConvergeCodexPluginOnlyOptions)
 
   let retired: readonly string[] = [];
   let preservedCollisions = 0;
+  let preservedUnrecognized = 0;
   if (fallbackDirPresent(fallbackSkillsDir)) {
     translateRetirementConflicts(() => (deps.recover ?? recoverCodexFallbackRetirements)(fallbackSkillsDir));
     const plan = (deps.plan ?? planCodexFallbackRetirement)({
@@ -2975,7 +2994,15 @@ export function convergeCodexPluginOnly(options: ConvergeCodexPluginOnlyOptions)
     // {accepted:false, reason:'missing'} preserved entry, so after a full
     // migration every subsequent run would otherwise report a phantom
     // "preserved 23 personal collision(s)". Count only real on-disk collisions.
-    preservedCollisions = plan.preserved.filter((entry) => entry.reason !== 'missing').length;
+    // 'ambiguous-ownership' is a well-formed genie marker whose (skillName,
+    // digest) is not yet in the frozen allowlist and has no matching verified
+    // target — that is unrecognized managed content, not a personal collision
+    // (the tree was never modified by the user), so it is counted and reported
+    // separately.
+    preservedCollisions = plan.preserved.filter(
+      (entry) => entry.reason !== 'missing' && entry.reason !== 'ambiguous-ownership',
+    ).length;
+    preservedUnrecognized = plan.preserved.filter((entry) => entry.reason === 'ambiguous-ownership').length;
     // A11: a zero-accepted plan is a true no-op — never open a fresh transaction
     // so a plugin-only second run cannot accumulate empty quarantine journals.
     if (plan.accepted.length > 0) {
@@ -2986,11 +3013,12 @@ export function convergeCodexPluginOnly(options: ConvergeCodexPluginOnlyOptions)
 
   const agents = installAgents(options.bundleRoot, codexHome);
   return {
-    result: { ...plugin, snapshot, retiredFallbacks: retired, preservedCollisions },
+    result: { ...plugin, snapshot, retiredFallbacks: retired, preservedCollisions, preservedUnrecognized },
     proof,
     agents,
     retired,
     preservedCollisions,
+    preservedUnrecognized,
   };
 }
 
@@ -3094,6 +3122,7 @@ function describeCodexIntegration(
   agents: CodexAgentInstallResult,
   retired: readonly string[],
   collisions: number,
+  unrecognized: number,
 ): string {
   const notes = [`${agents.installed} role agents installed`];
   if (agents.removed.length > 0) notes.push(`removed obsolete: ${agents.removed.join(', ')}`);
@@ -3102,6 +3131,14 @@ function describeCodexIntegration(
   if (retired.length > 0)
     notes.push(`retired ${retired.length} clean fallback skill${retired.length === 1 ? '' : 's'}`);
   if (collisions > 0) notes.push(`preserved ${collisions} personal collision${collisions === 1 ? '' : 's'}`);
+  // Distinct from a personal collision: the marker is well-formed genie
+  // provenance, but its (skillName, digest) is not in the frozen allowlist and
+  // has no matching verified target — an unrecognized managed version/content,
+  // not user-modified content. Manual review, not `genie update`, resolves it.
+  if (unrecognized > 0)
+    notes.push(
+      `preserved ${unrecognized} unrecognized managed fallback${unrecognized === 1 ? '' : 's'} (review manually)`,
+    );
   return `plugin refreshed; ${notes.join('; ')}`;
 }
 
@@ -3137,11 +3174,17 @@ function installCodexIntegration(
   return {
     runtime: 'codex',
     ok: true,
-    detail: describeCodexIntegration(outcome.agents, outcome.retired, outcome.preservedCollisions),
+    detail: describeCodexIntegration(
+      outcome.agents,
+      outcome.retired,
+      outcome.preservedCollisions,
+      outcome.preservedUnrecognized,
+    ),
     preservedDisabled: plugin.preservedDisabled,
     snapshot: plugin.snapshot,
     retiredFallbacks: outcome.retired,
     preservedCollisions: outcome.preservedCollisions,
+    preservedUnrecognized: outcome.preservedUnrecognized,
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes a confirmed HIGH-severity review finding on the codex fallback retirement engine (adversarially reviewed as SHIP, this is a targeted follow-up fix, not a restructure).

**Bug:** `classifyCodexFallback` (src/lib/agent-sync.ts) accepted a historical fallback only when the exact tuple `(markerVersion, skillName, physicalDigest)` matched `src/fixtures/codex-fallback-allowlist.json`, which freezes tuples from a single release (`5.260712.1`). Fallback seeding stamps `marker.version` to whatever release happens to be *installed*, and that seeding shipped across tags `v5.260710.14`..`v5.260713.4`. A pristine genie-seeded tree stamped by any later release — including current stable `5.260713.1` — with byte-identical content to the frozen allowlist was misclassified `ambiguous-ownership`, reported as a "personal collision", and never retired: `genie update`'s remediation ("run genie update to retire") was an infinite no-op for a fresh-install-over-residue tree.

**Fix (minimal, does not restructure the engine):**
1. `historicalTupleKey` now matches on `(skillName, physicalDigest)` only. The digest already proves exact byte-for-byte content; `markerVersion` is self-reported by the untrusted marker file and added zero proof value — it's retained on the tuple/journal purely as provenance metadata. Marker well-formedness checks (`managedBy`, `identityVersion === 2`, digest self-consistency) are unchanged. `matchesFallbackIdentity` (used for journal plan→move→recover re-verification) was checked and left untouched — it compares against the *observed* marker captured at plan time, not the allowlist tuple, so that internal consistency still holds exactly.
2. `describeCodexIntegration` / `convergeCodexPluginOnly` no longer lump a well-formed-but-unrecognized fallback marker (`ambiguous-ownership`: valid genie marker, digest self-consistent, but not yet in the frozen allowlist and no verified-target match) into the "personal collision" count. It now gets its own `preservedUnrecognized` count and a distinct `"preserved N unrecognized managed fallback(s) (review manually)"` message. A genuine collision (`modified-tree`, `malformed-marker`, `symlink`, `not-physical-directory` — i.e. content the classifier can prove was user-touched or corrupted) still reports as `"personal collision"`.
3. `genie doctor`'s `inspectCodexFallbackTier` / `checkCodexSync` were reviewed and need **no changes** — that path classifies via `inspectManagedSkillTree`, which was already version-agnostic (digest-only, no allowlist lookup at all), so doctor's diagnosis was already correct; only the actual `genie update` retirement engine and its own summary message disagreed with doctor. They're consistent now.

## Per-tag digest verification (blast radius)

Fallback seeding shipped across `v5.260710.14`..`v5.260713.4`. Comparing `git rev-parse <tag>:skills` tree hashes across every tag in that range (plus neighbors) shows exactly **two distinct content eras**, not one:

| Era | Tags | `skills/` tree hash |
|---|---|---|
| A (older, unretirable by this PR) | `v5.260710.14`..`v5.260711.6` | `991bf1c6987bc8ac00c891f93608de46e0c4c5fd` |
| B (frozen allowlist era) | `v5.260712.1`..`v5.260713.4` | `580b92965cc4e8ecae9d298f33f2c0306aa71998` |

`v5.260713.5` (current HEAD-ish) has moved to a third, different tree and is outside the stated seeding range.

I additionally materialized both era boundaries in worktrees and ran the real `computeDirDigest` (the classifier's own digest function) per skill against the committed fixture:
- **`v5.260713.1`** (current stable, the exact scenario in the bug report): all 23 skills' digests match the frozen fixture **exactly** — confirms this is a live, present-day bug, not theoretical, and confirms the fix retires it.
- **`v5.260710.14`** (era A): all 23 skills **mismatch** the frozen fixture — this older content era is correctly *not* retired by this PR. Per the agreed plan, no new frozen fixture was added for era A here; it stays preserved (safe, `ambiguous-ownership`) and is follow-up-wish territory if it needs retiring later.

## Test plan

- [x] `bun test src/lib/agent-sync.test.ts` — 181 pass (new test: accepts+retires a historical tuple stamped by a later, unlisted release, e.g. `5.260713.1`; digest excludes the marker file so content stays byte-identical)
- [x] `bun test src/lib/runtime-integrations.test.ts` — 121 pass (new tests: `preservedUnrecognized` counts an `ambiguous-ownership` entry separately from `preservedCollisions`; a genuine `modified-tree` collision still counts as a collision; end-to-end `installRuntimeIntegrations` detail-string assertions confirm `"unrecognized managed fallback"` vs `"personal collision"` messaging never cross-contaminate)
- [x] `bun test src/genie-commands/doctor.test.ts` — 55 pass (unchanged; confirms doctor's existing messaging stays correct with no code changes needed there)
- [x] `bun run typecheck` — clean
- [x] `bun run check:fast` — clean (full gate: typecheck, lint, dead-code, skills-lint, wishes-lint, complexity-budget, council-workflow-lint, hook-bundle-parity, hook-content-binding, plugin-executables-check)
- [x] `bun run check` — 1622 pass, 1 skip, 2 fail; the 2 failures are `src/hooks/__tests__/codex-manifest.test.ts` (SessionStart hookSpecificOutput shape), reproduced as pre-existing on a clean `origin/dev` checkout (unrelated to this change, part of the 6 known env-dependent tests called out for this task)
- [x] `bun run scripts/generate-codex-fallback-allowlist.ts --check` — still OK (fixture/tuple shape unchanged, only the runtime match key changed)

## Deviations from plan

None. Scope stayed to the match-key fix, the messaging split, and tests; no restructuring of the retirement engine; no new frozen fixtures added for the older content era.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>