### PR TITLE
fix(update): accept user-level CLIs and humanize the already-current handoff

### DIFF
--- a/src/genie-commands/__tests__/update.test.ts
+++ b/src/genie-commands/__tests__/update.test.ts
@@ -465,6 +465,19 @@ describe('updateCommand wiring', () => {
     expect(source).toContain('--rollback');
   });
 
+  test('the already-current handoff prints plain language and retries convergence (live-QA regression)', () => {
+    const source = readFileSync(join(__dirname, '..', 'update.ts'), 'utf-8');
+    // A bare machine trailer must never be the whole human output: the pending
+    // handoff states its meaning in plain language, and the rerun path still
+    // performs the non-cache-advancing convergence so a failed integration
+    // refresh (e.g. claude) is actually retried as the error message promises.
+    expect(source).toContain('Codex plugin activation is pending: retire Codex tasks');
+    const handoffBranch = source.slice(source.indexOf('handleAlreadyCurrentUpdate'));
+    expect(handoffBranch).toContain('runTrackedManualUpdateConvergence');
+    // The old dead-end shape (trailer + immediate return, no convergence) is gone.
+    expect(source).not.toContain('process.exitCode = 2;\n    log(CODEX_DELIVERY_RESULT_TRAILER);\n    return;');
+  });
+
   test('"Already up to date" exit logs version and channel', () => {
     const source = readFileSync(join(__dirname, '..', 'update.ts'), 'utf-8');
     expect(source).toContain('Already up to date');
@@ -2024,9 +2037,11 @@ describe('manual post-update convergence (2026-07-11 cascade regression)', () =>
         message = error instanceof Error ? error.message : String(error);
       }
       expect(message).toContain('fresh Genie integration convergence failed: exit 7');
-      expect(message).toContain('Close all Codex tasks first');
-      expect(message).toContain('external terminal');
-      expect(message.indexOf('Close all Codex tasks first')).toBeLessThan(message.indexOf('external terminal'));
+      // Integration-neutral operator recovery: retry the update itself first
+      // (the rerun re-converges), THEN the Codex activation steps if pending.
+      expect(message).toContain('Rerun `genie update`');
+      expect(message).toContain('genie setup --codex');
+      expect(message.indexOf('Rerun `genie update`')).toBeLessThan(message.indexOf('genie setup --codex'));
     } finally {
       lease.release();
       rmSync(home, { recursive: true, force: true });

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -1669,7 +1669,7 @@ export function runFreshBinaryPostDeliveryConvergence(
     // result trailer over inherited stdio; the parent only mirrors the code.
     if (childExitStatus(cause) === 2) return 'action-required';
     throw new Error(
-      `fresh Genie integration convergence failed: ${errMsg(cause)}. The verified CLI update is installed, but its integrations are not converged. Close all Codex tasks first. Then, from an external terminal, run \`genie update\` (or \`genie setup --codex\`), review \`/hooks\`, and start a new Codex task.`,
+      `fresh Genie integration convergence failed: ${errMsg(cause)}. The verified CLI update is installed, but the integration named above is not converged. Rerun \`genie update\` from a regular terminal to retry. If Codex activation is pending afterwards, close Codex tasks, run \`genie setup --codex\`, review \`/hooks\`, and start a new Codex task.`,
     );
   }
 }
@@ -2069,17 +2069,20 @@ async function handleAlreadyCurrentUpdate(
   latestVersion: string | null | undefined,
 ): Promise<void> {
   const repair = await attemptAlreadyCurrentDeliveryRepair(channel, platform);
-  if (repair.action === 'exit-handoff') {
-    // Old-parent repair published one bound record but the registered generation
-    // still trails the target: hand off to setup (exit 2) with the one delivery
-    // trailer and exact next action, keeping N registered.
-    process.exitCode = 2;
-    log(CODEX_DELIVERY_RESULT_TRAILER);
-    return;
-  }
   success(`Already up to date (v${normalizeVersion(installedVersion)}, channel ${channel})`);
   if (repair.action === 'repaired-current') {
     log('Repaired the missing Codex delivery record for the installed generation.');
+  }
+  if (repair.action === 'exit-handoff') {
+    // Old-parent repair published one bound record but the registered Codex
+    // generation still trails the target. Say so in PLAIN language BEFORE any
+    // machine trailer (live-QA: a bare JSON line as the whole output reads as
+    // a malfunction), and STILL run the non-cache-advancing convergence so a
+    // rerun after a failed integration refresh (e.g. claude) actually retries
+    // — the convergence exit signal carries the one delivery trailer.
+    log(
+      'Codex plugin activation is pending: retire Codex tasks, run `genie setup --codex`, review `/hooks`, then start a new Codex task.',
+    );
   }
   runTrackedManualUpdateConvergence(latestVersion ?? normalizeVersion(installedVersion));
   retireLegacyInstallMarkerSafe();

--- a/src/lib/trusted-executable.test.ts
+++ b/src/lib/trusted-executable.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { validateTrustedExecutablePath } from './trusted-executable.js';
+
+let home: string;
+
+function fakeExecutable(path: string): string {
+  mkdirSync(join(path, '..'), { recursive: true });
+  writeFileSync(path, '#!/bin/sh\nexit 0\n');
+  chmodSync(path, 0o755);
+  return path;
+}
+
+function gitInit(dir: string): void {
+  mkdirSync(dir, { recursive: true });
+  execFileSync('git', ['init', '-q'], { cwd: dir });
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'trusted-exe-home-'));
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe('validateTrustedExecutablePath — home containment is not a trust signal (live-QA regression)', () => {
+  test('a user-level CLI under ~/.local/bin is accepted when the CWD IS the home directory', () => {
+    // The 2026-07-23 dogfood failure: `genie update` run from $HOME refused
+    // /home/<user>/.local/bin/claude as "repository-local" because the bare CWD
+    // containment rule swallowed the whole home tree.
+    const claude = fakeExecutable(join(home, '.local', 'bin', 'claude'));
+    expect(validateTrustedExecutablePath('claude CLI', claude, home, process.platform, home)).toBe(
+      realpathSync(claude),
+    );
+  });
+
+  test('a dotfiles git repository AT the home directory does not ban user-level CLIs', () => {
+    gitInit(home);
+    const claude = fakeExecutable(join(home, '.local', 'bin', 'claude'));
+    expect(validateTrustedExecutablePath('claude CLI', claude, home, process.platform, home)).toBe(
+      realpathSync(claude),
+    );
+  });
+
+  test('a repository-local executable in a project BELOW home stays refused', () => {
+    const project = join(home, 'workspace', 'proj');
+    gitInit(project);
+    const evil = fakeExecutable(join(project, 'bin', 'claude'));
+    expect(() => validateTrustedExecutablePath('claude CLI', evil, project, process.platform, home)).toThrow(
+      /repository-local/,
+    );
+  });
+
+  test('a CWD-local executable in a plain (non-git) project directory stays refused', () => {
+    const scratch = join(home, 'downloads', 'unpacked');
+    const evil = fakeExecutable(join(scratch, 'claude'));
+    expect(() => validateTrustedExecutablePath('claude CLI', evil, scratch, process.platform, home)).toThrow(
+      /repository-local/,
+    );
+  });
+
+  test('from inside a project, a user-level CLI outside the project is accepted', () => {
+    const project = join(home, 'workspace', 'proj');
+    gitInit(project);
+    const claude = fakeExecutable(join(home, '.local', 'bin', 'claude'));
+    expect(validateTrustedExecutablePath('claude CLI', claude, project, process.platform, home)).toBe(
+      realpathSync(claude),
+    );
+  });
+});

--- a/src/lib/trusted-executable.ts
+++ b/src/lib/trusted-executable.ts
@@ -1,4 +1,5 @@
 import { constants, accessSync, lstatSync, readFileSync, realpathSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 
 const MAX_GIT_POINTER_BYTES = 4 * 1024;
@@ -11,6 +12,15 @@ function normalizeComparablePath(path: string): string {
     return realpathSync(logical) === path ? logical : path;
   } catch {
     return path;
+  }
+}
+
+/** Canonical (physical) form with a logical fallback for unresolvable paths. */
+function safeCanonical(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
   }
 }
 
