### PR TITLE
fix(genie-ui): defeat DNS rebinding on the ws PTY trust boundary

### DIFF
--- a/packages/genie-ui/README.md
+++ b/packages/genie-ui/README.md
@@ -91,7 +91,7 @@ imports instead of flagging them unused. `node-pty` is in root `trustedDependenc
 fresh `bun install` builds its native binary (needs a working `node-gyp`/toolchain — no
 prebuild ships for linux-x64 on this node-pty version).
 
-**Trust boundary — loopback by default, Origin-checked ws.** `MSG.INPUT` feeds arbitrary
+**Trust boundary — loopback by default, rebinding-proof ws.** `MSG.INPUT` feeds arbitrary
 keystrokes into live login shells (`fable`, `codex`), so the ws upgrade is a remote-control
 surface, not a read-only view. Two guards keep it closed by default:
 
@@ -100,12 +100,19 @@ surface, not a read-only view. Two guards keep it closed by default:
   (mac + phone on the LAN) is **opt-in** via `HOST=0.0.0.0` (or a specific interface). This
   is the seam G2 (genie state) and G3 (ACP control faces) build on, so the boundary is
   explicit here rather than retrofitted later.
-- **Origin allowlist on the ws upgrade.** `verifyClient` accepts a browser connection only
-  when its `Origin` is same-origin with the page's own host (works for any LAN hostname with
-  no config) or is listed in `GENIE_UI_ALLOWED_ORIGINS` (comma-separated, for a reverse
-  proxy). Browsers always send `Origin`, so this defeats a cross-origin drive-by — an open
-  website cannot `new WebSocket('ws://localhost:PORT')` into the shells. Non-browser clients
-  (CLI, tests) send no `Origin` and are gated by the loopback bind instead.
+- **Loopback-Host same-origin OR explicit allowlist on the ws upgrade.** `verifyClient`
+  accepts a browser connection only when its `Origin` is same-origin with the page's own host
+  **and that Host is a loopback identity** (`localhost`, `127.0.0.1`, `[::1]`), or when its
+  `Origin` is listed in `GENIE_UI_ALLOWED_ORIGINS` (comma-separated, for a reverse proxy or a
+  LAN host). Browsers always send `Origin`, so this defeats a cross-origin drive-by — an open
+  website cannot `new WebSocket('ws://localhost:PORT')` into the shells. Crucially it also
+  defeats **DNS rebinding**: a naive same-origin check does *not*, because both `Origin` and
+  `Host` are browser-set and after rebinding (`evil.com` → `127.0.0.1`) they carry the same
+  attacker value, so the connection *presents as same-origin*. Requiring the real `Host` to be
+  loopback closes that hole — the rebound request still carries `Host: evil.com` (non-loopback),
+  which falls through to the allowlist and is rejected. A LAN host (`HOST=0.0.0.0`) therefore
+  reaches the shells only if its origin is explicitly allowlisted, not by same-origin alone.
+  Non-browser clients (CLI, tests) send no `Origin` and are gated by the loopback bind instead.
 
 ## Gate wiring (done first, deliverable 5)
 

--- a/packages/genie-ui/server/index.test.ts
+++ b/packages/genie-ui/server/index.test.ts
@@ -1,5 +1,6 @@
-// Guards the ws trust boundary (README "Trust boundary" decision): the Origin
-// allowlist that keeps a cross-origin browser drive-by out of the live shells.
+// Guards the ws trust boundary (README "Trust boundary" decision): the loopback-Host
+// same-origin gate plus the GENIE_UI_ALLOWED_ORIGINS allowlist that together keep a
+// cross-origin browser drive-by AND a DNS-rebinding attack out of the live shells.
 import { describe, expect, it } from 'bun:test';
 import type http from 'node:http';
 import { verifyClient } from './index';
@@ -11,8 +12,41 @@ describe('verifyClient', () => {
     expect(verifyClient({ origin: 'http://localhost:8787', req: reqWith('localhost:8787') })).toBe(true);
   });
 
-  it('accepts any LAN hostname as long as Origin matches the Host header', () => {
-    expect(verifyClient({ origin: 'http://192.168.1.5:8787', req: reqWith('192.168.1.5:8787') })).toBe(true);
+  it('accepts a same-origin loopback IP connection (127.0.0.1)', () => {
+    expect(verifyClient({ origin: 'http://127.0.0.1:8787', req: reqWith('127.0.0.1:8787') })).toBe(true);
+  });
+
+  it('accepts a same-origin IPv6 loopback connection ([::1])', () => {
+    expect(verifyClient({ origin: 'http://[::1]:8787', req: reqWith('[::1]:8787') })).toBe(true);
+  });
+
+  it('rejects a non-loopback LAN host even when Origin matches the Host header', () => {
+    // Same-origin alone is NOT enough for a non-loopback Host: without an allowlist
+    // entry a LAN host must be rejected (this is the anti-rebinding contract).
+    expect(verifyClient({ origin: 'http://192.168.1.5:8787', req: reqWith('192.168.1.5:8787') })).toBe(false);
+  });
+
+  it('rejects a DNS-rebinding attack where Origin === Host are both attacker-controlled (evil.com)', () => {
+    // Classic DNS rebinding: attacker page on evil.com:8787 rebinds evil.com -> 127.0.0.1.
+    // The browser sends Origin: http://evil.com:8787 AND Host: evil.com:8787, so a naive
+    // same-origin check (Origin.host === Host) passes. The real Host is still the
+    // non-loopback evil.com, so the loopback-Host gate falls through to the allowlist
+    // and rejects. This test permanently owns that regression.
+    expect(verifyClient({ origin: 'http://evil.com:8787', req: reqWith('evil.com:8787') })).toBe(false);
+  });
+
+  it('accepts a LAN host when its Origin is in GENIE_UI_ALLOWED_ORIGINS (the escape hatch)', () => {
+    const prev = process.env.GENIE_UI_ALLOWED_ORIGINS;
+    process.env.GENIE_UI_ALLOWED_ORIGINS = 'http://192.168.1.5:8787';
+    try {
+      // Re-import a fresh module so the allowlist is read from the mutated env.
+      if (require.cache) Reflect.deleteProperty(require.cache, require.resolve('./index'));
+      const { verifyClient: fresh } = require('./index');
+      expect(fresh({ origin: 'http://192.168.1.5:8787', req: reqWith('192.168.1.5:8787') })).toBe(true);
+    } finally {
+      if (prev === undefined) Reflect.deleteProperty(process.env, 'GENIE_UI_ALLOWED_ORIGINS');
+      else process.env.GENIE_UI_ALLOWED_ORIGINS = prev;
+    }
   });
 
   it('rejects a cross-origin drive-by (open website -> ws://localhost)', () => {

--- a/packages/genie-ui/server/index.ts
+++ b/packages/genie-ui/server/index.ts
@@ -34,26 +34,40 @@ const PORT = Number(process.env.PORT ?? 8787);
 // Two guards keep it closed by default:
 //   1. Bind loopback unless HOST is set — the fleet is a single-operator tool; LAN
 //      reach (mac + phone) is opt-in via HOST=0.0.0.0 (or a specific interface).
-//   2. Origin allowlist on the ws upgrade — browsers always send Origin, so a
-//      same-origin check defeats a cross-origin drive-by (any open website could
-//      otherwise `new WebSocket('ws://localhost:PORT')` and type into the shells).
+//   2. Origin check on the ws upgrade — browsers always send Origin. Trust is
+//      loopback-Host same-origin OR the explicit allowlist (NOT Origin alone): a
+//      bare same-origin check is defeated by DNS rebinding, since Origin and Host
+//      are both browser-set and carry the same attacker value after a rebind. See
+//      verifyClient for the loopback-Host gate that closes that hole.
 const HOST = process.env.HOST ?? '127.0.0.1';
 const ALLOWED_ORIGINS = (process.env.GENIE_UI_ALLOWED_ORIGINS ?? '')
   .split(',')
   .map((s) => s.trim())
   .filter(Boolean);
 
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
+
 /**
- * Accept a ws upgrade only from a trusted Origin. Non-browser clients (CLI, tests)
- * send no Origin and are gated by the loopback bind; browsers must be same-origin
- * (the page's own host) or on the explicit GENIE_UI_ALLOWED_ORIGINS allowlist.
+ * Accept a ws upgrade only from a trusted Origin. The trust model is
+ * loopback-Host same-origin OR an explicit GENIE_UI_ALLOWED_ORIGINS allowlist —
+ * NOT Origin alone. Both Origin and Host are browser-set, so a naive
+ * `new URL(origin).host === host` check is defeated by DNS rebinding: an attacker
+ * page on evil.com:PORT rebinds evil.com -> 127.0.0.1 and connects, presenting
+ * Origin === Host === evil.com:PORT, which a bare same-origin check accepts as
+ * genuine. We defeat that by trusting the same-origin branch only when the real
+ * Host hostname is a loopback identity — after rebinding the Host is still
+ * evil.com (non-loopback), so it falls through to the allowlist and is rejected.
+ * Non-browser clients (CLI, tests) send no Origin and are gated by the loopback
+ * bind; non-loopback LAN/remote browsers must be listed in the allowlist.
  */
 export function verifyClient(info: { origin?: string; req: http.IncomingMessage }): boolean {
   const { origin } = info;
   if (!origin) return true;
   const host = info.req.headers.host;
   try {
-    if (host && new URL(origin).host === host) return true;
+    if (host && new URL(origin).host === host && LOOPBACK_HOSTNAMES.has(new URL(`http://${host}`).hostname)) {
+      return true;
+    }
   } catch {
     return false;
   }


