### PR TITLE
fix(agent-sync): harden codex fallback retirement engine (5 bounded fixes)

### DIFF
--- a/src/lib/agent-sync.test.ts
+++ b/src/lib/agent-sync.test.ts
@@ -47,6 +47,8 @@ import {
   type AgentSyncOptions,
   type AgentSyncReport,
   CODEX_FALLBACK_RETIREMENT_ROOT,
+  type CodexFallbackRetirementFailpoint,
+  type FsyncPathDeps,
   LIFECYCLE_LEASE_OWNER_ENV,
   LIFECYCLE_LEASE_PATH_ENV,
   TARGET_NAME,
@@ -55,6 +57,8 @@ import {
   applyCodexFallbackRetirement,
   atomicRenameDirectoryNoClobber,
   computeDirDigest,
+  currentSyncLockHostId,
+  fsyncPathForTest,
   inspectManagedWorkflow,
   lifecycleLockPath,
   planCodexFallbackRetirement,
@@ -65,6 +69,7 @@ import {
   removeManagedWorkflow,
   resolveGenieSource,
   resolveLinuxRenameat2,
+  retirementTransactionId,
   runAgentSync,
   stampWorkflow,
   writeAllSync,
@@ -1789,6 +1794,15 @@ const LOCK_NAME = '.agent-sync.lock';
 const MARKER_NAME = '.last-agent-sync';
 
 describe('cross-process sync lock', () => {
+  // Same-host identity every writer (this process + spawned runners on this
+  // machine) embeds as the 4th owner-record field; a lock is stealable ONLY when
+  // this matches AND the pid is dead. A pid past pid_max is always dead.
+  const HOST = currentSyncLockHostId();
+  const DEAD_PID = 2147483647;
+  const TOKEN = '0123456789abcdef0123456789abcdef';
+  /** Same-host owner record with an explicitly dead/live pid and 'unknown' start identity. */
+  const sameHostRecord = (pid: number) => `${pid}:${TOKEN}:unknown:${HOST}\n`;
+
   test('a fresh lock held elsewhere skips the whole sync with an advisory — zero writes, lock untouched', () => {
     present(fixture.claudeDir);
     const lockPath = join(fixture.genieHome, LOCK_NAME);
@@ -1806,10 +1820,10 @@ describe('cross-process sync lock', () => {
     expect(existsSync(lockPath)).toBe(true); // never releases someone else's live lock
   });
 
-  test('a stale lock (older than the age-out) is stolen and the sync proceeds', () => {
+  test('a stale SAME-HOST lock with a dead pid is stolen and the sync proceeds', () => {
     present(fixture.claudeDir);
     const lockPath = join(fixture.genieHome, LOCK_NAME);
-    writeFile(lockPath, '2147483647\n');
+    writeFile(lockPath, sameHostRecord(DEAD_PID)); // same host + dead pid → the only stealable shape
     const staleSec = (Date.now() - 11 * 60 * 1000) / 1000; // 11 min > 10 min age-out
     utimesSync(lockPath, staleSec, staleSec);
 
@@ -1820,10 +1834,45 @@ describe('cross-process sync lock', () => {
     expect(existsSync(lockPath)).toBe(false); // released after the run
   });
 
-  test('an ordinary stale timestamp never permits stealing from a live PID', () => {
+  test('a stale CROSS-HOST lock is never stolen even with a locally-dead pid (double-writer safety)', () => {
     present(fixture.claudeDir);
     const lockPath = join(fixture.genieHome, LOCK_NAME);
-    writeFile(lockPath, `${process.pid}:0123456789abcdef0123456789abcdef\n`);
+    // A peer on an NFS / pid-namespace-shared $HOME: its pid may be dead HERE but
+    // that says nothing about the remote host, so the lock must never be stolen.
+    writeFile(lockPath, `${DEAD_PID}:${TOKEN}:unknown:${'f'.repeat(64)}\n`);
+    const staleSec = (Date.now() - 11 * 60 * 1000) / 1000;
+    utimesSync(lockPath, staleSec, staleSec);
+
+    const report = run();
+
+    expect(report.skipped).toContain('holds the lock'); // fail closed, no steal
+    expect(existsSync(join(fixture.claudeDir, 'skills'))).toBe(false);
+    expect(readFileSync(lockPath, 'utf8')).toContain(`:${'f'.repeat(64)}`); // untouched
+  });
+
+  test('a stale OLD-FORMAT lock (no host field) keeps legacy pid+mtime steal semantics (shell parity)', () => {
+    present(fixture.claudeDir);
+    const lockPath = join(fixture.genieHome, LOCK_NAME);
+    // Pre-upgrade / shell-written record: no host field. Deliberately NOT refused
+    // (host-bearing cross-host records are — see the CROSS-HOST test): host-less
+    // records fall through to legacy pid+mtime liveness, in lockstep with
+    // install.sh which writes and reaps this exact shape. A dead pid + stale mtime
+    // is therefore reaped exactly as before, so the shell<->TS parity holds.
+    writeFile(lockPath, `${DEAD_PID}:${TOKEN}:unknown\n`);
+    const staleSec = (Date.now() - 11 * 60 * 1000) / 1000;
+    utimesSync(lockPath, staleSec, staleSec);
+
+    const report = run();
+
+    expect(report.skipped).toBeUndefined();
+    expect(skillAction(agentReport(report, 'claude'), 'alpha')).toBe('created');
+    expect(existsSync(lockPath)).toBe(false); // stolen (legacy behavior) then released
+  });
+
+  test('an ordinary stale timestamp never permits stealing from a live SAME-HOST PID', () => {
+    present(fixture.claudeDir);
+    const lockPath = join(fixture.genieHome, LOCK_NAME);
+    writeFile(lockPath, sameHostRecord(process.pid)); // live pid, same host, 'unknown' identity → live
     const staleSec = (Date.now() - 11 * 60 * 1000) / 1000;
     utimesSync(lockPath, staleSec, staleSec);
 
@@ -1834,10 +1883,10 @@ describe('cross-process sync lock', () => {
     expect(readFileSync(lockPath, 'utf8')).toContain(`${process.pid}:`);
   });
 
-  test('a stale lock with a reused live PID but mismatched start identity is stealable', () => {
+  test('a stale SAME-HOST lock with a reused live PID but mismatched start identity is stealable', () => {
     present(fixture.claudeDir);
     const lockPath = join(fixture.genieHome, LOCK_NAME);
-    writeFile(lockPath, `${process.pid}:0123456789abcdef0123456789abcdef:${'0'.repeat(64)}\n`);
+    writeFile(lockPath, `${process.pid}:${TOKEN}:${'0'.repeat(64)}:${HOST}\n`);
     const staleSec = (Date.now() - 11 * 60 * 1000) / 1000;
     utimesSync(lockPath, staleSec, staleSec);
 
@@ -1862,10 +1911,10 @@ describe('cross-process sync lock', () => {
     expect(existsSync(lockPath)).toBe(false);
   });
 
-  test('a far-future lock with a live owner is not stolen under clock skew', () => {
+  test('a far-future lock with a live SAME-HOST owner is not stolen under clock skew', () => {
     present(fixture.claudeDir);
     const lockPath = join(fixture.genieHome, LOCK_NAME);
-    writeFile(lockPath, `${process.pid}\n`);
+    writeFile(lockPath, sameHostRecord(process.pid)); // live, same host → live regardless of a skewed mtime
     const futureSec = (Date.now() + 11 * 60 * 1000) / 1000;
     utimesSync(lockPath, futureSec, futureSec);
 
@@ -1873,16 +1922,16 @@ describe('cross-process sync lock', () => {
 
     expect(report.skipped).toContain('holds the lock');
     expect(existsSync(join(fixture.claudeDir, 'skills'))).toBe(false);
-    expect(readFileSync(lockPath, 'utf8')).toBe(`${process.pid}\n`);
+    expect(readFileSync(lockPath, 'utf8')).toBe(sameHostRecord(process.pid));
   });
 
-  test('an aged, dead-owner steal guard is reaped so a subsequent run proceeds', () => {
+  test('an aged, dead-owner SAME-HOST steal guard is reaped so a subsequent run proceeds', () => {
     present(fixture.claudeDir);
     const lockPath = join(fixture.genieHome, LOCK_NAME);
     const guardPath = `${lockPath}.steal`;
     // A crashed run left both a stale lock and the abandoned steal guard behind.
-    writeFile(lockPath, '999999:0123456789abcdef0123456789abcdef:unknown\n');
-    writeFile(guardPath, '999999:abcdefabcdefabcdefabcdefabcdefab:unknown\n');
+    writeFile(lockPath, sameHostRecord(DEAD_PID));
+    writeFile(guardPath, `${DEAD_PID}:abcdefabcdefabcdefabcdefabcdefab:unknown:${HOST}\n`);
     const agedSec = (Date.now() - 11 * 60 * 1000) / 1000; // 11 min > 10 min age-out
     utimesSync(lockPath, agedSec, agedSec);
     utimesSync(guardPath, agedSec, agedSec);
@@ -1904,25 +1953,25 @@ describe('cross-process sync lock', () => {
     present(fixture.claudeDir);
     const lockPath = join(fixture.genieHome, LOCK_NAME);
     const guardPath = `${lockPath}.steal`;
-    writeFile(lockPath, '999999:0123456789abcdef0123456789abcdef:unknown\n');
+    writeFile(lockPath, sameHostRecord(DEAD_PID));
     const agedSec = (Date.now() - 11 * 60 * 1000) / 1000;
     utimesSync(lockPath, agedSec, agedSec);
-    writeFile(guardPath, '999999:abcdefabcdefabcdefabcdefabcdefab:unknown\n'); // fresh mtime
+    writeFile(guardPath, `${DEAD_PID}:abcdefabcdefabcdefabcdefabcdefab:unknown:${HOST}\n`); // fresh mtime
 
     const report = run();
 
     expect(report.skipped).toContain('holds the lock');
     expect(existsSync(guardPath)).toBe(true); // an in-window guard is a live stealer — untouched
     expect(existsSync(join(fixture.claudeDir, 'skills'))).toBe(false); // zero writes
-    expect(readFileSync(lockPath, 'utf8')).toContain('999999:'); // stale lock left in place
+    expect(readFileSync(lockPath, 'utf8')).toContain(`${DEAD_PID}:`); // stale lock left in place
   });
 
-  test('a future-mtime dead-owner steal guard is reaped (far-future = debris, per ± window)', () => {
+  test('a future-mtime dead-owner SAME-HOST steal guard is reaped (far-future = debris, per ± window)', () => {
     present(fixture.claudeDir);
     const lockPath = join(fixture.genieHome, LOCK_NAME);
     const guardPath = `${lockPath}.steal`;
-    writeFile(lockPath, '999999:0123456789abcdef0123456789abcdef:unknown\n');
-    writeFile(guardPath, '999999:abcdefabcdefabcdefabcdefabcdefab:unknown\n');
+    writeFile(lockPath, sameHostRecord(DEAD_PID));
+    writeFile(guardPath, `${DEAD_PID}:abcdefabcdefabcdefabcdefabcdefab:unknown:${HOST}\n`);
     const agedSec = (Date.now() - 11 * 60 * 1000) / 1000;
     const futureSec = (Date.now() + 11 * 60 * 1000) / 1000; // implausibly far future
     utimesSync(lockPath, agedSec, agedSec);
@@ -1942,11 +1991,11 @@ describe('cross-process sync lock', () => {
     const lockPath = join(fixture.genieHome, LOCK_NAME);
     const guardPath = `${lockPath}.steal`;
     const target = join(fixture.root, 'guard-symlink-target');
-    writeFile(lockPath, '999999:0123456789abcdef0123456789abcdef:unknown\n');
+    writeFile(lockPath, sameHostRecord(DEAD_PID)); // same-host dead lock → reach stealStaleLock, which then meets the guard
     const agedSec = (Date.now() - 11 * 60 * 1000) / 1000;
     utimesSync(lockPath, agedSec, agedSec);
     // Aged, dead-owner target: a symlink-FOLLOWING reap would have unlinked the guard.
-    writeFile(target, '999999:abcdefabcdefabcdefabcdefabcdefab:unknown\n');
+    writeFile(target, `${DEAD_PID}:abcdefabcdefabcdefabcdefabcdefab:unknown:${HOST}\n`);
     utimesSync(target, agedSec, agedSec);
     symlinkSync(target, guardPath);
 
@@ -1962,8 +2011,10 @@ describe('cross-process sync lock', () => {
     const lockPath = join(fixture.genieHome, LOCK_NAME);
     const target = join(fixture.root, 'lock-symlink-target');
     const agedSec = (Date.now() - 11 * 60 * 1000) / 1000;
-    // Aged, dead-owner target: a symlink-following reap would unlink the lock link.
-    writeFile(target, '999999:0123456789abcdef0123456789abcdef:unknown\n');
+    // Aged, dead-owner SAME-HOST target: read through the symlink it is a dead
+    // same-host owner, so acquisition reaches stealStaleLock — whose lstat refusal
+    // (never follow a symlinked lock) is what must leave the link intact.
+    writeFile(target, sameHostRecord(DEAD_PID));
     utimesSync(target, agedSec, agedSec);
     symlinkSync(target, lockPath);
 
@@ -2137,9 +2188,9 @@ describe('cross-process sync lock', () => {
     present(fixture.codexDir);
     present(fixture.hermesHome);
     const runnerPath = writeSyncRunner();
-    // A crashed run's stale lock that every racer will try to steal.
+    // A crashed run's stale SAME-HOST lock (dead pid) that every racer will try to steal.
     const lockPath = join(fixture.genieHome, LOCK_NAME);
-    writeFile(lockPath, '2147483647\n');
+    writeFile(lockPath, sameHostRecord(DEAD_PID));
     const staleSec = (Date.now() - 11 * 60 * 1000) / 1000; // 11 min > 10 min age-out
     utimesSync(lockPath, staleSec, staleSec);
 
@@ -3415,6 +3466,192 @@ describe('Codex fallback batch retirement', () => {
     expect(() => applyCodexFallbackRetirement(plan)).toThrow('source changed after planning');
     expect(readFileSync(join(alpha.path, 'USER.txt'), 'utf8')).toBe('integration content\n');
   });
+
+  // ---------------------------------------------------------------------------
+  // Fix 1 — residual last-copy-loss: a re-run's pristine archive must never
+  // overwrite a prior generation's changed evidence.
+  // ---------------------------------------------------------------------------
+
+  test('three-cycle evidence: a pristine re-run archive never overwrites the cycle-1 changed evidence', () => {
+    const { alpha, beta, plan } = batchFixture();
+    const txnDir = join(plan.fallbackSkillsDir, RETIREMENT_ROOT, `txn-${plan.transactionId}`);
+
+    // Cycle 1: a personal edit lands in alpha's move TOCTOU window. The edited
+    // tree is quarantined, destination verification fails, and the restore
+    // republishes the edited tree to live AND archives the edited quarantine
+    // copy to evidence/alpha. The transaction ends non-committed.
+    expect(() =>
+      applyCodexFallbackRetirement(plan, {
+        failpoint: (point) => {
+          if (point === 'after-move-boundary-identification:0') {
+            writeFile(join(alpha.path, 'USER.txt'), 'cycle-1 user edit\n');
+          }
+        },
+      }),
+    ).toThrow('destination verification failed');
+    expect(readFileSync(join(txnDir, 'evidence', 'alpha', 'USER.txt'), 'utf8')).toBe('cycle-1 user edit\n');
+
+    // Cycles 2/3: the user reverts alpha byte-exactly to genie content. On the
+    // same-txn re-run the initial restore leaves both live trees pristine and the
+    // forward pass re-quarantines them; a mid-batch failure on beta then
+    // re-enters restore for alpha (destinationMatches true → restoreDigest
+    // undefined) → republish → cleanup → dispose, which now finds the pre-existing
+    // DIFFERING evidence/alpha. The old engine rmSync'd it (the only copy of the
+    // user's edited bytes); the fix claims a fresh suffixed path instead.
+    rmSync(join(alpha.path, 'USER.txt')); // revert to the exact genie tree
+    expect(computeDirDigest(alpha.path)).toBe(alpha.digest);
+    expect(() =>
+      applyCodexFallbackRetirement(plan, {
+        failpoint: (point) => {
+          if (point === 'before-move:1') writeFile(join(beta.path, 'USER.txt'), 'beta perturbation\n');
+        },
+      }),
+    ).toThrow('source changed at move boundary');
+
+    // Cycle-1 changed evidence SURVIVES byte-for-byte; the pristine re-run copy is
+    // archived to a distinct suffixed path, never overwriting it.
+    expect(readFileSync(join(txnDir, 'evidence', 'alpha', 'USER.txt'), 'utf8')).toBe('cycle-1 user edit\n');
+    const suffixed = readdirSync(join(txnDir, 'evidence')).filter((n) => n.startsWith('alpha.'));
+    expect(suffixed).toHaveLength(1);
+    expect(existsSync(join(txnDir, 'evidence', suffixed[0]!, 'USER.txt'))).toBe(false); // pristine re-run copy
+    expect(computeDirDigest(join(txnDir, 'evidence', suffixed[0]!))).toBe(alpha.digest);
+    const journal = JSON.parse(readFileSync(join(txnDir, 'journal.json'), 'utf8')) as {
+      entries: Array<{ skillName: string; evidence?: string }>;
+    };
+    expect(journal.entries.find((e) => e.skillName === 'alpha')?.evidence).toBe(suffixed[0]);
+
+    // The suffixed-evidence journal still replays: a further retry is a clean
+    // recoverable conflict (beta stayed live-modified) and both archives survive.
+    expect(() => applyCodexFallbackRetirement(plan)).toThrow('source changed after planning');
+    expect(readFileSync(join(txnDir, 'evidence', 'alpha', 'USER.txt'), 'utf8')).toBe('cycle-1 user edit\n');
+    expect(existsSync(join(txnDir, 'evidence', suffixed[0]!))).toBe(true);
+  });
+
+  test('an existing byte-identical evidence archive is disposed as a duplicate (no suffix proliferation)', () => {
+    // A byte-identical pre-existing archive is disposed in place (prior behavior),
+    // never suffixed. Reached by two mid-batch restores of the SAME pristine alpha:
+    // run 1 archives pristine alpha to evidence/alpha; run 2 re-quarantines an
+    // identical pristine alpha, and disposal recognizes the duplicate.
+    const { alpha, beta, plan } = batchFixture();
+    const txnDir = join(plan.fallbackSkillsDir, RETIREMENT_ROOT, `txn-${plan.transactionId}`);
+    const perturbBeta = {
+      failpoint: (point: CodexFallbackRetirementFailpoint) => {
+        if (point === 'before-move:1') writeFile(join(beta.path, 'USER.txt'), 'beta perturbation\n');
+      },
+    } as const;
+
+    // Run 1: alpha (pristine) is quarantined, then restore archives it to evidence/alpha.
+    expect(() => applyCodexFallbackRetirement(plan, perturbBeta)).toThrow('source changed at move boundary');
+    expect(computeDirDigest(join(txnDir, 'evidence', 'alpha'))).toBe(alpha.digest);
+
+    // Revert beta; run 2 re-quarantines an IDENTICAL pristine alpha and re-disposes.
+    rmSync(join(beta.path, 'USER.txt'));
+    expect(() => applyCodexFallbackRetirement(plan, perturbBeta)).toThrow('source changed at move boundary');
+
+    const archives = readdirSync(join(txnDir, 'evidence')).filter((n) => n.startsWith('alpha'));
+    expect(archives).toEqual(['alpha']); // duplicate disposed in place — no alpha.2
+    expect(computeDirDigest(join(txnDir, 'evidence', 'alpha'))).toBe(alpha.digest);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Fix 2 — cross-host lock steal safety (retirement lock reuses acquireSyncLock).
+  // ---------------------------------------------------------------------------
+
+  test('a fresh retirement lock records this host identity as the 4th owner field', () => {
+    const { plan } = batchFixture();
+    let record = '';
+    const lockPath = join(plan.fallbackSkillsDir, RETIREMENT_ROOT, '.retirement.lock');
+    const result = applyCodexFallbackRetirement(plan, {
+      failpoint: (point) => {
+        if (point === 'after-journal-durable' && record === '') record = readFileSync(lockPath, 'utf8').trim();
+      },
+    });
+    expect(result.status).toBe('committed');
+    // pid:token32:(sha64|unknown):host64 — the host field is currentSyncLockHostId().
+    expect(record).toMatch(/^\d+:[a-f0-9]{32}:(?:[a-f0-9]{64}|unknown):[a-f0-9]{64}$/);
+    expect(record.endsWith(`:${currentSyncLockHostId()}`)).toBe(true);
+  });
+
+  test('a stale CROSS-HOST retirement lock is never stolen — apply fails closed with no data changed', () => {
+    const { alpha, beta, plan } = batchFixture();
+    const txnRoot = join(plan.fallbackSkillsDir, RETIREMENT_ROOT);
+    mkdirSync(txnRoot, { recursive: true });
+    const lockPath = join(txnRoot, '.retirement.lock');
+    // A peer holding the lock on another host of a shared $HOME; its pid is dead
+    // HERE but that proves nothing about the remote host, so it must not be stolen.
+    writeFileSync(lockPath, `2147483647:${'0'.repeat(32)}:unknown:${'f'.repeat(64)}\n`, 'utf8');
+    const staleSec = (Date.now() - 11 * 60 * 1000) / 1000;
+    utimesSync(lockPath, staleSec, staleSec);
+    const prev = process.env.GENIE_RETIREMENT_LOCK_WAIT_MS;
+    process.env.GENIE_RETIREMENT_LOCK_WAIT_MS = '120'; // bounded deadline → fail closed fast
+    try {
+      expect(() => applyCodexFallbackRetirement(plan)).toThrow('lock contended; no data changed');
+    } finally {
+      if (prev === undefined) Reflect.deleteProperty(process.env, 'GENIE_RETIREMENT_LOCK_WAIT_MS');
+      else process.env.GENIE_RETIREMENT_LOCK_WAIT_MS = prev;
+    }
+    // Nothing moved: both sources intact, no quarantine, foreign lock untouched.
+    expect(computeDirDigest(alpha.path)).toBe(alpha.digest);
+    expect(computeDirDigest(beta.path)).toBe(beta.digest);
+    expect(existsSync(join(txnRoot, `txn-${plan.transactionId}`, 'quarantine'))).toBe(false);
+    expect(readFileSync(lockPath, 'utf8')).toContain(`:${'f'.repeat(64)}`);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Fix 3 — forged-journal entry-name confinement (plan time + re-validation).
+  // ---------------------------------------------------------------------------
+
+  test('plan time rejects dot-prefixed and reserved-infra skill names', () => {
+    const fallback = join(fixture.root, 'confinement-plan');
+    mkdirSync(fallback, { recursive: true });
+    for (const name of ['.hidden', 'evidence', 'quarantine', 'journal.json', '.genie-codex-fallback-retirement']) {
+      expect(() => planCodexFallbackRetirement({ fallbackSkillsDir: fallback, skillNames: [name] })).toThrow(
+        'unique safe path entries',
+      );
+    }
+  });
+
+  test('forged-journal defense: recovery rejects a hash-consistent journal naming engine infrastructure', () => {
+    // fixture.root is already canonical (the batchFixture tests rely on it), so
+    // journal.fallbackSkillsDir === canonicalPhysicalFallbackRoot(fallback).
+    const fallback = join(fixture.root, 'confinement-recover');
+    mkdirSync(fallback, { recursive: true });
+    const txnRoot = join(fallback, RETIREMENT_ROOT);
+    for (const evil of ['.genie-codex-fallback-retirement', 'evidence', '.evil']) {
+      const accepted = [
+        {
+          skillName: evil,
+          source: join(fallback, evil),
+          markerVersion: 'v1',
+          physicalDigest: 'a'.repeat(64),
+          markerDigest: 'b'.repeat(64),
+          targetDigest: null,
+          ownership: 'historical-tuple' as const,
+        },
+      ];
+      const transactionId = retirementTransactionId(accepted); // self-consistent hash → passes the identity gate
+      const txnDir = join(txnRoot, `txn-${transactionId}`);
+      const quarantined = join(txnDir, 'quarantine', evil, 'SKILL.md');
+      writeFile(quarantined, '# forged\n'); // non-empty quarantine → not pre-journal debris
+      writeFile(
+        join(txnDir, 'journal.json'),
+        `${JSON.stringify({
+          version: 1,
+          fallbackSkillsDir: fallback,
+          transactionId,
+          accepted,
+          preserved: [],
+          phase: 'moving',
+          entries: accepted.map((a) => ({ ...a, destination: join(txnDir, 'quarantine', evil), phase: 'moved' })),
+        })}\n`,
+      );
+      // Rejected at re-validation (the isSafeEntryName gate, not the identity gate),
+      // and the forged tree is left in place — never moved/restored out of the txn.
+      expect(() => recoverCodexFallbackRetirements(fallback)).toThrow(`txn-${transactionId}`);
+      expect(existsSync(quarantined)).toBe(true);
+      rmSync(txnDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('Codex fallback allowlist generator', () => {
@@ -3572,5 +3809,61 @@ describe('no-clobber directory publish (G5 musl portability)', () => {
     atomicRenameDirectoryNoClobber(stagedTree('cache-2'), join(fixture.root, 'cache-t2'), { opener, probe });
     expect(calls).toBe(afterFirst); // the second publish reuses the memoized probe — no re-detection
     if (process.platform === 'linux') expect(afterFirst).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix 4 — directory-metadata fsync tolerance (Windows / network-fs failpoint).
+// A directory fsync that the platform refuses must NOT brick journal-prepare;
+// FILE fsync stays strict because journal/staging byte durability is load-bearing.
+// ---------------------------------------------------------------------------
+
+describe('fsyncPath directory-metadata flush tolerance (Fix 4)', () => {
+  const errno = (code: string): NodeJS.ErrnoException => Object.assign(new Error(code), { code });
+  const dir = (name: string): string => {
+    const d = join(fixture.root, name);
+    mkdirSync(d, { recursive: true });
+    return d;
+  };
+  const throwingFsync = (code: string): FsyncPathDeps['fsync'] =>
+    (() => {
+      throw errno(code);
+    }) as unknown as FsyncPathDeps['fsync'];
+
+  for (const code of ['EISDIR', 'EPERM', 'EINVAL', 'ENOTSUP'] as const) {
+    test(`a DIRECTORY fsync raising ${code} is swallowed (best-effort)`, () => {
+      expect(() => fsyncPathForTest(dir(`fsync-dir-${code}`), { fsync: throwingFsync(code) })).not.toThrow();
+    });
+  }
+
+  test('a DIRECTORY that cannot even be opened for fsync is tolerated', () => {
+    const open = (() => {
+      throw errno('EISDIR');
+    }) as unknown as FsyncPathDeps['open'];
+    expect(() => fsyncPathForTest(dir('fsync-open-eisdir'), { open })).not.toThrow();
+  });
+
+  test('a DIRECTORY fsync is skipped entirely on win32 (open never attempted)', () => {
+    let opened = false;
+    const open = (() => {
+      opened = true;
+      return 0;
+    }) as unknown as FsyncPathDeps['open'];
+    fsyncPathForTest(dir('fsync-win32'), { platform: 'win32', open });
+    expect(opened).toBe(false);
+  });
+
+  test('a FILE fsync failure stays strict — journal/staging durability is load-bearing', () => {
+    const f = join(fixture.root, 'fsync-file-strict');
+    writeFile(f, 'durable\n');
+    expect(() => fsyncPathForTest(f, { fsync: throwingFsync('EIO') })).toThrow('EIO');
+  });
+
+  test('a DIRECTORY fsync raising a NON-tolerable code still propagates', () => {
+    expect(() => fsyncPathForTest(dir('fsync-dir-eio'), { fsync: throwingFsync('EIO') })).toThrow('EIO');
+  });
+
+  test('a healthy directory fsync succeeds through the real syscalls', () => {
+    expect(() => fsyncPathForTest(dir('fsync-dir-ok'))).not.toThrow();
   });
 });

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -4112,11 +4112,15 @@ let cachedSyncLockHostId: string | null = null;
  * A stable identity for THIS host, embedded in every lock owner record so a
  * cross-host stealer can recognize "not my host" and refuse to steal. It is the
  * sha256 of the hostname plus, on linux, the kernel boot id
- * (`/proc/sys/kernel/random/boot_id`) — so a reused hostname across reboots (or
- * across container instances that share it) still yields distinct identities
- * where the boot id is readable. The boot id is best-effort: an empty read
- * degrades to hostname-only, which is still host-scoped. Exported for tests that
- * must forge same-host vs cross-host owner records.
+ * (`/proc/sys/kernel/random/boot_id`) — so a reused hostname across reboots
+ * still yields distinct identities where the boot id is readable. Coverage is
+ * scoped to distinct-hostname/distinct-kernel hosts: same-kernel containers
+ * SHARE the boot id (runc/containerd do not namespace it), so two containers
+ * with a pinned identical hostname and a shared $HOME collapse to one host id
+ * and fall back to pid-liveness semantics across pid namespaces. The boot id is
+ * best-effort: an empty read degrades to hostname-only, which is still
+ * host-scoped. Exported for tests that must forge same-host vs cross-host owner
+ * records.
  */
 export function currentSyncLockHostId(): string {
   if (cachedSyncLockHostId !== null) return cachedSyncLockHostId;

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -47,7 +47,7 @@ import {
   writeFileSync,
   writeSync,
 } from 'node:fs';
-import { homedir } from 'node:os';
+import { homedir, hostname } from 'node:os';
 import { dirname, join, relative, resolve, sep } from 'node:path';
 import historicalCodexFallbackAllowlist from '../fixtures/codex-fallback-allowlist.json';
 import { resolveClaudeDir, resolveCodexDir, resolveGenieHome, resolveHermesHome } from './genie-home.js';
@@ -1115,7 +1115,8 @@ function classifyCodexFallback(
   };
 }
 
-function retirementTransactionId(accepted: readonly CodexFallbackAcceptedIdentity[], generation = 0): string {
+/** Deterministic transaction id (sha256[:32]) — exported so a forged-journal test can build a self-consistent journal. */
+export function retirementTransactionId(accepted: readonly CodexFallbackAcceptedIdentity[], generation = 0): string {
   const stable = accepted.map((entry) => ({
     skillName: entry.skillName,
     markerVersion: entry.markerVersion,
@@ -1256,13 +1257,58 @@ export interface CodexFallbackRetirementResult {
   retired: string[];
 }
 
-function fsyncPath(path: string): void {
-  const fd = openSync(path, constants.O_RDONLY);
+/** Errors a DIRECTORY-metadata flush may legitimately raise on platforms/filesystems that refuse it. */
+function isTolerableDirectoryFsyncError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === 'EISDIR' || code === 'EPERM' || code === 'EINVAL' || code === 'ENOTSUP';
+}
+
+/**
+ * Test seam for {@link fsyncPath}: inject the open/fsync syscalls (and platform)
+ * so a directory-metadata flush can be forced to throw the way Windows and some
+ * network filesystems do. Real callers pass nothing.
+ */
+export interface FsyncPathDeps {
+  open?: typeof openSync;
+  fsync?: typeof fsyncSync;
+  platform?: NodeJS.Platform;
+}
+
+/**
+ * fsync a path's metadata to disk. FILE fsync is STRICT — journal and staging
+ * byte durability is the load-bearing crash-safety guarantee, so a failure
+ * propagates. DIRECTORY-metadata flush is best-effort: Windows (and some network
+ * filesystems) refuse to open/fsync a directory fd (EISDIR/EPERM/EINVAL/ENOTSUP),
+ * which must NOT brick the codex step of `genie update` at journal-prepare. On
+ * win32 a directory fsync is skipped entirely; elsewhere the tolerable errors are
+ * swallowed. A durable rename still lands; only the extra directory-entry flush
+ * is skipped, exactly as on filesystems that never guaranteed it.
+ */
+function fsyncPath(path: string, deps: FsyncPathDeps = {}): void {
+  const open = deps.open ?? openSync;
+  const fsync = deps.fsync ?? fsyncSync;
+  const platform = deps.platform ?? process.platform;
+  const isDirectory = lstatSafe(path)?.isDirectory() ?? false;
+  if (isDirectory && platform === 'win32') return; // never fsync a directory fd on Windows
+  let fd: number;
   try {
-    fsyncSync(fd);
+    fd = open(path, constants.O_RDONLY);
+  } catch (error) {
+    if (isDirectory && isTolerableDirectoryFsyncError(error)) return; // best-effort directory flush
+    throw error;
+  }
+  try {
+    fsync(fd);
+  } catch (error) {
+    if (!(isDirectory && isTolerableDirectoryFsyncError(error))) throw error; // FILE fsync stays strict
   } finally {
     closeSync(fd);
   }
+}
+
+/** Directly exercisable {@link fsyncPath} for the directory-fsync-tolerance proof (Windows/network-fs failpoint). */
+export function fsyncPathForTest(path: string, deps: FsyncPathDeps = {}): void {
+  fsyncPath(path, deps);
 }
 
 /**
@@ -1672,12 +1718,44 @@ function cleanupRestoredRetirementDestination(
 }
 
 /**
+ * Allocate an unused suffixed evidence basename (`<skill>.2`, `.3`, …) when the
+ * primary `evidence/<skill>` slot already holds a DIFFERING archived tree that
+ * must be preserved. Probed under the single-writer retirement lock; the
+ * no-clobber publish at the call site is the defense-in-depth guard against a
+ * probe/rename race. Both the path and its basename are returned so the chosen
+ * name can be journaled (it must round-trip {@link isSafeEntryName} — `<skill>.N`
+ * is not dot-prefixed and never collides with reserved infra names).
+ */
+function claimFreshEvidencePath(
+  evidenceRoot: string,
+  skillName: string,
+  transactionDir: string,
+): { path: string; name: string } {
+  for (let suffix = 2; suffix < 1000; suffix += 1) {
+    const name = `${skillName}.${suffix}`;
+    const path = join(evidenceRoot, name);
+    if (!isInside(transactionDir, path)) throw new Error(`unconfined retirement evidence: ${path}`);
+    if (lstatSafe(path) === null) return { path, name };
+  }
+  throw new Error(`could not allocate a fresh retirement evidence path for ${skillName}`);
+}
+
+/**
  * Archive the quarantine copy aside with a single atomic rename instead of a
- * recursive delete. The last intact copy is MOVED to `evidence/<skillName>`,
- * never destroyed, so no interval exists in which zero copies of the tree are
- * on disk. After the move a re-verify converts a source that vanished during
- * the check/disposal window into a recoverable conflict rather than a lost
- * commit — the journal never records `restored` while the live tree is absent.
+ * recursive delete. The last intact copy is MOVED to `evidence/<skillName>` (or
+ * a fresh suffixed sibling), never destroyed, so no interval exists in which
+ * zero copies of the tree are on disk. After the move a re-verify converts a
+ * source that vanished during the check/disposal window into a recoverable
+ * conflict rather than a lost commit — the journal never records `restored`
+ * while the live tree is absent.
+ *
+ * An OCCUPIED primary slot is only ever removed when it holds a byte-identical
+ * duplicate of the copy being archived. A DIFFERING archive — the residual
+ * last-copy-loss path: a cycle-1 restore archives the user's edited bytes to
+ * `evidence/<skill>`, then a later same-txn generation re-moves a byte-pristine
+ * tree and re-enters restore with `destinationMatches` true — is preserved
+ * in place and the incoming copy is moved to a fresh suffixed path via the
+ * no-clobber primitive. The chosen archive path is journaled BEFORE the move.
  */
 function disposeQuarantineToEvidence(
   transactionDir: string,
@@ -1691,13 +1769,35 @@ function disposeQuarantineToEvidence(
   failpoint?.(`before-quarantine-disposal:${index}`);
   const evidenceRoot = join(transactionDir, RETIREMENT_EVIDENCE_DIR);
   if (lstatSafe(evidenceRoot) === null) mkdirSync(evidenceRoot, { mode: 0o700 });
-  const evidencePath = join(evidenceRoot, entry.skillName);
-  if (!isInside(transactionDir, evidencePath)) throw new Error(`unconfined retirement evidence: ${evidencePath}`);
-  if (lstatSafe(evidencePath) !== null) rmSync(evidencePath, { recursive: true, force: true }); // only our own prior half-archive
-  entry.evidence = entry.skillName; // persist archive intent BEFORE the move
+  const primaryEvidence = join(evidenceRoot, entry.skillName);
+  if (!isInside(transactionDir, primaryEvidence)) throw new Error(`unconfined retirement evidence: ${primaryEvidence}`);
+  const existing = lstatSafe(primaryEvidence);
+  const incomingDigest = existing === null ? null : exactPhysicalDirectoryDigest(paths.destination);
+  const duplicate =
+    existing !== null && incomingDigest !== null && exactPhysicalDirectoryDigest(primaryEvidence) === incomingDigest;
+
+  let evidencePath: string;
+  if (duplicate || existing === null) {
+    // Empty slot, or the primary archive already holds these exact bytes. In the
+    // duplicate case removing the archive and re-moving the byte-identical copy
+    // loses nothing (this is the prior single-archive behavior, kept verbatim).
+    evidencePath = primaryEvidence;
+    entry.evidence = entry.skillName;
+  } else {
+    // Occupied by a DIFFERING tree that must survive: claim a fresh suffixed
+    // path and NEVER delete the existing archive.
+    const fresh = claimFreshEvidencePath(evidenceRoot, entry.skillName, transactionDir);
+    evidencePath = fresh.path;
+    entry.evidence = fresh.name;
+  }
   journal.phase = 'restoring';
-  writeDurableRetirementJournal(transactionDir, journal, failpoint);
-  renameSync(paths.destination, evidencePath); // ATOMIC — the last copy is MOVED aside, never deleted
+  writeDurableRetirementJournal(transactionDir, journal, failpoint); // persist the chosen archive path BEFORE the move
+  if (duplicate) rmSync(primaryEvidence, { recursive: true, force: true }); // remove only the byte-identical duplicate
+  if (existing === null || duplicate) {
+    renameSync(paths.destination, evidencePath); // ATOMIC — the last copy is MOVED aside, never recursive-deleted
+  } else {
+    atomicRenameDirectoryNoClobber(paths.destination, evidencePath); // no-clobber onto a fresh path; old archive untouched
+  }
   fsyncPath(evidenceRoot);
   fsyncPath(paths.quarantine);
   failpoint?.(`after-quarantine-disposal:${index}`);
@@ -2017,6 +2117,18 @@ function committedRetirementResult(
   };
 }
 
+/**
+ * Re-prove every source's identity before a forward (re-)move. This resets each
+ * entry to `planned` but DELIBERATELY does NOT clear `entry.evidence` between
+ * generations: that field is a durable pointer to a changed-tree copy archived
+ * aside by a PRIOR restore, and it is the only in-journal reference
+ * {@link resolveNeitherTreeRestore} uses to convert a catastrophic "neither
+ * tree" into a recoverable "changed evidence retained" — clearing it would
+ * weaken the never-lose-a-copy invariant. On-disk safety no longer depends on
+ * this field regardless: {@link disposeQuarantineToEvidence} re-reads the
+ * evidence slot from disk and refuses to overwrite a differing archive, so a
+ * stale `entry.evidence` can never authorize data loss.
+ */
 function validateRetirementSources(
   fallbackSkillsDir: string,
   transactionDir: string,
@@ -3889,7 +4001,12 @@ function tryInitializeSyncLock(lockPath: string): LockCreateAttempt {
   let fd: number;
   const token = randomBytes(16).toString('hex');
   const processIdentity = processStartIdentity(process.pid) ?? 'unknown';
-  const ownerRecord = `${process.pid}:${token}:${processIdentity}`;
+  // Host identity is appended as a 4th field so a lock created on one host can
+  // never be stolen from another on an NFS / pid-namespace-shared $HOME. The
+  // shell installer (install.sh) writes only the 3-field `pid:token:unknown`
+  // form and parses just the leading pid, so a 4th field is backward-compatible
+  // both ways: {@link lockOwner} reads it, the shell ignores it.
+  const ownerRecord = `${process.pid}:${token}:${processIdentity}:${currentSyncLockHostId()}`;
   try {
     fd = openSync(lockPath, 'wx');
   } catch (error) {
@@ -3930,19 +4047,49 @@ function isStaleOrInvalidLockTime(mtimeMs: number, nowMs = Date.now()): boolean 
   return ageMs > LOCK_STALE_MS || ageMs < -LOCK_STALE_MS;
 }
 
-/** Parse current pid/token/start locks plus legacy pid/token and pid-only records. */
-function lockOwner(lockPath: string): { pid: number; processIdentity: string | null } | null {
+/**
+ * Parse current `pid:token:start:host` locks plus every legacy form
+ * (`pid:token:start`, `pid:token`, `pid`) and the shell's `pid:token:unknown`.
+ * `host` is absent (→ null) for any record written before this field existed or
+ * by the shell installer; a null host is treated as "unknown host" downstream.
+ */
+function lockOwner(lockPath: string): { pid: number; processIdentity: string | null; host: string | null } | null {
   const raw = readTrimmed(lockPath);
-  const match = raw?.match(/^(\d+)(?::[a-f0-9]{32})?(?::([a-f0-9]{64}|unknown))?$/);
+  const match = raw?.match(/^(\d+)(?::[a-f0-9]{32})?(?::([a-f0-9]{64}|unknown))?(?::([a-f0-9]{64}))?$/);
   if (!match) return null;
   const pid = Number(match[1]);
-  return Number.isSafeInteger(pid) && pid > 0 ? { pid, processIdentity: match[2] ?? null } : null;
+  return Number.isSafeInteger(pid) && pid > 0
+    ? { pid, processIdentity: match[2] ?? null, host: match[3] ?? null }
+    : null;
 }
 
-/** Never steal a live lock; PID reuse is rejected by the process-start identity. */
+/**
+ * Never steal a live lock. Beyond PID-reuse rejection via the process-start
+ * identity, a recorded HOST identity that DIFFERS from this host is treated as a
+ * live owner and never stolen: `process.kill`/`ps` liveness on THIS host says
+ * nothing about a peer on an NFS- or pid-namespace-shared $HOME, so a locally
+ * "dead" pid cannot authorize stealing a lock a remote host may still hold. The
+ * fail-closed asymmetry is deliberate — a wrongly-kept stale lock costs one
+ * manual `rm`; a wrongly-stolen live lock costs a silent double writer.
+ *
+ * Deliberate scope decision (host-less records): a record with NO host field —
+ * pre-this-change debris OR the shell installer's `pid:token:unknown` — falls
+ * through to the legacy pid + start-identity liveness rather than being refused
+ * outright. This preserves the shipped, tested shell<->TS lifecycle-lock parity
+ * contract (install.sh writes and reaps host-less records by pid+mtime; the
+ * guard-debris parity test in update.test.ts pins it). Refusing host-less steals
+ * in TS alone would desynchronize the two acquirers AND still leave the shell
+ * able to cross-host-steal — trading a real regression for incomplete safety.
+ * Because every lock written after this change carries a host field — INCLUDING
+ * every retirement lock (TS-only) and every post-upgrade agent-sync/lifecycle
+ * lock — cross-host steal is prevented everywhere it can actually occur; only
+ * transient legacy/shell-shaped records retain the prior semantics, in lockstep
+ * with the shell.
+ */
 function lockHasLiveOwner(lockPath: string): boolean {
   const owner = lockOwner(lockPath);
-  if (owner === null) return false;
+  if (owner === null) return false; // empty / unparseable record is genuine dead-writer debris
+  if (owner.host !== null && owner.host !== currentSyncLockHostId()) return true; // host-bearing + cross-host → never steal
   try {
     process.kill(owner.pid, 0);
   } catch (error) {
@@ -3957,6 +4104,32 @@ function lockHasLiveOwner(lockPath: string): boolean {
 function releaseOwnedLock(lockPath: string, ownerRecord: string): void {
   if (readTrimmed(lockPath) !== ownerRecord) return;
   rmSyncSafe(lockPath);
+}
+
+let cachedSyncLockHostId: string | null = null;
+
+/**
+ * A stable identity for THIS host, embedded in every lock owner record so a
+ * cross-host stealer can recognize "not my host" and refuse to steal. It is the
+ * sha256 of the hostname plus, on linux, the kernel boot id
+ * (`/proc/sys/kernel/random/boot_id`) — so a reused hostname across reboots (or
+ * across container instances that share it) still yields distinct identities
+ * where the boot id is readable. The boot id is best-effort: an empty read
+ * degrades to hostname-only, which is still host-scoped. Exported for tests that
+ * must forge same-host vs cross-host owner records.
+ */
+export function currentSyncLockHostId(): string {
+  if (cachedSyncLockHostId !== null) return cachedSyncLockHostId;
+  let bootId = '';
+  if (process.platform === 'linux') {
+    try {
+      bootId = readFileSync('/proc/sys/kernel/random/boot_id', 'utf8').trim();
+    } catch {
+      bootId = '';
+    }
+  }
+  cachedSyncLockHostId = createHash('sha256').update(`${hostname()}\0${bootId}`).digest('hex');
+  return cachedSyncLockHostId;
 }
 
 function processStartIdentity(pid: number): string | null {
@@ -4264,8 +4437,39 @@ function isOptionalPhysicalMode(value: unknown): value is number | null {
   return value === null || isPhysicalMode(value);
 }
 
+/**
+ * Retirement infrastructure basenames a moved/restored entry name must never
+ * collide with. The dot-prefixed infra (`.retirement.lock`, `.restore-staging`,
+ * `.genie-codex-fallback-retirement`, every `.journal.*` temp) is already
+ * excluded by the leading-dot rule below; these are the non-hidden ones.
+ */
+const RETIREMENT_INFRA_ENTRY_NAMES: ReadonlySet<string> = new Set([
+  'journal.json',
+  'quarantine',
+  RETIREMENT_EVIDENCE_DIR,
+]);
+
+/**
+ * A journal/skill entry name must be a single path component that can never name
+ * the engine's own on-disk infrastructure. Rejecting dot-prefixed names (so
+ * `.`, `..`, `.retirement.lock`, `.restore-staging`,
+ * `.genie-codex-fallback-retirement`, and any `.journal.*` temp are refused) and
+ * the reserved non-hidden infra names (`journal.json`, `quarantine`, `evidence`)
+ * is a forged-journal defense: it is applied at BOTH plan time
+ * ({@link planCodexFallbackRetirement}) and journal re-validation
+ * ({@link validateRetirementPaths} / {@link readRetirementJournal}), so a
+ * crafted `accepted[]`/`entries[]` can never steer a recovery move or restore
+ * onto the transaction's own state. Suffixed evidence archives (`<skill>.2`) are
+ * NOT dot-prefixed and remain valid.
+ */
 function isSafeEntryName(value: string): boolean {
-  return value !== '' && value !== '.' && value !== '..' && !value.includes('/') && !value.includes('\\');
+  return (
+    value !== '' &&
+    !value.startsWith('.') &&
+    !value.includes('/') &&
+    !value.includes('\\') &&
+    !RETIREMENT_INFRA_ENTRY_NAMES.has(value)
+  );
 }
 
 function createExclusiveTransactionDir(parent: string, preferredName: string): string {

--- a/src/lib/runtime-integrations.test.ts
+++ b/src/lib/runtime-integrations.test.ts
@@ -14,7 +14,12 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
-import { CODEX_FALLBACK_RETIREMENT_ROOT, computeDirDigest } from './agent-sync.js';
+import {
+  CODEX_FALLBACK_RETIREMENT_ROOT,
+  applyCodexFallbackRetirement,
+  computeDirDigest,
+  planCodexFallbackRetirement,
+} from './agent-sync.js';
 import { REQUIRED_GENIE_MCP_TOOLS } from './codex-mcp-health-session.js';
 import type { CodexPluginProbe } from './codex-project-mcp.js';
 import {
@@ -2661,6 +2666,95 @@ describe('translateRetirementConflicts surfaces R8 conflict classes as manual-re
 
   test('returns the step result when it does not throw', () => {
     expect(translateRetirementConflicts(() => 42)).toBe(42);
+  });
+});
+
+describe('R8 retirement-conflict contract producer drift (agent-sync ↔ runtime-integrations)', () => {
+  // RETIREMENT_CONFLICT_CONTRACT pins raw substrings of agent-sync error messages
+  // but nothing else binds the PRODUCER side: a reword in agent-sync silently
+  // reverts a class to raw pass-through. This suite binds both sides so a reword
+  // on EITHER fails CI. The pinned substrings are extracted straight from the
+  // (unexported) contract source; each must appear in a producible agent-sync
+  // message AND still be recognized by translateRetirementConflicts.
+  const agentSyncSource = readFileSync(join(import.meta.dir, 'agent-sync.ts'), 'utf8');
+  const runtimeSource = readFileSync(join(import.meta.dir, 'runtime-integrations.ts'), 'utf8');
+  const contractStart = runtimeSource.indexOf('RETIREMENT_CONFLICT_CONTRACT');
+  const contractBody = runtimeSource.slice(contractStart, runtimeSource.indexOf('];', contractStart));
+  const pinned = [...contractBody.matchAll(/match:\s*'([^']+)'/g)].map((m) => m[1] as string);
+
+  test('the contract still pins exactly the 8 known conflict classes', () => {
+    expect([...pinned].sort()).toEqual([
+      'changed evidence retained',
+      'kept both versions for review',
+      'kept live and incoming versions for review',
+      'kept live removal transaction for review',
+      'restored source changed during cleanup',
+      'restored source changed during disposal',
+      'source changed after planning',
+      'source changed at move boundary',
+    ]);
+  });
+
+  // Producer-side binding for every pinned class. Classes 1-5 (retirement engine:
+  // 'source changed ...', 'changed evidence retained', 'restored source ...') are
+  // PROVOKED end-to-end across agent-sync.test.ts's batch suite, and 'source
+  // changed after planning' is re-provoked below through translateRetirementConflicts
+  // to prove the translation wiring on a real engine throw. Classes 6-8
+  // (managed-skill-tree: 'kept ... for review') are bound by static source
+  // presence — provoking them needs the managed-dir promotion failpoint seams,
+  // which are exercised directly in agent-sync.test.ts.
+  for (const substring of pinned) {
+    test(`"${substring}" is emitted by agent-sync and recognized by the contract`, () => {
+      expect(agentSyncSource).toContain(substring); // producer still emits it verbatim
+      expect(() =>
+        translateRetirementConflicts(() => {
+          throw new Error(`fallback retirement ${substring} at /path`);
+        }),
+      ).toThrow('needs manual recovery'); // consumer still recognizes it
+    });
+  }
+
+  test('provoked end-to-end: a source edited after planning throws the pinned message and is translated', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'r8-drift-'));
+    try {
+      const fallback = join(tmp, 'agents', 'skills');
+      const skill = join(fallback, 'wish');
+      mkdirSync(skill, { recursive: true });
+      writeFileSync(join(skill, 'SKILL.md'), '# wish\n', 'utf8');
+      const digest = computeDirDigest(skill);
+      writeFileSync(
+        join(skill, '.genie-sync.json'),
+        `${JSON.stringify({ managedBy: 'genie-agent-sync', version: 'v1', digest, syncedAt: 'now', identityVersion: 2 })}\n`,
+        'utf8',
+      );
+      const target = join(tmp, 'target', 'wish');
+      mkdirSync(target, { recursive: true });
+      writeFileSync(join(target, 'SKILL.md'), '# wish\n', 'utf8');
+      const plan = planCodexFallbackRetirement({
+        fallbackSkillsDir: fallback,
+        skillNames: ['wish'],
+        verifiedTargets: [
+          { skillName: 'wish', path: target, physicalDigest: computeDirDigest(target), canonicalVerified: true },
+        ],
+      });
+      expect(plan.accepted).toHaveLength(1);
+      // Personal edit after planning → the move-time identity check fails.
+      writeFileSync(join(skill, 'USER.txt'), 'edited after planning\n', 'utf8');
+      let raw = '';
+      expect(() =>
+        translateRetirementConflicts(() => {
+          try {
+            return applyCodexFallbackRetirement(plan);
+          } catch (error) {
+            raw = error instanceof Error ? error.message : String(error);
+            throw error;
+          }
+        }),
+      ).toThrow('needs manual recovery');
+      expect(raw).toContain('source changed after planning'); // the real throw carries the pinned substring
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Hardens the highest-risk code in the repo — the **codex fallback retirement engine** (quarantine-never-delete, digest-anchored ownership, journal-before-action, no interval with zero copies of any tree) — against five residual failure modes. Every change **strengthens, never weakens** the engine's safety envelope. Scope: `src/lib/agent-sync.ts` + its test + the R8 drift test in `runtime-integrations.test.ts`.

## The five fixes

### 1. Evidence-overwrite last-copy-loss (the one true residual)
`disposeQuarantineToEvidence` removed an existing `evidence/<skill>` on the assumption it was "only our own prior half-archive". Constructed loss: (c1) a TOCTOU edit is quarantined → restore republishes the edited tree and archives it to `evidence/<skill>`; (c2) the user reverts the live tree byte-exactly → a same-txn forward re-run re-quarantines the pristine tree; (c3) a mid-batch failure re-enters `restoreRetirementEntry` with `destinationMatches=true` (`restoreDigest` undefined) → publish → cleanup → dispose `rmSync`s the c1 archive (the only copy of the user's edited bytes) before archiving the pristine copy.

**Fix:** a **differing** evidence tree is never deleted. Empty slot → unchanged `renameSync`. Byte-identical occupied slot → prior dispose-duplicate behavior (safe: identical bytes). **Differing** occupied slot → claim a fresh `lstat`-probed suffixed path (`<skill>.2`, `.3`, …) via `atomicRenameDirectoryNoClobber`, journal the chosen path **before** the move, leave the old archive untouched.

**Compatibility:** `entry.evidence` remains a per-entry basename (compatible extension, no new field), so old journals (`evidence=<skill>`) and the recovery reader replay unchanged; `<skill>.N` passes `isSafeEntryName`. **Deliberate decision (documented in `validateRetirementSources`):** it does **not** clear `entry.evidence` between generations — that field is the durable pointer `resolveNeitherTreeRestore` uses to keep a catastrophic "neither tree" as a recoverable "changed evidence retained", and on-disk safety no longer depends on it (disposal re-reads the evidence slot from disk).

### 2. Cross-host lock steal
The steal used pid + process-start-identity, which lies across NFS / pid-namespace-shared `$HOME`. The owner record gains a 4th **host-identity** field (`sha256(hostname + linux boot_id)`).

- **Host-bearing** record whose host differs → **never stolen** (a locally-dead pid proves nothing about a remote peer); fails closed via the existing bounded-retry "no data changed" contract.
- **Host-less** record (pre-upgrade debris, the shell installer's `pid:token:unknown`) → **deliberately keeps legacy pid+mtime semantics** to preserve the shipped, tested **shell↔TS lifecycle-lock parity contract** (`install.sh` writes/reaps host-less records by pid+mtime; the guard-debris parity test pins it). Refusing host-less steals in TS alone would desync the two acquirers *and* still leave the shell able to cross-host-steal — a real regression for incomplete safety.

Because every lock written after this change carries a host field — **including every TS-only retirement lock** and every post-upgrade agent-sync/lifecycle lock — cross-host steal is prevented wherever it can actually occur. `lockOwner` tolerates all legacy shapes; the change stays inside the lock helpers.

### 3. Journal entry-name confinement (`isSafeEntryName`)
Rejects dot-prefixed names (`.`, `..`, `.retirement.lock`, `.restore-staging`, `.genie-codex-fallback-retirement`, `.journal.*` temps) and reserved non-hidden infra names (`journal.json`, `quarantine`, `evidence`), at **both** plan time and journal re-validation (forged-journal defense). Suffixed evidence archives (`<skill>.N`) stay valid.

### 4. Directory-fsync tolerance (`fsyncPath`)
A **directory**-metadata flush the platform refuses (win32; network fs `EISDIR`/`EPERM`/`EINVAL`/`ENOTSUP`) is now best-effort, so it can't brick the codex step of `genie update` at journal-prepare. **FILE** fsync stays strict — journal/staging byte durability is load-bearing. Injectable seam + failpoint tests included.

### 5. R8 contract drift test
`RETIREMENT_CONFLICT_CONTRACT` pins 8 raw substrings of agent-sync messages with nothing binding the producer side. New test extracts the 8 pinned substrings from the contract source, asserts each appears in a producible agent-sync message and is recognized by `translateRetirementConflicts` (plus one end-to-end provocation), so a reword on **either** side fails CI. Verified non-vacuous by mutation.

## Invariants preserved / strengthened
- **No interval with zero copies of any tree** — strengthened: disposal never deletes a differing archive; the last copy is always moved (`renameSync`/no-clobber), never `rmSync`'d.
- **Quarantine-never-delete / journal-before-action** — the chosen evidence path is journaled before every move; the R8 conflict vocabulary (`changed evidence retained`, `both trees retained`, `source changed …`) is unchanged.
- **Exactly one writer per fallback root** — strengthened cross-host; contended locks still fail closed with "no data changed".
- **Path confinement** — forged journals naming engine infrastructure are rejected at recovery, not just at plan time.
- **Durability** — file fsync stays strict; only directory-entry flush is best-effort on platforms that never guaranteed it.

## Tests / gates
- `bun test src/lib/agent-sync.test.ts` — **198 pass** (was 180): three-cycle evidence survival, duplicate disposal, cross-host / host-less / same-host lock steal, retirement cross-host fail-closed + host-field record, forged dot-name/reserved journal rejection, directory-fsync failpoints.
- `bun test src/lib/runtime-integrations.test.ts` — **131 pass** (was 118): R8 producer-drift suite.
- `bun run check:fast` — green.
- `bun run check` — red only on the known env-dependent `hooks/codex-manifest.test.ts` tests (no new failures; the pre-existing 4-way `simultaneous stale-lock steals` concurrency test is a documented "residual race (accepted)" that flakes under full-suite CPU load and passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)