### PR TITLE
fix(ci): check-action-pins matches quoted uses scalars, anchors SHA (#2669)

### DIFF
--- a/scripts/check-action-pins.sh
+++ b/scripts/check-action-pins.sh
@@ -8,31 +8,84 @@
 # no repository, and it took down three release-publish jobs the first time
 # they ever executed.
 #
+# The matcher recognises all three YAML scalar spellings of `uses:` (bare,
+# 'single-quoted', "double-quoted") and requires the ref to span the WHOLE
+# scalar — an action ending in 40 hex chars followed by trailing garbage
+# (`@<sha>oops`) is not a pin and must not be silently accepted (#2669).
+#
 # Usage: bash scripts/check-action-pins.sh   (needs gh auth; network required)
+#        bash scripts/check-action-pins.sh --extract < lines   (offline; prints
+#        the `owner/repo@sha` pin for every matching line, nothing for the rest)
 set -euo pipefail
+
+# YAML scalar spellings of the `uses:` value. Kept in variables because bash 3.2
+# treats quoted regex fragments as literals inside [[ =~ ]].
+uses_dquoted_re='uses:[[:space:]]*"([^"]*)"'
+uses_squoted_re="uses:[[:space:]]*'([^']*)'"
+uses_bare_re='uses:[[:space:]]*([^[:space:]#]+)'
+# Anchored: the pin must be the ENTIRE scalar and end in exactly 40 hex chars.
+pin_re='^([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)(/[A-Za-z0-9./_-]+)?@([0-9a-f]{40})$'
+
+# extract_pin <line> — echo `owner/repo@sha` for a SHA-pinned `uses:` line.
+# Returns 1 (printing nothing) for local (`./…`), docker://, tag/branch refs and
+# for a 40-hex run that does not terminate the scalar.
+extract_pin() {
+  local line="$1" scalar
+  line="${line%$'\r'}"
+  if [[ $line =~ $uses_dquoted_re ]]; then
+    scalar="${BASH_REMATCH[1]}"
+  elif [[ $line =~ $uses_squoted_re ]]; then
+    scalar="${BASH_REMATCH[1]}"
+  elif [[ $line =~ $uses_bare_re ]]; then
+    scalar="${BASH_REMATCH[1]}"
+  else
+    return 1
+  fi
+  [[ $scalar =~ $pin_re ]] || return 1
+  # BASH_REMATCH[2] is the optional subpath (`owner/repo/sub@sha`); the commit
+  # lives in the parent repository, so the API target and the dedupe key drop it.
+  printf '%s@%s\n' "${BASH_REMATCH[1]}" "${BASH_REMATCH[3]}"
+}
+
+if [[ "${1:-}" == "--extract" ]]; then
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    extract_pin "$line" || true
+  done
+  exit 0
+fi
+
+# Workflows, the repo's own composite actions, and any other action manifest
+# tracked anywhere in the tree (#2669). Overlap is harmless — pins are deduped.
+scan_targets() {
+  printf '%s\n' .github/workflows .github/actions
+  git ls-files -- '*action.yml' '*action.yaml' 2>/dev/null || true
+}
+
+targets=()
+while IFS= read -r target; do
+  if [[ -n "$target" ]]; then targets+=("$target"); fi
+done < <(scan_targets)
 
 status=0
 declare -a seen=()
 
 while IFS= read -r line; do
   file="${line%%:*}"
-  rest="${line#*:}"
-  [[ "$rest" =~ uses:[[:space:]]*([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)(/[A-Za-z0-9./_-]+)?@([0-9a-f]{40}) ]] || continue
-  repo="${BASH_REMATCH[1]}"
-  sha="${BASH_REMATCH[3]}"
-  key="${repo}@${sha}"
-  for s in ${seen[@]+"${seen[@]}"}; do [[ "$s" == "$key" ]] && continue 2; done
-  seen+=("$key")
+  pin="$(extract_pin "$line" || true)"
+  [[ -n "$pin" ]] || continue
+  repo="${pin%@*}"
+  sha="${pin##*@}"
+  for s in ${seen[@]+"${seen[@]}"}; do [[ "$s" == "$pin" ]] && continue 2; done
+  seen+=("$pin")
   if gh api "repos/${repo}/commits/${sha}" --jq .sha >/dev/null 2>&1; then
-    printf '  ok           %s\n' "$key"
+    printf '  ok           %s\n' "$pin"
   else
-    printf '  UNRESOLVABLE %s  (%s)\n' "$key" "$file" >&2
+    printf '  UNRESOLVABLE %s  (%s)\n' "$pin" "$file" >&2
     status=1
   fi
-done < <(grep -rn "uses:" .github/workflows .github/actions 2>/dev/null || true)
+done < <(grep -rn "uses:" ${targets[@]+"${targets[@]}"} 2>/dev/null || true)
 
 if [[ "$status" -ne 0 ]]; then
   echo "::error ::one or more actions are pinned to a SHA that does not exist" >&2
 fi
 exit "$status"
-

--- a/scripts/check-action-pins.sh
+++ b/scripts/check-action-pins.sh
@@ -8,21 +8,25 @@
 # no repository, and it took down three release-publish jobs the first time
 # they ever executed.
 #
-# The matcher recognises all three YAML scalar spellings of `uses:` (bare,
-# 'single-quoted', "double-quoted") and requires the ref to span the WHOLE
-# scalar — an action ending in 40 hex chars followed by trailing garbage
-# (`@<sha>oops`) is not a pin and must not be silently accepted (#2669).
+# The matcher reads the scalar that follows the FIRST `uses:` key on the line,
+# recognises all three YAML spellings (bare, 'single-quoted', "double-quoted"),
+# and requires the ref to span the WHOLE scalar — an action ending in 40 hex
+# chars followed by trailing garbage (`@<sha>oops`) is not a pin and must not be
+# silently accepted (#2669).
 #
 # Usage: bash scripts/check-action-pins.sh   (needs gh auth; network required)
 #        bash scripts/check-action-pins.sh --extract < lines   (offline; prints
 #        the `owner/repo@sha` pin for every matching line, nothing for the rest)
 set -euo pipefail
 
-# YAML scalar spellings of the `uses:` value. Kept in variables because bash 3.2
-# treats quoted regex fragments as literals inside [[ =~ ]].
-uses_dquoted_re='uses:[[:space:]]*"([^"]*)"'
-uses_squoted_re="uses:[[:space:]]*'([^']*)'"
-uses_bare_re='uses:[[:space:]]*([^[:space:]#]+)'
+# YAML scalar spellings of the `uses:` value, matched against the text AFTER the
+# key. Kept in variables because bash 3.2 treats quoted regex fragments as
+# literals inside [[ =~ ]]. All three are anchored so a later `uses:` inside a
+# trailing comment cannot shadow the real scalar. A bare scalar also ends at `,`
+# and `}` so flow mappings (`- { uses: owner/repo@<sha>, name: X }`) extract.
+uses_dquoted_re='^"([^"]*)"'
+uses_squoted_re="^'([^']*)'"
+uses_bare_re='^([^][:space:]#,}]+)'
 # Anchored: the pin must be the ENTIRE scalar and end in exactly 40 hex chars.
 pin_re='^([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)(/[A-Za-z0-9./_-]+)?@([0-9a-f]{40})$'
 
@@ -30,13 +34,15 @@ pin_re='^([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)(/[A-Za-z0-9./_-]+)?@([0-9a-f]{40})$'
 # Returns 1 (printing nothing) for local (`./…`), docker://, tag/branch refs and
 # for a 40-hex run that does not terminate the scalar.
 extract_pin() {
-  local line="$1" scalar
+  local line="$1" rest scalar
   line="${line%$'\r'}"
-  if [[ $line =~ $uses_dquoted_re ]]; then
+  case $line in *uses:*) rest="${line#*uses:}" ;; *) return 1 ;; esac
+  rest="${rest#"${rest%%[![:space:]]*}"}"
+  if [[ $rest =~ $uses_dquoted_re ]]; then
     scalar="${BASH_REMATCH[1]}"
-  elif [[ $line =~ $uses_squoted_re ]]; then
+  elif [[ $rest =~ $uses_squoted_re ]]; then
     scalar="${BASH_REMATCH[1]}"
-  elif [[ $line =~ $uses_bare_re ]]; then
+  elif [[ $rest =~ $uses_bare_re ]]; then
     scalar="${BASH_REMATCH[1]}"
   else
     return 1

--- a/tests/integration/check-action-pins-matcher.test.ts
+++ b/tests/integration/check-action-pins-matcher.test.ts
@@ -8,7 +8,11 @@
  * stay closed:
  *   - single-/double-quoted `uses:` scalars were skipped entirely;
  *   - a 40-hex run followed by trailing garbage (`@<sha>oops`) was accepted as
- *     a pin, because the SHA was not anchored to the end of the scalar.
+ *     a pin, because the SHA was not anchored to the end of the scalar;
+ *   - an unanchored match let a quoted pin inside a trailing comment shadow the
+ *     real bare pin on the same line;
+ *   - a flow-mapping step (`- { uses: owner/repo@<sha>, name: X }`) was skipped
+ *     because the comma stayed glued to the scalar.
  *
  * No network, no gh auth: `--extract` only runs the regex layer.
  */
@@ -21,6 +25,8 @@ import { join } from 'node:path';
 const REPO_ROOT = join(import.meta.dir, '..', '..');
 const SCRIPT = join(REPO_ROOT, 'scripts', 'check-action-pins.sh');
 const SHA = '93cb6efe18208431cddfb8368fd83d5badbf9bfd';
+/** A different well-formed SHA, used to prove which scalar the matcher picked. */
+const OTHER_SHA = '11b0e1c8d3d0f8f8d3ce4cd7d0d0a1b2c3d4e5f6';
 
 /** Feed raw YAML lines through the script's matcher; returns the pins it emitted. */
 function extract(...lines: string[]): string[] {
@@ -57,6 +63,21 @@ describe('check-action-pins matcher — accepted scalars', () => {
   test('CRLF line endings and extra spacing after the key', () => {
     expect(extract(`      - uses:    actions/checkout@${SHA}\r`)).toEqual([`actions/checkout@${SHA}`]);
     expect(extract(`      - uses: "actions/checkout@${SHA}"\r`)).toEqual([`actions/checkout@${SHA}`]);
+  });
+
+  test('a quoted pin in a trailing comment never shadows the real scalar', () => {
+    expect(extract(`      - uses: actions/checkout@${SHA} # was uses: "actions/checkout@${OTHER_SHA}"`)).toEqual([
+      `actions/checkout@${SHA}`,
+    ]);
+    expect(extract(`      - uses: actions/checkout@${SHA} # was uses: 'actions/checkout@${OTHER_SHA}'`)).toEqual([
+      `actions/checkout@${SHA}`,
+    ]);
+  });
+
+  test('flow mapping scalar ends at the comma or closing brace', () => {
+    expect(extract(`      - { uses: owner/repo@${SHA}, name: Build }`)).toEqual([`owner/repo@${SHA}`]);
+    expect(extract(`      - { uses: owner/repo@${SHA} }`)).toEqual([`owner/repo@${SHA}`]);
+    expect(extract(`      - { uses: "owner/repo@${SHA}", name: Build }`)).toEqual([`owner/repo@${SHA}`]);
   });
 });
 

--- a/tests/integration/check-action-pins-matcher.test.ts
+++ b/tests/integration/check-action-pins-matcher.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Matcher contract for scripts/check-action-pins.sh (#2669).
+ *
+ * The `Action Pin Resolvability` CI job runs the script against the live repo,
+ * which proves the 10 real pins resolve but never exercises the spellings the
+ * repo happens not to use. These tests drive the script's offline `--extract`
+ * mode with fixture YAML lines, so the two regressions the scanner was blind to
+ * stay closed:
+ *   - single-/double-quoted `uses:` scalars were skipped entirely;
+ *   - a 40-hex run followed by trailing garbage (`@<sha>oops`) was accepted as
+ *     a pin, because the SHA was not anchored to the end of the scalar.
+ *
+ * No network, no gh auth: `--extract` only runs the regex layer.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const REPO_ROOT = join(import.meta.dir, '..', '..');
+const SCRIPT = join(REPO_ROOT, 'scripts', 'check-action-pins.sh');
+const SHA = '93cb6efe18208431cddfb8368fd83d5badbf9bfd';
+
+/** Feed raw YAML lines through the script's matcher; returns the pins it emitted. */
+function extract(...lines: string[]): string[] {
+  const result = spawnSync('bash', [SCRIPT, '--extract'], {
+    input: `${lines.join('\n')}\n`,
+    encoding: 'utf8',
+  });
+  expect(result.status).toBe(0);
+  expect(result.stderr).toBe('');
+  return result.stdout.split('\n').filter((entry) => entry.length > 0);
+}
+
+describe('check-action-pins matcher — accepted scalars', () => {
+  test('bare scalar, with and without a trailing version comment', () => {
+    expect(extract(`      - uses: actions/checkout@${SHA}`)).toEqual([`actions/checkout@${SHA}`]);
+    expect(extract(`      - uses: actions/checkout@${SHA} # v5`)).toEqual([`actions/checkout@${SHA}`]);
+  });
+
+  test('double-quoted scalar', () => {
+    expect(extract(`      - uses: "actions/checkout@${SHA}"`)).toEqual([`actions/checkout@${SHA}`]);
+    expect(extract(`      - uses: "actions/checkout@${SHA}" # v5`)).toEqual([`actions/checkout@${SHA}`]);
+  });
+
+  test('single-quoted scalar', () => {
+    expect(extract(`      - uses: 'actions/checkout@${SHA}'`)).toEqual([`actions/checkout@${SHA}`]);
+    expect(extract(`        uses: 'actions/checkout@${SHA}' # v5`)).toEqual([`actions/checkout@${SHA}`]);
+  });
+
+  test('subpath action resolves against its parent repository', () => {
+    expect(extract(`      - uses: owner/repo/sub/path@${SHA}`)).toEqual([`owner/repo@${SHA}`]);
+    expect(extract(`      - uses: "owner/repo/sub/path@${SHA}"`)).toEqual([`owner/repo@${SHA}`]);
+  });
+
+  test('CRLF line endings and extra spacing after the key', () => {
+    expect(extract(`      - uses:    actions/checkout@${SHA}\r`)).toEqual([`actions/checkout@${SHA}`]);
+    expect(extract(`      - uses: "actions/checkout@${SHA}"\r`)).toEqual([`actions/checkout@${SHA}`]);
+  });
+});
+
+describe('check-action-pins matcher — rejected scalars', () => {
+  test('trailing garbage after the 40-hex SHA is not a pin (#2669)', () => {
+    expect(extract(`      - uses: actions/checkout@${SHA}deadbeef`)).toEqual([]);
+    expect(extract(`      - uses: "actions/checkout@${SHA}oops"`)).toEqual([]);
+    expect(extract(`      - uses: 'actions/checkout@${SHA}oops'`)).toEqual([]);
+    expect(extract(`      - uses: actions/checkout@${SHA}0`)).toEqual([]);
+  });
+
+  test('short SHA, tag and branch refs are not 40-hex pins', () => {
+    expect(extract(`      - uses: actions/checkout@${SHA.slice(0, 39)}`)).toEqual([]);
+    expect(extract('      - uses: actions/checkout@v5')).toEqual([]);
+    expect(extract('      - uses: actions/checkout@main')).toEqual([]);
+  });
+
+  test('local and docker references carry no commit to resolve', () => {
+    expect(extract('      - uses: ./.github/actions/ggshield')).toEqual([]);
+    expect(extract('      - uses: docker://alpine:3.19')).toEqual([]);
+  });
+});
+
+describe('check-action-pins matcher — real workflows', () => {
+  const workflowDir = join(REPO_ROOT, '.github', 'workflows');
+
+  test('every SHA-pinned uses: line in .github/workflows still extracts', () => {
+    const lines = readdirSync(workflowDir)
+      .filter((name) => name.endsWith('.yml') || name.endsWith('.yaml'))
+      .flatMap((name) => readFileSync(join(workflowDir, name), 'utf8').split('\n'))
+      .filter((line) => /uses:/.test(line) && /@[0-9a-f]{40}/.test(line));
+
+    expect(lines.length).toBeGreaterThan(0);
+    const pins = extract(...lines);
+    expect(pins.length).toBe(lines.length);
+    for (const pin of pins) {
+      expect(pin).toMatch(/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+@[0-9a-f]{40}$/);
+    }
+  });
+});


### PR DESCRIPTION
Closes #2669 (follow-up deferred out of PR #2660, CodeRabbit Major on `scripts/check-action-pins.sh:20`).

## Problem

The scanner matched exactly one YAML spelling and never anchored the SHA:

```bash
[[ "$rest" =~ uses:[[:space:]]*([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)(/[A-Za-z0-9./_-]+)?@([0-9a-f]{40}) ]]
```

1. `uses: 'owner/repo@<sha>'` and `uses: "owner/repo@<sha>"` were skipped — a quoted pin was invisible to the resolvability gate.
2. Unanchored `{40}` accepted any 40-hex prefix, so `uses: owner/repo@<sha>oops` "resolved" against the first 40 hex chars while the workflow itself would fail at runtime with `Unable to resolve action`.

No current exposure (all 10 pins in `.github/workflows` are bare and resolve), so this is pure hardening of the `Action Pin Resolvability` gate before someone quotes a pin.

## Change

`scripts/check-action-pins.sh`

- `extract_pin()` picks the scalar out of all three spellings — bare, `'single'`, `"double"` — then requires the ref to match `^owner/repo(/subpath)?@[0-9a-f]{40}$`, i.e. the SHA must terminate the scalar. Trailing `# v5` comments and CRLF endings still parse; local (`./…`), `docker://`, tag and branch refs are still ignored.
- Scan set now includes any tracked `action.yml`/`action.yaml` anywhere in the tree (issue point 3), not just `.github/workflows` + `.github/actions`. Overlap is harmless — pins are deduped as before.
- New offline `--extract` mode reads YAML lines from stdin and prints the pins the matcher accepts. No `gh`, no network — this is what makes the regex layer testable.

`tests/integration/check-action-pins-matcher.test.ts` (new, 9 tests / 151 assertions)

Feeds fixture lines through `--extract`: accepts bare/single/double-quoted, subpath (`owner/repo/sub@sha` → `owner/repo@sha`), trailing comments, CRLF; rejects `@<sha>deadbeef`, `@<sha>oops` in both quote styles, 39-hex, `@v5`, `@main`, `./…`, `docker://…`. A final case replays every SHA-pinned `uses:` line from the real `.github/workflows` and asserts each one still extracts, so the parity with today's behaviour is locked.

## Evidence

```
$ bash scripts/check-action-pins.sh
  ok           actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
  ok           actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
  ok           sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac
  ok           slsa-framework/slsa-verifier@ea584f4502babc6f60d9bc799dbbb13c1caa9ee6
  ok           actions/attest@67422f5511b7ff725f4dbd6fb9bd2cd925c65a8d
  ok           actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
  ok           oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
  ok           actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
  ok           actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
  ok           actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
exit=0   # same 10 unique pins the old matcher found — no regression, no drop
```

```
$ bun test tests/integration/check-action-pins-matcher.test.ts
 9 pass / 0 fail / 151 expect() calls

$ bun test
 2833 pass / 1 fail (2834 across 123 files)
 # the single failure is the pre-existing macOS-only
 # "ui-bridge lifetime > holds zero listening TCP sockets" case, which needs Linux `ss`

$ bun run check:fast
 typecheck + lint + dead-code + skills/wishes lint + complexity budget +
 council-workflow + hook-bundle + hook-content + plugin-executables: all OK
 (2 pre-existing doctor.ts complexity warnings, budget intact)

$ bash -n scripts/check-action-pins.sh   # clean; matcher is bash 3.2-compatible (verified on 3.2.57)
```

## Caveat

`--extract` deliberately reports `owner/repo@sha` for subpath actions, dropping the subpath: the commit being resolved lives in the parent repository, which is what `gh api repos/<repo>/commits/<sha>` needs and what the dedupe key has always used.
