### PR TITLE
fix(orphan-alert): treat closed incidents as operator ack — never refile (dev twin)

### DIFF
--- a/.github/workflows/release-orphan-alert.yml
+++ b/.github/workflows/release-orphan-alert.yml
@@ -104,13 +104,21 @@ jobs:
 
           echo "::warning::detected ${#ORPHANS[@]} orphan tag(s): ${ORPHANS[*]}"
 
-          # Open a release-incident issue for each orphan tag, unless
-          # an open issue with the same title already exists (idempotent).
+          # Open a release-incident issue for each orphan tag, unless an
+          # issue with the same exact title already exists in ANY state
+          # (idempotent). Closed issues count: closing an incident is an
+          # operator ack that the orphan tag is understood debris
+          # (versions auto-increment; pre-fanout failures are never
+          # re-dispatched — issue #2674), so the alarm must not refile
+          # it while the tag is still inside the 24h window. Exact-title
+          # grep (not search-substring) so v5.X.1 never suppresses v5.X.12.
           for TAG in "${ORPHANS[@]}"; do
             TITLE="release-incident: ${TAG} has no Release object"
-            EXISTS=$(gh issue list --repo "$REPO" --state open --search "$TITLE in:title" --json number --jq 'length')
+            EXISTS=$(gh issue list --repo "$REPO" --state all --limit 100 \
+              --search "\"$TITLE\" in:title" --json title --jq '.[].title' \
+              | grep -Fxc "$TITLE" || true)
             if [[ "$EXISTS" -gt 0 ]]; then
-              echo "issue already open for ${TAG}; skipping"
+              echo "issue already filed for ${TAG} (open or acked-closed); skipping"
               continue
             fi
             gh issue create \

--- a/.github/workflows/release-orphan-alert.yml
+++ b/.github/workflows/release-orphan-alert.yml
@@ -120,9 +120,16 @@ jobs:
             # an acknowledged incident. Only grep's no-match is expected.
             KNOWN_TITLES=$(gh issue list --repo "$REPO" --state all --limit 100 \
               --search "\"$TITLE\" in:title" --json title --jq '.[].title')
-            if grep -Fxq "$TITLE" <<<"$KNOWN_TITLES"; then
+            # Fail closed on the match too: only status 1 means "not found";
+            # anything else (grep error) must abort, never file a duplicate.
+            MATCH_STATUS=0
+            grep -Fxq "$TITLE" <<<"$KNOWN_TITLES" || MATCH_STATUS=$?
+            if [[ "$MATCH_STATUS" -eq 0 ]]; then
               echo "issue already filed for ${TAG} (open or acked-closed); skipping"
               continue
+            elif [[ "$MATCH_STATUS" -ne 1 ]]; then
+              echo "::error::issue-title match for ${TAG} failed with status ${MATCH_STATUS}"
+              exit "$MATCH_STATUS"
             fi
             gh issue create \
               --repo "$REPO" \

--- a/.github/workflows/release-orphan-alert.yml
+++ b/.github/workflows/release-orphan-alert.yml
@@ -114,10 +114,13 @@ jobs:
           # grep (not search-substring) so v5.X.1 never suppresses v5.X.12.
           for TAG in "${ORPHANS[@]}"; do
             TITLE="release-incident: ${TAG} has no Release object"
-            EXISTS=$(gh issue list --repo "$REPO" --state all --limit 100 \
-              --search "\"$TITLE\" in:title" --json title --jq '.[].title' \
-              | grep -Fxc "$TITLE" || true)
-            if [[ "$EXISTS" -gt 0 ]]; then
+            # The lookup must fail loudly (set -e aborts on the assignment):
+            # a transient API/rate-limit error killing the job is safer than
+            # an empty result being read as "no issue exists" and refiling
+            # an acknowledged incident. Only grep's no-match is expected.
+            KNOWN_TITLES=$(gh issue list --repo "$REPO" --state all --limit 100 \
+              --search "\"$TITLE\" in:title" --json title --jq '.[].title')
+            if grep -Fxq "$TITLE" <<<"$KNOWN_TITLES"; then
               echo "issue already filed for ${TAG} (open or acked-closed); skipping"
               continue
             fi


### PR DESCRIPTION
Dev twin of #2692 (same one-file patch; branches were identical on this file). Merge order per twin-PR discipline: #2692 lands on main first, main's CI push run completes, then this merges — and the merge fires the next dev release.

See #2692 for full rationale and the live verification evidence.