### PR TITLE
chore: rolling promotion dev -> main (upload-artifact pin + orphan alarm)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "5.260725.8",
+      "version": "5.260725.10",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/.github/workflows/release-orphan-alert.yml
+++ b/.github/workflows/release-orphan-alert.yml
@@ -21,12 +21,18 @@ name: Release Orphan Alert
 # surface; this workflow makes it automatic.
 
 on:
-  # Schedule disabled while the false-positive backlog is being
-  # cleaned up. Re-enable after the cron logic is verified against
-  # a fresh sample of tags. Until then, this workflow only fires
-  # via manual workflow_dispatch.
-  # schedule:
-  #   - cron: '*/30 * * * *'
+  # Re-enabled 2026-07-25. The re-enable condition — "verified against
+  # a fresh sample of tags" — was met by manual dispatch run 30178531358
+  # against the debris of the 2026-07-20..25 release outage: it detected
+  # exactly the 8 genuine orphans (v5.260725.1-.8, tags pushed with no
+  # Release) and filed issues #2651-#2658, with zero false positives from
+  # the 1000+ historical v1.0.x tags the 24h upper bound excludes.
+  #
+  # That outage is precisely the scenario this alarm exists for: five days
+  # of releases died between tag-push and release-publish and nothing
+  # surfaced it automatically.
+  schedule:
+    - cron: '*/30 * * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -324,7 +324,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Upload manifest-derived native dogfood matrix
-        uses: actions/upload-artifact@b7c4aadc2c921a8ff42c1c6b0e8950fc060e7c7e # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: codex-dogfood-candidate-matrix
           path: candidate-dogfood-matrix.json
@@ -332,7 +332,7 @@ jobs:
           retention-days: 30
 
       - name: Upload exact verified previous-stable inputs
-        uses: actions/upload-artifact@b7c4aadc2c921a8ff42c1c6b0e8950fc060e7c7e # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: codex-dogfood-previous-release
           path: previous-release
@@ -340,7 +340,7 @@ jobs:
           retention-days: 30
 
       - name: Upload exact candidate manifest bytes
-        uses: actions/upload-artifact@b7c4aadc2c921a8ff42c1c6b0e8950fc060e7c7e # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: delivery-candidate-manifests
           path: candidate-manifests/.well-known/*.json
@@ -348,7 +348,7 @@ jobs:
           retention-days: 1
 
       - name: Upload canonical descriptor subjects
-        uses: actions/upload-artifact@b7c4aadc2c921a8ff42c1c6b0e8950fc060e7c7e # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: delivery-descriptors
           path: descriptors/*.delivery.json
@@ -393,7 +393,7 @@ jobs:
           cp "$BUNDLE_PATH" "${DESCRIPTOR}.sigstore.json"
 
       - name: Upload persisted endorsement
-        uses: actions/upload-artifact@b7c4aadc2c921a8ff42c1c6b0e8950fc060e7c7e # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: delivery-endorsement-${{ matrix.channel }}-${{ matrix.platform }}
           path: descriptors/*.sigstore.json
@@ -607,7 +607,7 @@ jobs:
             --inputs-root dogfood-entry
 
       - name: Upload exact per-entry evidence and referenced inputs
-        uses: actions/upload-artifact@b7c4aadc2c921a8ff42c1c6b0e8950fc060e7c7e # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: codex-dogfood-evidence-${{ matrix.platform }}
           path: dogfood-entry
@@ -686,7 +686,7 @@ jobs:
             --output aggregate/codex-dogfood-completeness.json
 
       - name: Upload complete Codex dogfood evidence
-        uses: actions/upload-artifact@b7c4aadc2c921a8ff42c1c6b0e8950fc060e7c7e # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: codex-dogfood-completeness
           path: aggregate/codex-dogfood-completeness.json
@@ -908,7 +908,7 @@ jobs:
             ' security-gate/verified/*.json > security-gate/stable-release-security-gate.json
 
       - name: Upload independent security evidence
-        uses: actions/upload-artifact@b7c4aadc2c921a8ff42c1c6b0e8950fc060e7c7e # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: stable-release-security-gate
           path: security-gate/stable-release-security-gate.json

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@automagik/genie",
 
-  "version": "5.260725.8",
+  "version": "5.260725.10",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
 
   "license": "MIT",

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260725.8",
+  "version": "5.260725.10",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/.codex-plugin/plugin.json
+++ b/plugins/genie/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260725.8",
+  "version": "5.260725.10",
   "description": "Plan, execute, review, and ship software with Genie workflows in Codex.",
   "author": {
     "name": "Namastex Labs",

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "5.260725.8",
+  "version": "5.260725.10",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "license": "MIT",

--- a/plugins/hermes-genie/plugin.yaml
+++ b/plugins/hermes-genie/plugin.yaml
@@ -1,5 +1,5 @@
 name: genie
-version: 5.260725.8
+version: 5.260725.10
 description: "Native Hermes surface for Genie orchestration: read-only status plus work-plan and review-plan gap tools that the MCP board surface does not cover, hooks, commands, and a thin cockpit skill. Board/task truth comes from the genie MCP tools."
 provides_tools:
   # Default surface: exactly the three gap tools the MCP board surface does not cover.


### PR DESCRIPTION
Promotes two dev commits to `main`. **Required for effect** — `release-publish.yml` executes from `main`, so the pin fix is inert until this merges.

## What it carries

**`fix(release)`: `actions/upload-artifact` was pinned to a SHA that does not exist.** `b7c4aadc…` resolves to no commit in `actions/upload-artifact`, so all 8 usages failed instantly with `Unable to resolve action`, taking down *Build canonical delivery descriptors*, *Independent candidate security gate*, and *Require complete Codex native dogfood matrix*. Replaced with `ea165f8d…` — the real v4 tag, matching the file's own `# v4` comment and the `download-artifact@…# v4` pin already beside it.

Audited **every** pinned action across all workflows and composite actions against the GitHub API: 10 unique pins, this was the only unresolvable one.

**`chore(release)`: tag-orphan alarm re-enabled.** Its header required verification against a fresh sample; manual dispatch `30178531358` detected exactly the 8 genuine orphans (`v5.260725.1`–`.8`) and filed #2651–#2658, zero false positives. That alarm is the reason this outage went five days without automatic detection.

## Progress on v5.260725.10

The `TRIGGER_SHA` fix **worked** — sign-attest passed for the first time and the chain advanced past the wall it hit four times. It then died in the publish-side jobs that PR #2624 added and that had never executed. This is that shakeout, exactly as flagged.

Also verified statically for this pass: artifact upload/download pairing and every referenced script path resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the Genie plugin version to **5.260725.10** across all published metadata.

* **Reliability**
  * Re-enabled automated release monitoring every 30 minutes to detect orphaned release tags.

* **Maintenance**
  * Updated the artifact-upload tooling used during release evidence collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->