### PR TITLE
fix(update): give the release download its own 5-minute timeout

### DIFF
--- a/src/genie-commands/__tests__/update.test.ts
+++ b/src/genie-commands/__tests__/update.test.ts
@@ -1014,6 +1014,9 @@ describe('downloadAndVerifyTarball (G5)', () => {
       expect(argString).toContain(`genie-${manifest.version}-linux-x64-glibc.tar.gz`);
       expect(argString).toContain('.bundle');
       expect(argString).toContain('.intoto.jsonl');
+      // 37MB+ tarballs outgrew runCommandSilent's 4s default (v5.260714.8
+      // timeout regression) — the download must carry its own generous bound.
+      expect(calls[0].timeoutMs).toBe(300_000);
       // Second call — gh attestation verify with workflow identity pinned.
       expect(calls[1].cmd).toBe('gh');
       expect(calls[1].args).toEqual([

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -541,6 +541,13 @@ interface DownloadAndVerifyOptions {
  */
 const ATTESTATION_VERIFY_TIMEOUT_MS = 60_000;
 const COSIGN_VERIFY_TIMEOUT_MS = 30_000;
+/**
+ * The tarball download moves ~37MB+ per platform and outgrew runCommandSilent's
+ * 4s default the same way the verify steps did: genie update v5.260714.8 timed
+ * out at 4000ms on a healthy connection (Felipe, 2026-07-14). 5 minutes bounds
+ * a genuinely slow link without hanging forever.
+ */
+const RELEASE_DOWNLOAD_TIMEOUT_MS = 300_000;
 
 interface SignatureVerificationResult {
   method: 'gh-attestation' | 'cosign-bundle';
@@ -625,22 +632,26 @@ export async function downloadAndVerifyTarball(
 
   // gh release download retries by name; --pattern lets us pull the tarball
   // and its sidecar (.bundle, .intoto.jsonl) in one shot via wildcards.
-  const downloadResult = await runner('gh', [
-    'release',
-    'download',
-    versionTag,
-    '--repo',
-    `${RELEASES_OWNER}/${RELEASES_REPO}`,
-    '--dir',
-    destDir,
-    '--pattern',
-    tarballName,
-    '--pattern',
-    `${tarballName}.bundle`,
-    '--pattern',
-    `${tarballName}.intoto.jsonl`,
-    '--clobber',
-  ]);
+  const downloadResult = await runner(
+    'gh',
+    [
+      'release',
+      'download',
+      versionTag,
+      '--repo',
+      `${RELEASES_OWNER}/${RELEASES_REPO}`,
+      '--dir',
+      destDir,
+      '--pattern',
+      tarballName,
+      '--pattern',
+      `${tarballName}.bundle`,
+      '--pattern',
+      `${tarballName}.intoto.jsonl`,
+      '--clobber',
+    ],
+    RELEASE_DOWNLOAD_TIMEOUT_MS,
+  );
   if (!downloadResult.success) {
     throw new Error(
       `gh release download ${versionTag} failed for ${platform}: ${downloadResult.output.trim() || 'no output'}`,


### PR DESCRIPTION
`genie update` (both channels) fails on any connection where a 37MB+ tarball takes over 4 seconds:

```
✖ Update failed: gh release download v5.260714.8 failed for linux-arm64: Timed out after 4000ms
```

## Root cause

`downloadAndVerifyTarball` passes no timeout to the `gh release download` runner call, so it inherits `runCommandSilent`'s 4s default. This is the *same* bug fixed for the verify steps after PR #2421 (May 2026, also reproduced on a healthy connection) — `ATTESTATION_VERIFY_TIMEOUT_MS`/`COSIGN_VERIFY_TIMEOUT_MS` were added, but the download call was left on the default. Tarballs have since grown to 37–39MB and a healthy download now takes >4s (measured 4.14s on the reporting machine).

## Fix

`RELEASE_DOWNLOAD_TIMEOUT_MS = 300_000` passed to the download call, documented alongside the existing verify-timeout rationale. The existing runner-seam test (which already captures per-call `timeoutMs` and asserts the 60s attestation bound) now also pins the download bound.

Gates: update.test.ts 197 tests 0 fail; typecheck clean; biome clean.

Note: already-installed binaries carry the bug, so users on affected connections need one `curl -fsSL .../install.sh | bash` (or repo `install.sh`) hop to cross onto a fixed release; after that `genie update` self-updates fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)