### PR TITLE
feat(methodology): make simplicity a lifecycle gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Genie v5 is zero-daemon except for the explicitly launched `genie omni serve` br
 
 ## Engineering rules
 
+- KISS is a release gate, not a preference. Start with the simplest complete design that satisfies current user stories. Caches, deltas, sharding, background coordination, configurable policy, and other stateful machinery require a present contractual need or measured threshold; hypothetical future scale is not evidence. Prefer bounding data and separating history from current state before adding synchronization protocols.
 - Define type and error boundaries before implementation.
 - Preserve user-owned config and unrelated dirty-worktree changes.
 - Config migrations are narrow, backup-first, idempotent, and covered by fixtures.

--- a/plugins/genie/references/review-criteria.md
+++ b/plugins/genie/references/review-criteria.md
@@ -44,6 +44,13 @@ For PASS criteria, evidence includes:
 - No dead code
 - No unresolved TODOs
 
+### Simplicity
+- Simplest complete design is stated
+- Every cache, delta, shard, queue, retry state machine, abstraction, and configuration surface has a current criterion or measurement
+- Current state is bounded and history is separated before synchronization machinery is added
+- Plausible future complexity is deferred behind a concrete adoption trigger
+- Repeated gaps in optional machinery route back to planning instead of consuming fix loops
+
 ### Performance
 - No obvious N+1 queries
 - No unnecessary loops/allocations
@@ -68,5 +75,5 @@ For PASS criteria, evidence includes:
 ## Fix Loop Limits
 
 - Spec review fix loops: max 3
-- Quality review fix loops: max 2
+- Quality review fix loops: max 3
 - After max loops: mark task BLOCKED and continue

--- a/plugins/genie/skills/architecture/SKILL.md
+++ b/plugins/genie/skills/architecture/SKILL.md
@@ -9,7 +9,7 @@ description: Use when reviewing architecture in any codebase — module boundari
 
 ## Lens
 
-This lane treats complexity as anything that makes a system hard to understand or modify — it accumulates as dependencies and obscurity. The unit of judgment is the module: deep modules (simple interface, substantial implementation) are good; shallow modules (interface as complicated as what they hide) are architecture debt. Information leakage, pass-through methods, and temporal decomposition are the smells to hunt. Prize "define errors out of existence" and design-it-twice thinking.
+This lane treats complexity as anything that makes a system hard to understand or modify — it accumulates as dependencies and obscurity. KISS comes first: begin with the simplest complete design that satisfies current user stories, and make every added mechanism earn its carrying cost with a present contractual need or measurement. Hypothetical future scale is not evidence. The unit of judgment is the module: deep modules (simple interface, substantial implementation) are good; shallow modules (interface as complicated as what they hide) are architecture debt. Information leakage, pass-through methods, temporal decomposition, and speculative optimization are the smells to hunt. Prize "define errors out of existence" and design-it-twice thinking.
 
 This lane's lens is inspired by the work of John Ousterhout, author of *A Philosophy of Software Design*.
 
@@ -30,19 +30,20 @@ Architecture is judged against the repo's own stated intent, then against first 
 
 ## Workflow
 
-1. **Map the module graph.** Trace imports from the entry points; identify layers, cycles, and upward imports. Done when you have the real dependency picture, not the README's.
-2. **Verify the stated contracts.** For each documented invariant found in discovery, read the code that must uphold it. Done when each is confirmed intact or broken with file:line evidence.
-3. **Depth-score the key interfaces.** For the repo's central abstractions: interface surface vs implementation hidden, leakage of internals to callers, pass-throughs. Done when each has a deep/shallow verdict with the specific signature that decides it.
-4. **Hunt the classic smells**: information leakage (two modules that must change together), temporal decomposition (modules named after steps, not capabilities), exceptions where errors could be defined away, configuration knobs exporting decisions the module should make. Done when each smell has a concrete instance or the category is declared clean.
-5. **Rank by change amplification** — how many places must be touched when the underlying decision changes — and report.
+1. **Establish the simplicity baseline.** State the current user stories, realistic scale, and smallest complete design. For every cache, delta, shard, queue, retry state machine, abstraction, or configuration surface, name the present evidence that requires it and the simpler alternative it displaces. Prefer bounding current state and moving history behind pagination before distributing synchronization. Done when speculative machinery is deleted, deferred behind a measurable trigger, or justified.
+2. **Map the module graph.** Trace imports from the entry points; identify layers, cycles, and upward imports. Done when you have the real dependency picture, not the README's.
+3. **Verify the stated contracts.** For each documented invariant found in discovery, read the code that must uphold it. Done when each is confirmed intact or broken with file:line evidence.
+4. **Depth-score the key interfaces.** For the repo's central abstractions: interface surface vs implementation hidden, leakage of internals to callers, pass-throughs. Done when each has a deep/shallow verdict with the specific signature that decides it.
+5. **Hunt the classic smells**: information leakage (two modules that must change together), temporal decomposition (modules named after steps, not capabilities), exceptions where errors could be defined away, configuration knobs exporting decisions the module should make, and optimizations without measurements or present requirements. Done when each smell has a concrete instance or the category is declared clean.
+6. **Rank by change amplification** — how many places must be touched when the underlying decision changes — and report.
 
 ## Grounded Reporting
 
-Every structural claim traces to code read this session, cited file:line. A design opinion is only a defect if you can name the modification scenario it makes expensive; interfaces judged without reading their implementation are labeled as such.
+Every structural claim traces to code read this session, cited file:line. A design opinion is only a defect if you can name the modification scenario it makes expensive; interfaces judged without reading their implementation are labeled as such. Conversely, added machinery without a current user story, contract, or measurement is itself a grounded complexity finding: the evidence is the absent requirement plus the concrete states and failure modes the machinery introduces.
 
 ## Output Format
 
-Lead with a one-sentence verdict on architectural health. Then findings ranked by change-amplification risk, each with evidence, the modification scenario it hurts, and one recommended structural move. Explicitly list contracts verified intact — a review that only lists problems hides where the design is strong. Cross-lane handoffs last. In a genie-framework repo, use CRITICAL/HIGH/MEDIUM/LOW for finding severities and SHIP/FIX-FIRST/BLOCKED only for the overall verdict and note which findings warrant a refactor wish via `wish` rather than opportunistic edits.
+Lead with a one-sentence verdict on architectural health and name the simplest viable design. Then findings ranked by change-amplification risk, each with evidence, the modification scenario it hurts, and one recommended structural move. Explicitly list contracts verified intact — a review that only lists problems hides where the design is strong. Cross-lane handoffs last. In a genie-framework repo, treat unjustified stateful machinery as a blocking HIGH plan/design gap, use CRITICAL/HIGH/MEDIUM/LOW for finding severities and SHIP/FIX-FIRST/BLOCKED only for the overall verdict, and note which findings warrant a refactor wish via `wish` rather than opportunistic edits.
 
 ## Pitfalls
 

--- a/plugins/genie/skills/brainstorm/SKILL.md
+++ b/plugins/genie/skills/brainstorm/SKILL.md
@@ -22,8 +22,9 @@ All artifacts live in `.genie/` within the shared worktree. When spawned as a na
 3. **Scope-size check:** if the request spans multiple independent subsystems, decompose before refining (see Scope Size).
 4. **Refine:** fill WRS dimensions. Ask only what an unfilled dimension needs — when the request or context already settles a dimension, mark it filled and move on; never re-litigate decisions the user already made. Prefer concrete options over open questions.
 5. **Show the WRS bar** after every exchange; persist DRAFT.md whenever WRS changes.
-6. **Propose approaches:** 2-3 options with trade-offs, applying Design for Isolation. Recommend one and proceed when the choice follows from the request.
-7. **Crystallize** when WRS = 100 (see Crystallize).
+6. **Pass the Simplicity Gate:** establish the simplest complete approach before considering more machinery. Reject speculative complexity or defer it behind a measurable trigger (see Simplicity Gate).
+7. **Propose approaches:** 2-3 options with trade-offs, applying Design for Isolation. Recommend one and proceed when the choice follows from the request.
+8. **Crystallize** when WRS = 100 (see Crystallize).
 
 ## WRS — Wish Readiness Score
 
@@ -33,7 +34,7 @@ Five dimensions, 20 points each:
 |-----------|-------------|
 | **Problem** | One-sentence problem statement is clear |
 | **Scope** | IN and OUT boundaries defined |
-| **Decisions** | Key technical/design choices made with rationale |
+| **Decisions** | Key technical/design choices made with rationale and the Simplicity Gate passes |
 | **Risks** | Assumptions, constraints, failure modes identified |
 | **Criteria** | At least one testable acceptance criterion exists |
 
@@ -59,6 +60,18 @@ Apply to proposed approaches and the DESIGN.md Approach section:
 - Explicit interfaces and dependencies — contracts, not shared mutable state or hidden coupling.
 - Independent testability — each unit understandable without loading the whole system.
 - File size is a complexity signal — propose splits before a unit becomes unmanageable.
+
+## Simplicity Gate
+
+Before recommending an approach or declaring **Decisions** filled:
+
+1. State the simplest complete design that satisfies the current user stories.
+2. For every added cache, delta, shard, queue, retry state machine, abstraction, or configuration option, name the present requirement or measurement that pays for it.
+3. Count the new durable states, recovery paths, and cross-component invariants each option introduces; treat them as product cost, not implementation detail.
+4. Prefer bounding current data, separating history behind pagination, recomputing, replacement, and opinionated defaults before synchronization or configurability.
+5. Put plausible future machinery under a measurable adoption trigger instead of building it now. “This may scale later” is not evidence.
+
+If the more complex approach lacks present evidence, recommend the simpler one. Do not split the difference by shipping dormant machinery: unused branches still impose protocol, test, security, and maintenance cost.
 
 ## Index
 
