### PR TITLE
fix(release): bind provenance to the triggering CI head, not the built commit

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -52,6 +52,11 @@ on:
         description: 'Authorizing source CI run ID'
         required: true
         type: string
+      trigger_sha:
+        description: 'Head SHA of the admitting CI run (automated channels only; source_sha is the built commit)'
+        required: false
+        type: string
+        default: ''
       draft:
         description: 'Create as draft (require manual promotion)?'
         required: false
@@ -182,6 +187,7 @@ jobs:
           VERSION: ${{ inputs.version }}
           CHANNEL: ${{ inputs.channel }}
           SOURCE_SHA: ${{ inputs.source_sha }}
+          TRIGGER_SHA: ${{ inputs.trigger_sha }}
           SOURCE_BRANCH: ${{ inputs.source_branch }}
           SOURCE_CI_RUN_ID: ${{ inputs.source_ci_run_id }}
           CONTROL_SHA: ${{ github.sha }}
@@ -760,6 +766,7 @@ jobs:
           VERSION: ${{ inputs.version }}
           CHANNEL: ${{ inputs.channel }}
           SOURCE_SHA: ${{ inputs.source_sha }}
+          TRIGGER_SHA: ${{ inputs.trigger_sha }}
           SOURCE_BRANCH: ${{ inputs.source_branch }}
           SOURCE_CI_RUN_ID: ${{ inputs.source_ci_run_id }}
           CONTROL_SHA: ${{ github.sha }}
@@ -817,17 +824,28 @@ jobs:
             ARTIFACT_SHA256="$artifact_sha256" \
               bash scripts/release-native-predicate.sh verify-exact-subject "$native_result" \
               > "$native_identity"
+            # The generic SLSA provenance carries the TRIGGERING workflow_run for
+            # automated channels — CI's head commit, one before the
+            # [auto-version] bump the tarballs are built from. Only the stable
+            # dispatch records SOURCE_SHA itself. The native predicate always
+            # records SOURCE_SHA, so it stays compared against it below.
+            if [[ "$CHANNEL" == "stable" ]]; then
+              generic_expected_sha="$SOURCE_SHA"
+            else
+              generic_expected_sha="$TRIGGER_SHA"
+            fi
             jq -cn \
               --arg artifact "$artifact" \
               --slurpfile generic "$generic_identity" \
               --slurpfile native "$native_identity" \
               --arg sourceSha "$SOURCE_SHA" \
