### PR TITLE
fix(codex): stop doctor mislabeling unrecognized fallback markers as retirable

### DIFF
--- a/src/genie-commands/doctor.test.ts
+++ b/src/genie-commands/doctor.test.ts
@@ -699,7 +699,14 @@ describe('checkAgentSync', () => {
     writeFileSync(join(pluginRoot, 'skills', name, 'SKILL.md'), body, 'utf8');
   }
 
-  /** Copy a source skill into a target parent + stamp a manifest (current unless a digest is forced). */
+  /**
+   * Copy a source skill into a target parent + stamp a manifest (current unless
+   * a digest is forced). Stamps `identityVersion: 2`, matching what the real
+   * `buildManifest` always writes — the Codex-fallback ownership gate
+   * (`strictFallbackMarker`) requires that exact tag, so an untagged manifest
+   * would misrepresent a byte-identical, freshly-synced managed dir as
+   * unrecognized instead of clean.
+   */
   function seedManaged(sourceDir: string, destDir: string, digest?: string): void {
     cpSync(sourceDir, destDir, { recursive: true });
     writeFileSync(
@@ -709,6 +716,7 @@ describe('checkAgentSync', () => {
         version: '1',
         digest: digest ?? computeDirDigest(sourceDir),
         syncedAt: '2026-01-01T00:00:00.000Z',
+        identityVersion: 2,
       }),
       'utf8',
     );
@@ -878,7 +886,7 @@ describe('checkAgentSync', () => {
     expect(collision?.suggestion).not.toContain('retire');
   });
 
-  test('codex retirement quarantine with retained evidence → R8 manual-recovery line', () => {
+  test('codex retirement quarantine with retained evidence → R8 manual-recovery line naming the actual evidence path', () => {
     mkdirSync(codexDir, { recursive: true });
     const txn = join(agentsSkillsDir, '.genie-codex-fallback-retirement', 'txn-abc');
     mkdirSync(join(txn, 'quarantine'), { recursive: true });
@@ -891,7 +899,60 @@ describe('checkAgentSync', () => {
     const evidence = find(results, 'agent sync: codex quarantine evidence');
     expect(evidence?.status).toBe('warn');
     expect(evidence?.detail).toContain('retained changed-tree evidence');
+    expect(evidence?.detail).toContain('txn-abc');
+    // Item 3(b): naming the transaction id alone leaves the user to guess where
+    // the archived copy actually lives — the message must carry the real path.
+    expect(evidence?.detail).toContain(join(txn, 'evidence'));
     expect(evidence?.suggestion).toContain('reconcile it manually');
+  });
+
+  test('codex well-formed but unrecognized fallback → distinct "review manually" warn, main line stays plugin-only, never advises `genie update`', () => {
+    // identityVersion:2, digest self-consistent with its own manifest — but the
+    // content is NOT the installed plugin's payload and not in the frozen
+    // historical allowlist, so `planCodexFallbackRetirement` would refuse it
+    // ('ambiguous-ownership'). This is the PR #2575 no-op-loop bug: doctor must
+    // never call this "clean" or tell the user `genie update` fixes it.
+    mkdirSync(codexDir, { recursive: true });
+    const dir = join(agentsSkillsDir, 'orphaned-content');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'SKILL.md'), '# not the installed plugin payload\n', 'utf8');
+    writeFileSync(
+      join(dir, '.genie-sync.json'),
+      JSON.stringify({
+        managedBy: 'genie-agent-sync',
+        version: '1',
+        digest: computeDirDigest(dir),
+        syncedAt: '2026-01-01T00:00:00.000Z',
+        identityVersion: 2,
+      }),
+      'utf8',
+    );
+
+    const results = checkAgentSync(paths());
+    const codex = find(results, 'agent sync: codex');
+    expect(codex?.status).toBe('pass'); // no RECOGNIZED clean fallback → main line stays plugin-only
+    expect(codex?.detail).toContain('plugin-only');
+    const unrecognized = find(results, 'agent sync: codex unrecognized');
+    expect(unrecognized?.status).toBe('warn');
+    expect(unrecognized?.detail).toContain('unrecognized managed fallback');
+    expect(unrecognized?.detail).toContain('review manually');
+    expect(unrecognized?.detail).toContain('orphaned-content');
+    // The whole point: this warning must never send the user down the same
+    // no-op loop `genie update` already refuses to close.
+    expect(unrecognized?.suggestion).not.toContain('Run `genie update` to retire');
+  });
+
+  test('codex ~/.agents/skills exists but is unreadable → warn, never a false-healthy plugin-only pass', () => {
+    mkdirSync(codexDir, { recursive: true });
+    // A regular file at the fallback-tier path makes readdirSync fail ENOTDIR —
+    // portable across CI/root vs non-root, unlike permission-bit simulation.
+    mkdirSync(dirname(agentsSkillsDir), { recursive: true });
+    writeFileSync(agentsSkillsDir, '', 'utf8');
+
+    const codex = find(checkAgentSync(paths()), 'agent sync: codex');
+    expect(codex?.status).toBe('warn');
+    expect(codex?.detail).toContain(agentsSkillsDir);
+    expect(codex?.suggestion).toContain('permissions');
   });
 
   test('codex quarantine root is never counted as a managed fallback', () => {

--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -818,13 +818,27 @@ function checkClaudeSync(pluginRoot: string, claudeDir: string): CheckResult[] {
  * healthy plugin-only state, and any managed-clean fallback there is repairable
  * duplicate provider state, not health. Doctor reports the shared classifier's
  * counts (A9: pure read, never launches the plugin MCP) with DISTINCT
- * remediations — a clean fallback is repairable via `genie update`, a preserved
- * personal collision is manual — and surfaces retained changed-evidence as a
- * manual-recovery line (R8) rather than a raw recovery-sweep error.
+ * remediations — a clean fallback is repairable via `genie update`, a
+ * well-formed-but-unrecognized fallback is manual review (never `genie update`
+ * — the planner refuses it too, so recommending update would be an infinite
+ * no-op loop), and a preserved personal collision is manual — and surfaces
+ * retained changed-evidence as a manual-recovery line (R8) rather than a raw
+ * recovery-sweep error.
  */
-function checkCodexSync(codexDir: string, agentsSkillsDir: string): CheckResult[] {
+function checkCodexSync(codexDir: string, agentsSkillsDir: string, pluginRoot: string | null): CheckResult[] {
   if (!existsSync(codexDir)) return [{ name: 'agent sync: codex', status: 'pass', detail: 'not detected' }];
-  const tier = inspectCodexFallbackTier(agentsSkillsDir);
+  const tier = inspectCodexFallbackTier(agentsSkillsDir, pluginRoot);
+  if (tier.unreadable) {
+    return [
+      {
+        name: 'agent sync: codex',
+        status: 'warn',
+        detail: `~/.agents/skills (${agentsSkillsDir}) exists but could not be listed — fallback state is unknown`,
+        suggestion:
+          'Check read permissions on ~/.agents/skills; genie cannot classify Codex fallback state until it is readable.',
+      },
+    ];
+  }
   const quarantineNote =
     tier.quarantinedTransactions > 0
       ? `; ${tier.quarantinedTransactions} retired quarantine transaction(s) retained`
@@ -844,6 +858,21 @@ function checkCodexSync(codexDir: string, agentsSkillsDir: string): CheckResult[
       suggestion: 'Run `genie update` to retire these clean fallbacks; the installed plugin already provides them.',
     });
   }
+  if (tier.unrecognizedFallbacks.length > 0) {
+    // #2575 vocabulary: well-formed, self-consistent, genie-managed content the
+    // planner does not recognize (not in the frozen allowlist, no matching
+    // live-plugin payload, or missing the exact identityVersion:2 tag — this is
+    // also where a pre-identityVersion era-A fallback lands). Never user-edited,
+    // so it is NOT a personal collision — but `genie update` refuses to retire
+    // it, so recommending that here would be a no-op loop.
+    results.push({
+      name: 'agent sync: codex unrecognized',
+      status: 'warn',
+      detail: `${tier.unrecognizedFallbacks.length} unrecognized managed fallback(s) in ~/.agents/skills (review manually): ${tier.unrecognizedFallbacks.join(', ')}`,
+      suggestion:
+        '`genie update` will NOT retire these — the content is well-formed genie provenance but not in the frozen allowlist and does not match the installed plugin payload. Review each manually; do not expect `genie update` to clear this warning.',
+    });
+  }
   if (tier.preservedCollisions.length > 0) {
     // Decision 5: report each collision's name + classification + effective precedence + remediation.
     const classified = tier.preservedCollisions
@@ -858,10 +887,13 @@ function checkCodexSync(codexDir: string, agentsSkillsDir: string): CheckResult[
     });
   }
   if (tier.retainedEvidence.length > 0) {
+    const evidenceList = tier.retainedEvidence
+      .map((entry) => `${entry.transactionId} (${entry.evidencePath})`)
+      .join(', ');
     results.push({
       name: 'agent sync: codex quarantine evidence',
       status: 'warn',
-      detail: `${tier.retainedEvidence.length} retirement transaction(s) retained changed-tree evidence (${tier.retainedEvidence.join(', ')})`,
+      detail: `${tier.retainedEvidence.length} retirement transaction(s) retained changed-tree evidence: ${evidenceList}`,
       suggestion:
         'A Codex fallback changed during retirement; the changed copy was archived aside under the quarantine evidence directory. Review the retained evidence and reconcile it manually.',
     });
@@ -1178,7 +1210,7 @@ export function checkAgentSync(paths: AgentSyncPaths = {}): CheckResult[] {
   const hermesBinary = paths.hermesBinary !== undefined ? paths.hermesBinary : whichBinary('hermes');
   return [
     ...safeAgentChecks('claude', () => checkClaudeSync(pluginRoot, claudeDir)),
-    ...safeAgentChecks('codex', () => checkCodexSync(codexDir, agentsSkillsDir)),
+    ...safeAgentChecks('codex', () => checkCodexSync(codexDir, agentsSkillsDir, pluginRoot)),
     ...safeAgentChecks('hermes', () =>
       checkHermesSync({
         hermesRoot: source.hermesRoot,

--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -859,12 +859,13 @@ function checkCodexSync(codexDir: string, agentsSkillsDir: string, pluginRoot: s
     });
   }
   if (tier.unrecognizedFallbacks.length > 0) {
-    // #2575 vocabulary: well-formed, self-consistent, genie-managed content the
-    // planner does not recognize (not in the frozen allowlist, no matching
-    // live-plugin payload, or missing the exact identityVersion:2 tag — this is
-    // also where a pre-identityVersion era-A fallback lands). Never user-edited,
-    // so it is NOT a personal collision — but `genie update` refuses to retire
-    // it, so recommending that here would be a no-op loop.
+    // #2575 vocabulary: well-formed identityVersion:2, self-consistent,
+    // genie-managed content the planner does not recognize (not in the frozen
+    // allowlist and no matching live-plugin payload). Era-A fallbacks (v1
+    // legacy digest, no identityVersion) do NOT land here — their marker fails
+    // the v2 self-consistency check, so they surface as preservedCollisions.
+    // Never user-edited, so NOT a personal collision — but `genie update`
+    // refuses to retire it, so recommending that here would be a no-op loop.
     results.push({
       name: 'agent sync: codex unrecognized',
       status: 'warn',

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -1074,7 +1074,28 @@ function historicalTupleKey(tuple: Pick<CodexFallbackHistoricalTuple, 'skillName
   return `${tuple.skillName}\0${tuple.physicalDigest}`;
 }
 
-function classifyCodexFallback(
+/**
+ * Load the frozen historical-tuple allowlist as an ownership-key set. Exported
+ * so read-only callers (doctor's tier inspection) apply the SAME acceptance
+ * policy as {@link planCodexFallbackRetirement} instead of re-deriving their
+ * own notion of "recognized" — the fixture loading and key derivation live in
+ * exactly one place.
+ */
+export function loadHistoricalCodexFallbackTupleKeys(): ReadonlySet<string> {
+  const tuples = historicalCodexFallbackAllowlist as CodexFallbackHistoricalTuple[];
+  return new Set(tuples.map(historicalTupleKey));
+}
+
+/**
+ * Classify a single `~/.agents/skills/<name>` dir's Codex-fallback ownership.
+ * Exported so doctor's read-only tier inspection can split a structurally
+ * `managed-clean` tree into "recognized, retirable by `genie update`" vs
+ * "well-formed but unrecognized, needs manual review" using the identical
+ * marker/digest/allowlist gate {@link planCodexFallbackRetirement} uses to
+ * decide what it will actually retire — so doctor never promises a retirement
+ * the engine then refuses.
+ */
+export function classifyCodexFallback(
   path: string,
   skillName: string,
   target: VerifiedCodexSkillPayload | null | undefined,
@@ -1138,8 +1159,7 @@ export function planCodexFallbackRetirement(options: PlanCodexFallbackRetirement
     throw new Error('fallback retirement skill names must be unique safe path entries');
   }
   const targets = verifiedTargetByName(options.verifiedTargets ?? []);
-  const tuples = historicalCodexFallbackAllowlist as CodexFallbackHistoricalTuple[];
-  const historical = new Set(tuples.map(historicalTupleKey));
+  const historical = loadHistoricalCodexFallbackTupleKeys();
   const classified = names.map((skillName) =>
     classifyCodexFallback(join(fallbackSkillsDir, skillName), skillName, targets.get(skillName), historical),
   );

--- a/src/lib/runtime-integrations.test.ts
+++ b/src/lib/runtime-integrations.test.ts
@@ -2667,7 +2667,9 @@ describe('translateRetirementConflicts surfaces R8 conflict classes as manual-re
 describe('inspectCodexFallbackTier (shared doctor/uninstall classifier — read-only)', () => {
   let tmp: string;
   let agentsSkillsDir: string;
+  let pluginRoot: string;
 
+  /** Real `buildManifest` always stamps `identityVersion: 2` — fixtures match that. */
   function seedManaged(name: string, mutate?: (dir: string) => void): string {
     const dir = join(agentsSkillsDir, name);
     mkdirSync(dir, { recursive: true });
@@ -2675,16 +2677,25 @@ describe('inspectCodexFallbackTier (shared doctor/uninstall classifier — read-
     const digest = computeDirDigest(dir);
     writeFileSync(
       join(dir, '.genie-sync.json'),
-      JSON.stringify({ managedBy: 'genie-agent-sync', version: '1', digest, syncedAt: 'now' }),
+      JSON.stringify({ managedBy: 'genie-agent-sync', version: '1', digest, syncedAt: 'now', identityVersion: 2 }),
       'utf8',
     );
     mutate?.(dir);
     return dir;
   }
 
+  /** Mirror a fallback dir's content into `<pluginRoot>/skills/<name>` so it verifies as a live-plugin target. */
+  function mirrorToPlugin(name: string): void {
+    const source = join(agentsSkillsDir, name, 'SKILL.md');
+    const dest = join(pluginRoot, 'skills', name);
+    mkdirSync(dest, { recursive: true });
+    writeFileSync(join(dest, 'SKILL.md'), readFileSync(source, 'utf8'), 'utf8');
+  }
+
   beforeEach(() => {
     tmp = mkdtempSync(join(tmpdir(), 'fallback-tier-'));
     agentsSkillsDir = join(tmp, 'agents', 'skills');
+    pluginRoot = join(tmp, 'plugin');
     mkdirSync(agentsSkillsDir, { recursive: true });
   });
 
@@ -2696,16 +2707,31 @@ describe('inspectCodexFallbackTier (shared doctor/uninstall classifier — read-
     const report = inspectCodexFallbackTier(join(tmp, 'nonexistent'));
     expect(report).toEqual({
       cleanFallbacks: [],
+      unrecognizedFallbacks: [],
       preservedCollisions: [],
       preservedCollisionClass: {},
       quarantinedTransactions: 0,
       retainedEvidence: [],
+      unreadable: false,
     });
+  });
+
+  test('unreadable tier (exists but cannot be listed) → warns instead of passing as healthy plugin-only', () => {
+    // A regular file at the fallback-tier path makes readdirSync fail ENOTDIR —
+    // portable across CI/root vs non-root, unlike permission-bit simulation.
+    const blocked = join(tmp, 'blocked-tier');
+    writeFileSync(blocked, '', 'utf8');
+    const report = inspectCodexFallbackTier(blocked);
+    expect(report.unreadable).toBe(true);
+    expect(report.cleanFallbacks).toEqual([]);
+    expect(report.unrecognizedFallbacks).toEqual([]);
   });
 
   test('classifies clean fallbacks, personal collisions, and unmanaged skills distinctly', () => {
     seedManaged('wish');
     seedManaged('work');
+    mirrorToPlugin('wish');
+    mirrorToPlugin('work');
     // Personal edit after sync → managed-modified.
     seedManaged('review', (dir) => writeFileSync(join(dir, 'SKILL.md'), '# personal\n', 'utf8'));
     // Corrupt marker → corrupt-metadata (malformed-marker).
@@ -2715,15 +2741,66 @@ describe('inspectCodexFallbackTier (shared doctor/uninstall classifier — read-
     mkdirSync(mine, { recursive: true });
     writeFileSync(join(mine, 'SKILL.md'), '# mine\n', 'utf8');
 
-    const report = inspectCodexFallbackTier(agentsSkillsDir);
+    const report = inspectCodexFallbackTier(agentsSkillsDir, pluginRoot);
     expect(report.cleanFallbacks).toEqual(['wish', 'work']);
+    expect(report.unrecognizedFallbacks).toEqual([]);
     expect(report.preservedCollisions).toEqual(['review', 'trace']);
     // Decision 5: each preserved collision carries its classification for doctor.
     expect(report.preservedCollisionClass).toEqual({ review: 'modified-managed', trace: 'malformed-marker' });
     expect(report.quarantinedTransactions).toBe(0);
   });
 
-  test('counts committed quarantine transactions and flags retained changed-evidence (R8) without recursing into them', () => {
+  test('a structurally clean, self-consistent tree the planner does not recognize is unrecognized, never clean (#2575 no-op-loop bug)', () => {
+    // identityVersion:2, digest matches its own manifest — structurally
+    // indistinguishable from a real managed dir — but no pluginRoot mirror and
+    // no historical-tuple match, so `planCodexFallbackRetirement` would refuse
+    // it ('ambiguous-ownership'). Doctor must not tell this user to `genie
+    // update`; that would never converge.
+    seedManaged('orphaned-content');
+
+    const report = inspectCodexFallbackTier(agentsSkillsDir, pluginRoot);
+    expect(report.cleanFallbacks).toEqual([]);
+    expect(report.unrecognizedFallbacks).toEqual(['orphaned-content']);
+    expect(report.preservedCollisions).toEqual([]);
+  });
+
+  test('a pre-identityVersion (era-A) marker is preserved as managed-modified, never reported clean (era-A digest algorithm is not the current v2 physical-tree digest)', () => {
+    // Era-A genie (v5.260710.14–v5.260711.6) wrote managedBy/digest/syncedAt but
+    // no `identityVersion` field, and computed `digest` as sha256 over sorted
+    // (relpath, sha256(content)) file pairs only — no mode/kind, no version
+    // domain-separator prefix. That is a DIFFERENT algorithm than the current
+    // v2 physical-tree digest, so `acceptedManagedDirPhysicalDigest`'s untagged
+    // "transitional" fast-path (exact v2 match) never fires, and its legacy-v1
+    // fallback path requires a caller-supplied trusted digest that this
+    // read-only tier inspector never provides — so it lands as
+    // 'managed-modified', never 'managed-clean'/'clean, run genie update'.
+    const dir = join(agentsSkillsDir, 'legacy-era-a');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'SKILL.md'), '# legacy-era-a\n', 'utf8');
+    const legacyDigest = createHash('sha256')
+      .update('SKILL.md')
+      .update('\0')
+      .update(
+        createHash('sha256')
+          .update(readFileSync(join(dir, 'SKILL.md')))
+          .digest('hex'),
+      )
+      .update('\0')
+      .digest('hex');
+    writeFileSync(
+      join(dir, '.genie-sync.json'),
+      JSON.stringify({ managedBy: 'genie-agent-sync', version: '5.260711.6', digest: legacyDigest, syncedAt: 'now' }),
+      'utf8',
+    );
+
+    const report = inspectCodexFallbackTier(agentsSkillsDir, pluginRoot);
+    expect(report.cleanFallbacks).toEqual([]);
+    expect(report.unrecognizedFallbacks).toEqual([]);
+    expect(report.preservedCollisions).toEqual(['legacy-era-a']);
+    expect(report.preservedCollisionClass['legacy-era-a']).toBe('modified-managed');
+  });
+
+  test('counts committed quarantine transactions and flags retained changed-evidence (R8) with the actual on-disk path, without recursing into them', () => {
     const root = join(agentsSkillsDir, CODEX_FALLBACK_RETIREMENT_ROOT);
     // One plain committed transaction, one with archived changed-tree evidence.
     mkdirSync(join(root, 'txn-aaaa', 'quarantine', 'wish'), { recursive: true });
@@ -2735,7 +2812,9 @@ describe('inspectCodexFallbackTier (shared doctor/uninstall classifier — read-
 
     const report = inspectCodexFallbackTier(agentsSkillsDir);
     expect(report.quarantinedTransactions).toBe(2);
-    expect(report.retainedEvidence).toEqual(['txn-bbbb']);
+    expect(report.retainedEvidence).toEqual([
+      { transactionId: 'txn-bbbb', evidencePath: join(root, 'txn-bbbb', 'evidence') },
+    ]);
     // The quarantine root is never mistaken for a managed fallback.
     expect(report.cleanFallbacks).toEqual([]);
     expect(report.preservedCollisions).toEqual([]);

--- a/src/lib/runtime-integrations.ts
+++ b/src/lib/runtime-integrations.ts
@@ -24,14 +24,17 @@ import { basename, dirname, join, relative, resolve } from 'node:path';
 import { Worker } from 'node:worker_threads';
 import {
   CODEX_FALLBACK_RETIREMENT_ROOT,
+  type CodexFallbackOwnership,
   type CodexFallbackRetirementPlan,
   type CodexFallbackRetirementResult,
   type PlanCodexFallbackRetirementOptions,
   type VerifiedCodexSkillPayload,
   acquireLifecycleLease,
   applyCodexFallbackRetirement,
+  classifyCodexFallback,
   computeDirDigest,
   inspectManagedSkillTree,
+  loadHistoricalCodexFallbackTupleKeys,
   planCodexFallbackRetirement,
   publishRegularFileNoClobber,
   recoverCodexFallbackRetirements,
@@ -3028,29 +3031,58 @@ function emptyAgentInstallResult(): CodexAgentInstallResult {
 
 /**
  * Read-only classification of the shared `~/.agents/skills` tier for the doctor
- * diagnostic (R5/A9). Uses the SAME ownership classifier as sync and retirement
- * ({@link inspectManagedSkillTree}) so doctor never disagrees with what
- * `genie update` would retire, and NEVER launches the plugin MCP or mutates disk.
+ * diagnostic (R5/A9). Structural well-formedness alone
+ * ({@link inspectManagedSkillTree}) only tells doctor a tree is self-consistent
+ * (untampered content matching its own manifest) — it says nothing about
+ * whether {@link planCodexFallbackRetirement} will actually accept it, which
+ * additionally requires the exact `identityVersion: 2` marker tag AND either a
+ * frozen-allowlist historical tuple or a live-plugin verified-target digest
+ * match. Reporting every structurally clean tree as "clean, run `genie update`"
+ * therefore lies to any tree the planner would refuse (an infinite no-op loop:
+ * PR #2575's `ambiguous-ownership` case, and any pre-`identityVersion` era-A
+ * marker). This inspector applies the SAME two-stage gate the planner uses —
+ * {@link classifyCodexFallback} against the SAME frozen allowlist
+ * ({@link loadHistoricalCodexFallbackTupleKeys}) and a verified-target payload
+ * read directly from `<pluginRoot>/skills` (pure filesystem read; NEVER the
+ * plugin MCP) — so doctor never promises a retirement the engine then refuses.
  *
- * - `cleanFallbacks` — managed-clean genie skill dirs still in the user tier;
- *   under plugin-only semantics these are repairable duplicate providers that
- *   `genie update` retires (distinct remediation from a personal collision).
+ * - `cleanFallbacks` — recognized (historical-tuple or verified-target) genie
+ *   skill dirs still in the user tier; `genie update` retires these.
+ * - `unrecognizedFallbacks` — structurally well-formed, self-consistent, genie-
+ *   managed dirs whose content the planner does NOT recognize (not in the
+ *   frozen allowlist, no matching live-plugin payload, or missing the exact
+ *   `identityVersion: 2` tag). Never user-modified, but not retirable either —
+ *   manual review, not `genie update`, resolves these (#2575 vocabulary).
  * - `preservedCollisions` — managed-modified / corrupt-metadata dirs; personal
  *   content preserved in place that only manual review resolves.
  * - `quarantinedTransactions` — retained committed retirement transactions.
  * - `retainedEvidence` — transactions that archived a changed fallback tree aside;
- *   the Group A conflict class surfaced as manual-recovery guidance (R8).
+ *   the Group A conflict class surfaced as manual-recovery guidance (R8), each
+ *   carrying the actual on-disk evidence path so doctor can point at it directly.
+ * - `unreadable` — `agentsSkillsDir` exists but could not be listed (e.g.
+ *   permissions); distinct from "absent" (a fresh plugin-only install, which is
+ *   healthy). An unreadable tier can hide real fallback state, so it warns.
  */
 /** Decision-5 classification of a preserved personal collision (why genie left it in place). */
 export type PreservedCollisionClass = 'modified-managed' | 'malformed-marker';
 
+/** A retirement transaction that archived changed-tree evidence, with its actual on-disk path (R8). */
+export interface RetainedFallbackEvidence {
+  transactionId: string;
+  evidencePath: string;
+}
+
 export interface CodexFallbackTierReport {
   cleanFallbacks: string[];
+  /** Well-formed, self-consistent, genie-managed dirs the planner does not recognize as retirable. */
+  unrecognizedFallbacks: string[];
   preservedCollisions: string[];
   /** Per preserved-collision classification, so doctor can report Decision-5 fields (name + classification). */
   preservedCollisionClass: Record<string, PreservedCollisionClass>;
   quarantinedTransactions: number;
-  retainedEvidence: string[];
+  retainedEvidence: RetainedFallbackEvidence[];
+  /** `agentsSkillsDir` exists but readdir failed for a reason other than "absent" — classification is incomplete. */
+  unreadable: boolean;
 }
 
 /** Basename of a retirement transaction's archived changed-tree evidence dir (agent-sync on-disk contract). */
@@ -3082,30 +3114,77 @@ function summarizeCodexQuarantine(retirementRoot: string, report: CodexFallbackT
       continue;
     }
     report.quarantinedTransactions += 1;
-    if (retirementTransactionHasEvidence(txnDir)) report.retainedEvidence.push(name);
+    if (retirementTransactionHasEvidence(txnDir)) {
+      report.retainedEvidence.push({ transactionId: name, evidencePath: join(txnDir, RETIREMENT_EVIDENCE_DIRNAME) });
+    }
   }
 }
 
-export function inspectCodexFallbackTier(agentsSkillsDir: string): CodexFallbackTierReport {
+/**
+ * Build the read-only analog of {@link buildVerifiedCodexPayload}: the content
+ * genie's OWN plugin bundle would install for `skillName`, read straight from
+ * `<pluginRoot>/skills/<skillName>` on disk. No MCP session — doctor never
+ * launches the plugin — so this is a lighter-weight proof than the retirement
+ * engine's canonical-cache-bound `CodexHealthProof`, deliberately restricted to
+ * classification/messaging, never to authorize an actual retirement.
+ */
+function verifiedTargetFromPluginRoot(pluginRoot: string, skillName: string): VerifiedCodexSkillPayload | null {
+  const path = join(pluginRoot, 'skills', skillName);
+  try {
+    const stat = lstatSync(path);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return null;
+    return { skillName, path, physicalDigest: computeDirDigest(path), canonicalVerified: true };
+  } catch {
+    return null;
+  }
+}
+
+/** Codex-fallback ownership gate: `null` pluginRoot leaves every name unresolved (allowlist-only). */
+function classifyFallbackDirOwnership(
+  agentsSkillsDir: string,
+  name: string,
+  pluginRoot: string | null,
+  historical: ReadonlySet<string>,
+): CodexFallbackOwnership {
+  const path = join(agentsSkillsDir, name);
+  const target = pluginRoot === null ? null : verifiedTargetFromPluginRoot(pluginRoot, name);
+  return classifyCodexFallback(path, name, target, historical);
+}
+
+export function inspectCodexFallbackTier(
+  agentsSkillsDir: string,
+  pluginRoot: string | null = null,
+): CodexFallbackTierReport {
   const report: CodexFallbackTierReport = {
     cleanFallbacks: [],
+    unrecognizedFallbacks: [],
     preservedCollisions: [],
     preservedCollisionClass: {},
     quarantinedTransactions: 0,
     retainedEvidence: [],
+    unreadable: false,
   };
   let names: string[];
   try {
     names = readdirSync(agentsSkillsDir);
-  } catch {
+  } catch (error) {
+    // ENOENT ("absent") is a healthy fresh plugin-only install: no fallback tier
+    // exists yet, so an all-zero report is accurate. Any other failure (e.g.
+    // EACCES) means the tier exists but genie cannot see into it — classifying
+    // that as healthy would hide real fallback state, so it warns instead.
+    if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') report.unreadable = true;
     return report;
   }
+  const historical = loadHistoricalCodexFallbackTupleKeys();
   for (const name of names) {
     // The quarantine root is inspected as retained evidence, never as a live fallback.
     if (name === CODEX_FALLBACK_RETIREMENT_ROOT) continue;
     const state = inspectManagedSkillTree(join(agentsSkillsDir, name)).state;
-    if (state === 'managed-clean') report.cleanFallbacks.push(name);
-    else if (state === 'managed-modified' || state === 'corrupt-metadata') {
+    if (state === 'managed-clean') {
+      const ownership = classifyFallbackDirOwnership(agentsSkillsDir, name, pluginRoot, historical);
+      if (ownership.accepted) report.cleanFallbacks.push(name);
+      else report.unrecognizedFallbacks.push(name);
+    } else if (state === 'managed-modified' || state === 'corrupt-metadata') {
       report.preservedCollisions.push(name);
       report.preservedCollisionClass[name] = state === 'managed-modified' ? 'modified-managed' : 'malformed-marker';
     }
@@ -3113,8 +3192,11 @@ export function inspectCodexFallbackTier(agentsSkillsDir: string): CodexFallback
   }
   summarizeCodexQuarantine(join(agentsSkillsDir, CODEX_FALLBACK_RETIREMENT_ROOT), report);
   report.cleanFallbacks.sort();
+  report.unrecognizedFallbacks.sort();
   report.preservedCollisions.sort();
-  report.retainedEvidence.sort();
+  report.retainedEvidence.sort((a, b) =>
+    a.transactionId < b.transactionId ? -1 : a.transactionId > b.transactionId ? 1 : 0,
+  );
   return report;
 }
 

--- a/src/lib/runtime-integrations.ts
+++ b/src/lib/runtime-integrations.ts
@@ -3048,11 +3048,13 @@ function emptyAgentInstallResult(): CodexAgentInstallResult {
  *
  * - `cleanFallbacks` — recognized (historical-tuple or verified-target) genie
  *   skill dirs still in the user tier; `genie update` retires these.
- * - `unrecognizedFallbacks` — structurally well-formed, self-consistent, genie-
- *   managed dirs whose content the planner does NOT recognize (not in the
- *   frozen allowlist, no matching live-plugin payload, or missing the exact
- *   `identityVersion: 2` tag). Never user-modified, but not retirable either —
- *   manual review, not `genie update`, resolves these (#2575 vocabulary).
+ * - `unrecognizedFallbacks` — structurally well-formed identityVersion:2,
+ *   self-consistent genie-managed dirs whose content the planner does NOT
+ *   recognize (not in the frozen allowlist, no matching live-plugin payload).
+ *   Era-A dirs (v1 legacy digest, no identityVersion) fail v2 self-consistency
+ *   and land in `preservedCollisions` instead. Never user-modified, but not
+ *   retirable either — manual review, not `genie update`, resolves these
+ *   (#2575 vocabulary).
  * - `preservedCollisions` — managed-modified / corrupt-metadata dirs; personal
  *   content preserved in place that only manual review resolves.
  * - `quarantinedTransactions` — retained committed retirement transactions.


### PR DESCRIPTION
## Summary

Three items scoped from council review of the codex-fallback ownership/doctor-honesty gap.

### 1. Era-A frozen fixture — investigated, SKIPPED (documented, not faked)

Checked `git show v5.260711.6:src/lib/agent-sync.ts` (era-A range: v5.260710.14–v5.260711.6) against the current source.

**Finding: era-A markers are NOT `identityVersion`-2 compatible.**

- Era-A's `SyncManifest` interface has **no `identityVersion` field at all** — it was introduced later (first appears at v5.260712.1, era-B).
- Era-A's `digest` was computed by `computeDirDigest` = `sha256` over sorted `(relpath, sha256(content))` pairs of **regular files only** — no mode/kind, no directory entries, no version domain-separator prefix.
- The current v2 "physical tree identity" digest (`computePhysicalTreeDigest`) is a completely different algorithm: mode+kind+symlink-aware, domain-separated with a `genie-physical-tree-v2\0` prefix, and requires `identityVersion === 2` explicitly.
- The retirement engine's sole eligibility gate, `strictFallbackMarker` (in `classifyCodexFallback`), hard-requires `parsed.identityVersion === PHYSICAL_TREE_IDENTITY_VERSION` (exactly `2`) before it will even consider a historical-tuple or verified-target match.

Because that gate runs *before* any allowlist/digest lookup, **no fixture — however constructed — could make an era-A tree pass it.** Adding era-A digest tuples to the allowlist would be dead data: it would never change any real classification, only give false confidence. So the era-A fixture + allowlist-generator extension was **skipped**. `src/fixtures/codex-fallback-release-5.260712.1.json` and `scripts/generate-codex-fallback-allowlist.ts` are unchanged; `--check` still passes.

Era-A users are not left mislabeled, though — item 2 below verifies (with a new regression test) that era-A trees already land honestly in `preservedCollisions` (never `cleanFallbacks`/"run genie update"), via the pre-existing legacy-digest path in `acceptedManagedDirPhysicalDigest` (which requires a caller-supplied trusted digest that doctor's read-only tier inspector never supplies).

### 2. Doctor↔engine consistency

`inspectCodexFallbackTier` previously classified `cleanFallbacks` on structural well-formedness alone (`inspectManagedSkillTree`: marker parses, digest self-consistent with itself). That is a *weaker* bar than what `planCodexFallbackRetirement` actually requires to retire something (`classifyCodexFallback`: the exact `identityVersion: 2` tag **and** either a frozen-allowlist historical tuple or a live-plugin verified-target digest match). A tree that passed the loose bar but failed the strict one was reported "clean — run `genie update`" while the engine silently refused to retire it (`ambiguous-ownership`): an infinite no-op loop. This is exactly the bug PR #2575 partially addressed for the *applied* install/update path (`convergeCodexPluginOnly` → `preservedUnrecognized`); doctor's read-only diagnostic had not been updated to match.

Fix: `inspectCodexFallbackTier(agentsSkillsDir, pluginRoot)` now takes the plugin root and, for structurally-clean trees, re-runs the **exact planner gate** — newly exported `classifyCodexFallback` + `loadHistoricalCodexFallbackTupleKeys` from `agent-sync.ts` (no duplicated digest/marker logic) — against verified-target payloads read directly from `<pluginRoot>/skills/<name>` on disk (pure filesystem read via the already-exported `computeDirDigest`; doctor still never launches the plugin MCP).

- Recognized (historical-tuple or verified-target) → `cleanFallbacks`, "run `genie update`".
- Well-formed but unrecognized → new `unrecognizedFallbacks` bucket, distinct "review manually" message reusing #2575's vocabulary (`agent sync: codex unrecognized`), and the suggestion explicitly never recommends `genie update`.

`checkCodexSync` in `doctor.ts` renders both buckets with the distinct remediations.

### 3. Doctor minors

- **(a)** An unreadable `~/.agents/skills` (e.g. `EACCES`) previously fell into the same catch-all as "absent" (`ENOENT`, the healthy fresh-install case) and silently reported `plugin-only` pass. Now distinguished by error code: only `ENOENT` is healthy; anything else sets `report.unreadable` and doctor warns with the actual path.
- **(b)** Retained quarantine evidence (`R8`) previously reported only the bare transaction id (`txn-bbbb`). `CodexFallbackTierReport.retainedEvidence` is now `RetainedFallbackEvidence[]` (`{ transactionId, evidencePath }`), and doctor's message includes the real on-disk evidence path.

## Test plan

- [x] `bun test src/lib/agent-sync.test.ts src/lib/runtime-integrations.test.ts src/genie-commands/doctor.test.ts` — 362 pass, 0 fail
- [x] New: era-A-stamped marker (no `identityVersion`, legacy v1 digest) → `preservedCollisions`/`modified-managed`, never `cleanFallbacks` (`runtime-integrations.test.ts`)
- [x] New: structurally-clean, self-consistent, `identityVersion:2` tree not in the allowlist / not matching the live plugin → `unrecognizedFallbacks`, doctor says "review manually", suggestion never contains `Run \`genie update\` to retire` (`runtime-integrations.test.ts` + `doctor.test.ts`)
- [x] New: unreadable tier (`ENOTDIR` via a file at the tier path — portable across root/non-root CI) → `report.unreadable === true`, doctor warns instead of passing (`runtime-integrations.test.ts` + `doctor.test.ts`)
- [x] New: quarantine evidence message contains the actual evidence path, not just the txn id (`doctor.test.ts`)
- [x] `bun scripts/generate-codex-fallback-allowlist.ts --check` — still green, unchanged (23 tuples, single frozen release)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run check` — green except the pre-existing `dead-code` (knip) biome/commitlint/husky false positives (documented repo gotcha, not a regression)
- [x] `bun test` (full suite) — 1637 pass / 2 fail / 1 skip; the 2 failures (`src/hooks/__tests__/codex-manifest.test.ts`) reproduce identically on `origin/dev` with this branch's changes stashed out — pre-existing/environment-dependent, unrelated to this change
- [x] Pre-push hook (full gate incl. complexity budget, council-workflow, hook-bundle-parity, hook-content-binding, plugin-executables) ran and passed on push

Not merging — base is `dev`, human-gated per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>