### PR TITLE
fix(hermes): repair spec-invalid duplicate skills/mcp config keys

### DIFF
--- a/src/genie-commands/doctor.test.ts
+++ b/src/genie-commands/doctor.test.ts
@@ -1083,4 +1083,61 @@ describe('checkAgentSync', () => {
     expect(probe?.status).toBe('pass');
     expect(probe?.detail).toContain('unknown');
   });
+
+  // -------------------------------------------------------------------------
+  // Textual duplicate-key detection (DF-1): the mcp/skills legs must WARN when
+  // a spec-invalid duplicate child key is present under mcp_servers:/skills: —
+  // even when the last-wins PARSED value looks perfectly healthy, since that
+  // is exactly what let the duplicate persist forever before the repair.
+  // -------------------------------------------------------------------------
+
+  const dupMcpConfig = (command: string) =>
+    `mcp_servers:\n  genie:\n  genie:\n    command: ${JSON.stringify(command)}\n    args:\n      - mcp\n`;
+  const dupSkillsConfig = (dir: string) =>
+    `skills:\n  external_dirs: []\n  external_dirs:\n    - ${JSON.stringify(dir)}\n`;
+
+  test('hermes mcp leg: textual duplicate genie key → warn naming the config path, even though the parsed value is healthy', () => {
+    presentHermes();
+    const bin = presentGenieBinary();
+    writeHermesConfig(dupMcpConfig(bin));
+
+    // The parsed (last-wins) value looks completely correct...
+    const parsed = Bun.YAML.parse(readFileSync(join(hermesHome, 'config.yaml'), 'utf8')) as {
+      mcp_servers: { genie: { command: string } };
+    };
+    expect(parsed.mcp_servers.genie.command).toBe(bin);
+
+    // ...but doctor must still flag the textual duplicate.
+    const mcp = find(checkAgentSync(paths()), 'agent sync: hermes mcp');
+    expect(mcp?.status).toBe('warn');
+    expect(mcp?.detail).toContain('duplicate');
+    expect(mcp?.detail).toContain(join(hermesHome, 'config.yaml'));
+    expect(mcp?.suggestion).toContain('genie update');
+  });
+
+  test('hermes skills leg: textual duplicate external_dirs key → warn naming the config path, even though the parsed value is healthy', () => {
+    presentHermes();
+    writeHermesConfig(dupSkillsConfig(productSkillsRoot()));
+
+    const parsed = Bun.YAML.parse(readFileSync(join(hermesHome, 'config.yaml'), 'utf8')) as {
+      skills: { external_dirs: string[] };
+    };
+    expect(parsed.skills.external_dirs).toEqual([productSkillsRoot()]);
+
+    const skills = find(checkAgentSync(paths()), 'agent sync: hermes skills');
+    expect(skills?.status).toBe('warn');
+    expect(skills?.detail).toContain('duplicate');
+    expect(skills?.detail).toContain(join(hermesHome, 'config.yaml'));
+    expect(skills?.suggestion).toContain('genie update');
+  });
+
+  test('after repair (single key, no duplicate): both legs pass, no duplicate warning', () => {
+    presentHermes();
+    const bin = presentGenieBinary();
+    writeHermesConfig(`${mcpConfig(bin)}${skillsConfig(productSkillsRoot())}`);
+
+    const results = checkAgentSync(paths());
+    expect(find(results, 'agent sync: hermes mcp')?.status).toBe('pass');
+    expect(find(results, 'agent sync: hermes skills')?.status).toBe('pass');
+  });
 });

--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -50,7 +50,8 @@ import {
   resolveGenieHome as resolveGlobalGenieHome,
   resolveHermesHome,
 } from '../lib/genie-home.js';
-import { resolveProductSkillsRoot } from '../lib/hermes-skills-config.js';
+import { hasDuplicateMcpGenieKeys } from '../lib/hermes-mcp-config.js';
+import { hasDuplicateSkillsExternalDirsKeys, resolveProductSkillsRoot } from '../lib/hermes-skills-config.js';
 import { resolveOmniRuntimeConfig } from '../lib/omni-config.js';
 import {
   CANONICAL_GENIE_SKILL_NAMES,
@@ -920,6 +921,14 @@ function checkHermesMcp(configText: string | null, configPath: string): CheckRes
   }
   const inline = detectInlineTopLevelKey(configText, 'mcp_servers');
   if (inline) return { name, status: 'warn', detail: inline, suggestion: HERMES_INLINE_SUGGESTION };
