### PR TITLE
fix(agent-sync): honor home publish platform seam

### DIFF
--- a/src/lib/agent-sync.test.ts
+++ b/src/lib/agent-sync.test.ts
@@ -2753,6 +2753,33 @@ describe('cross-process sync lock', () => {
     expect(readdirSync(absentHome)).toEqual([]);
   });
 
+  test('an explicit Linux home platform with unavailable native setup selects the portable mkdir commit', () => {
+    const absentHome = join(fixture.root, 'linux-native-unavailable-home');
+    const candidates = ['missing-libc-one.so', 'missing-libc-two.so'] as const;
+    const attempted: string[] = [];
+    let portableClaimed = false;
+
+    const lock = acquireAgentSyncLock(absentHome, {
+      homePublishDeps: {
+        platform: 'linux',
+        candidates,
+        opener: (soname) => {
+          attempted.push(soname);
+          return null;
+        },
+      },
+      afterPortableHomeClaim: () => {
+        portableClaimed = true;
+      },
+    });
+
+    expect(attempted).toEqual([...candidates]);
+    expect(portableClaimed).toBe(true);
+    expect(lock).not.toBeNull();
+    lock?.release();
+    expect(readdirSync(absentHome)).toEqual([]);
+  });
+
   test('a Darwin home native invocation exception fails closed without a portable retry', () => {
     const absentHome = join(fixture.root, 'darwin-native-home-invocation-failure');
     let portableClaimed = false;

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -2087,7 +2087,7 @@ export interface NoClobberDeps {
   opener?: LibcRenameOpener;
   candidates?: readonly string[];
   probe?: RenameProbe;
-  /** Deterministically select the regular-file native family without mutating global process state. */
+  /** Deterministically select the native no-clobber family without mutating global process state. */
   platform?: NodeJS.Platform;
   /** Regular-file and lock-home callers use an explicit opener to select the Darwin branch on test hosts. */
   darwinOpener?: () => ((staged: Buffer, target: Buffer) => number) | null;
@@ -2267,13 +2267,13 @@ function exactFileStageMovedToTarget(stage: FileStage, targetFile: string): bool
   }
 }
 
-function selectedRegularFileNativePlatform(deps: NoClobberDeps): NodeJS.Platform {
+function selectedNoClobberPlatform(deps: NoClobberDeps): NodeJS.Platform {
   return deps.platform ?? (deps.darwinOpener === undefined ? process.platform : 'darwin');
 }
 
 /** Null means native setup was unavailable before invocation, so the portable commit remains safe to select. */
 function resolveRegularFileNativeRename(deps: NoClobberDeps): Renameat2 | null {
-  const platform = selectedRegularFileNativePlatform(deps);
+  const platform = selectedNoClobberPlatform(deps);
   if (platform === 'darwin') return resolveDarwinRenameExclusive(deps);
   if (platform === 'linux') return probeLinuxRenameat2(deps);
   return null;
@@ -6239,28 +6239,9 @@ function removeExactEmptyStagedHome(stagePath: string, expected: Stats): void {
 
 type AgentSyncHomePublisher = (stagedDir: string, targetDir: string) => void;
 
-/** Resolve native NOREPLACE before any publish call; unavailable setup selects the dedicated portable commit. */
-function resolveNativeAgentSyncHomePublisher(options: AgentSyncLockOptions): AgentSyncHomePublisher | null {
-  if (options.forcePortableHomePublish === true) return null;
-  const deps = options.homePublishDeps ?? {};
-  if (process.platform === 'darwin' || deps.darwinOpener !== undefined) {
-    const renameExclusive = resolveDarwinRenameExclusive(deps);
-    if (renameExclusive === null) return null;
-    return (stagedDir, targetDir) => {
-      const result = renameExclusive(Buffer.from(`${stagedDir}\0`), Buffer.from(`${targetDir}\0`));
-      if (result !== 0) {
-        const detail = lstatSafe(targetDir) === null ? 'rename failed' : 'target exists';
-        throw new NoClobberPublishError(
-          `atomic agent-sync home publish failed (${detail}); target preserved: ${targetDir}`,
-        );
-      }
-    };
-  }
-  if (process.platform !== 'linux') return null;
-  const renameNoReplace = probeLinuxRenameat2(deps);
-  if (renameNoReplace === null) return null;
+function makeAgentSyncHomePublisher(renameExclusive: Renameat2): AgentSyncHomePublisher {
   return (stagedDir, targetDir) => {
-    const result = renameNoReplace(Buffer.from(`${stagedDir}\0`), Buffer.from(`${targetDir}\0`));
+    const result = renameExclusive(Buffer.from(`${stagedDir}\0`), Buffer.from(`${targetDir}\0`));
     if (result !== 0) {
       const detail = lstatSafe(targetDir) === null ? 'rename failed' : 'target exists';
       throw new NoClobberPublishError(
@@ -6268,6 +6249,20 @@ function resolveNativeAgentSyncHomePublisher(options: AgentSyncLockOptions): Age
       );
     }
   };
+}
+
+/** Resolve native NOREPLACE before any publish call; unavailable setup selects the dedicated portable commit. */
+function resolveNativeAgentSyncHomePublisher(options: AgentSyncLockOptions): AgentSyncHomePublisher | null {
+  if (options.forcePortableHomePublish === true) return null;
+  const deps = options.homePublishDeps ?? {};
+  const platform = selectedNoClobberPlatform(deps);
+  if (platform === 'darwin') {
+    const renameExclusive = resolveDarwinRenameExclusive(deps);
+    return renameExclusive === null ? null : makeAgentSyncHomePublisher(renameExclusive);
+  }
+  if (platform !== 'linux') return null;
+  const renameNoReplace = probeLinuxRenameat2(deps);
+  return renameNoReplace === null ? null : makeAgentSyncHomePublisher(renameNoReplace);
 }
 
 /**


### PR DESCRIPTION
## Context

Carries the two accepted CodeRabbit changes from #2590 that were pushed after GitHub had already merged that PR's earlier head. This branch is rebased onto `dev` 5.260714.7 and contains exactly one commit.

## Changes

- Use the shared explicit no-clobber platform selector for missing-`GENIE_HOME` publication as well as regular-file publication.
- Extract the duplicated Darwin/Linux home publisher result/error handling into `makeAgentSyncHomePublisher()`.
- Add a deterministic forced-Linux test proving unavailable injected native setup selects the dedicated portable `mkdir` commit without process-global platform mutation or an explicit probe object.
- Update the seam documentation to cover both native no-clobber callers.

## Validation

- Affected agent-sync fan-out/lock suite — 65 pass
- Uninstall suite — 74 pass
- Rebased focused regression — pass
- `bun run check:fast` — pass
- `git diff --check origin/dev...HEAD` — pass
- Independent incremental review — SHIP, no CRITICAL/HIGH gaps
- CodeRabbit confirmed both findings addressed; its Darwin caching suggestion was withdrawn after the one-shot workload/lifetime contract was explained.
