### PR TITLE
release: dev → main — v5.260720.5 (release-chain first-run fixes)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "5.260720.4",
+      "version": "5.260720.5",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,11 @@ jobs:
 
   build:
     needs: authorize
+    # always() + explicit result check: the default success() status is
+    # poisoned transitively by the SKIPPED approve-stable job on dev/homolog
+    # (observed 2026-07-20: the v5.260720.4 dev release chain silently skipped
+    # build/sign/publish). authorize alone decides admission.
+    if: always() && needs.authorize.result == 'success'
     uses: ./.github/workflows/build-tarballs.yml
     permissions:
       contents: read
@@ -153,6 +158,7 @@ jobs:
 
   sign-attest:
     needs: build
+    if: always() && needs.build.result == 'success'
     uses: ./.github/workflows/sign-attest.yml
     permissions:
       contents: write
@@ -168,6 +174,7 @@ jobs:
 
   publish:
     needs: sign-attest
+    if: always() && needs.sign-attest.result == 'success'
     uses: ./.github/workflows/release-publish.yml
     permissions:
       contents: write

--- a/.github/workflows/sign-attest.yml
+++ b/.github/workflows/sign-attest.yml
@@ -427,7 +427,6 @@ jobs:
             --source-ref refs/heads/main \
             --source-digest "$CONTROL_SHA" \
             --signer-digest "$CONTROL_SHA" \
-            --signer-workflow "${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml" \
             --format json >"$RESULT"
           bash scripts/release-native-predicate.sh verify "$RESULT"
 
@@ -496,8 +495,7 @@ jobs:
               --cert-identity "https://github.com/${{ github.repository }}/.github/workflows/sign-attest.yml@refs/heads/main" \
               --source-ref refs/heads/main \
               --source-digest "$CONTROL_SHA" \
-              --signer-digest "$CONTROL_SHA" \
-              --signer-workflow "${{ github.repository }}/.github/workflows/sign-attest.yml" > /tmp/gh-tamper.log 2>&1; then
+              --signer-digest "$CONTROL_SHA" > /tmp/gh-tamper.log 2>&1; then
             echo "::error::gh attestation verify accepted a mutated tarball — Attestations API contract broken"
             cat /tmp/gh-tamper.log >&2 || true
             exit 1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/genie",
-  "version": "5.260720.4",
+  "version": "5.260720.5",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
   "license": "MIT",
   "type": "module",

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260720.4",
+  "version": "5.260720.5",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/.codex-plugin/plugin.json
+++ b/plugins/genie/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260720.4",
+  "version": "5.260720.5",
   "description": "Plan, execute, review, and ship software with Genie workflows in Codex.",
   "author": {
     "name": "Namastex Labs",

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "5.260720.4",
+  "version": "5.260720.5",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "license": "MIT",

--- a/plugins/hermes-genie/plugin.yaml
+++ b/plugins/hermes-genie/plugin.yaml
@@ -1,5 +1,5 @@
 name: genie
-version: 5.260720.4
+version: 5.260720.5
 description: "Native Hermes surface for Genie orchestration: read-only status plus work-plan and review-plan gap tools that the MCP board surface does not cover, hooks, commands, and a thin cockpit skill. Board/task truth comes from the genie MCP tools."
 provides_tools:
   # Default surface: exactly the three gap tools the MCP board surface does not cover.

--- a/scripts/reconcile-release-assets.sh
+++ b/scripts/reconcile-release-assets.sh
@@ -154,7 +154,6 @@ if remote_is_complete; then
       --predicate-type "https://github.com/${RELEASE_REPOSITORY}/release-tarballs@v1" \
       --cert-identity "https://github.com/${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml@refs/heads/main" \
       --source-ref refs/heads/main \
-      --signer-workflow "${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml" \
       --format json >"$result"
     native_helper="$(dirname "$0")/release-native-predicate.sh"
     remote_control_sha="$(bash "$native_helper" reusable-control-sha "$result")"
@@ -166,7 +165,6 @@ if remote_is_complete; then
       --source-ref refs/heads/main \
       --source-digest "$remote_control_sha" \
       --signer-digest "$remote_control_sha" \
-      --signer-workflow "${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml" \
       --format json >"$exact_result"
     exact_control_sha="$(bash "$native_helper" reusable-control-sha "$exact_result")"
     [[ "$exact_control_sha" == "$remote_control_sha" ]] || {

--- a/scripts/release-docs.test.ts
+++ b/scripts/release-docs.test.ts
@@ -132,7 +132,11 @@ describe('Group E release and documentation contracts', () => {
     );
     expect(read('scripts/release-generic-provenance.sh')).toContain('workflow_run');
     expect(signing).toContain('--source-digest "$CONTROL_SHA"');
-    expect(signing).toContain('--signer-workflow "${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml"');
+    // gh's flag group [cert-identity cert-identity-regex signer-repo
+    // signer-workflow] is mutually exclusive; --cert-identity is the pinned
+    // identity, so --signer-workflow must never reappear beside it (observed
+    // 2026-07-20: the combination hard-fails gh attestation verify).
+    expect(signing).not.toContain('--signer-workflow');
   });
 
   test('stable approval is explicit while dev and homolog remain automated', () => {


### PR DESCRIPTION
Promotes the skip-cascade and signer-workflow flag fixes (#2601) plus the v5.260720.5 bump so the stable chain can run them from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the Genie plugin and package version to 5.260720.5.

* **Bug Fixes**
  * Improved release workflow job gating to prevent downstream steps from running after failed prerequisites.
  * Updated attestation verification to use certificate, source, and digest checks for more reliable validation.

* **Tests**
  * Updated release verification tests to reflect the revised attestation validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->