### PR TITLE
feat(agent-sync): deliver pinned role agents through managed fan-out

### DIFF
--- a/.genie/wishes/routing-delivery-fix/WISH.md
+++ b/.genie/wishes/routing-delivery-fix/WISH.md
@@ -2,14 +2,14 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | IN PROGRESS — Group A **SHIP** (attempt 4, Fable-tier architecture-first repair, independent review 2026-07-12); Group B dispatched; Group C post-release user-gated |
+| **Status** | IN_PROGRESS — Groups A+B **SHIP** (2026-07-12); awaiting PR/release, then Group C day-3 QA (user-gated live ritual) |
 | **Slug** | `routing-delivery-fix` |
 | **Date** | 2026-07-11 |
 | **Author** | Felipe + team-lead session (rebaseline wish 1) |
 | **Appetite** | small |
 | **Branch** | `wish/routing-delivery-fix` |
 | **Repos touched** | genie |
-| **Design** | [DESIGN.md](../../brainstorms/token-efficiency-rebaseline/DESIGN.md) |
+| **Design** | _No brainstorm — direct wish_ |
 
 ## Summary
 
@@ -226,9 +226,12 @@ test -s "$(ls -t /Users/feliperosa/workspace/genie/.genie/wishes/routing-matrix/
 
 ## Dependencies
 
-- **blocks:** `work-on-workflows` (rebaseline wish 3 — sequenced after Fix per the ratified order;
-  no mechanical dependency).
-- `genie-spend` (rebaseline wish 2) is independent and may run in parallel.
+**depends-on:** none
+**blocks:** none
+
+Scheduling note: the future `work-on-workflows` rebaseline is sequenced after this fix per the ratified
+order, but has no canonical wish slug and therefore is not a machine dependency. `genie-spend`
+(rebaseline wish 2) is independent and may run in parallel.
 
 ## QA Criteria
 
