### PR TITLE
fix(release): refuse re-dispatch of published versions + delete dead channel default (#2674, #2675) (dev twin)

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -82,7 +82,12 @@ jobs:
     name: Admit trusted release orchestrator
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    permissions: {}
+    permissions:
+      # Read-only, and only so the replay guard below can ask whether the tag
+      # already carries a published release. contents:write still starts at the
+      # publish job: nothing may mutate the repository before the caller is
+      # proven, and the guard runs after the binding step for the same reason.
+      contents: read
     steps:
       - name: Bind caller workflow and control commit
         shell: bash
@@ -137,6 +142,43 @@ jobs:
               ;;
           esac
           echo "Trusted release caller admitted at ${CALLER_SHA}"
+
+      - name: Refuse re-dispatch of an already published release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          # A published (non-draft) release is immutable, and this pipeline is
+          # no longer able to replay one: reconcile-release-assets.sh expects
+          # the current 20/28/36-asset delivery fanout while every pre-fanout
+          # release carries 12 that can never be extended, and
+          # reconcile-channel-manifests.sh now derives a deterministic
+          # midnight-UTC released_at that no longer cmp-matches the wall-clock
+          # timestamps already committed to main. Both failures land AFTER the
+          # release is published and locked, so refuse the run here instead.
+          # Always allocate a fresh version (version.yml allocates max-plus-one
+          # and pushes a fresh tag). See automagik-dev/genie#2674.
+          # Drafts stay admissible on purpose: an interrupted run must still be
+          # able to finish the release it already opened.
+          RELEASE_JSON="$(mktemp)"
+          RELEASE_ERROR="$(mktemp)"
+          if gh api "repos/${RELEASE_REPOSITORY}/releases/tags/v${INPUT_VERSION}" \
+            >"$RELEASE_JSON" 2>"$RELEASE_ERROR"; then
+            if [[ "$(jq -r '.draft' "$RELEASE_JSON")" != true ]]; then
+              echo "::error ::release-replay.published v${INPUT_VERSION} already has a published GitHub Release — published releases are non-replayable (immutable asset inventory + deterministic released_at); allocate a fresh version instead. See automagik-dev/genie#2674"
+              exit 1
+            fi
+            echo "v${INPUT_VERSION} exists only as a draft release; admitting so the interrupted publish can complete"
+          elif grep -q 'HTTP 404' "$RELEASE_ERROR"; then
+            echo "v${INPUT_VERSION} has no GitHub Release yet"
+          else
+            cat "$RELEASE_ERROR" >&2
+            echo "::error ::release-replay.unknown could not determine whether v${INPUT_VERSION} already has a published release; failing closed. See automagik-dev/genie#2674"
+            exit 1
+          fi
 
   prepare-delivery-evidence:
     name: Build canonical delivery descriptors
@@ -1012,12 +1054,15 @@ jobs:
           name: delivery-candidate-manifests
           path: ${{ runner.temp }}/candidate-manifests
 
-      - name: Resolve version + channel + asset inventory
+      # Channel is NOT resolved here: admit already rejects an empty/unknown
+      # channel, and finalize/manifests read inputs.channel raw. A local
+      # default would only let publish upload a stable-sized inventory that
+      # finalize then aborts on, leaving a published-but-unfinalized release.
+      - name: Resolve version + asset inventory
         id: meta
         shell: bash
         env:
           INPUT_VERSION: ${{ inputs.version }}
-          INPUT_CHANNEL: ${{ inputs.channel }}
         run: |
           set -euo pipefail
           cd dist
@@ -1041,14 +1086,8 @@ jobs:
             echo "::error::workflow_dispatch input version='${INPUT_VERSION}' does not match upstream artifact version='${VERSION}'"
             exit 1
           fi
-          # Channel: workflow_dispatch picks; workflow_run defaults to stable.
-          CHANNEL="${INPUT_CHANNEL:-}"
-          if [[ -z "${CHANNEL}" ]]; then
-            CHANNEL="stable"
-          fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "channel=${CHANNEL}" >> "$GITHUB_OUTPUT"
-          echo "Resolved: VERSION=${VERSION} CHANNEL=${CHANNEL}"
+          echo "Resolved: VERSION=${VERSION}"
           echo "Tarballs: ${#TARBALLS[@]}"
           echo "=== dist/ exact inventory: 12 release assets plus selected-channel delivery evidence fanout ==="
           ls -la
@@ -1065,7 +1104,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.meta.outputs.version }}
-          CHANNEL: ${{ steps.meta.outputs.channel }}
+          CHANNEL: ${{ inputs.channel }}
           DRAFT: ${{ inputs.draft }}
           RELEASE_REPOSITORY: ${{ github.repository }}
           CANDIDATE_MANIFEST_DIR: ${{ runner.temp }}/candidate-manifests

