### PR TITLE
release: dev → main — attestation predicate-type fix (v5.260720.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "5.260720.1",
+      "version": "5.260720.2",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "5.260720.2",
+      "version": "5.260720.3",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/.github/workflows/sign-attest.yml
+++ b/.github/workflows/sign-attest.yml
@@ -341,7 +341,10 @@ jobs:
         uses: actions/attest@67422f5511b7ff725f4dbd6fb9bd2cd925c65a8d # v1.4.1
         with:
           subject-path: dist/genie-${{ needs.prepare.outputs.version }}-${{ matrix.platform }}.tar.gz
-          predicate-type: https://slsa.dev/provenance/v1
+          # Custom predicate type (same URI as the predicate's buildType):
+          # claiming https://slsa.dev/provenance/v1 makes GitHub's attestation
+          # API run SLSA validation, which rejects our custom buildType.
+          predicate-type: https://github.com/${{ github.repository }}/release-tarballs@v1
           predicate-path: ${{ runner.temp }}/genie-native-${{ matrix.platform }}.json
 
       - name: Verify cosign bundle (self-check)
@@ -419,7 +422,7 @@ jobs:
           RESULT="${RUNNER_TEMP}/genie-native-result-${PLATFORM}.json"
           gh attestation verify "${TARBALL}" \
             --repo "$RELEASE_REPOSITORY" \
-            --predicate-type https://slsa.dev/provenance/v1 \
+            --predicate-type "https://github.com/${RELEASE_REPOSITORY}/release-tarballs@v1" \
             --cert-identity "https://github.com/${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml@refs/heads/main" \
             --source-ref refs/heads/main \
             --source-digest "$CONTROL_SHA" \
@@ -489,7 +492,7 @@ jobs:
           echo "-> Expecting gh attestation verify to REJECT mutated tarball"
           if gh attestation verify "${MUTATED}" \
               --repo "${{ github.repository }}" \
-              --predicate-type https://slsa.dev/provenance/v1 \
+              --predicate-type "https://github.com/${{ github.repository }}/release-tarballs@v1" \
               --cert-identity "https://github.com/${{ github.repository }}/.github/workflows/sign-attest.yml@refs/heads/main" \
               --source-ref refs/heads/main \
               --source-digest "$CONTROL_SHA" \

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -236,16 +236,35 @@ jobs:
             exit 1
           fi
 
+          # Rewrite ONLY the version line in place. `jq '.version = $version'`
+          # re-serializes the whole document in jq's own style, which expands
+          # biome's single-line arrays and fails `bun run lint` on every bump
+          # (observed 2026-07-20: v5.260720.2 broke the Quality Gate and blocked
+          # promotion). A line-scoped edit also honors this job's own contract:
+          # the child commit must be a version-ONLY delta of its parent.
           for path in "${JSON_FILES[@]}"; do
-            tmp="$(mktemp)"
-            jq --arg version "$VERSION" '.version = $version' "$path" > "$tmp"
-            mv "$tmp" "$path"
+            perl -i -pe '
+              BEGIN { $version = $ENV{VERSION}; $done = 0 }
+              if (!$done && s/^(\s*"version":\s*)"[^"]*"/$1"$version"/) { $done = 1 }
+            ' "$path"
+            jq -e --arg version "$VERSION" '.version == $version' "$path" >/dev/null || {
+              echo "::error ::release-version.write_failed ${path} version was not updated in place"
+              exit 1
+            }
           done
-          tmp="$(mktemp)"
-          jq --arg version "$VERSION" '
-            .plugins |= map(if type == "object" and .name == "genie" then .version = $version else . end)
-          ' "$MARKETPLACE" > "$tmp"
-          mv "$tmp" "$MARKETPLACE"
+          # marketplace.json carries the version inside the single genie entry,
+          # so scope the edit to the line following that entry's name.
+          perl -i -pe '
+            BEGIN { $version = $ENV{VERSION}; $seen = 0; $done = 0 }
+            $seen = 1 if /^\s*"name":\s*"genie"\s*,?\s*$/;
+            if ($seen && !$done && s/^(\s*"version":\s*)"[^"]*"/$1"$version"/) { $done = 1 }
+          ' "$MARKETPLACE"
+          jq -e --arg version "$VERSION" '
+            [.plugins[]? | select(.name == "genie") | .version] == [$version]
+          ' "$MARKETPLACE" >/dev/null || {
+            echo "::error ::release-version.write_failed ${MARKETPLACE} genie version was not updated in place"
+            exit 1
+          }
           tmp="$(mktemp)"
           sed -E "s/^version: [^[:space:]]+$/version: ${VERSION}/" "$HERMES" > "$tmp"
           mv "$tmp" "$HERMES"