@@ -376,6 +379,26 @@ Gates re-run independently from a script file: 106 focused pass / 0 fail; `bun r
    fail-closed but unexplained in output.
 
 Budget closed: `attempts=4/4` (SHIP on 4); `effort_escalations=1/2`.
+
+### Execution review — Group B `doctor-duplicate-guard` (2026-07-12): **SHIP**
+
+- **Engineer pass (engineer-standard, pinned tier, attempt 1):** per-file classifier inside
+  `checkClaudeSync()` over the union of source ∪ manifest names (user-authored agents structurally
+  never reported); duplicate-surface warning on strict `enabledPlugins["genie@automagik"] === true`;
+  machine-readable `roleAgents` rider on the existing `doctor --json` check entry (`manifestStatus`,
+  name-sorted `files[{name, state}]`, `duplicateSurface`, `manifestReason` when unsafe) with the four
+  state names documented as a stability contract. Reuses Group A's `enumerateSourceAgentFiles` and
+  fail-closed `inspectAgentFilesManifest` (additive exports only — transaction core untouched).
+- **Independent review, loop 0: SHIP** — all three acceptance criteria verified test-pinned,
+  including the false-PASS discriminator (hand-copy-only host → `present-unmanaged` + warn, asserted
+  positively AND negatively); classifier semantics coherent across user-edit / outdated-version /
+  vanished-source / never-synced / fresh-host / unsafe-manifest edges; agent-sync delta confirmed
+  behaviorally inert; messaging coherent with `checkMarketplacePlugin`. Gates re-run independently:
+  43 doctor tests, 106 Group A regression tests, `bun run check` 976 pass / 1 skip / 0 fail,
+  `git diff --check` clean. Both declared open items judged acceptable.
+- **LOW advisories (non-blocking):** no dedicated human-detail line for `manifestStatus:'foreign'`;
+  two finer stale branches and the malformed-settings.json probe path handled in code but unpinned
+  by tests.
 
 ---
 

--- a/.genie/wishes/routing-delivery-fix/WISH.md
+++ b/.genie/wishes/routing-delivery-fix/WISH.md
@@ -1,0 +1,392 @@
+# Wish: Routing delivery fix — `genie update` fans the pinned role agents
+
+| Field | Value |
+|-------|-------|
+| **Status** | IN PROGRESS — Group A **SHIP** (attempt 4, Fable-tier architecture-first repair, independent review 2026-07-12); Group B dispatched; Group C post-release user-gated |
+| **Slug** | `routing-delivery-fix` |
+| **Date** | 2026-07-11 |
+| **Author** | Felipe + team-lead session (rebaseline wish 1) |
+| **Appetite** | small |
+| **Branch** | `wish/routing-delivery-fix` |
+| **Repos touched** | genie |
+| **Design** | [DESIGN.md](../../brainstorms/token-efficiency-rebaseline/DESIGN.md) |
+
+## Summary
+
+The seven pinned role agents (engineer-trivial/standard/complex, fixer, reviewer, final-gate, scout)
+ship only inside the genie Claude Code plugin, which is disabled — so the routing matrix's model pins
+never loaded and every dispatch inherited the session's Fable-max tier. This wish makes `genie update`
+(agent-sync) fan the role-agent files into `~/.claude/agents/` under the managed-stamp + backup
+contract it already uses for skills, with `genie doctor` able to distinguish genie-managed agents from
+merely-present files. Mechanism proven live 2026-07-11: a hand-copy into `~/.claude/agents/` surfaced
+all seven as bare-named agent types in fresh and reloaded sessions.
+
+## Scope
+
+### IN
+
+- agent-sync fans the canonical source's `agents/` dir into `~/.claude/agents/` on `genie update` /
+  `genie install` (and the SessionStart sync-only trigger), with: managed stamp (`.genie-sync.json`,
+  `managedBy: genie-agent-sync`), backup-first adoption of pre-existing unmanaged files (covers the
+  2026-07-11 hand-copy), stale refresh, orphan removal of genie-stamped agents whose source vanished,
+  and unmanaged (user-authored) entries never touched.
+- `genie uninstall` removes only provably genie-stamped role agents (backup-first), leaving
+  user-authored agents intact.
+- `genie doctor` reports role-agent state: genie-managed (stamped) vs merely-present vs stale vs
+  missing; warns when `enabledPlugins["genie@automagik"]` is true in `~/.claude/settings.json`
+  (duplicate-surface risk: plugin `genie:*` agents + fanned bare names).
+- Day-3 QA evidence: fresh-session surface check against **stamped** files (not the hand-copy) +
+  LangWatch pull re-running the day-2 recipe set with the mechanical `model×effort` fingerprint check
+  as the primary test.
+
+### OUT
+
+- Re-enabling the Claude Code plugin as a delivery path (rejected in the design).
+- Codex role-agent delivery (`codex-agents/` in the plugin) — separate track, not this wish.
+- Any change to the seven agent files' content (model/effort values are routing-matrix scope).
+- `genie spend` (rebaseline wish 2) and the /work workflow re-platform (rebaseline wish 3).
+- Windows shim/exec concerns — agent fan-out reuses the existing file-copy engine only.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | Deliver via agent-sync fan-out into `~/.claude/agents/`, plugin stays disabled | Felipe-ratified 2026-07-11; bare names match the acceptance test, dir is live-watched, no duplicate listings. Reuses the shipped managed-file CONTRACT (stamp/backup/orphan semantics) but requires **new per-FILE machinery** — the existing engine is directory-oriented (per-skill dirs, stamp inside each dir) and its whole-dir replace (`writeManagedDir`) is FORBIDDEN on `~/.claude/agents/`: applied there it would delete user-authored agent files (plan-review HIGH) |
+| 2 | Acceptance discriminator = the managed stamp, not file presence | The 2026-07-11 hand-copy already makes "files present + agents surface" pass; only `genie update` writing the stamp (or a clean-host QA) proves the fan-out itself (plan-review MEDIUM) |
+| 3 | Doctor warns (not blocks) on enabled genie plugin | Duplicate `genie:*` + bare-name agents degrade UX but break nothing; warn + document the resolution (design Risk 7) |
+| 4 | Adopt-with-backup for pre-existing files, never overwrite silently | Same contract as skills; the hand-copy must be adopted under the stamp, and user-authored agents with colliding names must be backed up before replacement, never lost |
+
+## Success Criteria
+
+- [ ] After `genie update`, `~/.claude/agents/` contains all seven role files AND the
+      `.genie-sync.json` managed stamp (`managedBy: genie-agent-sync`); the pre-existing hand-copy is
+      adopted with backups under `~/.genie/state-backups/`.
+- [ ] Fresh session (or `/reload-plugins`) lists all seven bare-named agent types sourced from the
+      stamped files (verify on this host post-update; mechanism itself already proven 2026-07-11).
+- [ ] `genie doctor` output distinguishes genie-managed vs merely-present vs stale role agents, and
+      emits the duplicate-surface warning when the genie plugin is enabled.
+- [ ] `genie uninstall` (dry-run acceptable for QA) removes only stamped agents; an injected
+      user-authored agent file survives untouched.
+- [ ] `bun run check` green; `bun run wishes:lint` green.
+- [ ] Day-3 LangWatch evidence recorded at `.genie/wishes/routing-matrix/qa/`: dispatched traces carry
+      the pinned `model×effort` fingerprints per role (primary); Fable-share trend reported as
+      directional only, with top-3-thread exclusion noted.
+
+## Execution Strategy
+
+### Wave 1 (sequential)
+
+| Group | Agent | Complexity | Model | Description |
+|-------|-------|------------|-------|-------------|
+| A | engineer-complex | 4 — agent-lifecycle/routing delivery (+2), stateful adopt/backup/orphan handling (+2); net-new per-file managed machinery mirroring the dir contract; deterministic tests exist | opus-xhigh | agents-fanout: per-file managed fan-out of `agents/` into `~/.claude/agents/` + uninstall coverage |
+
+### Wave 2 (after A merges to the wish branch)
+
+| Group | Agent | Complexity | Model | Description |
+|-------|-------|------------|-------|-------------|
+| B | engineer-standard | 2 — diagnostics over A's stamp format (+2 routing-adjacent surface); no state mutation, deterministic tests | opus-high | doctor-duplicate-guard: managed/present/stale reporting + enabledPlugins warning |
+
+### Wave 3 (post-release, evidence only — user-gated live ritual)
+
+| Group | Agent | Complexity | Model | Description |
+|-------|-------|------------|-------|-------------|
+| C | scout | 1 — bounded evidence collection with documented recipes | opus-low | day3-qa: stamped-surface check + LangWatch fingerprint pull, evidence to routing-matrix qa/ |
+
+> Group C cannot execute in the same /work run as A+B — it gates on a released build plus Felipe's
+> live update ritual. /work must treat the wish's code scope as complete after A+B ship; C stays a
+> ready task until the release lands and must NOT mark the wish blocked.
+
+## Execution Groups
+
+### Group A: agents-fanout
+
+**Goal:** `genie update` converges `~/.claude/agents/` from the canonical source's `agents/` dir under the same managed-stamp + backup contract as skills.
+
+**Deliverables:**
+1. agent-sync (src/lib/agent-sync.ts): extend `syncClaude()` (:471–477) to fan the source `agents/`
+   dir (confirmed at `plugins/genie/agents/` in repo and live install via `resolveGenieSource()`
+   :213–221) into `~/.claude/agents/` with **new per-FILE managed machinery** — the agents are flat
+   `*.md` files and MUST stay flat for Claude Code discovery, so the dir-oriented engine does not
+   apply. Contract (mirrors the dir contract's semantics, not its code):
+   - **Manifest:** one dir-level `~/.claude/agents/.genie-sync.json` mapping
+     `filename → { digest: sha256(file), version, syncedAt }` under `managedBy: 'genie-agent-sync'`
+     (`SyncManifest` :179–184 field shapes reused).
+   - **Create/update:** write the file + record its digest. **Adopt-with-backup:** an existing target
+     file not in the manifest (the 2026-07-11 hand-copy, or a user's colliding name) is backed up via
+     the `backupInto` closure pattern (:768–776 → `~/.genie/state-backups/…`) before replacement.
+   - **Orphans:** a manifest-recorded filename whose source vanished is backed-up-then-removed if its
+     digest matches (unmodified); a digest-mismatched (user-edited) managed file is KEPT with an
+     advisory, never deleted (semantics of `removeManagedOrphans` :418–440, per-file).
+   - **User files:** any filename absent from the manifest (other than adopt-on-collision above) is
+     NEVER touched. **`writeManagedDir()` (:333–343) is explicitly forbidden on `~/.claude/agents/`**
+     — its whole-dir atomic replace would delete user-authored agents.
+   - Target dir overridable for tests via the existing `targets` option pattern.
+2. Uninstall coverage (src/genie-commands/uninstall.ts): add a **per-file** collector + classifier to
+   `collectAgentSyncAssets()` (:193–208) — do NOT reuse `collectManagedSkillDirs()` (:134–155): its
+   `isDirectory` gate skips flat files. Classification per manifest entry: 'clean' (digest matches →
+   backup-then-remove) | 'modified' (user-edited → keep as `<name>.md.genie-kept`, preserving bytes
+   while unloading it from Claude Code) | absent-from-manifest (never touched).
+   `removeAgentSyncAssets()` (:232–255) stays the removal executor once collection is wired.
+3. Tests (src/lib/agent-sync.test.ts — tmpdir + `GENIE_HOME` isolation): add `writeSourceAgent()`
+   writing a **single `agents/<name>.md` file** (NOT a dir tree like `writeSourceSkill()` :78–82);
+   extend the `setup()` fixture (:91–120) with an agents dict. Cases: fresh fan-out writes files +
+   manifest; second run idempotent; adopt-with-backup over a pre-existing unmanaged copy; a
+   user-authored `my-own-agent.md` is **byte-identical after sync AND after uninstall**; unmodified
+   orphan backed-up-then-removed; modified managed file kept; uninstall removes only manifest-recorded
+   clean files (extend src/genie-commands/uninstall.test.ts).
+
+**Acceptance Criteria:**
+- [ ] Running the sync twice is idempotent (second run reports no changes).
+- [ ] A pre-existing unmanaged `scout.md` is adopted: backup exists under the state-backups dir, file
+      becomes stamped-managed.
+- [ ] A user file `my-own-agent.md` in `~/.claude/agents/` survives sync and uninstall untouched.
+- [ ] Deleting `scout.md` from the source and re-syncing removes the target copy (orphan removal),
+      with backup.
+
+**Validation:**
+```bash
+cd /Users/feliperosa/workspace/genie && bun test src/lib/agent-sync.test.ts src/genie-commands/uninstall.test.ts && bun run check
+```
+
+**depends-on:** none
+
+---
+
+### Group B: doctor-duplicate-guard
+
+**Goal:** `genie doctor` tells the truth about role-agent delivery — managed vs merely-present vs stale — and warns about the duplicate-surface hazard.
+
+**Deliverables:**
+1. Doctor summary for `~/.claude/agents/` (src/genie-commands/doctor.ts): a **new per-file
+   classifier** — `summarizeManagedSkills()` (:620–641) cannot be reused (subdir-based via
+   `listSubdirs` :570 + manifest-inside-dir via `readManagedDigest` :585; flat files are invisible to
+   it and it cannot emit a present-unmanaged state). Per-file states from the Group A manifest:
+   genie-managed-current / genie-managed-stale / **present-unmanaged** (file exists, no manifest
+   entry — the hand-copy case) / missing-from-target. Report inside `checkClaudeSync()` (:664–680)
+   alongside skills + council.js freshness.
+2. `enabledPlugins["genie@automagik"] === true` probe in `~/.claude/settings.json` → warning naming
+   the duplicate-surface consequence and the resolution (keep plugin disabled, or expect `genie:*`
+   duplicates).
+3. **Machine-readable contract (UI interface):** the per-file states and the duplicate warning ride
+   the existing `genie doctor --json` raw-check output (src/genie-commands/doctor.ts:12 — no new
+   flag). This is the "pins mechanically active" integrity fact the execution-optimization dashboard
+   (parallel brainstorm `genie-execution-optimization-dashboard`, block 20 measurement-integrity)
+   consumes. Doctor's `--json` emits `{ ok, checks: [{ name, status, detail?, suggestion? }] }`
+   (doctor.ts:837–838) — the per-file states (`genie-managed-current` / `genie-managed-stale` /
+   `present-unmanaged` / `missing-from-target`) must be **deterministically machine-parseable** from
+   that output: either a structured payload on the check entry or a documented stable format in
+   `detail` — never free prose the dashboard would have to guess at.
+4. Tests: fixture settings.json + fixture agents dir driving each state and the warning, asserted on
+   both the human and `--json` outputs.
+
+**Acceptance Criteria:**
+- [ ] Doctor on a host with only the unstamped hand-copy reports present-unmanaged (NOT healthy
+      genie-managed) — the false-PASS discriminator from the plan review.
+- [ ] Doctor with the plugin enabled emits the duplicate-surface warning; disabled emits none.
+- [ ] `genie doctor --json` carries the per-file role-agent states under stable field names
+      (dashboard-consumable without parsing human output).
+
+**Validation:**
+```bash
+cd /Users/feliperosa/workspace/genie && bun test src/genie-commands/doctor.test.ts && bun run check
+```
+
+**depends-on:** A
+
+---
+
+### Group C: day3-qa
+
+**Goal:** Prove the pins fire mechanically end-to-end on the released build, with evidence.
+
+**Deliverables:**
+1. Post-release, post-`genie update` (Felipe's live ritual): verify the stamp exists and the seven
+   agents surface in a fresh session; record doctor output.
+2. LangWatch pull re-running the day-2 recipe set (`.genie/wishes/routing-matrix/qa/routing-pin-qa-20260711.md`
+   methodology): primary = dispatched traces carry pinned `model×effort` fingerprints per role;
+   secondary = Fable/Opus/Haiku share trend, reported with top-3-thread exclusion. **Record RESOLVED
+   model IDs, not aliases** — the agent files pin `opus`/`haiku` aliases, which move across releases;
+   the evidence must state what they resolved to during the window (execution-optimization-lab
+   benchmark requirement, shared).
+3. Evidence file `.genie/wishes/routing-matrix/qa/routing-pin-qa-<date>.md`; if fingerprints pass,
+   mark routing-matrix QA CLOSED in `.genie/INDEX.md`.
+
+**Acceptance Criteria:**
+- [ ] Evidence file exists with commands + numbers; fingerprint verdict explicit (pass/fail per role).
+- [ ] routing-matrix INDEX entry updated to reflect the QA outcome.
+
+**Validation:**
+```bash
+test -s "$(ls -t /Users/feliperosa/workspace/genie/.genie/wishes/routing-matrix/qa/routing-pin-qa-*.md | head -1)"
+```
+
+**depends-on:** B (released build carrying A+B)
+
+---
+
+## Dependencies
+
+- **blocks:** `work-on-workflows` (rebaseline wish 3 — sequenced after Fix per the ratified order;
+  no mechanical dependency).
+- `genie-spend` (rebaseline wish 2) is independent and may run in parallel.
+
+## QA Criteria
+
+_What must be verified on dev after merge. The QA agent tests each criterion._
+
+- [ ] Functional: `genie update` on a real host populates `~/.claude/agents/` with stamp; the seven
+      agents surface after `/reload-plugins` or a fresh session.
+- [ ] Integration: `genie doctor` reflects the true managed state on that same host; enabling the
+      plugin flips the warning on.
+- [ ] Regression: skills fan-out, council.js stamping, and Codex/Hermes sync targets unchanged
+      (`bun test src/lib/agent-sync.test.ts` full suite green); user-authored agents never touched.
+
+---
+
+## Assumptions / Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Name collision with a user-authored agent of the same name (e.g. their own `reviewer.md`) | Medium | Adopt-with-backup, never silent overwrite; doctor lists the adoption; backups under `~/.genie/state-backups/` |
+| Hosts with the plugin ENABLED get duplicates (`genie:*` + bare) | Medium | Group B warning + documented resolution (design Risk 7) |
+| `CLAUDE_CODE_SUBAGENT_MODEL` env silently overrides pins | Medium | Carried from umbrella — doctor env check exists per routing-matrix wish; re-verify in Group C evidence |
+| Day-3 share numbers noise-dominated by thread mix | Low | Fingerprint check is primary; shares directional with top-3 exclusion (plan-review MEDIUM) |
+
+---
+
+## Review Results
+
+### Plan review — 2026-07-11 (reviewer role agent, opus-xhigh)
+
+- **Loop 0:** FIX-FIRST — 1 HIGH (Group A framed as reuse of the dir-oriented managed engine;
+  `writeManagedDir` whole-dir replace would delete user-authored agents; uninstall/doctor dir-walkers
+  skip flat files) + 2 MEDIUM (Group B validation targeted the wrong test dir; present-unmanaged state
+  unreachable via `summarizeManagedSkills`) + 2 LOW (Group C post-release gating note; Group A targeted
+  command missing uninstall.test.ts). All anchors verified accurate; semantics were the issue.
+- **Loop 1:** **SHIP** — all 5 findings verified resolved against the amended file; per-file design
+  confirmed sound (dotfile manifest can't surface as an agent; no collision with per-skill manifests).
+- **Post-SHIP amendment (Felipe-directed, 2026-07-11, after the SHIP verdict):** convergence with the
+  parallel `genie-execution-optimization-dashboard` brainstorm — Group B states explicitly ride the
+  existing `genie doctor --json` with stable field names (the dashboard's pins-active integrity fact);
+  Group C must record resolved model IDs, not aliases. Delta sent to the reviewer for a
+  flag-if-broken check; no engine-contract change.
+
+**Engineer note (non-blocking, Group A):** the clean-remove path can reuse `removeAgentSyncAssets()`'s
+file branch, but the MODIFIED-keep path must NOT assume `keepModifiedSkillDir` works unchanged — an
+agent's ownership is an ENTRY in the shared dir-level `~/.claude/agents/.genie-sync.json`, so keeping
+`<name>.md.genie-kept` also means deleting that filename's manifest entry (not unlinking a per-dir
+manifest). The acceptance tests force the correct behavior.
+
+### Execution review — Group A `agents-fanout` (2026-07-11)
+
+- **Engineer pass:** implementation completed in the four Group A files; targeted tests and the full
+  repository gate passed.
+- **Review loop 0:** **FIX-FIRST** — unsafe `.genie-kept` collision handling, uninstall backups
+  deleted by the full uninstall flow, remove-before-write updates, and unsafe shared-manifest paths.
+- **Fix/review loop 1:** **FIX-FIRST** — new adversarial evidence found unsafe backup destination
+  collisions, file/ownership TOCTOU, fixed staging paths that wedged retries, and a non-idempotent
+  backups-only uninstall state.
+- **Fix/review loop 2:** **BLOCKED** after the maximum two fix loops. Validation remained green
+  (92 focused tests; 953 full-suite passes, 1 skipped; scoped `git diff --check` clean), but the final
+  independent reviewer reproduced four remaining boundary defects:
+  1. **CRITICAL:** sync can overwrite or delete a replacement created after its final validation but
+     before publish/removal (`src/lib/agent-sync.ts`).
+  2. **HIGH:** uninstall ignores a failed ownership relinquish and can leave a removed file still
+     owned by the manifest (`src/genie-commands/uninstall.ts`).
+  3. **HIGH:** lock acquisition can return a usable-looking handle without owning a lock, and
+     release/stale-steal boundaries are not ownership-atomic (`src/lib/agent-sync.ts`).
+  4. **HIGH:** stage cleanup tracks only pathnames and can delete a replacement object it does not
+     own (`src/lib/agent-sync.ts`).
+
+**Escalation diagnosis:** Group A remains `in_progress`; Groups B/C were not dispatched. Cause is
+`missing-context`: each bounded fix brief addressed the then-reproduced gap list, while the terminal
+review supplied new atomic-boundary invariants (capture-before-validate/publish, checked ownership
+relinquish, fail-closed lock acquisition, identity-checked stage cleanup). Model/effort escalation is
+not authorized or evidenced. Corrective route: human authorization for a fresh, same-model
+engineering cycle carrying those four exact invariants, followed by an independent execution review.
+Budget: `attempts=2/2`; `effort_escalations=0/2`; appeal: none.
+
+**Human-authorized repair extension — 2026-07-11T23:41:07-03:00:** Felipe approved one fresh
+engineering-and-review cycle for Group A. The inherited model and effort remain unchanged; the
+extension carries only the four terminal atomic-boundary invariants above. Extended budget:
+`attempts=3/3`; `effort_escalations=0/2`. A non-SHIP re-review stops the group again; it does not
+authorize another automatic repair.
+
+**Human-authorized extension review — 2026-07-11:** **FIX-FIRST**. The first formal-review attempt
+hit an environment policy false positive; an unchanged-effort retry completed normally. Validation
+passed (99 focused tests; 960 full-suite passes, 1 skipped; scoped `git diff --check` clean), while
+the formal reviewer and architecture lens reproduced these remaining transaction-boundary defects:
+
+1. **CRITICAL:** sync and uninstall can discard changes made to a captured inode after their one-time
+   validation and before final unlink.
+2. **HIGH:** sync can commit manifest ownership for different live target bytes changed immediately
+   before manifest commit.
+3. **HIGH:** successful manifest publication can be misreported as failure when stage cleanup fails,
+   causing data rollback plus a multiply-linked manifest that future reads reject.
+4. **HIGH:** final-entry ownership relinquish can return success while a concurrently installed
+   replacement manifest still owns the removed agent.
+5. **HIGH:** full uninstall releases the shared sync lock before deleting the canonical source,
+   allowing a sync in the gap to recreate managed agents that uninstall then leaves behind.
+6. **HIGH:** exceptions after uninstall staging can hide bytes in a staging directory while leaving
+   the live path absent and manifest ownership unchanged.
+
+**Extension diagnosis:** cause is `model-capacity`: the behavioral contract, repository context,
+deterministic seams, and validation environment were complete, but the same inherited model/effort
+did not close the transaction reasoning after three implementation attempts. Corrective route:
+human authorization for an architecture-first repair that centralizes the flat-agent transaction
+(`capture → validate → publish → manifest CAS → finalize/rollback`) and holds one lock across the
+complete uninstall, using a higher-effort fresh engineering session if the runtime exposes one.
+Budget: `attempts=3/3`; `effort_escalations=0/2`; appeal: none. Group A remains `in_progress` and
+Groups B/C remain undispatched.
+
+**Human-authorized escalated repair — 2026-07-12:** Felipe approved attempt 4 as an
+architecture-first repair at **Fable-5 tier** (above the opus-xhigh pin used in attempts 1–3),
+consuming one effort escalation. Mandate: centralize the entire flat-agent transaction
+(`capture → validate → publish → manifest CAS → finalize/rollback`) and hold ONE lock across the
+complete uninstall, including canonical-source deletion. The six terminal transaction-boundary
+defects ride as hard invariants; the existing test suite is kept as the behavioral floor.
+Extended budget: `attempts=4/4`; `effort_escalations=1/2`. A non-SHIP re-review stops the group
+again; it does not authorize another automatic repair.
+
+### Execution review — Group A attempt 4 (2026-07-12): **SHIP**
+
+Independent Fable-tier reviewer, adversarial syscall-interleaving pass over the uncommitted working
+tree. No CRITICAL or HIGH gaps. All six terminal invariants closed — publish-outcome-at-rename,
+single-lock-across-uninstall, exception-path restore-or-park, and flat-file structural invisibility
+of user files CLOSED-BY-CONSTRUCTION; captured-inode disposal and bytes/ownership divergence
+CLOSED-BY-CHECK via at-the-instant re-verification, with residual windows reachable only by a
+non-genie process forging genie's own manifest and producing no byte loss on any constructed
+interleaving. All four engineer-declared open items judged acceptable (item (b), capture-mismatch
+relinquish, is in fact pinned by tests — the "no floor test" note was outdated). Wish-contract
+compliance verified in code, including `writeManagedDir` never touching `~/.claude/agents/` and
+durable backups now surviving full uninstall (prior code deleted state-backups — fixed and pinned).
+The 7 new INV tests were judged to pin the invariants (attempt-3 code would fail each behaviorally).
+Gates re-run independently from a script file: 106 focused pass / 0 fail; `bun run check` 967 pass /
+1 skip / 0 fail; wishes-lint OK; `git diff --check` clean.
+
+**Non-blocking advisories (follow-up hardening candidates):**
+1. MEDIUM — `state.published` re-read from the live path after linkSync instead of derived from the
+   staged inode (agent-sync.ts:1098); bounded (all consumers backup-first, no byte loss); recommend
+   constructing from stage.stat/stage.bytes.
+2. MEDIUM/LOW — SIGKILL between capture and finalize strands quarantine-dir debris with no recovery
+   sweep; kill-only, ms-scale, manually recoverable; a startup sweep would close it.
+3. LOW — `stealStaleLock` doc comment describes the retired guard-file mechanism (agent-sync.ts:2074).
+4. LOW — sync's publish-conflict advisory omits the `.genie-kept` path (agent-sync.ts:1677).
+5. LOW — uninstall silently collects zero agents when the shared manifest is unsafe (uninstall.ts:193);
+   fail-closed but unexplained in output.
+
+Budget closed: `attempts=4/4` (SHIP on 4); `effort_escalations=1/2`.
+
+---
+
+## Files to Create/Modify
+
+```
+src/lib/agent-sync.ts               # syncClaude :471 — NEW per-file managed fan-out (dir-level filename→digest manifest)
+src/lib/agent-sync.test.ts          # writeSourceAgent (single file) + fan-out/adopt/orphan/user-file-byte-identical cases
+src/genie-commands/doctor.ts        # checkClaudeSync :664 — NEW per-file classifier + enabledPlugins warning
+src/genie-commands/doctor.test.ts   # per-state fixtures incl. present-unmanaged (hand-copy) + warning on/off
+src/genie-commands/uninstall.ts     # collectAgentSyncAssets :193 — per-file collector/classifier (NOT collectManagedSkillDirs)
+src/genie-commands/uninstall.test.ts# removes-only-manifest-clean; user + modified files preserved
+.genie/wishes/routing-matrix/qa/    # Group C evidence file
+```

--- a/src/genie-commands/doctor.test.ts
+++ b/src/genie-commands/doctor.test.ts
@@ -16,7 +16,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
-import { computeDirDigest } from '../lib/agent-sync.js';
+import { computeDirDigest, computeFileDigest } from '../lib/agent-sync.js';
 import { reconcileCodexProjectMcp, resolveGitProjectRoots } from '../lib/codex-project-mcp.js';
 import { CANONICAL_GENIE_SKILL_NAMES } from '../lib/runtime-integrations.js';
 import {
@@ -1200,5 +1200,206 @@ describe('checkAgentSync', () => {
     const results = checkAgentSync(paths());
     expect(find(results, 'agent sync: hermes mcp')?.status).toBe('pass');
     expect(find(results, 'agent sync: hermes skills')?.status).toBe('pass');
+  });
+});
+
+// ============================================================================
+// Claude role-agent delivery (wish routing-delivery-fix, Group B) — per-file
+// classifier over the Group-A `~/.claude/agents/.genie-sync.json` manifest.
+// Read-only, all paths injected via checkAgentSync — the real $HOME is untouched.
+// ============================================================================
+
+describe('checkAgentSync — claude role agents', () => {
+  const ROLE_CHECK = 'agent sync: claude role agents';
+  const DUP_CHECK = 'agent sync: duplicate role-agent surface';
+
+  let tmp: string;
+  let genieHome: string;
+  let pluginRoot: string;
+  let claudeDir: string;
+  let agentsDir: string;
+
+  function paths() {
+    return {
+      genieHome,
+      claudeDir,
+      codexDir: join(tmp, 'codex'),
+      agentsSkillsDir: join(tmp, 'agents', 'skills'),
+      hermesHome: join(tmp, 'hermes'),
+      settingsPath: join(claudeDir, 'settings.json'),
+    };
+  }
+
+  const find = (results: ReturnType<typeof checkAgentSync>, name: string) => results.find((r) => r.name === name);
+
+  /** name → state map off the machine-readable rider (what `--json` carries). */
+  function stateMap(check: ReturnType<typeof checkAgentSync>[number] | undefined): Record<string, string> {
+    const files = check?.roleAgents?.files ?? [];
+    return Object.fromEntries(files.map((f) => [f.name, f.state]));
+  }
+
+  function writeSourceAgent(name: string, body: string): void {
+    mkdirSync(join(pluginRoot, 'agents'), { recursive: true });
+    writeFileSync(join(pluginRoot, 'agents', `${name}.md`), body, 'utf8');
+  }
+
+  function writeTargetAgent(name: string, body: string): void {
+    mkdirSync(agentsDir, { recursive: true });
+    writeFileSync(join(agentsDir, `${name}.md`), body, 'utf8');
+  }
+
+  /** Stamp the shared dir-level agent manifest (Group A shape: filename → digest entry). */
+  function writeAgentManifest(files: Record<string, { digest: string; version?: string; syncedAt?: string }>): void {
+    mkdirSync(agentsDir, { recursive: true });
+    const entries = Object.fromEntries(
+      Object.entries(files).map(([name, e]) => [
+        name,
+        { digest: e.digest, version: e.version ?? '1', syncedAt: e.syncedAt ?? '2026-01-01T00:00:00.000Z' },
+      ]),
+    );
+    writeFileSync(
+      join(agentsDir, '.genie-sync.json'),
+      JSON.stringify({ managedBy: 'genie-agent-sync', files: entries }),
+      'utf8',
+    );
+  }
+
+  function writeSettings(value: unknown): void {
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(join(claudeDir, 'settings.json'), JSON.stringify(value), 'utf8');
+  }
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'doctor-roleagents-'));
+    genieHome = join(tmp, 'genie');
+    pluginRoot = join(genieHome, 'plugins', 'genie');
+    claudeDir = join(tmp, 'claude');
+    agentsDir = join(claudeDir, 'agents');
+    mkdirSync(pluginRoot, { recursive: true });
+    mkdirSync(claudeDir, { recursive: true }); // claude "detected" so role-agent checks run
+    writeFileSync(join(genieHome, 'VERSION'), '5.0.0\n', 'utf8');
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test('hand-copy (no manifest) reports present-unmanaged, NOT healthy genie-managed', () => {
+    // The 2026-07-11 false-PASS discriminator: files present + agents surface,
+    // but no stamp → doctor must NOT call it genie-managed-current.
+    writeSourceAgent('scout', '# scout\n');
+    writeTargetAgent('scout', '# scout\n');
+
+    const check = find(checkAgentSync(paths()), ROLE_CHECK);
+    expect(check?.status).toBe('warn');
+    expect(check?.detail).toContain('present-unmanaged'); // human output carries the state
+    expect(check?.roleAgents?.manifestStatus).toBe('absent');
+    expect(stateMap(check)['scout.md']).toBe('present-unmanaged');
+    expect(stateMap(check)['scout.md']).not.toBe('genie-managed-current');
+  });
+
+  test('stamped + byte-matching target reports genie-managed-current → pass', () => {
+    writeSourceAgent('scout', '# scout\n');
+    writeTargetAgent('scout', '# scout\n');
+    writeAgentManifest({ 'scout.md': { digest: computeFileDigest(join(agentsDir, 'scout.md')) } });
+
+    const check = find(checkAgentSync(paths()), ROLE_CHECK);
+    expect(check?.status).toBe('pass');
+    expect(check?.roleAgents?.manifestStatus).toBe('managed');
+    expect(stateMap(check)['scout.md']).toBe('genie-managed-current');
+  });
+
+  test('source drifted past a stamped target reports genie-managed-stale → warn', () => {
+    writeTargetAgent('scout', '# scout v1\n');
+    const v1Digest = computeFileDigest(join(agentsDir, 'scout.md'));
+    writeAgentManifest({ 'scout.md': { digest: v1Digest } }); // on-disk == manifest
+    writeSourceAgent('scout', '# scout v2\n'); // but source moved on
+
+    const check = find(checkAgentSync(paths()), ROLE_CHECK);
+    expect(check?.status).toBe('warn');
+    expect(check?.suggestion).toContain('genie update');
+    expect(stateMap(check)['scout.md']).toBe('genie-managed-stale');
+  });
+
+  test('source agent absent from the target reports missing-from-target → warn', () => {
+    writeSourceAgent('fixer', '# fixer\n'); // no target file, no manifest entry
+
+    const check = find(checkAgentSync(paths()), ROLE_CHECK);
+    expect(check?.status).toBe('warn');
+    expect(stateMap(check)['fixer.md']).toBe('missing-from-target');
+  });
+
+  test('a user-authored agent (not in source, unmanaged) is never reported', () => {
+    writeSourceAgent('scout', '# scout\n');
+    writeTargetAgent('scout', '# scout\n');
+    writeAgentManifest({ 'scout.md': { digest: computeFileDigest(join(agentsDir, 'scout.md')) } });
+    writeTargetAgent('my-own-agent', '# mine\n'); // genie does not speak for it
+
+    const check = find(checkAgentSync(paths()), ROLE_CHECK);
+    const states = stateMap(check);
+    expect(states['my-own-agent.md']).toBeUndefined();
+    expect(states['scout.md']).toBe('genie-managed-current');
+    expect(check?.status).toBe('pass');
+  });
+
+  test('an unsafe (symlinked) manifest warns instead of silently reporting healthy', () => {
+    writeSourceAgent('scout', '# scout\n');
+    writeTargetAgent('scout', '# scout\n');
+    symlinkSync(join(tmp, 'elsewhere.json'), join(agentsDir, '.genie-sync.json'));
+
+    const check = find(checkAgentSync(paths()), ROLE_CHECK);
+    expect(check?.status).toBe('warn');
+    expect(check?.roleAgents?.manifestStatus).toBe('unsafe');
+    expect(check?.detail).toContain('manifest unusable');
+  });
+
+  test('plugin enabled → duplicate-surface warning + duplicateSurface flag true', () => {
+    writeSourceAgent('scout', '# scout\n');
+    writeTargetAgent('scout', '# scout\n');
+    writeAgentManifest({ 'scout.md': { digest: computeFileDigest(join(agentsDir, 'scout.md')) } });
+    writeSettings({ enabledPlugins: { 'genie@automagik': true } });
+
+    const results = checkAgentSync(paths());
+    const dup = find(results, DUP_CHECK);
+    expect(dup?.status).toBe('warn');
+    expect(dup?.detail).toContain('both surface');
+    expect(find(results, ROLE_CHECK)?.roleAgents?.duplicateSurface).toBe(true);
+  });
+
+  test('plugin disabled or absent → no duplicate warning, duplicateSurface flag false', () => {
+    writeSourceAgent('scout', '# scout\n');
+    writeTargetAgent('scout', '# scout\n');
+    writeAgentManifest({ 'scout.md': { digest: computeFileDigest(join(agentsDir, 'scout.md')) } });
+
+    writeSettings({ enabledPlugins: { 'genie@automagik': false } });
+    let results = checkAgentSync(paths());
+    expect(find(results, DUP_CHECK)).toBeUndefined();
+    expect(find(results, ROLE_CHECK)?.roleAgents?.duplicateSurface).toBe(false);
+
+    // absent settings.json → still no warning, flag false
+    rmSync(join(claudeDir, 'settings.json'), { force: true });
+    results = checkAgentSync(paths());
+    expect(find(results, DUP_CHECK)).toBeUndefined();
+    expect(find(results, ROLE_CHECK)?.roleAgents?.duplicateSurface).toBe(false);
+  });
+
+  test('--json carries the per-file states under stable field names (dashboard-consumable)', () => {
+    // Drive the exact document doctorCommand serializes: { ok, checks: results }.
+    writeSourceAgent('scout', '# scout\n'); // hand-copy → present-unmanaged
+    writeTargetAgent('scout', '# scout\n');
+    writeSourceAgent('reviewer', '# reviewer\n'); // stamped-current
+    writeTargetAgent('reviewer', '# reviewer\n');
+    writeSourceAgent('fixer', '# fixer\n'); // missing-from-target
+    writeAgentManifest({ 'reviewer.md': { digest: computeFileDigest(join(agentsDir, 'reviewer.md')) } });
+
+    const results = checkAgentSync(paths());
+    const doc = JSON.parse(JSON.stringify({ ok: true, checks: results })) as {
+      checks: Array<{ name: string; roleAgents?: { files: Array<{ name: string; state: string }> } }>;
+    };
+    const rider = doc.checks.find((c) => c.name === ROLE_CHECK)?.roleAgents;
+    const states = Object.fromEntries((rider?.files ?? []).map((f) => [f.name, f.state]));
+    expect(states['scout.md']).toBe('present-unmanaged');
+    expect(states['reviewer.md']).toBe('genie-managed-current');
+    expect(states['fixer.md']).toBe('missing-from-target');
   });
 });

--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -27,11 +27,15 @@ import {
 import { homedir } from 'node:os';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 import {
+  type AgentFileManifestEntry,
   CLAUDE_EXCLUDED_SKILLS,
   MANAGED_BY,
   MANIFEST_NAME,
   TARGET_NAME,
   computeDirDigest,
+  computeFileDigest,
+  enumerateSourceAgentFiles,
+  readAgentFilesManifestState,
   resolveAgentsSkillsDir,
   resolveGenieSource,
   resolveHermesConfigPath,
@@ -73,11 +77,48 @@ type CheckStatus = 'pass' | 'warn' | 'fail';
 
 export const MINIMUM_BUN_VERSION = '1.3.10';
 
+/**
+ * Per-file delivery state of one Claude role agent in `~/.claude/agents/`,
+ * derived from the Group-A `.genie-sync.json` manifest + the canonical source
+ * `agents/` dir. These four names are the STABLE machine-readable contract the
+ * execution-optimization dashboard parses off `genie doctor --json` — do NOT
+ * rename them without updating that consumer:
+ *   - genie-managed-current : manifest entry present, on-disk == manifest == source.
+ *   - genie-managed-stale   : manifest entry present, but on-disk / source drifted
+ *                             (edited target, moved-on source, or an orphaned managed file).
+ *   - present-unmanaged     : source role agent present on disk with NO manifest entry
+ *                             (the 2026-07-11 hand-copy — NOT healthy genie-managed).
+ *   - missing-from-target   : source role agent absent from `~/.claude/agents/`.
+ */
+export type RoleAgentFileState =
+  | 'genie-managed-current'
+  | 'genie-managed-stale'
+  | 'present-unmanaged'
+  | 'missing-from-target';
+
+/** Structured rider carried on the role-agent check for dashboard consumers. */
+export interface RoleAgentDelivery {
+  /** Trust verdict on the shared `~/.claude/agents/.genie-sync.json` manifest. */
+  manifestStatus: 'managed' | 'foreign' | 'absent' | 'unsafe';
+  /** Present only when `manifestStatus === 'unsafe'`. */
+  manifestReason?: string;
+  /** One entry per source role agent (and any managed manifest entry), name-sorted. */
+  files: Array<{ name: string; state: RoleAgentFileState }>;
+  /** True when the `genie@automagik` plugin is ALSO enabled — plugin `genie:*` and fanned bare names both surface. */
+  duplicateSurface: boolean;
+}
+
 interface CheckResult {
   name: string;
   status: CheckStatus;
   detail?: string;
   suggestion?: string;
+  /**
+   * Machine-readable payload rider (survives `--json` as `checks[].roleAgents`).
+   * Only the `agent sync: claude role agents` check sets it; see
+   * {@link RoleAgentDelivery} for the stable field/state-name contract.
+   */
+  roleAgents?: RoleAgentDelivery;
 }
 
 // ============================================================================
@@ -795,7 +836,154 @@ function councilStampState(councilPath: string, pluginRoot: string): { stale: bo
   return { stale: true, label: `stale (LENS_ROOT ${root ?? 'unreadable'})` };
 }
 
-function checkClaudeSync(pluginRoot: string, claudeDir: string): CheckResult[] {
+// ============================================================================
+// Claude role-agent delivery (~/.claude/agents) — per-file classifier
+//
+// summarizeManagedSkills() cannot be reused here: it is subdir-based (a manifest
+// INSIDE each skill dir) and so it is blind to flat `<name>.md` agent files and
+// cannot express a "present-unmanaged" state. Role agents are flat files under a
+// SINGLE shared dir-level manifest (Group A), so this classifier is per-FILE.
+// ============================================================================
+
+/** Digest of each flat source role agent under `<pluginRoot>/agents`; unreadable files are skipped. */
+function sourceAgentDigests(pluginRoot: string): Map<string, string> {
+  const digests = new Map<string, string>();
+  for (const agent of enumerateSourceAgentFiles(pluginRoot)) {
+    try {
+      digests.set(agent.name, computeFileDigest(agent.path));
+    } catch {
+      /* unreadable source file — omit rather than misclassify */
+    }
+  }
+  return digests;
+}
+
+function isRegularFile(path: string): boolean {
+  try {
+    return lstatSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function safeFileDigest(path: string): string | null {
+  try {
+    return computeFileDigest(path);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * State of one role-agent filename from the source digest set + manifest entries.
+ * "current" mirrors the skills contract (on-disk == manifest == source). Returns
+ * null for a name genie does not speak for (a user-authored agent absent from
+ * both source and the manifest is never reported).
+ */
+function classifyRoleAgentFile(
+  agentsDir: string,
+  name: string,
+  source: Map<string, string>,
+  entries: Record<string, AgentFileManifestEntry>,
+): RoleAgentFileState | null {
+  const present = isRegularFile(join(agentsDir, name));
+  const entry = entries[name];
+  const inSource = source.has(name);
+  if (entry === undefined) {
+    if (present) return inSource ? 'present-unmanaged' : null;
+    return inSource ? 'missing-from-target' : null;
+  }
+  if (!present) return inSource ? 'missing-from-target' : null;
+  const onDisk = safeFileDigest(join(agentsDir, name));
+  const current = inSource && onDisk !== null && onDisk === entry.digest && entry.digest === source.get(name);
+  return current ? 'genie-managed-current' : 'genie-managed-stale';
+}
+
+/** Classify every source role agent (and any managed manifest entry) under `<claudeDir>/agents`. */
+function classifyRoleAgents(pluginRoot: string, agentsDir: string): Omit<RoleAgentDelivery, 'duplicateSurface'> {
+  const source = sourceAgentDigests(pluginRoot);
+  const manifest = readAgentFilesManifestState(agentsDir);
+  const entries = manifest.kind === 'managed' ? manifest.files : {};
+  const names = new Set<string>([...source.keys(), ...Object.keys(entries)]);
+  const files: RoleAgentDelivery['files'] = [];
+  for (const name of [...names].sort()) {
+    const state = classifyRoleAgentFile(agentsDir, name, source, entries);
+    if (state !== null) files.push({ name, state });
+  }
+  return {
+    manifestStatus: manifest.kind,
+    manifestReason: manifest.kind === 'unsafe' ? manifest.reason : undefined,
+    files,
+  };
+}
+
+/** Human-facing summary + a stale flag (any non-current state, or an unusable manifest, warns). */
+function roleAgentSummary(delivery: Omit<RoleAgentDelivery, 'duplicateSurface'>): { detail: string; stale: boolean } {
+  if (delivery.manifestStatus === 'unsafe') {
+    return {
+      detail: `manifest unusable (${delivery.manifestReason}) — every role agent treated as unmanaged`,
+      stale: true,
+    };
+  }
+  if (delivery.files.length === 0) return { detail: 'no genie role agents detected', stale: false };
+  const counts: Record<RoleAgentFileState, number> = {
+    'genie-managed-current': 0,
+    'genie-managed-stale': 0,
+    'present-unmanaged': 0,
+    'missing-from-target': 0,
+  };
+  for (const file of delivery.files) counts[file.state] += 1;
+  const detail =
+    `${counts['genie-managed-current']}/${delivery.files.length} genie-managed-current, ` +
+    `${counts['present-unmanaged']} present-unmanaged, ${counts['genie-managed-stale']} stale, ` +
+    `${counts['missing-from-target']} missing-from-target`;
+  const stale = counts['genie-managed-current'] !== delivery.files.length;
+  return { detail, stale };
+}
+
+/** `enabledPlugins["genie@automagik"] === true` in Claude Code's settings.json (unreadable → false). */
+function roleAgentDuplicateSurface(settingsPath: string): boolean {
+  try {
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf8')) as { enabledPlugins?: Record<string, boolean> };
+    return settings.enabledPlugins?.['genie@automagik'] === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Per-file role-agent delivery check + the duplicate-surface warning. The
+ * structured {@link RoleAgentDelivery} rides `--json` as `checks[].roleAgents`
+ * so the dashboard reads the four state names without parsing prose; the
+ * duplicate warning is emitted as its own line ONLY when the plugin is enabled.
+ */
+function checkRoleAgents(pluginRoot: string, claudeDir: string, settingsPath: string): CheckResult[] {
+  const classification = classifyRoleAgents(pluginRoot, join(claudeDir, 'agents'));
+  const duplicateSurface = roleAgentDuplicateSurface(settingsPath);
+  const { detail, stale } = roleAgentSummary(classification);
+  const results: CheckResult[] = [
+    {
+      name: 'agent sync: claude role agents',
+      status: stale ? 'warn' : 'pass',
+      detail,
+      suggestion: stale ? SYNC_SUGGESTION : undefined,
+      roleAgents: { ...classification, duplicateSurface },
+    },
+  ];
+  if (duplicateSurface) {
+    results.push({
+      name: 'agent sync: duplicate role-agent surface',
+      status: 'warn',
+      detail:
+        'genie@automagik plugin enabled — plugin `genie:*` agents and fanned bare-named agents both surface (duplicate listings)',
+      suggestion:
+        'Keep the genie plugin disabled (bare-named agents are fanned by `genie update`), or expect duplicates.',
+    });
+  }
+  return results;
+}
+
+function checkClaudeSync(pluginRoot: string, claudeDir: string, settingsPath: string): CheckResult[] {
   if (!existsSync(claudeDir)) return [{ name: 'agent sync: claude', status: 'pass', detail: 'not detected' }];
   // Claude legitimately excludes `council` (the /council native workflow owns
   // that name), so its expected source set is source minus CLAUDE_EXCLUDED_SKILLS
@@ -810,6 +998,7 @@ function checkClaudeSync(pluginRoot: string, claudeDir: string): CheckResult[] {
       detail: `${skills.detail}; council.js ${council.label}`,
       suggestion: stale ? SYNC_SUGGESTION : undefined,
     },
+    ...checkRoleAgents(pluginRoot, claudeDir, settingsPath),
   ];
 }
 
@@ -1227,7 +1416,7 @@ export function checkAgentSync(paths: AgentSyncPaths = {}): CheckResult[] {
   const pluginRoot = source.pluginRoot;
   const hermesBinary = paths.hermesBinary !== undefined ? paths.hermesBinary : whichBinary('hermes');
   return [
-    ...safeAgentChecks('claude', () => checkClaudeSync(pluginRoot, claudeDir)),
+    ...safeAgentChecks('claude', () => checkClaudeSync(pluginRoot, claudeDir, settingsPath)),
     ...safeAgentChecks('codex', () => checkCodexSync(codexDir, agentsSkillsDir, pluginRoot)),
     ...safeAgentChecks('hermes', () =>
       checkHermesSync({

--- a/src/genie-commands/uninstall.test.ts
+++ b/src/genie-commands/uninstall.test.ts
@@ -1,15 +1,15 @@
 /**
  * Tests for the agent-sync managed-asset removal in `genie uninstall`.
  *
- * The full uninstallCommand is interactive (confirm prompt) and targets the real
- * home; here we only prove the manifest-verified collect/remove seams — the code
- * that decides WHICH external agent assets uninstall is allowed to delete. Every
- * path is injected into a tmpdir, so no test ever touches the real HOME.
+ * The interactive prompt stays out of scope. Manifest-verified removal seams and
+ * a fully injected noninteractive flow run under a tmpdir, so no test touches the
+ * real HOME.
  *
  * Ownership contract under test: uninstall deletes only what genie provably
  * shipped — a managed dir whose computeDirDigest still matches its manifest.
- * A digest MISMATCH means the user edited the dir: it is kept byte-identical at
- * the same path. Uninstall cannot rename, disable, or rewrite user data.
+ * A managed-skill digest mismatch stays byte-identical at the same path. A flat
+ * agent mismatch is transactionally disowned and kept aside so it stops loading
+ * while its exact user bytes survive.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
@@ -17,6 +17,7 @@ import { createHash } from 'node:crypto';
 import {
   chmodSync,
   existsSync,
+  linkSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
@@ -34,7 +35,10 @@ import {
   MANAGED_BY,
   PHYSICAL_TREE_IDENTITY_VERSION,
   WORKFLOW_MANIFEST_NAME,
+  acquireAgentSyncLock,
   computeDirDigest,
+  computeFileDigest,
+  readAgentFilesManifest,
   stampWorkflow,
 } from '../lib/agent-sync.js';
 import {
@@ -43,10 +47,12 @@ import {
   collectAgentSyncAssets,
   executeUninstallBatch,
   hasPendingUninstallTransactions,
+  hasRemovableGenieInstallState,
   hasUninstallWork,
   inspectUninstallPlan,
   isGenieSymlink,
   isSameOrContainedPath,
+  performUninstall,
   readUninstallBatchDecision,
   recordUninstallBatchDecision,
   recoverUninstallTransactions,
@@ -77,8 +83,21 @@ describe('agent-sync managed-asset removal', () => {
   let hermesHome: string;
   let genieHome: string;
 
+  const fixedNow = () => new Date('2026-07-11T12:00:00.000Z');
+
   function targets() {
-    return { claudeDir, codexDir, agentsSkillsDir, hermesHome, genieHome };
+    return { claudeDir, codexDir, agentsSkillsDir, hermesHome, genieHome, now: fixedNow };
+  }
+
+  function uninstallBackupCollisionPath(): string {
+    return join(
+      genieHome,
+      'state-backups',
+      'agent-sync-uninstall-2026-07-11T12:00:00.000Z',
+      'claude',
+      'agents',
+      'scout.md',
+    );
   }
 
   /** A managed dir exactly as agent-sync ships it: manifest digest matches content. */
@@ -121,6 +140,22 @@ describe('agent-sync managed-asset removal', () => {
     writeFileSync(join(dir, 'SKILL.md'), content, 'utf8');
     const manifest = { managedBy: MANAGED_BY, version: '1', digest: computeDirDigest(dir), syncedAt: 'now' };
     writeFileSync(join(dir, '.genie-sync.json'), JSON.stringify(manifest), 'utf8');
+  }
+
+  /** Add one flat Claude agent plus its entry in the shared per-file manifest. */
+  function managedAgent(name: string, content = '# managed agent\n'): string {
+    const parent = join(claudeDir, 'agents');
+    const path = join(parent, name);
+    mkdirSync(parent, { recursive: true });
+    writeFileSync(path, content, 'utf8');
+    const manifest = readAgentFilesManifest(parent) ?? { managedBy: MANAGED_BY, files: {} };
+    manifest.files[name] = {
+      digest: computeFileDigest(path),
+      version: '1',
+      syncedAt: '2026-07-11T10:00:00.000Z',
+    };
+    writeFileSync(join(parent, '.genie-sync.json'), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+    return path;
   }
 
   beforeEach(() => {
@@ -711,6 +746,461 @@ describe('agent-sync managed-asset removal', () => {
     expect(existsSync(uninstallBatchJournalPath(genieHome))).toBe(false);
     expect(existsSync(replacement)).toBe(true);
     expect(readFileSync(join(replacement, 'SKILL.md'), 'utf8')).toBe('# swapped in between attempts\n');
+  });
+  test('collects only flat Claude agents represented in the shared manifest', () => {
+    const scout = managedAgent('scout.md');
+    const own = join(claudeDir, 'agents', 'my-own-agent.md');
+    writeFileSync(own, '# entirely mine\n', 'utf8');
+
+    const assets = collectAgentSyncAssets(targets());
+    const agentPaths = assets.filter((asset) => asset.kind === 'agent').map((asset) => asset.path);
+
+    expect(agentPaths).toEqual([scout]);
+    expect(agentPaths).not.toContain(own);
+  });
+
+  test('agent uninstall backs up/removes clean entries, keeps modified bytes, and never touches user files', () => {
+    const scout = managedAgent('scout.md', '# shipped scout\n');
+    const reviewer = managedAgent('reviewer.md', '# shipped reviewer\n');
+    const reviewerBytes = Buffer.from('# reviewer with local edits\n');
+    writeFileSync(reviewer, reviewerBytes);
+    const own = join(claudeDir, 'agents', 'my-own-agent.md');
+    const ownBytes = Buffer.from([0x23, 0x20, 0x6d, 0x79, 0x20, 0x6f, 0x77, 0x6e, 0x0a]);
+    writeFileSync(own, ownBytes);
+
+    const { removed, kept } = removeAgentSyncAssets(targets());
+    const reviewerKept = `${reviewer}.genie-kept`;
+
+    expect(removed).toContain(scout);
+    expect(existsSync(scout)).toBe(false);
+    expect(kept).toContain(reviewerKept);
+    expect(existsSync(reviewer)).toBe(false);
+    expect(readFileSync(reviewerKept)).toEqual(reviewerBytes);
+    expect(readFileSync(own)).toEqual(ownBytes);
+    expect(readAgentFilesManifest(join(claudeDir, 'agents'))).toBeNull();
+
+    const backup = join(
+      genieHome,
+      'state-backups',
+      'agent-sync-uninstall-2026-07-11T12:00:00.000Z',
+      'claude',
+      'agents',
+      'scout.md',
+    );
+    expect(readFileSync(backup, 'utf8')).toBe('# shipped scout\n');
+  });
+
+  test('a symlink backup collision and its victim survive while uninstall allocates a distinct root', () => {
+    const scout = managedAgent('scout.md', '# shipped scout\n');
+    const collision = uninstallBackupCollisionPath();
+    const victim = join(tmp, 'uninstall-backup-symlink-victim');
+    const victimBytes = Buffer.from('symlink victim bytes\n');
+    writeFileSync(victim, victimBytes);
+    mkdirSync(dirname(collision), { recursive: true });
+    symlinkSync(victim, collision);
+
+    const result = removeAgentSyncAssets(targets());
+    const distinctBackup = join(
+      genieHome,
+      'state-backups',
+      'agent-sync-uninstall-2026-07-11T12:00:00.000Z-1',
+      'claude',
+      'agents',
+      'scout.md',
+    );
+
+    expect(result.removed).toEqual([scout]);
+    expect(lstatSync(collision).isSymbolicLink()).toBe(true);
+    expect(readFileSync(victim)).toEqual(victimBytes);
+    expect(readFileSync(distinctBackup, 'utf8')).toBe('# shipped scout\n');
+  });
+
+  test('a multiply-linked backup collision preserves both prior names and creates a distinct backup', () => {
+    managedAgent('scout.md', '# shipped scout\n');
+    const collision = uninstallBackupCollisionPath();
+    const victim = join(tmp, 'uninstall-backup-hardlink-victim');
+    const victimBytes = Buffer.from('hardlink victim bytes\n');
+    writeFileSync(victim, victimBytes);
+    mkdirSync(dirname(collision), { recursive: true });
+    linkSync(victim, collision);
+
+    removeAgentSyncAssets(targets());
+    const distinctBackup = join(
+      genieHome,
+      'state-backups',
+      'agent-sync-uninstall-2026-07-11T12:00:00.000Z-1',
+      'claude',
+      'agents',
+      'scout.md',
+    );
+
+    expect(lstatSync(victim).nlink).toBe(2);
+    expect(readFileSync(victim)).toEqual(victimBytes);
+    expect(readFileSync(collision)).toEqual(victimBytes);
+    expect(readFileSync(distinctBackup, 'utf8')).toBe('# shipped scout\n');
+  });
+
+  test('an existing regular backup collision is never overwritten', () => {
+    managedAgent('scout.md', '# shipped scout\n');
+    const collision = uninstallBackupCollisionPath();
+    const collisionBytes = Buffer.from('prior regular backup\n');
+    mkdirSync(dirname(collision), { recursive: true });
+    writeFileSync(collision, collisionBytes);
+
+    removeAgentSyncAssets(targets());
+    const distinctBackup = join(
+      genieHome,
+      'state-backups',
+      'agent-sync-uninstall-2026-07-11T12:00:00.000Z-1',
+      'claude',
+      'agents',
+      'scout.md',
+    );
+
+    expect(readFileSync(collision)).toEqual(collisionBytes);
+    expect(readFileSync(distinctBackup, 'utf8')).toBe('# shipped scout\n');
+  });
+
+  test('a replacement at the captured-to-remove boundary survives live and stays unowned', () => {
+    const scout = managedAgent('scout.md', '# shipped scout\n');
+    const replacementBytes = Buffer.from('# concurrent replacement\n');
+    let crossedBarrier = false;
+
+    const result = removeAgentSyncAssets({
+      ...targets(),
+      beforeAgentFileMutation: (event) => {
+        if (!crossedBarrier && event.operation === 'remove' && event.path === scout) {
+          crossedBarrier = true;
+          writeFileSync(scout, replacementBytes);
+        }
+      },
+    });
+
+    expect(crossedBarrier).toBe(true);
+    expect(result.removed).not.toContain(scout);
+    expect(result.kept).toEqual([]);
+    expect(readFileSync(scout)).toEqual(replacementBytes);
+    expect(readAgentFilesManifest(join(claudeDir, 'agents'))).toBeNull();
+    expect(result.advisories?.some((line) => line.includes('concurrently appeared'))).toBe(true);
+    expect(
+      readFileSync(
+        join(
+          genieHome,
+          'state-backups',
+          'agent-sync-uninstall-2026-07-11T12:00:00.000Z',
+          'claude',
+          'agents',
+          'scout.md',
+        ),
+      ),
+    ).toEqual(Buffer.from('# shipped scout\n'));
+  });
+
+  test('a replacement at the captured-to-keep boundary stays live while prior edits are kept', () => {
+    const reviewer = managedAgent('reviewer.md', '# shipped reviewer\n');
+    writeFileSync(reviewer, '# initial local edit\n');
+    const newestBytes = Buffer.from('# newest edit at barrier\n');
+
+    const result = removeAgentSyncAssets({
+      ...targets(),
+      beforeAgentFileMutation: (event) => {
+        if (event.operation === 'keep' && event.path === reviewer) writeFileSync(reviewer, newestBytes);
+      },
+    });
+
+    expect(result.kept).toHaveLength(1);
+    expect(readFileSync(result.kept[0] as string, 'utf8')).toBe('# initial local edit\n');
+    expect(readFileSync(reviewer)).toEqual(newestBytes);
+    expect(readAgentFilesManifest(join(claudeDir, 'agents'))).toBeNull();
+    expect(result.advisories?.some((line) => line.includes('concurrently appeared'))).toBe(true);
+  });
+
+  test('manifest CAS failure restores exact staged bytes and never claims removal', () => {
+    const scout = managedAgent('scout.md', '# shipped scout\n');
+    const agentsDir = join(claudeDir, 'agents');
+    const manifestPath = join(agentsDir, '.genie-sync.json');
+    const scoutBytes = readFileSync(scout);
+    let changedDigest = '';
+
+    const result = removeAgentSyncAssets({
+      ...targets(),
+      beforeAgentFileMutation: (event) => {
+        if (event.operation !== 'remove' || event.path !== scout) return;
+        const manifest = readAgentFilesManifest(agentsDir);
+        if (manifest === null) throw new Error('fixture manifest missing at CAS barrier');
+        changedDigest = 'concurrently-reowned-digest';
+        manifest.files['scout.md'] = { ...manifest.files['scout.md']!, digest: changedDigest };
+        writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+      },
+    });
+
+    expect(result.removed).not.toContain(scout);
+    expect(result.kept).toEqual([]);
+    expect(readFileSync(scout)).toEqual(scoutBytes);
+    expect(readAgentFilesManifest(agentsDir)?.files['scout.md']?.digest).toBe(changedDigest);
+    expect(result.advisories?.some((line) => line.includes('manifest ownership changed'))).toBe(true);
+  });
+
+  test('a manifest-owned directory at an agent filename is preserved at an exclusive kept path', () => {
+    const scout = managedAgent('scout.md', '# shipped scout\n');
+    rmSync(scout);
+    mkdirSync(scout);
+    writeFileSync(join(scout, 'precious.txt'), 'directory bytes\n');
+
+    const result = removeAgentSyncAssets(targets());
+
+    expect(result.kept).toEqual([`${scout}.genie-kept`]);
+    expect(readFileSync(join(`${scout}.genie-kept`, 'precious.txt'), 'utf8')).toBe('directory bytes\n');
+    expect(existsSync(scout)).toBe(false);
+  });
+
+  test('a manifest-owned symlink is kept as a symlink without following or changing its victim', () => {
+    const scout = managedAgent('scout.md', '# shipped scout\n');
+    const victim = join(tmp, 'agent-symlink-victim');
+    const victimBytes = Buffer.from('victim stays untouched\n');
+    writeFileSync(victim, victimBytes);
+    rmSync(scout);
+    symlinkSync(victim, scout);
+
+    const result = removeAgentSyncAssets(targets());
+    const keptPath = `${scout}.genie-kept`;
+
+    expect(result.kept).toEqual([keptPath]);
+    expect(lstatSync(keptPath).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(keptPath)).toBe(victim);
+    expect(readFileSync(victim)).toEqual(victimBytes);
+  });
+
+  test('the shared sync lock makes uninstall fail closed without touching live or manifest bytes', () => {
+    const scout = managedAgent('scout.md', '# shipped scout\n');
+    const manifestPath = join(claudeDir, 'agents', '.genie-sync.json');
+    const manifestBytes = readFileSync(manifestPath);
+    writeFileSync(join(genieHome, '.agent-sync.lock'), 'holder\n');
+
+    const result = removeAgentSyncAssets(targets());
+
+    expect(result.skipped).toContain('holds the lock');
+    expect(readFileSync(scout, 'utf8')).toBe('# shipped scout\n');
+    expect(readFileSync(manifestPath)).toEqual(manifestBytes);
+  });
+
+  test('fixed staging debris remains byte-identical while two uninstall runs converge', () => {
+    const scout = managedAgent('scout.md', '# shipped scout\n');
+    const agentsDir = join(claudeDir, 'agents');
+    const manifestDebris = join(agentsDir, '.genie-sync.json.genie-sync.staging');
+    const uninstallDebris = join(agentsDir, '.genie-uninstall.staging');
+    const manifestDebrisBytes = Buffer.from('manifest stage debris\n');
+    const uninstallDebrisBytes = Buffer.from('uninstall stage debris\n');
+    writeFileSync(manifestDebris, manifestDebrisBytes);
+    writeFileSync(uninstallDebris, uninstallDebrisBytes);
+
+    const first = removeAgentSyncAssets(targets());
+    const second = removeAgentSyncAssets(targets());
+
+    expect(first.removed).toEqual([scout]);
+    expect(second).toEqual({ removed: [], kept: [], identityMismatch: [], failures: [] });
+    expect(readFileSync(manifestDebris)).toEqual(manifestDebrisBytes);
+    expect(readFileSync(uninstallDebris)).toEqual(uninstallDebrisBytes);
+  });
+
+  test('modified-agent kept allocation never overwrites prior base or timestamp artifacts', () => {
+    const reviewer = managedAgent('reviewer.md', '# shipped reviewer\n');
+    const editedBytes = Buffer.from('# newest local reviewer edits\n');
+    writeFileSync(reviewer, editedBytes);
+    const baseKept = `${reviewer}.genie-kept`;
+    const timestampKept = `${baseKept}-${fixedNow().getTime()}`;
+    const baseBytes = Buffer.from('# older base kept artifact\n');
+    const timestampBytes = Buffer.from('# older timestamp kept artifact\n');
+    writeFileSync(baseKept, baseBytes);
+    writeFileSync(timestampKept, timestampBytes);
+
+    const result = removeAgentSyncAssets(targets());
+    const newestKept = `${timestampKept}-1`;
+
+    expect(result.kept).toEqual([newestKept]);
+    expect(readFileSync(baseKept)).toEqual(baseBytes);
+    expect(readFileSync(timestampKept)).toEqual(timestampBytes);
+    expect(readFileSync(newestKept)).toEqual(editedBytes);
+    expect(existsSync(reviewer)).toBe(false);
+  });
+
+  test('missing manifest-owned files are pruned and a second uninstall is a strict no-op', () => {
+    const live = managedAgent('live.md', '# live managed agent\n');
+    const parent = join(claudeDir, 'agents');
+    const manifest = readAgentFilesManifest(parent);
+    if (manifest === null) throw new Error('fixture manifest missing');
+    manifest.files['missing.md'] = {
+      digest: 'deadbeef',
+      version: '1',
+      syncedAt: '2026-07-11T10:00:00.000Z',
+    };
+    writeFileSync(join(parent, '.genie-sync.json'), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+
+    const first = removeAgentSyncAssets(targets());
+
+    expect(first.removed).toEqual([live]);
+    expect(first.kept).toEqual([]);
+    expect(existsSync(live)).toBe(false);
+    expect(readAgentFilesManifest(parent)).toBeNull();
+    expect(removeAgentSyncAssets(targets())).toEqual({ removed: [], kept: [], identityMismatch: [], failures: [] });
+  });
+
+  test('the fully injected uninstall flow is a strict second-run no-op with backups-only GENIE_HOME', () => {
+    const scout = managedAgent('scout.md', '# shipped scout\n');
+    const own = join(claudeDir, 'agents', 'my-own-agent.md');
+    const ownBytes = Buffer.from([0x00, 0x23, 0x20, 0x6d, 0x69, 0x6e, 0x65, 0xff]);
+    writeFileSync(own, ownBytes);
+    const installState = join(genieHome, 'plugins', 'genie', 'payload.txt');
+    mkdirSync(join(genieHome, 'plugins', 'genie'), { recursive: true });
+    writeFileSync(installState, 'remove me\n', 'utf8');
+
+    let runtimeRemovalCalls = 0;
+    const dependencies = {
+      agentSyncTargets: targets(),
+      orchestrationRulesPath: join(tmp, 'no-legacy-rules'),
+      removeRuntimeIntegrations: () => {
+        runtimeRemovalCalls += 1;
+      },
+    };
+
+    performUninstall(false, [], genieHome, true, true, false, dependencies);
+
+    const backup = join(
+      genieHome,
+      'state-backups',
+      'agent-sync-uninstall-2026-07-11T12:00:00.000Z',
+      'claude',
+      'agents',
+      'scout.md',
+    );
+    expect(existsSync(scout)).toBe(false);
+    expect(readFileSync(backup, 'utf8')).toBe('# shipped scout\n');
+    expect(readFileSync(own)).toEqual(ownBytes);
+    expect(existsSync(installState)).toBe(false);
+    expect(hasRemovableGenieInstallState(genieHome)).toBe(false);
+    expect(runtimeRemovalCalls).toBe(1);
+
+    const backupBytes = readFileSync(backup);
+    performUninstall(false, [], genieHome, true, true, false, dependencies);
+
+    expect(runtimeRemovalCalls).toBe(1);
+    expect(readFileSync(backup)).toEqual(backupBytes);
+    expect(readFileSync(own)).toEqual(ownBytes);
+  });
+
+  test('INV1: uninstall preserves captured bytes mutated after validation instead of discarding them', () => {
+    const scout = managedAgent('scout.md', '# shipped scout\n');
+    const agentsDir = join(claudeDir, 'agents');
+    const mutatedBytes = Buffer.from('# mutated after capture\n');
+
+    const result = removeAgentSyncAssets({
+      ...targets(),
+      beforeAgentFileMutation: (event) => {
+        if (event.operation !== 'remove' || event.path !== scout) return;
+        // The live file is already quarantined at this barrier; mutate the captured inode.
+        const quarantine = readdirSync(agentsDir).find((name) => name.startsWith('.scout.md.agent-retire-'));
+        if (quarantine === undefined) throw new Error('captured quarantine dir not found');
+        writeFileSync(join(agentsDir, quarantine, 'object'), mutatedBytes);
+      },
+    });
+
+    expect(result.removed).toEqual([scout]);
+    expect(readAgentFilesManifest(agentsDir)).toBeNull();
+    // the mutated bytes survive visibly instead of being unlinked into nothing
+    expect(result.kept).toEqual([`${scout}.genie-kept`]);
+    expect(readFileSync(`${scout}.genie-kept`)).toEqual(mutatedBytes);
+    expect(result.advisories?.some((line) => line.includes('changed after validation'))).toBe(true);
+    // the backup still holds exactly the validated bytes
+    expect(readFileSync(uninstallBackupCollisionPath(), 'utf8')).toBe('# shipped scout\n');
+  });
+
+  test('INV4: a replacement manifest installed during relinquish is detected — never a false success', () => {
+    const scout = managedAgent('scout.md', '# shipped scout\n');
+    const agentsDir = join(claudeDir, 'agents');
+    const manifestPath = join(agentsDir, '.genie-sync.json');
+    const replacement = {
+      managedBy: MANAGED_BY,
+      files: { 'scout.md': { digest: 'replacement-owner', version: '2', syncedAt: 'later' } },
+    };
+    const replacementBytes = Buffer.from(`${JSON.stringify(replacement, null, 2)}\n`);
+
+    const result = removeAgentSyncAssets({
+      ...targets(),
+      // fires inside the removal commit, after the base manifest is captured away
+      beforeAgentManifestCommit: () => {
+        writeFileSync(manifestPath, replacementBytes);
+      },
+    });
+
+    expect(result.removed).toEqual([]);
+    expect(result.kept).toEqual([]);
+    expect(readFileSync(scout, 'utf8')).toBe('# shipped scout\n'); // rollback restored the live agent
+    expect(readFileSync(manifestPath)).toEqual(replacementBytes); // the replacement stays live, unclobbered
+    expect(result.advisories?.some((line) => line.includes('replacement manifest appeared'))).toBe(true);
+    expect(result.advisories?.some((line) => line.includes('preserved previous manifest'))).toBe(true);
+  });
+
+  test('INV5: one lock spans asset removal and canonical-source deletion in the full uninstall', () => {
+    const scout = managedAgent('scout.md', '# shipped scout\n');
+    const sourcePayload = join(genieHome, 'plugins', 'genie', 'agents', 'scout.md');
+    mkdirSync(dirname(sourcePayload), { recursive: true });
+    writeFileSync(sourcePayload, '# canonical source\n', 'utf8');
+
+    let probedDuringAssets = false;
+    let probedBetween = false;
+    const dependencies = {
+      agentSyncTargets: {
+        ...targets(),
+        beforeAgentFileMutation: () => {
+          probedDuringAssets = true;
+          expect(acquireAgentSyncLock(genieHome)).toBeNull(); // lock held during asset removal
+        },
+      },
+      orchestrationRulesPath: join(tmp, 'no-legacy-rules'),
+      removeRuntimeIntegrations: () => {
+        probedBetween = true;
+        expect(acquireAgentSyncLock(genieHome)).toBeNull(); // still held in the former gap
+        expect(existsSync(sourcePayload)).toBe(true); // canonical source not yet deleted
+      },
+    };
+
+    performUninstall(false, [], genieHome, true, true, false, dependencies);
+
+    expect(probedDuringAssets).toBe(true);
+    expect(probedBetween).toBe(true);
+    expect(existsSync(sourcePayload)).toBe(false); // source deleted under the same lock
+    expect(existsSync(scout)).toBe(false);
+    const released = acquireAgentSyncLock(genieHome);
+    expect(released).not.toBeNull(); // lock released only after everything
+    released?.release();
+    expect(hasRemovableGenieInstallState(genieHome)).toBe(false);
+  });
+
+  test('INV6: an exception after staging restores the live agent — no hidden bytes, ownership intact', () => {
+    const reviewer = managedAgent('reviewer.md', '# shipped reviewer\n');
+    const editedBytes = Buffer.from('# precious local edits\n');
+    writeFileSync(reviewer, editedBytes);
+    const agentsDir = join(claudeDir, 'agents');
+
+    const first = removeAgentSyncAssets({
+      ...targets(),
+      beforeAgentFileMutation: (event) => {
+        if (event.operation === 'keep') throw new Error('injected post-staging fault');
+      },
+    });
+
+    expect(first.kept).toEqual([]);
+    expect(first.removed).toEqual([]);
+    expect(readFileSync(reviewer)).toEqual(editedBytes); // live path restored, byte-identical
+    expect(readAgentFilesManifest(agentsDir)?.files['reviewer.md']).toBeDefined(); // ownership unchanged
+    expect(first.advisories?.some((line) => line.includes('injected post-staging fault'))).toBe(true);
+    // no hidden staging or quarantine debris is left holding the bytes
+    expect(readdirSync(agentsDir).sort()).toEqual(['.genie-sync.json', 'reviewer.md']);
+
+    const second = removeAgentSyncAssets(targets()); // clean retry succeeds
+    expect(second.kept).toEqual([`${reviewer}.genie-kept`]);
+    expect(readFileSync(`${reviewer}.genie-kept`)).toEqual(editedBytes);
+    expect(readAgentFilesManifest(agentsDir)).toBeNull();
   });
 });
 

--- a/src/genie-commands/uninstall.ts
+++ b/src/genie-commands/uninstall.ts
@@ -24,6 +24,7 @@ import {
   readlinkSync,
   renameSync,
   rmSync,
+  rmdirSync,
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
@@ -32,17 +33,29 @@ import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'nod
 import { confirm } from '@inquirer/prompts';
 import { z } from 'zod';
 import {
+  AGENT_SYNC_LOCK_NAME,
+  type AgentFileMutationEvent,
+  type AgentManifestCommitEvent,
+  type AgentPathSnapshot,
   CODEX_FALLBACK_RETIREMENT_ROOT,
+  type FlatAgentOp,
+  type FlatAgentOutcome,
+  KEPT_SUFFIX,
   TARGET_NAME,
+  acquireAgentSyncLock,
   acquireLifecycleLease,
+  allocateExclusiveBackupRoot,
+  captureAgentPathSnapshot,
   codexLegacyCuratedDir,
   inspectManagedSkillTree,
   inspectManagedWorkflow,
+  readAgentFilesManifest,
   recoverManagedSkillTransactions,
   recoverManagedWorkflowTransactions,
   removeManagedSkillTree,
   removeManagedWorkflow,
   resolveAgentsSkillsDir,
+  runFlatAgentTransaction,
 } from '../lib/agent-sync.js';
 import { hookScriptExists } from '../lib/claude-settings.js';
 import { contractPath, getGenieDir } from '../lib/genie-config.js';
@@ -86,6 +99,15 @@ const absolutePathSchema = z
 const digestSchema = z.string().regex(/^[a-f0-9]{64}$/);
 const physicalModeSchema = z.number().int().min(0).max(0o7777);
 const codexRoleNameSchema = z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/);
+const agentOwnedDigestSchema = z.string().min(1).max(256);
+
+const agentSnapshotIdentitySchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('absent') }).strict(),
+  z.object({ kind: z.literal('file'), digest: digestSchema, mode: physicalModeSchema }).strict(),
+  z.object({ kind: z.literal('directory'), digest: digestSchema, mode: physicalModeSchema }).strict(),
+  z.object({ kind: z.literal('symlink'), target: z.string().max(4096) }).strict(),
+  z.object({ kind: z.literal('other'), mode: physicalModeSchema }).strict(),
+]);
 
 // Per-kind physical identity the classifier already computed at plan time. Every
 // removable managed asset carries the exact identity uninstall is authorized to
@@ -102,9 +124,17 @@ const agentAssetIdentitySchema = z.discriminatedUnion('kind', [
     })
     .strict(),
   z.object({ kind: z.literal('link'), target: z.string().min(1).max(4096) }).strict(),
+  z
+    .object({
+      kind: z.literal('agent'),
+      ownedDigest: agentOwnedDigestSchema,
+      snapshot: agentSnapshotIdentitySchema,
+    })
+    .strict(),
 ]);
 
 export type AgentAssetIdentity = z.infer<typeof agentAssetIdentitySchema>;
+type AgentSnapshotIdentity = z.infer<typeof agentSnapshotIdentitySchema>;
 
 // A removable asset records its identity; a kept (modified/corrupt) asset records
 // none because it holds user data now and is never a deletion candidate.
@@ -546,12 +576,30 @@ function hasRuntimeIntegrationWork(scope: UninstallBatchScope): boolean {
   );
 }
 
+function flatAgentBatchMember(scope: UninstallBatchScope): string | null {
+  const agentPaths = scope.agentAssets
+    .filter((asset) => asset.disposition === 'remove' && asset.identity.kind === 'agent')
+    .map((asset) => asset.path);
+  if (agentPaths.length === 0) return null;
+  const roots = new Set(agentPaths.map((path) => dirname(path)));
+  if (roots.size !== 1) throw new Error('uninstall batch flat-agent actions span multiple manifest directories');
+  return uninstallBatchMemberId(
+    'asset',
+    `flat-agents:${agentPaths
+      .map((path) => resolve(path))
+      .sort()
+      .join('\n')}`,
+  );
+}
+
 function uninstallBatchMembers(scope: UninstallBatchScope, genieHome: string): Set<string> {
   const members = new Set(
     scope.agentAssets
-      .filter((asset) => asset.disposition === 'remove')
+      .filter((asset) => asset.disposition === 'remove' && asset.identity.kind !== 'agent')
       .map((asset) => uninstallBatchMemberId('asset', asset.path)),
   );
+  const agentMember = flatAgentBatchMember(scope);
+  if (agentMember !== null) members.add(agentMember);
   if (scope.ownedRulesPath !== null) members.add(uninstallBatchMemberId('rules', scope.ownedRulesPath));
   if (hasRuntimeIntegrationWork(scope)) members.add(uninstallBatchRuntimeMemberId(scope));
   if (scope.genieHomePresent) members.add(uninstallBatchMemberId('home', resolve(genieHome)));
@@ -657,7 +705,16 @@ export interface AgentSyncRemovalTargets {
   agentsSkillsDir?: string;
   hermesHome?: string;
   genieHome?: string;
+  /** Injectable clock for deterministic state-backup and kept-aside paths in tests. */
+  now?: () => Date;
+  /** Deterministic race barrier after classification/capture and before a flat-agent mutation. */
+  beforeAgentFileMutation?: (event: AgentSyncRemovalMutationEvent) => void;
+  /** Deterministic barrier inside the single manifest commit of the flat-agent transaction. */
+  beforeAgentManifestCommit?: (event: AgentManifestCommitEvent) => void;
 }
+
+/** Uninstall shares the transaction core's mutation event verbatim. */
+export type AgentSyncRemovalMutationEvent = AgentFileMutationEvent;
 
 function directoryHasMatchingEntry(path: string, matches: (name: string) => boolean): boolean {
   try {
@@ -777,7 +834,7 @@ const LEGACY_KEPT_MARKER = '.genie-kept';
 
 interface AgentSyncAsset {
   agent: 'claude' | 'codex' | 'hermes';
-  kind: 'skill' | 'workflow' | 'link';
+  kind: 'skill' | 'agent' | 'workflow' | 'link';
   path: string;
   /** True when content diverged or ownership metadata is corrupt; uninstall preserves it. */
   modified?: boolean;
@@ -789,6 +846,12 @@ interface AgentSyncAsset {
    * refuse a replacement occupying the same path (F43).
    */
   identity?: AgentAssetIdentity;
+  /** Flat Claude agents only: the shared manifest entry that owns this path. */
+  manifestEntry?: { dir: string; name: string; digest: string };
+  /** Flat Claude agents only: ownership exists but the live file is already absent. */
+  missing?: boolean;
+  /** Flat Claude agents only: exact snapshot captured at classification — the removal CAS target. */
+  agentSnapshot?: AgentPathSnapshot;
 }
 
 function collectManagedSkillDirs(
@@ -837,6 +900,62 @@ function collectManagedSkillDirs(
     } else {
       out.push({ agent, kind: 'skill', path: dir, modified: true });
     }
+  }
+}
+
+function agentSnapshotIdentity(snapshot: AgentPathSnapshot): AgentSnapshotIdentity {
+  if (snapshot.kind === 'absent') return { kind: 'absent' };
+  if (snapshot.kind === 'file') {
+    return { kind: 'file', digest: snapshot.digest, mode: snapshot.stat.mode & 0o7777 };
+  }
+  if (snapshot.kind === 'directory') {
+    return { kind: 'directory', digest: snapshot.digest, mode: snapshot.stat.mode & 0o7777 };
+  }
+  if (snapshot.kind === 'symlink') return { kind: 'symlink', target: snapshot.target };
+  return { kind: 'other', mode: snapshot.stat.mode & 0o7777 };
+}
+
+function agentIdentityMatches(expected: AgentAssetIdentity, asset: AgentSyncAsset): boolean {
+  if (expected.kind !== 'agent' || asset.identity?.kind !== 'agent') return false;
+  return (
+    expected.ownedDigest === asset.identity.ownedDigest &&
+    JSON.stringify(expected.snapshot) === JSON.stringify(asset.identity.snapshot)
+  );
+}
+
+/** Collect only flat Claude-agent names explicitly owned by the shared per-file manifest. */
+function collectManagedAgentFiles(parent: string, out: AgentSyncAsset[], restrictToPaths?: ReadonlySet<string>): void {
+  const manifest = readAgentFilesManifest(parent);
+  if (manifest === null) return;
+  for (const [name, entry] of Object.entries(manifest.files).sort(([left], [right]) => left.localeCompare(right))) {
+    const path = join(parent, name);
+    if (restrictToPaths !== undefined && !restrictToPaths.has(resolve(path))) continue;
+    let snapshot: AgentPathSnapshot | undefined;
+    try {
+      snapshot = captureAgentPathSnapshot(path);
+    } catch {
+      // Uninspectable manifest-owned data is never a deletion/action candidate.
+      out.push({
+        agent: 'claude',
+        kind: 'agent',
+        path,
+        modified: true,
+        manifestEntry: { dir: parent, name, digest: entry.digest },
+      });
+      continue;
+    }
+    const missing = snapshot.kind === 'absent';
+    const clean = snapshot.kind === 'file' && snapshot.digest === entry.digest;
+    out.push({
+      agent: 'claude',
+      kind: 'agent',
+      path,
+      modified: !missing && !clean,
+      missing,
+      agentSnapshot: snapshot,
+      manifestEntry: { dir: parent, name, digest: entry.digest },
+      identity: { kind: 'agent', ownedDigest: entry.digest, snapshot: agentSnapshotIdentity(snapshot) },
+    });
   }
 }
 
@@ -945,6 +1064,7 @@ export function collectAgentSyncAssets(
   const genieHome = targets.genieHome ?? resolveGenieHome();
   const out: AgentSyncAsset[] = [];
   collectManagedSkillDirs(join(claudeDir, 'skills'), 'claude', out, restrictToPaths);
+  collectManagedAgentFiles(join(claudeDir, 'agents'), out, restrictToPaths);
   // Live codex tier + the retired `.curated` lane (machines that never synced
   // post-migration still carry managed dirs there). Manifest-gated either way —
   // unmanaged siblings in the shared ~/.agents/skills tier are invisible.
@@ -964,6 +1084,10 @@ export interface AgentSyncRemovalResult {
   identityMismatch: string[];
   /** Per-asset failures. Callers keep Genie installed so cleanup can be retried. */
   failures: Array<{ path: string; detail: string }>;
+  /** Non-fatal transaction/concurrency details for paths left safe and visible. */
+  advisories?: string[];
+  /** Set when the shared sync/uninstall lock was held by another process. */
+  skipped?: string;
 }
 
 export interface AgentSyncRemovalOptions {
@@ -997,6 +1121,43 @@ function recoverTransactionsBeforeRemoval(targets: AgentSyncRemovalTargets): { p
  * disable, rewrite, or relinquish ownership of a user-modified artifact.
  */
 export function removeAgentSyncAssets(
+  targets: AgentSyncRemovalTargets = {},
+  options: AgentSyncRemovalOptions = {},
+): AgentSyncRemovalResult {
+  const genieHome = targets.genieHome ?? resolveGenieHome();
+  let lock: { release: () => void } | null;
+  try {
+    lock = acquireAgentSyncLock(genieHome);
+  } catch (error) {
+    const skipped = `agent-sync lock acquisition failed closed; uninstall left synced assets untouched: ${errorMessage(error)}`;
+    return {
+      removed: [],
+      kept: [],
+      identityMismatch: [],
+      failures: [{ path: genieHome, detail: skipped }],
+      advisories: [skipped],
+      skipped,
+    };
+  }
+  if (lock === null) {
+    const skipped = 'another agent-sync mutation holds the lock; uninstall left synced assets untouched';
+    return {
+      removed: [],
+      kept: [],
+      identityMismatch: [],
+      failures: [{ path: genieHome, detail: skipped }],
+      advisories: [skipped],
+      skipped,
+    };
+  }
+  try {
+    return removeAgentSyncAssetsLocked(targets, options);
+  } finally {
+    lock.release();
+  }
+}
+
+function removeAgentSyncAssetsLocked(
   targets: AgentSyncRemovalTargets = {},
   options: AgentSyncRemovalOptions = {},
 ): AgentSyncRemovalResult {
@@ -1060,6 +1221,148 @@ function removeManagedLink(linkPath: string, expectedTarget: string | undefined,
   result.removed.push(linkPath);
 }
 
+function pushAgentAdvisory(result: AgentSyncRemovalResult, advisory: string): void {
+  if (result.advisories === undefined) result.advisories = [];
+  result.advisories.push(advisory);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** Lazily allocate one exclusive backup generation and persist the exact validated bytes. */
+function createAgentFileBackup(targets: AgentSyncRemovalTargets): (name: string, bytes: Buffer) => string {
+  const genieHome = targets.genieHome ?? resolveGenieHome();
+  const stamp = (targets.now ?? (() => new Date()))().toISOString();
+  let backupRoot: string | null = null;
+  return (name, bytes) => {
+    if (backupRoot === null) backupRoot = allocateExclusiveBackupRoot(genieHome, `agent-sync-uninstall-${stamp}`);
+    const destination = join(backupRoot, 'claude', 'agents', name);
+    mkdirSync(dirname(destination), { recursive: true });
+    writeFileSync(destination, bytes, { flag: 'wx' });
+    return destination;
+  };
+}
+
+function planAgentRemoval(
+  asset: AgentSyncAsset,
+  backupAgentBytes: (name: string, bytes: Buffer) => string,
+  result: AgentSyncRemovalResult,
+): FlatAgentOp | null {
+  const entry = asset.manifestEntry;
+  if (entry === undefined) return null;
+  if (asset.missing) return { kind: 'disown', name: entry.name, ownedDigest: entry.digest, prune: true };
+  const snapshot = asset.agentSnapshot;
+  if (snapshot === undefined || snapshot.kind === 'absent') {
+    result.failures.push({ path: asset.path, detail: 'could not inspect the manifest-owned agent during removal' });
+    return null;
+  }
+  if (asset.modified !== true && snapshot.kind === 'file') {
+    let backupPath: string;
+    try {
+      backupPath = backupAgentBytes(entry.name, snapshot.bytes);
+    } catch (error) {
+      result.failures.push({ path: asset.path, detail: `durable backup failed: ${errorMessage(error)}` });
+      return null;
+    }
+    return {
+      kind: 'retire',
+      name: entry.name,
+      expected: snapshot,
+      ownedDigest: entry.digest,
+      disposal: 'discard',
+      operation: 'remove',
+      backupPath,
+    };
+  }
+  return {
+    kind: 'retire',
+    name: entry.name,
+    expected: snapshot,
+    ownedDigest: entry.digest,
+    disposal: 'keep-aside',
+    operation: 'keep',
+  };
+}
+
+function reportAgentRemovalOutcome(
+  outcome: FlatAgentOutcome,
+  committed: boolean,
+  dir: string,
+  result: AgentSyncRemovalResult,
+): void {
+  const operation = outcome.op;
+  const path = join(dir, operation.name);
+  if (outcome.status === 'failed' || outcome.status === 'stale') {
+    const detail = outcome.reason ?? 'flat-agent transaction did not settle this path';
+    result.failures.push({ path, detail });
+    pushAgentAdvisory(result, `kept ${path}: ${detail}`);
+    return;
+  }
+  if (!committed) return;
+  if (operation.kind === 'disown') return;
+  if (operation.kind === 'publish') return;
+  if (outcome.status === 'applied') {
+    if (outcome.keptPath !== undefined) result.kept.push(outcome.keptPath);
+    if (operation.disposal === 'discard') result.removed.push(path);
+    if (operation.disposal === 'keep-aside' && outcome.keptPath === undefined) {
+      result.failures.push({ path, detail: 'modified agent was disowned without a visible kept-aside path' });
+    }
+    return;
+  }
+  if (outcome.conflict === 'changed-before-capture') {
+    pushAgentAdvisory(result, `left concurrently changed agent ${path} live and unowned`);
+    return;
+  }
+  if (outcome.keptPath !== undefined) {
+    result.kept.push(outcome.keptPath);
+    pushAgentAdvisory(
+      result,
+      `left concurrently appeared agent ${path} live and unowned; preserved prior bytes at ${outcome.keptPath}`,
+    );
+    return;
+  }
+  pushAgentAdvisory(result, `left concurrently appeared agent ${path} live and unowned`);
+}
+
+/** Execute all selected flat-agent actions in one shared manifest transaction. */
+function removeManagedAgentAssets(
+  assets: AgentSyncAsset[],
+  targets: AgentSyncRemovalTargets,
+  result: AgentSyncRemovalResult,
+): void {
+  const dir = assets[0]?.manifestEntry?.dir;
+  if (dir === undefined) return;
+  const backupAgentBytes = createAgentFileBackup(targets);
+  const operations: FlatAgentOp[] = [];
+  for (const asset of assets) {
+    const operation = planAgentRemoval(asset, backupAgentBytes, result);
+    if (operation !== null) operations.push(operation);
+  }
+  if (operations.length === 0) return;
+  try {
+    const transaction = runFlatAgentTransaction(dir, operations, {
+      now: targets.now ?? (() => new Date()),
+      beforeFileMutation: targets.beforeAgentFileMutation,
+      beforeManifestCommit: targets.beforeAgentManifestCommit,
+    });
+    for (const advisory of transaction.advisories) pushAgentAdvisory(result, advisory);
+    for (const outcome of transaction.outcomes) {
+      reportAgentRemovalOutcome(outcome, transaction.committed, dir, result);
+    }
+    if (!transaction.committed && !transaction.outcomes.some((outcome) => outcome.status === 'failed')) {
+      result.failures.push({
+        path: dir,
+        detail: transaction.advisories.join('; ') || 'flat-agent manifest transaction did not commit',
+      });
+    }
+  } catch (error) {
+    const detail = `flat-agent removal transaction failed: ${errorMessage(error)}`;
+    result.failures.push({ path: dir, detail });
+    pushAgentAdvisory(result, detail);
+  }
+}
+
 function removeCollectedAgentAssets(
   assets: AgentSyncAsset[],
   targets: AgentSyncRemovalTargets,
@@ -1067,6 +1370,7 @@ function removeCollectedAgentAssets(
   plannedByPath: Map<string, AgentAssetIdentity> | null,
   result: AgentSyncRemovalResult,
 ): void {
+  const agentAssets: AgentSyncAsset[] = [];
   for (const asset of assets) {
     const expectedIdentity = plannedByPath?.get(resolve(asset.path));
     // Defense in depth: a recorded identity whose kind does not match the object
@@ -1075,6 +1379,15 @@ function removeCollectedAgentAssets(
     if (expectedIdentity !== undefined && expectedIdentity.kind !== asset.kind) {
       result.kept.push(asset.path);
       result.identityMismatch.push(asset.path);
+      continue;
+    }
+    if (asset.kind === 'agent') {
+      if (expectedIdentity !== undefined && !agentIdentityMatches(expectedIdentity, asset)) {
+        result.kept.push(asset.path);
+        result.identityMismatch.push(asset.path);
+      } else {
+        agentAssets.push(asset);
+      }
       continue;
     }
     try {
@@ -1099,6 +1412,7 @@ function removeCollectedAgentAssets(
       result.failures.push({ path: asset.path, detail: error instanceof Error ? error.message : String(error) });
     }
   }
+  removeManagedAgentAssets(agentAssets, targets, result);
 }
 
 export interface UninstallFailure {
@@ -1385,7 +1699,7 @@ export function inspectUninstallPlan(
   const runtimeClients = (inspectors.inspectRuntimeClientAvailability ?? inspectRuntimeClientAvailability)();
   return {
     genieDir,
-    hasGenieDir: (inspectors.hasGenieDir ?? existsSync)(genieDir),
+    hasGenieDir: (inspectors.hasGenieDir ?? hasRemovableGenieInstallState)(genieDir),
     hasUnprovenHookScript: (inspectors.hookScriptExists ?? hookScriptExists)(),
     legacyReport,
     hasOwnedRules: legacyReport.rulesFile.status === 'v4-markers',
@@ -1404,6 +1718,114 @@ export function inspectUninstallPlan(
   };
 }
 
+interface PlannedRemovalAsset {
+  path: string;
+  identity: AgentAssetIdentity;
+}
+
+interface PlannedFlatAgent extends PlannedRemovalAsset {
+  identity: Extract<AgentAssetIdentity, { kind: 'agent' }>;
+}
+
+function recordRemovalFailures(removal: AgentSyncRemovalResult, label: string, result: UninstallResult): void {
+  for (const failure of removal.failures) {
+    result.failures.push({ step: `${label} ${contractPath(failure.path)}`, detail: failure.detail });
+  }
+}
+
+function removeOneNonAgentAsset(
+  asset: PlannedRemovalAsset,
+  result: UninstallResult,
+  progress: UninstallBatchProgressController,
+): void {
+  const member = uninstallBatchMemberId('asset', asset.path);
+  if (progress.isCompleted(member) || progress.isPreserved(member)) return;
+  progress.begin(member);
+  const removal = removeAgentSyncAssetsLocked({}, { plannedAssets: [{ path: asset.path, identity: asset.identity }] });
+  if (removal.failures.length > 0) {
+    if (removal.removed.length === 0) progress.abort(member);
+    recordRemovalFailures(removal, 'Removing synced asset', result);
+    return;
+  }
+  if (removal.kept.length === 0) {
+    progress.complete(member);
+    if (removal.removed.length > 0) {
+      console.log(`  \x1b[32m+\x1b[0m Removed managed asset: ${contractPath(asset.path)}`);
+    }
+    return;
+  }
+  const detail =
+    removal.identityMismatch.length > 0
+      ? 'recorded removable asset was replaced by a different managed object after the uninstall batch; preserved it byte-identical'
+      : 'recorded removable asset was modified after the uninstall batch; preserved it byte-identical';
+  console.log(`  \x1b[33m!\x1b[0m Preserved managed asset byte-identical: ${contractPath(asset.path)}`);
+  recordPreservation(result, { step: `Preserving synced asset ${contractPath(asset.path)}`, detail });
+  progress.preserve(member);
+}
+
+function appendRemovalAdvisories(removal: AgentSyncRemovalResult, result: UninstallResult): void {
+  if (removal.advisories === undefined || removal.advisories.length === 0) return;
+  if (result.notes === undefined) result.notes = [];
+  result.notes.push(...removal.advisories);
+}
+
+function settleFlatAgentProgress(
+  member: string,
+  removal: AgentSyncRemovalResult,
+  result: UninstallResult,
+  progress: UninstallBatchProgressController,
+): void {
+  if (removal.identityMismatch.length === 0) {
+    progress.complete(member);
+    return;
+  }
+  for (const path of removal.identityMismatch) {
+    recordPreservation(result, {
+      step: `Preserving flat agent ${contractPath(path)}`,
+      detail: 'recorded flat-agent identity changed after the uninstall batch; preserved it byte-identical',
+    });
+  }
+  progress.preserve(member);
+}
+
+function reportFlatAgentRemoval(removal: AgentSyncRemovalResult): void {
+  for (const path of removal.removed) {
+    console.log(`  \x1b[32m+\x1b[0m Removed managed flat agent: ${contractPath(path)}`);
+  }
+  for (const path of removal.kept.filter((path) => !removal.identityMismatch.includes(path))) {
+    console.log(`  \x1b[33m!\x1b[0m Preserved modified flat agent at ${contractPath(path)}`);
+  }
+}
+
+function removeFlatAgentBatch(
+  plannedAgents: PlannedFlatAgent[],
+  result: UninstallResult,
+  progress: UninstallBatchProgressController,
+): void {
+  if (plannedAgents.length === 0) return;
+  const member = uninstallBatchMemberId(
+    'asset',
+    `flat-agents:${plannedAgents
+      .map((asset) => resolve(asset.path))
+      .sort()
+      .join('\n')}`,
+  );
+  if (progress.isCompleted(member) || progress.isPreserved(member)) return;
+  progress.begin(member);
+  const removal = removeAgentSyncAssetsLocked(
+    {},
+    { plannedAssets: plannedAgents.map((asset) => ({ path: asset.path, identity: asset.identity })) },
+  );
+  appendRemovalAdvisories(removal, result);
+  if (removal.failures.length > 0) {
+    if (removal.removed.length === 0 && removal.kept.length === 0) progress.abort(member);
+    recordRemovalFailures(removal, 'Removing flat agent', result);
+    return;
+  }
+  settleFlatAgentProgress(member, removal, result, progress);
+  reportFlatAgentRemoval(removal);
+}
+
 function removeSyncedAgentAssets(
   agentAssets: UninstallBatchScope['agentAssets'],
   result: UninstallResult,
@@ -1412,35 +1834,17 @@ function removeSyncedAgentAssets(
   if (!agentAssets.some((asset) => asset.disposition === 'remove')) return;
   console.log('\x1b[2mRemoving synced agent assets...\x1b[0m');
   for (const asset of agentAssets) {
-    if (asset.disposition !== 'remove') continue;
-    const member = uninstallBatchMemberId('asset', asset.path);
-    // A member already settled on a prior attempt (removed or preserved) is never
-    // reprocessed; restoring the original bytes cannot resurrect removal authority.
-    if (progress.isCompleted(member) || progress.isPreserved(member)) continue;
-    progress.begin(member);
-    const removal = removeAgentSyncAssets({}, { plannedAssets: [{ path: asset.path, identity: asset.identity }] });
-    if (removal.failures.length > 0) {
-      if (removal.removed.length === 0) progress.abort(member);
-      for (const failure of removal.failures) {
-        result.failures.push({ step: `Removing synced asset ${contractPath(failure.path)}`, detail: failure.detail });
-      }
-      return;
-    }
-    if (removal.kept.length > 0) {
-      const detail =
-        removal.identityMismatch.length > 0
-          ? 'recorded removable asset was replaced by a different managed object after the uninstall batch; preserved it byte-identical'
-          : 'recorded removable asset was modified after the uninstall batch; preserved it byte-identical';
-      console.log(`  \x1b[33m!\x1b[0m Preserved managed asset byte-identical: ${contractPath(asset.path)}`);
-      recordPreservation(result, { step: `Preserving synced asset ${contractPath(asset.path)}`, detail });
-      progress.preserve(member);
-      continue;
-    }
-    progress.complete(member);
-    if (removal.removed.length > 0) {
-      console.log(`  \x1b[32m+\x1b[0m Removed managed asset: ${contractPath(asset.path)}`);
+    if (asset.disposition !== 'remove' || asset.identity.kind === 'agent') continue;
+    removeOneNonAgentAsset({ path: asset.path, identity: asset.identity }, result, progress);
+    if (result.failures.length > 0) return;
+  }
+  const flatAgents: PlannedFlatAgent[] = [];
+  for (const asset of agentAssets) {
+    if (asset.disposition === 'remove' && asset.identity.kind === 'agent') {
+      flatAgents.push({ path: asset.path, identity: asset.identity });
     }
   }
+  removeFlatAgentBatch(flatAgents, result, progress);
 }
 
 export function uninstallBatchIntegrationViolations(
@@ -1589,6 +1993,57 @@ function removeRulesMember(
   return failure;
 }
 
+function isNodeErrorCode(error: unknown, code: string): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === code;
+}
+
+function preservedGenieDirEntry(name: string): boolean {
+  return name === 'state-backups' || name === AGENT_SYNC_LOCK_NAME;
+}
+
+/** Remove canonical install state while retaining durable backups and the active sync lock generation. */
+function removeGenieDirPreservingStateBackups(genieDir: string): void {
+  let stat: Stats;
+  try {
+    stat = lstatSync(genieDir);
+  } catch (error) {
+    if (isNodeErrorCode(error, 'ENOENT')) return;
+    throw error;
+  }
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    rmSync(genieDir, { recursive: true, force: true });
+    return;
+  }
+  const names = readdirSync(genieDir);
+  if (!names.some(preservedGenieDirEntry)) {
+    rmSync(genieDir, { recursive: true, force: true });
+    return;
+  }
+  for (const name of names) {
+    if (!preservedGenieDirEntry(name)) rmSync(join(genieDir, name), { recursive: true, force: true });
+  }
+}
+
+function removeGenieDirIfEmpty(genieDir: string): void {
+  try {
+    rmdirSync(genieDir);
+  } catch {
+    // Durable backups, another safe retained object, or an already-absent root are all valid.
+  }
+}
+
+/** A durable-backups/active-lock-only root is recovery state, not an installed Genie tree. */
+export function hasRemovableGenieInstallState(genieDir: string): boolean {
+  try {
+    const stat = lstatSync(genieDir);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return true;
+    return readdirSync(genieDir).some((name) => !preservedGenieDirEntry(name));
+  } catch (error) {
+    if (isNodeErrorCode(error, 'ENOENT')) return false;
+    return true;
+  }
+}
+
 function removeGenieHomeMember(
   genieDir: string,
   genieHomePresent: boolean,
@@ -1598,8 +2053,8 @@ function removeGenieHomeMember(
   const member = uninstallBatchMemberId('home', resolve(genieDir));
   if (progress.isCompleted(member)) return null;
   progress.begin(member);
-  const failure = tryRemoveStep('Removing genie directory...', 'Directory removed', () =>
-    rmSync(genieDir, { recursive: true, force: true }),
+  const failure = tryRemoveStep('Removing genie directory...', 'Install state removed (state backups preserved)', () =>
+    removeGenieDirPreservingStateBackups(genieDir),
   );
   if (failure === null) progress.complete(member);
   return failure;
@@ -1634,7 +2089,7 @@ function removeSymlinkMembers(
 /**
  * Uninstall Genie CLI entirely
  */
-function performUninstall(
+function performUninstallScope(
   genieDir: string,
   scope: UninstallBatchScope,
   progress: UninstallBatchProgressController,
@@ -1668,13 +2123,77 @@ function performUninstall(
   return result;
 }
 
+export interface PerformUninstallDependencies {
+  /** Fully injected external agent roots for noninteractive full-flow tests. */
+  agentSyncTargets?: AgentSyncRemovalTargets;
+  /** Avoid consulting process-global legacy rules state in isolated tests. */
+  orchestrationRulesPath?: string;
+  /** Avoid process-global runtime integration mutation in isolated tests. */
+  removeRuntimeIntegrations?: (removeMarketplace: boolean) => void;
+}
+
+/**
+ * Fully injected compatibility seam retained for noninteractive uninstall-flow
+ * tests. Production uses the authenticated batch path below; both paths hold the
+ * same sync lock through flat-agent removal, runtime cleanup, and source deletion.
+ */
+export function performUninstall(
+  _hasHookScript: boolean,
+  existingSymlinks: string[],
+  genieDir: string,
+  hasGenieDir: boolean,
+  hasAgentAssets: boolean,
+  removeMarketplace: boolean,
+  dependencies: PerformUninstallDependencies = {},
+): void {
+  const targets = dependencies.agentSyncTargets ?? {};
+  const genieHome = targets.genieHome ?? resolveGenieHome();
+  const hasCurrentAgentAssets = hasAgentAssets && collectAgentSyncAssets(targets).length > 0;
+  const hasRemovableGenieDir = hasGenieDir && hasRemovableGenieInstallState(genieDir);
+  const hasInjectedRules =
+    dependencies.orchestrationRulesPath !== undefined && existsSync(dependencies.orchestrationRulesPath);
+  if (
+    !hasCurrentAgentAssets &&
+    !hasRemovableGenieDir &&
+    !hasInjectedRules &&
+    existingSymlinks.length === 0 &&
+    !removeMarketplace
+  ) {
+    return;
+  }
+
+  let lock: { release: () => void } | null;
+  try {
+    lock = acquireAgentSyncLock(genieHome);
+  } catch {
+    return;
+  }
+  if (lock === null) return;
+  try {
+    if (hasCurrentAgentAssets) {
+      const removal = removeAgentSyncAssetsLocked(targets);
+      if (removal.failures.length > 0) return;
+    }
+    if (hasInjectedRules) unlinkSync(dependencies.orchestrationRulesPath as string);
+    (dependencies.removeRuntimeIntegrations ?? removeRuntimeIntegrations)(removeMarketplace);
+    if (hasRemovableGenieDir) removeGenieDirPreservingStateBackups(genieDir);
+    const plannedNames = existingSymlinks.filter((name): name is (typeof SYMLINKS)[number] =>
+      SYMLINKS.some((candidate) => candidate === name),
+    );
+    if (plannedNames.length > 0) removeSymlinks(LOCAL_BIN, genieDir, plannedNames);
+  } finally {
+    lock.release();
+    removeGenieDirIfEmpty(genieDir);
+  }
+}
+
 function uninstallBatchScope(plan: UninstallPlan): UninstallBatchScope {
   return {
     agentAssets: plan.agentAssets
       .map((asset): UninstallBatchScope['agentAssets'][number] =>
-        // Only a clean asset carries a proven identity; a modified/corrupt one is
-        // recorded as keep and never becomes a deletion candidate.
-        !asset.modified && asset.identity !== undefined
+        // Flat agents carry an identity for clean deletion, missing-entry pruning,
+        // and modified-content keep-aside. Other modified/corrupt assets stay put.
+        asset.identity !== undefined && (asset.kind === 'agent' || !asset.modified)
           ? { path: resolve(asset.path), disposition: 'remove', identity: asset.identity }
           : { path: resolve(asset.path), disposition: 'keep' },
       )
@@ -1727,7 +2246,7 @@ export function performFreshUninstallPlan(
     throw new Error(`uninstall preflight found unreadable or corrupt integration state: ${unsafeState.join('; ')}`);
   }
   const batch = executeUninstallBatch(genieDir, uninstallBatchScope(execution), (scope, progress) =>
-    performUninstall(genieDir, scope, progress),
+    performUninstallScope(genieDir, scope, progress),
   );
   return {
     execution,
@@ -1782,6 +2301,54 @@ function reportPendingBatchPreview(genieDir: string): void {
   }
 }
 
+function reportAgentSyncLockFailure(error?: unknown): void {
+  process.exitCode = 1;
+  const suffix =
+    error === undefined ? 'another agent-sync mutation is active.' : 'the shared agent-sync lock is unsafe.';
+  console.log(`\x1b[31m!\x1b[0m Genie CLI uninstall is incomplete; ${suffix}`);
+  if (error !== undefined) console.log(`  \x1b[31m-\x1b[0m ${errorMessage(error)}`);
+  console.log();
+}
+
+function executeFreshUninstall(genieDir: string, removeMarketplace: boolean): void {
+  console.log();
+  // The prompt may remain open while another lifecycle process finishes.
+  // Discard every preview decision and rebuild the complete plan under both
+  // locks; destructive helpers still perform their per-artifact CAS checks.
+  let execution: UninstallPlan;
+  let result: UninstallResult;
+  try {
+    ({ execution, result } = performFreshUninstallPlan(genieDir, removeMarketplace));
+  } catch (error) {
+    process.exitCode = 1;
+    console.log('\x1b[31m!\x1b[0m Genie CLI uninstall is incomplete; recovery or batch validation failed.');
+    console.log(`  \x1b[31m-\x1b[0m ${errorMessage(error)}`);
+    console.log();
+    return;
+  }
+  reportUninstallResult(execution, result, genieDir);
+}
+
+function executeConfirmedUninstall(genieDir: string, removeMarketplace: boolean): void {
+  let agentSyncLock: { release: () => void } | null;
+  try {
+    agentSyncLock = acquireAgentSyncLock(genieDir);
+  } catch (error) {
+    reportAgentSyncLockFailure(error);
+    return;
+  }
+  if (agentSyncLock === null) {
+    reportAgentSyncLockFailure();
+    return;
+  }
+  try {
+    executeFreshUninstall(genieDir, removeMarketplace);
+  } finally {
+    agentSyncLock.release();
+    removeGenieDirIfEmpty(genieDir);
+  }
+}
+
 export async function uninstallCommand(options: { removeMarketplace?: boolean } = {}): Promise<void> {
   console.log();
   console.log('\x1b[1m\x1b[33m Uninstall Genie CLI\x1b[0m');
@@ -1820,17 +2387,28 @@ export async function uninstallCommand(options: { removeMarketplace?: boolean } 
   if (hasGenieDir) console.log(`  \x1b[31m-\x1b[0m Genie directory (${contractPath(genieDir)})`);
   if (existingSymlinks.length > 0)
     console.log(`  \x1b[31m-\x1b[0m Symlinks from ~/.local/bin: ${existingSymlinks.join(', ')}`);
-  const keptAssets = agentAssets.filter((asset) => asset.modified);
+  const keptAssets = agentAssets.filter(
+    (asset) => asset.modified && (asset.kind !== 'agent' || asset.identity === undefined),
+  );
+  const keptAsideAgents = agentAssets.filter(
+    (asset) => asset.kind === 'agent' && asset.modified && asset.identity?.kind === 'agent',
+  );
   const removableAssets = agentAssets.length - keptAssets.length;
   if (removableAssets > 0)
     console.log(
-      `  \x1b[31m-\x1b[0m Synced agent assets: ${removableAssets} unmodified managed skill dir(s)/council.js/hermes link across claude/codex/hermes`,
+      `  \x1b[31m-\x1b[0m Synced agent assets: ${removableAssets} managed skill dir(s)/agent file(s)/council.js/hermes link across claude/codex/hermes`,
     );
   if (keptAssets.length > 0) {
     console.log(
       `  \x1b[33m~\x1b[0m KEPT byte-identical (modified or ownership metadata needs review): ${keptAssets.length} managed asset(s):`,
     );
     for (const asset of keptAssets) console.log(`      \x1b[33m${contractPath(asset.path)}\x1b[0m`);
+  }
+  if (keptAsideAgents.length > 0) {
+    console.log(
+      `  \x1b[33m~\x1b[0m Modified flat agents will be preserved under *${KEPT_SUFFIX} and disowned: ${keptAsideAgents.length} file(s):`,
+    );
+    for (const asset of keptAsideAgents) console.log(`      \x1b[33m${contractPath(asset.path)}\x1b[0m`);
   }
   if (managedRoleAgents.length > 0) {
     const modified = managedRoleAgents.filter((entry) => entry.ownership === 'managed-modified').length;
@@ -1878,23 +2456,7 @@ export async function uninstallCommand(options: { removeMarketplace?: boolean } 
   if ('skipped' in lifecycleLease)
     throw new Error(`Another Genie lifecycle command is active: ${lifecycleLease.skipped}`);
   try {
-    console.log();
-    // The prompt may remain open while another lifecycle process finishes.
-    // Discard every preview decision and rebuild the complete plan under the
-    // lease; destructive helpers still perform their per-artifact CAS checks.
-    let execution: UninstallPlan;
-    let result: UninstallResult;
-    try {
-      ({ execution, result } = performFreshUninstallPlan(genieDir, options.removeMarketplace ?? false));
-    } catch (error) {
-      process.exitCode = 1;
-      console.log('\x1b[31m!\x1b[0m Genie CLI uninstall is incomplete; recovery or batch validation failed.');
-      console.log(`  \x1b[31m-\x1b[0m ${error instanceof Error ? error.message : String(error)}`);
-      console.log();
-      return;
-    }
-
-    reportUninstallResult(execution, result, genieDir);
+    executeConfirmedUninstall(genieDir, options.removeMarketplace ?? false);
   } finally {
     lifecycleLease.release();
   }

--- a/src/lib/agent-sync.test.ts
+++ b/src/lib/agent-sync.test.ts
@@ -18,6 +18,7 @@ import {
   closeSync,
   cpSync,
   existsSync,
+  linkSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
@@ -44,6 +45,7 @@ import { checkAgentSync } from '../genie-commands/doctor';
 import { runAgentSyncSafe } from '../genie-commands/update';
 import {
   type AgentReport,
+  AgentSyncLockError,
   type AgentSyncOptions,
   type AgentSyncReport,
   CODEX_FALLBACK_RETIREMENT_ROOT,
@@ -53,16 +55,19 @@ import {
   LIFECYCLE_LEASE_PATH_ENV,
   TARGET_NAME,
   WORKFLOW_MANIFEST_NAME,
+  acquireAgentSyncLock,
   acquireLifecycleLease,
   applyCodexFallbackRetirement,
   atomicRenameDirectoryNoClobber,
   computeDirDigest,
+  computeFileDigest,
   currentSyncLockHostId,
   fsyncPathForTest,
   inspectManagedWorkflow,
   lifecycleLockPath,
   planCodexFallbackRetirement,
   publishDirectoryViaNameClaim,
+  readAgentFilesManifest,
   recoverCodexFallbackRetirements,
   recoverManagedSkillTransactions,
   recoverManagedWorkflowTransactions,
@@ -132,10 +137,16 @@ function writeSourceSkill(pluginRoot: string, name: string, files: Record<string
   }
 }
 
+/** Materialize one flat source agent Markdown file under the plugin root. */
+function writeSourceAgent(pluginRoot: string, name: string, content: string): void {
+  writeFile(join(pluginRoot, 'agents', `${name}.md`), content);
+}
+
 interface SetupOptions {
   binLayout?: boolean;
   version?: string | null;
   skills?: Record<string, Record<string, string>>;
+  agents?: Record<string, string>;
   withTemplate?: boolean;
 }
 
@@ -151,6 +162,9 @@ function setup(opts: SetupOptions = {}): Fixture {
     beta: { 'SKILL.md': '# beta\n' },
   };
   for (const [name, files] of Object.entries(skills)) writeSourceSkill(pluginRoot, name, files);
+
+  const agents = opts.agents ?? { reviewer: '# reviewer\n', scout: '# scout\n' };
+  for (const [name, content] of Object.entries(agents)) writeSourceAgent(pluginRoot, name, content);
 
   if (opts.withTemplate ?? true) writeFile(join(pluginRoot, 'workflows', 'council.js'), TEMPLATE_BODY);
   writeFile(join(hermesSource, 'plugin.json'), '{"name":"hermes-genie"}\n');
@@ -203,6 +217,10 @@ function skillAction(report: AgentReport, name: string): string | undefined {
 
 function extraAction(report: AgentReport, kind: string): string | undefined {
   return report.extras.find((entry) => entry.kind === kind)?.action;
+}
+
+function agentFileAction(report: AgentReport, name: string): string | undefined {
+  return report.extras.find((entry) => entry.kind === 'agent' && entry.detail === `${name}.md`)?.action;
 }
 
 function readManifest(dir: string): { managedBy: string; version: string | null; digest: string; syncedAt: string } {
@@ -272,6 +290,525 @@ describe('fresh create', () => {
     expect(report.source.pluginRoot).toBe(fixture.pluginRoot);
     expect(report.source.hermesRoot).toBe(fixture.hermesSource);
     expect(report.source.version).toBe('9.9.9');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Claude flat agent fan-out
+// ---------------------------------------------------------------------------
+
+describe('claude agent fan-out', () => {
+  test('fresh sync writes flat files and one directory-level per-file manifest', () => {
+    present(fixture.claudeDir);
+
+    const claude = agentReport(run(), 'claude');
+    const agentsDir = join(fixture.claudeDir, 'agents');
+    const manifest = readAgentFilesManifest(agentsDir);
+
+    expect(agentFileAction(claude, 'reviewer')).toBe('created');
+    expect(agentFileAction(claude, 'scout')).toBe('created');
+    expect(readFileSync(join(agentsDir, 'reviewer.md'), 'utf8')).toBe('# reviewer\n');
+    expect(readFileSync(join(agentsDir, 'scout.md'), 'utf8')).toBe('# scout\n');
+    expect(manifest?.managedBy).toBe('genie-agent-sync');
+    expect(Object.keys(manifest?.files ?? {})).toEqual(['reviewer.md', 'scout.md']);
+    expect(manifest?.files['scout.md']).toEqual({
+      digest: computeFileDigest(join(agentsDir, 'scout.md')),
+      version: '9.9.9',
+      syncedAt: '2026-07-10T12:00:00.000Z',
+    });
+  });
+
+  test('second sync is byte-idempotent and reports only unchanged agent files', () => {
+    present(fixture.claudeDir);
+    run();
+    const manifestPath = join(fixture.claudeDir, 'agents', MANIFEST_NAME);
+    const before = readFileSync(manifestPath);
+
+    const second = run();
+    const claude = agentReport(second, 'claude');
+    const agentActions = claude.extras.filter((entry) => entry.kind === 'agent').map((entry) => entry.action);
+
+    expect(agentActions).toEqual(['unchanged', 'unchanged']);
+    expect(agentActions.some((action) => ['created', 'updated', 'adopted', 'removed'].includes(action))).toBe(false);
+    expect(readFileSync(manifestPath)).toEqual(before);
+    expect(second.backupsDir).toBeNull();
+  });
+
+  test('a clean managed agent updates in place when its source digest changes', () => {
+    present(fixture.claudeDir);
+    run();
+    const agentsDir = join(fixture.claudeDir, 'agents');
+    const beforeDigest = readAgentFilesManifest(agentsDir)?.files['scout.md']?.digest;
+    writeSourceAgent(fixture.pluginRoot, 'scout', '# scout v2\n');
+
+    const report = run();
+    const claude = agentReport(report, 'claude');
+
+    expect(agentFileAction(claude, 'scout')).toBe('updated');
+    expect(readFileSync(join(agentsDir, 'scout.md'), 'utf8')).toBe('# scout v2\n');
+    expect(readAgentFilesManifest(agentsDir)?.files['scout.md']?.digest).not.toBe(beforeDigest);
+    expect(report.backupsDir).toBeNull();
+  });
+
+  test('a pre-existing unmanaged scout is backed up before adoption; unrelated user agents are untouched', () => {
+    present(fixture.claudeDir);
+    const agentsDir = join(fixture.claudeDir, 'agents');
+    writeFile(join(agentsDir, 'scout.md'), '# pre-existing hand copy\n');
+    const ownPath = join(agentsDir, 'my-own-agent.md');
+    const ownBytes = Buffer.from([0x23, 0x20, 0x6d, 0x69, 0x6e, 0x65, 0x0a]);
+    mkdirSync(dirname(ownPath), { recursive: true });
+    writeFileSync(ownPath, ownBytes);
+
+    const report = run();
+    const claude = agentReport(report, 'claude');
+
+    expect(agentFileAction(claude, 'scout')).toBe('adopted');
+    expect(readFileSync(join(agentsDir, 'scout.md'), 'utf8')).toBe('# scout\n');
+    expect(readFileSync(ownPath)).toEqual(ownBytes);
+    expect(readAgentFilesManifest(agentsDir)?.files['my-own-agent.md']).toBeUndefined();
+    const backup = join(report.backupsDir as string, 'claude', 'agents', 'scout.md');
+    expect(readFileSync(backup, 'utf8')).toBe('# pre-existing hand copy\n');
+  });
+
+  test('an unmodified source orphan is backed up, removed, and dropped from the manifest', () => {
+    present(fixture.claudeDir);
+    run();
+    rmSync(join(fixture.pluginRoot, 'agents', 'scout.md'));
+
+    const report = run();
+    const claude = agentReport(report, 'claude');
+    const agentsDir = join(fixture.claudeDir, 'agents');
+
+    expect(agentFileAction(claude, 'scout')).toBe('removed');
+    expect(existsSync(join(agentsDir, 'scout.md'))).toBe(false);
+    expect(readAgentFilesManifest(agentsDir)?.files['scout.md']).toBeUndefined();
+    const backup = join(report.backupsDir as string, 'claude', 'agents', 'scout.md');
+    expect(readFileSync(backup, 'utf8')).toBe('# scout\n');
+  });
+
+  test('a modified source orphan stays byte-identical, is advised, and relinquishes ownership', () => {
+    present(fixture.claudeDir);
+    run();
+    const agentsDir = join(fixture.claudeDir, 'agents');
+    const scoutPath = join(agentsDir, 'scout.md');
+    const editedBytes = Buffer.from('# my local scout edits\n');
+    writeFileSync(scoutPath, editedBytes);
+    rmSync(join(fixture.pluginRoot, 'agents', 'scout.md'));
+
+    const report = run();
+    const claude = agentReport(report, 'claude');
+
+    expect(agentFileAction(claude, 'scout')).toBe('kept-modified-orphan');
+    expect(readFileSync(scoutPath)).toEqual(editedBytes);
+    expect(readAgentFilesManifest(agentsDir)?.files['scout.md']).toBeUndefined();
+    expect(claude.advisories.some((line) => line.includes('kept modified orphan scout.md'))).toBe(true);
+    expect(report.backupsDir).toBeNull();
+  });
+
+  test('a symlink manifest is refused without following it or changing victim bytes', () => {
+    present(fixture.claudeDir);
+    const agentsDir = join(fixture.claudeDir, 'agents');
+    mkdirSync(agentsDir, { recursive: true });
+    const victim = join(fixture.root, 'user-owned-manifest-target.json');
+    const victimBytes = Buffer.from('{"user":"owned through a symlink"}\n');
+    writeFileSync(victim, victimBytes);
+    const manifestPath = join(agentsDir, MANIFEST_NAME);
+    symlinkSync(victim, manifestPath);
+
+    const claude = agentReport(run(), 'claude');
+
+    expect(readFileSync(victim)).toEqual(victimBytes);
+    expect(lstatSync(manifestPath).isSymbolicLink()).toBe(true);
+    expect(readAgentFilesManifest(agentsDir)).toBeNull();
+    expect(existsSync(join(agentsDir, 'scout.md'))).toBe(false);
+    expect(claude.advisories.some((line) => line.includes('manifest') && line.includes('symlink'))).toBe(true);
+  });
+
+  test('a multiply-linked manifest is refused without changing either linked name', () => {
+    present(fixture.claudeDir);
+    const agentsDir = join(fixture.claudeDir, 'agents');
+    mkdirSync(agentsDir, { recursive: true });
+    const victim = join(fixture.root, 'hardlinked-manifest-victim.json');
+    const victimBytes = Buffer.from('{"user":"owns both links"}\n');
+    writeFileSync(victim, victimBytes);
+    const manifestPath = join(agentsDir, MANIFEST_NAME);
+    linkSync(victim, manifestPath);
+
+    const claude = agentReport(run(), 'claude');
+
+    expect(lstatSync(victim).nlink).toBe(2);
+    expect(readFileSync(victim)).toEqual(victimBytes);
+    expect(readFileSync(manifestPath)).toEqual(victimBytes);
+    expect(existsSync(join(agentsDir, 'scout.md'))).toBe(false);
+    expect(claude.advisories.some((line) => line.includes('manifest') && line.includes('hard links'))).toBe(true);
+  });
+
+  test('a foreign regular manifest is backed up byte-for-byte before safe adoption', () => {
+    present(fixture.claudeDir);
+    const agentsDir = join(fixture.claudeDir, 'agents');
+    mkdirSync(agentsDir, { recursive: true });
+    const manifestPath = join(agentsDir, MANIFEST_NAME);
+    const foreignBytes = Buffer.from('foreign manifest bytes\n');
+    writeFileSync(manifestPath, foreignBytes);
+
+    const report = run();
+    const manifest = readAgentFilesManifest(agentsDir);
+
+    expect(manifest?.managedBy).toBe('genie-agent-sync');
+    expect(Object.keys(manifest?.files ?? {})).toEqual(['reviewer.md', 'scout.md']);
+    expect(readFileSync(join(report.backupsDir as string, 'claude', 'agents', MANIFEST_NAME))).toEqual(foreignBytes);
+    expect(
+      agentReport(report, 'claude').advisories.some((line) => line.includes('adopted foreign agent manifest')),
+    ).toBe(true);
+  });
+
+  function backupCollisionPath(): string {
+    return join(
+      dirname(fixture.genieHome),
+      '.genie-recovery',
+      `agent-sync-2026-07-10T12-00-00-000Z-${process.pid}`,
+      'claude',
+      'agents',
+      'scout.md',
+    );
+  }
+
+  test('a destination symlink collision survives and adoption uses a distinct exclusive backup root', () => {
+    present(fixture.claudeDir);
+    const scoutPath = join(fixture.claudeDir, 'agents', 'scout.md');
+    writeFile(scoutPath, '# unmanaged scout\n');
+    const collision = backupCollisionPath();
+    const victim = join(fixture.root, 'backup-symlink-victim');
+    const victimBytes = Buffer.from('victim bytes must survive\n');
+    writeFileSync(victim, victimBytes);
+    mkdirSync(dirname(collision), { recursive: true });
+    symlinkSync(victim, collision);
+
+    const report = run();
+
+    expect(report.backupsDir).toBe(
+      join(dirname(fixture.genieHome), '.genie-recovery', `agent-sync-2026-07-10T12-00-00-000Z-${process.pid}-1`),
+    );
+    expect(lstatSync(collision).isSymbolicLink()).toBe(true);
+    expect(readFileSync(victim)).toEqual(victimBytes);
+    expect(readFileSync(join(report.backupsDir as string, 'claude', 'agents', 'scout.md'), 'utf8')).toBe(
+      '# unmanaged scout\n',
+    );
+  });
+
+  test('a destination hardlink collision preserves every linked byte and allocates a distinct backup', () => {
+    present(fixture.claudeDir);
+    writeFile(join(fixture.claudeDir, 'agents', 'scout.md'), '# unmanaged scout\n');
+    const collision = backupCollisionPath();
+    const victim = join(fixture.root, 'backup-hardlink-victim');
+    const victimBytes = Buffer.from('hardlink bytes must survive\n');
+    writeFileSync(victim, victimBytes);
+    mkdirSync(dirname(collision), { recursive: true });
+    linkSync(victim, collision);
+
+    const report = run();
+
+    expect(lstatSync(victim).nlink).toBe(2);
+    expect(readFileSync(victim)).toEqual(victimBytes);
+    expect(readFileSync(collision)).toEqual(victimBytes);
+    expect(readFileSync(join(report.backupsDir as string, 'claude', 'agents', 'scout.md'), 'utf8')).toBe(
+      '# unmanaged scout\n',
+    );
+  });
+
+  test('an existing regular backup collision is never overwritten', () => {
+    present(fixture.claudeDir);
+    writeFile(join(fixture.claudeDir, 'agents', 'scout.md'), '# unmanaged scout\n');
+    const collision = backupCollisionPath();
+    const collisionBytes = Buffer.from('prior backup bytes\n');
+    mkdirSync(dirname(collision), { recursive: true });
+    writeFileSync(collision, collisionBytes);
+
+    const report = run();
+
+    expect(readFileSync(collision)).toEqual(collisionBytes);
+    expect(report.backupsDir).not.toBe(dirname(dirname(dirname(collision))));
+    expect(readFileSync(join(report.backupsDir as string, 'claude', 'agents', 'scout.md'), 'utf8')).toBe(
+      '# unmanaged scout\n',
+    );
+  });
+
+  test('pre-existing fixed agent and manifest stage debris survives while two runs converge', () => {
+    present(fixture.claudeDir);
+    run();
+    const agentsDir = join(fixture.claudeDir, 'agents');
+    const scoutPath = join(agentsDir, 'scout.md');
+    const manifestPath = join(agentsDir, MANIFEST_NAME);
+    const agentStagePath = `${scoutPath}.genie-sync.staging`;
+    const manifestStagePath = `${manifestPath}.genie-sync.staging`;
+    const agentStageBytes = Buffer.from('agent crash debris\n');
+    const manifestStageBytes = Buffer.from('manifest crash debris\n');
+    writeFileSync(agentStagePath, agentStageBytes);
+    writeFileSync(manifestStagePath, manifestStageBytes);
+    writeSourceAgent(fixture.pluginRoot, 'scout', '# scout v2\n');
+
+    const first = agentReport(run(), 'claude');
+    const second = agentReport(run(), 'claude');
+
+    expect(agentFileAction(first, 'scout')).toBe('updated');
+    expect(agentFileAction(second, 'scout')).toBe('unchanged');
+    expect(readFileSync(scoutPath, 'utf8')).toBe('# scout v2\n');
+    expect(readFileSync(agentStagePath)).toEqual(agentStageBytes);
+    expect(readFileSync(manifestStagePath)).toEqual(manifestStageBytes);
+    expect(readAgentFilesManifest(agentsDir)?.files['scout.md']?.digest).toBe(computeFileDigest(scoutPath));
+  });
+
+  test('an injected agent commit failure preserves the prior valid live bytes and manifest', () => {
+    present(fixture.claudeDir);
+    run();
+    const agentsDir = join(fixture.claudeDir, 'agents');
+    const scoutPath = join(agentsDir, 'scout.md');
+    const manifestPath = join(agentsDir, MANIFEST_NAME);
+    const scoutBefore = readFileSync(scoutPath);
+    const manifestBefore = readFileSync(manifestPath);
+    writeSourceAgent(fixture.pluginRoot, 'scout', '# scout v2\n');
+
+    const claude = agentReport(
+      run({
+        beforeAgentFileMutation: (event) => {
+          if (event.operation === 'replace' && event.path === scoutPath) throw new Error('injected agent commit fault');
+        },
+      }),
+      'claude',
+    );
+
+    expect(readFileSync(scoutPath)).toEqual(scoutBefore);
+    expect(readFileSync(manifestPath)).toEqual(manifestBefore);
+    expect(claude.advisories.some((line) => line.includes('scout.md') && line.includes('injected'))).toBe(true);
+  });
+
+  test('an injected manifest commit failure preserves the prior valid manifest and recovers on retry', () => {
+    present(fixture.claudeDir);
+    run();
+    const agentsDir = join(fixture.claudeDir, 'agents');
+    const scoutPath = join(agentsDir, 'scout.md');
+    const manifestPath = join(agentsDir, MANIFEST_NAME);
+    const manifestBefore = readFileSync(manifestPath);
+    const editedBytes = Buffer.from('# locally edited orphan\n');
+    writeFileSync(scoutPath, editedBytes);
+    rmSync(join(fixture.pluginRoot, 'agents', 'scout.md'));
+    const first = agentReport(
+      run({
+        beforeAgentManifestCommit: () => {
+          throw new Error('injected manifest commit fault');
+        },
+      }),
+      'claude',
+    );
+
+    expect(readFileSync(scoutPath)).toEqual(editedBytes);
+    expect(readFileSync(manifestPath)).toEqual(manifestBefore);
+    expect(first.advisories.some((line) => line.includes('manifest') && line.includes('commit failed'))).toBe(true);
+    expect(first.failures?.join('\n')).toContain('agent transaction did not commit');
+
+    const second = agentReport(run(), 'claude');
+    expect(agentFileAction(second, 'scout')).toBe('kept-modified-orphan');
+    expect(readFileSync(scoutPath)).toEqual(editedBytes);
+    expect(readAgentFilesManifest(agentsDir)?.files['scout.md']).toBeUndefined();
+  });
+
+  test('a clean orphan is restored exactly when its ownership commit fails', () => {
+    present(fixture.claudeDir);
+    run();
+    const agentsDir = join(fixture.claudeDir, 'agents');
+    const scoutPath = join(agentsDir, 'scout.md');
+    const manifestPath = join(agentsDir, MANIFEST_NAME);
+    const scoutBefore = readFileSync(scoutPath);
+    const manifestBefore = readFileSync(manifestPath);
+    rmSync(join(fixture.pluginRoot, 'agents', 'scout.md'));
+
+    const first = agentReport(
+      run({
+        beforeAgentManifestCommit: () => {
+          throw new Error('injected clean-orphan manifest fault');
+        },
+      }),
+      'claude',
+    );
+
+    expect(readFileSync(scoutPath)).toEqual(scoutBefore);
+    expect(readFileSync(manifestPath)).toEqual(manifestBefore);
+    expect(agentFileAction(first, 'scout')).toBeUndefined();
+    expect(first.advisories.some((line) => line.includes('clean-orphan manifest fault'))).toBe(true);
+
+    const second = agentReport(run(), 'claude');
+    expect(agentFileAction(second, 'scout')).toBe('removed');
+    expect(existsSync(scoutPath)).toBe(false);
+  });
+
+  test('manifest-stage cleanup preserves a replacement payload byte-for-byte and advises', () => {
+    present(fixture.claudeDir);
+    run();
+    const agentsDir = join(fixture.claudeDir, 'agents');
+    const scoutPath = join(agentsDir, 'scout.md');
+    const manifestPath = join(agentsDir, MANIFEST_NAME);
+    const scoutBefore = readFileSync(scoutPath);
+    const manifestBefore = readFileSync(manifestPath);
+    const replacementBytes = Buffer.from('foreign replacement stage bytes\n');
+    let replacedStagePath = '';
+    writeSourceAgent(fixture.pluginRoot, 'scout', '# scout v2\n');
+
+    const claude = agentReport(
+      run({
+        beforeAgentManifestCommit: ({ stagePath }) => {
+          replacedStagePath = stagePath;
+          rmSync(stagePath);
+          writeFileSync(stagePath, replacementBytes);
+          throw new Error('manifest commit fault after stage replacement');
+        },
+      }),
+      'claude',
+    );
+
+    expect(replacedStagePath).not.toBe('');
+    expect(readFileSync(replacedStagePath)).toEqual(replacementBytes);
+    expect(readFileSync(scoutPath)).toEqual(scoutBefore);
+    expect(readFileSync(manifestPath)).toEqual(manifestBefore);
+    expect(claude.advisories.some((line) => line.includes('preserved replaced staged payload'))).toBe(true);
+  });
+
+  test('a replacement at the captured-to-publish barrier stays live and is not manifest-owned', () => {
+    present(fixture.claudeDir);
+    run();
+    const scoutPath = join(fixture.claudeDir, 'agents', 'scout.md');
+    const concurrentBytes = Buffer.from('# concurrent local edit\n');
+    writeSourceAgent(fixture.pluginRoot, 'scout', '# scout v2\n');
+
+    const claude = agentReport(
+      run({
+        beforeAgentFileMutation: (event) => {
+          if (event.operation === 'replace' && event.path === scoutPath) writeFileSync(scoutPath, concurrentBytes);
+        },
+      }),
+      'claude',
+    );
+
+    expect(readFileSync(scoutPath)).toEqual(concurrentBytes);
+    expect(readAgentFilesManifest(join(fixture.claudeDir, 'agents'))?.files['scout.md']).toBeUndefined();
+    expect(agentFileAction(claude, 'scout')).toBe('skipped-unmanaged-kept');
+    expect(claude.advisories.some((line) => line.includes('not published or claimed'))).toBe(true);
+    const keptPath = `${scoutPath}.genie-kept`;
+    expect(readFileSync(keptPath, 'utf8')).toBe('# scout\n');
+  });
+
+  test('an orphan replaced after backup survives live and relinquishes ownership immediately', () => {
+    present(fixture.claudeDir);
+    run();
+    const agentsDir = join(fixture.claudeDir, 'agents');
+    const scoutPath = join(agentsDir, 'scout.md');
+    const replacementBytes = Buffer.from('# replacement after orphan backup\n');
+    rmSync(join(fixture.pluginRoot, 'agents', 'scout.md'));
+
+    const first = agentReport(
+      run({
+        beforeAgentFileMutation: (event) => {
+          if (event.operation === 'remove' && event.path === scoutPath) {
+            writeFileSync(scoutPath, replacementBytes);
+          }
+        },
+      }),
+      'claude',
+    );
+
+    expect(readFileSync(scoutPath)).toEqual(replacementBytes);
+    expect(agentFileAction(first, 'scout')).toBe('kept-modified-orphan');
+    expect(readAgentFilesManifest(agentsDir)?.files['scout.md']).toBeUndefined();
+    expect(first.advisories.some((line) => line.includes('concurrently changed orphan'))).toBe(true);
+
+    const second = agentReport(run(), 'claude');
+    expect(agentFileAction(second, 'scout')).toBeUndefined();
+    expect(readFileSync(scoutPath)).toEqual(replacementBytes);
+  });
+
+  test('INV1: captured bytes mutated after validation are preserved, never discarded by the final unlink', () => {
+    present(fixture.claudeDir);
+    run();
+    const agentsDir = join(fixture.claudeDir, 'agents');
+    const scoutPath = join(agentsDir, 'scout.md');
+    const mutatedBytes = Buffer.from('# mutated through the captured inode\n');
+    rmSync(join(fixture.pluginRoot, 'agents', 'scout.md'));
+
+    const report = run({
+      beforeAgentFileMutation: (event) => {
+        if (event.operation !== 'remove' || event.path !== scoutPath) return;
+        // The old file is quarantined at this barrier; mutate the captured inode.
+        const quarantine = readdirSync(agentsDir).find((name) => name.startsWith('.scout.md.agent-retire-'));
+        if (quarantine === undefined) throw new Error('captured quarantine dir not found');
+        writeFileSync(join(agentsDir, quarantine, 'object'), mutatedBytes);
+      },
+    });
+    const claude = agentReport(report, 'claude');
+
+    expect(agentFileAction(claude, 'scout')).toBe('removed');
+    expect(readAgentFilesManifest(agentsDir)?.files['scout.md']).toBeUndefined();
+    // the mutated bytes survive visibly instead of being unlinked into nothing
+    expect(readFileSync(`${scoutPath}.genie-kept`)).toEqual(mutatedBytes);
+    expect(claude.advisories.some((line) => line.includes('changed after validation'))).toBe(true);
+    // the backup still holds exactly the validated bytes
+    expect(readFileSync(join(report.backupsDir as string, 'claude', 'agents', 'scout.md'), 'utf8')).toBe('# scout\n');
+  });
+
+  test('INV2: ownership is never committed for live bytes replaced at the commit barrier', () => {
+    present(fixture.claudeDir);
+    run();
+    const agentsDir = join(fixture.claudeDir, 'agents');
+    const scoutPath = join(agentsDir, 'scout.md');
+    const foreignBytes = Buffer.from('# foreign writer at the commit barrier\n');
+    writeSourceAgent(fixture.pluginRoot, 'scout', '# scout v2\n');
+
+    const claude = agentReport(
+      run({
+        beforeAgentManifestCommit: () => {
+          writeFileSync(scoutPath, foreignBytes);
+        },
+      }),
+      'claude',
+    );
+
+    const manifest = readAgentFilesManifest(agentsDir);
+    expect(readFileSync(scoutPath)).toEqual(foreignBytes); // the foreign object stays live
+    expect(manifest?.files['scout.md']).toBeUndefined(); // and is never claimed
+    expect(manifest?.files['reviewer.md']).toBeDefined(); // unaffected names stay owned
+    expect(agentFileAction(claude, 'scout')).toBe('skipped-unmanaged-kept');
+    expect(claude.advisories.some((line) => line.includes('not published or claimed'))).toBe(true);
+    expect(readFileSync(`${scoutPath}.genie-kept`, 'utf8')).toBe('# scout\n'); // prior managed bytes stay visible
+  });
+
+  test('INV3: a silently replaced manifest stage payload is never published and is preserved', () => {
+    present(fixture.claudeDir);
+    run();
+    const agentsDir = join(fixture.claudeDir, 'agents');
+    const scoutPath = join(agentsDir, 'scout.md');
+    const manifestPath = join(agentsDir, MANIFEST_NAME);
+    const scoutBefore = readFileSync(scoutPath);
+    const manifestBefore = readFileSync(manifestPath);
+    const tamperedBytes = Buffer.from('{"managedBy":"genie-agent-sync","files":{"evil.md":{"digest":"x"}}}\n');
+    let tamperedStagePath = '';
+    writeSourceAgent(fixture.pluginRoot, 'scout', '# scout v2\n');
+
+    const claude = agentReport(
+      run({
+        beforeAgentManifestCommit: ({ stagePath }) => {
+          tamperedStagePath = stagePath;
+          rmSync(stagePath);
+          writeFileSync(stagePath, tamperedBytes);
+          // no throw: the commit itself must detect the tampered payload
+        },
+      }),
+      'claude',
+    );
+
+    expect(tamperedStagePath).not.toBe('');
+    expect(readFileSync(scoutPath)).toEqual(scoutBefore); // published v2 was rolled back exactly
+    expect(readFileSync(manifestPath)).toEqual(manifestBefore); // tampered payload never became the manifest
+    expect(readFileSync(tamperedStagePath)).toEqual(tamperedBytes); // preserved byte-for-byte
+    expect(claude.advisories.some((line) => line.includes('preserved replaced staged payload'))).toBe(true);
+    expect(claude.advisories.some((line) => line.includes('commit failed'))).toBe(true);
   });
 });
 
@@ -965,7 +1502,7 @@ describe('staging cleanup', () => {
     const skillsDir = join(fixture.claudeDir, 'skills');
     const userBackup = join(skillsDir, 'alpha.old');
     writeFile(join(userBackup, 'SKILL.md'), '# user manual backup — do not delete\n');
-    // genie's own crashed-run staging debris sitting next to the same skill
+    // crashed-run staging debris sitting next to the same skill
     writeFile(join(skillsDir, 'alpha.genie-sync.staging', 'garbage.txt'), 'crash debris\n');
 
     const report = agentReport(run(), 'claude');
@@ -1656,6 +2193,12 @@ describe('stampWorkflow parity with council-stamp.cjs', () => {
 const LOCK_NAME = '.agent-sync.lock';
 const MARKER_NAME = '.last-agent-sync';
 
+function lockOwnerPath(lockPath: string): string {
+  const owner = readdirSync(lockPath).find((name) => name.startsWith('owner-'));
+  if (owner === undefined) throw new Error(`lock owner missing under ${lockPath}`);
+  return join(lockPath, owner);
+}
+
 describe('cross-process sync lock', () => {
   // Same-host identity every writer (this process + spawned runners on this
   // machine) embeds as the 4th owner-record field; a lock is stealable ONLY when
@@ -1665,6 +2208,9 @@ describe('cross-process sync lock', () => {
   const TOKEN = '0123456789abcdef0123456789abcdef';
   /** Same-host owner record with an explicitly dead/live pid and 'unknown' start identity. */
   const sameHostRecord = (pid: number) => `${pid}:${TOKEN}:unknown:${HOST}\n`;
+  const markOwnedGenerationCrashed = (lockPath: string): void => {
+    writeFileSync(lockOwnerPath(lockPath), sameHostRecord(DEAD_PID));
+  };
 
   test('a fresh lock held elsewhere skips the whole sync with an advisory — zero writes, lock untouched', () => {
     present(fixture.claudeDir);
@@ -1683,18 +2229,131 @@ describe('cross-process sync lock', () => {
     expect(existsSync(lockPath)).toBe(true); // never releases someone else's live lock
   });
 
-  test('a stale SAME-HOST lock with a dead pid is stolen and the sync proceeds', () => {
+  test('a stale owned generation is stolen and the sync proceeds', () => {
     present(fixture.claudeDir);
     const lockPath = join(fixture.genieHome, LOCK_NAME);
-    writeFile(lockPath, sameHostRecord(DEAD_PID)); // same host + dead pid → the only stealable shape
+    const crashed = acquireAgentSyncLock(fixture.genieHome);
+    if (crashed === null) throw new Error('stale fixture lock was not acquired');
+    markOwnedGenerationCrashed(lockPath);
     const staleSec = (Date.now() - 11 * 60 * 1000) / 1000; // 11 min > 10 min age-out
-    utimesSync(lockPath, staleSec, staleSec);
+    utimesSync(lockOwnerPath(lockPath), staleSec, staleSec);
 
     const report = run();
 
     expect(report.skipped).toBeUndefined();
     expect(skillAction(agentReport(report, 'claude'), 'alpha')).toBe('created');
     expect(existsSync(lockPath)).toBe(false); // released after the run
+    crashed.release(); // stale handle is now a no-op
+  });
+
+  test('a stale legacy regular-file lock is captured safely and upgraded', () => {
+    present(fixture.claudeDir);
+    const lockPath = join(fixture.genieHome, LOCK_NAME);
+    const legacyBytes = Buffer.from('999:legacy-token\n');
+    writeFileSync(lockPath, legacyBytes);
+    const staleSec = (Date.now() - 11 * 60 * 1000) / 1000;
+    utimesSync(lockPath, staleSec, staleSec);
+
+    const report = run();
+
+    expect(report.skipped).toBeUndefined();
+    expect(skillAction(agentReport(report, 'claude'), 'alpha')).toBe('created');
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  test('an older holder cannot release a replacement lock after a stale steal', () => {
+    const lockPath = join(fixture.genieHome, LOCK_NAME);
+    const older = acquireAgentSyncLock(fixture.genieHome);
+    if (older === null) throw new Error('older fixture lock was not acquired');
+    markOwnedGenerationCrashed(lockPath);
+    const staleSec = (Date.now() - 11 * 60 * 1000) / 1000;
+    utimesSync(lockOwnerPath(lockPath), staleSec, staleSec);
+    const replacement = acquireAgentSyncLock(fixture.genieHome);
+    if (replacement === null) throw new Error('replacement fixture lock was not acquired');
+
+    older.release();
+
+    expect(existsSync(lockPath)).toBe(true);
+    expect(acquireAgentSyncLock(fixture.genieHome)).toBeNull();
+    replacement.release();
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  test('lock acquisition failure is typed and stops every protected write', () => {
+    present(fixture.claudeDir);
+    const lines: string[] = [];
+
+    const report = run({
+      log: (line) => lines.push(line),
+      lockOptions: {
+        beforePublish: () => {
+          const error = new Error('injected lock publish denial') as NodeJS.ErrnoException;
+          error.code = 'EACCES';
+          throw error;
+        },
+      },
+    });
+
+    expect(report.skipped).toContain('lock acquisition failed closed');
+    expect(report.agents).toEqual([]);
+    expect(existsSync(join(fixture.claudeDir, 'skills'))).toBe(false);
+    expect(existsSync(join(fixture.genieHome, MARKER_NAME))).toBe(false);
+    expect(lines.some((line) => line.includes('failed closed'))).toBe(true);
+    expect(() => acquireAgentSyncLock(join(fixture.root, 'not-a-directory'))).toThrow(AgentSyncLockError);
+  });
+
+  test('a foreign owner replacement installed after release capture survives byte-for-byte', () => {
+    const lockPath = join(fixture.genieHome, LOCK_NAME);
+    let ownerPath = '';
+    const replacementBytes = Buffer.from('foreign release replacement\n');
+    const older = acquireAgentSyncLock(fixture.genieHome, {
+      afterCapture: (event) => {
+        if (event.operation !== 'release') return;
+        writeFileSync(ownerPath, replacementBytes);
+      },
+    });
+    if (older === null) throw new Error('older fixture lock was not acquired');
+    ownerPath = lockOwnerPath(lockPath);
+
+    older.release();
+
+    expect(readFileSync(ownerPath)).toEqual(replacementBytes);
+    expect(acquireAgentSyncLock(fixture.genieHome)).toBeNull();
+  });
+
+  test('a foreign owner replacement installed after stale capture survives and the stealer fails closed', () => {
+    const lockPath = join(fixture.genieHome, LOCK_NAME);
+    const stale = acquireAgentSyncLock(fixture.genieHome);
+    if (stale === null) throw new Error('stale fixture lock was not acquired');
+    const ownerPath = lockOwnerPath(lockPath);
+    markOwnedGenerationCrashed(lockPath);
+    const staleSec = (Date.now() - 11 * 60 * 1000) / 1000;
+    utimesSync(ownerPath, staleSec, staleSec);
+    const replacementBytes = Buffer.from('foreign stale replacement\n');
+
+    const contender = acquireAgentSyncLock(fixture.genieHome, {
+      afterCapture: (event) => {
+        if (event.operation !== 'stale-remove') return;
+        writeFileSync(ownerPath, replacementBytes);
+      },
+    });
+
+    expect(contender).toBeNull();
+    expect(readFileSync(ownerPath)).toEqual(replacementBytes);
+    expect(acquireAgentSyncLock(fixture.genieHome)).toBeNull();
+    stale.release();
+  });
+
+  test('an aged owned generation with a live same-host owner is never stolen', () => {
+    const lockPath = join(fixture.genieHome, LOCK_NAME);
+    const live = acquireAgentSyncLock(fixture.genieHome);
+    if (live === null) throw new Error('live fixture lock was not acquired');
+    const staleSec = (Date.now() - 11 * 60 * 1000) / 1000;
+    utimesSync(lockOwnerPath(lockPath), staleSec, staleSec);
+
+    expect(acquireAgentSyncLock(fixture.genieHome)).toBeNull();
+    live.release();
+    expect(existsSync(lockPath)).toBe(false);
   });
 
   test('a stale CROSS-HOST lock is never stolen even with a locally-dead pid (double-writer safety)', () => {
@@ -1918,11 +2577,11 @@ describe('cross-process sync lock', () => {
 
     const report = run({
       hermesBinary: '/fake/bin/hermes',
-      execHermesEnable: () => writeFileSync(lockPath, replacement, 'utf8'),
+      execHermesEnable: () => writeFileSync(lockOwnerPath(lockPath), replacement, 'utf8'),
     });
 
     expect(report.skipped).toBeUndefined();
-    expect(readFileSync(lockPath, 'utf8')).toBe(replacement);
+    expect(readFileSync(lockOwnerPath(lockPath), 'utf8')).toBe(replacement);
   });
 
   test('the raw engine never marks convergence complete', () => {
@@ -2051,11 +2710,13 @@ describe('cross-process sync lock', () => {
     present(fixture.codexDir);
     present(fixture.hermesHome);
     const runnerPath = writeSyncRunner();
-    // A crashed run's stale SAME-HOST lock (dead pid) that every racer will try to steal.
+    // A crashed run's stale owned generation that every racer will try to steal.
     const lockPath = join(fixture.genieHome, LOCK_NAME);
-    writeFile(lockPath, sameHostRecord(DEAD_PID));
+    const crashed = acquireAgentSyncLock(fixture.genieHome);
+    if (crashed === null) throw new Error('stale fixture lock was not acquired');
+    markOwnedGenerationCrashed(lockPath);
     const staleSec = (Date.now() - 11 * 60 * 1000) / 1000; // 11 min > 10 min age-out
-    utimesSync(lockPath, staleSec, staleSec);
+    utimesSync(lockOwnerPath(lockPath), staleSec, staleSec);
 
     // Pre-spawn four runners parked on the go-file barrier, then release them
     // together so the steal attempts overlap. The winner sleeps 2s INSIDE the
@@ -2083,6 +2744,7 @@ describe('cross-process sync lock', () => {
       expect(skillAction(agentReport(wrote[0] as AgentSyncReport, 'claude'), 'alpha')).toBe('created');
     }
     expect(existsSync(lockPath)).toBe(false); // stale lock is gone; any winner released its own
+    crashed.release();
   }, 30_000);
 });
 

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -354,7 +354,7 @@ interface SkillOutcome {
   detail?: string;
 }
 
-interface SourceAgentFile {
+export interface SourceAgentFile {
   name: string;
   path: string;
 }
@@ -597,6 +597,34 @@ function writeManifest(dir: string, manifest: SyncManifest): void {
 export function readAgentFilesManifest(dir: string): AgentFilesManifest | null {
   const state = inspectAgentFilesManifest(dir);
   return state.kind === 'managed' ? state.manifest : null;
+}
+
+/**
+ * Lightweight, read-only view of the shared agent manifest for external
+ * consumers (doctor). Distinguishes a genie-managed manifest (with its per-file
+ * entries) from foreign / absent / unsafe WITHOUT exposing the raw byte+stat
+ * snapshot. `unsafe` mirrors {@link inspectAgentFilesManifest}'s fail-closed
+ * verdict (symlink, non-regular file, multiple hard links, or unreadable) so a
+ * diagnostic can surface it as a warning instead of silently reporting healthy.
+ */
+export type AgentFilesManifestView =
+  | { kind: 'managed'; files: Record<string, AgentFileManifestEntry> }
+  | { kind: 'foreign' }
+  | { kind: 'absent' }
+  | { kind: 'unsafe'; reason: string };
+
+export function readAgentFilesManifestState(dir: string): AgentFilesManifestView {
+  const state = inspectAgentFilesManifest(dir);
+  switch (state.kind) {
+    case 'managed':
+      return { kind: 'managed', files: state.manifest.files };
+    case 'foreign':
+      return { kind: 'foreign' };
+    case 'absent':
+      return { kind: 'absent' };
+    default:
+      return { kind: 'unsafe', reason: state.reason };
+  }
 }
 
 function inspectAgentFilesManifest(dir: string): AgentManifestState {
@@ -3300,8 +3328,12 @@ function removeManagedOrphans(
 // Claude agent enumeration + per-file policy
 // ============================================================================
 
-/** Source agents are flat Markdown files directly under `<pluginRoot>/agents`. */
-function enumerateSourceAgentFiles(pluginRoot: string): SourceAgentFile[] {
+/**
+ * Source agents are flat Markdown files directly under `<pluginRoot>/agents`.
+ * Exported so doctor's read-only role-agent classifier enumerates the exact same
+ * source set the sync engine fans out (no divergent reimplementation).
+ */
+export function enumerateSourceAgentFiles(pluginRoot: string): SourceAgentFile[] {
   const agentsRoot = join(pluginRoot, 'agents');
   if (!existsSync(agentsRoot)) return [];
   return readdirSync(agentsRoot, { withFileTypes: true })

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -31,10 +31,12 @@ import {
   copyFileSync,
   cpSync,
   existsSync,
+  fstatSync,
   fsyncSync,
   linkSync,
   lstatSync,
   mkdirSync,
+  mkdtempSync,
   openSync,
   readFileSync,
   readdirSync,
@@ -42,13 +44,15 @@ import {
   realpathSync,
   renameSync,
   rmSync,
+  rmdirSync,
   statSync,
   symlinkSync,
+  unlinkSync,
   writeFileSync,
   writeSync,
 } from 'node:fs';
 import { homedir, hostname } from 'node:os';
-import { dirname, join, relative, resolve, sep } from 'node:path';
+import { basename, dirname, join, relative, resolve, sep } from 'node:path';
 import historicalCodexFallbackAllowlist from '../fixtures/codex-fallback-allowlist.json';
 import { resolveClaudeDir, resolveCodexDir, resolveGenieHome, resolveHermesHome } from './genie-home.js';
 import { HermesConfigError, mergeMcpServersGenie } from './hermes-mcp-config.js';
@@ -113,8 +117,14 @@ const LINUX_LIBC_CANDIDATES = ['libc.so.6', 'ld-musl-x86_64.so.1', 'libc.musl-x8
 export const LIFECYCLE_LEASE_PATH_ENV = 'GENIE_LIFECYCLE_LEASE_PATH';
 /** Exact on-disk owner record paired with {@link LIFECYCLE_LEASE_PATH_ENV}. */
 export const LIFECYCLE_LEASE_OWNER_ENV = 'GENIE_LIFECYCLE_LEASE_OWNER';
+/**
+ * Suffix a preserved managed object gets when its original pathname must be
+ * released (uninstall keep, conflict preservation): the runtime stops loading
+ * it, the user's bytes survive. Exported: uninstall shares the convention.
+ */
+export const KEPT_SUFFIX = '.genie-kept';
 /** Cross-process mutual-exclusion lockfile under genieHome — one sync writer per GENIE_HOME. */
-const LOCK_NAME = '.agent-sync.lock';
+export const AGENT_SYNC_LOCK_NAME = '.agent-sync.lock';
 /** A lock older than this is a crashed run's debris and may be stolen. */
 const LOCK_STALE_MS = 10 * 60 * 1000;
 /**
@@ -172,6 +182,58 @@ export interface AgentSyncOptions {
   beforeManagedDirPublish?: (destDir: string) => void;
   /** Failure-injection seam around managed-directory removal quarantine. */
   beforeManagedDirRemoval?: (destDir: string, stage: 'before-park' | 'before-delete') => void;
+  /** Deterministic barrier immediately before a flat agent pathname is replaced or removed. */
+  beforeAgentFileMutation?: (event: AgentFileMutationEvent) => void;
+  /** Fault-injection barrier after the shared manifest transaction is staged and before its atomic commit. */
+  beforeAgentManifestCommit?: (event: AgentManifestCommitEvent) => void;
+  /** Deterministic lock lifecycle seams used by boundary-level regression tests. */
+  lockOptions?: AgentSyncLockOptions;
+}
+
+/**
+ * One barrier event per flat-agent mutation. `replace`/`remove` fire from sync;
+ * `remove`/`keep`/`prune` fire from uninstall — both through the same
+ * transaction core, after the live object is captured and before it is
+ * irreversibly published or disposed.
+ */
+export interface AgentFileMutationEvent {
+  operation: 'replace' | 'remove' | 'keep' | 'prune';
+  path: string;
+  backupPath?: string;
+}
+
+/**
+ * Fires once per transaction, inside the manifest commit: after the staged
+ * payload (write path) or the captured manifest (removal path) exists, and
+ * before the atomic publish decides the transaction outcome.
+ */
+export interface AgentManifestCommitEvent {
+  path: string;
+  stagePath: string;
+}
+
+export interface AgentSyncLockMutationEvent {
+  operation: 'release' | 'stale-remove';
+  path: string;
+  capturedPath: string;
+}
+
+export interface AgentSyncLockOptions {
+  /** Deterministic barrier after a generation is prepared and before its atomic publish. */
+  beforePublish?: (event: { path: string }) => void;
+  /** Deterministic barrier after the lock pathname is captured and before the captured object is finalized. */
+  afterCapture?: (event: AgentSyncLockMutationEvent) => void;
+}
+
+/** A protected mutation must never proceed when the shared lock cannot be created or verified. */
+export class AgentSyncLockError extends Error {
+  constructor(
+    message: string,
+    readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'AgentSyncLockError';
+  }
 }
 
 export type AgentSyncSelection = 'auto' | 'codex' | 'claude' | 'all' | 'none';
@@ -215,6 +277,33 @@ export interface GenieSource {
   version: string | null;
 }
 
+/** Digest stamp for one flat Claude agent file in {@link AgentFilesManifest}. */
+export interface AgentFileManifestEntry {
+  digest: string;
+  version: string | null;
+  syncedAt: string;
+}
+
+/** Shared manifest stored at `~/.claude/agents/.genie-sync.json`. */
+export interface AgentFilesManifest {
+  managedBy: 'genie-agent-sync';
+  files: Record<string, AgentFileManifestEntry>;
+}
+
+interface ManifestFileSnapshot {
+  path: string;
+  bytes: Buffer;
+  stat: Stats;
+}
+
+type SafeManifestFile = ManifestFileSnapshot &
+  ({ kind: 'managed'; manifest: AgentFilesManifest } | { kind: 'foreign'; manifest: null });
+
+type AgentManifestState =
+  | SafeManifestFile
+  | { kind: 'absent'; path: string }
+  | { kind: 'unsafe'; path: string; reason: string };
+
 // ============================================================================
 // Internal types
 // ============================================================================
@@ -239,12 +328,20 @@ interface RunContext {
   targets: { claude: string; codex: string; hermes: string; agentsSkills: string };
   /** Copy `existingDir` into the run's backup root and return the backup path. */
   backupInto: (agent: string, name: string, existingDir: string) => string;
+  /**
+   * Write already-validated bytes into the run's backup root exclusively and
+   * return the backup path — the backup IS the validated snapshot, so no
+   * re-read of the live path can diverge from what the policy decided on.
+   */
+  backupBytes: (agent: string, name: string, bytes: Buffer) => string;
   /** The backup root path, or null when nothing has been backed up this run. */
   backupsDirIfCreated: () => string | null;
   renameManagedDir: typeof renameSync;
   beforeManagedDirPromotion?: (destDir: string) => void;
   beforeManagedDirPublish?: (destDir: string) => void;
   beforeManagedDirRemoval?: (destDir: string, stage: 'before-park' | 'before-delete') => void;
+  beforeAgentFileMutation?: AgentSyncOptions['beforeAgentFileMutation'];
+  beforeAgentManifestCommit?: AgentSyncOptions['beforeAgentManifestCommit'];
 }
 
 interface SourceSkill {
@@ -256,6 +353,18 @@ interface SkillOutcome {
   action: SkillAction;
   detail?: string;
 }
+
+interface SourceAgentFile {
+  name: string;
+  path: string;
+}
+
+export type AgentPathSnapshot =
+  | { kind: 'absent' }
+  | { kind: 'file'; stat: Stats; bytes: Buffer; digest: string }
+  | { kind: 'directory'; stat: Stats; digest: string }
+  | { kind: 'symlink'; stat: Stats; target: string }
+  | { kind: 'other'; stat: Stats };
 
 // ============================================================================
 // Source resolution
@@ -439,6 +548,10 @@ function hashFile(path: string): string {
   return createHash('sha256').update(readFileSync(path)).digest('hex');
 }
 
+export function computeFileDigest(path: string): string {
+  return hashFile(path);
+}
+
 // ============================================================================
 // Manifest + atomic managed-dir writes
 // ============================================================================
@@ -474,6 +587,323 @@ function readManifest(dir: string): { manifest: SyncManifest; fileDigest: string
 
 function writeManifest(dir: string, manifest: SyncManifest): void {
   writeFileSync(join(dir, MANIFEST_NAME), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+}
+
+/**
+ * Read the shared per-file Claude agent manifest. A malformed entry invalidates
+ * the whole ownership claim: callers then treat every target as unmanaged,
+ * which biases corrupt-state recovery toward backup/adoption instead of loss.
+ */
+export function readAgentFilesManifest(dir: string): AgentFilesManifest | null {
+  const state = inspectAgentFilesManifest(dir);
+  return state.kind === 'managed' ? state.manifest : null;
+}
+
+function inspectAgentFilesManifest(dir: string): AgentManifestState {
+  const path = join(dir, MANIFEST_NAME);
+  let stat: Stats;
+  try {
+    stat = lstatSync(path);
+  } catch (error) {
+    if (isNodeErrorCode(error, 'ENOENT')) return { kind: 'absent', path };
+    return { kind: 'unsafe', path, reason: `cannot inspect it: ${errMsg(error)}` };
+  }
+  if (stat.isSymbolicLink()) return { kind: 'unsafe', path, reason: 'it is a symlink' };
+  if (!stat.isFile()) return { kind: 'unsafe', path, reason: 'it is not a regular file' };
+  if (stat.nlink !== 1) return { kind: 'unsafe', path, reason: `it has ${stat.nlink} hard links` };
+
+  let bytes: Buffer;
+  try {
+    bytes = readFileSync(path);
+  } catch (error) {
+    return { kind: 'unsafe', path, reason: `cannot read it: ${errMsg(error)}` };
+  }
+  const manifest = parseAgentFilesManifest(bytes);
+  if (manifest === null) return { kind: 'foreign', path, bytes, stat, manifest: null };
+  return { kind: 'managed', path, bytes, stat, manifest };
+}
+
+function parseAgentFilesManifest(bytes: Buffer): AgentFilesManifest | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(bytes.toString('utf8'));
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return null;
+  const record = parsed as Record<string, unknown>;
+  if (record.managedBy !== MANAGED_BY) return null;
+  if (typeof record.files !== 'object' || record.files === null || Array.isArray(record.files)) return null;
+
+  const files: Record<string, AgentFileManifestEntry> = {};
+  for (const [name, rawEntry] of Object.entries(record.files)) {
+    if (!isFlatAgentFilename(name)) return null;
+    if (typeof rawEntry !== 'object' || rawEntry === null || Array.isArray(rawEntry)) return null;
+    const entry = rawEntry as Record<string, unknown>;
+    if (typeof entry.digest !== 'string') return null;
+    files[name] = {
+      digest: entry.digest,
+      version: typeof entry.version === 'string' ? entry.version : null,
+      syncedAt: typeof entry.syncedAt === 'string' ? entry.syncedAt : '',
+    };
+  }
+  return { managedBy: MANAGED_BY, files };
+}
+
+/**
+ * CAS predicate for the manifest commit: the captured object must still be the
+ * exact regular file (identity + bytes) the transaction inspected at its start.
+ */
+function manifestStillBase(path: string, base: AgentManifestState): boolean {
+  if (base.kind !== 'managed' && base.kind !== 'foreign') return false;
+  const current = inspectManifestPath(path);
+  return current !== null && sameManifestFile(base, current);
+}
+
+function inspectManifestPath(path: string): SafeManifestFile | null {
+  try {
+    const stat = lstatSync(path);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1) return null;
+    const bytes = readFileSync(path);
+    const manifest = parseAgentFilesManifest(bytes);
+    return manifest === null
+      ? { kind: 'foreign', path, bytes, stat, manifest: null }
+      : { kind: 'managed', path, bytes, stat, manifest };
+  } catch {
+    return null;
+  }
+}
+
+function sameManifestFile(expected: SafeManifestFile, current: SafeManifestFile): boolean {
+  return (
+    expected.stat.dev === current.stat.dev &&
+    expected.stat.ino === current.stat.ino &&
+    expected.stat.nlink === current.stat.nlink &&
+    expected.bytes.equals(current.bytes)
+  );
+}
+
+function writeExclusiveFile(path: string, content: Buffer): void {
+  const fd = openSync(path, 'wx');
+  const identity = fstatSync(fd);
+  let complete = false;
+  try {
+    writeFileSync(fd, content);
+    fsyncSync(fd);
+    complete = true;
+  } finally {
+    closeSync(fd);
+    if (!complete) cleanupFailedExclusiveWrite(path, identity);
+  }
+}
+
+function cleanupFailedExclusiveWrite(path: string, expected: Stats): void {
+  const captured = capturePath(path, 'write-cleanup');
+  if (captured === null) return;
+  const current = lstatSafe(captured.path);
+  if (current !== null && sameObjectIdentity(expected, current)) removeCapturedPath(captured);
+  else restoreOrPreserveCaptured(captured, path);
+}
+
+/**
+ * One staged payload in a uniquely and exclusively allocated sibling directory.
+ * Crashed-run debris is never reused or removed, so it cannot wedge a retry.
+ */
+interface FileStage {
+  dir: string;
+  path: string;
+  stat: Stats;
+  bytes: Buffer;
+}
+
+function createFileStage(targetPath: string, content: Buffer): FileStage {
+  const stageDir = mkdtempSync(join(dirname(targetPath), `.${basename(targetPath)}${STAGING_SUFFIX}-`));
+  const stagePath = join(stageDir, 'payload');
+  try {
+    writeExclusiveFile(stagePath, content);
+  } catch (error) {
+    removeEmptyDirSafe(stageDir);
+    throw error;
+  }
+  return { dir: stageDir, path: stagePath, stat: lstatSync(stagePath), bytes: content };
+}
+
+/** The staged payload is still the exact object this run wrote (identity + bytes). */
+function fileStageOwned(stage: FileStage): boolean {
+  try {
+    const stat = lstatSync(stage.path);
+    return stat.isFile() && sameObjectIdentity(stage.stat, stat) && readFileSync(stage.path).equals(stage.bytes);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Failure-path stage disposal: our own payload is removed; a payload someone
+ * replaced is preserved byte-for-byte and reported, never discarded.
+ */
+function cleanupFileStage(stage: FileStage): string | null {
+  if (fileStageOwned(stage)) {
+    try {
+      unlinkSync(stage.path);
+    } catch (error) {
+      if (!isNodeErrorCode(error, 'ENOENT')) {
+        removeEmptyDirSafe(stage.dir);
+        return `could not remove staged payload ${stage.path}: ${errMsg(error)}`;
+      }
+    }
+    removeEmptyDirSafe(stage.dir);
+    return null;
+  }
+  if (lstatSafe(stage.path) === null) {
+    removeEmptyDirSafe(stage.dir);
+    return null;
+  }
+  return `preserved replaced staged payload at ${stage.path}`;
+}
+
+/**
+ * Success-path stage disposal after a link-publish: the stage name is only an
+ * extra name for the now-live inode, so dropping it can never discard bytes.
+ */
+function consumeFileStageName(stage: FileStage): string | null {
+  try {
+    unlinkSync(stage.path);
+  } catch (error) {
+    if (!isNodeErrorCode(error, 'ENOENT')) return `could not remove staged name ${stage.path}: ${errMsg(error)}`;
+  }
+  removeEmptyDirSafe(stage.dir);
+  return null;
+}
+
+function removeEmptyDirSafe(path: string): void {
+  try {
+    rmdirSync(path);
+  } catch (error) {
+    if (
+      !isNodeErrorCode(error, 'ENOENT') &&
+      !isNodeErrorCode(error, 'ENOTEMPTY') &&
+      !isNodeErrorCode(error, 'EEXIST')
+    ) {
+      throw error;
+    }
+  }
+}
+
+interface CapturedPath {
+  dir: string;
+  path: string;
+}
+
+/** Atomically move the current pathname into a fresh attempt-owned directory. */
+function capturePath(path: string, label: string): CapturedPath | null {
+  const captureDir = mkdtempSync(join(dirname(path), `.${basename(path)}.${label}-`));
+  const capturedPath = join(captureDir, 'object');
+  try {
+    renameSync(path, capturedPath);
+    return { dir: captureDir, path: capturedPath };
+  } catch (error) {
+    removeEmptyDirSafe(captureDir);
+    if (isNodeErrorCode(error, 'ENOENT')) return null;
+    throw error;
+  }
+}
+
+/** Restore a captured file/symlink without replacing anything that appeared meanwhile. */
+function restoreCapturedPathNoReplace(capturedPath: string, originalPath: string): boolean {
+  const stat = lstatSync(capturedPath);
+  try {
+    if (stat.isFile()) {
+      linkSync(capturedPath, originalPath);
+      unlinkSync(capturedPath);
+      return true;
+    }
+    if (stat.isSymbolicLink()) {
+      symlinkSync(readlinkSync(capturedPath), originalPath);
+      unlinkSync(capturedPath);
+      return true;
+    }
+    return false;
+  } catch (error) {
+    if (isNodeErrorCode(error, 'EEXIST')) return false;
+    throw error;
+  }
+}
+
+/** Prefer restoring the original pathname; otherwise leave the object safely quarantined. */
+function restoreOrPreserveCaptured(captured: CapturedPath, originalPath: string): string | null {
+  if (restoreCapturedPathNoReplace(captured.path, originalPath)) {
+    removeEmptyDirSafe(captured.dir);
+    return originalPath;
+  }
+  return captured.path;
+}
+
+function removeCapturedPath(captured: CapturedPath): void {
+  const stat = lstatSafe(captured.path);
+  if (stat?.isDirectory()) rmSync(captured.path, { recursive: true, force: true });
+  else if (stat !== null) unlinkSync(captured.path);
+  removeEmptyDirSafe(captured.dir);
+}
+
+function sameObjectIdentity(expected: Stats, current: Stats): boolean {
+  return expected.dev === current.dev && expected.ino === current.ino && expected.mode === current.mode;
+}
+
+function isFlatAgentFilename(name: string): boolean {
+  return name === basename(name) && name.endsWith('.md') && name !== '.' && name !== '..';
+}
+
+/**
+ * Park a captured object at an exclusively allocated `<target>.genie-kept[-…]`
+ * sibling so the runtime stops loading it while the bytes stay visible on disk.
+ * Type-aware (file / symlink / directory); collisions advance to a timestamped
+ * candidate, never overwrite. Returns the kept path, or null when the object
+ * could not be parked and remains quarantined at `captured.path`.
+ */
+function keepAsideCaptured(captured: CapturedPath, targetPath: string, now: () => Date): string | null {
+  const base = `${targetPath}${KEPT_SUFFIX}`;
+  const timestamp = now().getTime();
+  const stat = lstatSafe(captured.path);
+  if (stat === null) {
+    removeEmptyDirSafe(captured.dir);
+    return null;
+  }
+  for (let collision = 0; collision < 10_000; collision += 1) {
+    const candidate =
+      collision === 0 ? base : collision === 1 ? `${base}-${timestamp}` : `${base}-${timestamp}-${collision - 1}`;
+    if (tryParkCapturedAt(captured.path, candidate, stat)) {
+      removeEmptyDirSafe(captured.dir);
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/** Exclusive no-replace park of one captured object; false only on candidate collision. */
+function tryParkCapturedAt(capturedPath: string, candidate: string, stat: Stats): boolean {
+  try {
+    if (stat.isFile()) {
+      linkSync(capturedPath, candidate);
+      unlinkSync(capturedPath);
+      return true;
+    }
+    if (stat.isSymbolicLink()) {
+      symlinkSync(readlinkSync(capturedPath), candidate);
+      unlinkSync(capturedPath);
+      return true;
+    }
+    if (stat.isDirectory()) {
+      mkdirSync(candidate, { mode: stat.mode & 0o777 });
+      for (const name of readdirSync(capturedPath)) renameSync(join(capturedPath, name), join(candidate, name));
+      rmdirSync(capturedPath);
+      return true;
+    }
+    throw new Error(`cannot safely keep non-regular agent path ${candidate}`);
+  } catch (error) {
+    if (isNodeErrorCode(error, 'EEXIST')) return false;
+    throw error;
+  }
 }
 
 function buildManifest(ctx: RunContext, digest: string): SyncManifest {
@@ -528,6 +958,10 @@ export function publishRegularFileNoClobber(stagedPath: string, targetPath: stri
   } finally {
     rmSync(candidate, { force: true });
   }
+}
+
+function buildAgentFileManifestEntry(ctx: RunContext, digest: string): AgentFileManifestEntry {
+  return { version: ctx.version, digest, syncedAt: ctx.now().toISOString() };
 }
 
 /**
@@ -2242,16 +2676,16 @@ function retirementLockWaitMs(): number {
 }
 
 /**
- * Bounded-blocking wrapper over the whole tested {@link acquireSyncLock}
+ * Bounded-blocking wrapper over the whole tested {@link acquireFileLock}
  * (reuses its O_EXCL create, pid + process-start-identity liveness, staleness,
  * and guard-file stealing verbatim). A stale/dead holder is stolen inside
- * `acquireSyncLock`; a live holder is retried until the deadline, then this
+ * `acquireFileLock`; a live holder is retried until the deadline, then this
  * fails closed having mutated nothing on disk.
  */
 function acquireRetirementLock(lockPath: string): { release: () => void } {
   const deadline = Date.now() + retirementLockWaitMs();
   for (;;) {
-    const lock = acquireSyncLock(lockPath);
+    const lock = acquireFileLock(lockPath);
     if (!('skipped' in lock)) return lock;
     if (Date.now() >= deadline) {
       throw new Error(`fallback retirement lock contended; no data changed: ${lockPath}`);
@@ -2863,7 +3297,883 @@ function removeManagedOrphans(
 }
 
 // ============================================================================
-// Workflow stamp (output parity-locked to council-stamp.cjs)
+// Claude agent enumeration + per-file policy
+// ============================================================================
+
+/** Source agents are flat Markdown files directly under `<pluginRoot>/agents`. */
+function enumerateSourceAgentFiles(pluginRoot: string): SourceAgentFile[] {
+  const agentsRoot = join(pluginRoot, 'agents');
+  if (!existsSync(agentsRoot)) return [];
+  return readdirSync(agentsRoot, { withFileTypes: true })
+    .filter((entry) => isFlatAgentFilename(entry.name) && classifyEntry(join(agentsRoot, entry.name), entry) === 'file')
+    .map((entry) => ({ name: entry.name, path: join(agentsRoot, entry.name) }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+// ============================================================================
+// Flat-agent transaction core
+//
+// One clearly-bounded transaction per target dir:
+//   capture → validate → publish → manifest CAS (single commit) → finalize/rollback
+// Sync and uninstall both run through {@link runFlatAgentTransaction} while
+// holding the shared per-GENIE_HOME lock, so the core only defends against
+// non-genie writers. Invariants closed by construction:
+//   - every irreversible unlink re-verifies the exact captured identity first;
+//   - ownership moves in ONE manifest commit whose claim set is re-verified
+//     against the live objects after the commit barrier;
+//   - the manifest publishes by rename of an exclusively staged payload, so a
+//     second hardlink to the manifest can never exist and post-publish cleanup
+//     is rmdir-only — advisory, never a rollback trigger;
+//   - final-entry relinquish verifies post-state before reporting success.
+// ============================================================================
+
+/** One planned mutation of a flat agent name inside a single transaction. */
+export type FlatAgentOp =
+  | {
+      kind: 'publish';
+      name: string;
+      payload: Buffer;
+      entry: AgentFileManifestEntry;
+      /** Live-path snapshot the policy decision validated; the publish CAS target. */
+      expected: AgentPathSnapshot;
+      action: 'created' | 'updated' | 'adopted';
+      backupPath?: string;
+    }
+  | {
+      kind: 'retire';
+      name: string;
+      expected: AgentPathSnapshot;
+      /** Base-manifest digest this op assumes; ownership drift aborts the op. */
+      ownedDigest: string;
+      disposal: 'discard' | 'keep-aside';
+      operation: 'remove' | 'keep';
+      backupPath?: string;
+    }
+  | { kind: 'disown'; name: string; ownedDigest: string; prune: boolean };
+
+export type FlatAgentConflict = 'changed-before-capture' | 'replaced-before-publish' | 'replaced-before-commit';
+
+export interface FlatAgentOutcome {
+  op: FlatAgentOp;
+  /**
+   * applied — mutation performed and its ownership delta committed;
+   * conflict — a non-genie writer won the pathname: the foreign object stays
+   *            live and unowned, prior managed bytes stay visible;
+   * stale   — ownership/classification drifted before mutation; nothing changed;
+   * failed  — an exception fired; the live path was restored or kept visible.
+   */
+  status: 'applied' | 'conflict' | 'stale' | 'failed';
+  conflict?: FlatAgentConflict;
+  reason?: string;
+  /** Where prior bytes were preserved when the disposal was keep-aside. */
+  keptPath?: string;
+}
+
+export interface FlatAgentTransactionResult {
+  /**
+   * False when a required manifest commit did not happen: every op carrying an
+   * ownership delta was rolled back and must not be reported as performed.
+   */
+  committed: boolean;
+  outcomes: FlatAgentOutcome[];
+  advisories: string[];
+}
+
+export interface FlatAgentTransactionSeams {
+  now: () => Date;
+  beforeFileMutation?: (event: AgentFileMutationEvent) => void;
+  beforeManifestCommit?: (event: AgentManifestCommitEvent) => void;
+}
+
+interface FlatAgentTxnCtx {
+  dir: string;
+  baseFiles: Record<string, AgentFileManifestEntry>;
+  seams: FlatAgentTransactionSeams;
+  advisories: string[];
+}
+
+interface FlatAgentOpState {
+  op: FlatAgentOp;
+  status: FlatAgentOutcome['status'];
+  conflict?: FlatAgentConflict;
+  reason?: string;
+  captured: CapturedPath | null;
+  published: AgentPathSnapshot | null;
+  delta: 'set' | 'delete' | null;
+  keptPath?: string;
+}
+
+/**
+ * Execute one batch of flat-agent ops against `dir` and its shared manifest.
+ * The base manifest is inspected once; every mutation CASes against the exact
+ * object it validated; ownership moves in ONE commit; commit failure rolls the
+ * data phase back. Callers translate outcomes into their own report shape.
+ */
+export function runFlatAgentTransaction(
+  dir: string,
+  ops: FlatAgentOp[],
+  seams: FlatAgentTransactionSeams,
+): FlatAgentTransactionResult {
+  const base = inspectAgentFilesManifest(dir);
+  if (base.kind === 'unsafe') {
+    return {
+      committed: false,
+      advisories: [`agent manifest ${base.path} is unsafe (${base.reason}); left untouched`],
+      outcomes: ops.map((op) => ({ op, status: 'stale', reason: 'manifest unsafe' })),
+    };
+  }
+  const ctx: FlatAgentTxnCtx = {
+    dir,
+    baseFiles: base.kind === 'managed' ? base.manifest.files : {},
+    seams,
+    advisories: [],
+  };
+  const states = ops.map((op) => executeFlatAgentOp(ctx, op));
+  let committed: boolean;
+  try {
+    committed = commitFlatAgentManifest(ctx, base, states);
+  } catch (error) {
+    // An unexpected commit exception is a failed commit, never a stranded batch.
+    ctx.advisories.push(`agent manifest ${join(dir, MANIFEST_NAME)} commit failed: ${errMsg(error)}`);
+    committed = false;
+  }
+  if (committed) finalizeFlatAgentOps(ctx, states);
+  else rollbackFlatAgentOps(ctx, states);
+  return {
+    committed,
+    advisories: ctx.advisories,
+    outcomes: states.map((state) => ({
+      op: state.op,
+      status: state.status,
+      conflict: state.conflict,
+      reason: state.reason,
+      keptPath: state.keptPath,
+    })),
+  };
+}
+
+// ---- file phase ------------------------------------------------------------
+
+function executeFlatAgentOp(ctx: FlatAgentTxnCtx, op: FlatAgentOp): FlatAgentOpState {
+  const state: FlatAgentOpState = { op, status: 'applied', captured: null, published: null, delta: null };
+  if (op.kind !== 'publish' && ctx.baseFiles[op.name]?.digest !== op.ownedDigest) {
+    state.status = 'stale';
+    state.reason = 'manifest ownership changed before staging';
+    return state;
+  }
+  try {
+    if (op.kind === 'publish') executePublishOp(ctx, op, state);
+    else if (op.kind === 'retire') executeRetireOp(ctx, op, state);
+    else executeDisownOp(ctx, op, state);
+  } catch (error) {
+    state.status = 'failed';
+    state.reason = state.reason ?? errMsg(error);
+    quarantinedCapturedToKeepAside(ctx, state);
+  }
+  return state;
+}
+
+/** Last-resort failure handling: captured bytes must never stay hidden in quarantine. */
+function quarantinedCapturedToKeepAside(ctx: FlatAgentTxnCtx, state: FlatAgentOpState): void {
+  const captured = state.captured;
+  if (captured === null) return;
+  state.captured = null;
+  const targetPath = join(ctx.dir, state.op.name);
+  try {
+    const kept = keepAsideCaptured(captured, targetPath, ctx.seams.now);
+    state.keptPath = kept ?? undefined;
+    ctx.advisories.push(`preserved prior agent bytes at ${kept ?? captured.path}`);
+  } catch (error) {
+    ctx.advisories.push(`prior agent bytes for ${targetPath} left quarantined at ${captured.path}: ${errMsg(error)}`);
+  }
+}
+
+function executePublishOp(
+  ctx: FlatAgentTxnCtx,
+  op: Extract<FlatAgentOp, { kind: 'publish' }>,
+  state: FlatAgentOpState,
+): void {
+  const targetPath = join(ctx.dir, op.name);
+  const stage = createFileStage(targetPath, op.payload);
+  try {
+    if (op.expected.kind !== 'absent' && captureValidatedTarget(ctx, op, state, 'agent-old') !== 'captured') {
+      markConflict(ctx, state, 'changed-before-capture');
+      pushAdvisory(ctx, cleanupFileStage(stage));
+      return;
+    }
+    ctx.seams.beforeFileMutation?.({ operation: 'replace', path: targetPath, backupPath: op.backupPath });
+    if (!fileStageOwned(stage)) throw new Error(`staged payload changed: ${stage.path}`);
+    try {
+      linkSync(stage.path, targetPath);
+    } catch (error) {
+      if (!isNodeErrorCode(error, 'EEXIST')) throw error;
+      markConflict(ctx, state, 'replaced-before-publish');
+      pushAdvisory(ctx, cleanupFileStage(stage));
+      return;
+    }
+    pushAdvisory(ctx, consumeFileStageName(stage));
+    state.published = captureAgentPathSnapshot(targetPath);
+    state.delta = 'set';
+  } catch (error) {
+    restoreCapturedAfterFailure(ctx, state, targetPath);
+    pushAdvisory(ctx, cleanupFileStage(stage));
+    state.status = 'failed';
+    state.reason = errMsg(error);
+  }
+}
+
+function executeRetireOp(
+  ctx: FlatAgentTxnCtx,
+  op: Extract<FlatAgentOp, { kind: 'retire' }>,
+  state: FlatAgentOpState,
+): void {
+  const targetPath = join(ctx.dir, op.name);
+  const capture = captureValidatedTarget(ctx, op, state, 'agent-retire');
+  if (capture === 'conflict') {
+    markConflict(ctx, state, 'changed-before-capture');
+    return;
+  }
+  if (capture === 'captured') {
+    try {
+      ctx.seams.beforeFileMutation?.({ operation: op.operation, path: targetPath, backupPath: op.backupPath });
+    } catch (error) {
+      restoreCapturedAfterFailure(ctx, state, targetPath);
+      state.status = 'failed';
+      state.reason = errMsg(error);
+      return;
+    }
+  }
+  state.delta = 'delete';
+}
+
+function executeDisownOp(
+  ctx: FlatAgentTxnCtx,
+  op: Extract<FlatAgentOp, { kind: 'disown' }>,
+  state: FlatAgentOpState,
+): void {
+  if (op.prune) {
+    const targetPath = join(ctx.dir, op.name);
+    ctx.seams.beforeFileMutation?.({ operation: 'prune', path: targetPath });
+    if (lstatSafe(targetPath) !== null) {
+      state.status = 'stale';
+      state.reason = 'it appeared after classification';
+      return;
+    }
+  }
+  state.delta = 'delete';
+}
+
+/**
+ * Atomically capture the live object and verify it is exactly the validated
+ * snapshot. On mismatch the concurrent object is restored (or quarantined
+ * visibly) and the caller records a conflict; on absence nothing is captured.
+ */
+function captureValidatedTarget(
+  ctx: FlatAgentTxnCtx,
+  op: Extract<FlatAgentOp, { kind: 'publish' | 'retire' }>,
+  state: FlatAgentOpState,
+  label: string,
+): 'captured' | 'absent' | 'conflict' {
+  const targetPath = join(ctx.dir, op.name);
+  const captured = capturePath(targetPath, label);
+  if (captured === null) return 'absent';
+  if (agentPathSnapshotMatches(captured.path, op.expected)) {
+    state.captured = captured;
+    return 'captured';
+  }
+  try {
+    if (restoreCapturedPathNoReplace(captured.path, targetPath)) {
+      removeEmptyDirSafe(captured.dir);
+    } else {
+      const kept = keepAsideCaptured(captured, targetPath, ctx.seams.now);
+      ctx.advisories.push(`preserved concurrently changed agent at ${kept ?? captured.path}`);
+    }
+  } catch (error) {
+    ctx.advisories.push(`concurrently changed agent left quarantined at ${captured.path}: ${errMsg(error)}`);
+  }
+  return 'conflict';
+}
+
+/** A conflict relinquishes any base ownership of the name; the foreign object is never claimed. */
+function markConflict(ctx: FlatAgentTxnCtx, state: FlatAgentOpState, conflict: FlatAgentConflict): void {
+  state.status = 'conflict';
+  state.conflict = conflict;
+  state.delta = ctx.baseFiles[state.op.name] === undefined ? null : 'delete';
+}
+
+/** Failure path: the live pathname is restored, or the bytes stay visible at a kept path. */
+function restoreCapturedAfterFailure(ctx: FlatAgentTxnCtx, state: FlatAgentOpState, targetPath: string): void {
+  const captured = state.captured;
+  if (captured === null) return;
+  state.captured = null;
+  try {
+    restoreCapturedForFailure(ctx, state, captured, targetPath);
+  } catch (error) {
+    ctx.advisories.push(`prior agent bytes for ${targetPath} left quarantined at ${captured.path}: ${errMsg(error)}`);
+  }
+}
+
+function restoreCapturedForFailure(
+  ctx: FlatAgentTxnCtx,
+  state: FlatAgentOpState,
+  captured: CapturedPath,
+  targetPath: string,
+): void {
+  if (restoreCapturedPathNoReplace(captured.path, targetPath)) {
+    removeEmptyDirSafe(captured.dir);
+    return;
+  }
+  const kept = keepAsideCaptured(captured, targetPath, ctx.seams.now);
+  state.keptPath = kept ?? undefined;
+  ctx.advisories.push(`preserved prior agent bytes at ${kept ?? captured.path}`);
+}
+
+function pushAdvisory(ctx: FlatAgentTxnCtx, advisory: string | null): void {
+  if (advisory !== null) ctx.advisories.push(advisory);
+}
+
+// ---- commit phase ----------------------------------------------------------
+
+/**
+ * Re-verify, immediately before ownership moves, that every published object is
+ * still the exact one this transaction created and every retired pathname is
+ * still free. A non-genie writer that raced the gap demotes the op to a
+ * conflict: the foreign object stays live and unowned.
+ */
+function reverifyFlatAgentOps(ctx: FlatAgentTxnCtx, states: FlatAgentOpState[]): void {
+  for (const state of states) {
+    if (state.status !== 'applied') continue;
+    const targetPath = join(ctx.dir, state.op.name);
+    if (state.published !== null) {
+      if (!agentPathSnapshotMatches(targetPath, state.published)) {
+        state.published = null;
+        markConflict(ctx, state, 'replaced-before-commit');
+      }
+    } else if (state.op.kind === 'retire' && lstatSafe(targetPath) !== null) {
+      // The delta stays 'delete': ownership of the foreign replacement is relinquished.
+      state.status = 'conflict';
+      state.conflict = 'replaced-before-commit';
+    }
+  }
+}
+
+function buildFlatAgentClaim(ctx: FlatAgentTxnCtx, states: FlatAgentOpState[]): Record<string, AgentFileManifestEntry> {
+  const files: Record<string, AgentFileManifestEntry> = { ...ctx.baseFiles };
+  for (const state of states) {
+    if (state.delta === null) continue;
+    if (state.delta === 'set' && state.op.kind === 'publish') files[state.op.name] = state.op.entry;
+    else delete files[state.op.name];
+  }
+  return files;
+}
+
+function manifestPayload(files: Record<string, AgentFileManifestEntry>): Buffer {
+  const manifest: AgentFilesManifest = { managedBy: MANAGED_BY, files };
+  return Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+}
+
+interface ManifestCommitResult {
+  committed: boolean;
+  reason?: string;
+}
+
+/** The single ownership commit; false means every ownership delta must roll back. */
+function commitFlatAgentManifest(ctx: FlatAgentTxnCtx, base: AgentManifestState, states: FlatAgentOpState[]): boolean {
+  if (!states.some((state) => state.delta !== null)) return true;
+  const provisional = buildFlatAgentClaim(ctx, states);
+  const result =
+    Object.keys(provisional).length > 0
+      ? commitFlatAgentManifestWrite(ctx, base, states, provisional)
+      : commitFlatAgentManifestRemoval(ctx, base, states);
+  if (!result.committed) {
+    ctx.advisories.push(`agent manifest ${join(ctx.dir, MANIFEST_NAME)} commit failed: ${result.reason}`);
+  }
+  return result.committed;
+}
+
+/**
+ * Write path: stage exclusively → barrier → re-verify live objects → CAS the
+ * base manifest out of the way → RENAME the payload in. The rename both decides
+ * the outcome and consumes the staged payload, so no second hardlink to the
+ * manifest can ever exist; everything after it is advisory-only.
+ */
+function commitFlatAgentManifestWrite(
+  ctx: FlatAgentTxnCtx,
+  base: AgentManifestState,
+  states: FlatAgentOpState[],
+  provisional: Record<string, AgentFileManifestEntry>,
+): ManifestCommitResult {
+  const manifestPath = join(ctx.dir, MANIFEST_NAME);
+  let stage = createFileStage(manifestPath, manifestPayload(provisional));
+  try {
+    ctx.seams.beforeManifestCommit?.({ path: manifestPath, stagePath: stage.path });
+  } catch (error) {
+    pushAdvisory(ctx, cleanupFileStage(stage));
+    return { committed: false, reason: errMsg(error) };
+  }
+  if (!fileStageOwned(stage)) {
+    pushAdvisory(ctx, cleanupFileStage(stage));
+    return { committed: false, reason: 'staged manifest payload changed before commit' };
+  }
+  reverifyFlatAgentOps(ctx, states);
+  const claim = buildFlatAgentClaim(ctx, states);
+  if (Object.keys(claim).length === 0) {
+    // every remaining claim was demoted at the barrier — fall back to removal
+    pushAdvisory(ctx, cleanupFileStage(stage));
+    if (base.kind === 'absent') return { committed: true };
+    return removeBaseManifestExact(ctx, base, manifestPath, false);
+  }
+  const payload = manifestPayload(claim);
+  if (!payload.equals(stage.bytes)) {
+    pushAdvisory(ctx, cleanupFileStage(stage));
+    stage = createFileStage(manifestPath, payload);
+  }
+  let captured: CapturedPath | null = null;
+  if (base.kind !== 'absent') {
+    captured = capturePath(manifestPath, 'manifest-old');
+    if (captured === null || !manifestStillBase(captured.path, base)) {
+      if (captured !== null) restorePreviousManifest(ctx, captured, manifestPath);
+      pushAdvisory(ctx, cleanupFileStage(stage));
+      return { committed: false, reason: 'manifest ownership changed before commit' };
+    }
+  }
+  try {
+    renameSync(stage.path, manifestPath);
+  } catch (error) {
+    if (captured !== null) restorePreviousManifest(ctx, captured, manifestPath);
+    pushAdvisory(ctx, cleanupFileStage(stage));
+    return { committed: false, reason: errMsg(error) };
+  }
+  // Outcome decided at the rename. Nothing below may throw or roll back.
+  if (captured !== null) {
+    try {
+      removeCapturedPath(captured);
+    } catch (error) {
+      ctx.advisories.push(`previous manifest left quarantined at ${captured.path}: ${errMsg(error)}`);
+    }
+  }
+  try {
+    removeEmptyDirSafe(stage.dir);
+  } catch {
+    // empty-stage-dir debris is inert; the payload itself was consumed by the rename
+  }
+  return { committed: true };
+}
+
+/** Removal path: the transaction ends with zero owned names — the manifest itself goes. */
+function commitFlatAgentManifestRemoval(
+  ctx: FlatAgentTxnCtx,
+  base: AgentManifestState,
+  states: FlatAgentOpState[],
+): ManifestCommitResult {
+  reverifyFlatAgentOps(ctx, states);
+  if (base.kind === 'absent') return { committed: true };
+  return removeBaseManifestExact(ctx, base, join(ctx.dir, MANIFEST_NAME), true);
+}
+
+/**
+ * Remove the base manifest as the final ownership relinquish. The live pathname
+ * is re-checked before AND after the unlink: success is reported only when no
+ * manifest object exists there anymore, so a concurrently installed replacement
+ * can never ride a false-success relinquish.
+ */
+function removeBaseManifestExact(
+  ctx: FlatAgentTxnCtx,
+  base: AgentManifestState,
+  manifestPath: string,
+  fireBarrier: boolean,
+): ManifestCommitResult {
+  const captured = capturePath(manifestPath, 'manifest-remove');
+  if (fireBarrier) {
+    try {
+      ctx.seams.beforeManifestCommit?.({ path: manifestPath, stagePath: captured?.path ?? manifestPath });
+    } catch (error) {
+      if (captured !== null) restorePreviousManifest(ctx, captured, manifestPath);
+      return { committed: false, reason: errMsg(error) };
+    }
+  }
+  if (captured === null || !manifestStillBase(captured.path, base)) {
+    if (captured !== null) restorePreviousManifest(ctx, captured, manifestPath);
+    return { committed: false, reason: 'manifest ownership changed before commit' };
+  }
+  if (lstatSafe(manifestPath) !== null) {
+    restorePreviousManifest(ctx, captured, manifestPath);
+    return { committed: false, reason: 'manifest ownership changed before commit: a replacement manifest appeared' };
+  }
+  removeCapturedPath(captured);
+  if (lstatSafe(manifestPath) !== null) {
+    return { committed: false, reason: 'manifest ownership changed before commit: a replacement manifest appeared' };
+  }
+  return { committed: true };
+}
+
+function restorePreviousManifest(ctx: FlatAgentTxnCtx, captured: CapturedPath, manifestPath: string): void {
+  const preserved = restoreOrPreserveCaptured(captured, manifestPath);
+  if (preserved !== null && preserved !== manifestPath) {
+    ctx.advisories.push(`preserved previous manifest at ${preserved}`);
+  }
+}
+
+// ---- finalize / rollback ----------------------------------------------------
+
+/**
+ * Success path: dispose captured prior objects. Discard re-verifies the exact
+ * captured identity at the instant of unlink — bytes that changed after
+ * validation are parked visibly instead of being discarded.
+ */
+function finalizeFlatAgentOps(ctx: FlatAgentTxnCtx, states: FlatAgentOpState[]): void {
+  for (const state of states) {
+    const captured = state.captured;
+    if (captured === null) continue;
+    state.captured = null;
+    const targetPath = join(ctx.dir, state.op.name);
+    try {
+      finalizeCapturedDisposal(ctx, state, captured, targetPath);
+    } catch (error) {
+      // Disposal failure never fails the committed transaction or hides bytes.
+      ctx.advisories.push(`prior agent bytes for ${targetPath} left quarantined at ${captured.path}: ${errMsg(error)}`);
+    }
+  }
+}
+
+function finalizeCapturedDisposal(
+  ctx: FlatAgentTxnCtx,
+  state: FlatAgentOpState,
+  captured: CapturedPath,
+  targetPath: string,
+): void {
+  const keepAside = state.op.kind === 'retire' ? state.op.disposal === 'keep-aside' : state.status === 'conflict';
+  if (keepAside) {
+    const kept = keepAsideCaptured(captured, targetPath, ctx.seams.now);
+    state.keptPath = kept ?? undefined;
+    if (kept === null) ctx.advisories.push(`preserved prior agent bytes at ${captured.path}`);
+    return;
+  }
+  disposeCapturedExact(ctx, state, captured, targetPath);
+}
+
+function disposeCapturedExact(
+  ctx: FlatAgentTxnCtx,
+  state: FlatAgentOpState,
+  captured: CapturedPath,
+  targetPath: string,
+): void {
+  if (state.op.kind !== 'disown' && agentPathSnapshotMatches(captured.path, state.op.expected)) {
+    removeCapturedPath(captured);
+    return;
+  }
+  const kept = keepAsideCaptured(captured, targetPath, ctx.seams.now);
+  state.keptPath = kept ?? undefined;
+  ctx.advisories.push(
+    `agent bytes for ${targetPath} changed after validation; preserved at ${kept ?? captured.path} instead of discarding`,
+  );
+}
+
+/**
+ * Commit-failure path: every published object that is still exactly ours is
+ * un-published and the prior object restored; foreign objects that appeared
+ * meanwhile stay live while prior bytes are parked visibly.
+ */
+function rollbackFlatAgentOps(ctx: FlatAgentTxnCtx, states: FlatAgentOpState[]): void {
+  for (const state of [...states].reverse()) {
+    const targetPath = join(ctx.dir, state.op.name);
+    try {
+      rollbackFlatAgentOp(ctx, state, targetPath);
+    } catch (error) {
+      // A rollback failure on one name never strands the rest of the batch.
+      const captured = state.captured;
+      state.captured = null;
+      ctx.advisories.push(
+        `rollback for ${targetPath} incomplete${
+          captured === null ? '' : `; prior bytes quarantined at ${captured.path}`
+        }: ${errMsg(error)}`,
+      );
+    }
+  }
+}
+
+function rollbackFlatAgentOp(ctx: FlatAgentTxnCtx, state: FlatAgentOpState, targetPath: string): void {
+  if (state.published !== null) unpublishFlatAgent(ctx, state, targetPath);
+  const captured = state.captured;
+  if (captured === null) return;
+  state.captured = null;
+  try {
+    if (restoreCapturedPathNoReplace(captured.path, targetPath)) {
+      removeEmptyDirSafe(captured.dir);
+      return;
+    }
+    const kept = keepAsideCaptured(captured, targetPath, ctx.seams.now);
+    state.keptPath = kept ?? undefined;
+    ctx.advisories.push(`manifest commit failed; preserved prior managed agent at ${kept ?? captured.path}`);
+  } catch (error) {
+    ctx.advisories.push(`prior agent bytes for ${targetPath} left quarantined at ${captured.path}: ${errMsg(error)}`);
+  }
+}
+
+function unpublishFlatAgent(ctx: FlatAgentTxnCtx, state: FlatAgentOpState, targetPath: string): void {
+  const current = capturePath(targetPath, 'agent-rollback');
+  if (current === null) return;
+  if (state.published !== null && agentPathSnapshotMatches(current.path, state.published)) {
+    removeCapturedPath(current);
+    return;
+  }
+  const preserved = restoreOrPreserveCaptured(current, targetPath);
+  if (preserved !== null && preserved !== targetPath) {
+    ctx.advisories.push(`preserved concurrent agent replacement at ${preserved}`);
+  }
+}
+
+// ---- sync driver -----------------------------------------------------------
+
+/**
+ * Converge flat source agent files without replacing their shared parent dir.
+ * Only names in source or in the shared manifest are candidates for mutation;
+ * every unrelated sibling in `~/.claude/agents` remains invisible. All ops run
+ * in ONE transaction with a single ownership commit.
+ */
+function syncClaudeAgentFiles(ctx: RunContext, claudeDir: string, report: AgentReport): void {
+  const sourceAgents = enumerateSourceAgentFiles(ctx.pluginRoot);
+  const targetDir = join(claudeDir, 'agents');
+  const initialState = inspectAgentFilesManifest(targetDir);
+  if (initialState.kind === 'unsafe') {
+    report.advisories.push(`agent manifest ${initialState.path} is unsafe (${initialState.reason}); left untouched`);
+    return;
+  }
+  const existingManifest = initialState.kind === 'managed' ? initialState.manifest : null;
+  if (sourceAgents.length === 0 && existingManifest === null) return;
+
+  mkdirSync(targetDir, { recursive: true });
+  if (initialState.kind === 'foreign') {
+    const backup = ctx.backupBytes('claude', join('agents', MANIFEST_NAME), initialState.bytes);
+    report.advisories.push(`adopted foreign agent manifest after backing it up to ${backup}`);
+  }
+  const plan = buildClaudeAgentPlan(ctx, sourceAgents, targetDir, existingManifest?.files ?? {}, report);
+  if (plan.ops.length === 0) return;
+  const result = runFlatAgentTransaction(targetDir, plan.ops, {
+    now: ctx.now,
+    beforeFileMutation: ctx.beforeAgentFileMutation,
+    beforeManifestCommit: ctx.beforeAgentManifestCommit,
+  });
+  report.advisories.push(...result.advisories);
+  if (!result.committed) {
+    recordFailure(report, `claude agent transaction did not commit under ${targetDir}`);
+  }
+  reportClaudeAgentOutcomes(result, plan.orphanActions, report);
+}
+
+interface ClaudeAgentPlan {
+  ops: FlatAgentOp[];
+  /** Reporting action for each disown op: absent orphans read as removed. */
+  orphanActions: Map<string, 'removed' | 'kept-modified-orphan'>;
+}
+
+function buildClaudeAgentPlan(
+  ctx: RunContext,
+  sourceAgents: SourceAgentFile[],
+  targetDir: string,
+  baseFiles: Record<string, AgentFileManifestEntry>,
+  report: AgentReport,
+): ClaudeAgentPlan {
+  const ops: FlatAgentOp[] = [];
+  const orphanActions: ClaudeAgentPlan['orphanActions'] = new Map();
+  const sourceNames = new Set(sourceAgents.map((agent) => agent.name));
+  for (const source of sourceAgents) {
+    try {
+      const op = planAgentPublish(ctx, source, targetDir, baseFiles[source.name]);
+      if (op === 'unchanged') report.extras.push({ kind: 'agent', action: 'unchanged', detail: source.name });
+      else ops.push(op);
+    } catch (err) {
+      const failure = `agent ${source.name} (claude) failed: ${errMsg(err)}`;
+      report.advisories.push(failure);
+      recordFailure(report, failure);
+    }
+  }
+  for (const [name, entry] of Object.entries(baseFiles).sort(([a], [b]) => a.localeCompare(b))) {
+    if (sourceNames.has(name)) continue;
+    try {
+      ops.push(planAgentOrphan(ctx, targetDir, name, entry, orphanActions));
+    } catch (err) {
+      const failure = `agent orphan ${name} (claude) failed: ${errMsg(err)}`;
+      report.advisories.push(failure);
+      recordFailure(report, failure);
+    }
+  }
+  return { ops, orphanActions };
+}
+
+/**
+ * Per-file policy mirrors managed skill dirs without ever swapping the parent:
+ * missing creates; clean+same skips; clean+changed updates; anything else is
+ * backed up before adoption. The snapshot the policy validated is the exact
+ * CAS target of the later publish.
+ */
+function planAgentPublish(
+  ctx: RunContext,
+  source: SourceAgentFile,
+  targetDir: string,
+  entry: AgentFileManifestEntry | undefined,
+): FlatAgentOp | 'unchanged' {
+  // Read first: a source read failure must leave an existing target untouched.
+  const payload = readFileSync(source.path);
+  const sourceDigest = hashBytes(payload);
+  const targetPath = join(targetDir, source.name);
+  const expected = captureAgentPathSnapshot(targetPath);
+  const manifestEntry = buildAgentFileManifestEntry(ctx, sourceDigest);
+  if (expected.kind === 'absent') {
+    return { kind: 'publish', name: source.name, payload, entry: manifestEntry, expected, action: 'created' };
+  }
+  const targetDigest = expected.kind === 'file' ? expected.digest : null;
+  if (entry !== undefined && targetDigest === entry.digest) {
+    if (sourceDigest === entry.digest) return 'unchanged';
+    return { kind: 'publish', name: source.name, payload, entry: manifestEntry, expected, action: 'updated' };
+  }
+  const backupPath = backupAgentSnapshot(ctx, source.name, targetPath, expected);
+  return { kind: 'publish', name: source.name, payload, entry: manifestEntry, expected, action: 'adopted', backupPath };
+}
+
+/** Back up exactly the bytes the policy validated; non-file objects fall back to a path copy. */
+function backupAgentSnapshot(ctx: RunContext, name: string, targetPath: string, expected: AgentPathSnapshot): string {
+  if (expected.kind === 'file') return ctx.backupBytes('claude', join('agents', name), expected.bytes);
+  return ctx.backupInto('claude', join('agents', name), targetPath);
+}
+
+/**
+ * A source orphan is deleted only when its live regular-file bytes still match
+ * the entry that owns it. Modified/non-file targets stay byte-for-byte in place
+ * and only lose their manifest entry, relinquishing ownership.
+ */
+function planAgentOrphan(
+  ctx: RunContext,
+  targetDir: string,
+  name: string,
+  entry: AgentFileManifestEntry,
+  orphanActions: ClaudeAgentPlan['orphanActions'],
+): FlatAgentOp {
+  const targetPath = join(targetDir, name);
+  const expected = captureAgentPathSnapshot(targetPath);
+  if (expected.kind === 'file' && expected.digest === entry.digest) {
+    const backupPath = ctx.backupBytes('claude', join('agents', name), expected.bytes);
+    return {
+      kind: 'retire',
+      name,
+      expected,
+      ownedDigest: entry.digest,
+      disposal: 'discard',
+      operation: 'remove',
+      backupPath,
+    };
+  }
+  orphanActions.set(name, expected.kind === 'absent' ? 'removed' : 'kept-modified-orphan');
+  return { kind: 'disown', name, ownedDigest: entry.digest, prune: false };
+}
+
+function reportClaudeAgentOutcomes(
+  result: FlatAgentTransactionResult,
+  orphanActions: ClaudeAgentPlan['orphanActions'],
+  report: AgentReport,
+): void {
+  for (const outcome of result.outcomes) {
+    const name = outcome.op.name;
+    if (outcome.status === 'failed') {
+      const failure = `agent ${name} (claude) failed: ${outcome.reason ?? 'unknown failure'}`;
+      report.advisories.push(failure);
+      recordFailure(report, failure);
+      continue;
+    }
+    if (outcome.status === 'stale') {
+      report.advisories.push(`agent ${name} (claude) skipped: ${outcome.reason ?? 'stale classification'}`);
+      continue;
+    }
+    if (!result.committed) continue; // rolled back — nothing happened for this name
+    report.extras.push({ kind: 'agent', action: claudeAgentAction(outcome, orphanActions), detail: name });
+    pushClaudeAgentConflictAdvisories(outcome, report);
+    if (outcome.op.kind === 'disown' && orphanActions.get(name) === 'kept-modified-orphan') {
+      report.advisories.push(`kept modified orphan ${name} (claude agents); relinquished manifest ownership`);
+    }
+  }
+}
+
+function claudeAgentAction(outcome: FlatAgentOutcome, orphanActions: ClaudeAgentPlan['orphanActions']): SkillAction {
+  const { op, status } = outcome;
+  if (op.kind === 'publish') return status === 'applied' ? op.action : 'skipped-unmanaged-kept';
+  if (op.kind === 'retire') return status === 'applied' ? 'removed' : 'kept-modified-orphan';
+  return orphanActions.get(op.name) ?? 'removed';
+}
+
+function pushClaudeAgentConflictAdvisories(outcome: FlatAgentOutcome, report: AgentReport): void {
+  if (outcome.status !== 'conflict') return;
+  const name = outcome.op.name;
+  if (outcome.op.kind === 'publish') {
+    report.advisories.push(
+      `kept concurrently changed agent ${name} (claude agents); it was not published or claimed by the managed manifest`,
+    );
+    return;
+  }
+  report.advisories.push(
+    outcome.conflict === 'changed-before-capture'
+      ? `kept concurrently changed orphan ${name} (claude agents)`
+      : `kept concurrently changed orphan ${name} (claude agents); relinquished ownership`,
+  );
+}
+
+/**
+ * Type-aware stable snapshot of one live path: identity (dev/ino/mode/nlink)
+ * plus content (bytes / dir digest / symlink target). Exported: uninstall
+ * classification captures the exact snapshots its removal ops later CAS on.
+ */
+export function captureAgentPathSnapshot(path: string): AgentPathSnapshot {
+  let before: Stats;
+  try {
+    before = lstatSync(path);
+  } catch (error) {
+    if (isNodeErrorCode(error, 'ENOENT')) return { kind: 'absent' };
+    throw error;
+  }
+  if (before.isFile()) {
+    const bytes = readFileSync(path);
+    const after = lstatSync(path);
+    if (!samePathIdentity(before, after)) throw new Error(`agent path changed while reading ${path}`);
+    return { kind: 'file', stat: after, bytes, digest: hashBytes(bytes) };
+  }
+  if (before.isDirectory()) return { kind: 'directory', stat: before, digest: computeDirDigest(path) };
+  if (before.isSymbolicLink()) return { kind: 'symlink', stat: before, target: readlinkSync(path) };
+  return { kind: 'other', stat: before };
+}
+
+/** Any inspection failure reads as a mismatch, biasing every caller toward preservation. */
+function agentPathSnapshotMatches(path: string, expected: AgentPathSnapshot): boolean {
+  try {
+    return sameAgentPathSnapshot(expected, captureAgentPathSnapshot(path));
+  } catch {
+    return false;
+  }
+}
+
+function sameAgentPathSnapshot(expected: AgentPathSnapshot, current: AgentPathSnapshot): boolean {
+  if (expected.kind !== current.kind) return false;
+  if (expected.kind === 'absent' || current.kind === 'absent') return true;
+  if (!samePathIdentity(expected.stat, current.stat)) return false;
+  if (expected.kind === 'file' && current.kind === 'file') return expected.bytes.equals(current.bytes);
+  if (expected.kind === 'directory' && current.kind === 'directory') return expected.digest === current.digest;
+  if (expected.kind === 'symlink' && current.kind === 'symlink') return expected.target === current.target;
+  return true;
+}
+
+function samePathIdentity(expected: Stats, current: Stats): boolean {
+  return (
+    expected.dev === current.dev &&
+    expected.ino === current.ino &&
+    expected.mode === current.mode &&
+    expected.nlink === current.nlink
+  );
+}
+
+function hashBytes(bytes: Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+// ============================================================================
+// Workflow stamp (parity-locked to council-stamp.cjs)
 // ============================================================================
 
 export type ManagedWorkflowState = 'unmanaged' | 'managed-clean' | 'managed-modified' | 'corrupt-metadata';
@@ -3703,6 +5013,7 @@ function syncClaude(ctx: RunContext, report: AgentReport): void {
   if (!existsSync(claudeDir)) return;
   report.detected = true;
   syncSkillDirsInto(ctx, 'claude', join(claudeDir, 'skills'), report, CLAUDE_EXCLUDED_SKILLS);
+  syncClaudeAgentFiles(ctx, claudeDir, report);
   stampClaudeWorkflow(ctx, claudeDir, report);
 }
 
@@ -3934,9 +5245,9 @@ function detectHermesBinary(opts: AgentSyncOptions): string | null {
  * live. Stealing is serialized by another token-owned lock. Any other lock I/O
  * failure fails closed; a destructive sync never runs without ownership.
  */
-function acquireSyncLock(lockPath: string): { release: () => void } | { skipped: string } {
+function acquireFileLock(lockPath: string): { release: () => void } | { skipped: string } {
   for (let attempt = 0; attempt < 3; attempt += 1) {
-    const created = tryInitializeSyncLock(lockPath);
+    const created = tryInitializeFileLock(lockPath);
     if (created.status === 'acquired') return created.lock;
     if (created.status === 'failed') return { skipped: created.reason };
     const stat = statSafe(lockPath);
@@ -3945,7 +5256,7 @@ function acquireSyncLock(lockPath: string): { release: () => void } | { skipped:
     // Age alone never proves abandonment. A slow or clock-skewed live owner
     // retains the lock regardless of whether its timestamp is old or future.
     if (lockHasLiveOwner(lockPath)) return heldLockSkip();
-    if (stealStaleLock(lockPath) === 'contended') return heldLockSkip();
+    if (stealStaleFileLock(lockPath) === 'contended') return heldLockSkip();
     // stale debris cleared — loop and retry the exclusive create
   }
   return { skipped: 'agent-sync lock remained contended after retries; skipped safely' };
@@ -3956,7 +5267,7 @@ type LockCreateAttempt =
   | { status: 'exists' }
   | { status: 'failed'; reason: string };
 
-function tryInitializeSyncLock(lockPath: string): LockCreateAttempt {
+function tryInitializeFileLock(lockPath: string): LockCreateAttempt {
   let fd: number;
   const token = randomBytes(16).toString('hex');
   const processIdentity = processStartIdentity(process.pid) ?? 'unknown';
@@ -4012,14 +5323,23 @@ function isStaleOrInvalidLockTime(mtimeMs: number, nowMs = Date.now()): boolean 
  * `host` is absent (→ null) for any record written before this field existed or
  * by the shell installer; a null host is treated as "unknown host" downstream.
  */
-function lockOwner(lockPath: string): { pid: number; processIdentity: string | null; host: string | null } | null {
-  const raw = readTrimmed(lockPath);
+interface LockOwner {
+  pid: number;
+  processIdentity: string | null;
+  host: string | null;
+}
+
+function parseLockOwner(raw: string | null): LockOwner | null {
   const match = raw?.match(/^(\d+)(?::[a-f0-9]{32})?(?::([a-f0-9]{64}|unknown))?(?::([a-f0-9]{64}))?$/);
   if (!match) return null;
   const pid = Number(match[1]);
   return Number.isSafeInteger(pid) && pid > 0
     ? { pid, processIdentity: match[2] ?? null, host: match[3] ?? null }
     : null;
+}
+
+function lockOwner(lockPath: string): LockOwner | null {
+  return parseLockOwner(readTrimmed(lockPath));
 }
 
 /**
@@ -4046,7 +5366,10 @@ function lockOwner(lockPath: string): { pid: number; processIdentity: string | n
  * with the shell.
  */
 function lockHasLiveOwner(lockPath: string): boolean {
-  const owner = lockOwner(lockPath);
+  return lockOwnerIsLive(lockOwner(lockPath));
+}
+
+function lockOwnerIsLive(owner: LockOwner | null): boolean {
   if (owner === null) return false; // empty / unparseable record is genuine dead-writer debris
   if (owner.host !== null && owner.host !== currentSyncLockHostId()) return true; // host-bearing + cross-host → never steal
   try {
@@ -4175,7 +5498,7 @@ export function acquireLifecycleLease(genieHome = resolveGenieHome()): Lifecycle
       },
     };
   }
-  const acquired = acquireSyncLock(path);
+  const acquired = acquireFileLock(path);
   if ('skipped' in acquired) return acquired;
   const releaseOnExit = () => acquired.release();
   process.once('exit', releaseOnExit);
@@ -4237,9 +5560,9 @@ export function acquireLifecycleLease(genieHome = resolveGenieHome()): Lifecycle
  *     still let two acquirers proceed as concurrent owners. This is pre-existing
  *     in the TS path; the shell matches it at parity rather than widening it.
  */
-function stealStaleLock(lockPath: string): 'cleared' | 'contended' {
+function stealStaleFileLock(lockPath: string): 'cleared' | 'contended' {
   const guardPath = `${lockPath}.steal`;
-  const guardAttempt = tryInitializeSyncLock(guardPath);
+  const guardAttempt = tryInitializeFileLock(guardPath);
   if (guardAttempt.status !== 'acquired') {
     // lstat (never follow): a symlinked or otherwise non-regular guard is never
     // ours to reap — refuse it, matching the shell's `! -L` guard, so neither
@@ -4263,6 +5586,304 @@ function stealStaleLock(lockPath: string): 'cleared' | 'contended' {
   } finally {
     guardAttempt.lock.release();
   }
+}
+
+// ============================================================================
+// Generation-safe shared agent mutation lock
+// ============================================================================
+
+/**
+ * Acquire the per-GENIE_HOME sync lock via O_EXCL create. Returns a release
+ * handle, or null when another live sync holds the lock (the caller must skip).
+ * An out-of-window lock is stealable only when its host/PID/start record is not
+ * live. It is captured via {@link stealStaleAgentLock}, then exclusive create
+ * is retried. Any acquisition failure other than contention fails closed with
+ * an {@link AgentSyncLockError}; protected mutation never proceeds unlocked.
+ */
+function acquireAgentMutationLock(lockPath: string, options: AgentSyncLockOptions): { release: () => void } | null {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const owned = createOwnedLockDirectory(lockPath, options);
+    if (owned !== null) {
+      return { release: () => releaseOwnedSyncLock(lockPath, owned, options, 'release') };
+    }
+    const observed = inspectLockObject(lockPath);
+    if (observed === null) continue; // holder released between exclusive-create and inspection
+    if (!isStaleOrInvalidLockTime(observed.stat.mtimeMs)) return null;
+    if (observed.kind === 'foreign') return null;
+    if (observed.kind === 'legacy-file') {
+      // Upgrade compatibility retains the current dev lock protocol's
+      // cross-host/PID liveness rule. A generation lock is self-identifying by
+      // its owner pathname, while a legacy file carries this record in bytes.
+      if (lockHasLiveOwner(lockPath)) return null;
+      if (stealLegacyStaleLock(lockPath, observed, options) === 'contended') return null;
+      continue;
+    }
+    if (lockOwnerIsLive(parseLockOwner(observed.token.trim()))) return null;
+    if (stealStaleAgentLock(lockPath, observed, options) === 'contended') return null;
+    // stale owner token was removed; retry the atomic generation publish
+  }
+  return null; // lost the steal race to another process whose lock is now fresh
+}
+
+interface OwnedLockDirectory {
+  kind: 'owned-directory';
+  ownerName: string;
+  ownerPath: string;
+  stat: Stats;
+  token: string;
+}
+
+interface LegacyLockFile {
+  kind: 'legacy-file';
+  stat: Stats;
+  bytes: Buffer;
+}
+
+interface ForeignLockObject {
+  kind: 'foreign';
+  stat: Stats;
+}
+
+/** Publish one non-empty lock generation atomically; existing objects are contention. */
+function createOwnedLockDirectory(lockPath: string, options: AgentSyncLockOptions): OwnedLockDirectory | null {
+  let stageDir: string;
+  try {
+    stageDir = mkdtempSync(`${lockPath}.stage-`);
+  } catch (error) {
+    throw new AgentSyncLockError(
+      `could not acquire agent-sync lock; acquisition failed closed for ${lockPath}: ${errMsg(error)}`,
+      error,
+    );
+  }
+  const token = `${process.pid}:${randomBytes(16).toString('hex')}:${
+    processStartIdentity(process.pid) ?? 'unknown'
+  }:${currentSyncLockHostId()}\n`;
+  const ownerName = `owner-${hashBytes(Buffer.from(token)).slice(0, 32)}`;
+  const stagedOwnerPath = join(stageDir, ownerName);
+  try {
+    writeExclusiveFile(stagedOwnerPath, Buffer.from(token));
+  } catch (error) {
+    removeEmptyDirSafe(stageDir);
+    throw new AgentSyncLockError(
+      `agent-sync lock initialization failed closed for ${lockPath}: ${errMsg(error)}`,
+      error,
+    );
+  }
+  const stagedStat = lstatSync(stagedOwnerPath);
+  try {
+    options.beforePublish?.({ path: lockPath });
+    renameSync(stageDir, lockPath);
+  } catch (error) {
+    unlinkExactOwnedLockFile(stagedOwnerPath, stagedStat, token);
+    removeEmptyDirSafe(stageDir);
+    if (lstatSafe(lockPath) !== null) return null;
+    throw new AgentSyncLockError(`agent-sync lock publish failed closed for ${lockPath}: ${errMsg(error)}`, error);
+  }
+  const ownerPath = join(lockPath, ownerName);
+  const current = inspectOwnedLockFile(ownerPath);
+  if (current === null || !sameOwnedLock(stagedStat, token, current)) {
+    throw new AgentSyncLockError(`agent-sync lock ownership could not be verified for ${lockPath}`);
+  }
+  return { kind: 'owned-directory', ownerName, ownerPath, stat: current.stat, token };
+}
+
+function inspectLockObject(lockPath: string): OwnedLockDirectory | LegacyLockFile | ForeignLockObject | null {
+  try {
+    const stat = lstatSync(lockPath);
+    if (stat.isFile() && !stat.isSymbolicLink() && stat.nlink === 1) {
+      const bytes = readFileSync(lockPath);
+      const after = lstatSync(lockPath);
+      if (!samePathIdentity(stat, after)) throw new AgentSyncLockError('legacy agent-sync lock changed while reading');
+      return { kind: 'legacy-file', stat: after, bytes };
+    }
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return { kind: 'foreign', stat };
+    const owners = readdirSync(lockPath).filter((name) => name.startsWith('owner-'));
+    if (owners.length !== 1 || readdirSync(lockPath).length !== 1) return { kind: 'foreign', stat };
+    const ownerName = owners[0] as string;
+    const ownerPath = join(lockPath, ownerName);
+    const owner = inspectOwnedLockFile(ownerPath);
+    if (owner === null) throw new AgentSyncLockError(`agent-sync lock owner disappeared at ${ownerPath}`);
+    return { kind: 'owned-directory', ownerName, ownerPath, stat: owner.stat, token: owner.token };
+  } catch (error) {
+    if (isNodeErrorCode(error, 'ENOENT')) return null;
+    if (error instanceof AgentSyncLockError) throw error;
+    throw new AgentSyncLockError(`agent-sync lock inspection failed closed for ${lockPath}: ${errMsg(error)}`, error);
+  }
+}
+
+function inspectOwnedLockFile(ownerPath: string): { stat: Stats; token: string } | null {
+  try {
+    const before = lstatSync(ownerPath);
+    if (!before.isFile() || before.isSymbolicLink() || before.nlink !== 1) return null;
+    const token = readFileSync(ownerPath, 'utf8');
+    const after = lstatSync(ownerPath);
+    if (!samePathIdentity(before, after)) return null;
+    return { stat: after, token };
+  } catch (error) {
+    if (isNodeErrorCode(error, 'ENOENT')) return null;
+    throw error;
+  }
+}
+
+/** Acquire the same per-GENIE_HOME mutation lock used by sync and uninstall. */
+export function acquireAgentSyncLock(
+  genieHome: string,
+  options: AgentSyncLockOptions = {},
+): { release: () => void } | null {
+  return acquireAgentMutationLock(join(genieHome, AGENT_SYNC_LOCK_NAME), options);
+}
+
+/**
+ * Clear a stale lock safely under a `.steal` guard file. The previous
+ * unlink-then-retry steal let two processes both "win": between one stealer's
+ * unlink and its re-create, a second stealer's unlink silently removed the
+ * first's FRESH lock (observed as two concurrent writers in the regression
+ * test). The guard closes that hole with two properties: (a) the O_EXCL guard
+ * admits exactly one stealer at a time, and (b) the lock's staleness is
+ * RE-verified while holding the guard, so a fresh lock created after the
+ * caller's first observation is never removed. A guard left by a crashed
+ * stealer ages out via {@link LOCK_STALE_MS} like the lock itself.
+ */
+function stealStaleAgentLock(
+  lockPath: string,
+  observed: OwnedLockDirectory,
+  options: AgentSyncLockOptions,
+): 'cleared' | 'contended' {
+  if (!unlinkExactOwnedLockFile(observed.ownerPath, observed.stat, observed.token, options, 'stale-remove')) {
+    return 'contended';
+  }
+  return removeEmptyLockGeneration(lockPath) ? 'cleared' : 'contended';
+}
+
+/** Upgrade-safe stale removal for the regular-file lock format shipped before generation directories. */
+function stealLegacyStaleLock(
+  lockPath: string,
+  observed: LegacyLockFile,
+  options: AgentSyncLockOptions,
+): 'cleared' | 'contended' {
+  const guard = acquireLegacyStealGuard(lockPath);
+  if (guard === null) return 'contended';
+  try {
+    const current = inspectLegacyLockFile(lockPath);
+    if (current === null) return 'cleared';
+    if (
+      !samePathIdentity(observed.stat, current.stat) ||
+      !observed.bytes.equals(current.bytes) ||
+      !isStaleOrInvalidLockTime(current.stat.mtimeMs) ||
+      lockHasLiveOwner(lockPath)
+    ) {
+      return 'contended';
+    }
+    const captured = capturePath(lockPath, 'legacy-lock-stale');
+    if (captured === null) return 'cleared';
+    options.afterCapture?.({ operation: 'stale-remove', path: lockPath, capturedPath: captured.path });
+    const capturedState = inspectLegacyLockFile(captured.path);
+    if (
+      capturedState === null ||
+      !samePathIdentity(observed.stat, capturedState.stat) ||
+      !observed.bytes.equals(capturedState.bytes)
+    ) {
+      restoreOrPreserveCaptured(captured, lockPath);
+      return 'contended';
+    }
+    removeCapturedPath(captured);
+    return 'cleared';
+  } finally {
+    guard.release();
+  }
+}
+
+/** Preserve the current file-lock guard protocol while upgrading the payload capture to a pathname CAS. */
+function acquireLegacyStealGuard(lockPath: string): { release: () => void } | null {
+  const guardPath = `${lockPath}.steal`;
+  const attempt = tryInitializeFileLock(guardPath);
+  if (attempt.status === 'acquired') return attempt.lock;
+  if (attempt.status === 'exists') {
+    const guardStat = lstatSafe(guardPath);
+    if (guardStat?.isFile() && isStaleOrInvalidLockTime(guardStat.mtimeMs) && !lockHasLiveOwner(guardPath)) {
+      rmSyncSafe(guardPath);
+    }
+  }
+  return null;
+}
+
+function inspectLegacyLockFile(path: string): LegacyLockFile | null {
+  try {
+    const before = lstatSync(path);
+    if (!before.isFile() || before.isSymbolicLink() || before.nlink !== 1) return null;
+    const bytes = readFileSync(path);
+    const after = lstatSync(path);
+    if (!samePathIdentity(before, after)) return null;
+    return { kind: 'legacy-file', stat: after, bytes };
+  } catch (error) {
+    if (isNodeErrorCode(error, 'ENOENT')) return null;
+    throw error;
+  }
+}
+
+/** The token pathname is the ownership CAS; a replacement generation has a different owner name. */
+function releaseOwnedSyncLock(
+  lockPath: string,
+  expected: OwnedLockDirectory,
+  options: AgentSyncLockOptions,
+  operation: AgentSyncLockMutationEvent['operation'],
+): void {
+  try {
+    if (!unlinkExactOwnedLockFile(expected.ownerPath, expected.stat, expected.token, options, operation)) return;
+    removeEmptyLockGeneration(lockPath);
+  } catch {
+    // Release is best-effort but fail-closed: any unverified object remains preserved.
+  }
+}
+
+function unlinkExactOwnedLockFile(
+  ownerPath: string,
+  expectedStat: Stats,
+  expectedToken: string,
+  options: AgentSyncLockOptions = {},
+  operation: AgentSyncLockMutationEvent['operation'] = 'release',
+): boolean {
+  const lockPath = dirname(ownerPath);
+  let quarantineDir: string;
+  try {
+    quarantineDir = mkdtempSync(join(lockPath, '.owner-quarantine-'));
+  } catch (error) {
+    if (isNodeErrorCode(error, 'ENOENT') || isNodeErrorCode(error, 'ENOTDIR')) return false;
+    throw error;
+  }
+  const capturedPath = join(quarantineDir, 'object');
+  try {
+    renameSync(ownerPath, capturedPath);
+  } catch (error) {
+    removeEmptyDirSafe(quarantineDir);
+    if (isNodeErrorCode(error, 'ENOENT')) return false;
+    throw error;
+  }
+  options.afterCapture?.({ operation, path: lockPath, capturedPath });
+  const current = inspectOwnedLockFile(capturedPath);
+  if (current === null || !sameOwnedLock(expectedStat, expectedToken, current)) {
+    restoreCapturedPathNoReplace(capturedPath, ownerPath);
+    removeEmptyDirSafe(quarantineDir);
+    return false;
+  }
+  unlinkSync(capturedPath);
+  removeEmptyDirSafe(quarantineDir);
+  return true;
+}
+
+function removeEmptyLockGeneration(lockPath: string): boolean {
+  try {
+    rmdirSync(lockPath);
+    return true;
+  } catch (error) {
+    if (isNodeErrorCode(error, 'ENOENT')) return true;
+    if (isNodeErrorCode(error, 'ENOTEMPTY') || isNodeErrorCode(error, 'EEXIST')) return false;
+    throw error;
+  }
+}
+
+function sameOwnedLock(expectedStat: Stats, expectedToken: string, current: { stat: Stats; token: string }): boolean {
+  return samePathIdentity(expectedStat, current.stat) && expectedToken === current.token;
 }
 
 // ============================================================================
@@ -4290,10 +5911,18 @@ export function runAgentSync(opts: AgentSyncOptions = {}): AgentSyncReport {
     log('agent-sync: no genie plugin source found (looked for plugins/genie); skipping');
     return { source, agents: [], backupsDir: null };
   }
-  const lock = acquireSyncLock(join(genieHome, LOCK_NAME));
-  if ('skipped' in lock) {
-    log(`agent-sync: ${lock.skipped}`);
-    return { source, agents: [], backupsDir: null, skipped: lock.skipped };
+  let lock: { release: () => void } | null;
+  try {
+    lock = acquireAgentSyncLock(genieHome, opts.lockOptions);
+  } catch (error) {
+    const skipped = `agent-sync lock acquisition failed closed: ${errMsg(error)}`;
+    log(`agent-sync: ${skipped}`);
+    return { source, agents: [], backupsDir: null, skipped };
+  }
+  if (lock === null) {
+    const skipped = 'another agent-sync run holds the lock; skipped (the holder converges the same targets)';
+    log(`agent-sync: ${skipped}`);
+    return { source, agents: [], backupsDir: null, skipped };
   }
   try {
     const ctx = createRunContext(genieHome, source.pluginRoot, source, opts);
@@ -4326,19 +5955,27 @@ function createRunContext(
   };
   const stamp = now().toISOString().replace(/[:.]/g, '-');
   let backupsDir: string | null = null;
-  const backupInto = (agent: string, name: string, existingDir: string): string => {
+  const backupDest = (agent: string, name: string): string => {
     if (backupsDir === null) {
       // Uninstall removes GENIE_HOME. Recovery material therefore lives in a
       // sibling root so a later uninstall cannot erase the only surviving copy.
-      const recoveryRoot = join(dirname(resolve(genieHome)), '.genie-recovery');
-      const base = join(recoveryRoot, `agent-sync-${stamp}-${process.pid}`);
-      backupsDir = base;
-      for (let suffix = 1; existsSync(backupsDir); suffix += 1) backupsDir = `${base}-${suffix}`;
-      mkdirSync(backupsDir, { recursive: true });
+      backupsDir = allocateExclusiveBackupRootAt(
+        join(dirname(resolve(genieHome)), '.genie-recovery'),
+        `agent-sync-${stamp}-${process.pid}`,
+      );
     }
     const dest = join(backupsDir, agent, name);
     mkdirSync(dirname(dest), { recursive: true });
-    cpSync(existingDir, dest, { recursive: true });
+    return dest;
+  };
+  const backupInto = (agent: string, name: string, existingDir: string): string => {
+    const dest = backupDest(agent, name);
+    copyPathExclusive(existingDir, dest);
+    return dest;
+  };
+  const backupBytes = (agent: string, name: string, bytes: Buffer): string => {
+    const dest = backupDest(agent, name);
+    writeExclusiveFile(dest, bytes);
     return dest;
   };
   return {
@@ -4349,12 +5986,53 @@ function createRunContext(
     now,
     targets,
     backupInto,
+    backupBytes,
     backupsDirIfCreated: () => backupsDir,
     renameManagedDir: opts.renameManagedDir ?? renameSync,
     beforeManagedDirPromotion: opts.beforeManagedDirPromotion,
     beforeManagedDirPublish: opts.beforeManagedDirPublish,
     beforeManagedDirRemoval: opts.beforeManagedDirRemoval,
+    beforeAgentFileMutation: opts.beforeAgentFileMutation,
+    beforeAgentManifestCommit: opts.beforeAgentManifestCommit,
   };
+}
+
+/**
+ * Allocate a durable backup attempt root without opening or replacing any
+ * existing artifact. Timestamp collisions simply advance to a fresh suffix.
+ */
+export function allocateExclusiveBackupRoot(genieHome: string, baseName: string): string {
+  return allocateExclusiveBackupRootAt(join(genieHome, 'state-backups'), baseName);
+}
+
+function allocateExclusiveBackupRootAt(parent: string, baseName: string): string {
+  mkdirSync(parent, { recursive: true, mode: 0o700 });
+  const parentStat = lstatSync(parent);
+  if (!parentStat.isDirectory() || parentStat.isSymbolicLink()) {
+    throw new Error(`unsafe backup root path: ${parent}`);
+  }
+  for (let collision = 0; collision < 10_000; collision += 1) {
+    const candidate = collision === 0 ? join(parent, baseName) : join(parent, `${baseName}-${collision}`);
+    try {
+      mkdirSync(candidate, { mode: 0o700 });
+      return candidate;
+    } catch (error) {
+      if (isNodeErrorCode(error, 'EEXIST')) continue;
+      throw error;
+    }
+  }
+  throw new Error(`could not allocate backup root for ${baseName}`);
+}
+
+/** Copy to a path that must not already exist; links and regular collisions are never followed or overwritten. */
+function copyPathExclusive(source: string, destination: string): void {
+  try {
+    lstatSync(destination);
+    throw new Error(`backup destination already exists: ${destination}`);
+  } catch (error) {
+    if (!isNodeErrorCode(error, 'ENOENT')) throw error;
+  }
+  cpSync(source, destination, { recursive: true, force: false, errorOnExist: true });
 }
 
 /**
@@ -4465,14 +6143,6 @@ function quarantineTransactionDebris(parent: string, path: string): void {
   renameSync(path, destination);
 }
 
-function removeEmptyDirSafe(path: string): void {
-  try {
-    if (readdirSync(path).length === 0) rmSync(path, { recursive: true, force: true });
-  } catch {
-    // Already absent, non-directory, or concurrently populated: leave it fail-safe.
-  }
-}
-
 function lstatSafe(path: string): Stats | null {
   try {
     return lstatSync(path);
@@ -4517,4 +6187,8 @@ function readTrimmed(path: string): string | null {
 
 function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+function isNodeErrorCode(error: unknown, code: string): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === code;
 }


### PR DESCRIPTION
## What

- centralize Claude flat-agent sync as one capture/validate/publish/manifest-CAS/finalize transaction
- hold the generation-safe agent-sync lock across the complete uninstall, including canonical-source deletion
- adopt colliding agent files backup-first, preserve user-authored files, and retire managed orphans safely
- expose stable `doctor --json` role-agent states through `checks[].roleAgents`
- warn when the Claude plugin and fanned bare role agents would create duplicate surfaces

## Why

The seven pinned role agents were packaged only inside the disabled Claude plugin, so normal Genie update/install flows did not activate their model/effort routing. This makes the existing agent-sync delivery path own those flat files without treating the user-owned agents directory as a managed directory.

## Safety and compatibility

- user-authored agents are structurally outside ownership and remain byte-identical
- adoption, removal, and modified-file keep-aside paths are backup-first and collision-safe
- unsafe/foreign manifests and uncertain lock ownership fail closed
- current `dev` skill/workflow, Codex, and Hermes sync behavior is retained through the rebase
- the wish remains `IN_PROGRESS` until post-release Group C dogfood evidence is recorded

## Validation

- `bun run typecheck` — pass
- `bun run lint` — pass
- `bun run dead-code` — pass
- `bun run wishes:lint` — pass
- `bun test src/lib/agent-sync.test.ts -t "claude agent fan-out"` — 22 pass
- `bun test src/genie-commands/uninstall.test.ts` — 72 pass
- `bun test src/genie-commands/doctor.test.ts` — 69 pass
- `git diff --check origin/dev...HEAD` — pass

The repository-wide test invocation on this macOS host is not a valid aggregate gate because current `origin/dev` tests disagree on canonical `/tmp` versus `/private/tmp` paths and include one Linux/musl-specific error-message assertion. The feature suites above pass under their canonical temp roots; Linux PR CI is the authoritative full-suite gate.

## After merge

Wait for the SHA-pinned dev prerelease and signed/attested platform assets, install it with `genie update --dev -y`, then complete the wish's Group C fresh-session/doctor/LangWatch evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `genie update` now delivers role-agent files to Claude’s agents directory with reliable per-file synchronization.
  * `genie doctor` reports agent delivery status, including current, outdated, missing, and unmanaged files.
  * JSON diagnostics now include structured role-agent results for tooling and dashboards.
* **Bug Fixes**
  * Improved handling of conflicting or concurrently changed agent files.
  * Added duplicate-agent-surface warnings when overlapping plugin configuration is enabled.
* **Uninstall**
  * Removes only verified Genie-managed agent files while preserving user changes and creating backups when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->