### PR TITLE
feat(codex): Group E — lifecycle-truth integration (wish codex-plugin-dogfood-remediation)

### DIFF
--- a/.genie/wishes/codex-plugin-dogfood-remediation/HANDOFF-20260722.md
+++ b/.genie/wishes/codex-plugin-dogfood-remediation/HANDOFF-20260722.md
@@ -1,0 +1,43 @@
+# Handoff — codex-plugin-dogfood-remediation (2026-07-22)
+
+**Wish:** `.genie/wishes/codex-plugin-dogfood-remediation/WISH.md` (APPROVED, 7 groups A–G).
+**Status: Waves 1 + 2 DONE and merged to dev. Next = Wave 3 (Group E).**
+
+## DAG
+`B → A`, `B → D`, `{A,B,D} → E`, `{C,E} → F`, `F → G`. Groups B,C = Wave 1; A,D = Wave 2; E = Wave 3; F = Wave 4; G = Wave 5.
+
+## Merged so far (all in `origin/dev`, tip was `8a92fbd6`)
+| Group | PR | Verified |
+|---|---|---|
+| B host-observation-attestation | #2625 | 165/0 incl. live app-server proof; pre-mutation guard real |
+| C managed-assets-convergence | #2626 | 403/0; byte-identical preservation, R3 intact |
+| A project-route-context | #2629 | 94/0; empty-board masquerade closed; plugin Codex MCP route removed |
+| D immutable-delivery-repair | #2628 | 397/0; one-shot repair + `.install-version` module |
+
+Files landed: `src/lib/codex-host-observation.ts`, `src/fixtures/codex-role-agent-allowlist.json`, `src/lib/codex-project-mcp.ts` + `resolveProjectContext` in `src/lib/v5/mcp-tools.ts`/`mcp-server.ts`, `src/lib/install-version-marker.ts`, delivery-repair in `src/genie-commands/update.ts`/`install.ts`/`codex-delivery*.ts`. Plugin `.mcp.json` + manifest `mcpServers` DELETED (Claude's `scripts/mcp-launcher.cjs` retained).
+
+## CARRY-FORWARD into Group E (lifecycle-truth-integration) — do these, they were deliberately deferred, not dropped
+1. **A's config-layer typed states** (deferred per Decision 15): distinct classification for `untrusted-config`, `global same-key route`, `effective-layer shadowing`, `route-collision`, `route-shadowed`, `project-trust-required` — these are doctor/init diagnostics, not read-only-MCP-server states. A shipped only `project-context-unavailable`/`project-database-unavailable`/`unsupported-project-layout`.
+2. **D's `uninstallInstallVersionMarker` wiring**: exported+unit-tested but NOT called by `src/genie-commands/uninstall.ts`. Behavior is already correct (`.install-version` removed by the digest-verified wholesale GENIE_HOME child removal — it's absent from `preservedGenieDirEntry`). Wire the explicit symlink-safe call **with awareness the wholesale removal is digest-verified** (removing the marker first could invalidate `scope.genieHomeRemovalDigest`), OR delete it + document. Do NOT rush this into the digest path.
+3. **A's live-QA-only item (AC3)**: `codex mcp get genie --json` showing one marker-owned facade route + no plugin route — Felipe's post-merge live-QA ritual, kept out of CI.
+
+## Group E scope (from WISH)
+"lifecycle-truth-integration: wire route/context, observation, repair handoff, setup, and doctor" — integrate A+B+D contracts into setup/doctor WITHOUT changing their contracts. Complexity 5. depends-on {A,B,D} (all merged ✓).
+
+## HOW to run a wave (the working pattern — reuse it)
+`Workflow` tool, isolated worktrees, `model:'opus' effort:'max'`, `agentType:'engineer-complex'`, `isolation:'worktree'`. Pipeline: implement → adversarial `reviewer`. Engineers commit to `wish/dogfood-<G>` (NO push), report structured. Then ORCHESTRATOR:
+- Re-run the group's validation YOURSELF in its worktree (`.claude/worktrees/wf_*-N`) — do not trust the report.
+- **Run codex-touching tests with `codex` STRIPPED from PATH** (`PATH="$HOME/.bun/bin:/usr/bin:/bin"`) — this is the CI condition; it caught the flake.
+- Strip any stray `.well-known/dev.json` (`git checkout origin/dev -- .well-known/dev.json`).
+- Push, open PR to dev, then **`gh run watch` the CI to green** — the black-box **Codex Plugin Smoke** and **E2E** jobs run things the file-level review can't. Fix reds via a `fixer` (opus) with the smoke as the gate.
+- `SKIP_CI_CHECK=1 git commit` is the sanctioned escape when a commit IS the CI fix.
+
+## Hard-won gotchas (cost us fix loops this session)
+- **CI has NO `codex` binary and NO network.** Any test spawning `codex` must do a synchronous `execFileSync('codex',['--version'])` preflight and skip; never let an async spawn `'error'` (ENOENT) throw unhandled at module load (that aborts the whole file — Group B's first CI fail).
+- **Readonly SQLite opens must carry `busy_timeout`.** Raw `new Database(p,{readonly:true})` bypasses `sqlite-open.ts`'s `BUSY_TIMEOUT_MS` → flaky "database is locked" under concurrent writers (Group A's HIGH). Import `BUSY_TIMEOUT_MS`; checkpoint (`wal_checkpoint(TRUNCATE)`) writers before readers in tests.
+- **Plugin health ≠ Codex MCP provider anymore.** A removed the plugin MCP route; `proveCodexPluginHealth`/`parseCodexPluginSnapshot`/`codex-mcp-health-session.ts` were reconciled so health = installed+enabled+version+canonical-root+payload+working launcher, and the throwaway-cwd health probe now accepts A's typed `project-context-*` errors as healthy. Don't regress this.
+- Discipline reminders: reviewer ≠ engineer; verify every subagent claim with your own runs; Felipe merges PRs himself (present them, don't merge); the roadmap board + this wish are the trackers.
+
+## Separately open (not this wish)
+- `stable-release-security-gate` wish still blocks STABLE promotion.
+- codex-plugin-update-handoff live homolog dogfood ritual (Felipe's) gates that wish → SHIPPED.

--- a/.genie/wishes/codex-plugin-dogfood-remediation/WISH.md
+++ b/.genie/wishes/codex-plugin-dogfood-remediation/WISH.md
@@ -558,15 +558,15 @@ activation, and doctor surfaces.
    doctor current, including PATH advisory, stale historical config, route collision, and context errors.
 
 **Acceptance Criteria:**
-- [ ] Missing/invalid/mismatched record reaches neither prompt nor activation-owned mutation and produces
+- [x] Missing/invalid/mismatched record reaches neither prompt nor activation-owned mutation and produces
       one consistent `delivery-incomplete` result with the update/install recovery command.
-- [ ] After target-current repair, setup performs zero second plugin add, completes parity/H3, restores
+- [x] After target-current repair, setup performs zero second plugin add, completes parity/H3, restores
       enabled state, and clears the journal only through normal protocol.
-- [ ] Failed/pending standalone setup preserves config bytes and omits the green banner even when
+- [x] Failed/pending standalone setup preserves config bytes and omits the green banner even when
       historical config says configured; only this invocation's current success persists that state.
-- [ ] Doctor spawns exactly one plugin observation and cannot combine PASS/current with query-failed,
+- [x] Doctor spawns exactly one plugin observation and cannot combine PASS/current with query-failed,
       unhealthy project context, route collision/shadowing, or missing delivery.
-- [ ] Real PATH advisory yields one ANSI-free JSON object and consistent human/trailer/exit; timeout,
+- [x] Real PATH advisory yields one ANSI-free JSON object and consistent human/trailer/exit; timeout,
       overflow, malformed/duplicate JSON, and nonzero exit fail consistently.
 
 **Validation:**
@@ -794,6 +794,40 @@ _The read-only reviewer returns evidence; the invoking orchestrator appends a ti
   candidate execution read-only and secretless, pass one trusted candidate-inventory digest through
   dogfood/publication/channel advancement, and prevent write-capable jobs from executing candidate code.
   The advisory audit passed 258 focused tests with 0 failures and made no profile changes.
+
+### 2026-07-23T01:55:00Z — Group E execution review
+
+- **Context:** Group E (lifecycle-truth-integration) execution review, PR #2630 (`wish/dogfood-E` → dev)
+- **Branch commits:** fc96d3ee (handoff doc), f660d902 (doctor single observation), 51374f2c (setup
+  delivery gate + typed outcome), c73850cb (post-activation route fix + real-PTY flow), ed75b432
+  (uninstall-marker retirement), 6878189 (review LOW fixes: dotted-key route detection, typed
+  context-state PTY assertion)
+- **Reviewer:** independent adversarial execution reviewer (not the author); verdict **SHIP** —
+  CRITICAL none; HIGH none; MEDIUM two (both confirmed intended: doctor `deliveryComplete` now
+  requires a matching authenticated record per the authority matrix, so pre-record installs report
+  `delivery-incomplete` until one `genie update`; `project-trust-required` warns for never-trusted
+  projects per "never claim health for an untrusted project"); LOW three (two fixed in 6878189, one
+  noted: collision-after-activation throw is pre-existing polish debt)
+- **Reviewer validation (self-run):** 277/0 across the seven touched suites; 194/0 adjacent
+  executor/project-mcp/activation/host-observation suites; typecheck and lint exit 0; A/B/D contract
+  files byte-identical to origin/dev (empty diffstat)
+- **Orchestrator validation (own runs):** full `bun test` 2528 tests with the sole failure being the
+  pre-existing Linux-only `ss`-based ui-bridge socket test (green in CI); CI condition (codex stripped
+  from PATH) 277/0 including the real-PTY flow; `bun run smoke:codex` exit 0; PR CI rollup all
+  SUCCESS, merge state CLEAN
+- **Defect found by the new PTY flow and fixed in-wave:** setup's post-activation reconcile used the
+  pre-Group-A synthetic usable-plugin probe whose documented behavior removed the project fallback,
+  leaving a repository with NO Codex route after successful activation (Decision 1 violation); the
+  post-activation probe now declares route-unusability and reconciles the stable absolute
+  `GENIE_HOME/bin/genie` facade route exactly as trusted init writes it (Decision 2)
+- **Carry-forwards resolved:** A's deferred typed config-layer states shipped as the route-layer
+  classifier (`route-collision`, `route-shadowed`, `global-route-same-key`, `untrusted-config`,
+  `project-trust-required`) with doctor JSON riders; D's `uninstallInstallVersionMarker` retired with
+  documented digest-window rationale and both legacy layouts pinned through the real digest-verified
+  batch path; A's live-QA item (AC3 `codex mcp get genie --json`) remains reserved for the operator's
+  post-merge ritual
+- **Verdict:** **SHIP** — Group E awaits operator merge of PR #2630; durable wish status unchanged
+  until merge
 
 ---
 

--- a/src/genie-commands/doctor.test.ts
+++ b/src/genie-commands/doctor.test.ts
@@ -164,6 +164,17 @@ describe('doctorCommand', () => {
   });
 });
 
