### PR TITLE
fix(setup): consume journal-quarantine permits (Group E live-QA regression)

### DIFF
--- a/src/genie-commands/setup.test.ts
+++ b/src/genie-commands/setup.test.ts
@@ -491,6 +491,104 @@ describe('setup Codex activation (Group D)', () => {
   // Group E, Decision 9/12: the setup-side delivery gate + typed outcome
   // ==========================================================================
 
+  // ==========================================================================
+  // Group E live-QA regression: a journal-quarantine permit must be consumed by
+  // A's quarantineIntent (then re-observe), never fed to the activation executor.
+  // ==========================================================================
+
+  /** A corrupt activation journal → state intent-invalid → authority journal-quarantine-only. */
+  function corruptIntentSnapshot(): CodexActivationSnapshot {
+    return {
+      ...pendingSnapshot(),
+      intent: { status: 'corrupt', contentSha256: 'd'.repeat(64), detail: 'not json' },
+    };
+  }
+  const FAKE_LEASE = {
+    ok: true,
+    kind: 'setup-activation',
+    operationId: 'op-quarantine-test',
+    assertOperation: () => {},
+    release: () => {},
+  };
+
+  test('Group E: a stale journal is quarantined via the REAL consent/authorize chain, then activation proceeds', async () => {
+    let observeCalls = 0;
+    let quarantineCalls = 0;
+    const cap = capture();
+    await setupCommand(
+      { codex: true },
+      baseDeps({
+        observeCodexActivation: () => {
+          observeCalls += 1;
+          return observeCalls === 1 ? corruptIntentSnapshot() : pendingSnapshot();
+        },
+        // REAL requestRetirementAssertion + REAL authorizeCodexActivation run:
+        // pass 1 mints a journal-quarantine permit, pass 2 an activation permit.
+        acquireActivationLease: (() => FAKE_LEASE) as never,
+        openCodexActivationStore: (() => ({
+          quarantineIntent: () => {
+            quarantineCalls += 1;
+            return { quarantinedTo: '/quarantine/intent.invalid-d' };
+          },
+        })) as never,
+        executeCodexActivation: () => ACTIVATED,
+      }),
+    );
+    const { out, exitCode } = cap.restore();
+    expect(exitCode).toBe(0);
+    expect(quarantineCalls).toBe(1);
+    expect(observeCalls).toBe(2);
+    expect(out).toContain('Quarantined stale activation journal');
+    expect(out).toContain('Activated Codex plugin');
+    expect((await loadGenieConfig()).codex?.configured).toBe(true);
+  });
+
+  test('Group E: a skipped quarantine reports and exits 1 without touching the executor', async () => {
+    let executeCalls = 0;
+    const cap = capture();
+    await setupCommand(
+      { codex: true },
+      baseDeps({
+        observeCodexActivation: () => corruptIntentSnapshot(),
+        acquireActivationLease: (() => FAKE_LEASE) as never,
+        openCodexActivationStore: (() => ({
+          quarantineIntent: () => ({ skipped: 'unsafe intent path is not quarantined (symlink)' }),
+        })) as never,
+        executeCodexActivation: () => {
+          executeCalls += 1;
+          return ACTIVATED;
+        },
+      }),
+    );
+    const { err, exitCode } = cap.restore();
+    expect(exitCode).toBe(1);
+    expect(executeCalls).toBe(0);
+    expect(err).toContain('not quarantined');
+  });
+
+  test('Group E: a second quarantine grant in one invocation refuses instead of looping', async () => {
+    let quarantineCalls = 0;
+    const cap = capture();
+    await setupCommand(
+      { codex: true },
+      baseDeps({
+        // The journal never clears: every pass re-observes the corrupt intent.
+        observeCodexActivation: () => corruptIntentSnapshot(),
+        acquireActivationLease: (() => FAKE_LEASE) as never,
+        openCodexActivationStore: (() => ({
+          quarantineIntent: () => {
+            quarantineCalls += 1;
+            return { quarantinedTo: '/quarantine/intent.invalid-d' };
+          },
+        })) as never,
+      }),
+    );
+    const { err, exitCode } = cap.restore();
+    expect(exitCode).toBe(1);
+    expect(quarantineCalls).toBe(1);
+    expect(err).toContain('refusing to loop');
+  });
+
   test('Group E: an ABSENT delivery record refuses before any consent prompt with the recovery command (exit 1)', async () => {
     let assertionRequested = 0;
     let executeCalls = 0;

--- a/src/genie-commands/setup.ts
+++ b/src/genie-commands/setup.ts
@@ -28,8 +28,16 @@ import {
 // Setup never reimplements the TTY/env/flag guards, constructs a RetirementAssertion,
 // or retains a permit — it supplies a real-terminal ConsentContext and routes the
 // permit-gated cache advance through B's `executeCodexActivation`.
-import type { ActivationEntryPath, CodexActivationSnapshot, ConsentContext } from '../lib/codex-activation.js';
+import type {
+  ActivationEntryPath,
+  ActivationPermit,
+  CodexActivationSnapshot,
+  ConsentContext,
+} from '../lib/codex-activation.js';
 import { getCodexConfigPath } from '../lib/codex-config.js';
+// The quarantine hop holds the SAME `setup-activation` lease kind the executor
+// acquires (aliased: agent-sync exports an unrelated same-named lease helper).
+import { acquireLifecycleLease as acquireActivationLifecycleLease } from '../lib/codex-lifecycle-lease.js';
 // Group E: the shared Decision-9 delivery gate — the same assessment the
 // executor's `beginActivation` inner guard re-applies before its first write.
 import { assessSnapshotDelivery } from '../lib/codex-lifecycle-truth.js';
@@ -75,6 +83,8 @@ export interface SetupDeps {
   /** Interactive confirmation seam; production uses @inquirer/prompts. */
   confirm?: typeof confirm;
   acquireLifecycleLease?: typeof acquireLifecycleLease;
+  /** Test seam for the `setup-activation` codex lifecycle lease held during a journal quarantine. */
+  acquireActivationLease?: typeof acquireActivationLifecycleLease;
   /** Test seam for the once-bound absolute Codex CLI path. */
   resolveExecutable?: (name: string, cwd: string) => string | null;
   cwd?: string;
@@ -373,7 +383,8 @@ type SetupCodexOutcomeCode =
   | 'busy'
   | 'stale'
   | 'refused'
-  | 'broken';
+  | 'broken'
+  | 'quarantine-skipped';
 
 interface ActivationOutcome {
   exitCode: 0 | 1 | 2;
@@ -407,6 +418,7 @@ function runCodexActivation(
   codexPath: string,
   entry: ActivationEntryPath,
   quick: boolean,
+  attempt = 0,
 ): ActivationOutcome {
   const genieHome = resolveGenieHome();
   const codexHome = resolveCodexDir();
@@ -480,6 +492,16 @@ function runCodexActivation(
     return { exitCode: resolveSetupExitCode(state, authorization), activated: false, code: 'not-authorized' };
   }
 
+  // Group E (live-QA find): an intent-invalid/intent-mismatch state grants a
+  // JOURNAL-QUARANTINE permit, not an activation permit. Feeding it to the
+  // executor made beginActivation refuse ("permit lacks activation capability")
+  // and left the state's own recovery — "quarantine the mismatched intent after
+  // a fresh assertion, then re-observe" — unreachable, looping forever. Route
+  // the permit to A's quarantine API, then re-observe and continue once.
+  if (authorization.permit.capability === 'journal-quarantine') {
+    return runJournalQuarantine(deps, codexPath, entry, quick, authorization.permit, attempt);
+  }
+
   // Permit granted — the executor acquires the `setup-activation` lease itself.
   const store = (deps.openCodexActivationStore ?? openCodexActivationStore)({
     genieHome,
@@ -495,6 +517,57 @@ function runCodexActivation(
     configPath: getCodexConfigPath(),
   });
   return reportActivationExecution(result);
+}
+
+/**
+ * Consume a journal-quarantine permit: move the invalid/mismatched activation
+ * journal aside under the same `setup-activation` lifecycle lease the executor
+ * would hold, then re-observe with one fresh pass through `runCodexActivation`
+ * (the fresh state prompts its own consent for any actual activation). One hop
+ * only — a second quarantine grant in the same invocation reports instead of
+ * looping.
+ */
+function runJournalQuarantine(
+  deps: SetupDeps,
+  codexPath: string,
+  entry: ActivationEntryPath,
+  quick: boolean,
+  permit: ActivationPermit,
+  attempt: number,
+): ActivationOutcome {
+  const genieHome = resolveGenieHome();
+  const codexHome = resolveCodexDir();
+  if (attempt > 0) {
+    console.error('  \x1b[31m✖\x1b[0m A second quarantine was requested in one invocation; refusing to loop.');
+    console.error(
+      '    Rerun \x1b[36mgenie setup --codex\x1b[0m; if it recurs, include `genie doctor --json` in an issue.',
+    );
+    return { exitCode: 1, activated: false, code: 'quarantine-skipped' };
+  }
+  const acquire = deps.acquireActivationLease ?? acquireActivationLifecycleLease;
+  const lease = acquire('setup-activation', { genieHome });
+  if (!lease.ok) {
+    console.error(`  \x1b[31m✖\x1b[0m Another Genie lifecycle command holds the Codex lease: ${lease.detail}`);
+    return { exitCode: 2, activated: false, code: 'busy' };
+  }
+  let quarantined: { quarantinedTo: string } | { skipped: string };
+  try {
+    const store = (deps.openCodexActivationStore ?? openCodexActivationStore)({
+      genieHome,
+      codexHome,
+      command: codexPath,
+    });
+    quarantined = store.quarantineIntent(lease, permit);
+  } finally {
+    lease.release();
+  }
+  if ('skipped' in quarantined) {
+    console.error(`  \x1b[31m✖\x1b[0m Stale activation journal was not quarantined: ${quarantined.skipped}`);
+    return { exitCode: 1, activated: false, code: 'quarantine-skipped' };
+  }
+  console.log(`  \x1b[33m!\x1b[0m Quarantined stale activation journal → ${quarantined.quarantinedTo}`);
+  console.log('  Re-observing the delivered generation...');
+  return runCodexActivation(deps, codexPath, entry, quick, attempt + 1);
 }
 
 function reportActivationExecution(result: ActivationExecutionResult): ActivationOutcome {

--- a/tests/integration/codex-lifecycle-pty.test.ts
+++ b/tests/integration/codex-lifecycle-pty.test.ts
@@ -24,6 +24,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   rmSync,
   writeFileSync,
@@ -348,6 +349,27 @@ describe.skipIf(!CAN_PTY)('codex lifecycle over a real PTY (Group E deliverable 
       writeFileSync(deliveryRecordPath(), recordBytes);
     }
   }, 120_000);
+
+  test('stage 6b — a stale activation journal is quarantined under one consent, then re-observed (live-QA regression)', () => {
+    // The 2026-07-23 live-QA failure: a leftover journal from a prior
+    // generation made consent mint a quarantine permit that setup fed to the
+    // activation executor ("permit lacks activation capability"), leaving the
+    // prescribed recovery unreachable. One consented run must now quarantine
+    // the journal, re-observe, and land on the truthful current state.
+    const journalPath = join(genieHome, '.codex-plugin-refresh-intent.json');
+    writeFileSync(journalPath, 'not json at all\n');
+    const { exitCode, output } = runPty(['setup', '--codex'], 'yes\n');
+    expect(output).toContain('Quarantined stale activation journal');
+    expect(output).toContain('already current');
+    expect(output).not.toContain('permit lacks activation capability');
+    expect(exitCode).toBe(0);
+    expect(existsSync(journalPath)).toBe(false);
+    // The journal was moved aside (content-addressed), not destroyed.
+    const quarantinedSiblings = readdirSync(genieHome).filter((name) =>
+      name.startsWith('.codex-plugin-refresh-intent.json.invalid-'),
+    );
+    expect(quarantinedSiblings.length).toBe(1);
+  }, 180_000);
 
   test('stage 7 — route collision and nested shadowing are typed doctor failures, never green', () => {
     // Unmanaged same-key route: replace the project config with a user-owned one.


### PR DESCRIPTION
## Live-QA regression from the v5.260723.1 dogfood (Group E follow-up)

Felipe's post-release ritual hit this on `genie setup --codex`:

```
✖ permit lacks activation capability (Quarantine the mismatched intent after a fresh assertion, then re-observe)
{"code":"intent-mismatch","deliveryComplete":true,"retry":true,...}
```

**Root cause:** a stale activation journal from the prior generation classifies as `intent-mismatch` (authority `journal-quarantine-only`). The consent chain correctly mints a **journal-quarantine** permit and A's store even exposes `quarantineIntent(lease, permit)` — but setup routed every granted permit into `executeCodexActivation`, whose `beginActivation` refuses non-activation capability. The state's own prescribed recovery was permanently unreachable: re-running setup reproduced the refusal forever.

**Fix:** setup routes quarantine-capability permits to `store.quarantineIntent` under the same `setup-activation` lifecycle lease the executor holds, prints the content-addressed quarantine target, then re-observes with one fresh pass (the fresh state prompts its own consent for any actual activation). A second quarantine grant in the same invocation refuses instead of looping. New typed outcome `quarantine-skipped` covers the fail-closed skip arms (symlink/non-regular journal path). No A/B/D contract changes — the fix is pure consumption of A's existing API.

**Coverage:**
- Unit (real consent + real authorize, no permit stubbing): corrupt journal → quarantine permit → quarantined → re-observe → activation permit → activated; skipped quarantine exits 1 without touching the executor; loop guard.
- PTY end-to-end stage 6b reproduces the live failure: corrupt journal on a current machine → one consent → quarantined sibling on disk → `already current` → exit 0, and asserts the old "permit lacks activation capability" message never appears.

**Validation (all self-run):** 172/0 across setup/doctor/executor/PTY suites; 284/0 with codex stripped from PATH (CI condition); typecheck + lint clean.

Also carries the wish-ledger commit from the merged #2630 cycle (Group E execution-review SHIP evidence) via the dev merge-back.