### PR TITLE
refactor(codex): trim delivery lifecycle duplication

### DIFF
--- a/src/genie-commands/__tests__/update.test.ts
+++ b/src/genie-commands/__tests__/update.test.ts
@@ -541,9 +541,7 @@ describe('updateCommand wiring', () => {
 
   test('no hard process exit is reachable while normal or explicit update leases are held', () => {
     const source = readFileSync(join(__dirname, '..', 'update.ts'), 'utf-8');
-    const normalStart = source.indexOf(
-      'const lifecycleLease = acquireRequiredLifecycleLease(dependencies.acquireLease)',
-    );
+    const normalStart = source.indexOf('const acquired = acquireUpdateLifecycleLeasesOrProject(dependencies);');
     const normalEnd = source.indexOf('\n/**\n * Post-swap v4 legacy cleanup', normalStart);
     const explicitStart = source.indexOf('async function runExplicitUpdateMode');
     const explicitEnd = source.indexOf('\nasync function dispatchNonNormalUpdateMode', explicitStart);
@@ -615,6 +613,87 @@ describe('updateCommand wiring', () => {
       logSpy.mockRestore();
       errorSpy.mockRestore();
       process.exitCode = priorExitCode;
+    }
+  });
+
+  test('an initial Codex fencing failure releases in reverse order before projecting and runs no mutation', async () => {
+    const priorExitCode = process.exitCode;
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const events: string[] = [];
+    const logSpy = spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      const line = args.join(' ');
+      stdout.push(line);
+      if (line.includes('Update failed: stale lifecycle authority')) events.push('terminal-error');
+      if (line.includes('"deliveryComplete":false')) events.push('terminal-trailer');
+    });
+    const errorSpy = spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      const line = args.join(' ');
+      stderr.push(line);
+      if (line.includes('Update failed: stale lifecycle authority')) events.push('terminal-error');
+    });
+    process.exitCode = undefined;
+    try {
+      await updateCommand(
+        { yes: true, stable: true },
+        {
+          fetchManifest: async () => commandManifest,
+          readInstalledVersion: () => '5.260700.1',
+          resolvePlatform: () => 'darwin-arm64',
+          acquireLease: () => {
+            events.push('agent-acquire');
+            return {
+              path: '/fixture/.agent-sync.lock',
+              release: () => events.push('agent-release'),
+            };
+          },
+          acquireCodexLease: () => {
+            events.push('codex-acquire');
+            return {
+              ok: true,
+              operationId: 'e'.repeat(32),
+              kind: 'update-delivery',
+              assertOperation: () => {
+                events.push('codex-assert');
+                throw new Error('stale lifecycle authority');
+              },
+              release: () => events.push('codex-release'),
+            };
+          },
+          recoverPendingState: () => events.push('MUTATION:recovery'),
+          persistSelectedChannel: async () => {
+            events.push('MUTATION:channel');
+          },
+          requireCanonicalInstall: () => events.push('MUTATION:canonical'),
+          deliverSelectedManifest: async () => {
+            events.push('MUTATION:delivery');
+            return [];
+          },
+          finalizeSelectedDelivery: async () => {
+            events.push('MUTATION:finalize');
+            return true;
+          },
+        },
+      );
+
+      expect(events).toEqual([
+        'agent-acquire',
+        'codex-acquire',
+        'codex-assert',
+        'codex-release',
+        'agent-release',
+        'terminal-error',
+        'terminal-trailer',
+      ]);
+      expect(events.some((event) => event.startsWith('MUTATION:'))).toBe(false);
+      expect(Number(process.exitCode)).toBe(1);
+      const output = [...stdout, ...stderr].join('\n');
+      expect(output).toContain('Update failed: stale lifecycle authority');
+      expect(output.match(/"deliveryComplete":false/g)).toHaveLength(1);
+    } finally {
+      logSpy.mockRestore();
+      errorSpy.mockRestore();
+      process.exitCode = priorExitCode ?? 0;
     }
   });
 

--- a/src/genie-commands/codex-delivery-repair.ts
+++ b/src/genie-commands/codex-delivery-repair.ts
@@ -35,19 +35,18 @@
  * activation-owned prompt, journal, enabled-state, plugin, or role mutation.
  */
 
-// Group B's contract, consumed (not reimplemented) via the stable executor facade
-// for the assessment and directly from the leaf module for its record/expectation types.
-import { assessAuthenticatedDelivery } from '../lib/codex-activation-executor.js';
 import type { CodexActivationStore, DeliveryFact, DeliveryRecord } from '../lib/codex-activation.js';
 import {
+  type AuthenticatedDeliveryRecordFields,
   type DeliveryEvidenceChannel,
   type DeliveryEvidencePlatformId,
   type VerifiedDeliveryEvidence,
   type VerifiedDeliveryEvidenceFacts,
   type VerifyDownloadedDeliveryEvidenceInput,
-  deriveDeliveryId,
+  authenticatedDeliveryBindingFromRecord,
+  authenticatedDeliveryRecordFields,
+  createAuthenticatedDeliveryBinding,
 } from '../lib/codex-delivery-evidence.js';
-import type { ActivationDeliveryExpectation } from '../lib/codex-host-observation.js';
 import type { HeldLifecycleLease } from '../lib/codex-lifecycle-lease.js';
 import { classifyCodexDelivery } from './codex-delivery.js';
 
@@ -168,24 +167,11 @@ export function buildLocalRepairExpectation(
   pinned: RepairPinnedTarget,
   installed: InstalledProof,
   evidence: VerifiedDeliveryEvidenceFacts,
-): ActivationDeliveryExpectation {
-  const descriptor = evidence.descriptor;
-  return {
-    targetVersion: pinned.targetVersion,
-    canonicalPayloadSha256: installed.pluginTreeSha256,
-    channel: pinned.channel,
-    deliveryId: deriveDeliveryId(evidence.evidenceDigest, installed.deliveryRoot),
-    evidenceDigest: evidence.evidenceDigest,
-    platformId: pinned.platformId,
-    platformTriple: pinned.platformTriple,
-    releaseTag: pinned.releaseTag,
-    releaseName: pinned.releaseName,
-    releaseManifestSha256: descriptor.releaseManifestSha256,
-    artifactSha256: descriptor.artifactSha256,
-    installedBinarySha256: installed.binarySha256,
-    deliveryRoot: installed.deliveryRoot,
-    deliveredAt: evidence.deliveredAt,
-  };
+): AuthenticatedDeliveryRecordFields {
+  if (!evidenceMatchesPinned(evidence, pinned) || !evidenceMatchesInstalled(evidence, installed)) {
+    throw new Error('verified delivery evidence does not match the pinned installed target');
+  }
+  return authenticatedDeliveryRecordFields(createAuthenticatedDeliveryBinding(evidence, installed.deliveryRoot));
 }
 
 /**
@@ -296,12 +282,22 @@ export function localDeliveryMatches(
   pinned: RepairPinnedTarget,
   installed: InstalledProof,
 ): boolean {
-  if (fact.status !== 'present' || !evidenceMatchesPinned(fact.evidence, pinned)) return false;
+  if (
+    fact.status !== 'present' ||
+    !evidenceMatchesPinned(fact.evidence, pinned) ||
+    !evidenceMatchesInstalled(fact.evidence, installed)
+  ) {
+    return false;
+  }
+  return authenticatedDeliveryBindingFromRecord(fact.record, fact.evidence, installed.deliveryRoot) !== null;
+}
+
+function evidenceMatchesInstalled(evidence: VerifiedDeliveryEvidenceFacts, installed: InstalledProof): boolean {
+  const descriptor = evidence.descriptor;
   return (
-    assessAuthenticatedDelivery(
-      { status: 'present', record: fact.record },
-      buildLocalRepairExpectation(pinned, installed, fact.evidence),
-    ) === 'matching'
+    descriptor.version === installed.version &&
+    descriptor.canonicalPayloadSha256 === installed.pluginTreeSha256 &&
+    descriptor.installedBinarySha256 === installed.binarySha256
   );
 }
 

--- a/src/genie-commands/codex-delivery.ts
+++ b/src/genie-commands/codex-delivery.ts
@@ -32,15 +32,12 @@ import {
   parseReleaseVersion,
 } from '../lib/codex-activation.js';
 import {
+  type AuthenticatedDeliveryRecordFields,
   type VerifiedDeliveryEvidence,
-  deriveDeliveryId,
+  authenticatedDeliveryBindingFromRecord,
   verifiedDeliveryEvidenceFacts,
 } from '../lib/codex-delivery-evidence.js';
-import {
-  type AuthenticatedDeliveryRecord,
-  type DeliveryRecordReadState,
-  assessAuthenticatedDelivery,
-} from '../lib/codex-host-observation.js';
+import type { DeliveryRecordReadState } from '../lib/codex-host-observation.js';
 import type { HeldLifecycleLease } from '../lib/codex-lifecycle-lease.js';
 
 /** The exact operator recovery every delivered-but-action-required Codex path names. */
@@ -182,25 +179,7 @@ export function buildDeliveryPublication(facts: CodexDeliveryFacts): PublishDeli
 function existingDeliveryMatches(facts: CodexDeliveryFacts): boolean {
   if (facts.existingRecord?.status !== 'present') return false;
   const evidence = verifiedDeliveryEvidenceFacts(facts.evidence);
-  const descriptor = evidence.descriptor;
-  return (
-    assessAuthenticatedDelivery(facts.existingRecord, {
-      targetVersion: descriptor.version,
-      canonicalPayloadSha256: descriptor.canonicalPayloadSha256,
-      channel: descriptor.channel,
-      deliveryId: deriveDeliveryId(evidence.evidenceDigest, facts.deliveryRoot),
-      evidenceDigest: evidence.evidenceDigest,
-      platformId: descriptor.platformId,
-      platformTriple: descriptor.platformTriple,
-      releaseTag: descriptor.releaseTag,
-      releaseName: descriptor.releaseName,
-      releaseManifestSha256: descriptor.releaseManifestSha256,
-      artifactSha256: descriptor.artifactSha256,
-      installedBinarySha256: descriptor.installedBinarySha256,
-      deliveryRoot: facts.deliveryRoot,
-      deliveredAt: evidence.deliveredAt,
-    }) === 'matching'
-  );
+  return authenticatedDeliveryBindingFromRecord(facts.existingRecord.record, evidence, facts.deliveryRoot) !== null;
 }
 
 export interface PublishCodexDeliveryInput extends CodexDeliveryFacts {
@@ -216,7 +195,7 @@ export type PublishedCodexDelivery =
       state: CodexDeliveryState;
       published: false;
       wroteDowngradeReceipt: false;
-      record: AuthenticatedDeliveryRecord;
+      record: AuthenticatedDeliveryRecordFields;
     }
   | {
       outcome: 'published';

--- a/src/genie-commands/install-promote.ts
+++ b/src/genie-commands/install-promote.ts
@@ -49,6 +49,7 @@ import {
   physicalPathIdentitiesEqual,
   renamePathNoClobber,
 } from '../lib/install-transaction.js';
+import { releaseOrderedLifecycleLeases } from '../lib/ordered-lifecycle-leases.js';
 import { VERSION } from '../lib/version.js';
 
 const VERSION_PATTERN = /(?:^|[^0-9A-Za-z.+-])v?([0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?)(?:[^0-9A-Za-z.+-]|$)/;
@@ -361,11 +362,7 @@ export function installPromoteCommand(
         }
       }
     } finally {
-      try {
-        codexLease?.release();
-      } finally {
-        lease.release();
-      }
+      releaseOrderedLifecycleLeases(codexLease, lease);
     }
   }
 }

--- a/src/genie-commands/install.ts
+++ b/src/genie-commands/install.ts
@@ -25,6 +25,7 @@ import {
 } from '../lib/codex-lifecycle-lease.js';
 import { genieConfigExists, getGenieConfigPath } from '../lib/genie-config.js';
 import { retireInstallVersionMarker } from '../lib/install-version-marker.js';
