### PR TITLE
docs: teach reader-boundary documentation (landing #2595)

### DIFF
--- a/plugins/genie/skills/docs/SKILL.md
+++ b/plugins/genie/skills/docs/SKILL.md
@@ -43,4 +43,5 @@ Example brief: "Audit README.md, CLAUDE.md, and skills/work/SKILL.md after PR #7
 ## Rules
 - Grounded progress: report only what was audited or generated in this session, each claim backed by a check actually run — "3 files verified current, 1 updated, 0 dead references", never just "docs written".
 - No fiction: never document features that don't exist yet; no dead paths or APIs.
+- Write to the reader's interface boundary: explain what they need to decide, do, observe, and verify. Prefer observable promises, outcomes, failure behavior, and next steps over internal machinery. Include implementation details only when the reader needs them to use the feature safely, troubleshoot it, or extend it; otherwise keep that mechanism in internal or architecture documentation.
 - Match existing project conventions for style and structure.

--- a/plugins/genie/skills/dx-docs/SKILL.md
+++ b/plugins/genie/skills/dx-docs/SKILL.md
@@ -48,6 +48,7 @@ Lead with a one-sentence verdict: did the repo pass its contributor test, and wh
 ## Pitfalls
 
 - Never evaluate docs by reading them — a page can read beautifully and be unfollowable; every "docs are good" claim must trace to a followed procedure.
+- Treat mechanism leakage as reader friction. If a reader can act safely from an observable promise, do not require them to learn internal components, protocols, state, or recovery machinery. Keep details only when they change a decision, safety boundary, troubleshooting step, or extension point; move the rest to internal explanation or architecture docs.
 - Internal-only docs deliberately excluded from a public site are design, not gaps — check the exclusion mechanism before reporting "missing" pages.
 - If docs live in a submodule or separate repo, a fix recommendation that says "edit and commit here" strands changes — name the real workflow in the fix.
 - Agent-context files (CLAUDE.md and kin) drifting from the product is real drift, but its fix lands in this repo, not the docs pipeline — route the two drift classes separately.

--- a/skills/docs/SKILL.md
+++ b/skills/docs/SKILL.md
@@ -43,4 +43,5 @@ Example brief: "Audit README.md, CLAUDE.md, and skills/work/SKILL.md after PR #7
 ## Rules
 - Grounded progress: report only what was audited or generated in this session, each claim backed by a check actually run — "3 files verified current, 1 updated, 0 dead references", never just "docs written".
 - No fiction: never document features that don't exist yet; no dead paths or APIs.
+- Write to the reader's interface boundary: explain what they need to decide, do, observe, and verify. Prefer observable promises, outcomes, failure behavior, and next steps over internal machinery. Include implementation details only when the reader needs them to use the feature safely, troubleshoot it, or extend it; otherwise keep that mechanism in internal or architecture documentation.
 - Match existing project conventions for style and structure.

--- a/skills/dx-docs/SKILL.md
+++ b/skills/dx-docs/SKILL.md
@@ -48,6 +48,7 @@ Lead with a one-sentence verdict: did the repo pass its contributor test, and wh
 ## Pitfalls
 
 - Never evaluate docs by reading them — a page can read beautifully and be unfollowable; every "docs are good" claim must trace to a followed procedure.
+- Treat mechanism leakage as reader friction. If a reader can act safely from an observable promise, do not require them to learn internal components, protocols, state, or recovery machinery. Keep details only when they change a decision, safety boundary, troubleshooting step, or extension point; move the rest to internal explanation or architecture docs.
 - Internal-only docs deliberately excluded from a public site are design, not gaps — check the exclusion mechanism before reporting "missing" pages.
 - If docs live in a submodule or separate repo, a fix recommendation that says "edit and commit here" strands changes — name the real workflow in the fix.
 - Agent-context files (CLAUDE.md and kin) drifting from the product is real drift, but its fix lands in this repo, not the docs pipeline — route the two drift classes separately.


### PR DESCRIPTION
Lands fork PR #2595 onto the current dev-first flow, per maintainer triage.

**Author credit:** @lirazsiri — the original commit is cherry-picked, so their authorship is preserved (`Liraz Siri <liraz@liraz.org>`); this branch only changes the committer. #2595 targeted a fork branch we cannot push to, so this in-repo branch carries the same commit onto `dev`.

**What it does:** teaches reader-boundary documentation — two guidance bullets, one in the `docs` skill and one in the `dx-docs` skill, plus their `plugins/genie` mirrors so the plugin-parity gate stays green.

- `skills/docs/SKILL.md` — write to the reader's interface boundary; prefer observable promises over internal machinery.
- `skills/dx-docs/SKILL.md` — treat mechanism leakage as reader friction.
- `plugins/genie/skills/docs/SKILL.md`, `plugins/genie/skills/dx-docs/SKILL.md` — mirrors, byte-identical to the canonical copies.

4 files changed, +4/-0, docs-only.

**Validation** (`bun run check:fast` + `bun test` on this branch):
- typecheck, biome lint, knip dead-code, skills-lint (41 files), wishes-lint (64 files), council-workflow-lint, hook-bundle-parity, hook-content-binding, plugin-executables-check — all OK.
- complexity budget: OK, budget intact (the 2 retained `doctor.ts` hotspots are pre-existing).
- `bun test`: 2802 pass, 1 fail — the pre-existing macOS-only `ui-bridge lifetime > holds zero listening TCP sockets while running`, which shells out to Linux `ss` and returns ENOENT on darwin. Unrelated to this change.
- Canonical and plugin mirrors verified identical via `diff`.

#2595 will be closed in favor of this PR by the maintainer once this merges.
