### PR TITLE
fix(release): keep version bumps format-preserving and lint-clean

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -236,16 +236,35 @@ jobs:
             exit 1
           fi
 
+          # Rewrite ONLY the version line in place. `jq '.version = $version'`
+          # re-serializes the whole document in jq's own style, which expands
+          # biome's single-line arrays and fails `bun run lint` on every bump
+          # (observed 2026-07-20: v5.260720.2 broke the Quality Gate and blocked
+          # promotion). A line-scoped edit also honors this job's own contract:
+          # the child commit must be a version-ONLY delta of its parent.
           for path in "${JSON_FILES[@]}"; do
-            tmp="$(mktemp)"
-            jq --arg version "$VERSION" '.version = $version' "$path" > "$tmp"
-            mv "$tmp" "$path"
+            perl -i -pe '
+              BEGIN { $version = $ENV{VERSION}; $done = 0 }
+              if (!$done && s/^(\s*"version":\s*)"[^"]*"/$1"$version"/) { $done = 1 }
+            ' "$path"
+            jq -e --arg version "$VERSION" '.version == $version' "$path" >/dev/null || {
+              echo "::error ::release-version.write_failed ${path} version was not updated in place"
+              exit 1
+            }
           done
-          tmp="$(mktemp)"
-          jq --arg version "$VERSION" '
-            .plugins |= map(if type == "object" and .name == "genie" then .version = $version else . end)
-          ' "$MARKETPLACE" > "$tmp"
-          mv "$tmp" "$MARKETPLACE"
+          # marketplace.json carries the version inside the single genie entry,
+          # so scope the edit to the line following that entry's name.
+          perl -i -pe '
+            BEGIN { $version = $ENV{VERSION}; $seen = 0; $done = 0 }
+            $seen = 1 if /^\s*"name":\s*"genie"\s*,?\s*$/;
+            if ($seen && !$done && s/^(\s*"version":\s*)"[^"]*"/$1"$version"/) { $done = 1 }
+          ' "$MARKETPLACE"
+          jq -e --arg version "$VERSION" '
+            [.plugins[]? | select(.name == "genie") | .version] == [$version]
+          ' "$MARKETPLACE" >/dev/null || {
+            echo "::error ::release-version.write_failed ${MARKETPLACE} genie version was not updated in place"
+            exit 1
+          }
           tmp="$(mktemp)"
           sed -E "s/^version: [^[:space:]]+$/version: ${VERSION}/" "$HERMES" > "$tmp"
           mv "$tmp" "$HERMES"

--- a/package.json
+++ b/package.json
@@ -7,14 +7,7 @@
   "bin": {
     "genie": "./dist/genie.js"
   },
-  "files": [
-    "dist/",
-    "skills/",
-    "plugins/genie/",
-    "templates/",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist/", "skills/", "plugins/genie/", "templates/", "README.md", "LICENSE"],
   "scripts": {
     "prepare": "test \"$CI\" = true || husky",
     "version": "bun run scripts/version.ts",
@@ -72,8 +65,5 @@
   "engines": {
     "bun": ">=1.3.10"
   },
-  "trustedDependencies": [
-    "@biomejs/biome",
-    "bun"
-  ]
+  "trustedDependencies": ["@biomejs/biome", "bun"]
 }

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -7,20 +7,11 @@
   },
   "repository": "https://github.com/automagik-dev/genie",
   "license": "MIT",
-  "keywords": [
-    "workflow",
-    "orchestration",
-    "collaboration",
-    "claude-code",
-    "tmux",
-    "agents"
-  ],
+  "keywords": ["workflow", "orchestration", "collaboration", "claude-code", "tmux", "agents"],
   "mcpServers": {
     "genie": {
       "command": "node",
-      "args": [
-        "${CLAUDE_PLUGIN_ROOT}/scripts/mcp-launcher.cjs"
-      ]
+      "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/mcp-launcher.cjs"]
     }
   }
 }

--- a/plugins/genie/.codex-plugin/plugin.json
+++ b/plugins/genie/.codex-plugin/plugin.json
@@ -9,13 +9,7 @@
   "homepage": "https://github.com/automagik-dev/genie",
   "repository": "https://github.com/automagik-dev/genie",
   "license": "MIT",
-  "keywords": [
-    "workflow",
-    "orchestration",
-    "codex",
-    "skills",
-    "agents"
-  ],
+  "keywords": ["workflow", "orchestration", "codex", "skills", "agents"],
   "skills": "./skills/",
   "hooks": "./hooks/codex-hooks.json",
   "mcpServers": "./.mcp.json",
@@ -25,11 +19,7 @@
     "longDescription": "First-class Genie workflows for Codex, including shared skills, lifecycle hooks, and MCP task state. Genie CLI setup can install optional role agents.",
     "developerName": "Namastex Labs",
     "category": "Developer Tools",
-    "capabilities": [
-      "Skills",
-      "Hooks",
-      "MCP"
-    ],
+    "capabilities": ["Skills", "Hooks", "MCP"],
     "websiteURL": "https://github.com/automagik-dev/genie",
     "defaultPrompt": [
       "Use $genie:wish to turn this request into an executable plan.",


### PR DESCRIPTION
## Problem

The `v5.260720.2` auto-version commit ([8255ee04](https://github.com/automagik-dev/genie/commit/8255ee04)) **reformatted** `package.json`, `plugins/genie/.claude-plugin/plugin.json`, and `plugins/genie/.codex-plugin/plugin.json` — biome's single-line arrays were expanded to one element per line. `bun run lint` fails, so **Quality Gate failed on the dev→main promotion PR #2598** and nothing can be promoted or released.

## Why this is a deadlock, not a one-off

The new `version.yml` writes each manifest with:

```bash
jq --arg version "$VERSION" '.version = $version' "$path" > "$tmp"
```

`jq` re-serializes the *entire document* in its own style rather than editing the version in place. So **every** future auto-version bump reformats these files and breaks lint. Since promotion requires a green Quality Gate, and every release version is produced by this job, the pipeline could never ship again without manual repair after each bump.

It also violates this job's own stated contract — that the child commit be a **version-only** delta of its parent (the release guard's `version_child_matches_parent` check survives only because it compares semantically).

## Fix

Rewrite only the version line:

- **Four JSON manifests** — `perl` replaces the first top-level `"version"` line. Verified it leaves `package.json`'s `"version": "bun run scripts/version.ts"` *script* entry untouched (only line 3 changes).
- **marketplace.json** — the edit is scoped to the line following the single `genie` entry's `"name"`.
- **Each write is asserted** with `jq -e` afterward, so a pattern that silently fails to match errors loudly instead of tagging a release whose manifests still carry the old version.

Also restores the three reformatted manifests to canonical biome formatting. **Versions are unchanged** (`5.260720.2`).

## Verification

- `bun run lint` and `bun run typecheck` clean on this branch
- Perl rewrite exercised against the real `package.json` and `marketplace.json`: exactly one line changes per file, the script entry is skipped, and the nested genie version updates correctly
- Real proof is the next auto-version bump landing lint-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)