+import { acquireOrderedLifecycleLeases, releaseOrderedLifecycleLeases } from '../lib/ordered-lifecycle-leases.js';
 import {
   type InstallIntegrationsOptions,
   type IntegrationResult,
@@ -371,55 +372,6 @@ function runPermittedPostDeliveryIntegrations(
 }
 
 /**
- * Acquire the Codex lifecycle lease unconditionally, or project the AC8 loser
- * refusal. The release payload always owns plugins/bin normalization even when
- * runtime selection is `none` or `claude`, so selection never bypasses this
- * inner lock. A busy holder refuses before the first payload mutation.
- */
-function acquireCodexLeaseOrRefuse(
-  acquire: CodexLifecycleLeaseAcquirer,
-): { refused: true } | { refused: false; lease: HeldLifecycleLease } {
-  const lease = acquire();
-  if (!lease.ok) {
-    console.log(new CodexLifecycleBusyError(lease.holderKind).message);
-    console.log(CODEX_LIFECYCLE_BUSY_TRAILER);
-    process.exitCode = 2;
-    return { refused: true };
-  }
-  return { refused: false, lease };
-}
-
-/**
- * Release in reverse acquisition order without letting an inner-release
- * failure strand the outer lifecycle authority. Preserve the first cleanup
- * failure; if both releases fail, report both instead of replacing either one.
- */
-function releaseInstallLifecycleLeases(codexLease: HeldLifecycleLease | null, lifecycleLease: LifecycleLease): void {
-  let codexReleaseFailed = false;
-  let codexReleaseError: unknown;
-  try {
-    codexLease?.release();
-  } catch (error) {
-    codexReleaseFailed = true;
-    codexReleaseError = error;
-  }
-
-  try {
-    lifecycleLease.release();
-  } catch (lifecycleReleaseError) {
-    if (codexReleaseFailed) {
-      throw new AggregateError(
-        [codexReleaseError, lifecycleReleaseError],
-        'Codex and agent-sync lifecycle lease releases both failed',
-      );
-    }
-    throw lifecycleReleaseError;
-  }
-
-  if (codexReleaseFailed) throw codexReleaseError;
-}
-
-/**
  * Run the post-install finishers. `runV4Cleanup` / `normalizeLayout` / `runSync`
  * are injection seams for tests (mirrors runV4CleanupSafe) — production callers
  * pass options only.
@@ -445,18 +397,18 @@ export async function installCommand(
   // stable and a malformed internal handoff cannot mutate anything.
   const deliveryChannel = resolveDeliveryChannelForInstall();
   const selection = resolveIntegrationSelection(options);
-  const lease = acquireLease();
-  if ('skipped' in lease) throw new Error(`Another Genie lifecycle command is active: ${lease.skipped}`);
-  // The Codex lifecycle lease (.codex-lifecycle.lock) coexists with the agent-sync
-  // lease above (.agent-sync.lock): they guard different things and are always
-  // acquired agent-sync-first (identically in `genie update`), so no lock-ordering
-  // hazard. It is unconditional because payload normalization owns plugin trees
-  // regardless of the selected runtime; released in the finally.
-  let codexLease: HeldLifecycleLease | null = null;
+  const acquired = acquireOrderedLifecycleLeases(acquireLease, acquireCodexLease);
+  if (!acquired.ok) {
+    if (acquired.busy === 'agent-sync') {
+      throw new Error(`Another Genie lifecycle command is active: ${acquired.detail}`);
+    }
+    console.log(new CodexLifecycleBusyError(acquired.refusal.holderKind).message);
+    console.log(CODEX_LIFECYCLE_BUSY_TRAILER);
+    process.exitCode = 2;
+    return;
+  }
+  const { agentSyncLease: lease, codexLease } = acquired;
   try {
-    const gate = acquireCodexLeaseOrRefuse(acquireCodexLease);
-    if (gate.refused) return;
-    codexLease = gate.lease;
     codexLease.assertOperation(codexLease.operationId);
 
     // Both lifecycle locks are now held before canonical payload normalization,
@@ -498,10 +450,7 @@ export async function installCommand(
     // an installer exit 2 (deliverable 3).
     if (projectInstallDeliveryOutcome(delivery, actionRequired)) return;
   } finally {
-    // Release the Codex lifecycle lease (if held) before the agent-sync lease,
-    // the reverse of the agent-sync-first acquisition order. A failed inner
-    // release must never strand the outer authority.
-    releaseInstallLifecycleLeases(codexLease, lease);
+    releaseOrderedLifecycleLeases(codexLease, lease);
   }
 }
 

--- a/src/genie-commands/setup.test.ts
+++ b/src/genie-commands/setup.test.ts
@@ -1118,17 +1118,13 @@ describe('setup Codex activation (Group D)', () => {
     expect(start).toBeGreaterThan(-1);
     expect(end).toBeGreaterThan(start);
     const finalization = source.slice(start, end);
-    const acquireAgentSync = finalization.indexOf('const agentSyncLease =');
-    const acquireCodex = finalization.indexOf('const acquiredCodexLease =');
+    const acquireOrdered = finalization.indexOf('const acquired = acquireOrderedLifecycleLeases(');
     const persistConfig = finalization.indexOf('await saveSetupConfigUnderHeldLease(');
-    const releaseCodex = finalization.indexOf('codexLease?.release()');
-    const releaseAgentSync = finalization.indexOf('agentSyncLease.release()');
+    const releaseOrdered = finalization.indexOf('releaseOrderedLifecycleLeases(codexLease, agentSyncLease)');
 
-    expect(acquireAgentSync).toBeGreaterThan(-1);
-    expect(acquireAgentSync).toBeLessThan(acquireCodex);
-    expect(acquireCodex).toBeLessThan(persistConfig);
-    expect(persistConfig).toBeLessThan(releaseCodex);
-    expect(releaseCodex).toBeLessThan(releaseAgentSync);
+    expect(acquireOrdered).toBeGreaterThan(-1);
+    expect(acquireOrdered).toBeLessThan(persistConfig);
+    expect(persistConfig).toBeLessThan(releaseOrdered);
   });
 
   test('source-checkout setup performs zero writes while another process owns the GENIE_HOME lease', () => {

--- a/src/genie-commands/setup.ts
+++ b/src/genie-commands/setup.ts
@@ -60,6 +60,7 @@ import {
   saveGenieConfig,
 } from '../lib/genie-config.js';
 import { resolveCodexDir, resolveGenieHome } from '../lib/genie-home.js';
+import { acquireOrderedLifecycleLeases, releaseOrderedLifecycleLeases } from '../lib/ordered-lifecycle-leases.js';
 import {
   type CodexAgentInstallResult,
   type IntegrationSelection,
@@ -764,19 +765,19 @@ async function finalizeCodexSetup(
   prepared: PreparedCodexFinalization,
 ): Promise<FinalizedCodexSetup> {
   deps.codexFinalizationHooks?.beforeLocks?.();
-  const agentSyncLease = (deps.acquireLifecycleLease ?? acquireLifecycleLease)(resolveGenieHome());
-  if ('skipped' in agentSyncLease) {
-    throw new SetupCodexLifecycleBusyError('agent-sync', agentSyncLease.skipped);
-  }
-  let codexLease: HeldLifecycleLease | null = null;
-  try {
-    const acquireCodexLease = deps.acquireActivationLease ?? acquireActivationLifecycleLease;
-    const acquiredCodexLease = acquireCodexLease('setup-activation', { genieHome: resolveGenieHome() });
-    if (!acquiredCodexLease.ok) {
-      throw new SetupCodexLifecycleBusyError(acquiredCodexLease.holderKind, acquiredCodexLease.detail);
+  const genieHome = resolveGenieHome();
+  const acquired = acquireOrderedLifecycleLeases(
+    () => (deps.acquireLifecycleLease ?? acquireLifecycleLease)(genieHome),
+    () => (deps.acquireActivationLease ?? acquireActivationLifecycleLease)('setup-activation', { genieHome }),
+  );
+  if (!acquired.ok) {
+    if (acquired.busy === 'agent-sync') {
+      throw new SetupCodexLifecycleBusyError('agent-sync', acquired.detail);
     }
-    codexLease = acquiredCodexLease;
-
+    throw new SetupCodexLifecycleBusyError(acquired.refusal.holderKind, acquired.refusal.detail);
+  }
+  const { agentSyncLease, codexLease } = acquired;
+  try {
     const assets = convergePostActivationCodexAssetsUnderLease(deps, prepared.codexPath, prepared.outcome, codexLease);
     deps.codexFinalizationHooks?.afterAssets?.();
 
@@ -794,11 +795,7 @@ async function finalizeCodexSetup(
       ...(runtimeHint === undefined ? {} : { runtimeHint }),
     };
   } finally {
-    try {
-      codexLease?.release();
-    } finally {
-      agentSyncLease.release();
-    }
+    releaseOrderedLifecycleLeases(codexLease, agentSyncLease);
   }
 }
 

--- a/src/genie-commands/uninstall.ts
+++ b/src/genie-commands/uninstall.ts
@@ -75,6 +75,11 @@ import {
 import { contractPath, getGenieDir } from '../lib/genie-config.js';
 import { resolveClaudeDir, resolveCodexDir, resolveGenieHome, resolveHermesHome } from '../lib/genie-home.js';
 import {
+  type HeldOrderedLifecycleLeases,
+  acquireOrderedLifecycleLeases,
+  releaseOrderedLifecycleLeases,
+} from '../lib/ordered-lifecycle-leases.js';
+import {
   inspectCodexAgentOwnership,
   inspectRuntimeIntegrationEvidence,
   recoverCodexAgentTransactions,
@@ -3465,6 +3470,26 @@ function codexLifecycleBusyTrailer(holderKind: string | null): string {
   });
 }
 
+function acquireUninstallLifecycleLeasesOrProject(
+  genieDir: string,
+  deps: UninstallDeps,
+): HeldOrderedLifecycleLeases | null {
+  const acquired = acquireOrderedLifecycleLeases(
+    () => acquireLifecycleLease(genieDir),
+    () => (deps.acquireCodexLifecycleLease ?? acquireCodexLifecycleLease)('uninstall'),
+  );
+  if (acquired.ok) return acquired;
+  if (acquired.busy === 'agent-sync') {
+    throw new Error(`Another Genie lifecycle command is active: ${acquired.detail}`);
+  }
+  process.stdout.write(`${codexLifecycleBusyTrailer(acquired.refusal.holderKind)}\n`);
+  console.error(
+    `\x1b[33mcodex-lifecycle-busy:\x1b[0m ${acquired.refusal.detail}. No files were removed; retry once it completes.`,
+  );
+  process.exitCode = 2;
+  return null;
+}
+
 export async function uninstallCommand(
   options: { removeMarketplace?: boolean } = {},
   deps: UninstallDeps = {},
@@ -3585,30 +3610,13 @@ export async function uninstallCommand(
   }
 
   // Existing agent-sync safeguard lock (unchanged). Acquired after confirmation.
-  const lifecycleLease = acquireLifecycleLease(genieDir);
-  if ('skipped' in lifecycleLease)
-    throw new Error(`Another Genie lifecycle command is active: ${lifecycleLease.skipped}`);
+  // Ratified acquisition point: agent-sync first, then the exclusive Codex
+  // lifecycle lease, after destructive confirmation but before the first removal.
+  const acquired = acquireUninstallLifecycleLeasesOrProject(genieDir, deps);
+  if (acquired === null) return;
   try {
-    // Ratified acquisition point: the exclusive Codex lifecycle lease, after
-    // destructive confirmation but before the first removal, so uninstall
-    // serialises against setup/update/rollback/install on the shared GENIE_HOME.
-    const acquire = deps.acquireCodexLifecycleLease ?? acquireCodexLifecycleLease;
-    const codexLease = acquire('uninstall');
-    if (!codexLease.ok) {
-      // Loser: zero mutation. Emit the machine-readable trailer and exit 2.
-      process.stdout.write(`${codexLifecycleBusyTrailer(codexLease.holderKind)}\n`);
-      console.error(
-        `\x1b[33mcodex-lifecycle-busy:\x1b[0m ${codexLease.detail}. No files were removed; retry once it completes.`,
-      );
-      process.exitCode = 2;
-      return;
-    }
-    try {
-      executeConfirmedUninstall(genieDir, options.removeMarketplace ?? false);
-    } finally {
-      codexLease.release();
-    }
+    executeConfirmedUninstall(genieDir, options.removeMarketplace ?? false);
   } finally {
-    lifecycleLease.release();
+    releaseOrderedLifecycleLeases(acquired.codexLease, acquired.agentSyncLease);
   }
 }

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -58,6 +58,11 @@ import {
 import { inspectPhysicalPath } from '../lib/install-transaction.js';
 import { retireInstallVersionMarker } from '../lib/install-version-marker.js';
 import {
+  type HeldOrderedLifecycleLeases,
+  acquireOrderedLifecycleLeases,
+  releaseOrderedLifecycleLeases,
+} from '../lib/ordered-lifecycle-leases.js';
+import {
   type CodexAgentInstallResult,
   type IntegrationResult,
   type IntegrationSelection,
@@ -2467,25 +2472,38 @@ function projectDeferredUpdateTerminal(terminal: DeferredUpdateTerminal): void {
   process.exitCode = terminal.exitCode;
 }
 
+function acquireUpdateLifecycleLeasesOrProject(
+  dependencies: UpdateCommandDependencies,
+): HeldOrderedLifecycleLeases | null {
+  const acquired = acquireOrderedLifecycleLeases(
+    dependencies.acquireLease ?? (() => acquireLifecycleLease(GENIE_HOME)),
+    dependencies.acquireCodexLease ?? (() => acquireCodexLifecycleLease('update-delivery', { genieHome: GENIE_HOME })),
+  );
+  if (acquired.ok) return acquired;
+  if (acquired.busy === 'agent-sync') {
+    throw new Error(`Another Genie lifecycle command is active: ${acquired.detail}`);
+  }
+  projectDeferredUpdateTerminal(
+    new DeferredUpdateTerminal(
+      2,
+      new CodexLifecycleBusyError(acquired.refusal.holderKind).message,
+      CODEX_LIFECYCLE_BUSY_TRAILER,
+    ),
+  );
+  return null;
+}
+
+function assertInitialUpdateLifecycleAuthority(codexLease: HeldLifecycleLease): void {
+  try {
+    codexLease.assertOperation(codexLease.operationId);
+  } catch (err) {
+    throw new DeferredUpdateTerminal(1, `Update failed: ${errMsg(err)}`, CODEX_DELIVERY_INCOMPLETE_TRAILER);
+  }
+}
+
 function captureDeferredUpdateTerminal(error: unknown): DeferredUpdateTerminal {
   if (error instanceof DeferredUpdateTerminal) return error;
   throw error;
-}
-
-function acquireCodexUpdateLeaseOrRefuse(
-  acquire: NonNullable<UpdateCommandDependencies['acquireCodexLease']> = () =>
-    acquireCodexLifecycleLease('update-delivery', { genieHome: GENIE_HOME }),
-): HeldLifecycleLease {
-  const acquired = acquire();
-  if (!acquired.ok) {
-    throw new DeferredUpdateTerminal(
-      2,
-      new CodexLifecycleBusyError(acquired.holderKind).message,
-      CODEX_LIFECYCLE_BUSY_TRAILER,
-    );
-  }
-  acquired.assertOperation(acquired.operationId);
-  return acquired;
 }
 
 function recoverPendingUpdateStateOrThrow(recover?: () => void): void {
@@ -2499,14 +2517,6 @@ function recoverPendingUpdateStateOrThrow(recover?: () => void): void {
     )();
   } catch (err) {
     throw new DeferredUpdateTerminal(1, `Pending update recovery failed: ${errMsg(err)}`);
-  }
-}
-
-function releaseUpdateLifecycleLeases(codexLease: HeldLifecycleLease | null, lifecycleLease: LifecycleLease): void {
-  try {
-    codexLease?.release();
-  } finally {
-    lifecycleLease.release();
   }
 }
 
@@ -2541,13 +2551,16 @@ export async function updateCommand(
 
   if (!(await confirmPlannedDelivery(options, plannedInstalledVersion, latestVersion))) return;
 
-  const lifecycleLease = acquireRequiredLifecycleLease(dependencies.acquireLease);
-  let codexLease: HeldLifecycleLease | null = null;
+  const acquired = acquireUpdateLifecycleLeasesOrProject(dependencies);
+  if (acquired === null) return;
+  const { agentSyncLease: lifecycleLease, codexLease } = acquired;
   let terminal: DeferredUpdateTerminal | null = null;
   try {
     try {
-      const acquired = acquireCodexUpdateLeaseOrRefuse(dependencies.acquireCodexLease);
-      codexLease = acquired;
+      // The first fencing observation belongs inside the reverse-unwind
+      // boundary. A stale acquisition therefore releases both leases before
+      // projecting failure and cannot reach recovery or any later mutation.
+      assertInitialUpdateLifecycleAuthority(codexLease);
 
       // Revalidate durable recovery and the installed binary immediately after
       // acquiring both locks, before the first mutation owned by this plan.
@@ -2565,7 +2578,7 @@ export async function updateCommand(
           installedVersion,
           latestVersion,
           dependencies.alreadyCurrent,
-          acquired,
+          codexLease,
         );
         if (advancedManifest === null) return;
         manifest = advancedManifest;
@@ -2601,11 +2614,11 @@ export async function updateCommand(
       const resolvedManifest = manifest as LatestManifest;
 
       try {
-        acquired.assertOperation(acquired.operationId);
+        codexLease.assertOperation(codexLease.operationId);
         const complete = await runNormalUpdatePublicationBoundary(
           () =>
             dependencies.deliverSelectedManifest?.(resolvedManifest, platform) ??
-            runDelivery(resolvedManifest, platform, diagnosticsCtx, acquired, dependencies),
+            runDelivery(resolvedManifest, platform, diagnosticsCtx, codexLease, dependencies),
           dependencies.finalizeSelectedDelivery ??
             (async () => {
               runV4CleanupSafe();
@@ -2632,7 +2645,7 @@ export async function updateCommand(
       terminal = captureDeferredUpdateTerminal(err);
     }
   } finally {
-    releaseUpdateLifecycleLeases(codexLease, lifecycleLease);
+    releaseOrderedLifecycleLeases(codexLease, lifecycleLease);
   }
   if (terminal !== null) projectDeferredUpdateTerminal(terminal);
 }

--- a/src/lib/codex-activation.test.ts
+++ b/src/lib/codex-activation.test.ts
@@ -971,18 +971,8 @@ describe('CodexActivationStore — delivery + downgrade receipt', () => {
       expect(existsSync(join(fx.genieHome, '.codex-plugin-delivery-record.json'))).toBe(true);
       expect(existsSync(join(fx.genieHome, '.codex-plugin-downgrade-receipt.json'))).toBe(false);
       const fingerprint = computeActivationFingerprint(store.observe());
-      expect(fingerprint.deliveryEvidenceDigest).toBe(record.evidenceDigest);
-      expect(fingerprint).toMatchObject({
-        deliveryEvidenceSchemaVersion: 1,
-        deliveryRepository: 'automagik-dev/genie',
-        deliveryTargetVersion: T,
-        deliveryPlatformId: record.platformId,
-        deliverySourceSha: 'a'.repeat(40),
-        deliverySourceBranch: 'main',
-        deliverySourceCiRunId: '123456789',
-        deliveryControlSha: 'b'.repeat(40),
-        deliveryDigestAlgorithm: 'genie-physical-tree-v1',
-      });
+      expect(fingerprint.deliveryBindingDigest).toMatch(/^[0-9a-f]{64}$/);
+      expect(Object.keys(fingerprint).filter((key) => key.startsWith('delivery'))).toEqual(['deliveryBindingDigest']);
     } finally {
       lease.release();
     }

--- a/src/lib/codex-activation.ts
+++ b/src/lib/codex-activation.ts
@@ -39,22 +39,28 @@ import {
   unlinkWithParentFsync,
 } from './codex-activation-persistence.js';
 import {
+  type AuthenticatedDeliveryBinding,
   type DeliveryEvidenceVerificationDependencies,
+  type PersistedAuthenticatedDeliveryRecord,
   type VerifiedDeliveryEvidence,
   type VerifiedDeliveryEvidenceFacts,
-  deriveDeliveryId,
+  authenticatedDeliveryBindingDigest,
+  authenticatedDeliveryBindingFromRecord,
+  authenticatedDeliveryRecordFields,
+  createAuthenticatedDeliveryBinding,
+  encodeAuthenticatedDeliveryRecord,
   observePersistedDeliveryEvidence,
+  parseAuthenticatedDeliveryRecord,
   persistVerifiedDeliveryEvidence,
   verifiedDeliveryEvidenceFacts,
 } from './codex-delivery-evidence.js';
 // Group B (host-observation-attestation): the single pure delivery-attestation
 // classifier + its typed result. Imported here so the inner activation guard
 // (`beginActivationImpl`) applies exactly the same assessment the standalone
-// contract test exercises. `codex-host-observation.ts` imports only the leaf
-// `codex-release-version.ts` + `runtime-integrations.ts`, never this module, so
-// this dependency is one-directional (no import cycle).
+// contract test exercises. `codex-host-observation.ts` delegates tuple validation
+// to the evidence-owned codec and never imports this module, so this dependency
+// is one-directional (no import cycle).
 import {
-  type ActivationDeliveryExpectation,
   type DeliveryAssessment,
   type DeliveryRecordReadState,
   assessAuthenticatedDelivery,
@@ -141,33 +147,8 @@ export interface DowngradeReceipt {
   channel: string;
 }
 
-export interface DeliveryRecord {
-  schemaVersion: 2;
-  /** The 128-bit delivery transaction id; a downgrade receipt copies it as its receiptId. */
-  deliveryId: string;
-  targetVersion: string;
-  canonicalPayloadSha256: string;
-  channel: string;
-  deliveredAt: string;
-  /** Digest of the exact descriptor/bundle/manifest evidence pack. */
-  evidenceDigest: string;
-  /** Release asset platform identity (`linux-x64-glibc`, etc.). */
-  platformId: string;
-  /** os-arch platform triple (`process.platform-process.arch`), matches PLATFORM_TRIPLE_RE. */
-  platformTriple: string;
-  /** Release tag, e.g. `v5.260722.11`. */
-  releaseTag: string;
-  /** Release/asset name pinned before download. */
-  releaseName: string;
-  /** SHA-256 of the fetched release-manifest bytes (NOT an artifact digest source). */
-  releaseManifestSha256: string;
-  /** SHA-256 computed over the downloaded asset AFTER download and authenticated via attestation/cosign. */
-  artifactSha256: string;
-  /** SHA-256 of the installed binary the candidate was proven against. */
-  installedBinarySha256: string;
-  /** Absolute canonical delivery root the payload was proven against. */
-  deliveryRoot: string;
-}
+/** Byte-compatible schema-2 record; its field set and codec live with delivery evidence. */
+export type DeliveryRecord = PersistedAuthenticatedDeliveryRecord;
 
 export interface ReceiptTombstone {
   schemaVersion: 1;
@@ -256,90 +237,8 @@ export function parseDowngradeReceiptStructure(content: string): DowngradeReceip
   };
 }
 
