### PR TITLE
fix(doctor): re-prove ancestry at removal time (CodeRabbit Major on #2702)

### DIFF
--- a/src/genie-commands/doctor-worktrees.test.ts
+++ b/src/genie-commands/doctor-worktrees.test.ts
@@ -8,6 +8,7 @@ import {
   checkLaunchWorktrees,
   cleanupLaunchWorktrees,
   parseWorktreePorcelain,
+  removeLaunchWorktree,
   resolveIntegrationBranch,
   scanLaunchWorktrees,
 } from './doctor-worktrees.js';
@@ -369,7 +370,10 @@ describe('doctor wiring', () => {
     process.env.GENIE_WORKTREES_DIR = fx.base;
   }
 
-  async function runDoctor(fx: Fixture, options: { json?: boolean; fix?: boolean }): Promise<string> {
+  async function runDoctor(
+    fx: Fixture,
+    options: { json?: boolean; fix?: boolean },
+  ): Promise<{ output: string; exitCode: number }> {
     const realWrite = process.stdout.write.bind(process.stdout);
     const priorExit = process.exitCode;
     process.exitCode = 0;
@@ -388,7 +392,7 @@ describe('doctor wiring', () => {
         bunVersion: '1.3.10',
         bunPath: '/usr/bin/bun',
       });
-      return buffer;
+      return { output: buffer, exitCode: typeof process.exitCode === 'number' ? process.exitCode : 0 };
     } finally {
       process.stdout.write = realWrite;
       process.exitCode = priorExit ?? 0;
@@ -402,7 +406,10 @@ describe('doctor wiring', () => {
     const dirty = addWorktree(fx, 'repo-demo-beta', 'wish/demo-beta');
     writeFileSync(join(dirty, 'scratch.txt'), 'wip\n');
 
-    const json = JSON.parse(await runDoctor(fx, { json: true })) as {
+    const { output: detectOutput, exitCode } = await runDoctor(fx, { json: true });
+    // Residue is warn-only: it must never make `genie doctor` exit non-zero.
+    expect(exitCode).toBe(0);
+    const json = JSON.parse(detectOutput) as {
       checks: Array<{ name: string; status: string; detail?: string }>;
     };
     const worktreeChecks = json.checks.filter((check) => check.name.startsWith('launch worktrees'));
@@ -417,6 +424,31 @@ describe('doctor wiring', () => {
     expect(branchExists(fx.root, 'wish/demo-alpha')).toBe(true);
   });
 
+  test("a commit landing between cleanup's scan and the delete is not orphaned (ancestry re-proof)", () => {
+    const fx = makeFixture();
+    const wt = addWorktree(fx, 'repo-demo-alpha', 'wish/demo-alpha');
+
+    // Capture the entry exactly as cleanup's internal scan would see it:
+    // merged+clean, authorized for removal.
+    const entry = scanLaunchWorktrees(fx.root, fx.base).entries.find((e) => e.branch === 'wish/demo-alpha');
+    expect(entry?.disposition).toBe('removable');
+    if (!entry) throw new Error('unreachable');
+
+    // The race: a commit lands on the branch AFTER that scan, BEFORE removal.
+    // (cleanupLaunchWorktrees re-scans on entry, so only a direct call can
+    // place the mutation inside the window the re-proof exists to close.)
+    writeFileSync(join(wt, 'late.txt'), 'landed after the scan\n');
+    git(wt, 'add', 'late.txt');
+    git(wt, 'commit', '-q', '-m', 'late: after scan, before removal');
+
+    const failure = removeLaunchWorktree(fx.root, entry, { name: 'dev', ref: 'refs/heads/dev' });
+    // Fail-closed: the re-proof refuses; worktree, branch, and the late commit survive.
+    expect(failure).toContain('ancestry re-proof failed');
+    expect(existsSync(wt)).toBe(true);
+    expect(branchExists(fx.root, 'wish/demo-alpha')).toBe(true);
+    expect(existsSync(join(wt, 'late.txt'))).toBe(true);
+  });
+
   test('doctor --fix reclaims only the provably safe worktree', async () => {
     const fx = makeFixture();
     isolate(fx);
@@ -424,7 +456,8 @@ describe('doctor wiring', () => {
     const dirty = addWorktree(fx, 'repo-demo-beta', 'wish/demo-beta');
     writeFileSync(join(dirty, 'scratch.txt'), 'wip\n');
 
-    const output = await runDoctor(fx, { json: true, fix: true });
+    const { output, exitCode } = await runDoctor(fx, { json: true, fix: true });
+    expect(exitCode).toBe(0);
     expect(existsSync(clean)).toBe(false);
     expect(branchExists(fx.root, 'wish/demo-alpha')).toBe(false);
     expect(existsSync(dirty)).toBe(true);

--- a/src/genie-commands/doctor-worktrees.ts
+++ b/src/genie-commands/doctor-worktrees.ts
@@ -399,7 +399,26 @@ export function checkLaunchWorktrees(root: string | null, deps: LaunchWorktreeDe
  * integration branch. `-D` deletes a ref whose every commit is reachable
  * elsewhere; nothing is lost.
  */
-function removeLaunchWorktree(root: string, entry: LaunchWorktreeEntry): string | null {
+/**
+ * Exported for direct testing: the ancestry re-proof below guards the window
+ * BETWEEN cleanup's own scan and this removal, which no public-API test can
+ * reach deterministically (cleanupLaunchWorktrees re-scans on entry, so a
+ * commit landed before the call is already filtered by classification).
+ */
+export function removeLaunchWorktree(
+  root: string,
+  entry: LaunchWorktreeEntry,
+  integration: IntegrationBranch,
+): string | null {
+  // Re-prove ancestry at removal time: a commit landing on the branch between
+  // the scan and this call would leave the tree clean (so `worktree remove`
+  // would still succeed) while making `-D` an orphaning force-delete. Once the
+  // worktree is gone the branch can gain no commits — git refuses a second
+  // checkout of the same branch — so re-proving HERE closes the whole window.
+  if (entry.branch !== null) {
+    const ancestry = git(root, ['merge-base', '--is-ancestor', `refs/heads/${entry.branch}`, integration.ref]);
+    if (!ancestry.ok) return `kept: branch advanced past ${integration.name} after the scan (ancestry re-proof failed)`;
+  }
   const removed = git(root, ['worktree', 'remove', entry.path]);
   if (!removed.ok) return `git worktree remove refused: ${firstLine(removed.stderr, 'unknown git error')}`;
   if (entry.branch === null) return null;
@@ -423,10 +442,18 @@ export function cleanupLaunchWorktrees(root: string | null, deps: LaunchWorktree
     (entry) => entry.disposition === 'removable',
   );
   if (removable.length === 0) return;
+  // A `removable` disposition implies the scan resolved an integration branch;
+  // re-resolve rather than thread it through, and refuse everything if it
+  // vanished mid-run (fail-closed, same posture as the scan).
+  const integration = resolveIntegration(root);
   const emit = deps.logSink ?? ((line: string) => process.stdout.write(`${line}\n`));
+  if (integration === null) {
+    emit(`  \x1b[33m!\x1b[0m kept all ${removable.length}: integration branch no longer resolvable`);
+    return;
+  }
   emit(`\x1b[2mRemoving ${removable.length} merged, clean launch worktree(s)...\x1b[0m`);
   for (const entry of removable) {
-    const failure = removeLaunchWorktree(root, entry);
+    const failure = removeLaunchWorktree(root, entry, integration);
     if (failure === null) emit(`  \x1b[32m✔\x1b[0m removed ${entry.path} (${entry.branch})`);
     else emit(`  \x1b[33m!\x1b[0m kept ${entry.path}: ${failure}`);
   }


### PR DESCRIPTION
Closes the two findings CodeRabbit posted on promotion PR #2702's second pass:

- **Major (real TOCTOU):** the ancestry proof authorizing `branch -D` ran only at scan time; a commit landing on a launch branch between cleanup's internal scan and the delete would be orphaned (clean tree, so `worktree remove` can't object). `removeLaunchWorktree` now re-runs the fully-qualified `--is-ancestor` probe immediately before removal and refuses on any non-zero; after worktree removal the branch cannot gain commits (git refuses a second same-branch checkout), so the re-proof closes the entire window. Cleanup re-resolves the integration branch fail-closed. Regression test at the function's own layer (the public API re-scans on entry — empirically proven while writing the test — so the inner window is unreachable from outside).
- **Trivial:** wiring tests now assert `process.exitCode === 0`, locking in that residue is warn-only.

618 tests green in src/genie-commands/, check:fast exit 0. Needed on dev before the recreated dev→main promotion so the stable candidate carries it.