### PR TITLE
fix(release): unskip non-stable channels and drop the conflicting signer-workflow flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,11 @@ jobs:
 
   build:
     needs: authorize
+    # always() + explicit result check: the default success() status is
+    # poisoned transitively by the SKIPPED approve-stable job on dev/homolog
+    # (observed 2026-07-20: the v5.260720.4 dev release chain silently skipped
+    # build/sign/publish). authorize alone decides admission.
+    if: always() && needs.authorize.result == 'success'
     uses: ./.github/workflows/build-tarballs.yml
     permissions:
       contents: read
@@ -153,6 +158,7 @@ jobs:
 
   sign-attest:
     needs: build
+    if: always() && needs.build.result == 'success'
     uses: ./.github/workflows/sign-attest.yml
     permissions:
       contents: write
@@ -168,6 +174,7 @@ jobs:
 
   publish:
     needs: sign-attest
+    if: always() && needs.sign-attest.result == 'success'
     uses: ./.github/workflows/release-publish.yml
     permissions:
       contents: write

--- a/.github/workflows/sign-attest.yml
+++ b/.github/workflows/sign-attest.yml
@@ -427,7 +427,6 @@ jobs:
             --source-ref refs/heads/main \
             --source-digest "$CONTROL_SHA" \
             --signer-digest "$CONTROL_SHA" \
-            --signer-workflow "${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml" \
             --format json >"$RESULT"
           bash scripts/release-native-predicate.sh verify "$RESULT"
 
@@ -496,8 +495,7 @@ jobs:
               --cert-identity "https://github.com/${{ github.repository }}/.github/workflows/sign-attest.yml@refs/heads/main" \
               --source-ref refs/heads/main \
               --source-digest "$CONTROL_SHA" \
-              --signer-digest "$CONTROL_SHA" \
-              --signer-workflow "${{ github.repository }}/.github/workflows/sign-attest.yml" > /tmp/gh-tamper.log 2>&1; then
+              --signer-digest "$CONTROL_SHA" > /tmp/gh-tamper.log 2>&1; then
             echo "::error::gh attestation verify accepted a mutated tarball — Attestations API contract broken"
             cat /tmp/gh-tamper.log >&2 || true
             exit 1

--- a/scripts/reconcile-release-assets.sh
+++ b/scripts/reconcile-release-assets.sh
@@ -154,7 +154,6 @@ if remote_is_complete; then
       --predicate-type "https://github.com/${RELEASE_REPOSITORY}/release-tarballs@v1" \
       --cert-identity "https://github.com/${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml@refs/heads/main" \
       --source-ref refs/heads/main \
-      --signer-workflow "${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml" \
       --format json >"$result"
     native_helper="$(dirname "$0")/release-native-predicate.sh"
     remote_control_sha="$(bash "$native_helper" reusable-control-sha "$result")"
@@ -166,7 +165,6 @@ if remote_is_complete; then
       --source-ref refs/heads/main \
       --source-digest "$remote_control_sha" \
       --signer-digest "$remote_control_sha" \
-      --signer-workflow "${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml" \
       --format json >"$exact_result"
     exact_control_sha="$(bash "$native_helper" reusable-control-sha "$exact_result")"
     [[ "$exact_control_sha" == "$remote_control_sha" ]] || {

--- a/scripts/release-docs.test.ts
+++ b/scripts/release-docs.test.ts
@@ -132,7 +132,11 @@ describe('Group E release and documentation contracts', () => {
     );
     expect(read('scripts/release-generic-provenance.sh')).toContain('workflow_run');
     expect(signing).toContain('--source-digest "$CONTROL_SHA"');
-    expect(signing).toContain('--signer-workflow "${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml"');
+    // gh's flag group [cert-identity cert-identity-regex signer-repo
+    // signer-workflow] is mutually exclusive; --cert-identity is the pinned
+    // identity, so --signer-workflow must never reappear beside it (observed
+    // 2026-07-20: the combination hard-fails gh attestation verify).
+    expect(signing).not.toContain('--signer-workflow');
   });
 
   test('stable approval is explicit while dev and homolog remain automated', () => {


### PR DESCRIPTION
Two first-run pipeline defects from the v5.260720.4 attempt: (1) skipped approve-stable transitively skips build/sign/publish on dev/homolog — explicit always()+result admissions fix it; (2) gh attestation verify rejects --cert-identity combined with --signer-workflow (exclusive flag group) — dropped the redundant flag everywhere, absence pinned by release-docs.test.ts. Details in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)