### PR TITLE
feat(hooks): mechanical git-freeze guard for shared-workspace subagents (#2705)

### DIFF
--- a/src/hooks/__tests__/git-freeze-guard.test.ts
+++ b/src/hooks/__tests__/git-freeze-guard.test.ts
@@ -235,6 +235,81 @@ describe('git-freeze-guard', () => {
   });
 
   // =========================================================================
+  // Subshells — `(…)` scopes a cd, and its parens are not part of the command
+  // =========================================================================
+
+  describe('subshell grouping', () => {
+    test('allows a subshell that cd s into another repo before the frozen call', async () => {
+      expect(await run(subagent('(cd /other && git switch main)'))).toBeUndefined();
+    });
+
+    test('allows the same subshell written with the parens as their own tokens', async () => {
+      expect(await run(subagent('( cd /other && git switch main )'))).toBeUndefined();
+    });
+
+    test('allows a nested subshell', async () => {
+      expect(await run(subagent('((cd /other && git switch main))'))).toBeUndefined();
+    });
+
+    test('allows a subshell cd into an owned worktree', async () => {
+      expect(await run(subagent(`(cd ${LANE} && git switch -c feat/x)`))).toBeUndefined();
+    });
+
+    test('denies once the subshell closes, because its cd does not leak', async () => {
+      expect((await run(subagent(`(cd ${LANE} && git status) && git switch dev`)))?.decision).toBe('deny');
+    });
+
+    test('denies a frozen call that follows a closed subshell', async () => {
+      expect((await run(subagent('(cd /other && git switch main) ; git switch dev')))?.decision).toBe('deny');
+    });
+
+    test('a command substitution inside a subshell does not close it early', async () => {
+      expect(await run(subagent(`(cd ${LANE} && echo $(pwd) && git switch dev)`))).toBeUndefined();
+    });
+
+    test('still denies after a command substitution in an earlier statement', async () => {
+      expect((await run(subagent('echo $(date) && git switch dev')))?.decision).toBe('deny');
+      expect((await run(subagent('echo `date` && git switch dev')))?.decision).toBe('deny');
+    });
+
+    test('allows a git -C whose target is a command substitution', async () => {
+      expect(await run(subagent('git -C $(pwd) switch dev'))).toBeUndefined();
+    });
+  });
+
+  // =========================================================================
+  // Every frozen invocation is evaluated, not just the first
+  // =========================================================================
+
+  describe('multiple frozen invocations in one command', () => {
+    test('denies a shared-checkout call hidden behind a legitimate git -C', async () => {
+      expect((await run(subagent('git -C /other switch main && git switch dev')))?.decision).toBe('deny');
+    });
+
+    test('denies a shared-checkout call hidden behind a legitimate worktree call', async () => {
+      expect((await run(subagent(`cd ${LANE} && git switch x && cd ${SHARED} && git switch dev`)))?.decision).toBe(
+        'deny',
+      );
+    });
+
+    test('allows when every frozen invocation lands outside the shared checkout', async () => {
+      expect(await run(subagent(`git -C ${LANE} switch x && git -C /other switch y`))).toBeUndefined();
+    });
+
+    test('the deny names the invocation that targets the shared checkout', async () => {
+      const result = await run(subagent('git -C /other switch main && git reset --hard HEAD~1'));
+      expect(result?.decision).toBe('deny');
+      expect(result?.reason ?? '').toContain('`git reset`');
+    });
+
+    test('resolves each distinct directory at most once', async () => {
+      const mock = mockDeps();
+      expect(await gitFreezeGuard(subagent('cd /other && git switch a && git switch b'), mock.deps)).toBeUndefined();
+      expect(mock.calls).toEqual([SHARED, '/other']);
+    });
+  });
+
+  // =========================================================================
   // Quoting — a frozen command named inside an argument is not a command
   // =========================================================================
 
@@ -277,6 +352,15 @@ describe('git-freeze-guard', () => {
       const payload = subagent('git checkout dev');
       payload.tool_input = {};
       expect(await run(payload)).toBeUndefined();
+    });
+
+    test('allows a frozen call nested inside a substitution — the documented boundary', async () => {
+      // The guard masks a substitution's interior instead of walking it, so a
+      // frozen call in there is not seen. Pinned deliberately: see the module
+      // header. The freeze targets the accidental `git switch dev`, and this is
+      // not a form anyone reaches for by accident.
+      expect(await run(subagent('$(cd /repo && git switch dev)'))).toBeUndefined();
+      expect(await run(subagent('`git switch dev`'))).toBeUndefined();
     });
 
     test('does not shell out to git for commands that never mention git', async () => {

--- a/src/hooks/__tests__/git-freeze-guard.test.ts
+++ b/src/hooks/__tests__/git-freeze-guard.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, test } from 'bun:test';
+import { type GitFreezeGuardDeps, gitFreezeGuard } from '../handlers/git-freeze-guard.js';
+import type { HookPayload } from '../types.js';
+
+/** The shared checkout every dispatched subagent starts in. */
+const SHARED = '/repo';
+/** A linked worktree an agent owns — its own HEAD, so the freeze does not apply. */
+const LANE = '/wt/lane-a';
+
+/**
+ * Working-tree topology the mock resolves against. Mirrors what
+ * `git rev-parse --show-toplevel` returns for each directory; anything absent
+ * is "not a git working tree" (the mock returns `null`, and the guard allows).
+ */
+const TOPOLOGY: Record<string, string> = {
+  [SHARED]: SHARED,
+  [`${SHARED}/src`]: SHARED,
+  [`${SHARED}/src/hooks`]: SHARED,
+  [LANE]: LANE,
+  [`${LANE}/src`]: LANE,
+  '/other': '/other',
+};
+
+interface CallLog {
+  deps: GitFreezeGuardDeps;
+  calls: string[];
+}
+
+function mockDeps(topology: Record<string, string> = TOPOLOGY): CallLog {
+  const calls: string[] = [];
+  return {
+    calls,
+    deps: {
+      resolveWorktreeRoot: (dir) => {
+        calls.push(dir);
+        return topology[dir] ?? null;
+      },
+    },
+  };
+}
+
+/** A Bash call issued by a dispatched subagent (Claude Code fills `agent_id`). */
+function subagent(command: string, cwd: string = SHARED): HookPayload {
+  return {
+    hook_event_name: 'PreToolUse',
+    tool_name: 'Bash',
+    cwd,
+    agent_id: 'a59efa9aa4e5c4138',
+    agent_type: 'general-purpose',
+    tool_input: { command },
+  };
+}
+
+/** The same Bash call issued by the orchestrator (main thread: no `agent_id`). */
+function orchestrator(command: string, cwd: string = SHARED): HookPayload {
+  return {
+    hook_event_name: 'PreToolUse',
+    tool_name: 'Bash',
+    cwd,
+    agent_id: null,
+    agent_type: null,
+    tool_input: { command },
+  };
+}
+
+async function run(payload: HookPayload, topology?: Record<string, string>) {
+  return gitFreezeGuard(payload, mockDeps(topology).deps);
+}
+
+describe('git-freeze-guard', () => {
+  // =========================================================================
+  // DENIES — subagent moving the shared checkout's git state
+  // =========================================================================
+
+  describe('denies frozen subcommands from a subagent in the shared workspace', () => {
+    const blocked = [
+      'git checkout dev',
+      'git checkout -b feat/thing',
+      'git checkout -- src/foo.ts',
+      'git switch dev',
+      'git switch -c feat/thing',
+      'git reset --hard HEAD~1',
+      'git reset --soft HEAD~1',
+      'git stash',
+      'git stash push -m wip',
+      'git stash pop',
+      'git rebase origin/dev',
+      'git rebase --abort',
+      'git rebase -i HEAD~3',
+    ];
+
+    for (const cmd of blocked) {
+      test(`denies: ${cmd}`, async () => {
+        const result = await run(subagent(cmd));
+        expect(result?.decision).toBe('deny');
+      });
+    }
+  });
+
+  test('deny reason cites the AGENTS.md freeze and both escape hatches', async () => {
+    const result = await run(subagent('git checkout dev'));
+    const reason = result?.reason ?? '';
+    expect(reason).toContain('AGENTS.md');
+    expect(reason).toContain('only the orchestrator moves HEAD');
+    expect(reason).toContain('genie launch');
+    expect(reason).toContain('git worktree add');
+    expect(reason).toContain('sequence the work');
+    expect(reason).toContain(SHARED);
+  });
+
+  // =========================================================================
+  // ALLOWS — the orchestrator owns HEAD
+  // =========================================================================
+
+  describe('never fires for the orchestrator', () => {
+    for (const cmd of ['git checkout dev', 'git reset --hard HEAD~1', 'git rebase origin/dev']) {
+      test(`allows from main thread: ${cmd}`, async () => {
+        expect(await run(orchestrator(cmd))).toBeUndefined();
+      });
+    }
+
+    test('allows when agent_type is explicitly main', async () => {
+      const payload = subagent('git switch dev');
+      payload.agent_type = 'main';
+      expect(await run(payload)).toBeUndefined();
+    });
+
+    test('allows when the runtime supplies no agent_id at all (Codex, older clients)', async () => {
+      const payload = subagent('git switch dev');
+      payload.agent_id = undefined;
+      payload.agent_type = undefined;
+      expect(await run(payload)).toBeUndefined();
+    });
+  });
+
+  // =========================================================================
+  // ALLOWS — read-only and worktree plumbing
+  // =========================================================================
+
+  describe('allows non-frozen git usage from a subagent', () => {
+    const allowed = [
+      'git status',
+      'git log --oneline -10',
+      'git diff --stat',
+      'git show HEAD',
+      'git add -A',
+      'git commit -m wip',
+      'git fetch origin',
+      'git worktree add /wt/lane-b -b feat/x origin/dev',
+      'git worktree remove /wt/lane-b',
+      'git worktree prune',
+      'git worktree list',
+      'git stash list',
+      'git stash show -p',
+      'git branch --show-current',
+    ];
+
+    for (const cmd of allowed) {
+      test(`allows: ${cmd}`, async () => {
+        expect(await run(subagent(cmd))).toBeUndefined();
+      });
+    }
+  });
+
+  // =========================================================================
+  // `git -C <path>` — the worktree an agent owns
+  // =========================================================================
+
+  describe('git -C targeting', () => {
+    test('allows git -C into a worktree the agent owns', async () => {
+      expect(await run(subagent(`git -C ${LANE} checkout -b feat/x`))).toBeUndefined();
+    });
+
+    test('denies git -C pointed back at the shared checkout', async () => {
+      expect((await run(subagent(`git -C ${SHARED} switch dev`)))?.decision).toBe('deny');
+    });
+
+    test('denies git -C . in the shared checkout', async () => {
+      expect((await run(subagent('git -C . reset --hard HEAD~1')))?.decision).toBe('deny');
+    });
+
+    test('denies git -C on a subdirectory of the shared checkout', async () => {
+      expect((await run(subagent('git -C src/hooks checkout dev')))?.decision).toBe('deny');
+    });
+
+    test('allows git -C to an unrelated repo outside the shared checkout', async () => {
+      expect(await run(subagent('git -C ../other checkout dev'))).toBeUndefined();
+    });
+
+    test('allows a non-literal git -C target rather than guessing', async () => {
+      expect(await run(subagent('git -C "$WT" checkout -b feat/x'))).toBeUndefined();
+    });
+  });
+
+  // =========================================================================
+  // Compound commands — the documented false-positive trap
+  // =========================================================================
+
+  describe('compound commands', () => {
+    test('allows cd into an owned worktree before checkout', async () => {
+      expect(await run(subagent(`cd ${LANE} && git checkout -b feat/x`))).toBeUndefined();
+    });
+
+    test('denies when a later cd lands back in the shared checkout', async () => {
+      expect((await run(subagent(`cd ${LANE} && cd ${SHARED} && git switch dev`)))?.decision).toBe('deny');
+    });
+
+    test('denies a relative cd that stays inside the shared checkout', async () => {
+      expect((await run(subagent('cd src && git switch dev')))?.decision).toBe('deny');
+    });
+
+    test('denies a frozen command that follows an unrelated command', async () => {
+      expect((await run(subagent('bun test && git checkout dev')))?.decision).toBe('deny');
+    });
+
+    test('denies across a semicolon separator', async () => {
+      expect((await run(subagent('echo hi; git rebase origin/dev')))?.decision).toBe('deny');
+    });
+
+    test('denies across a pipe separator', async () => {
+      expect((await run(subagent('git checkout dev | tee /dev/null')))?.decision).toBe('deny');
+    });
+
+    test('allows when the cd target is a variable (unresolvable, so not guessed)', async () => {
+      expect(await run(subagent('cd "$WORKTREE" && git checkout -b feat/x'))).toBeUndefined();
+    });
+
+    test('allows when the cd target is tilde-expanded (unresolvable)', async () => {
+      expect(await run(subagent('cd ~/work/lane && git checkout -b feat/x'))).toBeUndefined();
+    });
+
+    test('allows after popd discards the known directory', async () => {
+      expect(await run(subagent(`pushd ${LANE} && popd && git checkout dev`))).toBeUndefined();
+    });
+  });
+
+  // =========================================================================
+  // Quoting — a frozen command named inside an argument is not a command
+  // =========================================================================
+
+  describe('quoted arguments never trigger a deny', () => {
+    const allowed = [
+      'git commit -m "git checkout main to reproduce"',
+      "gh pr create --base dev --body 'the fix removes a stray git rebase origin/dev'",
+      'gh issue comment 2705 --body "shared-workspace subagents never run git reset --hard"',
+      'echo "cd /repo && git switch dev"',
+    ];
+
+    for (const cmd of allowed) {
+      test(`allows: ${cmd}`, async () => {
+        expect(await run(subagent(cmd))).toBeUndefined();
+      });
+    }
+  });
+
+  // =========================================================================
+  // Fail-open boundaries
+  // =========================================================================
+
+  describe('fails open on anything it cannot resolve', () => {
+    test('allows repo-redirecting global flags rather than re-deriving git discovery', async () => {
+      expect(await run(subagent('git --git-dir=/repo/.git checkout dev'))).toBeUndefined();
+      expect(await run(subagent('git --work-tree /repo checkout dev'))).toBeUndefined();
+    });
+
+    test('allows when the payload carries no cwd', async () => {
+      const payload = subagent('git checkout dev');
+      payload.cwd = undefined;
+      expect(await run(payload)).toBeUndefined();
+    });
+
+    test('allows when the shared cwd is not a git working tree', async () => {
+      expect(await run(subagent('git checkout dev', '/not/a/repo'))).toBeUndefined();
+    });
+
+    test('allows when tool_input has no command', async () => {
+      const payload = subagent('git checkout dev');
+      payload.tool_input = {};
+      expect(await run(payload)).toBeUndefined();
+    });
+
+    test('does not shell out to git for commands that never mention git', async () => {
+      const mock = mockDeps();
+      expect(await gitFreezeGuard(subagent('bun run check:fast'), mock.deps)).toBeUndefined();
+      expect(mock.calls).toEqual([]);
+    });
+
+    test('does not shell out to git for read-only git commands', async () => {
+      const mock = mockDeps();
+      expect(await gitFreezeGuard(subagent('git status --short'), mock.deps)).toBeUndefined();
+      expect(mock.calls).toEqual([]);
+    });
+  });
+
+  // =========================================================================
+  // Worktree-scoped sessions
+  // =========================================================================
+
+  describe('worktree-scoped sessions', () => {
+    test('a subagent may not move the HEAD of the worktree it shares with its orchestrator', async () => {
+      expect((await run(subagent('git checkout dev', LANE)))?.decision).toBe('deny');
+    });
+
+    test('but may move a different worktree it addresses explicitly', async () => {
+      expect(await run(subagent(`git -C ${SHARED} checkout dev`, LANE))).toBeUndefined();
+    });
+  });
+});

--- a/src/hooks/handlers/branch-guard.ts
+++ b/src/hooks/handlers/branch-guard.ts
@@ -14,6 +14,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
+import { maskQuotedRegions } from '../shell-quoting.js';
 import type { HandlerResult, HookPayload } from '../types.js';
 
 /** Branches that agents are allowed to merge PRs into. */
@@ -156,70 +157,6 @@ function extractPrNumber(cmd: string): string | null {
 function extractRepoFlag(cmd: string): string | null {
   const match = cmd.match(/(?:--repo|-R)(?:\s+|=)([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)\b/);
   return match ? match[1] : null;
-}
-
-/**
- * Mask the interior of single/double-quoted shell regions with spaces,
- * preserving string length so regex word-boundaries behave identically on the
- * remaining unmasked characters.
- *
- * Closes a class of over-matches where a blocked substring (`gh pr merge N`,
- * `git push origin main`, `git checkout main && git commit`) appearing inside
- * a `--body` / `--message` / `-m` argument triggered a false-positive deny.
- *
- * Live reproducer: opening PR #1264 (the branch-guard subprocess-diagnostics
- * fix) was blocked twice because the PR body described the very commands the
- * hook denies. Required a workaround — paraphrase every literal occurrence —
- * that doesn't generalize.
- *
- * Scope: handles single-quotes (no escapes), double-quotes with `\X` escapes,
- * and unterminated quotes (mask to end of string — safer than the alternative
- * of leaving a runaway region unmasked). Backtick command substitution and
- * heredocs are intentionally not parsed — they're rare in agent-issued
- * commands and falling back to fully unmasked treatment is fail-closed for
- * the original policy, which matches the hook's overall posture.
- */
-type QuoteState = 'none' | 'single' | 'double';
-interface MaskStep {
-  out: string;
-  next: QuoteState;
-  consumed: number;
-}
-
-/** Unquoted char: pass through, or open a quote region. */
-function stepUnquoted(ch: string): MaskStep {
-  if (ch === "'") return { out: ' ', next: 'single', consumed: 1 };
-  if (ch === '"') return { out: ' ', next: 'double', consumed: 1 };
-  return { out: ch, next: 'none', consumed: 1 };
-}
-
-/** Single-quoted char: always masked; `'` closes the region (no escapes in bash single-quotes). */
-function stepSingleQuoted(ch: string): MaskStep {
-  return { out: ' ', next: ch === "'" ? 'none' : 'single', consumed: 1 };
-}
-
-/** Double-quoted char: always masked; `\X` consumes two chars; `"` closes. */
-function stepDoubleQuoted(ch: string, hasNext: boolean): MaskStep {
-  if (ch === '\\' && hasNext) return { out: '  ', next: 'double', consumed: 2 };
-  return { out: ' ', next: ch === '"' ? 'none' : 'double', consumed: 1 };
-}
-
-function maskQuotedRegions(cmd: string): string {
-  let out = '';
-  let state: QuoteState = 'none';
-  let i = 0;
-  while (i < cmd.length) {
-    const step: MaskStep =
-      state === 'double'
-        ? stepDoubleQuoted(cmd[i], i + 1 < cmd.length)
-        : state === 'single'
-          ? stepSingleQuoted(cmd[i])
-          : stepUnquoted(cmd[i]);
-    out += step.out;
-    state = step.next;
-    i += step.consumed;
-  }
-  return out;
 }
 
 export async function branchGuard(payload: HookPayload, deps: BranchGuardDeps = defaultDeps): Promise<HandlerResult> {

--- a/src/hooks/handlers/git-freeze-guard.ts
+++ b/src/hooks/handlers/git-freeze-guard.ts
@@ -1,0 +1,248 @@
+/**
+ * Git-Freeze Guard Handler — PreToolUse:Bash
+ *
+ * Mechanical enforcement of the shared-workspace git-state freeze recorded in
+ * AGENTS.md ("Engineering rules"): *shared-workspace subagents never mutate
+ * repo-level git state (no `checkout`/`switch`/`reset`/`stash`/`rebase`) — only
+ * the orchestrator moves HEAD*. Until this handler, that invariant was enforced
+ * by brief prose alone (issue #2705).
+ *
+ * ## Why this can be enforced at all
+ *
+ * Claude Code's PreToolUse payload carries `agent_id` / `agent_type`. Measured
+ * on Claude Code 2.1.220: the main thread's Bash calls arrive with
+ * `agent_id: null, agent_type: null`; a spawned subagent's Bash calls arrive
+ * with `agent_id: "<id>", agent_type: "general-purpose"` under the *same*
+ * `session_id` and the *same* `cwd`. That is the orchestrator-vs-subagent
+ * discriminator the freeze needs.
+ *
+ * ## Fail-open, deliberately
+ *
+ * Every ambiguity resolves to *allow*, not deny:
+ *   - no `agent_id` on the payload (main thread, Codex, an older/newer client
+ *     that drops the field) → allow;
+ *   - a `cd` / `git -C` target that isn't a literal path (variable, glob,
+ *     `~`, command substitution, quoted-and-masked) → allow;
+ *   - `git --git-dir` / `--work-tree` / `--namespace` overrides → allow;
+ *   - a worktree root that git cannot resolve → allow.
+ *
+ * This is the opposite of {@link branchGuard}'s fail-closed posture, and it is
+ * the point. The freeze has no server-side backstop the way branch protection
+ * backstops `gh pr merge`, so a wrong deny here has no escape hatch and simply
+ * breaks a working agent. The founding incident was an *accidental* HEAD move
+ * in a shared checkout, not an adversarial one; a guard that reliably catches
+ * the literal, common forms and never fires on a legitimate one is worth more
+ * than a guard nobody can keep enabled. This is a guardrail, not a sandbox: an
+ * agent that wants to route around it trivially can.
+ *
+ * ## What "targets the shared checkout" means
+ *
+ * A linked worktree has its own HEAD, so `git switch` inside one is exactly the
+ * escape hatch AGENTS.md points at (`genie launch`). The guard therefore
+ * compares `git rev-parse --show-toplevel` of the command's effective directory
+ * against the same for the session `cwd`, and denies only when they are the
+ * same working tree. Subagents operating in their own worktree are untouched.
+ *
+ * Priority: 2 (a deny-guard — runs with branch-guard/orchestration-guard,
+ * before omni-approval (5) and the context handlers (8)).
+ */
+
+import { execFileSync } from 'node:child_process';
+import { isAbsolute, resolve } from 'node:path';
+import { resolveTrustedExecutable } from '../../lib/trusted-executable.js';
+import { maskQuotedRegions } from '../shell-quoting.js';
+import type { HandlerResult, HookPayload } from '../types.js';
+
+/**
+ * Git subcommands the freeze names. Kept literally in sync with AGENTS.md so a
+ * reader can diff the two lists by eye.
+ */
+const FROZEN_SUBCOMMANDS = new Set(['checkout', 'switch', 'reset', 'stash', 'rebase']);
+
+/**
+ * `git stash list` / `git stash show` mutate nothing. Denying them would be a
+ * pure false positive against a subcommand the freeze only cares about because
+ * of its *mutating* forms.
+ */
+const READ_ONLY_STASH_VERBS = new Set(['list', 'show']);
+
+/** Git global options that consume the following token as their value. */
+const VALUE_TAKING_GLOBAL_FLAGS = new Set(['-C', '-c', '--config-env']);
+
+/**
+ * Git global options that re-point the repository itself. Resolving what they
+ * mean would duplicate git's own discovery rules, so their presence makes the
+ * invocation opaque and the guard steps aside.
+ */
+const REPO_REDIRECTING_GLOBAL_FLAGS = ['--git-dir', '--work-tree', '--namespace', '--exec-path'];
+
+/** Shell metacharacters that make a path argument non-literal. */
+const NON_LITERAL_PATH = /[$`*?~!]|\\$/;
+
+/** Statement separators. `&&` and `||` must be tried before `&` and `|`. */
+const SEGMENT_SEPARATORS = /&&|\|\||;|\||&|\n/;
+
+/** git must answer fast; a hook that stalls is worse than a hook that allows. */
+const GIT_TIMEOUT_MS = 2_000;
+
+export interface GitFreezeGuardDeps {
+  /**
+   * Resolve the working-tree root containing `dir`, or `null` when `dir` is not
+   * inside a git working tree / git is unavailable. Injected so tests can
+   * exercise the classifier without a real repository on disk.
+   */
+  resolveWorktreeRoot: (dir: string) => string | null;
+}
+
+const defaultDeps: GitFreezeGuardDeps = {
+  resolveWorktreeRoot(dir) {
+    let git: string;
+    try {
+      git = resolveTrustedExecutable('git', dir);
+    } catch {
+      return null;
+    }
+    try {
+      const out = execFileSync(git, ['rev-parse', '--show-toplevel'], {
+        encoding: 'utf8',
+        timeout: GIT_TIMEOUT_MS,
+        cwd: dir,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+      return out.length > 0 ? out : null;
+    } catch {
+      return null;
+    }
+  },
+};
+
+/**
+ * True when this payload came from a subagent rather than the orchestrator.
+ *
+ * `agent_id` is the discriminator; `agent_type === 'main'` is checked as well
+ * because Claude Code labels the main thread that way internally and a future
+ * build could populate both fields for it.
+ */
+function isSubagentPayload(payload: HookPayload): boolean {
+  const agentId = payload.agent_id;
+  if (typeof agentId !== 'string' || agentId.length === 0) return false;
+  return payload.agent_type !== 'main';
+}
+
+/** Join `arg` onto `base`, or return `null` when either side is unusable. */
+function joinPath(base: string | null, arg: string | undefined): string | null {
+  if (!arg || NON_LITERAL_PATH.test(arg)) return null;
+  if (isAbsolute(arg)) return resolve(arg);
+  if (base === null) return null;
+  return resolve(base, arg);
+}
+
+interface GitInvocation {
+  subcommand: string;
+  /** Tokens after the subcommand. */
+  rest: string[];
+  /** Directory the invocation runs in, or `null` when it could not be resolved. */
+  dir: string | null;
+}
+
+/**
+ * Parse a single statement into a git invocation, or `null` when the statement
+ * is not a plain `git …` call the guard can reason about.
+ */
+function parseGitInvocation(tokens: string[], cwd: string | null): GitInvocation | null {
+  if (tokens[0] !== 'git') return null;
+  let dir = cwd;
+  let i = 1;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    if (!token.startsWith('-')) {
+      return { subcommand: token, rest: tokens.slice(i + 1), dir };
+    }
+    if (REPO_REDIRECTING_GLOBAL_FLAGS.some((flag) => token === flag || token.startsWith(`${flag}=`))) return null;
+    if (VALUE_TAKING_GLOBAL_FLAGS.has(token)) {
+      if (token === '-C') dir = joinPath(dir, tokens[i + 1]);
+      i += 2;
+      continue;
+    }
+    i += 1;
+  }
+  return null;
+}
+
+/** True when this invocation is one the freeze forbids (mutating forms only). */
+function isFrozenInvocation(invocation: GitInvocation): boolean {
+  if (!FROZEN_SUBCOMMANDS.has(invocation.subcommand)) return false;
+  if (invocation.subcommand !== 'stash') return true;
+  const verb = invocation.rest.find((token) => !token.startsWith('-'));
+  return verb === undefined ? true : !READ_ONLY_STASH_VERBS.has(verb);
+}
+
+/**
+ * Walk the statements of a compound command left to right, tracking `cd` as it
+ * goes, and return the first frozen git invocation found.
+ */
+function findFrozenInvocation(command: string, cwd: string | null): GitInvocation | null {
+  const masked = maskQuotedRegions(command);
+  if (!/\bgit\b/.test(masked)) return null;
+  let dir = cwd;
+  for (const segment of masked.split(SEGMENT_SEPARATORS)) {
+    const tokens = segment.trim().split(/\s+/).filter(Boolean);
+    if (tokens.length === 0) continue;
+    if (tokens[0] === 'cd' || tokens[0] === 'pushd') {
+      dir = joinPath(dir, tokens[1]);
+      continue;
+    }
+    if (tokens[0] === 'popd') {
+      dir = null;
+      continue;
+    }
+    const invocation = parseGitInvocation(tokens, dir);
+    if (invocation && isFrozenInvocation(invocation)) return invocation;
+  }
+  return null;
+}
+
+function denyReason(subcommand: string, sharedRoot: string): string {
+  return [
+    `BLOCKED: \`git ${subcommand}\` targets the shared workspace at ${sharedRoot}.`,
+    '',
+    'AGENTS.md (Engineering rules) freezes repo-level git state for shared-workspace subagents:',
+    'no `checkout`/`switch`/`reset`/`stash`/`rebase` — **only the orchestrator moves HEAD**.',
+    '',
+    'DO INSTEAD:',
+    '- Need your own HEAD? Take a worktree and address it explicitly — `git worktree add` is',
+    '  permitted plumbing, and this guard never fires on another working tree:',
+    '    git worktree add <path> -b <branch> <base>',
+    '    git -C <path> switch <branch>          # allowed: different working tree',
+    '- Whole execution group needs isolation? `genie launch <wish-slug>` gives each group its',
+    '  own pane + worktree by construction.',
+    '- Otherwise sequence the work: hand the repo-level mutation back to the orchestrator,',
+    '  which owns HEAD, and continue once it reports the move is done.',
+    '- Read-only inspection stays allowed: `git status`, `git log`, `git diff`, `git show`,',
+    '  `git stash list`, `git worktree list`.',
+  ].join('\n');
+}
+
+export async function gitFreezeGuard(
+  payload: HookPayload,
+  deps: GitFreezeGuardDeps = defaultDeps,
+): Promise<HandlerResult> {
+  if (!isSubagentPayload(payload)) return;
+
+  const command = payload.tool_input?.command;
+  if (typeof command !== 'string' || command.length === 0) return;
+
+  const sessionCwd = typeof payload.cwd === 'string' && payload.cwd.length > 0 ? payload.cwd : null;
+  const invocation = findFrozenInvocation(command, sessionCwd);
+  if (!invocation || invocation.dir === null || sessionCwd === null) return;
+
+  const sharedRoot = deps.resolveWorktreeRoot(sessionCwd);
+  if (sharedRoot === null) return;
+  const targetRoot = deps.resolveWorktreeRoot(invocation.dir);
+  if (targetRoot === null || targetRoot !== sharedRoot) return;
+
+  return {
+    decision: 'deny',
+    reason: denyReason(invocation.subcommand, sharedRoot),
+  };
+}

--- a/src/hooks/handlers/git-freeze-guard.ts
+++ b/src/hooks/handlers/git-freeze-guard.ts
@@ -24,7 +24,17 @@
  *   - a `cd` / `git -C` target that isn't a literal path (variable, glob,
  *     `~`, command substitution, quoted-and-masked) → allow;
  *   - `git --git-dir` / `--work-tree` / `--namespace` overrides → allow;
- *   - a worktree root that git cannot resolve → allow.
+ *   - a worktree root that git cannot resolve → allow;
+ *   - a `cd` inside a subshell — `(cd /elsewhere && git switch main)` — moves
+ *     only that subshell, and the guard tracks it that way rather than judging
+ *     the git call against the session cwd;
+ *   - a frozen call nested *inside* a command substitution — `$(git switch dev)`
+ *     — is not descended into and so is allowed. The substitution's interior is
+ *     masked wholesale because its parentheses and separators are not the outer
+ *     statement's, and reading it would mean tracking a second scope's cwd
+ *     through the same walk. That is a knowing gap, and a cheap one: the freeze
+ *     exists to catch the accidental `git switch dev`, and nobody types the
+ *     substituted form by accident.
  *
  * This is the opposite of {@link branchGuard}'s fail-closed posture, and it is
  * the point. The freeze has no server-side backstop the way branch protection
@@ -42,6 +52,11 @@
  * compares `git rev-parse --show-toplevel` of the command's effective directory
  * against the same for the session `cwd`, and denies only when they are the
  * same working tree. Subagents operating in their own worktree are untouched.
+ *
+ * A compound command can hold several frozen invocations in several directories
+ * — `git -C /elsewhere switch main && git switch dev`. *Every* one is resolved
+ * and the deny is raised for the first that lands in the shared checkout, so a
+ * legitimate lead invocation cannot shield a frozen one behind it.
  *
  * Priority: 2 (a deny-guard — runs with branch-guard/orchestration-guard,
  * before omni-approval (5) and the context handlers (8)).
@@ -81,6 +96,9 @@ const NON_LITERAL_PATH = /[$`*?~!]|\\$/;
 
 /** Statement separators. `&&` and `||` must be tried before `&` and `|`. */
 const SEGMENT_SEPARATORS = /&&|\|\||;|\||&|\n/;
+
+/** Openers of a region that runs in its own shell and yields a value, not a statement. */
+const OPAQUE_REGION_OPENERS = ['$(', '<(', '>('];
 
 /** git must answer fast; a hook that stalls is worse than a hook that allows. */
 const GIT_TIMEOUT_MS = 2_000;
@@ -177,29 +195,117 @@ function isFrozenInvocation(invocation: GitInvocation): boolean {
   return verb === undefined ? true : !READ_ONLY_STASH_VERBS.has(verb);
 }
 
+/** Index just past the `)` that closes the group opened before `from`, or the end of `cmd`. */
+function closingParen(cmd: string, from: number): number {
+  let depth = 1;
+  for (let i = from; i < cmd.length; i += 1) {
+    if (cmd[i] === '(') depth += 1;
+    else if (cmd[i] === ')') {
+      depth -= 1;
+      if (depth === 0) return i + 1;
+    }
+  }
+  return cmd.length;
+}
+
+/**
+ * Mask command/process substitutions and backticks with `$`, preserving length
+ * the way {@link maskQuotedRegions} does.
+ *
+ * Two things would otherwise be misread. Their parentheses are not the subshell
+ * grouping {@link findFrozenInvocations} tracks, so the stray `)` of a `$(pwd)`
+ * would close a real `(…)` group early and leak its `cd` outward. And their
+ * result is not a literal path, so `$` — which {@link NON_LITERAL_PATH} already
+ * rejects — is the mask character that keeps `git -C $(pwd)` failing open.
+ *
+ * An unterminated region masks to end of string, matching the quote masker's
+ * treatment of a runaway quote.
+ */
+function maskOpaqueRegions(cmd: string): string {
+  let out = '';
+  let i = 0;
+  while (i < cmd.length) {
+    const opener = OPAQUE_REGION_OPENERS.find((candidate) => cmd.startsWith(candidate, i));
+    if (opener) {
+      const end = closingParen(cmd, i + opener.length);
+      out += '$'.repeat(end - i);
+      i = end;
+      continue;
+    }
+    if (cmd[i] === '`') {
+      const close = cmd.indexOf('`', i + 1);
+      const end = close === -1 ? cmd.length : close + 1;
+      out += '$'.repeat(end - i);
+      i = end;
+      continue;
+    }
+    out += cmd[i];
+    i += 1;
+  }
+  return out;
+}
+
+interface Statement {
+  tokens: string[];
+  /** Subshell groups this statement opens with `(` and closes with `)`. */
+  opened: number;
+  closed: number;
+}
+
+/**
+ * Tokenize one statement, peeling the subshell parentheses off its ends. Both
+ * spellings occur in the wild — `(cd /x` and `( cd /x` — so the parens are
+ * stripped character-wise rather than expected as tokens of their own.
+ */
+function parseStatement(segment: string): Statement {
+  const tokens = segment.trim().split(/\s+/).filter(Boolean);
+  let opened = 0;
+  while (tokens.length > 0 && tokens[0].startsWith('(')) {
+    const head = tokens[0].slice(1);
+    opened += 1;
+    if (head.length === 0) tokens.shift();
+    else tokens[0] = head;
+  }
+  let closed = 0;
+  while (tokens.length > 0 && tokens[tokens.length - 1].endsWith(')')) {
+    const tail = tokens[tokens.length - 1].slice(0, -1);
+    closed += 1;
+    if (tail.length === 0) tokens.pop();
+    else tokens[tokens.length - 1] = tail;
+  }
+  return { tokens, opened, closed };
+}
+
 /**
  * Walk the statements of a compound command left to right, tracking `cd` as it
- * goes, and return the first frozen git invocation found.
+ * goes, and return every frozen git invocation found.
+ *
+ * Directories are a stack rather than a single value because `(` opens a scope
+ * the shell discards at the matching `)`: a `cd` inside a subshell applies to
+ * the statements within it and to nothing after it.
  */