@@ -89,7 +102,7 @@ it was tracked. Never update or retain both indexes after a successful merge.
 At WRS = 100:
 
 1. Write `.genie/brainstorms/<slug>/DESIGN.md` from DRAFT.md using `references/design-template.md` (in this skill dir) — fill every placeholder.
-2. **Spec self-review** — fix inline before handing off: no TBD/TODO leftovers (fill or mark explicit OUT), no contradictions between sections, scope fits a single wish (split if not), no requirement readable two different ways.
+2. **Spec self-review** — fix inline before handing off: no TBD/TODO leftovers (fill or mark explicit OUT), no contradictions between sections, scope fits a single wish (split if not), no requirement readable two different ways, and the Simplicity Case justifies every mechanism beyond the simplest complete design.
 3. Stage the design, draft, and canonical index:
    ```bash
    git add .genie/brainstorms/<slug>/DESIGN.md .genie/brainstorms/<slug>/DRAFT.md .genie/INDEX.md
@@ -135,7 +148,7 @@ Never reuse design-review evidence after editing DESIGN.md. `verify` must pass i
 Note cross-repo or cross-agent dependencies — they become `depends-on`/`blocks` fields in the wish.
 
 ## Rules
-- YAGNI and simplicity first; propose alternatives before recommending.
+- KISS and YAGNI are gates, not tie-breakers; speculative machinery blocks crystallization.
 - No implementation during brainstorm.
 - Persist early and often — never wait until the end.
 - Never present an unconfirmed assumption as a settled decision — confirm it or list it under Risks.

--- a/plugins/genie/skills/brainstorm/references/design-template.md
+++ b/plugins/genie/skills/brainstorm/references/design-template.md
@@ -25,6 +25,13 @@
 
 <Chosen approach with rationale. Name the alternatives considered and why they lost.>
 
+## Simplicity Case
+
+- **Simplest complete design:** <smallest design that satisfies current user stories>
+- **Added machinery:** <none, or each mechanism with the present requirement/measurement that justifies it>
+- **Deferred until measured:** <plausible future complexity and the concrete trigger for reconsidering it>
+- **Complexity removed:** <states, failure modes, options, or dependencies deliberately avoided>
+
 ## Decisions
 
 | # | Decision | Rationale |

--- a/plugins/genie/skills/dream/SKILL.md
+++ b/plugins/genie/skills/dream/SKILL.md
@@ -61,7 +61,7 @@ Each worker, independently:
 
 1. Dispatch one reviewer subagent per PR via the native delegation surface (reviewer ≠ worker) to run `review` against the wish's acceptance criteria.
 2. Read bot comments critically — never blindly accept automated findings.
-3. On FIX-FIRST: dispatch `fix` for valid gaps (max 2 loops per PR). On an architectural issue: escalate in the report, no fix attempt.
+3. On FIX-FIRST: diagnose first; return an overdesigned plan to wish/design review, otherwise dispatch `fix` for valid gaps (max 3 loops per PR). On another architectural issue: escalate in the report, no fix attempt.
 4. CI must be green before proceeding — poll status, do not sleep.
 5. On SHIP: mark the PR review-complete.
 

--- a/plugins/genie/skills/fix/SKILL.md
+++ b/plugins/genie/skills/fix/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: fix
-description: "Dispatch fix subagent for FIX-FIRST gaps from review, re-review, then diagnose unresolved failures after 2 loops."
+description: "Dispatch fix subagent for FIX-FIRST gaps from review, re-review, then diagnose unresolved failures after 3 loops."
 ---
 
 # fix — Fix-Review Loop
 
 **Runtime syntax:** in Codex, invoke the plugin copy with the owner-qualified `$genie:<skill>` selector; use bare `$<skill>` only when intentionally selecting a user-tier copy (a separately installed personal copy; Genie no longer seeds this tier). Claude Code and Hermes use `/<skill>`. Cross-skill prose below uses bare names as portable semantic routes; the orchestrator resolves the selector for the active tier.
 
-Resolve FIX-FIRST gaps from `review`: dispatch a fix subagent, re-review, repeat up to 2 loops, then diagnose and route any unresolved failure.
+Resolve FIX-FIRST gaps from `review`: dispatch a fix subagent, re-review, repeat up to 3 loops, then diagnose and route any unresolved failure.
 
 ## When to Use
 - `review` returned a **FIX-FIRST** verdict with CRITICAL or HIGH gaps
 - Orchestrator hands off unresolved gaps after execution review
 
 ## Flow
-1. **Parse gaps:** severity, files, failing checks from the FIX-FIRST verdict.
+1. **Parse and diagnose gaps:** severity, files, failing checks from the FIX-FIRST verdict. If the evidence is `overdesigned-plan`, stop and return to `brainstorm`/`wish`; removing optional machinery is a plan correction, not a code-fix attempt.
 2. **Dispatch fixer:** native delegation surface → fix subagent, briefed with the gap list, the original wish criteria, and any `trace` diagnosis.
 3. **Re-review:** native delegation surface → a separate reviewer subagent (never the fixer) running `review` on the same pipeline.
 4. **Evaluate verdict:**
@@ -22,8 +22,8 @@ Resolve FIX-FIRST gaps from `review`: dispatch a fix subagent, re-review, repeat
 | Verdict | Condition | Action |
 |---------|-----------|--------|
 | SHIP | — | Done. Return to orchestrator. |
-| FIX-FIRST | loop < 2 | Increment loop, go to step 2. |
-| FIX-FIRST | loop = 2 | Stop fixing and run Escalation Diagnosis; max loops reached. |
+| FIX-FIRST | loop < 3 | Increment loop, go to step 2. |
+| FIX-FIRST | loop = 3 | Stop fixing and run Escalation Diagnosis; max loops reached. |
 | BLOCKED | — | Run Escalation Diagnosis and take the cause-specific route. |
 
 5. **Route the diagnosis:** report the remaining gaps with exact files, failing checks, cause class, and corrective route; the group's task stays `in_progress`.
@@ -44,6 +44,7 @@ Use this policy before any model or effort change; keep this contract identical 
 | `missing-context` | The attempt identifies absent files, history, criteria, logs, or other inputs needed to decide. | Supply the missing context and retry at the same model and effort; MUST NOT escalate model or effort. |
 | `ambiguous-spec` | Two or more materially different behaviors remain consistent with the stated criteria. | Request a human decision or wish clarification; MUST NOT escalate model or effort. |
 | `env-tool-failure` | A reproducible environment, dependency, permission, timeout, or tool error prevents valid execution. | Repair or retry the environment/tool, or report blocked with the error; MUST NOT escalate model or effort. |
+| `overdesigned-plan` | Gaps cluster in optional machinery that lacks a current criterion or measurement, while a simpler design satisfies the user stories with fewer durable states or recovery paths. | Stop the fix loop and return to `brainstorm`/`wish` to remove or defer the mechanism. Re-review the amended design/plan; MUST NOT spend retries or model escalation defending it. |
 
 Escalation eligibility requires **new evidence** produced since the previous attempt: attach the new failing output or diagnostic result, the correction already tried, and why it rules out the other three causes. A repeated verdict or unchanged failure is not new evidence and cannot authorize a model or effort change.
 
@@ -58,14 +59,14 @@ The fix loop never mutates task state. The group's task stays `in_progress` thro
 ## Diagnosis / Appeal Format
 
 ```
-Fix loop exhausted (2/2). Group remains in progress.
+Fix loop exhausted (3/3). Group remains in progress.
 Remaining gaps:
 - [CRITICAL] <gap description> — <file>
 - [HIGH] <gap description> — <file>
-Cause: <model-capacity|missing-context|ambiguous-spec|env-tool-failure>
+Cause: <model-capacity|missing-context|ambiguous-spec|env-tool-failure|overdesigned-plan>
 New evidence: <new output/diagnosis, or "none — model/effort escalation prohibited">
 Corrective route: <one cause-specific next step>
-Budget: attempts=<used>/2; effort_escalations=<used>/2
+Budget: attempts=<used>/3; effort_escalations=<used>/2
 Appeal: <reviewer/final-gate disagreement record, or "none">
 ```
 
@@ -78,12 +79,13 @@ Appeal: <reviewer/final-gate disagreement record, or "none">
 - [HIGH] sendMessage result not checked — dispatch.ts:541
 ```
 
-Loop 1: native delegation surface → fixer briefed with both gaps, the wish criteria, and `bun test` as validation. The fixer edits, runs the validation, reports its changes with outcomes, and ends `done`. Then native delegation surface → a fresh reviewer briefed to re-run `review` against the same criteria. SHIP → report success to the orchestrator. FIX-FIRST again → loop 2; after that, classify the cause and take its corrective route. A model or effort raise is permitted only for evidenced `model-capacity` within both caps.
+Loop 1: native delegation surface → fixer briefed with both gaps, the wish criteria, and `bun test` as validation. The fixer edits, runs the validation, reports its changes with outcomes, and ends `done`. Then native delegation surface → a fresh reviewer briefed to re-run `review` against the same criteria. SHIP → report success to the orchestrator. FIX-FIRST again → loops 2 and 3; after loop 3, classify the cause and take its corrective route. A model or effort raise is permitted only for evidenced `model-capacity` within both caps. An `overdesigned-plan` diagnosis stops immediately and returns to planning instead.
 
 ## Rules
 - Tight scope: fix exactly the tagged gaps — no unrequested refactors, features, or drive-by cleanups.
 - Never fix and review in the same session — always separate subagents.
