### PR TITLE
feat(orchestration): isolate concurrent delivery lanes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,9 @@ yarn-error.log*
 .genie/genie.db-wal
 .genie/genie.db-shm
 
+# Per-worktree kickoff prompts emitted by `genie launch`
+.genie/launch/
+
 # Local genie state (not part of the package)
 .genie/agents.json
 .genie/teams/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Genie v5 is zero-daemon except for the explicitly launched `genie omni serve` br
 
 ## Engineering rules
 
+- KISS is a release gate, not a preference. Start with the simplest complete design that satisfies current user stories. Caches, deltas, sharding, background coordination, configurable policy, and other stateful machinery require a present contractual need or measured threshold; hypothetical future scale is not evidence. Prefer bounding data and separating history from current state before adding synchronization protocols.
 - Define type and error boundaries before implementation.
 - Preserve user-owned config and unrelated dirty-worktree changes.
 - Config migrations are narrow, backup-first, idempotent, and covered by fixtures.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,16 @@ Genie v5 is zero-daemon except for the explicitly launched `genie omni serve` br
 - Config migrations are narrow, backup-first, idempotent, and covered by fixtures.
 - Every new CLI surface tests success, error exit code, stderr, and idempotency.
 - Shared skills use roles and native delegation language, never a hardcoded client tool name.
-- Subagents share a workspace unless the client explicitly guarantees otherwise. Genie task claims own shared-workspace scope; `genie launch` owns worktree isolation.
+- Treat each concurrently active execution group as an isolated delivery lane with its own branch and worktree; never
+  run parallel writers in one checkout, even when their expected file scopes are disjoint. The PM owns the wish
+  integration worktree, merge order, and conflict resolution. After a reviewed group is merged and validated, the PM
+  removes its clean worktree and merged branch so active worktrees and branches represent active work.
+- Mainline ownership follows repository topology. When `main` has an authoritative GitHub upstream, local `main` is a
+  clean fast-forward mirror of that remote's `main`: wishes reach it through reviewed GitHub PRs, never a local feature
+  merge. With no configured remotes, the PM may integrate a finished wish through a validated temporary candidate,
+  archive that exact integrated closure as `archive/wish/<slug>`, remove its clean active lanes, and then fast-forward
+  unchanged local `main` to the archived commit. A non-GitHub or ambiguous remote requires an explicit user-selected
+  integration policy.
 - Reviewer and engineer are different roles. Never accept self-review as independent evidence.
 - Codex agents inherit the active model; do not hardcode unstable model identifiers.
 - Hook trust and workspace trust remain explicit user decisions.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ Skills are the product. Invoke them as `/name` in Claude, `$genie:name` from the
 | `review` | Severity-gated verdict — SHIP, FIX-FIRST, or BLOCKED |
 | `council` | Independent architecture, delivery, product, security, and dissent assessment |
 
-Shared skill bodies use a runtime-neutral delegation contract. Codex maps it to the optional `genie_*` custom-agent profiles installed by the CLI; a plugin-only install still has skills but no custom agents. Codex subagents share a workspace, so task claims own scope; use `genie launch` when worktree isolation is required. The engineer reports completion, an independent reviewer returns a verdict, and only the orchestrator runs `genie task done`. `/level-up` remains Claude-only because it evaluates Claude Code mastery.
+Shared skill bodies use a runtime-neutral delegation contract. Codex maps it to the optional `genie_*` custom-agent profiles installed by the CLI; a plugin-only install still has skills but no custom agents. Every concurrent execution group uses its own branch and worktree; native subagents that cannot be placed in isolated worktrees must be sequenced or dispatched through `genie launch`. The PM owns the wish integration worktree, merges reviewed group commits, resolves conflicts, and removes merged group worktrees and branches. The engineer reports completion, an independent reviewer returns a verdict, and only the orchestrator runs `genie task done` after integration, validation, and cleanup. `/level-up` remains Claude-only because it evaluates Claude Code mastery.
+
+At the wish boundary, Genie derives mainline ownership from Git topology. If `main` tracks a GitHub remote's `main`, local `main` is fast-forwarded and proven equal to that upstream, and completed wishes enter through reviewed GitHub PRs. A repository with no remotes is local-only: the PM validates a temporary merge candidate, archives that exact integrated closure as `archive/wish/<slug>`, removes its clean active lanes, and then fast-forwards unchanged `main` to the archived commit. Other or ambiguous remote layouts require an explicit user decision.
 
 ### Codex surface boundaries
 

--- a/plugins/genie/README.md
+++ b/plugins/genie/README.md
@@ -89,10 +89,18 @@ For non-trivial work, brainstorm automatically invokes read-only design review b
 separate plan review and persisted `APPROVED` status before work, followed by an independent implementation review. Design SHIP is persisted in DESIGN.md with reviewer identity, UTC timestamp, and a SHA-256 of the exact reviewed content; wish creation and lint reject missing, non-SHIP, or stale evidence. Codex
 invokes the plugin copies as `$genie:brainstorm`, `$genie:wish`, `$genie:review`, and `$genie:work`; bare selectors
 intentionally select the user tier, which now only ever holds a separately installed personal copy. Claude Code uses the
-equivalent slash skills. Native subagents do not imply separate worktrees. Every engineer first claims its assigned task
-with `genie task checkout <id> --worker <name>`, reports completion without mutating task state, and is reviewed by a
-different agent. Only the orchestrator calls `genie task done <id>` after a SHIP verdict and passing validation. Use
-`genie launch` when separate worktrees or a human-supervised Warp cockpit are required.
+equivalent slash skills. Every concurrent execution group uses a dedicated branch and worktree; native subagents that
+cannot be placed in isolated worktrees must be sequenced or dispatched through `genie launch`. Every engineer first
+claims its assigned task with `genie task checkout <id> --worker <name>`, commits in its group worktree, reports
+completion without mutating task state, and is reviewed by a different agent against that exact commit. The PM merges
+reviewed group commits into the wish integration worktree, resolves conflicts, validates the integrated tree, and
+removes each clean group worktree and merged branch. Only then does the orchestrator call `genie task done <id>`.
+
+At the wish boundary, a local `main` tracking a GitHub remote's `main` is fast-forwarded and proven equal to that
+upstream, and accepts completed wishes only after reviewed PR merge. With no configured remotes, the PM validates a
+temporary merge candidate, archives that exact integrated closure as `archive/wish/<slug>`, removes its clean active
+lanes, and then fast-forwards unchanged local `main` to the archived commit. Non-GitHub or ambiguous remotes require an
+explicit user-selected policy.
 
 Those selectors are for manual invocation. Each physical skill's `agents/openai.yaml` starter card is selector-free, so selecting a plugin-tier or user-tier card executes that already-selected physical skill instead of naming and potentially redirecting to the other tier.
 

--- a/plugins/genie/agents/engineer-complex.md
+++ b/plugins/genie/agents/engineer-complex.md
@@ -14,10 +14,14 @@ state, and failure boundaries before changing code; test boundary cases alongsid
 acceptance criterion. Report blocked when the required design or dependency is missing. Never self-review or mark the task
 done.
 
+Work only in the dedicated group worktree and branch named in the brief. Commit the validated review candidate before
+reporting completion.
+
 ## Context diet
 
 The brief **must contain** the task claim command, full group goal and deliverables, acceptance criteria, exact validation,
-dependency guarantees, relevant architecture and invariants, known failure modes, and a focused starting file set.
+dependency guarantees, dedicated worktree path and branch, relevant architecture and invariants, known failure modes,
+and a focused starting file set.
 
 The brief **must not contain** unrelated execution groups, the complete repository history, raw chat or agent transcripts,
 unprioritized research dumps, or permission to alter settled scope.

--- a/plugins/genie/agents/engineer-standard.md
+++ b/plugins/genie/agents/engineer-standard.md
@@ -13,10 +13,14 @@ Implement one execution group whose interfaces and acceptance criteria are alrea
 contracts, add or update focused tests with the implementation, validate the result, and surface any assumption that the
 evidence disproves. Do not expand the group, review your own work, or mark the task done.
 
+Work only in the dedicated group worktree and branch named in the brief. Commit the validated review candidate before
+reporting completion.
+
 ## Context diet
 
 The brief **must contain** the task claim command, group goal, deliverables, acceptance criteria, validation command,
-dependency assumptions, relevant interfaces, and the files or tests most likely to change.
+dependency assumptions, dedicated worktree path and branch, relevant interfaces, and the files or tests most likely to
+change.
 
 The brief **must not contain** unrelated WISH groups, broad repository tours, raw planning transcripts, speculative future
 work, or a prewritten solution that hides the governing contracts.

--- a/plugins/genie/agents/engineer-trivial.md
+++ b/plugins/genie/agents/engineer-trivial.md
@@ -13,10 +13,13 @@ Implement one tightly bounded execution group using established patterns. Keep t
 behavior, run the supplied validation, and report concrete evidence. Stop and report a scope or specification mismatch
 instead of redesigning the system. You do not review your own work or mark the task done.
 
+Work only in the dedicated group worktree and branch named in the brief. Commit the validated review candidate before
+reporting completion.
+
 ## Context diet
 
 The brief **must contain** the task claim command, group goal, concrete deliverables, acceptance criteria, exact validation
-command, dependency assumptions, and the small set of relevant files or symbols.
+command, dependency assumptions, dedicated worktree path and branch, and the small set of relevant files or symbols.
 
 The brief **must not contain** the full WISH, unrelated groups, repository-wide history, raw conversation transcripts, or
 open-ended architecture questions. If the work is no longer isolated and deterministic, stop for rerouting.

--- a/plugins/genie/agents/fixer.md
+++ b/plugins/genie/agents/fixer.md
@@ -13,10 +13,14 @@ Correct the smallest root cause that resolves the supplied failing evidence with
 Reproduce the failure first, classify whether it is code, environment, tooling, or specification, and rerun the focused
 proof after the patch. Do not redesign adjacent code, review the result as an independent reviewer, or mark the task done.
 
+Return to the existing group worktree and branch named in the brief. Commit the validated review candidate before
+reporting completion.
+
 ## Context diet
 
 The brief **must contain** the exact failure or review finding, reproduction command and output, intended behavior,
-applicable acceptance criteria, focused diff or file set, relevant tests, and the current fix-loop count.
+applicable acceptance criteria, existing group worktree path and branch, focused diff or file set, relevant tests, and
+the current fix-loop count.
 
 The brief **must not contain** unrelated findings, the whole WISH, raw worker transcripts, severity claims without evidence,
 or an instruction to escalate model capability for environment, tool, or specification failures.

--- a/plugins/genie/codex-agents/genie-engineer-complex.toml
+++ b/plugins/genie/codex-agents/genie-engineer-complex.toml
@@ -4,5 +4,5 @@ description = "Deep implementation role for high-coupling or stateful work with 
 model_reasoning_effort = "xhigh"
 sandbox_mode = "workspace-write"
 developer_instructions = """
-Implement one high-complexity execution group while protecting cross-module invariants. Establish type, state, and failure boundaries before changing code; test boundary cases; validate every criterion. Claim the task before editing in a shared workspace. Report blockers instead of redesigning settled scope. Never self-review or mark the task done.
+Implement one high-complexity execution group while protecting cross-module invariants. Work only in the dedicated worktree and branch named in the brief. Establish type, state, and failure boundaries before changing code; test boundary cases; validate every criterion; commit the review candidate. Claim the task before editing. Report blockers instead of redesigning settled scope. Never self-review or mark the task done.
 """

--- a/plugins/genie/codex-agents/genie-engineer-standard.toml
+++ b/plugins/genie/codex-agents/genie-engineer-standard.toml
@@ -4,5 +4,5 @@ description = "General implementation role for moderately coupled work with clea
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """
-Implement one bounded execution group whose interfaces and criteria are decided. Claim the task before editing, trace local contracts, add focused tests, validate the result, and surface disproved assumptions. Do not expand scope, review your own work, or mark the task done.
+Implement one bounded execution group whose interfaces and criteria are decided. Work only in the dedicated worktree and branch named in the brief. Claim the task before editing, trace local contracts, add focused tests, validate and commit the review candidate, and surface disproved assumptions. Do not expand scope, review your own work, or mark the task done.
 """

--- a/plugins/genie/codex-agents/genie-engineer-trivial.toml
+++ b/plugins/genie/codex-agents/genie-engineer-trivial.toml
@@ -4,5 +4,5 @@ description = "Low-uncertainty implementation role for isolated, mechanically ve
 model_reasoning_effort = "low"
 sandbox_mode = "workspace-write"
 developer_instructions = """
-Implement one tightly bounded execution group using established patterns. Claim the task before editing, keep the patch minimal, preserve surrounding behavior, run validation, and report evidence. Stop for rerouting if the work is no longer isolated. Never self-review or mark the task done.
+Implement one tightly bounded execution group using established patterns. Work only in the dedicated worktree and branch named in the brief. Claim the task before editing, keep the patch minimal, preserve surrounding behavior, run validation, commit the review candidate, and report evidence. Stop for rerouting if the work is no longer isolated. Never self-review or mark the task done.
 """

--- a/plugins/genie/codex-agents/genie-fixer.toml
+++ b/plugins/genie/codex-agents/genie-fixer.toml
@@ -4,5 +4,5 @@ description = "Surgical remediation role for a reproduced implementation or revi
 model_reasoning_effort = "medium"
 sandbox_mode = "workspace-write"
 developer_instructions = """
-Correct the smallest root cause that resolves supplied failing evidence without weakening tests or criteria. Claim the task before editing, reproduce first, classify the failure, and rerun focused proof. Do not redesign adjacent code, independently review your own result, or mark the task done.
+Correct the smallest root cause that resolves supplied failing evidence without weakening tests or criteria. Work only in the existing group worktree and branch named in the brief. Claim the task before editing, reproduce first, classify the failure, rerun focused proof, and commit the new review candidate. Do not redesign adjacent code, independently review your own result, or mark the task done.
 """

--- a/plugins/genie/references/codex-integration-map.md
+++ b/plugins/genie/references/codex-integration-map.md
@@ -85,9 +85,9 @@ The 2026-07-11 dogfood incident demonstrated the failure mode: `5.260710.13` sel
 
 ## Native orchestration
 
-The active client supplies its native spawn/follow-up/wait/interrupt tools; shared skills do not name undocumented functions. Codex uses installed `genie_*` profiles when available, but native subagents share the caller's workspace unless the runtime explicitly provides isolation. For guaranteed per-group Git isolation, use `genie launch`/worktrees.
+The active client supplies its native spawn/follow-up/wait/interrupt tools; shared skills do not name undocumented functions. Codex uses installed `genie_*` profiles when available. Every concurrent execution group must be placed in a dedicated runtime-managed or ordinary Git worktree; use `genie launch` for a human-supervised isolated wave, and sequence groups when isolated dispatch is unavailable.
 
-Each engineer claims with `genie task checkout <task-id> --worker <name>`, reports completion, and remains `in_progress`. An independent reviewer validates the group. Only the orchestrator calls `genie task done` after SHIP and passing evidence.
+Each engineer claims with `genie task checkout <task-id> --worker <name>`, commits in its group worktree, reports completion, and remains `in_progress`. An independent reviewer validates that exact commit from an ephemeral read-only worktree. The PM merges it into the wish integration worktree, resolves conflicts, validates the integrated tree, and removes the clean group worktree and merged branch. Only then does the orchestrator call `genie task done`.
 
 Reviewer verdicts and WISH status are distinct. Reviewers return read-only
 SHIP/FIX-FIRST/BLOCKED evidence; the invoking orchestrator appends it and owns

--- a/plugins/genie/references/dispatch-contract.md
+++ b/plugins/genie/references/dispatch-contract.md
@@ -14,13 +14,24 @@ Use the native subagent tools actually exposed in the current session. Do not in
 
 1. The orchestrator creates one task per execution group.
 2. The engineer's first command is `genie task checkout <task-id> --worker <name>`.
-3. Parallel writers require disjoint file ownership or separate worktrees.
-4. The engineer reports completion; it never marks the task done.
-5. A different reviewer checks the exact criteria and evidence.
-6. FIX-FIRST dispatches a separate fixer and then a separate re-reviewer, at most two loops.
-7. Only the orchestrator runs `genie task done <task-id>` after SHIP and passing validation.
+3. Every concurrent execution group owns a dedicated branch and worktree, even when expected file scopes are disjoint.
+4. A group worktree has one writer at a time and persists across engineer and fixer handoffs.
+5. The engineer commits and reports completion; it never marks the task done.
+6. A different reviewer checks that exact commit in an ephemeral read-only worktree.
+7. FIX-FIRST returns a separate fixer to the group worktree and then uses a fresh reviewer, at most three loops.
+8. The PM merges reviewed group commits into the wish integration worktree and owns merge order and conflict resolution.
+9. Only the orchestrator runs `genie task done <task-id>` after integrated validation and removal of the clean group
+   worktree and merged branch.
 
 Task completion notifications are push-based. Do not poll a running subagent. Use the active runtime's native follow-up or interrupt surface when it is exposed; if it is not, re-dispatch once with curated context rather than claiming an undocumented cross-client API.
+
+## Wish mainline boundary
+
+- When `main` tracks a GitHub remote's `main`, wishes ship through reviewed PRs. Local `main` is fast-forwarded and
+  proven equal to that fetched ref before work and after merge evidence; direct local feature merges are forbidden.
+- With zero configured remotes, the PM validates a temporary merge candidate, archives the exact integrated closure
+  commit, removes its clean active lanes, and then fast-forwards unchanged local `main` to that archived commit.
+- Non-GitHub or ambiguous remote topology requires an explicit user decision.
 
 ## Role map
 
@@ -34,4 +45,4 @@ Task completion notifications are push-based. Do not poll a running subagent. Us
 | Surgical correction | `genie_fixer` | Workspace write; never self-review |
 | Aggregate gate | `genie_final_gate` | Read-only |
 
-The profile pins reasoning/sandbox policy, not the lifecycle decision. The wish owns complexity, acceptance criteria, dependencies, and file scope.
+The profile pins reasoning/sandbox policy, not the lifecycle decision. The wish owns complexity, acceptance criteria, and dependencies; the dispatch brief owns the group's worktree path and branch.

--- a/plugins/genie/references/native-surfaces.md
+++ b/plugins/genie/references/native-surfaces.md
@@ -4,8 +4,8 @@ Genie skills describe roles and coordination without inventing a cross-client to
 
 | Runtime | Dispatch | Isolation | Follow-up |
 |---------|----------|-----------|-----------|
-| Claude Code | Use its current native Agent surface and an available named role | Use the runtime's supported isolation/worktree option when present | Use the runtime's documented messaging surface when available; otherwise re-dispatch with curated context |
-| Codex | Use the matching `genie_*` custom agent when the CLI-installed profiles are present; otherwise use an available generic subagent | Native subagents share the caller's workspace by default | Use the active native follow-up tool exposed in the session; do not hardcode an undocumented function name into a skill |
+| Claude Code | Use its current native Agent surface and an available named role | Place every concurrent group in a dedicated runtime-managed or ordinary Git worktree | Use the runtime's documented messaging surface when available; otherwise re-dispatch with curated context |
+| Codex | Use the matching `genie_*` custom agent when the CLI-installed profiles are present; otherwise use an available generic subagent | Place every concurrent group in a dedicated runtime-managed or ordinary Git worktree; otherwise sequence it | Use the active native follow-up tool exposed in the session; do not hardcode an undocumented function name into a skill |
 | Hermes | Chat/reasoning cockpit; drives the shared skills through `skills.external_dirs` and reads task truth via the read-only MCP tools plus native `genie_status`/`genie_work_plan`/`genie_review_plan` | Genie remains the execution system — Hermes issues no isolated worktrees itself; use `genie launch`/worktrees for per-group Git isolation | Read-only surface: every payload reports `mutation: "none"`; mutations are deferred behind an explicit human gate (see `plugins/hermes-genie/references/mutation-gates.md`) |
 | Warp cockpit | `genie launch <slug>` emits one pane per ready group | Dedicated Git worktree per pane | Human-supervised; panes are not awaitable native subagents |
 
@@ -15,6 +15,6 @@ Every implementation brief opens with the atomic claim:
 genie task checkout <task-id> --worker <name>
 ```
 
-The claim owns file scope in a shared workspace. Engineers and fixers report completion but never call `genie task done`. A different reviewer validates the group; only the orchestrator marks it done after a SHIP verdict and passing evidence. Native client completion notifications replace polling.
+The task claim owns group state; the dedicated worktree and branch own its mutable file state. Engineers and fixers report completion but never call `genie task done`. A different reviewer validates an exact commit in an ephemeral read-only worktree. The PM merges that commit into the wish integration worktree, resolves conflicts, validates the integrated tree, and removes the clean group worktree and merged branch before marking the task done. Native client completion notifications replace polling.
 
 User decisions use the runtime's native input or permission surface. Shared workflows name the semantic action—dispatch, follow up, interrupt, wait—while the active client supplies the concrete tool.

--- a/plugins/genie/references/review-criteria.md
+++ b/plugins/genie/references/review-criteria.md
@@ -44,6 +44,13 @@ For PASS criteria, evidence includes:
 - No dead code
 - No unresolved TODOs
 
+### Simplicity
+- Simplest complete design is stated
+- Every cache, delta, shard, queue, retry state machine, abstraction, and configuration surface has a current criterion or measurement
+- Current state is bounded and history is separated before synchronization machinery is added
+- Plausible future complexity is deferred behind a concrete adoption trigger
+- Repeated gaps in optional machinery route back to planning instead of consuming fix loops
+
 ### Performance
 - No obvious N+1 queries
 - No unnecessary loops/allocations
@@ -68,5 +75,5 @@ For PASS criteria, evidence includes:
 ## Fix Loop Limits
 
 - Spec review fix loops: max 3
-- Quality review fix loops: max 2
+- Quality review fix loops: max 3
 - After max loops: mark task BLOCKED and continue

--- a/plugins/genie/rules/genie-orchestration.md
+++ b/plugins/genie/rules/genie-orchestration.md
@@ -2,7 +2,8 @@
 Genie is zero-daemon: docs live in git, task state in SQLite. Load `/genie` for full guidance.
 
 ## Dispatch — native teams
-- Spawn workers with the **Agent tool**: one call per execution group, all groups in a single message for parallel waves; workers run in the background and notify on completion.
+- Give every concurrent execution group its own branch and worktree; never place two writers in one checkout.
+- Spawn workers with the **Agent tool** in those group worktrees: one call per execution group, all groups in a single message for parallel waves; workers run in the background and notify on completion.
 - Follow-ups via **SendMessage**; each worker's final report returns as its Agent tool result. Push, not poll.
 - Multi-session cockpit: `genie launch <slug> [--groups <csv>]` — one pane per ready group.
 
@@ -12,9 +13,15 @@ genie task checkout <id> --worker <name>  # worker atomically claims its task
 genie task status <id>                    # task detail + stage log
 genie task list --json                    # all task state
 genie board --wish <slug> --json          # wish progress
-genie task done <id>                      # ORCHESTRATOR marks done, after review + validation
+genie task done <id>                      # ORCHESTRATOR, after merge, validation, and lane cleanup
 ```
 
 ## Never
 - Terminal-scrape (`tmux capture-pane`) or sleep-poll workers — use the primitives above; a hook nudges this.
 - Workers marking their own tasks done — `done` is the orchestrator's verb, post-review.
+- Force-removing dirty/unmerged worktrees or branches — completed clean lanes are garbage-collected only after merge proof.
+- Locally merge a wish into GitHub-backed `main` — use reviewed PRs, then fast-forward local `main` to its remote.
+
+With zero configured remotes, the PM may validate a temporary candidate, archive that exact integrated closure as
+`archive/wish/<slug>`, remove its clean active lanes, and then fast-forward unchanged local `main` to it. Other remote
+topologies require a user decision.

--- a/plugins/genie/skills/README.md
+++ b/plugins/genie/skills/README.md
@@ -30,7 +30,12 @@ All runtimes share the same durable contracts:
 - operational task state is in the per-repository `.genie/genie.db`;
 - implementation is delegated through the runtime's native named roles;
 - the engineer and reviewer are always different agents;
-- the orchestrator alone marks a task done after review and validation.
+- every concurrent execution group owns a dedicated branch and worktree with one active writer;
+- the orchestrator merges reviewed group commits into the wish integration branch and owns conflict decisions;
+- the orchestrator alone marks a task done after integrated validation and garbage collection of the clean merged lane.
+- a GitHub-backed `main` is updated only by fast-forwarding to its authoritative remote after reviewed PR merge;
+- with no remotes, the PM validates a temporary candidate, archives that exact integrated closure under
+  `archive/wish/<slug>`, removes its clean active lanes, and then fast-forwards unchanged local `main` to it.
 
 ## Distribution contract
 

--- a/plugins/genie/skills/architecture/SKILL.md
+++ b/plugins/genie/skills/architecture/SKILL.md
@@ -9,7 +9,7 @@ description: Use when reviewing architecture in any codebase — module boundari
 
 ## Lens
 
-This lane treats complexity as anything that makes a system hard to understand or modify — it accumulates as dependencies and obscurity. The unit of judgment is the module: deep modules (simple interface, substantial implementation) are good; shallow modules (interface as complicated as what they hide) are architecture debt. Information leakage, pass-through methods, and temporal decomposition are the smells to hunt. Prize "define errors out of existence" and design-it-twice thinking.
+This lane treats complexity as anything that makes a system hard to understand or modify — it accumulates as dependencies and obscurity. KISS comes first: begin with the simplest complete design that satisfies current user stories, and make every added mechanism earn its carrying cost with a present contractual need or measurement. Hypothetical future scale is not evidence. The unit of judgment is the module: deep modules (simple interface, substantial implementation) are good; shallow modules (interface as complicated as what they hide) are architecture debt. Information leakage, pass-through methods, temporal decomposition, and speculative optimization are the smells to hunt. Prize "define errors out of existence" and design-it-twice thinking.
 
 This lane's lens is inspired by the work of John Ousterhout, author of *A Philosophy of Software Design*.
 
@@ -30,19 +30,20 @@ Architecture is judged against the repo's own stated intent, then against first 
 
 ## Workflow
 