-const DELIVERY_KEYS: ReadonlySet<string> = new Set([
-  'schemaVersion',
-  'deliveryId',
-  'targetVersion',
-  'canonicalPayloadSha256',
-  'channel',
-  'deliveredAt',
-  'evidenceDigest',
-  'platformId',
-  'platformTriple',
-  'releaseTag',
-  'releaseName',
-  'releaseManifestSha256',
-  'artifactSha256',
-  'installedBinarySha256',
-  'deliveryRoot',
-]);
-
-const PLATFORM_TRIPLE_RE = /^[a-z0-9]+-[a-z0-9_]+$/;
-/** A bounded free-text attestation field (tag/name/root): non-empty and length-capped. */
-function isBoundedText(value: unknown): value is string {
-  return typeof value === 'string' && value.length > 0 && value.length <= 256;
-}
-
 export function parseDeliveryRecordStructure(content: string): DeliveryRecord | null {
-  const parsed = safeJson(content);
-  if (!isPlainObject(parsed)) return null;
-  if (Object.keys(parsed).some((key) => !DELIVERY_KEYS.has(key))) return null;
-  const record = parsed;
-  // Schema 1 is deliberately legacy-invalid: it has no signed evidence-pack
-  // binding and can never authorize activation.
-  if (record.schemaVersion !== 2) return null;
-  if (!isHex128(record.deliveryId)) return null;
-  if (parseReleaseVersion(record.targetVersion) === null) return null;
-  if (!isHex256(record.canonicalPayloadSha256)) return null;
-  if (typeof record.channel !== 'string' || record.channel.length === 0 || record.channel.length > 128) return null;
-  if (typeof record.deliveredAt !== 'string' || record.deliveredAt.length === 0) return null;
-  if (!isHex256(record.evidenceDigest)) return null;
-  if (!isBoundedText(record.platformId)) return null;
-  if (!attestationFieldsValid(record)) return null;
-  return {
-    schemaVersion: 2,
-    deliveryId: record.deliveryId as string,
-    targetVersion: record.targetVersion as string,
-    canonicalPayloadSha256: record.canonicalPayloadSha256 as string,
-    channel: record.channel as string,
-    deliveredAt: record.deliveredAt as string,
-    evidenceDigest: record.evidenceDigest as string,
-    platformId: record.platformId as string,
-    ...pickAttestationFields(record),
-  };
-}
-
-/** Every authenticated-delivery binding is mandatory and shape-valid. */
-function attestationFieldsValid(record: Record<string, unknown>): boolean {
-  if (!(typeof record.platformTriple === 'string' && PLATFORM_TRIPLE_RE.test(record.platformTriple))) return false;
-  if (!isBoundedText(record.releaseTag)) return false;
-  if (!isBoundedText(record.releaseName)) return false;
-  if (!isBoundedText(record.deliveryRoot) || !isAbsolute(record.deliveryRoot)) return false;
-  for (const key of ['releaseManifestSha256', 'artifactSha256', 'installedBinarySha256'] as const) {
-    if (!isHex256(record[key])) return false;
-  }
-  if (record.releaseTag !== `v${record.targetVersion}`) return false;
-  if (
-    typeof record.releaseName !== 'string' ||
-    !record.releaseName.startsWith(`genie-${record.targetVersion}-`) ||
-    !record.releaseName.endsWith('.tar.gz')
-  )
-    return false;
-  if (typeof record.deliveredAt !== 'string' || !Number.isFinite(Date.parse(record.deliveredAt))) return false;
-  return true;
-}
-
-/** Copy the already-validated mandatory attestation fields onto the parsed record. */
-function pickAttestationFields(record: Record<string, unknown>): DeliveryAttestationFields {
-  return {
-    platformTriple: record.platformTriple as string,
-    releaseTag: record.releaseTag as string,
-    releaseName: record.releaseName as string,
-    releaseManifestSha256: record.releaseManifestSha256 as string,
-    artifactSha256: record.artifactSha256 as string,
-    installedBinarySha256: record.installedBinarySha256 as string,
-    deliveryRoot: record.deliveryRoot as string,
-  };
+  return parseAuthenticatedDeliveryRecord(content);
 }
 
 const TOMBSTONE_KEYS: ReadonlySet<string> = new Set(['schemaVersion', 'receiptId', 'consumedAt', 'operationId']);