-- Never exceed 2 fix loops — stop, diagnose, and take the cause-specific route.
+- Never exceed 3 fix loops — stop, diagnose, and take the cause-specific route.
+- Never use a fix loop to preserve optional machinery when a simpler plan satisfies the user stories.
 - Include the original wish criteria in every fix dispatch.
 - Identical gaps across loops = no progress; classify the cause. Repetition is not new evidence and never authorizes a model or effort raise.
 - Grounded progress: report only what tool output from this session verifies — state what was fixed, what failed, what was skipped. Never report an attempted fix as complete.

--- a/plugins/genie/skills/pm/SKILL.md
+++ b/plugins/genie/skills/pm/SKILL.md
@@ -36,7 +36,7 @@ The lifecycle is owned by its skills — route to them, never restate them here:
 | Explore | `brainstorm` | Dispatch when scope is fuzzy |
 | Plan | `wish` | Dispatch when scope is clear; the wish creates per-group tasks |
 | Execute | `work` | Dispatch orchestration; waves come from WISH.md |
-| Validate | `review` | Gate every group; FIX-FIRST → `fix` (max 2 loops) |
+| Validate | `review` | Gate every group; FIX-FIRST → `fix` (max 3 loops) |
 | Investigate | `trace`, `report` | Unknown failure: diagnose before fixing |
 | Ship | PR to `dev` | Request or consume task-scoped PR/merge authority; merge only when CI green + review SHIP |
 
@@ -51,7 +51,7 @@ Default chain: engineer → reviewer → qa → fix. Augment when the work calls
 | Docs deliverables in scope | docs subagent, parallel with engineer |
 | Architecture restructuring | refactor-briefed engineer for that group |
 | Failure with unknown root cause | `trace` before `fix` |
-| Review returns FIX-FIRST | `fix` (max 2 loops, then escalate) |
+| Review returns FIX-FIRST | Diagnose first; simplify an overdesigned plan, otherwise `fix` (max 3 loops) |
 | High-stakes decision with tradeoffs | `council` (advisory) |
 
 ## Dispatch

--- a/plugins/genie/skills/review/SKILL.md
+++ b/plugins/genie/skills/review/SKILL.md
@@ -37,6 +37,7 @@ Use this policy before any model or effort change; keep this contract identical 
 | `missing-context` | The attempt identifies absent files, history, criteria, logs, or other inputs needed to decide. | Supply the missing context and retry at the same model and effort; MUST NOT escalate model or effort. |
 | `ambiguous-spec` | Two or more materially different behaviors remain consistent with the stated criteria. | Request a human decision or wish clarification; MUST NOT escalate model or effort. |
 | `env-tool-failure` | A reproducible environment, dependency, permission, timeout, or tool error prevents valid execution. | Repair or retry the environment/tool, or report blocked with the error; MUST NOT escalate model or effort. |
+| `overdesigned-plan` | Gaps cluster in optional machinery that lacks a current criterion or measurement, while a simpler design satisfies the user stories with fewer durable states or recovery paths. | Stop the fix loop and return to `brainstorm`/`wish` to remove or defer the mechanism. Re-review the amended design/plan; MUST NOT spend retries or model escalation defending it. |
 
 Escalation eligibility requires **new evidence** produced since the previous attempt: attach the new failing output or diagnostic result, the correction already tried, and why it rules out the other three causes. A repeated verdict or unchanged failure is not new evidence and cannot authorize a model or effort change.
 
@@ -50,6 +51,8 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 - [ ] Problem is explicit, consequential, and readable one way
 - [ ] Scope has concrete IN and OUT boundaries that fit one wish
 - [ ] Chosen approach names its rationale and rejected alternatives
+- [ ] Simplicity Case states the simplest complete design; every added mechanism has a present requirement or measurement, and future complexity has a concrete adoption trigger
+- [ ] Current state is bounded and history is separated before deltas, sharding, caches, or distributed synchronization are considered
 - [ ] Decisions are consistent with the approach and repository constraints
 - [ ] Risks and assumptions name mitigations or explicit acceptance
 - [ ] Success criteria are testable without requiring execution-group details
@@ -62,6 +65,7 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 - [ ] Tasks are bite-sized and independently shippable
 - [ ] Dependencies tagged (`depends-on` / `blocks`)
 - [ ] Validation commands exist for each execution group
+- [ ] Simplicity Case is executable: no group builds machinery marked deferred, and every stateful mechanism maps to a current success criterion
 
 ### Execution Review (after `work`)
 - [ ] All acceptance criteria met with evidence
@@ -70,6 +74,7 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 - [ ] Work is auditable — commands and outcomes captured
 - [ ] Quality pass: security, maintainability, correctness
 - [ ] No regressions introduced
+- [ ] Implementation did not introduce caches, synchronization states, configuration, or abstractions absent from the approved Simplicity Case
 
 ### PR Review (before merge)
 - [ ] Diff matches wish scope — no unrelated changes
@@ -79,6 +84,8 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 - [ ] Commit messages reference wish slug
 
 ## Severity & Verdicts
+
+In design and plan review, unjustified stateful machinery—such as speculative caches, deltas, sharding, background coordination, or retry state machines—is a HIGH gap because it creates permanent correctness and maintenance obligations without delivering a current criterion. If removing it changes the governing approach, return BLOCKED with `overdesigned-plan` and replan instead of asking a fixer to preserve it.
 
 | Severity | Meaning | Blocks? |
 |----------|---------|---------|
@@ -123,9 +130,10 @@ write. Never edit WISH.md, the brainstorm jar, or task state as the reviewer.
 | PR review (before merge) | Merge to `dev` (agents) or approve for human merge |
 
 ### FIX-FIRST loop
-1. Auto-invoke `fix` with the severity-tagged gap list.
-2. After `fix` completes, re-run `review` (max 2 fix loops).
-3. Still FIX-FIRST after 2 loops → return BLOCKED with an Escalation Diagnosis; never raise model or effort automatically.
+1. Diagnose first. For `overdesigned-plan`, return to `brainstorm`/`wish` without consuming a fix attempt.
+2. Otherwise auto-invoke `fix` with the severity-tagged gap list.
+3. After `fix` completes, re-run `review` (max 3 fix loops).
+4. Still FIX-FIRST after 3 loops → return BLOCKED with an Escalation Diagnosis; never raise model or effort automatically.
 
 When a failure's root cause is unclear, invoke `trace` before dispatching `fix` — `fix` then applies the cause-specific correction from the trace report. An unclear cause is not evidence of `model-capacity`.
 

--- a/plugins/genie/skills/wish/SKILL.md
+++ b/plugins/genie/skills/wish/SKILL.md
@@ -33,9 +33,10 @@ node "<wish-skill-dir>/references/design-review-evidence.mjs" verify ".genie/bra
 ## Flow
 1. **Gate check:** if the request is fuzzy (no prior design, unclear scope, vague requirements), run `brainstorm` first and say so. If a design exists, do not scaffold until its digest-bound design-review evidence verifies as SHIP.
 2. **Align intent:** clarify until success criteria are testable.
-3. **Define scope:** explicit IN and OUT lists. OUT cannot be empty.
-4. **Decompose:** small, loosely coupled execution groups.
-5. **Scaffold** — always copy the template, never hand-write WISH.md. Resolve
+3. **Pass the simplicity gate:** state the simplest complete design, justify every mechanism beyond it with a present requirement or measurement, and defer plausible future complexity behind a concrete trigger. A wish cannot outsource this decision to implementation.
+4. **Define scope:** explicit IN and OUT lists. OUT cannot be empty.
+5. **Decompose:** small, loosely coupled execution groups.
+6. **Scaffold** — always copy the template, never hand-write WISH.md. Resolve
    the absolute directory containing this loaded `SKILL.md`, replace only the
    two placeholder assignments below, and run the complete command from the
    repository root:
@@ -56,20 +57,20 @@ node "<wish-skill-dir>/references/design-review-evidence.mjs" verify ".genie/bra
    <!-- wish-scaffold-command:end -->
 
    The template ships inside this skill as the single source of truth for wish structure — a plain document, no runtime scaffolder. Copying guarantees the skeleton the parser and linter expect; ad-hoc wishes regularly fail structural lint.
-6. **Fill:** replace the `{{slug}}`/`{{date}}` tokens and every `<TODO: …>` marker with real content. Every group gets acceptance criteria plus a validation command.
-7. **Declare dependencies:** use the wish-level `## Dependencies` keys
+7. **Fill:** replace the `{{slug}}`/`{{date}}` tokens and every `<TODO: …>` marker with real content. Every group gets acceptance criteria plus a validation command.
+8. **Declare dependencies:** use the wish-level `## Dependencies` keys
    `**depends-on:** <comma-separated slugs or none>` and
    `**blocks:** <comma-separated slugs or none>` for cross-wish edges. Keep
    per-group `**depends-on:**` fields under each execution group. The spelling
    is always hyphenated; the DAG is a machine-readable planning artifact in git.