+              --arg genericSourceSha "$generic_expected_sha" \
               --arg sourceBranch "$SOURCE_BRANCH" \
               --arg sourceCiRunId "$SOURCE_CI_RUN_ID" \
               --arg controlSha "$CONTROL_SHA" \
               '
                 ($generic[0] | [
-                  .sourceSha == $sourceSha,
+                  .sourceSha == $genericSourceSha,
                   .sourceBranch == $sourceBranch,
                   .sourceCiRunId == $sourceCiRunId,
                   .controlSha == $controlSha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,11 @@ on:
           - main
           - homolog
           - dev
+      trigger_sha:
+        description: 'Head SHA of the admitting CI run (automated channels only; source_sha is the built commit)'
+        required: false
+        type: string
+        default: ''
       source_ci_run_id:
         description: 'Authorizing CI run ID (exact promotion SHA, or parent of a deterministic dev version child)'
         required: true
@@ -54,6 +59,11 @@ on:
         description: 'Branch on the successful source CI run'
         required: true
         type: string
+      trigger_sha:
+        description: 'Head SHA of the admitting CI run (automated channels only; source_sha is the built commit)'
+        required: false
+        type: string
+        default: ''
       source_ci_run_id:
         description: 'Authorizing CI run ID'
         required: true
@@ -172,6 +182,7 @@ jobs:
       source_sha: ${{ inputs.source_sha }}
       source_branch: ${{ inputs.source_branch }}
       source_ci_run_id: ${{ inputs.source_ci_run_id }}
+      trigger_sha: ${{ inputs.trigger_sha }}
 
   publish:
     needs: sign-attest
@@ -187,6 +198,7 @@ jobs:
       source_sha: ${{ inputs.source_sha }}
       source_branch: ${{ inputs.source_branch }}
       source_ci_run_id: ${{ inputs.source_ci_run_id }}
+      trigger_sha: ${{ inputs.trigger_sha }}
       draft: false
     # Without inherit, the called workflow's secrets context is empty and the
     # manifests job sees RELEASE_MANIFESTS_APP_ID/_PRIVATE_KEY as unset even

--- a/.github/workflows/sign-attest.yml
+++ b/.github/workflows/sign-attest.yml
@@ -51,6 +51,11 @@ on:
         description: 'Authorizing source CI run ID'
         required: true
         type: string
+      trigger_sha:
+        description: 'Head SHA of the admitting CI run (automated channels only; source_sha is the built commit)'
+        required: false
+        type: string
+        default: ''
     outputs:
       version:
         description: 'Resolved version (parsed from upstream tarball filenames)'
@@ -332,6 +337,7 @@ jobs:
           SOURCE_SHA: ${{ inputs.source_sha }}
           SOURCE_BRANCH: ${{ inputs.source_branch }}
           SOURCE_CI_RUN_ID: ${{ inputs.source_ci_run_id }}
+          TRIGGER_SHA: ${{ inputs.trigger_sha }}
           CONTROL_SHA: ${{ github.sha }}
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -440,6 +440,10 @@ jobs:
       source_sha: ${{ needs.auto-version.outputs.source_sha }}
       source_branch: ${{ needs.auto-version.outputs.source_branch }}
       source_ci_run_id: ${{ needs.auto-version.outputs.source_ci_run_id }}
+      # The CI run that admitted this release. Distinct from source_sha: this
+      # is the commit CI ran on, while source_sha is the [auto-version] bump
+      # commit built one later. Provenance embeds the former.
+      trigger_sha: ${{ github.event.workflow_run.head_sha }}
     # Propagate secrets through the call chain so release-publish.yml's
     # manifests job can read the RELEASE_MANIFESTS App credentials (see
     # release.yml publish).

--- a/scripts/release-generic-provenance.sh
+++ b/scripts/release-generic-provenance.sh
@@ -70,10 +70,22 @@ verify_dispatch_parameters() {
 
 verify_automated_event() {
   local input="$1" require_exact="$2"
-  local source_sha="${SOURCE_SHA:-}" source_branch="${SOURCE_BRANCH:-}" source_ci_run_id="${SOURCE_CI_RUN_ID:-}"
+  local source_branch="${SOURCE_BRANCH:-}" source_ci_run_id="${SOURCE_CI_RUN_ID:-}"
+  # The provenance embeds the workflow_run that TRIGGERED this release — CI on
+  # dev/homolog — whose head_sha is the commit CI ran on. That is NOT
+  # SOURCE_SHA: auto-version commits the version bump afterwards and the
+  # tarballs are built from that bump commit, so the two differ by exactly one
+  # commit on every automated release. Binding head_sha to SOURCE_SHA is
+  # therefore unsatisfiable (it broke every dev release from 2026-07-25); bind
+  # it to the trigger commit the orchestrator actually observed instead. The
+  # run id still pins the admitting run exactly.
+  local trigger_sha="${TRIGGER_SHA:-}"
+  if [[ "$require_exact" == true ]]; then
+    [[ "$trigger_sha" =~ ^[0-9a-f]{40}$ ]] || exit 2
+  fi
   jq -e \
     --arg repository "$RELEASE_REPOSITORY" \
-    --arg source_sha "$source_sha" \
+    --arg trigger_sha "$trigger_sha" \
     --arg source_branch "$source_branch" \
     --arg source_ci_run_id "$source_ci_run_id" \
     --argjson require_exact "$require_exact" \
@@ -87,7 +99,7 @@ verify_automated_event() {
       ($run.head_branch | test("^(dev|homolog)$")) and
       $run.repository.full_name == $repository and
       (if $require_exact then
-         $run.head_sha == $source_sha and
+         $run.head_sha == $trigger_sha and
          $run.head_branch == $source_branch and
          ($run.id | tostring) == $source_ci_run_id
        else true end)

--- a/scripts/release-generic-provenance.test.ts
+++ b/scripts/release-generic-provenance.test.ts
@@ -5,7 +5,13 @@ import { join } from 'node:path';
 
 const SCRIPT = join(import.meta.dir, 'release-generic-provenance.sh');
 const CONTROL_SHA = 'b'.repeat(40);
+// The commit the tarballs are built from: the [auto-version] bump.
 const SOURCE_SHA = 'a'.repeat(40);
+// The commit CI ran on, one BEFORE the bump. This is what the provenance's
+// triggering workflow_run carries, and the two are never equal on an
+// automated release — modelling them as equal is what hid the 2026-07-25
+// verification break.
+const TRIGGER_SHA = 'e'.repeat(40);
 const ARTIFACT_SHA256 = 'd'.repeat(64);
 const roots: string[] = [];
 
@@ -51,7 +57,7 @@ function automatedStatement() {
           event: 'push',
           status: 'completed',
           conclusion: 'success',
-          head_sha: SOURCE_SHA,
+          head_sha: TRIGGER_SHA,
           head_branch: 'dev',
           repository: { full_name: 'automagik-dev/genie' },
         },
@@ -101,6 +107,7 @@ function invoke(
       VERSION: '5.260714.2',
       CHANNEL: 'dev',
       SOURCE_SHA,
+      TRIGGER_SHA,
       SOURCE_BRANCH: 'dev',
       SOURCE_CI_RUN_ID: '123456',
       CONTROL_SHA,
@@ -168,12 +175,37 @@ describe('verified generic SLSA provenance policy', () => {
     }
   });
 
+  test('binds the triggering CI head, not the built bump commit (2026-07-25 regression)', () => {
+    // Realistic shape: provenance carries the CI head, the build carries the
+    // [auto-version] bump one commit later. This must PASS.
+    expect(invoke('verify-exact', automatedStatement()).exitCode).toBe(0);
+
+    // The pre-fix contract compared head_sha to SOURCE_SHA. That is
+    // unsatisfiable in production and broke every dev release; a statement
+    // whose trigger head equals the built commit must NOT be accepted as
+    // matching a different TRIGGER_SHA.
+    const built = automatedStatement();
+    built.predicate.invocation.environment.github_event_payload.workflow_run.head_sha = SOURCE_SHA;
+    expect(invoke('verify-exact', built).exitCode).not.toBe(0);
+
+    // A forged trigger commit is still rejected.
+    expect(invoke('verify-exact', automatedStatement(), { TRIGGER_SHA: 'f'.repeat(40) }).exitCode).not.toBe(0);
+
+    // Exact verification refuses to run at all without a well-formed trigger.
+    expect(invoke('verify-exact', automatedStatement(), { TRIGGER_SHA: '' }).exitCode).toBe(2);
+    expect(invoke('verify-exact', automatedStatement(), { TRIGGER_SHA: 'nope' }).exitCode).toBe(2);
+  });
+
   test('emits identity only after the verified statement binds the exact artifact subject', () => {
     const verified = invoke('verify-exact-subject', automatedStatement());
     expect(verified.exitCode).toBe(0);
     expect(JSON.parse(verified.stdout.toString())).toEqual({
       artifactSha256: ARTIFACT_SHA256,
-      sourceSha: SOURCE_SHA,
+      // On automated channels this field is the TRIGGER commit (the generic
+      // provenance has no record of the later bump commit). release-publish.yml
+      // compares it against TRIGGER_SHA for dev/homolog and SOURCE_SHA only for
+      // the stable dispatch.
+      sourceSha: TRIGGER_SHA,
       sourceBranch: 'dev',
       sourceCiRunId: '123456',
       controlSha: CONTROL_SHA,


### PR DESCRIPTION
## Every dev release has failed silently since 2026-07-25

`v5.260725.1`, `.2`, and `.4` all died at **sign-attest**: `verify_exact` exits 1 with **no error message**, immediately after printing `PASSED: SLSA verification passed`. All four Sign jobs fail, `publish` is skipped, no manifest advances.

## Root cause: comparing two deliberately-different commits

`verify_automated_event` asserted:

```
$run.head_sha == $source_sha
```

`$run` is the CI `workflow_run` that **triggered** the release. `source_sha` is documented as *"Exact CI-approved commit that produced the tarballs"*. Those are never equal on an automated release — `auto-version` commits the version bump *after* CI, and the build runs from the bump commit:

| | commit |
|---|---|
| CI run `30173890949` `head_sha` | `7b084992` |
| `SOURCE_SHA` (built) | `0466b433` |
| parent of `0466b433` | **`7b084992`** |

They differ by exactly one commit, always. The assertion is unsatisfiable by construction, and `jq -e` fails silently, which is why the log shows a bare `exit code 1`.

**`release-publish.yml` carried the same defect one stage later** — it compares the generic descriptor's `sourceSha` (also the trigger head) against `SOURCE_SHA`. It would have failed the moment signing was fixed.

## Fix

- Plumb `trigger_sha` (`github.event.workflow_run.head_sha`) through `version.yml` → `release.yml` → `sign-attest.yml` + `release-publish.yml`. Optional input, so the **stable dispatch path is unaffected** (it records `source_sha` directly and is already self-consistent).
- `verify_automated_event` binds `head_sha` to `TRIGGER_SHA`, and *requires* a well-formed one whenever exact verification is demanded. **No binding is lost** — the run id still pins the admitting run exactly, and `head_sha` is an attribute of that same run.
- `release-publish.yml` compares the generic descriptor against `TRIGGER_SHA` for dev/homolog and `SOURCE_SHA` for stable. The native predicate records `source_sha` directly and stays compared against it.

## Why it shipped

The test fixture set `head_sha: SOURCE_SHA` — modelling a world that cannot occur. It now models the real one, plus a regression test asserting the old shape is rejected and covering forged, absent, and malformed trigger SHAs.

## Attribution

**Not caused by the GitHub App change (#2643).** The first failure was 16:55; that fix only reached `main` at 20:01. This regression arrived with the verification tightening promoted in #2624.

Verification: `release-generic-provenance.test.ts` 6 pass, plus `release-docs` + `release-native-predicate` — 48 pass / 0 fail. `bash -n` clean, all four workflows valid YAML. (`bun run check` also reports 2 pre-existing `doctor.ts` complexity errors that are present on clean `dev` and unrelated to this change.)