-1. **Map the module graph.** Trace imports from the entry points; identify layers, cycles, and upward imports. Done when you have the real dependency picture, not the README's.
-2. **Verify the stated contracts.** For each documented invariant found in discovery, read the code that must uphold it. Done when each is confirmed intact or broken with file:line evidence.
-3. **Depth-score the key interfaces.** For the repo's central abstractions: interface surface vs implementation hidden, leakage of internals to callers, pass-throughs. Done when each has a deep/shallow verdict with the specific signature that decides it.
-4. **Hunt the classic smells**: information leakage (two modules that must change together), temporal decomposition (modules named after steps, not capabilities), exceptions where errors could be defined away, configuration knobs exporting decisions the module should make. Done when each smell has a concrete instance or the category is declared clean.
-5. **Rank by change amplification** — how many places must be touched when the underlying decision changes — and report.
+1. **Establish the simplicity baseline.** State the current user stories, realistic scale, and smallest complete design. For every cache, delta, shard, queue, retry state machine, abstraction, or configuration surface, name the present evidence that requires it and the simpler alternative it displaces. Prefer bounding current state and moving history behind pagination before distributing synchronization. Done when speculative machinery is deleted, deferred behind a measurable trigger, or justified.
+2. **Map the module graph.** Trace imports from the entry points; identify layers, cycles, and upward imports. Done when you have the real dependency picture, not the README's.
+3. **Verify the stated contracts.** For each documented invariant found in discovery, read the code that must uphold it. Done when each is confirmed intact or broken with file:line evidence.
+4. **Depth-score the key interfaces.** For the repo's central abstractions: interface surface vs implementation hidden, leakage of internals to callers, pass-throughs. Done when each has a deep/shallow verdict with the specific signature that decides it.
+5. **Hunt the classic smells**: information leakage (two modules that must change together), temporal decomposition (modules named after steps, not capabilities), exceptions where errors could be defined away, configuration knobs exporting decisions the module should make, and optimizations without measurements or present requirements. Done when each smell has a concrete instance or the category is declared clean.
+6. **Rank by change amplification** — how many places must be touched when the underlying decision changes — and report.
 
 ## Grounded Reporting
 
-Every structural claim traces to code read this session, cited file:line. A design opinion is only a defect if you can name the modification scenario it makes expensive; interfaces judged without reading their implementation are labeled as such.
+Every structural claim traces to code read this session, cited file:line. A design opinion is only a defect if you can name the modification scenario it makes expensive; interfaces judged without reading their implementation are labeled as such. Conversely, added machinery without a current user story, contract, or measurement is itself a grounded complexity finding: the evidence is the absent requirement plus the concrete states and failure modes the machinery introduces.
 
 ## Output Format
 
-Lead with a one-sentence verdict on architectural health. Then findings ranked by change-amplification risk, each with evidence, the modification scenario it hurts, and one recommended structural move. Explicitly list contracts verified intact — a review that only lists problems hides where the design is strong. Cross-lane handoffs last. In a genie-framework repo, use CRITICAL/HIGH/MEDIUM/LOW for finding severities and SHIP/FIX-FIRST/BLOCKED only for the overall verdict and note which findings warrant a refactor wish via `wish` rather than opportunistic edits.
+Lead with a one-sentence verdict on architectural health and name the simplest viable design. Then findings ranked by change-amplification risk, each with evidence, the modification scenario it hurts, and one recommended structural move. Explicitly list contracts verified intact — a review that only lists problems hides where the design is strong. Cross-lane handoffs last. In a genie-framework repo, treat unjustified stateful machinery as a blocking HIGH plan/design gap, use CRITICAL/HIGH/MEDIUM/LOW for finding severities and SHIP/FIX-FIRST/BLOCKED only for the overall verdict, and note which findings warrant a refactor wish via `wish` rather than opportunistic edits.
 
 ## Pitfalls
 

--- a/plugins/genie/skills/brainstorm/SKILL.md
+++ b/plugins/genie/skills/brainstorm/SKILL.md
@@ -22,8 +22,9 @@ All artifacts live in `.genie/` within the shared worktree. When spawned as a na
 3. **Scope-size check:** if the request spans multiple independent subsystems, decompose before refining (see Scope Size).
 4. **Refine:** fill WRS dimensions. Ask only what an unfilled dimension needs — when the request or context already settles a dimension, mark it filled and move on; never re-litigate decisions the user already made. Prefer concrete options over open questions.
 5. **Show the WRS bar** after every exchange; persist DRAFT.md whenever WRS changes.
-6. **Propose approaches:** 2-3 options with trade-offs, applying Design for Isolation. Recommend one and proceed when the choice follows from the request.
-7. **Crystallize** when WRS = 100 (see Crystallize).
+6. **Pass the Simplicity Gate:** establish the simplest complete approach before considering more machinery. Reject speculative complexity or defer it behind a measurable trigger (see Simplicity Gate).
+7. **Propose approaches:** 2-3 options with trade-offs, applying Design for Isolation. Recommend one and proceed when the choice follows from the request.
+8. **Crystallize** when WRS = 100 (see Crystallize).
 
 ## WRS — Wish Readiness Score
 
@@ -33,7 +34,7 @@ Five dimensions, 20 points each:
 |-----------|-------------|
 | **Problem** | One-sentence problem statement is clear |
 | **Scope** | IN and OUT boundaries defined |
-| **Decisions** | Key technical/design choices made with rationale |
+| **Decisions** | Key technical/design choices made with rationale and the Simplicity Gate passes |
 | **Risks** | Assumptions, constraints, failure modes identified |
 | **Criteria** | At least one testable acceptance criterion exists |
 
@@ -59,6 +60,18 @@ Apply to proposed approaches and the DESIGN.md Approach section:
 - Explicit interfaces and dependencies — contracts, not shared mutable state or hidden coupling.
 - Independent testability — each unit understandable without loading the whole system.
 - File size is a complexity signal — propose splits before a unit becomes unmanageable.
+
+## Simplicity Gate
+
+Before recommending an approach or declaring **Decisions** filled:
+
+1. State the simplest complete design that satisfies the current user stories.
+2. For every added cache, delta, shard, queue, retry state machine, abstraction, or configuration option, name the present requirement or measurement that pays for it.
+3. Count the new durable states, recovery paths, and cross-component invariants each option introduces; treat them as product cost, not implementation detail.
+4. Prefer bounding current data, separating history behind pagination, recomputing, replacement, and opinionated defaults before synchronization or configurability.
+5. Put plausible future machinery under a measurable adoption trigger instead of building it now. “This may scale later” is not evidence.
+
+If the more complex approach lacks present evidence, recommend the simpler one. Do not split the difference by shipping dormant machinery: unused branches still impose protocol, test, security, and maintenance cost.
 
 ## Index
 
@@ -89,7 +102,7 @@ it was tracked. Never update or retain both indexes after a successful merge.
 At WRS = 100:
 
 1. Write `.genie/brainstorms/<slug>/DESIGN.md` from DRAFT.md using `references/design-template.md` (in this skill dir) — fill every placeholder.
-2. **Spec self-review** — fix inline before handing off: no TBD/TODO leftovers (fill or mark explicit OUT), no contradictions between sections, scope fits a single wish (split if not), no requirement readable two different ways.
+2. **Spec self-review** — fix inline before handing off: no TBD/TODO leftovers (fill or mark explicit OUT), no contradictions between sections, scope fits a single wish (split if not), no requirement readable two different ways, and the Simplicity Case justifies every mechanism beyond the simplest complete design.
 3. Stage the design, draft, and canonical index:
    ```bash
    git add .genie/brainstorms/<slug>/DESIGN.md .genie/brainstorms/<slug>/DRAFT.md .genie/INDEX.md
@@ -135,7 +148,7 @@ Never reuse design-review evidence after editing DESIGN.md. `verify` must pass i
 Note cross-repo or cross-agent dependencies — they become `depends-on`/`blocks` fields in the wish.
 
 ## Rules
-- YAGNI and simplicity first; propose alternatives before recommending.
+- KISS and YAGNI are gates, not tie-breakers; speculative machinery blocks crystallization.
 - No implementation during brainstorm.
 - Persist early and often — never wait until the end.
 - Never present an unconfirmed assumption as a settled decision — confirm it or list it under Risks.

--- a/plugins/genie/skills/brainstorm/references/design-template.md
+++ b/plugins/genie/skills/brainstorm/references/design-template.md
@@ -25,6 +25,13 @@
 
 <Chosen approach with rationale. Name the alternatives considered and why they lost.>
 
+## Simplicity Case
+
+- **Simplest complete design:** <smallest design that satisfies current user stories>
+- **Added machinery:** <none, or each mechanism with the present requirement/measurement that justifies it>
+- **Deferred until measured:** <plausible future complexity and the concrete trigger for reconsidering it>
+- **Complexity removed:** <states, failure modes, options, or dependencies deliberately avoided>
+
 ## Decisions
 
 | # | Decision | Rationale |

--- a/plugins/genie/skills/council/references/native-surfaces.md
+++ b/plugins/genie/skills/council/references/native-surfaces.md
@@ -4,8 +4,8 @@ Genie skills describe roles and coordination without inventing a cross-client to
 
 | Runtime | Dispatch | Isolation | Follow-up |
 |---------|----------|-----------|-----------|
-| Claude Code | Use its current native Agent surface and an available named role | Use the runtime's supported isolation/worktree option when present | Use the runtime's documented messaging surface when available; otherwise re-dispatch with curated context |
-| Codex | Use the matching `genie_*` custom agent when the CLI-installed profiles are present; otherwise use an available generic subagent | Native subagents share the caller's workspace by default | Use the active native follow-up tool exposed in the session; do not hardcode an undocumented function name into a skill |
+| Claude Code | Use its current native Agent surface and an available named role | Place every concurrent group in a dedicated runtime-managed or ordinary Git worktree | Use the runtime's documented messaging surface when available; otherwise re-dispatch with curated context |
+| Codex | Use the matching `genie_*` custom agent when the CLI-installed profiles are present; otherwise use an available generic subagent | Place every concurrent group in a dedicated runtime-managed or ordinary Git worktree; otherwise sequence it | Use the active native follow-up tool exposed in the session; do not hardcode an undocumented function name into a skill |
 | Warp cockpit | `genie launch <slug>` emits one pane per ready group | Dedicated Git worktree per pane | Human-supervised; panes are not awaitable native subagents |
 
 Every implementation brief opens with the atomic claim:
@@ -14,6 +14,6 @@ Every implementation brief opens with the atomic claim:
 genie task checkout <task-id> --worker <name>
 ```
 
-The claim owns file scope in a shared workspace. Engineers and fixers report completion but never call `genie task done`. A different reviewer validates the group; only the orchestrator marks it done after a SHIP verdict and passing evidence. Native client completion notifications replace polling.
+The task claim owns group state; the dedicated worktree and branch own its mutable file state. Engineers and fixers report completion but never call `genie task done`. A different reviewer validates an exact commit in an ephemeral read-only worktree. The PM merges that commit into the wish integration worktree, resolves conflicts, validates the integrated tree, and removes the clean group worktree and merged branch before marking the task done. Native client completion notifications replace polling.
 
 User decisions use the runtime's native input or permission surface. Shared workflows name the semantic action—dispatch, follow up, interrupt, wait—while the active client supplies the concrete tool.

--- a/plugins/genie/skills/dream/SKILL.md
+++ b/plugins/genie/skills/dream/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: dream
-description: "Batch-execute SHIP-ready wishes overnight — pick wishes, orchestrate workers, review PRs, wake up to results."
+description: "Batch-execute SHIP-ready wishes overnight — pick wishes, orchestrate workers, review delivery candidates, wake up to results."
 ---
 
 # dream — Overnight Batch Execution
 
 **Runtime syntax:** in Codex, invoke the plugin copy with the owner-qualified `$genie:<skill>` selector; use bare `$<skill>` only when intentionally selecting a user-tier copy (a separately installed personal copy; Genie no longer seeds this tier). Claude Code and Hermes use `/<skill>`. Cross-skill prose below uses bare names as portable semantic routes; the orchestrator resolves the selector for the active tier.
 
-Pick SHIP-ready wishes, build a dependency-ordered plan, dispatch one worker subagent per wish, review PRs, merge to dev, run the QA loop, and write a wake-up report. The dream orchestrator dispatches — it never executes wish work directly.
+Pick SHIP-ready wishes, build a dependency-ordered plan, dispatch one worker subagent per wish, review delivery candidates, integrate them through the repository's PM mainline mode, run the QA loop, and write a wake-up report. The dream orchestrator dispatches — it never executes wish work directly.
 
-This is a high-impact, explicit-only workflow. The user must approve the selected wishes, the generated plan, PR creation, and merge-to-`dev` authority. Never merge to `main` or `master`, deploy, send external messages, or expand scope without separate authority.
+This is a high-impact, explicit-only workflow. The user must approve the selected wishes and generated plan. In GitHub-backed mode, PR creation and remote merge retain their external-write authority gates; third-party review/checks remain mandatory. In zero-remote mode, validated candidate integration into local `main` plus wish archival is autonomous after plan approval. Never deploy, send external messages, expand scope, or infer policy for a non-GitHub remote without separate authority.
 
 ## When to Use
 - Human wants to queue multiple wishes for autonomous overnight execution
@@ -19,8 +19,8 @@ This is a high-impact, explicit-only workflow. The user must approve the selecte
 1. **Pick wishes** (Picker below); human confirms the selection.
 2. **Generate `.genie/DREAM.md`** — dependency-ordered plan; human may edit before the run.
 3. **Phase 1 — Execute:** dispatch workers layer by layer, collect outcomes.
-4. **Phase 2 — Review + PR:** review every PR, fix valid gaps, CI green.
-5. **Phase 3 — Merge + QA:** merge to dev in order, QA loop until criteria proven.
+4. **Phase 2 — Review + delivery gate:** review every PR or local delivery candidate; fix valid gaps.
+5. **Phase 3 — Mainline + QA:** integrate in order using PM repository mode; QA until criteria are proven.
 6. **Phase 4 — Report:** write `.genie/DREAM-REPORT.md`, the wake-up artifact.
 
 ## Picker
@@ -32,7 +32,7 @@ This is a high-impact, explicit-only workflow. The user must approve the selecte
 1. Read the wish-level `**depends-on:**` value from each selected WISH.md's `## Dependencies` section (`none` means no edge).
 2. Topologically sort into `merge_order` layers `1..N` — layer 1 has no selected dependencies; same-layer wishes are parallel.
 3. Per-wish entry: `slug`, `branch: feat/<slug>`, `wish-path: .genie/wishes/<slug>/WISH.md`, `depends-on`, `merge-order`. Keep the canonical hyphenated keys so the plan can be checked directly against each wish.
-4. Write `.genie/DREAM.md` in the shared worktree; present for human confirmation before executing.
+4. Write `.genie/DREAM.md` in the dream PM's integration worktree; present for human confirmation before executing.
 
 ## Phase 1: Execute
 
@@ -46,33 +46,37 @@ For each `merge_order` layer, in order:
 ### Worker Contract
 
 Each worker, independently:
-1. Work in a dedicated branch and worktree for `feat/<slug>`; never let parallel writers share one checkout. Use Codex-managed or ordinary Git worktrees according to the active environment.
-2. Execute the wish per `work` (its dispatch, review-gate, and task-state rules govern): dispatched engineers claim via `genie task checkout`; the worker leaves task state `in_progress` and reports evidence. Only the dream PM/orchestrator runs `genie task done` after clean review and passing validation.
+1. Work in a dedicated wish integration branch and worktree for `feat/<slug>`. Within it, execute each concurrent group in its own branch and worktree per `work`; never let parallel writers share one checkout. Use runtime-managed or ordinary Git worktrees according to the active environment.
+2. Execute the wish per `work` (its group-lane dispatch, review, integration, garbage-collection, and task-state rules govern): dispatched engineers claim via `genie task checkout`; the worker leaves task state `in_progress` and reports evidence. Only the dream PM/orchestrator runs `genie task done` after clean review, integration, passing validation, and cleanup of the completed group lane.
 3. Run `review` per group against acceptance criteria.
-4. Run CI; on failure fix and retry (max 3 attempts; poll CI status, never sleep-loop). After 3 failures → blocked.
-5. Only after CI green and authorized PR creation: create a PR targeting `dev`, preferring the GitHub connector.
+4. Run the wish validation. In GitHub-backed mode, CI must also pass; on failure fix and retry (max 3 attempts; poll CI status, never sleep-loop). After 3 failures → blocked.
+5. GitHub-backed: only after CI green and authorized PR creation, create a PR targeting authoritative `main`, preferring the GitHub connector. Zero remotes: report the reviewed `feat/<slug>` tip as the local delivery candidate; do not touch `main`.
 6. Final message is the completion signal, every claim audited against tool output:
    - `done — PR <url>, CI green, groups N/N`
+   - `done — local candidate <sha>, validation green, groups N/N`
    - `blocked — <reason>, groups N/N`
 
-## Phase 2: Review + PR
+## Phase 2: Review + Delivery Gate
 
 **Trigger:** all workers in the layer reported done or blocked.
 
-1. Dispatch one reviewer subagent per PR via the native delegation surface (reviewer ≠ worker) to run `review` against the wish's acceptance criteria.
+1. Dispatch one reviewer subagent per PR or exact local candidate commit via the native delegation surface (reviewer ≠ worker) to run `review` against the wish's acceptance criteria.
 2. Read bot comments critically — never blindly accept automated findings.
 3. On FIX-FIRST: diagnose first; return an overdesigned plan to wish/design review, otherwise dispatch `fix` for valid gaps (max 3 loops per PR). On another architectural issue: escalate in the report, no fix attempt.
-4. CI must be green before proceeding — poll status, do not sleep.
-5. On SHIP: mark the PR review-complete.
+4. In GitHub-backed mode CI must be green before proceeding — poll status, do not sleep. In zero-remote mode rerun the declared validation against the exact candidate.
+5. On SHIP: mark the PR or local candidate review-complete.
 
-## Phase 3: Merge + QA
+## Phase 3: Mainline + QA
 
-**Trigger:** all PRs marked SHIP.
+**Trigger:** all delivery candidates marked SHIP.
 
-1. After explicit merge authorization, merge PRs to `dev` in `merge_order`; never merge to `main` or `master`.
-2. Dispatch a qa subagent on dev to test against each wish's QA criteria.
-3. Each failure: `report` → `trace` → `fix` → retest. Every fix is a new PR through review and merge.
-4. Continue until all criteria are proven or blocked.
+For each wish in `merge_order`:
+
+1. GitHub-backed: run required QA on the exact PR candidate. On success, persist `SHIPPED` and completion evidence in a final closure commit, rerun required checks/review, then wait for authorized or third-party PR merge. That merge makes remote `main` authoritative. Fetch it, require clean local `main`, attempt a fast-forward/equality proof, archive the exact reviewed closure commit, then remove the clean local wish lane. Never reset, force, or locally merge the feature branch into `main`; record a failed mirror as lifecycle debt.
+2. Zero remotes: create a temporary candidate from current `main`, merge the reviewed wish branch there, resolve conflicts through a bounded fixer, and validate/QA the exact result. On success, persist staged `SHIPPED` and completion evidence in the candidate and rerun required checks/review. Archive that exact integrated closure commit, remove clean wish/candidate worktrees and refs with compare-and-swap, then prove `main` is unchanged and fast-forward it to the archived commit.
+3. A pre-promotion failure retains or recreates the active lane and leaves the wish `IN_PROGRESS`. A hosted mirror, archive, or cleanup failure after remote merge is reported as lifecycle debt and retried without rewriting authoritative `SHIPPED` history.
+4. Each failure before mainline promotion: `report` → `trace` → `fix` → retest. In GitHub-backed mode every fix remains in the reviewed PR; in zero-remote mode every fix repeats candidate review before main fast-forward.
+5. Continue until all criteria are proven or blocked.
 
 ## Phase 4: Report
 
@@ -82,14 +86,14 @@ Write `.genie/DREAM-REPORT.md` — always, even if every wish blocked:
 # Dream Report — <date>
 
 ## Per-Wish Status
-| merge_order | slug | PR | CI | Review | Merged | QA |
-|-------------|------|----|----|--------|--------|----|
+| merge_order | slug | Delivery | Validation/CI | Review | Mainline | Local mirror | Archive/cleanup | QA |
+|-------------|------|----------|---------------|--------|----------|--------------|-----------------|----|
 
 ## Blocked Wishes
 - `<slug>`: <blocking reason>
 
 ## QA Findings
-- `<slug>`: <criterion failed — root cause, fix PR>
+- `<slug>`: <criterion failed — root cause, fix delivery>
 
 ## Follow-ups
 - <items requiring human intervention>
@@ -97,11 +101,11 @@ Write `.genie/DREAM-REPORT.md` — always, even if every wish blocked:
 
 ## Grounded Progress
 
-The report is an audit, not a recollection. Every cell traces to tool output from the run: PR URLs, CI results, review verdicts, `genie task list --wish <slug>` state, worker final messages. State per wish exactly what is verified, what failed, and what was skipped. Never report a wish shipped until its merge and QA evidence is in hand — dispatched is not done.
+The report is an audit, not a recollection. Every cell traces to tool output from the run: PR URL or local candidate SHA, validation/CI results, review verdicts, mainline and archive refs, local-mirror and cleanup state, `genie task list --wish <slug>` state, and worker final messages. State per wish exactly what is verified, what failed, and what was skipped. Report a wish shipped only with authoritative mainline and QA evidence; list every mirror, archive, or cleanup debt, and never report the lifecycle fully closed while any remains.
 
 ## Rules
 - Never early-stop: a blocked wish is recorded and the remaining wishes continue.
-- Never skip Phase 2 or Phase 3 — every PR is reviewed, every merge is QA-tested against wish criteria.
+- Never skip Phase 2 or Phase 3 — every delivery candidate is reviewed and every mainline result is QA-tested against wish criteria.
 - The orchestrator never executes wish work — always dispatch worker subagents.
 - No scope beyond what each WISH.md defines.
 - Poll CI status — never `sleep` in retry loops.

--- a/plugins/genie/skills/dream/SKILL.md
+++ b/plugins/genie/skills/dream/SKILL.md
@@ -61,7 +61,7 @@ Each worker, independently:
 
 1. Dispatch one reviewer subagent per PR via the native delegation surface (reviewer ≠ worker) to run `review` against the wish's acceptance criteria.
 2. Read bot comments critically — never blindly accept automated findings.
-3. On FIX-FIRST: dispatch `fix` for valid gaps (max 2 loops per PR). On an architectural issue: escalate in the report, no fix attempt.
+3. On FIX-FIRST: diagnose first; return an overdesigned plan to wish/design review, otherwise dispatch `fix` for valid gaps (max 3 loops per PR). On another architectural issue: escalate in the report, no fix attempt.
 4. CI must be green before proceeding — poll status, do not sleep.
 5. On SHIP: mark the PR review-complete.
 

--- a/plugins/genie/skills/fix/SKILL.md
+++ b/plugins/genie/skills/fix/SKILL.md
@@ -15,8 +15,8 @@ Resolve FIX-FIRST gaps from `review`: dispatch a fix subagent, re-review, repeat
 
 ## Flow
 1. **Parse and diagnose gaps:** severity, files, failing checks from the FIX-FIRST verdict. If the evidence is `overdesigned-plan`, stop and return to `brainstorm`/`wish`; removing optional machinery is a plan correction, not a code-fix attempt.
-2. **Dispatch fixer:** native delegation surface → fix subagent, briefed with the gap list, the original wish criteria, and any `trace` diagnosis.
-3. **Re-review:** native delegation surface → a separate reviewer subagent (never the fixer) running `review` on the same pipeline.
+2. **Dispatch fixer:** native delegation surface → fix subagent in the existing group worktree, briefed with its path and branch, the gap list, the original wish criteria, and any `trace` diagnosis. The fixer commits the new review candidate.
+3. **Re-review:** native delegation surface → a separate reviewer subagent (never the fixer) running `review` against that exact commit in an ephemeral read-only worktree; remove the review worktree afterward.
 4. **Evaluate verdict:**
 
 | Verdict | Condition | Action |
@@ -32,7 +32,7 @@ Resolve FIX-FIRST gaps from `review`: dispatch a fix subagent, re-review, repeat
 
 Fix and re-review are **separate native-dispatch dispatches** — never combined in one subagent, and the re-reviewer is never the fixer. Subagents notify on completion — no polling. Follow-ups to a running fixer go through native follow-up messaging.
 
-The fixer's brief must carry: the severity-tagged gaps (file:line), the original wish acceptance criteria, the validation command(s) to re-run, and stop conditions — fix only the listed gaps; report blocked rather than expand scope.
+The fixer's brief must carry: the existing group worktree path and branch, the severity-tagged gaps (file:line), the original wish acceptance criteria, the validation command(s) to re-run, and stop conditions — edit only that worktree, fix only the listed gaps, commit the review candidate, and report blocked rather than expand scope.
 
 ## Escalation Diagnosis
 
@@ -54,7 +54,7 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 
 ## Task State
 
-The fix loop never mutates task state. The group's task stays `in_progress` through every loop; the orchestrator calls `genie task done <task-id>` only after a clean re-review. During any diagnosed route or appeal, the task remains `in_progress` with the remaining gaps recorded in the wish notes/handoff. If no task row exists for the work, proceed — the loop runs off the review verdict alone.
+The fix loop never mutates task state. The group's task stays `in_progress` through every loop; after a clean re-review, the orchestrator must still integrate the reviewed commit, validate the integrated tree, and garbage-collect the clean merged lane before calling `genie task done <task-id>`. During any diagnosed route or appeal, the task remains `in_progress` with the remaining gaps recorded in the wish notes/handoff. If no task row exists for the work, proceed — the loop runs off the review verdict alone.
 
 ## Diagnosis / Appeal Format
 

--- a/plugins/genie/skills/fix/SKILL.md
+++ b/plugins/genie/skills/fix/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: fix
-description: "Dispatch fix subagent for FIX-FIRST gaps from review, re-review, then diagnose unresolved failures after 2 loops."
+description: "Dispatch fix subagent for FIX-FIRST gaps from review, re-review, then diagnose unresolved failures after 3 loops."
 ---
 
 # fix — Fix-Review Loop
 
 **Runtime syntax:** in Codex, invoke the plugin copy with the owner-qualified `$genie:<skill>` selector; use bare `$<skill>` only when intentionally selecting a user-tier copy (a separately installed personal copy; Genie no longer seeds this tier). Claude Code and Hermes use `/<skill>`. Cross-skill prose below uses bare names as portable semantic routes; the orchestrator resolves the selector for the active tier.
 
-Resolve FIX-FIRST gaps from `review`: dispatch a fix subagent, re-review, repeat up to 2 loops, then diagnose and route any unresolved failure.
+Resolve FIX-FIRST gaps from `review`: dispatch a fix subagent, re-review, repeat up to 3 loops, then diagnose and route any unresolved failure.
 
 ## When to Use
 - `review` returned a **FIX-FIRST** verdict with CRITICAL or HIGH gaps
 - Orchestrator hands off unresolved gaps after execution review
 
 ## Flow
