### PR TITLE
fix(agent-sync): reconcile native publication outcomes

### DIFF
--- a/src/genie-commands/uninstall.test.ts
+++ b/src/genie-commands/uninstall.test.ts
@@ -1106,6 +1106,33 @@ describe('agent-sync managed-asset removal', () => {
     expect(readFileSync(own)).toEqual(ownBytes);
   });
 
+  test('full uninstall preserves a foreign empty GENIE_HOME swapped in while its lock is held', () => {
+    const displacedHome = join(tmp, 'displaced-lock-home');
+    const foreignIdentity = { dev: -1, ino: -1, mode: -1 };
+    let runtimeRemovalCalls = 0;
+    rmSync(genieHome, { recursive: true, force: true });
+
+    performUninstall(false, [], genieHome, false, false, true, {
+      agentSyncTargets: { genieHome },
+      removeRuntimeIntegrations: () => {
+        runtimeRemovalCalls += 1;
+        expect(existsSync(join(genieHome, '.agent-sync.lock'))).toBe(true);
+        renameSync(genieHome, displacedHome);
+        mkdirSync(genieHome);
+        const stat = lstatSync(genieHome);
+        foreignIdentity.dev = stat.dev;
+        foreignIdentity.ino = stat.ino;
+        foreignIdentity.mode = stat.mode;
+      },
+    });
+
+    expect(runtimeRemovalCalls).toBe(1);
+    const after = lstatSync(genieHome);
+    expect({ dev: after.dev, ino: after.ino, mode: after.mode }).toEqual(foreignIdentity);
+    expect(readdirSync(genieHome)).toEqual([]);
+    expect(existsSync(join(displacedHome, '.agent-sync.lock'))).toBe(true);
+  });
+
   test('INV1: uninstall preserves captured bytes mutated after validation instead of discarding them', () => {
     const scout = managedAgent('scout.md', '# shipped scout\n');
     const agentsDir = join(claudeDir, 'agents');

--- a/src/genie-commands/uninstall.ts
+++ b/src/genie-commands/uninstall.ts
@@ -24,7 +24,6 @@ import {
   readlinkSync,
   renameSync,
   rmSync,
-  rmdirSync,
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
@@ -2024,14 +2023,6 @@ function removeGenieDirPreservingStateBackups(genieDir: string): void {
   }
 }
 
-function removeGenieDirIfEmpty(genieDir: string): void {
-  try {
-    rmdirSync(genieDir);
-  } catch {
-    // Durable backups, another safe retained object, or an already-absent root are all valid.
-  }
-}
-
 /** A durable-backups/active-lock-only root is recovery state, not an installed Genie tree. */
 export function hasRemovableGenieInstallState(genieDir: string): boolean {
   try {
@@ -2183,7 +2174,6 @@ export function performUninstall(
     if (plannedNames.length > 0) removeSymlinks(LOCAL_BIN, genieDir, plannedNames);
   } finally {
     lock.release();
-    removeGenieDirIfEmpty(genieDir);
   }
 }
 
@@ -2345,7 +2335,6 @@ function executeConfirmedUninstall(genieDir: string, removeMarketplace: boolean)
     executeFreshUninstall(genieDir, removeMarketplace);
   } finally {
     agentSyncLock.release();
-    removeGenieDirIfEmpty(genieDir);
   }
 }
 

--- a/src/lib/agent-sync.test.ts
+++ b/src/lib/agent-sync.test.ts
@@ -686,6 +686,176 @@ describe('claude agent fan-out', () => {
     expect(lstatSync(manifestPath).nlink).toBe(1);
   });
 
+  test('unavailable Darwin FFI setup falls back to the verified portable manifest commit', () => {
+    present(fixture.claudeDir);
+    const agentsDir = join(fixture.claudeDir, 'agents');
+    const manifestPath = join(agentsDir, MANIFEST_NAME);
+    let setupAttempts = 0;
+
+    const claude = agentReport(
+      run({
+        agentManifestPublishOptions: {
+          noClobberDeps: {
+            darwinOpener: () => {
+              setupAttempts += 1;
+              throw new Error('injected Bun --no-ffi setup denial');
+            },
+          },
+        },
+      }),
+      'claude',
+    );
+
+    expect(setupAttempts).toBe(1);
+    expect(claude.failures).toBeUndefined();
+    expect(readAgentFilesManifest(agentsDir)?.files['scout.md']).toBeDefined();
+    expect(lstatSync(manifestPath).nlink).toBe(1);
+  });
+
+  test('a completed Darwin native call returning failure stays NoClobber and never retries portably', () => {
+    present(fixture.claudeDir);
+    const agentsDir = join(fixture.claudeDir, 'agents');
+    const manifestPath = join(agentsDir, MANIFEST_NAME);
+    let nativeCalls = 0;
+
+    const claude = agentReport(
+      run({
+        agentManifestPublishOptions: {
+          noClobberDeps: {
+            darwinOpener: () => () => {
+              nativeCalls += 1;
+              return -1;
+            },
+          },
+        },
+      }),
+      'claude',
+    );
+
+    expect(nativeCalls).toBe(1);
+    expect(existsSync(manifestPath)).toBe(false);
+    expect(existsSync(join(agentsDir, 'scout.md'))).toBe(false);
+    expect(claude.failures?.join('\n')).toContain('agent transaction did not commit');
+    expect(claude.advisories.some((line) => line.includes('no-clobber publish failed'))).toBe(true);
+  });
+
+  test('a Darwin native invocation exception fails closed without a portable retry', () => {
+    present(fixture.claudeDir);
+    const agentsDir = join(fixture.claudeDir, 'agents');
+    const manifestPath = join(agentsDir, MANIFEST_NAME);
+    let nativeCalls = 0;
+
+    const claude = agentReport(
+      run({
+        agentManifestPublishOptions: {
+          noClobberDeps: {
+            darwinOpener: () => () => {
+              nativeCalls += 1;
+              throw new Error('injected native invocation failure');
+            },
+          },
+        },
+      }),
+      'claude',
+    );
+
+    expect(nativeCalls).toBe(1);
+    expect(existsSync(manifestPath)).toBe(false);
+    expect(existsSync(join(agentsDir, 'scout.md'))).toBe(false);
+    expect(claude.advisories.join('\n')).toContain('injected native invocation failure');
+  });
+
+  test('a Darwin exception after the native rename reconciles the exact committed manifest', () => {
+    present(fixture.claudeDir);
+    const agentsDir = join(fixture.claudeDir, 'agents');
+    const manifestPath = join(agentsDir, MANIFEST_NAME);
+    const scoutPath = join(agentsDir, 'scout.md');
+    let nativeCalls = 0;
+
+    const claude = agentReport(
+      run({
+        agentManifestPublishOptions: {
+          noClobberDeps: {
+            darwinOpener: () => (staged, target) => {
+              nativeCalls += 1;
+              renameSync(staged.subarray(0, -1).toString(), target.subarray(0, -1).toString());
+              throw new Error('injected exception after native rename committed');
+            },
+          },
+        },
+      }),
+      'claude',
+    );
+
+    expect(nativeCalls).toBe(1);
+    expect(claude.failures).toBeUndefined();
+    expect(existsSync(scoutPath)).toBe(true);
+    expect(readAgentFilesManifest(agentsDir)?.files['scout.md']).toBeDefined();
+    expect(lstatSync(manifestPath).nlink).toBe(1);
+    expect(readdirSync(agentsDir).some((name) => name.includes(`${MANIFEST_NAME}.genie-sync.staging-`))).toBe(false);
+  });
+
+  test('a Linux native invocation exception before rename fails closed without a portable retry', () => {
+    present(fixture.claudeDir);
+    const agentsDir = join(fixture.claudeDir, 'agents');
+    const manifestPath = join(agentsDir, MANIFEST_NAME);
+    let nativeCalls = 0;
+
+    const claude = agentReport(
+      run({
+        agentManifestPublishOptions: {
+          noClobberDeps: {
+            platform: 'linux',
+            probe: {},
+            opener: () => () => {
+              nativeCalls += 1;
+              throw new Error('injected Linux exception before native rename');
+            },
+          },
+        },
+      }),
+      'claude',
+    );
+
+    expect(nativeCalls).toBe(1);
+    expect(existsSync(manifestPath)).toBe(false);
+    expect(existsSync(join(agentsDir, 'scout.md'))).toBe(false);
+    expect(claude.failures?.join('\n')).toContain('agent transaction did not commit');
+    expect(claude.advisories.join('\n')).toContain('injected Linux exception before native rename');
+  });
+
+  test('a Linux exception after the native rename reconciles the exact committed manifest', () => {
+    present(fixture.claudeDir);
+    const agentsDir = join(fixture.claudeDir, 'agents');
+    const manifestPath = join(agentsDir, MANIFEST_NAME);
+    const scoutPath = join(agentsDir, 'scout.md');
+    let nativeCalls = 0;
+
+    const claude = agentReport(
+      run({
+        agentManifestPublishOptions: {
+          noClobberDeps: {
+            platform: 'linux',
+            probe: {},
+            opener: () => (staged, target) => {
+              nativeCalls += 1;
+              renameSync(staged.subarray(0, -1).toString(), target.subarray(0, -1).toString());
+              throw new Error('injected Linux exception after native rename committed');
+            },
+          },
+        },
+      }),
+      'claude',
+    );
+
+    expect(nativeCalls).toBe(1);
+    expect(claude.failures).toBeUndefined();
+    expect(existsSync(scoutPath)).toBe(true);
+    expect(readAgentFilesManifest(agentsDir)?.files['scout.md']).toBeDefined();
+    expect(lstatSync(manifestPath).nlink).toBe(1);
+    expect(readdirSync(agentsDir).some((name) => name.includes(`${MANIFEST_NAME}.genie-sync.staging-`))).toBe(false);
+  });
+
   test('portable manifest cleanup failure unpublishes the linked inode and restores the prior base', () => {
     present(fixture.claudeDir);
     run();
@@ -2557,6 +2727,60 @@ describe('cross-process sync lock', () => {
     expect(readlinkSync(racedHome)).toBe(victim);
     expect(readdirSync(victim)).toEqual([]);
     expect(lstatSync(displacedClaim).isDirectory()).toBe(true);
+  });
+
+  test('unavailable Darwin FFI setup selects the dedicated portable missing-home commit', () => {
+    const absentHome = join(fixture.root, 'darwin-ffi-unavailable-home');
+    let portableClaimed = false;
+    let setupAttempts = 0;
+
+    const lock = acquireAgentSyncLock(absentHome, {
+      homePublishDeps: {
+        darwinOpener: () => {
+          setupAttempts += 1;
+          throw new Error('injected Bun --no-ffi home setup denial');
+        },
+      },
+      afterPortableHomeClaim: () => {
+        portableClaimed = true;
+      },
+    });
+
+    expect(setupAttempts).toBe(1);
+    expect(portableClaimed).toBe(true);
+    expect(lock).not.toBeNull();
+    lock?.release();
+    expect(readdirSync(absentHome)).toEqual([]);
+  });
+
+  test('a Darwin home native invocation exception fails closed without a portable retry', () => {
+    const absentHome = join(fixture.root, 'darwin-native-home-invocation-failure');
+    let portableClaimed = false;
+    let stagedHome = '';
+    let nativeCalls = 0;
+
+    expect(() =>
+      acquireAgentSyncLock(absentHome, {
+        homePublishDeps: {
+          darwinOpener: () => () => {
+            nativeCalls += 1;
+            throw new Error('injected native home invocation failure');
+          },
+        },
+        beforeHomePublish: ({ stagePath }) => {
+          stagedHome = stagePath;
+        },
+        afterPortableHomeClaim: () => {
+          portableClaimed = true;
+        },
+      }),
+    ).toThrow(AgentSyncLockError);
+
+    expect(nativeCalls).toBe(1);
+    expect(portableClaimed).toBe(false);
+    expect(existsSync(absentHome)).toBe(false);
+    expect(stagedHome).not.toBe('');
+    expect(existsSync(stagedHome)).toBe(false);
   });
 
   test('a foreign owner replacement installed after release capture survives byte-for-byte', () => {

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -225,6 +225,8 @@ export interface PortableManifestStageCleanupEvent {
 export interface AgentManifestPublishOptions {
   /** Force the hard-link fallback even when the host exposes native NOREPLACE rename. */
   forcePortable?: boolean;
+  /** Injectable native capability setup for deterministic fallback tests. */
+  noClobberDeps?: NoClobberDeps;
   /** Deterministic failure/race barrier after the stage name is captured but before it is retired. */
   beforePortableStageNameCleanup?: (event: PortableManifestStageCleanupEvent) => void;
 }
@@ -242,6 +244,8 @@ export interface AgentSyncLockOptions {
   beforeHomePublish?: (event: { path: string; stagePath: string }) => void;
   /** Force missing-home publication through the portable mkdir commit (test seam). */
   forcePortableHomePublish?: boolean;
+  /** Injectable native capability setup for missing-home publication. */
+  homePublishDeps?: NoClobberDeps;
   /** Deterministic barrier after the portable mkdir commit and before the live home is inspected. */
   afterPortableHomeClaim?: (event: { path: string; stagePath: string }) => void;
   /** Deterministic barrier after the lock pathname is captured and before the captured object is finalized. */
@@ -2078,11 +2082,15 @@ type LibcRenameOpener = (soname: string) => Renameat2 | null;
 interface RenameProbe {
   resolved?: Renameat2 | null;
 }
-/** Dependency-injection seam for the Linux no-clobber fast path — no global mutable state, no test-only setter. */
+/** Native no-clobber capability seams — no global mutable state or test-only setter. */
 export interface NoClobberDeps {
   opener?: LibcRenameOpener;
   candidates?: readonly string[];
   probe?: RenameProbe;
+  /** Deterministically select the regular-file native family without mutating global process state. */
+  platform?: NodeJS.Platform;
+  /** Regular-file and lock-home callers use an explicit opener to select the Darwin branch on test hosts. */
+  darwinOpener?: () => ((staged: Buffer, target: Buffer) => number) | null;
 }
 
 const defaultLibcOpener: LibcRenameOpener = (soname) => {
@@ -2111,9 +2119,67 @@ export function resolveLinuxRenameat2(
 
 const defaultLinuxProbe: RenameProbe = {};
 function probeLinuxRenameat2(deps: NoClobberDeps): Renameat2 | null {
-  const probe = deps.probe ?? defaultLinuxProbe;
-  if (!('resolved' in probe)) probe.resolved = resolveLinuxRenameat2(deps.opener, deps.candidates);
+  const hasInjectedResolution = deps.opener !== undefined || deps.candidates !== undefined;
+  const probe = deps.probe ?? (hasInjectedResolution ? {} : defaultLinuxProbe);
+  if (!('resolved' in probe)) {
+    try {
+      probe.resolved = resolveLinuxRenameat2(deps.opener, deps.candidates);
+    } catch {
+      probe.resolved = null;
+    }
+  }
   return probe.resolved ?? null;
+}
+
+const defaultDarwinRenameOpener: NonNullable<NoClobberDeps['darwinOpener']> = () => {
+  try {
+    const libc = dlopen('/usr/lib/libSystem.B.dylib', {
+      renamex_np: { args: ['cstring', 'cstring', 'u32'], returns: 'i32' },
+    } as const);
+    try {
+      const renamex = libc.symbols.renamex_np;
+      if (typeof renamex !== 'function') {
+        libc.close();
+        return null;
+      }
+      return (staged, target) => {
+        let result: number;
+        try {
+          result = renamex(staged, target, DARWIN_RENAME_EXCL);
+        } catch (error) {
+          try {
+            libc.close();
+          } catch {
+            // Preserve the native invocation error; cleanup cannot authorize a portable retry.
+          }
+          throw error;
+        }
+        try {
+          libc.close();
+        } catch {
+          // The native result is already known; close-only failure cannot rewrite the commit outcome.
+        }
+        return result;
+      };
+    } catch {
+      try {
+        libc.close();
+      } catch {
+        // Setup already failed; inability to close the incomplete handle does not make the capability available.
+      }
+      return null;
+    }
+  } catch {
+    return null;
+  }
+};
+
+function resolveDarwinRenameExclusive(deps: NoClobberDeps): ((staged: Buffer, target: Buffer) => number) | null {
+  try {
+    return (deps.darwinOpener ?? defaultDarwinRenameOpener)();
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -2182,6 +2248,59 @@ export function atomicRenameDirectoryNoClobber(stagedDir: string, targetDir: str
 
 type RegularFileNoClobberPublish = 'renamed' | 'linked';
 
+/** Reconcile an exception only when the exact staged payload moved completely onto the target name. */
+function exactFileStageMovedToTarget(stage: FileStage, targetFile: string): boolean {
+  if (lstatSafe(stage.path) !== null) return false;
+  try {
+    const before = lstatSync(targetFile);
+    if (
+      !before.isFile() ||
+      before.isSymbolicLink() ||
+      !samePathIdentity(stage.stat, before) ||
+      !readFileSync(targetFile).equals(stage.bytes)
+    ) {
+      return false;
+    }
+    return samePathIdentity(before, lstatSync(targetFile));
+  } catch {
+    return false;
+  }
+}
+
+function selectedRegularFileNativePlatform(deps: NoClobberDeps): NodeJS.Platform {
+  return deps.platform ?? (deps.darwinOpener === undefined ? process.platform : 'darwin');
+}
+
+/** Null means native setup was unavailable before invocation, so the portable commit remains safe to select. */
+function resolveRegularFileNativeRename(deps: NoClobberDeps): Renameat2 | null {
+  const platform = selectedRegularFileNativePlatform(deps);
+  if (platform === 'darwin') return resolveDarwinRenameExclusive(deps);
+  if (platform === 'linux') return probeLinuxRenameat2(deps);
+  return null;
+}
+
+/** Once invoked, native return and exception outcomes are authoritative and never select a portable retry. */
+function publishRegularFileViaNativeNoClobber(
+  stage: FileStage,
+  targetFile: string,
+  renameExclusive: Renameat2,
+): RegularFileNoClobberPublish {
+  let result: number;
+  try {
+    result = renameExclusive(Buffer.from(`${stage.path}\0`), Buffer.from(`${targetFile}\0`));
+  } catch (error) {
+    if (exactFileStageMovedToTarget(stage, targetFile)) return 'renamed';
+    throw error;
+  }
+  if (result !== 0) {
+    const detail = lstatSafe(targetFile) === null ? 'rename failed' : 'target exists';
+    throw new NoClobberPublishError(
+      `atomic regular-file no-clobber publish failed (${detail}); target preserved: ${targetFile}`,
+    );
+  }
+  return 'renamed';
+}
+
 /**
  * Publish one staged regular file while atomically rejecting every existing
  * target inode. Linux and Darwin consume the staged name with their native
@@ -2190,48 +2309,26 @@ type RegularFileNoClobberPublish = 'renamed' | 'linked';
  * committed only after retiring the extra name and verifying a safe nlink=1.
  */
 function atomicRenameRegularFileNoClobber(
-  stagedFile: string,
+  stage: FileStage,
   targetFile: string,
   deps: NoClobberDeps = {},
   forcePortable = false,
 ): RegularFileNoClobberPublish {
-  const stagedStat = lstatSync(stagedFile);
-  if (!stagedStat.isFile() || stagedStat.isSymbolicLink()) {
-    throw new Error(`atomic publish source is not a physical regular file: ${stagedFile}`);
+  const stagedStat = lstatSync(stage.path);
+  if (
+    !stagedStat.isFile() ||
+    stagedStat.isSymbolicLink() ||
+    !samePathIdentity(stage.stat, stagedStat) ||
+    !readFileSync(stage.path).equals(stage.bytes)
+  ) {
+    throw new Error(`atomic publish source is not the expected physical regular file: ${stage.path}`);
   }
-  const stagedPath = Buffer.from(`${stagedFile}\0`);
-  const targetPath = Buffer.from(`${targetFile}\0`);
-  if (!forcePortable && process.platform === 'linux') {
-    const rn = probeLinuxRenameat2(deps);
-    if (rn !== null) {
-      if (rn(stagedPath, targetPath) !== 0) {
-        const detail = lstatSafe(targetFile) === null ? 'rename failed' : 'target exists';
-        throw new NoClobberPublishError(
-          `atomic regular-file no-clobber publish failed (${detail}); target preserved: ${targetFile}`,
-        );
-      }
-      return 'renamed';
-    }
-  } else if (!forcePortable && process.platform === 'darwin') {
-    const libc = dlopen('/usr/lib/libSystem.B.dylib', {
-      renamex_np: { args: ['cstring', 'cstring', 'u32'], returns: 'i32' },
-    } as const);
-    let result: number;
-    try {
-      result = libc.symbols.renamex_np(stagedPath, targetPath, DARWIN_RENAME_EXCL);
-    } finally {
-      libc.close();
-    }
-    if (result !== 0) {
-      const detail = lstatSafe(targetFile) === null ? 'rename failed' : 'target exists';
-      throw new NoClobberPublishError(
-        `atomic regular-file no-clobber publish failed (${detail}); target preserved: ${targetFile}`,
-      );
-    }
-    return 'renamed';
+  if (!forcePortable) {
+    const nativeRename = resolveRegularFileNativeRename(deps);
+    if (nativeRename !== null) return publishRegularFileViaNativeNoClobber(stage, targetFile, nativeRename);
   }
   try {
-    linkSync(stagedFile, targetFile);
+    linkSync(stage.path, targetFile);
     return 'linked';
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code ?? 'UNKNOWN';
@@ -4063,9 +4160,9 @@ function publishFlatAgentManifestStage(
   let publish: RegularFileNoClobberPublish;
   try {
     publish = atomicRenameRegularFileNoClobber(
-      stage.path,
+      stage,
       manifestPath,
-      {},
+      ctx.seams.manifestPublishOptions?.noClobberDeps,
       ctx.seams.manifestPublishOptions?.forcePortable,
     );
   } catch (error) {
@@ -6140,11 +6237,37 @@ function removeExactEmptyStagedHome(stagePath: string, expected: Stats): void {
   }
 }
 
-/** Native NOREPLACE is safe to move the pre-statted generation; every other path uses mkdir as the commit. */
-function hasNativeAgentSyncHomePublish(options: AgentSyncLockOptions): boolean {
-  if (options.forcePortableHomePublish === true) return false;
-  if (process.platform === 'darwin') return true;
-  return process.platform === 'linux' && probeLinuxRenameat2({}) !== null;
+type AgentSyncHomePublisher = (stagedDir: string, targetDir: string) => void;
+
+/** Resolve native NOREPLACE before any publish call; unavailable setup selects the dedicated portable commit. */
+function resolveNativeAgentSyncHomePublisher(options: AgentSyncLockOptions): AgentSyncHomePublisher | null {
+  if (options.forcePortableHomePublish === true) return null;
+  const deps = options.homePublishDeps ?? {};
+  if (process.platform === 'darwin' || deps.darwinOpener !== undefined) {
+    const renameExclusive = resolveDarwinRenameExclusive(deps);
+    if (renameExclusive === null) return null;
+    return (stagedDir, targetDir) => {
+      const result = renameExclusive(Buffer.from(`${stagedDir}\0`), Buffer.from(`${targetDir}\0`));
+      if (result !== 0) {
+        const detail = lstatSafe(targetDir) === null ? 'rename failed' : 'target exists';
+        throw new NoClobberPublishError(
+          `atomic agent-sync home publish failed (${detail}); target preserved: ${targetDir}`,
+        );
+      }
+    };
+  }
+  if (process.platform !== 'linux') return null;
+  const renameNoReplace = probeLinuxRenameat2(deps);
+  if (renameNoReplace === null) return null;
+  return (stagedDir, targetDir) => {
+    const result = renameNoReplace(Buffer.from(`${stagedDir}\0`), Buffer.from(`${targetDir}\0`));
+    if (result !== 0) {
+      const detail = lstatSafe(targetDir) === null ? 'rename failed' : 'target exists';
+      throw new NoClobberPublishError(
+        `atomic agent-sync home publish failed (${detail}); target preserved: ${targetDir}`,
+      );
+    }
+  };
 }
 
 /**
@@ -6211,11 +6334,12 @@ function ensurePhysicalAgentSyncHome(genieHome: string, options: AgentSyncLockOp
       error,
     );
   }
-  if (!hasNativeAgentSyncHomePublish(options)) {
+  const nativePublish = resolveNativeAgentSyncHomePublisher(options);
+  if (nativePublish === null) {
     return publishPortableEmptyAgentSyncHome(genieHome, stagePath, stagedStat, options);
   }
   try {
-    atomicRenameDirectoryNoClobber(stagePath, genieHome);
+    nativePublish(stagePath, genieHome);
   } catch (error) {
     removeExactEmptyStagedHome(stagePath, stagedStat);
     const winner = inspectPhysicalAgentSyncHome(genieHome);


### PR DESCRIPTION
## Context

Post-merge closure for review findings discovered while #2588 was still being audited. This branch is rebased onto current `dev`, including #2588 and the adjacent #2589 lock-quarantine repair.

## Fixes

- Centralize Darwin `renamex_np` and Linux `renameat2` regular-file publication behind one exact-outcome reconciler.
  - Native capability setup unavailable: use the verified portable hard-link transaction.
  - Native nonzero result: preserve the no-clobber failure.
  - Exception before the syscall commits: fail closed with no portable retry.
  - Exception after the syscall commits: recognize the commit only when the staged name is absent and the target has the exact staged inode identity and bytes with a stable re-stat.
  - Injected Linux capability probes do not reuse the process-global memoized probe.
- Let missing-home publication select its dedicated portable `mkdir` commit when Darwin FFI setup is unavailable.
- Remove both post-release pathname-only empty-home deletions from full uninstall. Identity-bound lock cleanup remains authoritative, so a foreign `GENIE_HOME` replacement is never deleted.
- Add deterministic Darwin/Linux pre- and post-syscall regressions plus the full-uninstall foreign-home swap regression.

## Validation

- `bun test src/lib/agent-sync.test.ts -t 'claude agent fan-out|cross-process sync lock'` — 64 pass
- `bun test src/genie-commands/uninstall.test.ts` — 74 pass
- `bun run check:fast` — pass
- `git diff --check origin/dev...HEAD` — pass
- Independent final review — SHIP, no CRITICAL/HIGH gaps

## Scope note

The pre-existing shared `publishDirectoryViaNameClaim` claim-to-rename advisory remains outside this regular-file and dedicated lock-home repair. Neither portable path changed here reaches that primitive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved uninstall behavior when the installation directory changes during removal, preserving lock files and existing state backups.
  * Prevented sync updates from overwriting existing agent manifests or installation directories.
  * Improved recovery after interrupted or partially completed publication operations.
  * Added safer platform-specific handling, including portable fallbacks when native operations are unavailable and clear failures when they cannot be completed safely.

* **Tests**
  * Expanded coverage for uninstall and cross-platform synchronization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->