### PR TITLE
fix: repair Warp launch configuration handoff

### DIFF
--- a/src/lib/v5/warp-launch.test.ts
+++ b/src/lib/v5/warp-launch.test.ts
@@ -76,9 +76,9 @@ describe('buildLaunchConfig — tab chunking', () => {
   });
 
   test('tab colors cycle through the allowed ANSI set', () => {
-    // 28 panes → 7 tabs, so the 6-color cycle wraps once (tab 7 reuses Red).
+    // 28 panes → 7 tabs, so the 6-color cycle wraps once (tab 7 reuses red).
     const tabs = tabsOf(roundTrip(specWith(28)));
-    expect(tabs.map((t) => t.color)).toEqual(['Red', 'Green', 'Yellow', 'Blue', 'Magenta', 'Cyan', 'Red']);
+    expect(tabs.map((t) => t.color)).toEqual(['red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'red']);
   });
 
   test('only the very first pane is focused', () => {
@@ -288,21 +288,15 @@ describe('writeLaunchConfig', () => {
 });
 
 describe('launchUri', () => {
-  test('prefixes the absolute path with warp://launch/', () => {
-    expect(launchUri('/Users/me/.warp/launch_configurations/genie-x.yaml')).toBe(
-      'warp://launch//Users/me/.warp/launch_configurations/genie-x.yaml',
-    );
+  test('uses the relative config name accepted by Warp', () => {
+    expect(launchUri('my-wish')).toBe('warp://launch/my-wish');
   });
 
-  test('percent-encodes spaces while preserving path slashes', () => {
-    expect(launchUri('/Users/me/My Repo/.warp/genie-x.yaml')).toBe(
-      'warp://launch//Users/me/My%20Repo/.warp/genie-x.yaml',
-    );
+  test('does not emit the rejected double-slash absolute-path form', () => {
+    expect(launchUri('my-wish')).not.toStartWith('warp://launch//');
   });
 
-  test('percent-encodes a "#" (which encodeURI would leave to truncate the path) per segment', () => {
-    expect(launchUri('/Users/me/My#Repo/.warp/genie-x.yaml')).toBe(
-      'warp://launch//Users/me/My%23Repo/.warp/genie-x.yaml',
-    );
+  test('percent-encodes reserved characters in a config name', () => {
+    expect(launchUri('My Wish#1')).toBe('warp://launch/My%20Wish%231');
   });
 });

--- a/src/lib/v5/warp-launch.ts
+++ b/src/lib/v5/warp-launch.ts
@@ -10,9 +10,9 @@
  * Warp facts baked in here:
  *   - config files live in a platform-specific dir (see {@link resolveWarpConfigDir}),
  *   - `cwd` MUST be an absolute path — Warp rejects `~` and relative paths,
- *   - tab `color` accepts ANSI color names only (Red/Green/Yellow/Blue/Magenta/Cyan),
+ *   - tab `color` accepts lowercase ANSI color names only (red/green/yellow/blue/magenta/cyan),
  *   - a tab holds up to a 2x2 grid of panes via nested `split_direction` layouts,
- *   - the launch URI is `warp://launch/<absolute-path-to-yaml>`.
+ *   - the launch URI is `warp://launch/<config-name>` (the wish slug).
  *
  * Pure library: no CLI wiring, no console output. Callers own presentation.
  */
@@ -131,7 +131,7 @@ export interface LaunchConfig {
 // ============================================================================
 
 /** ANSI color names Warp accepts for `tab.color`, cycled across tabs. */
-const TAB_COLORS = ['Red', 'Green', 'Yellow', 'Blue', 'Magenta', 'Cyan'] as const;
+const TAB_COLORS = ['red', 'green', 'yellow', 'blue', 'magenta', 'cyan'] as const;
 
 /** Max panes Warp lays out cleanly as a 2x2 grid before overflowing to a new tab. */
 const MAX_PANES_PER_TAB = 4;
@@ -305,15 +305,12 @@ export function writeLaunchConfig(spec: LaunchSpec, opts: WriteOptions = {}): st
 }
 
 /**
- * Build the `warp://launch/<abs-path>` URI that opens a written config.
- * The path is encoded per segment: each `/`-delimited component is passed
- * through `encodeURIComponent` and the slashes are rejoined. This preserves the
- * path separators while escaping every other reserved character inside a
- * segment — including `#` (which `encodeURI` leaves intact, letting it be
- * mistaken for a URI fragment and truncate the path) as well as spaces — so the
- * URI survives being handed to `open`/`xdg-open` intact.
+ * Build the `warp://launch/<config-name>` URI that opens a written config.
+ * Warp resolves this relative identifier against its launch-configuration
+ * directory and matches it to the YAML top-level `name`. Absolute paths produce
+ * a double-slash URI that Warp rejects. Encode the identifier as one URI path
+ * component so reserved characters cannot change URI semantics.
  */
-export function launchUri(absPath: string): string {
-  const encoded = absPath.split('/').map(encodeURIComponent).join('/');
-  return `warp://launch/${encoded}`;
+export function launchUri(configName: string): string {
+  return `warp://launch/${encodeURIComponent(configName)}`;
 }

--- a/src/term-commands/launch.test.ts
+++ b/src/term-commands/launch.test.ts
@@ -377,7 +377,7 @@ describe('genie launch (real run, --no-open)', () => {
     };
     executeLaunch(slug, {}, deps({ openImpl: record }));
     expect(opened).toHaveLength(1);
-    expect(opened[0]).toBe(`warp://launch/${configPath(slug)}`);
+    expect(opened[0]).toBe(`warp://launch/${slug}`);
   });
 });
 

--- a/src/term-commands/launch.ts
+++ b/src/term-commands/launch.ts
@@ -614,7 +614,7 @@ function materialize(plan: LaunchPlan, deps: LaunchDeps, write: (line: string) =
   }
 
   const configPath = writeLaunchConfig({ slug: plan.slug, panes: plan.panes }, { dir: deps.warpDir, platform });
-  const uri = launchUri(configPath);
+  const uri = launchUri(plan.slug);
   write(`Wrote launch config: ${configPath}`);
 
   const openImpl = deps.openImpl ?? defaultOpen;


### PR DESCRIPTION
## What changed

- Emit lowercase ANSI tab colors in Warp launch configuration YAML.
- Open launch configurations with `warp://launch/<config-name>` instead of an absolute YAML path.
- Update library and command-level tests to cover Warp's accepted color and URI contracts.

## Why

`genie launch <slug>` successfully created worktrees and wrote a YAML file, but current Warp silently ignored the cockpit for two reasons:

1. Genie generated links such as `warp://launch//home/...`; Warp rejects launch paths beginning with `/`.
2. Genie emitted `Red` and `Green`; Warp's YAML parser accepts lowercase ANSI color identifiers only.

Together these defects made the command report that it was opening Warp without creating any panes.

## User impact

`genie launch <slug>` now opens the generated Warp cockpit and starts one agent pane per ready group. Dry-run, no-open, and worktree reuse behavior remain unchanged.

## Validation

- Focused launch tests: 71 passed, 0 failed.
- TypeScript typecheck: passed.
- Biome on the four changed files: passed.
- Pre-push fast gate: passed.
- Real Linux smoke test: the command exited 0, reused seven worktrees, and Warp created seven panes with seven Codex sessions.
- Full suite: 1436 passed; one pre-existing unrelated `agent-sync` recovery test failed in isolation as well.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Warp launch links now use configuration names and correctly encode spaces and reserved characters.
  * Launch links avoid invalid absolute-path formats.

* **Bug Fixes**
  * Updated tab color handling to use lowercase ANSI color names.
  * Opening Warp now targets the correct configuration name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->