### PR TITLE
chore: reconcile main into dev after #2581

### DIFF
--- a/.well-known/dev.json
+++ b/.well-known/dev.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "channel": "dev",
-  "version": "5.260713.9",
-  "released_at": "2026-07-13T22:38:40Z",
-  "tarball_base": "https://github.com/automagik-dev/genie/releases/download/v5.260713.9",
+  "version": "5.260713.10",
+  "released_at": "2026-07-13T23:06:20Z",
+  "tarball_base": "https://github.com/automagik-dev/genie/releases/download/v5.260713.10",
   "platforms": ["linux-x64-glibc", "linux-x64-musl", "linux-arm64", "darwin-arm64"]
 }

--- a/.well-known/dev.json
+++ b/.well-known/dev.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "channel": "dev",
-  "version": "5.260713.4",
-  "released_at": "2026-07-13T17:33:43Z",
-  "tarball_base": "https://github.com/automagik-dev/genie/releases/download/v5.260713.4",
+  "version": "5.260713.5",
+  "released_at": "2026-07-13T18:47:25Z",
+  "tarball_base": "https://github.com/automagik-dev/genie/releases/download/v5.260713.5",
   "platforms": ["linux-x64-glibc", "linux-x64-musl", "linux-arm64", "darwin-arm64"]
 }

--- a/.well-known/dev.json
+++ b/.well-known/dev.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "channel": "dev",
-  "version": "5.260713.3",
-  "released_at": "2026-07-13T09:04:10Z",
-  "tarball_base": "https://github.com/automagik-dev/genie/releases/download/v5.260713.3",
+  "version": "5.260713.4",
+  "released_at": "2026-07-13T17:33:43Z",
+  "tarball_base": "https://github.com/automagik-dev/genie/releases/download/v5.260713.4",
   "platforms": ["linux-x64-glibc", "linux-x64-musl", "linux-arm64", "darwin-arm64"]
 }

--- a/.well-known/dev.json
+++ b/.well-known/dev.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "channel": "dev",
-  "version": "5.260713.8",
-  "released_at": "2026-07-13T22:29:34Z",
-  "tarball_base": "https://github.com/automagik-dev/genie/releases/download/v5.260713.8",
+  "version": "5.260713.9",
+  "released_at": "2026-07-13T22:38:40Z",
+  "tarball_base": "https://github.com/automagik-dev/genie/releases/download/v5.260713.9",
   "platforms": ["linux-x64-glibc", "linux-x64-musl", "linux-arm64", "darwin-arm64"]
 }

--- a/.well-known/dev.json
+++ b/.well-known/dev.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "channel": "dev",
-  "version": "5.260713.11",
-  "released_at": "2026-07-13T23:43:24Z",
-  "tarball_base": "https://github.com/automagik-dev/genie/releases/download/v5.260713.11",
+  "version": "5.260714.1",
+  "released_at": "2026-07-14T14:56:16Z",
+  "tarball_base": "https://github.com/automagik-dev/genie/releases/download/v5.260714.1",
   "platforms": ["linux-x64-glibc", "linux-x64-musl", "linux-arm64", "darwin-arm64"]
 }

--- a/.well-known/dev.json
+++ b/.well-known/dev.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "channel": "dev",
-  "version": "5.260713.6",
-  "released_at": "2026-07-13T21:31:10Z",
-  "tarball_base": "https://github.com/automagik-dev/genie/releases/download/v5.260713.6",
+  "version": "5.260713.7",
+  "released_at": "2026-07-13T21:35:19Z",
+  "tarball_base": "https://github.com/automagik-dev/genie/releases/download/v5.260713.7",
   "platforms": ["linux-x64-glibc", "linux-x64-musl", "linux-arm64", "darwin-arm64"]
 }

--- a/.well-known/dev.json
+++ b/.well-known/dev.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "channel": "dev",
-  "version": "5.260713.10",
-  "released_at": "2026-07-13T23:06:20Z",
-  "tarball_base": "https://github.com/automagik-dev/genie/releases/download/v5.260713.10",
+  "version": "5.260713.11",
+  "released_at": "2026-07-13T23:43:24Z",
+  "tarball_base": "https://github.com/automagik-dev/genie/releases/download/v5.260713.11",
   "platforms": ["linux-x64-glibc", "linux-x64-musl", "linux-arm64", "darwin-arm64"]
 }

