### PR TITLE
fix(router): bypass Genie when lifecycle adds no value

### DIFF
--- a/plugins/genie/skills/genie/SKILL.md
+++ b/plugins/genie/skills/genie/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: genie
-description: "Entry point for all genie operations — auto-routes natural language to the right skill, detects lifecycle state, and handles operational commands. Use when planning features, reporting bugs, orchestrating execution, or asking about genie."
+description: "Entry point for Genie operations — resumes existing lifecycle state and orchestrates work that needs durable planning or coordination. Ordinary requests bypass Genie unless the user asks for it."
 ---
 
 # genie — Auto-Router
 
 **Runtime syntax:** in Codex, invoke the plugin copy with the owner-qualified `$genie:<skill>` selector; use bare `$<skill>` only when intentionally selecting a user-tier copy (a separately installed personal copy; Genie no longer seeds this tier). Claude Code and Hermes use `/<skill>`. Cross-skill prose below uses bare names as portable semantic routes; the orchestrator resolves the selector for the active tier.
 
-You are the Automagik Genie — the single entry point for orchestration. Classify intent, detect existing lifecycle state, and route to the right skill or CLI command. State the chosen route in one line, then invoke it, passing the user's topic through as args.
+You are the Automagik Genie — the single entry point for orchestration. First apply the lightweight bypass check below. Requests that do not bypass are classified, matched to existing lifecycle state, and routed to the right skill or CLI command. State a Genie route only when using Genie; a bypass returns control to the ordinary agent workflow without invoking another Genie skill.
 
 ## Bare skill invocation (no request text)
 