### PR DESCRIPTION
## What

The genie-ui PTY WebSocket auth (`verifyClient`) trusted its same-origin branch (`new URL(origin).host === host`) unconditionally. Both `Origin` and `Host` are browser-set, so a DNS-rebinding attack (`evil.com → 127.0.0.1`) presents `Origin === Host === evil.com:PORT` and passed the check — letting a malicious page send `MSG.INPUT` frames that flow `handleClientMsg → manager.write → proc.write()` into a live login shell (**RCE as the operator**). The loopback bind is no defense because the browser itself is the loopback client.

## Fix

The same-origin branch now additionally requires the real Host hostname to be a loopback identity (`localhost` / `127.0.0.1` / `::1`). After a rebind the Host is still `evil.com` (non-loopback), so it falls through to the existing `GENIE_UI_ALLOWED_ORIGINS` allowlist and is rejected. The allowlist escape hatch for legitimate LAN/remote browsers is unchanged.

## Tests

- Named DNS-rebinding regression test (`Origin === Host === evil.com` → rejected) — permanently owns the scenario.
- Inverted the prior `accepts any LAN hostname` test (which enshrined the hole) → non-loopback same-origin now rejected.
- Added allowlist-accept and IPv6 `[::1]` loopback cases; retained cross-origin / mismatched-port / malformed / no-Origin cases.
- `bun test packages/genie-ui/server/index.test.ts` → **10 pass / 0 fail**. Biome + typecheck clean.

## Provenance

Found by an ultracode review of PR #2619 (dev→main promotion). One confirmed HIGH; adversarially verified (rebinding closed, escape hatch intact, no parsing bypass — IP-normalization tricks fail closed, credential/fragment/subdomain smuggling all rejected). Reviewed post-fix by an independent reviewer: SHIP.

Rated HIGH not CRITICAL because `genie-ui` is `private: true`, unpublished, absent from the CLI dist bundle, and manually launched — vulnerable source shipped, but no always-on exposure. Landing before genie-ui is recommended to anyone or exposed as a product surface.