### PR TITLE
fix(agent-sync): quarantine owner capture beside the lock dir, not inside it

### DIFF
--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -5878,7 +5878,11 @@ function unlinkExactOwnedLockFile(
   const lockPath = dirname(ownerPath);
   let quarantineDir: string;
   try {
-    quarantineDir = mkdtempSync(join(lockPath, '.owner-quarantine-'));
+    // Sibling, never child: a child quarantine dir makes lockPath non-empty, so a
+    // concurrent stealer's transient quarantine fails the winner's rmdir(lockPath)
+    // with ENOTEMPTY (steal skipped, lock orphaned) and misclassifies the lock as
+    // 'foreign' in inspectLockObject. Mirrors the `.stage-` sibling pattern.
+    quarantineDir = mkdtempSync(`${lockPath}.owner-quarantine-`);
   } catch (error) {
     if (isNodeErrorCode(error, 'ENOENT') || isNodeErrorCode(error, 'ENOTDIR')) return false;
     throw error;


### PR DESCRIPTION
Fixes the intermittent CI red on the dev→main promotion (#2587): `cross-process sync lock > simultaneous stale-lock steals` failing ~25% in isolated runs on dev (0% on main).

## Root cause

The `2315671a` single-lock rewrite created the owner-capture quarantine directory **inside** the lock directory (`mkdtempSync(join(lockPath, '.owner-quarantine-'))`). During simultaneous stale-lock steals, a losing stealer's transient quarantine subdir makes the winner's `rmdirSync(lockPath)` fail `ENOTEMPTY` → steal reported 'contended' → the rightful winner skips and an orphaned lock dir remains. The same pattern held a latent LOW edge: a crash mid-steal leaves a quarantine child that makes `inspectLockObject` classify the lock `'foreign'` — never stealable again.

Mutual exclusion was never violated (0 two-winners across 80 probe runs pre+post); this was a liveness/cleanup regression only.

## Fix

One line: the quarantine becomes a **sibling** (`${lockPath}.owner-quarantine-`), matching the existing `.stage-`/`.steal` sibling pattern. Quarantine cleanup was already explicit on every exit path, so no new debris.

## Evidence (fixer + independent reviewer, separately)

| Check | Pre-fix (dev) | Post-fix |
|---|---|---|
| Isolated steal test ×20 | 15/20 pass (25% fail) | **20/20 and 20/20** (two independent runs) |
| 40-run lock-API probe | winners `{0:1, 1:39}`, 1 orphaned dir | **`{1:40}`, 0 orphaned** |
| `src/lib` suite | — | 756/756 |
| typecheck / biome | — | clean |

Reviewer verdict: SHIP for this fix; the #2587 promotion is SHIP contingent on this landing on dev first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)