### PR TITLE
fix(orphan-alert): treat closed incidents as operator ack — never refile

### DIFF
--- a/.github/workflows/release-orphan-alert.yml
+++ b/.github/workflows/release-orphan-alert.yml
@@ -104,13 +104,21 @@ jobs:
 
           echo "::warning::detected ${#ORPHANS[@]} orphan tag(s): ${ORPHANS[*]}"
 
-          # Open a release-incident issue for each orphan tag, unless
-          # an open issue with the same title already exists (idempotent).
+          # Open a release-incident issue for each orphan tag, unless an
+          # issue with the same exact title already exists in ANY state
+          # (idempotent). Closed issues count: closing an incident is an
+          # operator ack that the orphan tag is understood debris
+          # (versions auto-increment; pre-fanout failures are never
+          # re-dispatched — issue #2674), so the alarm must not refile
+          # it while the tag is still inside the 24h window. Exact-title
+          # grep (not search-substring) so v5.X.1 never suppresses v5.X.12.
           for TAG in "${ORPHANS[@]}"; do
             TITLE="release-incident: ${TAG} has no Release object"
-            EXISTS=$(gh issue list --repo "$REPO" --state open --search "$TITLE in:title" --json number --jq 'length')
+            EXISTS=$(gh issue list --repo "$REPO" --state all --limit 100 \
+              --search "\"$TITLE\" in:title" --json title --jq '.[].title' \
+              | grep -Fxc "$TITLE" || true)
             if [[ "$EXISTS" -gt 0 ]]; then
-              echo "issue already open for ${TAG}; skipping"
+              echo "issue already filed for ${TAG} (open or acked-closed); skipping"
               continue
             fi
             gh issue create \

--- a/.github/workflows/release-orphan-alert.yml
+++ b/.github/workflows/release-orphan-alert.yml
@@ -120,9 +120,16 @@ jobs:
             # an acknowledged incident. Only grep's no-match is expected.
             KNOWN_TITLES=$(gh issue list --repo "$REPO" --state all --limit 100 \
               --search "\"$TITLE\" in:title" --json title --jq '.[].title')
-            if grep -Fxq "$TITLE" <<<"$KNOWN_TITLES"; then
+            # Fail closed on the match too: only status 1 means "not found";
+            # anything else (grep error) must abort, never file a duplicate.
+            MATCH_STATUS=0
+            grep -Fxq "$TITLE" <<<"$KNOWN_TITLES" || MATCH_STATUS=$?
+            if [[ "$MATCH_STATUS" -eq 0 ]]; then
               echo "issue already filed for ${TAG} (open or acked-closed); skipping"
               continue
+            elif [[ "$MATCH_STATUS" -ne 1 ]]; then
+              echo "::error::issue-title match for ${TAG} failed with status ${MATCH_STATUS}"
+              exit "$MATCH_STATUS"
             fi
             gh issue create \
               --repo "$REPO" \

--- a/.github/workflows/release-orphan-alert.yml
+++ b/.github/workflows/release-orphan-alert.yml
@@ -114,10 +114,13 @@ jobs:
           # grep (not search-substring) so v5.X.1 never suppresses v5.X.12.
           for TAG in "${ORPHANS[@]}"; do
             TITLE="release-incident: ${TAG} has no Release object"
-            EXISTS=$(gh issue list --repo "$REPO" --state all --limit 100 \
-              --search "\"$TITLE\" in:title" --json title --jq '.[].title' \
-              | grep -Fxc "$TITLE" || true)
-            if [[ "$EXISTS" -gt 0 ]]; then
+            # The lookup must fail loudly (set -e aborts on the assignment):
+            # a transient API/rate-limit error killing the job is safer than
+            # an empty result being read as "no issue exists" and refiling
+            # an acknowledged incident. Only grep's no-match is expected.
+            KNOWN_TITLES=$(gh issue list --repo "$REPO" --state all --limit 100 \
+              --search "\"$TITLE\" in:title" --json title --jq '.[].title')
+            if grep -Fxq "$TITLE" <<<"$KNOWN_TITLES"; then
               echo "issue already filed for ${TAG} (open or acked-closed); skipping"
               continue
             fi


### PR DESCRIPTION
## Why

Bulk-closing the 2026-07-20→26 outage debris (24 `release-incident` issues) hit a refile trap: the alarm's idempotency check only counts **open** issues, and 13 of the orphan tags (v5.260725.12 → v5.260726.11) are still inside the 24h scan window. Close those issues today and the every-30-min cron refiles them.

## What

One change in the `Scan tags vs releases` step: the EXISTS check goes from `--state open` + substring search to `--state all` + **exact-title** match (`grep -Fx`).

Semantics: **closing a release-incident issue is an operator ack** — the tag is understood debris (versions auto-increment; pre-fanout failures are never re-dispatched, #2674) and must not be refiled while it ages out of the window. Exact-title matching also fixes a latent precision bug: GitHub search tokenizes on punctuation, so `v5.X.1` could previously be confused with `v5.X.12`; `grep -Fxc` counts full-line matches only.

## Verified live before committing

Ran the new check against the real repo:
- closed debris title (`v5.260725.8`, closed today) → EXISTS=1 → skip ✓
- open incident (`v5.260726.10`) → EXISTS=1 → skip ✓
- nonexistent tag (`v5.999999.1`) → EXISTS=0 → would file ✓
- exact-match precision: `v5.260725.1` → EXISTS=1 (not 4, despite `.11/.12/.13` issues existing) ✓

## Choreography

Twin-PR discipline: this main PR merges first (workflow executes from main's default branch on schedule), then the dev twin. Once this is live on main, the remaining 13 in-window incident issues (#2662–#2664, #2670–#2672, #2680–#2682, #2686, #2687, #2689, #2690) get bulk-closed with the v5.260726.12 green-run rationale — already applied to the 11 aged-out ones (#2651–#2658, #2665–#2667).

Dev twin: #2693

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate release-incident issues from being created for orphan tags, including when a matching issue was previously closed.
  * Improved existing-issue detection by using an exact, title-scoped match across issue states, and safely skipping creation when a match is found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->