### PR TITLE
fix(wishes): satisfy wishes-lint schema broken by ledger commit (#2694)

### DIFF
--- a/.genie/wishes/agent-sync-hardening/WISH.md
+++ b/.genie/wishes/agent-sync-hardening/WISH.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | SUPERSEDED — criterion-by-criterion by the PR #2545 remediation ledger; its mapped gates closed with [pr-2545-ultra-release-gate](../pr-2545-ultra-release-gate/WISH.md) (DONE 2026-07-24) except F02 (no independent APPROVED review — recorded unmet, not waived). Nothing in this wish blocks the stable pointer anymore. Historical PR #2546 plan and blocker details remain recorded below. Header reconciled to INDEX 2026-07-26 (was BLOCKED) |
+| **Status** | DONE — SUPERSEDED criterion-by-criterion by the PR #2545 remediation ledger; its mapped gates closed with [pr-2545-ultra-release-gate](../pr-2545-ultra-release-gate/WISH.md) (DONE 2026-07-24) except F02 (no independent APPROVED review — recorded unmet, not waived). Nothing in this wish blocks the stable pointer anymore. Historical PR #2546 plan and blocker details remain recorded below. Header reconciled to INDEX 2026-07-26 (was BLOCKED) |
 | **Slug** | `agent-sync-hardening` |
 | **Date** | 2026-07-10 |
 | **Author** | Felipe (planned with Fable 5) |

--- a/.genie/wishes/genie-ui/WISH.md
+++ b/.genie/wishes/genie-ui/WISH.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | SUPERSEDED (2026-07-21) — Felipe rejected this substrate after seeing it live; the UI direction moved to [genie-ui-dash](../genie-ui-dash/WISH.md). The browser shell itself merged as PR #2609; salvage retained: the ~1,270-LoC chat backend (no PTY imports) as conductor-wish substrate. All 4 groups + final gate had SHIPped 2026-07-21. Header reconciled to INDEX 2026-07-26 (was IN_PROGRESS, inviting resumption of dead work) |
+| **Status** | DONE — SUPERSEDED as the UI direction (2026-07-21): Felipe rejected this substrate after seeing it live; direction moved to [genie-ui-dash](../genie-ui-dash/WISH.md). The browser shell itself merged as PR #2609; salvage retained: the ~1,270-LoC chat backend (no PTY imports) as conductor-wish substrate. All 4 groups + final gate had SHIPped 2026-07-21. Header reconciled to INDEX 2026-07-26 (was IN_PROGRESS, inviting resumption of dead work) |
 | **Slug** | `genie-ui` |
 | **Date** | 2026-07-21 |
 | **Author** | Felipe + Genie |

--- a/.genie/wishes/release-ops-hardening/WISH.md
+++ b/.genie/wishes/release-ops-hardening/WISH.md
@@ -2,18 +2,20 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | DRAFT (2026-07-26; not plan-reviewed — needs Felipe approval + a plan gate before execution) |
+| **Status** | DRAFT — not plan-reviewed (2026-07-26); needs Felipe approval + a plan gate before execution |
 | **Slug** | `release-ops-hardening` |
 | **Date** | 2026-07-26 |
 | **Author** | Genie (roadmap triage session, from the 2026-07-20→26 outage post-mortem + stable-path study) |
 | **Appetite** | small-medium (fix wave over existing surfaces, no redesign) |
 | **Branch** | `wish/release-ops-hardening` |
 | **Repos touched** | `automagik-dev/genie` |
-| **Design** | No brainstorm — direct wish. Evidence base: issues #2669, #2674, #2675; stable-path study 2026-07-26 (risks R6/R7); runbook `/Users/feliperosa/workspace/genie-stable-release-runbook.md` |
+| **Design** | _No brainstorm — direct wish_ |
 
 ## The problem
 
 The 2026-07-20→26 release outage produced three hardening follow-ups (#2669, #2674, #2675) plus two structural findings from the stable-promotion study. Each is currently a *remembered* rule — enforced by handoff documents and operator discipline, not by the pipeline. Rules that live in prose get relearned the expensive way.
+
+Evidence base: issues #2669, #2674, #2675; the stable-path promotion study of 2026-07-26 (findings R6/R7); the operator runbook at `~/workspace/genie-stable-release-runbook.md`.
 
 ## Groups
 
@@ -55,6 +57,27 @@ Criteria:
 Criteria:
 - [ ] Fixture derives N from (or asserts against) `.well-known/latest.json` instead of a hard-coded literal
 - [ ] A stable release that advances latest.json causes a visible, attributable test signal — not silent staleness
+
+## Dependencies
+
+**depends-on:** stable-release-security-gate
+**blocks:** none
+
+## Execution Strategy
+
+### Wave 1 (parallel — disjoint surfaces)
+
+| Group | Agent | Complexity | Model | Description |
+|-------|-------|------------|-------|-------------|
+| G1 admit-refuse | engineer | 2 (+1 twin-PR workflow choreography) | engineer-standard / high | Publish admit fails fast on already-published versions (#2674) |
+| G4 fixture-N | engineer | 1 | engineer-trivial / medium | Dogfood fixture derives N from latest.json instead of a literal |
+
+### Wave 2 (after Wave 1 merges — same workflow files)
+
+| Group | Agent | Complexity | Model | Description |
+|-------|-------|------------|-------|-------------|
+| G2 orphan-exempt | engineer | 2 (+1 alarm-semantics validation) | engineer-standard / high | Orphan-alert exempts pending stable candidates |
+| G3 cleanups | engineer | 2 (+1 test-harness shapes) | engineer-standard / medium | #2675 dead default + multi-attestation/CAS-loop tests + #2669 pin-checker |
 
 ## Non-goals
 


### PR DESCRIPTION
Dev CI is red at **Wishes lint** since #2694 merged — my error: I merged after reading only the tail of the checks list, and dev PRs have no required-check protection to catch it. This restores green:

- `SUPERSEDED` is not in the lint's allowed status set → `genie-ui` and `agent-sync-hardening` now read `DONE — SUPERSEDED …` (parser takes the token before the first em-dash; supersession context preserved in prose).
- `release-ops-hardening`: status keyword now leads the cell; Design cell is the exact `_No brainstorm — direct wish_` stub (evidence base moved into the problem section); added the required `## Dependencies` section and an Execution Strategy table with the mandatory Complexity/Model columns.

Validated locally: `wishes:lint` OK (65 files, 0 broken links), `skills:lint` OK, full `check:fast` green. Docs-only.

Note: #2696's check failure is this same dev breakage surfacing through the PR merge-ref — re-run after this merges.