+  if (hasDuplicateMcpGenieKeys(configText)) {
+    return {
+      name,
+      status: 'warn',
+      detail: `duplicate "mcp_servers.genie" key detected in ${configPath} — a stale duplicate can persist even when the parsed value looks correct`,
+      suggestion: SYNC_SUGGESTION,
+    };
+  }
   const command = readMcpGenieCommand(configText);
   if (command === null) {
     return { name, status: 'warn', detail: 'mcp_servers.genie absent', suggestion: SYNC_SUGGESTION };
@@ -958,6 +967,14 @@ function checkHermesSkills(
   if (configText !== null) {
     const inline = detectInlineTopLevelKey(configText, 'skills');
     if (inline) return { name, status: 'warn', detail: inline, suggestion: HERMES_INLINE_SUGGESTION };
+    if (hasDuplicateSkillsExternalDirsKeys(configText)) {
+      return {
+        name,
+        status: 'warn',
+        detail: `duplicate "skills.external_dirs" key detected in ${configPath} — a stale duplicate can persist even when the parsed value looks correct`,
+        suggestion: SYNC_SUGGESTION,
+      };
+    }
   }
   const skillsRoot = safeResolveProductSkillsRoot(genieHome);
   const externalDirs = configText === null ? [] : readSkillsExternalDirs(configText);

--- a/src/lib/hermes-mcp-config.test.ts
+++ b/src/lib/hermes-mcp-config.test.ts
@@ -2,7 +2,12 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { HermesConfigError, mergeMcpServersGenie, resolveGenieBinaryPath } from './hermes-mcp-config.js';
+import {
+  HermesConfigError,
+  hasDuplicateMcpGenieKeys,
+  mergeMcpServersGenie,
+  resolveGenieBinaryPath,
+} from './hermes-mcp-config.js';
 
 const roots: string[] = [];
 afterEach(() => {
@@ -384,5 +389,168 @@ describe('mergeMcpServersGenie', () => {
       expect(second.status).toBe('unchanged');
       expect(readFileSync(configPath, 'utf8')).toBe(afterFirst);
     });
+  });
+});
+
+describe('DF-1: duplicate mcp_servers.genie key repair', () => {
+  const markerBegin = '  # genie:managed:mcp_servers.genie — begin (managed by genie; edit via genie only)';
+  const markerEnd = '  # genie:managed:mcp_servers.genie — end';
+  const managedBlock = (command: string) =>
+    `${markerBegin}\n  genie:\n    command: ${JSON.stringify(command)}\n    args:\n      - mcp\n${markerEnd}\n`;
+
+  test('an empty stray unmarked genie: key alongside the marker-wrapped region repairs to ONE entry, parseable, backup written', () => {
+    const root = tmp();
+    const configPath = join(root, 'config.yaml');
+    const command = bin(root);
+    // An earlier buggy release left a bare `genie:` header with nothing under it,
+    // alongside the current marker-wrapped managed region — spec-invalid
+    // duplicate-key YAML that last-wins parsing hides.
+    const original = `mcp_servers:\n  genie:\n${managedBlock(command)}`;
+    writeFileSync(configPath, original);
+    expect(hasDuplicateMcpGenieKeys(original)).toBe(true);
+
+    const result = mergeMcpServersGenie({
+      configPath,
+      binaryPath: command,
+      genieHome: root,
+      fsExists: () => false,
+      now: new Date('2026-07-13T00:00:00Z'),
+    });
+    expect(result.status).toBe('updated');
+    expect(result.backupPath).toBeDefined();
+    expect(readFileSync(result.backupPath as string, 'utf8')).toBe(original);
+
+    const text = readFileSync(configPath, 'utf8');
+    expect(text.match(/^\s*genie:\s*$/gm)?.length).toBe(1);
+    expect(hasDuplicateMcpGenieKeys(text)).toBe(false);
+
+    const parsed = Bun.YAML.parse(text) as { mcp_servers: { genie: { command: string; args: string[] } } };
+    expect(parsed.mcp_servers.genie.command).toBe(command);
+    expect(parsed.mcp_servers.genie.args).toEqual(['mcp']);
+  });
+
+  test('repair is idempotent: a second merge on the repaired file is unchanged', () => {
+    const root = tmp();
+    const configPath = join(root, 'config.yaml');
+    const command = bin(root);
+    const original = `mcp_servers:\n  genie:\n${managedBlock(command)}`;
+    writeFileSync(configPath, original);
+
+    const first = mergeMcpServersGenie({ configPath, binaryPath: command, genieHome: root, fsExists: () => false });
+    expect(first.status).toBe('updated');
+    const afterFirst = readFileSync(configPath, 'utf8');
+
+    const second = mergeMcpServersGenie({ configPath, binaryPath: command, genieHome: root, fsExists: () => false });
+    expect(second.status).toBe('unchanged');
+    expect(second.backupPath).toBeUndefined();
+    expect(readFileSync(configPath, 'utf8')).toBe(afterFirst);
+  });
+
+  test('a duplicate with content identical to the managed region also repairs safely', () => {
+    const root = tmp();
+    const configPath = join(root, 'config.yaml');
+    const command = bin(root);
+    // Unmarked leftover carrying the EXACT same command/args as the managed
+    // region — safe to drop even though it is not empty.
+    const original = `mcp_servers:\n  genie:\n    command: ${JSON.stringify(command)}\n    args:\n      - mcp\n${managedBlock(command)}`;
+    writeFileSync(configPath, original);
+
+    const result = mergeMcpServersGenie({ configPath, binaryPath: command, genieHome: root, fsExists: () => false });
+    expect(result.status).toBe('updated');
+
+    const text = readFileSync(configPath, 'utf8');
+    expect(text.match(/^\s*genie:\s*$/gm)?.length).toBe(1);
+    const parsed = Bun.YAML.parse(text) as { mcp_servers: { genie: { command: string } } };
+    expect(parsed.mcp_servers.genie.command).toBe(command);
+  });
+
+  test('a duplicate with conflicting (non-empty, non-identical) content → typed refusal with the conflict code', () => {
+    const root = tmp();
+    const configPath = join(root, 'config.yaml');
+    const command = bin(root);
+    const original = `mcp_servers:\n  genie:\n    command: /old/stale/genie\n    args:\n      - mcp\n${managedBlock(command)}`;
+    writeFileSync(configPath, original);
+
+    try {
+      mergeMcpServersGenie({ configPath, binaryPath: command, genieHome: root, fsExists: () => false });
+      throw new Error('expected a HermesConfigError to be thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(HermesConfigError);
+      expect((err as HermesConfigError).code).toBe('duplicate-mcp-genie-conflict');
+    }
+    expect(readFileSync(configPath, 'utf8')).toBe(original);
+    expect(hasBackup(root)).toBe(false);
+  });
+
+  test('no marker-wrapped region among the duplicates → typed refusal with the unmarked code', () => {
+    const root = tmp();
+    const configPath = join(root, 'config.yaml');
+    const command = bin(root);
+    // Two plain unmarked `genie:` children, neither wrapped in markers —
+    // ambiguous which one (if either) is authoritative.
+    const original =
+      'mcp_servers:\n' +
+      '  genie:\n    command: /usr/bin/a\n    args:\n      - mcp\n' +
+      '  other:\n    command: /usr/bin/other\n' +
+      '  genie:\n    command: /usr/bin/b\n    args:\n      - mcp\n';
+    writeFileSync(configPath, original);
+
+    try {
+      mergeMcpServersGenie({ configPath, binaryPath: command, genieHome: root, fsExists: () => false });
+      throw new Error('expected a HermesConfigError to be thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(HermesConfigError);
+      expect((err as HermesConfigError).code).toBe('duplicate-mcp-genie-unmarked');
+    }
+    expect(readFileSync(configPath, 'utf8')).toBe(original);
+    expect(hasBackup(root)).toBe(false);
+  });
+
+  test('two marker-wrapped regions (ambiguous which is managed) → typed refusal with the unmarked code', () => {
+    const root = tmp();
+    const configPath = join(root, 'config.yaml');
+    const command = bin(root);
+    const original = `mcp_servers:\n${managedBlock('/old/genie')}${managedBlock(command)}`;
+    writeFileSync(configPath, original);
+
+    try {
+      mergeMcpServersGenie({ configPath, binaryPath: command, genieHome: root, fsExists: () => false });
+      throw new Error('expected a HermesConfigError to be thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(HermesConfigError);
+      expect((err as HermesConfigError).code).toBe('duplicate-mcp-genie-unmarked');
+    }
+    expect(readFileSync(configPath, 'utf8')).toBe(original);
+    expect(hasBackup(root)).toBe(false);
+  });
+
+  test('refusal is idempotent: a repeated call still throws and never writes or backs up', () => {
+    const root = tmp();
+    const configPath = join(root, 'config.yaml');
+    const command = bin(root);
+    const original = `mcp_servers:\n  genie:\n    command: /old/stale/genie\n    args:\n      - mcp\n${managedBlock(command)}`;
+    writeFileSync(configPath, original);
+
+    for (let i = 0; i < 2; i++) {
+      expect(() =>
+        mergeMcpServersGenie({ configPath, binaryPath: command, genieHome: root, fsExists: () => false }),
+      ).toThrow(HermesConfigError);
+    }
+    expect(readFileSync(configPath, 'utf8')).toBe(original);
+    expect(hasBackup(root)).toBe(false);
+  });
+});
+
+describe('hasDuplicateMcpGenieKeys', () => {
+  test('false for no mcp_servers key, single key, and empty text', () => {
+    expect(hasDuplicateMcpGenieKeys('')).toBe(false);
+    expect(hasDuplicateMcpGenieKeys('other: 1\n')).toBe(false);
+    expect(hasDuplicateMcpGenieKeys('mcp_servers:\n  genie:\n    command: /x\n')).toBe(false);
+  });
+
+  test('true for a textual duplicate even when the parsed value looks correct (last-wins hides it)', () => {
+    const text = 'mcp_servers:\n  genie:\n  genie:\n    command: /x\n    args:\n      - mcp\n';
+    expect(Bun.YAML.parse(text)).toEqual({ mcp_servers: { genie: { command: '/x', args: ['mcp'] } } });
+    expect(hasDuplicateMcpGenieKeys(text)).toBe(true);
   });
 });

--- a/src/lib/hermes-mcp-config.ts
+++ b/src/lib/hermes-mcp-config.ts
@@ -57,6 +57,21 @@
  * Backups: any mutation of an existing non-empty file writes a
  * `<config>.genie-backup-<timestamp>` copy of the original bytes first. Creating
  * a brand-new file is not a mutation and writes no backup.
+ *
+ * ## Duplicate-key repair (DF-1)
+ *
+ * An earlier buggy genie release could leave a second `genie:` child key under
+ * `mcp_servers:` — spec-invalid duplicate-key YAML that `Bun.YAML.parse`
+ * silently resolves last-wins, so it is invisible to a parse-only check and
+ * survives every future merge. `mergeMcpServersGenie` detects this textual
+ * duplicate BEFORE deciding `unchanged`/`updated`/`created` and repairs it when
+ * safe: exactly one `genie:` occurrence is the marker-wrapped managed region,
+ * and every other occurrence is either an empty `genie:` block or one whose
+ * parsed command/args/env are identical to the managed region's — those
+ * duplicates are dropped, leaving exactly one `genie` key. Any other duplicate
+ * shape (two non-empty, non-identical entries, or content genie cannot prove
+ * safe to drop) is refused with a typed `HermesConfigError` before any backup
+ * or write, so the original file survives byte-for-byte.
  */
 
 import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
@@ -146,19 +161,28 @@ export function mergeMcpServersGenie(opts: MergeMcpGenieOptions): MergeMcpGenieR
   if (opts.includeGenieHomeEnv) entry.env = { GENIE_HOME: genieHome };
 
   const exists = existsSync(opts.configPath);
-  const original = exists ? readFileSync(opts.configPath, 'utf8') : '';
-  const existingGenie = exists ? readGenieEntry(original) : undefined;
+  const diskOriginal = exists ? readFileSync(opts.configPath, 'utf8') : '';
 
-  if (existingGenie && entrySatisfies(existingGenie, entry)) {
+  // DF-1: repair a spec-invalid duplicate `genie:` child key BEFORE any other
+  // decision — see the module doc comment. Throws (fail-closed) when the
+  // duplicate shape cannot be proven safe to collapse.
+  const repaired = exists ? repairDuplicateMcpGenieEntries(diskOriginal) : diskOriginal;
+  const wasRepaired = repaired !== diskOriginal;
+
+  const existingGenie = exists ? readGenieEntry(repaired) : undefined;
+
+  // A repair always forces a write, since the duplicate key itself must be
+  // removed from disk even if the managed entry's content is unchanged.
+  if (!wasRepaired && existingGenie && entrySatisfies(existingGenie, entry)) {
     return { status: 'unchanged', path: opts.configPath, entry };
   }
 
   const status: 'created' | 'updated' = existingGenie ? 'updated' : 'created';
-  const nextText = spliceGenieEntry(original, entry);
+  const nextText = spliceGenieEntry(repaired, entry);
   assertMergedGenieEntryInvariant(nextText, entry);
 
   let backupPath: string | undefined;
-  if (exists && original.length > 0) {
+  if (exists && diskOriginal.length > 0) {
     backupPath = writeBackup(opts.configPath, now);
   }
   mkdirSync(dirname(opts.configPath), { recursive: true });
@@ -198,6 +222,130 @@ function entrySatisfies(existing: McpGenieEntry, desired: McpGenieEntry): boolea
     }
   }
   return true;
+}
+
+interface GenieChildOccurrence {
+  headerIndex: number;
+  bodyRange: { start: number; end: number };
+  /** True when immediately wrapped by MARKER_BEGIN above and MARKER_END below — the managed region. */
+  markerWrapped: boolean;
+}
+
+/**
+ * Every `genie:` child-key occurrence under an `mcp_servers:` block, in
+ * document order. Unlike `findChildRange` (which returns only the FIRST
+ * match), this is the duplicate-detection primitive: a spec-invalid config can
+ * carry more than one `genie` key, at most one of which is marker-wrapped.
+ */
+function findAllGenieChildOccurrences(
+  lines: string[],
+  start: number,
+  blockEnd: number,
+  childIndent: number,
+): GenieChildOccurrence[] {
+  const headerRe = new RegExp(`^ {${childIndent}}genie:\\s*(#.*)?$`);
+  const out: GenieChildOccurrence[] = [];
+  for (let i = start; i < blockEnd; i++) {
+    if (indentOf(lines[i]) !== childIndent || !headerRe.test(lines[i])) continue;
+    let end = i + 1;
+    while (end < blockEnd && (isBlank(lines[end]) || indentOf(lines[end]) > childIndent)) end++;
+    const before = lines[i - 1];
+    const after = lines[end];
+    const markerWrapped =
+      before !== undefined && before.trim() === MARKER_BEGIN && after !== undefined && after.trim() === MARKER_END;
+    out.push({ headerIndex: i, bodyRange: { start: i + 1, end }, markerWrapped });
+  }
+  return out;
+}
+
+/** Reconstruct and parse a single `genie:` occurrence's content, ignoring the rest of the document. */
+function parseGenieOccurrenceEntry(lines: string[], occ: GenieChildOccurrence): McpGenieEntry | undefined {
+  const snippet = ['mcp_servers:', lines[occ.headerIndex], ...lines.slice(occ.bodyRange.start, occ.bodyRange.end)].join(
+    '\n',
+  );
+  return readGenieEntry(`${snippet}\n`);
+}
+
+/** True when two entries carry the exact same command, args, and env — a stricter check than `entrySatisfies`. */
+function genieEntriesIdentical(a: McpGenieEntry | undefined, b: McpGenieEntry | undefined): boolean {
+  if (!a || !b) return false;
+  if (a.command !== b.command) return false;
+  if (!stringArraysEqual(a.args, b.args)) return false;
+  const aEnv = a.env ?? {};
+  const bEnv = b.env ?? {};
+  const aKeys = Object.keys(aEnv).sort();
+  const bKeys = Object.keys(bEnv).sort();
+  return aKeys.length === bKeys.length && aKeys.every((k, i) => k === bKeys[i] && aEnv[k] === bEnv[k]);
+}
+
+/**
+ * DF-1 repair: detect and collapse a spec-invalid duplicate `genie:` child key
+ * under `mcp_servers:` — see the module doc comment for the full contract.
+ * Returns `original` unchanged when there is nothing to repair (fewer than 2
+ * occurrences, or no `mcp_servers:` block at all — an inline top-level
+ * `mcp_servers:` is left for `assertNoInlineTopLevelKey` to refuse
+ * downstream). Throws a typed `HermesConfigError` for any duplicate shape that
+ * cannot be proven safe to collapse.
+ */
+function repairDuplicateMcpGenieEntries(original: string): string {
+  if (original.length === 0) return original;
+  const { lines, trailingNewline } = toLines(original);
+  const header = findTopLevelKeyLine(lines, 'mcp_servers');
+  if (header < 0) return original;
+
+  const blockEnd = blockEndIndex(lines, header);
+  const childIndent = childIndentOf(lines, header, blockEnd);
+  const occurrences = findAllGenieChildOccurrences(lines, header + 1, blockEnd, childIndent);
+  if (occurrences.length < 2) return original;
+
+  const managedList = occurrences.filter((o) => o.markerWrapped);
+  if (managedList.length !== 1) {
+    throw new HermesConfigError(
+      'duplicate-mcp-genie-unmarked',
+      `cannot repair: "mcp_servers.genie" appears ${occurrences.length} times and ${managedList.length} of them are the marker-wrapped managed region (expected exactly 1); resolve the duplicate manually`,
+    );
+  }
+  const managed = managedList[0];
+  const managedEntry = parseGenieOccurrenceEntry(lines, managed);
+  for (const occ of occurrences) {
+    if (occ === managed) continue;
+    const bodyEmpty = occ.bodyRange.start >= occ.bodyRange.end;
+    const occEntry = bodyEmpty ? undefined : parseGenieOccurrenceEntry(lines, occ);
+    const safe = bodyEmpty || genieEntriesIdentical(managedEntry, occEntry);
+    if (!safe) {
+      throw new HermesConfigError(
+        'duplicate-mcp-genie-conflict',
+        `cannot repair: a duplicate "genie" entry under "mcp_servers:" (line ${occ.headerIndex + 1}) has content genie cannot prove is safe to drop; resolve the duplicate manually`,
+      );
+    }
+  }
+
+  // Safe: drop every non-managed occurrence's header+body lines, keep the
+  // managed (marker-wrapped) region exactly as-is. Remove last-to-first so
+  // earlier indices survive.
+  const sorted = [...occurrences].sort((a, b) => b.headerIndex - a.headerIndex);
+  for (const occ of sorted) {
+    if (occ === managed) continue;
+    lines.splice(occ.headerIndex, occ.bodyRange.end - occ.headerIndex);
+  }
+  return fromLines(lines, trailingNewline);
+}
+
+/**
+ * Read-only textual duplicate-key detector for `genie doctor` — mirrors the
+ * repair machinery's occurrence scan but never repairs or throws. True when
+ * `mcp_servers.genie` appears more than once, even if the parsed document
+ * happens to look correct (last-wins hides the duplicate from any parse-only
+ * check).
+ */
+export function hasDuplicateMcpGenieKeys(text: string): boolean {
+  if (text.length === 0) return false;
+  const { lines } = toLines(text);
+  const header = findTopLevelKeyLine(lines, 'mcp_servers');
+  if (header < 0) return false;
+  const blockEnd = blockEndIndex(lines, header);
+  const childIndent = childIndentOf(lines, header, blockEnd);
+  return findAllGenieChildOccurrences(lines, header + 1, blockEnd, childIndent).length > 1;
 }
 
 /**

--- a/src/lib/hermes-skills-config.test.ts
+++ b/src/lib/hermes-skills-config.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { HermesConfigError } from './hermes-mcp-config.js';
 import {
   copyProductSkillsDigestManaged,
+  hasDuplicateSkillsExternalDirsKeys,
   mergeSkillsExternalDir,
   resolveProductSkillsRoot,
 } from './hermes-skills-config.js';
@@ -414,6 +415,209 @@ describe('mergeSkillsExternalDir', () => {
       expect(second.status).toBe('unchanged');
       expect(readFileSync(configPath, 'utf8')).toBe(afterFirst);
     });
+  });
+});
+
+describe('DF-1: duplicate skills.external_dirs key repair', () => {
+  test('the real damaged shape: inline empty + marked block duplicate → repairs to ONE managed entry, parseable, backup written', () => {
+    const root = tmp();
+    const skillsRoot = makeSkillsRoot(join(root, 'skills'));
+    const configPath = join(root, 'config.yaml');
+    // Exact damaged shape from an earlier buggy release: `skills:` carries BOTH
+    // an inline empty `external_dirs: []` and a later block-style `external_dirs`
+    // holding the genie-marked managed entry — spec-invalid duplicate-key YAML
+    // that last-wins parsing hides.
+    const original = `skills:\n  external_dirs: []\n  template_vars: true\n  external_dirs:\n    - ${JSON.stringify(skillsRoot)}  # genie:managed:skills.external_dirs\n`;
+    writeFileSync(configPath, original);
+    expect(hasDuplicateSkillsExternalDirsKeys(original)).toBe(true);
+
+    const result = mergeSkillsExternalDir({ configPath, skillsRoot, now: new Date('2026-07-13T00:00:00Z') });
+    expect(result.status).toBe('updated');
+    expect(result.backupPath).toBeDefined();
+    expect(readFileSync(result.backupPath as string, 'utf8')).toBe(original);
+
+    const text = readFileSync(configPath, 'utf8');
+    expect(text.match(/external_dirs:/g)?.length).toBe(1);
+    expect(text).toContain('  template_vars: true\n');
+    expect(hasDuplicateSkillsExternalDirsKeys(text)).toBe(false);
+
+    const parsed = Bun.YAML.parse(text) as { skills: { external_dirs: string[]; template_vars: boolean } };
+    expect(parsed.skills.external_dirs).toEqual([skillsRoot]);
+    expect(parsed.skills.template_vars).toBe(true);
+  });
+
+  test('repair is idempotent: a second merge on the repaired file is unchanged', () => {
+    const root = tmp();
+    const skillsRoot = makeSkillsRoot(join(root, 'skills'));
+    const configPath = join(root, 'config.yaml');
+    const original = `skills:\n  external_dirs: []\n  external_dirs:\n    - ${JSON.stringify(skillsRoot)}  # genie:managed:skills.external_dirs\n`;
+    writeFileSync(configPath, original);
+
+    const first = mergeSkillsExternalDir({ configPath, skillsRoot });
+    expect(first.status).toBe('updated');
+    const afterFirst = readFileSync(configPath, 'utf8');
+
+    const second = mergeSkillsExternalDir({ configPath, skillsRoot });
+    expect(second.status).toBe('unchanged');
+    expect(second.backupPath).toBeUndefined();
+    expect(readFileSync(configPath, 'utf8')).toBe(afterFirst);
+  });
+
+  test('a duplicate whose entries are a subset of the managed one also repairs safely', () => {
+    const root = tmp();
+    const skillsRoot = makeSkillsRoot(join(root, 'skills'));
+    const configPath = join(root, 'config.yaml');
+    // First (unmarked) duplicate's item duplicates the managed one's own value —
+    // a subset of the managed entry's items, so it is safe to drop.
+    const original = `skills:\n  external_dirs:\n    - ${JSON.stringify(skillsRoot)}\n  external_dirs:\n    - ${JSON.stringify(skillsRoot)}  # genie:managed:skills.external_dirs\n`;
+    writeFileSync(configPath, original);
+
+    const result = mergeSkillsExternalDir({ configPath, skillsRoot });
+    expect(result.status).toBe('updated');
+
+    const text = readFileSync(configPath, 'utf8');
+    expect(text.match(/external_dirs:/g)?.length).toBe(1);
+    const parsed = Bun.YAML.parse(text) as { skills: { external_dirs: string[] } };
+    expect(parsed.skills.external_dirs).toEqual([skillsRoot]);
+  });
+
+  test('two non-empty, non-managed duplicate lists → typed refusal, file and backup untouched', () => {
+    const root = tmp();
+    const skillsRoot = makeSkillsRoot(join(root, 'skills'));
+    const configPath = join(root, 'config.yaml');
+    // Neither occurrence is genie-marked — ambiguous which one (if either) is
+    // the "real" managed entry, so genie must refuse rather than guess.
+    const original = 'skills:\n  external_dirs:\n    - /home/a\n  external_dirs:\n    - /home/b\n';
+    writeFileSync(configPath, original);
+
+    expect(() => mergeSkillsExternalDir({ configPath, skillsRoot })).toThrow(HermesConfigError);
+    expect(readFileSync(configPath, 'utf8')).toBe(original);
+    expect(hasBackup(root)).toBe(false);
+  });
+
+  test('duplicate conflict carries the distinct conflict error code', () => {
+    const root = tmp();
+    const skillsRoot = makeSkillsRoot(join(root, 'skills'));
+    const configPath = join(root, 'config.yaml');
+    const original = `skills:\n  external_dirs:\n    - /home/not-a-subset\n  external_dirs:\n    - ${JSON.stringify(skillsRoot)}  # genie:managed:skills.external_dirs\n`;
+    writeFileSync(configPath, original);
+
+    try {
+      mergeSkillsExternalDir({ configPath, skillsRoot });
+      throw new Error('expected a HermesConfigError to be thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(HermesConfigError);
+      expect((err as HermesConfigError).code).toBe('duplicate-external-dirs-conflict');
+    }
+    expect(readFileSync(configPath, 'utf8')).toBe(original);
+    expect(hasBackup(root)).toBe(false);
+  });
+
+  test('two marker-carrying duplicates (ambiguous which is managed) → typed refusal with the unmarked-count code', () => {
+    const root = tmp();
+    const skillsRoot = makeSkillsRoot(join(root, 'skills'));
+    const configPath = join(root, 'config.yaml');
+    const original = `skills:\n  external_dirs:\n    - ${JSON.stringify(skillsRoot)}  # genie:managed:skills.external_dirs\n  external_dirs:\n    - /home/other  # genie:managed:skills.external_dirs\n`;
+    writeFileSync(configPath, original);
+
+    try {
+      mergeSkillsExternalDir({ configPath, skillsRoot });
+      throw new Error('expected a HermesConfigError to be thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(HermesConfigError);
+      expect((err as HermesConfigError).code).toBe('duplicate-external-dirs-unmarked');
+    }
+    expect(readFileSync(configPath, 'utf8')).toBe(original);
+    expect(hasBackup(root)).toBe(false);
+  });
+
+  test('refusal is idempotent: a repeated call still throws and never writes or backs up', () => {
+    const root = tmp();
+    const skillsRoot = makeSkillsRoot(join(root, 'skills'));
+    const configPath = join(root, 'config.yaml');
+    const original = 'skills:\n  external_dirs:\n    - /home/a\n  external_dirs:\n    - /home/b\n';
+    writeFileSync(configPath, original);
+
+    for (let i = 0; i < 2; i++) {
+      expect(() => mergeSkillsExternalDir({ configPath, skillsRoot })).toThrow(HermesConfigError);
+    }
+    expect(readFileSync(configPath, 'utf8')).toBe(original);
+    expect(hasBackup(root)).toBe(false);
+  });
+});
+
+describe('hasDuplicateSkillsExternalDirsKeys', () => {
+  test('false for no skills key, single key, and empty text', () => {
+    expect(hasDuplicateSkillsExternalDirsKeys('')).toBe(false);
+    expect(hasDuplicateSkillsExternalDirsKeys('other: 1\n')).toBe(false);
+    expect(hasDuplicateSkillsExternalDirsKeys('skills:\n  external_dirs:\n    - /home/a\n')).toBe(false);
+  });
+
+  test('true for a textual duplicate even when the parsed value looks correct (last-wins hides it)', () => {
+    const text = 'skills:\n  external_dirs: []\n  external_dirs:\n    - /home/a\n';
+    // Parsed last-wins value looks completely fine...
+    expect(Bun.YAML.parse(text)).toEqual({ skills: { external_dirs: ['/home/a'] } });
+    // ...but the textual duplicate is still there and must be flagged.
+    expect(hasDuplicateSkillsExternalDirsKeys(text)).toBe(true);
+  });
+});
+
+describe('stale-marker orphan avoidance', () => {
+  test('marked entry points at a previous root while the current root also appears unmarked → marker migrates, unmarked entry untouched', () => {
+    const root = tmp();
+    const oldRoot = makeSkillsRoot(join(root, 'old-skills'));
+    const newRoot = makeSkillsRoot(join(root, 'new-skills'));
+    const configPath = join(root, 'config.yaml');
+    // A hand-added, unmarked entry happens to equal the NEW root, while the
+    // genie marker is still stuck on the OLD root. The old "root present
+    // anywhere" check would call this unchanged forever, orphaning the marker.
+    const original = `skills:\n  external_dirs:\n    - ${JSON.stringify(newRoot)}\n    - ${JSON.stringify(oldRoot)}  # genie:managed:skills.external_dirs\n`;
+    writeFileSync(configPath, original);
+
+    const result = mergeSkillsExternalDir({ configPath, skillsRoot: newRoot, now: new Date('2026-07-13T00:00:00Z') });
+    expect(result.status).toBe('updated');
+    expect(result.backupPath).toBeDefined();
+    expect(readFileSync(result.backupPath as string, 'utf8')).toBe(original);
+
+    const text = readFileSync(configPath, 'utf8');
+    const parsed = Bun.YAML.parse(text) as { skills: { external_dirs: string[] } };
+    // Exactly one occurrence of the current root — the marker migrates onto it
+    // instead of leaving a stale marked old-root entry beside an orphaned
+    // duplicate. The redundant hand-added duplicate is absorbed into the single
+    // managed entry rather than accumulating a second identical item.
+    expect(parsed.skills.external_dirs).toEqual([newRoot]);
+    expect((text.match(/genie:managed:skills\.external_dirs/g) ?? []).length).toBe(1);
+    expect(text).not.toContain(oldRoot);
+  });
+
+  test('is idempotent: a second merge after the marker migration is unchanged', () => {
+    const root = tmp();
+    const oldRoot = makeSkillsRoot(join(root, 'old-skills'));
+    const newRoot = makeSkillsRoot(join(root, 'new-skills'));
+    const configPath = join(root, 'config.yaml');
+    const original = `skills:\n  external_dirs:\n    - ${JSON.stringify(newRoot)}\n    - ${JSON.stringify(oldRoot)}  # genie:managed:skills.external_dirs\n`;
+    writeFileSync(configPath, original);
+
+    const first = mergeSkillsExternalDir({ configPath, skillsRoot: newRoot });
+    expect(first.status).toBe('updated');
+    const afterFirst = readFileSync(configPath, 'utf8');
+
+    const second = mergeSkillsExternalDir({ configPath, skillsRoot: newRoot });
+    expect(second.status).toBe('unchanged');
+    expect(readFileSync(configPath, 'utf8')).toBe(afterFirst);
+  });
+
+  test('marked entry already equals the current root → unchanged, even with an unrelated unmarked sibling', () => {
+    const root = tmp();
+    const skillsRoot = makeSkillsRoot(join(root, 'skills'));
+    const configPath = join(root, 'config.yaml');
+    const original = `skills:\n  external_dirs:\n    - /home/user/my-skills\n    - ${JSON.stringify(skillsRoot)}  # genie:managed:skills.external_dirs\n`;
+    writeFileSync(configPath, original);
+
+    const result = mergeSkillsExternalDir({ configPath, skillsRoot });
+    expect(result.status).toBe('unchanged');
+    expect(result.backupPath).toBeUndefined();
+    expect(readFileSync(configPath, 'utf8')).toBe(original);
   });
 });
 

--- a/src/lib/hermes-skills-config.ts
+++ b/src/lib/hermes-skills-config.ts
@@ -50,6 +50,34 @@
  *     re-serializing user bytes, so it is refused with a typed
  *     `HermesConfigError('inline-nested-key')` before any backup or write.
  *
+ * ## Duplicate-key repair (DF-1)
+ *
+ * An earlier buggy genie release could append a second `external_dirs:` child
+ * key under `skills:` instead of merging into the existing one — spec-invalid
+ * duplicate-key YAML that `Bun.YAML.parse` silently resolves last-wins, so it
+ * is invisible to any check that only reads the parsed document and survives
+ * every future merge untouched. `mergeSkillsExternalDir` detects this textual
+ * duplicate BEFORE deciding `unchanged`/`updated`/`created` and repairs it when
+ * safe: exactly one occurrence carries the genie marker (the managed entry) and
+ * every other occurrence is either empty (`[]` / an empty block) or a subset of
+ * the managed entry's own items — those duplicates are collapsed away, leaving
+ * exactly one `external_dirs` key. Any other duplicate shape (two non-empty
+ * non-managed lists, or content genie cannot prove is safe to drop) is refused
+ * with a typed `HermesConfigError` before any backup or write, so the original
+ * file survives byte-for-byte — refusal is always acceptable, corruption never
+ * is.
+ *
+ * ## Stale-marker orphan avoidance
+ *
+ * The old "unchanged" check only asked whether the resolved root appeared
+ * *anywhere* in the parsed `external_dirs` list. That let a stale scenario slip
+ * through forever: the genie-marked entry still points at a previous root while
+ * the current root also appears as a separate, hand-added, unmarked entry — the
+ * marker never migrates, orphaning it. The check now asks specifically whether
+ * the *marked* entry (when one exists) already equals the resolved root; if not,
+ * the marked line is rewritten to the current root exactly like a normal root
+ * change, and any genuine user-added unmarked entry is left untouched.
+ *
  * ## Older-Hermes fallback
  *
  * `copyProductSkillsDigestManaged` stages the resolved skills tree into a
@@ -148,17 +176,31 @@ export function mergeSkillsExternalDir(opts: MergeSkillsExternalDirOptions): Mer
   const skillsRoot = resolveProductSkillsRoot(opts);
 
   const exists = existsSync(opts.configPath);
-  const original = exists ? readFileSync(opts.configPath, 'utf8') : '';
-  if (exists && listedExternalDirs(original).includes(skillsRoot)) {
+  const diskOriginal = exists ? readFileSync(opts.configPath, 'utf8') : '';
+
+  // DF-1: repair a spec-invalid duplicate `external_dirs` child key BEFORE any
+  // other decision — see the module doc comment. Throws (fail-closed) when the
+  // duplicate shape cannot be proven safe to collapse.
+  const repaired = exists ? repairDuplicateSkillsExternalDirs(diskOriginal) : diskOriginal;
+  const wasRepaired = repaired !== diskOriginal;
+
+  // "Already correct" now asks specifically about the *marked* entry (when one
+  // exists) rather than "root appears anywhere" — see the stale-marker-orphan
+  // doc comment above. A repair always forces a write, since the duplicate key
+  // itself must be removed from disk even if the managed value is unchanged.
+  const marked = exists ? markedExternalDirValue(repaired) : undefined;
+  const rootListed = exists ? listedExternalDirs(repaired).includes(skillsRoot) : false;
+  const alreadyCorrect = marked !== undefined ? marked === skillsRoot : rootListed;
+  if (exists && !wasRepaired && alreadyCorrect) {
     return { status: 'unchanged', path: opts.configPath, skillsRoot };
   }
 
-  const status: 'created' | 'updated' = exists && original.length > 0 ? 'updated' : 'created';
-  const nextText = spliceExternalDir(original, skillsRoot);
+  const status: 'created' | 'updated' = exists && diskOriginal.length > 0 ? 'updated' : 'created';
+  const nextText = spliceExternalDir(repaired, skillsRoot);
   assertMergedSkillsInvariant(nextText, skillsRoot);
 
   let backupPath: string | undefined;
-  if (exists && original.length > 0) {
+  if (exists && diskOriginal.length > 0) {
     backupPath = writeBackup(opts.configPath, now);
   }
   mkdirSync(dirname(opts.configPath), { recursive: true });
@@ -200,6 +242,176 @@ function listedExternalDirs(text: string): string[] {
   if (!isRecord(parsed) || !isRecord(parsed.skills)) return [];
   const dirs = parsed.skills.external_dirs;
   return Array.isArray(dirs) ? dirs.filter((d): d is string => typeof d === 'string') : [];
+}
+
+/**
+ * The value carried by the genie-marked `external_dirs` list item, or
+ * `undefined` when no marker is present anywhere in the text. Scans raw lines
+ * rather than the parsed document: the parsed value alone cannot distinguish
+ * "the marked item already equals the resolved root" from "the root merely
+ * appears somewhere else in the list" — exactly the distinction the
+ * stale-marker-orphan fix depends on.
+ */
+function markedExternalDirValue(text: string): string | undefined {
+  const markerRe = new RegExp(`^\\s*-\\s+(.*?)\\s+${escapeRegExp(MARKER)}\\s*$`);
+  for (const line of text.split('\n')) {
+    const match = line.match(markerRe);
+    if (!match) continue;
+    try {
+      const parsed = Bun.YAML.parse(match[1]);
+      if (typeof parsed === 'string') return parsed;
+    } catch {
+      /* fall through to the raw token below */
+    }
+    return match[1].trim();
+  }
+  return undefined;
+}
+
+interface ExternalDirsOccurrence {
+  headerIndex: number;
+  kind: 'block' | 'inline';
+  /** Item line range for a block occurrence; absent for an inline occurrence. */
+  itemsRange?: { start: number; end: number };
+  /** True only for an inline empty flow list (`external_dirs: []`). */
+  isEmptyInline: boolean;
+}
+
+/**
+ * Every `external_dirs` child-key occurrence under a `skills:` block, block or
+ * inline, in document order. Unlike `findChildKeyLine`/`findInlineChildKeyLine`
+ * (which each return only the FIRST match of their own kind), this is the
+ * duplicate-detection primitive: a spec-invalid config can carry more than one
+ * `external_dirs` key, mixing block and inline shapes.
+ */
+function findAllExternalDirsOccurrences(
+  lines: string[],
+  start: number,
+  blockEnd: number,
+  childIndent: number,
+): ExternalDirsOccurrence[] {
+  const blockRe = new RegExp(`^ {${childIndent}}external_dirs:\\s*(#.*)?$`);
+  const inlinePrefix = new RegExp(`^ {${childIndent}}external_dirs:(?:\\s|$)`);
+  const emptyRe = new RegExp(`^ {${childIndent}}external_dirs:\\s+\\[\\s*\\]\\s*(#.*)?$`);
+  const out: ExternalDirsOccurrence[] = [];
+  for (let i = start; i < blockEnd; i++) {
+    if (indentOf(lines[i]) !== childIndent) continue;
+    if (blockRe.test(lines[i])) {
+      const end = blockEndIndexFrom(lines, i, blockEnd, childIndent);
+      out.push({ headerIndex: i, kind: 'block', itemsRange: { start: i + 1, end }, isEmptyInline: false });
+    } else if (inlinePrefix.test(lines[i])) {
+      out.push({ headerIndex: i, kind: 'inline', isEmptyInline: emptyRe.test(lines[i]) });
+    }
+  }
+  return out;
+}
+
+/** Parsed list-item values of an occurrence, plus whether any item carries the genie marker. */
+function occurrenceItems(lines: string[], occ: ExternalDirsOccurrence): { items: string[]; hasMarker: boolean } {
+  if (occ.kind === 'inline') {
+    // An empty inline list has no items; a non-empty inline list cannot be
+    // safely compared without re-serializing user bytes, so it is treated as an
+    // opaque, never-subset-safe blob (a sentinel that matches nothing).
+    return occ.isEmptyInline ? { items: [], hasMarker: false } : { items: ['<inline-non-empty>'], hasMarker: false };
+  }
+  const items: string[] = [];
+  let hasMarker = false;
+  const range = occ.itemsRange;
+  if (!range) return { items, hasMarker };
+  for (let i = range.start; i < range.end; i++) {
+    const line = lines[i];
+    if (isSkippable(line)) continue;
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('-')) continue;
+    const withMarker = line.includes(MARKER);
+    const valuePart = trimmed
+      .replace(/^-\s*/, '')
+      .replace(new RegExp(`\\s*${escapeRegExp(MARKER)}\\s*$`), '')
+      .trim();
+    let value: string;
+    try {
+      const parsed = Bun.YAML.parse(valuePart);
+      value = typeof parsed === 'string' ? parsed : valuePart;
+    } catch {
+      value = valuePart;
+    }
+    items.push(value);
+    if (withMarker) hasMarker = true;
+  }
+  return { items, hasMarker };
+}
+
+/**
+ * DF-1 repair: detect and collapse a spec-invalid duplicate `external_dirs`
+ * child key under `skills:` — see the module doc comment for the full
+ * contract. Returns `original` unchanged when there is nothing to repair
+ * (fewer than 2 occurrences, or no `skills:` block at all — an inline
+ * top-level `skills:` is left for `assertNoInlineTopLevelKey` to refuse
+ * downstream). Throws a typed `HermesConfigError` for any duplicate shape that
+ * cannot be proven safe to collapse.
+ */
+function repairDuplicateSkillsExternalDirs(original: string): string {
+  if (original.length === 0) return original;
+  const { lines, trailingNewline } = toLines(original);
+  const skillsHeader = findTopLevelKeyLine(lines, 'skills');
+  if (skillsHeader < 0) return original;
+
+  const skillsEnd = blockEndIndex(lines, skillsHeader);
+  const childIndent = childIndentOf(lines, skillsHeader, skillsEnd);
+  const occurrences = findAllExternalDirsOccurrences(lines, skillsHeader + 1, skillsEnd, childIndent);
+  if (occurrences.length < 2) return original;
+
+  const classified = occurrences.map((occ) => ({ occ, ...occurrenceItems(lines, occ) }));
+  const marked = classified.filter((c) => c.hasMarker);
+  if (marked.length !== 1) {
+    throw new HermesConfigError(
+      'duplicate-external-dirs-unmarked',
+      `cannot repair: "skills.external_dirs" appears ${occurrences.length} times under "skills:" and ${marked.length} of them carry the genie marker (expected exactly 1); resolve the duplicate manually`,
+    );
+  }
+  const managed = marked[0];
+  const managedItemSet = new Set(managed.items);
+  for (const other of classified) {
+    if (other === managed) continue;
+    const safe = other.items.length === 0 || other.items.every((item) => managedItemSet.has(item));
+    if (!safe) {
+      throw new HermesConfigError(
+        'duplicate-external-dirs-conflict',
+        `cannot repair: a duplicate "external_dirs" under "skills:" (line ${other.occ.headerIndex + 1}) has entries genie cannot prove are safe to drop; resolve the duplicate manually`,
+      );
+    }
+  }
+
+  // Safe: drop every non-managed occurrence's lines entirely, keeping the
+  // managed one exactly as-is. Remove last-to-first so earlier indices survive.
+  const sorted = [...occurrences].sort((a, b) => b.headerIndex - a.headerIndex);
+  for (const occ of sorted) {
+    if (occ === managed.occ) continue;
+    const delEnd = occ.kind === 'block' ? (occ.itemsRange?.end ?? occ.headerIndex + 1) : occ.headerIndex + 1;
+    lines.splice(occ.headerIndex, delEnd - occ.headerIndex);
+  }
+  return fromLines(lines, trailingNewline);
+}
+
+/**
+ * Read-only textual duplicate-key detector for `genie doctor` — mirrors the
+ * repair machinery's occurrence scan but never repairs or throws. True when
+ * `skills.external_dirs` appears more than once under `skills:`, even if the
+ * parsed document happens to look correct (last-wins hides the duplicate from
+ * any parse-only check).
+ */
+export function hasDuplicateSkillsExternalDirsKeys(text: string): boolean {
+  if (text.length === 0) return false;
+  const { lines } = toLines(text);
+  const header = findTopLevelKeyLine(lines, 'skills');
+  if (header < 0) return false;
+  const blockEnd = blockEndIndex(lines, header);
+  const childIndent = childIndentOf(lines, header, blockEnd);
+  return findAllExternalDirsOccurrences(lines, header + 1, blockEnd, childIndent).length > 1;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 /**
@@ -277,11 +489,52 @@ function spliceExternalDir(original: string, skillsRoot: string): string {
   const itemIndent = listItemIndentOf(lines, extHeader + 1, listEnd, childIndent);
   const managed = findMarkedItem(lines, extHeader + 1, listEnd);
   if (managed >= 0) {
-    lines.splice(managed, 1, managedItem(itemIndent));
+    // Stale-marker orphan avoidance: if the resolved root ALREADY appears as a
+    // separate, unmarked item (e.g. hand-added by a user, or left behind by an
+    // older root), drop that redundant duplicate value first. Replacing only the
+    // marked line while leaving the duplicate in place would produce two items
+    // with the same value — violating the "exactly one occurrence" invariant
+    // enforced below — and leaving the marker on its stale old-root value would
+    // orphan it forever instead of migrating to the current root.
+    const duplicate = findPlainItemWithValue(lines, extHeader + 1, listEnd, skillsRoot, managed);
+    if (duplicate >= 0) {
+      lines.splice(duplicate, 1);
+      const adjusted = duplicate < managed ? managed - 1 : managed;
+      lines.splice(adjusted, 1, managedItem(itemIndent));
+    } else {
+      lines.splice(managed, 1, managedItem(itemIndent));
+    }
   } else {
     lines.splice(listEnd, 0, managedItem(itemIndent));
   }
   return fromLines(lines, trailingNewline);
+}
+
+/** Scalar value of a block list item line, stripping the leading `- ` and any trailing marker comment. */
+function parseListItemValue(line: string): string {
+  const withoutDash = line.trim().replace(/^-\s*/, '');
+  const withoutMarker = withoutDash.replace(new RegExp(`\\s*${escapeRegExp(MARKER)}\\s*$`), '').trim();
+  try {
+    const parsed = Bun.YAML.parse(withoutMarker);
+    return typeof parsed === 'string' ? parsed : withoutMarker;
+  } catch {
+    return withoutMarker;
+  }
+}
+
+/** Index of a block list item (other than `excludeIndex`) whose value equals `value`, or -1. */
+function findPlainItemWithValue(
+  lines: string[],
+  start: number,
+  end: number,
+  value: string,
+  excludeIndex: number,
+): number {
+  for (let i = start; i < end; i++) {
+    if (i === excludeIndex || isBlank(lines[i]) || !lines[i].trim().startsWith('-')) continue;
+    if (parseListItemValue(lines[i]) === value) return i;
+  }
+  return -1;
 }
 
 // --- digest helpers ---


### PR DESCRIPTION
## Problem

An earlier buggy genie release could append a second `external_dirs:` child key under `skills:` (or a second `genie:` child key under `mcp_servers:`) instead of merging into the existing one, producing spec-invalid duplicate-key YAML:

```yaml
skills:
  external_dirs: []
  ...
  external_dirs:
    - "/path/to/skills" # genie:managed:skills.external_dirs
```

`Bun.YAML.parse` (like PyYAML) resolves duplicate mapping keys last-wins, so the parsed document looked perfectly healthy — the duplicate was invisible to `mergeSkillsExternalDir`'s `unchanged` short-circuit, which only checked "does the resolved root appear *somewhere* in the parsed `external_dirs` list?" That let the spec-invalid duplicate persist forever across every future `genie update`.

A related bug: when the genie-marked entry pointed at a *previous* resolved root while the *current* root also happened to appear as a separate hand-added unmarked entry, the same coarse "root appears anywhere" check reported `unchanged`, permanently orphaning the marker on the stale value.

## Fix

1. **DF-1 duplicate-key repair** (`src/lib/hermes-skills-config.ts`, `src/lib/hermes-mcp-config.ts`): both merge functions now textually detect multiple child-key occurrences under `skills:`/`mcp_servers:` *before* deciding `unchanged`/`updated`/`created`, reusing the existing line-level indentation/comment-skip machinery. Repair collapses the duplicates when safe:
   - **Skills**: exactly one occurrence carries the genie marker, and every other occurrence is empty (`[]`/empty block) or a subset of the managed entry's own items.
   - **MCP**: exactly one occurrence is the marker-wrapped managed region, and every other occurrence is empty or has content identical (same command/args/env) to the managed region.

   Any other duplicate shape (two non-empty, non-managed/non-identical entries, or content genie cannot prove safe to drop) is refused with a typed `HermesConfigError` — fail-closed, before any backup or write, so the original file survives byte-for-byte. The existing `assertMergedSkillsInvariant`/`assertMergedGenieEntryInvariant` fail-closed backstops and the comment-skip fix from #2574 are reused as-is.

2. **Stale-marker orphan avoidance** (skills only, per the wish scope): when the marked entry points at a previous root while the current root also appears as a hand-added unmarked entry, the marker now migrates onto the current root instead of being silently orphaned. To keep the existing "exactly one occurrence of the resolved root" invariant intact, the now-redundant duplicate value is absorbed into the single managed entry (the marker moves, the file ends up with one correct entry) rather than producing two identical values. Genuine user-added entries with *different* values are left completely untouched.

3. **`genie doctor` detection** (`src/genie-commands/doctor.ts`): the `agent sync: hermes mcp` and `agent sync: hermes skills` legs now WARN when a textual duplicate child key is detected — even when the parsed (last-wins) value looks perfectly healthy — naming the config path and suggesting `genie update` (which now repairs it). After repair, the legs report `pass` again.

## Test evidence

```
$ bun test src/lib/hermes-skills-config.test.ts src/lib/hermes-mcp-config.test.ts src/genie-commands/doctor.test.ts
 127 pass
 0 fail
 435 expect() calls
```

New coverage:
- The exact damaged shape from the bug report repairs to one managed entry, output parses, backup is written with the original bytes.
- Idempotent re-run after repair reports `unchanged`.
- Subset/empty duplicates repair safely; conflicting/ambiguous duplicates refuse with distinct typed error codes (`duplicate-external-dirs-unmarked`, `duplicate-external-dirs-conflict`, `duplicate-mcp-genie-unmarked`, `duplicate-mcp-genie-conflict`), and refusal never writes or backs up (including on repeated calls).
- Stale-marker orphan rewrite: marker migrates onto the current root, unrelated unmarked entries survive untouched, idempotent on re-run.
- `hasDuplicateSkillsExternalDirsKeys`/`hasDuplicateMcpGenieKeys` unit coverage, including the "parsed value looks correct but a textual duplicate exists" case.
- `genie doctor` warns on textual duplicates (naming the config path, suggesting `genie update`) and passes again after repair.

### Gates

```
$ bun run check:fast   # green
$ bun run check        # 2 failures, both pre-existing/env-dependent (hooks/codex-manifest.test.ts — subprocess dispatch,
                        # unrelated to this change; confirmed via `git status` that no touched file overlaps)
```

Refusal shapes chosen (typed `HermesConfigError` codes, fail-closed before any backup/write):
- `duplicate-external-dirs-unmarked` — not exactly one genie-marked `external_dirs` occurrence (0 or ≥2 marked)
- `duplicate-external-dirs-conflict` — a non-managed duplicate has entries that aren't empty/subset of the managed entry
- `duplicate-mcp-genie-unmarked` — not exactly one marker-wrapped `genie:` occurrence
- `duplicate-mcp-genie-conflict` — a non-managed duplicate has non-empty content that isn't identical to the managed region

Not merged to `main` — this PR targets `dev` per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)