### PR TITLE
fix(delivery): publish the delivery record for absent-N (fresh-host setup gate)

### DIFF
--- a/src/genie-commands/codex-delivery.test.ts
+++ b/src/genie-commands/codex-delivery.test.ts
@@ -54,7 +54,10 @@ describe('buildDeliveryPublication — publish facts only for pending', () => {
       }),
     ).toEqual({ targetVersion: N, canonicalPayloadSha256: DIGEST, channel: 'stable', downgradeFrom: T });
   });
-  test('absent and current publish nothing', () => {
+  test('absent-N publishes the delivery facts (fresh host: setup gate needs the record); no downgrade binding', () => {
+    // Group E live-QA regression: without this, a fresh codex host required a
+    // SECOND `genie update` (already-current repair) before setup could pass
+    // the Decision-9 record gate.
     expect(
       buildDeliveryPublication({
         installedVersion: null,
@@ -62,7 +65,10 @@ describe('buildDeliveryPublication — publish facts only for pending', () => {
         canonicalPayloadSha256: DIGEST,
         channel: 'dev',
       }),
-    ).toBeNull();
+    ).toEqual({ targetVersion: T, canonicalPayloadSha256: DIGEST, channel: 'dev' });
+  });
+
+  test('current publishes nothing', () => {
     expect(
       buildDeliveryPublication({
         installedVersion: T,
@@ -159,21 +165,36 @@ describe('publishCodexDelivery — parent publishes facts, nothing else', () => 
     expect(forbidden).toEqual([]);
   });
 
-  test('absent and current publish nothing and never touch activation state', () => {
-    for (const installed of [null, T]) {
-      const { store, publishCalls, forbidden } = spyStore();
-      const result = publishCodexDelivery({
-        lease: spyLease(),
-        store,
-        installedVersion: installed,
-        targetVersion: T,
-        canonicalPayloadSha256: DIGEST,
-        channel: 'dev',
-      });
-      expect(result.published).toBe(false);
-      expect(publishCalls).toHaveLength(0);
-      expect(forbidden).toEqual([]);
-    }
+  test('current publishes nothing and never touches activation state', () => {
+    const { store, publishCalls, forbidden } = spyStore();
+    const result = publishCodexDelivery({
+      lease: spyLease(),
+      store,
+      installedVersion: T,
+      targetVersion: T,
+      canonicalPayloadSha256: DIGEST,
+      channel: 'dev',
+    });
+    expect(result.published).toBe(false);
+    expect(publishCalls).toHaveLength(0);
+    expect(forbidden).toEqual([]);
+  });
+
+  test('absent-N publishes the facts once, with no receipt and no activation-state touch', () => {
+    const { store, publishCalls, forbidden } = spyStore();
+    const result = publishCodexDelivery({
+      lease: spyLease(),
+      store,
+      installedVersion: null,
+      targetVersion: T,
+      canonicalPayloadSha256: DIGEST,
+      channel: 'dev',
+    });
+    expect(result.published).toBe(true);
+    expect(result.wroteDowngradeReceipt).toBe(false);
+    expect(publishCalls).toHaveLength(1);
+    expect(publishCalls[0]).toMatchObject({ targetVersion: T, canonicalPayloadSha256: DIGEST, channel: 'dev' });
+    expect(forbidden).toEqual([]);
   });
 });
 

--- a/src/genie-commands/codex-delivery.ts
+++ b/src/genie-commands/codex-delivery.ts
@@ -121,19 +121,27 @@ export interface CodexDeliveryFacts {
 }
 
 /**
- * Build the `publishDelivery` input for a pending delivery, or null when there
- * is nothing to publish (absent/current/indeterminate). A downgrade binds
+ * Build the `publishDelivery` input for a pending OR absent-N delivery, or null
+ * when there is nothing to publish (current/indeterminate). A downgrade binds
  * `downgradeFrom = N` so A writes the one-time downgrade receipt.
+ *
+ * Group E: `absent` (no installed plugin generation) publishes too. The record
+ * binds the DELIVERY facts, not an activation — and setup's Decision-9 gate
+ * refuses to activate a fresh host without a matching record, so a delivery
+ * that skipped publication forced a second `genie update` (already-current
+ * repair) before the first `genie setup --codex` could ever succeed
+ * (2026-07-23 live-QA finding). Publication remains a pure fact write: no
+ * journal, activation, or cache mutation.
  */
 export function buildDeliveryPublication(facts: CodexDeliveryFacts): PublishDeliveryInput | null {
   const state = classifyCodexDelivery(facts.installedVersion, facts.targetVersion);
-  if (state.kind !== 'pending') return null;
+  if (state.kind !== 'pending' && state.kind !== 'absent') return null;
   const input: PublishDeliveryInput = {
     targetVersion: facts.targetVersion,
     canonicalPayloadSha256: facts.canonicalPayloadSha256,
     channel: facts.channel,
   };
-  if (state.direction === 'downgrade' && facts.installedVersion !== null) {
+  if (state.kind === 'pending' && state.direction === 'downgrade' && facts.installedVersion !== null) {
     input.downgradeFrom = facts.installedVersion;
   }
   return input;
@@ -151,7 +159,7 @@ export interface PublishCodexDeliveryInput extends CodexDeliveryFacts {
 
 export interface PublishedCodexDelivery {
   state: CodexDeliveryState;
-  /** True when this call wrote a delivery record (pending only). */
+  /** True when this call wrote a delivery record (pending or absent-N delivery). */
   published: boolean;
   /** True when this call wrote a downgrade receipt (explicit-channel downgrade). */
   wroteDowngradeReceipt: boolean;


### PR DESCRIPTION
## Live-QA finding from the v5.260723.3 dogfood (fresh-plugin linux host)

`genie setup --codex` on a host whose codex plugin was never installed refused with `delivery-incomplete` — and its recovery ("run genie update") looped, because the delivery path only publishes a record for **pending** deliveries (installed N ≠ T). With N **absent**, delivery published nothing; only the *already-current repair* path mints the record, forcing this dance on every fresh codex host:

update (delivers, no record) → setup refuses → update again (repair publishes) → setup works

## Fix
`buildDeliveryPublication` now publishes for `absent` too. The record binds **delivery facts**, not an activation — publication stays a pure fact write (no journal, activation, receipt, or cache mutation), which Decision 10 permits (only update/install publish). `current`/`indeterminate` still publish nothing. Downgrade binding remains pending-only.

Result: one `genie update` → one `genie setup --codex` on fresh hosts, exactly as the recovery text promises.

**Validation (self-run):** codex-delivery/install/update/install-promote/repair suites 277/0 with the two absent-N contract tests inverted and extended; full suite green except the pre-existing macOS-only `ss` ui-bridge test and one isolated-pass concurrency flake; typecheck + lint clean.