@@ -107,19 +117,31 @@ export function resolveEnclosingGitTrustRoots(cwd: string): string[] {
   return [...roots];
 }
 
-/** Validate an already-selected absolute executable against repository trust roots. */
+/**
+ * Validate an already-selected absolute executable against repository trust
+ * roots. The threat is a repository-local binary in an untrusted checkout — so
+ * a forbidden root that IS the user's home directory (or an ancestor of it,
+ * e.g. a dotfiles repo at `~`, or simply running from `$HOME`) is excluded:
+ * "contained in $HOME" bans every user-installed CLI (`~/.local/bin/claude`,
+ * `~/.bun/bin/...`) while providing no isolation, since effectively everything
+ * user-owned lives under home. Real project roots BELOW home stay forbidden.
+ */
 export function validateTrustedExecutablePath(
   name: string,
   candidate: string,
   childCwd: string,
   platform: NodeJS.Platform = process.platform,
+  home: string = homedir(),
 ): string {
   if (!isAbsolute(candidate)) throw new Error(`${name} did not resolve to an absolute executable`);
 
   const canonicalCwd = realpathSync(childCwd);
   const selectedPath = resolve(candidate);
   const canonical = realpathSync(candidate);
-  const forbiddenRoots = new Set([canonicalCwd, ...resolveEnclosingGitTrustRoots(canonicalCwd)]);
+  const canonicalHome = safeCanonical(home);
+  const forbiddenRoots = [...new Set([canonicalCwd, ...resolveEnclosingGitTrustRoots(canonicalCwd)])].filter(
+    (root) => !isSameOrContainedPath(root, canonicalHome),
+  );
   for (const root of forbiddenRoots) {
     if (isSameOrContainedPath(root, selectedPath) || isSameOrContainedPath(root, canonical)) {
       throw new Error(`Refusing repository-local ${name} executable: ${candidate}`);


### PR DESCRIPTION
## Live-QA findings from the v5.260723.2 linux dogfood

Running `genie update --dev` **from the home directory** surfaced three defects (transcript from the operator's host):

```
▸ integration refresh: claude — FAILED: Refusing repository-local claude CLI executable: /home/namastex/.local/bin/claude
✖ Post-delivery convergence failed: claude: Refusing repository-local claude CLI executable ...
# rerun, as instructed:
▸ {"schemaVersion":1,"code":"activation-pending",...}     ← the ENTIRE output
```

### 1. Trusted-executable: $HOME containment is not a trust signal (functional bug)
`validateTrustedExecutablePath` forbids any candidate under the CWD or its enclosing git roots. When the CWD is `$HOME` (or home is a dotfiles git repo), that rule swallows the whole home tree — banning every user-installed CLI, including the XDG-standard `~/.local/bin/claude`, so claude convergence could NEVER succeed from `$HOME`. Forbidden roots that are home or an ancestor of home are now excluded; real project roots below home stay refused. New focused test file pins both directions (home-CWD accepted, dotfiles-repo-at-home accepted, repo-local and plain-CWD-local executables still refused, user-level CLI from inside a project accepted).

### 2. The prescribed recovery was a dead end (functional bug)
The failure message says "rerun `genie update`" — but the already-current `exit-handoff` path printed a bare JSON trailer as the **entire output** and returned before any convergence, silently skipping the failed claude refresh forever. The handoff now prints "Already up to date" + a plain-language pending-activation line, and still runs the non-cache-advancing convergence: the failed integration is actually retried, and the convergence exit signal carries the one trailer (exit 2 when Codex is genuinely pending; truthful output on hosts where it isn't).

### 3. Message accuracy
The fresh-convergence failure no longer prescribes codex-only recovery ("Close all Codex tasks ... start a new Codex task") for a claude failure — it names the retry that now works, then the Codex steps only if activation is pending.

**Validation (self-run):** full suite 2540 pass (sole failure: pre-existing Linux-only `ss` ui-bridge test, green in CI); codex-stripped CI-condition run 284/0; typecheck + lint clean; no A/B/D contract changes.