--- a/.well-known/dev.json
+++ b/.well-known/dev.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "channel": "dev",
-  "version": "5.260713.5",
-  "released_at": "2026-07-13T18:47:25Z",
-  "tarball_base": "https://github.com/automagik-dev/genie/releases/download/v5.260713.5",
+  "version": "5.260713.6",
+  "released_at": "2026-07-13T21:31:10Z",
+  "tarball_base": "https://github.com/automagik-dev/genie/releases/download/v5.260713.6",
   "platforms": ["linux-x64-glibc", "linux-x64-musl", "linux-arm64", "darwin-arm64"]
 }

--- a/.well-known/dev.json
+++ b/.well-known/dev.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "channel": "dev",
-  "version": "5.260713.7",
-  "released_at": "2026-07-13T21:35:19Z",
-  "tarball_base": "https://github.com/automagik-dev/genie/releases/download/v5.260713.7",
+  "version": "5.260713.8",
+  "released_at": "2026-07-13T22:29:34Z",
+  "tarball_base": "https://github.com/automagik-dev/genie/releases/download/v5.260713.8",
   "platforms": ["linux-x64-glibc", "linux-x64-musl", "linux-arm64", "darwin-arm64"]
 }

--- a/src/lib/v5/warp-launch.test.ts
+++ b/src/lib/v5/warp-launch.test.ts
@@ -76,9 +76,9 @@ describe('buildLaunchConfig — tab chunking', () => {
   });
 
   test('tab colors cycle through the allowed ANSI set', () => {
-    // 28 panes → 7 tabs, so the 6-color cycle wraps once (tab 7 reuses Red).
+    // 28 panes → 7 tabs, so the 6-color cycle wraps once (tab 7 reuses red).
     const tabs = tabsOf(roundTrip(specWith(28)));
-    expect(tabs.map((t) => t.color)).toEqual(['Red', 'Green', 'Yellow', 'Blue', 'Magenta', 'Cyan', 'Red']);
+    expect(tabs.map((t) => t.color)).toEqual(['red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'red']);
   });
 
   test('only the very first pane is focused', () => {
@@ -288,21 +288,15 @@ describe('writeLaunchConfig', () => {
 });
 
 describe('launchUri', () => {
-  test('prefixes the absolute path with warp://launch/', () => {
-    expect(launchUri('/Users/me/.warp/launch_configurations/genie-x.yaml')).toBe(
-      'warp://launch//Users/me/.warp/launch_configurations/genie-x.yaml',
-    );
+  test('uses the relative config name accepted by Warp', () => {
+    expect(launchUri('my-wish')).toBe('warp://launch/my-wish');
   });
 
-  test('percent-encodes spaces while preserving path slashes', () => {
-    expect(launchUri('/Users/me/My Repo/.warp/genie-x.yaml')).toBe(
-      'warp://launch//Users/me/My%20Repo/.warp/genie-x.yaml',
-    );
+  test('does not emit the rejected double-slash absolute-path form', () => {
+    expect(launchUri('my-wish')).not.toStartWith('warp://launch//');
   });
 
-  test('percent-encodes a "#" (which encodeURI would leave to truncate the path) per segment', () => {
-    expect(launchUri('/Users/me/My#Repo/.warp/genie-x.yaml')).toBe(
-      'warp://launch//Users/me/My%23Repo/.warp/genie-x.yaml',
-    );
+  test('percent-encodes reserved characters in a config name', () => {
+    expect(launchUri('My Wish#1')).toBe('warp://launch/My%20Wish%231');
   });
 });

--- a/src/lib/v5/warp-launch.ts
+++ b/src/lib/v5/warp-launch.ts
@@ -10,9 +10,9 @@
  * Warp facts baked in here:
  *   - config files live in a platform-specific dir (see {@link resolveWarpConfigDir}),
  *   - `cwd` MUST be an absolute path — Warp rejects `~` and relative paths,
- *   - tab `color` accepts ANSI color names only (Red/Green/Yellow/Blue/Magenta/Cyan),
+ *   - tab `color` accepts lowercase ANSI color names only (red/green/yellow/blue/magenta/cyan),
  *   - a tab holds up to a 2x2 grid of panes via nested `split_direction` layouts,
- *   - the launch URI is `warp://launch/<absolute-path-to-yaml>`.
+ *   - the launch URI is `warp://launch/<config-name>` (the wish slug).
  *
  * Pure library: no CLI wiring, no console output. Callers own presentation.
  */
@@ -131,7 +131,7 @@ export interface LaunchConfig {
 // ============================================================================
 
 /** ANSI color names Warp accepts for `tab.color`, cycled across tabs. */
-const TAB_COLORS = ['Red', 'Green', 'Yellow', 'Blue', 'Magenta', 'Cyan'] as const;
+const TAB_COLORS = ['red', 'green', 'yellow', 'blue', 'magenta', 'cyan'] as const;
 
 /** Max panes Warp lays out cleanly as a 2x2 grid before overflowing to a new tab. */
 const MAX_PANES_PER_TAB = 4;
@@ -305,15 +305,12 @@ export function writeLaunchConfig(spec: LaunchSpec, opts: WriteOptions = {}): st
 }
 
 /**
- * Build the `warp://launch/<abs-path>` URI that opens a written config.
- * The path is encoded per segment: each `/`-delimited component is passed
- * through `encodeURIComponent` and the slashes are rejoined. This preserves the
- * path separators while escaping every other reserved character inside a
- * segment — including `#` (which `encodeURI` leaves intact, letting it be
- * mistaken for a URI fragment and truncate the path) as well as spaces — so the
- * URI survives being handed to `open`/`xdg-open` intact.
+ * Build the `warp://launch/<config-name>` URI that opens a written config.
+ * Warp resolves this relative identifier against its launch-configuration
+ * directory and matches it to the YAML top-level `name`. Absolute paths produce
+ * a double-slash URI that Warp rejects. Encode the identifier as one URI path
+ * component so reserved characters cannot change URI semantics.
  */
-export function launchUri(absPath: string): string {
-  const encoded = absPath.split('/').map(encodeURIComponent).join('/');
-  return `warp://launch/${encoded}`;
+export function launchUri(configName: string): string {
+  return `warp://launch/${encodeURIComponent(configName)}`;
 }

--- a/src/term-commands/launch.test.ts
+++ b/src/term-commands/launch.test.ts
@@ -377,7 +377,7 @@ describe('genie launch (real run, --no-open)', () => {
     };
     executeLaunch(slug, {}, deps({ openImpl: record }));
     expect(opened).toHaveLength(1);
-    expect(opened[0]).toBe(`warp://launch/${configPath(slug)}`);
+    expect(opened[0]).toBe(`warp://launch/${slug}`);
   });
 });
 

--- a/src/term-commands/launch.ts
+++ b/src/term-commands/launch.ts
@@ -614,7 +614,7 @@ function materialize(plan: LaunchPlan, deps: LaunchDeps, write: (line: string) =
   }
 
   const configPath = writeLaunchConfig({ slug: plan.slug, panes: plan.panes }, { dir: deps.warpDir, platform });
-  const uri = launchUri(configPath);
+  const uri = launchUri(plan.slug);
   write(`Wrote launch config: ${configPath}`);
 
   const openImpl = deps.openImpl ?? defaultOpen;


### PR DESCRIPTION
## Why

PR #2581 landed directly on main after the Codex live gate was recorded, leaving rolling promotion PR #2573 conflicting.

## What

- Merge current main into current dev so the Warp launch repair is present on both long-lived branches.
- Resolve the sole merge conflict in .well-known/dev.json to the already-published 5.260714.1 dev manifest from main.
- Preserve the new Codex Plugin Smoke job already landed on dev.

## Verification

- git merge-tree identified exactly one conflict before reconciliation: .well-known/dev.json.
- 71 targeted Warp launch tests pass.
- git diff --check passes.
- The full repository pre-push gate passes: typecheck, Biome, dead-code, skill/wish lint, complexity, council workflow, hook parity/content, and plugin executable checks.

After this PR merges, #2573 should become history-clean and can rerun its promotion checks. Merge this PR through the reviewed server-side/UI path; the live Codex hook intentionally denies gh pr merge.