### PR TITLE
fix(release): use a slash predicate-type URI the attestations query API accepts

### DIFF
--- a/.github/workflows/sign-attest.yml
+++ b/.github/workflows/sign-attest.yml
@@ -344,7 +344,7 @@ jobs:
           # Custom predicate type (same URI as the predicate's buildType):
           # claiming https://slsa.dev/provenance/v1 makes GitHub's attestation
           # API run SLSA validation, which rejects our custom buildType.
-          predicate-type: https://github.com/${{ github.repository }}/release-tarballs@v1
+          predicate-type: https://github.com/${{ github.repository }}/release-tarballs/v1
           predicate-path: ${{ runner.temp }}/genie-native-${{ matrix.platform }}.json
 
       - name: Verify cosign bundle (self-check)
@@ -422,7 +422,7 @@ jobs:
           RESULT="${RUNNER_TEMP}/genie-native-result-${PLATFORM}.json"
           gh attestation verify "${TARBALL}" \
             --repo "$RELEASE_REPOSITORY" \
-            --predicate-type "https://github.com/${RELEASE_REPOSITORY}/release-tarballs@v1" \
+            --predicate-type "https://github.com/${RELEASE_REPOSITORY}/release-tarballs/v1" \
             --cert-identity "https://github.com/${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml@refs/heads/main" \
             --source-ref refs/heads/main \
             --source-digest "$CONTROL_SHA" \
@@ -491,7 +491,7 @@ jobs:
           echo "-> Expecting gh attestation verify to REJECT mutated tarball"
           if gh attestation verify "${MUTATED}" \
               --repo "${{ github.repository }}" \
-              --predicate-type "https://github.com/${{ github.repository }}/release-tarballs@v1" \
+              --predicate-type "https://github.com/${{ github.repository }}/release-tarballs/v1" \
               --cert-identity "https://github.com/${{ github.repository }}/.github/workflows/sign-attest.yml@refs/heads/main" \
               --source-ref refs/heads/main \
               --source-digest "$CONTROL_SHA" \

--- a/scripts/reconcile-release-assets.sh
+++ b/scripts/reconcile-release-assets.sh
@@ -151,7 +151,7 @@ if remote_is_complete; then
     result="$WORK_ROOT/native-${platform}.json"
     gh attestation verify "$tarball" \
       --repo "$RELEASE_REPOSITORY" \
-      --predicate-type "https://github.com/${RELEASE_REPOSITORY}/release-tarballs@v1" \
+      --predicate-type "https://github.com/${RELEASE_REPOSITORY}/release-tarballs/v1" \
       --cert-identity "https://github.com/${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml@refs/heads/main" \
       --source-ref refs/heads/main \
       --format json >"$result"
@@ -160,7 +160,7 @@ if remote_is_complete; then
     exact_result="$WORK_ROOT/native-exact-${platform}.json"
     gh attestation verify "$tarball" \
       --repo "$RELEASE_REPOSITORY" \
-      --predicate-type "https://github.com/${RELEASE_REPOSITORY}/release-tarballs@v1" \
+      --predicate-type "https://github.com/${RELEASE_REPOSITORY}/release-tarballs/v1" \
       --cert-identity "https://github.com/${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml@refs/heads/main" \
       --source-ref refs/heads/main \
       --source-digest "$remote_control_sha" \

--- a/scripts/reconcile-release-assets.test.ts
+++ b/scripts/reconcile-release-assets.test.ts
@@ -90,11 +90,11 @@ if (args[0] === 'attestation' && args[1] === 'verify') {
   const sourceSha = state.invalidNative ? 'not-a-sha' : 'a'.repeat(40);
   const predicateControlSha = digest && state.secondControlSha ? state.secondControlSha : state.controlSha;
   const statement = {
-    predicateType: 'https://github.com/automagik-dev/genie/release-tarballs@v1',
+    predicateType: 'https://github.com/automagik-dev/genie/release-tarballs/v1',
     predicate: {
       runDetails: { builder: { id: 'https://github.com/automagik-dev/genie/.github/workflows/sign-attest.yml@refs/heads/main' } },
       buildDefinition: {
-        buildType: 'https://github.com/automagik-dev/genie/release-tarballs@v1',
+        buildType: 'https://github.com/automagik-dev/genie/release-tarballs/v1',
         externalParameters: {
           version: '${VERSION}', channel: 'dev', source_sha: sourceSha, source_branch: 'dev',
           source_ci_run_id: '123', control_sha: predicateControlSha,

--- a/scripts/release-native-predicate.sh
+++ b/scripts/release-native-predicate.sh
@@ -9,13 +9,16 @@ set -euo pipefail
 [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || exit 2
 
 BUILDER_ID="https://github.com/${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml@refs/heads/main"
-BUILD_TYPE="https://github.com/${RELEASE_REPOSITORY}/release-tarballs@v1"
+BUILD_TYPE="https://github.com/${RELEASE_REPOSITORY}/release-tarballs/v1"
 # The statement predicateType is the custom buildType URI, NOT
 # https://slsa.dev/provenance/v1: GitHub's attestation persistence API runs
 # SLSA-provenance validation for that type and rejects non-allowlisted
 # buildTypes ("unsupported build type", observed 2026-07-20 on the first
 # stable run). A custom predicate type skips that validation while keeping
 # the SLSA-v1-shaped body; every verifier passes the same --predicate-type.
+# The URI must not contain '@': the attestations QUERY API rejects it as an
+# invalid predicate_type (HTTP 422, observed 2026-07-20) even though the
+# write API accepts it — hence /v1, not @v1.
 PREDICATE_TYPE="$BUILD_TYPE"
 
 require_exact_identity() {

--- a/scripts/release-native-predicate.test.ts
+++ b/scripts/release-native-predicate.test.ts
@@ -68,7 +68,7 @@ describe('native release attestation predicate', () => {
     const verification = [
       {
         verificationResult: {
-          statement: { predicateType: 'https://github.com/automagik-dev/genie/release-tarballs@v1', predicate },
+          statement: { predicateType: 'https://github.com/automagik-dev/genie/release-tarballs/v1', predicate },
         },
       },
     ];
@@ -101,7 +101,7 @@ describe('native release attestation predicate', () => {
     const result = [
       {
         verificationResult: {
-          statement: { predicateType: 'https://github.com/automagik-dev/genie/release-tarballs@v1', predicate },
+          statement: { predicateType: 'https://github.com/automagik-dev/genie/release-tarballs/v1', predicate },
         },
       },
     ];
@@ -115,7 +115,7 @@ describe('native release attestation predicate', () => {
     writeFileSync(resultPath, JSON.stringify(result));
     expect(invoke('reusable-control-sha', resultPath).exitCode).not.toBe(0);
 
-    predicate.buildDefinition.buildType = 'https://github.com/automagik-dev/genie/release-tarballs@v1';
+    predicate.buildDefinition.buildType = 'https://github.com/automagik-dev/genie/release-tarballs/v1';
     predicate.buildDefinition.resolvedDependencies[1].digest.gitCommit = 'd'.repeat(40);
     writeFileSync(resultPath, JSON.stringify(result));
     expect(invoke('reusable-control-sha', resultPath).exitCode).not.toBe(0);


### PR DESCRIPTION
GitHub's attestations query API rejects predicate_type values containing '@' (HTTP 422) while the write API accepts them — so v5.260720.5's native attestations persisted but were unfindable by the self-checks. Verified against the live API. Predicate type/buildType become `release-tarballs/v1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)