### PR TITLE
fix(release): keep the musl adapter's bootstrap noise off stderr

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "5.260726.5",
+      "version": "5.260726.7",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@automagik/genie",
 
-  "version": "5.260726.5",
+  "version": "5.260726.7",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
 
   "license": "MIT",

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260726.5",
+  "version": "5.260726.7",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/.codex-plugin/plugin.json
+++ b/plugins/genie/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260726.5",
+  "version": "5.260726.7",
   "description": "Plan, execute, review, and ship software with Genie workflows in Codex.",
   "author": {
     "name": "Namastex Labs",

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "5.260726.5",
+  "version": "5.260726.7",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "license": "MIT",

--- a/plugins/hermes-genie/plugin.yaml
+++ b/plugins/hermes-genie/plugin.yaml
@@ -1,5 +1,5 @@
 name: genie
-version: 5.260726.5
+version: 5.260726.7
 description: "Native Hermes surface for Genie orchestration: read-only status plus work-plan and review-plan gap tools that the MCP board surface does not cover, hooks, commands, and a thin cockpit skill. Board/task truth comes from the genie MCP tools."
 provides_tools:
   # Default surface: exactly the three gap tools the MCP board surface does not cover.

--- a/scripts/run-musl-dogfood.sh
+++ b/scripts/run-musl-dogfood.sh
@@ -47,7 +47,11 @@ if ! command -v docker >/dev/null 2>&1; then
   exit 1
 fi
 
-docker_args=(run --rm --pull=always -i --security-opt no-new-privileges)
+# The image reference is digest-pinned, so pull-if-missing already guarantees
+# exact bytes; `--pull=always` would re-resolve the manifest on EVERY run and
+# write pull progress to stderr, which the harness's stderr-strict capability
+# probe treats as failure. The dogfood workflow pre-pulls the digest.
+docker_args=(run --rm -i --security-opt no-new-privileges)
 container_candidate="/candidate/${candidate_name}"
 
 # The one-shot capability probe needs only a read-only candidate directory.
@@ -91,7 +95,10 @@ if [[ -t 0 && -t 1 ]]; then docker_args+=(-t); fi
 exec docker "${docker_args[@]}" \
   "$ALPINE_IMAGE" \
   sh -ec '
-    apk add --no-cache bash git libstdc++ >/dev/null
+    # Bootstrap noise must never reach stderr: the probe fails on any stderr
+    # byte, and only the candidate binary output is meaningful to it. apk
+    # failures still abort through set -e.
+    apk add --no-cache bash git libstdc++ >/dev/null 2>&1
     candidate=$1
     shift
     exec "$candidate" "$@"

--- a/scripts/run-musl-dogfood.test.ts
+++ b/scripts/run-musl-dogfood.test.ts
@@ -50,7 +50,10 @@ describe('musl dogfood execution adapter', () => {
     );
     expect(result.exitCode).toBe(0);
     const args = readFileSync(fx.log, 'utf8').split('\n');
-    expect(args).toContain('--pull=always');
+    // Digest-pinned image + pull-if-missing: `--pull=always` would re-resolve
+    // the manifest every run and write pull progress to stderr, failing the
+    // harness's stderr-strict capability probe.
+    expect(args).not.toContain('--pull=always');
     expect(args).toContain('alpine:3.19@sha256:6baf43584bcb78f2e5847d1de515f23499913ac9f12bdf834811a3145eb11ca1');
     expect(args).toContain(`type=bind,src=${fx.root},dst=/candidate,readonly`);
     expect(args).toContain('$(touch should-not-exist); spaced');

--- a/src/lib/v5/mcp-tools.test.ts
+++ b/src/lib/v5/mcp-tools.test.ts
@@ -19,8 +19,14 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, linkSync, mkdirSync, mkdtempSync, realpathSync, renameSync, rmSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
-import { openDb } from './genie-db.js';
-import { MCP_TOOLS, openReadonlyDb, readonlyDatabaseHandleMatchesPath, resolveProjectContext } from './mcp-tools.js';
+import { isCurrentGenieDb, openDb } from './genie-db.js';
+import {
+  MCP_TOOLS,
+  openReadonlyDb,
+  openReadonlyDbHealingStaleSchema,
+  readonlyDatabaseHandleMatchesPath,
+  resolveProjectContext,
+} from './mcp-tools.js';
 import { createBoard, createTask } from './task-state.js';
 
 let base: string;
@@ -368,5 +374,90 @@ describe('tools serve real state under an ok context', () => {
     };
     expect(payload.counts.total).toBe(1);
     db?.close();
+  });
+});
+
+// ============================================================================
+// openReadonlyDbHealingStaleSchema — additive-lag self-heal (the N→T dogfood
+// regression: a DB stamped by an older build fails isCurrentGenieDb on the
+// readonly path until a write-path open backfills the additive columns, and a
+// pure-MCP consumer never performs one)
+// ============================================================================
+
+describe('openReadonlyDbHealingStaleSchema', () => {
+  /** Rewind a current DB to an older build's shape: same user_version, missing additive columns. */
+  function makeAdditiveLagDb(repo: string): string {
+    seedDb(repo);
+    const path = join(repo, '.genie', 'genie.db');
+    const db = new Database(path);
+    for (const column of ['agent_kind', 'heartbeat_at', 'blocked_by', 'blocked_reason']) {
+      db.exec(`ALTER TABLE tasks DROP COLUMN ${column}`);
+    }
+    db.exec('ALTER TABLE boards DROP COLUMN lanes');
+    db.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+    db.close();
+    return path;
+  }
+
+  test('heals an older build database in place and returns a validating handle', () => {
+    const repo = initRepo(join(base, 'repo'));
+    makeAdditiveLagDb(repo);
+
+    const stale = openReadonlyDb(repo);
+    expect(stale).not.toBeNull();
+    expect(isCurrentGenieDb(stale as Database)).toBe(false);
+    stale?.close();
+
+    const healed = openReadonlyDbHealingStaleSchema(repo);
+    expect(healed).not.toBeNull();
+    expect(isCurrentGenieDb(healed as Database)).toBe(true);
+    // The seeded task is served through the healed handle, additive columns included.
+    const row = (healed as Database).query('SELECT title, wish, agent_kind FROM tasks').get() as {
+      title: string;
+      wish: string;
+      agent_kind: string | null;
+    };
+    expect(row.title).toBe('seed');
+    expect(row.wish).toBe('w');
+    healed?.close();
+
+    // The heal is durable on disk: a plain readonly reopen validates current.
+    const reopened = openReadonlyDb(repo);
+    expect(isCurrentGenieDb(reopened as Database)).toBe(true);
+    reopened?.close();
+  });
+
+  test('accepts the databaseBinding target form the MCP loop passes', () => {
+    const repo = initRepo(join(base, 'repo'));
+    makeAdditiveLagDb(repo);
+    const context = resolveProjectContext(repo);
+    if (context.kind !== 'ok' || context.databaseBinding === undefined) {
+      throw new Error(`expected ok context with binding, got ${context.kind}`);
+    }
+    const healed = openReadonlyDbHealingStaleSchema(context.databaseBinding);
+    expect(healed).not.toBeNull();
+    expect(isCurrentGenieDb(healed as Database)).toBe(true);
+    healed?.close();
+  });
+
+  test('never creates an absent database', () => {
+    const repo = initRepo(join(base, 'repo'));
+    expect(openReadonlyDbHealingStaleSchema(repo)).toBeNull();
+    expect(existsSync(join(repo, '.genie', 'genie.db'))).toBe(false);
+  });
+
+  test('fails closed on a future user_version instead of healing it', () => {
+    const repo = initRepo(join(base, 'repo'));
+    seedDb(repo);
+    const path = join(repo, '.genie', 'genie.db');
+    const db = new Database(path);
+    db.exec('PRAGMA user_version = 99');
+    db.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+    db.close();
+    expect(openReadonlyDbHealingStaleSchema(repo)).toBeNull();
+    // The refusal left the foreign version untouched.
+    const check = new Database(path, { readonly: true });
+    expect((check.query('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(99);
+    check.close();
   });
 });

--- a/src/lib/v5/mcp-tools.test.ts
+++ b/src/lib/v5/mcp-tools.test.ts
@@ -446,6 +446,26 @@ describe('openReadonlyDbHealingStaleSchema', () => {
     expect(existsSync(join(repo, '.genie', 'genie.db'))).toBe(false);
   });
 
+  test('refuses to heal through a binding whose database was substituted', () => {
+    const repo = initRepo(join(base, 'repo'));
+    makeAdditiveLagDb(repo);
+    const context = resolveProjectContext(repo);
+    if (context.kind !== 'ok' || context.databaseBinding === undefined) {
+      throw new Error(`expected ok context with binding, got ${context.kind}`);
+    }
+    const binding = context.databaseBinding;
+    // Replace the bound database with a different file (new inode) after the
+    // binding was captured — the heal must fail closed, never write-open the
+    // substituted file (openDb would otherwise run ensureSchema DDL on it).
+    rmSync(join(repo, '.genie'), { recursive: true, force: true });
+    makeAdditiveLagDb(repo);
+    expect(openReadonlyDbHealingStaleSchema(binding)).toBeNull();
+    // The substituted database was left untouched by any write-path open.
+    const untouched = openReadonlyDb(repo);
+    expect(isCurrentGenieDb(untouched as Database)).toBe(false);
+    untouched?.close();
+  });
+
   test('fails closed on a future user_version instead of healing it', () => {
     const repo = initRepo(join(base, 'repo'));
     seedDb(repo);

--- a/src/lib/v5/mcp-tools.test.ts
+++ b/src/lib/v5/mcp-tools.test.ts
@@ -16,7 +16,17 @@
 import { Database } from 'bun:sqlite';
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { execFileSync } from 'node:child_process';
-import { existsSync, linkSync, mkdirSync, mkdtempSync, realpathSync, renameSync, rmSync, symlinkSync } from 'node:fs';
+import {
+  copyFileSync,
+  existsSync,
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
 import { isCurrentGenieDb, openDb } from './genie-db.js';
@@ -454,11 +464,16 @@ describe('openReadonlyDbHealingStaleSchema', () => {
       throw new Error(`expected ok context with binding, got ${context.kind}`);
     }
     const binding = context.databaseBinding;
-    // Replace the bound database with a different file (new inode) after the
-    // binding was captured — the heal must fail closed, never write-open the
-    // substituted file (openDb would otherwise run ensureSchema DDL on it).
-    rmSync(join(repo, '.genie'), { recursive: true, force: true });
-    makeAdditiveLagDb(repo);
+    // Replace the bound database after the binding was captured — the heal
+    // must fail closed, never write-open the substituted file (openDb would
+    // otherwise run ensureSchema DDL on it). The substitute is created while
+    // the original still exists so it is guaranteed a distinct inode even on
+    // filesystems that recycle inode numbers immediately (ext4), then renamed
+    // over the original — the realistic atomic-swap shape.
+    const dbPath = join(repo, '.genie', 'genie.db');
+    const substitute = join(repo, '.genie', 'genie.db.substitute');
+    copyFileSync(dbPath, substitute);
+    renameSync(substitute, dbPath);
     expect(openReadonlyDbHealingStaleSchema(binding)).toBeNull();
     // The substituted database was left untouched by any write-path open.
     const untouched = openReadonlyDb(repo);

--- a/src/lib/v5/mcp-tools.ts
+++ b/src/lib/v5/mcp-tools.ts
@@ -155,7 +155,18 @@ export function openReadonlyDbHealingStaleSchema(target?: string | ProjectDataba
   if (current) return db;
   closeReadonlyDb(db);
   try {
-    openDb({ path: typeof target === 'object' ? target.physicalPath : resolveDbPath(target) }).close();
+    if (typeof target === 'object') {
+      // The validated readonly handle is closed, so nothing pins the path's
+      // identity while openDb creates a WRITABLE handle. Revalidate the exact
+      // binding at the last moment so a racing substitution cannot route
+      // ensureSchema's DDL into a swapped file or symlink target; the
+      // post-heal hardened reopen below re-verifies both the binding and the
+      // opened handle before any tool can observe a healed database.
+      if (!resolveProjectDatabaseBinding(target.logicalPath, target).ok) return null;
+      openDb({ path: target.physicalPath }).close();
+    } else {
+      openDb({ path: resolveDbPath(target) }).close();
+    }
   } catch {
     return null;
   }

--- a/src/lib/v5/mcp-tools.ts
+++ b/src/lib/v5/mcp-tools.ts
@@ -18,6 +18,8 @@ import { execFileSync } from 'node:child_process';
 import {
   type ProjectContext,
   type ProjectDatabaseBinding,
+  isCurrentGenieDb,
+  openDb,
   resolveDbPath,
   resolveProjectDatabaseBinding,
 } from './genie-db.js';
@@ -121,6 +123,43 @@ export function openReadonlyDb(
     closeReadonlyDb(db);
     return null;
   }
+}
+
+/**
+ * Read-only open that self-heals an additive-lag schema before failing closed.
+ *
+ * Additive columns land within `user_version = 1` and are backfilled only by
+ * write-path opens (`openDb` → `ensureSchema`), so a database stamped by an
+ * earlier build stays permanently rejected by `isCurrentGenieDb` for a consumer
+ * that only ever reads — exactly the post-update Codex plugin, whose first
+ * contact with the repo is `genie mcp`. When (and only when) a successful
+ * readonly open validates stale, run the same idempotent write-path open every
+ * CLI command already performs, then reopen readonly through the full hardened
+ * binding path.
+ *
+ * An ABSENT database never reaches the write open (`openReadonlyDb` returns
+ * null first), preserving this module's no-create contract. A foreign, future
+ * (`user_version` ≠ current), or malformed database is refused by `openDb`'s
+ * typed guards, so everything that is not additive lag still fails closed.
+ */
+export function openReadonlyDbHealingStaleSchema(target?: string | ProjectDatabaseBinding): Database | null {
+  const db = openReadonlyDb(target);
+  if (db === null) return null;
+  let current = false;
+  try {
+    current = isCurrentGenieDb(db);
+  } catch {
+    closeReadonlyDb(db);
+    return null;
+  }
+  if (current) return db;
+  closeReadonlyDb(db);
+  try {
+    openDb({ path: typeof target === 'object' ? target.physicalPath : resolveDbPath(target) }).close();
+  } catch {
+    return null;
+  }
+  return openReadonlyDb(target);
 }
 
 // ============================================================================

--- a/src/term-commands/mcp.ts
+++ b/src/term-commands/mcp.ts
@@ -38,11 +38,15 @@ const PROTOCOL_VERSION = '2024-11-05';
 export async function runMcpServer(): Promise<void> {
   // Lazy: the read-only bun:sqlite open + tools load here, not at genie startup.
   const mcpTools = await import('../lib/v5/mcp-tools.js');
-  const { isCurrentGenieDb, MCP_TOOLS, openReadonlyDb, resolveProjectContext } = mcpTools;
+  const { isCurrentGenieDb, MCP_TOOLS, openReadonlyDbHealingStaleSchema, resolveProjectContext } = mcpTools;
   const { runMcpServerLoop } = await import('../lib/v5/mcp-server.js');
   await runMcpServerLoop({
     tools: MCP_TOOLS,
-    openReadonlyDb,
+    // Heals an additive-lag schema (older build's DB, same user_version) via the
+    // standard idempotent write-path open before the readonly validator can
+    // fail-close it — the post-update Codex plugin's first contact with a repo
+    // is this server, so no CLI command has had a chance to run the backfill.
+    openReadonlyDb: openReadonlyDbHealingStaleSchema,
     validateReadonlyDb: isCurrentGenieDb,
     // Fail-closed: missing repository context / genie.db / unsupported layouts
     // surface as a typed MCP error instead of a healthy-looking empty board.


### PR DESCRIPTION
## The last platform standing

Run 30217058060 (v5.260726.8): with the runner-env fixes live, **glibc, linux-arm64, and darwin dogfood all passed** — musl was the only failure, on exactly the class this closes.

The dogfood capability probe fails on any stderr byte. Two bootstrap sources inside `scripts/run-musl-dogfood.sh` violate that before the candidate binary ever runs:

1. `docker run --pull=always` re-resolves the manifest on **every** invocation and writes pull progress to stderr — the workflow's pre-pull step can never help. The image ref is digest-pinned, so pull-if-missing already guarantees exact bytes; the flag added nothing but the failure. Dropped (test updated to pin its absence).
2. `apk add --no-cache` fetches the package index over the network and can emit warnings to stderr. Only the candidate's stderr is meaningful to the probe — bootstrap output is now fully silenced, with `set -e` still aborting on real apk failure.

Main-first because the dogfood job executes the adapter from the main checkout; dev twin follows immediately so its merge fires the (hopefully fully green) release.

Validation: `bun test scripts/run-musl-dogfood.test.ts` 3 pass, `bash -n` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MCP database access by automatically repairing compatible, outdated schemas before read-only operations.
  - Added fail-closed handling for missing databases, future schema versions, and unrecoverable validation errors.
  - Reduced Alpine capability-probe noise by suppressing package-install output and avoiding repeated image pulls.

- **Tests**
  - Added coverage for schema repair, database binding support, and safe failure scenarios.

- **Chores**
  - Updated the Genie plugin and package version to 5.260726.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->