@@ -913,27 +812,8 @@ export interface ActivationRequestFingerprint {
   observedTarget: string | null;
   canonicalPayloadSha256: string | null;
   installedDeliveryDigest: string | null;
-  deliveryEvidenceSchemaVersion: number | null;
-  deliveryRepository: string | null;
-  deliveryEvidenceDigest: string | null;
-  deliveryId: string | null;
-  deliveryTargetVersion: string | null;
-  deliveryCanonicalPayloadSha256: string | null;
-  deliveryChannel: string | null;
-  deliveryPlatformId: string | null;
-  deliveryPlatformTriple: string | null;
-  deliveryReleaseTag: string | null;
-  deliveryReleaseName: string | null;
-  deliveryManifestSha256: string | null;
-  deliveryArtifactSha256: string | null;
-  deliveryInstalledBinarySha256: string | null;
-  deliveryRoot: string | null;
-  deliveryPublishedAt: string | null;
-  deliverySourceSha: string | null;
-  deliverySourceBranch: string | null;
-  deliverySourceCiRunId: string | null;
-  deliveryControlSha: string | null;
-  deliveryDigestAlgorithm: string | null;
+  /** Commits the complete verified descriptor plus publication transaction/root. */
+  deliveryBindingDigest: string | null;
   registrationIdentity: string | null;
   cacheIdentity: string | null;
   enabled: boolean | null;
@@ -950,27 +830,7 @@ const FINGERPRINT_FIELDS: readonly (keyof ActivationRequestFingerprint)[] = [
   'observedTarget',
   'canonicalPayloadSha256',
   'installedDeliveryDigest',
-  'deliveryEvidenceSchemaVersion',
-  'deliveryRepository',
-  'deliveryEvidenceDigest',
-  'deliveryId',
-  'deliveryTargetVersion',
-  'deliveryCanonicalPayloadSha256',
-  'deliveryChannel',
-  'deliveryPlatformId',
-  'deliveryPlatformTriple',
-  'deliveryReleaseTag',
-  'deliveryReleaseName',
-  'deliveryManifestSha256',
-  'deliveryArtifactSha256',
-  'deliveryInstalledBinarySha256',
-  'deliveryRoot',
-  'deliveryPublishedAt',
-  'deliverySourceSha',
-  'deliverySourceBranch',
-  'deliverySourceCiRunId',
-  'deliveryControlSha',
-  'deliveryDigestAlgorithm',
+  'deliveryBindingDigest',
   'registrationIdentity',
   'cacheIdentity',
   'enabled',
@@ -980,85 +840,12 @@ const FINGERPRINT_FIELDS: readonly (keyof ActivationRequestFingerprint)[] = [
   'receiptId',
 ];
 
-type DeliveryFingerprintFields = Pick<
-  ActivationRequestFingerprint,
-  | 'deliveryEvidenceSchemaVersion'
-  | 'deliveryRepository'
-  | 'deliveryEvidenceDigest'
-  | 'deliveryId'
-  | 'deliveryTargetVersion'
-  | 'deliveryCanonicalPayloadSha256'
-  | 'deliveryChannel'
-  | 'deliveryPlatformId'
-  | 'deliveryPlatformTriple'
-  | 'deliveryReleaseTag'
-  | 'deliveryReleaseName'
-  | 'deliveryManifestSha256'
-  | 'deliveryArtifactSha256'
-  | 'deliveryInstalledBinarySha256'
-  | 'deliveryRoot'
-  | 'deliveryPublishedAt'
-  | 'deliverySourceSha'
-  | 'deliverySourceBranch'
-  | 'deliverySourceCiRunId'
-  | 'deliveryControlSha'
-  | 'deliveryDigestAlgorithm'
->;
-
-function deliveryFingerprintFields(
+function authenticatedDeliveryBindingForSnapshot(
   snapshot: CodexActivationSnapshot,
   canonical: Extract<CanonicalFact, { status: 'ok' }> | null,
-): DeliveryFingerprintFields {
-  if (snapshot.delivery.status !== 'present') {
-    return {
-      deliveryEvidenceSchemaVersion: null,
-      deliveryRepository: null,
-      deliveryEvidenceDigest: null,
-      deliveryId: null,
-      deliveryTargetVersion: null,
-      deliveryCanonicalPayloadSha256: null,
-      deliveryChannel: null,
-      deliveryPlatformId: null,
-      deliveryPlatformTriple: null,
-      deliveryReleaseTag: null,
-      deliveryReleaseName: null,
-      deliveryManifestSha256: null,
-      deliveryArtifactSha256: null,
-      deliveryInstalledBinarySha256: null,
-      deliveryRoot: canonical?.deliveryRoot ?? null,
-      deliveryPublishedAt: null,
-      deliverySourceSha: null,
-      deliverySourceBranch: null,
-      deliverySourceCiRunId: null,
-      deliveryControlSha: null,
-      deliveryDigestAlgorithm: null,
-    };
-  }
-  const evidence = snapshot.delivery.evidence;
-  const descriptor = evidence.descriptor;
-  return {
-    deliveryEvidenceSchemaVersion: descriptor.schemaVersion,
-    deliveryRepository: descriptor.repository,
-    deliveryEvidenceDigest: evidence.evidenceDigest,
-    deliveryId: canonical === null ? null : deriveDeliveryId(evidence.evidenceDigest, canonical.deliveryRoot),
-    deliveryTargetVersion: descriptor.version,
-    deliveryCanonicalPayloadSha256: descriptor.canonicalPayloadSha256,
-    deliveryChannel: descriptor.channel,
-    deliveryPlatformId: descriptor.platformId,
-    deliveryPlatformTriple: descriptor.platformTriple,
-    deliveryReleaseTag: descriptor.releaseTag,
-    deliveryReleaseName: descriptor.releaseName,
-    deliveryManifestSha256: descriptor.releaseManifestSha256,
-    deliveryArtifactSha256: descriptor.artifactSha256,
-    deliveryInstalledBinarySha256: descriptor.installedBinarySha256,
-    deliveryRoot: canonical?.deliveryRoot ?? null,
-    deliveryPublishedAt: evidence.deliveredAt,
-    deliverySourceSha: descriptor.sourceSha,
-    deliverySourceBranch: descriptor.sourceBranch,
-    deliverySourceCiRunId: descriptor.sourceCiRunId,
-    deliveryControlSha: descriptor.controlSha,
-    deliveryDigestAlgorithm: descriptor.digestAlgorithm,
-  };
+): AuthenticatedDeliveryBinding | null {
+  if (snapshot.delivery.status !== 'present' || canonical === null) return null;
+  return createAuthenticatedDeliveryBinding(snapshot.delivery.evidence, canonical.deliveryRoot);
 }
 
 export function computeActivationFingerprint(snapshot: CodexActivationSnapshot): ActivationRequestFingerprint {
@@ -1068,12 +855,13 @@ export function computeActivationFingerprint(snapshot: CodexActivationSnapshot):
   const cache = snapshot.cache;
   const intent = snapshot.intent;
   const family = snapshot.observationWitness.after;
+  const binding = authenticatedDeliveryBindingForSnapshot(snapshot, canonical);
   return {
     observedFrom: registered,
     observedTarget: canonical ? canonical.version.canonical : null,
     canonicalPayloadSha256: canonical ? canonical.digest : null,
     installedDeliveryDigest: cache.kind === 'present' ? cache.digest : null,
-    ...deliveryFingerprintFields(snapshot, canonical),
+    deliveryBindingDigest: binding === null ? null : authenticatedDeliveryBindingDigest(binding),
     registrationIdentity: cache.kind === 'present' ? cache.identity : null,
     cacheIdentity: family.status === 'present' ? family.identity : null,
     enabled: registration.present ? registration.enabled : null,
@@ -1742,16 +1530,6 @@ export interface PublishDeliveryInput {
   downgradeFrom?: string;
 }
 
-interface DeliveryAttestationFields {
-  platformTriple: string;
-  releaseTag: string;
-  releaseName: string;
-  releaseManifestSha256: string;
-  artifactSha256: string;
-  installedBinarySha256: string;
-  deliveryRoot: string;
-}
-
 export interface DeliveryRootOps {
   inventoryDigest(): string;
   deliveredVersion(): string;
@@ -1838,28 +1616,12 @@ function publishDeliveryImpl(
   const facts = verifiedDeliveryEvidenceFacts(input.evidence);
   const descriptor = facts.descriptor;
   const physicalDeliveryRoot = validatePublishedDeliveryRoot(input.deliveryRoot, facts);
-  const deliveryId = deriveDeliveryId(facts.evidenceDigest, physicalDeliveryRoot);
+  const binding = createAuthenticatedDeliveryBinding(facts, physicalDeliveryRoot);
 
   // Evidence is the durable prerequisite. The delivery record remains the last
   // commit point, so no record can name bytes that publication did not persist.
   persistVerifiedDeliveryEvidence(genieHome, input.evidence);
-  const record: DeliveryRecord = {
-    schemaVersion: 2,
-    deliveryId,
-    targetVersion: descriptor.version,
-    canonicalPayloadSha256: descriptor.canonicalPayloadSha256,
-    channel: descriptor.channel,
-    deliveredAt: facts.deliveredAt,
-    evidenceDigest: facts.evidenceDigest,
-    platformId: descriptor.platformId,
-    platformTriple: descriptor.platformTriple,
-    releaseTag: descriptor.releaseTag,
-    releaseName: descriptor.releaseName,
-    releaseManifestSha256: descriptor.releaseManifestSha256,
-    artifactSha256: descriptor.artifactSha256,
-    installedBinarySha256: descriptor.installedBinarySha256,
-    deliveryRoot: physicalDeliveryRoot,
-  };
+  const record = encodeAuthenticatedDeliveryRecord(binding);
   if (input.downgradeFrom !== undefined) {
     const from = parseReleaseVersion(input.downgradeFrom);
     const target = parseReleaseVersion(descriptor.version);
@@ -1868,7 +1630,7 @@ function publishDeliveryImpl(
     }
     const receipt: DowngradeReceipt = {
       schemaVersion: 1,
-      receiptId: deliveryId,
+      receiptId: binding.deliveryId,
       fromPluginVersion: input.downgradeFrom,
       targetVersion: descriptor.version,
       canonicalPayloadSha256: descriptor.canonicalPayloadSha256,
@@ -2014,26 +1776,8 @@ function revalidateDeliveryRootState(
   ) {
     throw new Error('verified delivery evidence no longer matches the physical delivery root');
   }
-  const assessment = assessAuthenticatedDelivery(
-    { status: 'present', record },
-    {
-      targetVersion: descriptor.version,
-      canonicalPayloadSha256: tree.digest ?? '',
-      channel: descriptor.channel,
-      deliveryId: deriveDeliveryId(evidence.facts.evidenceDigest, physicalRoot),
-      evidenceDigest: evidence.facts.evidenceDigest,
-      platformId: descriptor.platformId,
-      platformTriple: `${process.platform}-${process.arch}`,
-      releaseTag: descriptor.releaseTag,
-      releaseName: descriptor.releaseName,
-      releaseManifestSha256: descriptor.releaseManifestSha256,
-      artifactSha256: descriptor.artifactSha256,
-      installedBinarySha256,
-      deliveryRoot: physicalRoot,
-      deliveredAt: evidence.facts.deliveredAt,
-    },
-  );
-  if (assessment !== 'matching') throw new Error(`delivery record no longer matches verified evidence: ${assessment}`);
+  const binding = authenticatedDeliveryBindingFromRecord(record, evidence.facts, physicalRoot);
+  if (binding === null) throw new Error('delivery record no longer matches verified evidence');
   if (record.targetVersion !== version.canonical) throw new Error('delivery version no longer matches the payload');
 
   const rootIdentity = physicalNodeIdentity(physicalRoot, 'directory');
@@ -2061,7 +1805,7 @@ function revalidateDeliveryRootState(
     binaryIdentity,
     deliveryRecordDigest: createHash('sha256').update(deliveryRead.content).digest('hex'),
     deliveryRecordIdentity,
-    deliveryId: record.deliveryId,
+    deliveryId: binding.deliveryId,
     evidenceDigest: evidence.facts.evidenceDigest,
   };
 }
@@ -2109,7 +1853,7 @@ function beginActivationImpl(
   // Group B inner guard (deliverable 5): immediately before the first journal
   // write, re-assess the delivery record against THIS activation's intent. A
   // non-matching record refuses with zero mutation — defense in depth so a stale
-  // permit (whose fingerprint bound the old deliveryId) still cannot advance
+  // permit (whose fingerprint bound the complete delivery value) still cannot advance
   // activation-owned state without a re-observed matching authenticated record.
   const assessment = assessActivationDelivery(snapshot, resolved.intent, permit.fingerprint);
   if (assessment !== 'matching') {
@@ -2148,8 +1892,10 @@ function assessActivationDelivery(
   const delivery = deliveryReadState(snapshot.delivery);
   if (delivery.status === 'absent') return 'absent';
   if (delivery.status === 'invalid') return 'invalid';
-  const expectation = deliveryExpectationFromFingerprint(fingerprint);
-  if (expectation === null) return 'mismatch';
+  if (snapshot.delivery.status !== 'present' || snapshot.canonical.status !== 'ok') return 'mismatch';
+  const binding = createAuthenticatedDeliveryBinding(snapshot.delivery.evidence, snapshot.canonical.deliveryRoot);
+  if (fingerprint.deliveryBindingDigest !== authenticatedDeliveryBindingDigest(binding)) return 'mismatch';
+  const expectation = authenticatedDeliveryRecordFields(binding);
   if (
     intent.targetVersion !== expectation.targetVersion ||
     intent.canonicalPayloadSha256 !== expectation.canonicalPayloadSha256
@@ -2157,61 +1903,6 @@ function assessActivationDelivery(
     return 'mismatch';
   if (intent.direction === 'downgrade' && intent.receiptId !== expectation.deliveryId) return 'mismatch';
   return assessAuthenticatedDelivery(delivery, expectation);
-}
-
-/** Rehydrate the trusted full tuple carried by the genuine activation permit. */
-function deliveryExpectationFromFingerprint(
-  fingerprint: ActivationRequestFingerprint,
-): ActivationDeliveryExpectation | null {
-  const {
-    deliveryTargetVersion: targetVersion,
-    deliveryCanonicalPayloadSha256: canonicalPayloadSha256,
-    deliveryChannel: channel,
-    deliveryId,
-    deliveryEvidenceDigest: evidenceDigest,
-    deliveryPlatformId: platformId,
-    deliveryPlatformTriple: platformTriple,
-    deliveryReleaseTag: releaseTag,
-    deliveryReleaseName: releaseName,
-    deliveryManifestSha256: releaseManifestSha256,
-    deliveryArtifactSha256: artifactSha256,
-    deliveryInstalledBinarySha256: installedBinarySha256,
-    deliveryRoot,
-    deliveryPublishedAt: deliveredAt,
-  } = fingerprint;
-  if (
-    targetVersion === null ||
-    canonicalPayloadSha256 === null ||
-    channel === null ||
-    deliveryId === null ||
-    evidenceDigest === null ||
-    platformId === null ||
-    platformTriple === null ||
-    releaseTag === null ||
-    releaseName === null ||
-    releaseManifestSha256 === null ||
-    artifactSha256 === null ||
-    installedBinarySha256 === null ||
-    deliveryRoot === null ||
-    deliveredAt === null
-  )
-    return null;
-  return {
-    targetVersion,
-    canonicalPayloadSha256,
-    channel,
-    deliveryId,
-    evidenceDigest,
-    platformId,
-    platformTriple,
-    releaseTag,
-    releaseName,
-    releaseManifestSha256,
-    artifactSha256,
-    installedBinarySha256,
-    deliveryRoot,
-    deliveredAt,
-  };
 }
 
 /** Map the snapshot's delivery fact onto the assessment's read-state shape. */

--- a/src/lib/codex-delivery-evidence.test.ts
+++ b/src/lib/codex-delivery-evidence.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   DELIVERY_EVIDENCE_WORKFLOW_IDENTITY,
   DELIVERY_EVIDENCE_WORKFLOW_IDENTITY_PATTERN,
+  authenticatedDeliveryBindingDigest,
+  authenticatedDeliveryBindingFromRecord,
+  createAuthenticatedDeliveryBinding,
   deriveDeliveryId,
+  encodeAuthenticatedDeliveryRecord,
   observePersistedDeliveryEvidence,
+  parseAuthenticatedDeliveryRecord,
   persistVerifiedDeliveryEvidence,
   verifiedDeliveryEvidenceFacts,
   verifyDownloadedDeliveryEvidence,
@@ -150,6 +156,86 @@ describe('Codex signed delivery evidence', () => {
     expect(deriveDeliveryId('a'.repeat(64), '/physical/a')).toBe(a);
     expect(deriveDeliveryId('b'.repeat(64), '/physical/a')).not.toBe(a);
     expect(deriveDeliveryId('a'.repeat(64), '/physical/b')).not.toBe(a);
+  });
+
+  test('round-trips the byte-compatible schema-2 record through the single binding codec', () => {
+    const { evidence } = mintTestDeliveryEvidence();
+    const facts = verifiedDeliveryEvidenceFacts(evidence);
+    const binding = createAuthenticatedDeliveryBinding(facts, '/physical/a');
+    const record = encodeAuthenticatedDeliveryRecord(binding);
+
+    expect(Object.keys(record)).toEqual([
+      'schemaVersion',
+      'deliveryId',
+      'targetVersion',
+      'canonicalPayloadSha256',
+      'channel',
+      'deliveredAt',
+      'evidenceDigest',
+      'platformId',
+      'platformTriple',
+      'releaseTag',
+      'releaseName',
+      'releaseManifestSha256',
+      'artifactSha256',
+      'installedBinarySha256',
+      'deliveryRoot',
+    ]);
+    expect(parseAuthenticatedDeliveryRecord(`${JSON.stringify(record, null, 2)}\n`)).toEqual(record);
+    expect(authenticatedDeliveryBindingFromRecord(record, facts, '/physical/a')).toEqual(binding);
+    expect(parseAuthenticatedDeliveryRecord(JSON.stringify({ ...record, schemaVersion: 1 }))).toBeNull();
+    expect(parseAuthenticatedDeliveryRecord(JSON.stringify({ ...record, unknown: true }))).toBeNull();
+    expect(
+      authenticatedDeliveryBindingFromRecord({ ...record, artifactSha256: 'f'.repeat(64) }, facts, '/physical/a'),
+    ).toBeNull();
+  });
+
+  test('keeps binding creation closed under the record delivery-root limit', () => {
+    const facts = verifiedDeliveryEvidenceFacts(mintTestDeliveryEvidence().evidence);
+    const acceptedRoot = `/${'x'.repeat(255)}`;
+
+    expect(acceptedRoot).toHaveLength(256);
+    expect(
+      parseAuthenticatedDeliveryRecord(
+        JSON.stringify(encodeAuthenticatedDeliveryRecord(createAuthenticatedDeliveryBinding(facts, acceptedRoot))),
+      )?.deliveryRoot,
+    ).toBe(acceptedRoot);
+    expect(() => createAuthenticatedDeliveryBinding(facts, `${acceptedRoot}x`)).toThrow(
+      'physical delivery root is malformed',
+    );
+  });
+
+  test('uses one compact digest to bind the complete evidence pack and physical publication transaction', () => {
+    const { evidence } = mintTestDeliveryEvidence();
+    const facts = verifiedDeliveryEvidenceFacts(evidence);
+    const binding = createAuthenticatedDeliveryBinding(facts, '/physical/a');
+    const digest = authenticatedDeliveryBindingDigest(binding);
+
+    expect(digest).toMatch(/^[0-9a-f]{64}$/);
+    expect(authenticatedDeliveryBindingDigest(createAuthenticatedDeliveryBinding(facts, '/physical/b'))).not.toBe(
+      digest,
+    );
+    expect(
+      authenticatedDeliveryBindingDigest(
+        createAuthenticatedDeliveryBinding({ ...facts, deliveredAt: '2025-07-23T00:00:01.000Z' }, '/physical/a'),
+      ),
+    ).not.toBe(digest);
+  });
+
+  test('does not initialize Sigstore modules or its trusted root when evidence support is only imported', () => {
+    const moduleUrl = new URL('./codex-delivery-evidence.ts', import.meta.url).href;
+    const child = spawnSync(
+      process.execPath,
+      [
+        '-e',
+        `await import(${JSON.stringify(moduleUrl)}); process.stdout.write(String(Object.keys(require.cache).filter((key) => key.includes('@sigstore') || key.endsWith('codex-delivery-public-good-trusted-root.json')).length));`,
+      ],
+      { encoding: 'utf8' },
+    );
+
+    expect(child.status).toBe(0);
+    expect(child.stderr).toBe('');
+    expect(child.stdout).toBe('0');
   });
 });
 

--- a/src/lib/codex-delivery-evidence.ts
+++ b/src/lib/codex-delivery-evidence.ts
@@ -17,10 +17,6 @@
 import { createHash, randomBytes } from 'node:crypto';
 import { chmodSync, lstatSync, mkdirSync, readdirSync, renameSync, rmSync } from 'node:fs';
 import { isAbsolute, join } from 'node:path';
-import { bundleFromJSON, isBundleWithDsseEnvelope } from '@sigstore/bundle';
-import { TrustedRoot } from '@sigstore/protobuf-specs';
-import { Verifier, toSignedEntity, toTrustMaterial } from '@sigstore/verify';
-import publicGoodTrustedRoot from '../fixtures/codex-delivery-public-good-trusted-root.json';
 import { atomicWriteFileSync, fsyncParentDir, readBoundedRegularFile } from './codex-activation-persistence.js';
 import { parseReleaseVersion } from './codex-release-version.js';
 
@@ -44,9 +40,11 @@ const PACK_FILES = [BUNDLE_FILE, DESCRIPTOR_FILE, MANIFEST_FILE] as const;
 const MAX_DESCRIPTOR_BYTES = 32 * 1024;
 const MAX_MANIFEST_BYTES = 64 * 1024;
 const MAX_BUNDLE_BYTES = 2 * 1024 * 1024;
+const HEX_128_RE = /^[0-9a-f]{32}$/;
 const HEX_160_RE = /^[0-9a-f]{40}$/;
 const HEX_256_RE = /^[0-9a-f]{64}$/;
 const DECIMAL_RE = /^(?:0|[1-9]\d*)$/;
+const MAX_DELIVERY_ROOT_CHARACTERS = 256;
 const RELEASE_CHANNELS = ['stable', 'homolog', 'dev'] as const;
 const PLATFORM_IDS = ['linux-x64-glibc', 'linux-x64-musl', 'linux-arm64', 'darwin-arm64'] as const;
 
@@ -121,6 +119,51 @@ export interface VerifiedDeliveryEvidenceFacts {
   /** ISO timestamp derived from a transparency-log entry's verified integratedTime. */
   deliveredAt: string;
 }
+
+/**
+ * The durable flat record remains schema 2 for on-disk compatibility. This
+ * interface and its codec are the single owner of the record field set.
+ */
+export interface AuthenticatedDeliveryRecordFields {
+  targetVersion: string;
+  canonicalPayloadSha256: string;
+  channel: string;
+  deliveryId: string;
+  evidenceDigest: string;
+  platformId: string;
+  platformTriple: string;
+  releaseTag: string;
+  releaseName: string;
+  releaseManifestSha256: string;
+  artifactSha256: string;
+  installedBinarySha256: string;
+  deliveryRoot: string;
+  deliveredAt: string;
+}
+
+export interface PersistedAuthenticatedDeliveryRecord extends AuthenticatedDeliveryRecordFields {
+  schemaVersion: 2;
+}
+
+/**
+ * One complete authenticated delivery value. The evidence digest commits the
+ * exact descriptor, bundle, and manifest bytes, while the remaining fields bind
+ * that verified release provenance to its physical publication transaction.
+ */
+export interface AuthenticatedDeliveryBinding {
+  readonly descriptor: Readonly<DeliveryEvidenceDescriptor>;
+  readonly evidenceDigest: string;
+  readonly deliveryId: string;
+  readonly deliveryRoot: string;
+  readonly deliveredAt: string;
+}
+
+export type AuthenticatedDeliveryAssessment = 'matching' | 'absent' | 'invalid' | 'mismatch';
+
+export type AuthenticatedDeliveryRecordReadState =
+  | { status: 'absent' }
+  | { status: 'invalid'; detail: string }
+  | { status: 'present'; record: AuthenticatedDeliveryRecordFields };
 
 interface VerifiedDeliveryEvidenceState extends VerifiedDeliveryEvidenceFacts {
   descriptorBytes: Buffer;
@@ -285,6 +328,236 @@ export function deriveDeliveryId(evidenceDigest: string, physicalDeliveryRoot: s
     .slice(0, 32);
 }
 
+/**
+ * Bind independently verified release facts to one physical delivery root.
+ * Callers never reconstruct individual provenance fields.
+ */
+export function createAuthenticatedDeliveryBinding(
+  evidence: VerifiedDeliveryEvidenceFacts,
+  physicalDeliveryRoot: string,
+): AuthenticatedDeliveryBinding {
+  if (!HEX_256_RE.test(evidence.evidenceDigest)) throw new Error('evidence digest is malformed');
+  if (
+    physicalDeliveryRoot.length > MAX_DELIVERY_ROOT_CHARACTERS ||
+    !isAbsolute(physicalDeliveryRoot) ||
+    physicalDeliveryRoot.includes('\0')
+  ) {
+    throw new Error('physical delivery root is malformed');
+  }
+  if (!Number.isFinite(Date.parse(evidence.deliveredAt))) throw new Error('delivery timestamp is malformed');
+  return Object.freeze({
+    descriptor: evidence.descriptor,
+    evidenceDigest: evidence.evidenceDigest,
+    deliveryId: deriveDeliveryId(evidence.evidenceDigest, physicalDeliveryRoot),
+    deliveryRoot: physicalDeliveryRoot,
+    deliveredAt: evidence.deliveredAt,
+  });
+}
+
+/** Project the canonical binding onto the complete authenticated field tuple. */
+export function authenticatedDeliveryRecordFields(
+  binding: AuthenticatedDeliveryBinding,
+): AuthenticatedDeliveryRecordFields {
+  const descriptor = binding.descriptor;
+  return {
+    deliveryId: binding.deliveryId,
+    targetVersion: descriptor.version,
+    canonicalPayloadSha256: descriptor.canonicalPayloadSha256,
+    channel: descriptor.channel,
+    deliveredAt: binding.deliveredAt,
+    evidenceDigest: binding.evidenceDigest,
+    platformId: descriptor.platformId,
+    platformTriple: descriptor.platformTriple,
+    releaseTag: descriptor.releaseTag,
+    releaseName: descriptor.releaseName,
+    releaseManifestSha256: descriptor.releaseManifestSha256,
+    artifactSha256: descriptor.artifactSha256,
+    installedBinarySha256: descriptor.installedBinarySha256,
+    deliveryRoot: binding.deliveryRoot,
+  };
+}
+
+/** Encode the canonical binding as the byte-compatible schema-2 record. */
+export function encodeAuthenticatedDeliveryRecord(
+  binding: AuthenticatedDeliveryBinding,
+): PersistedAuthenticatedDeliveryRecord {
+  return { schemaVersion: 2, ...authenticatedDeliveryRecordFields(binding) };
+}
+
+/** Parse the legacy-compatible flat schema without accepting partial attestation. */
+export function parseAuthenticatedDeliveryRecord(content: string): PersistedAuthenticatedDeliveryRecord | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return null;
+  }
+  if (!isPlainObject(parsed)) return null;
+  if (
+    Object.keys(parsed).length !== AUTHENTICATED_DELIVERY_RECORD_KEYS.size ||
+    Object.keys(parsed).some((key) => !AUTHENTICATED_DELIVERY_RECORD_KEYS.has(key))
+  ) {
+    return null;
+  }
+  if (parsed.schemaVersion !== 2 || !authenticatedDeliveryRecordFieldsValid(parsed)) return null;
+  return {
+    schemaVersion: 2,
+    deliveryId: parsed.deliveryId,
+    targetVersion: parsed.targetVersion,
+    canonicalPayloadSha256: parsed.canonicalPayloadSha256,
+    channel: parsed.channel,
+    deliveredAt: parsed.deliveredAt,
+    evidenceDigest: parsed.evidenceDigest,
+    platformId: parsed.platformId,
+    platformTriple: parsed.platformTriple,
+    releaseTag: parsed.releaseTag,
+    releaseName: parsed.releaseName,
+    releaseManifestSha256: parsed.releaseManifestSha256,
+    artifactSha256: parsed.artifactSha256,
+    installedBinarySha256: parsed.installedBinarySha256,
+    deliveryRoot: parsed.deliveryRoot,
+  };
+}
+
+/**
+ * Pure record assessment shared by lifecycle truth, repair, delivery, and the
+ * activation inner guard. Structural invalidity is distinct from tuple drift.
+ */
+export function assessAuthenticatedDeliveryRecord(
+  fact: AuthenticatedDeliveryRecordReadState,
+  expectation: AuthenticatedDeliveryRecordFields,
+): AuthenticatedDeliveryAssessment {
+  if (fact.status === 'absent') return 'absent';
+  if (fact.status === 'invalid') return 'invalid';
+  if (!authenticatedDeliveryRecordFieldsValid(fact.record)) return 'invalid';
+  return authenticatedDeliveryRecordFieldsMatch(fact.record, expectation) ? 'matching' : 'mismatch';
+}
+
+/**
+ * Return the canonical value only when the durable flat record agrees with all
+ * independently reverified evidence and physical-root facts.
+ */
+export function authenticatedDeliveryBindingFromRecord(
+  record: AuthenticatedDeliveryRecordFields,
+  evidence: VerifiedDeliveryEvidenceFacts,
+  physicalDeliveryRoot: string,
+): AuthenticatedDeliveryBinding | null {
+  const binding = createAuthenticatedDeliveryBinding(evidence, physicalDeliveryRoot);
+  return assessAuthenticatedDeliveryRecord(
+    { status: 'present', record },
+    authenticatedDeliveryRecordFields(binding),
+  ) === 'matching'
+    ? binding
+    : null;
+}
+
+/**
+ * Compact consent fingerprint. `evidenceDigest` already commits every exact
+ * descriptor/bundle/manifest byte, so descriptor provenance additions do not
+ * amplify into activation request fields.
+ */
+export function authenticatedDeliveryBindingDigest(binding: AuthenticatedDeliveryBinding): string {
+  return createHash('sha256')
+    .update('genie-authenticated-delivery-binding-v1\0')
+    .update(binding.evidenceDigest)
+    .update('\0')
+    .update(binding.deliveryId)
+    .update('\0')
+    .update(binding.deliveryRoot)
+    .update('\0')
+    .update(binding.deliveredAt)
+    .digest('hex');
+}
+
+const AUTHENTICATED_DELIVERY_RECORD_KEYS: ReadonlySet<string> = new Set([
+  'schemaVersion',
+  'deliveryId',
+  'targetVersion',
+  'canonicalPayloadSha256',
+  'channel',
+  'deliveredAt',
+  'evidenceDigest',
+  'platformId',
+  'platformTriple',
+  'releaseTag',
+  'releaseName',
+  'releaseManifestSha256',
+  'artifactSha256',
+  'installedBinarySha256',
+  'deliveryRoot',
+]);
+
+const PLATFORM_TRIPLE_RE = /^[a-z0-9]+-[a-z0-9_]+$/;
+
+function authenticatedDeliveryRecordFieldsValid(
+  record: Record<string, unknown> | AuthenticatedDeliveryRecordFields,
+): record is AuthenticatedDeliveryRecordFields {
+  const version = parseReleaseVersion(record.targetVersion);
+  if (version === null) return false;
+  if (typeof record.canonicalPayloadSha256 !== 'string' || !HEX_256_RE.test(record.canonicalPayloadSha256))
+    return false;
+  if (typeof record.deliveryId !== 'string' || !HEX_128_RE.test(record.deliveryId)) return false;
+  if (typeof record.evidenceDigest !== 'string' || !HEX_256_RE.test(record.evidenceDigest)) return false;
+  if (typeof record.channel !== 'string' || record.channel.length === 0 || record.channel.length > 128) return false;
+  if (typeof record.platformId !== 'string' || record.platformId.length === 0 || record.platformId.length > 64)
+    return false;
+  if (typeof record.platformTriple !== 'string' || !PLATFORM_TRIPLE_RE.test(record.platformTriple)) return false;
+  for (const key of ['releaseManifestSha256', 'artifactSha256', 'installedBinarySha256'] as const) {
+    if (typeof record[key] !== 'string' || !HEX_256_RE.test(record[key])) return false;
+  }
+  if (record.releaseTag !== `v${version.canonical}`) return false;
+  if (
+    typeof record.releaseName !== 'string' ||
+    !record.releaseName.startsWith(`genie-${version.canonical}-`) ||
+    !record.releaseName.endsWith('.tar.gz') ||
+    record.releaseName.length > 256
+  ) {
+    return false;
+  }
+  if (
+    typeof record.deliveryRoot !== 'string' ||
+    record.deliveryRoot.length === 0 ||
+    record.deliveryRoot.length > MAX_DELIVERY_ROOT_CHARACTERS ||
+    !isAbsolute(record.deliveryRoot) ||
+    record.deliveryRoot.includes('\0')
+  ) {
+    return false;
+  }
+  if (typeof record.deliveredAt !== 'string' || !Number.isFinite(Date.parse(record.deliveredAt))) return false;
+  return true;
+}
+
+function authenticatedDeliveryRecordFieldsMatch(
+  record: AuthenticatedDeliveryRecordFields,
+  expectation: AuthenticatedDeliveryRecordFields,
+): boolean {
+  const recordVersion = parseReleaseVersion(record.targetVersion);
+  const expectedVersion = parseReleaseVersion(expectation.targetVersion);
+  if (recordVersion === null || expectedVersion === null || recordVersion.canonical !== expectedVersion.canonical) {
+    return false;
+  }
+  for (const key of AUTHENTICATED_DELIVERY_BINDING_FIELDS) {
+    if (record[key] !== expectation[key]) return false;
+  }
+  return true;
+}
+
+const AUTHENTICATED_DELIVERY_BINDING_FIELDS: readonly (keyof AuthenticatedDeliveryRecordFields)[] = [
+  'canonicalPayloadSha256',
+  'channel',
+  'deliveryId',
+  'evidenceDigest',
+  'platformId',
+  'platformTriple',
+  'releaseTag',
+  'releaseName',
+  'releaseManifestSha256',
+  'artifactSha256',
+  'installedBinarySha256',
+  'deliveryRoot',
+  'deliveredAt',
+];
+
 function mintVerifiedEvidence(state: VerifiedDeliveryEvidenceState): VerifiedDeliveryEvidence {
   const evidence = Object.freeze({}) as VerifiedDeliveryEvidence;
   VERIFIED_EVIDENCE.set(evidence, state);
@@ -447,6 +720,15 @@ function parseDsseStatement(bundleJson: unknown): { subjectSha256: string } {
 }
 
 function verifyBundleWithEmbeddedTrustRoot(bundleJson: unknown): { integratedTime: string } {
+  const {
+    bundleFromJSON,
+    isBundleWithDsseEnvelope,
+    publicGoodTrustedRoot,
+    TrustedRoot,
+    Verifier,
+    toSignedEntity,
+    toTrustMaterial,
+  } = loadSigstoreVerifier();
   const bundle = bundleFromJSON(bundleJson);
   if (!isBundleWithDsseEnvelope(bundle)) throw new Error('delivery evidence bundle is not a DSSE bundle');
   const root = TrustedRoot.fromJSON(publicGoodTrustedRoot);
@@ -469,6 +751,36 @@ function verifyBundleWithEmbeddedTrustRoot(bundleJson: unknown): { integratedTim
   return {
     integratedTime: integratedTimes.reduce((earliest, value) => (BigInt(value) < BigInt(earliest) ? value : earliest)),
   };
+}
+
+type SigstoreVerifierModules = {
+  bundleFromJSON: typeof import('@sigstore/bundle')['bundleFromJSON'];
+  isBundleWithDsseEnvelope: typeof import('@sigstore/bundle')['isBundleWithDsseEnvelope'];
+  TrustedRoot: typeof import('@sigstore/protobuf-specs')['TrustedRoot'];
+  Verifier: typeof import('@sigstore/verify')['Verifier'];
+  toSignedEntity: typeof import('@sigstore/verify')['toSignedEntity'];
+  toTrustMaterial: typeof import('@sigstore/verify')['toTrustMaterial'];
+  publicGoodTrustedRoot: Parameters<typeof import('@sigstore/protobuf-specs')['TrustedRoot']['fromJSON']>[0];
+};
+
+let sigstoreVerifierModules: SigstoreVerifierModules | undefined;
+
+/** Load the heavy verifier graph only on a production cryptographic check. */
+function loadSigstoreVerifier(): SigstoreVerifierModules {
+  if (sigstoreVerifierModules !== undefined) return sigstoreVerifierModules;
+  const bundle = require('@sigstore/bundle') as typeof import('@sigstore/bundle');
+  const protobuf = require('@sigstore/protobuf-specs') as typeof import('@sigstore/protobuf-specs');
+  const verify = require('@sigstore/verify') as typeof import('@sigstore/verify');
+  sigstoreVerifierModules = {
+    bundleFromJSON: bundle.bundleFromJSON,
+    isBundleWithDsseEnvelope: bundle.isBundleWithDsseEnvelope,
+    TrustedRoot: protobuf.TrustedRoot,
+    Verifier: verify.Verifier,
+    toSignedEntity: verify.toSignedEntity,
+    toTrustMaterial: verify.toTrustMaterial,
+    publicGoodTrustedRoot: require('../fixtures/codex-delivery-public-good-trusted-root.json'),
+  };
+  return sigstoreVerifierModules;
 }
 
 function escapeRegexLiteral(value: string): string {

--- a/src/lib/codex-host-observation.ts
+++ b/src/lib/codex-host-observation.ts
@@ -24,14 +24,21 @@
  *     activation protocol's inner guard (`beginActivation`) applies exactly this
  *     assessment before its first journal write.
  *
- * This module imports only the leaf `codex-release-version.ts` and the leaf
- * `runtime-integrations.ts`; it never imports `codex-activation.ts`, so the
- * activation protocol can import the assessment from here with no import cycle.
+ * This module imports the evidence-owned binding codec plus the leaf
+ * `codex-release-version.ts` and `runtime-integrations.ts`; it never imports
+ * `codex-activation.ts`, so the activation protocol can import the assessment
+ * from here with no import cycle.
  */
 
 import { createHash } from 'node:crypto';
 import { type Stats, lstatSync, readdirSync } from 'node:fs';
-import { isAbsolute, join } from 'node:path';
+import { join } from 'node:path';
+import {
+  type AuthenticatedDeliveryAssessment,
+  type AuthenticatedDeliveryRecordFields,
+  type AuthenticatedDeliveryRecordReadState,
+  assessAuthenticatedDeliveryRecord,
+} from './codex-delivery-evidence.js';
 import { parseReleaseVersion, stripControl } from './codex-release-version.js';
 import { type CommandResult, parseCodexPluginState } from './runtime-integrations.js';
 
@@ -39,10 +46,7 @@ import { type CommandResult, parseCodexPluginState } from './runtime-integration
 // Production host observation (facts observable from ONE bounded query)
 // ============================================================================
 
-const HEX_128_RE = /^[0-9a-f]{32}$/;
-const HEX_256_RE = /^[0-9a-f]{64}$/;
 const DEV_INO_RE = /^\d+:\d+$/;
-const PLATFORM_TRIPLE_RE = /^[a-z0-9]+-[a-z0-9_]+$/;
 const DEFAULT_MAX_ADVISORY_BYTES = 4 * 1024;
 
 /**
@@ -302,54 +306,20 @@ export function projectHostQuery(observation: CodexHostObservation): HostQueryPr
 // Authenticated delivery record + pure assessment
 // ============================================================================
 
-export type DeliveryAssessment = 'matching' | 'absent' | 'invalid' | 'mismatch';
+export type DeliveryAssessment = AuthenticatedDeliveryAssessment;
 
 /**
  * The authenticated delivery record. Every field is mandatory: a legacy
  * minimal/core-only record is structurally invalid and can never authorize
  * activation.
  */
-export interface AuthenticatedDeliveryRecord {
-  targetVersion: string;
-  canonicalPayloadSha256: string;
-  channel: string;
-  deliveryId: string;
-  evidenceDigest: string;
-  platformId: string;
-  platformTriple: string;
-  releaseTag: string;
-  releaseName: string;
-  releaseManifestSha256: string;
-  artifactSha256: string;
-  installedBinarySha256: string;
-  deliveryRoot: string;
-  deliveredAt: string;
-}
+export type AuthenticatedDeliveryRecord = AuthenticatedDeliveryRecordFields;
 
 /** The read-state of the on-disk delivery record (mirrors the activation snapshot's delivery fact). */
-export type DeliveryRecordReadState =
-  | { status: 'absent' }
-  | { status: 'invalid'; detail: string }
-  | { status: 'present'; record: AuthenticatedDeliveryRecord };
+export type DeliveryRecordReadState = AuthenticatedDeliveryRecordReadState;
 
 /** The complete authenticated tuple trusted by the current activation request. */
-export interface ActivationDeliveryExpectation {
-  targetVersion: string;
-  canonicalPayloadSha256: string;
-  channel: string;
-  /** Downgrade binding: the record's `deliveryId` must equal the consumed receipt id. */
-  deliveryId: string;
-  evidenceDigest: string;
-  platformId: string;
-  platformTriple: string;
-  releaseTag: string;
-  releaseName: string;
-  releaseManifestSha256: string;
-  artifactSha256: string;
-  installedBinarySha256: string;
-  deliveryRoot: string;
-  deliveredAt: string;
-}
+export type ActivationDeliveryExpectation = AuthenticatedDeliveryRecordFields;
 
 /**
  * Pure classifier: `absent` (no record), `invalid` (present but structurally
@@ -361,61 +331,7 @@ export function assessAuthenticatedDelivery(
   fact: DeliveryRecordReadState,
   expectation: ActivationDeliveryExpectation,
 ): DeliveryAssessment {
-  if (fact.status === 'absent') return 'absent';
-  if (fact.status === 'invalid') return 'invalid';
-  const record = fact.record;
-  if (!isStructurallyValidRecord(record)) return 'invalid';
-  return matchesExpectation(record, expectation) ? 'matching' : 'mismatch';
-}
-
-/** Every field is mandatory and shape-consistent; malformed/legacy records are `invalid`. */
-function isStructurallyValidRecord(record: AuthenticatedDeliveryRecord): boolean {
-  const version = parseReleaseVersion(record.targetVersion);
-  if (version === null) return false;
-  if (!HEX_256_RE.test(record.canonicalPayloadSha256)) return false;
-  if (!HEX_128_RE.test(record.deliveryId)) return false;
-  if (!HEX_256_RE.test(record.evidenceDigest)) return false;
-  if (typeof record.channel !== 'string' || record.channel.length === 0 || record.channel.length > 128) return false;
-  if (typeof record.platformId !== 'string' || record.platformId.length === 0 || record.platformId.length > 64)
-    return false;
-  if (typeof record.platformTriple !== 'string' || !PLATFORM_TRIPLE_RE.test(record.platformTriple)) return false;
-  for (const digest of [record.releaseManifestSha256, record.artifactSha256, record.installedBinarySha256]) {
-    if (!HEX_256_RE.test(digest)) return false;
-  }
-  if (typeof record.releaseTag !== 'string' || record.releaseTag !== `v${version.canonical}`) return false;
-  if (
-    typeof record.releaseName !== 'string' ||
-    !record.releaseName.startsWith(`genie-${version.canonical}-`) ||
-    !record.releaseName.endsWith('.tar.gz')
-  )
-    return false;
-  if (typeof record.deliveryRoot !== 'string' || !isAbsolute(record.deliveryRoot)) return false;
-  if (typeof record.deliveredAt !== 'string' || !Number.isFinite(Date.parse(record.deliveredAt))) return false;
-  return true;
-}
-
-/** Compare every field in the immutable authenticated tuple. */
-function matchesExpectation(record: AuthenticatedDeliveryRecord, expectation: ActivationDeliveryExpectation): boolean {
-  const recordVersion = parseReleaseVersion(record.targetVersion);
-  const expectVersion = parseReleaseVersion(expectation.targetVersion);
-  if (recordVersion === null || expectVersion === null || recordVersion.canonical !== expectVersion.canonical) {
-    return false;
-  }
-  if (record.canonicalPayloadSha256 !== expectation.canonicalPayloadSha256) return false;
-  return (
-    record.channel === expectation.channel &&
-    record.deliveryId === expectation.deliveryId &&
-    record.evidenceDigest === expectation.evidenceDigest &&
-    record.platformId === expectation.platformId &&
-    record.platformTriple === expectation.platformTriple &&
-    record.releaseTag === expectation.releaseTag &&
-    record.releaseName === expectation.releaseName &&
-    record.releaseManifestSha256 === expectation.releaseManifestSha256 &&
-    record.artifactSha256 === expectation.artifactSha256 &&
-    record.installedBinarySha256 === expectation.installedBinarySha256 &&
-    record.deliveryRoot === expectation.deliveryRoot &&
-    record.deliveredAt === expectation.deliveredAt
-  );
+  return assessAuthenticatedDeliveryRecord(fact, expectation);
 }
 
 // ============================================================================

--- a/src/lib/codex-lifecycle-truth.ts
+++ b/src/lib/codex-lifecycle-truth.ts
@@ -25,9 +25,8 @@
 import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import { dirname, join, relative, resolve, sep } from 'node:path';
 import type { CodexActivationSnapshot } from './codex-activation.js';
-import { deriveDeliveryId } from './codex-delivery-evidence.js';
+import { authenticatedDeliveryRecordFields, createAuthenticatedDeliveryBinding } from './codex-delivery-evidence.js';
 import {
-  type ActivationDeliveryExpectation,
   type DeliveryIncompleteResult,
   type DeliveryRecordReadState,
   assessAuthenticatedDelivery,
@@ -74,22 +73,9 @@ export function assessSnapshotDelivery(snapshot: CodexActivationSnapshot): Snaps
   ) {
     return { kind: 'incomplete', result: buildDeliveryIncompleteResult('mismatch') };
   }
-  const expectation: ActivationDeliveryExpectation = {
-    targetVersion: descriptor.version,
-    canonicalPayloadSha256: snapshot.canonical.digest,
-    channel: descriptor.channel,
-    deliveryId: deriveDeliveryId(evidence.evidenceDigest, snapshot.canonical.deliveryRoot),
-    evidenceDigest: evidence.evidenceDigest,
-    platformId: descriptor.platformId,
-    platformTriple: snapshot.canonical.platformTriple,
-    releaseTag: descriptor.releaseTag,
-    releaseName: descriptor.releaseName,
-    releaseManifestSha256: descriptor.releaseManifestSha256,
-    artifactSha256: descriptor.artifactSha256,
-    installedBinarySha256: snapshot.canonical.installedBinarySha256,
-    deliveryRoot: snapshot.canonical.deliveryRoot,
-    deliveredAt: evidence.deliveredAt,
-  };
+  const expectation = authenticatedDeliveryRecordFields(
+    createAuthenticatedDeliveryBinding(evidence, snapshot.canonical.deliveryRoot),
+  );
   const assessment = assessAuthenticatedDelivery(readState, expectation);
   if (assessment === 'matching') return { kind: 'matching' };
   return { kind: 'incomplete', result: buildDeliveryIncompleteResult(assessment) };

--- a/src/lib/ordered-lifecycle-leases.test.ts
+++ b/src/lib/ordered-lifecycle-leases.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from 'bun:test';
+import { acquireOrderedLifecycleLeases, releaseOrderedLifecycleLeases } from './ordered-lifecycle-leases.js';
+
+function heldCodexLease(release: () => void = () => undefined) {
+  return {
+    ok: true as const,
+    operationId: 'a'.repeat(32),
+    kind: 'update-delivery' as const,
+    assertOperation: () => undefined,
+    release,
+  };
+}
+
+describe('ordered lifecycle leases', () => {
+  test('acquires agent-sync before Codex and releases in reverse order', () => {
+    const events: string[] = [];
+    const acquired = acquireOrderedLifecycleLeases(
+      () => {
+        events.push('acquire-agent-sync');
+        return { path: '/fixture/agent-sync.lock', release: () => events.push('release-agent-sync') };
+      },
+      () => {
+        events.push('acquire-codex');
+        return heldCodexLease(() => events.push('release-codex'));
+      },
+    );
+
+    expect(acquired.ok).toBe(true);
+    if (!acquired.ok) throw new Error('fixture acquisition unexpectedly busy');
+    releaseOrderedLifecycleLeases(acquired.codexLease, acquired.agentSyncLease);
+    expect(events).toEqual(['acquire-agent-sync', 'acquire-codex', 'release-codex', 'release-agent-sync']);
+  });
+
+  test('returns a discriminated agent-sync busy result without acquiring Codex', () => {
+    let codexAcquisitions = 0;
+    const acquired = acquireOrderedLifecycleLeases(
+      () => ({ skipped: 'outer busy' }),
+      () => {
+        codexAcquisitions += 1;
+        return heldCodexLease();
+      },
+    );
+
+    expect(acquired).toEqual({ ok: false, busy: 'agent-sync', detail: 'outer busy' });
+    expect(codexAcquisitions).toBe(0);
+  });
+
+  test('returns a discriminated Codex busy result after releasing agent-sync', () => {
+    const events: string[] = [];
+    const acquired = acquireOrderedLifecycleLeases(
+      () => ({ path: '/fixture/agent-sync.lock', release: () => events.push('release-agent-sync') }),
+      () => ({
+        ok: false as const,
+        reason: 'codex-lifecycle-busy' as const,
+        holderKind: 'setup-activation' as const,
+        detail: 'inner busy',
+      }),
+    );
+
+    expect(acquired).toEqual({
+      ok: false,
+      busy: 'codex',
+      refusal: {
+        ok: false,
+        reason: 'codex-lifecycle-busy',
+        holderKind: 'setup-activation',
+        detail: 'inner busy',
+      },
+    });
+    expect(events).toEqual(['release-agent-sync']);
+  });
+
+  test('releases agent-sync when Codex acquisition throws', () => {
+    const acquisitionError = new Error('Codex acquisition fixture');
+    const events: string[] = [];
+
+    expect(() =>
+      acquireOrderedLifecycleLeases(
+        () => {
+          events.push('acquire-agent-sync');
+          return { path: '/fixture/agent-sync.lock', release: () => events.push('release-agent-sync') };
+        },
+        () => {
+          events.push('acquire-codex');
+          throw acquisitionError;
+        },
+      ),
+    ).toThrow(acquisitionError);
+    expect(events).toEqual(['acquire-agent-sync', 'acquire-codex', 'release-agent-sync']);
+  });
+
+  test('aggregates Codex acquisition and agent-sync release failures in causal order', () => {
+    const acquisitionError = new Error('Codex acquisition fixture');
+    const releaseError = new Error('agent-sync release fixture');
+    const events: string[] = [];
+    let thrown: unknown;
+
+    try {
+      acquireOrderedLifecycleLeases(
+        () => {
+          events.push('acquire-agent-sync');
+          return {
+            path: '/fixture/agent-sync.lock',
+            release: () => {
+              events.push('release-agent-sync');
+              throw releaseError;
+            },
+          };
+        },
+        () => {
+          events.push('acquire-codex');
+          throw acquisitionError;
+        },
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(events).toEqual(['acquire-agent-sync', 'acquire-codex', 'release-agent-sync']);
+    expect(thrown).toBeInstanceOf(AggregateError);
+    expect((thrown as AggregateError).errors).toEqual([acquisitionError, releaseError]);
+  });
+
+  test('an inner-only release failure is preserved after the outer release runs', () => {
+    const innerError = new Error('inner release fixture');
+    const events: string[] = [];
+
+    expect(() =>
+      releaseOrderedLifecycleLeases(
+        {
+          release: () => {
+            events.push('release-codex');
+            throw innerError;
+          },
+        },
+        { release: () => events.push('release-agent-sync') },
+      ),
+    ).toThrow(innerError);
+    expect(events).toEqual(['release-codex', 'release-agent-sync']);
+  });
+
+  test('an outer-only release failure is preserved after the inner release runs', () => {
+    const outerError = new Error('outer release fixture');
+    const events: string[] = [];
+
+    expect(() =>
+      releaseOrderedLifecycleLeases(
+        { release: () => events.push('release-codex') },
+        {
+          release: () => {
+            events.push('release-agent-sync');
+            throw outerError;
+          },
+        },
+      ),
+    ).toThrow(outerError);
+    expect(events).toEqual(['release-codex', 'release-agent-sync']);
+  });
+
+  test('dual release failures are aggregated deterministically after both run', () => {
+    const innerError = new Error('inner release fixture');
+    const outerError = new Error('outer release fixture');
+    const events: string[] = [];
+    let thrown: unknown;
+
+    try {
+      releaseOrderedLifecycleLeases(
+        {
+          release: () => {
+            events.push('release-codex');
+            throw innerError;
+          },
+        },
+        {
+          release: () => {
+            events.push('release-agent-sync');
+            throw outerError;
+          },
+        },
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(events).toEqual(['release-codex', 'release-agent-sync']);
+    expect(thrown).toBeInstanceOf(AggregateError);
+    expect((thrown as AggregateError).errors).toEqual([innerError, outerError]);
+  });
+});

--- a/src/lib/ordered-lifecycle-leases.ts
+++ b/src/lib/ordered-lifecycle-leases.ts
@@ -1,0 +1,99 @@
+import type { LifecycleLease } from './agent-sync.js';
+import type { HeldLifecycleLease, LifecycleLeaseBusy, LifecycleLeaseResult } from './codex-lifecycle-lease.js';
+
+export interface ReleasableLifecycleLease {
+  release(): void;
+}
+
+export type OrderedLifecycleLeaseAcquisition =
+  | {
+      ok: true;
+      agentSyncLease: LifecycleLease;
+      codexLease: HeldLifecycleLease;
+    }
+  | {
+      ok: false;
+      busy: 'agent-sync';
+      detail: string;
+    }
+  | {
+      ok: false;
+      busy: 'codex';
+      refusal: LifecycleLeaseBusy;
+    };
+
+export type HeldOrderedLifecycleLeases = Extract<OrderedLifecycleLeaseAcquisition, { ok: true }>;
+
+/**
+ * Acquire the process-wide agent-sync lease before the Codex lifecycle lease.
+ * A Codex loser releases the already-held outer lease before returning busy.
+ */
+export function acquireOrderedLifecycleLeases(
+  acquireAgentSync: () => LifecycleLease | { skipped: string },
+  acquireCodex: () => LifecycleLeaseResult,
+): OrderedLifecycleLeaseAcquisition {
+  const agentSyncLease = acquireAgentSync();
+  if ('skipped' in agentSyncLease) {
+    return { ok: false, busy: 'agent-sync', detail: agentSyncLease.skipped };
+  }
+
+  let codexLease: LifecycleLeaseResult;
+  try {
+    codexLease = acquireCodex();
+  } catch (acquisitionError) {
+    releaseAfterFailedAcquisition(acquisitionError, agentSyncLease);
+  }
+  if (!codexLease.ok) {
+    releaseOrderedLifecycleLeases(null, agentSyncLease);
+    return { ok: false, busy: 'codex', refusal: codexLease };
+  }
+  return { ok: true, agentSyncLease, codexLease };
+}
+
+/**
+ * Release in exact reverse acquisition order. Both releases are attempted;
+ * one failure is preserved and two are aggregated inner-first.
+ */
+export function releaseOrderedLifecycleLeases(
+  codexLease: ReleasableLifecycleLease | null,
+  agentSyncLease: ReleasableLifecycleLease,
+): void {
+  let codexReleaseFailed = false;
+  let codexReleaseError: unknown;
+  try {
+    codexLease?.release();
+  } catch (error) {
+    codexReleaseFailed = true;
+    codexReleaseError = error;
+  }
+
+  let agentSyncReleaseFailed = false;
+  let agentSyncReleaseError: unknown;
+  try {
+    agentSyncLease.release();
+  } catch (error) {
+    agentSyncReleaseFailed = true;
+    agentSyncReleaseError = error;
+  }
+
+  if (codexReleaseFailed && agentSyncReleaseFailed) {
+    throw new AggregateError(
+      [codexReleaseError, agentSyncReleaseError],
+      'Codex and agent-sync lifecycle lease releases both failed',
+    );
+  }
+  if (codexReleaseFailed) throw codexReleaseError;
+  if (agentSyncReleaseFailed) throw agentSyncReleaseError;
+}
+
+function releaseAfterFailedAcquisition(acquisitionError: unknown, agentSyncLease: ReleasableLifecycleLease): never {
+  try {
+    agentSyncLease.release();
+  } catch (releaseError) {
+    throw new AggregateError(
+      [acquisitionError, releaseError],
+      'Codex lifecycle lease acquisition and agent-sync lifecycle lease release both failed',
+    );
+  }
+  throw acquisitionError;
+}

--- a/tests/support/codex-app-server-transport.ts
+++ b/tests/support/codex-app-server-transport.ts
@@ -1,0 +1,222 @@
+import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
+import { createInterface } from 'node:readline';
+
+export interface AppServerJsonRpcEnvelope {
+  id?: number | string | null;
+  result?: unknown;
+  error?: unknown;
+}
+
+type ErrorKind = 'process' | 'rpc' | 'timeout' | 'cleanup';
+
+interface TransportOptions<E extends Error> {
+  executable: string;
+  args: string[];
+  env: NodeJS.ProcessEnv;
+  initializeParams: unknown;
+  initializeTimeoutMs: number;
+  cleanupGraceMs: number;
+  initialSignal: 'SIGTERM' | 'SIGKILL';
+  label: string;
+  error: (kind: ErrorKind, message: string, cause?: Error) => E;
+  windowsHide?: boolean;
+}
+
+interface Pending {
+  method: string;
+  resolve: (message: AppServerJsonRpcEnvelope) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+/** Process-owning newline JSON-RPC transport shared by the independent evidence builders. */
+export class CodexAppServerTransport<E extends Error = Error> {
+  private readonly pending = new Map<number, Pending>();
+  private readonly closed: Promise<void>;
+  private closing: Promise<E | null> | null = null;
+  private nextId = 1;
+  private didClose = false;
+  private stderr = '';
+
+  private constructor(
+    private readonly child: ChildProcessWithoutNullStreams,
+    private readonly options: TransportOptions<E>,
+  ) {
+    this.closed = new Promise((resolve) =>
+      child.once('close', () => {
+        this.didClose = true;
+        resolve();
+      }),
+    );
+    child.stderr.on('data', (chunk: Buffer | string) => {
+      this.stderr = `${this.stderr}${String(chunk)}`.slice(-16_384);
+    });
+    child.on('error', (error) => this.rejectAll(this.error('process', `process error: ${error.message}`, error)));
+    child.on('exit', (code, signal) =>
+      this.rejectAll(
+        this.error(
+          'process',
+          `exited before replying (code=${String(code)}, signal=${String(signal)}): ${this.stderr.trim().slice(-2_000)}`,
+        ),
+      ),
+    );
+    child.stdin.on('error', (error) => this.rejectAll(this.error('rpc', `stdin error: ${error.message}`, error)));
+    createInterface({ input: child.stdout }).on('line', (line) => this.receive(line));
+  }
+
+  static async launch<E extends Error>(options: TransportOptions<E>): Promise<CodexAppServerTransport<E>> {
+    const child = spawn(options.executable, options.args, {
+      detached: process.platform !== 'win32',
+      env: options.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: options.windowsHide,
+    }) as ChildProcessWithoutNullStreams;
+    child.on('error', () => {}); // prevent a late spawn failure from becoming unhandled
+    const transport = new CodexAppServerTransport(child, options);
+    try {
+      await transport.request('initialize', options.initializeParams, options.initializeTimeoutMs);
+      transport.notify('initialized', {});
+      return transport;
+    } catch (error) {
+      const cleanupError = await transport.close();
+      if (cleanupError) {
+        throw new AggregateError([asError(error), cleanupError], `${options.label} initialize and cleanup both failed`);
+      }
+      throw error;
+    }
+  }
+
+  pid(): number {
+    const pid = this.child.pid;
+    if (pid === undefined) throw this.error('process', 'has no process id');
+    return pid;
+  }
+
+  request(method: string, params: unknown, timeoutMs: number): Promise<AppServerJsonRpcEnvelope> {
+    if (this.closing) return Promise.reject(this.error('process', `${method} requested after close`));
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(this.error('timeout', `${method} timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      this.pending.set(id, { method, resolve, reject, timer });
+      try {
+        this.child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`, (writeError) => {
+          if (writeError)
+            this.reject(id, this.error('rpc', `${method} write failed: ${writeError.message}`, writeError));
+        });
+      } catch (error) {
+        this.reject(id, this.error('rpc', `${method} write failed`, asError(error)));
+      }
+    });
+  }
+
+  notify(method: string, params: unknown): void {
+    if (this.closing) return;
+    try {
+      this.child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', method, params })}\n`, () => {});
+    } catch {}
+  }
+
+  close(candidatePid?: number): Promise<E | null> {
+    this.closing ??= this.closeOnce(candidatePid);
+    return this.closing;
+  }
+
+  private async closeOnce(candidatePid: number | undefined): Promise<E | null> {
+    this.rejectAll(this.error('process', 'evidence session closed'));
+    const appPid = this.child.pid;
+    const treePid = process.platform === 'win32' ? appPid : appPid === undefined ? undefined : -appPid;
+    const targets = [candidatePid, appPid, treePid];
+    const failures: Error[] = [];
+    signal(candidatePid, this.options.initialSignal, failures);
+    signal(treePid, this.options.initialSignal, failures);
+    await waitStopped(targets, this.options.cleanupGraceMs);
+    signal(candidatePid, 'SIGKILL', failures);
+    signal(treePid, 'SIGKILL', failures);
+    await Promise.race([this.closed, delay(this.options.cleanupGraceMs)]);
+    await waitStopped(targets, this.options.cleanupGraceMs);
+    if (running(candidatePid)) failures.push(new Error(`candidate process ${String(candidatePid)} survived SIGKILL`));
+    if (running(treePid)) failures.push(new Error(`app-server process group ${String(appPid)} survived SIGKILL`));
+    if (running(appPid) || !this.didClose)
+      failures.push(new Error(`app-server process ${String(appPid)} did not close`));
+    if (failures.length === 0) return null;
+    const message = `${this.options.label} cleanup failed: ${failures.map((failure) => failure.message).join('; ')}`;
+    return this.error('cleanup', message, new AggregateError(failures));
+  }
+
+  private receive(line: string): void {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      return;
+    }
+    if (typeof parsed !== 'object' || parsed === null) return;
+    const message = parsed as AppServerJsonRpcEnvelope;
+    if (typeof message.id !== 'number') return;
+    const pending = this.pending.get(message.id);
+    if (!pending) return;
+    this.pending.delete(message.id);
+    clearTimeout(pending.timer);
+    if (message.error === undefined) pending.resolve(message);
+    else pending.reject(this.error('rpc', `${pending.method} error: ${truncate(message.error)}`));
+  }
+
+  private reject(id: number, error: Error): void {
+    const pending = this.pending.get(id);
+    if (!pending) return;
+    this.pending.delete(id);
+    clearTimeout(pending.timer);
+    pending.reject(error);
+  }
+
+  private rejectAll(error: Error): void {
+    for (const id of [...this.pending.keys()]) this.reject(id, error);
+  }
+
+  private error(kind: ErrorKind, message: string, cause?: Error): E {
+    return this.options.error(kind, `codex app-server ${message}`, cause);
+  }
+}
+
+function signal(pid: number | undefined, value: NodeJS.Signals, failures: Error[]): void {
+  if (pid === undefined || Math.abs(pid) <= 1 || pid === process.pid) return;
+  try {
+    process.kill(pid, value);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ESRCH') failures.push(asError(error));
+  }
+}
+
+function running(pid: number | undefined): boolean {
+  if (pid === undefined || Math.abs(pid) <= 1) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH';
+  }
+}
+
+async function waitStopped(pids: Array<number | undefined>, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (pids.some(running) && Date.now() < deadline) await delay(25);
+}
+
+function truncate(value: unknown): string {
+  try {
+    return JSON.stringify(value).slice(0, 1_000);
+  } catch {
+    return String(value).slice(0, 1_000);
+  }
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/tests/support/codex-cwd-evidence.ts
+++ b/tests/support/codex-cwd-evidence.ts
@@ -19,11 +19,11 @@
  * the control exec that carry the CWD facts.
  */
 
-import { type ChildProcessWithoutNullStreams, execFileSync, spawn } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { createInterface } from 'node:readline';
+import { CodexAppServerTransport } from './codex-app-server-transport.js';
 
 /** Per-case black-box evidence pairing the raw request with observed child facts. */
 export interface CwdCaseEvidence {
@@ -90,34 +90,17 @@ const s = statSync(c);
 process.stdout.write(JSON.stringify({ cwd: c, dev: s.dev, ino: s.ino, pid: process.pid }) + '\n');
 `;
 
-interface PendingRequest {
-  resolve: (message: Record<string, unknown>) => void;
-  reject: (error: Error) => void;
-  timer: ReturnType<typeof setTimeout>;
-}
-
 export class CodexCwdEvidence {
-  private nextId = 1;
-  private readonly pending = new Map<number, PendingRequest>();
   private closePromise: Promise<void> | null = null;
-  private childClosed = false;
-  private readonly childClosePromise: Promise<void>;
 
   private constructor(
-    private readonly child: ChildProcessWithoutNullStreams,
+    private readonly transport: CodexAppServerTransport,
     private readonly harnessRoot: string,
     private readonly sentinelFile: string,
     private readonly fakeMcpScript: string,
     private readonly controlReporter: string,
     private readonly nodeExecutable: string,
-  ) {
-    this.childClosePromise = new Promise((resolve) => {
-      child.once('close', () => {
-        this.childClosed = true;
-        resolve();
-      });
-    });
-  }
+  ) {}
 
   /** Start the pinned app-server and complete the `initialize` handshake. */
   static async launch(
@@ -136,7 +119,6 @@ export class CodexCwdEvidence {
       throw new Error(`codex binary not runnable in this environment: ${codexCommand}`);
     }
     const harnessRoot = mkdtempSync(join(tmpdir(), 'genie-cwd-evidence-'));
-    let harness: CodexCwdEvidence | null = null;
     try {
       const codexHome = join(harnessRoot, 'codex-home');
       mkdirSync(codexHome, { recursive: true });
@@ -150,29 +132,20 @@ export class CodexCwdEvidence {
       const nodeExecutable = process.execPath;
       beforeSpawnForTest?.(harnessRoot);
 
-      const child = spawn(codexCommand, ['app-server'], {
+      const transport = await CodexAppServerTransport.launch({
+        executable: codexCommand,
+        args: ['app-server'],
         env: { ...process.env, CODEX_HOME: codexHome, RUST_LOG: 'error' },
-        stdio: ['pipe', 'pipe', 'pipe'],
-        // A dedicated POSIX process group lets cleanup terminate app-server
-        // descendants (including MCP children), not merely their direct parent.
-        detached: process.platform !== 'win32',
-      }) as ChildProcessWithoutNullStreams;
-      // A late spawn/runtime failure must surface as a rejected initialize (caught by
-      // callers), never as an unhandled 'error' event that throws and aborts the file.
-      child.on('error', () => {});
-      harness = new CodexCwdEvidence(child, harnessRoot, sentinelFile, fakeMcpScript, controlReporter, nodeExecutable);
-      harness.wireLifecycle();
-      harness.wireStdout();
-      await harness.request(
-        'initialize',
-        { clientInfo: { name: 'genie-cwd-evidence', version: '0.0.0' } },
+        initializeParams: { clientInfo: { name: 'genie-cwd-evidence', version: '0.0.0' } },
         initializeTimeoutMs,
-      );
-      child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', method: 'initialized', params: {} })}\n`);
-      return harness;
+        cleanupGraceMs: 2_000,
+        initialSignal: 'SIGKILL',
+        label: 'codex app-server harness',
+        error: (_kind, message, cause) => new Error(message, cause ? { cause } : undefined),
+      });
+      return new CodexCwdEvidence(transport, harnessRoot, sentinelFile, fakeMcpScript, controlReporter, nodeExecutable);
     } catch (error) {
-      if (harness === null) rmSync(harnessRoot, { recursive: true, force: true });
-      else await harness.close();
+      rmSync(harnessRoot, { recursive: true, force: true });
       throw error;
     }
   }
@@ -257,7 +230,7 @@ export class CodexCwdEvidence {
 
   /** Run a Codex-launched control process (`command/exec`) in a directory. */
   async runControl(requestedCwd: string, timeoutMs = 20_000): Promise<ControlEvidence> {
-    const response = await this.request(
+    const response = await this.transport.request(
       'command/exec',
       { command: [this.nodeExecutable, this.controlReporter], cwd: requestedCwd },
       timeoutMs,
@@ -281,46 +254,11 @@ export class CodexCwdEvidence {
   }
 
   private async closeOnce(): Promise<void> {
-    this.rejectPending(new Error('codex app-server harness closed'));
     try {
-      this.killProcessTree();
-      await this.waitForChildClose();
-      await this.waitForProcessGroupExit();
+      const cleanupError = await this.transport.close();
+      if (cleanupError) throw cleanupError;
     } finally {
       rmSync(this.harnessRoot, { recursive: true, force: true });
-    }
-  }
-
-  // --------------------------------------------------------------------------
-
-  private killProcessTree(): void {
-    const pid = this.child.pid;
-    if (process.platform !== 'win32' && pid !== undefined && pid > 1) {
-      try {
-        process.kill(-pid, 'SIGKILL');
-      } catch {
-        // The process group may already be gone.
-      }
-    }
-    try {
-      this.child.kill('SIGKILL');
-    } catch {
-      // The direct child may already be gone.
-    }
-  }
-
-  private async waitForProcessGroupExit(timeoutMs = 2_000): Promise<void> {
-    const pid = this.child.pid;
-    if (process.platform === 'win32' || pid === undefined || pid <= 1) return;
-    const deadline = Date.now() + timeoutMs;
-    while (Date.now() < deadline) {
-      try {
-        process.kill(-pid, 0);
-        process.kill(-pid, 'SIGKILL');
-      } catch {
-        return;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 25));
     }
   }
 
@@ -331,80 +269,10 @@ export class CodexCwdEvidence {
         mcp_servers: { probe: { command: this.nodeExecutable, args: [this.fakeMcpScript, this.sentinelFile, tag] } },
       },
     };
-    const response = await this.request('thread/start', params, timeoutMs);
+    const response = await this.transport.request('thread/start', params, timeoutMs);
     const thread = (response.result as { thread?: { id?: string } } | undefined)?.thread;
     if (!thread?.id) throw new Error(`thread/start returned no thread id: ${JSON.stringify(response).slice(0, 300)}`);
     return thread.id;
-  }
-
-  private request(method: string, params: unknown, timeoutMs: number): Promise<Record<string, unknown>> {
-    const id = this.nextId++;
-    return new Promise<Record<string, unknown>>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.pending.delete(id);
-        reject(new Error(`${method} timed out after ${timeoutMs}ms`));
-      }, timeoutMs);
-      this.pending.set(id, { resolve, reject, timer });
-      this.child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`, (error) => {
-        if (error) this.rejectRequest(id, new Error(`${method} write failed: ${error.message}`));
-      });
-    });
-  }
-
-  private wireLifecycle(): void {
-    this.child.on('error', (error) => {
-      this.rejectPending(new Error(`codex app-server process error: ${error.message}`));
-    });
-    this.child.on('exit', (code, signal) => {
-      this.rejectPending(
-        new Error(`codex app-server exited before replying (code=${String(code)}, signal=${String(signal)})`),
-      );
-    });
-    this.child.stdin.on('error', (error) => {
-      this.rejectPending(new Error(`codex app-server stdin error: ${error.message}`));
-    });
-  }
-
-  private wireStdout(): void {
-    const rl = createInterface({ input: this.child.stdout });
-    rl.on('line', (line) => {
-      const trimmed = line.trim();
-      if (!trimmed) return;
-      let message: Record<string, unknown>;
-      try {
-        message = JSON.parse(trimmed) as Record<string, unknown>;
-      } catch {
-        return;
-      }
-      const id = message.id;
-      if (typeof id === 'number' && this.pending.has(id)) {
-        const request = this.pending.get(id);
-        this.pending.delete(id);
-        if (!request) return;
-        clearTimeout(request.timer);
-        if (message.error) request.reject(new Error(`request error: ${JSON.stringify(message.error).slice(0, 300)}`));
-        else request.resolve(message);
-      }
-    });
-  }
-
-  private rejectRequest(id: number, error: Error): void {
-    const request = this.pending.get(id);
-    if (!request) return;
-    this.pending.delete(id);
-    clearTimeout(request.timer);
-    request.reject(error);
-  }
-
-  private rejectPending(error: Error): void {
-    for (const id of [...this.pending.keys()]) {
-      this.rejectRequest(id, error);
-    }
-  }
-
-  private async waitForChildClose(): Promise<void> {
-    if (this.childClosed) return;
-    await this.childClosePromise;
   }
 
   private async waitForSentinel(

--- a/tests/support/codex-dogfood-fixture.ts
+++ b/tests/support/codex-dogfood-fixture.ts
@@ -2,13 +2,14 @@ import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { chmodSync, cpSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import packageMetadata from '../../package.json';
 import { scanPhysicalTree } from '../../src/lib/codex-activation.js';
 import { buildTestDeliveryEvidencePack } from '../../src/lib/codex-delivery-evidence.test-support.js';
 import type { DogfoodEntryInput, DogfoodHarnessDependencies } from './codex-dogfood-harness.js';
 
 const REPO_ROOT = join(import.meta.dir, '..', '..');
 export const FIXTURE_N = '5.260720.10';
-export const FIXTURE_T = '5.260723.8';
+export const FIXTURE_T = packageMetadata.version;
 
 function sha256(path: string): string {
   return createHash('sha256').update(readFileSync(path)).digest('hex');

--- a/tests/support/codex-native-mcp-evidence.test.ts
+++ b/tests/support/codex-native-mcp-evidence.test.ts
@@ -18,6 +18,7 @@ import {
   type NativeMcpTaskSentinel,
   assertUniqueBoardSentinel,
   captureCodexNativeMcpEvidence,
+  probeCodexAppServer,
 } from './codex-native-mcp-evidence.js';
 
 const LAUNCHER = fileURLToPath(new URL('./codex-native-mcp-launcher.sh', import.meta.url));
@@ -133,6 +134,57 @@ test('launcher records exact target and preserves its PID through a native adapt
   expect(fields.slice(6)).toEqual([candidatePidFile]);
   expect(readFileSync(candidatePidFile, 'utf8')).toBe(String(child.pid));
 });
+
+test.skipIf(process.platform === 'win32')(
+  'initialize rejection reaps the native app-server process group',
+  async () => {
+    const root = makeRoot('genie-native-initialize-cleanup-');
+    const codexHome = join(root, 'codex-home');
+    const pidRecord = join(root, 'pids.json');
+    await Bun.$`mkdir -p ${codexHome}`.quiet();
+    const fakeCodex = join(root, 'fake-codex.mjs');
+    writeFileSync(
+      fakeCodex,
+      `#!${process.execPath}
+import { spawn } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import { createInterface } from 'node:readline';
+if (process.argv.includes('--version')) {
+  process.stdout.write('codex-cli initialize-cleanup-test\\n');
+  process.exit(0);
+}
+const descendant = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1 << 30)'], { stdio: 'ignore' });
+writeFileSync(process.env.PID_RECORD, JSON.stringify({ appServer: process.pid, descendant: descendant.pid }));
+const rl = createInterface({ input: process.stdin });
+rl.on('line', (line) => {
+  const message = JSON.parse(line);
+  if (message.method === 'initialize') {
+    const error = { code: -32000, message: 'forced native initialize rejection' };
+    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: message.id, error }) + '\\n');
+  }
+});
+setInterval(() => {}, 1 << 30);
+`,
+      'utf8',
+    );
+    chmodSync(fakeCodex, 0o755);
+
+    const support = await probeCodexAppServer(
+      { executable: fakeCodex, version: 'codex-cli initialize-cleanup-test' },
+      { ...process.env, CODEX_HOME: codexHome, PID_RECORD: pidRecord },
+      { initializeMs: 1_000, cleanupGraceMs: 100 },
+    );
+
+    expect(support.supported).toBe(false);
+    if (support.supported) throw new Error('fake Codex unexpectedly initialized');
+    expect(support.errorCode).toBe('rpc-error');
+    expect(support.reason).toContain('forced native initialize rejection');
+    const pids = JSON.parse(readFileSync(pidRecord, 'utf8')) as { appServer: number; descendant: number };
+    await Promise.all([waitForExit(pids.appServer), waitForExit(pids.descendant)]);
+    expect(processExists(pids.appServer)).toBe(false);
+    expect(processExists(pids.descendant)).toBe(false);
+  },
+);
 
 test('RPC timeout TERM/KILLs an uncooperative app-server tree and removes the helper temp child', async () => {
   const root = makeRoot('genie-native-cleanup-');

--- a/tests/support/codex-native-mcp-evidence.ts
+++ b/tests/support/codex-native-mcp-evidence.ts
@@ -10,14 +10,14 @@
  */
 
 import { Database } from 'bun:sqlite';
-import { type ChildProcessWithoutNullStreams, type SpawnSyncReturns, spawn, spawnSync } from 'node:child_process';
+import { type SpawnSyncReturns, spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { isAbsolute, join } from 'node:path';
-import { createInterface } from 'node:readline';
 import { fileURLToPath } from 'node:url';
 import { resolveProjectContext } from '../../src/lib/v5/genie-db.js';
+import { CodexAppServerTransport } from './codex-app-server-transport.js';
 
 export type CodexNativeMcpEvidenceErrorCode =
   | 'invalid-options'
@@ -205,21 +205,6 @@ export type CodexAppServerSupport =
   | { supported: true; reason: 'ok' }
   | { supported: false; reason: string; errorCode: CodexNativeMcpEvidenceErrorCode };
 
-interface PendingRequest {
-  method: string;
-  resolve: (message: JsonRpcEnvelope) => void;
-  reject: (error: Error) => void;
-  timer: ReturnType<typeof setTimeout>;
-}
-
-interface JsonRpcEnvelope {
-  id?: number | string | null;
-  result?: unknown;
-  error?: unknown;
-  method?: string;
-  params?: unknown;
-}
-
 interface McpInventory {
   name: string;
   tools: string[];
@@ -245,206 +230,34 @@ const CONTROL_SOURCE =
   "const fs = require('node:fs'); const cwd = process.cwd(); const s = fs.statSync(cwd); " +
   "process.stdout.write(JSON.stringify({ pid: process.pid, cwd, dev: s.dev, ino: s.ino }) + '\\n');";
 
-class AppServerSession {
-  private readonly pending = new Map<number, PendingRequest>();
-  private readonly closePromise: Promise<void>;
-  private nextId = 1;
-  private closed = false;
-  private didClose = false;
-  private stderrTail = '';
+type AppServerSession = CodexAppServerTransport<CodexNativeMcpEvidenceError>;
 
-  private constructor(
-    private readonly child: ChildProcessWithoutNullStreams,
-    readonly pin: CodexAppServerPin,
-  ) {
-    this.closePromise = new Promise((resolve) => {
-      child.once('close', () => {
-        this.didClose = true;
-        resolve();
-      });
-    });
-    this.wireLifecycle();
-    this.wireProtocol();
-  }
-
-  static async launch(
-    pin: CodexAppServerPin,
-    env: NodeJS.ProcessEnv,
-    timeouts: CodexNativeMcpEvidenceTimeouts,
-  ): Promise<AppServerSession> {
-    assertCodexPin(pin, env, timeouts.preflightMs);
-    const child = spawn(pin.executable, ['app-server', '--stdio'], {
-      detached: process.platform !== 'win32',
-      env,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      windowsHide: true,
-    }) as ChildProcessWithoutNullStreams;
-    child.on('error', () => {});
-    const session = new AppServerSession(child, pin);
-    try {
-      await session.request(
-        'initialize',
-        { clientInfo: { name: 'genie-native-mcp-evidence', version: '1' } },
-        timeouts.initializeMs,
-      );
-      session.notify('initialized', {});
-      return session;
-    } catch (error) {
-      const cleanupError = await session.close(undefined, timeouts.cleanupGraceMs);
-      if (cleanupError) {
-        throw new AggregateError([asError(error), cleanupError], 'app-server initialize and cleanup both failed');
-      }
-      throw error;
-    }
-  }
-
-  pid(): number {
-    const pid = this.child.pid;
-    if (pid === undefined) {
-      throw new CodexNativeMcpEvidenceError('app-server-failure', 'codex app-server has no process id');
-    }
-    return pid;
-  }
-
-  async request(method: string, params: unknown, timeoutMs: number): Promise<JsonRpcEnvelope> {
-    if (this.closed) {
-      throw new CodexNativeMcpEvidenceError('app-server-failure', `${method} requested after app-server close`);
-    }
-    const id = this.nextId++;
-    return new Promise<JsonRpcEnvelope>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.pending.delete(id);
-        reject(new CodexNativeMcpEvidenceError('rpc-timeout', `${method} timed out after ${timeoutMs}ms`));
-      }, timeoutMs);
-      this.pending.set(id, { method, resolve, reject, timer });
-      const message = `${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`;
-      try {
-        this.child.stdin.write(message, (error) => {
-          if (error) {
-            this.rejectRequest(
-              id,
-              new CodexNativeMcpEvidenceError('rpc-error', `${method} write failed: ${error.message}`),
-            );
-          }
-        });
-      } catch (error) {
-        this.rejectRequest(
-          id,
-          new CodexNativeMcpEvidenceError('rpc-error', `${method} write failed`, { cause: asError(error) }),
-        );
-      }
-    });
-  }
-
-  notify(method: string, params: unknown): void {
-    if (this.closed) return;
-    this.child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', method, params })}\n`, () => {});
-  }
-
-  /**
-   * TERM then KILL the recorded candidate and the app-server process group.
-   * Returns a cleanup error instead of masking the primary evidence failure.
-   */
-  async close(candidatePid: number | undefined, graceMs: number): Promise<Error | null> {
-    if (this.closed) return null;
-    this.closed = true;
-    this.rejectPending(new CodexNativeMcpEvidenceError('app-server-failure', 'app-server evidence session closed'));
-    const failures: Error[] = [];
-
-    signalPid(candidatePid, 'SIGTERM', failures);
-    this.signalTree('SIGTERM', failures);
-    await waitUntilStopped([candidatePid, this.child.pid], graceMs);
-
-    if (isProcessAlive(candidatePid)) signalPid(candidatePid, 'SIGKILL', failures);
-    if (isProcessAlive(this.child.pid)) this.signalTree('SIGKILL', failures);
-    await Promise.race([this.closePromise, delay(graceMs)]);
-    await waitUntilStopped([candidatePid, this.child.pid], graceMs);
-
-    if (isProcessAlive(candidatePid)) {
-      failures.push(new Error(`candidate process ${String(candidatePid)} survived SIGKILL`));
-    }
-    if (isProcessAlive(this.child.pid) || !this.didClose) {
-      failures.push(new Error(`codex app-server process ${String(this.child.pid)} did not close`));
-    }
-    if (failures.length === 0) return null;
-    return new CodexNativeMcpEvidenceError(
-      'cleanup-failure',
-      `native MCP cleanup failed: ${failures.map((failure) => failure.message).join('; ')}`,
-      { cause: new AggregateError(failures) },
-    );
-  }
-
-  diagnostics(): string {
-    return this.stderrTail.trim().slice(-2_000);
-  }
-
-  private signalTree(signal: NodeJS.Signals, failures: Error[]): void {
-    const pid = this.child.pid;
-    if (pid === undefined) return;
-    if (process.platform !== 'win32') {
-      signalPid(-pid, signal, failures);
-      return;
-    }
-    signalPid(pid, signal, failures);
-  }
-
-  private wireLifecycle(): void {
-    this.child.stderr.on('data', (chunk: Buffer | string) => {
-      this.stderrTail = `${this.stderrTail}${String(chunk)}`.slice(-16_384);
-    });
-    this.child.on('error', (error) => {
-      this.rejectPending(
-        new CodexNativeMcpEvidenceError('app-server-failure', `codex app-server process error: ${error.message}`),
-      );
-    });
-    this.child.on('exit', (code, signal) => {
-      this.rejectPending(
-        new CodexNativeMcpEvidenceError(
-          'app-server-failure',
-          `codex app-server exited before reply (code=${String(code)}, signal=${String(signal)}): ${this.diagnostics()}`,
-        ),
-      );
-    });
-    this.child.stdin.on('error', (error) => {
-      this.rejectPending(
-        new CodexNativeMcpEvidenceError('rpc-error', `codex app-server stdin error: ${error.message}`),
-      );
-    });
-  }
-
-  private wireProtocol(): void {
-    const lines = createInterface({ input: this.child.stdout });
-    lines.on('line', (line) => {
-      const message = parseJsonEnvelope(line);
-      if (!message || typeof message.id !== 'number') return;
-      const pending = this.pending.get(message.id);
-      if (!pending) return;
-      this.pending.delete(message.id);
-      clearTimeout(pending.timer);
-      if (message.error !== undefined) {
-        pending.reject(
-          new CodexNativeMcpEvidenceError(
-            'rpc-error',
-            `${pending.method} error: ${truncateJson(message.error, 1_000)}`,
-          ),
-        );
-        return;
-      }
-      pending.resolve(message);
-    });
-  }
-
-  private rejectRequest(id: number, error: Error): void {
-    const pending = this.pending.get(id);
-    if (!pending) return;
-    this.pending.delete(id);
-    clearTimeout(pending.timer);
-    pending.reject(error);
-  }
-
-  private rejectPending(error: Error): void {
-    for (const id of [...this.pending.keys()]) this.rejectRequest(id, error);
-  }
+async function launchAppServer(
+  pin: CodexAppServerPin,
+  env: NodeJS.ProcessEnv,
+  timeouts: CodexNativeMcpEvidenceTimeouts,
+): Promise<AppServerSession> {
+  assertCodexPin(pin, env, timeouts.preflightMs);
+  return CodexAppServerTransport.launch({
+    executable: pin.executable,
+    args: ['app-server', '--stdio'],
+    env,
+    windowsHide: true,
+    initializeParams: { clientInfo: { name: 'genie-native-mcp-evidence', version: '1' } },
+    initializeTimeoutMs: timeouts.initializeMs,
+    cleanupGraceMs: timeouts.cleanupGraceMs,
+    initialSignal: 'SIGTERM',
+    label: 'native MCP',
+    error: (kind, message, cause) => {
+      const code = {
+        process: 'app-server-failure',
+        rpc: 'rpc-error',
+        timeout: 'rpc-timeout',
+        cleanup: 'cleanup-failure',
+      }[kind] as CodexNativeMcpEvidenceErrorCode;
+      return new CodexNativeMcpEvidenceError(code, message, cause ? { cause } : undefined);
+    },
+  });
 }
 
 /**
@@ -461,12 +274,12 @@ export async function probeCodexAppServer(
   let session: AppServerSession | null = null;
   try {
     assertEnvironment(env);
-    session = await AppServerSession.launch(pin, env, timeouts);
+    session = await launchAppServer(pin, env, timeouts);
   } catch (error) {
     const typed = toEvidenceError(error, 'codex-unavailable', 'codex app-server is unavailable');
     return { supported: false, reason: typed.message, errorCode: typed.code };
   }
-  const cleanupError = await session.close(undefined, timeouts.cleanupGraceMs);
+  const cleanupError = await session.close();
   if (cleanupError) return { supported: false, reason: cleanupError.message, errorCode: cleanupError.code };
   return { supported: true, reason: 'ok' };
 }
@@ -489,7 +302,7 @@ export async function captureCodexNativeMcpEvidence(
   let primaryError: Error | null = null;
 
   try {
-    session = await AppServerSession.launch(normalized.codex, normalized.env, normalized.timeouts);
+    session = await launchAppServer(normalized.codex, normalized.env, normalized.timeouts);
     const threadId = await startThread(session, normalized, launcherRecord);
     launcher = await waitForLauncherObservation(launcherRecord, normalized.candidate, normalized.timeouts.launcherMs);
     const inventory = await waitForMcpInventory(session, threadId, normalized.timeouts.inventoryMs);
@@ -520,7 +333,7 @@ export async function captureCodexNativeMcpEvidence(
   }
 
   if (!launcher) launcher = tryReadLauncherObservation(launcherRecord);
-  let cleanupError = await session?.close(launcher?.pid, normalized.timeouts.cleanupGraceMs);
+  let cleanupError = await session?.close(launcher?.pid);
   try {
     rmSync(tempRoot, { recursive: true, force: true });
   } catch (error) {
@@ -1108,17 +921,6 @@ function assertAbsolute(name: string, path: string): void {
   }
 }
 
-function parseJsonEnvelope(line: string): JsonRpcEnvelope | null {
-  const trimmed = line.trim();
-  if (!trimmed) return null;
-  try {
-    const parsed = JSON.parse(trimmed) as unknown;
-    return isRecord(parsed) ? (parsed as JsonRpcEnvelope) : null;
-  } catch {
-    return null;
-  }
-}
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -1148,32 +950,6 @@ function toEvidenceError(
   return new CodexNativeMcpEvidenceError(fallbackCode, `${fallbackMessage}: ${asError(error).message}`, {
     cause: asError(error),
   });
-}
-
-function signalPid(pid: number | undefined, signal: NodeJS.Signals, failures: Error[]): void {
-  if (pid === undefined || pid === process.pid || pid === 0) return;
-  try {
-    process.kill(pid, signal);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== 'ESRCH') failures.push(asError(error));
-  }
-}
-
-function isProcessAlive(pid: number | undefined): boolean {
-  if (pid === undefined || pid <= 0) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code !== 'ESRCH';
-  }
-}
-
-async function waitUntilStopped(pids: Array<number | undefined>, timeoutMs: number): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (pids.some(isProcessAlive) && Date.now() < deadline) {
-    await delay(Math.min(25, Math.max(1, deadline - Date.now())));
-  }
 }
 
 function delay(ms: number): Promise<void> {


### PR DESCRIPTION
## Summary

- centralize the complete authenticated delivery binding and defer Sigstore initialization
- share app-server test transport and process-tree cleanup
- centralize ordered lifecycle lease acquisition/release and preserve fail-closed terminal outcomes
- close the review-found update assertion leak and codec/acquisition edge cases

## Bloat and performance

- runtime TypeScript: net 57 lines smaller than dev
- repository total: net 201 lines larger, entirely from focused regression coverage after implementation/support deletion
- final JS bundle: 2,466 bytes smaller than dev
- paired startup benchmark: compiled median 3.29% faster; JS median 3.17% faster

## Validation

- 730 focused tests passed across 18 files
- typecheck, Biome, dead-code, policy hooks, and diff integrity passed
- independent architecture, supply-chain, performance, and QA reviews: SHIP
- full check reached 2,786 pass / 3 fail; all three reproduce on clean dev (macOS ss probe and two stale 5.260723.8 fixtures against 5.260723.9)

Wish: codex-plugin-dogfood-remediation