-8. **Create tasks** — one per execution group, so `work` can claim and complete each group and the board reflects progress:
+9. **Create tasks** — one per execution group, so `work` can claim and complete each group and the board reflects progress:
    ```bash
    genie task create --title "<group title>" --wish <slug> --group <group-name>
    genie task list --wish <slug>   # inspect what was created
    ```
    Tasks carry the `--wish`/`--group` linkage; the dependency DAG stays in the WISH.md document, not in task rows. If creation fails (no `.genie/genie.db` yet, CLI unavailable), warn and continue — WISH.md in git is the source of truth and must remain usable by `work` without task rows.
-9. **Handoff:** run the wish linter — inside the genie repo, `grep -q '"wishes:lint"' package.json 2>/dev/null && bun run wishes:lint`. If it reports any error, surface it and stop — never hand a structurally broken wish onward. Only after lint passes, auto-invoke `review` (plan review) on the WISH.md. Never suggest `work` directly — the review gate comes first.
-10. **Persist the verdict:** the reviewer only returns evidence. The invoking orchestrator appends that evidence under `## Review Results` and sets the WISH status to `APPROVED` on SHIP, `FIX-FIRST` on FIX-FIRST, or `BLOCKED` on BLOCKED. Do not route to `work` until the `APPROVED` status is on disk.
+10. **Handoff:** run the wish linter — inside the genie repo, `grep -q '"wishes:lint"' package.json 2>/dev/null && bun run wishes:lint`. If it reports any error, surface it and stop — never hand a structurally broken wish onward. Only after lint passes, auto-invoke `review` (plan review) on the WISH.md. Never suggest `work` directly — the review gate comes first.
+11. **Persist the verdict:** the reviewer only returns evidence. The invoking orchestrator appends that evidence under `## Review Results` and sets the WISH status to `APPROVED` on SHIP, `FIX-FIRST` on FIX-FIRST, or `BLOCKED` on BLOCKED. Do not route to `work` until the `APPROVED` status is on disk.
 
 ## Wish Document Sections
 
@@ -79,6 +80,7 @@ node "<wish-skill-dir>/references/design-review-evidence.mjs" verify ".genie/bra
 | Summary | Yes | 2-3 sentences: what and why |
 | Scope IN / OUT | Yes | OUT cannot be empty |
 | Decisions | Yes | Key choices with rationale |
+| Simplicity Case | Yes | Simplest complete design, justified additions, and measurable deferrals |
 | Success Criteria | Yes | Checkboxes, each testable |
 | Execution Strategy | Yes | Wave-based plan — mandatory even if a single sequential wave; forces ordering, parallelism, and dependency thinking upfront |
 | Execution Groups | Yes | Goal, deliverables, acceptance criteria, validation command |
@@ -92,6 +94,7 @@ node "<wish-skill-dir>/references/design-review-evidence.mjs" verify ".genie/bra
 - Never emit a bracket-link to a non-existent brainstorm — use the `_No brainstorm — direct wish_` stub.
 - Never consume a linked design whose persisted review evidence is missing, non-SHIP, or stale; the wish linter independently enforces this for new wishes.
 - No implementation during `wish` — planning only.
+- No speculative optimization: caches, deltas, sharding, background coordination, and configuration surfaces require a current criterion or measurement in the Simplicity Case.
 - Every group testable, bite-sized, and independently shippable; no vague tasks ("improve everything").
 - OUT scope must contain at least one concrete exclusion.
 - Declare cross-wish dependencies early.

--- a/plugins/genie/skills/wish/templates/wish-template.md
+++ b/plugins/genie/skills/wish/templates/wish-template.md
@@ -32,6 +32,13 @@
 |---|----------|-----------|
 | 1 | <TODO: decision> | <TODO: why this over alternatives> |
 
+## Simplicity Case
+
+- **Simplest complete design:** <TODO: smallest design that satisfies current user stories>
+- **Added machinery:** <TODO: none, or each mechanism and the present evidence that requires it>
+- **Deferred until measured:** <TODO: future complexity and its concrete adoption trigger>
+- **Complexity removed:** <TODO: states, failure modes, options, or dependencies deliberately avoided>
+
 ## Dependencies
 
 **depends-on:** none