--- a/scripts/reconcile-release-assets.test.ts
+++ b/scripts/reconcile-release-assets.test.ts
@@ -33,6 +33,7 @@ interface FakeState {
   prerelease?: boolean;
   assets: Record<string, string>;
   calls?: Array<{ tool: string; args: string[] }>;
+  attestationBatchSizes?: number[];
   failOn?: string;
   controlSha?: string;
   secondControlSha?: string;
@@ -168,7 +169,24 @@ if (args[0] === 'attestation' && args[1] === 'verify') {
       },
     },
   };
-  console.log(JSON.stringify([{ verificationResult: { statement } }]));
+  // A published tarball carries TWO attestations for the same digest: GitHub's
+  // own in-toto immutable-release attestation (minted when the release is
+  // locked) and ours. The attestations API returns both, GitHub's first.
+  // Production must select by predicate type — never by position or by count.
+  const immutableRelease = {
+    verificationResult: {
+      statement: {
+        _type: 'https://in-toto.io/Statement/v1',
+        predicateType: 'https://in-toto.io/attestation/release/v0.2',
+        subject: [{ name: 'genie-${VERSION}', digest: { sha256: 'e'.repeat(64) } }],
+        predicate: { purl: 'pkg:github/automagik-dev/genie@v${VERSION}', releaseId: 4242 },
+      },
+    },
+  };
+  const attestations = [immutableRelease, { verificationResult: { statement } }];
+  state.attestationBatchSizes ??= [];
+  state.attestationBatchSizes.push(attestations.length);
+  console.log(JSON.stringify(attestations));
   save(); process.exit(0);
 }
 save(); process.exit(2);
@@ -375,6 +393,18 @@ describe('exact GitHub release asset reconciliation', () => {
         'https://github.com/automagik-dev/genie/.github/workflows/release-publish.yml@refs/heads/main',
       );
     }