--- a/package.json
+++ b/package.json
@@ -7,14 +7,7 @@
   "bin": {
     "genie": "./dist/genie.js"
   },
-  "files": [
-    "dist/",
-    "skills/",
-    "plugins/genie/",
-    "templates/",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist/", "skills/", "plugins/genie/", "templates/", "README.md", "LICENSE"],
   "scripts": {
     "prepare": "test \"$CI\" = true || husky",
     "version": "bun run scripts/version.ts",
@@ -72,8 +65,5 @@
   "engines": {
     "bun": ">=1.3.10"
   },
-  "trustedDependencies": [
-    "@biomejs/biome",
-    "bun"
-  ]
+  "trustedDependencies": ["@biomejs/biome", "bun"]
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,20 @@
 {
   "name": "@automagik/genie",
-  "version": "5.260720.2",
+  "version": "5.260720.3",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
   "license": "MIT",
   "type": "module",
   "bin": {
     "genie": "./dist/genie.js"
   },
-  "files": ["dist/", "skills/", "plugins/genie/", "templates/", "README.md", "LICENSE"],
+  "files": [
+    "dist/",
+    "skills/",
+    "plugins/genie/",
+    "templates/",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "prepare": "test \"$CI\" = true || husky",
     "version": "bun run scripts/version.ts",
@@ -65,5 +72,8 @@
   "engines": {
     "bun": ">=1.3.10"
   },
-  "trustedDependencies": ["@biomejs/biome", "bun"]
+  "trustedDependencies": [
+    "@biomejs/biome",
+    "bun"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,20 @@
 {
   "name": "@automagik/genie",
-  "version": "5.260720.1",
+  "version": "5.260720.2",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
   "license": "MIT",
   "type": "module",
   "bin": {
     "genie": "./dist/genie.js"
   },
-  "files": ["dist/", "skills/", "plugins/genie/", "templates/", "README.md", "LICENSE"],
+  "files": [
+    "dist/",
+    "skills/",
+    "plugins/genie/",
+    "templates/",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "prepare": "test \"$CI\" = true || husky",
     "version": "bun run scripts/version.ts",
@@ -65,5 +72,8 @@
   "engines": {
     "bun": ">=1.3.10"
   },
-  "trustedDependencies": ["@biomejs/biome", "bun"]
+  "trustedDependencies": [
+    "@biomejs/biome",
+    "bun"
+  ]
 }

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,17 +1,26 @@
 {
   "name": "genie",
-  "version": "5.260720.2",
+  "version": "5.260720.3",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"
   },
   "repository": "https://github.com/automagik-dev/genie",
   "license": "MIT",
-  "keywords": ["workflow", "orchestration", "collaboration", "claude-code", "tmux", "agents"],
+  "keywords": [
+    "workflow",
+    "orchestration",
+    "collaboration",
+    "claude-code",
+    "tmux",
+    "agents"
+  ],
   "mcpServers": {
     "genie": {
       "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/mcp-launcher.cjs"]
+      "args": [
+        "${CLAUDE_PLUGIN_ROOT}/scripts/mcp-launcher.cjs"
+      ]
     }
   }
 }

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -7,20 +7,11 @@
   },
   "repository": "https://github.com/automagik-dev/genie",
   "license": "MIT",
-  "keywords": [
-    "workflow",
-    "orchestration",
-    "collaboration",
-    "claude-code",
-    "tmux",
-    "agents"
-  ],
+  "keywords": ["workflow", "orchestration", "collaboration", "claude-code", "tmux", "agents"],
   "mcpServers": {
     "genie": {
       "command": "node",
-      "args": [
-        "${CLAUDE_PLUGIN_ROOT}/scripts/mcp-launcher.cjs"
-      ]
+      "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/mcp-launcher.cjs"]
     }
   }
 }

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,17 +1,26 @@
 {
   "name": "genie",
-  "version": "5.260720.1",
+  "version": "5.260720.2",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"
   },
   "repository": "https://github.com/automagik-dev/genie",
   "license": "MIT",
-  "keywords": ["workflow", "orchestration", "collaboration", "claude-code", "tmux", "agents"],
+  "keywords": [
+    "workflow",
+    "orchestration",
+    "collaboration",
+    "claude-code",
+    "tmux",
+    "agents"
+  ],
   "mcpServers": {
     "genie": {
       "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/mcp-launcher.cjs"]
+      "args": [
+        "${CLAUDE_PLUGIN_ROOT}/scripts/mcp-launcher.cjs"
+      ]
     }
   }
 }