--- a/plugins/genie/skills/work/SKILL.md
+++ b/plugins/genie/skills/work/SKILL.md
@@ -26,8 +26,8 @@ When you are spawned as a subagent for a group, your dispatch prompt carries the
    ```
    If two agents race one task, exactly one wins; the loser gets a conflict error and stands down.
 4. **Await completion — never poll:** background subagents notify you when they finish. Inspect `genie board --wish <slug>` on demand; completion is push, not poll.
-5. **Local review:** per finished group, dispatch a reviewer subagent (reviewer ≠ engineer) to run `review` against that group's acceptance criteria. The orchestrator appends each returned evidence block under `## Review Results`; the reviewer never edits it. On FIX-FIRST, dispatch a fix subagent (max 2 loops); if unresolved, apply Escalation Diagnosis instead of automatically changing model or effort.
-6. **Quality review:** dispatch a reviewer for a quality pass (security, maintainability, perf). On FIX-FIRST, one fix loop.
+5. **Local review:** per finished group, dispatch a reviewer subagent (reviewer ≠ engineer) to run `review` against that group's acceptance criteria. The orchestrator appends each returned evidence block under `## Review Results`; the reviewer never edits it. Diagnose before fixing: `overdesigned-plan` returns to wish/design review without consuming a fix attempt; other FIX-FIRST gaps may use at most 3 fix loops.
+6. **Quality review:** dispatch a reviewer for a quality pass (security, maintainability, perf). On FIX-FIRST, use the same maximum of 3 fix loops.
 7. **Validate:** run the group's validation command yourself (Bash); record the output as evidence.
 8. **Group done** — only after clean review AND passing validation:
    ```bash
@@ -80,6 +80,7 @@ Extract the group's context from WISH.md and paste it into the dispatch prompt �
 ## State Management
 
 - **Engineers claim** via `genie task checkout <task-id> --worker <name>` as the first step of their brief.
+- **Environment setup is feature work.** Read-only discovery may precede a claim, but before mutating shared host state—installing toolchains or runtimes, starting services or emulators, provisioning credentials, or preparing test infrastructure—claim the group that owns the setup and keep it `in_progress` until setup and validation finish. The visible claim is the concurrency lock: if another live worker owns it, coordinate or stand down; reclaim only a stale claim. When setup is a prerequisite shared by multiple groups, give it an explicit group/task in the wish instead of running untracked preflight. Never let multiple threads independently prepare the same environment.
 - **Engineers signal** completion in their final message; the native team notifies the orchestrator — no manual send.
 - **Orchestrator tracks** via `genie task list --wish <slug>` / `genie board --wish <slug>` (on demand) and completes each verified group with `genie task done <task-id>`. Engineers never call `genie task done`.
 - **The dependency DAG is doc-only.** The v5 CLI has no dependency-edge commands — every CLI-created task is `ready` from birth, so DB status is NOT a dependency signal. Sequence waves from the WISH.md Execution Strategy alone; never dispatch a group just because its task shows `ready`.
@@ -95,6 +96,7 @@ Use this policy before any model or effort change; keep this contract identical 
 | `missing-context` | The attempt identifies absent files, history, criteria, logs, or other inputs needed to decide. | Supply the missing context and retry at the same model and effort; MUST NOT escalate model or effort. |
 | `ambiguous-spec` | Two or more materially different behaviors remain consistent with the stated criteria. | Request a human decision or wish clarification; MUST NOT escalate model or effort. |
 | `env-tool-failure` | A reproducible environment, dependency, permission, timeout, or tool error prevents valid execution. | Repair or retry the environment/tool, or report blocked with the error; MUST NOT escalate model or effort. |
+| `overdesigned-plan` | Gaps cluster in optional machinery that lacks a current criterion or measurement, while a simpler design satisfies the user stories with fewer durable states or recovery paths. | Stop the fix loop and return to `brainstorm`/`wish` to remove or defer the mechanism. Re-review the amended design/plan; MUST NOT spend retries or model escalation defending it. |
 
 Escalation eligibility requires **new evidence** produced since the previous attempt: attach the new failing output or diagnostic result, the correction already tried, and why it rules out the other three causes. A repeated verdict or unchanged failure is not new evidence and cannot authorize a model or effort change.
 
@@ -104,9 +106,12 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 
 When a subagent fails or a fix-loop limit is exhausted, the orchestrator records the cause, evidence, selected route, and current cap counters before another dispatch. It leaves the task `in_progress`, keeps dispatching ready groups that do not depend on the blocked one, and includes unresolved diagnoses and appeals in the final handoff.
 
+A user-approved simplification invalidates the superseded plan/review evidence and starts a fresh plan review; it is not an extra fix attempt. Preserve useful completed work only when it still satisfies the simpler contract, and delete machinery that exists solely for the rejected design.
+
 ## Rules
 - Never execute group work directly — always dispatch via the native delegation surface.
 - Never expand scope during execution; never skip validation commands.
+- Never spend fix loops preserving optional complexity; route an `overdesigned-plan` diagnosis back through wish/design review.
 - Never overwrite WISH.md from subagent output — curated prompts are runtime context; the WISH.md in git is the source of truth.
 - Reviewer ≠ engineer, always.
 - `genie task done` only after clean review and passing validation — and only by the orchestrator.

--- a/scripts/release-docs.test.ts
+++ b/scripts/release-docs.test.ts
@@ -329,6 +329,28 @@ describe('Group E release and documentation contracts', () => {
     expect(pm).toMatch(/Selecting Autopilot\s+does not itself authorize external repository writes/);
   });
 
+  test('lifecycle treats simplicity as a hard gate and replans overdesigned work', () => {
+    const architecture = read('skills/architecture/SKILL.md');
+    const brainstorm = read('skills/brainstorm/SKILL.md');
+    const designTemplate = read('skills/brainstorm/references/design-template.md');
+    const wish = read('skills/wish/SKILL.md');
+    const wishTemplate = read('skills/wish/templates/wish-template.md');
+    const review = read('skills/review/SKILL.md');
+    const fix = read('skills/fix/SKILL.md');
+    const work = read('skills/work/SKILL.md');
+
+    expect(architecture).toContain('KISS comes first');
+    expect(brainstorm).toContain('## Simplicity Gate');
+    expect(designTemplate).toContain('## Simplicity Case');
+    expect(wish).toContain('Pass the simplicity gate');
+    expect(wishTemplate).toContain('## Simplicity Case');
+    expect(review).toContain('unjustified stateful machinery');
+    expect(review).toContain('a HIGH gap');
+    for (const lifecycleSkill of [review, fix, work]) expect(lifecycleSkill).toContain('`overdesigned-plan`');
+    expect(fix).toContain('up to 3 loops');
+    expect(work).toContain('A user-approved simplification invalidates the superseded plan/review evidence');
+  });
+
   test('wizard discloses init MCP writes and owner-qualified lifecycle order', () => {
     const wizard = read('skills/wizard/SKILL.md');
     for (const path of ['.mcp.json', '.warp/.mcp.json', '.codex/config.toml']) expect(wizard).toContain(path);

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -9,7 +9,7 @@ description: Use when reviewing architecture in any codebase — module boundari
 
 ## Lens
 
-This lane treats complexity as anything that makes a system hard to understand or modify — it accumulates as dependencies and obscurity. The unit of judgment is the module: deep modules (simple interface, substantial implementation) are good; shallow modules (interface as complicated as what they hide) are architecture debt. Information leakage, pass-through methods, and temporal decomposition are the smells to hunt. Prize "define errors out of existence" and design-it-twice thinking.
+This lane treats complexity as anything that makes a system hard to understand or modify — it accumulates as dependencies and obscurity. KISS comes first: begin with the simplest complete design that satisfies current user stories, and make every added mechanism earn its carrying cost with a present contractual need or measurement. Hypothetical future scale is not evidence. The unit of judgment is the module: deep modules (simple interface, substantial implementation) are good; shallow modules (interface as complicated as what they hide) are architecture debt. Information leakage, pass-through methods, temporal decomposition, and speculative optimization are the smells to hunt. Prize "define errors out of existence" and design-it-twice thinking.
 
 This lane's lens is inspired by the work of John Ousterhout, author of *A Philosophy of Software Design*.
 
@@ -30,19 +30,20 @@ Architecture is judged against the repo's own stated intent, then against first 
 
 ## Workflow
 
-1. **Map the module graph.** Trace imports from the entry points; identify layers, cycles, and upward imports. Done when you have the real dependency picture, not the README's.
-2. **Verify the stated contracts.** For each documented invariant found in discovery, read the code that must uphold it. Done when each is confirmed intact or broken with file:line evidence.
-3. **Depth-score the key interfaces.** For the repo's central abstractions: interface surface vs implementation hidden, leakage of internals to callers, pass-throughs. Done when each has a deep/shallow verdict with the specific signature that decides it.
-4. **Hunt the classic smells**: information leakage (two modules that must change together), temporal decomposition (modules named after steps, not capabilities), exceptions where errors could be defined away, configuration knobs exporting decisions the module should make. Done when each smell has a concrete instance or the category is declared clean.
-5. **Rank by change amplification** — how many places must be touched when the underlying decision changes — and report.
+1. **Establish the simplicity baseline.** State the current user stories, realistic scale, and smallest complete design. For every cache, delta, shard, queue, retry state machine, abstraction, or configuration surface, name the present evidence that requires it and the simpler alternative it displaces. Prefer bounding current state and moving history behind pagination before distributing synchronization. Done when speculative machinery is deleted, deferred behind a measurable trigger, or justified.
+2. **Map the module graph.** Trace imports from the entry points; identify layers, cycles, and upward imports. Done when you have the real dependency picture, not the README's.
+3. **Verify the stated contracts.** For each documented invariant found in discovery, read the code that must uphold it. Done when each is confirmed intact or broken with file:line evidence.
+4. **Depth-score the key interfaces.** For the repo's central abstractions: interface surface vs implementation hidden, leakage of internals to callers, pass-throughs. Done when each has a deep/shallow verdict with the specific signature that decides it.
+5. **Hunt the classic smells**: information leakage (two modules that must change together), temporal decomposition (modules named after steps, not capabilities), exceptions where errors could be defined away, configuration knobs exporting decisions the module should make, and optimizations without measurements or present requirements. Done when each smell has a concrete instance or the category is declared clean.
+6. **Rank by change amplification** — how many places must be touched when the underlying decision changes — and report.
 
 ## Grounded Reporting
 
-Every structural claim traces to code read this session, cited file:line. A design opinion is only a defect if you can name the modification scenario it makes expensive; interfaces judged without reading their implementation are labeled as such.
+Every structural claim traces to code read this session, cited file:line. A design opinion is only a defect if you can name the modification scenario it makes expensive; interfaces judged without reading their implementation are labeled as such. Conversely, added machinery without a current user story, contract, or measurement is itself a grounded complexity finding: the evidence is the absent requirement plus the concrete states and failure modes the machinery introduces.
 
 ## Output Format
 
-Lead with a one-sentence verdict on architectural health. Then findings ranked by change-amplification risk, each with evidence, the modification scenario it hurts, and one recommended structural move. Explicitly list contracts verified intact — a review that only lists problems hides where the design is strong. Cross-lane handoffs last. In a genie-framework repo, use CRITICAL/HIGH/MEDIUM/LOW for finding severities and SHIP/FIX-FIRST/BLOCKED only for the overall verdict and note which findings warrant a refactor wish via `wish` rather than opportunistic edits.
+Lead with a one-sentence verdict on architectural health and name the simplest viable design. Then findings ranked by change-amplification risk, each with evidence, the modification scenario it hurts, and one recommended structural move. Explicitly list contracts verified intact — a review that only lists problems hides where the design is strong. Cross-lane handoffs last. In a genie-framework repo, treat unjustified stateful machinery as a blocking HIGH plan/design gap, use CRITICAL/HIGH/MEDIUM/LOW for finding severities and SHIP/FIX-FIRST/BLOCKED only for the overall verdict, and note which findings warrant a refactor wish via `wish` rather than opportunistic edits.
 
 ## Pitfalls
 

--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -22,8 +22,9 @@ All artifacts live in `.genie/` within the shared worktree. When spawned as a na
 3. **Scope-size check:** if the request spans multiple independent subsystems, decompose before refining (see Scope Size).
 4. **Refine:** fill WRS dimensions. Ask only what an unfilled dimension needs — when the request or context already settles a dimension, mark it filled and move on; never re-litigate decisions the user already made. Prefer concrete options over open questions.
 5. **Show the WRS bar** after every exchange; persist DRAFT.md whenever WRS changes.
-6. **Propose approaches:** 2-3 options with trade-offs, applying Design for Isolation. Recommend one and proceed when the choice follows from the request.
-7. **Crystallize** when WRS = 100 (see Crystallize).
+6. **Pass the Simplicity Gate:** establish the simplest complete approach before considering more machinery. Reject speculative complexity or defer it behind a measurable trigger (see Simplicity Gate).
+7. **Propose approaches:** 2-3 options with trade-offs, applying Design for Isolation. Recommend one and proceed when the choice follows from the request.
+8. **Crystallize** when WRS = 100 (see Crystallize).
 
 ## WRS — Wish Readiness Score
 
@@ -33,7 +34,7 @@ Five dimensions, 20 points each:
 |-----------|-------------|
 | **Problem** | One-sentence problem statement is clear |
 | **Scope** | IN and OUT boundaries defined |
-| **Decisions** | Key technical/design choices made with rationale |
+| **Decisions** | Key technical/design choices made with rationale and the Simplicity Gate passes |
 | **Risks** | Assumptions, constraints, failure modes identified |
 | **Criteria** | At least one testable acceptance criterion exists |
 
@@ -59,6 +60,18 @@ Apply to proposed approaches and the DESIGN.md Approach section:
 - Explicit interfaces and dependencies — contracts, not shared mutable state or hidden coupling.
 - Independent testability — each unit understandable without loading the whole system.
 - File size is a complexity signal — propose splits before a unit becomes unmanageable.
+
+## Simplicity Gate
+
+Before recommending an approach or declaring **Decisions** filled:
+
+1. State the simplest complete design that satisfies the current user stories.
+2. For every added cache, delta, shard, queue, retry state machine, abstraction, or configuration option, name the present requirement or measurement that pays for it.
+3. Count the new durable states, recovery paths, and cross-component invariants each option introduces; treat them as product cost, not implementation detail.
+4. Prefer bounding current data, separating history behind pagination, recomputing, replacement, and opinionated defaults before synchronization or configurability.
+5. Put plausible future machinery under a measurable adoption trigger instead of building it now. “This may scale later” is not evidence.
+
+If the more complex approach lacks present evidence, recommend the simpler one. Do not split the difference by shipping dormant machinery: unused branches still impose protocol, test, security, and maintenance cost.
 
 ## Index
 
@@ -89,7 +102,7 @@ it was tracked. Never update or retain both indexes after a successful merge.
 At WRS = 100:
 
 1. Write `.genie/brainstorms/<slug>/DESIGN.md` from DRAFT.md using `references/design-template.md` (in this skill dir) — fill every placeholder.
-2. **Spec self-review** — fix inline before handing off: no TBD/TODO leftovers (fill or mark explicit OUT), no contradictions between sections, scope fits a single wish (split if not), no requirement readable two different ways.
+2. **Spec self-review** — fix inline before handing off: no TBD/TODO leftovers (fill or mark explicit OUT), no contradictions between sections, scope fits a single wish (split if not), no requirement readable two different ways, and the Simplicity Case justifies every mechanism beyond the simplest complete design.
 3. Stage the design, draft, and canonical index:
    ```bash
    git add .genie/brainstorms/<slug>/DESIGN.md .genie/brainstorms/<slug>/DRAFT.md .genie/INDEX.md
