### PR TITLE
test(install): pin exit-2 fixture temp-parent mode to 0700

### DIFF
--- a/tests/integration/install-exit2-propagation.test.ts
+++ b/tests/integration/install-exit2-propagation.test.ts
@@ -115,7 +115,9 @@ function runHarness(): { status: number | null; output: string } {
 
 describe('install.sh delivered-not-activated exit-2 propagation (executed)', () => {
   test('propagates exit 2 with the result trailer, no all-green footer, lock released, idempotent rerun', () => {
-    mkdirSync(join(work, 'tmp'), { recursive: true });
+    // install.sh's validate_private_temp_root rejects a group-writable temp parent,
+    // so pin the mode instead of inheriting the host umask (0002 hosts create 775).
+    mkdirSync(join(work, 'tmp'), { recursive: true, mode: 0o700 });
 
     const first = runHarness();
     // Delivered-not-activated is exit 2, NOT the die-1 failure path.
@@ -151,7 +153,9 @@ describe('install.sh delivered-not-activated exit-2 propagation (executed)', () 
       ].join('\n'),
       { mode: 0o755 },
     );
-    mkdirSync(join(work, 'tmp'), { recursive: true });
+    // install.sh's validate_private_temp_root rejects a group-writable temp parent,
+    // so pin the mode instead of inheriting the host umask (0002 hosts create 775).
+    mkdirSync(join(work, 'tmp'), { recursive: true, mode: 0o700 });
     const result = runHarness();
     expect(result.status).toBe(1);
     expect(result.output).toContain('installation remains incomplete and retryable');


### PR DESCRIPTION
## Summary
- The `install-exit2-propagation` integration suite failed (exit 127 instead of the exit-2 contract) on any host with `umask 0002`: `mkdirSync(work/tmp)` inherited the umask and produced a group-writable (775) temp parent, which `install.sh`'s `validate_private_temp_root` correctly rejects.
- Pin the fixture dir to `0o700` so the test exercises the real exit-2 lifecycle regardless of host umask.

## Verification
- Before: both tests in the suite fail with status 127 on a umask-0002 host.
- After: `bun test tests/integration/install-exit2-propagation.test.ts` → 2 pass / 0 fail on the same host.

## Note (not fixed here)
When `validate_private_temp_root` dies at source time, `die` calls `release_lifecycle_lock` before it is defined, so the installer exits 127 instead of the contractual 1. Worth a small follow-up in install.sh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)