### PR TITLE
chore(release): restore published dev manifest pointer

### DIFF
--- a/.well-known/dev.json
+++ b/.well-known/dev.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
   "channel": "dev",
-  "version": "5.260722.7",
-  "released_at": "2026-07-22T17:48:20Z",
-  "tarball_base": "https://github.com/automagik-dev/genie/releases/download/v5.260722.7",
+  "version": "5.260723.8",
+  "released_at": "2026-07-23T06:43:34Z",
+  "tarball_base": "https://github.com/automagik-dev/genie/releases/download/v5.260723.8",
   "platforms": [
     "linux-x64-glibc",
     "linux-x64-musl",


### PR DESCRIPTION
## Summary

- restore .well-known/dev.json to the exact immutable bytes already published on main
- advance the stale dev copy from 5.260722.7 to the released 5.260723.8 pointer
- resolve the only conflict blocking rolling promotion PR #2624

## Validation

- byte-identical to origin/main:.well-known/dev.json
- 47 release-manifest and release-contract tests passed
- typecheck, lint, dead-code, and repository policy pre-push gates passed

No release is created or republished by this change.