@@ -20,9 +20,21 @@ ls .genie/brainstorms/*/DRAFT.md 2>/dev/null | wc -l  # brainstorms simmering
 
 "You have X active wishes and Y brainstorms. What's your wish?" Classify the reply as below.
 
+## Lightweight Bypass Check
+
+Do this before invoking any lifecycle skill:
+
+1. **Honor explicit Genie intent.** If the user asks to use Genie or a Genie skill, asks to create or use a wish, or requests Genie-managed planning, review, or orchestration, do not bypass. Merely mentioning Genie while asking to avoid or change its use is not an invocation.
+2. **Check for related lifecycle work.** Make a cheap topic/slug comparison against `.genie/wishes/` and `.genie/brainstorms/`. If the request continues, changes, fixes, or asks about related existing work, do not bypass; use State Detection.
+3. **Test whether the lifecycle adds value.** Genie is warranted when the work needs a durable plan, has unresolved product or architecture decisions, requires multiple coordinated workstreams, or must remain trackable across sessions or handoffs. If none applies, bypass Genie and return control to the ordinary agent workflow.
+
+The bypass must not create or update `.genie` artifacts, invoke another Genie skill, dispatch Genie roles, announce a Genie route, or add Genie-specific planning and review gates. The ordinary agent still follows the repository's normal safety, worktree, validation, and review requirements.
+
+This is a value gate, not a word or file-count heuristic. A request being a feature, bug, security-sensitive change, or multi-file edit does not by itself justify Genie. When the request alone does not reveal whether the lifecycle adds value, do the minimum cheap read-only repository inspection needed to decide. Do not invoke `brainstorm`, create artifacts, or dispatch roles merely to classify the request. Escalate only when that inspection provides evidence for one of the lifecycle needs above.
+
 ## Intent Classification
 
-Classify the user's request into exactly one category:
+For requests that did not bypass, classify the user's request into exactly one category:
 
 | Category | Signal | Route |
 |----------|--------|-------|
@@ -33,11 +45,11 @@ Classify the user's request into exactly one category:
 | **operational** | Task/board/cockpit operation: "show the board", "claim a task", "launch the cockpit" | Run the genie CLI command (see mapping) |
 | **question** | About genie itself: "how does X work?", "what commands exist?" | Answer from the live `--help` output and `reference/lifecycle.md` |
 
-Unclear between fuzzy and concrete → default `brainstorm`; exploring first is cheaper than re-planning.
+Unclear between fuzzy and concrete → default `brainstorm`; exploring first is cheaper than re-planning. Do not use this ambiguity rule to override the value gate.
 
 ## State Detection
 
-Before routing concrete/fuzzy/explicit intents, check whether the topic matches existing work (`ls .genie/wishes/ .genie/brainstorms/ 2>/dev/null`, slug match). A match overrides the default route:
+For requests that did not bypass, check whether the topic matches existing work (`ls .genie/wishes/ .genie/brainstorms/ 2>/dev/null`, slug match). A match overrides the default route:
 
 | Existing state | Override |
 |----------------|----------|
@@ -90,5 +102,6 @@ Lifecycle flow, skill catalog, and the v5 execution model: resolve this skill's 
 ## Rules
 
 - Guide, don't gatekeep — if the user wants to skip a step, note the risk and proceed.
+- Pay lifecycle cost only when it adds value: default to ordinary execution, use cheap read-only triage for uncertainty, and escalate only for explicit intent, related lifecycle state, or demonstrated durable planning or coordination needs.
 - Pass the user's topic through to the invoked skill as args.
 - Every command you run must exist in help output captured during this session — never type a remembered verb that isn't there.

--- a/plugins/genie/skills/genie/SKILL.md
+++ b/plugins/genie/skills/genie/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: genie
-description: "Entry point for Genie operations — resumes existing lifecycle state and orchestrates work that needs durable planning or coordination. Ordinary requests bypass Genie unless the user asks for it."
+description: "Entry point for Genie operations — routes bug reports, questions, and operational commands, resumes existing lifecycle state, and orchestrates work that needs durable planning or coordination. Other ordinary requests bypass the lifecycle with a one-line notice unless the user asks for Genie."
 ---
 
 # genie — Auto-Router
 
 **Runtime syntax:** in Codex, invoke the plugin copy with the owner-qualified `$genie:<skill>` selector; use bare `$<skill>` only when intentionally selecting a user-tier copy (a separately installed personal copy; Genie no longer seeds this tier). Claude Code and Hermes use `/<skill>`. Cross-skill prose below uses bare names as portable semantic routes; the orchestrator resolves the selector for the active tier.
 
-You are the Automagik Genie — the single entry point for orchestration. First apply the lightweight bypass check below. Requests that do not bypass are classified, matched to existing lifecycle state, and routed to the right skill or CLI command. State a Genie route only when using Genie; a bypass returns control to the ordinary agent workflow without invoking another Genie skill.
+You are the Automagik Genie — the single entry point for orchestration. First apply the lightweight bypass check below. Requests that do not bypass are classified, matched to existing lifecycle state, and routed to the right skill or CLI command. State a Genie route when using Genie and a one-line bypass notice otherwise; a bypass returns control to the ordinary agent workflow without invoking another Genie skill.
 
 ## Bare skill invocation (no request text)
 
@@ -25,12 +25,13 @@ ls .genie/brainstorms/*/DRAFT.md 2>/dev/null | wc -l  # brainstorms simmering
 Do this before invoking any lifecycle skill:
 
 1. **Honor explicit Genie intent.** If the user asks to use Genie or a Genie skill, asks to create or use a wish, or requests Genie-managed planning, review, or orchestration, do not bypass. Merely mentioning Genie while asking to avoid or change its use is not an invocation.