--- a/plugins/genie/.codex-plugin/plugin.json
+++ b/plugins/genie/.codex-plugin/plugin.json
@@ -9,13 +9,7 @@
   "homepage": "https://github.com/automagik-dev/genie",
   "repository": "https://github.com/automagik-dev/genie",
   "license": "MIT",
-  "keywords": [
-    "workflow",
-    "orchestration",
-    "codex",
-    "skills",
-    "agents"
-  ],
+  "keywords": ["workflow", "orchestration", "codex", "skills", "agents"],
   "skills": "./skills/",
   "hooks": "./hooks/codex-hooks.json",
   "mcpServers": "./.mcp.json",
@@ -25,11 +19,7 @@
     "longDescription": "First-class Genie workflows for Codex, including shared skills, lifecycle hooks, and MCP task state. Genie CLI setup can install optional role agents.",
     "developerName": "Namastex Labs",
     "category": "Developer Tools",
-    "capabilities": [
-      "Skills",
-      "Hooks",
-      "MCP"
-    ],
+    "capabilities": ["Skills", "Hooks", "MCP"],
     "websiteURL": "https://github.com/automagik-dev/genie",
     "defaultPrompt": [
       "Use $genie:wish to turn this request into an executable plan.",

--- a/plugins/genie/.codex-plugin/plugin.json
+++ b/plugins/genie/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260720.2",
+  "version": "5.260720.3",
   "description": "Plan, execute, review, and ship software with Genie workflows in Codex.",
   "author": {
     "name": "Namastex Labs",
@@ -9,7 +9,13 @@
   "homepage": "https://github.com/automagik-dev/genie",
   "repository": "https://github.com/automagik-dev/genie",
   "license": "MIT",
-  "keywords": ["workflow", "orchestration", "codex", "skills", "agents"],
+  "keywords": [
+    "workflow",
+    "orchestration",
+    "codex",
+    "skills",
+    "agents"
+  ],
   "skills": "./skills/",
   "hooks": "./hooks/codex-hooks.json",
   "mcpServers": "./.mcp.json",
@@ -19,7 +25,11 @@
     "longDescription": "First-class Genie workflows for Codex, including shared skills, lifecycle hooks, and MCP task state. Genie CLI setup can install optional role agents.",
     "developerName": "Namastex Labs",
     "category": "Developer Tools",
-    "capabilities": ["Skills", "Hooks", "MCP"],
+    "capabilities": [
+      "Skills",
+      "Hooks",
+      "MCP"
+    ],
     "websiteURL": "https://github.com/automagik-dev/genie",
     "defaultPrompt": [
       "Use $genie:wish to turn this request into an executable plan.",

--- a/plugins/genie/.codex-plugin/plugin.json
+++ b/plugins/genie/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260720.1",
+  "version": "5.260720.2",
   "description": "Plan, execute, review, and ship software with Genie workflows in Codex.",
   "author": {
     "name": "Namastex Labs",
@@ -9,7 +9,13 @@
   "homepage": "https://github.com/automagik-dev/genie",
   "repository": "https://github.com/automagik-dev/genie",
   "license": "MIT",
-  "keywords": ["workflow", "orchestration", "codex", "skills", "agents"],
+  "keywords": [
+    "workflow",
+    "orchestration",
+    "codex",
+    "skills",
+    "agents"
+  ],
   "skills": "./skills/",
   "hooks": "./hooks/codex-hooks.json",
   "mcpServers": "./.mcp.json",
@@ -19,7 +25,11 @@
     "longDescription": "First-class Genie workflows for Codex, including shared skills, lifecycle hooks, and MCP task state. Genie CLI setup can install optional role agents.",
     "developerName": "Namastex Labs",
     "category": "Developer Tools",
-    "capabilities": ["Skills", "Hooks", "MCP"],
+    "capabilities": [
+      "Skills",
+      "Hooks",
+      "MCP"
+    ],
     "websiteURL": "https://github.com/automagik-dev/genie",
     "defaultPrompt": [
       "Use $genie:wish to turn this request into an executable plan.",

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "5.260720.1",
+  "version": "5.260720.2",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "license": "MIT",

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "5.260720.2",
+  "version": "5.260720.3",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "license": "MIT",

--- a/plugins/hermes-genie/plugin.yaml
+++ b/plugins/hermes-genie/plugin.yaml
@@ -1,5 +1,5 @@
 name: genie
-version: 5.260720.1
+version: 5.260720.2
 description: "Native Hermes surface for Genie orchestration: read-only status plus work-plan and review-plan gap tools that the MCP board surface does not cover, hooks, commands, and a thin cockpit skill. Board/task truth comes from the genie MCP tools."
 provides_tools:
   # Default surface: exactly the three gap tools the MCP board surface does not cover.

--- a/plugins/hermes-genie/plugin.yaml
+++ b/plugins/hermes-genie/plugin.yaml
@@ -1,5 +1,5 @@
 name: genie
-version: 5.260720.2
+version: 5.260720.3
 description: "Native Hermes surface for Genie orchestration: read-only status plus work-plan and review-plan gap tools that the MCP board surface does not cover, hooks, commands, and a thin cockpit skill. Board/task truth comes from the genie MCP tools."
 provides_tools:
   # Default surface: exactly the three gap tools the MCP board surface does not cover.

--- a/scripts/reconcile-release-assets.sh
+++ b/scripts/reconcile-release-assets.sh
@@ -151,7 +151,7 @@ if remote_is_complete; then
     result="$WORK_ROOT/native-${platform}.json"
     gh attestation verify "$tarball" \
       --repo "$RELEASE_REPOSITORY" \
-      --predicate-type https://slsa.dev/provenance/v1 \
+      --predicate-type "https://github.com/${RELEASE_REPOSITORY}/release-tarballs@v1" \
       --cert-identity "https://github.com/${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml@refs/heads/main" \
       --source-ref refs/heads/main \
       --signer-workflow "${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml" \
@@ -161,7 +161,7 @@ if remote_is_complete; then
     exact_result="$WORK_ROOT/native-exact-${platform}.json"
     gh attestation verify "$tarball" \
       --repo "$RELEASE_REPOSITORY" \
-      --predicate-type https://slsa.dev/provenance/v1 \
+      --predicate-type "https://github.com/${RELEASE_REPOSITORY}/release-tarballs@v1" \
       --cert-identity "https://github.com/${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml@refs/heads/main" \
       --source-ref refs/heads/main \
       --source-digest "$remote_control_sha" \

--- a/scripts/reconcile-release-assets.test.ts
+++ b/scripts/reconcile-release-assets.test.ts
@@ -90,7 +90,7 @@ if (args[0] === 'attestation' && args[1] === 'verify') {
   const sourceSha = state.invalidNative ? 'not-a-sha' : 'a'.repeat(40);
   const predicateControlSha = digest && state.secondControlSha ? state.secondControlSha : state.controlSha;
   const statement = {
-    predicateType: 'https://slsa.dev/provenance/v1',
+    predicateType: 'https://github.com/automagik-dev/genie/release-tarballs@v1',
     predicate: {
       runDetails: { builder: { id: 'https://github.com/automagik-dev/genie/.github/workflows/sign-attest.yml@refs/heads/main' } },
       buildDefinition: {

--- a/scripts/release-native-predicate.sh
+++ b/scripts/release-native-predicate.sh
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 
-PREDICATE_TYPE='https://slsa.dev/provenance/v1'
 : "${RELEASE_REPOSITORY:?RELEASE_REPOSITORY is required}"
 : "${VERSION:?VERSION is required}"
 
@@ -11,6 +10,13 @@ PREDICATE_TYPE='https://slsa.dev/provenance/v1'
 
 BUILDER_ID="https://github.com/${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml@refs/heads/main"
 BUILD_TYPE="https://github.com/${RELEASE_REPOSITORY}/release-tarballs@v1"
+# The statement predicateType is the custom buildType URI, NOT
+# https://slsa.dev/provenance/v1: GitHub's attestation persistence API runs
+# SLSA-provenance validation for that type and rejects non-allowlisted
+# buildTypes ("unsupported build type", observed 2026-07-20 on the first
+# stable run). A custom predicate type skips that validation while keeping
+# the SLSA-v1-shaped body; every verifier passes the same --predicate-type.
+PREDICATE_TYPE="$BUILD_TYPE"
 
 require_exact_identity() {
   : "${CHANNEL:?CHANNEL is required}"

--- a/scripts/release-native-predicate.test.ts
+++ b/scripts/release-native-predicate.test.ts
@@ -68,7 +68,7 @@ describe('native release attestation predicate', () => {
     const verification = [
       {
         verificationResult: {
-          statement: { predicateType: 'https://slsa.dev/provenance/v1', predicate },
+          statement: { predicateType: 'https://github.com/automagik-dev/genie/release-tarballs@v1', predicate },
         },
       },
     ];
@@ -101,7 +101,7 @@ describe('native release attestation predicate', () => {
     const result = [
       {
         verificationResult: {
-          statement: { predicateType: 'https://slsa.dev/provenance/v1', predicate },
+          statement: { predicateType: 'https://github.com/automagik-dev/genie/release-tarballs@v1', predicate },
         },
       },
     ];


### PR DESCRIPTION
Promotes the release-pipeline fix so the stable channel can publish.

## Why this is needed

The first stable run of the new pipeline ([29720262451](https://github.com/automagik-dev/genie/actions/runs/29720262451)) failed in all four Sign jobs — `unsupported build type` — because `actions/attest` declared `predicate-type: https://slsa.dev/provenance/v1` while the predicate carries a repo-specific `buildType`. GitHub's Attestations API validates SLSA-typed payloads against an allowlist of buildTypes and rejected ours, so `publish` was skipped and no stable release was produced.

PR #2597 fixed it on `dev`, but the stable pipeline resolves `sign-attest.yml` from **main** — so the fix only takes effect once it lands here.

## Contents

- #2597 — publish the native attestation under its custom `buildType` URI; predicate body and every binding check unchanged; cosign + SLSA L3 trust anchors untouched
- `chore(version): bump to 5.260720.2`

## After merge

Stable release dispatch for **v5.260720.2** (Version prints the exact inputs on the main-CI promotion path), then production-environment approval.

Note: `v5.260720.1` is tagged but never published — superseded by this version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated release artifact signing and attestation verification to use repository-specific predicate metadata (`release-tarballs@v1`) for consistent tamper detection and self-check behavior.
* **Chores**
  * Bumped package and plugin versions to **5.260720.3** across release/version manifests.
  * Improved the release-version synchronization workflow to update only version fields in-place and verify the expected updates afterward.
* **Tests**
  * Updated attestation verification test expectations to match the new repository-specific predicate metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->