@@ -135,7 +148,7 @@ Never reuse design-review evidence after editing DESIGN.md. `verify` must pass i
 Note cross-repo or cross-agent dependencies — they become `depends-on`/`blocks` fields in the wish.
 
 ## Rules
-- YAGNI and simplicity first; propose alternatives before recommending.
+- KISS and YAGNI are gates, not tie-breakers; speculative machinery blocks crystallization.
 - No implementation during brainstorm.
 - Persist early and often — never wait until the end.
 - Never present an unconfirmed assumption as a settled decision — confirm it or list it under Risks.

--- a/skills/brainstorm/references/design-template.md
+++ b/skills/brainstorm/references/design-template.md
@@ -25,6 +25,13 @@
 
 <Chosen approach with rationale. Name the alternatives considered and why they lost.>
 
+## Simplicity Case
+
+- **Simplest complete design:** <smallest design that satisfies current user stories>
+- **Added machinery:** <none, or each mechanism with the present requirement/measurement that justifies it>
+- **Deferred until measured:** <plausible future complexity and the concrete trigger for reconsidering it>
+- **Complexity removed:** <states, failure modes, options, or dependencies deliberately avoided>
+
 ## Decisions
 
 | # | Decision | Rationale |

--- a/skills/dream/SKILL.md
+++ b/skills/dream/SKILL.md
@@ -61,7 +61,7 @@ Each worker, independently:
 
 1. Dispatch one reviewer subagent per PR via the native delegation surface (reviewer ≠ worker) to run `review` against the wish's acceptance criteria.
 2. Read bot comments critically — never blindly accept automated findings.
-3. On FIX-FIRST: dispatch `fix` for valid gaps (max 2 loops per PR). On an architectural issue: escalate in the report, no fix attempt.
+3. On FIX-FIRST: diagnose first; return an overdesigned plan to wish/design review, otherwise dispatch `fix` for valid gaps (max 3 loops per PR). On another architectural issue: escalate in the report, no fix attempt.
 4. CI must be green before proceeding — poll status, do not sleep.
 5. On SHIP: mark the PR review-complete.
 

--- a/skills/fix/SKILL.md
+++ b/skills/fix/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: fix
-description: "Dispatch fix subagent for FIX-FIRST gaps from review, re-review, then diagnose unresolved failures after 2 loops."
+description: "Dispatch fix subagent for FIX-FIRST gaps from review, re-review, then diagnose unresolved failures after 3 loops."
 ---
 
 # fix — Fix-Review Loop
 
 **Runtime syntax:** in Codex, invoke the plugin copy with the owner-qualified `$genie:<skill>` selector; use bare `$<skill>` only when intentionally selecting a user-tier copy (a separately installed personal copy; Genie no longer seeds this tier). Claude Code and Hermes use `/<skill>`. Cross-skill prose below uses bare names as portable semantic routes; the orchestrator resolves the selector for the active tier.
 
-Resolve FIX-FIRST gaps from `review`: dispatch a fix subagent, re-review, repeat up to 2 loops, then diagnose and route any unresolved failure.
+Resolve FIX-FIRST gaps from `review`: dispatch a fix subagent, re-review, repeat up to 3 loops, then diagnose and route any unresolved failure.
 
 ## When to Use
 - `review` returned a **FIX-FIRST** verdict with CRITICAL or HIGH gaps
 - Orchestrator hands off unresolved gaps after execution review
 
 ## Flow
-1. **Parse gaps:** severity, files, failing checks from the FIX-FIRST verdict.
+1. **Parse and diagnose gaps:** severity, files, failing checks from the FIX-FIRST verdict. If the evidence is `overdesigned-plan`, stop and return to `brainstorm`/`wish`; removing optional machinery is a plan correction, not a code-fix attempt.
 2. **Dispatch fixer:** native delegation surface → fix subagent, briefed with the gap list, the original wish criteria, and any `trace` diagnosis.
 3. **Re-review:** native delegation surface → a separate reviewer subagent (never the fixer) running `review` on the same pipeline.
 4. **Evaluate verdict:**
@@ -22,8 +22,8 @@ Resolve FIX-FIRST gaps from `review`: dispatch a fix subagent, re-review, repeat
 | Verdict | Condition | Action |
 |---------|-----------|--------|
 | SHIP | — | Done. Return to orchestrator. |
-| FIX-FIRST | loop < 2 | Increment loop, go to step 2. |
-| FIX-FIRST | loop = 2 | Stop fixing and run Escalation Diagnosis; max loops reached. |
+| FIX-FIRST | loop < 3 | Increment loop, go to step 2. |
+| FIX-FIRST | loop = 3 | Stop fixing and run Escalation Diagnosis; max loops reached. |
 | BLOCKED | — | Run Escalation Diagnosis and take the cause-specific route. |
 
 5. **Route the diagnosis:** report the remaining gaps with exact files, failing checks, cause class, and corrective route; the group's task stays `in_progress`.
@@ -44,6 +44,7 @@ Use this policy before any model or effort change; keep this contract identical 
 | `missing-context` | The attempt identifies absent files, history, criteria, logs, or other inputs needed to decide. | Supply the missing context and retry at the same model and effort; MUST NOT escalate model or effort. |
 | `ambiguous-spec` | Two or more materially different behaviors remain consistent with the stated criteria. | Request a human decision or wish clarification; MUST NOT escalate model or effort. |
 | `env-tool-failure` | A reproducible environment, dependency, permission, timeout, or tool error prevents valid execution. | Repair or retry the environment/tool, or report blocked with the error; MUST NOT escalate model or effort. |
+| `overdesigned-plan` | Gaps cluster in optional machinery that lacks a current criterion or measurement, while a simpler design satisfies the user stories with fewer durable states or recovery paths. | Stop the fix loop and return to `brainstorm`/`wish` to remove or defer the mechanism. Re-review the amended design/plan; MUST NOT spend retries or model escalation defending it. |
 
 Escalation eligibility requires **new evidence** produced since the previous attempt: attach the new failing output or diagnostic result, the correction already tried, and why it rules out the other three causes. A repeated verdict or unchanged failure is not new evidence and cannot authorize a model or effort change.
 
@@ -58,14 +59,14 @@ The fix loop never mutates task state. The group's task stays `in_progress` thro
 ## Diagnosis / Appeal Format
 
 ```
-Fix loop exhausted (2/2). Group remains in progress.
+Fix loop exhausted (3/3). Group remains in progress.
 Remaining gaps:
 - [CRITICAL] <gap description> — <file>
 - [HIGH] <gap description> — <file>
-Cause: <model-capacity|missing-context|ambiguous-spec|env-tool-failure>
+Cause: <model-capacity|missing-context|ambiguous-spec|env-tool-failure|overdesigned-plan>
 New evidence: <new output/diagnosis, or "none — model/effort escalation prohibited">
 Corrective route: <one cause-specific next step>
-Budget: attempts=<used>/2; effort_escalations=<used>/2
+Budget: attempts=<used>/3; effort_escalations=<used>/2
 Appeal: <reviewer/final-gate disagreement record, or "none">
 ```
 
