### PR TITLE
feat(skills): make validation proportional across repositories

### DIFF
--- a/.genie/wishes/proportional-validation-policy/WISH.md
+++ b/.genie/wishes/proportional-validation-policy/WISH.md
@@ -1,0 +1,201 @@
+# Wish: Proportional validation policy
+
+| Field | Value |
+|-------|-------|
+| **Status** | IN_PROGRESS |
+| **Slug** | `proportional-validation-policy` |
+| **Date** | 2026-07-28 |
+| **Author** | Codex with user direction |
+| **Appetite** | small |
+| **Branch** | `policy/proportional-validation` |
+| **Repos touched** | `automagik-dev/genie` |
+| **Issue** | [#2724](https://github.com/automagik-dev/genie/issues/2724) |
+| **Design** | _No brainstorm — direct wish_ |
+
+## Summary
+
+When Genie plans, executes, or reviews work in any target repository, it will require validation effort to match the
+risk and reach of the actual diff. A documentation-only change such as a README edit will use focused documentation
+checks, while cross-cutting runtime, dependency, generated
+executable/runtime artifact, CI, integration, and release changes will still escalate to the aggregate gate.
+Deterministic generated documentation and plugin mirrors may instead use focused generator, parity, and content checks.
+
+## Scope
+
+### IN
+
+- Make the shipped, runtime-neutral `wish`, `work`, and `review` workflows select, execute, and assess the smallest
+  sufficient validation command in whichever target repository invokes Genie, with explicit triggers for widening.
+- Regenerate the committed Codex plugin skill mirror so the shipped workflow matches the canonical skills.
+
+### OUT
+
+- Automatic changed-file classification, a validation-command generator, caches, and new CI jobs.
+- Modifying target repositories' `AGENTS.md`, CI configuration, package scripts, or test commands.
+- Weakening a target repository's aggregate CI, integration, release, or pre-merge gates.
+- Retrofitting historical wishes whose validation commands were correct under their original policy.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | Proportional means risk-and-reach based, not file-extension based | A README can contain generated or tested contracts, while a small source diff can affect every command. |
+| 2 | Every change gets targeted validation; widening is trigger-based | This removes waste without turning “proportional” into permission to skip evidence. |
+| 3 | Keep the aggregate gate at integration/release boundaries | A focused local loop and a final system gate serve different purposes. |
+| 4 | Change shipped workflow policy surfaces only | The workflow already carries each target repo's per-group validation commands; no selector engine or target-repo edit is required. |
+
+## Simplicity Case
+
+- **Simplest complete design:** Rewrite the portable workflow guidance so Genie chooses the narrowest target-repository
+  checks that directly exercise the changed contract, then widens only for named risk triggers.
+- **Added machinery:** None. Existing validation-command fields and review evidence carry the policy.
+- **Deferred until measured:** Automate selection only after repeated review evidence shows humans or agents choose
+  insufficient checks; add a classifier only when at least three concrete misses share a deterministic rule.
+- **Complexity removed:** No path matrix, config surface, cache, changed-file parser, or second CI workflow.
+
+## Dependencies
+
+**depends-on:** none
+**blocks:** none
+
+## Success Criteria
+
+- [x] Shipped `wish`, `work`, and `review` consistently require the smallest sufficient target-repository validation
+  and the same widening triggers.
+- [x] The policy never permits zero validation and preserves aggregate validation for integration/release risk.
+- [x] Canonical and plugin-mirrored skills remain byte-identical.
+
+## Execution Strategy
+
+### Wave 1 (sequential)
+
+| Group | Agent | Complexity | Model | Description |
+|-------|-------|------------|-------|-------------|
+| 1 | engineer | 1 — prompt-skill change | engineer-trivial / low | Update and validate the proportional policy surfaces. |
+
+Complexity scoring rubric: score each group independently and record the total plus a short rationale in **Complexity**. Add:
+
+- **+2** each for orchestration / agent-lifecycle / routing; cost / model / escalation; stateful work; subjective acceptance.
+- **+1** each for multi-package work; OTel-label dependency; no deterministic test; prior rework; prompt-skill change; CI / release work.
+
+Route the total in **Model** by portable role and reasoning effort: **0–1** →
+`engineer-trivial` / low; **2–3** → `engineer-standard` / medium or high;
+**4–6** → `engineer-complex` / high; **7+** → `engineer-complex` plus an
+independent `final-gate` at the highest justified effort. Codex maps these to
+the `genie_*` profiles; other runtimes use their matching native roles. Keep
+model and effort in runtime session/agent configuration, never skill frontmatter.
+
+## Execution Groups
+
+### Group 1: Make validation proportional
+
+**Goal:** Make Genie's cross-repository per-group validation requirements scale with the target diff's risk and reach.
+
+**Deliverables:**
+1. Update `skills/wish/SKILL.md`, `skills/work/SKILL.md`, and `skills/review/SKILL.md` so plans, execution, and reviews
+   apply the same rule.
+2. Regenerate `plugins/genie/skills/` from the canonical skill tree.
+
+**Acceptance Criteria:**
+- [x] Documentation-only changes use relevant formatting, link, or content-contract checks rather than `bun run check`
+  by default.
+- [x] Runtime changes name focused tests for changed behavior and add type/lint/build checks only when the diff reaches
+  those contracts.
+- [x] Shared runtime/core behavior, dependency/lockfile, generated executable/runtime artifact, config/schema,
+  CI/release, broad refactor, or uncertain impact explicitly widen to `bun run check` and any affected build/e2e gate;
+  deterministic documentation/plugin mirrors may use focused generator, parity, and content checks.
+- [x] Review rejects both under-validation and unexplained full-suite validation.
+- [x] Canonical and mirrored skills pass their focused structural/parity checks.
+
+**Validation:**
+```bash
+bun run wishes:lint
+bun run skills:lint
+bun scripts/sync-plugin-skills.ts --check
+bun test scripts/sync-plugin-skills.test.ts
+```
+
+**depends-on:** none
+
+---
+
+## QA Criteria
+
+_What must be verified on dev after merge. The QA agent tests each criterion._
+
+- [ ] A README-only example clearly selects focused documentation checks without the full suite.
+- [ ] A shared runtime or release example clearly selects the aggregate gate.
+- [ ] The installed plugin payload carries the same policy as the source skills.
+
+---
+
+## Assumptions / Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| “Proportional” becomes subjective under-testing | Medium | Name a minimum evidence rule and explicit widening triggers. |
+| Aggregate checks are removed from true integration boundaries | Medium | State that CI, release, and cross-cutting gates remain mandatory. |
+| Canonical/plugin policy drift | Low | Regenerate the mirror and run the parity check. |
+
+---
+
+## Review Results
+
+### Plan review — 2026-07-28T09:58:10Z
+
+- **Context:** Plan review before execution
+- **Target SHA-256:** `f72a6b3dd11763a870ca75a49b39622e84e3657a014fcd82f89f4ee9888a8f57`
+- **Base HEAD:** `614e472c43977c3c122f1ea0410b3338f2a8f063`
+- **Verdict:** **SHIP**
+- **Validation:** `BUN_RUNTIME_TRANSPILER_CACHE_PATH=0 bun run wishes:lint` passed (67 files, zero broken
+  brainstorm links).
+- **Gaps:** No CRITICAL, HIGH, MEDIUM, or LOW gaps.
+- **Finding:** The actual problem is blanket validation, not testing itself. The plan preserves targeted evidence,
+  forbids zero validation, retains aggregate integration/release gates, and defers automation until repeated
+  deterministic misses justify it.
+
+### Plan re-review — 2026-07-28T10:10:33Z
+
+- **Target SHA-256:** `ddc3793965ce3581a22a9f0e2e8410a3f9246df69cc8a1aee92e372ce402def2`
+- **Verdict:** **SHIP**
+- **Validation:** `BUN_RUNTIME_TRANSPILER_CACHE_PATH=0 bun run wishes:lint` passed (67 files, zero broken
+  brainstorm links).
+- **Gaps:** No CRITICAL, HIGH, MEDIUM, or LOW gaps.
+- **Finding:** The amended criterion consistently distinguishes generated executable/runtime artifacts from
+  deterministic documentation/plugin mirrors and preserves the aggregate-gate boundary without adding machinery.
+
+### Group 1 execution review — 2026-07-28
+
+- **Verdict:** **SHIP** after fix loop 1.
+- **Validation:** `bun run wishes:lint`, `bun run skills:lint`, `bun scripts/sync-plugin-skills.ts --check`,
+  `bun test scripts/sync-plugin-skills.test.ts` (8 pass, 0 fail), and `git diff --check` all passed.
+- **Gaps:** None. Manual semantic enforcement is the explicitly accepted simplicity decision; automation remains
+  deferred until three concrete misses share a deterministic rule.
+
+### Group 1 quality review — 2026-07-28
+
+- **Initial verdict:** **FIX-FIRST** because “generated artifact” and “shared core” were too broad.
+- **Fix loop 1:** Distinguished deterministic documentation/plugin mirrors from generated executable/runtime artifacts
+  and narrowed the shared trigger to shared runtime/core behavior.
+- **Final verdict:** **SHIP**. No CRITICAL, HIGH, MEDIUM, or LOW gaps remain.
+
+### Scope clarification review — 2026-07-28
+
+- **Verdict:** **SHIP**.
+- **Finding:** The control plane is the shipped runtime-neutral `wish`, `work`, and `review` skills plus their plugin
+  mirrors. Target repositories retain ownership of their `AGENTS.md`, CI, scripts, and test commands.
+- **Gaps:** No CRITICAL, HIGH, MEDIUM, or LOW gaps.
+
+---
+
+## Files to Create/Modify
+
+```
+.genie/wishes/proportional-validation-policy/WISH.md
+skills/wish/SKILL.md
+skills/work/SKILL.md
+skills/review/SKILL.md
+plugins/genie/skills/wish/SKILL.md
+plugins/genie/skills/work/SKILL.md
+plugins/genie/skills/review/SKILL.md
+```

--- a/.genie/wishes/proportional-validation-policy/WISH.md
+++ b/.genie/wishes/proportional-validation-policy/WISH.md
@@ -104,7 +104,8 @@ model and effort in runtime session/agent configuration, never skill frontmatter
 - [x] Shared runtime/core behavior, dependency/lockfile, generated executable/runtime artifact, config/schema,
   CI/release, broad refactor, or uncertain impact explicitly widen to `bun run check` and any affected build/e2e gate;
   deterministic documentation/plugin mirrors may use focused generator, parity, and content checks.
-- [x] Review rejects both under-validation and unexplained full-suite validation.
+- [x] Review rejects under-validation and zero validation; a passing full suite missing only its scope rationale is at
+  most a MEDIUM gap, never by itself a blocker.
 - [x] Canonical and mirrored skills pass their focused structural/parity checks.
 
 **Validation:**

--- a/plugins/genie/skills/review/SKILL.md
+++ b/plugins/genie/skills/review/SKILL.md
@@ -23,7 +23,14 @@ When spawned as a reviewer subagent, your dispatch prompt carries the curated sc
 1. **Detect target** — DESIGN.md, wish draft, completed work, or PR diff.
 2. **Select pipeline** — the matching checklist below.
 3. **Run checklist** — evaluate each criterion, collecting evidence.
-4. **Run validations** — execute validation commands; capture pass/fail output.
+4. **Run validations** — execute validation commands; capture pass/fail output and confirm their scope is proportional
+   to the diff's risk and reach. Documentation-only changes, including deterministic generated documentation or plugin
+   skill mirrors, use relevant format, link, example, generator, parity, or content-contract checks; runtime changes use
+   focused behavior tests and add type, lint, or build checks for boundaries reached. Shared runtime/core behavior,
+   dependency or lockfile, generated executable or runtime artifact, configuration or schema, CI or release,
+   broad-refactor, or uncertain-impact changes require the repository full gate plus affected build or end-to-end checks.
+   Reject zero validation, under-validation, and unexplained full-suite validation. Preserve required aggregate
+   integration and release gates.
 5. **Tag gaps** — classify every unmet criterion by severity.
 6. **Return verdict** — SHIP, FIX-FIRST, or BLOCKED, with exact fixes (files, commands, what to change) for each gap.
 
@@ -64,12 +71,14 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 - [ ] Every task has testable acceptance criteria
 - [ ] Tasks are bite-sized and independently shippable
 - [ ] Dependencies tagged (`depends-on` / `blocks`)
-- [ ] Validation commands exist for each execution group
+- [ ] Every group has non-zero validation proportional to its planned risk and reach, with escalation and scope rationale
+- [ ] Aggregate integration and release gates remain present where the repository requires them
 - [ ] Simplicity Case is executable: no group builds machinery marked deferred, and every stateful mechanism maps to a current success criterion
 
 ### Execution Review (after `work`)
 - [ ] All acceptance criteria met with evidence
-- [ ] Validation commands run and passing
+- [ ] Validation commands run and passing; their recorded scope matches the actual diff's risk and reach
+- [ ] No under-validation, zero validation, or unexplained full-suite validation
 - [ ] No scope creep — only wish-scoped changes
 - [ ] Work is auditable — commands and outcomes captured
 - [ ] Quality pass: security, maintainability, correctness
@@ -80,7 +89,7 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 - [ ] Diff matches wish scope — no unrelated changes
 - [ ] File list matches wish's "Files to Create/Modify"
 - [ ] No secrets, credentials, or hardcoded tokens in diff
-- [ ] Tests pass (if applicable)
+- [ ] Risk-proportional validation passes, and required aggregate gates remain intact
 - [ ] Commit messages reference wish slug
 
 ## Severity & Verdicts

--- a/plugins/genie/skills/review/SKILL.md
+++ b/plugins/genie/skills/review/SKILL.md
@@ -29,8 +29,9 @@ When spawned as a reviewer subagent, your dispatch prompt carries the curated sc
    focused behavior tests and add type, lint, or build checks for boundaries reached. Shared runtime/core behavior,
    dependency or lockfile, generated executable or runtime artifact, configuration or schema, CI or release,
    broad-refactor, or uncertain-impact changes require the repository full gate plus affected build or end-to-end checks.
-   Reject zero validation, under-validation, and unexplained full-suite validation. Preserve required aggregate
-   integration and release gates.
+   Reject zero validation and under-validation. A passing full-suite run is always valid evidence; a missing scope
+   rationale is at most a MEDIUM gap, never by itself grounds for FIX-FIRST. A repository-documented gate is by itself
+   sufficient justification for its scope. Preserve required aggregate integration and release gates.
 5. **Tag gaps** — classify every unmet criterion by severity.
 6. **Return verdict** — SHIP, FIX-FIRST, or BLOCKED, with exact fixes (files, commands, what to change) for each gap.
 
@@ -78,7 +79,7 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 ### Execution Review (after `work`)
 - [ ] All acceptance criteria met with evidence
 - [ ] Validation commands run and passing; their recorded scope matches the actual diff's risk and reach
-- [ ] No under-validation, zero validation, or unexplained full-suite validation
+- [ ] No under-validation or zero validation; full-suite runs carry a scope rationale (a missing rationale is at most MEDIUM)
 - [ ] No scope creep — only wish-scoped changes
 - [ ] Work is auditable — commands and outcomes captured
 - [ ] Quality pass: security, maintainability, correctness

--- a/plugins/genie/skills/wish/SKILL.md
+++ b/plugins/genie/skills/wish/SKILL.md
@@ -57,7 +57,15 @@ node "<wish-skill-dir>/references/design-review-evidence.mjs" verify ".genie/bra
    <!-- wish-scaffold-command:end -->
 
    The template ships inside this skill as the single source of truth for wish structure — a plain document, no runtime scaffolder. Copying guarantees the skeleton the parser and linter expect; ad-hoc wishes regularly fail structural lint.
-7. **Fill:** replace the `{{slug}}`/`{{date}}` tokens and every `<TODO: …>` marker with real content. Every group gets acceptance criteria plus a validation command.
+7. **Fill:** replace the `{{slug}}`/`{{date}}` tokens and every `<TODO: …>` marker with real content. Every group gets
+   acceptance criteria plus a non-zero validation command proportional to the planned diff's risk and reach. Start with
+   the narrowest checks that can disprove the changed behavior or contract: documentation-only groups, including
+   deterministic generated documentation or plugin skill mirrors, use relevant format, link, example, generator, parity,
+   or content-contract checks; runtime groups use focused behavior tests and add type, lint, or build checks only for
+   boundaries they reach. Escalate shared runtime/core behavior, dependency or lockfile, generated executable or runtime
+   artifact, configuration or schema, CI or release, broad-refactor, or uncertain-impact groups to the repository full
+   gate plus affected build or end-to-end checks. State why the command scope fits; do not prescribe an unexplained full
+   suite. Preserve any repository-defined aggregate integration or release gate separately from per-group validation.
 8. **Declare dependencies:** use the wish-level `## Dependencies` keys
    `**depends-on:** <comma-separated slugs or none>` and
    `**blocks:** <comma-separated slugs or none>` for cross-wish edges. Keep
@@ -96,5 +104,7 @@ node "<wish-skill-dir>/references/design-review-evidence.mjs" verify ".genie/bra
 - No implementation during `wish` — planning only.
 - No speculative optimization: caches, deltas, sharding, background coordination, and configuration surfaces require a current criterion or measurement in the Simplicity Case.
 - Every group testable, bite-sized, and independently shippable; no vague tasks ("improve everything").
+- Every group has non-zero, risk-proportional validation with its scope explained; aggregate integration and release
+  gates remain intact.
 - OUT scope must contain at least one concrete exclusion.
 - Declare cross-wish dependencies early.

--- a/plugins/genie/skills/wish/SKILL.md
+++ b/plugins/genie/skills/wish/SKILL.md
@@ -64,8 +64,9 @@ node "<wish-skill-dir>/references/design-review-evidence.mjs" verify ".genie/bra
    or content-contract checks; runtime groups use focused behavior tests and add type, lint, or build checks only for
    boundaries they reach. Escalate shared runtime/core behavior, dependency or lockfile, generated executable or runtime
    artifact, configuration or schema, CI or release, broad-refactor, or uncertain-impact groups to the repository full
-   gate plus affected build or end-to-end checks. State why the command scope fits; do not prescribe an unexplained full
-   suite. Preserve any repository-defined aggregate integration or release gate separately from per-group validation.
+   gate plus affected build or end-to-end checks. State why the command scope fits; a repository-documented
+   gate is by itself sufficient justification for its scope. Preserve any repository-defined aggregate integration or
+   release gate separately from per-group validation.
 8. **Declare dependencies:** use the wish-level `## Dependencies` keys
    `**depends-on:** <comma-separated slugs or none>` and
    `**blocks:** <comma-separated slugs or none>` for cross-wish edges. Keep

--- a/plugins/genie/skills/work/SKILL.md
+++ b/plugins/genie/skills/work/SKILL.md
@@ -28,7 +28,14 @@ When you are spawned as a subagent for a group, your dispatch prompt carries the
 4. **Await completion — never poll:** background subagents notify you when they finish. Inspect `genie board --wish <slug>` on demand; completion is push, not poll.
 5. **Local review:** per finished group, dispatch a reviewer subagent (reviewer ≠ engineer) to run `review` against that group's acceptance criteria. The orchestrator appends each returned evidence block under `## Review Results`; the reviewer never edits it. Diagnose before fixing: `overdesigned-plan` returns to wish/design review without consuming a fix attempt; other FIX-FIRST gaps may use at most 2 fix loops.
 6. **Quality review:** dispatch a reviewer for a quality pass (security, maintainability, perf). On FIX-FIRST, one fix loop.
-7. **Validate:** run the group's validation command yourself (Bash); record the output as evidence.
+7. **Validate:** run the group's validation command yourself (Bash); record the output and the scope rationale as
+   evidence. Confirm it remains proportional to the actual diff, widening it when implementation reached beyond the
+   plan: documentation-only changes, including deterministic generated documentation or plugin skill mirrors, use
+   relevant format, link, example, generator, parity, or content-contract checks; runtime changes use focused behavior
+   tests and add type, lint, or build checks for boundaries reached. Shared runtime/core behavior, dependency or lockfile,
+   generated executable or runtime artifact, configuration or schema, CI or release, broad-refactor, or uncertain-impact
+   changes require the repository full gate plus affected build or end-to-end checks. Validation may never be zero, and
+   an unexplained full-suite run is not acceptable evidence. Preserve required aggregate integration and release gates.
 8. **Group done** — only after clean review AND passing validation:
    ```bash
    genie task done <task-id>
@@ -115,7 +122,8 @@ A user-approved simplification invalidates the superseded plan/review evidence a
 
 ## Rules
 - Never execute group work directly — always dispatch via the native delegation surface.
-- Never expand scope during execution; never skip validation commands.
+- Never expand scope during execution; never skip validation commands or substitute unexplained over-validation for a
+  risk-based choice.
 - Never spend fix loops preserving optional complexity; route an `overdesigned-plan` diagnosis back through wish/design review.
 - Never overwrite WISH.md from subagent output — curated prompts are runtime context; the WISH.md in git is the source of truth.
 - Reviewer ≠ engineer, always.

--- a/plugins/genie/skills/work/SKILL.md
+++ b/plugins/genie/skills/work/SKILL.md
@@ -34,8 +34,10 @@ When you are spawned as a subagent for a group, your dispatch prompt carries the
    relevant format, link, example, generator, parity, or content-contract checks; runtime changes use focused behavior
    tests and add type, lint, or build checks for boundaries reached. Shared runtime/core behavior, dependency or lockfile,
    generated executable or runtime artifact, configuration or schema, CI or release, broad-refactor, or uncertain-impact
-   changes require the repository full gate plus affected build or end-to-end checks. Validation may never be zero, and
-   an unexplained full-suite run is not acceptable evidence. Preserve required aggregate integration and release gates.
+   changes require the repository full gate plus affected build or end-to-end checks. Validation may never be zero. A
+   passing full-suite run is always valid evidence — record why that scope was chosen; a missing scope rationale is a
+   gap in the write-up, not in the validation. A repository-documented gate is by itself sufficient justification for
+   its scope. Preserve required aggregate integration and release gates.
 8. **Group done** — only after clean review AND passing validation:
    ```bash
    genie task done <task-id>
@@ -80,7 +82,7 @@ Extract the group's context from WISH.md and paste it into the dispatch prompt �
 1. **Goal** — one sentence
 2. **Deliverables** — the numbered list of concrete outputs
 3. **Acceptance criteria** — the checkboxes to satisfy
-4. **Validation command** — the exact command proving the work (e.g. `bun run check`)
+4. **Validation command** — the exact command proving the work, with its scope rationale (e.g. `bun run check` because the group touches shared runtime behavior)
 5. **Depends-on** — what the engineer may assume already exists
 6. **File scope** — the group's explicit file scope (the paths it owns), so disjoint ownership is legible to the engineer rather than inferred
 7. **Stop conditions** — claim the task first; report blocked instead of expanding scope; end with an outcome word (see Session close)

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -23,7 +23,14 @@ When spawned as a reviewer subagent, your dispatch prompt carries the curated sc
 1. **Detect target** — DESIGN.md, wish draft, completed work, or PR diff.
 2. **Select pipeline** — the matching checklist below.
 3. **Run checklist** — evaluate each criterion, collecting evidence.
-4. **Run validations** — execute validation commands; capture pass/fail output.
+4. **Run validations** — execute validation commands; capture pass/fail output and confirm their scope is proportional
+   to the diff's risk and reach. Documentation-only changes, including deterministic generated documentation or plugin
+   skill mirrors, use relevant format, link, example, generator, parity, or content-contract checks; runtime changes use
+   focused behavior tests and add type, lint, or build checks for boundaries reached. Shared runtime/core behavior,
+   dependency or lockfile, generated executable or runtime artifact, configuration or schema, CI or release,
+   broad-refactor, or uncertain-impact changes require the repository full gate plus affected build or end-to-end checks.
+   Reject zero validation, under-validation, and unexplained full-suite validation. Preserve required aggregate
+   integration and release gates.
 5. **Tag gaps** — classify every unmet criterion by severity.
 6. **Return verdict** — SHIP, FIX-FIRST, or BLOCKED, with exact fixes (files, commands, what to change) for each gap.
 
@@ -64,12 +71,14 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 - [ ] Every task has testable acceptance criteria
 - [ ] Tasks are bite-sized and independently shippable
 - [ ] Dependencies tagged (`depends-on` / `blocks`)
-- [ ] Validation commands exist for each execution group
+- [ ] Every group has non-zero validation proportional to its planned risk and reach, with escalation and scope rationale
+- [ ] Aggregate integration and release gates remain present where the repository requires them
 - [ ] Simplicity Case is executable: no group builds machinery marked deferred, and every stateful mechanism maps to a current success criterion
 
 ### Execution Review (after `work`)
 - [ ] All acceptance criteria met with evidence
-- [ ] Validation commands run and passing
+- [ ] Validation commands run and passing; their recorded scope matches the actual diff's risk and reach
+- [ ] No under-validation, zero validation, or unexplained full-suite validation
 - [ ] No scope creep — only wish-scoped changes
 - [ ] Work is auditable — commands and outcomes captured
 - [ ] Quality pass: security, maintainability, correctness
@@ -80,7 +89,7 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 - [ ] Diff matches wish scope — no unrelated changes
 - [ ] File list matches wish's "Files to Create/Modify"
 - [ ] No secrets, credentials, or hardcoded tokens in diff
-- [ ] Tests pass (if applicable)
+- [ ] Risk-proportional validation passes, and required aggregate gates remain intact
 - [ ] Commit messages reference wish slug
 
 ## Severity & Verdicts

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -29,8 +29,9 @@ When spawned as a reviewer subagent, your dispatch prompt carries the curated sc
    focused behavior tests and add type, lint, or build checks for boundaries reached. Shared runtime/core behavior,
    dependency or lockfile, generated executable or runtime artifact, configuration or schema, CI or release,
    broad-refactor, or uncertain-impact changes require the repository full gate plus affected build or end-to-end checks.
-   Reject zero validation, under-validation, and unexplained full-suite validation. Preserve required aggregate
-   integration and release gates.
+   Reject zero validation and under-validation. A passing full-suite run is always valid evidence; a missing scope
+   rationale is at most a MEDIUM gap, never by itself grounds for FIX-FIRST. A repository-documented gate is by itself
+   sufficient justification for its scope. Preserve required aggregate integration and release gates.
 5. **Tag gaps** — classify every unmet criterion by severity.
 6. **Return verdict** — SHIP, FIX-FIRST, or BLOCKED, with exact fixes (files, commands, what to change) for each gap.
 
@@ -78,7 +79,7 @@ If an ordinary reviewer and the `final-gate` disagree, log an appeal with the wi
 ### Execution Review (after `work`)
 - [ ] All acceptance criteria met with evidence
 - [ ] Validation commands run and passing; their recorded scope matches the actual diff's risk and reach
-- [ ] No under-validation, zero validation, or unexplained full-suite validation
+- [ ] No under-validation or zero validation; full-suite runs carry a scope rationale (a missing rationale is at most MEDIUM)
 - [ ] No scope creep — only wish-scoped changes
 - [ ] Work is auditable — commands and outcomes captured
 - [ ] Quality pass: security, maintainability, correctness

--- a/skills/wish/SKILL.md
+++ b/skills/wish/SKILL.md
@@ -57,7 +57,15 @@ node "<wish-skill-dir>/references/design-review-evidence.mjs" verify ".genie/bra
    <!-- wish-scaffold-command:end -->
 
    The template ships inside this skill as the single source of truth for wish structure — a plain document, no runtime scaffolder. Copying guarantees the skeleton the parser and linter expect; ad-hoc wishes regularly fail structural lint.
-7. **Fill:** replace the `{{slug}}`/`{{date}}` tokens and every `<TODO: …>` marker with real content. Every group gets acceptance criteria plus a validation command.
+7. **Fill:** replace the `{{slug}}`/`{{date}}` tokens and every `<TODO: …>` marker with real content. Every group gets
+   acceptance criteria plus a non-zero validation command proportional to the planned diff's risk and reach. Start with
+   the narrowest checks that can disprove the changed behavior or contract: documentation-only groups, including
+   deterministic generated documentation or plugin skill mirrors, use relevant format, link, example, generator, parity,
+   or content-contract checks; runtime groups use focused behavior tests and add type, lint, or build checks only for
+   boundaries they reach. Escalate shared runtime/core behavior, dependency or lockfile, generated executable or runtime
+   artifact, configuration or schema, CI or release, broad-refactor, or uncertain-impact groups to the repository full
+   gate plus affected build or end-to-end checks. State why the command scope fits; do not prescribe an unexplained full
+   suite. Preserve any repository-defined aggregate integration or release gate separately from per-group validation.
 8. **Declare dependencies:** use the wish-level `## Dependencies` keys
    `**depends-on:** <comma-separated slugs or none>` and
    `**blocks:** <comma-separated slugs or none>` for cross-wish edges. Keep
@@ -96,5 +104,7 @@ node "<wish-skill-dir>/references/design-review-evidence.mjs" verify ".genie/bra
 - No implementation during `wish` — planning only.
 - No speculative optimization: caches, deltas, sharding, background coordination, and configuration surfaces require a current criterion or measurement in the Simplicity Case.
 - Every group testable, bite-sized, and independently shippable; no vague tasks ("improve everything").
+- Every group has non-zero, risk-proportional validation with its scope explained; aggregate integration and release
+  gates remain intact.
 - OUT scope must contain at least one concrete exclusion.
 - Declare cross-wish dependencies early.

--- a/skills/wish/SKILL.md
+++ b/skills/wish/SKILL.md
@@ -64,8 +64,9 @@ node "<wish-skill-dir>/references/design-review-evidence.mjs" verify ".genie/bra
    or content-contract checks; runtime groups use focused behavior tests and add type, lint, or build checks only for
    boundaries they reach. Escalate shared runtime/core behavior, dependency or lockfile, generated executable or runtime
    artifact, configuration or schema, CI or release, broad-refactor, or uncertain-impact groups to the repository full
-   gate plus affected build or end-to-end checks. State why the command scope fits; do not prescribe an unexplained full
-   suite. Preserve any repository-defined aggregate integration or release gate separately from per-group validation.
+   gate plus affected build or end-to-end checks. State why the command scope fits; a repository-documented
+   gate is by itself sufficient justification for its scope. Preserve any repository-defined aggregate integration or
+   release gate separately from per-group validation.
 8. **Declare dependencies:** use the wish-level `## Dependencies` keys
    `**depends-on:** <comma-separated slugs or none>` and
    `**blocks:** <comma-separated slugs or none>` for cross-wish edges. Keep

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -28,7 +28,14 @@ When you are spawned as a subagent for a group, your dispatch prompt carries the
 4. **Await completion — never poll:** background subagents notify you when they finish. Inspect `genie board --wish <slug>` on demand; completion is push, not poll.
 5. **Local review:** per finished group, dispatch a reviewer subagent (reviewer ≠ engineer) to run `review` against that group's acceptance criteria. The orchestrator appends each returned evidence block under `## Review Results`; the reviewer never edits it. Diagnose before fixing: `overdesigned-plan` returns to wish/design review without consuming a fix attempt; other FIX-FIRST gaps may use at most 2 fix loops.
 6. **Quality review:** dispatch a reviewer for a quality pass (security, maintainability, perf). On FIX-FIRST, one fix loop.
-7. **Validate:** run the group's validation command yourself (Bash); record the output as evidence.
+7. **Validate:** run the group's validation command yourself (Bash); record the output and the scope rationale as
+   evidence. Confirm it remains proportional to the actual diff, widening it when implementation reached beyond the
+   plan: documentation-only changes, including deterministic generated documentation or plugin skill mirrors, use
+   relevant format, link, example, generator, parity, or content-contract checks; runtime changes use focused behavior
+   tests and add type, lint, or build checks for boundaries reached. Shared runtime/core behavior, dependency or lockfile,
+   generated executable or runtime artifact, configuration or schema, CI or release, broad-refactor, or uncertain-impact
+   changes require the repository full gate plus affected build or end-to-end checks. Validation may never be zero, and
+   an unexplained full-suite run is not acceptable evidence. Preserve required aggregate integration and release gates.
 8. **Group done** — only after clean review AND passing validation:
    ```bash
    genie task done <task-id>
@@ -115,7 +122,8 @@ A user-approved simplification invalidates the superseded plan/review evidence a
 
 ## Rules
 - Never execute group work directly — always dispatch via the native delegation surface.
-- Never expand scope during execution; never skip validation commands.
+- Never expand scope during execution; never skip validation commands or substitute unexplained over-validation for a
+  risk-based choice.
 - Never spend fix loops preserving optional complexity; route an `overdesigned-plan` diagnosis back through wish/design review.
 - Never overwrite WISH.md from subagent output — curated prompts are runtime context; the WISH.md in git is the source of truth.
 - Reviewer ≠ engineer, always.

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -34,8 +34,10 @@ When you are spawned as a subagent for a group, your dispatch prompt carries the
    relevant format, link, example, generator, parity, or content-contract checks; runtime changes use focused behavior
    tests and add type, lint, or build checks for boundaries reached. Shared runtime/core behavior, dependency or lockfile,
    generated executable or runtime artifact, configuration or schema, CI or release, broad-refactor, or uncertain-impact
-   changes require the repository full gate plus affected build or end-to-end checks. Validation may never be zero, and
-   an unexplained full-suite run is not acceptable evidence. Preserve required aggregate integration and release gates.
+   changes require the repository full gate plus affected build or end-to-end checks. Validation may never be zero. A
+   passing full-suite run is always valid evidence — record why that scope was chosen; a missing scope rationale is a
+   gap in the write-up, not in the validation. A repository-documented gate is by itself sufficient justification for
+   its scope. Preserve required aggregate integration and release gates.
 8. **Group done** — only after clean review AND passing validation:
    ```bash
    genie task done <task-id>
@@ -80,7 +82,7 @@ Extract the group's context from WISH.md and paste it into the dispatch prompt �
 1. **Goal** — one sentence
 2. **Deliverables** — the numbered list of concrete outputs
 3. **Acceptance criteria** — the checkboxes to satisfy
-4. **Validation command** — the exact command proving the work (e.g. `bun run check`)
+4. **Validation command** — the exact command proving the work, with its scope rationale (e.g. `bun run check` because the group touches shared runtime behavior)
 5. **Depends-on** — what the engineer may assume already exists
 6. **File scope** — the group's explicit file scope (the paths it owns), so disjoint ownership is legible to the engineer rather than inferred
 7. **Stop conditions** — claim the task first; report blocked instead of expanding scope; end with an outcome word (see Session close)


### PR DESCRIPTION
## Summary

- make Genie wish planning choose non-zero validation proportional to the target diff risk and reach
- make work execution re-evaluate validation scope against the actual diff
- make review reject under-validation, zero validation, and unexplained full-suite runs
- preserve each target repository aggregate integration and release gates
- keep canonical and shipped plugin skills byte-identical

## Why

A narrow change such as a README edit should use focused documentation checks instead of automatically running an entire application test suite. Broader runtime, dependency, schema, CI, release, and uncertain-impact changes still escalate to the target repository full gate.

## Validation

- bun run wishes:lint
- bun run skills:lint
- bun scripts/sync-plugin-skills.ts --check
- bun test scripts/sync-plugin-skills.test.ts (8 pass, 0 fail)
- git diff --check

The aggregate suite was intentionally not run because this change only modifies workflow policy documents and deterministic plugin mirrors.

Closes #2724

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a proportional validation policy for Genie workflows, defining how to choose the smallest sufficient validation effort based on risk and reach.
  * Updated work, wish, and review guidance to require **non-zero** validation with an explicit **scope rationale**.
  * Documentation-only changes now use focused checks; runtime and cross-cutting changes escalate to full and affected integration/release gates.
  * Strengthened rules to prevent under-validation and require proper justification when using broader/full-suite validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->