### PR TITLE
fix(release): use a custom predicate type for the native attestation

### DIFF
--- a/.github/workflows/sign-attest.yml
+++ b/.github/workflows/sign-attest.yml
@@ -341,7 +341,10 @@ jobs:
         uses: actions/attest@67422f5511b7ff725f4dbd6fb9bd2cd925c65a8d # v1.4.1
         with:
           subject-path: dist/genie-${{ needs.prepare.outputs.version }}-${{ matrix.platform }}.tar.gz
-          predicate-type: https://slsa.dev/provenance/v1
+          # Custom predicate type (same URI as the predicate's buildType):
+          # claiming https://slsa.dev/provenance/v1 makes GitHub's attestation
+          # API run SLSA validation, which rejects our custom buildType.
+          predicate-type: https://github.com/${{ github.repository }}/release-tarballs@v1
           predicate-path: ${{ runner.temp }}/genie-native-${{ matrix.platform }}.json
 
       - name: Verify cosign bundle (self-check)
@@ -419,7 +422,7 @@ jobs:
           RESULT="${RUNNER_TEMP}/genie-native-result-${PLATFORM}.json"
           gh attestation verify "${TARBALL}" \
             --repo "$RELEASE_REPOSITORY" \
-            --predicate-type https://slsa.dev/provenance/v1 \
+            --predicate-type "https://github.com/${RELEASE_REPOSITORY}/release-tarballs@v1" \
             --cert-identity "https://github.com/${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml@refs/heads/main" \
             --source-ref refs/heads/main \
             --source-digest "$CONTROL_SHA" \
@@ -489,7 +492,7 @@ jobs:
           echo "-> Expecting gh attestation verify to REJECT mutated tarball"
           if gh attestation verify "${MUTATED}" \
               --repo "${{ github.repository }}" \
-              --predicate-type https://slsa.dev/provenance/v1 \
+              --predicate-type "https://github.com/${{ github.repository }}/release-tarballs@v1" \
               --cert-identity "https://github.com/${{ github.repository }}/.github/workflows/sign-attest.yml@refs/heads/main" \
               --source-ref refs/heads/main \
               --source-digest "$CONTROL_SHA" \

--- a/scripts/reconcile-release-assets.sh
+++ b/scripts/reconcile-release-assets.sh
@@ -151,7 +151,7 @@ if remote_is_complete; then
     result="$WORK_ROOT/native-${platform}.json"
     gh attestation verify "$tarball" \
       --repo "$RELEASE_REPOSITORY" \
-      --predicate-type https://slsa.dev/provenance/v1 \
+      --predicate-type "https://github.com/${RELEASE_REPOSITORY}/release-tarballs@v1" \
       --cert-identity "https://github.com/${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml@refs/heads/main" \
       --source-ref refs/heads/main \
       --signer-workflow "${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml" \
@@ -161,7 +161,7 @@ if remote_is_complete; then
     exact_result="$WORK_ROOT/native-exact-${platform}.json"
     gh attestation verify "$tarball" \
       --repo "$RELEASE_REPOSITORY" \
-      --predicate-type https://slsa.dev/provenance/v1 \
+      --predicate-type "https://github.com/${RELEASE_REPOSITORY}/release-tarballs@v1" \
       --cert-identity "https://github.com/${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml@refs/heads/main" \
       --source-ref refs/heads/main \
       --source-digest "$remote_control_sha" \