@@ -78,12 +79,13 @@ Appeal: <reviewer/final-gate disagreement record, or "none">
 - [HIGH] sendMessage result not checked — dispatch.ts:541
 ```
 
-Loop 1: native delegation surface → fixer briefed with both gaps, the wish criteria, and `bun test` as validation. The fixer edits, runs the validation, reports its changes with outcomes, and ends `done`. Then native delegation surface → a fresh reviewer briefed to re-run `review` against the same criteria. SHIP → report success to the orchestrator. FIX-FIRST again → loop 2; after that, classify the cause and take its corrective route. A model or effort raise is permitted only for evidenced `model-capacity` within both caps.
+Loop 1: native delegation surface → fixer briefed with both gaps, the wish criteria, and `bun test` as validation. The fixer edits, runs the validation, reports its changes with outcomes, and ends `done`. Then native delegation surface → a fresh reviewer briefed to re-run `review` against the same criteria. SHIP → report success to the orchestrator. FIX-FIRST again → loops 2 and 3; after loop 3, classify the cause and take its corrective route. A model or effort raise is permitted only for evidenced `model-capacity` within both caps. An `overdesigned-plan` diagnosis stops immediately and returns to planning instead.
 
 ## Rules
 - Tight scope: fix exactly the tagged gaps — no unrequested refactors, features, or drive-by cleanups.
 - Never fix and review in the same session — always separate subagents.
-- Never exceed 2 fix loops — stop, diagnose, and take the cause-specific route.
+- Never exceed 3 fix loops — stop, diagnose, and take the cause-specific route.
+- Never use a fix loop to preserve optional machinery when a simpler plan satisfies the user stories.
 - Include the original wish criteria in every fix dispatch.
 - Identical gaps across loops = no progress; classify the cause. Repetition is not new evidence and never authorizes a model or effort raise.
 - Grounded progress: report only what tool output from this session verifies — state what was fixed, what failed, what was skipped. Never report an attempted fix as complete.

--- a/skills/pm/SKILL.md
+++ b/skills/pm/SKILL.md
@@ -36,7 +36,7 @@ The lifecycle is owned by its skills — route to them, never restate them here:
 | Explore | `brainstorm` | Dispatch when scope is fuzzy |
 | Plan | `wish` | Dispatch when scope is clear; the wish creates per-group tasks |
 | Execute | `work` | Dispatch orchestration; waves come from WISH.md |
-| Validate | `review` | Gate every group; FIX-FIRST → `fix` (max 2 loops) |
+| Validate | `review` | Gate every group; FIX-FIRST → `fix` (max 3 loops) |
 | Investigate | `trace`, `report` | Unknown failure: diagnose before fixing |
 | Ship | PR to `dev` | Request or consume task-scoped PR/merge authority; merge only when CI green + review SHIP |
 
@@ -51,7 +51,7 @@ Default chain: engineer → reviewer → qa → fix. Augment when the work calls
 | Docs deliverables in scope | docs subagent, parallel with engineer |
 | Architecture restructuring | refactor-briefed engineer for that group |
 | Failure with unknown root cause | `trace` before `fix` |
-| Review returns FIX-FIRST | `fix` (max 2 loops, then escalate) |
+| Review returns FIX-FIRST | Diagnose first; simplify an overdesigned plan, otherwise `fix` (max 3 loops) |
 | High-stakes decision with tradeoffs | `council` (advisory) |
 
 ## Dispatch

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -37,6 +37,7 @@ Use this policy before any model or effort change; keep this contract identical 
 | `missing-context` | The attempt identifies absent files, history, criteria, logs, or other inputs needed to decide. | Supply the missing context and retry at the same model and effort; MUST NOT escalate model or effort. |
 | `ambiguous-spec` | Two or more materially different behaviors remain consistent with the stated criteria. | Request a human decision or wish clarification; MUST NOT escalate model or effort. |
 | `env-tool-failure` | A reproducible environment, dependency, permission, timeout, or tool error prevents valid execution. | Repair or retry the environment/tool, or report blocked with the error; MUST NOT escalate model or effort. |
+| `overdesigned-plan` | Gaps cluster in optional machinery that lacks a current criterion or measurement, while a simpler design satisfies the user stories with fewer durable states or recovery paths. | Stop the fix loop and return to `brainstorm`/`wish` to remove or defer the mechanism. Re-review the amended design/plan; MUST NOT spend retries or model escalation defending it. |
 
 Escalation eligibility requires **new evidence** produced since the previous attempt: attach the new failing output or diagnostic result, the correction already tried, and why it rules out the other three causes. A repeated verdict or unchanged failure is not new evidence and cannot authorize a model or effort change.
 
@@ -50,6 +51,8 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 - [ ] Problem is explicit, consequential, and readable one way
 - [ ] Scope has concrete IN and OUT boundaries that fit one wish
 - [ ] Chosen approach names its rationale and rejected alternatives
+- [ ] Simplicity Case states the simplest complete design; every added mechanism has a present requirement or measurement, and future complexity has a concrete adoption trigger
+- [ ] Current state is bounded and history is separated before deltas, sharding, caches, or distributed synchronization are considered
 - [ ] Decisions are consistent with the approach and repository constraints
 - [ ] Risks and assumptions name mitigations or explicit acceptance
 - [ ] Success criteria are testable without requiring execution-group details
@@ -62,6 +65,7 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 - [ ] Tasks are bite-sized and independently shippable
 - [ ] Dependencies tagged (`depends-on` / `blocks`)
 - [ ] Validation commands exist for each execution group
+- [ ] Simplicity Case is executable: no group builds machinery marked deferred, and every stateful mechanism maps to a current success criterion
 
 ### Execution Review (after `work`)
 - [ ] All acceptance criteria met with evidence
@@ -70,6 +74,7 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 - [ ] Work is auditable — commands and outcomes captured
 - [ ] Quality pass: security, maintainability, correctness
 - [ ] No regressions introduced
+- [ ] Implementation did not introduce caches, synchronization states, configuration, or abstractions absent from the approved Simplicity Case
 
 ### PR Review (before merge)
 - [ ] Diff matches wish scope — no unrelated changes
@@ -79,6 +84,8 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 - [ ] Commit messages reference wish slug
 
 ## Severity & Verdicts
+
+In design and plan review, unjustified stateful machinery—such as speculative caches, deltas, sharding, background coordination, or retry state machines—is a HIGH gap because it creates permanent correctness and maintenance obligations without delivering a current criterion. If removing it changes the governing approach, return BLOCKED with `overdesigned-plan` and replan instead of asking a fixer to preserve it.
 
 | Severity | Meaning | Blocks? |
 |----------|---------|---------|
@@ -123,9 +130,10 @@ write. Never edit WISH.md, the brainstorm jar, or task state as the reviewer.
 | PR review (before merge) | Merge to `dev` (agents) or approve for human merge |
 
 ### FIX-FIRST loop
-1. Auto-invoke `fix` with the severity-tagged gap list.
-2. After `fix` completes, re-run `review` (max 2 fix loops).
-3. Still FIX-FIRST after 2 loops → return BLOCKED with an Escalation Diagnosis; never raise model or effort automatically.
+1. Diagnose first. For `overdesigned-plan`, return to `brainstorm`/`wish` without consuming a fix attempt.
+2. Otherwise auto-invoke `fix` with the severity-tagged gap list.
+3. After `fix` completes, re-run `review` (max 3 fix loops).
+4. Still FIX-FIRST after 3 loops → return BLOCKED with an Escalation Diagnosis; never raise model or effort automatically.
 
 When a failure's root cause is unclear, invoke `trace` before dispatching `fix` — `fix` then applies the cause-specific correction from the trace report. An unclear cause is not evidence of `model-capacity`.
 

--- a/skills/wish/SKILL.md
+++ b/skills/wish/SKILL.md
@@ -33,9 +33,10 @@ node "<wish-skill-dir>/references/design-review-evidence.mjs" verify ".genie/bra
 ## Flow
 1. **Gate check:** if the request is fuzzy (no prior design, unclear scope, vague requirements), run `brainstorm` first and say so. If a design exists, do not scaffold until its digest-bound design-review evidence verifies as SHIP.
 2. **Align intent:** clarify until success criteria are testable.
-3. **Define scope:** explicit IN and OUT lists. OUT cannot be empty.
-4. **Decompose:** small, loosely coupled execution groups.
-5. **Scaffold** — always copy the template, never hand-write WISH.md. Resolve
+3. **Pass the simplicity gate:** state the simplest complete design, justify every mechanism beyond it with a present requirement or measurement, and defer plausible future complexity behind a concrete trigger. A wish cannot outsource this decision to implementation.
+4. **Define scope:** explicit IN and OUT lists. OUT cannot be empty.
+5. **Decompose:** small, loosely coupled execution groups.
+6. **Scaffold** — always copy the template, never hand-write WISH.md. Resolve
    the absolute directory containing this loaded `SKILL.md`, replace only the
    two placeholder assignments below, and run the complete command from the
    repository root:
@@ -56,20 +57,20 @@ node "<wish-skill-dir>/references/design-review-evidence.mjs" verify ".genie/bra
    <!-- wish-scaffold-command:end -->
 
    The template ships inside this skill as the single source of truth for wish structure — a plain document, no runtime scaffolder. Copying guarantees the skeleton the parser and linter expect; ad-hoc wishes regularly fail structural lint.
-6. **Fill:** replace the `{{slug}}`/`{{date}}` tokens and every `<TODO: …>` marker with real content. Every group gets acceptance criteria plus a validation command.
-7. **Declare dependencies:** use the wish-level `## Dependencies` keys
+7. **Fill:** replace the `{{slug}}`/`{{date}}` tokens and every `<TODO: …>` marker with real content. Every group gets acceptance criteria plus a validation command.
+8. **Declare dependencies:** use the wish-level `## Dependencies` keys
    `**depends-on:** <comma-separated slugs or none>` and
    `**blocks:** <comma-separated slugs or none>` for cross-wish edges. Keep
    per-group `**depends-on:**` fields under each execution group. The spelling
    is always hyphenated; the DAG is a machine-readable planning artifact in git.
-8. **Create tasks** — one per execution group, so `work` can claim and complete each group and the board reflects progress:
+9. **Create tasks** — one per execution group, so `work` can claim and complete each group and the board reflects progress:
    ```bash
    genie task create --title "<group title>" --wish <slug> --group <group-name>
    genie task list --wish <slug>   # inspect what was created
    ```
    Tasks carry the `--wish`/`--group` linkage; the dependency DAG stays in the WISH.md document, not in task rows. If creation fails (no `.genie/genie.db` yet, CLI unavailable), warn and continue — WISH.md in git is the source of truth and must remain usable by `work` without task rows.
