### PR TITLE
release: dev → main — v5.260720.6 (query-safe predicate type)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "5.260720.5",
+      "version": "5.260720.6",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/.github/workflows/sign-attest.yml
+++ b/.github/workflows/sign-attest.yml
@@ -344,7 +344,7 @@ jobs:
           # Custom predicate type (same URI as the predicate's buildType):
           # claiming https://slsa.dev/provenance/v1 makes GitHub's attestation
           # API run SLSA validation, which rejects our custom buildType.
-          predicate-type: https://github.com/${{ github.repository }}/release-tarballs@v1
+          predicate-type: https://github.com/${{ github.repository }}/release-tarballs/v1
           predicate-path: ${{ runner.temp }}/genie-native-${{ matrix.platform }}.json
 
       - name: Verify cosign bundle (self-check)
@@ -422,7 +422,7 @@ jobs:
           RESULT="${RUNNER_TEMP}/genie-native-result-${PLATFORM}.json"
           gh attestation verify "${TARBALL}" \
             --repo "$RELEASE_REPOSITORY" \
-            --predicate-type "https://github.com/${RELEASE_REPOSITORY}/release-tarballs@v1" \
+            --predicate-type "https://github.com/${RELEASE_REPOSITORY}/release-tarballs/v1" \
             --cert-identity "https://github.com/${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml@refs/heads/main" \
             --source-ref refs/heads/main \
             --source-digest "$CONTROL_SHA" \
@@ -491,7 +491,7 @@ jobs:
           echo "-> Expecting gh attestation verify to REJECT mutated tarball"
           if gh attestation verify "${MUTATED}" \
               --repo "${{ github.repository }}" \
-              --predicate-type "https://github.com/${{ github.repository }}/release-tarballs@v1" \
+              --predicate-type "https://github.com/${{ github.repository }}/release-tarballs/v1" \
               --cert-identity "https://github.com/${{ github.repository }}/.github/workflows/sign-attest.yml@refs/heads/main" \
               --source-ref refs/heads/main \
               --source-digest "$CONTROL_SHA" \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/genie",