-function findFrozenInvocation(command: string, cwd: string | null): GitInvocation | null {
-  const masked = maskQuotedRegions(command);
-  if (!/\bgit\b/.test(masked)) return null;
-  let dir = cwd;
+function findFrozenInvocations(command: string, cwd: string | null): GitInvocation[] {
+  const masked = maskOpaqueRegions(maskQuotedRegions(command));
+  if (!/\bgit\b/.test(masked)) return [];
+  const scopes: (string | null)[] = [cwd];
+  const found: GitInvocation[] = [];
   for (const segment of masked.split(SEGMENT_SEPARATORS)) {
-    const tokens = segment.trim().split(/\s+/).filter(Boolean);
-    if (tokens.length === 0) continue;
-    if (tokens[0] === 'cd' || tokens[0] === 'pushd') {
-      dir = joinPath(dir, tokens[1]);
-      continue;
+    const { tokens, opened, closed } = parseStatement(segment);
+    for (let n = 0; n < opened; n += 1) scopes.push(scopes[scopes.length - 1]);
+    const dir = scopes[scopes.length - 1];
+    if (tokens.length > 0) {
+      if (tokens[0] === 'cd' || tokens[0] === 'pushd') {
+        scopes[scopes.length - 1] = joinPath(dir, tokens[1]);
+      } else if (tokens[0] === 'popd') {
+        scopes[scopes.length - 1] = null;
+      } else {
+        const invocation = parseGitInvocation(tokens, dir);
+        if (invocation && isFrozenInvocation(invocation)) found.push(invocation);
+      }
     }
-    if (tokens[0] === 'popd') {
-      dir = null;
-      continue;
-    }
-    const invocation = parseGitInvocation(tokens, dir);
-    if (invocation && isFrozenInvocation(invocation)) return invocation;
+    for (let n = 0; n < closed && scopes.length > 1; n += 1) scopes.pop();
   }
-  return null;
+  return found;
 }
 
 function denyReason(subcommand: string, sharedRoot: string): string {
@@ -233,16 +339,31 @@ export async function gitFreezeGuard(
   if (typeof command !== 'string' || command.length === 0) return;
 
   const sessionCwd = typeof payload.cwd === 'string' && payload.cwd.length > 0 ? payload.cwd : null;
-  const invocation = findFrozenInvocation(command, sessionCwd);
-  if (!invocation || invocation.dir === null || sessionCwd === null) return;
+  if (sessionCwd === null) return;
+
+  // Only invocations whose directory resolved are decidable; the rest fail open.
+  // Nothing below this point runs — no `git` subprocess — unless one survives.
+  const targets = findFrozenInvocations(command, sessionCwd).filter(
+    (invocation): invocation is GitInvocation & { dir: string } => invocation.dir !== null,
+  );
+  if (targets.length === 0) return;
 
   const sharedRoot = deps.resolveWorktreeRoot(sessionCwd);
   if (sharedRoot === null) return;
-  const targetRoot = deps.resolveWorktreeRoot(invocation.dir);
-  if (targetRoot === null || targetRoot !== sharedRoot) return;
 
-  return {
-    decision: 'deny',
-    reason: denyReason(invocation.subcommand, sharedRoot),
+  const rootCache = new Map<string, string | null>();
+  const rootOf = (dir: string): string | null => {
+    if (!rootCache.has(dir)) rootCache.set(dir, deps.resolveWorktreeRoot(dir));
+    return rootCache.get(dir) ?? null;
   };
+
+  for (const target of targets) {
+    if (rootOf(target.dir) === sharedRoot) {
+      return {
+        decision: 'deny',
+        reason: denyReason(target.subcommand, sharedRoot),
+      };
+    }
+  }
+  return;
 }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -26,6 +26,7 @@ import { codexPermissionDecision } from './codex-adapter.js';
 import { auditContext } from './handlers/audit-context.js';
 import { branchGuard } from './handlers/branch-guard.js';
 import { freshness } from './handlers/freshness.js';
+import { gitFreezeGuard } from './handlers/git-freeze-guard.js';
 import { identityInject } from './handlers/identity-inject.js';
 import { omniApproval } from './handlers/omni-approval.js';
 import { orchestrationGuard } from './handlers/orchestration-guard.js';
@@ -56,6 +57,16 @@ const builtinHandlers: ReadonlyArray<Handler> = [
     matcher: /^Bash$/,
     priority: 1,
     fn: branchGuard,
+  },
+  {
+    version: '1',
+    source: 'builtin',
+    manifest_path: BUILTIN_MANIFEST_PATH,
+    name: 'git-freeze-guard',
+    event: 'PreToolUse',
+    matcher: /^Bash$/,
+    priority: 2,
+    fn: gitFreezeGuard,
   },
   {
     version: '1',

--- a/src/hooks/shell-quoting.ts
+++ b/src/hooks/shell-quoting.ts
@@ -1,0 +1,67 @@
+/**
+ * Shell quote masking — shared by every PreToolUse:Bash classifier.
+ *
+ * Mask the interior of single/double-quoted shell regions with spaces,
+ * preserving string length so regex word-boundaries behave identically on the
+ * remaining unmasked characters.
+ *
+ * Closes a class of over-matches where a blocked substring (`gh pr merge N`,
+ * `git push origin main`, `git checkout main && git commit`) appearing inside
+ * a `--body` / `--message` / `-m` argument triggered a false-positive deny.
+ *
+ * Live reproducer: opening PR #1264 (the branch-guard subprocess-diagnostics
+ * fix) was blocked twice because the PR body described the very commands the
+ * hook denies. Required a workaround — paraphrase every literal occurrence —
+ * that doesn't generalize.
+ *
+ * Scope: handles single-quotes (no escapes), double-quotes with `\X` escapes,
+ * and unterminated quotes (mask to end of string — safer than the alternative
+ * of leaving a runaway region unmasked). Backtick command substitution and
+ * heredocs are intentionally not parsed — they're rare in agent-issued
+ * commands and falling back to fully unmasked treatment is fail-closed for
+ * the original policy, which matches the hook's overall posture.
+ */
+
+type QuoteState = 'none' | 'single' | 'double';
+
+interface MaskStep {
+  out: string;
+  next: QuoteState;
+  consumed: number;
+}
+
+/** Unquoted char: pass through, or open a quote region. */
+function stepUnquoted(ch: string): MaskStep {
+  if (ch === "'") return { out: ' ', next: 'single', consumed: 1 };
+  if (ch === '"') return { out: ' ', next: 'double', consumed: 1 };
+  return { out: ch, next: 'none', consumed: 1 };
+}
+
+/** Single-quoted char: always masked; `'` closes the region (no escapes in bash single-quotes). */
+function stepSingleQuoted(ch: string): MaskStep {
+  return { out: ' ', next: ch === "'" ? 'none' : 'single', consumed: 1 };
+}
+
+/** Double-quoted char: always masked; `\X` consumes two chars; `"` closes. */
+function stepDoubleQuoted(ch: string, hasNext: boolean): MaskStep {
+  if (ch === '\\' && hasNext) return { out: '  ', next: 'double', consumed: 2 };
+  return { out: ' ', next: ch === '"' ? 'none' : 'double', consumed: 1 };
+}
+
+export function maskQuotedRegions(cmd: string): string {
+  let out = '';
+  let state: QuoteState = 'none';
+  let i = 0;
+  while (i < cmd.length) {
+    const step: MaskStep =
+      state === 'double'
+        ? stepDoubleQuoted(cmd[i], i + 1 < cmd.length)
+        : state === 'single'
+          ? stepSingleQuoted(cmd[i])
+          : stepUnquoted(cmd[i]);
+    out += step.out;
+    state = step.next;
+    i += step.consumed;
+  }
+  return out;
+}


### PR DESCRIPTION
Closes the investigation half of #2705 and lands the guard it asked for.

## Verdict: feasible on Claude Code, not portable

#2705 asked whether the shared-workspace git-state freeze can be enforced mechanically at dispatch, and named three false-positive traps: compound commands, `git -C <path>` forms targeting a worktree the agent owns, and the orchestrator's own operations.

**The orchestrator-vs-subagent question — the one the issue flagged as possibly fatal — is answered by the runtime, not by inference.** Claude Code's `PreToolUse` payload carries `agent_id` and `agent_type`. Measured empirically on Claude Code 2.1.220 (headless run, hook dumping raw stdin, one main-thread Bash call and one Task-subagent Bash call):

| caller | `agent_id` | `agent_type` | `session_id` | `cwd` |
|---|---|---|---|---|
| orchestrator (main thread) | `null` | `null` | `cbc35a0d-…` | `<project>` |
| spawned subagent | `"a59efa9aa4e5c4138"` | `"general-purpose"` | `cbc35a0d-…` (same) | `<project>` (same) |

Same session, same cwd, different `agent_id`. Nothing else in the payload distinguishes them, and no environment variable does either — `CLAUDE_CODE_SESSION_ID` / `CLAUDE_PID` are identical for both.

Per-runtime assessment (full write-up posted on #2705):

- **Claude Code** — expressible. Shipped here.
- **Codex** — not expressible. The Codex `PreToolUse` payload has no subagent identity field; the guard cannot distinguish a Codex subagent shell from the Codex orchestrator, so it fails open there and the freeze stays prose-only on Codex.
- **Warp / `genie launch`** — no hook surface at all; panes are plain shells. Moot: panes are worktree-isolated by construction and already exempt.

## What landed

`src/hooks/handlers/git-freeze-guard.ts` — `PreToolUse:Bash`, priority 2, registered in `src/hooks/index.ts` alongside the existing deny-guards.

For a payload that carries `agent_id`, it:

1. masks quoted regions (shared with `branch-guard`, see below) so a frozen command *named inside* a `-m` / `--body` argument is never a match;
2. splits the command on `&&`, `||`, `;`, `|`, `&`, newline and walks the statements left to right, tracking literal `cd` / `pushd` and dropping to "unknown" on `popd`;
3. parses `git` global flags, honouring `-C <path>` (chained, relative-resolved);
4. classifies the subcommand against the freeze list — `checkout`, `switch`, `reset`, `stash`, `rebase` — exempting the read-only `git stash list` / `git stash show`, and never matching `git worktree add/remove/prune/list` (permitted orchestrator-side plumbing per AGENTS.md);
5. denies **only** when `git rev-parse --show-toplevel` of the resolved target directory equals that of the session `cwd`.

Step 5 is what makes `git -C <owned-worktree>` safe: a linked worktree has its own HEAD and its own top level, so it never compares equal to the shared checkout. That also makes the in-session escape hatch work without any special-casing:

```
git worktree add <path> -b <branch> <base>   # permitted plumbing
git -C <path> switch <branch>                # allowed: different working tree
```

The deny message cites the AGENTS.md freeze verbatim and lists all three remedies: take a worktree and address it with `git -C`, use `genie launch <wish-slug>` for a whole group, or sequence the mutation back through the orchestrator.

## Fail-open, deliberately

Every ambiguity resolves to **allow**: no `agent_id` (main thread, Codex, a client that drops the field), a non-literal `cd` / `-C` target (`$VAR`, `~`, glob, command substitution, quoted), `--git-dir` / `--work-tree` / `--namespace` overrides, or a top level git cannot resolve.

This is the opposite of `branch-guard`'s fail-closed posture and the inversion is the point. `branch-guard` can fail closed because server-side branch protection backstops it; the freeze has no backstop, so a wrong deny simply breaks a working agent with no escape hatch. The founding incident was an *accidental* HEAD move in a shared checkout. A guard that catches the literal common forms and never fires on a legitimate one is worth more than a guard nobody keeps enabled.

Stated plainly in the module header: **this is a guardrail, not a sandbox.** An agent that wants to route around it (`bash -c`, a script file, `GIT_DIR=`, a Python `subprocess`) trivially can. It closes the accident class, not an adversarial one.

Cost is near-zero on the hot path: no subprocess runs unless a frozen subcommand is actually found in the command text — asserted by two tests.

## Drive-by

`branch-guard`'s quote masker moved verbatim to `src/hooks/shell-quoting.ts`; both Bash classifiers now import one implementation instead of two copies. No behavior change — `branch-guard`'s existing suite is unmodified and green.

## Validation

```
bun run check:fast                       # OK (typecheck, lint, dead-code, skills, wishes,
                                         #     complexity, council, hook-bundles, hook-content,
                                         #     plugin-executables) — 2 pre-existing doctor.ts warnings
bun test src/hooks/__tests__/git-freeze-guard.test.ts   #  60 pass, 0 fail
bun test src/hooks tests/hooks scripts/hook-*.test.ts   # 288 pass, 0 fail (17 files)
bun test                                                # 2884 pass, 1 fail
```

The single full-suite failure is the known pre-existing macOS-only `ui-bridge lifetime > holds zero listening TCP sockets while running` (needs Linux `ss`), unrelated to this change.

Coverage: 60 tests spanning all 13 frozen forms, the orchestrator exemption, the three `agent_id`-absent paths, 14 allowed non-frozen commands, 6 `git -C` cases, 9 compound-command cases (including every fail-open trap), 4 quoted-argument cases, and the worktree-scoped-session semantics.

## Left for the orchestrator to disposition

AGENTS.md is **unchanged**. Its "Flip conditions" section still lists #2705 as an open investigation whose infeasibility would be evidence toward flip condition (i). The finding is *partial* feasibility — mechanical on Claude Code, prose-only on Codex — which is a council call, not an engineer call. The per-runtime analysis is posted on #2705 so it can be weighed there.