+  });
+
+  test('selects our release predicate when GitHub also attests the immutable release', () => {
+    const publishedAssets = localAssets('published');
+    const { result, state } = run({ draft: false, assets: publishedAssets });
+    expect(result.exitCode).toBe(0);
+    expect(state.assets).toEqual(publishedAssets);
+    expect(calls(state, 'gh', 'release upload')).toHaveLength(0);
+    // 4 platforms x 2 passes (unfiltered, then certificate-filtered), each
+    // answered with GitHub's immutable-release attestation ahead of ours.
+    expect(state.attestationBatchSizes).toHaveLength(8);
+    expect(state.attestationBatchSizes?.every((size) => size === 2)).toBe(true);
   });
 
   test('never repairs a partial published release or accepts remote extras', () => {

--- a/scripts/release-docs.test.ts
+++ b/scripts/release-docs.test.ts
@@ -82,7 +82,6 @@ describe('Group E release and documentation contracts', () => {
   test('privileged reusable workflows admit only the exact channel-specific main caller', () => {
     for (const path of ['.github/workflows/sign-attest.yml', '.github/workflows/release-publish.yml']) {
       const workflow = read(path);
-      expect(workflow).toContain('permissions: {}');
       expect(workflow).toContain(
         'EXPECTED_STABLE_CALLER: automagik-dev/genie/.github/workflows/release.yml@refs/heads/main',
       );
@@ -96,6 +95,65 @@ describe('Group E release and documentation contracts', () => {
       expect(workflow).toContain('"$CALLER_WORKFLOW_SHA" != "$CALLER_SHA"');
       expect(workflow).toContain('needs: admit');
     }
+
+    // sign-attest's admit needs no token at all. release-publish's admit holds
+    // exactly contents:read — the least that lets the replay guard ask whether
+    // the tag already carries a published release — and never write, so an
+    // unproven caller still cannot mutate anything.
+    expect(read('.github/workflows/sign-attest.yml')).toContain('permissions: {}');
+    const publishAdmit =
+      read('.github/workflows/release-publish.yml')
+        .split('\n  admit:')[1]
+        ?.split('\n  prepare-delivery-evidence:')[0] ?? '';
+    expect(publishAdmit).toContain('permissions:\n      # Read-only');
+    expect(publishAdmit).toContain('contents: read');
+    expect(publishAdmit).not.toContain('contents: write');
+    expect(publishAdmit).not.toContain('id-token:');
+  });
+
+  // A published release is immutable and this pipeline can no longer replay
+  // one (asset fanout grew past the 12 assets pre-fanout releases carry, and
+  // released_at became deterministic), so re-dispatching a published version
+  // fails only AFTER the release is locked. Admit must refuse it up front,
+  // while still admitting a draft so an interrupted run can finish. #2674.
+  test('admit refuses re-dispatch of a version that already has a published release', () => {
+    const admit =
+      read('.github/workflows/release-publish.yml')
+        .split('\n  admit:')[1]
+        ?.split('\n  prepare-delivery-evidence:')[0] ?? '';
+    expect(admit).toContain('name: Refuse re-dispatch of an already published release');
+    expect(admit).toContain('GH_TOKEN: ${{ github.token }}');
+    expect(admit).toContain('gh api "repos/${RELEASE_REPOSITORY}/releases/tags/v${INPUT_VERSION}"');
+    // non-draft is the refusal, and the refusal cites the rule + issue
+    expect(admit).toContain(`jq -r '.draft'`);
+    expect(admit).toContain('release-replay.published');
+    expect(admit).toContain('allocate a fresh version');
+    expect(admit).toContain('automagik-dev/genie#2674');
+    // ambiguous API failures fail closed rather than silently admitting
+    expect(admit).toContain('release-replay.unknown');
+    expect(admit).toContain(`grep -q 'HTTP 404'`);
+    // the guard runs only after the caller is proven
+    expect(admit.indexOf('name: Refuse re-dispatch of an already published release')).toBeGreaterThan(
+      admit.indexOf('name: Bind caller workflow and control commit'),
+    );
+  });
+
+  // The publish job used to keep its own CHANNEL="${INPUT_CHANNEL:-}" default
+  // to stable. admit already rejects an empty/unknown channel, so it was dead;
+  // had it ever fired, publish would have uploaded a 36-asset stable inventory
+  // that finalize aborts on, leaving a published-but-unfinalized release. #2675
+  test('publish reads the channel input directly instead of defaulting it', () => {
+    const workflow = read('.github/workflows/release-publish.yml');
+    const publishJob = workflow.split('\n  publish:')[1]?.split('\n  manifests:')[0] ?? '';
+    expect(publishJob).not.toContain('INPUT_CHANNEL');
+    expect(publishJob).not.toContain('CHANNEL="stable"');
+    expect(publishJob).not.toContain('steps.meta.outputs.channel');
+    expect(publishJob).toContain('CHANNEL: ${{ inputs.channel }}');
+    expect(workflow).not.toContain('channel=${CHANNEL}');
+    const manifestsJob = workflow.split('\n  manifests:')[1]?.split('\n  finalize:')[0] ?? '';
+    const finalizeJob = workflow.split('\n  finalize:')[1] ?? '';
+    expect(manifestsJob).toContain('CHANNEL: ${{ inputs.channel }}');
+    expect(finalizeJob).toContain('CHANNEL: ${{ inputs.channel }}');
   });
 
   test('release stages consume only artifacts from their current orchestrator run', () => {


### PR DESCRIPTION
> **TWIN-PR — this is the `dev` half.** The `main` half is **https://github.com/automagik-dev/genie/pull/2716**, which carries the full rationale.
> Both PRs are **human-merge only**, and neither may be merged while a stable release run is in flight. Land them together so `main` and `dev` do not diverge on `.github/workflows/release-publish.yml`.

Refs #2674, #2675 (closed by the main twin, #2716).

## Relationship to #2716

`.github/workflows/release-publish.yml` and `scripts/release-docs.test.ts` are **byte-identical** to the main twin (verified with `cmp` against the twin commit before pushing). This PR adds one file the main half deliberately does not carry.

## What changed (same as #2716)

1. **#2674 — `admit` refuses re-dispatch of an already published version.** New step queries `gh api repos/<repo>/releases/tags/v<version>`; a `draft == false` release fails the job with `::error ::release-replay.published` citing "published releases are non-replayable — allocate a fresh version" and #2674. Drafts stay admissible (an interrupted run must finish the release it opened), 404 is the normal fresh-version path, and any other API answer fails closed. `admit` moves from `permissions: {}` to `contents: read` — never write, which still starts at `publish`.

2. **#2675 — dead `CHANNEL=stable` default deleted from `publish`.** `CHANNEL="${INPUT_CHANNEL:-}"` → stable was unreachable (`admit` exits 1 on an empty/unknown channel), its comment was stale, and it was the only reader of `steps.meta.outputs.channel`. `publish` now reads `inputs.channel` raw like `finalize`/`manifests`; the step is renamed `Resolve version + asset inventory`.

## Dev-only addition: multi-attestation shape (#2675)

`scripts/reconcile-release-assets.test.ts` — the fake `gh` returned exactly one attestation per tarball, so nothing pinned the real API shape. A published tarball actually carries **two** attestations for the same digest: GitHub's in-toto immutable-release attestation (minted when the release is locked) and ours. Production tolerates it — `scripts/release-native-predicate.sh` `reusable_control_sha()` uses `first(.[] | select(predicateType == ...))`, i.e. selection by predicate type — but no test would have caught a regression to positional selection.

- The fake now emits `[github-immutable-release, ours]` for every non-`--bundle` tarball verification, **GitHub's first**, and records each batch size in state.
- New test `selects our release predicate when GitHub also attests the immutable release` asserts a clean run plus `attestationBatchSizes` of `[2 x 8]` (4 platforms x 2 passes: unfiltered, then certificate-filtered).
- The `--bundle` delivery path still returns exactly one, matching the script's `length == 1` assertion on the descriptor equality check.

Mutation-checked: rewriting `first(.[] | select(...))` to `first(.[0] | select(...))` in `release-native-predicate.sh` makes the new test fail (exit 4). Reverted before commit.

## CAS-loop coverage: not added, recorded here

The manifests job's inline fetch/detach/reconcile/add/commit/push loop with 403-vs-non-fast-forward failure classification is **workflow-inline shell with no testable seam** — no script under `scripts/` owns it (`reconcile-channel-manifests.sh`, which is tested, is only the reconcile step the loop calls). Covering it would require extracting the classifier into a new script and wiring it through the `RUNNER_TEMP` copy the loop already performs for the reconciler, identically on both branches — a substantive refactor of the most fragile job in the release path, out of scope here. Deferred deliberately rather than faked, per #2675.

## Validation

```
bun test scripts/reconcile-release-assets.test.ts                        # 14 pass, 0 fail (was 13)
bun test scripts/release-docs.test.ts                                    # 41 pass, 0 fail
bun test scripts/release-guard scripts/release-native-predicate \
         scripts/release-generic-provenance scripts/reconcile-* \
         scripts/release-immutability                                    # 68 pass, 0 fail
bun run check:fast                                                       # OK: all checks passed
bunx actionlint .github/workflows/release-publish.yml                    # only the pre-existing
                                                                         # `queue: max` note, identical
                                                                         # on origin/dev
```

`actionlint` ran with `shellcheck` present, so the new inline shell was shellcheck-clean.