-1. **Parse gaps:** severity, files, failing checks from the FIX-FIRST verdict.
+1. **Parse and diagnose gaps:** severity, files, failing checks from the FIX-FIRST verdict. If the evidence is `overdesigned-plan`, stop and return to `brainstorm`/`wish`; removing optional machinery is a plan correction, not a code-fix attempt.
 2. **Dispatch fixer:** native delegation surface → fix subagent, briefed with the gap list, the original wish criteria, and any `trace` diagnosis.
 3. **Re-review:** native delegation surface → a separate reviewer subagent (never the fixer) running `review` on the same pipeline.
 4. **Evaluate verdict:**
@@ -22,8 +22,8 @@ Resolve FIX-FIRST gaps from `review`: dispatch a fix subagent, re-review, repeat
 | Verdict | Condition | Action |
 |---------|-----------|--------|
 | SHIP | — | Done. Return to orchestrator. |
-| FIX-FIRST | loop < 2 | Increment loop, go to step 2. |
-| FIX-FIRST | loop = 2 | Stop fixing and run Escalation Diagnosis; max loops reached. |
+| FIX-FIRST | loop < 3 | Increment loop, go to step 2. |
+| FIX-FIRST | loop = 3 | Stop fixing and run Escalation Diagnosis; max loops reached. |
 | BLOCKED | — | Run Escalation Diagnosis and take the cause-specific route. |
 
 5. **Route the diagnosis:** report the remaining gaps with exact files, failing checks, cause class, and corrective route; the group's task stays `in_progress`.
@@ -44,6 +44,7 @@ Use this policy before any model or effort change; keep this contract identical 
 | `missing-context` | The attempt identifies absent files, history, criteria, logs, or other inputs needed to decide. | Supply the missing context and retry at the same model and effort; MUST NOT escalate model or effort. |
 | `ambiguous-spec` | Two or more materially different behaviors remain consistent with the stated criteria. | Request a human decision or wish clarification; MUST NOT escalate model or effort. |
 | `env-tool-failure` | A reproducible environment, dependency, permission, timeout, or tool error prevents valid execution. | Repair or retry the environment/tool, or report blocked with the error; MUST NOT escalate model or effort. |
+| `overdesigned-plan` | Gaps cluster in optional machinery that lacks a current criterion or measurement, while a simpler design satisfies the user stories with fewer durable states or recovery paths. | Stop the fix loop and return to `brainstorm`/`wish` to remove or defer the mechanism. Re-review the amended design/plan; MUST NOT spend retries or model escalation defending it. |
 
 Escalation eligibility requires **new evidence** produced since the previous attempt: attach the new failing output or diagnostic result, the correction already tried, and why it rules out the other three causes. A repeated verdict or unchanged failure is not new evidence and cannot authorize a model or effort change.
 
@@ -58,14 +59,14 @@ The fix loop never mutates task state. The group's task stays `in_progress` thro
 ## Diagnosis / Appeal Format
 
 ```
-Fix loop exhausted (2/2). Group remains in progress.
+Fix loop exhausted (3/3). Group remains in progress.
 Remaining gaps:
 - [CRITICAL] <gap description> — <file>
 - [HIGH] <gap description> — <file>
-Cause: <model-capacity|missing-context|ambiguous-spec|env-tool-failure>
+Cause: <model-capacity|missing-context|ambiguous-spec|env-tool-failure|overdesigned-plan>
 New evidence: <new output/diagnosis, or "none — model/effort escalation prohibited">
 Corrective route: <one cause-specific next step>
-Budget: attempts=<used>/2; effort_escalations=<used>/2
+Budget: attempts=<used>/3; effort_escalations=<used>/2
 Appeal: <reviewer/final-gate disagreement record, or "none">
 ```
 
@@ -78,12 +79,13 @@ Appeal: <reviewer/final-gate disagreement record, or "none">
 - [HIGH] sendMessage result not checked — dispatch.ts:541
 ```
 
-Loop 1: native delegation surface → fixer briefed with both gaps, the wish criteria, and `bun test` as validation. The fixer edits, runs the validation, reports its changes with outcomes, and ends `done`. Then native delegation surface → a fresh reviewer briefed to re-run `review` against the same criteria. SHIP → report success to the orchestrator. FIX-FIRST again → loop 2; after that, classify the cause and take its corrective route. A model or effort raise is permitted only for evidenced `model-capacity` within both caps.
+Loop 1: native delegation surface → fixer briefed with both gaps, the wish criteria, and `bun test` as validation. The fixer edits, runs the validation, reports its changes with outcomes, and ends `done`. Then native delegation surface → a fresh reviewer briefed to re-run `review` against the same criteria. SHIP → report success to the orchestrator. FIX-FIRST again → loops 2 and 3; after loop 3, classify the cause and take its corrective route. A model or effort raise is permitted only for evidenced `model-capacity` within both caps. An `overdesigned-plan` diagnosis stops immediately and returns to planning instead.
 
 ## Rules
 - Tight scope: fix exactly the tagged gaps — no unrequested refactors, features, or drive-by cleanups.
 - Never fix and review in the same session — always separate subagents.
-- Never exceed 2 fix loops — stop, diagnose, and take the cause-specific route.
+- Never exceed 3 fix loops — stop, diagnose, and take the cause-specific route.
+- Never use a fix loop to preserve optional machinery when a simpler plan satisfies the user stories.
 - Include the original wish criteria in every fix dispatch.
 - Identical gaps across loops = no progress; classify the cause. Repetition is not new evidence and never authorizes a model or effort raise.
 - Grounded progress: report only what tool output from this session verifies — state what was fixed, what failed, what was skipped. Never report an attempted fix as complete.

--- a/plugins/genie/skills/genie-hacks/references/catalog.md
+++ b/plugins/genie/skills/genie-hacks/references/catalog.md
@@ -42,7 +42,7 @@ The local registry powering `genie-hacks list|search|show|help`. Canonical publi
 - **Title:** Multi-Team Coordination at Scale
 - **Category:** teams
 - **Problem:** You have multiple wishes that depend on each other, and running them sequentially wastes time.
-- **Solution:** Use `dream` to batch-execute wishes with dependency ordering, or open one `genie launch` cockpit per independent wish. Use the active runtime's native subagents for independent work, steer the same thread with follow-up messaging, and isolate parallel writers in disjoint scopes or separate worktrees. Track shared wish state in the task DB.
+- **Solution:** Use `dream` to batch-execute wishes with dependency ordering, or open one `genie launch` cockpit per independent wish. Use the active runtime's native subagents for independent work, steer the same thread with follow-up messaging, and give every concurrent execution group a dedicated branch and worktree. The PM merges reviewed commits into the wish integration branch and removes clean merged lanes so worktrees and branches reflect active work. Track shared wish state in the task DB.
 - **Code:**
   ```bash
   # Queue wishes for overnight execution

--- a/plugins/genie/skills/genie/reference/lifecycle.md
+++ b/plugins/genie/skills/genie/reference/lifecycle.md
@@ -3,7 +3,7 @@
 Every piece of work follows this flow:
 
 ```
- Idea → brainstorm → design review → wish → plan review → work → implementation review → PR → Ship
+ Idea → brainstorm → design review → wish → plan review → work → implementation review → mainline integration → Ship
          (explore)   (design gate)    (plan)   (plan gate)  (build)       (verify)
 ```
 
@@ -25,18 +25,43 @@ and `BLOCKED` are evidence returned by a reviewer. The `Status` field in
 | `DRAFT` | Plan exists but has not passed plan review | `wish`, then plan `review` |
 | `FIX-FIRST` | Plan review found blocking gaps | `fix`, then plan `review` |
 | `APPROVED` | Plan review returned SHIP and the plan is ready | `work` or `genie launch <slug>` |
-| `IN_PROGRESS` | At least one execution group has started; execution/PR gates are not complete | resume `work` or the recorded corrective route |
+| `IN_PROGRESS` | At least one execution group has started; execution/mainline gates are not complete | resume `work` or the recorded corrective route |
 | `BLOCKED` | A recorded external, environment, or specification blocker prevents progress | resolve the recorded blocker, then resume the prior stage |
-| `SHIPPED` | The authorized merge and required QA/release gate completed | terminal/history only |
+| `SHIPPED` | Authoritative mainline integration and required QA/release gate completed | terminal delivery; finish any recorded archive/cleanup debt |
 
 The invoking orchestrator is the single mutation owner. After a reviewer sends
 its final evidence, the orchestrator appends a timestamped entry under
 `## Review Results` and applies the transition: plan SHIP → `APPROVED`; plan
 FIX-FIRST → `FIX-FIRST`; plan BLOCKED → `BLOCKED`; beginning execution →
 `IN_PROGRESS`; execution FIX-FIRST/BLOCKED stays `IN_PROGRESS` unless a real
-external blocker is recorded; authorized merge plus required QA → `SHIPPED`.
+external blocker is recorded; proven mainline integration plus required QA → `SHIPPED`.
 The reviewer remains read-only and never edits WISH.md or task state. A chat
 verdict that was not persisted does not advance the lifecycle.
+
+## Mainline ownership
+
+The PM resolves repository mode before shipping:
+
+- **GitHub-backed:** a configured `<remote>/main` GitHub upstream is authoritative. Before work, local `main` must be
+  clean, fast-forwarded, and proven equal to that ref. Third-party PR merge makes remote `main` authoritative; the PM
+  then attempts the same clean fast-forward/equality proof locally. A failed post-merge mirror is lifecycle debt. Genie
+  never resets, force-pushes, or locally merges the wish into hosted `main`.
+- **Local-only:** exactly zero configured remotes. The PM merges the finished wish in a temporary candidate worktree,
+  resolves conflicts there, validates the exact candidate, records the closure commit, archives and cleans its lanes,
+  then fast-forwards unchanged local `main` to that exact archived commit.
+- **Other or ambiguous remotes:** require an explicit user-selected integration policy.
+
+The GitHub PR plus archive tag, or the local archive tag, is durable closure evidence. Worktrees and local feature
+branches represent active work only. A local failure before mainline promotion keeps the wish `IN_PROGRESS` and
+preserves or recreates its lane. A hosted mirror, archive, or cleanup failure after remote merge is recorded lifecycle
+debt: it cannot undo authoritative history, so the wish stays `SHIPPED`, any affected lane remains for retry, and
+closure is not reported as fully clean.
+
+Because WISH status is git-tracked, the PM stages `SHIPPED` plus completion evidence only in an exact candidate that has
+already passed required QA, then reruns the candidate's final checks. In GitHub-backed mode that branch-local status is
+not authoritative until third-party merge places it on remote `main`; failed local mirroring is recorded lifecycle debt.
+In local-only mode archival and clean-lane removal happen first; it becomes authoritative only when unchanged local
+`main` fast-forwards to that archived closure commit.
 
 ## Skill Catalog
 
@@ -46,7 +71,7 @@ verdict that was not persisted does not advance the lifecycle.
 | `wish` | Convert a design into a structured plan at `.genie/wishes/<slug>/WISH.md` — scope, execution groups, acceptance criteria, validation | Idea is concrete, needs a plan |
 | `review` | Genie criteria gate — SHIP / FIX-FIRST / BLOCKED with severity-tagged gaps | Before and after `work`, or any plan/PR |
 | `work` | Execute an approved wish — dispatch native subagents per group in waves, fix loops, validation | Wish is SHIP-approved |
-| `fix` | Resolve FIX-FIRST gaps, re-review, escalate after 2 failed loops | Review returned FIX-FIRST |
+| `fix` | Resolve FIX-FIRST gaps, re-review, escalate after 3 failed loops | Review returned FIX-FIRST |
 | `council` | Multi-perspective deliberation with specialist viewpoints | Major design decisions, tradeoffs |
 | `refine` | Transform a brief into a production-ready prompt | Prompt needs sharpening |
 | `report` | Investigate bugs — trace, capture evidence, open a GitHub issue with confirmation | Bug reports |

--- a/plugins/genie/skills/pm/SKILL.md
+++ b/plugins/genie/skills/pm/SKILL.md
@@ -36,7 +36,7 @@ The lifecycle is owned by its skills — route to them, never restate them here:
 | Explore | `brainstorm` | Dispatch when scope is fuzzy |
 | Plan | `wish` | Dispatch when scope is clear; the wish creates per-group tasks |
 | Execute | `work` | Dispatch orchestration; waves come from WISH.md |
-| Validate | `review` | Gate every group; FIX-FIRST → `fix` (max 2 loops) |
+| Validate | `review` | Gate every group; FIX-FIRST → `fix` (max 3 loops) |
 | Investigate | `trace`, `report` | Unknown failure: diagnose before fixing |
 | Ship | PR to `dev` | Request or consume task-scoped PR/merge authority; merge only when CI green + review SHIP |
 
@@ -51,7 +51,7 @@ Default chain: engineer → reviewer → qa → fix. Augment when the work calls
 | Docs deliverables in scope | docs subagent, parallel with engineer |
 | Architecture restructuring | refactor-briefed engineer for that group |
 | Failure with unknown root cause | `trace` before `fix` |
-| Review returns FIX-FIRST | `fix` (max 2 loops, then escalate) |
+| Review returns FIX-FIRST | Diagnose first; simplify an overdesigned plan, otherwise `fix` (max 3 loops) |
 | High-stakes decision with tradeoffs | `council` (advisory) |
 
 ## Dispatch

--- a/plugins/genie/skills/pm/SKILL.md
+++ b/plugins/genie/skills/pm/SKILL.md
@@ -38,9 +38,60 @@ The lifecycle is owned by its skills — route to them, never restate them here:
 | Execute | `work` | Dispatch orchestration; waves come from WISH.md |
 | Validate | `review` | Gate every group; FIX-FIRST → `fix` (max 3 loops) |
 | Investigate | `trace`, `report` | Unknown failure: diagnose before fixing |
-| Ship | PR to `dev` | Request or consume task-scoped PR/merge authority; merge only when CI green + review SHIP |
+| Ship | Repository integration mode | Deliver through reviewed GitHub PR or validated local-only mainline integration |
 
 Document status (`DRAFT` / `FIX-FIRST` / `APPROVED` / `IN_PROGRESS` / `BLOCKED` / `SHIPPED`) tracks lifecycle phase; SHIP/FIX-FIRST/BLOCKED are reviewer verdicts, and the invoking orchestrator persists the corresponding transition. The task DB tracks per-group execution state.
+
+## Repository Integration Mode
+
+Resolve this once before shipping a wish; never infer the authoritative remote from its conventional name alone.
+
+1. Read `main`'s configured upstream. If one exists, accept it only when it resolves to `<remote>/main` on GitHub; that
+   remote is authoritative. Any other configured upstream requires an explicit user decision.
+2. If `main` has no upstream and exactly one GitHub remote exists, use that remote's `main`.
+3. If no remotes are configured, use local-only mode.
+4. Every remaining topology requires an explicit integration policy. Never classify a repository with remotes as
+   local-only.
+
+### GitHub-backed mode
+
+Local `main` is a mirror, not an integration branch. Before work, fetch the authoritative remote, require a clean local
+`main`, fast-forward it to `<remote>/main`, and prove both refs resolve to the same commit. An ahead or diverged local
+`main` is a blocker and is never reset, force-updated, or pushed as reconciliation. Completed wishes target `main`
+through a GitHub PR with independent review and required checks. PR creation and remote merge retain their
+external-write authority gates. Never locally merge the wish branch into `main`.
+
+After required QA passes on the exact PR candidate, persist the wish's `SHIPPED` status and completion evidence in a
+final closure commit on that PR branch, then rerun required checks and third-party review. The branch-local status is
+staged evidence only: the task remains in progress and the wish is not authoritatively shipped until GitHub merges that
+closure into remote `main`.
+
+Third-party merge makes the staged status authoritative on remote `main`. Fetch again and re-require a clean local
+`main`; fast-forward it and prove equality with `<remote>/main`. A dirty, ahead, diverged, or failed local update becomes
+mirror debt and is never repaired with reset, force, or a local feature merge. Independently archive the exact reviewed
+closure commit as `archive/wish/<slug>`, verify the tag resolves to that recorded commit, remove its clean worktree, and
+delete the active wish ref with a compare-and-swap against the same commit. If the ref moved, cleanup stops. The PR plus
+archive tag preserve the completed lane; no active wish branch remains. Post-merge mirror, archive, or cleanup failure
+does not rewrite `SHIPPED`; the PM records lifecycle debt, retains any affected lane, and does not report the lifecycle
+fully closed until retry succeeds.
+
+### Local-only mode
+
+With zero remotes, the PM may integrate a finished wish autonomously. Keep the primary `main` worktree clean. Create a
+temporary integration branch/worktree from the current `main`, merge `feat/<slug>` there, route code-level conflicts to
+a bounded fixer in that candidate worktree, and run the full wish validation and QA against the resolved candidate.
+Record the original `main` commit and require it to remain unchanged during this process. Only after the candidate
+passes may the PM persist the wish's staged `SHIPPED` status and completion evidence in the candidate and rerun required
+checks. Record that validated integrated closure commit.
+
+Archive that exact closure commit as the annotated tag `archive/wish/<slug>` and verify the tag resolves to it. Remove
+the clean wish and candidate worktrees, then delete their active refs with compare-and-swap operations against the
+recorded tips; a moved ref blocks cleanup. Only after archival and cleanup succeed may the PM recheck that `main` is
+clean and still at the recorded base, fast-forward it to the archive tag, and prove equality with the closure commit.
+The status becomes authoritative at that final fast-forward. Existing archive tags are idempotent only when they
+resolve to the same closure commit; any mismatch blocks cleanup. A failure before promotion keeps the authoritative
+wish `IN_PROGRESS`; if the final fast-forward fails after cleanup, recreate the candidate lane from the archive tag for
+recovery.
 
 ## Specialist Routing
 
@@ -56,7 +107,9 @@ Default chain: engineer → reviewer → qa → fix. Augment when the work calls
 
 ## Dispatch
 
-All implementation goes to subagents via the **native delegation surface** (native runtime). Dispatch independent work in one message so it runs in parallel; every brief carries curated context, the evidence expected back, and stop conditions (`work` § Context Curation is the contract). Background subagents notify you on completion — never sleep-poll. Follow-ups to a running subagent go through **native follow-up messaging**. When the user wants parallel Warp sessions they can supervise, hand the wave to `genie launch <slug> [--groups <csv>]` instead (human-in-the-loop; see `work` § Multi-session dispatch).
+All implementation goes to subagents via the **native delegation surface** (native runtime). The PM owns one wish integration worktree and creates one dedicated branch and worktree for every concurrently active execution group. Dispatch independent group lanes in one message so they run in parallel; never place two writers in one checkout, even when expected file scopes are disjoint. Every brief carries the lane path and branch, curated context, the evidence expected back, and stop conditions (`work` § Context Curation is the contract). Background subagents notify you on completion — never sleep-poll. Follow-ups to a running subagent go through **native follow-up messaging**. When the user wants parallel Warp sessions they can supervise, hand the wave to `genie launch <slug> [--groups <csv>]` instead (human-in-the-loop; see `work` § Multi-session dispatch).
+
+After an engineer commits, review that exact commit in an ephemeral read-only worktree. On SHIP, merge it into the wish integration branch in dependency order, own the conflict decision, and delegate code-level conflict edits to a bounded fixer in the integration worktree. After integrated validation passes, prove the group tip is merged, remove the clean group worktree without force, delete the merged local branch without force, and prune stale worktree metadata. Only then mark its task done. A blocked, dirty, unmerged, or unreviewed lane remains active and is never garbage-collected automatically.
 
 ## Board Operations
 
