### PR TITLE
docs: teach reader-boundary documentation

### DIFF
--- a/plugins/genie/skills/docs/SKILL.md
+++ b/plugins/genie/skills/docs/SKILL.md
@@ -43,4 +43,5 @@ Example brief: "Audit README.md, CLAUDE.md, and skills/work/SKILL.md after PR #7
 ## Rules
 - Grounded progress: report only what was audited or generated in this session, each claim backed by a check actually run — "3 files verified current, 1 updated, 0 dead references", never just "docs written".
 - No fiction: never document features that don't exist yet; no dead paths or APIs.
+- Write to the reader's interface boundary: explain what they need to decide, do, observe, and verify. Prefer observable promises, outcomes, failure behavior, and next steps over internal machinery. Include implementation details only when the reader needs them to use the feature safely, troubleshoot it, or extend it; otherwise keep that mechanism in internal or architecture documentation.
 - Match existing project conventions for style and structure.

--- a/plugins/genie/skills/dx-docs/SKILL.md
+++ b/plugins/genie/skills/dx-docs/SKILL.md
@@ -48,6 +48,7 @@ Lead with a one-sentence verdict: did the repo pass its contributor test, and wh
 ## Pitfalls
 
 - Never evaluate docs by reading them — a page can read beautifully and be unfollowable; every "docs are good" claim must trace to a followed procedure.
+- Treat mechanism leakage as reader friction. If a reader can act safely from an observable promise, do not require them to learn internal components, protocols, state, or recovery machinery. Keep details only when they change a decision, safety boundary, troubleshooting step, or extension point; move the rest to internal explanation or architecture docs.
 - Internal-only docs deliberately excluded from a public site are design, not gaps — check the exclusion mechanism before reporting "missing" pages.
 - If docs live in a submodule or separate repo, a fix recommendation that says "edit and commit here" strands changes — name the real workflow in the fix.
 - Agent-context files (CLAUDE.md and kin) drifting from the product is real drift, but its fix lands in this repo, not the docs pipeline — route the two drift classes separately.

--- a/skills/docs/SKILL.md
+++ b/skills/docs/SKILL.md
@@ -43,4 +43,5 @@ Example brief: "Audit README.md, CLAUDE.md, and skills/work/SKILL.md after PR #7
 ## Rules
 - Grounded progress: report only what was audited or generated in this session, each claim backed by a check actually run — "3 files verified current, 1 updated, 0 dead references", never just "docs written".
 - No fiction: never document features that don't exist yet; no dead paths or APIs.
+- Write to the reader's interface boundary: explain what they need to decide, do, observe, and verify. Prefer observable promises, outcomes, failure behavior, and next steps over internal machinery. Include implementation details only when the reader needs them to use the feature safely, troubleshoot it, or extend it; otherwise keep that mechanism in internal or architecture documentation.
 - Match existing project conventions for style and structure.

--- a/skills/dx-docs/SKILL.md
+++ b/skills/dx-docs/SKILL.md
@@ -48,6 +48,7 @@ Lead with a one-sentence verdict: did the repo pass its contributor test, and wh
 ## Pitfalls
 
 - Never evaluate docs by reading them — a page can read beautifully and be unfollowable; every "docs are good" claim must trace to a followed procedure.
+- Treat mechanism leakage as reader friction. If a reader can act safely from an observable promise, do not require them to learn internal components, protocols, state, or recovery machinery. Keep details only when they change a decision, safety boundary, troubleshooting step, or extension point; move the rest to internal explanation or architecture docs.
 - Internal-only docs deliberately excluded from a public site are design, not gaps — check the exclusion mechanism before reporting "missing" pages.
 - If docs live in a submodule or separate repo, a fix recommendation that says "edit and commit here" strands changes — name the real workflow in the fix.
 - Agent-context files (CLAUDE.md and kin) drifting from the product is real drift, but its fix lands in this repo, not the docs pipeline — route the two drift classes separately.


### PR DESCRIPTION
## What changed

- teach the docs skill to explain decisions, actions, observable outcomes, failure behavior, and next steps
- keep implementation machinery out of user-facing documentation unless it is needed for safe use, troubleshooting, or extension
- add the same mechanism-leakage guidance to the DX documentation audit skill
- keep canonical skills and plugin mirrors synchronized

## Why

User documentation should preserve the reader's attention for what they need to know. When an internal mechanism does not affect a decision or interaction, documentation can promise the observable result instead of requiring a detailed mental model.

## Validation

- push-time static check suite passed, including typecheck, Biome, dead-code analysis, skill and wish lint, complexity budget, workflow checks, and bundled-hook parity
- canonical and plugin skill mirrors are byte-identical
- full test suite currently has six unrelated runtime failures that reproduce on main