### PR TITLE
fix(release): make the Codex dogfood runners able to execute the real harness

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -519,8 +519,46 @@ jobs:
         with:
           cosign-release: 'v2.4.1'
 
+      # The upstream installer action bootstraps through a linux-amd64 binary,
+      # so it can never run on this job's arm64 runners (darwin-arm64 ENOEXEC,
+      # ubuntu-24.04-arm exit 2). Install the platform-correct release asset
+      # directly, pinned to the upstream SHA256SUM.md ledger for v2.7.1.
       - name: Install slsa-verifier for previous-stable verification
-        uses: slsa-framework/slsa-verifier/actions/installer@ea584f4502babc6f60d9bc799dbbb13c1caa9ee6 # v2.7.1
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "$(uname -s)-$(uname -m)" in
+            Linux-x86_64)  ASSET=slsa-verifier-linux-amd64  SHA256=946dbec729094195e88ef78e1734324a27869f03e2c6bd2f61cbc06bd5350339 ;;
+            Linux-aarch64) ASSET=slsa-verifier-linux-arm64  SHA256=5d3b2349ede7bfec19e7a21569f18b9f7410145ad12e9584b175370669e14061 ;;
+            Darwin-arm64)  ASSET=slsa-verifier-darwin-arm64 SHA256=39abfcf5f1d690c3e889ce3d2d6a8b87711424d83368511868d414e8f8bcb05c ;;
+            *)
+              echo "::error::unsupported runner platform for slsa-verifier: $(uname -s)-$(uname -m)"
+              exit 1
+              ;;
+          esac
+          mkdir -p "${RUNNER_TEMP}/slsa-verifier-bin"
+          curl -fsSL --retry 3 -o "${RUNNER_TEMP}/slsa-verifier-bin/slsa-verifier" \
+            "https://github.com/slsa-framework/slsa-verifier/releases/download/v2.7.1/${ASSET}"
+          echo "${SHA256}  ${RUNNER_TEMP}/slsa-verifier-bin/slsa-verifier" | shasum -a 256 -c -
+          chmod +x "${RUNNER_TEMP}/slsa-verifier-bin/slsa-verifier"
+          echo "${RUNNER_TEMP}/slsa-verifier-bin" >> "$GITHUB_PATH"
+
+      # Ubuntu 24.04 images permit creating unprivileged user namespaces but
+      # AppArmor denies capability use inside them, so the real Codex sandbox
+      # dies at loopback setup ("bwrap: loopback: Failed RTM_NEWADDR"). Lift the
+      # restriction so the dogfood exercises Codex's actual bubblewrap sandbox
+      # instead of disabling it.
+      - name: Allow the Codex bubblewrap sandbox to configure its network namespace
+        if: runner.os == 'Linux'
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+      # The harness fails a capability probe on ANY stderr output, and the
+      # adapter's first `docker run` of an unpulled image streams pull progress
+      # to stderr. Pull the exact pinned digest up front so probe stderr stays
+      # clean. Image pin must match scripts/run-musl-dogfood.sh.
+      - name: Pre-pull the pinned Alpine image for the musl execution adapter
+        if: matrix.execution == 'alpine-container'
+        run: docker pull -q 'alpine:3.19@sha256:6baf43584bcb78f2e5847d1de515f23499913ac9f12bdf834811a3145eb11ca1'
 
       - name: Download exact verified previous-stable inputs
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4


### PR DESCRIPTION
## Why main-first

The dogfood job executes from `github.sha` = **main**, so this fix is inert until it lands here — and landing it on main BEFORE merging to dev means the dev merge fires the first release that can go full green, with zero wasted cycles. A twin PR to dev follows immediately after this merges.

## The three per-platform environment defects (run 30216261391 — the first run past bundle verification and the DB self-heal)

1. **linux-x64-glibc / linux-arm64 — `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`.** Ubuntu 24.04 images permit creating unprivileged user namespaces but AppArmor denies capability use inside them, killing Codex's bubblewrap sandbox at loopback setup. Fix: lift `kernel.apparmor_restrict_unprivileged_userns` on Linux runners so the dogfood exercises Codex's *real* sandbox rather than disabling it.

2. **darwin-arm64 / linux-arm64 — slsa-verifier installer action cannot run on arm64.** Its bootstrap is a linux-amd64 binary: `spawn ENOEXEC` on macOS (failed on *every* darwin run to date), exit 2 on ubuntu-24.04-arm. Fix: install the platform-correct v2.7.1 release asset directly, SHA256-pinned to upstream's checksum ledger and cross-verified against fresh downloads. The other jobs keep the action — they run on amd64 where it works.

3. **linux-x64-musl — capability probe fails on docker pull noise.** The harness fails any probe that writes stderr; the adapter's first `docker run` of the unpulled Alpine image streams pull progress there. Fix: pre-pull the exact pinned digest (same pin as `scripts/run-musl-dogfood.sh`).

## Evidence this is the last dogfood layer

The complete dogfood entry passes offline on darwin-arm64 against the **real signed v5.260726.7 candidate** (which carries both product fixes): `codex-dogfood-entry: OK` — full N→T lifecycle through real Codex 0.144.1, evidence emitted. The publish tail beyond dogfood was independently reviewed clean (verdict SHIP; latent findings filed as #2674/#2675).

Validation: YAML lint clean, all action pins resolve, the four workflow-referencing test files pass (67 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release validation reliability by securely installing the required verification tool.
  * Enabled sandbox networking on supported Linux environments.
  * Preloaded the required Alpine container image when applicable to reduce unnecessary probe output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->