### PR TITLE
chore: rolling promotion dev -> main (publish-side first-run fixes)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "5.260725.12",
+      "version": "5.260725.13",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "5.260725.11",
+      "version": "5.260725.12",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "5.260725.13",
+      "version": "5.260726.1",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "5.260725.10",
+      "version": "5.260725.11",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,25 @@ jobs:
           GITHUB_DEFAULT_BRANCH: main
           GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
 
+  # A 40-hex pin is not proof the SHA exists. actions/upload-artifact was pinned
+  # to b7c4aadc..., which resolves to no commit anywhere; it passed every static
+  # lint and failed only when the job first executed, taking down three
+  # release-publish jobs mid-outage. This resolves every pin against the API so
+  # that class fails here instead of in a release.
+  action-pins:
+    name: Action Pin Resolvability
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Resolve every pinned action SHA
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/check-action-pins.sh
+
   # The survivor gate — the same battery `bun run check` runs locally, plus a
   # build. v5 is a zero-daemon CLI over `.genie/genie.db`; there is no resident
   # database daemon, no TUI, and no generated tmux theme, so the whole suite

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -343,6 +343,12 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: delivery-candidate-manifests
+          # `.well-known` is a dot-directory. actions/upload-artifact defaults
+          # include-hidden-files to false, which makes @actions/glob skip the
+          # traversal root itself (internal-globber.ts drops any item whose
+          # basename matches /^\./), so the manifests the previous step just
+          # wrote resolve to zero matches and `if-no-files-found: error` fires.
+          include-hidden-files: true
           path: candidate-manifests/.well-known/*.json
           if-no-files-found: error
           retention-days: 1

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@automagik/genie",
 
-  "version": "5.260725.12",
+  "version": "5.260725.13",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
 
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@automagik/genie",
 
-  "version": "5.260725.10",
+  "version": "5.260725.11",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
 
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@automagik/genie",
 
-  "version": "5.260725.11",
+  "version": "5.260725.12",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
 
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@automagik/genie",
 
-  "version": "5.260725.13",
+  "version": "5.260726.1",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
 
   "license": "MIT",

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260725.11",
+  "version": "5.260725.12",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260725.10",
+  "version": "5.260725.11",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260725.13",
+  "version": "5.260726.1",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260725.12",
+  "version": "5.260725.13",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/.codex-plugin/plugin.json
+++ b/plugins/genie/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260725.13",
+  "version": "5.260726.1",
   "description": "Plan, execute, review, and ship software with Genie workflows in Codex.",
   "author": {
     "name": "Namastex Labs",

--- a/plugins/genie/.codex-plugin/plugin.json
+++ b/plugins/genie/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260725.10",
+  "version": "5.260725.11",
   "description": "Plan, execute, review, and ship software with Genie workflows in Codex.",
   "author": {
     "name": "Namastex Labs",

--- a/plugins/genie/.codex-plugin/plugin.json
+++ b/plugins/genie/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260725.11",
+  "version": "5.260725.12",
   "description": "Plan, execute, review, and ship software with Genie workflows in Codex.",
   "author": {
     "name": "Namastex Labs",

--- a/plugins/genie/.codex-plugin/plugin.json
+++ b/plugins/genie/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260725.12",
+  "version": "5.260725.13",
   "description": "Plan, execute, review, and ship software with Genie workflows in Codex.",
   "author": {
     "name": "Namastex Labs",

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "5.260725.10",
+  "version": "5.260725.11",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "license": "MIT",

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "5.260725.12",
+  "version": "5.260725.13",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "license": "MIT",

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "5.260725.11",
+  "version": "5.260725.12",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "license": "MIT",

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "5.260725.13",
+  "version": "5.260726.1",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "license": "MIT",

--- a/plugins/hermes-genie/plugin.yaml
+++ b/plugins/hermes-genie/plugin.yaml
@@ -1,5 +1,5 @@
 name: genie
-version: 5.260725.13
+version: 5.260726.1
 description: "Native Hermes surface for Genie orchestration: read-only status plus work-plan and review-plan gap tools that the MCP board surface does not cover, hooks, commands, and a thin cockpit skill. Board/task truth comes from the genie MCP tools."
 provides_tools:
   # Default surface: exactly the three gap tools the MCP board surface does not cover.

--- a/plugins/hermes-genie/plugin.yaml
+++ b/plugins/hermes-genie/plugin.yaml
@@ -1,5 +1,5 @@
 name: genie
-version: 5.260725.12
+version: 5.260725.13
 description: "Native Hermes surface for Genie orchestration: read-only status plus work-plan and review-plan gap tools that the MCP board surface does not cover, hooks, commands, and a thin cockpit skill. Board/task truth comes from the genie MCP tools."
 provides_tools:
   # Default surface: exactly the three gap tools the MCP board surface does not cover.

--- a/plugins/hermes-genie/plugin.yaml
+++ b/plugins/hermes-genie/plugin.yaml
@@ -1,5 +1,5 @@
 name: genie
-version: 5.260725.10
+version: 5.260725.11
 description: "Native Hermes surface for Genie orchestration: read-only status plus work-plan and review-plan gap tools that the MCP board surface does not cover, hooks, commands, and a thin cockpit skill. Board/task truth comes from the genie MCP tools."
 provides_tools:
   # Default surface: exactly the three gap tools the MCP board surface does not cover.

--- a/plugins/hermes-genie/plugin.yaml
+++ b/plugins/hermes-genie/plugin.yaml
@@ -1,5 +1,5 @@
 name: genie
-version: 5.260725.11
+version: 5.260725.12
 description: "Native Hermes surface for Genie orchestration: read-only status plus work-plan and review-plan gap tools that the MCP board surface does not cover, hooks, commands, and a thin cockpit skill. Board/task truth comes from the genie MCP tools."
 provides_tools:
   # Default surface: exactly the three gap tools the MCP board surface does not cover.

--- a/scripts/check-action-pins.sh
+++ b/scripts/check-action-pins.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Verify every pinned GitHub Action SHA actually resolves to a commit.
+#
+# Pinning to a 40-hex SHA is necessary but not sufficient: a typo'd or
+# hallucinated SHA is still "pinned" and passes every static lint, then fails
+# at runtime with "Unable to resolve action". That is exactly what happened on
+# 2026-07-25 — actions/upload-artifact was pinned to b7c4aadc…, which exists in
+# no repository, and it took down three release-publish jobs the first time
+# they ever executed.
+#
+# Usage: bash scripts/check-action-pins.sh   (needs gh auth; network required)
+set -euo pipefail
+
+status=0
+declare -a seen=()
+
+while IFS= read -r line; do
+  file="${line%%:*}"
+  rest="${line#*:}"
+  [[ "$rest" =~ uses:[[:space:]]*([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)(/[A-Za-z0-9./_-]+)?@([0-9a-f]{40}) ]] || continue
+  repo="${BASH_REMATCH[1]}"
+  sha="${BASH_REMATCH[3]}"
+  key="${repo}@${sha}"
+  for s in ${seen[@]+"${seen[@]}"}; do [[ "$s" == "$key" ]] && continue 2; done
+  seen+=("$key")
+  if gh api "repos/${repo}/commits/${sha}" --jq .sha >/dev/null 2>&1; then
+    printf '  ok           %s\n' "$key"
+  else
+    printf '  UNRESOLVABLE %s  (%s)\n' "$key" "$file" >&2
+    status=1
+  fi
+done < <(grep -rn "uses:" .github/workflows .github/actions 2>/dev/null || true)
+
+if [[ "$status" -ne 0 ]]; then
+  echo "::error ::one or more actions are pinned to a SHA that does not exist" >&2
+fi
+exit "$status"

--- a/scripts/validate-live-dogfood-evidence.ts
+++ b/scripts/validate-live-dogfood-evidence.ts
@@ -196,8 +196,27 @@ function validateProvenance(errors: string[], label: string, value: unknown, com
     COMMIT_SHA,
     'a 40-character lowercase commit sha',
   );
-  if (channel === 'stable') same(errors, `${label}.sourceBranch`, provenance.sourceBranch, 'main');
-  else same(errors, `${label}.sourceBranch`, provenance.sourceBranch, channel);
+  // Delivery-era provenance carries the release inputs the orchestrator
+  // admitted, so its branch is bound to its channel (`admit` accepts only
+  // stable:main / homolog:homolog / dev:dev).
+  //
+  // Legacy release-tarball provenance is the generic SLSA statement of an
+  // ALREADY-PUBLISHED release, so its branch records where that release was
+  // BUILT, not the channel it was later promoted into. A stable release
+  // promotes an already-published dev prerelease and preserves its immutable
+  // signed bytes, so the previous stable N legitimately carries sourceBranch
+  // "dev" while its manifest channel is "stable" — v5.260720.10, the currently
+  // pinned N, is exactly this. Demanding "main" there is unsatisfiable; accept
+  // any branch the release chain admits instead.
+  if (provenance.kind === 'release-tarball') {
+    if (!['main', 'homolog', 'dev'].includes(String(provenance.sourceBranch))) {
+      errors.push(`${label}.sourceBranch must be main, homolog, or dev`);
+    }
+  } else if (channel === 'stable') {
+    same(errors, `${label}.sourceBranch`, provenance.sourceBranch, 'main');
+  } else {
+    same(errors, `${label}.sourceBranch`, provenance.sourceBranch, channel);
+  }
   if (typeof provenance.sourceCiRunId !== 'string' || !/^(?:0|[1-9]\d*)$/.test(provenance.sourceCiRunId)) {
     errors.push(`${label}.sourceCiRunId must be an unsigned decimal string`);
   }

--- a/tests/support/codex-dogfood-harness.ts
+++ b/tests/support/codex-dogfood-harness.ts
@@ -711,19 +711,47 @@ function verifyLegacyReleaseProvenance(input: {
     const statement = JSON.parse(verified) as {
       predicate?: {
         invocation?: {
-          configSource?: { digest?: { sha1?: unknown } };
+          configSource?: { entryPoint?: unknown; digest?: { sha1?: unknown } };
           parameters?: { event_inputs?: Record<string, unknown> };
+          environment?: { github_event_payload?: { workflow_run?: Record<string, unknown> } };
         };
       };
     };
-    const parameters = statement.predicate?.invocation?.parameters?.event_inputs;
-    const controlCommit = statement.predicate?.invocation?.configSource?.digest?.sha1;
-    const facts = {
-      sourceCommit: parameters?.source_sha,
-      sourceBranch: parameters?.source_branch,
-      sourceCiRunId: parameters?.source_ci_run_id,
-      controlCommit,
-    };
+    const invocation = statement.predicate?.invocation;
+    const controlCommit = invocation?.configSource?.digest?.sha1;
+    // Two provenance shapes reach this leg, exactly as
+    // scripts/release-generic-provenance.sh `verify_reusable` (run just above)
+    // discriminates them by entryPoint. A stable release.yml dispatch records
+    // the release identity in `event_inputs`; an automated version.yml run is a
+    // `workflow_run` and records it in the triggering CI event payload instead.
+    //
+    // The previous stable N is routinely the automated shape: a stable release
+    // promotes an already-published dev prerelease and preserves its immutable
+    // signed bytes (see release-publish.yml "Promotions must endorse the
+    // already-published immutable subject bytes" and reconcile-release-note.sh
+    // stable finalize), so N's generic provenance stays the dev build's.
+    // Reading only `event_inputs` therefore yields undefined for every real N.
+    const entryPoint = invocation?.configSource?.entryPoint;
+    let facts: Record<string, unknown>;
+    if (entryPoint === '.github/workflows/release.yml') {
+      const parameters = invocation?.parameters?.event_inputs;
+      facts = {
+        sourceCommit: parameters?.source_sha,
+        sourceBranch: parameters?.source_branch,
+        sourceCiRunId: parameters?.source_ci_run_id,
+        controlCommit,
+      };
+    } else if (entryPoint === '.github/workflows/version.yml') {
+      const run = invocation?.environment?.github_event_payload?.workflow_run;
+      facts = {
+        sourceCommit: run?.head_sha,
+        sourceBranch: run?.head_branch,
+        sourceCiRunId: typeof run?.id === 'number' || typeof run?.id === 'string' ? String(run.id) : undefined,
+        controlCommit,
+      };
+    } else {
+      throw new Error('verified previous-release provenance has an unknown release entry point');
+    }
     if (
       typeof facts.sourceCommit !== 'string' ||
       !/^[0-9a-f]{40}$/.test(facts.sourceCommit) ||

--- a/tests/support/codex-dogfood-harness.ts
+++ b/tests/support/codex-dogfood-harness.ts
@@ -437,7 +437,18 @@ function verifyGeneration(
   const tree = scanPhysicalTree(payloadPath);
   if (tree.status !== 'ok' || tree.digest === undefined) throw new Error(`${label} extracted payload is invalid`);
   const binarySha256 = sha256File(binaryPath);
-  verifyCapability(binaryPath, manifest.version, binarySha256, executionAdapter, root);
+  // `genie update --print-update-capabilities` is part of the delivery-era CLI
+  // surface, so only a generation authenticated by a delivery descriptor is
+  // required to expose it. The previous stable N is authenticated by legacy
+  // SLSA provenance precisely because it predates that surface: N is pinned to
+  // `.well-known/latest.json` (v5.260720.10), which is older than the commit
+  // that added the flag, and N only advances on a stable release that must
+  // itself pass this gate. Probing N therefore deadlocks every channel.
+  // N still has to execute natively — runLifecycle runs its binary and
+  // requires it to report N's own version as the active parent.
+  if (paths.identityKind === 'delivery-descriptor') {
+    verifyCapability(binaryPath, manifest.version, binarySha256, executionAdapter, root);
+  }
 
   const bound = bindExtractedGeneration({
     label,

--- a/tests/support/codex-dogfood-harness.ts
+++ b/tests/support/codex-dogfood-harness.ts
@@ -956,6 +956,15 @@ function installGeneration(generation: VerifiedGeneration, genieHome: string): s
   chmodSync(binary, 0o755);
   cpSync(generation.payloadPath, payload, { recursive: true });
   writeFileSync(join(genieHome, 'VERSION'), `${generation.facts.version}\n`);
+  // A real release binary resolves its own version from the VERSION file
+  // ADJACENT to the executable, which in the live layout is
+  // `$GENIE_HOME/bin/VERSION` — scripts/install-swap.test.ts asserts exactly
+  // that path. Writing only `$GENIE_HOME/VERSION` leaves the installed
+  // generation reporting "0.0.0-unknown", so runLifecycle's first assertion
+  // (that N is the active parent) can never hold for a real published
+  // tarball. The CI fixture hides this: its stand-in binary is a generated
+  // shim that hard-codes its version string instead of reading VERSION.
+  writeFileSync(join(dirname(binary), 'VERSION'), `${generation.facts.version}\n`);
   if (sha256File(binary) !== generation.binarySha256) throw new Error('installed generation binary digest drifted');
   const tree = scanPhysicalTree(payload);
   if (tree.status !== 'ok' || tree.digest !== generation.payloadSha256) {


### PR DESCRIPTION
Promotes five first-run fixes for the publish-side jobs. **Required for effect** — `release-publish.yml` executes from `main`.

## Why five at once

PR #2624 grew `release-publish.yml` from 3 jobs to 10, and nothing ever reached those jobs. Five defects sat latent behind one another, each only observable once the one before it was cleared. That is why this looked like an endless loop: not one bug recurring, but a queue draining one release at a time. They were found by reproducing the jobs **locally** against real published artifacts instead of one release per defect.

| Defect | Root cause |
|---|---|
| Candidate-manifest upload matched **zero files** | `.well-known` is a dot-directory; `upload-artifact` defaults `include-hidden-files: false`, and `@actions/glob` skips a traversal root whose basename starts with `.` — so `if-no-files-found: error` fired on files that were written correctly |
| Previous-release provenance unreadable | Only the `workflow_dispatch` shape was parsed. A stable release promotes an already-published dev prerelease and keeps its immutable bytes, so the real N carries the `workflow_run` shape — every identity field came back `undefined` |
| `sourceBranch` forced to `main` | Correct for delivery-evidence provenance, unsatisfiable for legacy release-tarball provenance, whose branch records where the release was *built* (`dev`), not the channel it was promoted into |
| Capability probe on pre-delivery N — **bootstrap deadlock** | `--print-update-capabilities` postdates N (v5.260720.10). N only advances when a stable release publishes, and stable cannot publish until this job passes. Permanently blocked on every platform |
| `VERSION` written one directory too high | Release binaries read VERSION adjacent to the executable; N answered `0.0.0-unknown` and failed the active-parent assertion |

## Verification

`stable-release-security-gate` was **replayed verbatim** against the run's real artifacts — manifest digest, matrix re-derivation, `verify-release.sh`, `slsa-verifier`, `gh attestation verify`, native/generic cross-check — **all 4 artifacts pass, no independent defect**; its failure was purely the prerequisite guard reacting to defect 1. The dogfood harness was run against the real v5.260720.10 binary on darwin-arm64 and now reaches T's local delivery publication.

Tests: 333 pass / 0 fail across `scripts/` + codex cross-version integration; `tsc --noEmit` clean; all 10 action pins resolve.

## Known-unverified

`actions/attest` and anything downstream of a real Sigstore endorsement cannot be minted locally. Static assessment is sound (predicate type avoids both documented traps, SAN resolves via `job_workflow_ref`, public repo → `publicGoodTrustedRoot`). The next run settles it.

## Follow-ups (not in this PR)

- The dogfood fixture builds N as a shim from the current tree, hard-coding its version and capability report — which is exactly why defects 2–5 hid from CI. It should model a promoted stable N.
- `collectEvidenceFiles` caps traversal at depth 4 and the artifact layout uses exactly 4; one more nesting level breaks it silently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the Genie plugin and package version to **5.260725.13**.

* **Reliability**
  * Improved release artifact handling so hidden manifest files are uploaded correctly.
  * Enhanced validation for legacy release provenance across supported channels.
  * Added checks to verify pinned automation actions resolve successfully.

* **Testing**
  * Updated dogfood validation for legacy provenance, capability checks, and installed binary version detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->