@@ -66,7 +119,7 @@ genie task list [--status blocked|ready|in_progress|done] [--wish <slug>] [--jso
 genie board [--wish <slug>] [--json]       # kanban snapshot
 genie task status <id>                     # detail, dependencies, stage log
 genie task checkout <id> --worker <name>   # atomic claim — workers run this
-genie task done <id>                       # complete after review + validation
+genie task done <id>                       # complete after integration, validation, and lane cleanup
 genie task export                          # full DB state as JSON (reporting)
 ```
 
@@ -78,7 +131,7 @@ Every claim in a status report must trace to tool output from this session — `
 
 ```
 ## Status — <date>
-Shipped: <what, with PR links>
+Shipped: <what, with PR link or local archive tag>
 In progress: <task ids, owners>
 Blocked: <reason, owner, next unblocking action>
 Next: <planned actions>
@@ -88,19 +141,24 @@ Next: <planned actions>
 
 Apply in every mode; exceeding one escalates to the human. Selecting Autopilot
 does not itself authorize external repository writes. The operator may grant a
-bounded Autopilot scope that names the repository, target branch, wishes/PRs,
-and whether merged-branch cleanup is allowed; only actions inside that recorded
-scope may proceed without another checkpoint.
+bounded Autopilot scope that names the repository, target branch, and
+wishes/PRs; only actions inside that recorded scope may proceed without another
+checkpoint. Verified cleanup of Genie-managed lanes is part of their lifecycle,
+not a separate external-write grant.
 
 | Action | Authority |
 |--------|-----------|
 | Create/claim/complete tasks | Autonomous |
 | Dispatch subagents (engineer, reviewer, qa, fix, docs, trace) | Autonomous |
-| Prepare commits and a proposed PR targeting `dev` | Autonomous inside the assigned repository/worktree |
+| Prepare commits and a proposed PR targeting the authoritative GitHub `main` | Autonomous inside the assigned repository/worktree |
 | Create or publish a PR | Explicit task-scoped grant, or a bounded Autopilot grant that names the repository and target branch |
-| Merge to `dev` | Separate explicit task-scoped merge grant, or a bounded Autopilot grant that names the eligible wishes/PRs |
-| Delete feature branches | Explicit cleanup grant; only after the associated merge is verified |
-| Merge to `main`/`master` | **Human only** |
+| Merge a GitHub PR | Third-party or human action by default; another policy requires explicit user direction and compatible repository protections |
+| Fast-forward local `main` to verified authoritative GitHub `main` | Autonomous mirror maintenance; never reset or force |
+| Integrate a finished wish into `main` when the repository has zero remotes | Autonomous through a validated temporary candidate |
+| Remove a clean Genie-managed worktree and delete its verified-merged local branch | Autonomous lifecycle cleanup |
+| Create or verify `archive/wish/<slug>` for a validated closure commit | Autonomous lifecycle archival |
+| Delete any other feature branch or unmerged lane | Explicit cleanup grant |
+| Directly merge into GitHub-backed `main`, or choose policy for another remote topology | Human decision required |
 | Client communication; budget/spending | **Human only** |
 | Scope changes (add/remove features) | Human approval required |
 
@@ -114,6 +172,8 @@ remain autonomous inside the assigned scope.
 
 ## Rules
 - Never write code — dispatch engineers.
+- Own wish integration, merge order, conflict decisions, and verified cleanup of completed group lanes.
+- Keep GitHub-backed `main` equal to its authoritative remote; use validated candidate integration only with zero remotes.
 - Never skip the review gate; never ship CRITICAL/HIGH gaps.
 - Surface blockers immediately, each with a proposed unblocking action.
 - Track only real, concrete work — no speculative tasks.

--- a/plugins/genie/skills/pm/references/modes.md
+++ b/plugins/genie/skills/pm/references/modes.md
@@ -20,9 +20,13 @@ Spawn one fresh-context decision-maker subagent at run start. Route ship/no-ship
 
 Entry: human says "run autonomously" / "autopilot". That phrase grants decision
 autonomy only; external repository writes still require the bounded scope from
-`../SKILL.md` (repository, target branch, eligible wishes/PRs, and cleanup
-policy). Exit: all authorized tasks shipped, or a decision/action exceeds that
-scope.
+`../SKILL.md` (repository, target branch, and eligible wishes/PRs). Verified
+cleanup of Genie-managed group lanes follows the normal lifecycle; cleanup of
+any other branch must be explicitly included in the grant. In a repository
+with zero remotes, validated candidate integration into local `main` and
+`archive/wish/<slug>` lifecycle cleanup are autonomous; GitHub PR creation and
+merge remain externally gated. Exit: all authorized tasks shipped, or a
+decision/action exceeds that scope.
 
 ### Default persona: pragmatic engineering manager
 

--- a/plugins/genie/skills/repo-hygiene/SKILL.md
+++ b/plugins/genie/skills/repo-hygiene/SKILL.md
@@ -21,7 +21,7 @@ Assess and report by default. Apply changes only when the invocation explicitly 
 
 Never judge against generic convention when the repo states its own. Before any verdict, read what exists of: `CLAUDE.md` / `AGENTS.md`, `README`, `CONTRIBUTING`, the package manifest, `.gitignore`, git hook tooling (husky, pre-commit, commitlint or equivalents), and CI config. These define the repo's *intended* contracts — your job is to find where reality has drifted from them, and where a contract is missing entirely. Deliberate tradeoffs documented there (bot commits, generated files kept on purpose, submodule workflows) are design, not defects.
 
-**Genie-framework repos**: if `.genie/` exists, its contract is: `wishes/`, `brainstorms/`, and `INDEX.md` are git-tracked; `genie.db` (and WAL/SHM siblings) must be ignored. Verify with `git check-ignore` and `git ls-files .genie/`.
+**Genie-framework repos**: if `.genie/` exists, its contract is: `wishes/`, `brainstorms/`, and `INDEX.md` are git-tracked; `genie.db` (and WAL/SHM siblings) plus per-worktree `launch/` prompts must be ignored. Verify with `git check-ignore` and `git ls-files .genie/`.
 
 **Repo profile — recall, verify, persist.** Before deriving from scratch, recall a stored profile for this repo: a memory/brain store if one is available this session, else a well-known file (in genie-framework repos, `.genie/repo-profile.md`). For this lane the profile records the ignore contracts, config-to-enforcement map, commit conventions, and documented tradeoffs. Recalled anchors are hypotheses, not truth — spot-check them against current code and report drift as a finding. After the audit, persist what discovery learned back to the store: update rather than duplicate, delete what proved wrong.
 

--- a/plugins/genie/skills/report/SKILL.md
+++ b/plugins/genie/skills/report/SKILL.md
@@ -17,10 +17,13 @@ Investigate a bug end-to-end: collect symptoms, run `trace` for root cause, capt
 
 ## QA Loop Integration
 
-When invoked during the QA loop (after merge to dev):
+When invoked during pre-promotion QA against the exact PR or local integration candidate:
 1. Read the wish's criteria from `.genie/wishes/<slug>/WISH.md`.
 2. Map each failure to the criterion it violates: `Criterion: "<text>" — FAIL`.
-3. Chain: QA failure → `report` → `trace` → `fix` → retest.
+3. Chain: QA failure → `report` → `trace` → `fix` in the candidate lane → retest and independent review.
+
+A defect discovered after authoritative mainline promotion starts a new corrective wish; `report` never routes fixes
+directly onto hosted or local `main`.
 
 ## Flow
 

--- a/plugins/genie/skills/review/SKILL.md
+++ b/plugins/genie/skills/review/SKILL.md
@@ -11,7 +11,7 @@ Validate a design, wish plan, completed execution, or PR against its governing c
 
 ## Context Injection
 
-When spawned as a reviewer subagent, your dispatch prompt carries the curated scope: the target (DESIGN.md, wish draft, completed work, or PR diff), its exact path, and the extracted design or acceptance criteria. A design review does not require a wish path; later pipelines include `.genie/wishes/<slug>/WISH.md`. Use the supplied context directly — do not re-parse information already provided.
+When spawned as a reviewer subagent, your dispatch prompt carries the curated scope: the target (DESIGN.md, wish draft, completed work, or PR diff), its exact path or commit, and the extracted design or acceptance criteria. Implementation review uses an ephemeral, detached, read-only worktree at the exact candidate commit; it never inspects a concurrently mutable engineer checkout. A design review does not require a wish path; later pipelines include `.genie/wishes/<slug>/WISH.md`. Use the supplied context directly — do not re-parse information already provided.
 
 ## When to Use
 - After `brainstorm` — validate DESIGN.md before converting it into a wish
@@ -110,12 +110,13 @@ orchestrator passes that value unchanged to the stamp command as
 `--reviewed-sha256`. Stamping rejects a current design that differs from the
 reviewed content, verification rejects any later edit, and the reviewer never
 recomputes a digest for content it did not review. For plan,
-execution, and PR review, the orchestrator appends the block under the wish's
+execution, PR, and local integration review, the orchestrator appends the block under the wish's
 `## Review Results` and owns every durable transition:
 
 - plan SHIP → `APPROVED`; plan FIX-FIRST → `FIX-FIRST`; plan BLOCKED → `BLOCKED`;
 - execution and PR verdicts are appended while the wish remains `IN_PROGRESS`;
-- only an authorized merge plus required QA changes the wish to `SHIPPED`.
+- only proven mainline integration plus required QA changes the wish to `SHIPPED`; unresolved post-merge local mirroring,
+  archival, or lane cleanup is recorded separately and must not be hidden.
 
 Do not claim the next stage is active until the orchestrator confirms the
 write. Never edit WISH.md, the brainstorm jar, or task state as the reviewer.
@@ -126,8 +127,9 @@ write. Never edit WISH.md, the brainstorm jar, or task state as the reviewer.
 |---------------|---------|
 | Design review (after `brainstorm`) | Proceed to `wish` to create the executable plan |
 | Plan review (after `wish`) | Proceed to `work` to execute the plan |
-| Execution review (after `work`) | Create PR targeting `dev` |
-| PR review (before merge) | Merge to `dev` (agents) or approve for human merge |
+| Execution review (after `work`) | GitHub-backed → create PR targeting authoritative `main`; zero remotes → prepare the validated local integration candidate |
+| PR review (before merge) | Record SHIP evidence for third-party GitHub merge; never merge locally into GitHub-backed `main` |
+| Local integration review | After candidate QA, review the closure commit containing staged `SHIPPED`; archive that exact commit and clean its lanes before fast-forwarding unchanged local `main` to it |
 
 ### FIX-FIRST loop
 1. Diagnose first. For `overdesigned-plan`, return to `brainstorm`/`wish` without consuming a fix attempt.
@@ -166,11 +168,11 @@ The verdict plus severity-tagged gaps ARE the review output — deliver them in 
 
 | Verdict | Orchestrator's next move |
 |---------|-------------------------|
-| **SHIP** | Execution review → complete the group with `genie task done <task-id>`; plan review → advance to the next lifecycle stage |
+| **SHIP** | Execution review → return the exact reviewed commit for PM integration, validation, lane cleanup, and `genie task done <task-id>`; plan review → advance to the next lifecycle stage |
 | **FIX-FIRST** | Auto-invoke `fix` with the gap list; the task stays `in_progress` until a clean re-review |
 | **BLOCKED** | Take the diagnosed corrective route; the task stays `in_progress` |
 
-`genie task done` belongs to the orchestrator, after a clean verdict — never to the reviewer.
+`genie task done` belongs to the orchestrator after a clean verdict, integration, validation, and lane cleanup — never to the reviewer.
 
 ## Rules
 - Never mark PASS without evidence from this session — verify, don't assume.

--- a/plugins/genie/skills/review/SKILL.md
+++ b/plugins/genie/skills/review/SKILL.md
@@ -37,6 +37,7 @@ Use this policy before any model or effort change; keep this contract identical 
 | `missing-context` | The attempt identifies absent files, history, criteria, logs, or other inputs needed to decide. | Supply the missing context and retry at the same model and effort; MUST NOT escalate model or effort. |
 | `ambiguous-spec` | Two or more materially different behaviors remain consistent with the stated criteria. | Request a human decision or wish clarification; MUST NOT escalate model or effort. |
 | `env-tool-failure` | A reproducible environment, dependency, permission, timeout, or tool error prevents valid execution. | Repair or retry the environment/tool, or report blocked with the error; MUST NOT escalate model or effort. |
+| `overdesigned-plan` | Gaps cluster in optional machinery that lacks a current criterion or measurement, while a simpler design satisfies the user stories with fewer durable states or recovery paths. | Stop the fix loop and return to `brainstorm`/`wish` to remove or defer the mechanism. Re-review the amended design/plan; MUST NOT spend retries or model escalation defending it. |
 
 Escalation eligibility requires **new evidence** produced since the previous attempt: attach the new failing output or diagnostic result, the correction already tried, and why it rules out the other three causes. A repeated verdict or unchanged failure is not new evidence and cannot authorize a model or effort change.
 
@@ -50,6 +51,8 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 - [ ] Problem is explicit, consequential, and readable one way
 - [ ] Scope has concrete IN and OUT boundaries that fit one wish
 - [ ] Chosen approach names its rationale and rejected alternatives
+- [ ] Simplicity Case states the simplest complete design; every added mechanism has a present requirement or measurement, and future complexity has a concrete adoption trigger
+- [ ] Current state is bounded and history is separated before deltas, sharding, caches, or distributed synchronization are considered
 - [ ] Decisions are consistent with the approach and repository constraints
 - [ ] Risks and assumptions name mitigations or explicit acceptance
 - [ ] Success criteria are testable without requiring execution-group details
@@ -62,6 +65,7 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 - [ ] Tasks are bite-sized and independently shippable
 - [ ] Dependencies tagged (`depends-on` / `blocks`)
 - [ ] Validation commands exist for each execution group
+- [ ] Simplicity Case is executable: no group builds machinery marked deferred, and every stateful mechanism maps to a current success criterion
 
 ### Execution Review (after `work`)
 - [ ] All acceptance criteria met with evidence
@@ -70,6 +74,7 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 - [ ] Work is auditable — commands and outcomes captured
 - [ ] Quality pass: security, maintainability, correctness
 - [ ] No regressions introduced
+- [ ] Implementation did not introduce caches, synchronization states, configuration, or abstractions absent from the approved Simplicity Case
 
 ### PR Review (before merge)
 - [ ] Diff matches wish scope — no unrelated changes
@@ -79,6 +84,8 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 - [ ] Commit messages reference wish slug
 
 ## Severity & Verdicts
+
+In design and plan review, unjustified stateful machinery—such as speculative caches, deltas, sharding, background coordination, or retry state machines—is a HIGH gap because it creates permanent correctness and maintenance obligations without delivering a current criterion. If removing it changes the governing approach, return BLOCKED with `overdesigned-plan` and replan instead of asking a fixer to preserve it.
 
 | Severity | Meaning | Blocks? |
 |----------|---------|---------|
@@ -123,9 +130,10 @@ write. Never edit WISH.md, the brainstorm jar, or task state as the reviewer.
 | PR review (before merge) | Merge to `dev` (agents) or approve for human merge |
 
 ### FIX-FIRST loop
-1. Auto-invoke `fix` with the severity-tagged gap list.
-2. After `fix` completes, re-run `review` (max 2 fix loops).
-3. Still FIX-FIRST after 2 loops → return BLOCKED with an Escalation Diagnosis; never raise model or effort automatically.
+1. Diagnose first. For `overdesigned-plan`, return to `brainstorm`/`wish` without consuming a fix attempt.
+2. Otherwise auto-invoke `fix` with the severity-tagged gap list.
+3. After `fix` completes, re-run `review` (max 3 fix loops).
+4. Still FIX-FIRST after 3 loops → return BLOCKED with an Escalation Diagnosis; never raise model or effort automatically.
 
 When a failure's root cause is unclear, invoke `trace` before dispatching `fix` — `fix` then applies the cause-specific correction from the trace report. An unclear cause is not evidence of `model-capacity`.
 

--- a/plugins/genie/skills/wish/SKILL.md
+++ b/plugins/genie/skills/wish/SKILL.md
@@ -33,9 +33,10 @@ node "<wish-skill-dir>/references/design-review-evidence.mjs" verify ".genie/bra
 ## Flow
 1. **Gate check:** if the request is fuzzy (no prior design, unclear scope, vague requirements), run `brainstorm` first and say so. If a design exists, do not scaffold until its digest-bound design-review evidence verifies as SHIP.
 2. **Align intent:** clarify until success criteria are testable.
-3. **Define scope:** explicit IN and OUT lists. OUT cannot be empty.
-4. **Decompose:** small, loosely coupled execution groups.
-5. **Scaffold** — always copy the template, never hand-write WISH.md. Resolve
+3. **Pass the simplicity gate:** state the simplest complete design, justify every mechanism beyond it with a present requirement or measurement, and defer plausible future complexity behind a concrete trigger. A wish cannot outsource this decision to implementation.
+4. **Define scope:** explicit IN and OUT lists. OUT cannot be empty.
+5. **Decompose:** small, loosely coupled execution groups.
+6. **Scaffold** — always copy the template, never hand-write WISH.md. Resolve
    the absolute directory containing this loaded `SKILL.md`, replace only the
    two placeholder assignments below, and run the complete command from the
    repository root:
@@ -56,20 +57,20 @@ node "<wish-skill-dir>/references/design-review-evidence.mjs" verify ".genie/bra
    <!-- wish-scaffold-command:end -->
 
    The template ships inside this skill as the single source of truth for wish structure — a plain document, no runtime scaffolder. Copying guarantees the skeleton the parser and linter expect; ad-hoc wishes regularly fail structural lint.
-6. **Fill:** replace the `{{slug}}`/`{{date}}` tokens and every `<TODO: …>` marker with real content. Every group gets acceptance criteria plus a validation command.
-7. **Declare dependencies:** use the wish-level `## Dependencies` keys
+7. **Fill:** replace the `{{slug}}`/`{{date}}` tokens and every `<TODO: …>` marker with real content. Every group gets acceptance criteria plus a validation command.
+8. **Declare dependencies:** use the wish-level `## Dependencies` keys
    `**depends-on:** <comma-separated slugs or none>` and
    `**blocks:** <comma-separated slugs or none>` for cross-wish edges. Keep
    per-group `**depends-on:**` fields under each execution group. The spelling
    is always hyphenated; the DAG is a machine-readable planning artifact in git.
-8. **Create tasks** — one per execution group, so `work` can claim and complete each group and the board reflects progress:
+9. **Create tasks** — one per execution group, so `work` can claim and complete each group and the board reflects progress:
    ```bash
    genie task create --title "<group title>" --wish <slug> --group <group-name>
    genie task list --wish <slug>   # inspect what was created
    ```
    Tasks carry the `--wish`/`--group` linkage; the dependency DAG stays in the WISH.md document, not in task rows. If creation fails (no `.genie/genie.db` yet, CLI unavailable), warn and continue — WISH.md in git is the source of truth and must remain usable by `work` without task rows.
-9. **Handoff:** run the wish linter — inside the genie repo, `grep -q '"wishes:lint"' package.json 2>/dev/null && bun run wishes:lint`. If it reports any error, surface it and stop — never hand a structurally broken wish onward. Only after lint passes, auto-invoke `review` (plan review) on the WISH.md. Never suggest `work` directly — the review gate comes first.
-10. **Persist the verdict:** the reviewer only returns evidence. The invoking orchestrator appends that evidence under `## Review Results` and sets the WISH status to `APPROVED` on SHIP, `FIX-FIRST` on FIX-FIRST, or `BLOCKED` on BLOCKED. Do not route to `work` until the `APPROVED` status is on disk.
+10. **Handoff:** run the wish linter — inside the genie repo, `grep -q '"wishes:lint"' package.json 2>/dev/null && bun run wishes:lint`. If it reports any error, surface it and stop — never hand a structurally broken wish onward. Only after lint passes, auto-invoke `review` (plan review) on the WISH.md. Never suggest `work` directly — the review gate comes first.
+11. **Persist the verdict:** the reviewer only returns evidence. The invoking orchestrator appends that evidence under `## Review Results` and sets the WISH status to `APPROVED` on SHIP, `FIX-FIRST` on FIX-FIRST, or `BLOCKED` on BLOCKED. Do not route to `work` until the `APPROVED` status is on disk.
 
 ## Wish Document Sections
 
@@ -79,6 +80,7 @@ node "<wish-skill-dir>/references/design-review-evidence.mjs" verify ".genie/bra
 | Summary | Yes | 2-3 sentences: what and why |
 | Scope IN / OUT | Yes | OUT cannot be empty |
 | Decisions | Yes | Key choices with rationale |
+| Simplicity Case | Yes | Simplest complete design, justified additions, and measurable deferrals |
 | Success Criteria | Yes | Checkboxes, each testable |
 | Execution Strategy | Yes | Wave-based plan — mandatory even if a single sequential wave; forces ordering, parallelism, and dependency thinking upfront |
 | Execution Groups | Yes | Goal, deliverables, acceptance criteria, validation command |
@@ -92,6 +94,7 @@ node "<wish-skill-dir>/references/design-review-evidence.mjs" verify ".genie/bra
 - Never emit a bracket-link to a non-existent brainstorm — use the `_No brainstorm — direct wish_` stub.
 - Never consume a linked design whose persisted review evidence is missing, non-SHIP, or stale; the wish linter independently enforces this for new wishes.
 - No implementation during `wish` — planning only.
+- No speculative optimization: caches, deltas, sharding, background coordination, and configuration surfaces require a current criterion or measurement in the Simplicity Case.
 - Every group testable, bite-sized, and independently shippable; no vague tasks ("improve everything").
 - OUT scope must contain at least one concrete exclusion.
 - Declare cross-wish dependencies early.

--- a/plugins/genie/skills/wish/templates/wish-template.md
+++ b/plugins/genie/skills/wish/templates/wish-template.md
@@ -32,6 +32,13 @@
 |---|----------|-----------|
 | 1 | <TODO: decision> | <TODO: why this over alternatives> |
 
+## Simplicity Case
+
+- **Simplest complete design:** <TODO: smallest design that satisfies current user stories>
+- **Added machinery:** <TODO: none, or each mechanism and the present evidence that requires it>
+- **Deferred until measured:** <TODO: future complexity and its concrete adoption trigger>
+- **Complexity removed:** <TODO: states, failure modes, options, or dependencies deliberately avoided>
+
 ## Dependencies
 
 **depends-on:** none

--- a/plugins/genie/skills/work/SKILL.md
+++ b/plugins/genie/skills/work/SKILL.md
@@ -19,28 +19,53 @@ When you are spawned as a subagent for a group, your dispatch prompt carries the
 
 ## Flow
 1. **Load and enter execution:** read `.genie/wishes/<slug>/WISH.md` and require persisted status `APPROVED` (or `IN_PROGRESS` when resuming). Before the first dispatch, the orchestrator sets `APPROVED` → `IN_PROGRESS`; read group state with `genie task list --wish <slug>` (or `genie board --wish <slug>`).
-2. **Pick the wave:** every group whose `depends-on` groups are done, per the wish's Execution Strategy.
-3. **Dispatch the wave in ONE message** — one native delegation surface call per group, each using the named engineer role selected from the WISH's Complexity and Model columns with curated context (see Dispatch, Context Curation). Each engineer's brief opens with the atomic claim:
+2. **Pick the wave:** every group whose `depends-on` groups are integrated and done, per the wish's Execution Strategy.
+   The current PM checkout is the wish integration worktree. Before dispatch, create one branch and worktree from its
+   current HEAD for every group in the wave; a group lane persists across engineer and fixer handoffs.
+3. **Dispatch the wave in ONE message** — one native delegation surface call per group, each placed in its dedicated
+   group worktree and using the named engineer role selected from the WISH's Complexity and Model columns with curated
+   context (see Dispatch, Context Curation). Each engineer's brief names the worktree and branch and opens with the
+   atomic claim:
    ```bash
    genie task checkout <task-id> --worker <engineer-name>
    ```
    If two agents race one task, exactly one wins; the loser gets a conflict error and stands down.
 4. **Await completion — never poll:** background subagents notify you when they finish. Inspect `genie board --wish <slug>` on demand; completion is push, not poll.
-5. **Local review:** per finished group, dispatch a reviewer subagent (reviewer ≠ engineer) to run `review` against that group's acceptance criteria. The orchestrator appends each returned evidence block under `## Review Results`; the reviewer never edits it. Diagnose before fixing: `overdesigned-plan` returns to wish/design review without consuming a fix attempt; other FIX-FIRST gaps may use at most 3 fix loops.
+5. **Checkpoint and local review:** require the engineer to commit the group result, then dispatch a reviewer subagent
+   (reviewer ≠ engineer) in an ephemeral, detached, read-only worktree at that exact commit. Remove the review worktree
+   when the review ends. The orchestrator appends each returned evidence block under `## Review Results`; the reviewer
+   never edits it. Diagnose before fixing: `overdesigned-plan` returns to wish/design review without consuming a fix
+   attempt; other FIX-FIRST gaps return a fixer to the existing group worktree for at most 3 fix loops.
 6. **Quality review:** dispatch a reviewer for a quality pass (security, maintainability, perf). On FIX-FIRST, use the same maximum of 3 fix loops.
-7. **Validate:** run the group's validation command yourself (Bash); record the output as evidence.
-8. **Group done** — only after clean review AND passing validation:
+7. **Integrate and validate:** after clean review, merge the group branch into the wish integration branch in the WISH's
+   declared order. The PM owns merge decisions and conflict resolution; route code-level conflict edits to a bounded
+   fixer in the integration worktree. Run the group's validation command on the integrated tree and record the output.
+8. **Garbage collect and mark done:** after the group tip is proven merged and integrated validation passes, require a
+   clean group worktree, remove it without force, delete its merged branch without force, and prune stale worktree
+   metadata. Any failed proof or cleanup leaves the task `in_progress` and the lane intact:
+   ```bash
+   git -C <integration-worktree> merge-base --is-ancestor <group-tip> HEAD
+   test -z "$(git -C <group-worktree> status --porcelain)"
+   git -C <integration-worktree> worktree remove <group-worktree>
+   git -C <integration-worktree> branch -d <group-branch>
+   git -C <integration-worktree> worktree prune
+   ```
+   Only then:
    ```bash
    genie task done <task-id>
    ```
 9. **Next wave:** re-derive from the WISH.md Execution Strategy (the DAG lives in the document, not in task rows — see State Management); repeat 2-8 until all groups are done.
-10. **Handoff:** when every group's task is done: `All work groups complete. Run review.` Keep status `IN_PROGRESS` through execution review, PR review, and CI. Only the authorized merge plus required QA may transition it to `SHIPPED`.
+10. **Handoff:** when every group's task is done: `All work groups complete. Run review.` Keep status `IN_PROGRESS`
+    through execution review and the PM's repository integration mode. A GitHub-backed repository requires reviewed PR
+    integration plus local-main fast-forward; a repository with zero remotes uses a validated local candidate. Only
+    mainline integration and required QA may transition it to `SHIPPED`; the PM must also finish or explicitly report
+    any local-mirror, archive, or lane-cleanup debt.
 
 ## Dispatch
 
 Spawn subagents with the **native delegation surface**; never execute group work directly. Dispatch a wave together so independent groups can run concurrently. Subagents notify you on completion. Every dispatch selects one named role below; implicit or unnamed roles are forbidden.
 
-Use the active runtime's named roles. In Codex, use the matching `genie_*` custom-agent profile when installed; Claude and Hermes use their native named-role surfaces. Parallel writers must have disjoint file ownership or dedicated worktrees; otherwise sequence them. Reviewers and scouts stay read-only. Wait for completion notifications, steer a running thread with native follow-up messaging, and interrupt drift rather than spawning a duplicate worker.
+Use the active runtime's named roles. In Codex, use the matching `genie_*` custom-agent profile when installed; Claude and Hermes use their native named-role surfaces. Every concurrent execution group must use a dedicated branch and worktree, even when expected file scopes are disjoint. If the runtime cannot place native subagents in those worktrees, use `genie launch` or sequence the groups. Never dispatch two writers into one worktree. Reviewers and scouts stay read-only and use ephemeral snapshot worktrees when concurrent. Wait for completion notifications, steer a running thread with native follow-up messaging, and interrupt drift rather than spawning a duplicate worker.
 
 | Need | Portable role (Codex profile) |
 |------|----------------------------|
@@ -64,7 +89,7 @@ Native subagent dispatch is the default. When the user wants parallel Warp sessi
 genie launch <slug> [--groups <csv>]
 ```
 
-One pane per ready group, each in its own git worktree, running that group's agent on a kickoff prompt. Everything governing correctness is identical: engineers still claim with `genie task checkout` against the shared `genie.db`, reviewer ≠ engineer holds, the orchestrator still validates and marks groups done, and waves still come from the Execution Strategy. The one limit: pane sessions cannot be awaited — Warp mode is human-in-the-loop. For hands-off, awaitable dispatch, use native subagents.
+One pane per ready group, each in its own git worktree, running that group's agent on a kickoff prompt. Everything governing correctness is identical: engineers still claim with `genie task checkout` against the shared `genie.db`, reviewer ≠ engineer holds, the orchestrator merges each reviewed branch into the wish integration worktree, and waves still come from the Execution Strategy. After integration and validation, the PM removes the clean group worktree and merged branch before marking its task done. The one limit: pane sessions cannot be awaited — Warp mode is human-in-the-loop. For hands-off, awaitable dispatch, use isolated native subagents.
 
 ## Context Curation
 
@@ -75,14 +100,15 @@ Extract the group's context from WISH.md and paste it into the dispatch prompt �
 3. **Acceptance criteria** — the checkboxes to satisfy
 4. **Validation command** — the exact command proving the work (e.g. `bun run check`)
 5. **Depends-on** — what the engineer may assume already exists
-6. **Stop conditions** — claim the task first; report blocked instead of expanding scope; end with an outcome word (see Session close)
+6. **Lane** — the absolute group worktree path and branch; do not edit outside it
+7. **Stop conditions** — claim the task first; commit before review; report blocked instead of expanding scope; end with an outcome word (see Session close)
 
 ## State Management
 
 - **Engineers claim** via `genie task checkout <task-id> --worker <name>` as the first step of their brief.
 - **Environment setup is feature work.** Read-only discovery may precede a claim, but before mutating shared host state—installing toolchains or runtimes, starting services or emulators, provisioning credentials, or preparing test infrastructure—claim the group that owns the setup and keep it `in_progress` until setup and validation finish. The visible claim is the concurrency lock: if another live worker owns it, coordinate or stand down; reclaim only a stale claim. When setup is a prerequisite shared by multiple groups, give it an explicit group/task in the wish instead of running untracked preflight. Never let multiple threads independently prepare the same environment.
-- **Engineers signal** completion in their final message; the native team notifies the orchestrator — no manual send.
-- **Orchestrator tracks** via `genie task list --wish <slug>` / `genie board --wish <slug>` (on demand) and completes each verified group with `genie task done <task-id>`. Engineers never call `genie task done`.
+- **Engineers signal** completion in their final message with the reviewed commit candidate; the native team notifies the orchestrator — no manual send.
+- **Orchestrator tracks** via `genie task list --wish <slug>` / `genie board --wish <slug>` (on demand) and completes each group only after its reviewed commit is merged, the integrated tree passes validation, and the clean group worktree and merged branch are removed. Engineers never call `genie task done`.
 - **The dependency DAG is doc-only.** The v5 CLI has no dependency-edge commands — every CLI-created task is `ready` from birth, so DB status is NOT a dependency signal. Sequence waves from the WISH.md Execution Strategy alone; never dispatch a group just because its task shows `ready`.
 - **No task row?** (wish predates the state DB, or `.genie/genie.db` unavailable): skip the `genie task` calls and drive the wave from the WISH.md directly — task tracking is an enhancement, never a blocker.
 
@@ -114,7 +140,7 @@ A user-approved simplification invalidates the superseded plan/review evidence a
 - Never spend fix loops preserving optional complexity; route an `overdesigned-plan` diagnosis back through wish/design review.
 - Never overwrite WISH.md from subagent output — curated prompts are runtime context; the WISH.md in git is the source of truth.
 - Reviewer ≠ engineer, always.
-- `genie task done` only after clean review and passing validation — and only by the orchestrator.
+- `genie task done` only after clean review, integration, passing validation, and group-lane garbage collection — and only by the orchestrator.
 - Grounded progress: before reporting, audit each claim against tool output from this session — state what is verified, what failed, what was skipped. Never present intentions, or subagent claims you did not verify, as completed work.
 
 ## Session close (required)

--- a/plugins/genie/skills/work/SKILL.md
+++ b/plugins/genie/skills/work/SKILL.md
@@ -26,8 +26,8 @@ When you are spawned as a subagent for a group, your dispatch prompt carries the
    ```
    If two agents race one task, exactly one wins; the loser gets a conflict error and stands down.
 4. **Await completion — never poll:** background subagents notify you when they finish. Inspect `genie board --wish <slug>` on demand; completion is push, not poll.
-5. **Local review:** per finished group, dispatch a reviewer subagent (reviewer ≠ engineer) to run `review` against that group's acceptance criteria. The orchestrator appends each returned evidence block under `## Review Results`; the reviewer never edits it. On FIX-FIRST, dispatch a fix subagent (max 2 loops); if unresolved, apply Escalation Diagnosis instead of automatically changing model or effort.
-6. **Quality review:** dispatch a reviewer for a quality pass (security, maintainability, perf). On FIX-FIRST, one fix loop.
+5. **Local review:** per finished group, dispatch a reviewer subagent (reviewer ≠ engineer) to run `review` against that group's acceptance criteria. The orchestrator appends each returned evidence block under `## Review Results`; the reviewer never edits it. Diagnose before fixing: `overdesigned-plan` returns to wish/design review without consuming a fix attempt; other FIX-FIRST gaps may use at most 3 fix loops.
+6. **Quality review:** dispatch a reviewer for a quality pass (security, maintainability, perf). On FIX-FIRST, use the same maximum of 3 fix loops.
 7. **Validate:** run the group's validation command yourself (Bash); record the output as evidence.
 8. **Group done** — only after clean review AND passing validation:
    ```bash
@@ -80,6 +80,7 @@ Extract the group's context from WISH.md and paste it into the dispatch prompt �
 ## State Management
 
 - **Engineers claim** via `genie task checkout <task-id> --worker <name>` as the first step of their brief.
+- **Environment setup is feature work.** Read-only discovery may precede a claim, but before mutating shared host state—installing toolchains or runtimes, starting services or emulators, provisioning credentials, or preparing test infrastructure—claim the group that owns the setup and keep it `in_progress` until setup and validation finish. The visible claim is the concurrency lock: if another live worker owns it, coordinate or stand down; reclaim only a stale claim. When setup is a prerequisite shared by multiple groups, give it an explicit group/task in the wish instead of running untracked preflight. Never let multiple threads independently prepare the same environment.
 - **Engineers signal** completion in their final message; the native team notifies the orchestrator — no manual send.
 - **Orchestrator tracks** via `genie task list --wish <slug>` / `genie board --wish <slug>` (on demand) and completes each verified group with `genie task done <task-id>`. Engineers never call `genie task done`.
 - **The dependency DAG is doc-only.** The v5 CLI has no dependency-edge commands — every CLI-created task is `ready` from birth, so DB status is NOT a dependency signal. Sequence waves from the WISH.md Execution Strategy alone; never dispatch a group just because its task shows `ready`.
@@ -95,6 +96,7 @@ Use this policy before any model or effort change; keep this contract identical 
 | `missing-context` | The attempt identifies absent files, history, criteria, logs, or other inputs needed to decide. | Supply the missing context and retry at the same model and effort; MUST NOT escalate model or effort. |
 | `ambiguous-spec` | Two or more materially different behaviors remain consistent with the stated criteria. | Request a human decision or wish clarification; MUST NOT escalate model or effort. |
 | `env-tool-failure` | A reproducible environment, dependency, permission, timeout, or tool error prevents valid execution. | Repair or retry the environment/tool, or report blocked with the error; MUST NOT escalate model or effort. |
+| `overdesigned-plan` | Gaps cluster in optional machinery that lacks a current criterion or measurement, while a simpler design satisfies the user stories with fewer durable states or recovery paths. | Stop the fix loop and return to `brainstorm`/`wish` to remove or defer the mechanism. Re-review the amended design/plan; MUST NOT spend retries or model escalation defending it. |
 
 Escalation eligibility requires **new evidence** produced since the previous attempt: attach the new failing output or diagnostic result, the correction already tried, and why it rules out the other three causes. A repeated verdict or unchanged failure is not new evidence and cannot authorize a model or effort change.
 
@@ -104,9 +106,12 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 
 When a subagent fails or a fix-loop limit is exhausted, the orchestrator records the cause, evidence, selected route, and current cap counters before another dispatch. It leaves the task `in_progress`, keeps dispatching ready groups that do not depend on the blocked one, and includes unresolved diagnoses and appeals in the final handoff.
 
+A user-approved simplification invalidates the superseded plan/review evidence and starts a fresh plan review; it is not an extra fix attempt. Preserve useful completed work only when it still satisfies the simpler contract, and delete machinery that exists solely for the rejected design.
+
 ## Rules
 - Never execute group work directly — always dispatch via the native delegation surface.
 - Never expand scope during execution; never skip validation commands.
+- Never spend fix loops preserving optional complexity; route an `overdesigned-plan` diagnosis back through wish/design review.
 - Never overwrite WISH.md from subagent output — curated prompts are runtime context; the WISH.md in git is the source of truth.
 - Reviewer ≠ engineer, always.
 - `genie task done` only after clean review and passing validation — and only by the orchestrator.

--- a/plugins/genie/skills/work/references/native-surfaces.md
+++ b/plugins/genie/skills/work/references/native-surfaces.md
@@ -4,8 +4,8 @@ Genie skills describe roles and coordination without inventing a cross-client to
 
 | Runtime | Dispatch | Isolation | Follow-up |
 |---------|----------|-----------|-----------|
-| Claude Code | Use its current native Agent surface and an available named role | Use the runtime's supported isolation/worktree option when present | Use the runtime's documented messaging surface when available; otherwise re-dispatch with curated context |
-| Codex | Use the matching `genie_*` custom agent when the CLI-installed profiles are present; otherwise use an available generic subagent | Native subagents share the caller's workspace by default | Use the active native follow-up tool exposed in the session; do not hardcode an undocumented function name into a skill |
+| Claude Code | Use its current native Agent surface and an available named role | Place every concurrent group in a dedicated runtime-managed or ordinary Git worktree | Use the runtime's documented messaging surface when available; otherwise re-dispatch with curated context |
+| Codex | Use the matching `genie_*` custom agent when the CLI-installed profiles are present; otherwise use an available generic subagent | Place every concurrent group in a dedicated runtime-managed or ordinary Git worktree; otherwise sequence it | Use the active native follow-up tool exposed in the session; do not hardcode an undocumented function name into a skill |
 | Warp cockpit | `genie launch <slug>` emits one pane per ready group | Dedicated Git worktree per pane | Human-supervised; panes are not awaitable native subagents |
 
 Every implementation brief opens with the atomic claim:
@@ -14,6 +14,6 @@ Every implementation brief opens with the atomic claim:
 genie task checkout <task-id> --worker <name>
 ```
 
-The claim owns file scope in a shared workspace. Engineers and fixers report completion but never call `genie task done`. A different reviewer validates the group; only the orchestrator marks it done after a SHIP verdict and passing evidence. Native client completion notifications replace polling.
+The task claim owns group state; the dedicated worktree and branch own its mutable file state. Engineers and fixers report completion but never call `genie task done`. A different reviewer validates an exact commit in an ephemeral read-only worktree. The PM merges that commit into the wish integration worktree, resolves conflicts, validates the integrated tree, and removes the clean group worktree and merged branch before marking the task done. Native client completion notifications replace polling.
 
 User decisions use the runtime's native input or permission surface. Shared workflows name the semantic action—dispatch, follow up, interrupt, wait—while the active client supplies the concrete tool.

--- a/scripts/release-docs.test.ts
+++ b/scripts/release-docs.test.ts
@@ -329,6 +329,28 @@ describe('Group E release and documentation contracts', () => {
     expect(pm).toMatch(/Selecting Autopilot\s+does not itself authorize external repository writes/);
   });
 
+  test('lifecycle treats simplicity as a hard gate and replans overdesigned work', () => {
+    const architecture = read('skills/architecture/SKILL.md');
+    const brainstorm = read('skills/brainstorm/SKILL.md');
+    const designTemplate = read('skills/brainstorm/references/design-template.md');
+    const wish = read('skills/wish/SKILL.md');
+    const wishTemplate = read('skills/wish/templates/wish-template.md');
+    const review = read('skills/review/SKILL.md');
+    const fix = read('skills/fix/SKILL.md');
+    const work = read('skills/work/SKILL.md');
+
+    expect(architecture).toContain('KISS comes first');
+    expect(brainstorm).toContain('## Simplicity Gate');
+    expect(designTemplate).toContain('## Simplicity Case');
+    expect(wish).toContain('Pass the simplicity gate');
+    expect(wishTemplate).toContain('## Simplicity Case');
+    expect(review).toContain('unjustified stateful machinery');
+    expect(review).toContain('a HIGH gap');
+    for (const lifecycleSkill of [review, fix, work]) expect(lifecycleSkill).toContain('`overdesigned-plan`');
+    expect(fix).toContain('up to 3 loops');
+    expect(work).toContain('A user-approved simplification invalidates the superseded plan/review evidence');
+  });
+
   test('wizard discloses init MCP writes and owner-qualified lifecycle order', () => {
     const wizard = read('skills/wizard/SKILL.md');
     for (const path of ['.mcp.json', '.warp/.mcp.json', '.codex/config.toml']) expect(wizard).toContain(path);

--- a/scripts/release-docs.test.ts
+++ b/scripts/release-docs.test.ts
@@ -329,6 +329,59 @@ describe('Group E release and documentation contracts', () => {
     expect(pm).toMatch(/Selecting Autopilot\s+does not itself authorize external repository writes/);
   });
 
+  test('parallel execution uses isolated group lanes and garbage-collects only verified merged work', () => {
+    const agents = read('AGENTS.md');
+    const work = read('skills/work/SKILL.md');
+    const pm = read('skills/pm/SKILL.md');
+    const review = read('skills/review/SKILL.md');
+    const dispatch = read('plugins/genie/references/dispatch-contract.md');
+    const launch = read('src/term-commands/launch.ts');
+
+    expect(agents).toContain('each concurrently active execution group as an isolated delivery lane');
+    expect(work).toContain('even when expected file scopes are disjoint');
+    expect(work).toContain('Any failed proof or cleanup leaves the task `in_progress` and the lane intact');
+    expect(pm).toContain('A blocked, dirty, unmerged, or unreviewed lane remains active');
+    expect(review).toContain('ephemeral, detached, read-only worktree at the exact candidate commit');
+    expect(dispatch).toContain('The PM merges reviewed group commits into the wish integration worktree');
+    expect(launch).toContain('only the PM integrates, cleans up the lane, and marks tasks done');
+  });
+
+  test('mainline ownership follows GitHub-backed and zero-remote repository modes', () => {
+    const agents = read('AGENTS.md');
+    const lifecycle = read('skills/genie/reference/lifecycle.md');
+    const pm = read('skills/pm/SKILL.md');
+    const dream = read('skills/dream/SKILL.md');
+    const review = read('skills/review/SKILL.md');
+    const report = read('skills/report/SKILL.md');
+    const dispatch = read('plugins/genie/references/dispatch-contract.md');
+
+    expect(agents).toMatch(/local `main` is a\s+clean fast-forward mirror/);
+    expect(lifecycle).toMatch(/Before work, local `main` must be\s+clean, fast-forwarded, and proven equal/);
+    expect(pm).toMatch(/Never locally merge the\s+wish branch into `main`/);
+    expect(pm).toContain('Any other configured upstream requires an explicit user decision');
+    expect(pm).toContain('fast-forward it to `<remote>/main`, and prove both refs resolve to the same commit');
+    expect(pm).toContain('With zero remotes, the PM may integrate a finished wish autonomously');
+    expect(pm).toContain('annotated tag `archive/wish/<slug>`');
+    expect(pm).toContain('compare-and-swap');
+    expect(pm.indexOf('Archive that exact closure commit')).toBeLessThan(
+      pm.indexOf('Only after archival and cleanup succeed'),
+    );
+    expect(pm).toMatch(/branch-local status is\s+staged evidence only/);
+    expect(lifecycle).toMatch(/not authoritative until third-party merge/);
+    expect(lifecycle).toContain('hosted mirror, archive, or cleanup failure after remote merge is recorded lifecycle');
+    expect(lifecycle).toContain('failed local mirroring is recorded lifecycle debt');
+    expect(dream).toMatch(/PR targeting authoritative `main`/);
+    expect(dream).toContain('final closure commit');
+    expect(dream).toContain('Report a wish shipped only with authoritative mainline and QA evidence');
+    expect(review).toContain('zero remotes → prepare the validated local integration candidate');
+    expect(report).toContain('during pre-promotion QA against the exact PR or local integration candidate');
+    expect(dispatch).toContain('fresh reviewer, at most three loops');
+    for (const doc of [pm, dream, review]) {
+      expect(doc).not.toContain('targeting `dev`');
+      expect(doc).not.toContain('merge to `dev`');
+    }
+  });
+
   test('lifecycle treats simplicity as a hard gate and replans overdesigned work', () => {
     const architecture = read('skills/architecture/SKILL.md');
     const brainstorm = read('skills/brainstorm/SKILL.md');

--- a/skills/README.md
+++ b/skills/README.md
@@ -30,7 +30,12 @@ All runtimes share the same durable contracts:
 - operational task state is in the per-repository `.genie/genie.db`;
 - implementation is delegated through the runtime's native named roles;
 - the engineer and reviewer are always different agents;
-- the orchestrator alone marks a task done after review and validation.
+- every concurrent execution group owns a dedicated branch and worktree with one active writer;
+- the orchestrator merges reviewed group commits into the wish integration branch and owns conflict decisions;
+- the orchestrator alone marks a task done after integrated validation and garbage collection of the clean merged lane.
+- a GitHub-backed `main` is updated only by fast-forwarding to its authoritative remote after reviewed PR merge;
+- with no remotes, the PM validates a temporary candidate, archives that exact integrated closure under
+  `archive/wish/<slug>`, removes its clean active lanes, and then fast-forwards unchanged local `main` to it.
 
 ## Distribution contract
 

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -9,7 +9,7 @@ description: Use when reviewing architecture in any codebase — module boundari
 
 ## Lens
 
-This lane treats complexity as anything that makes a system hard to understand or modify — it accumulates as dependencies and obscurity. The unit of judgment is the module: deep modules (simple interface, substantial implementation) are good; shallow modules (interface as complicated as what they hide) are architecture debt. Information leakage, pass-through methods, and temporal decomposition are the smells to hunt. Prize "define errors out of existence" and design-it-twice thinking.
+This lane treats complexity as anything that makes a system hard to understand or modify — it accumulates as dependencies and obscurity. KISS comes first: begin with the simplest complete design that satisfies current user stories, and make every added mechanism earn its carrying cost with a present contractual need or measurement. Hypothetical future scale is not evidence. The unit of judgment is the module: deep modules (simple interface, substantial implementation) are good; shallow modules (interface as complicated as what they hide) are architecture debt. Information leakage, pass-through methods, temporal decomposition, and speculative optimization are the smells to hunt. Prize "define errors out of existence" and design-it-twice thinking.
 
 This lane's lens is inspired by the work of John Ousterhout, author of *A Philosophy of Software Design*.
 
@@ -30,19 +30,20 @@ Architecture is judged against the repo's own stated intent, then against first 
 
 ## Workflow
 
-1. **Map the module graph.** Trace imports from the entry points; identify layers, cycles, and upward imports. Done when you have the real dependency picture, not the README's.
-2. **Verify the stated contracts.** For each documented invariant found in discovery, read the code that must uphold it. Done when each is confirmed intact or broken with file:line evidence.
-3. **Depth-score the key interfaces.** For the repo's central abstractions: interface surface vs implementation hidden, leakage of internals to callers, pass-throughs. Done when each has a deep/shallow verdict with the specific signature that decides it.
-4. **Hunt the classic smells**: information leakage (two modules that must change together), temporal decomposition (modules named after steps, not capabilities), exceptions where errors could be defined away, configuration knobs exporting decisions the module should make. Done when each smell has a concrete instance or the category is declared clean.
-5. **Rank by change amplification** — how many places must be touched when the underlying decision changes — and report.
+1. **Establish the simplicity baseline.** State the current user stories, realistic scale, and smallest complete design. For every cache, delta, shard, queue, retry state machine, abstraction, or configuration surface, name the present evidence that requires it and the simpler alternative it displaces. Prefer bounding current state and moving history behind pagination before distributing synchronization. Done when speculative machinery is deleted, deferred behind a measurable trigger, or justified.
+2. **Map the module graph.** Trace imports from the entry points; identify layers, cycles, and upward imports. Done when you have the real dependency picture, not the README's.
+3. **Verify the stated contracts.** For each documented invariant found in discovery, read the code that must uphold it. Done when each is confirmed intact or broken with file:line evidence.
+4. **Depth-score the key interfaces.** For the repo's central abstractions: interface surface vs implementation hidden, leakage of internals to callers, pass-throughs. Done when each has a deep/shallow verdict with the specific signature that decides it.
+5. **Hunt the classic smells**: information leakage (two modules that must change together), temporal decomposition (modules named after steps, not capabilities), exceptions where errors could be defined away, configuration knobs exporting decisions the module should make, and optimizations without measurements or present requirements. Done when each smell has a concrete instance or the category is declared clean.
+6. **Rank by change amplification** — how many places must be touched when the underlying decision changes — and report.
 
 ## Grounded Reporting
 
-Every structural claim traces to code read this session, cited file:line. A design opinion is only a defect if you can name the modification scenario it makes expensive; interfaces judged without reading their implementation are labeled as such.
+Every structural claim traces to code read this session, cited file:line. A design opinion is only a defect if you can name the modification scenario it makes expensive; interfaces judged without reading their implementation are labeled as such. Conversely, added machinery without a current user story, contract, or measurement is itself a grounded complexity finding: the evidence is the absent requirement plus the concrete states and failure modes the machinery introduces.
 
 ## Output Format
 
-Lead with a one-sentence verdict on architectural health. Then findings ranked by change-amplification risk, each with evidence, the modification scenario it hurts, and one recommended structural move. Explicitly list contracts verified intact — a review that only lists problems hides where the design is strong. Cross-lane handoffs last. In a genie-framework repo, use CRITICAL/HIGH/MEDIUM/LOW for finding severities and SHIP/FIX-FIRST/BLOCKED only for the overall verdict and note which findings warrant a refactor wish via `wish` rather than opportunistic edits.
+Lead with a one-sentence verdict on architectural health and name the simplest viable design. Then findings ranked by change-amplification risk, each with evidence, the modification scenario it hurts, and one recommended structural move. Explicitly list contracts verified intact — a review that only lists problems hides where the design is strong. Cross-lane handoffs last. In a genie-framework repo, treat unjustified stateful machinery as a blocking HIGH plan/design gap, use CRITICAL/HIGH/MEDIUM/LOW for finding severities and SHIP/FIX-FIRST/BLOCKED only for the overall verdict, and note which findings warrant a refactor wish via `wish` rather than opportunistic edits.
 
 ## Pitfalls
 

--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -22,8 +22,9 @@ All artifacts live in `.genie/` within the shared worktree. When spawned as a na
 3. **Scope-size check:** if the request spans multiple independent subsystems, decompose before refining (see Scope Size).
 4. **Refine:** fill WRS dimensions. Ask only what an unfilled dimension needs — when the request or context already settles a dimension, mark it filled and move on; never re-litigate decisions the user already made. Prefer concrete options over open questions.
 5. **Show the WRS bar** after every exchange; persist DRAFT.md whenever WRS changes.
-6. **Propose approaches:** 2-3 options with trade-offs, applying Design for Isolation. Recommend one and proceed when the choice follows from the request.
-7. **Crystallize** when WRS = 100 (see Crystallize).
+6. **Pass the Simplicity Gate:** establish the simplest complete approach before considering more machinery. Reject speculative complexity or defer it behind a measurable trigger (see Simplicity Gate).
+7. **Propose approaches:** 2-3 options with trade-offs, applying Design for Isolation. Recommend one and proceed when the choice follows from the request.
+8. **Crystallize** when WRS = 100 (see Crystallize).
 
 ## WRS — Wish Readiness Score
 
@@ -33,7 +34,7 @@ Five dimensions, 20 points each:
 |-----------|-------------|
 | **Problem** | One-sentence problem statement is clear |
 | **Scope** | IN and OUT boundaries defined |
-| **Decisions** | Key technical/design choices made with rationale |
+| **Decisions** | Key technical/design choices made with rationale and the Simplicity Gate passes |
 | **Risks** | Assumptions, constraints, failure modes identified |
 | **Criteria** | At least one testable acceptance criterion exists |
 
@@ -59,6 +60,18 @@ Apply to proposed approaches and the DESIGN.md Approach section:
 - Explicit interfaces and dependencies — contracts, not shared mutable state or hidden coupling.
 - Independent testability — each unit understandable without loading the whole system.
 - File size is a complexity signal — propose splits before a unit becomes unmanageable.
+
+## Simplicity Gate
+
+Before recommending an approach or declaring **Decisions** filled:
+
+1. State the simplest complete design that satisfies the current user stories.
+2. For every added cache, delta, shard, queue, retry state machine, abstraction, or configuration option, name the present requirement or measurement that pays for it.
+3. Count the new durable states, recovery paths, and cross-component invariants each option introduces; treat them as product cost, not implementation detail.
+4. Prefer bounding current data, separating history behind pagination, recomputing, replacement, and opinionated defaults before synchronization or configurability.
+5. Put plausible future machinery under a measurable adoption trigger instead of building it now. “This may scale later” is not evidence.
+
+If the more complex approach lacks present evidence, recommend the simpler one. Do not split the difference by shipping dormant machinery: unused branches still impose protocol, test, security, and maintenance cost.
 
 ## Index
 
@@ -89,7 +102,7 @@ it was tracked. Never update or retain both indexes after a successful merge.
 At WRS = 100:
 
 1. Write `.genie/brainstorms/<slug>/DESIGN.md` from DRAFT.md using `references/design-template.md` (in this skill dir) — fill every placeholder.
-2. **Spec self-review** — fix inline before handing off: no TBD/TODO leftovers (fill or mark explicit OUT), no contradictions between sections, scope fits a single wish (split if not), no requirement readable two different ways.
+2. **Spec self-review** — fix inline before handing off: no TBD/TODO leftovers (fill or mark explicit OUT), no contradictions between sections, scope fits a single wish (split if not), no requirement readable two different ways, and the Simplicity Case justifies every mechanism beyond the simplest complete design.
 3. Stage the design, draft, and canonical index:
    ```bash
    git add .genie/brainstorms/<slug>/DESIGN.md .genie/brainstorms/<slug>/DRAFT.md .genie/INDEX.md
@@ -135,7 +148,7 @@ Never reuse design-review evidence after editing DESIGN.md. `verify` must pass i
 Note cross-repo or cross-agent dependencies — they become `depends-on`/`blocks` fields in the wish.
 
 ## Rules
-- YAGNI and simplicity first; propose alternatives before recommending.
+- KISS and YAGNI are gates, not tie-breakers; speculative machinery blocks crystallization.
 - No implementation during brainstorm.
 - Persist early and often — never wait until the end.
 - Never present an unconfirmed assumption as a settled decision — confirm it or list it under Risks.

--- a/skills/brainstorm/references/design-template.md
+++ b/skills/brainstorm/references/design-template.md
@@ -25,6 +25,13 @@
 
 <Chosen approach with rationale. Name the alternatives considered and why they lost.>
 
+## Simplicity Case
+
+- **Simplest complete design:** <smallest design that satisfies current user stories>
+- **Added machinery:** <none, or each mechanism with the present requirement/measurement that justifies it>
+- **Deferred until measured:** <plausible future complexity and the concrete trigger for reconsidering it>
+- **Complexity removed:** <states, failure modes, options, or dependencies deliberately avoided>
+
 ## Decisions
 
 | # | Decision | Rationale |

--- a/skills/council/references/native-surfaces.md
+++ b/skills/council/references/native-surfaces.md
@@ -4,8 +4,8 @@ Genie skills describe roles and coordination without inventing a cross-client to
 
 | Runtime | Dispatch | Isolation | Follow-up |
 |---------|----------|-----------|-----------|
-| Claude Code | Use its current native Agent surface and an available named role | Use the runtime's supported isolation/worktree option when present | Use the runtime's documented messaging surface when available; otherwise re-dispatch with curated context |
-| Codex | Use the matching `genie_*` custom agent when the CLI-installed profiles are present; otherwise use an available generic subagent | Native subagents share the caller's workspace by default | Use the active native follow-up tool exposed in the session; do not hardcode an undocumented function name into a skill |
+| Claude Code | Use its current native Agent surface and an available named role | Place every concurrent group in a dedicated runtime-managed or ordinary Git worktree | Use the runtime's documented messaging surface when available; otherwise re-dispatch with curated context |
+| Codex | Use the matching `genie_*` custom agent when the CLI-installed profiles are present; otherwise use an available generic subagent | Place every concurrent group in a dedicated runtime-managed or ordinary Git worktree; otherwise sequence it | Use the active native follow-up tool exposed in the session; do not hardcode an undocumented function name into a skill |
 | Warp cockpit | `genie launch <slug>` emits one pane per ready group | Dedicated Git worktree per pane | Human-supervised; panes are not awaitable native subagents |
 
 Every implementation brief opens with the atomic claim:
@@ -14,6 +14,6 @@ Every implementation brief opens with the atomic claim:
 genie task checkout <task-id> --worker <name>
 ```
 
-The claim owns file scope in a shared workspace. Engineers and fixers report completion but never call `genie task done`. A different reviewer validates the group; only the orchestrator marks it done after a SHIP verdict and passing evidence. Native client completion notifications replace polling.
+The task claim owns group state; the dedicated worktree and branch own its mutable file state. Engineers and fixers report completion but never call `genie task done`. A different reviewer validates an exact commit in an ephemeral read-only worktree. The PM merges that commit into the wish integration worktree, resolves conflicts, validates the integrated tree, and removes the clean group worktree and merged branch before marking the task done. Native client completion notifications replace polling.
 
 User decisions use the runtime's native input or permission surface. Shared workflows name the semantic action—dispatch, follow up, interrupt, wait—while the active client supplies the concrete tool.

--- a/skills/dream/SKILL.md
+++ b/skills/dream/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: dream
-description: "Batch-execute SHIP-ready wishes overnight — pick wishes, orchestrate workers, review PRs, wake up to results."
+description: "Batch-execute SHIP-ready wishes overnight — pick wishes, orchestrate workers, review delivery candidates, wake up to results."
 ---
 
 # dream — Overnight Batch Execution
 
 **Runtime syntax:** in Codex, invoke the plugin copy with the owner-qualified `$genie:<skill>` selector; use bare `$<skill>` only when intentionally selecting a user-tier copy (a separately installed personal copy; Genie no longer seeds this tier). Claude Code and Hermes use `/<skill>`. Cross-skill prose below uses bare names as portable semantic routes; the orchestrator resolves the selector for the active tier.
 
-Pick SHIP-ready wishes, build a dependency-ordered plan, dispatch one worker subagent per wish, review PRs, merge to dev, run the QA loop, and write a wake-up report. The dream orchestrator dispatches — it never executes wish work directly.
+Pick SHIP-ready wishes, build a dependency-ordered plan, dispatch one worker subagent per wish, review delivery candidates, integrate them through the repository's PM mainline mode, run the QA loop, and write a wake-up report. The dream orchestrator dispatches — it never executes wish work directly.
 
-This is a high-impact, explicit-only workflow. The user must approve the selected wishes, the generated plan, PR creation, and merge-to-`dev` authority. Never merge to `main` or `master`, deploy, send external messages, or expand scope without separate authority.
+This is a high-impact, explicit-only workflow. The user must approve the selected wishes and generated plan. In GitHub-backed mode, PR creation and remote merge retain their external-write authority gates; third-party review/checks remain mandatory. In zero-remote mode, validated candidate integration into local `main` plus wish archival is autonomous after plan approval. Never deploy, send external messages, expand scope, or infer policy for a non-GitHub remote without separate authority.
 
 ## When to Use
 - Human wants to queue multiple wishes for autonomous overnight execution
@@ -19,8 +19,8 @@ This is a high-impact, explicit-only workflow. The user must approve the selecte
 1. **Pick wishes** (Picker below); human confirms the selection.
 2. **Generate `.genie/DREAM.md`** — dependency-ordered plan; human may edit before the run.
 3. **Phase 1 — Execute:** dispatch workers layer by layer, collect outcomes.
-4. **Phase 2 — Review + PR:** review every PR, fix valid gaps, CI green.
-5. **Phase 3 — Merge + QA:** merge to dev in order, QA loop until criteria proven.
+4. **Phase 2 — Review + delivery gate:** review every PR or local delivery candidate; fix valid gaps.
+5. **Phase 3 — Mainline + QA:** integrate in order using PM repository mode; QA until criteria are proven.
 6. **Phase 4 — Report:** write `.genie/DREAM-REPORT.md`, the wake-up artifact.
 
 ## Picker
@@ -32,7 +32,7 @@ This is a high-impact, explicit-only workflow. The user must approve the selecte
 1. Read the wish-level `**depends-on:**` value from each selected WISH.md's `## Dependencies` section (`none` means no edge).
 2. Topologically sort into `merge_order` layers `1..N` — layer 1 has no selected dependencies; same-layer wishes are parallel.
 3. Per-wish entry: `slug`, `branch: feat/<slug>`, `wish-path: .genie/wishes/<slug>/WISH.md`, `depends-on`, `merge-order`. Keep the canonical hyphenated keys so the plan can be checked directly against each wish.
-4. Write `.genie/DREAM.md` in the shared worktree; present for human confirmation before executing.
+4. Write `.genie/DREAM.md` in the dream PM's integration worktree; present for human confirmation before executing.
 
 ## Phase 1: Execute
 
@@ -46,33 +46,37 @@ For each `merge_order` layer, in order:
 ### Worker Contract
 
 Each worker, independently:
-1. Work in a dedicated branch and worktree for `feat/<slug>`; never let parallel writers share one checkout. Use Codex-managed or ordinary Git worktrees according to the active environment.
-2. Execute the wish per `work` (its dispatch, review-gate, and task-state rules govern): dispatched engineers claim via `genie task checkout`; the worker leaves task state `in_progress` and reports evidence. Only the dream PM/orchestrator runs `genie task done` after clean review and passing validation.
+1. Work in a dedicated wish integration branch and worktree for `feat/<slug>`. Within it, execute each concurrent group in its own branch and worktree per `work`; never let parallel writers share one checkout. Use runtime-managed or ordinary Git worktrees according to the active environment.
+2. Execute the wish per `work` (its group-lane dispatch, review, integration, garbage-collection, and task-state rules govern): dispatched engineers claim via `genie task checkout`; the worker leaves task state `in_progress` and reports evidence. Only the dream PM/orchestrator runs `genie task done` after clean review, integration, passing validation, and cleanup of the completed group lane.
 3. Run `review` per group against acceptance criteria.
-4. Run CI; on failure fix and retry (max 3 attempts; poll CI status, never sleep-loop). After 3 failures → blocked.
-5. Only after CI green and authorized PR creation: create a PR targeting `dev`, preferring the GitHub connector.
+4. Run the wish validation. In GitHub-backed mode, CI must also pass; on failure fix and retry (max 3 attempts; poll CI status, never sleep-loop). After 3 failures → blocked.
+5. GitHub-backed: only after CI green and authorized PR creation, create a PR targeting authoritative `main`, preferring the GitHub connector. Zero remotes: report the reviewed `feat/<slug>` tip as the local delivery candidate; do not touch `main`.
 6. Final message is the completion signal, every claim audited against tool output:
    - `done — PR <url>, CI green, groups N/N`
+   - `done — local candidate <sha>, validation green, groups N/N`
    - `blocked — <reason>, groups N/N`
 
-## Phase 2: Review + PR
+## Phase 2: Review + Delivery Gate
 
 **Trigger:** all workers in the layer reported done or blocked.
 
-1. Dispatch one reviewer subagent per PR via the native delegation surface (reviewer ≠ worker) to run `review` against the wish's acceptance criteria.
+1. Dispatch one reviewer subagent per PR or exact local candidate commit via the native delegation surface (reviewer ≠ worker) to run `review` against the wish's acceptance criteria.
 2. Read bot comments critically — never blindly accept automated findings.
 3. On FIX-FIRST: diagnose first; return an overdesigned plan to wish/design review, otherwise dispatch `fix` for valid gaps (max 3 loops per PR). On another architectural issue: escalate in the report, no fix attempt.
-4. CI must be green before proceeding — poll status, do not sleep.
-5. On SHIP: mark the PR review-complete.
+4. In GitHub-backed mode CI must be green before proceeding — poll status, do not sleep. In zero-remote mode rerun the declared validation against the exact candidate.
+5. On SHIP: mark the PR or local candidate review-complete.
 
-## Phase 3: Merge + QA
+## Phase 3: Mainline + QA
 
-**Trigger:** all PRs marked SHIP.
+**Trigger:** all delivery candidates marked SHIP.
 
-1. After explicit merge authorization, merge PRs to `dev` in `merge_order`; never merge to `main` or `master`.
-2. Dispatch a qa subagent on dev to test against each wish's QA criteria.
-3. Each failure: `report` → `trace` → `fix` → retest. Every fix is a new PR through review and merge.
-4. Continue until all criteria are proven or blocked.
+For each wish in `merge_order`:
+
+1. GitHub-backed: run required QA on the exact PR candidate. On success, persist `SHIPPED` and completion evidence in a final closure commit, rerun required checks/review, then wait for authorized or third-party PR merge. That merge makes remote `main` authoritative. Fetch it, require clean local `main`, attempt a fast-forward/equality proof, archive the exact reviewed closure commit, then remove the clean local wish lane. Never reset, force, or locally merge the feature branch into `main`; record a failed mirror as lifecycle debt.
+2. Zero remotes: create a temporary candidate from current `main`, merge the reviewed wish branch there, resolve conflicts through a bounded fixer, and validate/QA the exact result. On success, persist staged `SHIPPED` and completion evidence in the candidate and rerun required checks/review. Archive that exact integrated closure commit, remove clean wish/candidate worktrees and refs with compare-and-swap, then prove `main` is unchanged and fast-forward it to the archived commit.
+3. A pre-promotion failure retains or recreates the active lane and leaves the wish `IN_PROGRESS`. A hosted mirror, archive, or cleanup failure after remote merge is reported as lifecycle debt and retried without rewriting authoritative `SHIPPED` history.
+4. Each failure before mainline promotion: `report` → `trace` → `fix` → retest. In GitHub-backed mode every fix remains in the reviewed PR; in zero-remote mode every fix repeats candidate review before main fast-forward.
+5. Continue until all criteria are proven or blocked.
 
 ## Phase 4: Report
 
@@ -82,14 +86,14 @@ Write `.genie/DREAM-REPORT.md` — always, even if every wish blocked:
 # Dream Report — <date>
 
 ## Per-Wish Status
-| merge_order | slug | PR | CI | Review | Merged | QA |
-|-------------|------|----|----|--------|--------|----|
+| merge_order | slug | Delivery | Validation/CI | Review | Mainline | Local mirror | Archive/cleanup | QA |
+|-------------|------|----------|---------------|--------|----------|--------------|-----------------|----|
 
 ## Blocked Wishes
 - `<slug>`: <blocking reason>
 
 ## QA Findings
-- `<slug>`: <criterion failed — root cause, fix PR>
+- `<slug>`: <criterion failed — root cause, fix delivery>
 
 ## Follow-ups
 - <items requiring human intervention>
@@ -97,11 +101,11 @@ Write `.genie/DREAM-REPORT.md` — always, even if every wish blocked:
 
 ## Grounded Progress
 
-The report is an audit, not a recollection. Every cell traces to tool output from the run: PR URLs, CI results, review verdicts, `genie task list --wish <slug>` state, worker final messages. State per wish exactly what is verified, what failed, and what was skipped. Never report a wish shipped until its merge and QA evidence is in hand — dispatched is not done.
+The report is an audit, not a recollection. Every cell traces to tool output from the run: PR URL or local candidate SHA, validation/CI results, review verdicts, mainline and archive refs, local-mirror and cleanup state, `genie task list --wish <slug>` state, and worker final messages. State per wish exactly what is verified, what failed, and what was skipped. Report a wish shipped only with authoritative mainline and QA evidence; list every mirror, archive, or cleanup debt, and never report the lifecycle fully closed while any remains.
 
 ## Rules
 - Never early-stop: a blocked wish is recorded and the remaining wishes continue.
-- Never skip Phase 2 or Phase 3 — every PR is reviewed, every merge is QA-tested against wish criteria.
+- Never skip Phase 2 or Phase 3 — every delivery candidate is reviewed and every mainline result is QA-tested against wish criteria.
 - The orchestrator never executes wish work — always dispatch worker subagents.
 - No scope beyond what each WISH.md defines.
 - Poll CI status — never `sleep` in retry loops.

--- a/skills/dream/SKILL.md
+++ b/skills/dream/SKILL.md
@@ -61,7 +61,7 @@ Each worker, independently:
 
 1. Dispatch one reviewer subagent per PR via the native delegation surface (reviewer ≠ worker) to run `review` against the wish's acceptance criteria.
 2. Read bot comments critically — never blindly accept automated findings.
-3. On FIX-FIRST: dispatch `fix` for valid gaps (max 2 loops per PR). On an architectural issue: escalate in the report, no fix attempt.
+3. On FIX-FIRST: diagnose first; return an overdesigned plan to wish/design review, otherwise dispatch `fix` for valid gaps (max 3 loops per PR). On another architectural issue: escalate in the report, no fix attempt.
 4. CI must be green before proceeding — poll status, do not sleep.
 5. On SHIP: mark the PR review-complete.
 

--- a/skills/fix/SKILL.md
+++ b/skills/fix/SKILL.md
@@ -15,8 +15,8 @@ Resolve FIX-FIRST gaps from `review`: dispatch a fix subagent, re-review, repeat
 
 ## Flow
 1. **Parse and diagnose gaps:** severity, files, failing checks from the FIX-FIRST verdict. If the evidence is `overdesigned-plan`, stop and return to `brainstorm`/`wish`; removing optional machinery is a plan correction, not a code-fix attempt.
-2. **Dispatch fixer:** native delegation surface → fix subagent, briefed with the gap list, the original wish criteria, and any `trace` diagnosis.
-3. **Re-review:** native delegation surface → a separate reviewer subagent (never the fixer) running `review` on the same pipeline.
+2. **Dispatch fixer:** native delegation surface → fix subagent in the existing group worktree, briefed with its path and branch, the gap list, the original wish criteria, and any `trace` diagnosis. The fixer commits the new review candidate.
+3. **Re-review:** native delegation surface → a separate reviewer subagent (never the fixer) running `review` against that exact commit in an ephemeral read-only worktree; remove the review worktree afterward.
 4. **Evaluate verdict:**
 
 | Verdict | Condition | Action |
@@ -32,7 +32,7 @@ Resolve FIX-FIRST gaps from `review`: dispatch a fix subagent, re-review, repeat
 
 Fix and re-review are **separate native-dispatch dispatches** — never combined in one subagent, and the re-reviewer is never the fixer. Subagents notify on completion — no polling. Follow-ups to a running fixer go through native follow-up messaging.
 
-The fixer's brief must carry: the severity-tagged gaps (file:line), the original wish acceptance criteria, the validation command(s) to re-run, and stop conditions — fix only the listed gaps; report blocked rather than expand scope.
+The fixer's brief must carry: the existing group worktree path and branch, the severity-tagged gaps (file:line), the original wish acceptance criteria, the validation command(s) to re-run, and stop conditions — edit only that worktree, fix only the listed gaps, commit the review candidate, and report blocked rather than expand scope.
 
 ## Escalation Diagnosis
 
@@ -54,7 +54,7 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 
 ## Task State
 
-The fix loop never mutates task state. The group's task stays `in_progress` through every loop; the orchestrator calls `genie task done <task-id>` only after a clean re-review. During any diagnosed route or appeal, the task remains `in_progress` with the remaining gaps recorded in the wish notes/handoff. If no task row exists for the work, proceed — the loop runs off the review verdict alone.
+The fix loop never mutates task state. The group's task stays `in_progress` through every loop; after a clean re-review, the orchestrator must still integrate the reviewed commit, validate the integrated tree, and garbage-collect the clean merged lane before calling `genie task done <task-id>`. During any diagnosed route or appeal, the task remains `in_progress` with the remaining gaps recorded in the wish notes/handoff. If no task row exists for the work, proceed — the loop runs off the review verdict alone.
 
 ## Diagnosis / Appeal Format
 

--- a/skills/fix/SKILL.md
+++ b/skills/fix/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: fix
-description: "Dispatch fix subagent for FIX-FIRST gaps from review, re-review, then diagnose unresolved failures after 2 loops."
+description: "Dispatch fix subagent for FIX-FIRST gaps from review, re-review, then diagnose unresolved failures after 3 loops."
 ---
 
 # fix — Fix-Review Loop
 
 **Runtime syntax:** in Codex, invoke the plugin copy with the owner-qualified `$genie:<skill>` selector; use bare `$<skill>` only when intentionally selecting a user-tier copy (a separately installed personal copy; Genie no longer seeds this tier). Claude Code and Hermes use `/<skill>`. Cross-skill prose below uses bare names as portable semantic routes; the orchestrator resolves the selector for the active tier.
 
-Resolve FIX-FIRST gaps from `review`: dispatch a fix subagent, re-review, repeat up to 2 loops, then diagnose and route any unresolved failure.
+Resolve FIX-FIRST gaps from `review`: dispatch a fix subagent, re-review, repeat up to 3 loops, then diagnose and route any unresolved failure.
 
 ## When to Use
 - `review` returned a **FIX-FIRST** verdict with CRITICAL or HIGH gaps
 - Orchestrator hands off unresolved gaps after execution review
 
 ## Flow
-1. **Parse gaps:** severity, files, failing checks from the FIX-FIRST verdict.
+1. **Parse and diagnose gaps:** severity, files, failing checks from the FIX-FIRST verdict. If the evidence is `overdesigned-plan`, stop and return to `brainstorm`/`wish`; removing optional machinery is a plan correction, not a code-fix attempt.
 2. **Dispatch fixer:** native delegation surface → fix subagent, briefed with the gap list, the original wish criteria, and any `trace` diagnosis.
 3. **Re-review:** native delegation surface → a separate reviewer subagent (never the fixer) running `review` on the same pipeline.
 4. **Evaluate verdict:**
@@ -22,8 +22,8 @@ Resolve FIX-FIRST gaps from `review`: dispatch a fix subagent, re-review, repeat
 | Verdict | Condition | Action |
 |---------|-----------|--------|
 | SHIP | — | Done. Return to orchestrator. |
-| FIX-FIRST | loop < 2 | Increment loop, go to step 2. |
-| FIX-FIRST | loop = 2 | Stop fixing and run Escalation Diagnosis; max loops reached. |
+| FIX-FIRST | loop < 3 | Increment loop, go to step 2. |
+| FIX-FIRST | loop = 3 | Stop fixing and run Escalation Diagnosis; max loops reached. |
 | BLOCKED | — | Run Escalation Diagnosis and take the cause-specific route. |
 
 5. **Route the diagnosis:** report the remaining gaps with exact files, failing checks, cause class, and corrective route; the group's task stays `in_progress`.
@@ -44,6 +44,7 @@ Use this policy before any model or effort change; keep this contract identical 
 | `missing-context` | The attempt identifies absent files, history, criteria, logs, or other inputs needed to decide. | Supply the missing context and retry at the same model and effort; MUST NOT escalate model or effort. |
 | `ambiguous-spec` | Two or more materially different behaviors remain consistent with the stated criteria. | Request a human decision or wish clarification; MUST NOT escalate model or effort. |
 | `env-tool-failure` | A reproducible environment, dependency, permission, timeout, or tool error prevents valid execution. | Repair or retry the environment/tool, or report blocked with the error; MUST NOT escalate model or effort. |
+| `overdesigned-plan` | Gaps cluster in optional machinery that lacks a current criterion or measurement, while a simpler design satisfies the user stories with fewer durable states or recovery paths. | Stop the fix loop and return to `brainstorm`/`wish` to remove or defer the mechanism. Re-review the amended design/plan; MUST NOT spend retries or model escalation defending it. |
 
 Escalation eligibility requires **new evidence** produced since the previous attempt: attach the new failing output or diagnostic result, the correction already tried, and why it rules out the other three causes. A repeated verdict or unchanged failure is not new evidence and cannot authorize a model or effort change.
 
@@ -58,14 +59,14 @@ The fix loop never mutates task state. The group's task stays `in_progress` thro
 ## Diagnosis / Appeal Format
 
 ```
-Fix loop exhausted (2/2). Group remains in progress.
+Fix loop exhausted (3/3). Group remains in progress.
 Remaining gaps:
 - [CRITICAL] <gap description> — <file>
 - [HIGH] <gap description> — <file>
-Cause: <model-capacity|missing-context|ambiguous-spec|env-tool-failure>
+Cause: <model-capacity|missing-context|ambiguous-spec|env-tool-failure|overdesigned-plan>
 New evidence: <new output/diagnosis, or "none — model/effort escalation prohibited">
 Corrective route: <one cause-specific next step>
-Budget: attempts=<used>/2; effort_escalations=<used>/2
+Budget: attempts=<used>/3; effort_escalations=<used>/2
 Appeal: <reviewer/final-gate disagreement record, or "none">
 ```
 
@@ -78,12 +79,13 @@ Appeal: <reviewer/final-gate disagreement record, or "none">
 - [HIGH] sendMessage result not checked — dispatch.ts:541
 ```
 
-Loop 1: native delegation surface → fixer briefed with both gaps, the wish criteria, and `bun test` as validation. The fixer edits, runs the validation, reports its changes with outcomes, and ends `done`. Then native delegation surface → a fresh reviewer briefed to re-run `review` against the same criteria. SHIP → report success to the orchestrator. FIX-FIRST again → loop 2; after that, classify the cause and take its corrective route. A model or effort raise is permitted only for evidenced `model-capacity` within both caps.
+Loop 1: native delegation surface → fixer briefed with both gaps, the wish criteria, and `bun test` as validation. The fixer edits, runs the validation, reports its changes with outcomes, and ends `done`. Then native delegation surface → a fresh reviewer briefed to re-run `review` against the same criteria. SHIP → report success to the orchestrator. FIX-FIRST again → loops 2 and 3; after loop 3, classify the cause and take its corrective route. A model or effort raise is permitted only for evidenced `model-capacity` within both caps. An `overdesigned-plan` diagnosis stops immediately and returns to planning instead.
 
 ## Rules
 - Tight scope: fix exactly the tagged gaps — no unrequested refactors, features, or drive-by cleanups.
 - Never fix and review in the same session — always separate subagents.
-- Never exceed 2 fix loops — stop, diagnose, and take the cause-specific route.
+- Never exceed 3 fix loops — stop, diagnose, and take the cause-specific route.
+- Never use a fix loop to preserve optional machinery when a simpler plan satisfies the user stories.
 - Include the original wish criteria in every fix dispatch.
 - Identical gaps across loops = no progress; classify the cause. Repetition is not new evidence and never authorizes a model or effort raise.
 - Grounded progress: report only what tool output from this session verifies — state what was fixed, what failed, what was skipped. Never report an attempted fix as complete.

--- a/skills/genie-hacks/references/catalog.md
+++ b/skills/genie-hacks/references/catalog.md
@@ -42,7 +42,7 @@ The local registry powering `genie-hacks list|search|show|help`. Canonical publi
 - **Title:** Multi-Team Coordination at Scale
 - **Category:** teams
 - **Problem:** You have multiple wishes that depend on each other, and running them sequentially wastes time.
-- **Solution:** Use `dream` to batch-execute wishes with dependency ordering, or open one `genie launch` cockpit per independent wish. Use the active runtime's native subagents for independent work, steer the same thread with follow-up messaging, and isolate parallel writers in disjoint scopes or separate worktrees. Track shared wish state in the task DB.
+- **Solution:** Use `dream` to batch-execute wishes with dependency ordering, or open one `genie launch` cockpit per independent wish. Use the active runtime's native subagents for independent work, steer the same thread with follow-up messaging, and give every concurrent execution group a dedicated branch and worktree. The PM merges reviewed commits into the wish integration branch and removes clean merged lanes so worktrees and branches reflect active work. Track shared wish state in the task DB.
 - **Code:**
   ```bash
   # Queue wishes for overnight execution

--- a/skills/genie/reference/lifecycle.md
+++ b/skills/genie/reference/lifecycle.md
@@ -3,7 +3,7 @@
 Every piece of work follows this flow:
 
 ```
- Idea → brainstorm → design review → wish → plan review → work → implementation review → PR → Ship
+ Idea → brainstorm → design review → wish → plan review → work → implementation review → mainline integration → Ship
          (explore)   (design gate)    (plan)   (plan gate)  (build)       (verify)
 ```
 
@@ -25,18 +25,43 @@ and `BLOCKED` are evidence returned by a reviewer. The `Status` field in
 | `DRAFT` | Plan exists but has not passed plan review | `wish`, then plan `review` |
 | `FIX-FIRST` | Plan review found blocking gaps | `fix`, then plan `review` |
 | `APPROVED` | Plan review returned SHIP and the plan is ready | `work` or `genie launch <slug>` |
-| `IN_PROGRESS` | At least one execution group has started; execution/PR gates are not complete | resume `work` or the recorded corrective route |
+| `IN_PROGRESS` | At least one execution group has started; execution/mainline gates are not complete | resume `work` or the recorded corrective route |
 | `BLOCKED` | A recorded external, environment, or specification blocker prevents progress | resolve the recorded blocker, then resume the prior stage |
-| `SHIPPED` | The authorized merge and required QA/release gate completed | terminal/history only |
+| `SHIPPED` | Authoritative mainline integration and required QA/release gate completed | terminal delivery; finish any recorded archive/cleanup debt |
 
 The invoking orchestrator is the single mutation owner. After a reviewer sends
 its final evidence, the orchestrator appends a timestamped entry under
 `## Review Results` and applies the transition: plan SHIP → `APPROVED`; plan
 FIX-FIRST → `FIX-FIRST`; plan BLOCKED → `BLOCKED`; beginning execution →
 `IN_PROGRESS`; execution FIX-FIRST/BLOCKED stays `IN_PROGRESS` unless a real
-external blocker is recorded; authorized merge plus required QA → `SHIPPED`.
+external blocker is recorded; proven mainline integration plus required QA → `SHIPPED`.
 The reviewer remains read-only and never edits WISH.md or task state. A chat
 verdict that was not persisted does not advance the lifecycle.
+
+## Mainline ownership
+
+The PM resolves repository mode before shipping:
+
+- **GitHub-backed:** a configured `<remote>/main` GitHub upstream is authoritative. Before work, local `main` must be
+  clean, fast-forwarded, and proven equal to that ref. Third-party PR merge makes remote `main` authoritative; the PM
+  then attempts the same clean fast-forward/equality proof locally. A failed post-merge mirror is lifecycle debt. Genie
+  never resets, force-pushes, or locally merges the wish into hosted `main`.
+- **Local-only:** exactly zero configured remotes. The PM merges the finished wish in a temporary candidate worktree,
+  resolves conflicts there, validates the exact candidate, records the closure commit, archives and cleans its lanes,
+  then fast-forwards unchanged local `main` to that exact archived commit.
+- **Other or ambiguous remotes:** require an explicit user-selected integration policy.
+
+The GitHub PR plus archive tag, or the local archive tag, is durable closure evidence. Worktrees and local feature
+branches represent active work only. A local failure before mainline promotion keeps the wish `IN_PROGRESS` and
+preserves or recreates its lane. A hosted mirror, archive, or cleanup failure after remote merge is recorded lifecycle
+debt: it cannot undo authoritative history, so the wish stays `SHIPPED`, any affected lane remains for retry, and
+closure is not reported as fully clean.
+
+Because WISH status is git-tracked, the PM stages `SHIPPED` plus completion evidence only in an exact candidate that has
+already passed required QA, then reruns the candidate's final checks. In GitHub-backed mode that branch-local status is
+not authoritative until third-party merge places it on remote `main`; failed local mirroring is recorded lifecycle debt.
+In local-only mode archival and clean-lane removal happen first; it becomes authoritative only when unchanged local
+`main` fast-forwards to that archived closure commit.
 
 ## Skill Catalog
 
@@ -46,7 +71,7 @@ verdict that was not persisted does not advance the lifecycle.
 | `wish` | Convert a design into a structured plan at `.genie/wishes/<slug>/WISH.md` — scope, execution groups, acceptance criteria, validation | Idea is concrete, needs a plan |
 | `review` | Genie criteria gate — SHIP / FIX-FIRST / BLOCKED with severity-tagged gaps | Before and after `work`, or any plan/PR |
 | `work` | Execute an approved wish — dispatch native subagents per group in waves, fix loops, validation | Wish is SHIP-approved |
-| `fix` | Resolve FIX-FIRST gaps, re-review, escalate after 2 failed loops | Review returned FIX-FIRST |
+| `fix` | Resolve FIX-FIRST gaps, re-review, escalate after 3 failed loops | Review returned FIX-FIRST |
 | `council` | Multi-perspective deliberation with specialist viewpoints | Major design decisions, tradeoffs |
 | `refine` | Transform a brief into a production-ready prompt | Prompt needs sharpening |
 | `report` | Investigate bugs — trace, capture evidence, open a GitHub issue with confirmation | Bug reports |

--- a/skills/pm/SKILL.md
+++ b/skills/pm/SKILL.md
@@ -36,7 +36,7 @@ The lifecycle is owned by its skills — route to them, never restate them here:
 | Explore | `brainstorm` | Dispatch when scope is fuzzy |
 | Plan | `wish` | Dispatch when scope is clear; the wish creates per-group tasks |
 | Execute | `work` | Dispatch orchestration; waves come from WISH.md |
-| Validate | `review` | Gate every group; FIX-FIRST → `fix` (max 2 loops) |
+| Validate | `review` | Gate every group; FIX-FIRST → `fix` (max 3 loops) |
 | Investigate | `trace`, `report` | Unknown failure: diagnose before fixing |
 | Ship | PR to `dev` | Request or consume task-scoped PR/merge authority; merge only when CI green + review SHIP |
 
@@ -51,7 +51,7 @@ Default chain: engineer → reviewer → qa → fix. Augment when the work calls
 | Docs deliverables in scope | docs subagent, parallel with engineer |
 | Architecture restructuring | refactor-briefed engineer for that group |
 | Failure with unknown root cause | `trace` before `fix` |
-| Review returns FIX-FIRST | `fix` (max 2 loops, then escalate) |
+| Review returns FIX-FIRST | Diagnose first; simplify an overdesigned plan, otherwise `fix` (max 3 loops) |
 | High-stakes decision with tradeoffs | `council` (advisory) |
 
 ## Dispatch

--- a/skills/pm/SKILL.md
+++ b/skills/pm/SKILL.md
@@ -38,9 +38,60 @@ The lifecycle is owned by its skills — route to them, never restate them here:
 | Execute | `work` | Dispatch orchestration; waves come from WISH.md |
 | Validate | `review` | Gate every group; FIX-FIRST → `fix` (max 3 loops) |
 | Investigate | `trace`, `report` | Unknown failure: diagnose before fixing |
-| Ship | PR to `dev` | Request or consume task-scoped PR/merge authority; merge only when CI green + review SHIP |
+| Ship | Repository integration mode | Deliver through reviewed GitHub PR or validated local-only mainline integration |
 
 Document status (`DRAFT` / `FIX-FIRST` / `APPROVED` / `IN_PROGRESS` / `BLOCKED` / `SHIPPED`) tracks lifecycle phase; SHIP/FIX-FIRST/BLOCKED are reviewer verdicts, and the invoking orchestrator persists the corresponding transition. The task DB tracks per-group execution state.
+
+## Repository Integration Mode
+
+Resolve this once before shipping a wish; never infer the authoritative remote from its conventional name alone.
+
+1. Read `main`'s configured upstream. If one exists, accept it only when it resolves to `<remote>/main` on GitHub; that
+   remote is authoritative. Any other configured upstream requires an explicit user decision.
+2. If `main` has no upstream and exactly one GitHub remote exists, use that remote's `main`.
+3. If no remotes are configured, use local-only mode.
+4. Every remaining topology requires an explicit integration policy. Never classify a repository with remotes as
+   local-only.
+
+### GitHub-backed mode
+
+Local `main` is a mirror, not an integration branch. Before work, fetch the authoritative remote, require a clean local
+`main`, fast-forward it to `<remote>/main`, and prove both refs resolve to the same commit. An ahead or diverged local
+`main` is a blocker and is never reset, force-updated, or pushed as reconciliation. Completed wishes target `main`
+through a GitHub PR with independent review and required checks. PR creation and remote merge retain their
+external-write authority gates. Never locally merge the wish branch into `main`.
+
+After required QA passes on the exact PR candidate, persist the wish's `SHIPPED` status and completion evidence in a
+final closure commit on that PR branch, then rerun required checks and third-party review. The branch-local status is
+staged evidence only: the task remains in progress and the wish is not authoritatively shipped until GitHub merges that
+closure into remote `main`.
+
+Third-party merge makes the staged status authoritative on remote `main`. Fetch again and re-require a clean local
+`main`; fast-forward it and prove equality with `<remote>/main`. A dirty, ahead, diverged, or failed local update becomes
+mirror debt and is never repaired with reset, force, or a local feature merge. Independently archive the exact reviewed
+closure commit as `archive/wish/<slug>`, verify the tag resolves to that recorded commit, remove its clean worktree, and
+delete the active wish ref with a compare-and-swap against the same commit. If the ref moved, cleanup stops. The PR plus
+archive tag preserve the completed lane; no active wish branch remains. Post-merge mirror, archive, or cleanup failure
+does not rewrite `SHIPPED`; the PM records lifecycle debt, retains any affected lane, and does not report the lifecycle
+fully closed until retry succeeds.
+
+### Local-only mode
+
+With zero remotes, the PM may integrate a finished wish autonomously. Keep the primary `main` worktree clean. Create a
+temporary integration branch/worktree from the current `main`, merge `feat/<slug>` there, route code-level conflicts to
+a bounded fixer in that candidate worktree, and run the full wish validation and QA against the resolved candidate.
+Record the original `main` commit and require it to remain unchanged during this process. Only after the candidate
+passes may the PM persist the wish's staged `SHIPPED` status and completion evidence in the candidate and rerun required
+checks. Record that validated integrated closure commit.
+
+Archive that exact closure commit as the annotated tag `archive/wish/<slug>` and verify the tag resolves to it. Remove
+the clean wish and candidate worktrees, then delete their active refs with compare-and-swap operations against the
+recorded tips; a moved ref blocks cleanup. Only after archival and cleanup succeed may the PM recheck that `main` is
+clean and still at the recorded base, fast-forward it to the archive tag, and prove equality with the closure commit.
+The status becomes authoritative at that final fast-forward. Existing archive tags are idempotent only when they
+resolve to the same closure commit; any mismatch blocks cleanup. A failure before promotion keeps the authoritative
+wish `IN_PROGRESS`; if the final fast-forward fails after cleanup, recreate the candidate lane from the archive tag for
+recovery.
 
 ## Specialist Routing
 
@@ -56,7 +107,9 @@ Default chain: engineer → reviewer → qa → fix. Augment when the work calls
 
 ## Dispatch
 
-All implementation goes to subagents via the **native delegation surface** (native runtime). Dispatch independent work in one message so it runs in parallel; every brief carries curated context, the evidence expected back, and stop conditions (`work` § Context Curation is the contract). Background subagents notify you on completion — never sleep-poll. Follow-ups to a running subagent go through **native follow-up messaging**. When the user wants parallel Warp sessions they can supervise, hand the wave to `genie launch <slug> [--groups <csv>]` instead (human-in-the-loop; see `work` § Multi-session dispatch).
+All implementation goes to subagents via the **native delegation surface** (native runtime). The PM owns one wish integration worktree and creates one dedicated branch and worktree for every concurrently active execution group. Dispatch independent group lanes in one message so they run in parallel; never place two writers in one checkout, even when expected file scopes are disjoint. Every brief carries the lane path and branch, curated context, the evidence expected back, and stop conditions (`work` § Context Curation is the contract). Background subagents notify you on completion — never sleep-poll. Follow-ups to a running subagent go through **native follow-up messaging**. When the user wants parallel Warp sessions they can supervise, hand the wave to `genie launch <slug> [--groups <csv>]` instead (human-in-the-loop; see `work` § Multi-session dispatch).
+
+After an engineer commits, review that exact commit in an ephemeral read-only worktree. On SHIP, merge it into the wish integration branch in dependency order, own the conflict decision, and delegate code-level conflict edits to a bounded fixer in the integration worktree. After integrated validation passes, prove the group tip is merged, remove the clean group worktree without force, delete the merged local branch without force, and prune stale worktree metadata. Only then mark its task done. A blocked, dirty, unmerged, or unreviewed lane remains active and is never garbage-collected automatically.
 
 ## Board Operations
 
@@ -66,7 +119,7 @@ genie task list [--status blocked|ready|in_progress|done] [--wish <slug>] [--jso
 genie board [--wish <slug>] [--json]       # kanban snapshot
 genie task status <id>                     # detail, dependencies, stage log
 genie task checkout <id> --worker <name>   # atomic claim — workers run this
-genie task done <id>                       # complete after review + validation
+genie task done <id>                       # complete after integration, validation, and lane cleanup
 genie task export                          # full DB state as JSON (reporting)
 ```
 
@@ -78,7 +131,7 @@ Every claim in a status report must trace to tool output from this session — `
 
 ```
 ## Status — <date>
-Shipped: <what, with PR links>
+Shipped: <what, with PR link or local archive tag>
 In progress: <task ids, owners>
 Blocked: <reason, owner, next unblocking action>
 Next: <planned actions>
@@ -88,19 +141,24 @@ Next: <planned actions>
 
 Apply in every mode; exceeding one escalates to the human. Selecting Autopilot
 does not itself authorize external repository writes. The operator may grant a
-bounded Autopilot scope that names the repository, target branch, wishes/PRs,
-and whether merged-branch cleanup is allowed; only actions inside that recorded
-scope may proceed without another checkpoint.
+bounded Autopilot scope that names the repository, target branch, and
+wishes/PRs; only actions inside that recorded scope may proceed without another
+checkpoint. Verified cleanup of Genie-managed lanes is part of their lifecycle,
+not a separate external-write grant.
 
 | Action | Authority |
 |--------|-----------|
 | Create/claim/complete tasks | Autonomous |
 | Dispatch subagents (engineer, reviewer, qa, fix, docs, trace) | Autonomous |
-| Prepare commits and a proposed PR targeting `dev` | Autonomous inside the assigned repository/worktree |
+| Prepare commits and a proposed PR targeting the authoritative GitHub `main` | Autonomous inside the assigned repository/worktree |
 | Create or publish a PR | Explicit task-scoped grant, or a bounded Autopilot grant that names the repository and target branch |
-| Merge to `dev` | Separate explicit task-scoped merge grant, or a bounded Autopilot grant that names the eligible wishes/PRs |
-| Delete feature branches | Explicit cleanup grant; only after the associated merge is verified |
-| Merge to `main`/`master` | **Human only** |
+| Merge a GitHub PR | Third-party or human action by default; another policy requires explicit user direction and compatible repository protections |
+| Fast-forward local `main` to verified authoritative GitHub `main` | Autonomous mirror maintenance; never reset or force |
+| Integrate a finished wish into `main` when the repository has zero remotes | Autonomous through a validated temporary candidate |
+| Remove a clean Genie-managed worktree and delete its verified-merged local branch | Autonomous lifecycle cleanup |
+| Create or verify `archive/wish/<slug>` for a validated closure commit | Autonomous lifecycle archival |
+| Delete any other feature branch or unmerged lane | Explicit cleanup grant |
+| Directly merge into GitHub-backed `main`, or choose policy for another remote topology | Human decision required |
 | Client communication; budget/spending | **Human only** |
 | Scope changes (add/remove features) | Human approval required |
 
@@ -114,6 +172,8 @@ remain autonomous inside the assigned scope.
 
 ## Rules
 - Never write code — dispatch engineers.
+- Own wish integration, merge order, conflict decisions, and verified cleanup of completed group lanes.
+- Keep GitHub-backed `main` equal to its authoritative remote; use validated candidate integration only with zero remotes.
 - Never skip the review gate; never ship CRITICAL/HIGH gaps.
 - Surface blockers immediately, each with a proposed unblocking action.
 - Track only real, concrete work — no speculative tasks.

--- a/skills/pm/references/modes.md
+++ b/skills/pm/references/modes.md
@@ -20,9 +20,13 @@ Spawn one fresh-context decision-maker subagent at run start. Route ship/no-ship
 
 Entry: human says "run autonomously" / "autopilot". That phrase grants decision
 autonomy only; external repository writes still require the bounded scope from
-`../SKILL.md` (repository, target branch, eligible wishes/PRs, and cleanup
-policy). Exit: all authorized tasks shipped, or a decision/action exceeds that
-scope.
+`../SKILL.md` (repository, target branch, and eligible wishes/PRs). Verified
+cleanup of Genie-managed group lanes follows the normal lifecycle; cleanup of
+any other branch must be explicitly included in the grant. In a repository
+with zero remotes, validated candidate integration into local `main` and
+`archive/wish/<slug>` lifecycle cleanup are autonomous; GitHub PR creation and
+merge remain externally gated. Exit: all authorized tasks shipped, or a
+decision/action exceeds that scope.
 
 ### Default persona: pragmatic engineering manager
 

--- a/skills/repo-hygiene/SKILL.md
+++ b/skills/repo-hygiene/SKILL.md
@@ -21,7 +21,7 @@ Assess and report by default. Apply changes only when the invocation explicitly 
 
 Never judge against generic convention when the repo states its own. Before any verdict, read what exists of: `CLAUDE.md` / `AGENTS.md`, `README`, `CONTRIBUTING`, the package manifest, `.gitignore`, git hook tooling (husky, pre-commit, commitlint or equivalents), and CI config. These define the repo's *intended* contracts — your job is to find where reality has drifted from them, and where a contract is missing entirely. Deliberate tradeoffs documented there (bot commits, generated files kept on purpose, submodule workflows) are design, not defects.
 
-**Genie-framework repos**: if `.genie/` exists, its contract is: `wishes/`, `brainstorms/`, and `INDEX.md` are git-tracked; `genie.db` (and WAL/SHM siblings) must be ignored. Verify with `git check-ignore` and `git ls-files .genie/`.
+**Genie-framework repos**: if `.genie/` exists, its contract is: `wishes/`, `brainstorms/`, and `INDEX.md` are git-tracked; `genie.db` (and WAL/SHM siblings) plus per-worktree `launch/` prompts must be ignored. Verify with `git check-ignore` and `git ls-files .genie/`.
 
 **Repo profile — recall, verify, persist.** Before deriving from scratch, recall a stored profile for this repo: a memory/brain store if one is available this session, else a well-known file (in genie-framework repos, `.genie/repo-profile.md`). For this lane the profile records the ignore contracts, config-to-enforcement map, commit conventions, and documented tradeoffs. Recalled anchors are hypotheses, not truth — spot-check them against current code and report drift as a finding. After the audit, persist what discovery learned back to the store: update rather than duplicate, delete what proved wrong.
 

--- a/skills/report/SKILL.md
+++ b/skills/report/SKILL.md
@@ -17,10 +17,13 @@ Investigate a bug end-to-end: collect symptoms, run `trace` for root cause, capt
 
 ## QA Loop Integration
 
-When invoked during the QA loop (after merge to dev):
+When invoked during pre-promotion QA against the exact PR or local integration candidate:
 1. Read the wish's criteria from `.genie/wishes/<slug>/WISH.md`.
 2. Map each failure to the criterion it violates: `Criterion: "<text>" — FAIL`.
-3. Chain: QA failure → `report` → `trace` → `fix` → retest.
+3. Chain: QA failure → `report` → `trace` → `fix` in the candidate lane → retest and independent review.
+
+A defect discovered after authoritative mainline promotion starts a new corrective wish; `report` never routes fixes
+directly onto hosted or local `main`.
 
 ## Flow
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -11,7 +11,7 @@ Validate a design, wish plan, completed execution, or PR against its governing c
 
 ## Context Injection
 
-When spawned as a reviewer subagent, your dispatch prompt carries the curated scope: the target (DESIGN.md, wish draft, completed work, or PR diff), its exact path, and the extracted design or acceptance criteria. A design review does not require a wish path; later pipelines include `.genie/wishes/<slug>/WISH.md`. Use the supplied context directly — do not re-parse information already provided.
+When spawned as a reviewer subagent, your dispatch prompt carries the curated scope: the target (DESIGN.md, wish draft, completed work, or PR diff), its exact path or commit, and the extracted design or acceptance criteria. Implementation review uses an ephemeral, detached, read-only worktree at the exact candidate commit; it never inspects a concurrently mutable engineer checkout. A design review does not require a wish path; later pipelines include `.genie/wishes/<slug>/WISH.md`. Use the supplied context directly — do not re-parse information already provided.
 
 ## When to Use
 - After `brainstorm` — validate DESIGN.md before converting it into a wish
@@ -110,12 +110,13 @@ orchestrator passes that value unchanged to the stamp command as
 `--reviewed-sha256`. Stamping rejects a current design that differs from the
 reviewed content, verification rejects any later edit, and the reviewer never
 recomputes a digest for content it did not review. For plan,
-execution, and PR review, the orchestrator appends the block under the wish's
+execution, PR, and local integration review, the orchestrator appends the block under the wish's
 `## Review Results` and owns every durable transition:
 
 - plan SHIP → `APPROVED`; plan FIX-FIRST → `FIX-FIRST`; plan BLOCKED → `BLOCKED`;
 - execution and PR verdicts are appended while the wish remains `IN_PROGRESS`;
-- only an authorized merge plus required QA changes the wish to `SHIPPED`.
+- only proven mainline integration plus required QA changes the wish to `SHIPPED`; unresolved post-merge local mirroring,
+  archival, or lane cleanup is recorded separately and must not be hidden.
 
 Do not claim the next stage is active until the orchestrator confirms the
 write. Never edit WISH.md, the brainstorm jar, or task state as the reviewer.
@@ -126,8 +127,9 @@ write. Never edit WISH.md, the brainstorm jar, or task state as the reviewer.
 |---------------|---------|
 | Design review (after `brainstorm`) | Proceed to `wish` to create the executable plan |
 | Plan review (after `wish`) | Proceed to `work` to execute the plan |
-| Execution review (after `work`) | Create PR targeting `dev` |
-| PR review (before merge) | Merge to `dev` (agents) or approve for human merge |
+| Execution review (after `work`) | GitHub-backed → create PR targeting authoritative `main`; zero remotes → prepare the validated local integration candidate |
+| PR review (before merge) | Record SHIP evidence for third-party GitHub merge; never merge locally into GitHub-backed `main` |
+| Local integration review | After candidate QA, review the closure commit containing staged `SHIPPED`; archive that exact commit and clean its lanes before fast-forwarding unchanged local `main` to it |
 
 ### FIX-FIRST loop
 1. Diagnose first. For `overdesigned-plan`, return to `brainstorm`/`wish` without consuming a fix attempt.
@@ -166,11 +168,11 @@ The verdict plus severity-tagged gaps ARE the review output — deliver them in 
 
 | Verdict | Orchestrator's next move |
 |---------|-------------------------|
-| **SHIP** | Execution review → complete the group with `genie task done <task-id>`; plan review → advance to the next lifecycle stage |
+| **SHIP** | Execution review → return the exact reviewed commit for PM integration, validation, lane cleanup, and `genie task done <task-id>`; plan review → advance to the next lifecycle stage |
 | **FIX-FIRST** | Auto-invoke `fix` with the gap list; the task stays `in_progress` until a clean re-review |
 | **BLOCKED** | Take the diagnosed corrective route; the task stays `in_progress` |
 
-`genie task done` belongs to the orchestrator, after a clean verdict — never to the reviewer.
+`genie task done` belongs to the orchestrator after a clean verdict, integration, validation, and lane cleanup — never to the reviewer.
 
 ## Rules
 - Never mark PASS without evidence from this session — verify, don't assume.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -37,6 +37,7 @@ Use this policy before any model or effort change; keep this contract identical 
 | `missing-context` | The attempt identifies absent files, history, criteria, logs, or other inputs needed to decide. | Supply the missing context and retry at the same model and effort; MUST NOT escalate model or effort. |
 | `ambiguous-spec` | Two or more materially different behaviors remain consistent with the stated criteria. | Request a human decision or wish clarification; MUST NOT escalate model or effort. |
 | `env-tool-failure` | A reproducible environment, dependency, permission, timeout, or tool error prevents valid execution. | Repair or retry the environment/tool, or report blocked with the error; MUST NOT escalate model or effort. |
+| `overdesigned-plan` | Gaps cluster in optional machinery that lacks a current criterion or measurement, while a simpler design satisfies the user stories with fewer durable states or recovery paths. | Stop the fix loop and return to `brainstorm`/`wish` to remove or defer the mechanism. Re-review the amended design/plan; MUST NOT spend retries or model escalation defending it. |
 
 Escalation eligibility requires **new evidence** produced since the previous attempt: attach the new failing output or diagnostic result, the correction already tried, and why it rules out the other three causes. A repeated verdict or unchanged failure is not new evidence and cannot authorize a model or effort change.
 
@@ -50,6 +51,8 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 - [ ] Problem is explicit, consequential, and readable one way
 - [ ] Scope has concrete IN and OUT boundaries that fit one wish
 - [ ] Chosen approach names its rationale and rejected alternatives
+- [ ] Simplicity Case states the simplest complete design; every added mechanism has a present requirement or measurement, and future complexity has a concrete adoption trigger
+- [ ] Current state is bounded and history is separated before deltas, sharding, caches, or distributed synchronization are considered
 - [ ] Decisions are consistent with the approach and repository constraints
 - [ ] Risks and assumptions name mitigations or explicit acceptance
 - [ ] Success criteria are testable without requiring execution-group details
@@ -62,6 +65,7 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 - [ ] Tasks are bite-sized and independently shippable
 - [ ] Dependencies tagged (`depends-on` / `blocks`)
 - [ ] Validation commands exist for each execution group
+- [ ] Simplicity Case is executable: no group builds machinery marked deferred, and every stateful mechanism maps to a current success criterion
 
 ### Execution Review (after `work`)
 - [ ] All acceptance criteria met with evidence
@@ -70,6 +74,7 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 - [ ] Work is auditable — commands and outcomes captured
 - [ ] Quality pass: security, maintainability, correctness
 - [ ] No regressions introduced
+- [ ] Implementation did not introduce caches, synchronization states, configuration, or abstractions absent from the approved Simplicity Case
 
 ### PR Review (before merge)
 - [ ] Diff matches wish scope — no unrelated changes
@@ -79,6 +84,8 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 - [ ] Commit messages reference wish slug
 
 ## Severity & Verdicts
+
+In design and plan review, unjustified stateful machinery—such as speculative caches, deltas, sharding, background coordination, or retry state machines—is a HIGH gap because it creates permanent correctness and maintenance obligations without delivering a current criterion. If removing it changes the governing approach, return BLOCKED with `overdesigned-plan` and replan instead of asking a fixer to preserve it.
 
 | Severity | Meaning | Blocks? |
 |----------|---------|---------|
@@ -123,9 +130,10 @@ write. Never edit WISH.md, the brainstorm jar, or task state as the reviewer.
 | PR review (before merge) | Merge to `dev` (agents) or approve for human merge |
 
 ### FIX-FIRST loop
-1. Auto-invoke `fix` with the severity-tagged gap list.
-2. After `fix` completes, re-run `review` (max 2 fix loops).
-3. Still FIX-FIRST after 2 loops → return BLOCKED with an Escalation Diagnosis; never raise model or effort automatically.
+1. Diagnose first. For `overdesigned-plan`, return to `brainstorm`/`wish` without consuming a fix attempt.
+2. Otherwise auto-invoke `fix` with the severity-tagged gap list.
+3. After `fix` completes, re-run `review` (max 3 fix loops).
+4. Still FIX-FIRST after 3 loops → return BLOCKED with an Escalation Diagnosis; never raise model or effort automatically.
 
 When a failure's root cause is unclear, invoke `trace` before dispatching `fix` — `fix` then applies the cause-specific correction from the trace report. An unclear cause is not evidence of `model-capacity`.
 

--- a/skills/wish/SKILL.md
+++ b/skills/wish/SKILL.md
@@ -33,9 +33,10 @@ node "<wish-skill-dir>/references/design-review-evidence.mjs" verify ".genie/bra
 ## Flow
 1. **Gate check:** if the request is fuzzy (no prior design, unclear scope, vague requirements), run `brainstorm` first and say so. If a design exists, do not scaffold until its digest-bound design-review evidence verifies as SHIP.
 2. **Align intent:** clarify until success criteria are testable.
-3. **Define scope:** explicit IN and OUT lists. OUT cannot be empty.
-4. **Decompose:** small, loosely coupled execution groups.
-5. **Scaffold** — always copy the template, never hand-write WISH.md. Resolve
+3. **Pass the simplicity gate:** state the simplest complete design, justify every mechanism beyond it with a present requirement or measurement, and defer plausible future complexity behind a concrete trigger. A wish cannot outsource this decision to implementation.
+4. **Define scope:** explicit IN and OUT lists. OUT cannot be empty.
+5. **Decompose:** small, loosely coupled execution groups.
+6. **Scaffold** — always copy the template, never hand-write WISH.md. Resolve
    the absolute directory containing this loaded `SKILL.md`, replace only the
    two placeholder assignments below, and run the complete command from the
    repository root:
@@ -56,20 +57,20 @@ node "<wish-skill-dir>/references/design-review-evidence.mjs" verify ".genie/bra
    <!-- wish-scaffold-command:end -->
 
    The template ships inside this skill as the single source of truth for wish structure — a plain document, no runtime scaffolder. Copying guarantees the skeleton the parser and linter expect; ad-hoc wishes regularly fail structural lint.
-6. **Fill:** replace the `{{slug}}`/`{{date}}` tokens and every `<TODO: …>` marker with real content. Every group gets acceptance criteria plus a validation command.
-7. **Declare dependencies:** use the wish-level `## Dependencies` keys
+7. **Fill:** replace the `{{slug}}`/`{{date}}` tokens and every `<TODO: …>` marker with real content. Every group gets acceptance criteria plus a validation command.
+8. **Declare dependencies:** use the wish-level `## Dependencies` keys
    `**depends-on:** <comma-separated slugs or none>` and
    `**blocks:** <comma-separated slugs or none>` for cross-wish edges. Keep
    per-group `**depends-on:**` fields under each execution group. The spelling
    is always hyphenated; the DAG is a machine-readable planning artifact in git.
-8. **Create tasks** — one per execution group, so `work` can claim and complete each group and the board reflects progress:
+9. **Create tasks** — one per execution group, so `work` can claim and complete each group and the board reflects progress:
    ```bash
    genie task create --title "<group title>" --wish <slug> --group <group-name>
    genie task list --wish <slug>   # inspect what was created
    ```
    Tasks carry the `--wish`/`--group` linkage; the dependency DAG stays in the WISH.md document, not in task rows. If creation fails (no `.genie/genie.db` yet, CLI unavailable), warn and continue — WISH.md in git is the source of truth and must remain usable by `work` without task rows.
-9. **Handoff:** run the wish linter — inside the genie repo, `grep -q '"wishes:lint"' package.json 2>/dev/null && bun run wishes:lint`. If it reports any error, surface it and stop — never hand a structurally broken wish onward. Only after lint passes, auto-invoke `review` (plan review) on the WISH.md. Never suggest `work` directly — the review gate comes first.
-10. **Persist the verdict:** the reviewer only returns evidence. The invoking orchestrator appends that evidence under `## Review Results` and sets the WISH status to `APPROVED` on SHIP, `FIX-FIRST` on FIX-FIRST, or `BLOCKED` on BLOCKED. Do not route to `work` until the `APPROVED` status is on disk.
+10. **Handoff:** run the wish linter — inside the genie repo, `grep -q '"wishes:lint"' package.json 2>/dev/null && bun run wishes:lint`. If it reports any error, surface it and stop — never hand a structurally broken wish onward. Only after lint passes, auto-invoke `review` (plan review) on the WISH.md. Never suggest `work` directly — the review gate comes first.
+11. **Persist the verdict:** the reviewer only returns evidence. The invoking orchestrator appends that evidence under `## Review Results` and sets the WISH status to `APPROVED` on SHIP, `FIX-FIRST` on FIX-FIRST, or `BLOCKED` on BLOCKED. Do not route to `work` until the `APPROVED` status is on disk.
 
 ## Wish Document Sections
 
@@ -79,6 +80,7 @@ node "<wish-skill-dir>/references/design-review-evidence.mjs" verify ".genie/bra
 | Summary | Yes | 2-3 sentences: what and why |
 | Scope IN / OUT | Yes | OUT cannot be empty |
 | Decisions | Yes | Key choices with rationale |
+| Simplicity Case | Yes | Simplest complete design, justified additions, and measurable deferrals |
 | Success Criteria | Yes | Checkboxes, each testable |
 | Execution Strategy | Yes | Wave-based plan — mandatory even if a single sequential wave; forces ordering, parallelism, and dependency thinking upfront |
 | Execution Groups | Yes | Goal, deliverables, acceptance criteria, validation command |
@@ -92,6 +94,7 @@ node "<wish-skill-dir>/references/design-review-evidence.mjs" verify ".genie/bra
 - Never emit a bracket-link to a non-existent brainstorm — use the `_No brainstorm — direct wish_` stub.
 - Never consume a linked design whose persisted review evidence is missing, non-SHIP, or stale; the wish linter independently enforces this for new wishes.
 - No implementation during `wish` — planning only.
+- No speculative optimization: caches, deltas, sharding, background coordination, and configuration surfaces require a current criterion or measurement in the Simplicity Case.
 - Every group testable, bite-sized, and independently shippable; no vague tasks ("improve everything").
 - OUT scope must contain at least one concrete exclusion.
 - Declare cross-wish dependencies early.

--- a/skills/wish/templates/wish-template.md
+++ b/skills/wish/templates/wish-template.md
@@ -32,6 +32,13 @@
 |---|----------|-----------|
 | 1 | <TODO: decision> | <TODO: why this over alternatives> |
 
+## Simplicity Case
+
+- **Simplest complete design:** <TODO: smallest design that satisfies current user stories>
+- **Added machinery:** <TODO: none, or each mechanism and the present evidence that requires it>
+- **Deferred until measured:** <TODO: future complexity and its concrete adoption trigger>
+- **Complexity removed:** <TODO: states, failure modes, options, or dependencies deliberately avoided>
+
 ## Dependencies
 
 **depends-on:** none

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -19,28 +19,53 @@ When you are spawned as a subagent for a group, your dispatch prompt carries the
 
 ## Flow
 1. **Load and enter execution:** read `.genie/wishes/<slug>/WISH.md` and require persisted status `APPROVED` (or `IN_PROGRESS` when resuming). Before the first dispatch, the orchestrator sets `APPROVED` → `IN_PROGRESS`; read group state with `genie task list --wish <slug>` (or `genie board --wish <slug>`).
-2. **Pick the wave:** every group whose `depends-on` groups are done, per the wish's Execution Strategy.
-3. **Dispatch the wave in ONE message** — one native delegation surface call per group, each using the named engineer role selected from the WISH's Complexity and Model columns with curated context (see Dispatch, Context Curation). Each engineer's brief opens with the atomic claim:
+2. **Pick the wave:** every group whose `depends-on` groups are integrated and done, per the wish's Execution Strategy.
+   The current PM checkout is the wish integration worktree. Before dispatch, create one branch and worktree from its
+   current HEAD for every group in the wave; a group lane persists across engineer and fixer handoffs.
+3. **Dispatch the wave in ONE message** — one native delegation surface call per group, each placed in its dedicated
+   group worktree and using the named engineer role selected from the WISH's Complexity and Model columns with curated
+   context (see Dispatch, Context Curation). Each engineer's brief names the worktree and branch and opens with the
+   atomic claim:
    ```bash
    genie task checkout <task-id> --worker <engineer-name>
    ```
    If two agents race one task, exactly one wins; the loser gets a conflict error and stands down.
 4. **Await completion — never poll:** background subagents notify you when they finish. Inspect `genie board --wish <slug>` on demand; completion is push, not poll.
-5. **Local review:** per finished group, dispatch a reviewer subagent (reviewer ≠ engineer) to run `review` against that group's acceptance criteria. The orchestrator appends each returned evidence block under `## Review Results`; the reviewer never edits it. Diagnose before fixing: `overdesigned-plan` returns to wish/design review without consuming a fix attempt; other FIX-FIRST gaps may use at most 3 fix loops.
+5. **Checkpoint and local review:** require the engineer to commit the group result, then dispatch a reviewer subagent
+   (reviewer ≠ engineer) in an ephemeral, detached, read-only worktree at that exact commit. Remove the review worktree
+   when the review ends. The orchestrator appends each returned evidence block under `## Review Results`; the reviewer
+   never edits it. Diagnose before fixing: `overdesigned-plan` returns to wish/design review without consuming a fix
+   attempt; other FIX-FIRST gaps return a fixer to the existing group worktree for at most 3 fix loops.
 6. **Quality review:** dispatch a reviewer for a quality pass (security, maintainability, perf). On FIX-FIRST, use the same maximum of 3 fix loops.
-7. **Validate:** run the group's validation command yourself (Bash); record the output as evidence.
-8. **Group done** — only after clean review AND passing validation:
+7. **Integrate and validate:** after clean review, merge the group branch into the wish integration branch in the WISH's
+   declared order. The PM owns merge decisions and conflict resolution; route code-level conflict edits to a bounded
+   fixer in the integration worktree. Run the group's validation command on the integrated tree and record the output.
+8. **Garbage collect and mark done:** after the group tip is proven merged and integrated validation passes, require a
+   clean group worktree, remove it without force, delete its merged branch without force, and prune stale worktree
+   metadata. Any failed proof or cleanup leaves the task `in_progress` and the lane intact:
+   ```bash
+   git -C <integration-worktree> merge-base --is-ancestor <group-tip> HEAD
+   test -z "$(git -C <group-worktree> status --porcelain)"
+   git -C <integration-worktree> worktree remove <group-worktree>
+   git -C <integration-worktree> branch -d <group-branch>
+   git -C <integration-worktree> worktree prune
+   ```
+   Only then:
    ```bash
    genie task done <task-id>
    ```
 9. **Next wave:** re-derive from the WISH.md Execution Strategy (the DAG lives in the document, not in task rows — see State Management); repeat 2-8 until all groups are done.
-10. **Handoff:** when every group's task is done: `All work groups complete. Run review.` Keep status `IN_PROGRESS` through execution review, PR review, and CI. Only the authorized merge plus required QA may transition it to `SHIPPED`.
+10. **Handoff:** when every group's task is done: `All work groups complete. Run review.` Keep status `IN_PROGRESS`
+    through execution review and the PM's repository integration mode. A GitHub-backed repository requires reviewed PR
+    integration plus local-main fast-forward; a repository with zero remotes uses a validated local candidate. Only
+    mainline integration and required QA may transition it to `SHIPPED`; the PM must also finish or explicitly report
+    any local-mirror, archive, or lane-cleanup debt.
 
 ## Dispatch
 
 Spawn subagents with the **native delegation surface**; never execute group work directly. Dispatch a wave together so independent groups can run concurrently. Subagents notify you on completion. Every dispatch selects one named role below; implicit or unnamed roles are forbidden.
 
-Use the active runtime's named roles. In Codex, use the matching `genie_*` custom-agent profile when installed; Claude and Hermes use their native named-role surfaces. Parallel writers must have disjoint file ownership or dedicated worktrees; otherwise sequence them. Reviewers and scouts stay read-only. Wait for completion notifications, steer a running thread with native follow-up messaging, and interrupt drift rather than spawning a duplicate worker.
+Use the active runtime's named roles. In Codex, use the matching `genie_*` custom-agent profile when installed; Claude and Hermes use their native named-role surfaces. Every concurrent execution group must use a dedicated branch and worktree, even when expected file scopes are disjoint. If the runtime cannot place native subagents in those worktrees, use `genie launch` or sequence the groups. Never dispatch two writers into one worktree. Reviewers and scouts stay read-only and use ephemeral snapshot worktrees when concurrent. Wait for completion notifications, steer a running thread with native follow-up messaging, and interrupt drift rather than spawning a duplicate worker.
 
 | Need | Portable role (Codex profile) |
 |------|----------------------------|
@@ -64,7 +89,7 @@ Native subagent dispatch is the default. When the user wants parallel Warp sessi
 genie launch <slug> [--groups <csv>]
 ```
 
-One pane per ready group, each in its own git worktree, running that group's agent on a kickoff prompt. Everything governing correctness is identical: engineers still claim with `genie task checkout` against the shared `genie.db`, reviewer ≠ engineer holds, the orchestrator still validates and marks groups done, and waves still come from the Execution Strategy. The one limit: pane sessions cannot be awaited — Warp mode is human-in-the-loop. For hands-off, awaitable dispatch, use native subagents.
+One pane per ready group, each in its own git worktree, running that group's agent on a kickoff prompt. Everything governing correctness is identical: engineers still claim with `genie task checkout` against the shared `genie.db`, reviewer ≠ engineer holds, the orchestrator merges each reviewed branch into the wish integration worktree, and waves still come from the Execution Strategy. After integration and validation, the PM removes the clean group worktree and merged branch before marking its task done. The one limit: pane sessions cannot be awaited — Warp mode is human-in-the-loop. For hands-off, awaitable dispatch, use isolated native subagents.
 
 ## Context Curation
 
@@ -75,14 +100,15 @@ Extract the group's context from WISH.md and paste it into the dispatch prompt �
 3. **Acceptance criteria** — the checkboxes to satisfy
 4. **Validation command** — the exact command proving the work (e.g. `bun run check`)
 5. **Depends-on** — what the engineer may assume already exists
-6. **Stop conditions** — claim the task first; report blocked instead of expanding scope; end with an outcome word (see Session close)
+6. **Lane** — the absolute group worktree path and branch; do not edit outside it
+7. **Stop conditions** — claim the task first; commit before review; report blocked instead of expanding scope; end with an outcome word (see Session close)
 
 ## State Management
 
 - **Engineers claim** via `genie task checkout <task-id> --worker <name>` as the first step of their brief.
 - **Environment setup is feature work.** Read-only discovery may precede a claim, but before mutating shared host state—installing toolchains or runtimes, starting services or emulators, provisioning credentials, or preparing test infrastructure—claim the group that owns the setup and keep it `in_progress` until setup and validation finish. The visible claim is the concurrency lock: if another live worker owns it, coordinate or stand down; reclaim only a stale claim. When setup is a prerequisite shared by multiple groups, give it an explicit group/task in the wish instead of running untracked preflight. Never let multiple threads independently prepare the same environment.
-- **Engineers signal** completion in their final message; the native team notifies the orchestrator — no manual send.
-- **Orchestrator tracks** via `genie task list --wish <slug>` / `genie board --wish <slug>` (on demand) and completes each verified group with `genie task done <task-id>`. Engineers never call `genie task done`.
+- **Engineers signal** completion in their final message with the reviewed commit candidate; the native team notifies the orchestrator — no manual send.
+- **Orchestrator tracks** via `genie task list --wish <slug>` / `genie board --wish <slug>` (on demand) and completes each group only after its reviewed commit is merged, the integrated tree passes validation, and the clean group worktree and merged branch are removed. Engineers never call `genie task done`.
 - **The dependency DAG is doc-only.** The v5 CLI has no dependency-edge commands — every CLI-created task is `ready` from birth, so DB status is NOT a dependency signal. Sequence waves from the WISH.md Execution Strategy alone; never dispatch a group just because its task shows `ready`.
 - **No task row?** (wish predates the state DB, or `.genie/genie.db` unavailable): skip the `genie task` calls and drive the wave from the WISH.md directly — task tracking is an enhancement, never a blocker.
 
@@ -114,7 +140,7 @@ A user-approved simplification invalidates the superseded plan/review evidence a
 - Never spend fix loops preserving optional complexity; route an `overdesigned-plan` diagnosis back through wish/design review.
 - Never overwrite WISH.md from subagent output — curated prompts are runtime context; the WISH.md in git is the source of truth.
 - Reviewer ≠ engineer, always.
-- `genie task done` only after clean review and passing validation — and only by the orchestrator.
+- `genie task done` only after clean review, integration, passing validation, and group-lane garbage collection — and only by the orchestrator.
 - Grounded progress: before reporting, audit each claim against tool output from this session — state what is verified, what failed, what was skipped. Never present intentions, or subagent claims you did not verify, as completed work.
 
 ## Session close (required)

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -26,8 +26,8 @@ When you are spawned as a subagent for a group, your dispatch prompt carries the
    ```
    If two agents race one task, exactly one wins; the loser gets a conflict error and stands down.
 4. **Await completion — never poll:** background subagents notify you when they finish. Inspect `genie board --wish <slug>` on demand; completion is push, not poll.
-5. **Local review:** per finished group, dispatch a reviewer subagent (reviewer ≠ engineer) to run `review` against that group's acceptance criteria. The orchestrator appends each returned evidence block under `## Review Results`; the reviewer never edits it. On FIX-FIRST, dispatch a fix subagent (max 2 loops); if unresolved, apply Escalation Diagnosis instead of automatically changing model or effort.
-6. **Quality review:** dispatch a reviewer for a quality pass (security, maintainability, perf). On FIX-FIRST, one fix loop.
+5. **Local review:** per finished group, dispatch a reviewer subagent (reviewer ≠ engineer) to run `review` against that group's acceptance criteria. The orchestrator appends each returned evidence block under `## Review Results`; the reviewer never edits it. Diagnose before fixing: `overdesigned-plan` returns to wish/design review without consuming a fix attempt; other FIX-FIRST gaps may use at most 3 fix loops.
+6. **Quality review:** dispatch a reviewer for a quality pass (security, maintainability, perf). On FIX-FIRST, use the same maximum of 3 fix loops.
 7. **Validate:** run the group's validation command yourself (Bash); record the output as evidence.
 8. **Group done** — only after clean review AND passing validation:
    ```bash
@@ -80,6 +80,7 @@ Extract the group's context from WISH.md and paste it into the dispatch prompt �
 ## State Management
 
 - **Engineers claim** via `genie task checkout <task-id> --worker <name>` as the first step of their brief.
+- **Environment setup is feature work.** Read-only discovery may precede a claim, but before mutating shared host state—installing toolchains or runtimes, starting services or emulators, provisioning credentials, or preparing test infrastructure—claim the group that owns the setup and keep it `in_progress` until setup and validation finish. The visible claim is the concurrency lock: if another live worker owns it, coordinate or stand down; reclaim only a stale claim. When setup is a prerequisite shared by multiple groups, give it an explicit group/task in the wish instead of running untracked preflight. Never let multiple threads independently prepare the same environment.
 - **Engineers signal** completion in their final message; the native team notifies the orchestrator — no manual send.
 - **Orchestrator tracks** via `genie task list --wish <slug>` / `genie board --wish <slug>` (on demand) and completes each verified group with `genie task done <task-id>`. Engineers never call `genie task done`.
 - **The dependency DAG is doc-only.** The v5 CLI has no dependency-edge commands — every CLI-created task is `ready` from birth, so DB status is NOT a dependency signal. Sequence waves from the WISH.md Execution Strategy alone; never dispatch a group just because its task shows `ready`.
@@ -95,6 +96,7 @@ Use this policy before any model or effort change; keep this contract identical 
 | `missing-context` | The attempt identifies absent files, history, criteria, logs, or other inputs needed to decide. | Supply the missing context and retry at the same model and effort; MUST NOT escalate model or effort. |
 | `ambiguous-spec` | Two or more materially different behaviors remain consistent with the stated criteria. | Request a human decision or wish clarification; MUST NOT escalate model or effort. |
 | `env-tool-failure` | A reproducible environment, dependency, permission, timeout, or tool error prevents valid execution. | Repair or retry the environment/tool, or report blocked with the error; MUST NOT escalate model or effort. |
+| `overdesigned-plan` | Gaps cluster in optional machinery that lacks a current criterion or measurement, while a simpler design satisfies the user stories with fewer durable states or recovery paths. | Stop the fix loop and return to `brainstorm`/`wish` to remove or defer the mechanism. Re-review the amended design/plan; MUST NOT spend retries or model escalation defending it. |
 
 Escalation eligibility requires **new evidence** produced since the previous attempt: attach the new failing output or diagnostic result, the correction already tried, and why it rules out the other three causes. A repeated verdict or unchanged failure is not new evidence and cannot authorize a model or effort change.
 
@@ -104,9 +106,12 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 
 When a subagent fails or a fix-loop limit is exhausted, the orchestrator records the cause, evidence, selected route, and current cap counters before another dispatch. It leaves the task `in_progress`, keeps dispatching ready groups that do not depend on the blocked one, and includes unresolved diagnoses and appeals in the final handoff.
 
+A user-approved simplification invalidates the superseded plan/review evidence and starts a fresh plan review; it is not an extra fix attempt. Preserve useful completed work only when it still satisfies the simpler contract, and delete machinery that exists solely for the rejected design.
+
 ## Rules
 - Never execute group work directly — always dispatch via the native delegation surface.
 - Never expand scope during execution; never skip validation commands.
+- Never spend fix loops preserving optional complexity; route an `overdesigned-plan` diagnosis back through wish/design review.
 - Never overwrite WISH.md from subagent output — curated prompts are runtime context; the WISH.md in git is the source of truth.
 - Reviewer ≠ engineer, always.
 - `genie task done` only after clean review and passing validation — and only by the orchestrator.

--- a/skills/work/references/native-surfaces.md
+++ b/skills/work/references/native-surfaces.md
@@ -4,8 +4,8 @@ Genie skills describe roles and coordination without inventing a cross-client to
 
 | Runtime | Dispatch | Isolation | Follow-up |
 |---------|----------|-----------|-----------|
-| Claude Code | Use its current native Agent surface and an available named role | Use the runtime's supported isolation/worktree option when present | Use the runtime's documented messaging surface when available; otherwise re-dispatch with curated context |
-| Codex | Use the matching `genie_*` custom agent when the CLI-installed profiles are present; otherwise use an available generic subagent | Native subagents share the caller's workspace by default | Use the active native follow-up tool exposed in the session; do not hardcode an undocumented function name into a skill |
+| Claude Code | Use its current native Agent surface and an available named role | Place every concurrent group in a dedicated runtime-managed or ordinary Git worktree | Use the runtime's documented messaging surface when available; otherwise re-dispatch with curated context |
+| Codex | Use the matching `genie_*` custom agent when the CLI-installed profiles are present; otherwise use an available generic subagent | Place every concurrent group in a dedicated runtime-managed or ordinary Git worktree; otherwise sequence it | Use the active native follow-up tool exposed in the session; do not hardcode an undocumented function name into a skill |
 | Warp cockpit | `genie launch <slug>` emits one pane per ready group | Dedicated Git worktree per pane | Human-supervised; panes are not awaitable native subagents |
 
 Every implementation brief opens with the atomic claim:
@@ -14,6 +14,6 @@ Every implementation brief opens with the atomic claim:
 genie task checkout <task-id> --worker <name>
 ```
 
-The claim owns file scope in a shared workspace. Engineers and fixers report completion but never call `genie task done`. A different reviewer validates the group; only the orchestrator marks it done after a SHIP verdict and passing evidence. Native client completion notifications replace polling.
+The task claim owns group state; the dedicated worktree and branch own its mutable file state. Engineers and fixers report completion but never call `genie task done`. A different reviewer validates an exact commit in an ephemeral read-only worktree. The PM merges that commit into the wish integration worktree, resolves conflicts, validates the integrated tree, and removes the clean group worktree and merged branch before marking the task done. Native client completion notifications replace polling.
 
 User decisions use the runtime's native input or permission surface. Shared workflows name the semantic action—dispatch, follow up, interrupt, wait—while the active client supplies the concrete tool.

--- a/src/term-commands/init.test.ts
+++ b/src/term-commands/init.test.ts
@@ -7,7 +7,7 @@ import { mergeCodexMcpFallback, removeCodexMcpFallback } from './init.js';
 
 const CLI = join(import.meta.dir, '..', 'genie.ts');
 const INTERPRETED_MCP_ARGS = [realpathSync(CLI), 'mcp'];
-const GITIGNORE_RULES = ['.genie/genie.db', '.genie/genie.db-wal', '.genie/genie.db-shm'];
+const GITIGNORE_RULES = ['.genie/genie.db', '.genie/genie.db-wal', '.genie/genie.db-shm', '.genie/launch/'];
 
 let dir: string;
 
@@ -57,6 +57,14 @@ describe('genie init', () => {
     for (const rule of GITIGNORE_RULES) {
       expect(gitignore).toContain(rule);
     }
+    mkdirSync(join(dir, '.genie', 'launch'), { recursive: true });
+    writeFileSync(join(dir, '.genie', 'launch', 'group.prompt'), 'kickoff\n');
+    expect(
+      execFileSync('git', ['check-ignore', '.genie/launch/group.prompt'], {
+        cwd: dir,
+        encoding: 'utf-8',
+      }).trim(),
+    ).toBe('.genie/launch/group.prompt');
     expect(stdout).toContain('brainstorm');
     expect(stdout).toContain('$genie:brainstorm');
     expect(stdout).toContain('$genie:review');

--- a/src/term-commands/init.ts
+++ b/src/term-commands/init.ts
@@ -72,8 +72,8 @@ const INDEX_SKELETON = `# Plans Index
 ## Poured
 `;
 
-/** SQLite state artifacts that must never be committed. */
-const GITIGNORE_RULES = ['.genie/genie.db', '.genie/genie.db-wal', '.genie/genie.db-shm'];
+/** Operational artifacts that must never be committed. */
+const GITIGNORE_RULES = ['.genie/genie.db', '.genie/genie.db-wal', '.genie/genie.db-shm', '.genie/launch/'];
 
 // ============================================================================
 // Git repo resolution
@@ -108,7 +108,7 @@ function scaffoldIndex(root: string): ArtifactAction {
 }
 
 /**
- * Append any missing SQLite ignore rules to `.gitignore`, creating the file
+ * Append any missing operational ignore rules to `.gitignore`, creating the file
  * when absent. Existing content is preserved byte-for-byte; rules already
  * present are left untouched, so a second run writes nothing.
  */

--- a/src/term-commands/launch.test.ts
+++ b/src/term-commands/launch.test.ts
@@ -126,7 +126,7 @@ describe('genie launch --dry-run', () => {
     const apiGroup = plan.groups.find((g) => g.name === 'api');
     expect(apiGroup?.prompt).toContain(a.id);
     expect(apiGroup?.prompt).not.toContain('genie task done');
-    expect(apiGroup?.prompt).toContain('only the PM marks tasks done');
+    expect(apiGroup?.prompt).toContain('only the PM integrates, cleans up the lane, and marks tasks done');
     const uiGroup = plan.groups.find((g) => g.name === 'ui');
     expect(uiGroup?.prompt).toContain(b.id);
 
@@ -346,6 +346,9 @@ describe('genie launch (real run, --no-open)', () => {
     const corePrompt = readFileSync(join(coreWt, '.genie', 'launch', 'core.prompt'), 'utf-8');
     expect(corePrompt).toContain(t1.id);
     expect(corePrompt).toContain(t2.id);
+    expect(corePrompt).toContain('dedicated mutable lane for this group');
+    expect(corePrompt).toContain('Commit the validated review candidate');
+    expect(corePrompt).toContain('only the PM integrates, cleans up the lane, and marks tasks done');
     const docsPrompt = readFileSync(join(docsWt, '.genie', 'launch', 'docs.prompt'), 'utf-8');
     expect(docsPrompt).toContain(t3.id);
 

--- a/src/term-commands/launch.ts
+++ b/src/term-commands/launch.ts
@@ -352,14 +352,16 @@ function buildPrompt(slug: string, group: string, tasks: TaskRow[]): string {
     `Group: ${group}`,
     '',
     `You own group "${group}" of wish "${slug}". It has ${tasks.length} ready task(s).`,
-    'Claim each task before you work it. When complete, report evidence to the PM; only the PM marks tasks done:',
+    'This checkout is the dedicated mutable lane for this group. Do not edit another checkout.',
+    'Claim each task before you work it. Commit the validated review candidate, then report its commit and evidence',
+    'to the PM; only the PM integrates, cleans up the lane, and marks tasks done:',
     '',
   ];
   for (const task of tasks) {
     lines.push(`- ${task.id}  ${task.title}`);
     lines.push(`    claim:  genie task checkout ${task.id} --worker ${group}`);
     lines.push(
-      '    finish: report implementation and validation evidence to the PM (do not mutate task completion state)',
+      '    finish: commit and report the candidate plus validation evidence (do not mutate task completion state)',
     );
   }
   lines.push('');


### PR DESCRIPTION
## What changed

- Define `genie launch` worktrees as the isolation boundary for parallel delivery lanes.
- Clarify that task claims coordinate shared-workspace scope and do not imply filesystem isolation.
- Align Claude and Codex role guidance, lifecycle skills, and runtime-neutral dispatch documentation with that contract.
- Extend init, launch, and release-documentation tests to enforce the policy.

## Why

Native subagents can share a workspace, so concurrent writers need an explicit isolation contract. This revision makes the existing worktree mechanism the canonical boundary and documents when agents must sequence work instead.

## Impact

Parallel implementation groups get isolated Git worktrees through `genie launch`; reviewers and scouts remain read-only, and shared-workspace work stays coordinated through visible task claims.

## Stack

Depends on #2593 (`feat(methodology): make simplicity a lifecycle gate`). Until that PR merges, GitHub shows both commits in this PR; afterward this PR reduces to commit `a82507b3`.

## Validation

- `bun run check:fast` — passed in the pre-push hook.
- `bun test src/term-commands/init.test.ts src/term-commands/launch.test.ts scripts/release-docs.test.ts` — 71 passed, 0 failed.
- `bun run check` — reached the full suite; 1,683 passed and 6 failed. The same six failures reproduce on parent commit `28377f9e`, so they are inherited from #2593 and not introduced by this revision.
