### PR TITLE
fix: gitignore .genie/launch/ so genie launch stops dirtying worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,9 @@ yarn-error.log*
 .genie/genie.db-wal
 .genie/genie.db-shm
 
+# Per-worktree kickoff prompts emitted by `genie launch`
+.genie/launch/
+
 # Local genie state (not part of the package)
 .genie/agents.json
 .genie/teams/

--- a/src/term-commands/init.test.ts
+++ b/src/term-commands/init.test.ts
@@ -7,7 +7,7 @@ import { mergeCodexMcpFallback, removeCodexMcpFallback } from './init.js';
 
 const CLI = join(import.meta.dir, '..', 'genie.ts');
 const INTERPRETED_MCP_ARGS = [realpathSync(CLI), 'mcp'];
-const GITIGNORE_RULES = ['.genie/genie.db', '.genie/genie.db-wal', '.genie/genie.db-shm'];
+const GITIGNORE_RULES = ['.genie/genie.db', '.genie/genie.db-wal', '.genie/genie.db-shm', '.genie/launch/'];
 
 let dir: string;
 
@@ -62,6 +62,21 @@ describe('genie init', () => {
     expect(stdout).toContain('$genie:review');
     expect(stdout.indexOf('$genie:review')).toBeLessThan(stdout.indexOf('$genie:work'));
     expect(stdout).toContain('genie board');
+  });
+
+  test('the kickoff prompts `genie launch` writes into a worktree are ignored', () => {
+    initGitRepo(dir);
+    expect(runInit(dir).code).toBe(0);
+
+    mkdirSync(join(dir, '.genie', 'launch'), { recursive: true });
+    writeFileSync(join(dir, '.genie', 'launch', 'group.prompt'), 'kickoff\n');
+
+    expect(
+      execFileSync('git', ['check-ignore', '.genie/launch/group.prompt'], { cwd: dir, encoding: 'utf-8' }).trim(),
+    ).toBe('.genie/launch/group.prompt');
+    expect(execFileSync('git', ['status', '--porcelain'], { cwd: dir, encoding: 'utf-8' })).not.toContain(
+      '.genie/launch',
+    );
   });
 
   test('--help discloses every project MCP file class init may reconcile', () => {

--- a/src/term-commands/init.ts
+++ b/src/term-commands/init.ts
@@ -73,8 +73,8 @@ const INDEX_SKELETON = `# Plans Index
 ## Poured
 `;
 
-/** SQLite state artifacts that must never be committed. */
-const GITIGNORE_RULES = ['.genie/genie.db', '.genie/genie.db-wal', '.genie/genie.db-shm'];
+/** Operational artifacts that must never be committed. */
+const GITIGNORE_RULES = ['.genie/genie.db', '.genie/genie.db-wal', '.genie/genie.db-shm', '.genie/launch/'];
 
 // ============================================================================
 // Git repo resolution
@@ -109,7 +109,7 @@ function scaffoldIndex(root: string): ArtifactAction {
 }
 
 /**
- * Append any missing SQLite ignore rules to `.gitignore`, creating the file
+ * Append any missing operational ignore rules to `.gitignore`, creating the file
  * when absent. Existing content is preserved byte-for-byte; rules already
  * present are left untouched, so a second run writes nothing.
  */

--- a/src/term-commands/launch.test.ts
+++ b/src/term-commands/launch.test.ts
@@ -367,6 +367,23 @@ describe('genie launch (real run, --no-open)', () => {
     expect(opened).toEqual([]);
   });
 
+  test('a launched worktree stays clean: the kickoff prompt is covered by the rule `genie init` scaffolds', () => {
+    writeFileSync(join(fx.repo, '.gitignore'), '.genie/launch/\n');
+    git(fx.repo, ['add', '.gitignore']);
+    git(fx.repo, ['commit', '-q', '-m', 'ignore launch prompts']);
+
+    const slug = 'clean-tree';
+    createTask(fx.db, { title: 'a task', wish: slug, group: 'main' });
+    executeLaunch(slug, { open: false }, deps());
+
+    const wt = worktreeFor(slug, 'main');
+    expect(existsSync(join(wt, '.genie', 'launch', 'main.prompt'))).toBe(true);
+    // -uall so git lists the prompt itself rather than collapsing to `?? .genie/`.
+    // The per-worktree MCP configs are a separate class of artifact; only the
+    // kickoff prompt is asserted here.
+    expect(git(wt, ['status', '--porcelain', '-uall'])).not.toContain('.genie/launch');
+  });
+
   test('opens Warp best-effort when open is enabled', () => {
     const slug = 'openable';
     createTask(fx.db, { title: 'a task', wish: slug, group: 'main' });


### PR DESCRIPTION
Extracts the standalone bug fix from #2594 by @lirazsiri, per maintainer triage. Credit to @lirazsiri for finding and diagnosing this.

The orchestration-policy portion of #2594 is **not** included here and remains open for the maintainer's decision. Only the independently-verifiable ignore-rule bug is landed.

Reimplemented against current `dev` rather than cherry-picked: #2594's base is 383 commits stale and it is stacked on #2593.

## The bug

`genie launch` writes a kickoff prompt to `.genie/launch/<group>.prompt` inside every worktree it creates:

https://github.com/automagik-dev/genie/blob/dev/src/term-commands/launch.ts#L410

No ignore rule covered that path — `.gitignore` has entries for `.genie/genie.db*`, `.genie/teams/`, `.genie/state/` and friends, but nothing for `.genie/launch/`, and there is no blanket `.genie/` rule (v5 deliberately tracks planning documents under `.genie/`). Confirmed on current `dev`:

```
$ git check-ignore -v .genie/launch/api.prompt; echo $?
1        # not ignored
```

Result: every worktree `genie launch` creates reports a dirty `git status` before the agent has done anything.

## The fix

- `.gitignore` — add `.genie/launch/` so this repo's own launched worktrees start clean.
- `src/term-commands/init.ts` — add `.genie/launch/` to `GITIGNORE_RULES` so freshly-initialized repos get the same rule from `genie init`. Doc comments updated ("SQLite state artifacts" no longer describes the set).

## Tests

- `src/term-commands/init.test.ts` — new test asserting `git check-ignore` reports the launch prompt as ignored after `genie init`, plus `.genie/launch/` added to the suite's expected-rules list (which the existing idempotency, ordering, and `--json rulesAdded` tests all assert against).
- `src/term-commands/launch.test.ts` — new end-to-end test: after a real `executeLaunch` run against a repo carrying the rule, the created worktree's `git status --porcelain -uall` contains no `.genie/launch` entry. Uses `-uall` because plain `--porcelain` collapses untracked files to `?? .genie/`, which would make the assertion vacuous.

Both new tests were verified to fail with the fix reverted.

```
$ bun test src/term-commands/init.test.ts src/term-commands/launch.test.ts
 58 pass
 0 fail
```

`bun run typecheck` and `biome check` on the changed files are clean.

## Noted, not fixed here

`launch.ts:612` also calls `registerProjectMcpConfigs(group.worktree, …)`, which writes `.mcp.json`, `.warp/` and `.codex/` into each worktree. Those show as untracked too, but they are project-scope config files a repo may legitimately want committed, so they are a separate decision and out of scope for this fix.