### PR TITLE
fix(mcp): self-heal an additive-lag schema before the readonly validator fails closed

### DIFF
--- a/src/lib/v5/mcp-tools.test.ts
+++ b/src/lib/v5/mcp-tools.test.ts
@@ -19,8 +19,14 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, linkSync, mkdirSync, mkdtempSync, realpathSync, renameSync, rmSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
-import { openDb } from './genie-db.js';
-import { MCP_TOOLS, openReadonlyDb, readonlyDatabaseHandleMatchesPath, resolveProjectContext } from './mcp-tools.js';
+import { isCurrentGenieDb, openDb } from './genie-db.js';
+import {
+  MCP_TOOLS,
+  openReadonlyDb,
+  openReadonlyDbHealingStaleSchema,
+  readonlyDatabaseHandleMatchesPath,
+  resolveProjectContext,
+} from './mcp-tools.js';
 import { createBoard, createTask } from './task-state.js';
 
 let base: string;
@@ -368,5 +374,90 @@ describe('tools serve real state under an ok context', () => {
     };
     expect(payload.counts.total).toBe(1);
     db?.close();
+  });
+});
+
+// ============================================================================
+// openReadonlyDbHealingStaleSchema — additive-lag self-heal (the N→T dogfood
+// regression: a DB stamped by an older build fails isCurrentGenieDb on the
+// readonly path until a write-path open backfills the additive columns, and a
+// pure-MCP consumer never performs one)
+// ============================================================================
+
+describe('openReadonlyDbHealingStaleSchema', () => {
+  /** Rewind a current DB to an older build's shape: same user_version, missing additive columns. */
+  function makeAdditiveLagDb(repo: string): string {
+    seedDb(repo);
+    const path = join(repo, '.genie', 'genie.db');
+    const db = new Database(path);
+    for (const column of ['agent_kind', 'heartbeat_at', 'blocked_by', 'blocked_reason']) {
+      db.exec(`ALTER TABLE tasks DROP COLUMN ${column}`);
+    }
+    db.exec('ALTER TABLE boards DROP COLUMN lanes');
+    db.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+    db.close();
+    return path;
+  }
+
+  test('heals an older build database in place and returns a validating handle', () => {
+    const repo = initRepo(join(base, 'repo'));
+    makeAdditiveLagDb(repo);
+
+    const stale = openReadonlyDb(repo);
+    expect(stale).not.toBeNull();
+    expect(isCurrentGenieDb(stale as Database)).toBe(false);
+    stale?.close();
+
+    const healed = openReadonlyDbHealingStaleSchema(repo);
+    expect(healed).not.toBeNull();
+    expect(isCurrentGenieDb(healed as Database)).toBe(true);
+    // The seeded task is served through the healed handle, additive columns included.
+    const row = (healed as Database).query('SELECT title, wish, agent_kind FROM tasks').get() as {
+      title: string;
+      wish: string;
+      agent_kind: string | null;
+    };
+    expect(row.title).toBe('seed');
+    expect(row.wish).toBe('w');
+    healed?.close();
+
+    // The heal is durable on disk: a plain readonly reopen validates current.
+    const reopened = openReadonlyDb(repo);
+    expect(isCurrentGenieDb(reopened as Database)).toBe(true);
+    reopened?.close();
+  });
+
+  test('accepts the databaseBinding target form the MCP loop passes', () => {
+    const repo = initRepo(join(base, 'repo'));
+    makeAdditiveLagDb(repo);
+    const context = resolveProjectContext(repo);
+    if (context.kind !== 'ok' || context.databaseBinding === undefined) {
+      throw new Error(`expected ok context with binding, got ${context.kind}`);
+    }
+    const healed = openReadonlyDbHealingStaleSchema(context.databaseBinding);
+    expect(healed).not.toBeNull();
+    expect(isCurrentGenieDb(healed as Database)).toBe(true);
+    healed?.close();
+  });
+
+  test('never creates an absent database', () => {
+    const repo = initRepo(join(base, 'repo'));
+    expect(openReadonlyDbHealingStaleSchema(repo)).toBeNull();
+    expect(existsSync(join(repo, '.genie', 'genie.db'))).toBe(false);
+  });
+
+  test('fails closed on a future user_version instead of healing it', () => {
+    const repo = initRepo(join(base, 'repo'));
+    seedDb(repo);
+    const path = join(repo, '.genie', 'genie.db');
+    const db = new Database(path);
+    db.exec('PRAGMA user_version = 99');
+    db.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+    db.close();
+    expect(openReadonlyDbHealingStaleSchema(repo)).toBeNull();
+    // The refusal left the foreign version untouched.
+    const check = new Database(path, { readonly: true });
+    expect((check.query('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(99);
+    check.close();
   });
 });

--- a/src/lib/v5/mcp-tools.ts
+++ b/src/lib/v5/mcp-tools.ts
@@ -18,6 +18,8 @@ import { execFileSync } from 'node:child_process';
 import {
   type ProjectContext,
   type ProjectDatabaseBinding,
+  isCurrentGenieDb,
+  openDb,
   resolveDbPath,
   resolveProjectDatabaseBinding,
 } from './genie-db.js';
@@ -121,6 +123,43 @@ export function openReadonlyDb(
     closeReadonlyDb(db);
     return null;
   }
+}
+
+/**
+ * Read-only open that self-heals an additive-lag schema before failing closed.
+ *
+ * Additive columns land within `user_version = 1` and are backfilled only by
+ * write-path opens (`openDb` → `ensureSchema`), so a database stamped by an
+ * earlier build stays permanently rejected by `isCurrentGenieDb` for a consumer
+ * that only ever reads — exactly the post-update Codex plugin, whose first
+ * contact with the repo is `genie mcp`. When (and only when) a successful
+ * readonly open validates stale, run the same idempotent write-path open every
+ * CLI command already performs, then reopen readonly through the full hardened
+ * binding path.
+ *
+ * An ABSENT database never reaches the write open (`openReadonlyDb` returns
+ * null first), preserving this module's no-create contract. A foreign, future
+ * (`user_version` ≠ current), or malformed database is refused by `openDb`'s
+ * typed guards, so everything that is not additive lag still fails closed.
+ */
+export function openReadonlyDbHealingStaleSchema(target?: string | ProjectDatabaseBinding): Database | null {
+  const db = openReadonlyDb(target);
+  if (db === null) return null;
+  let current = false;
+  try {
+    current = isCurrentGenieDb(db);
+  } catch {
+    closeReadonlyDb(db);
+    return null;
+  }
+  if (current) return db;
+  closeReadonlyDb(db);
+  try {
+    openDb({ path: typeof target === 'object' ? target.physicalPath : resolveDbPath(target) }).close();
+  } catch {
+    return null;
+  }
+  return openReadonlyDb(target);
 }
 
 // ============================================================================

--- a/src/term-commands/mcp.ts
+++ b/src/term-commands/mcp.ts
@@ -38,11 +38,15 @@ const PROTOCOL_VERSION = '2024-11-05';
 export async function runMcpServer(): Promise<void> {
   // Lazy: the read-only bun:sqlite open + tools load here, not at genie startup.
   const mcpTools = await import('../lib/v5/mcp-tools.js');
-  const { isCurrentGenieDb, MCP_TOOLS, openReadonlyDb, resolveProjectContext } = mcpTools;
+  const { isCurrentGenieDb, MCP_TOOLS, openReadonlyDbHealingStaleSchema, resolveProjectContext } = mcpTools;
   const { runMcpServerLoop } = await import('../lib/v5/mcp-server.js');
   await runMcpServerLoop({
     tools: MCP_TOOLS,
-    openReadonlyDb,
+    // Heals an additive-lag schema (older build's DB, same user_version) via the
+    // standard idempotent write-path open before the readonly validator can
+    // fail-close it — the post-update Codex plugin's first contact with a repo
+    // is this server, so no CLI command has had a chance to run the backfill.
+    openReadonlyDb: openReadonlyDbHealingStaleSchema,
     validateReadonlyDb: isCurrentGenieDb,
     // Fail-closed: missing repository context / genie.db / unsupported layouts
     // surface as a typed MCP error instead of a healthy-looking empty board.


### PR DESCRIPTION
## The next stacked defect behind the release outage (found offline, before CI reached it)

With the sigstore fix live, run 30214153213's dogfood jobs stop failing at bundle verification — and the local replay of the same harness (real N=5.260720.10 and T=5.260726.4 artifacts) surfaces what fails next: `genie_board returned an error instead of the sentinel: {"error":"project-database-unavailable"}` on every platform.

### Root cause

Additive nullable columns (`agent_kind`, `heartbeat_at`, `blocked_by`, `blocked_reason`, `boards.lanes`) deliberately stay within `user_version = 1` and are backfilled only by **write-path** opens (`openDb` → `ensureSchema`). The MCP server opens **read-only** and `isCurrentGenieDb` demands the complete current schema — so a DB created by an older build is permanently rejected for a consumer that only ever reads. The post-update Codex plugin is exactly that consumer: its first contact with a repo is `genie mcp`. The dogfood (N creates the DB → update to T → MCP sentinel check) catches this correctly; real users updating genie would hit the same fail-closed MCP until some CLI command happens to touch the repo.

Proven offline: T CLI `genie board` on the N-created DB works (write open migrates); T MCP fail-closes; after one CLI touch T MCP works.

### Fix

`genie mcp` now opens through `openReadonlyDbHealingStaleSchema`: when — and only when — a successful readonly open validates stale, it runs the same idempotent `openDb` write-path open every CLI command already performs, then reopens readonly through the full hardened binding path.

Contracts preserved:
- An **absent** DB never reaches the write open (readonly open returns null first) — the module's no-create contract holds.
- **Foreign / future / malformed** databases are refused by `openDb`'s typed guards and still fail closed (regression test pins `user_version = 99` staying untouched).
- Tools still cannot write; the heal is the standard schema backfill, not a data write.

### Evidence

- Fixed tree's MCP server against a genuine N-created DB (verified missing additive columns): returns the board where T fail-closed.
- 4 new regression tests: durable in-place heal, `databaseBinding` target form (the shape the MCP loop passes), no-create on absent DB, fail-closed on future user_version.
- `bun test src/term-commands/mcp.test.ts src/lib/v5/mcp-tools.test.ts`: 50 pass (includes the lazy-load import-graph probe). Full `bun run check` battery: only failure is the pre-existing macOS-environment `ui-bridge` socket test (needs Linux `ss`).

### Deployment note

This fixes the **candidate binary** (source_sha side): it takes effect for dogfood from dev alone, no main promotion required. Independent of — but sequenced after — promotion PR #2660, which fixes the main-side harness's sigstore verification.