-2. **Check for related lifecycle work.** Make a cheap topic/slug comparison against `.genie/wishes/` and `.genie/brainstorms/`. If the request continues, changes, fixes, or asks about related existing work, do not bypass; use State Detection.
-3. **Test whether the lifecycle adds value.** Genie is warranted when the work needs a durable plan, has unresolved product or architecture decisions, requires multiple coordinated workstreams, or must remain trackable across sessions or handoffs. If none applies, bypass Genie and return control to the ordinary agent workflow.
+2. **Route cheap categories normally.** Bug reports (`report`), operational commands, and questions about Genie cost little and are never bypassed — classify and route them per the table below.
+3. **Check for related lifecycle work.** Make a cheap topic/slug comparison against `.genie/wishes/` and `.genie/brainstorms/`. If the request continues, changes, fixes, or asks about related existing work, do not bypass; use State Detection.
+4. **Test whether the lifecycle adds value.** Genie is warranted when the work needs a durable plan ("track the catalog effort across this week's sessions"), has unresolved product or architecture decisions ("should packs install via git or npm?"), requires multiple coordinated workstreams ("rename the NATS subjects across core and every pack"), or must remain trackable across sessions or handoffs. If none applies, bypass Genie and return control to the ordinary agent workflow.
 
-The bypass must not create or update `.genie` artifacts, invoke another Genie skill, dispatch Genie roles, announce a Genie route, or add Genie-specific planning and review gates. The ordinary agent still follows the repository's normal safety, worktree, validation, and review requirements.
+Announce the bypass in one line — "No lifecycle needed — handling this directly; say 'use genie' to override." — then proceed. The bypass must not create or update `.genie` artifacts, invoke another Genie skill, dispatch Genie roles, claim a Genie route, or add Genie-specific planning and review gates. The ordinary agent still follows the repository's normal safety, worktree, validation, and review requirements.
 
-This is a value gate, not a word or file-count heuristic. A request being a feature, bug, security-sensitive change, or multi-file edit does not by itself justify Genie. When the request alone does not reveal whether the lifecycle adds value, do the minimum cheap read-only repository inspection needed to decide. Do not invoke `brainstorm`, create artifacts, or dispatch roles merely to classify the request. Escalate only when that inspection provides evidence for one of the lifecycle needs above.
+This is a value gate, not a word or file-count heuristic. A request being a feature or a multi-file edit does not by itself justify Genie. Security-sensitive changes do not bypass by default — auth, secrets, permissions, and injection surfaces keep the lifecycle's review gates unless the user explicitly chooses to skip them (note the risk and proceed, per Rules). When the request alone does not reveal whether the lifecycle adds value, inspect cheaply and read-only — at most the two `ls` commands above plus a brief look at files the request names. Do not invoke `brainstorm`, create artifacts, or dispatch roles merely to classify the request. Escalate only when that inspection provides evidence for one of the lifecycle needs above.
 
 ## Intent Classification
 

--- a/plugins/genie/skills/genie/agents/openai.yaml
+++ b/plugins/genie/skills/genie/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Genie Router"
-  short_description: "Route requests to the right Genie lifecycle step"
-  default_prompt: "Route this request through the appropriate Genie workflow."
+  short_description: "Route work that warrants the Genie lifecycle"
+  default_prompt: "Use Genie only when explicitly requested, related to existing lifecycle work, or warranted by durable planning or coordination needs; otherwise bypass it."

--- a/plugins/genie/skills/genie/agents/openai.yaml
+++ b/plugins/genie/skills/genie/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Genie Router"
   short_description: "Route work that warrants the Genie lifecycle"
-  default_prompt: "Use Genie only when explicitly requested, related to existing lifecycle work, or warranted by durable planning or coordination needs; otherwise bypass it."
+  default_prompt: "Use Genie when explicitly requested, related to existing lifecycle work, or warranted by durable planning or coordination needs; otherwise bypass it with a one-line notice. Security-sensitive work does not bypass by default."

--- a/plugins/genie/skills/genie/reference/lifecycle.md
+++ b/plugins/genie/skills/genie/reference/lifecycle.md
@@ -1,11 +1,17 @@
 # Genie Lifecycle & v5 Execution Model
 
-Every piece of work follows this flow:
+Genie-managed work follows this flow:
 
 ```
  Idea → brainstorm → design review → wish → plan review → work → implementation review → PR → Ship
          (explore)   (design gate)    (plan)   (plan gate)  (build)       (verify)
 ```
