### PR TITLE
fix(agent-sync): restore hermes sync leg killed by the codex-plugin-only narrowing

### DIFF
--- a/src/genie-commands/__tests__/update.test.ts
+++ b/src/genie-commands/__tests__/update.test.ts
@@ -29,7 +29,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { type AgentSyncReport, acquireLifecycleLease, lifecycleLockPath } from '../../lib/agent-sync';
+import { type AgentSyncReport, acquireLifecycleLease, lifecycleLockPath, runAgentSync } from '../../lib/agent-sync';
 import { REQUIRED_GENIE_MCP_TOOLS } from '../../lib/codex-mcp-health-session';
 import type { CodexPluginProbe } from '../../lib/codex-project-mcp';
 import {
@@ -37,6 +37,7 @@ import {
   type CodexHealthProof,
   type CodexPluginOnlyDeps,
   type CommandRunner,
+  type IntegrationSelection,
 } from '../../lib/runtime-integrations';
 import { VERSION } from '../../lib/version';
 import type { AuxiliaryTreeOutcome, AuxiliaryTreeStage } from '../auxiliary-trees.js';
@@ -2882,6 +2883,137 @@ describe('manual post-update convergence (2026-07-11 cascade regression)', () =>
   });
 });
 
+describe('runManualUpdateConvergence — hermes leg restored end-to-end (restore-hermes-sync-leg regression)', () => {
+  // A prior release (#2572) narrowed every production selection to 'claude'
+  // before it reached runAgentSync, so `genie update`'s hermes leg (which
+  // only fires on a verbatim 'auto'/'all' selection) silently stopped
+  // converging — confirmed live via `genie update --sync-only` printing only
+  // 'agent-sync: claude'. This suite drives the REAL runSync path (no `sync`
+  // mock) through real GENIE_HOME/HERMES_HOME fixtures, isolated the way
+  // doctor.test.ts isolates its lifecycle env, to prove the hermes leg
+  // converges again and that the PR #2576 duplicate-external_dirs repair is
+  // reachable from the update lifecycle, not just the low-level helper test.
+  const ENV_KEYS = ['HOME', 'GENIE_HOME', 'HERMES_HOME', 'CLAUDE_CONFIG_DIR', 'CODEX_HOME'] as const;
+  let isolatedHome: string;
+  let savedEnv: Partial<Record<(typeof ENV_KEYS)[number], string>>;
+  let genieHome: string;
+  let hermesHome: string;
+  let genieBin: string;
+
+  beforeEach(() => {
+    isolatedHome = mkdtempSync(join(tmpdir(), 'genie-update-hermes-'));
+    savedEnv = {};
+    for (const key of ENV_KEYS) {
+      if (process.env[key] !== undefined) savedEnv[key] = process.env[key];
+    }
+    genieHome = join(isolatedHome, 'genie');
+    hermesHome = join(isolatedHome, 'hermes');
+    process.env.HOME = isolatedHome;
+    process.env.GENIE_HOME = genieHome;
+    process.env.HERMES_HOME = hermesHome;
+    process.env.CLAUDE_CONFIG_DIR = join(isolatedHome, 'claude'); // absent: claude leg simply undetected
+    process.env.CODEX_HOME = join(isolatedHome, 'codex');
+
+    // Minimal real genie plugin source: a populated skills root + VERSION +
+    // an executable bin/genie (resolveGenieBinaryPath / resolveProductSkillsRoot
+    // both require real files, not injected targets, since this test exercises
+    // the default env-resolved paths exactly like production `genie update`).
+    mkdirSync(join(genieHome, 'plugins', 'genie', 'skills', 'alpha'), { recursive: true });
+    writeFileSync(join(genieHome, 'plugins', 'genie', 'skills', 'alpha', 'SKILL.md'), '# alpha\n');
+    // resolveGenieSource requires plugins/hermes-genie NEXT TO plugins/genie for
+    // ctx.hermesRoot to resolve — without it, syncHermes bails before either
+    // config leg runs (see the 'hermes source ... not found' advisory).
+    mkdirSync(join(genieHome, 'plugins', 'hermes-genie'), { recursive: true });
+    writeFileSync(join(genieHome, 'plugins', 'hermes-genie', 'plugin.json'), '{"name":"hermes-genie"}\n');
+    writeFileSync(join(genieHome, 'VERSION'), '9.9.9\n');
+    mkdirSync(join(genieHome, 'bin'), { recursive: true });
+    genieBin = join(genieHome, 'bin', 'genie');
+    writeFileSync(genieBin, '#!/usr/bin/env bun\n');
+    chmodSync(genieBin, 0o755);
+    mkdirSync(hermesHome, { recursive: true });
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const saved = savedEnv[key];
+      if (saved === undefined) Reflect.deleteProperty(process.env, key);
+      else process.env[key] = saved;
+    }
+    rmSync(isolatedHome, { recursive: true, force: true });
+  });
+
+  /**
+   * Mirrors `runManualUpdateConvergence`'s own default `runSync` closure
+   * (narrow the selection, then `runAgentSyncSafe`), but pins `markerPath`
+   * inside the isolated tmpdir. `update.ts`'s `GENIE_HOME` constant is
+   * captured once at module import time, before this suite's `beforeEach` can
+   * repoint `process.env.GENIE_HOME` — the default marker path would
+   * otherwise write `.last-agent-sync` outside this test's sandbox. The sync
+   * engine itself is unaffected: `runAgentSync` resolves every target via the
+   * live `resolveGenieHome()`/`resolveHermesHome()` env reads, so this still
+   * exercises the real narrowing + the real engine end-to-end.
+   */
+  function realRunSync(selection: IntegrationSelection): () => void {
+    return () => {
+      const agentSyncSelection = narrowUpdateAgentSyncSelection(selection);
+      if (agentSyncSelection !== null) {
+        runAgentSyncSafe({
+          strict: true,
+          selection: agentSyncSelection,
+          markerPath: join(isolatedHome, '.last-agent-sync'),
+          // hermesBinary: null keeps this test-safe (no `hermes plugins enable`
+          // exec) — the same posture agent-sync.test.ts's `run()` fixture takes.
+          sync: (opts) => runAgentSync({ ...opts, hermesBinary: null }),
+        });
+      }
+    };
+  }
+
+  test('selection auto converges the hermes leg (mcp_servers.genie + skills.external_dirs) into a fresh config', () => {
+    const result = runManualUpdateConvergence({
+      expectedVersion: '9.9.9',
+      selection: 'auto',
+      runSync: realRunSync('auto'),
+      refreshPlugins: () => [],
+      log: () => undefined,
+    });
+    expect(result.integrations).toEqual([]);
+
+    const configPath = join(hermesHome, 'config.yaml');
+    const text = readFileSync(configPath, 'utf8');
+    expect(text).toContain('mcp_servers:');
+    expect(text).toContain(genieBin);
+    expect(text).toContain('skills:');
+    expect(text).toContain('external_dirs:');
+    expect(text).toContain(join(genieHome, 'plugins', 'genie', 'skills'));
+  });
+
+  test('selection auto repairs a config damaged with the duplicate-external_dirs shape (PR #2576)', () => {
+    const configPath = join(hermesHome, 'config.yaml');
+    const skillsRoot = join(genieHome, 'plugins', 'genie', 'skills');
+    // Exact damaged shape from an earlier buggy release: `skills:` carries BOTH
+    // an inline empty `external_dirs: []` and a later block-style `external_dirs`
+    // holding the genie-marked managed entry — spec-invalid duplicate-key YAML.
+    const damaged = `skills:\n  external_dirs: []\n  template_vars: true\n  external_dirs:\n    - ${JSON.stringify(skillsRoot)}  # genie:managed:skills.external_dirs\n`;
+    writeFileSync(configPath, damaged);
+
+    runManualUpdateConvergence({
+      expectedVersion: '9.9.9',
+      selection: 'auto',
+      runSync: realRunSync('auto'),
+      refreshPlugins: () => [],
+      log: () => undefined,
+    });
+
+    const text = readFileSync(configPath, 'utf8');
+    expect(text.match(/external_dirs:/g)?.length).toBe(1);
+    expect(text).toContain('template_vars: true');
+    const parsed = Bun.YAML.parse(text) as { skills: { external_dirs: string[]; template_vars: boolean } };
+    expect(parsed.skills.external_dirs).toEqual([skillsRoot]);
+    expect(parsed.skills.template_vars).toBe(true);
+  });
+});
+
 describe('operator-driven plugin refresh', () => {
   let pluginStateDir: string;
 
@@ -3351,11 +3483,15 @@ describe('--sync-only codex inspection (A14/R3)', () => {
   });
   const staleProbe = (): CodexPluginProbe => ({ ...healthyUpdateCodexProbe(), version: '0.0.0' });
 
-  test('narrowUpdateAgentSyncSelection keeps agent-sync Claude-scoped', () => {
+  test('narrowUpdateAgentSyncSelection passes the real selection through (restore-hermes-sync-leg)', () => {
+    // codex/none: agent-sync has nothing to do (codex is plugin-only; none is none).
     expect(narrowUpdateAgentSyncSelection('codex')).toBeNull();
     expect(narrowUpdateAgentSyncSelection('none')).toBeNull();
-    expect(narrowUpdateAgentSyncSelection('auto')).toBe('claude');
-    expect(narrowUpdateAgentSyncSelection('all')).toBe('claude');
+    // auto/all/claude pass through UNCHANGED. Collapsing these to 'claude' (the
+    // prior behavior) silently killed runAgentSync's hermes leg, which only
+    // fires on a verbatim 'auto'/'all' — see runAgentSync in agent-sync.ts.
+    expect(narrowUpdateAgentSyncSelection('auto')).toBe('auto');
+    expect(narrowUpdateAgentSyncSelection('all')).toBe('all');
     expect(narrowUpdateAgentSyncSelection('claude')).toBe('claude');
   });
 

--- a/src/genie-commands/install.test.ts
+++ b/src/genie-commands/install.test.ts
@@ -422,7 +422,7 @@ describe('installCommand', () => {
     expect(selection).toBe('none');
   });
 
-  test('agent-sync is Claude-scoped: codex and none never invoke it; auto/all/claude sync Claude only', () => {
+  test('agent-sync selection passes through unchanged (restore-hermes-sync-leg): codex/none skip it, auto/all/claude reach it as-is', () => {
     const observed: string[] = [];
     const runFor = (integrations: 'codex' | 'none' | 'auto' | 'all' | 'claude') =>
       installCommand(
@@ -434,15 +434,19 @@ describe('installCommand', () => {
         noopLease,
         noopConsent,
       );
-    // codex converges through runIntegrations only — agent-sync (the sole
-    // ~/.agents/skills writer) must never run for codex (R2/A1).
+    // codex converges through runIntegrations only — agent-sync never writes
+    // ~/.agents/skills at all now (R2/A1 is structural in runAgentSync), so
+    // codex/none simply have nothing for agent-sync to do.
     runFor('codex');
     runFor('none');
     expect(observed).toEqual([]);
+    // auto/all/claude pass through UNCHANGED — narrowAgentSyncSelection no
+    // longer collapses them to 'claude', which is what silently killed the
+    // hermes leg (runAgentSync's hermes gate needs 'auto'/'all' verbatim).
     runFor('auto');
     runFor('all');
     runFor('claude');
-    expect(observed).toEqual(['claude', 'claude', 'claude']);
+    expect(observed).toEqual(['auto', 'all', 'claude']);
   });
 
   test('a failed codex integration gates the Claude skill sync so Claude trees stay byte-identical (A2)', () => {
@@ -476,7 +480,7 @@ describe('installCommand', () => {
         noopConsent,
       );
       const output = lines.join('\n');
-      expect(output).toContain('Skipped Claude agent-sync');
+      expect(output).toContain('Skipped agent-sync');
       expect(output).toContain('codex integration failed');
     } finally {
       console.log = originalLog;

--- a/src/genie-commands/install.ts
+++ b/src/genie-commands/install.ts
@@ -142,10 +142,11 @@ export function installCommand(
       }
     }
     // Codex is now converged end-to-end (plugin → single health proof →
-    // fallback retirement → role agents) through runIntegrations; agent-sync is
-    // scoped to Claude only so it never re-writes Genie product skills into
-    // ~/.agents/skills (R2). Integrations run BEFORE the Claude skill sync so a
-    // plugin-incapable Codex leaves Claude trees byte-identical (R1/A2).
+    // fallback retirement → role agents) through runIntegrations; agent-sync
+    // never writes Genie product skills into ~/.agents/skills (R2) because
+    // `runAgentSync` has no codex arm at all — structural, not selection-gated.
+    // Integrations run BEFORE the Claude/hermes agent-sync so a plugin-incapable
+    // Codex leaves Claude trees byte-identical (R1/A2).
     const results = runIntegrations({ selection });
     for (const result of results) {
       const glyph = result.ok ? '\x1b[32m+\x1b[0m' : '\x1b[33m!\x1b[0m';
@@ -166,9 +167,9 @@ export function installCommand(
         // selection === 'auto' is the only surviving case here: an explicit
         // --integrations all/claude/codex codex failure already threw above,
         // so a silent codexFailed-guarded skip here would otherwise exit 0
-        // with Claude agent-sync never having run and no trace of why.
+        // with agent-sync never having run and no trace of why.
         console.log(
-          '  \x1b[33m!\x1b[0m Skipped Claude agent-sync: codex integration failed under --integrations auto (rerun with --integrations claude to sync Claude only, or fix codex and rerun).',
+          '  \x1b[33m!\x1b[0m Skipped agent-sync: codex integration failed under --integrations auto (rerun with --integrations claude to sync Claude/hermes only, or fix codex and rerun).',
         );
       }
     }
@@ -181,14 +182,17 @@ export function installCommand(
 }
 
 /**
- * Narrow a client selection to the agent-sync scope. Codex product skills now
- * live only in the plugin, so agent-sync (the sole ~/.agents/skills writer via
- * syncCodex) must never run for codex: `auto`/`all`/`claude` sync Claude only,
- * and `codex`/`none` skip agent-sync entirely (R2/A1). runIntegrations keeps the
- * full selection so codex still converges through installCodexIntegration.
+ * Gate the agent-sync scope for install. R2/A1 (agent-sync must never write
+ * codex product skills into ~/.agents/skills) is now structural in
+ * `runAgentSync` itself — there is no `codex` arm to narrow away from — so
+ * this only needs to skip agent-sync where it has nothing to do: `none`
+ * (nothing selected) and `codex` (codex converges entirely through
+ * `installCodexIntegration`, never through agent-sync). Every other selection
+ * (`auto`/`all`/`claude`) passes through UNCHANGED so `runAgentSync` sees the
+ * real selection and converges hermes on `auto`/`all` too.
  */
-export function narrowAgentSyncSelection(selection: IntegrationSelection): 'claude' | null {
-  return selection === 'auto' || selection === 'all' || selection === 'claude' ? 'claude' : null;
+export function narrowAgentSyncSelection(selection: IntegrationSelection): IntegrationSelection | null {
+  return selection === 'none' || selection === 'codex' ? null : selection;
 }
 
 /** Validate raw Commander input before cleanup, synchronization, or install side effects. */

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -1945,9 +1945,17 @@ export function legacySyncOnlyPluginAdvisory(options: LegacySyncOnlyAdvisoryOpti
   return `Legacy --sync-only left selected plugin integration${stale.length === 1 ? '' : 's'} stale (${stale.join(', ')}; CLI/source v${normalizeVersion(options.expectedVersion)}). Close all Codex tasks first. Then, from an external terminal, run \`genie update\` (or \`genie setup --codex\`), review \`/hooks\`, and start a new Codex task.`;
 }
 
-/** Agent-sync is Claude-scoped in every lifecycle path: codex product skills are plugin-only (R2/A1). */
-export function narrowUpdateAgentSyncSelection(selection: IntegrationSelection): 'claude' | null {
-  return selection === 'auto' || selection === 'all' || selection === 'claude' ? 'claude' : null;
+/**
+ * Gate the agent-sync scope for update. R2/A1 (agent-sync must never write
+ * codex product skills into ~/.agents/skills) is structural in `runAgentSync`
+ * itself now — there is no `codex` arm to narrow away from — so this only
+ * skips agent-sync where it has nothing to do: `none` and `codex` (codex
+ * converges entirely through the plugin-only integration refresh, never
+ * through agent-sync). `auto`/`all`/`claude` pass through UNCHANGED so
+ * `runAgentSync` sees the real selection and converges hermes on `auto`/`all`.
+ */
+export function narrowUpdateAgentSyncSelection(selection: IntegrationSelection): IntegrationSelection | null {
+  return selection === 'none' || selection === 'codex' ? null : selection;
 }
 
 export interface SyncOnlyCodexInspectionOptions {
@@ -2023,8 +2031,9 @@ export interface LegacySyncOnlyConvergenceOptions extends LegacySyncOnlyAdvisory
 /**
  * Emit version-drift recovery, INSPECT codex health (R3/A14 — fail nonzero and
  * byte-identical before any write on a missing/disabled/stale/unhealthy plugin),
- * then run the Claude-scoped strict skill sync. Sync is Claude-only so codex
- * product skills are never rewritten under ~/.agents/skills (R2/A1).
+ * then run the strict agent-sync skill sync for the requested scope. Codex
+ * product skills are never rewritten under ~/.agents/skills (R2/A1) — that
+ * guarantee is structural in `runAgentSync`, not a Claude-only narrowing here.
  */
 export function runLegacySyncOnlyConvergence(options: LegacySyncOnlyConvergenceOptions): void {
   const advisory = legacySyncOnlyPluginAdvisory(options);
@@ -2398,8 +2407,10 @@ export function runManualUpdateConvergence(options: ManualUpdateConvergenceOptio
   const emit = options.log ?? log;
   const selection = options.selection ?? readIntegrationConsent(GENIE_HOME);
   if (selection === 'none') return { integrations: [] };
-  // R2/A1/A13: agent-sync is the sole ~/.agents/skills writer (via syncCodex), so
-  // a full update scopes it to Claude only. Codex product skills stay
+  // R2/A1/A13: `runAgentSync` has no codex arm, so it structurally never
+  // writes ~/.agents/skills — a full update passes the real selection through
+  // (converging claude + hermes on auto/all) and only gates the codex-only /
+  // none cases, where agent-sync has nothing to do. Codex product skills stay
   // plugin-only, and codex role agents + fallback retirement are refreshed by
   // refreshUpdatePlugins → convergeCodexPluginOnly below.
   const agentSyncSelection = narrowUpdateAgentSyncSelection(selection);

--- a/src/lib/agent-sync.test.ts
+++ b/src/lib/agent-sync.test.ts
@@ -249,18 +249,6 @@ describe('fresh create', () => {
     expect(workflowManifest.digest).toMatch(/^[a-f0-9]{64}$/);
   });
 
-  test('codex: skills land top-level under the agents skills tier with a restart advisory', () => {
-    present(fixture.codexDir);
-    const report = agentReport(run(), 'codex');
-
-    expect(report.detected).toBe(true);
-    expect(existsSync(join(fixture.agentsSkillsDir, 'alpha', 'SKILL.md'))).toBe(true);
-    expect(readManifest(join(fixture.agentsSkillsDir, 'alpha')).managedBy).toBe('genie-agent-sync');
-    // nothing is ever written into the retired `<codexDir>/skills/.curated` lane
-    expect(existsSync(join(fixture.codexDir, 'skills', '.curated'))).toBe(false);
-    expect(report.advisories).toContain('restart Codex to pick up updated skills');
-  });
-
   test('hermes: symlink created + enable exec fired exactly once', () => {
     present(fixture.hermesHome);
     const enableCalls: string[][] = [];
@@ -309,10 +297,6 @@ describe('idempotent re-run', () => {
     expect(skillAction(claude, 'alpha')).toBe('unchanged');
     expect(skillAction(claude, 'beta')).toBe('unchanged');
     expect(extraAction(claude, 'stamp')).toBe('skipped');
-
-    const codex = agentReport(second, 'codex');
-    expect(skillAction(codex, 'alpha')).toBe('unchanged');
-    expect(codex.advisories).not.toContain('restart Codex to pick up updated skills');
 
     const hermes = agentReport(second, 'hermes');
     expect(extraAction(hermes, 'symlink')).toBe('unchanged');
@@ -541,20 +525,16 @@ describe('managed orphan handling', () => {
 describe('claude council exclusion', () => {
   const councilFiles = { 'SKILL.md': '# council (portable, non-workflow runtimes)\n' };
 
-  test('council is synced to codex but never to claude (workflow owns the name there)', () => {
+  test('council is excluded from claude (the native /council workflow owns the name there)', () => {
     rmSync(fixture.root, { recursive: true, force: true });
     fixture = setup({ skills: { alpha: { 'SKILL.md': '# alpha\n' }, council: councilFiles } });
     present(fixture.claudeDir);
-    present(fixture.codexDir);
 
     const report = run();
     const claude = agentReport(report, 'claude');
-    const codex = agentReport(report, 'codex');
     expect(skillAction(claude, 'council')).toBeUndefined();
     expect(existsSync(join(fixture.claudeDir, 'skills', 'council'))).toBe(false);
     expect(skillAction(claude, 'alpha')).toBe('created');
-    expect(skillAction(codex, 'council')).toBe('created');
-    expect(existsSync(join(fixture.agentsSkillsDir, 'council', 'SKILL.md'))).toBe(true);
   });
 
   test('a managed council already synced to claude (pre-exclusion release) is backed up and removed', () => {
@@ -600,9 +580,11 @@ describe('undetected agents', () => {
   test('a missing agent dir yields detected:false and zero writes', () => {
     // no target dirs created at all
     const report = run();
-    for (const agent of ['claude', 'codex', 'hermes'] as const) {
+    for (const agent of ['claude', 'hermes'] as const) {
       expect(agentReport(report, agent).detected).toBe(false);
     }
+    // codex never appears in the report at all — runAgentSync has no codex arm.
+    expect(report.agents.some((agent) => agent.agent === 'codex')).toBe(false);
     expect(existsSync(fixture.claudeDir)).toBe(false);
     expect(existsSync(fixture.codexDir)).toBe(false);
     expect(existsSync(join(fixture.hermesHome, 'plugins'))).toBe(false);
@@ -620,15 +602,18 @@ describe('undetected agents', () => {
 });
 
 describe('explicit client selection', () => {
-  test('codex selection leaves Claude and Hermes homes byte-identical', () => {
+  test('codex selection is structurally a no-op: zero agents, every home byte-identical', () => {
     present(fixture.claudeDir);
     present(fixture.codexDir);
     present(fixture.hermesHome);
+    writeFile(join(fixture.agentsSkillsDir, 'alpha', 'SKILL.md'), '# seeded, pre-existing\n');
     const report = run({ selection: 'codex' });
-    expect(report.agents.map((agent) => agent.agent)).toEqual(['codex']);
-    expect(existsSync(join(fixture.agentsSkillsDir, 'alpha', 'SKILL.md'))).toBe(true);
+    // runAgentSync has no `codex` arm at all: `selection: 'codex'` matches
+    // none of the claude/hermes gates either, so nothing runs.
+    expect(report.agents).toEqual([]);
     expect(existsSync(join(fixture.claudeDir, 'skills'))).toBe(false);
     expect(existsSync(join(fixture.hermesHome, 'plugins', 'genie'))).toBe(false);
+    expect(readFileSync(join(fixture.agentsSkillsDir, 'alpha', 'SKILL.md'), 'utf8')).toBe('# seeded, pre-existing\n');
   });
 
   test('none selection mutates no client home', () => {
@@ -640,6 +625,28 @@ describe('explicit client selection', () => {
     expect(existsSync(join(fixture.claudeDir, 'skills'))).toBe(false);
     expect(existsSync(join(fixture.agentsSkillsDir, 'alpha'))).toBe(false);
     expect(existsSync(join(fixture.hermesHome, 'plugins', 'genie'))).toBe(false);
+  });
+
+  // Regression (restore-hermes-sync-leg): a prior release narrowed every
+  // production caller's selection to 'claude' before it ever reached
+  // runAgentSync, so 'auto'/'all' never converged hermes — see the
+  // update.ts-level lifecycle test for the end-to-end version of this bug.
+  // This is the R2/A1 + hermes-restoration contract pinned at the engine
+  // level: 'auto' must converge BOTH claude and hermes, and must NEVER touch
+  // the shared ~/.agents/skills tier (there is no codex arm to do so).
+  test('auto selection converges claude AND hermes, and never touches a seeded ~/.agents/skills fixture', () => {
+    present(fixture.claudeDir);
+    present(fixture.hermesHome);
+    writeFile(join(fixture.agentsSkillsDir, 'alpha', 'SKILL.md'), '# seeded, pre-existing\n');
+
+    const report = run({ selection: 'auto' });
+
+    expect(report.agents.map((agent) => agent.agent).sort()).toEqual(['claude', 'hermes']);
+    expect(skillAction(agentReport(report, 'claude'), 'alpha')).toBe('created');
+    expect(extraAction(agentReport(report, 'hermes'), 'symlink')).toBe('created');
+    // R2/A1: the seeded ~/.agents/skills fixture is byte-identical — no codex
+    // arm exists to have written or removed anything there.
+    expect(readFileSync(join(fixture.agentsSkillsDir, 'alpha', 'SKILL.md'), 'utf8')).toBe('# seeded, pre-existing\n');
   });
 });
 
@@ -1210,22 +1217,6 @@ describe('hermes config convergence', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Codex: .system protection + one-time .curated → ~/.agents/skills migration
-// ---------------------------------------------------------------------------
-
-/** Materialize a dir that looks exactly like one agent-sync shipped (manifest incl. matching digest). */
-function seedManagedDir(dir: string, files: Record<string, string>): void {
-  for (const [rel, content] of Object.entries(files)) writeFile(join(dir, rel), content);
-  const manifest = {
-    managedBy: 'genie-agent-sync',
-    version: '9.9.8',
-    digest: computeDirDigest(dir),
-    syncedAt: '2026-01-01T00:00:00.000Z',
-  };
-  writeFile(join(dir, MANIFEST_NAME), `${JSON.stringify(manifest, null, 2)}\n`);
-}
-
 function seedV1ManagedDir(dir: string, files: Record<string, string>): void {
   for (const [rel, content] of Object.entries(files)) writeFile(join(dir, rel), content);
   const digest = createHash('sha256');
@@ -1246,142 +1237,14 @@ function seedV1ManagedDir(dir: string, files: Record<string, string>): void {
   );
 }
 
-describe('codex .system', () => {
-  test('the OpenAI-owned .system tree is never enumerated or touched', () => {
-    present(fixture.codexDir);
-    const systemSkill = join(fixture.codexDir, 'skills', '.system', 'openai-builtin', 'SKILL.md');
-    writeFile(systemSkill, '# openai builtin\n');
-
-    const report = agentReport(run(), 'codex');
-    expect(skillAction(report, 'openai-builtin')).toBeUndefined();
-    expect(readFileSync(systemSkill, 'utf8')).toBe('# openai builtin\n');
-    expect(existsSync(join(systemSkill, '..', MANIFEST_NAME))).toBe(false);
-  });
-});
-
-describe('codex legacy .curated migration', () => {
-  test('manifest-managed legacy dirs are backed up then removed; the empty lane dir goes too', () => {
-    present(fixture.codexDir);
-    const legacyDir = join(fixture.codexDir, 'skills', '.curated');
-    seedManagedDir(join(legacyDir, 'alpha'), { 'SKILL.md': '# legacy alpha\n' });
-    seedManagedDir(join(legacyDir, 'zombie'), { 'SKILL.md': '# legacy zombie\n' });
-
-    const report = run();
-    const codex = agentReport(report, 'codex');
-
-    expect(existsSync(legacyDir)).toBe(false); // lane fully retired
-    expect((report.backupsDir as string).startsWith(`${fixture.genieHome}/`)).toBe(false);
-    // both legacy dirs were backed up before removal
-    const backupRoot = join(report.backupsDir as string, 'codex-legacy-curated');
-    expect(readFileSync(join(backupRoot, 'alpha', 'SKILL.md'), 'utf8')).toBe('# legacy alpha\n');
-    expect(readFileSync(join(backupRoot, 'zombie', 'SKILL.md'), 'utf8')).toBe('# legacy zombie\n');
-    rmSync(fixture.genieHome, { recursive: true, force: true });
-    expect(readFileSync(join(backupRoot, 'alpha', 'SKILL.md'), 'utf8')).toBe('# legacy alpha\n');
-    const removed = codex.extras.filter((entry) => entry.kind === 'legacy-curated' && entry.action === 'removed');
-    expect(removed).toHaveLength(2);
-    // and the live tier got the current source skills
-    expect(readFileSync(join(fixture.agentsSkillsDir, 'alpha', 'SKILL.md'), 'utf8')).toBe('# alpha\n');
-  });
-
-  test('a user-modified managed legacy dir is preserved in place byte-identically', () => {
-    present(fixture.codexDir);
-    const legacyAlpha = join(fixture.codexDir, 'skills', '.curated', 'alpha');
-    seedManagedDir(legacyAlpha, { 'SKILL.md': '# legacy alpha\n' });
-    writeFile(join(legacyAlpha, 'SKILL.md'), '# hand-edited legacy\n'); // digest now diverges
-    const manifestBefore = readFileSync(join(legacyAlpha, MANIFEST_NAME), 'utf8');
-
-    const report = run();
-    const codex = agentReport(report, 'codex');
-    expect(readFileSync(join(legacyAlpha, 'SKILL.md'), 'utf8')).toBe('# hand-edited legacy\n');
-    expect(readFileSync(join(legacyAlpha, MANIFEST_NAME), 'utf8')).toBe(manifestBefore);
-    expect(report.backupsDir).toBeNull();
-    expect(codex.extras).toContainEqual({
-      kind: 'legacy-curated',
-      action: 'kept-modified',
-      detail: legacyAlpha,
-    });
-  });
-
-  test('content-only v1 ownership never authorizes destructive legacy cleanup', () => {
-    present(fixture.codexDir);
-    const legacyAlpha = join(fixture.codexDir, 'skills', '.curated', 'alpha');
-    seedV1ManagedDir(legacyAlpha, { 'SKILL.md': '# legacy alpha\n' });
-
-    const codex = agentReport(run(), 'codex');
-
-    expect(readFileSync(join(legacyAlpha, 'SKILL.md'), 'utf8')).toBe('# legacy alpha\n');
-    expect(codex.extras).toContainEqual({
-      kind: 'legacy-curated',
-      action: 'kept-modified',
-      detail: legacyAlpha,
-    });
-  });
-
-  test('a legacy managed dir changed after classification stays live and is not removed', () => {
-    present(fixture.codexDir);
-    const legacyAlpha = join(fixture.codexDir, 'skills', '.curated', 'alpha');
-    seedManagedDir(legacyAlpha, { 'SKILL.md': '# legacy alpha\n' });
-    const report = run({
-      beforeManagedDirRemoval(destDir, stage) {
-        if (destDir === legacyAlpha && stage === 'before-park') {
-          writeFileSync(join(legacyAlpha, 'SKILL.md'), '# legacy raced\n');
-        }
-      },
-    });
-    expect(readFileSync(join(legacyAlpha, 'SKILL.md'), 'utf8')).toBe('# legacy raced\n');
-    expect(agentReport(report, 'codex').failures?.some((line) => line.includes('changed before removal'))).toBe(true);
-  });
-
-  test('unmanaged legacy entries are kept (with an advisory) and keep the lane dir alive', () => {
-    present(fixture.codexDir);
-    const legacyDir = join(fixture.codexDir, 'skills', '.curated');
-    seedManagedDir(join(legacyDir, 'alpha'), { 'SKILL.md': '# legacy alpha\n' });
-    const userSkill = join(legacyDir, 'my-own-thing', 'SKILL.md');
-    writeFile(userSkill, '# not genie-managed\n'); // no manifest
-
-    const codex = agentReport(run(), 'codex');
-
-    expect(existsSync(join(legacyDir, 'alpha'))).toBe(false); // managed dir migrated out
-    expect(readFileSync(userSkill, 'utf8')).toBe('# not genie-managed\n'); // user content untouched
-    expect(codex.advisories.some((line) => line.includes('unmanaged entries'))).toBe(true);
-  });
-
-  test('the migration is one-time: a second run sees no legacy lane and reports no legacy extras', () => {
-    present(fixture.codexDir);
-    seedManagedDir(join(fixture.codexDir, 'skills', '.curated', 'alpha'), { 'SKILL.md': '# legacy alpha\n' });
-    run();
-
-    const second = agentReport(run(), 'codex');
-    expect(second.extras.filter((entry) => entry.kind === 'legacy-curated')).toHaveLength(0);
-    expect(skillAction(second, 'alpha')).toBe('unchanged'); // live tier already converged
-  });
-
-  test('unmanaged siblings already in the shared agents skills tier are never touched', () => {
-    present(fixture.codexDir);
-    const foreign = join(fixture.agentsSkillsDir, 'somebody-elses-skill');
-    writeFile(join(foreign, 'SKILL.md'), '# installed by another tool\n');
-
-    const report = run();
-    const codex = agentReport(report, 'codex');
-    expect(skillAction(codex, 'somebody-elses-skill')).toBeUndefined();
-    expect(readFileSync(join(foreign, 'SKILL.md'), 'utf8')).toBe('# installed by another tool\n');
-    expect(existsSync(join(foreign, MANIFEST_NAME))).toBe(false);
-  });
-
-  test('a personal Codex skill colliding with a shipped name remains byte-identical and unmanaged', () => {
-    present(fixture.codexDir);
-    const personal = join(fixture.agentsSkillsDir, 'alpha');
-    writeFile(join(personal, 'SKILL.md'), '# personal Codex adaptation\n');
-    writeFile(join(personal, 'agents', 'openai.yaml'), 'policy:\n  allow_implicit_invocation: false\n');
-
-    const codex = agentReport(run(), 'codex');
-
-    expect(skillAction(codex, 'alpha')).toBe('skipped-unmanaged-kept');
-    expect(readFileSync(join(personal, 'SKILL.md'), 'utf8')).toBe('# personal Codex adaptation\n');
-    expect(readFileSync(join(personal, 'agents', 'openai.yaml'), 'utf8')).toContain('allow_implicit_invocation');
-    expect(existsSync(join(personal, MANIFEST_NAME))).toBe(false);
-  });
-});
+// The `codex .system` and `codex legacy .curated migration` describes that
+// used to live here tested `syncCodex`, which is retired: codex product
+// skills are plugin-only now (installCodexIntegration), and `runAgentSync`
+// has no codex arm at all. `.system` protection and `.curated` migration are
+// moot when nothing writes into ~/.agents/skills or reads <codexDir>/skills/
+// from this engine anymore. `genie uninstall`'s own `.curated` classifier
+// (codexLegacyCuratedDir + inspectManagedSkillTree) is unaffected and covered
+// in uninstall.test.ts.
 
 // ---------------------------------------------------------------------------
 // Source resolution
@@ -3144,16 +3007,12 @@ describe('Codex fallback batch retirement', () => {
     expect(readdirSync(join(fallback, '.genie-codex-fallback-retirement'))).toHaveLength(1);
   });
 
-  test('active sync remains unwired and preserves the dangling legacy symlink behavior', () => {
-    present(fixture.codexDir);
-    const dangling = join(fixture.agentsSkillsDir, 'alpha');
-    mkdirSync(dirname(dangling), { recursive: true });
-    symlinkSync('/definitely/missing', dangling);
-    const report = agentReport(run(), 'codex');
-    expect(skillAction(report, 'alpha')).toBe('skipped-unmanaged-kept');
-    expect(lstatSync(dangling).isSymbolicLink()).toBe(true);
-    expect(existsSync(join(fixture.agentsSkillsDir, '.genie-codex-fallback-retirement'))).toBe(false);
-  });
+  // The 'active sync remains unwired...' boundary test that used to live here
+  // pinned that `run()` (agent-sync's `syncCodex`) never triggered the
+  // fallback retirement transaction machinery even though both existed in the
+  // same binary. `syncCodex` is retired, so there is no longer an active-sync
+  // codex leg for the retirement machinery to be unwired FROM — the two
+  // systems can no longer collide because only one of them exists.
 
   // ---------------------------------------------------------------------------
   // Group A recovery gaps (G1 final-copy safety, G2 serialization, G3 discovery)

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -84,8 +84,6 @@ export const MANAGED_BY = 'genie-agent-sync';
  * never reports a legitimately-excluded skill as "missing/stale".
  */
 export const CLAUDE_EXCLUDED_SKILLS = new Set(['council']);
-/** Skill actions that represent an actual write to the target. */
-const WRITE_ACTIONS = new Set<SkillAction>(['created', 'updated', 'removed']);
 /**
  * Collision-proof staging suffixes for atomic managed-dir writes. Chosen so no
  * human backup convention (e.g. `mv review review.old`, or a `review.new`) can
@@ -3724,75 +3722,16 @@ function stampClaudeWorkflow(ctx: RunContext, claudeDir: string, report: AgentRe
   report.extras.push({ kind: 'stamp', action: res.action, detail: res.targetPath });
 }
 
-function syncCodex(ctx: RunContext, report: AgentReport): void {
-  const codexDir = ctx.targets.codex;
-  if (!existsSync(codexDir)) return;
-  report.detected = true;
-  migrateLegacyCodexCurated(ctx, codexDir, report);
-  // Codex loads user skills from the top-level `~/.agents/skills/<name>` tier.
-  // Everything under `<codexDir>/skills/` (incl. OpenAI's `.system/`) is left
-  // alone: hidden dirs are pruned by codex and were never genie's to manage.
-  syncSkillDirsInto(ctx, 'codex', ctx.targets.agentsSkills, report);
-  if (report.skills.some((skill) => WRITE_ACTIONS.has(skill.action))) {
-    report.advisories.push('restart Codex to pick up updated skills');
-  }
-}
-
-/**
- * One-time cleanup of the retired `<codexDir>/skills/.curated` lane (see
- * {@link codexLegacyCuratedDir}): every manifest-managed dir there is a
- * stranded orphan codex never loaded. Digest-clean managed dirs are backed up
- * outside GENIE_HOME and removed. Modified or unmanaged entries are preserved
- * in place; a migration must never trade live user data for a backup that a
- * later uninstall deletes. The lane dir itself goes only once it is empty.
- * Genie's own crashed-run staging debris is swept unbacked.
- */
-function migrateLegacyCodexCurated(ctx: RunContext, codexDir: string, report: AgentReport): void {
-  const legacyDir = codexLegacyCuratedDir(codexDir);
-  if (!existsSync(legacyDir)) return;
-  let kept = 0;
-  for (const entry of readdirSync(legacyDir, { withFileTypes: true })) {
-    const dir = join(legacyDir, entry.name);
-    if (entry.name.endsWith(STAGING_SUFFIX) || entry.name.endsWith(PREV_SUFFIX)) {
-      rmSync(dir, { recursive: true, force: true });
-      continue;
-    }
-    if (classifyEntry(dir, entry) !== 'dir') {
-      kept += 1;
-      continue;
-    }
-    const manifest = readManifest(dir);
-    if (manifest === null) {
-      kept += 1;
-      continue;
-    }
-    const contentDigest = acceptedManagedDirPhysicalDigest(dir, manifest.manifest);
-    if (contentDigest === null) {
-      kept += 1;
-      report.extras.push({ kind: 'legacy-curated', action: 'kept-modified', detail: dir });
-      report.advisories.push(`kept modified legacy codex skill ${entry.name} at ${dir}`);
-      continue;
-    }
-    try {
-      removeManagedDir(ctx, 'codex-legacy-curated', entry.name, dir, {
-        contentDigest,
-        manifestDigest: manifest.fileDigest,
-      });
-      report.extras.push({ kind: 'legacy-curated', action: 'removed', detail: dir });
-    } catch (error) {
-      kept += 1;
-      const failure = `legacy codex skill ${entry.name} removal failed: ${errMsg(error)}`;
-      report.extras.push({ kind: 'legacy-curated', action: 'kept-modified', detail: dir });
-      report.advisories.push(failure);
-      recordFailure(report, failure);
-    }
-  }
-  if (kept === 0) {
-    rmSync(legacyDir, { recursive: true, force: true });
-  } else {
-    report.advisories.push(`legacy codex lane ${legacyDir} contains unmanaged entries; left in place`);
-  }
-}
+// The codex writer (`syncCodex`) that used to live here is retired: codex
+// product skills are plugin-only, converged end-to-end by
+// `installCodexIntegration` in runtime-integrations.ts (plugin → health proof
+// → fallback retirement → role agents). `runAgentSync` has no `codex` arm, so
+// this module never writes into `~/.agents/skills` again (R2/A1, structural).
+// The classifier/retirement primitives that flow — `codexLegacyCuratedDir`,
+// `inspectManagedSkillTree`, `planCodexFallbackRetirement`,
+// `applyCodexFallbackRetirement`, `recoverCodexFallbackRetirements` — remain:
+// they are shared with `genie uninstall` and `genie doctor`, which read/repair
+// that tier independently of this file's write path.
 
 type LinkAction = 'created' | 'unchanged' | 'adopted' | 'skipped-unmanaged-kept';
 
@@ -4335,6 +4274,13 @@ function stealStaleLock(lockPath: string): 'cleared' | 'contended' {
  * agent-level failures; a null pluginRoot yields an empty report. Exactly one
  * run per GENIE_HOME may write at a time: a concurrent run returns a report
  * with `skipped` set and performs zero writes.
+ *
+ * R2/A1 is structural here, not caller discipline: there is no `codex` arm
+ * below, so no `selection` value can ever make this function write into
+ * `~/.agents/skills`. Codex product skills are plugin-only, converged
+ * end-to-end by `installCodexIntegration` (plugin → health proof → fallback
+ * retirement → role agents) in runtime-integrations.ts; the old codex writer
+ * (`syncCodex`) is retired.
  */
 export function runAgentSync(opts: AgentSyncOptions = {}): AgentSyncReport {
   const genieHome = opts.genieHome ?? resolveGenieHome();
@@ -4355,9 +4301,6 @@ export function runAgentSync(opts: AgentSyncOptions = {}): AgentSyncReport {
     const agents: AgentReport[] = [];
     if (selection === 'auto' || selection === 'all' || selection === 'claude') {
       agents.push(runAgentSafe('claude', (report) => syncClaude(ctx, report)));
-    }
-    if (selection === 'auto' || selection === 'all' || selection === 'codex') {
-      agents.push(runAgentSafe('codex', (report) => syncCodex(ctx, report)));
     }
     if (selection === 'auto' || selection === 'all') {
       agents.push(runAgentSafe('hermes', (report) => syncHermes(ctx, opts, report)));


### PR DESCRIPTION
## Summary

Live-dogfood regression, missed by review on #2572 (plugin-only codex skills).

- `narrowAgentSyncSelection` (`install.ts`) and `narrowUpdateAgentSyncSelection` (`update.ts`) collapsed **every** selection (`auto`/`all`/`claude`) down to `'claude'` before it ever reached `runAgentSync`. `runAgentSync`'s hermes leg only fires on a verbatim `'auto'`/`'all'` selection, so the narrowing silently killed hermes convergence on **every** lifecycle path (`install`, `update`, `update --sync-only`).
- Confirmed live: `genie update --sync-only` on a machine with hermes on PATH printed only `agent-sync: claude`, and the hermes leg never ran — which also meant the PR #2576 duplicate-`external_dirs` repair could never fire in production, even though its own unit tests passed.
- The narrowing's only legitimate purpose (R2/A1) was to stop `agent-sync`'s `syncCodex` writer from ever touching `~/.agents/skills`, now that codex product skills are plugin-only.

## Fix

Root-cause the R2/A1 guarantee instead of re-widening a caller-side narrowing that can drift again:

1. **`runAgentSync`'s `codex` arm is deleted outright** (`src/lib/agent-sync.ts`) — there is no `selection` value that can ever make agent-sync write into `~/.agents/skills` anymore. The guarantee is now structural, not caller discipline.
2. **`syncCodex` and its sole caller `migrateLegacyCodexCurated` are removed as dead code.** Codex product skills have converged entirely through `installCodexIntegration` (plugin → health proof → fallback retirement → role agents) since #2572; `doctor.ts` already treats any managed `~/.agents/skills` fallback as "repairable duplicate provider state," confirming nothing production-facing depended on `syncCodex` still running. The classifier/retirement primitives it never owned — `codexLegacyCuratedDir`, `inspectManagedSkillTree`, `plan/applyCodexFallbackRetirement`, `recoverCodexFallbackRetirements` — are untouched; `genie uninstall` and `genie doctor` use them directly and are unaffected.
3. **`narrowAgentSyncSelection` / `narrowUpdateAgentSyncSelection` now only gate `none`/`codex`** (agent-sync has nothing to do for either) and pass every other selection through **unchanged**, so `auto`/`all` reach `runAgentSync`'s hermes gate again.

## Test plan

- [x] `bun test src/lib/agent-sync.test.ts src/genie-commands/install.test.ts src/genie-commands/__tests__/update.test.ts src/lib/hermes-skills-config.test.ts` — all green (580+ pass)
- [x] New regression: `agent-sync.test.ts` — `'auto'` selection converges claude **and** hermes and never touches a seeded `~/.agents/skills` fixture (R2/A1 pinned at the engine level); `'codex'` selection is a structural no-op.
- [x] New regression: `install.test.ts` / `update.test.ts` — selection passes through unchanged (`auto`/`all`/`claude`); `codex`/`none` still skip agent-sync entirely.
- [x] New end-to-end regression: `update.test.ts` — real `GENIE_HOME`/`HERMES_HOME` tmpdir fixtures (isolated the way `doctor.test.ts` isolates its lifecycle env) drive the real `runManualUpdateConvergence` path, proving `mcp_servers.genie` + `skills.external_dirs` land in a fresh Hermes `config.yaml`, **and** that a config damaged with the PR #2576 duplicate-`external_dirs` shape gets repaired — binding that repair into the actual update lifecycle, which is what was silently broken.
- [x] `bun run check:fast` — green
- [x] `bun run check` — red only on the known env-dependent set (`hooks/codex-manifest.test.ts` x2; unrelated to this change, no `agent-sync`/`hermes`/`codex-sync-selection` references)

Not merging — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>