+/**
+ * Group E: mark a project trusted in the isolated CODEX_HOME global config so
+ * the route-layer classifier can claim route health for it.
+ */
+function trustProjectInCodexConfig(root: string): void {
+  const configPath = join(process.env.CODEX_HOME as string, 'config.toml');
+  mkdirSync(dirname(configPath), { recursive: true });
+  const existing = existsSync(configPath) ? readFileSync(configPath, 'utf8') : '';
+  writeFileSync(configPath, `${existing}[projects."${root}"]\ntrust_level = "trusted"\n`);
+}
+
 describe('Codex doctor lifecycle results', () => {
   test('a timed-out plugin query is a structured hard failure, not a false pass', async () => {
     const checks = await checkCodexIntegration(process.cwd(), {
@@ -182,6 +193,7 @@ describe('Codex doctor lifecycle results', () => {
   test('missing configured Node is actionable and never displaces the fallback', async () => {
     const root = mkdtempSync(join(tmpdir(), 'doctor-node-availability-'));
     try {
+      trustProjectInCodexConfig(root);
       reconcileCodexProjectMcp(
         root,
         { cliAvailable: true, status: 'ok', installed: true, enabled: false, usable: false, detail: 'disabled' },
@@ -212,6 +224,7 @@ describe('Codex doctor lifecycle results', () => {
     const priorCodexHome = process.env.CODEX_HOME;
     process.env.CODEX_HOME = join(root, 'codex-home');
     try {
+      trustProjectInCodexConfig(root);
       expect(existsSync(join(import.meta.dir, '..', '..', 'plugins', 'genie', '.codex-plugin', 'plugin.json'))).toBe(
         true,
       );
@@ -1776,13 +1789,27 @@ function docRegPresent(version = DOC_T): QueryFact {
 function docCachePresent(digest = DOC_DIGEST): PhysicalCacheFact {
   return { kind: 'present', digest, identity: '10:200' };
 }
+/** A matching authenticated delivery record binding the canonical target (Group E delivery gate). */
+function docDeliveryPresent(): CodexActivationSnapshot['delivery'] {
+  return {
+    status: 'present',
+    record: {
+      schemaVersion: 1,
+      deliveryId: 'c'.repeat(32),
+      targetVersion: DOC_T,
+      canonicalPayloadSha256: DOC_DIGEST,
+      channel: 'stable',
+      deliveredAt: '2026-07-12T00:00:00.000Z',
+    },
+  };
+}
 function docCurrentSnapshot(): CodexActivationSnapshot {
   return {
     canonical: docOkCanonical(),
     query: docRegPresent(),
     cache: docCachePresent(),
     receipt: { status: 'absent' },
-    delivery: { status: 'absent' },
+    delivery: docDeliveryPresent(),
     intent: { status: 'absent' },
     receiptConsumed: false,
     observationWitness: { before: docFamily(), after: docFamily() },
@@ -1913,5 +1940,145 @@ describe('doctor --json integrationSummary (Group D)', () => {
   test('doctor.ts never touches the lifecycle lease (read-only observer path)', () => {
     const source = readFileSync(join(import.meta.dir, 'doctor.ts'), 'utf8');
     expect(source.includes('acquireLifecycleLease')).toBe(false);
+  });
+});
+
+describe('Group E lifecycle truth (doctor)', () => {
+  test('current state with an ABSENT delivery record presents delivery-incomplete, exit 1, recovery command', async () => {
+    const missingRecord = { ...docCurrentSnapshot(), delivery: { status: 'absent' as const } };
+    const { output, exitCode } = await captureDoctor(() =>
+      doctorCommand({ json: true }, doctorDepsWith(missingRecord)),
+    );
+    const json = JSON.parse(output) as DoctorJson;
+    expect(json.integrationSummary?.codexPlugin).toMatchObject({
+      state: 'delivery-incomplete',
+      deliveryComplete: false,
+      actionRequired: true,
+      mutationAuthority: 'none',
+    });
+    expect(json.integrationSummary?.codexPlugin.recovery).toContain('genie update');
+    expect(exitCode).toBe(1);
+  });
+
+  test('an INVALID record and a MISMATCHED record present the same consistent delivery-incomplete state', async () => {
+    const invalid = { ...docCurrentSnapshot(), delivery: { status: 'invalid' as const, detail: 'corrupt' } };
+    const mismatched = {
+      ...docCurrentSnapshot(),
+      delivery: {
+        status: 'present' as const,
+        record: {
+          schemaVersion: 1 as const,
+          deliveryId: 'c'.repeat(32),
+          targetVersion: DOC_OLD,
+          canonicalPayloadSha256: DOC_DIGEST,
+          channel: 'stable',
+          deliveredAt: '2026-07-12T00:00:00.000Z',
+        },
+      },
+    };
+    for (const snapshot of [invalid, mismatched]) {
+      const { output, exitCode } = await captureDoctor(() => doctorCommand({ json: true }, doctorDepsWith(snapshot)));
+      const json = JSON.parse(output) as DoctorJson;
+      expect(json.integrationSummary?.codexPlugin.state).toBe('delivery-incomplete');
+      expect(json.integrationSummary?.codexPlugin.deliveryComplete).toBe(false);
+      expect(exitCode).toBe(1);
+    }
+  });
+
+  test('a harder exit-1 state (query-failed) keeps its own presentation; deliveryComplete still false', async () => {
+    const queryFailedNoRecord = { ...docQueryFailedSnapshot(), delivery: { status: 'absent' as const } };
+    const { output, exitCode } = await captureDoctor(() =>
+      doctorCommand({ json: true }, doctorDepsWith(queryFailedNoRecord)),
+    );
+    const json = JSON.parse(output) as DoctorJson;
+    expect(json.integrationSummary?.codexPlugin.state).toBe('query-failed');
+    expect(json.integrationSummary?.codexPlugin.deliveryComplete).toBe(false);
+    expect(exitCode).toBe(1);
+  });
+
+  test('matching record keeps current green: exit 0, deliveryComplete true (regression anchor)', async () => {
+    const { output, exitCode } = await captureDoctor(() =>
+      doctorCommand({ json: true }, doctorDepsWith(docCurrentSnapshot())),
+    );
+    const json = JSON.parse(output) as DoctorJson;
+    expect(json.integrationSummary?.codexPlugin).toMatchObject({ state: 'current', deliveryComplete: true });
+    expect(exitCode).toBe(0);
+  });
+
+  test('unified host path: one canned query feeds advisory rider AND a non-query-failed summary (Decision 11)', async () => {
+    const calls: string[][] = [];
+    const stdout = JSON.stringify({
+      installed: [{ pluginId: 'genie@automagik', version: '5.260722.1', enabled: true }],
+    });
+    const { output } = await captureDoctor(() =>
+      doctorCommand(
+        { json: true },
+        {
+          root: join(isolatedHome, 'repo'),
+          databaseRoot: join(isolatedHome, 'repo'),
+          bunVersion: '1.3.10',
+          bunPath: '/usr/bin/bun',
+          codexHost: {
+            which: () => process.execPath,
+            codexHome: join(isolatedHome, 'codex'),
+            runner: (command, args) => {
+              calls.push([command, ...args]);
+              return {
+                exitCode: 0,
+                stdout,
+                stderr: '\x1b[33mWARN: PATH advisory\x1b[0m',
+              };
+            },
+          },
+        },
+      ),
+    );
+    // Exactly one spawn fed the probe AND (via replay) the activation snapshot.
+    expect(calls).toEqual([[process.execPath, 'plugin', 'list', '--json']]);
+    const json = JSON.parse(output) as DoctorJson;
+    const cli = json.checks.find((check) => check.name === 'Codex CLI') as
+      | { name: string; status: string; advisory?: string; detail?: string }
+      | undefined;
+    expect(cli?.advisory).toBe('WARN: PATH advisory');
+    expect(cli?.detail).toContain('advisory: WARN: PATH advisory');
+    // The advisory did NOT flip the fail-closed activation parser to query-failed.
+    expect(json.integrationSummary?.codexPlugin.state).not.toBe('query-failed');
+    // One ANSI-free JSON document: the raw advisory's escape bytes never reach stdout.
+    expect(output).not.toContain('\x1b[33m');
+  });
+
+  test('project context: ok / database-unavailable / unsupported-layout map to pass / warn / fail', async () => {
+    const base = {
+      effectiveLaunchCwd: '/repo',
+      worktreeConfigRoot: '/repo',
+      gitCommonDir: '/repo/.git',
+      genieStorageRoot: '/repo',
+      dbPath: '/repo/.genie/genie.db',
+    };
+    const cases = [
+      { context: { kind: 'ok' as const, ...base }, status: 'pass' },
+      {
+        context: { kind: 'project-database-unavailable' as const, effectiveLaunchCwd: '/repo', detail: 'no db' },
+        status: 'warn',
+      },
+      {
+        context: { kind: 'unsupported-project-layout' as const, effectiveLaunchCwd: '/repo', detail: 'bare repo' },
+        status: 'fail',
+      },
+    ];
+    for (const { context, status } of cases) {
+      const { output } = await captureDoctor(() =>
+        doctorCommand({ json: true }, { ...doctorDepsWith(null), projectContext: context }),
+      );
+      const json = JSON.parse(output) as DoctorJson;
+      const check = json.checks.find((c) => c.name === 'Codex project context');
+      expect(check?.status).toBe(status);
+    }
+  });
+
+  test('injected root without injected context skips the context check (unit-test seam, not a repo)', async () => {
+    const { output } = await captureDoctor(() => doctorCommand({ json: true }, doctorDepsWith(null)));
+    const json = JSON.parse(output) as DoctorJson;
+    expect(json.checks.find((c) => c.name === 'Codex project context')).toBeUndefined();
   });
 });

--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -54,6 +54,10 @@ import {
 } from '../lib/codex-activation-executor.js';
 import type { CodexActivationSnapshot, IntegrationSummaryEnvelope } from '../lib/codex-activation.js';
 import { DEAD_GENIE_OTEL_EXPORTER, getCodexConfigPath } from '../lib/codex-config.js';
+// Group E: ONE bounded host observation feeds probe, summary, advisory, and
+// replay runner; the lifecycle-truth seams keep delivery/route claims aligned.
+import { type DoctorCodexObservation, observeDoctorCodexHost } from '../lib/codex-doctor-observation.js';
+import { type RouteLayerFinding, assessSnapshotDelivery, classifyRouteLayers } from '../lib/codex-lifecycle-truth.js';
 import {
   type CodexPluginProbe,
   inspectCodexProjectMcp,
@@ -76,7 +80,13 @@ import {
   inspectCodexAgentOwnership,
   inspectCodexFallbackTier,
 } from '../lib/runtime-integrations.js';
-import { CURRENT_SCHEMA_VERSION, GenieDbError, openDb } from '../lib/v5/genie-db.js';
+import {
+  CURRENT_SCHEMA_VERSION,
+  GenieDbError,
+  type ProjectContext,
+  openDb,
+  resolveProjectContext,
+} from '../lib/v5/genie-db.js';
 import { VERSION } from '../lib/version.js';
 import {
   cleanupV4,
@@ -141,6 +151,20 @@ interface CheckResult {
    * for the stable per-entry state contract.
    */
   indexLane?: { entries: IndexLaneEntry[] };
+  /**
+   * Machine-readable payload rider (survives `--json` as `checks[].routeLayers`).
+   * Only the `Codex Genie MCP registration` check sets it: the typed config-layer
+   * findings (collision, shadowing, global same-key, trust states) from the
+   * Group E route-layer classifier.
+   */
+  routeLayers?: RouteLayerFinding[];
+  /**
+   * Machine-readable payload rider (survives `--json` as `checks[].advisory`).
+   * Only the `Codex CLI` check sets it: the sanitized bounded advisory stderr
+   * (e.g. the real sandbox PATH advisory) from the single host observation.
+   * Diagnostic metadata only — never a policy decision (Decision 11).
+   */
+  advisory?: string;
 }
 
 // ============================================================================
@@ -436,7 +460,7 @@ function codexAgentCheck(): CheckResult {
   };
 }
 
-function codexProjectRouteCheck(root: string | null, probe: CodexPluginProbe): CheckResult {
+function codexProjectRouteCheck(root: string | null, probe: CodexPluginProbe, cwd = process.cwd()): CheckResult {
   if (root === null) {
     return {
       name: 'Codex Genie MCP registration',
@@ -447,11 +471,34 @@ function codexProjectRouteCheck(root: string | null, probe: CodexPluginProbe): C
   }
   try {
     const route = inspectCodexProjectMcp(root, probe);
+    // Group E: distinct typed config-layer findings. Collisions, shadowing, and
+    // a global same-key route are hard route defects (preserved, never edited);
+    // the trust states block a health CLAIM without failing intact route bytes.
+    const findings = classifyRouteLayers({ worktreeRoot: root, cwd, route, globalConfigPath: getCodexConfigPath() });
+    const hard = findings.filter(
+      (finding) =>
+        finding.kind === 'route-collision' ||
+        finding.kind === 'route-shadowed' ||
+        finding.kind === 'global-route-same-key',
+    );
+    const trust = findings.filter(
+      (finding) => finding.kind === 'untrusted-config' || finding.kind === 'project-trust-required',
+    );
+    const status: CheckStatus = !route.ok || hard.length > 0 ? 'fail' : trust.length > 0 ? 'warn' : 'pass';
+    const findingText = findings.map((finding) => `${finding.kind}: ${finding.detail}`).join('; ');
     return {
       name: 'Codex Genie MCP registration',
-      status: route.ok ? 'pass' : 'fail',
-      detail: `${route.route}: ${route.detail ?? 'no detail'}`,
-      suggestion: route.ok ? undefined : 'Run `genie init` in this worktree to reconcile the project fallback.',
+      status,
+      detail: `${route.route}: ${route.detail ?? 'no detail'}${findingText.length > 0 ? `; ${findingText}` : ''}`,
+      suggestion:
+        status === 'pass'
+          ? undefined
+          : hard.length > 0
+            ? 'Resolve the reported same-key/shadowing layer yourself (Genie never edits user-owned config), then run `genie init`.'
+            : trust.length > 0 && route.ok
+              ? 'Trust this project in Codex, then start a new Codex task.'
+              : 'Run `genie init` in this worktree to reconcile the project fallback.',
+      ...(findings.length > 0 ? { routeLayers: findings } : {}),
     };
   } catch (error) {
     return {
@@ -461,6 +508,49 @@ function codexProjectRouteCheck(root: string | null, probe: CodexPluginProbe): C
       suggestion: 'Repair the incomplete marker block, then run `genie init`.',
     };
   }
+}
+
+/**
+ * Group E: report what a Codex MCP child launched in this repository would
+ * resolve — the SAME `resolveProjectContext` the read-only MCP server uses, so
+ * doctor and the server can never disagree about project context. An absent
+ * database mirrors the `genie.db` check's "created on first use" stance as a
+ * warn (the MCP returns a typed error, never a healthy empty board); a
+ * bare/submodule/external layout or an unresolvable context is a hard fail.
+ */
+function checkCodexProjectContext(root: string | null, injected?: ProjectContext | null): CheckResult[] {
+  if (root === null || injected === null) return [];
+  const context = injected ?? resolveProjectContext(root);
+  if (context.kind === 'ok') {
+    return [
+      {
+        name: 'Codex project context',
+        status: 'pass',
+        detail: `storage root ${context.genieStorageRoot}; db ${context.dbPath}`,
+      },
+    ];
+  }
+  if (context.kind === 'project-database-unavailable') {
+    return [
+      {
+        name: 'Codex project context',
+        status: 'warn',
+        detail: `Codex MCP returns typed '${context.kind}' (never a healthy empty board): ${context.detail}`,
+        suggestion: 'Run `genie init` (or create the first task) to initialize .genie/genie.db.',
+      },
+    ];
+  }
+  return [
+    {
+      name: 'Codex project context',
+      status: 'fail',
+      detail: `Codex MCP returns typed '${context.kind}': ${context.detail}`,
+      suggestion:
+        context.kind === 'unsupported-project-layout'
+          ? 'Run Codex tasks from an ordinary or linked non-bare worktree; bare/submodule/external-git-dir layouts are a hard boundary.'
+          : 'Verify this is an initialized Git worktree, then run `genie init`.',
+    },
+  ];
 }
 
 /**
@@ -529,11 +619,19 @@ function codexPluginSurfaceChecks(probe: CodexPluginProbe): CheckResult[] {
 export async function checkCodexIntegration(
   root: string | null,
   probe: CodexPluginProbe = probeCodexGeniePlugin(),
+  advisory: string | null = null,
 ): Promise<CheckResult[]> {
   if (!probe.cliAvailable)
     return [{ name: 'Codex CLI', status: 'warn', detail: 'not installed (Claude-only mode available)' }];
   const codex = whichBinary('codex');
-  const results: CheckResult[] = [{ name: 'Codex CLI', status: 'pass', detail: codex ?? 'detected by bounded probe' }];
+  const results: CheckResult[] = [
+    {
+      name: 'Codex CLI',
+      status: 'pass',
+      detail: `${codex ?? 'detected by bounded probe'}${advisory !== null ? `; advisory: ${advisory}` : ''}`,
+      ...(advisory !== null ? { advisory } : {}),
+    },
+  ];
   results.push(codexPluginCheck(probe), codexAgentCheck());
   const configPath = getCodexConfigPath();
   const obsolete = existsSync(configPath) && readFileSync(configPath, 'utf8').includes(DEAD_GENIE_OTEL_EXPORTER);
@@ -1688,6 +1786,14 @@ export interface DoctorDeps {
   bunVersion?: string | null;
   /** PATH seam paired with bunVersion. */
   bunPath?: string | null;
+  /**
+   * Group E seams for the single host observation. `codexHost` feeds
+   * `observeDoctorCodexHost` (inject a canned runner to drive the WHOLE unified
+   * derivation without a live Codex home); `projectContext` injects the typed
+   * project-context fact (explicit `null` = skip the check).
+   */
+  codexHost?: Parameters<typeof observeDoctorCodexHost>[0];
+  projectContext?: ProjectContext | null;
 }
 
 // ============================================================================
@@ -1705,9 +1811,18 @@ export interface DoctorDeps {
 function resolveCodexActivationSnapshot(
   deps: DoctorDeps,
   pluginProbe: CodexPluginProbe,
+  hostObservation: DoctorCodexObservation | null,
 ): CodexActivationSnapshot | null {
   if (deps.codexActivation !== undefined) return deps.codexActivation;
   if (!pluginProbe.cliAvailable) return null;
+  // Group E: replay the single captured host query instead of spawning again —
+  // the check list and the integration summary always describe the same fact.
+  if (hostObservation?.codexCommand != null && hostObservation.activationRunner !== null) {
+    return observeCodexActivation({
+      command: hostObservation.codexCommand,
+      runner: hostObservation.activationRunner,
+    });
+  }
   return observeCodexActivation({ command: whichBinary('codex') });
 }
 
@@ -1720,9 +1835,13 @@ interface CodexIntegration {
 
 /**
  * Build the additive integration summary + human projection from one snapshot.
- * Doctor never mutates, so `deliveryComplete` reflects only whether target payload
- * T is physically delivered (canonical present) — the same fact the human and JSON
- * projections share, so they agree across repeated runs.
+ * Doctor never mutates. Group E: `deliveryComplete` is true only when the
+ * canonical payload is physically delivered AND a matching authenticated
+ * delivery record binds it (Decision 9); a missing/invalid/mismatched record on
+ * an otherwise green state presents as the one consistent `delivery-incomplete`
+ * result with the update/install recovery command. A harder exit-1 state
+ * (query-failed, unsafe cache, ...) keeps its own presentation — the summary
+ * still carries `deliveryComplete: false`, so the surfaces cannot disagree.
  */
 function buildCodexIntegration(snapshot: CodexActivationSnapshot): CodexIntegration {
   const state = classifyCodexActivation(snapshot);
@@ -1731,10 +1850,29 @@ function buildCodexIntegration(snapshot: CodexActivationSnapshot): CodexIntegrat
     snapshot,
     invocation: { entry: 'doctor', assertion: null },
   });
-  const deliveryComplete = snapshot.canonical.status === 'ok';
+  const deliveryGate = assessSnapshotDelivery(snapshot);
+  const deliveryComplete = deliveryGate.kind === 'matching';
   const summary = projectIntegrationSummary(state, snapshot, authorization, deliveryComplete);
   const descriptor = describeState(state);
   const projection = projectHumanStatus(state, snapshot);
+  if (deliveryGate.kind === 'incomplete' && descriptor.exit !== 1) {
+    const result = deliveryGate.result;
+    return {
+      summary: {
+        ...summary,
+        codexPlugin: {
+          ...summary.codexPlugin,
+          state: result.code,
+          mutationAuthority: result.authority,
+          actionRequired: true,
+          deliveryComplete: false,
+          recovery: result.recovery,
+        },
+      },
+      exit: result.exit,
+      human: { stream: 'stderr', text: `${result.detail}; ${result.recovery}` },
+    };
+  }
   return {
     summary,
     exit: descriptor.exit,
@@ -1760,7 +1898,17 @@ export async function doctorCommand(options?: { json?: boolean; fix?: boolean },
     deps.databaseRoot === null || typeof deps.databaseRoot === 'string'
       ? deps.databaseRoot
       : (gitRoots?.commonRoot ?? root);
-  const pluginProbe = deps.pluginProbe?.cliAvailable !== undefined ? deps.pluginProbe : probeCodexGeniePlugin();
+  // Group E: ONE bounded host observation feeds the probe, the advisory, and
+  // (via the replay runner) the activation snapshot. It is skipped entirely
+  // only when tests inject both seams.
+  const hostObservation =
+    deps.pluginProbe?.cliAvailable !== undefined && deps.codexActivation !== undefined
+      ? null
+      : observeDoctorCodexHost(deps.codexHost);
+  const pluginProbe =
+    deps.pluginProbe?.cliAvailable !== undefined
+      ? deps.pluginProbe
+      : (hostObservation?.probe ?? probeCodexGeniePlugin());
   const results: CheckResult[] = [
     ...checkGenieBinary(),
     ...checkGit(root),
@@ -1768,7 +1916,13 @@ export async function doctorCommand(options?: { json?: boolean; fix?: boolean },
     ...checkSkills(root),
     ...checkBun(deps.bunVersion, deps.bunPath),
     ...checkSubagentModelOverride(),
-    ...(await checkCodexIntegration(root, pluginProbe)),
+    ...(await checkCodexIntegration(root, pluginProbe, hostObservation?.advisory ?? null)),
+    // Live context resolution only when the root itself was live-resolved: an
+    // injected root without an injected context is a unit-test seam, not a repo.
+    ...checkCodexProjectContext(
+      root,
+      deps.projectContext !== undefined ? deps.projectContext : injectedRoot ? null : undefined,
+    ),
     ...checkV4Residue(),
     ...checkAgentSync(),
     ...(await checkOmniHookTimeout()),
@@ -1780,7 +1934,7 @@ export async function doctorCommand(options?: { json?: boolean; fix?: boolean },
   // One bounded activation observation feeds the additive integration summary.
   // It is purely additive: `{ ok, checks }` meanings are unchanged, and a pending
   // Codex generation keeps `ok:true` while the command exits 2.
-  const activationSnapshot = resolveCodexActivationSnapshot(deps, pluginProbe);
+  const activationSnapshot = resolveCodexActivationSnapshot(deps, pluginProbe, hostObservation);
   const integration = activationSnapshot ? buildCodexIntegration(activationSnapshot) : null;
 
   if (options?.json) {

--- a/src/genie-commands/setup.test.ts
+++ b/src/genie-commands/setup.test.ts
@@ -76,13 +76,27 @@ function reg(version: string): QueryFact {
 function cache(digest = DIGEST): PhysicalCacheFact {
   return { kind: 'present', digest, identity: '10:200' };
 }
+/** A matching authenticated delivery record binding the canonical target (Group E delivery gate). */
+function deliveryPresent(): CodexActivationSnapshot['delivery'] {
+  return {
+    status: 'present',
+    record: {
+      schemaVersion: 1,
+      deliveryId: 'c'.repeat(32),
+      targetVersion: T,
+      canonicalPayloadSha256: DIGEST,
+      channel: 'stable',
+      deliveredAt: '2026-07-12T00:00:00.000Z',
+    },
+  };
+}
 function snapshot(over: Partial<CodexActivationSnapshot> = {}): CodexActivationSnapshot {
   return {
     canonical: okCanonical(),
     query: reg(T),
     cache: cache(),
     receipt: { status: 'absent' },
-    delivery: { status: 'absent' },
+    delivery: deliveryPresent(),
     intent: { status: 'absent' },
     receiptConsumed: false,
     observationWitness: { before: family(), after: family() },
@@ -472,5 +486,108 @@ describe('setup Codex activation (Group D)', () => {
       lease.release();
     }
     expect(existsSync(lockPath)).toBe(false);
+  });
+  // ==========================================================================
+  // Group E, Decision 9/12: the setup-side delivery gate + typed outcome
+  // ==========================================================================
+
+  test('Group E: an ABSENT delivery record refuses before any consent prompt with the recovery command (exit 1)', async () => {
+    let assertionRequested = 0;
+    let executeCalls = 0;
+    const cap = capture();
+    await setupCommand(
+      { codex: true },
+      baseDeps({
+        observeCodexActivation: () => ({ ...pendingSnapshot(), delivery: { status: 'absent' } }),
+        requestRetirementAssertion: () => {
+          assertionRequested += 1;
+          return { result: 'granted', assertion: {} as never };
+        },
+        executeCodexActivation: () => {
+          executeCalls += 1;
+          return ACTIVATED;
+        },
+      }),
+    );
+    const { err, trailer, exitCode } = cap.restore();
+    expect(exitCode).toBe(1);
+    expect(assertionRequested).toBe(0);
+    expect(executeCalls).toBe(0);
+    expect(err).toContain('delivery record is absent');
+    expect(err).toContain('genie update');
+    const parsed = JSON.parse(trailer) as { code: string; deliveryComplete: boolean; retry: boolean };
+    expect(parsed).toMatchObject({ code: 'delivery-incomplete', deliveryComplete: false, retry: true });
+  });
+
+  test('INVALID and MISMATCHED records produce the same consistent delivery-incomplete refusal', async () => {
+    const mismatchedRecord: CodexActivationSnapshot['delivery'] = {
+      status: 'present',
+      record: {
+        schemaVersion: 1,
+        deliveryId: 'c'.repeat(32),
+        targetVersion: OLD,
+        canonicalPayloadSha256: DIGEST,
+        channel: 'stable',
+        deliveredAt: '2026-07-12T00:00:00.000Z',
+      },
+    };
+    const cases: Array<{ delivery: CodexActivationSnapshot['delivery']; assessment: string }> = [
+      { delivery: { status: 'invalid', detail: 'corrupt json' }, assessment: 'invalid' },
+      { delivery: mismatchedRecord, assessment: 'mismatch' },
+    ];
+    for (const { delivery, assessment } of cases) {
+      const cap = capture();
+      await setupCommand(
+        { codex: true },
+        baseDeps({ observeCodexActivation: () => ({ ...pendingSnapshot(), delivery }) }),
+      );
+      const { err, exitCode } = cap.restore();
+      expect(exitCode).toBe(1);
+      expect(err).toContain(`delivery record is ${assessment}`);
+    }
+  });
+
+  test('even an already-current machine without a record is delivery-incomplete, never a success claim', async () => {
+    const cap = capture();
+    await setupCommand(
+      { codex: true },
+      baseDeps({ observeCodexActivation: () => ({ ...currentSnapshot(), delivery: { status: 'absent' } }) }),
+    );
+    const { out, err, exitCode } = cap.restore();
+    expect(exitCode).toBe(1);
+    expect(out).not.toContain('already current');
+    expect(out).not.toContain('Codex configuration saved');
+    expect(err).toContain('delivery record is absent');
+    expect((await loadGenieConfig()).codex?.configured).not.toBe(true);
+  });
+
+  test('historically configured machine: a failed run preserves config bytes and prints NO green banner (Decision 12)', async () => {
+    // Run 1: current + matching record → success, banner, configured persisted.
+    const capFirst = capture();
+    await setupCommand({ codex: true }, baseDeps({ observeCodexActivation: () => currentSnapshot() }));
+    const first = capFirst.restore();
+    expect(first.out).toContain('Codex configuration saved');
+    expect((await loadGenieConfig()).codex?.configured).toBe(true);
+
+    // Run 2: same machine, record now missing → failed run, historical
+    // configured stays persisted (bytes preserved) but no success banner.
+    const capSecond = capture();
+    await setupCommand(
+      { codex: true },
+      baseDeps({ observeCodexActivation: () => ({ ...currentSnapshot(), delivery: { status: 'absent' } }) }),
+    );
+    const second = capSecond.restore();
+    expect(second.exitCode).toBe(1);
+    expect(second.out).not.toContain('Codex configuration saved');
+    expect((await loadGenieConfig()).codex?.configured).toBe(true);
+  });
+
+  test("full wizard summary reflects THIS run's typed outcome, not historical state", async () => {
+    const cap = capture();
+    await setupCommand({ quick: true }, baseDeps());
+    const { out, exitCode } = cap.restore();
+    expect(exitCode).toBe(2);
+    expect(out).toContain('not configured this run (consent-refused)');
+    expect(out).not.toContain('Codex:   \x1b[32mconfigured');
   });
 });

--- a/src/genie-commands/setup.ts
+++ b/src/genie-commands/setup.ts
@@ -30,6 +30,9 @@ import {
 // permit-gated cache advance through B's `executeCodexActivation`.
 import type { ActivationEntryPath, CodexActivationSnapshot, ConsentContext } from '../lib/codex-activation.js';
 import { getCodexConfigPath } from '../lib/codex-config.js';
+// Group E: the shared Decision-9 delivery gate — the same assessment the
+// executor's `beginActivation` inner guard re-applies before its first write.
+import { assessSnapshotDelivery } from '../lib/codex-lifecycle-truth.js';
 import { type CodexPluginProbe, reconcileCodexProjectMcp, resolveGitWorktreeRoot } from '../lib/codex-project-mcp.js';
 import {
   contractPath,
@@ -338,10 +341,31 @@ function preserveRuntimeChoiceAfterCodex(config: GenieConfig): void {
   if (decision.hint) console.log(`  \x1b[2m${decision.hint}\x1b[0m`);
 }
 
+/**
+ * The typed per-invocation setup outcome (Decision 12). Success (a green banner
+ * + persisted `codex.configured`) flows ONLY from this invocation's outcome —
+ * never from historical config state — so a failed or pending run can never
+ * print or persist success.
+ */
+type SetupCodexOutcomeCode =
+  | 'activated'
+  | 'current'
+  | 'payload-missing'
+  | 'delivery-incomplete'
+  | 'status-reported'
+  | 'consent-refused'
+  | 'not-authorized'
+  | 'busy'
+  | 'stale'
+  | 'refused'
+  | 'broken';
+
 interface ActivationOutcome {
   exitCode: 0 | 1 | 2;
   /** True when the plugin is verified-current (freshly activated or already current). */
   activated: boolean;
+  /** The one typed code this invocation ends with; `activated` is true only for 'activated' | 'current'. */
+  code: SetupCodexOutcomeCode;
 }
 
 function emitTrailer(trailer: ReturnType<typeof buildActivationResultTrailer>): void {
@@ -383,16 +407,36 @@ function runCodexActivation(
     console.error(
       '    Delivery is done by \x1b[36mgenie update\x1b[0m / \x1b[36mgenie install\x1b[0m — run one, then rerun \x1b[36mgenie setup --codex\x1b[0m.',
     );
-    return { exitCode: 1, activated: false };
+    return { exitCode: 1, activated: false, code: 'payload-missing' };
+  }
+  // Condition 2 (Group E, Decision 9): a matching authenticated delivery record
+  // is required BEFORE the first prompt or activation-owned mutation — even on
+  // an already-current machine, because only update/install may publish the
+  // record and setup must not claim success it cannot attest. The executor's
+  // `beginActivation` inner guard re-checks the same assessment immediately
+  // before its first write (defense in depth).
+  const deliveryGate = assessSnapshotDelivery(snapshot);
+  if (deliveryGate.kind === 'incomplete') {
+    const gate = deliveryGate.result;
+    console.error(`  \x1b[31m✖\x1b[0m ${gate.detail}`);
+    console.error(`    Recovery: \x1b[36m${gate.recovery}\x1b[0m`);
+    emitTrailer({
+      schemaVersion: 1,
+      code: 'delivery-incomplete',
+      deliveryComplete: false,
+      retry: true,
+      nextAction: gate.recovery,
+    });
+    return { exitCode: gate.exit, activated: false, code: 'delivery-incomplete' };
   }
   if (state.kind === 'current') {
     console.log('  \x1b[32m✓\x1b[0m Codex plugin is already current; no activation needed.');
-    return { exitCode: 0, activated: true };
+    return { exitCode: 0, activated: true, code: 'current' };
   }
   if (descriptor.authority === 'none') {
     const projection = projectHumanStatus(state, snapshot);
     (projection.stream === 'stderr' ? process.stderr : process.stdout).write(`  ${projection.text}\n`);
-    return { exitCode: projection.exitCode, activated: false };
+    return { exitCode: projection.exitCode, activated: false, code: 'status-reported' };
   }
 
   // Activation authority — gate on A's deep consent API (owns TTY/env/flag/prompt).
@@ -403,7 +447,11 @@ function runCodexActivation(
   if (consent.result !== 'granted') {
     console.error(`  \x1b[31m✖\x1b[0m Retirement assertion refused: ${consent.reason}`);
     emitTrailer(buildActivationResultTrailer(state, deliveryComplete));
-    return { exitCode: resolveSetupExitCode(state, { result: 'refused', reason: consent.reason }), activated: false };
+    return {
+      exitCode: resolveSetupExitCode(state, { result: 'refused', reason: consent.reason }),
+      activated: false,
+      code: 'consent-refused',
+    };
   }
   const authorization = (deps.authorizeCodexActivation ?? authorizeCodexActivation)({
     state,
@@ -414,7 +462,7 @@ function runCodexActivation(
     const reason = 'reason' in authorization ? authorization.reason : authorization.result;
     console.error(`  \x1b[31m✖\x1b[0m Activation not authorized: ${reason}`);
     emitTrailer(buildActivationResultTrailer(state, deliveryComplete));
-    return { exitCode: resolveSetupExitCode(state, authorization), activated: false };
+    return { exitCode: resolveSetupExitCode(state, authorization), activated: false, code: 'not-authorized' };
   }
 
   // Permit granted — the executor acquires the `setup-activation` lease itself.
@@ -438,7 +486,7 @@ function reportActivationExecution(result: ActivationExecutionResult): Activatio
   if (result.status === 'activated') {
     console.log(`  \x1b[32m✓\x1b[0m Activated Codex plugin v${result.version} (enabled=${result.enabled}).`);
     console.log(`  \x1b[33m!\x1b[0m ${result.recovery}`);
-    return { exitCode: 0, activated: true };
+    return { exitCode: 0, activated: true, code: 'activated' };
   }
   console.error(`  \x1b[31m✖\x1b[0m ${result.detail}`);
   if (result.status === 'broken') {
@@ -447,8 +495,16 @@ function reportActivationExecution(result: ActivationExecutionResult): Activatio
     );
   }
   emitTrailer(result.trailer);
-  // busy/stale/refused are action-required (exit 2); broken is retry (exit 1).
-  return { exitCode: result.status === 'broken' ? 1 : 2, activated: false };
+  // The executor's own delivery-incomplete inner-guard refusal is exit 1 like
+  // broken; busy/stale/refused stay action-required (exit 2).
+  const exitCode = result.status === 'broken' || result.status === 'delivery-incomplete' ? 1 : 2;
+  return { exitCode, activated: false, code: result.status };
+}
+
+interface ConfigureCodexResult {
+  config: GenieConfig;
+  /** Null when the Codex CLI is absent/skipped — nothing was attempted this invocation. */
+  outcome: ActivationOutcome | null;
 }
 
 async function configureCodex(
@@ -456,20 +512,20 @@ async function configureCodex(
   quick: boolean,
   deps: SetupDeps,
   entry: ActivationEntryPath,
-): Promise<GenieConfig> {
+): Promise<ConfigureCodexResult> {
   printSection('5. Codex Integration', 'Activate the delivered Codex plugin generation for genie agents');
 
   const cwd = deps.cwd ?? process.cwd();
   const codexPath = resolveCodexPath(deps, cwd);
   if (codexPath === null) {
     console.log('  \x1b[33m!\x1b[0m Codex CLI not found. Skipping codex integration.');
-    return config;
+    return { config, outcome: null };
   }
   const codexCheck = await (deps.checkCommand ?? checkCommand)(codexPath, { which: () => codexPath });
   if (codexCheck.timedOut) throw new SetupIntegrationError(codexCheck.error ?? 'Codex CLI detection timed out');
   if (!codexCheck.exists) {
     console.log('  \x1b[33m!\x1b[0m Codex CLI not found. Skipping codex integration.');
-    return config;
+    return { config, outcome: null };
   }
   console.log(`  \x1b[32m✓\x1b[0m Codex CLI found (${codexCheck.version ?? 'unknown version'})`);
   console.log();
@@ -498,7 +554,7 @@ async function configureCodex(
   } else if (outcome.exitCode !== 0) {
     process.exitCode = outcome.exitCode;
   }
-  return config;
+  return { config, outcome };
 }
 
 type DefaultAgent = GenieConfig['runtime']['defaultAgent'];
@@ -588,15 +644,30 @@ async function configurePromptMode(config: GenieConfig, quick: boolean): Promise
 // Summary and Save
 // ============================================================================
 
-async function showSummaryAndSave(config: GenieConfig, baseline: GenieConfig, deps: SetupDeps): Promise<void> {
+async function showSummaryAndSave(
+  config: GenieConfig,
+  baseline: GenieConfig,
+  deps: SetupDeps,
+  codexOutcome?: ActivationOutcome | null,
+): Promise<void> {
   printSection('Summary', `Configuration will be saved to ${contractPath(getGenieConfigPath())}`);
 
+  // Decision 12: when this run attempted Codex, the summary states THIS run's
+  // typed outcome; historical `configured` state cannot masquerade as success.
+  const codexLine =
+    codexOutcome === undefined || codexOutcome === null
+      ? config.codex?.configured
+        ? '\x1b[32mconfigured\x1b[0m'
+        : '\x1b[2mnot configured\x1b[0m'
+      : codexOutcome.activated
+        ? '\x1b[32mconfigured\x1b[0m'
+        : `\x1b[2mnot configured this run (${codexOutcome.code})\x1b[0m`;
   console.log(`  Session: \x1b[36m${config.session.name}\x1b[0m (window: ${config.session.defaultWindow})`);
   console.log(`  Terminal: timeout=${config.terminal.execTimeout}ms, lines=${config.terminal.readLines}`);
   console.log(
     `  Shortcuts: ${config.shortcuts.tmuxInstalled ? '\x1b[32minstalled\x1b[0m' : '\x1b[2mnot installed\x1b[0m'}`,
   );
-  console.log(`  Codex:   ${config.codex?.configured ? '\x1b[32mconfigured\x1b[0m' : '\x1b[2mnot configured\x1b[0m'}`);
+  console.log(`  Codex:   ${codexLine}`);
   console.log(`  Debug: tmux=${config.logging.tmuxDebug}, verbose=${config.logging.verbose}`);
   console.log(`  Prompt mode: \x1b[36m${config.promptMode}\x1b[0m`);
   console.log();
@@ -687,9 +758,13 @@ async function runSetupCommand(options: SetupOptions, deps: SetupDeps): Promise<
 
   if (options.codex) {
     printHeader();
-    config = await configureCodex(config, options.quick ?? false, deps, 'setup-codex');
+    const codexRun = await configureCodex(config, options.quick ?? false, deps, 'setup-codex');
+    config = codexRun.config;
     await saveSetupConfig(config, baseline, deps);
-    if (config.codex?.configured) {
+    // Decision 12: the green banner flows from THIS invocation's typed outcome,
+    // never from historical `codex.configured` state \u2014 a failed or pending run
+    // on a historically configured machine prints no success.
+    if (codexRun.outcome?.activated) {
       console.log('\x1b[32m\u2713 Codex configuration saved.\x1b[0m');
     }
     return;
@@ -708,12 +783,14 @@ async function runSetupCommand(options: SetupOptions, deps: SetupDeps): Promise<
   config = await configureSession(config, quick);
   config = await configureTerminal(config, quick);
   config = await configureShortcuts(config, quick, deps);
-  config = await configureCodex(config, quick, deps, 'full-setup-codex-step');
+  const codexRun = await configureCodex(config, quick, deps, 'full-setup-codex-step');
+  config = codexRun.config;
   config = await configureDebug(config, quick);
   config = await configurePromptMode(config, quick);
 
-  // Save and show summary
-  await showSummaryAndSave(config, baseline, deps);
+  // Save and show summary (unrelated completed sections save regardless; the
+  // Codex line reflects THIS run's typed outcome, not historical state).
+  await showSummaryAndSave(config, baseline, deps, codexRun.outcome);
 
   // This file mutation follows the same just-acquired/revalidated config
   // commit rather than extending a lease across any wizard prompt.

--- a/src/genie-commands/setup.ts
+++ b/src/genie-commands/setup.ts
@@ -33,7 +33,12 @@ import { getCodexConfigPath } from '../lib/codex-config.js';
 // Group E: the shared Decision-9 delivery gate — the same assessment the
 // executor's `beginActivation` inner guard re-applies before its first write.
 import { assessSnapshotDelivery } from '../lib/codex-lifecycle-truth.js';
-import { type CodexPluginProbe, reconcileCodexProjectMcp, resolveGitWorktreeRoot } from '../lib/codex-project-mcp.js';
+import {
+  type CodexPluginProbe,
+  genieFacadeMcpEntry,
+  reconcileCodexProjectMcp,
+  resolveGitWorktreeRoot,
+} from '../lib/codex-project-mcp.js';
 import {
   contractPath,
   getGenieConfigPath,
@@ -311,20 +316,30 @@ function reconcileSetupCodexProject(root: string | null, plugin: CodexPluginProb
     console.log('  \x1b[2mNo Git worktree detected; project MCP fallback was not changed.\x1b[0m');
     return;
   }
-  const project = reconcileCodexProjectMcp(root, plugin);
+  // Decision 2: the marker route carries the stable absolute GENIE_HOME facade,
+  // exactly as trusted `genie init` writes it.
+  const project = reconcileCodexProjectMcp(root, plugin, genieFacadeMcpEntry());
   if (!project.ok) throw new SetupIntegrationError(project.detail ?? 'Codex project MCP reconciliation failed');
   console.log(`  \x1b[32m✓\x1b[0m Project MCP route: ${project.route} (${project.detail ?? project.action})`);
 }
 
-/** A synthetic verified-current probe: an activated plugin removes the project fallback. */
+/**
+ * Post-activation route probe (Group E). The installed Codex plugin ships NO
+ * MCP route (Group A removed the manifest declaration), so for ROUTE purposes
+ * an activated plugin is never "usable" and the marker-owned project route
+ * remains required. Decision 1: plugin availability never creates or removes
+ * the project route — the pre-A behavior of removing the fallback after
+ * activation left a repository with no Codex route at all.
+ */
 function verifiedCurrentPluginProbe(): CodexPluginProbe {
   return {
     cliAvailable: true,
     status: 'ok',
     installed: true,
     enabled: true,
-    usable: true,
-    detail: 'activation verified-current (plugin trusted, project fallback removed)',
+    usable: false,
+    usabilityDetail: 'installed plugin contributes no Codex MCP route; the marker-owned project route is authoritative',
+    detail: 'activation verified-current; project route remains marker-owned',
   };
 }
 

--- a/src/genie-commands/uninstall.test.ts
+++ b/src/genie-commands/uninstall.test.ts
@@ -1356,6 +1356,34 @@ describe('agent-sync managed-asset removal', () => {
     expect(existsSync(uninstallBatchJournalPath(genieHome))).toBe(true);
   });
 
+  // Group E carry-forward (Decision 14): the legacy `.install-version` marker
+  // has NO dedicated uninstall call — the digest-verified wholesale GENIE_HOME
+  // removal owns it. A dedicated delete inside the plan→execute window would
+  // poison `genieHomeRemovalDigest` (the marker is a snapshotted removable
+  // child); before the window it is redundant; after, a no-op. These pin both
+  // legacy layouts through the REAL batch path instead.
+  test('uninstall removes a GENIE_HOME carrying a legacy regular-file .install-version marker', () => {
+    mkdirSync(join(genieHome, 'plugins', 'genie'), { recursive: true });
+    writeFileSync(join(genieHome, 'plugins', 'genie', 'payload.txt'), 'delivered\n');
+    writeFileSync(join(genieHome, '.install-version'), '4.9.9\n');
+    const outcome = withIsolatedHomes(() => performFreshUninstallPlan(genieHome, false));
+    expect(outcome.result.failures).toEqual([]);
+    expect(existsSync(join(genieHome, '.install-version'))).toBe(false);
+    expect(existsSync(join(genieHome, 'plugins'))).toBe(false);
+  });
+
+  test('uninstall unlinks a symlinked .install-version marker without following it to its target', () => {
+    const target = join(tmp, 'outside-marker-target.txt');
+    writeFileSync(target, 'survives uninstall\n');
+    mkdirSync(join(genieHome, 'plugins', 'genie'), { recursive: true });
+    writeFileSync(join(genieHome, 'plugins', 'genie', 'payload.txt'), 'delivered\n');
+    symlinkSync(target, join(genieHome, '.install-version'));
+    const outcome = withIsolatedHomes(() => performFreshUninstallPlan(genieHome, false));
+    expect(outcome.result.failures).toEqual([]);
+    expect(existsSync(join(genieHome, '.install-version'))).toBe(false);
+    expect(readFileSync(target, 'utf8')).toBe('survives uninstall\n');
+  });
+
   test('late nested insertion survives the final non-recursive rmdir check without a completion receipt', () => {
     const payload = join(genieHome, 'plugins', 'genie', 'payload.txt');
     const foreignBytes = Buffer.from('late foreign must survive\n');

--- a/src/lib/codex-doctor-observation.test.ts
+++ b/src/lib/codex-doctor-observation.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { observeDoctorCodexHost } from './codex-doctor-observation.js';
+import type { CommandResult } from './runtime-integrations.js';
+
+const T = '5.260722.1';
+// An absolute, existing, executable path so the probe's trusted-executable
+// validation passes without a real Codex install.
+const FAKE_CODEX = process.execPath;
+
+function pluginListJson(entries: Array<{ version: string; enabled?: boolean }>): string {
+  return JSON.stringify({
+    installed: entries.map((e) => ({ pluginId: 'genie@automagik', version: e.version, enabled: e.enabled ?? true })),
+  });
+}
+
+let codexHome: string;
+beforeEach(() => {
+  codexHome = mkdtempSync(join(tmpdir(), 'doctor-obs-codex-'));
+});
+afterEach(() => {
+  rmSync(codexHome, { recursive: true, force: true });
+});
+
+function observe(result: Partial<CommandResult>, calls: string[][] = []) {
+  return observeDoctorCodexHost({
+    which: () => FAKE_CODEX,
+    codexHome,
+    runner: (command, args) => {
+      calls.push([command, ...args]);
+      return { exitCode: 0, stdout: '', stderr: '', ...result };
+    },
+  });
+}
+
+describe('observeDoctorCodexHost — one bounded observation, every surface derived', () => {
+  test('absent CLI: zero spawns, probe reports Claude-only mode', () => {
+    const calls: string[][] = [];
+    const obs = observeDoctorCodexHost({
+      which: () => null,
+      runner: () => {
+        calls.push(['spawned']);
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    });
+    expect(calls).toEqual([]);
+    expect(obs.codexCommand).toBeNull();
+    expect(obs.observation).toBeNull();
+    expect(obs.projection).toBeNull();
+    expect(obs.advisory).toBeNull();
+    expect(obs.activationRunner).toBeNull();
+    expect(obs.probe.cliAvailable).toBe(false);
+  });
+
+  test('exactly ONE bounded query feeds probe, projection, and replay runner', () => {
+    const calls: string[][] = [];
+    const obs = observe({ stdout: pluginListJson([{ version: T, enabled: true }]) }, calls);
+    expect(calls).toEqual([[FAKE_CODEX, 'plugin', 'list', '--json']]);
+    expect(obs.observation?.status).toBe('ok');
+    expect(obs.probe).toMatchObject({ cliAvailable: true, installed: true, enabled: true, version: T });
+    expect(obs.projection).toMatchObject({ registration: 'present', installedVersion: T, queryFailed: false });
+    // Deriving the activation snapshot must NOT spawn again.
+    obs.activationRunner?.(FAKE_CODEX, ['plugin', 'list', '--json']);
+    expect(calls).toHaveLength(1);
+  });
+
+  test('the real sandbox PATH advisory: ok observation, advisory retained, replay stderr blanked (Decision 11)', () => {
+    const obs = observe({
+      stdout: pluginListJson([{ version: T }]),
+      stderr: '\x1b[33mWARN: PATH does not include codex shims\x1b[0m',
+    });
+    expect(obs.observation?.status).toBe('ok');
+    expect(obs.advisory).toBe('WARN: PATH does not include codex shims');
+    // Probe side already tolerated exit-0 stderr; replay side must now agree.
+    expect(obs.probe.installed).toBe(true);
+    const replay = obs.activationRunner?.(FAKE_CODEX, ['plugin', 'list', '--json']);
+    expect(replay?.stderr).toBe('');
+    expect(replay?.stdout).toBe(pluginListJson([{ version: T }]));
+  });
+
+  test('nonzero exit fails BOTH surfaces from the same fact', () => {
+    const obs = observe({ exitCode: 3, stderr: 'boom' });
+    expect(obs.observation?.status).toBe('failed');
+    expect(obs.projection?.queryFailed).toBe(true);
+    expect(obs.probe.status).toBe('error');
+    const replay = obs.activationRunner?.(FAKE_CODEX, ['plugin', 'list', '--json']);
+    expect(replay?.exitCode).toBe(3);
+    expect(replay?.stderr).toBe('boom');
+  });
+
+  test('timeout fails both surfaces', () => {
+    const obs = observe({ timedOut: true });
+    expect(obs.observation).toMatchObject({ status: 'failed', code: 'timeout' });
+    expect(obs.probe).toMatchObject({ status: 'error', timedOut: true });
+    expect(obs.activationRunner?.(FAKE_CODEX, [])?.timedOut).toBe(true);
+  });
+
+  test('output overflow can never replay as a smaller valid answer (e.g. "not installed")', () => {
+    const obs = observe({ outputOverflow: true, stdout: '{"installed":' });
+    expect(obs.observation).toMatchObject({ status: 'failed', code: 'output-overflow' });
+    expect(obs.probe.status).toBe('error');
+    expect(obs.probe.installed).toBe(false);
+    expect(obs.probe.detail).toContain('output cap');
+    const replay = obs.activationRunner?.(FAKE_CODEX, []);
+    expect(replay?.outputOverflow).toBe(true);
+  });
+
+  test('malformed stdout fails both surfaces', () => {
+    const obs = observe({ stdout: 'not json' });
+    expect(obs.observation).toMatchObject({ status: 'failed', code: 'malformed-json' });
+    const replay = obs.activationRunner?.(FAKE_CODEX, []);
+    expect(replay?.stdout).toBe('not json');
+  });
+});

--- a/src/lib/codex-doctor-observation.ts
+++ b/src/lib/codex-doctor-observation.ts
@@ -1,0 +1,147 @@
+/**
+ * Group E — the ONE bounded Codex host observation per doctor run.
+ *
+ * Doctor previously spawned `codex plugin list --json` twice — once through
+ * `probeCodexGeniePlugin` (feeding the check list) and once through
+ * `observeCodexActivation` (feeding the integration summary/trailer/exit) —
+ * with divergent stderr policy: the probe ignored exit-0 stderr while the
+ * activation observer failed closed on ANY stderr. A single benign sandbox
+ * PATH advisory therefore produced a healthy check list alongside a
+ * query-failed integration summary and exit 1: two contradictory answers to
+ * one question from one host.
+ *
+ * This module runs the bounded query EXACTLY ONCE, classifies the result
+ * through Group B's `parseCodexHostObservation` (Decision 11: exit 0 plus
+ * exactly one schema-valid JSON stdout value succeeds; bounded advisory stderr
+ * is retained only as sanitized diagnostic metadata, never a second policy
+ * decision), and derives every downstream doctor input from that single
+ * observation:
+ *
+ *  - a `CodexPluginProbe` via `probeCodexGeniePlugin`'s replay seam;
+ *  - a replay `CommandRunner` for `observeCodexActivation` — the SAME captured
+ *    bytes, with advisory stderr blanked ONLY when the observation succeeded,
+ *    so the fail-closed activation parser cannot contradict the check list
+ *    while every real failure (timeout, overflow, nonzero exit, malformed or
+ *    duplicate JSON) replays raw and fails both surfaces consistently;
+ *  - the sanitized advisory text for diagnostics.
+ *
+ * Pure over the injected seams; the only IO is the one bounded subprocess and
+ * Group B's bounded cache-family witness.
+ */
+
+import {
+  type CodexHostObservation,
+  type HostQueryProjection,
+  parseCodexHostObservation,
+  projectHostQuery,
+  witnessCodexCacheFamily,
+} from './codex-host-observation.js';
+import { type CodexPluginProbe, type CodexProbeCommandResult, probeCodexGeniePlugin } from './codex-project-mcp.js';
+import { resolveCodexDir } from './genie-home.js';
+import { type CommandResult, type CommandRunner, runBoundedIntegrationCommand } from './runtime-integrations.js';
+
+/** Same bounds `observeCodexActivation` applies to its own plugin query. */
+const PLUGIN_LIST_TIMEOUT_MS = 5_000;
+const PLUGIN_LIST_MAX_BYTES = 64 * 1024;
+
+export interface DoctorCodexObservationDeps {
+  /** Codex CLI resolution seam; default is a safe `Bun.which`. */
+  which?: (name: string) => string | null;
+  /** Bounded subprocess seam; default is the shared integration runner. */
+  runner?: CommandRunner;
+  codexHome?: string;
+  cwd?: string;
+}
+
+export interface DoctorCodexObservation {
+  /** Absolute Codex CLI path, or null when the CLI is absent (Claude-only host). */
+  codexCommand: string | null;
+  /** Group B's typed observation of the one bounded query; null when the CLI is absent. */
+  observation: CodexHostObservation | null;
+  /** The single projection every doctor surface derives from; null when the CLI is absent. */
+  projection: HostQueryProjection | null;
+  /** Sanitized, bounded advisory stderr (e.g. the real sandbox PATH advisory); diagnostic metadata only. */
+  advisory: string | null;
+  /** The check-list probe, derived from the SAME captured query result. */
+  probe: CodexPluginProbe;
+  /** Replay runner for `observeCodexActivation`; null when the CLI is absent. */
+  activationRunner: CommandRunner | null;
+}
+
+/**
+ * Observe the Codex host once and derive every doctor-side consumer input.
+ * Spawns exactly one bounded `codex plugin list --json` when the CLI is
+ * present, and nothing at all when it is absent.
+ */
+export function observeDoctorCodexHost(deps: DoctorCodexObservationDeps = {}): DoctorCodexObservation {
+  const which = deps.which ?? safeWhich;
+  const codexCommand = which('codex');
+  if (codexCommand === null) {
+    return {
+      codexCommand: null,
+      observation: null,
+      projection: null,
+      advisory: null,
+      probe: probeCodexGeniePlugin({ which: () => null }),
+      activationRunner: null,
+    };
+  }
+  const codexHome = deps.codexHome ?? resolveCodexDir();
+  const cacheFamily = witnessCodexCacheFamily(codexHome);
+  const runner = deps.runner ?? runBoundedIntegrationCommand;
+  const result = runner(codexCommand, ['plugin', 'list', '--json'], {
+    timeoutMs: PLUGIN_LIST_TIMEOUT_MS,
+    maxOutputBytes: PLUGIN_LIST_MAX_BYTES,
+  });
+  const observation = parseCodexHostObservation({ result, cacheFamily });
+  const projection = projectHostQuery(observation);
+  const probe = probeCodexGeniePlugin({
+    which: () => codexCommand,
+    codexHome,
+    cwd: deps.cwd,
+    run: () => replayProbeResult(result),
+  });
+  // Decision 11 applied once, at the seam: an ok observation already proved
+  // exit 0 + exactly one schema-valid JSON value, so its advisory stderr is
+  // metadata — blank it for the fail-closed activation parser. Every failed
+  // observation replays the raw bytes so both parsers fail for the same fact.
+  const activationRunner: CommandRunner =
+    observation.status === 'ok' ? () => ({ ...result, stderr: '' }) : () => result;
+  return {
+    codexCommand,
+    observation,
+    projection,
+    advisory: projection.advisory,
+    probe,
+    activationRunner,
+  };
+}
+
+/** Map the captured bounded result onto the probe's replay-runner shape. */
+function replayProbeResult(result: CommandResult): CodexProbeCommandResult {
+  if (result.outputOverflow === true) {
+    // The probe runner shape has no overflow flag; a truncated stdout must not
+    // parse as a smaller valid answer (e.g. "not installed"), so overflow
+    // replays as an explicit command failure on both surfaces.
+    return {
+      exitCode: 1,
+      stdout: '',
+      stderr: 'codex plugin list exceeded the bounded output cap',
+      timedOut: false,
+    };
+  }
+  return {
+    exitCode: result.exitCode,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    timedOut: result.timedOut === true,
+  };
+}
+
+function safeWhich(name: string): string | null {
+  try {
+    return Bun.which(name);
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/codex-lifecycle-truth.test.ts
+++ b/src/lib/codex-lifecycle-truth.test.ts
@@ -200,6 +200,44 @@ describe('classifyRouteLayers (typed config-layer diagnostics)', () => {
     expect(findings).toEqual([]);
   });
 
+  test('the dotted-key route spelling (the marker form) is detected in nested and global layers', () => {
+    const nested = join(root, 'packages');
+    const dottedConfig = 'mcp_servers.genie.command = "/elsewhere/genie"\nmcp_servers.genie.args = ["mcp"]\n';
+    const files: Record<string, string> = {
+      [join(nested, '.codex', 'config.toml')]: dottedConfig,
+      '/codex-home/config.toml': `${dottedConfig}${trustedGlobal}`,
+    };
+    const findings = classifyRouteLayers(
+      input({ cwd: nested, readFile: (path) => files[path] ?? null, exists: (path) => path in files }),
+    );
+    expect(findings.map((finding) => finding.kind).sort()).toEqual(['global-route-same-key', 'route-shadowed']);
+  });
+
+  test('a dotted-key inline-table route (mcp_servers.genie = {…}) is detected', () => {
+    const findings = classifyRouteLayers(
+      input({
+        readFile: (path) =>
+          path === '/codex-home/config.toml'
+            ? `mcp_servers.genie = { command = "/old/genie", args = [] }\n${trustedGlobal}`
+            : null,
+      }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ kind: 'global-route-same-key' });
+  });
+
+  test('a non-genie dotted key or unrelated assignment does not false-positive', () => {
+    const findings = classifyRouteLayers(
+      input({
+        readFile: (path) =>
+          path === '/codex-home/config.toml'
+            ? `mcp_servers.other.command = "/x"\nsome_genie_note = "mcp_servers.genie"\n${trustedGlobal}`
+            : null,
+      }),
+    );
+    expect(findings).toEqual([]);
+  });
+
   test('a global same-key route is reported and preserved', () => {
     const findings = classifyRouteLayers(
       input({

--- a/src/lib/codex-lifecycle-truth.test.ts
+++ b/src/lib/codex-lifecycle-truth.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, test } from 'bun:test';
+import { join, resolve } from 'node:path';
+import type { CodexActivationSnapshot } from './codex-activation.js';
+import { parseReleaseVersion } from './codex-activation.js';
+import { DELIVERY_INCOMPLETE_RECOVERY } from './codex-host-observation.js';
+import {
+  type RouteLayerInput,
+  assessSnapshotDelivery,
+  classifyRouteLayers,
+  projectTrustState,
+  snapshotDeliveryReadState,
+} from './codex-lifecycle-truth.js';
+
+const T = '5.260722.1';
+const DIGEST = 'a'.repeat(64);
+
+function ver(s: string) {
+  const parsed = parseReleaseVersion(s);
+  if (!parsed) throw new Error(`bad test version ${s}`);
+  return parsed;
+}
+
+function snapshot(over: Partial<CodexActivationSnapshot> = {}): CodexActivationSnapshot {
+  return {
+    canonical: { status: 'ok', version: ver(T), digest: DIGEST, identity: '10:100' },
+    query: { status: 'ok', registration: { present: true, enabled: true, version: ver(T) } },
+    cache: { kind: 'present', digest: DIGEST, identity: '10:200' },
+    receipt: { status: 'absent' },
+    delivery: { status: 'absent' },
+    intent: { status: 'absent' },
+    receiptConsumed: false,
+    observationWitness: {
+      before: { status: 'present', digest: 'f'.repeat(64), identity: '10:300' },
+      after: { status: 'present', digest: 'f'.repeat(64), identity: '10:300' },
+    },
+    observedAt: '2026-07-22T00:00:00.000Z',
+    ...over,
+  };
+}
+
+function matchingDelivery(over: Partial<Record<string, string>> = {}): CodexActivationSnapshot['delivery'] {
+  return {
+    status: 'present',
+    record: {
+      schemaVersion: 1,
+      deliveryId: 'c'.repeat(32),
+      targetVersion: T,
+      canonicalPayloadSha256: DIGEST,
+      channel: 'stable',
+      deliveredAt: '2026-07-22T00:00:00.000Z',
+      ...over,
+    },
+  };
+}
+
+describe('assessSnapshotDelivery (Decision 9 shared gate)', () => {
+  test('matching record binding the canonical target passes', () => {
+    expect(assessSnapshotDelivery(snapshot({ delivery: matchingDelivery() }))).toEqual({ kind: 'matching' });
+  });
+
+  test('absent record is the one consistent delivery-incomplete result with the recovery command', () => {
+    const gate = assessSnapshotDelivery(snapshot());
+    if (gate.kind !== 'incomplete') throw new Error(`expected incomplete, got ${gate.kind}`);
+    expect(gate.result).toMatchObject({
+      code: 'delivery-incomplete',
+      authority: 'none',
+      exit: 1,
+      deliveryComplete: false,
+      assessment: 'absent',
+      recovery: DELIVERY_INCOMPLETE_RECOVERY,
+    });
+  });
+
+  test('invalid record classifies invalid, never mismatch', () => {
+    const gate = assessSnapshotDelivery(snapshot({ delivery: { status: 'invalid', detail: 'corrupt json' } }));
+    if (gate.kind !== 'incomplete') throw new Error(`expected incomplete, got ${gate.kind}`);
+    expect(gate.result.assessment).toBe('invalid');
+  });
+
+  test('record bound to a different target version is a mismatch', () => {
+    const gate = assessSnapshotDelivery(snapshot({ delivery: matchingDelivery({ targetVersion: '5.260711.9' }) }));
+    if (gate.kind !== 'incomplete') throw new Error(`expected incomplete, got ${gate.kind}`);
+    expect(gate.result.assessment).toBe('mismatch');
+  });
+
+  test('record bound to a different payload digest is a mismatch', () => {
+    const gate = assessSnapshotDelivery(
+      snapshot({ delivery: matchingDelivery({ canonicalPayloadSha256: 'b'.repeat(64) }) }),
+    );
+    if (gate.kind !== 'incomplete') throw new Error(`expected incomplete, got ${gate.kind}`);
+    expect(gate.result.assessment).toBe('mismatch');
+  });
+
+  test('missing canonical payload is unassessable — the earlier payload guard owns that state', () => {
+    const gate = assessSnapshotDelivery(
+      snapshot({ canonical: { status: 'error', detail: 'payload root not found' }, delivery: matchingDelivery() }),
+    );
+    expect(gate).toEqual({ kind: 'unassessable', detail: 'canonical payload is unavailable: payload root not found' });
+  });
+
+  test('snapshotDeliveryReadState maps all three fact arms', () => {
+    expect(snapshotDeliveryReadState(snapshot()).status).toBe('absent');
+    expect(snapshotDeliveryReadState(snapshot({ delivery: { status: 'invalid', detail: 'x' } }))).toEqual({
+      status: 'invalid',
+      detail: 'x',
+    });
+    expect(snapshotDeliveryReadState(snapshot({ delivery: matchingDelivery() })).status).toBe('present');
+  });
+});
+
+describe('classifyRouteLayers (typed config-layer diagnostics)', () => {
+  const root = resolve('/repo');
+  function input(over: Partial<RouteLayerInput> = {}): RouteLayerInput {
+    return {
+      worktreeRoot: root,
+      cwd: root,
+      route: { route: 'fallback', detail: 'project fallback' },
+      globalConfigPath: '/codex-home/config.toml',
+      readFile: () => null,
+      exists: () => false,
+      ...over,
+    };
+  }
+  const trustedGlobal = `[projects."${root}"]\ntrust_level = "trusted"\n`;
+
+  test('an intact trusted route yields zero findings', () => {
+    const findings = classifyRouteLayers(
+      input({ readFile: (path) => (path === '/codex-home/config.toml' ? trustedGlobal : null) }),
+    );
+    expect(findings).toEqual([]);
+  });
+
+  test('plugin+project conflict is a route-collision', () => {
+    const findings = classifyRouteLayers(
+      input({
+        route: { route: 'conflict', detail: 'both routes effective' },
+        readFile: (path) => (path === '/codex-home/config.toml' ? trustedGlobal : null),
+      }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ kind: 'route-collision' });
+    expect(findings[0]?.detail).toContain('both routes effective');
+  });
+
+  test('a user-owned same-key project route is a route-collision that names user resolution', () => {
+    const findings = classifyRouteLayers(
+      input({
+        route: { route: 'unmanaged-fallback', detail: 'unmanaged [mcp_servers.genie]' },
+        readFile: (path) => (path === '/codex-home/config.toml' ? trustedGlobal : null),
+      }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ kind: 'route-collision' });
+    expect(findings[0]?.detail).toContain('user-owned');
+    expect(findings[0]?.detail).toContain('user resolution');
+  });
+
+  test('a nested .codex/config.toml nearer to the CWD shadows the root marker (nearest owner reported)', () => {
+    const nested = join(root, 'packages', 'web');
+    const mid = join(root, 'packages');
+    const shadowConfig = '[mcp_servers.genie]\ncommand = "other"\n';
+    const files: Record<string, string> = {
+      [join(nested, '.codex', 'config.toml')]: shadowConfig,
+      [join(mid, '.codex', 'config.toml')]: shadowConfig,
+      '/codex-home/config.toml': trustedGlobal,
+    };
+    const findings = classifyRouteLayers(
+      input({
+        cwd: nested,
+        readFile: (path) => files[path] ?? null,
+        exists: (path) => path in files,
+      }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ kind: 'route-shadowed', ownerPath: nested });
+  });
+
+  test('a nested config without a genie route does not shadow', () => {
+    const nested = join(root, 'packages');
+    const files: Record<string, string> = {
+      [join(nested, '.codex', 'config.toml')]: '[mcp_servers.other]\ncommand = "x"\n',
+      '/codex-home/config.toml': trustedGlobal,
+    };
+    const findings = classifyRouteLayers(
+      input({ cwd: nested, readFile: (path) => files[path] ?? null, exists: (path) => path in files }),
+    );
+    expect(findings).toEqual([]);
+  });
+
+  test('a CWD outside the worktree root never walks the chain', () => {
+    const findings = classifyRouteLayers(
+      input({
+        cwd: '/elsewhere',
+        readFile: (path) => (path === '/codex-home/config.toml' ? trustedGlobal : null),
+        exists: () => {
+          throw new Error('chain walk must not run for an outside CWD');
+        },
+      }),
+    );
+    expect(findings).toEqual([]);
+  });
+
+  test('a global same-key route is reported and preserved', () => {
+    const findings = classifyRouteLayers(
+      input({
+        readFile: (path) =>
+          path === '/codex-home/config.toml' ? `[mcp_servers.genie]\ncommand = "old"\n${trustedGlobal}` : null,
+      }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ kind: 'global-route-same-key', path: '/codex-home/config.toml' });
+  });
+
+  test('an explicit non-trusted trust_level is untrusted-config', () => {
+    const findings = classifyRouteLayers(
+      input({
+        readFile: (path) =>
+          path === '/codex-home/config.toml' ? `[projects."${root}"]\ntrust_level = "untrusted"\n` : null,
+      }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ kind: 'untrusted-config' });
+    expect(findings[0]?.detail).toContain("'untrusted'");
+  });
+
+  test('no trust entry at all is project-trust-required', () => {
+    const findings = classifyRouteLayers(input());
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ kind: 'project-trust-required' });
+  });
+
+  test('trust entry for a DIFFERENT project does not trust this one', () => {
+    const findings = classifyRouteLayers(
+      input({
+        readFile: (path) =>
+          path === '/codex-home/config.toml' ? `[projects."/other/repo"]\ntrust_level = "trusted"\n` : null,
+      }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ kind: 'project-trust-required' });
+  });
+});
+
+describe('projectTrustState (bounded targeted parse)', () => {
+  const root = resolve('/repo');
+
+  test('trusted entry is trusted', () => {
+    expect(projectTrustState(`[projects."${root}"]\ntrust_level = "trusted"\n`, root)).toEqual({ state: 'trusted' });
+  });
+
+  test('trust_level read stops at the next section header', () => {
+    const config = `[projects."${root}"]\nother = 1\n[projects."/other"]\ntrust_level = "trusted"\n`;
+    expect(projectTrustState(config, root)).toEqual({ state: 'unknown' });
+  });
+
+  test('null config (absent/unreadable/oversized) is unknown', () => {
+    expect(projectTrustState(null, root)).toEqual({ state: 'unknown' });
+  });
+});

--- a/src/lib/codex-lifecycle-truth.ts
+++ b/src/lib/codex-lifecycle-truth.ts
@@ -22,7 +22,7 @@
  *    or shadowing layer is preserved exactly as found (Decision 8).
  */
 
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import { dirname, join, relative, resolve, sep } from 'node:path';
 import type { CodexActivationSnapshot } from './codex-activation.js';
 import {
@@ -188,8 +188,11 @@ function nearestShadowingConfig(
   readFile: (path: string) => string | null,
   exists: (path: string) => boolean,
 ): string | null {
-  const root = resolve(worktreeRoot);
-  let current = resolve(cwd);
+  // Physical identity: a logical root (e.g. macOS /var/...) and a physical CWD
+  // (/private/var/...) describe the same chain; without realpath the walk
+  // would silently skip and under-report shadowing.
+  const root = safeRealpath(worktreeRoot);
+  let current = safeRealpath(cwd);
   const rel = relative(root, current);
   if (rel.startsWith('..') || rel.split(sep).includes('..')) return null;
   while (current !== root) {
@@ -217,11 +220,21 @@ type ProjectTrustState = { state: 'trusted' } | { state: 'untrusted'; level: str
  */
 export function projectTrustState(globalConfig: string | null, worktreeRoot: string): ProjectTrustState {
   if (globalConfig === null) return { state: 'unknown' };
-  const escapedPath = resolve(worktreeRoot).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-  const lines = globalConfig.split('\n');
+  // Codex records the project path as it saw it; tolerate both the logical and
+  // the physical spelling of the same directory (macOS /var vs /private/var).
+  const candidates = [...new Set([resolve(worktreeRoot), safeRealpath(worktreeRoot)])];
+  for (const candidate of candidates) {
+    const found = trustEntryFor(globalConfig, candidate);
+    if (found !== null) return found;
+  }
+  return { state: 'unknown' };
+}
+
+function trustEntryFor(globalConfig: string, projectPath: string): ProjectTrustState | null {
+  const escapedPath = projectPath.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
   const headerExact = `[projects."${escapedPath}"]`;
   let inSection = false;
-  for (const rawLine of lines) {
+  for (const rawLine of globalConfig.split('\n')) {
     const line = rawLine.trim();
     if (line.startsWith('[')) {
       inSection = line === headerExact;
@@ -233,5 +246,14 @@ export function projectTrustState(globalConfig: string | null, worktreeRoot: str
       return match[1] === 'trusted' ? { state: 'trusted' } : { state: 'untrusted', level: match[1] ?? '' };
     }
   }
-  return { state: 'unknown' };
+  return null;
+}
+
+/** Physical path identity with a logical fallback for not-yet-existing paths. */
+function safeRealpath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
 }

--- a/src/lib/codex-lifecycle-truth.ts
+++ b/src/lib/codex-lifecycle-truth.ts
@@ -1,0 +1,237 @@
+/**
+ * Group E — lifecycle-truth integration: the pure policy seams that make
+ * `genie setup --codex` and `genie doctor` derive their Codex claims from the
+ * SAME observed facts instead of re-deciding them per surface.
+ *
+ * Two concerns live here, both pure (all IO is injected):
+ *
+ * 1. The shared delivery gate (Decision 9): one assessment of the observed
+ *    snapshot's authenticated delivery record against the installed canonical
+ *    target. Setup applies it BEFORE its first prompt or activation-owned
+ *    mutation; doctor applies it so a missing/invalid/mismatched record can
+ *    never coexist with a green `current` claim. The executor's
+ *    `beginActivation` inner guard remains the authoritative defense in depth
+ *    immediately before the first journal write — this gate never replaces it.
+ *
+ * 2. The route-layer classifier: distinct typed findings for the config-layer
+ *    states doctor/init must report WITHOUT editing user-owned config — a
+ *    plugin/project route collision, a user-owned same-key project route, a
+ *    nested `.codex/config.toml` shadowing the root marker block (the
+ *    effective-layer shadowing case), a global same-key route, and the Codex
+ *    project-trust states. Findings are reports, never mutations: a collision
+ *    or shadowing layer is preserved exactly as found (Decision 8).
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import type { CodexActivationSnapshot } from './codex-activation.js';
+import {
+  type ActivationDeliveryExpectation,
+  type DeliveryIncompleteResult,
+  type DeliveryRecordReadState,
+  assessAuthenticatedDelivery,
+  buildDeliveryIncompleteResult,
+} from './codex-host-observation.js';
+import type { CodexProjectMcpResult } from './codex-project-mcp.js';
+
+// ============================================================================
+// 1. Shared delivery gate (Decision 9)
+// ============================================================================
+
+export type SnapshotDeliveryGate =
+  /** A present, structurally valid record binding the installed canonical target. */
+  | { kind: 'matching' }
+  /** The canonical payload itself is unavailable; the caller's earlier payload guard owns this state. */
+  | { kind: 'unassessable'; detail: string }
+  /** Missing/invalid/mismatched record: the one consistent `delivery-incomplete` result. */
+  | { kind: 'incomplete'; result: DeliveryIncompleteResult };
+
+/**
+ * Assess the snapshot's delivery record against the installed canonical target
+ * (core binding: exact target version + canonical payload tree digest). This is
+ * the same expectation shape `beginActivation`'s inner guard enforces, so setup
+ * refusing here and the executor refusing later can never disagree on why.
+ */
+export function assessSnapshotDelivery(snapshot: CodexActivationSnapshot): SnapshotDeliveryGate {
+  if (snapshot.canonical.status !== 'ok') {
+    return { kind: 'unassessable', detail: `canonical payload is unavailable: ${snapshot.canonical.detail}` };
+  }
+  const expectation: ActivationDeliveryExpectation = {
+    targetVersion: snapshot.canonical.version.canonical,
+    canonicalPayloadSha256: snapshot.canonical.digest,
+  };
+  const assessment = assessAuthenticatedDelivery(snapshotDeliveryReadState(snapshot), expectation);
+  if (assessment === 'matching') return { kind: 'matching' };
+  return { kind: 'incomplete', result: buildDeliveryIncompleteResult(assessment) };
+}
+
+/** Map the snapshot's delivery fact onto the pure assessment's read-state shape. */
+export function snapshotDeliveryReadState(snapshot: CodexActivationSnapshot): DeliveryRecordReadState {
+  const fact = snapshot.delivery;
+  if (fact.status === 'present') return { status: 'present', record: fact.record };
+  if (fact.status === 'invalid') return { status: 'invalid', detail: fact.detail };
+  return { status: 'absent' };
+}
+
+// ============================================================================
+// 2. Route-layer classifier (typed config-layer diagnostics)
+// ============================================================================
+
+export type RouteLayerFinding =
+  /** Two effective same-key routes (plugin+project) or a user-owned same-key project route. */
+  | { kind: 'route-collision'; detail: string }
+  /** A nested `.codex/config.toml` nearer to the CWD defines `mcp_servers.genie`, shadowing the root marker. */
+  | { kind: 'route-shadowed'; ownerPath: string; detail: string }
+  /** The global `~/.codex/config.toml` defines a same-key `mcp_servers.genie` route. */
+  | { kind: 'global-route-same-key'; path: string; detail: string }
+  /** The project has an explicit non-trusted `trust_level` in the global Codex config. */
+  | { kind: 'untrusted-config'; detail: string }
+  /** No Codex trust entry exists for the project; trust is required before route health can be claimed. */
+  | { kind: 'project-trust-required'; detail: string };
+
+export interface RouteLayerInput {
+  /** The worktree root owning the marker-managed project route. */
+  worktreeRoot: string;
+  /** The effective CWD whose root-to-CWD config chain is inspected for shadowing. */
+  cwd: string;
+  /** The read-only route inspection result (`inspectCodexProjectMcp`). */
+  route: Pick<CodexProjectMcpResult, 'route' | 'detail'>;
+  /** The global Codex config path (`getCodexConfigPath()`). */
+  globalConfigPath: string;
+  /** Bounded file reader seam; returns null when absent/unreadable. */
+  readFile?: (path: string) => string | null;
+  /** Existence seam for chain-walk directories. */
+  exists?: (path: string) => boolean;
+}
+
+const MAX_CONFIG_BYTES = 512 * 1024;
+const GENIE_SERVER_HEADER_RE = /^\s*\[mcp_servers\.(?:genie|"genie")\]\s*(?:#.*)?$/m;
+
+function defaultReadFile(path: string): string | null {
+  try {
+    const content = readFileSync(path, 'utf8');
+    return content.length > MAX_CONFIG_BYTES ? null : content;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Classify the config-layer states around the project route. Pure over the
+ * injected readers; reports findings without touching any layer. Collisions and
+ * shadowing are hard route defects; the trust states are advisories that block
+ * a health CLAIM (doctor must say trust is required) without failing the route
+ * bytes themselves.
+ */
+export function classifyRouteLayers(input: RouteLayerInput): RouteLayerFinding[] {
+  const readFile = input.readFile ?? defaultReadFile;
+  const exists = input.exists ?? existsSync;
+  const findings: RouteLayerFinding[] = [];
+
+  if (input.route.route === 'conflict') {
+    findings.push({
+      kind: 'route-collision',
+      detail: `plugin and project routes are both effective: ${input.route.detail ?? 'route conflict'}`,
+    });
+  } else if (input.route.route === 'unmanaged-fallback') {
+    findings.push({
+      kind: 'route-collision',
+      detail: `user-owned [mcp_servers.genie] project route is preserved and requires user resolution: ${input.route.detail ?? 'unmanaged route'}`,
+    });
+  }
+
+  const shadowOwner = nearestShadowingConfig(input.worktreeRoot, input.cwd, readFile, exists);
+  if (shadowOwner !== null) {
+    findings.push({
+      kind: 'route-shadowed',
+      ownerPath: shadowOwner,
+      detail: `nested ${join(shadowOwner, '.codex', 'config.toml')} defines [mcp_servers.genie] nearer to the CWD and shadows the root marker route`,
+    });
+  }
+
+  const globalConfig = readFile(input.globalConfigPath);
+  if (globalConfig !== null && GENIE_SERVER_HEADER_RE.test(globalConfig)) {
+    findings.push({
+      kind: 'global-route-same-key',
+      path: input.globalConfigPath,
+      detail:
+        'global Codex config defines a same-key [mcp_servers.genie] route; it is preserved and requires user resolution',
+    });
+  }
+
+  const trust = projectTrustState(globalConfig, input.worktreeRoot);
+  if (trust.state === 'untrusted') {
+    findings.push({
+      kind: 'untrusted-config',
+      detail: `Codex marks this project '${trust.level}'; its project config (including the Genie route) is inert until the user trusts it`,
+    });
+  } else if (trust.state === 'unknown') {
+    findings.push({
+      kind: 'project-trust-required',
+      detail:
+        'Codex has no trust entry for this project; approve it in Codex before the project route can be claimed healthy',
+    });
+  }
+
+  return findings;
+}
+
+/**
+ * Walk the root-to-CWD directory chain (nearest to CWD first, root excluded)
+ * and return the first directory whose `.codex/config.toml` defines a same-key
+ * genie route. Returns null when the CWD is not under the root or no layer
+ * shadows the marker.
+ */
+function nearestShadowingConfig(
+  worktreeRoot: string,
+  cwd: string,
+  readFile: (path: string) => string | null,
+  exists: (path: string) => boolean,
+): string | null {
+  const root = resolve(worktreeRoot);
+  let current = resolve(cwd);
+  const rel = relative(root, current);
+  if (rel.startsWith('..') || rel.split(sep).includes('..')) return null;
+  while (current !== root) {
+    const configPath = join(current, '.codex', 'config.toml');
+    if (exists(configPath)) {
+      const content = readFile(configPath);
+      if (content !== null && GENIE_SERVER_HEADER_RE.test(content)) return current;
+    }
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return null;
+}
+
+type ProjectTrustState = { state: 'trusted' } | { state: 'untrusted'; level: string } | { state: 'unknown' };
+
+/**
+ * Bounded, targeted read of the global Codex config's `[projects."<root>"]`
+ * trust entry. TOML-shaped but deliberately not a full TOML parser: it matches
+ * the exact section header Codex writes for the absolute project path and reads
+ * `trust_level` within that section only. An unreadable/absent config or a
+ * missing section is `unknown` (trust cannot be inferred; Decision: never claim
+ * health for a project Codex has not trusted).
+ */
+export function projectTrustState(globalConfig: string | null, worktreeRoot: string): ProjectTrustState {
+  if (globalConfig === null) return { state: 'unknown' };
+  const escapedPath = resolve(worktreeRoot).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  const lines = globalConfig.split('\n');
+  const headerExact = `[projects."${escapedPath}"]`;
+  let inSection = false;
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (line.startsWith('[')) {
+      inSection = line === headerExact;
+      continue;
+    }
+    if (!inSection) continue;
+    const match = line.match(/^trust_level\s*=\s*"([^"]*)"/);
+    if (match !== null) {
+      return match[1] === 'trusted' ? { state: 'trusted' } : { state: 'untrusted', level: match[1] ?? '' };
+    }
+  }
+  return { state: 'unknown' };
+}

--- a/src/lib/codex-lifecycle-truth.ts
+++ b/src/lib/codex-lifecycle-truth.ts
@@ -105,7 +105,11 @@ export interface RouteLayerInput {
 }
 
 const MAX_CONFIG_BYTES = 512 * 1024;
-const GENIE_SERVER_HEADER_RE = /^\s*\[mcp_servers\.(?:genie|"genie")\]\s*(?:#.*)?$/m;
+// A same-key genie route in either TOML spelling: the `[mcp_servers.genie]`
+// section header, or the dotted-key form (`mcp_servers.genie.command = …` /
+// `mcp_servers.genie = {…}`) that the marker block itself uses.
+const GENIE_SERVER_HEADER_RE =
+  /^\s*(?:\[mcp_servers\.(?:genie|"genie")\]\s*(?:#.*)?$|mcp_servers\.(?:genie|"genie")\s*(?:\.[A-Za-z0-9_.-]+\s*)?=)/m;
 
 function defaultReadFile(path: string): string | null {
   try {

--- a/src/lib/install-version-marker.test.ts
+++ b/src/lib/install-version-marker.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -7,7 +7,6 @@ import {
   readInstallVersionMarker,
   resolveInstallVersionMarkerPath,
   retireInstallVersionMarker,
-  uninstallInstallVersionMarker,
 } from './install-version-marker.js';
 
 let genieHome: string;
@@ -98,64 +97,5 @@ describe('retireInstallVersionMarker — retire only after success, preserve on 
   test('an empty marker retires with a null previous value', () => {
     writeMarker('   \n');
     expect(retireInstallVersionMarker(genieHome)).toEqual({ status: 'retired', previousValue: null });
-  });
-});
-
-describe('uninstallInstallVersionMarker — tolerates either layout, idempotent, dry-run safe', () => {
-  test('absent marker uninstalls cleanly (post-convergence layout)', () => {
-    expect(uninstallInstallVersionMarker(genieHome)).toEqual({ status: 'absent' });
-  });
-
-  test('present regular marker is removed (legacy layout)', () => {
-    writeMarker('5.260500.3');
-    expect(uninstallInstallVersionMarker(genieHome)).toEqual({ status: 'removed', path: markerPath() });
-    expect(readInstallVersionMarker(genieHome)).toEqual({ status: 'absent' });
-  });
-
-  test('dry-run reports would-remove and mutates nothing', () => {
-    writeMarker('5.260500.3');
-    expect(uninstallInstallVersionMarker(genieHome, { dryRun: true })).toEqual({
-      status: 'would-remove',
-      path: markerPath(),
-    });
-    expect(readInstallVersionMarker(genieHome)).toEqual({ status: 'present', value: '5.260500.3' });
-  });
-
-  test('a symlink marker is unlinked (never its target)', () => {
-    const target = join(genieHome, 'real-version');
-    writeFileSync(target, '9.9.9');
-    symlinkSync(target, markerPath());
-    expect(uninstallInstallVersionMarker(genieHome)).toEqual({ status: 'removed', path: markerPath() });
-    // Marker link gone; the target it pointed at is preserved on disk.
-    expect(readInstallVersionMarker(genieHome)).toEqual({ status: 'absent' });
-    expect(existsSync(target)).toBe(true);
-  });
-
-  test('uninstall is idempotent — a second removal is a benign absent', () => {
-    writeMarker('5.260500.3');
-    uninstallInstallVersionMarker(genieHome);
-    expect(uninstallInstallVersionMarker(genieHome)).toEqual({ status: 'absent' });
-  });
-
-  test('a directory in the marker slot is reported, never recursively removed', () => {
-    mkdirSync(markerPath());
-    const result = uninstallInstallVersionMarker(genieHome);
-    expect(result.status).toBe('error');
-  });
-});
-
-describe('retire → uninstall interplay proves both layouts are safe to rerun', () => {
-  test('successful convergence retires the marker so a later uninstall sees no marker', () => {
-    writeMarker('5.260500.3');
-    expect(retireInstallVersionMarker(genieHome).status).toBe('retired');
-    // Post-convergence machine: uninstall tolerates the already-retired layout.
-    expect(uninstallInstallVersionMarker(genieHome)).toEqual({ status: 'absent' });
-  });
-
-  test('a machine that never retired still uninstalls the legacy marker', () => {
-    writeMarker('4.260428.19');
-    // Interrupted/failed convergence never called retire — the legacy marker persists.
-    expect(readInstallVersionMarker(genieHome)).toEqual({ status: 'present', value: '4.260428.19' });
-    expect(uninstallInstallVersionMarker(genieHome)).toEqual({ status: 'removed', path: markerPath() });
   });
 });

--- a/src/lib/install-version-marker.ts
+++ b/src/lib/install-version-marker.ts
@@ -24,17 +24,20 @@
  *     partial write. An unsafe (symlink/non-regular) marker is preserved and
  *     reported rather than followed. Idempotent: an already-absent marker is a
  *     no-op success.
- *   - `uninstallInstallVersionMarker` — remove the marker during uninstall,
- *     tolerating either layout (present regular file, present symlink, or already
- *     absent) and honouring a dry-run. The symlink itself is unlinked, never its
- *     target.
+ * UNINSTALL deliberately has NO dedicated marker call (Group E decision): the
+ * digest-verified wholesale GENIE_HOME removal already deletes the marker in
+ * both legacy layouts (regular file, symlink — the link is unlinked, never its
+ * target; pinned by uninstall.test.ts). The marker is a snapshotted removable
+ * child of `genieHomeRemovalDigest`, so any extra delete inside the
+ * plan→execute window would poison that commitment and abort home removal;
+ * before the window it is redundant, after it a no-op.
  *
  * Canonical `VERSION` is authoritative: this module never writes a version into
  * the marker and never reads it back as the installed version.
  */
 
 import { randomBytes } from 'node:crypto';
-import { type Stats, copyFileSync, lstatSync, unlinkSync } from 'node:fs';
+import { copyFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fsyncParentDir, readBoundedRegularFile, unlinkWithParentFsync } from './codex-activation-persistence.js';
 import { resolveGenieHome } from './genie-home.js';
@@ -107,52 +110,6 @@ export function retireInstallVersionMarker(genieHome: string = resolveGenieHome(
   return { status: 'retired', previousValue: read.value.length > 0 ? read.value : null };
 }
 
-export interface UninstallMarkerOptions {
-  /** When true, report what would be removed without mutating anything. */
-  dryRun?: boolean;
-}
-
-export type UninstallMarkerResult =
-  | { status: 'absent' }
-  | { status: 'would-remove'; path: string }
-  | { status: 'removed'; path: string }
-  | { status: 'error'; path: string; detail: string };
-
-/**
- * Remove the legacy marker during uninstall, tolerating either layout so a
- * machine that already retired the marker (post-convergence) and one that still
- * carries it both uninstall cleanly and idempotently. A symlink is unlinked
- * (never followed); an already-absent marker is a benign `absent`. Uninstall does
- * NOT back the marker up — the whole install is being removed.
- */
-export function uninstallInstallVersionMarker(
-  genieHome: string = resolveGenieHome(),
-  options: UninstallMarkerOptions = {},
-): UninstallMarkerResult {
-  const path = resolveInstallVersionMarkerPath(genieHome);
-  let stat: Stats;
-  try {
-    stat = lstatSync(path);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { status: 'absent' };
-    return { status: 'error', path, detail: errorText(error) };
-  }
-  // A directory here is unexpected legacy corruption; unlinkSync would EISDIR.
-  // Report it rather than recursively removing an unknown tree.
-  if (stat.isDirectory()) {
-    return { status: 'error', path, detail: 'install-version marker is unexpectedly a directory' };
-  }
-  if (options.dryRun) return { status: 'would-remove', path };
-  try {
-    unlinkSync(path);
-    fsyncParentDir(path);
-    return { status: 'removed', path };
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { status: 'absent' };
-    return { status: 'error', path, detail: errorText(error) };
-  }
-}
-
 /** Best-effort copy of prior marker bytes to a unique sidecar; a backup failure never blocks retirement. */
 function backupRegularFile(path: string): void {
   const backup = `${path}.genie-backup-${new Date().toISOString().replace(/[:.]/g, '-')}-${randomBytes(6).toString('hex')}`;
@@ -163,8 +120,4 @@ function backupRegularFile(path: string): void {
     // Prior bytes are already durable on disk until the unlink below; a failed
     // forensic copy must not prevent retirement of a proven-current install.
   }
-}
-
-function errorText(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/tests/integration/codex-lifecycle-pty.test.ts
+++ b/tests/integration/codex-lifecycle-pty.test.ts
@@ -1,0 +1,386 @@
+/**
+ * Group E deliverable 5 — the real-PTY lifecycle flow:
+ *
+ *   repair handoff (missing delivery record → typed refusal with the one
+ *   recovery command) → record published (as update/install repair would) →
+ *   `genie setup --codex` under a REAL pty (consent answered on /dev/tty) →
+ *   explicit new-task instruction → `genie doctor --json` state `current`,
+ *   plus the real PATH advisory, stale historical config, route collision /
+ *   shadowing, context states, and a hard query failure — all through the
+ *   actual CLI (`bun src/genie.ts …`), a stateful fake `codex` executable, and
+ *   the production GENIE_HOME payload layout (no canonical-root override).
+ *
+ * PTY allocation uses the platform `script(1)`; the suite skips cleanly where
+ * a pty cannot be allocated (no `script`, or Windows). The fake codex lives
+ * OUTSIDE the repo/CWD so trusted-executable validation applies unchanged.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import {
+  chmodSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { acquireLifecycleLease } from '../../src/lib/codex-lifecycle-lease.js';
+
+const REPO_ROOT = join(import.meta.dir, '..', '..');
+const GENIE_CLI = join(REPO_ROOT, 'src', 'genie.ts');
+const REAL_SESSION_CONTEXT = join(REPO_ROOT, 'plugins', 'genie', 'scripts', 'session-context.cjs');
+const TARGET = '5.260722.1';
+const OLD = '5.260711.9';
+
+// PTY driver: GNU `script -qec` forwards piped stdin to the pty on Linux (the
+// CI condition); macOS `script` refuses a non-tty stdin (tcgetattr), so darwin
+// drives the pty through the preinstalled `expect` instead.
+const SCRIPT_BIN = Bun.which('script');
+const EXPECT_BIN = Bun.which('expect');
+const CAN_PTY =
+  process.platform === 'linux' ? SCRIPT_BIN !== null : process.platform === 'darwin' ? EXPECT_BIN !== null : false;
+
+let root: string;
+let genieHome: string;
+let codexHome: string;
+let repo: string;
+let binDir: string;
+let stateDir: string;
+let fakeCodex: string;
+let childEnv: Record<string, string>;
+
+function deliveryRecordPath(): string {
+  return join(genieHome, '.codex-plugin-delivery-record.json');
+}
+
+/** Stage the whole fixture once; individual tests advance the lifecycle in order. */
+beforeAll(() => {
+  if (!CAN_PTY) return;
+  root = mkdtempSync(join(tmpdir(), 'genie-pty-lifecycle-'));
+  genieHome = join(root, 'genie-home');
+  codexHome = join(root, 'codex-home');
+  repo = join(root, 'repo');
+  binDir = join(root, 'bin');
+  stateDir = join(root, 'codex-state');
+  for (const dir of [genieHome, codexHome, repo, binDir, stateDir, join(root, 'home'), join(root, 'tmp')]) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  // Canonical payload at the PRODUCTION location: $GENIE_HOME/plugins/genie
+  // (+ VERSION beside it) — no canonicalRoot override anywhere in this suite.
+  const payload = join(genieHome, 'plugins', 'genie');
+  mkdirSync(join(payload, 'scripts'), { recursive: true });
+  mkdirSync(join(payload, 'hooks'), { recursive: true });
+  cpSync(REAL_SESSION_CONTEXT, join(payload, 'scripts', 'session-context.cjs'));
+  writeFileSync(join(payload, 'README.md'), 'genie codex payload\n');
+  writeFileSync(join(payload, 'hooks', 'codex-hooks.json'), '{"hooks":{}}\n');
+  writeFileSync(join(genieHome, 'VERSION'), `${TARGET}\n`);
+
+  // Codex home: enabled plugin flag + an OLD physical cache generation so the
+  // pre-activation state is genuinely activation-pending.
+  writeFileSync(join(codexHome, 'config.toml'), `[plugins."genie@automagik"]\nenabled = true\n`);
+  const familyDir = join(codexHome, 'plugins', 'cache', 'automagik', 'genie');
+  mkdirSync(join(familyDir, OLD), { recursive: true });
+  writeFileSync(join(familyDir, OLD, 'README.md'), 'old generation\n');
+  writeFileSync(join(stateDir, 'registered'), `${OLD}\n`);
+
+  // The stateful fake codex CLI (outside the repo → passes trusted-executable).
+  fakeCodex = join(binDir, 'codex');
+  writeFileSync(
+    fakeCodex,
+    `#!/bin/bash
+set -u
+cmd="$*"
+if [ "\${1:-}" = "--version" ]; then echo "codex 0.0.0-fake"; exit 0; fi
+if [ "$cmd" = "plugin list --json" ]; then
+  if [ -n "\${FAKE_CODEX_ADVISORY:-}" ]; then printf '\\033[33m%s\\033[0m\\n' "$FAKE_CODEX_ADVISORY" >&2; fi
+  if [ -n "\${FAKE_CODEX_EXIT:-}" ]; then echo "hard failure" >&2; exit "$FAKE_CODEX_EXIT"; fi
+  ver=$(cat "$FAKE_CODEX_STATE/registered" 2>/dev/null | tr -d '\\n')
+  enabled=true
+  grep -q 'enabled = false' "$CODEX_HOME/config.toml" 2>/dev/null && enabled=false
+  if [ -z "$ver" ]; then echo '{"installed":[]}'; else
+    printf '{"installed":[{"pluginId":"genie@automagik","enabled":%s,"version":"%s"}]}\\n' "$enabled" "$ver"
+  fi
+  exit 0
+fi
+if [ "$cmd" = "plugin add genie@automagik --json" ]; then
+  target_dir="$CODEX_HOME/plugins/cache/automagik/genie/$FAKE_CODEX_TARGET"
+  mkdir -p "$target_dir"
+  cp -R "$GENIE_HOME/plugins/genie/." "$target_dir/"
+  printf '%s\\n' "$FAKE_CODEX_TARGET" > "$FAKE_CODEX_STATE/registered"
+  printf '[plugins."genie@automagik"]\\nenabled = true\\n' > "$CODEX_HOME/config.toml"
+  echo '{}'
+  exit 0
+fi
+echo '{}'
+exit 0
+`,
+  );
+  chmodSync(fakeCodex, 0o755);
+
+  // A real project repo, initialized + trusted, whose route genie init owns.
+  execFileSync('git', ['init', '-q'], { cwd: repo });
+  execFileSync('git', ['config', 'user.email', 'pty@test.local'], { cwd: repo });
+  execFileSync('git', ['config', 'user.name', 'PTY Test'], { cwd: repo });
+  execFileSync('git', ['commit', '--allow-empty', '-q', '-m', 'seed'], { cwd: repo });
+
+  childEnv = {
+    ...process.env,
+    HOME: join(root, 'home'),
+    GENIE_HOME: genieHome,
+    CODEX_HOME: codexHome,
+    CLAUDE_CONFIG_DIR: join(root, 'home', 'claude'),
+    HERMES_HOME: join(root, 'home', 'hermes'),
+    TMPDIR: join(root, 'tmp'),
+    PATH: `${binDir}:${process.env.PATH ?? ''}`,
+    FAKE_CODEX_STATE: stateDir,
+    FAKE_CODEX_TARGET: TARGET,
+    TERM: 'xterm',
+  } as Record<string, string>;
+  for (const key of ['CI', 'CODEX_THREAD_ID', 'GENIE_BUNDLE_ROOT', 'GENIE_WORKER', 'FAKE_CODEX_ADVISORY']) {
+    delete childEnv[key];
+  }
+
+  // Trust the repo in the global Codex config (Group E trust classifier).
+  // Codex records whatever spelling it saw; cover the logical AND physical
+  // spelling of the tmp path (macOS /var vs /private/var).
+  const repoSpellings = [...new Set([repo, realpathSync(repo)])];
+  writeFileSync(
+    join(codexHome, 'config.toml'),
+    `[plugins."genie@automagik"]\nenabled = true\n${repoSpellings
+      .map((spelling) => `[projects."${spelling}"]\ntrust_level = "trusted"\n`)
+      .join('')}`,
+  );
+
+  // `genie init` owns the marker-managed project route (the ONLY command that
+  // may create it — authority matrix row 1). Route-only, delivery-independent.
+  const init = Bun.spawnSync([process.execPath, GENIE_CLI, 'init'], {
+    cwd: repo,
+    env: childEnv,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    timeout: 60_000,
+  });
+  if (init.exitCode !== 0) {
+    throw new Error(`genie init failed (${init.exitCode}): ${init.stdout.toString()}${init.stderr.toString()}`);
+  }
+});
+
+afterAll(() => {
+  if (root !== undefined) rmSync(root, { recursive: true, force: true });
+});
+
+function runCli(
+  args: string[],
+  opts: { env?: Record<string, string>; cwd?: string } = {},
+): { exitCode: number; stdout: string; stderr: string } {
+  const proc = Bun.spawnSync([process.execPath, GENIE_CLI, ...args], {
+    cwd: opts.cwd ?? repo,
+    env: opts.env ?? childEnv,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    timeout: 60_000,
+  });
+  return { exitCode: proc.exitCode, stdout: proc.stdout.toString(), stderr: proc.stderr.toString() };
+}
+
+/** Run the CLI under a REAL pty; `input` is delivered to the pty (read via /dev/tty). */
+function runPty(
+  args: string[],
+  input: string,
+  opts: { env?: Record<string, string> } = {},
+): { exitCode: number; output: string } {
+  const cli = [process.execPath, GENIE_CLI, ...args];
+  if (process.platform === 'darwin') {
+    // expect(1): spawn on a pty, queue the consent answer, exit with the
+    // child's status. Braced words keep tmp paths literal (no spaces in them).
+    const spawnWords = cli.map((part) => `{${part}}`).join(' ');
+    const sendWords = input.replaceAll('\n', '\\r');
+    const expectScript = [
+      'set timeout 120',
+      `spawn -noecho ${spawnWords}`,
+      `send -- "${sendWords}"`,
+      'expect eof',
+      'catch wait result',
+      'exit [lindex $result 3]',
+    ].join('\n');
+    const proc = Bun.spawnSync([EXPECT_BIN as string, '-c', expectScript], {
+      cwd: repo,
+      env: opts.env ?? childEnv,
+      stdout: 'pipe',
+      stderr: 'pipe',
+      timeout: 150_000,
+    });
+    return { exitCode: proc.exitCode, output: proc.stdout.toString() + proc.stderr.toString() };
+  }
+  const argv = [
+    SCRIPT_BIN as string,
+    '-qec',
+    cli.map((part) => `'${part.replaceAll("'", `'\\''`)}'`).join(' '),
+    '/dev/null',
+  ];
+  const proc = Bun.spawnSync(argv, {
+    cwd: repo,
+    env: opts.env ?? childEnv,
+    stdin: Buffer.from(input),
+    stdout: 'pipe',
+    stderr: 'pipe',
+    timeout: 120_000,
+  });
+  return { exitCode: proc.exitCode, output: proc.stdout.toString() + proc.stderr.toString() };
+}
+
+interface DoctorJson {
+  ok: boolean;
+  checks: Array<{ name: string; status: string; detail?: string; advisory?: string; routeLayers?: unknown[] }>;
+  integrationSummary?: { codexPlugin: { state: string; deliveryComplete: boolean; recovery: string } };
+}
+
+function doctorJson(opts: { env?: Record<string, string>; cwd?: string } = {}): {
+  json: DoctorJson;
+  exitCode: number;
+  raw: string;
+} {
+  const { exitCode, stdout } = runCli(['doctor', '--json'], opts);
+  return { json: JSON.parse(stdout) as DoctorJson, exitCode, raw: stdout };
+}
+
+describe.skipIf(!CAN_PTY)('codex lifecycle over a real PTY (Group E deliverable 5)', () => {
+  test('stage 1 — missing delivery record: setup refuses BEFORE consent with the one recovery command', () => {
+    expect(existsSync(deliveryRecordPath())).toBe(false);
+    const { exitCode, stdout, stderr } = runCli(['setup', '--codex']);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('delivery record is absent');
+    expect(stderr).toContain('genie update');
+    expect(stdout).not.toContain('Codex configuration saved');
+    // Doctor agrees, from the same facts: delivery-incomplete, never current.
+    const { json, exitCode: doctorExit } = doctorJson();
+    expect(json.integrationSummary?.codexPlugin.state).toBe('delivery-incomplete');
+    expect(json.integrationSummary?.codexPlugin.deliveryComplete).toBe(false);
+    expect(doctorExit).toBe(1);
+  }, 120_000);
+
+  test('stage 2 — record published (as update/install repair would): pending, not incomplete', async () => {
+    // Publish through the REAL deep store under the real lifecycle lease —
+    // the same API the repair path drives; setup/doctor never mint records.
+    const { openCodexActivationStore, observeCodexActivation } = await import(
+      '../../src/lib/codex-activation-executor.js'
+    );
+    const snapshot = observeCodexActivation({ genieHome, codexHome, command: fakeCodex });
+    if (snapshot.canonical.status !== 'ok') throw new Error(`canonical not ok: ${JSON.stringify(snapshot.canonical)}`);
+    const lease = acquireLifecycleLease('update-delivery', { genieHome });
+    if (!lease.ok) throw new Error(`lease: ${lease.detail}`);
+    try {
+      const store = openCodexActivationStore({ genieHome, codexHome, command: fakeCodex });
+      store.publishDelivery(lease, {
+        targetVersion: TARGET,
+        canonicalPayloadSha256: snapshot.canonical.digest,
+        channel: 'stable',
+      });
+    } finally {
+      lease.release();
+    }
+    expect(existsSync(deliveryRecordPath())).toBe(true);
+    const { json } = doctorJson();
+    expect(json.integrationSummary?.codexPlugin.state).toBe('activation-pending');
+    expect(json.integrationSummary?.codexPlugin.deliveryComplete).toBe(true);
+  }, 120_000);
+
+  test('stage 3 — PTY consent activates: add once, enabled restored, journal cleared, new-task instruction printed', () => {
+    const { exitCode, output } = runPty(['setup', '--codex'], 'yes\n');
+    expect(output).toContain('Activated Codex plugin v');
+    expect(output).toContain('new Codex task');
+    expect(output).toContain('Codex configuration saved');
+    expect(exitCode).toBe(0);
+    // Normal journal clearing: no refresh-intent journal left behind.
+    expect(existsSync(join(genieHome, '.codex-plugin-refresh-intent.json'))).toBe(false);
+    // The cache now physically carries the target generation.
+    expect(existsSync(join(codexHome, 'plugins', 'cache', 'automagik', 'genie', TARGET, 'README.md'))).toBe(true);
+    expect(readFileSync(join(stateDir, 'registered'), 'utf8').trim()).toBe(TARGET);
+  }, 180_000);
+
+  test('stage 4 — doctor ends current: consistent human/JSON/exit, project context surfaced', () => {
+    const { json, exitCode } = doctorJson();
+    expect(json.integrationSummary?.codexPlugin).toMatchObject({ state: 'current', deliveryComplete: true });
+    // The host bun version is environmental; every OTHER check must be clean.
+    const failing = json.checks.filter((check) => check.status === 'fail' && !check.name.startsWith('bun'));
+    expect(JSON.stringify(failing, null, 2)).toBe('[]');
+    const bunFails = json.checks.some((check) => check.status === 'fail' && check.name.startsWith('bun'));
+    expect(exitCode).toBe(bunFails ? 1 : 0);
+    const context = json.checks.find((check) => check.name === 'Codex project context');
+    expect(context).toBeDefined();
+    // Route: the marker-owned project route from `genie init` + trusted repo.
+    const human = runCli(['doctor']);
+    expect(human.stdout).toContain('Codex integration:');
+    expect(human.exitCode).toBe(bunFails ? 1 : 0);
+  }, 120_000);
+
+  test('stage 5 — real PATH advisory: one ANSI-free JSON, advisory rider, still current (Decision 11)', () => {
+    const env = { ...childEnv, FAKE_CODEX_ADVISORY: 'WARN: PATH does not include codex shims' };
+    const { json, exitCode, raw } = doctorJson({ env });
+    expect(json.integrationSummary?.codexPlugin.state).toBe('current');
+    const bunFails = json.checks.some((check) => check.status === 'fail' && check.name.startsWith('bun'));
+    expect(exitCode).toBe(bunFails ? 1 : 0);
+    const cli = json.checks.find((check) => check.name === 'Codex CLI');
+    expect(cli?.advisory).toBe('WARN: PATH does not include codex shims');
+    expect(raw).not.toContain('\x1b[33m');
+  }, 120_000);
+
+  test('stage 6 — stale historical config: record removed → no green banner despite configured history', () => {
+    const recordBytes = readFileSync(deliveryRecordPath());
+    rmSync(deliveryRecordPath());
+    try {
+      const { exitCode, stdout, stderr } = runCli(['setup', '--codex']);
+      expect(exitCode).toBe(1);
+      expect(stdout).not.toContain('Codex configuration saved');
+      expect(stderr).toContain('delivery record is absent');
+    } finally {
+      writeFileSync(deliveryRecordPath(), recordBytes);
+    }
+  }, 120_000);
+
+  test('stage 7 — route collision and nested shadowing are typed doctor failures, never green', () => {
+    // Unmanaged same-key route: replace the project config with a user-owned one.
+    const projectConfig = join(repo, '.codex', 'config.toml');
+    mkdirSync(join(repo, '.codex'), { recursive: true });
+    const prior = existsSync(projectConfig) ? readFileSync(projectConfig) : null;
+    writeFileSync(projectConfig, '[mcp_servers.genie]\ncommand = "/usr/local/bin/other"\nargs = []\n');
+    try {
+      const collision = doctorJson();
+      const route = collision.json.checks.find((check) => check.name === 'Codex Genie MCP registration');
+      expect(route?.status).toBe('fail');
+      expect(JSON.stringify(route?.routeLayers ?? [])).toContain('route-collision');
+    } finally {
+      if (prior === null) rmSync(projectConfig);
+      else writeFileSync(projectConfig, prior);
+    }
+
+    // Nested shadowing: a nearer .codex/config.toml between root and CWD.
+    const nested = join(repo, 'packages', 'web');
+    mkdirSync(join(nested, '.codex'), { recursive: true });
+    writeFileSync(join(nested, '.codex', 'config.toml'), '[mcp_servers.genie]\ncommand = "/elsewhere"\n');
+    try {
+      const shadowed = doctorJson({ cwd: nested });
+      const route = shadowed.json.checks.find((check) => check.name === 'Codex Genie MCP registration');
+      expect(route?.status).toBe('fail');
+      expect(JSON.stringify(route?.routeLayers ?? [])).toContain('route-shadowed');
+    } finally {
+      rmSync(join(repo, 'packages'), { recursive: true, force: true });
+    }
+  }, 120_000);
+
+  test('stage 8 — a hard query failure fails BOTH surfaces consistently (no PASS + query-failed split)', () => {
+    const env = { ...childEnv, FAKE_CODEX_EXIT: '7' };
+    const { json, exitCode } = doctorJson({ env });
+    expect(json.integrationSummary?.codexPlugin.state).toBe('query-failed');
+    const plugin = json.checks.find((check) => check.name === 'Codex Genie plugin');
+    expect(plugin?.status).toBe('fail');
+    expect(exitCode).toBe(1);
+  }, 120_000);
+});

--- a/tests/integration/codex-lifecycle-pty.test.ts
+++ b/tests/integration/codex-lifecycle-pty.test.ts
@@ -313,8 +313,12 @@ describe.skipIf(!CAN_PTY)('codex lifecycle over a real PTY (Group E deliverable 
     expect(JSON.stringify(failing, null, 2)).toBe('[]');
     const bunFails = json.checks.some((check) => check.status === 'fail' && check.name.startsWith('bun'));
     expect(exitCode).toBe(bunFails ? 1 : 0);
+    // The typed context state, end-to-end: init scaffolds no genie.db, so a
+    // Codex task would see the typed database-unavailable error (warn) —
+    // never a healthy empty board and never a hard context failure.
     const context = json.checks.find((check) => check.name === 'Codex project context');
-    expect(context).toBeDefined();
+    expect(context?.status).toBe('warn');
+    expect(context?.detail).toContain('project-database-unavailable');
     // Route: the marker-owned project route from `genie init` + trusted repo.
     const human = runCli(['doctor']);
     expect(human.stdout).toContain('Codex integration:');


### PR DESCRIPTION
## Wave 3 / Group E: lifecycle-truth-integration

Wires the merged Group A (route/context), B (host observation), and D (delivery) contracts into truthful setup/doctor surfaces — **without changing any A/B/D contract** (the two consumer seams already existed: the probe's `run` replay and the observer's `runner`).

### Doctor — one bounded observation (Decision 11, AC4/AC5)
- **New `src/lib/codex-doctor-observation.ts`**: doctor previously spawned `codex plugin list --json` TWICE (probe + activation observer) with contradictory stderr policy — a benign sandbox PATH advisory produced a healthy check list next to a query-failed summary and exit 1. Now ONE bounded query is classified through B's `parseCodexHostObservation` and replayed into both consumers; the advisory rides as sanitized metadata (`checks[].advisory`), never a second policy decision.
- **New `src/lib/codex-lifecycle-truth.ts`**: the shared Decision-9 delivery gate + the deferred typed config-layer classifier (`route-collision`, `route-shadowed`, `global-route-same-key`, `untrusted-config`, `project-trust-required`) surfaced as a `checks[].routeLayers` rider; physical-path identity (macOS `/var` vs `/private/var`) for the shadow chain walk and trust entries.
- Doctor presents `delivery-incomplete` (exit 1, recovery command) whenever a green state lacks a matching authenticated record; a harder exit-1 state keeps its own presentation with `deliveryComplete:false`. New `Codex project context` check reuses the MCP server's `resolveProjectContext` so doctor and the server can never disagree.

### Setup — record-gated activation + typed outcome (Decisions 9/12, AC1–AC3)
- The authenticated-delivery-record assessment now runs **before the first consent prompt or activation-owned mutation** (the executor's `beginActivation` inner guard stays as defense in depth). Missing/invalid/mismatched → one consistent `delivery-incomplete` refusal + trailer + the update/install recovery command — even on an already-current machine.
- Every invocation ends in one typed `SetupCodexOutcomeCode`; the green banner and wizard summary flow from THIS run's outcome, never historical `codex.configured` state.

### Real bug found & fixed by the new PTY flow (Decision 1)
Setup's post-activation reconcile still used the pre-Group-A synthetic "usable plugin" probe whose documented behavior **removed the project fallback** — leaving a repository with NO Codex route at all now that the plugin ships no MCP declaration. Post-activation now reconciles the stable absolute GENIE_HOME facade route exactly as trusted init writes it.

### Real-PTY lifecycle flow (deliverable 5)
`tests/integration/codex-lifecycle-pty.test.ts` drives the REAL CLI: missing-record refusal → record published via the real deep store under the real lease → consent on a real pty (`expect(1)` on darwin, `script(1)` on linux CI) → activation with exactly one plugin add → doctor `current`; plus PATH advisory, stale historical config, route collision/shadowing, and hard query-failure consistency. Brings its own fake codex (CI has none); skips cleanly where no pty can be allocated.

### Carry-forward: uninstall marker (Decision 14)
`uninstallInstallVersionMarker` was unwired, and the digest trace shows no safe insertion point (any delete inside the plan→execute window poisons `genieHomeRemovalDigest`; outside it is redundant/no-op). Removed with documented rationale; two new uninstall tests pin the regular-file and symlink legacy layouts through the REAL digest-verified batch path.

### Validation (all reproduced locally)
- `bun test` full suite: 2528 tests, sole failure is the pre-existing Linux-only `ss`-based ui-bridge socket test (macOS-local; green in CI)
- CI condition (codex stripped from PATH): 277/277 across all touched suites incl. the PTY flow
- `bun run smoke:codex`: exit 0
- `bun run check` stages (typecheck/lint/dead-code/complexity budget): pass