### PR TITLE
fix(release): refuse re-dispatch of published versions + delete dead channel default (#2674, #2675)

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -82,7 +82,12 @@ jobs:
     name: Admit trusted release orchestrator
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    permissions: {}
+    permissions:
+      # Read-only, and only so the replay guard below can ask whether the tag
+      # already carries a published release. contents:write still starts at the
+      # publish job: nothing may mutate the repository before the caller is
+      # proven, and the guard runs after the binding step for the same reason.
+      contents: read
     steps:
       - name: Bind caller workflow and control commit
         shell: bash
@@ -137,6 +142,43 @@ jobs:
               ;;
           esac
           echo "Trusted release caller admitted at ${CALLER_SHA}"
+
+      - name: Refuse re-dispatch of an already published release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          # A published (non-draft) release is immutable, and this pipeline is
+          # no longer able to replay one: reconcile-release-assets.sh expects
+          # the current 20/28/36-asset delivery fanout while every pre-fanout
+          # release carries 12 that can never be extended, and
+          # reconcile-channel-manifests.sh now derives a deterministic
+          # midnight-UTC released_at that no longer cmp-matches the wall-clock
+          # timestamps already committed to main. Both failures land AFTER the
+          # release is published and locked, so refuse the run here instead.
+          # Always allocate a fresh version (version.yml allocates max-plus-one
+          # and pushes a fresh tag). See automagik-dev/genie#2674.
+          # Drafts stay admissible on purpose: an interrupted run must still be
+          # able to finish the release it already opened.
+          RELEASE_JSON="$(mktemp)"
+          RELEASE_ERROR="$(mktemp)"
+          if gh api "repos/${RELEASE_REPOSITORY}/releases/tags/v${INPUT_VERSION}" \
+            >"$RELEASE_JSON" 2>"$RELEASE_ERROR"; then
+            if [[ "$(jq -r '.draft' "$RELEASE_JSON")" != true ]]; then
+              echo "::error ::release-replay.published v${INPUT_VERSION} already has a published GitHub Release — published releases are non-replayable (immutable asset inventory + deterministic released_at); allocate a fresh version instead. See automagik-dev/genie#2674"
+              exit 1
+            fi
+            echo "v${INPUT_VERSION} exists only as a draft release; admitting so the interrupted publish can complete"
+          elif grep -q 'HTTP 404' "$RELEASE_ERROR"; then
+            echo "v${INPUT_VERSION} has no GitHub Release yet"
+          else
+            cat "$RELEASE_ERROR" >&2
+            echo "::error ::release-replay.unknown could not determine whether v${INPUT_VERSION} already has a published release; failing closed. See automagik-dev/genie#2674"
+            exit 1
+          fi
 
   prepare-delivery-evidence:
     name: Build canonical delivery descriptors
@@ -1012,12 +1054,15 @@ jobs:
           name: delivery-candidate-manifests
           path: ${{ runner.temp }}/candidate-manifests
 
-      - name: Resolve version + channel + asset inventory
+      # Channel is NOT resolved here: admit already rejects an empty/unknown
+      # channel, and finalize/manifests read inputs.channel raw. A local
+      # default would only let publish upload a stable-sized inventory that
+      # finalize then aborts on, leaving a published-but-unfinalized release.
+      - name: Resolve version + asset inventory
         id: meta
         shell: bash
         env:
           INPUT_VERSION: ${{ inputs.version }}
-          INPUT_CHANNEL: ${{ inputs.channel }}
         run: |
           set -euo pipefail
           cd dist
@@ -1041,14 +1086,8 @@ jobs:
             echo "::error::workflow_dispatch input version='${INPUT_VERSION}' does not match upstream artifact version='${VERSION}'"
             exit 1
           fi
-          # Channel: workflow_dispatch picks; workflow_run defaults to stable.
-          CHANNEL="${INPUT_CHANNEL:-}"
-          if [[ -z "${CHANNEL}" ]]; then
-            CHANNEL="stable"
-          fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "channel=${CHANNEL}" >> "$GITHUB_OUTPUT"
-          echo "Resolved: VERSION=${VERSION} CHANNEL=${CHANNEL}"
+          echo "Resolved: VERSION=${VERSION}"
           echo "Tarballs: ${#TARBALLS[@]}"
           echo "=== dist/ exact inventory: 12 release assets plus selected-channel delivery evidence fanout ==="
           ls -la
@@ -1065,7 +1104,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.meta.outputs.version }}
-          CHANNEL: ${{ steps.meta.outputs.channel }}
+          CHANNEL: ${{ inputs.channel }}
           DRAFT: ${{ inputs.draft }}
           RELEASE_REPOSITORY: ${{ github.repository }}
           CANDIDATE_MANIFEST_DIR: ${{ runner.temp }}/candidate-manifests