+
+Ordinary requests unrelated to an existing wish or brainstorm bypass this lifecycle unless the user explicitly asks for
+Genie or the work demonstrably needs durable planning, unresolved product or architecture decisions, multiple coordinated
+workstreams, or tracking across sessions. When uncertain, use cheap read-only inspection and escalate only when it finds
+one of those needs. The bypass adds no Genie artifacts, roles, or gates; ordinary repository safety and validation rules
+still apply. Related existing work always resumes through its persisted state.
 
 The gates review different artifacts. For non-trivial work, `brainstorm` automatically routes the completed DESIGN.md
 through read-only design review before `wish` may consume it. The resulting WISH.md must then pass plan review and persist

--- a/plugins/genie/skills/genie/reference/lifecycle.md
+++ b/plugins/genie/skills/genie/reference/lifecycle.md
@@ -10,8 +10,10 @@ Genie-managed work follows this flow:
 Ordinary requests unrelated to an existing wish or brainstorm bypass this lifecycle unless the user explicitly asks for
 Genie or the work demonstrably needs durable planning, unresolved product or architecture decisions, multiple coordinated
 workstreams, or tracking across sessions. When uncertain, use cheap read-only inspection and escalate only when it finds
-one of those needs. The bypass adds no Genie artifacts, roles, or gates; ordinary repository safety and validation rules
-still apply. Related existing work always resumes through its persisted state.
+one of those needs. A bypass is announced in one line and adds no Genie artifacts, roles, or gates; ordinary repository
+safety and validation rules still apply. Security-sensitive changes do not bypass by default — only an explicit user
+choice skips their review gates. Bug triage (`report`), operational commands, and Genie questions are cheap and always
+route normally. Related existing work always resumes through its persisted state.
 
 The gates review different artifacts. For non-trivial work, `brainstorm` automatically routes the completed DESIGN.md
 through read-only design review before `wish` may consume it. The resulting WISH.md must then pass plan review and persist