-  "version": "5.260720.5",
+  "version": "5.260720.6",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
   "license": "MIT",
   "type": "module",

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260720.5",
+  "version": "5.260720.6",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/.codex-plugin/plugin.json
+++ b/plugins/genie/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260720.5",
+  "version": "5.260720.6",
   "description": "Plan, execute, review, and ship software with Genie workflows in Codex.",
   "author": {
     "name": "Namastex Labs",

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "5.260720.5",
+  "version": "5.260720.6",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "license": "MIT",

--- a/plugins/hermes-genie/plugin.yaml
+++ b/plugins/hermes-genie/plugin.yaml
@@ -1,5 +1,5 @@
 name: genie
-version: 5.260720.5
+version: 5.260720.6
 description: "Native Hermes surface for Genie orchestration: read-only status plus work-plan and review-plan gap tools that the MCP board surface does not cover, hooks, commands, and a thin cockpit skill. Board/task truth comes from the genie MCP tools."
 provides_tools:
   # Default surface: exactly the three gap tools the MCP board surface does not cover.

--- a/scripts/reconcile-release-assets.sh
+++ b/scripts/reconcile-release-assets.sh
@@ -151,7 +151,7 @@ if remote_is_complete; then
     result="$WORK_ROOT/native-${platform}.json"
     gh attestation verify "$tarball" \
       --repo "$RELEASE_REPOSITORY" \
-      --predicate-type "https://github.com/${RELEASE_REPOSITORY}/release-tarballs@v1" \
+      --predicate-type "https://github.com/${RELEASE_REPOSITORY}/release-tarballs/v1" \
       --cert-identity "https://github.com/${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml@refs/heads/main" \
       --source-ref refs/heads/main \
       --format json >"$result"
@@ -160,7 +160,7 @@ if remote_is_complete; then
     exact_result="$WORK_ROOT/native-exact-${platform}.json"
     gh attestation verify "$tarball" \
       --repo "$RELEASE_REPOSITORY" \
-      --predicate-type "https://github.com/${RELEASE_REPOSITORY}/release-tarballs@v1" \
+      --predicate-type "https://github.com/${RELEASE_REPOSITORY}/release-tarballs/v1" \
       --cert-identity "https://github.com/${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml@refs/heads/main" \
       --source-ref refs/heads/main \
       --source-digest "$remote_control_sha" \

--- a/scripts/reconcile-release-assets.test.ts
+++ b/scripts/reconcile-release-assets.test.ts
@@ -90,11 +90,11 @@ if (args[0] === 'attestation' && args[1] === 'verify') {
   const sourceSha = state.invalidNative ? 'not-a-sha' : 'a'.repeat(40);
   const predicateControlSha = digest && state.secondControlSha ? state.secondControlSha : state.controlSha;
   const statement = {
-    predicateType: 'https://github.com/automagik-dev/genie/release-tarballs@v1',
+    predicateType: 'https://github.com/automagik-dev/genie/release-tarballs/v1',
     predicate: {
       runDetails: { builder: { id: 'https://github.com/automagik-dev/genie/.github/workflows/sign-attest.yml@refs/heads/main' } },
       buildDefinition: {
-        buildType: 'https://github.com/automagik-dev/genie/release-tarballs@v1',
+        buildType: 'https://github.com/automagik-dev/genie/release-tarballs/v1',
         externalParameters: {
           version: '${VERSION}', channel: 'dev', source_sha: sourceSha, source_branch: 'dev',
           source_ci_run_id: '123', control_sha: predicateControlSha,

--- a/scripts/release-native-predicate.sh
+++ b/scripts/release-native-predicate.sh
@@ -9,13 +9,16 @@ set -euo pipefail
 [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || exit 2
 
 BUILDER_ID="https://github.com/${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml@refs/heads/main"
-BUILD_TYPE="https://github.com/${RELEASE_REPOSITORY}/release-tarballs@v1"
+BUILD_TYPE="https://github.com/${RELEASE_REPOSITORY}/release-tarballs/v1"
 # The statement predicateType is the custom buildType URI, NOT
 # https://slsa.dev/provenance/v1: GitHub's attestation persistence API runs
 # SLSA-provenance validation for that type and rejects non-allowlisted
 # buildTypes ("unsupported build type", observed 2026-07-20 on the first
 # stable run). A custom predicate type skips that validation while keeping
 # the SLSA-v1-shaped body; every verifier passes the same --predicate-type.
+# The URI must not contain '@': the attestations QUERY API rejects it as an
+# invalid predicate_type (HTTP 422, observed 2026-07-20) even though the
+# write API accepts it — hence /v1, not @v1.
 PREDICATE_TYPE="$BUILD_TYPE"
 
 require_exact_identity() {

--- a/scripts/release-native-predicate.test.ts
+++ b/scripts/release-native-predicate.test.ts
@@ -68,7 +68,7 @@ describe('native release attestation predicate', () => {
     const verification = [
       {
         verificationResult: {
-          statement: { predicateType: 'https://github.com/automagik-dev/genie/release-tarballs@v1', predicate },
+          statement: { predicateType: 'https://github.com/automagik-dev/genie/release-tarballs/v1', predicate },
         },
       },
     ];
@@ -101,7 +101,7 @@ describe('native release attestation predicate', () => {
     const result = [
       {
         verificationResult: {
-          statement: { predicateType: 'https://github.com/automagik-dev/genie/release-tarballs@v1', predicate },
+          statement: { predicateType: 'https://github.com/automagik-dev/genie/release-tarballs/v1', predicate },
         },
       },
     ];
@@ -115,7 +115,7 @@ describe('native release attestation predicate', () => {
     writeFileSync(resultPath, JSON.stringify(result));
     expect(invoke('reusable-control-sha', resultPath).exitCode).not.toBe(0);
 
-    predicate.buildDefinition.buildType = 'https://github.com/automagik-dev/genie/release-tarballs@v1';
+    predicate.buildDefinition.buildType = 'https://github.com/automagik-dev/genie/release-tarballs/v1';
     predicate.buildDefinition.resolvedDependencies[1].digest.gitCommit = 'd'.repeat(40);
     writeFileSync(resultPath, JSON.stringify(result));
     expect(invoke('reusable-control-sha', resultPath).exitCode).not.toBe(0);


### PR DESCRIPTION
Promotes the slash predicate-type fix (#2603) plus the v5.260720.6 bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the Genie plugin and package version to **5.260720.6**.

- **Reliability**
  - Improved release artifact attestation verification by standardizing predicate identifiers.
  - Updated validation checks to consistently recognize the revised release metadata format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->