--- a/scripts/reconcile-release-assets.test.ts
+++ b/scripts/reconcile-release-assets.test.ts
@@ -90,7 +90,7 @@ if (args[0] === 'attestation' && args[1] === 'verify') {
   const sourceSha = state.invalidNative ? 'not-a-sha' : 'a'.repeat(40);
   const predicateControlSha = digest && state.secondControlSha ? state.secondControlSha : state.controlSha;
   const statement = {
-    predicateType: 'https://slsa.dev/provenance/v1',
+    predicateType: 'https://github.com/automagik-dev/genie/release-tarballs@v1',
     predicate: {
       runDetails: { builder: { id: 'https://github.com/automagik-dev/genie/.github/workflows/sign-attest.yml@refs/heads/main' } },
       buildDefinition: {

--- a/scripts/release-native-predicate.sh
+++ b/scripts/release-native-predicate.sh
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 
-PREDICATE_TYPE='https://slsa.dev/provenance/v1'
 : "${RELEASE_REPOSITORY:?RELEASE_REPOSITORY is required}"
 : "${VERSION:?VERSION is required}"
 
@@ -11,6 +10,13 @@ PREDICATE_TYPE='https://slsa.dev/provenance/v1'
 
 BUILDER_ID="https://github.com/${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml@refs/heads/main"
 BUILD_TYPE="https://github.com/${RELEASE_REPOSITORY}/release-tarballs@v1"
+# The statement predicateType is the custom buildType URI, NOT
+# https://slsa.dev/provenance/v1: GitHub's attestation persistence API runs
+# SLSA-provenance validation for that type and rejects non-allowlisted
+# buildTypes ("unsupported build type", observed 2026-07-20 on the first
+# stable run). A custom predicate type skips that validation while keeping
+# the SLSA-v1-shaped body; every verifier passes the same --predicate-type.
+PREDICATE_TYPE="$BUILD_TYPE"
 
 require_exact_identity() {
   : "${CHANNEL:?CHANNEL is required}"

--- a/scripts/release-native-predicate.test.ts
+++ b/scripts/release-native-predicate.test.ts
@@ -68,7 +68,7 @@ describe('native release attestation predicate', () => {
     const verification = [
       {
         verificationResult: {
-          statement: { predicateType: 'https://slsa.dev/provenance/v1', predicate },
+          statement: { predicateType: 'https://github.com/automagik-dev/genie/release-tarballs@v1', predicate },
         },
       },
     ];
@@ -101,7 +101,7 @@ describe('native release attestation predicate', () => {
     const result = [
       {
         verificationResult: {
-          statement: { predicateType: 'https://slsa.dev/provenance/v1', predicate },
+          statement: { predicateType: 'https://github.com/automagik-dev/genie/release-tarballs@v1', predicate },
         },
       },
     ];


### PR DESCRIPTION
## Problem

The first stable run of the new release pipeline (`v5.260720.1`, [run 29720262451](https://github.com/automagik-dev/genie/actions/runs/29720262451)) failed in **all four Sign jobs**:

```
Failed to persist attestation: Invalid Argument - unsupported build type:
https://github.com/automagik-dev/genie/release-tarballs@v1
```

Builds and SLSA Level 3 provenance succeeded; cosign signing succeeded; persistence of the GitHub-native attestation failed, so `publish` was skipped and no stable release was produced.

## Cause

`actions/attest` was called with `predicate-type: https://slsa.dev/provenance/v1`. Declaring that type makes GitHub's Attestations API validate the payload *as SLSA provenance*, and that validation only accepts an allowlist of known `buildType` values. Our source/control-bound predicate deliberately uses a repo-specific `buildType` (`.../release-tarballs@v1`), so the API rejected it.

## Fix

Publish the statement under the custom `buildType` URI as its predicate type. The predicate body keeps its SLSA-v1 shape and every binding check (builder id, version, channel, source/control SHAs, resolved dependencies); it just skips the API's SLSA-specific validation.

Updated consistently across all consumers, which now pass the same `--predicate-type`:
- `.github/workflows/sign-attest.yml` — `actions/attest` step, native self-check, tamper-detection self-test
- `scripts/release-native-predicate.sh` — `PREDICATE_TYPE` now derives from `BUILD_TYPE`
- `scripts/reconcile-release-assets.sh` — both verification passes
- test fixtures in `release-native-predicate.test.ts` / `reconcile-release-assets.test.ts`

**Trust anchors unchanged**: the keyless cosign leg and the SLSA Level 3 generic provenance leg are untouched. The native attestation remains a cross-check bound to the same pinned signer identity.

## Verification

`typecheck` + `lint` clean; `bun test scripts/` passes except three pre-existing `install.sh` failures unrelated to this change (they also fail on `dev`). Real verification is the next stable run reaching `publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)