--- a/scripts/release-docs.test.ts
+++ b/scripts/release-docs.test.ts
@@ -82,7 +82,6 @@ describe('Group E release and documentation contracts', () => {
   test('privileged reusable workflows admit only the exact channel-specific main caller', () => {
     for (const path of ['.github/workflows/sign-attest.yml', '.github/workflows/release-publish.yml']) {
       const workflow = read(path);
-      expect(workflow).toContain('permissions: {}');
       expect(workflow).toContain(
         'EXPECTED_STABLE_CALLER: automagik-dev/genie/.github/workflows/release.yml@refs/heads/main',
       );
@@ -96,6 +95,65 @@ describe('Group E release and documentation contracts', () => {
       expect(workflow).toContain('"$CALLER_WORKFLOW_SHA" != "$CALLER_SHA"');
       expect(workflow).toContain('needs: admit');
     }
+
+    // sign-attest's admit needs no token at all. release-publish's admit holds
+    // exactly contents:read — the least that lets the replay guard ask whether
+    // the tag already carries a published release — and never write, so an
+    // unproven caller still cannot mutate anything.
+    expect(read('.github/workflows/sign-attest.yml')).toContain('permissions: {}');
+    const publishAdmit =
+      read('.github/workflows/release-publish.yml')
+        .split('\n  admit:')[1]
+        ?.split('\n  prepare-delivery-evidence:')[0] ?? '';
+    expect(publishAdmit).toContain('permissions:\n      # Read-only');
+    expect(publishAdmit).toContain('contents: read');
+    expect(publishAdmit).not.toContain('contents: write');
+    expect(publishAdmit).not.toContain('id-token:');
+  });
+
+  // A published release is immutable and this pipeline can no longer replay
+  // one (asset fanout grew past the 12 assets pre-fanout releases carry, and
+  // released_at became deterministic), so re-dispatching a published version
+  // fails only AFTER the release is locked. Admit must refuse it up front,
+  // while still admitting a draft so an interrupted run can finish. #2674.
+  test('admit refuses re-dispatch of a version that already has a published release', () => {
+    const admit =
+      read('.github/workflows/release-publish.yml')
+        .split('\n  admit:')[1]
+        ?.split('\n  prepare-delivery-evidence:')[0] ?? '';
+    expect(admit).toContain('name: Refuse re-dispatch of an already published release');
+    expect(admit).toContain('GH_TOKEN: ${{ github.token }}');
+    expect(admit).toContain('gh api "repos/${RELEASE_REPOSITORY}/releases/tags/v${INPUT_VERSION}"');
+    // non-draft is the refusal, and the refusal cites the rule + issue
+    expect(admit).toContain(`jq -r '.draft'`);
+    expect(admit).toContain('release-replay.published');
+    expect(admit).toContain('allocate a fresh version');
+    expect(admit).toContain('automagik-dev/genie#2674');
+    // ambiguous API failures fail closed rather than silently admitting
+    expect(admit).toContain('release-replay.unknown');
+    expect(admit).toContain(`grep -q 'HTTP 404'`);
+    // the guard runs only after the caller is proven
+    expect(admit.indexOf('name: Refuse re-dispatch of an already published release')).toBeGreaterThan(
+      admit.indexOf('name: Bind caller workflow and control commit'),
+    );
+  });
+
+  // The publish job used to keep its own CHANNEL="${INPUT_CHANNEL:-}" default
+  // to stable. admit already rejects an empty/unknown channel, so it was dead;
+  // had it ever fired, publish would have uploaded a 36-asset stable inventory
+  // that finalize aborts on, leaving a published-but-unfinalized release. #2675
+  test('publish reads the channel input directly instead of defaulting it', () => {
+    const workflow = read('.github/workflows/release-publish.yml');
+    const publishJob = workflow.split('\n  publish:')[1]?.split('\n  manifests:')[0] ?? '';
+    expect(publishJob).not.toContain('INPUT_CHANNEL');
+    expect(publishJob).not.toContain('CHANNEL="stable"');
+    expect(publishJob).not.toContain('steps.meta.outputs.channel');
+    expect(publishJob).toContain('CHANNEL: ${{ inputs.channel }}');
+    expect(workflow).not.toContain('channel=${CHANNEL}');
+    const manifestsJob = workflow.split('\n  manifests:')[1]?.split('\n  finalize:')[0] ?? '';
+    const finalizeJob = workflow.split('\n  finalize:')[1] ?? '';
+    expect(manifestsJob).toContain('CHANNEL: ${{ inputs.channel }}');
+    expect(finalizeJob).toContain('CHANNEL: ${{ inputs.channel }}');
   });
 
   test('release stages consume only artifacts from their current orchestrator run', () => {


### PR DESCRIPTION
> **TWIN-PR — this is the `main` half. Human-merge only.**
> This touches `.github/workflows/release-publish.yml`, the live release surface. **Do NOT merge while a stable release run is in flight** (a run that has passed `admit` reads its control code from the admitted `main` commit; merging under it changes the workflow mid-flight). Merge only when no release run is executing, and land the `dev` twin alongside it so the two branches do not diverge on this file.

Closes #2674. Closes #2675.

## What changed

### 1. `admit` refuses re-dispatch of an already published version (#2674)

New step `Refuse re-dispatch of an already published release`, running **after** the caller-binding step (an unproven caller is still rejected before any API call):

- `gh api repos/<repo>/releases/tags/v<version>` with `GH_TOKEN: ${{ github.token }}`.
- **Published (`draft == false`) → job fails** with `::error ::release-replay.published`, citing the rule ("published releases are non-replayable — allocate a fresh version") and #2674.
- **Draft → admitted**, on purpose: an interrupted run must still be able to finish the release it already opened. `reconcile-release-assets.sh` resumes partial drafts by design.
- **404 → admitted** (fresh version, the normal path).
- **Any other API answer → fails closed** (`::error ::release-replay.unknown`) instead of silently admitting on an ambiguous read.

Why mechanically and not by convention — both defects from the publish-tail review fire only on this precondition and both land *after* the release is published and locked, i.e. unrecoverable:

- **F1** `scripts/reconcile-release-assets.sh` now expects the 20 (dev) / 28 (homolog) / 36 (stable) delivery fanout; every pre-fanout published release carries exactly 12 assets and is `immutable=true`, so the missing descriptors can never be added → `exit 3`.
- **F2** `scripts/reconcile-channel-manifests.sh` now derives a deterministic midnight-UTC `released_at`; the manifests already committed to `main` carry wall-clock timestamps, so an equal-version replay fails `cmp` in the manifests job.

`version.yml` always allocates max-plus-one and pushes a fresh tag, so no legitimate release path is affected.

**Permissions note:** `admit` moves from `permissions: {}` to `permissions:\n  contents: read`. That is the least the query needs, it matches the workflow-level default, and `contents: write` still starts only at the `publish` job — nothing may mutate the repository before the caller is proven. `sign-attest.yml`'s admit keeps `permissions: {}`.

### 2. Dead `CHANNEL=stable` default deleted from `publish` (#2675)

`publish`'s `Resolve version + channel + asset inventory` step carried:

```bash
# Channel: workflow_dispatch picks; workflow_run defaults to stable.
CHANNEL="${INPUT_CHANNEL:-}"
if [[ -z "${CHANNEL}" ]]; then CHANNEL="stable"; fi
```

Unreachable (`admit` exits 1 on an empty/unknown channel and both callers always pass one), the comment was stale (this workflow is `workflow_call`-only), and it was the one place reading `steps.meta.outputs.channel` while `finalize` and `manifests` read `inputs.channel` raw. Had it ever fired, `publish` would have uploaded a 36-asset stable inventory that `finalize` then aborts on — a published-but-unfinalized release.

Now: the step is `Resolve version + asset inventory` (version parse + upstream cross-check only, unchanged), and `publish` reads `CHANNEL: ${{ inputs.channel }}` exactly like `finalize`/`manifests`. Fail-hard on a bad channel stays where it belongs, in `admit`.

## Tests

`scripts/release-docs.test.ts` gains two pinning tests (both branches):

- `admit refuses re-dispatch of a version that already has a published release` — pins the guard, the `.draft` check, the fail-closed branch, the issue citation, and that the guard runs after caller binding.
- `publish reads the channel input directly instead of defaulting it` — pins that the publish job carries no `INPUT_CHANNEL` / `CHANNEL="stable"` / `steps.meta.outputs.channel`, and that publish/finalize/manifests all read `inputs.channel`.

The existing `permissions: {}` assertion was split: `sign-attest.yml` still asserts it; `release-publish.yml`'s admit block now asserts `contents: read` and explicitly *not* `contents: write` / `id-token:`.

**Multi-attestation coverage (#2675) rides the dev twin** — `scripts/reconcile-release-assets.test.ts` is unchanged here so the two branches stay identical on the release-critical surface. See the dev PR.

**CAS-loop coverage: not added, recorded here instead.** The manifests job's fetch/detach/reconcile/add/commit/push loop with 403-vs-non-fast-forward failure classification is **workflow-inline shell with no testable seam** — there is no script under `scripts/` that owns it (`reconcile-channel-manifests.sh`, which *is* tested, is only the reconcile step the loop calls). Adding coverage would mean extracting the classifier into a new script, wiring it through the `RUNNER_TEMP` copy the loop already does for the reconciler, and doing so identically on both branches — a substantive refactor of the most fragile job in the release path, out of scope for a hardening PR that must be merged by hand. Per issue #2675 this is deliberately deferred rather than faked.

## Validation

```
bun test scripts/reconcile-release-assets.test.ts scripts/release-docs.test.ts   # 54 pass, 0 fail
bun run check:fast                                                              # OK: all checks passed
bunx actionlint .github/workflows/release-publish.yml                           # only the pre-existing
                                                                                # `queue: max` syntax note,
                                                                                # identical on origin/main
```

`actionlint` ran with `shellcheck` present, so the new inline shell was shellcheck-clean.

---

**Dev twin:** https://github.com/automagik-dev/genie/pull/2717


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened release publishing safeguards to prevent reusing versions that already have a published release.
  * Improved release channel handling so publishing consistently uses the selected workflow channel.
  * Restricted release admission workflow access to read-only repository content.

* **Tests**
  * Expanded release workflow validation to cover permission settings, duplicate-release refusal, failure-safe behavior, and channel selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->