--- a/scripts/release-docs.test.ts
+++ b/scripts/release-docs.test.ts
@@ -980,17 +980,16 @@ describe('Group E release and documentation contracts', () => {
 
     expect(router).toContain('## Lightweight Bypass Check');
     expect(router).toContain('Honor explicit Genie intent');
-    expect(router).toContain('Merely mentioning Genie while asking to avoid or change its use is not an invocation');
+    expect(router).toContain('Route cheap categories normally');
     expect(router).toContain('Check for related lifecycle work');
     expect(router).toContain('Test whether the lifecycle adds value');
-    expect(router).toContain('do the minimum cheap read-only repository inspection needed to decide');
-    expect(router).toContain(
-      'A request being a feature, bug, security-sensitive change, or multi-file edit does not by itself justify Genie',
-    );
+    expect(router).toContain('Announce the bypass in one line');
+    expect(router).toContain('Security-sensitive changes do not bypass by default');
     expect(router).toContain('must not create or update `.genie` artifacts');
     expect(lifecycle).toContain('Ordinary requests unrelated to an existing wish or brainstorm bypass this lifecycle');
+    expect(lifecycle).toContain('Security-sensitive changes do not bypass by default');
     expect(lifecycle).toContain('Related existing work always resumes through its persisted state');
-    expect(metadata).toContain('warranted by durable planning or coordination needs; otherwise bypass it');
+    expect(metadata).toContain('otherwise bypass it with a one-line notice');
   });
 
   test('wizard discloses init MCP writes and owner-qualified lifecycle order', () => {

--- a/scripts/release-docs.test.ts
+++ b/scripts/release-docs.test.ts
@@ -973,6 +973,26 @@ describe('Group E release and documentation contracts', () => {
     expect(work).toContain('A user-approved simplification invalidates the superseded plan/review evidence');
   });
 
+  test('router pays Genie lifecycle cost only when it adds value', () => {
+    const router = read('skills/genie/SKILL.md');
+    const lifecycle = read('skills/genie/reference/lifecycle.md');
+    const metadata = read('skills/genie/agents/openai.yaml');
+
+    expect(router).toContain('## Lightweight Bypass Check');
+    expect(router).toContain('Honor explicit Genie intent');
+    expect(router).toContain('Merely mentioning Genie while asking to avoid or change its use is not an invocation');
+    expect(router).toContain('Check for related lifecycle work');
+    expect(router).toContain('Test whether the lifecycle adds value');
+    expect(router).toContain('do the minimum cheap read-only repository inspection needed to decide');
+    expect(router).toContain(
+      'A request being a feature, bug, security-sensitive change, or multi-file edit does not by itself justify Genie',
+    );
+    expect(router).toContain('must not create or update `.genie` artifacts');
+    expect(lifecycle).toContain('Ordinary requests unrelated to an existing wish or brainstorm bypass this lifecycle');
+    expect(lifecycle).toContain('Related existing work always resumes through its persisted state');
+    expect(metadata).toContain('warranted by durable planning or coordination needs; otherwise bypass it');
+  });
+
   test('wizard discloses init MCP writes and owner-qualified lifecycle order', () => {
     const wizard = read('skills/wizard/SKILL.md');
     for (const path of ['.mcp.json', '.warp/.mcp.json', '.codex/config.toml']) expect(wizard).toContain(path);

--- a/skills/genie/SKILL.md
+++ b/skills/genie/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: genie
-description: "Entry point for all genie operations — auto-routes natural language to the right skill, detects lifecycle state, and handles operational commands. Use when planning features, reporting bugs, orchestrating execution, or asking about genie."
+description: "Entry point for Genie operations — resumes existing lifecycle state and orchestrates work that needs durable planning or coordination. Ordinary requests bypass Genie unless the user asks for it."
 ---
 
 # genie — Auto-Router
 
 **Runtime syntax:** in Codex, invoke the plugin copy with the owner-qualified `$genie:<skill>` selector; use bare `$<skill>` only when intentionally selecting a user-tier copy (a separately installed personal copy; Genie no longer seeds this tier). Claude Code and Hermes use `/<skill>`. Cross-skill prose below uses bare names as portable semantic routes; the orchestrator resolves the selector for the active tier.
 
-You are the Automagik Genie — the single entry point for orchestration. Classify intent, detect existing lifecycle state, and route to the right skill or CLI command. State the chosen route in one line, then invoke it, passing the user's topic through as args.
+You are the Automagik Genie — the single entry point for orchestration. First apply the lightweight bypass check below. Requests that do not bypass are classified, matched to existing lifecycle state, and routed to the right skill or CLI command. State a Genie route only when using Genie; a bypass returns control to the ordinary agent workflow without invoking another Genie skill.
 
 ## Bare skill invocation (no request text)
 
@@ -20,9 +20,21 @@ ls .genie/brainstorms/*/DRAFT.md 2>/dev/null | wc -l  # brainstorms simmering
 
 "You have X active wishes and Y brainstorms. What's your wish?" Classify the reply as below.
 
+## Lightweight Bypass Check
+
+Do this before invoking any lifecycle skill:
+
+1. **Honor explicit Genie intent.** If the user asks to use Genie or a Genie skill, asks to create or use a wish, or requests Genie-managed planning, review, or orchestration, do not bypass. Merely mentioning Genie while asking to avoid or change its use is not an invocation.
+2. **Check for related lifecycle work.** Make a cheap topic/slug comparison against `.genie/wishes/` and `.genie/brainstorms/`. If the request continues, changes, fixes, or asks about related existing work, do not bypass; use State Detection.
+3. **Test whether the lifecycle adds value.** Genie is warranted when the work needs a durable plan, has unresolved product or architecture decisions, requires multiple coordinated workstreams, or must remain trackable across sessions or handoffs. If none applies, bypass Genie and return control to the ordinary agent workflow.
+
+The bypass must not create or update `.genie` artifacts, invoke another Genie skill, dispatch Genie roles, announce a Genie route, or add Genie-specific planning and review gates. The ordinary agent still follows the repository's normal safety, worktree, validation, and review requirements.
+
+This is a value gate, not a word or file-count heuristic. A request being a feature, bug, security-sensitive change, or multi-file edit does not by itself justify Genie. When the request alone does not reveal whether the lifecycle adds value, do the minimum cheap read-only repository inspection needed to decide. Do not invoke `brainstorm`, create artifacts, or dispatch roles merely to classify the request. Escalate only when that inspection provides evidence for one of the lifecycle needs above.
+
 ## Intent Classification
 
-Classify the user's request into exactly one category:
+For requests that did not bypass, classify the user's request into exactly one category:
 
 | Category | Signal | Route |
 |----------|--------|-------|
@@ -33,11 +45,11 @@ Classify the user's request into exactly one category:
 | **operational** | Task/board/cockpit operation: "show the board", "claim a task", "launch the cockpit" | Run the genie CLI command (see mapping) |
 | **question** | About genie itself: "how does X work?", "what commands exist?" | Answer from the live `--help` output and `reference/lifecycle.md` |
 
-Unclear between fuzzy and concrete → default `brainstorm`; exploring first is cheaper than re-planning.
+Unclear between fuzzy and concrete → default `brainstorm`; exploring first is cheaper than re-planning. Do not use this ambiguity rule to override the value gate.
 
 ## State Detection
 
-Before routing concrete/fuzzy/explicit intents, check whether the topic matches existing work (`ls .genie/wishes/ .genie/brainstorms/ 2>/dev/null`, slug match). A match overrides the default route:
+For requests that did not bypass, check whether the topic matches existing work (`ls .genie/wishes/ .genie/brainstorms/ 2>/dev/null`, slug match). A match overrides the default route:
 
 | Existing state | Override |
 |----------------|----------|
@@ -90,5 +102,6 @@ Lifecycle flow, skill catalog, and the v5 execution model: resolve this skill's 
 ## Rules
 
 - Guide, don't gatekeep — if the user wants to skip a step, note the risk and proceed.
+- Pay lifecycle cost only when it adds value: default to ordinary execution, use cheap read-only triage for uncertainty, and escalate only for explicit intent, related lifecycle state, or demonstrated durable planning or coordination needs.
 - Pass the user's topic through to the invoked skill as args.
 - Every command you run must exist in help output captured during this session — never type a remembered verb that isn't there.

--- a/skills/genie/SKILL.md
+++ b/skills/genie/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: genie
-description: "Entry point for Genie operations — resumes existing lifecycle state and orchestrates work that needs durable planning or coordination. Ordinary requests bypass Genie unless the user asks for it."
+description: "Entry point for Genie operations — routes bug reports, questions, and operational commands, resumes existing lifecycle state, and orchestrates work that needs durable planning or coordination. Other ordinary requests bypass the lifecycle with a one-line notice unless the user asks for Genie."
 ---
 
 # genie — Auto-Router
 
 **Runtime syntax:** in Codex, invoke the plugin copy with the owner-qualified `$genie:<skill>` selector; use bare `$<skill>` only when intentionally selecting a user-tier copy (a separately installed personal copy; Genie no longer seeds this tier). Claude Code and Hermes use `/<skill>`. Cross-skill prose below uses bare names as portable semantic routes; the orchestrator resolves the selector for the active tier.
 
-You are the Automagik Genie — the single entry point for orchestration. First apply the lightweight bypass check below. Requests that do not bypass are classified, matched to existing lifecycle state, and routed to the right skill or CLI command. State a Genie route only when using Genie; a bypass returns control to the ordinary agent workflow without invoking another Genie skill.
+You are the Automagik Genie — the single entry point for orchestration. First apply the lightweight bypass check below. Requests that do not bypass are classified, matched to existing lifecycle state, and routed to the right skill or CLI command. State a Genie route when using Genie and a one-line bypass notice otherwise; a bypass returns control to the ordinary agent workflow without invoking another Genie skill.
 
 ## Bare skill invocation (no request text)
 
@@ -25,12 +25,13 @@ ls .genie/brainstorms/*/DRAFT.md 2>/dev/null | wc -l  # brainstorms simmering
 Do this before invoking any lifecycle skill:
 
 1. **Honor explicit Genie intent.** If the user asks to use Genie or a Genie skill, asks to create or use a wish, or requests Genie-managed planning, review, or orchestration, do not bypass. Merely mentioning Genie while asking to avoid or change its use is not an invocation.
-2. **Check for related lifecycle work.** Make a cheap topic/slug comparison against `.genie/wishes/` and `.genie/brainstorms/`. If the request continues, changes, fixes, or asks about related existing work, do not bypass; use State Detection.
-3. **Test whether the lifecycle adds value.** Genie is warranted when the work needs a durable plan, has unresolved product or architecture decisions, requires multiple coordinated workstreams, or must remain trackable across sessions or handoffs. If none applies, bypass Genie and return control to the ordinary agent workflow.
+2. **Route cheap categories normally.** Bug reports (`report`), operational commands, and questions about Genie cost little and are never bypassed — classify and route them per the table below.
+3. **Check for related lifecycle work.** Make a cheap topic/slug comparison against `.genie/wishes/` and `.genie/brainstorms/`. If the request continues, changes, fixes, or asks about related existing work, do not bypass; use State Detection.
+4. **Test whether the lifecycle adds value.** Genie is warranted when the work needs a durable plan ("track the catalog effort across this week's sessions"), has unresolved product or architecture decisions ("should packs install via git or npm?"), requires multiple coordinated workstreams ("rename the NATS subjects across core and every pack"), or must remain trackable across sessions or handoffs. If none applies, bypass Genie and return control to the ordinary agent workflow.
 
-The bypass must not create or update `.genie` artifacts, invoke another Genie skill, dispatch Genie roles, announce a Genie route, or add Genie-specific planning and review gates. The ordinary agent still follows the repository's normal safety, worktree, validation, and review requirements.
+Announce the bypass in one line — "No lifecycle needed — handling this directly; say 'use genie' to override." — then proceed. The bypass must not create or update `.genie` artifacts, invoke another Genie skill, dispatch Genie roles, claim a Genie route, or add Genie-specific planning and review gates. The ordinary agent still follows the repository's normal safety, worktree, validation, and review requirements.
 
-This is a value gate, not a word or file-count heuristic. A request being a feature, bug, security-sensitive change, or multi-file edit does not by itself justify Genie. When the request alone does not reveal whether the lifecycle adds value, do the minimum cheap read-only repository inspection needed to decide. Do not invoke `brainstorm`, create artifacts, or dispatch roles merely to classify the request. Escalate only when that inspection provides evidence for one of the lifecycle needs above.
+This is a value gate, not a word or file-count heuristic. A request being a feature or a multi-file edit does not by itself justify Genie. Security-sensitive changes do not bypass by default — auth, secrets, permissions, and injection surfaces keep the lifecycle's review gates unless the user explicitly chooses to skip them (note the risk and proceed, per Rules). When the request alone does not reveal whether the lifecycle adds value, inspect cheaply and read-only — at most the two `ls` commands above plus a brief look at files the request names. Do not invoke `brainstorm`, create artifacts, or dispatch roles merely to classify the request. Escalate only when that inspection provides evidence for one of the lifecycle needs above.
 
 ## Intent Classification
 

--- a/skills/genie/agents/openai.yaml
+++ b/skills/genie/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Genie Router"
-  short_description: "Route requests to the right Genie lifecycle step"
-  default_prompt: "Route this request through the appropriate Genie workflow."
+  short_description: "Route work that warrants the Genie lifecycle"
+  default_prompt: "Use Genie only when explicitly requested, related to existing lifecycle work, or warranted by durable planning or coordination needs; otherwise bypass it."

--- a/skills/genie/agents/openai.yaml
+++ b/skills/genie/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Genie Router"
   short_description: "Route work that warrants the Genie lifecycle"
-  default_prompt: "Use Genie only when explicitly requested, related to existing lifecycle work, or warranted by durable planning or coordination needs; otherwise bypass it."
+  default_prompt: "Use Genie when explicitly requested, related to existing lifecycle work, or warranted by durable planning or coordination needs; otherwise bypass it with a one-line notice. Security-sensitive work does not bypass by default."

--- a/skills/genie/reference/lifecycle.md
+++ b/skills/genie/reference/lifecycle.md
@@ -1,11 +1,17 @@
 # Genie Lifecycle & v5 Execution Model
 
-Every piece of work follows this flow:
+Genie-managed work follows this flow:
 
 ```
  Idea → brainstorm → design review → wish → plan review → work → implementation review → PR → Ship
          (explore)   (design gate)    (plan)   (plan gate)  (build)       (verify)
 ```
+
+Ordinary requests unrelated to an existing wish or brainstorm bypass this lifecycle unless the user explicitly asks for
+Genie or the work demonstrably needs durable planning, unresolved product or architecture decisions, multiple coordinated
+workstreams, or tracking across sessions. When uncertain, use cheap read-only inspection and escalate only when it finds
+one of those needs. The bypass adds no Genie artifacts, roles, or gates; ordinary repository safety and validation rules
+still apply. Related existing work always resumes through its persisted state.
 
 The gates review different artifacts. For non-trivial work, `brainstorm` automatically routes the completed DESIGN.md
 through read-only design review before `wish` may consume it. The resulting WISH.md must then pass plan review and persist

--- a/skills/genie/reference/lifecycle.md
+++ b/skills/genie/reference/lifecycle.md
@@ -10,8 +10,10 @@ Genie-managed work follows this flow:
 Ordinary requests unrelated to an existing wish or brainstorm bypass this lifecycle unless the user explicitly asks for
 Genie or the work demonstrably needs durable planning, unresolved product or architecture decisions, multiple coordinated
 workstreams, or tracking across sessions. When uncertain, use cheap read-only inspection and escalate only when it finds
-one of those needs. The bypass adds no Genie artifacts, roles, or gates; ordinary repository safety and validation rules
-still apply. Related existing work always resumes through its persisted state.
+one of those needs. A bypass is announced in one line and adds no Genie artifacts, roles, or gates; ordinary repository
+safety and validation rules still apply. Security-sensitive changes do not bypass by default — only an explicit user
+choice skips their review gates. Bug triage (`report`), operational commands, and Genie questions are cheap and always
+route normally. Related existing work always resumes through its persisted state.
 
 The gates review different artifacts. For non-trivial work, `brainstorm` automatically routes the completed DESIGN.md
 through read-only design review before `wish` may consume it. The resulting WISH.md must then pass plan review and persist


### PR DESCRIPTION
## What changed

- add a lightweight value gate before Genie's lifecycle intent router
- preserve Genie routing for explicit requests and work related to an existing wish or brainstorm
- default unrelated ordinary work to the host agent workflow
- use cheap read-only inspection when lifecycle value is unclear
- keep canonical skills and the shipped plugin mirror byte-identical

## Why

The router currently sends every clear feature, fuzzy request, or bug report into a durable Genie workflow. That imposes substantial token, latency, artifact, and orchestration costs even when ordinary agent execution is sufficient.

The new policy activates Genie only when the user asks for it, related lifecycle state exists, or the work demonstrably needs durable planning, unresolved product or architecture decisions, coordinated workstreams, or tracking across sessions or handoffs. Being a feature, bug, security-sensitive change, or multi-file edit is not enough by itself.

## Impact

Simple and otherwise ordinary requests avoid Genie-specific artifacts, roles, announcements, and review gates. Existing wishes still resume through persisted state, and repository safety, worktree, validation, and review requirements continue to apply outside Genie.

## Validation

- `bun scripts/sync-plugin-skills.ts --check`
- `bun test scripts/release-docs.test.ts scripts/sync-plugin-skills.test.ts` (26 passed)
- `git diff --check`