-9. **Handoff:** run the wish linter — inside the genie repo, `grep -q '"wishes:lint"' package.json 2>/dev/null && bun run wishes:lint`. If it reports any error, surface it and stop — never hand a structurally broken wish onward. Only after lint passes, auto-invoke `review` (plan review) on the WISH.md. Never suggest `work` directly — the review gate comes first.
-10. **Persist the verdict:** the reviewer only returns evidence. The invoking orchestrator appends that evidence under `## Review Results` and sets the WISH status to `APPROVED` on SHIP, `FIX-FIRST` on FIX-FIRST, or `BLOCKED` on BLOCKED. Do not route to `work` until the `APPROVED` status is on disk.
+10. **Handoff:** run the wish linter — inside the genie repo, `grep -q '"wishes:lint"' package.json 2>/dev/null && bun run wishes:lint`. If it reports any error, surface it and stop — never hand a structurally broken wish onward. Only after lint passes, auto-invoke `review` (plan review) on the WISH.md. Never suggest `work` directly — the review gate comes first.
+11. **Persist the verdict:** the reviewer only returns evidence. The invoking orchestrator appends that evidence under `## Review Results` and sets the WISH status to `APPROVED` on SHIP, `FIX-FIRST` on FIX-FIRST, or `BLOCKED` on BLOCKED. Do not route to `work` until the `APPROVED` status is on disk.
 
 ## Wish Document Sections
 
@@ -79,6 +80,7 @@ node "<wish-skill-dir>/references/design-review-evidence.mjs" verify ".genie/bra
 | Summary | Yes | 2-3 sentences: what and why |
 | Scope IN / OUT | Yes | OUT cannot be empty |
 | Decisions | Yes | Key choices with rationale |
+| Simplicity Case | Yes | Simplest complete design, justified additions, and measurable deferrals |
 | Success Criteria | Yes | Checkboxes, each testable |
 | Execution Strategy | Yes | Wave-based plan — mandatory even if a single sequential wave; forces ordering, parallelism, and dependency thinking upfront |
 | Execution Groups | Yes | Goal, deliverables, acceptance criteria, validation command |
@@ -92,6 +94,7 @@ node "<wish-skill-dir>/references/design-review-evidence.mjs" verify ".genie/bra
 - Never emit a bracket-link to a non-existent brainstorm — use the `_No brainstorm — direct wish_` stub.
 - Never consume a linked design whose persisted review evidence is missing, non-SHIP, or stale; the wish linter independently enforces this for new wishes.
 - No implementation during `wish` — planning only.
+- No speculative optimization: caches, deltas, sharding, background coordination, and configuration surfaces require a current criterion or measurement in the Simplicity Case.
 - Every group testable, bite-sized, and independently shippable; no vague tasks ("improve everything").
 - OUT scope must contain at least one concrete exclusion.
 - Declare cross-wish dependencies early.

--- a/skills/wish/templates/wish-template.md
+++ b/skills/wish/templates/wish-template.md
@@ -32,6 +32,13 @@
 |---|----------|-----------|
 | 1 | <TODO: decision> | <TODO: why this over alternatives> |
 
+## Simplicity Case
+
+- **Simplest complete design:** <TODO: smallest design that satisfies current user stories>
+- **Added machinery:** <TODO: none, or each mechanism and the present evidence that requires it>
+- **Deferred until measured:** <TODO: future complexity and its concrete adoption trigger>
+- **Complexity removed:** <TODO: states, failure modes, options, or dependencies deliberately avoided>
+
 ## Dependencies
 
 **depends-on:** none

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -26,8 +26,8 @@ When you are spawned as a subagent for a group, your dispatch prompt carries the
    ```
    If two agents race one task, exactly one wins; the loser gets a conflict error and stands down.
 4. **Await completion — never poll:** background subagents notify you when they finish. Inspect `genie board --wish <slug>` on demand; completion is push, not poll.
-5. **Local review:** per finished group, dispatch a reviewer subagent (reviewer ≠ engineer) to run `review` against that group's acceptance criteria. The orchestrator appends each returned evidence block under `## Review Results`; the reviewer never edits it. On FIX-FIRST, dispatch a fix subagent (max 2 loops); if unresolved, apply Escalation Diagnosis instead of automatically changing model or effort.
-6. **Quality review:** dispatch a reviewer for a quality pass (security, maintainability, perf). On FIX-FIRST, one fix loop.
+5. **Local review:** per finished group, dispatch a reviewer subagent (reviewer ≠ engineer) to run `review` against that group's acceptance criteria. The orchestrator appends each returned evidence block under `## Review Results`; the reviewer never edits it. Diagnose before fixing: `overdesigned-plan` returns to wish/design review without consuming a fix attempt; other FIX-FIRST gaps may use at most 3 fix loops.
+6. **Quality review:** dispatch a reviewer for a quality pass (security, maintainability, perf). On FIX-FIRST, use the same maximum of 3 fix loops.
 7. **Validate:** run the group's validation command yourself (Bash); record the output as evidence.
 8. **Group done** — only after clean review AND passing validation:
    ```bash
@@ -80,6 +80,7 @@ Extract the group's context from WISH.md and paste it into the dispatch prompt �
 ## State Management
 
 - **Engineers claim** via `genie task checkout <task-id> --worker <name>` as the first step of their brief.
+- **Environment setup is feature work.** Read-only discovery may precede a claim, but before mutating shared host state—installing toolchains or runtimes, starting services or emulators, provisioning credentials, or preparing test infrastructure—claim the group that owns the setup and keep it `in_progress` until setup and validation finish. The visible claim is the concurrency lock: if another live worker owns it, coordinate or stand down; reclaim only a stale claim. When setup is a prerequisite shared by multiple groups, give it an explicit group/task in the wish instead of running untracked preflight. Never let multiple threads independently prepare the same environment.
 - **Engineers signal** completion in their final message; the native team notifies the orchestrator — no manual send.
 - **Orchestrator tracks** via `genie task list --wish <slug>` / `genie board --wish <slug>` (on demand) and completes each verified group with `genie task done <task-id>`. Engineers never call `genie task done`.
 - **The dependency DAG is doc-only.** The v5 CLI has no dependency-edge commands — every CLI-created task is `ready` from birth, so DB status is NOT a dependency signal. Sequence waves from the WISH.md Execution Strategy alone; never dispatch a group just because its task shows `ready`.
@@ -95,6 +96,7 @@ Use this policy before any model or effort change; keep this contract identical 
 | `missing-context` | The attempt identifies absent files, history, criteria, logs, or other inputs needed to decide. | Supply the missing context and retry at the same model and effort; MUST NOT escalate model or effort. |
 | `ambiguous-spec` | Two or more materially different behaviors remain consistent with the stated criteria. | Request a human decision or wish clarification; MUST NOT escalate model or effort. |
 | `env-tool-failure` | A reproducible environment, dependency, permission, timeout, or tool error prevents valid execution. | Repair or retry the environment/tool, or report blocked with the error; MUST NOT escalate model or effort. |
+| `overdesigned-plan` | Gaps cluster in optional machinery that lacks a current criterion or measurement, while a simpler design satisfies the user stories with fewer durable states or recovery paths. | Stop the fix loop and return to `brainstorm`/`wish` to remove or defer the mechanism. Re-review the amended design/plan; MUST NOT spend retries or model escalation defending it. |
 
 Escalation eligibility requires **new evidence** produced since the previous attempt: attach the new failing output or diagnostic result, the correction already tried, and why it rules out the other three causes. A repeated verdict or unchanged failure is not new evidence and cannot authorize a model or effort change.
 
@@ -104,9 +106,12 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 
 When a subagent fails or a fix-loop limit is exhausted, the orchestrator records the cause, evidence, selected route, and current cap counters before another dispatch. It leaves the task `in_progress`, keeps dispatching ready groups that do not depend on the blocked one, and includes unresolved diagnoses and appeals in the final handoff.
 
+A user-approved simplification invalidates the superseded plan/review evidence and starts a fresh plan review; it is not an extra fix attempt. Preserve useful completed work only when it still satisfies the simpler contract, and delete machinery that exists solely for the rejected design.
+
 ## Rules
 - Never execute group work directly — always dispatch via the native delegation surface.
 - Never expand scope during execution; never skip validation commands.
+- Never spend fix loops preserving optional complexity; route an `overdesigned-plan` diagnosis back through wish/design review.
 - Never overwrite WISH.md from subagent output — curated prompts are runtime context; the WISH.md in git is the source of truth.
 - Reviewer ≠ engineer, always.
 - `genie task done` only after clean review and passing validation — and only by the orchestrator.


### PR DESCRIPTION
## What changed

- Make KISS/YAGNI a hard gate across brainstorm, wish, review, fix, work, architecture, dream, and PM guidance.
- Add a required Simplicity Case to design and wish templates.
- Route overdesigned plans back to brainstorm/wish instead of spending fix retries defending optional machinery.
- Keep canonical and shipped plugin skill copies in sync.
- Add a release-doc contract test covering the new lifecycle behavior.

## Why

Genie already valued simplicity, but the lifecycle could still approve speculative caches, coordination states, configuration, or abstractions without a present requirement. This change makes the smallest complete design the baseline and requires added machinery to earn its carrying cost with current evidence.

## Impact

Plans should become easier to review, execute, and maintain. Plausible future complexity is deferred behind measurable adoption triggers instead of being shipped dormant.

## Validation

- `bun install --frozen-lockfile`
- `bun test scripts/release-docs.test.ts` — 18 passed
- `bun run check` — typecheck, Biome, knip, skill/wish/complexity/council/hook/plugin gates passed; the full test phase reached 1,683 passing tests and 4 failures
- The same 4 failing `src/lib/agent-sync.test.ts` cases reproduce on a clean detached `origin/main`: one council journal recovery case and three frozen Codex fallback digest cases. They are upstream baseline failures and are unrelated to this documentation/methodology diff.
