### PR TITLE
fix(board): clear heartbeat_at on release so the next owner has no stale liveness

### DIFF
--- a/src/lib/v5/task-state.test.ts
+++ b/src/lib/v5/task-state.test.ts
@@ -449,6 +449,21 @@ describe('runtime layer — claim / release timeline events', () => {
     expect(getTaskEvents(db, a.id).at(-1)?.kind).toBe('release');
   });
 
+  test('releaseTask clears heartbeat_at so the next owner does not inherit stale liveness', () => {
+    const a = createTask(db, { title: 'a' });
+    claimTask(db, a.id, 'w1');
+    recordHeartbeat(db, a.id, 10_000_000);
+    expect(getTaskCard(db, a.id)?.heartbeatAt).toBe(10_000_000);
+
+    releaseTask(db, a.id, HUMAN);
+    // The card is back to ready with no lingering pulse; a fresh checkout by
+    // worker B must read stale (never running) until B itself heartbeats.
+    expect(getTaskCard(db, a.id)?.heartbeatAt).toBeNull();
+
+    claimTask(db, a.id, 'w2');
+    expect(getTaskCard(db, a.id)?.heartbeatAt).toBeNull();
+  });
+
   test('releaseTask REFUSES a done card — never resurrects it, emits no release event', () => {
     const a = createTask(db, { title: 'a' });
     claimTask(db, a.id, 'w1');

--- a/src/lib/v5/task-state.ts
+++ b/src/lib/v5/task-state.ts
@@ -792,7 +792,9 @@ function releaseFailure(db: Database, taskId: string): never {
 
 /**
  * Release a claim WITHOUT completing — returns an `in_progress` card to the
- * `ready` queue and clears the claim so another runtime can pick it up. The state
+ * `ready` queue and clears the claim (including `heartbeat_at`, so the next
+ * runtime to check the card out does not inherit the prior owner's liveness) so
+ * another runtime can pick it up. The state
  * check lives IN the SQL (`WHERE ... AND status = 'in_progress'`) exactly like
  * {@link claimTask}, so a concurrent `done`/re-claim that transitions the card out
  * of `in_progress` between decision and write can never be clobbered: the
@@ -807,7 +809,7 @@ export function releaseTask(db: Database, taskId: string, author: EventAuthor): 
     const res = db
       .query(
         `UPDATE tasks
-         SET status = 'ready', claimed_by = NULL, claimed_at = NULL, updated_at = ?
+         SET status = 'ready', claimed_by = NULL, claimed_at = NULL, heartbeat_at = NULL, updated_at = ?
          WHERE id = ? AND status = 'in_progress'`,
       )
       .run(now, taskId);


### PR DESCRIPTION
## What

`releaseTask` returned an `in_progress` card to `ready` and cleared `claimed_by`/`claimed_at` but left `heartbeat_at` behind. After a release the card kept the prior owner's pulse, so when a new worker checked it out the liveness badge computed from the **old** heartbeat and could show a fresh checkout as ▶ running before it ever pulsed.

## Fix

Clear `heartbeat_at` in the same conditional release UPDATE (the atomic `WHERE ... AND status = 'in_progress'` CAS is unchanged, so the done-card no-resurrection and phantom-event guarantees hold). Added a regression test: release → `heartbeatAt` null → survives re-claim. Right-reason verified (test fails without the source change).

## Provenance

Found by the codex bot's P2 review comment on the #2619 dev→main promotion; deferred out of that promotion and landed here per the resolution note. `typecheck` / `biome` clean; `bun test src/lib/v5/task-state.test.ts` → 67 pass / 0 fail.