### PR TITLE
fix: resolve all 8 bot review findings from promotion PR #2722

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -39,9 +39,7 @@ on:
     types: [completed]
     branches: [main, dev]
 
-permissions:
-  contents: write          # commit + push version bump + tag
-  actions: write           # dispatch trusted release.yml control on main
+permissions: {}
 
 # RACES: CI completes twice per dev merge (push + pull_request), so separate
 # those event classes and never cancel an in-flight version operation. Within
@@ -58,6 +56,9 @@ jobs:
     name: Auto Version
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 5
+    permissions:
+      contents: write        # commit + push version bump + tag
+      actions: write         # gh workflow run ci.yml at the version-child tag
     outputs:
       release_ready: ${{ steps.commit_and_tag.outputs.release_ready || steps.promoted_tag.outputs.release_ready }}
       version: ${{ steps.commit_and_tag.outputs.version || steps.promoted_tag.outputs.version }}

--- a/scripts/check-action-pins.sh
+++ b/scripts/check-action-pins.sh
@@ -8,8 +8,9 @@
 # no repository, and it took down three release-publish jobs the first time
 # they ever executed.
 #
-# The matcher reads the scalar that follows the FIRST `uses:` key on the line,
-# recognises all three YAML spellings (bare, 'single-quoted', "double-quoted"),
+# The matcher reads the scalar that follows each `uses:` occurrence on the line
+# and keeps the first one that is a pin, recognises all three YAML spellings
+# (bare, 'single-quoted', "double-quoted"),
 # and requires the ref to span the WHOLE scalar — an action ending in 40 hex
 # chars followed by trailing garbage (`@<sha>oops`) is not a pin and must not be
 # silently accepted (#2669).
@@ -33,24 +34,38 @@ pin_re='^([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)(/[A-Za-z0-9./_-]+)?@([0-9a-f]{40})$'
 # extract_pin <line> — echo `owner/repo@sha` for a SHA-pinned `uses:` line.
 # Returns 1 (printing nothing) for local (`./…`), docker://, tag/branch refs and
 # for a 40-hex run that does not terminate the scalar.
+#
+# Every `uses:` occurrence is tried in order and the FIRST scalar that parses as
+# a pin wins. Stopping at the first occurrence failed open: a literal `uses:`
+# inside an earlier quoted value (`- { name: "literal uses: x", uses: o/r@<sha> }`)
+# shadowed the real key, so the pin was silently never validated. Returning on
+# the first VALID pin still keeps a trailing comment from shadowing a good
+# scalar, because the real pin is matched before the comment is reached.
 extract_pin() {
-  local line="$1" rest scalar
+  local line="$1" rest cand scalar
   line="${line%$'\r'}"
-  case $line in *uses:*) rest="${line#*uses:}" ;; *) return 1 ;; esac
-  rest="${rest#"${rest%%[![:space:]]*}"}"
-  if [[ $rest =~ $uses_dquoted_re ]]; then
-    scalar="${BASH_REMATCH[1]}"
-  elif [[ $rest =~ $uses_squoted_re ]]; then
-    scalar="${BASH_REMATCH[1]}"
-  elif [[ $rest =~ $uses_bare_re ]]; then
-    scalar="${BASH_REMATCH[1]}"
-  else
-    return 1
-  fi
-  [[ $scalar =~ $pin_re ]] || return 1
-  # BASH_REMATCH[2] is the optional subpath (`owner/repo/sub@sha`); the commit
-  # lives in the parent repository, so the API target and the dedupe key drop it.
-  printf '%s@%s\n' "${BASH_REMATCH[1]}" "${BASH_REMATCH[3]}"
+  rest="$line"
+  while [[ $rest == *uses:* ]]; do
+    rest="${rest#*uses:}"
+    cand="${rest#"${rest%%[![:space:]]*}"}"
+    if [[ $cand =~ $uses_dquoted_re ]]; then
+      scalar="${BASH_REMATCH[1]}"
+    elif [[ $cand =~ $uses_squoted_re ]]; then
+      scalar="${BASH_REMATCH[1]}"
+    elif [[ $cand =~ $uses_bare_re ]]; then
+      scalar="${BASH_REMATCH[1]}"
+    else
+      continue
+    fi
+    if [[ $scalar =~ $pin_re ]]; then
+      # BASH_REMATCH[2] is the optional subpath (`owner/repo/sub@sha`); the
+      # commit lives in the parent repository, so the API target and the dedupe
+      # key drop it.
+      printf '%s@%s\n' "${BASH_REMATCH[1]}" "${BASH_REMATCH[3]}"
+      return 0
+    fi
+  done
+  return 1
 }
 
 if [[ "${1:-}" == "--extract" ]]; then

--- a/scripts/release-docs.test.ts
+++ b/scripts/release-docs.test.ts
@@ -100,7 +100,10 @@ describe('Group E release and documentation contracts', () => {
     // exactly contents:read — the least that lets the replay guard ask whether
     // the tag already carries a published release — and never write, so an
     // unproven caller still cannot mutate anything.
-    expect(read('.github/workflows/sign-attest.yml')).toContain('permissions: {}');
+    const signAdmit = read('.github/workflows/sign-attest.yml').split('\n  admit:')[1]?.split('\n  prepare:')[0] ?? '';
+    expect(signAdmit).toContain('permissions: {}');
+    expect(signAdmit).not.toContain('contents: write');
+    expect(signAdmit).not.toContain('id-token:');
     const publishAdmit =
       read('.github/workflows/release-publish.yml')
         .split('\n  admit:')[1]
@@ -1033,16 +1036,10 @@ describe('Group E release and documentation contracts', () => {
     expect(readme).toContain('The Codex route is plugin-independent');
     for (const path of ['.mcp.json', '.warp/.mcp.json', '.codex/config.toml']) expect(readme).toContain(path);
   });
-});
 
-test('the retired homolog channel never reappears in release workflows', () => {
-  for (const wf of [
-    '.github/workflows/version.yml',
-    '.github/workflows/release.yml',
-    '.github/workflows/release-publish.yml',
-    '.github/workflows/sign-attest.yml',
-    '.github/workflows/build-tarballs.yml',
-  ]) {
-    expect(readFileSync(wf, 'utf-8')).not.toContain('homolog');
-  }
+  test('the retired homolog channel never reappears in any workflow', () => {
+    for (const name of readdirSync(join(ROOT, '.github/workflows')).filter((entry) => entry.endsWith('.yml'))) {
+      expect(read(`.github/workflows/${name}`), name).not.toContain('homolog');
+    }
+  });
 });

--- a/scripts/release-replay-guard.test.ts
+++ b/scripts/release-replay-guard.test.ts
@@ -1,0 +1,102 @@
+// The release replay guard is a pure-bash `run:` body (every GitHub expression
+// is confined to the step's `env:`), so it can be lifted out of the workflow
+// and executed directly. release-docs.test.ts asserts the step's text; this
+// file asserts what it DOES: which gh responses admit the run and which refuse
+// it. See automagik-dev/genie#2674.
+import { afterEach, describe, expect, test } from 'bun:test';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const ROOT = join(import.meta.dir, '..');
+const WORKFLOW = join(ROOT, '.github/workflows/release-publish.yml');
+const STEP = 'Refuse re-dispatch of an already published release';
+
+/** Pull a step's `run: |` body out of a workflow and dedent it. */
+function stepScript(workflow: string, stepName: string): string {
+  const afterName = workflow.split(`- name: ${stepName}\n`)[1] ?? '';
+  const afterRun = afterName.split(/^\s*run: \|\s*\n/m)[1] ?? '';
+  const lines = afterRun.split('\n');
+  const indent = (lines[0].match(/^ */) ?? [''])[0].length;
+  const body: string[] = [];
+  for (const line of lines) {
+    if (line.trim() === '') {
+      body.push('');
+      continue;
+    }
+    if ((line.match(/^ */) ?? [''])[0].length < indent) break;
+    body.push(line.slice(indent));
+  }
+  return body.join('\n').trimEnd();
+}
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+interface GhStub {
+  stdout?: string;
+  stderr?: string;
+  exit: number;
+}
+
+/** Run the extracted guard with `gh` stubbed on PATH. */
+function runGuard(stub: GhStub, version = '5.260728.4') {
+  const root = mkdtempSync(join(tmpdir(), 'genie-replay-guard-'));
+  roots.push(root);
+  const bin = join(root, 'bin');
+  mkdirSync(bin, { recursive: true });
+  writeFileSync(
+    join(bin, 'gh'),
+    `#!/bin/sh\n${stub.stdout ? `printf '%s' '${stub.stdout}'\n` : ''}${stub.stderr ? `printf '%s\\n' '${stub.stderr}' >&2\n` : ''}exit ${stub.exit}\n`,
+  );
+  chmodSync(join(bin, 'gh'), 0o755);
+
+  const scriptPath = join(root, 'guard.sh');
+  writeFileSync(scriptPath, stepScript(readFileSync(WORKFLOW, 'utf8'), STEP));
+
+  return Bun.spawnSync(['bash', scriptPath], {
+    env: {
+      PATH: `${bin}:${process.env.PATH ?? ''}`,
+      GH_TOKEN: 'stub-token',
+      RELEASE_REPOSITORY: 'automagik-dev/genie',
+      INPUT_VERSION: version,
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+}
+
+describe('release-publish replay guard behavior', () => {
+  test('the guard body is self-contained bash with no un-evaluated GitHub expressions', () => {
+    const script = stepScript(readFileSync(WORKFLOW, 'utf8'), STEP);
+    expect(script.startsWith('set -euo pipefail')).toBe(true);
+    expect(script).toContain('RELEASE_JSON="$(mktemp)"');
+    expect(script.includes('${{')).toBe(false);
+  });
+
+  test('a published release is refused', () => {
+    const run = runGuard({ stdout: '{"draft":false}', exit: 0 });
+    expect(run.exitCode).toBe(1);
+    expect(run.stdout.toString() + run.stderr.toString()).toContain('release-replay.published');
+  });
+
+  test('a draft release is admitted so an interrupted publish can finish', () => {
+    const run = runGuard({ stdout: '{"draft":true}', exit: 0 });
+    expect(run.exitCode).toBe(0);
+    expect(run.stdout.toString()).toContain('draft release; admitting');
+  });
+
+  test('a missing release (HTTP 404) is admitted', () => {
+    const run = runGuard({ stderr: 'gh: Not Found (HTTP 404)', exit: 1 });
+    expect(run.exitCode).toBe(0);
+    expect(run.stdout.toString()).toContain('has no GitHub Release yet');
+  });
+
+  test('an ambiguous API failure fails closed', () => {
+    const run = runGuard({ stderr: 'gh: Server Error (HTTP 500)', exit: 1 });
+    expect(run.exitCode).toBe(1);
+    expect(run.stdout.toString() + run.stderr.toString()).toContain('release-replay.unknown');
+  });
+});

--- a/src/hooks/__tests__/branch-guard.test.ts
+++ b/src/hooks/__tests__/branch-guard.test.ts
@@ -421,6 +421,17 @@ describe('branch-guard', () => {
       expect(result!.reason).toContain('--base');
     });
 
+    // Regression: PR #2722 review (CodeRabbit 3662114937, Codex 3661572682).
+    // An *unquoted* `\"` opened a phantom quote region whose closing `\"` was
+    // eaten by the double-quote escape rule, masking to end of string — so the
+    // real `git push` after the message was invisible to every pattern here
+    // while bash still executed it.
+    test('still blocks a push to main hidden behind a shell-escaped message', async () => {
+      const result = await branchGuard(makePayload('git commit -m \\"x\\" && git push --force origin main'));
+      expect(result).toBeDefined();
+      expect(result!.decision).toBe('deny');
+    });
+
     test('still blocks real gh pr merge targeting main (quoted args do not shield the actual command)', async () => {
       const result = await branchGuard(makePayload('gh pr merge 123 --squash --body "some note"'), mockDeps('main'));
       expect(result).toBeDefined();

--- a/src/hooks/__tests__/git-freeze-guard.test.ts
+++ b/src/hooks/__tests__/git-freeze-guard.test.ts
@@ -328,6 +328,25 @@ describe('git-freeze-guard', () => {
     }
   });
 
+  // Regression: PR #2722 review (CodeRabbit 3662114937, Codex 3661572682).
+  // The masker read an *unquoted* `\"` as a quote opener, and the closing `\"`
+  // was then swallowed by the double-quoted `\X` rule — so the phantom region
+  // masked to end of string and everything after the message vanished. bash
+  // runs the whole line; the guard only ever saw its head.
+  describe('shell-escaped quotes do not hide the rest of the command', () => {
+    const blocked = ['git commit -m \\"fix\\" && git checkout main', 'echo \\" ; git switch dev'];
+
+    for (const cmd of blocked) {
+      test(`denies: ${cmd}`, async () => {
+        expect((await run(subagent(cmd)))?.decision).toBe('deny');
+      });
+    }
+
+    test('but an escaped-quote message with nothing frozen after it still passes', async () => {
+      expect(await run(subagent('git commit -m \\"fix\\" && git status'))).toBeUndefined();
+    });
+  });
+
   // =========================================================================
   // Fail-open boundaries
   // =========================================================================

--- a/src/hooks/__tests__/git-freeze-guard.test.ts
+++ b/src/hooks/__tests__/git-freeze-guard.test.ts
@@ -235,6 +235,38 @@ describe('git-freeze-guard', () => {
   });
 
   // =========================================================================
+  // Separators decide whether a cd moves the shell the git call runs in
+  // =========================================================================
+
+  // Regression: PR #2722 review (CodeRabbit 3662114937, Codex 3661572682).
+  // The walk applied every `cd` to every later statement whatever operators
+  // sat around it. A `cd` beside `|` or `&` is its own process and moves
+  // nothing; a `cd` before `||` only takes effect when it succeeded, in which
+  // case the else-branch never runs at all. Reading either as effective let a
+  // frozen call through while bash ran it in the shared checkout.
+  describe('cd propagates only across separators that keep the parent shell', () => {
+    const blocked = [
+      'cd /other | git switch dev',
+      'cd /other & git reset --hard HEAD~1',
+      'cd /missing || git rebase origin/dev',
+      'foo | cd /other && git switch dev',
+    ];
+
+    for (const cmd of blocked) {
+      test(`denies: ${cmd}`, async () => {
+        expect((await run(subagent(cmd)))?.decision).toBe('deny');
+      });
+    }
+
+    // The counterweight: `cd <worktree> || exit 1` is the ordinary way to make
+    // a lane script abort on a bad path, and the git call after it genuinely
+    // runs in the worktree. A blanket "`||` never propagates" rule would deny it.
+    test('allows the guarded-cd idiom into an owned worktree', async () => {
+      expect(await run(subagent(`cd ${LANE} || exit 1; git switch dev`))).toBeUndefined();
+    });
+  });
+
+  // =========================================================================
   // Subshells — `(…)` scopes a cd, and its parens are not part of the command
   // =========================================================================
 

--- a/src/hooks/handlers/git-freeze-guard.ts
+++ b/src/hooks/handlers/git-freeze-guard.ts
@@ -94,8 +94,22 @@ const REPO_REDIRECTING_GLOBAL_FLAGS = ['--git-dir', '--work-tree', '--namespace'
 /** Shell metacharacters that make a path argument non-literal. */
 const NON_LITERAL_PATH = /[$`*?~!]|\\$/;
 
-/** Statement separators. `&&` and `||` must be tried before `&` and `|`. */
-const SEGMENT_SEPARATORS = /&&|\|\||;|\||&|\n/;
+/**
+ * Statement separators. `&&` and `||` must be tried before `&` and `|`.
+ *
+ * The group is capturing so `String.split` interleaves each operator between
+ * the statements it joins: a `cd`'s effect on the parent shell depends on which
+ * separators sit either side of it, and that is unreadable from the statements
+ * alone.
+ */
+const SEGMENT_SEPARATORS = /(&&|\|\||;|\||&|\n)/;
+
+/**
+ * Separators that put the statement beside them in a subshell: a pipeline
+ * component and a backgrounded job both get their own process, so a `cd` there
+ * never moves the parent shell's directory and must not move the guard's.
+ */
+const SUBSHELL_SEPARATORS = new Set(['|', '&']);
 
 /** Openers of a region that runs in its own shell and yields a value, not a statement. */
 const OPAQUE_REGION_OPENERS = ['$(', '<(', '>('];
@@ -276,6 +290,37 @@ function parseStatement(segment: string): Statement {
   return { tokens, opened, closed };
 }
 
+/** True when this separator makes the statement beside it run in its own shell. */
+function isSubshellEdge(separator: string | undefined): boolean {
+  return separator !== undefined && SUBSHELL_SEPARATORS.has(separator);
+}
+
+/** How far a `cd`/`pushd` statement reaches, given the operators around it. */
+interface DirectoryChange {
+  /** The scope's directory afterwards — unchanged when the `cd` ran in a subshell. */
+  scope: string | null;
+  /** Pre-`cd` directory the `||` else-branch runs in, when one follows. */
+  elseDir?: string | null;
+}
+
+/**
+ * Decide what a `cd <target>` does to the directories the walk tracks.
+ *
+ * Beside `|` or `&` it does nothing: that `cd` is a separate process, and the
+ * parent shell — where the later statements run — never moves. Before `||` it
+ * applies, but the else-branch it guards runs only on failure, so that one
+ * statement belongs to the directory the shell was in beforehand.
+ */
+function applyDirectoryChange(
+  target: string | undefined,
+  dir: string | null,
+  before: string | undefined,
+  after: string | undefined,
+): DirectoryChange {
+  if (isSubshellEdge(before) || isSubshellEdge(after)) return { scope: dir };
+  return { scope: joinPath(dir, target), elseDir: after === '||' ? dir : undefined };
+}
+
 /**
  * Walk the statements of a compound command left to right, tracking `cd` as it
  * goes, and return every frozen git invocation found.
@@ -283,25 +328,41 @@ function parseStatement(segment: string): Statement {
  * Directories are a stack rather than a single value because `(` opens a scope
  * the shell discards at the matching `)`: a `cd` inside a subshell applies to
  * the statements within it and to nothing after it.
+ *
+ * A `cd`'s reach also depends on the separators around it, so the walk reads
+ * the operators as well as the statements:
+ *   - beside `|` or `&` the `cd` is its own process and moves nothing the later
+ *     statements can see (`cd /other | git switch dev` runs git in the *shared*
+ *     checkout, and treating the `cd` as effective let it through);
+ *   - before `||` the `cd` does apply, but the statement guarded by the `||`
+ *     runs only when the `cd` *failed*, so that one statement is judged against
+ *     the directory the shell was in beforehand. Both halves matter: without
+ *     the first, `cd /missing || git rebase origin/dev` slips past; without the
+ *     second, the routine `cd <worktree> || exit 1; git switch dev` is denied.
  */
 function findFrozenInvocations(command: string, cwd: string | null): GitInvocation[] {
   const masked = maskOpaqueRegions(maskQuotedRegions(command));
   if (!/\bgit\b/.test(masked)) return [];
+  // Capturing separators, so even indices are statements and odd are operators.
+  const parts = masked.split(SEGMENT_SEPARATORS);
   const scopes: (string | null)[] = [cwd];
   const found: GitInvocation[] = [];
-  for (const segment of masked.split(SEGMENT_SEPARATORS)) {
-    const { tokens, opened, closed } = parseStatement(segment);
+  /** One-shot override: the pre-`cd` directory an `||` else-branch runs in. */
+  let elseDir: string | null | undefined;
+  for (let p = 0; p < parts.length; p += 2) {
+    const { tokens, opened, closed } = parseStatement(parts[p]);
     for (let n = 0; n < opened; n += 1) scopes.push(scopes[scopes.length - 1]);
-    const dir = scopes[scopes.length - 1];
-    if (tokens.length > 0) {
-      if (tokens[0] === 'cd' || tokens[0] === 'pushd') {
-        scopes[scopes.length - 1] = joinPath(dir, tokens[1]);
-      } else if (tokens[0] === 'popd') {
-        scopes[scopes.length - 1] = null;
-      } else {
-        const invocation = parseGitInvocation(tokens, dir);
-        if (invocation && isFrozenInvocation(invocation)) found.push(invocation);
-      }
+    const dir = elseDir === undefined ? scopes[scopes.length - 1] : elseDir;
+    elseDir = undefined;
+    if (tokens[0] === 'cd' || tokens[0] === 'pushd') {
+      const change = applyDirectoryChange(tokens[1], dir, parts[p - 1], parts[p + 1]);
+      scopes[scopes.length - 1] = change.scope;
+      elseDir = change.elseDir;
+    } else if (tokens[0] === 'popd') {
+      scopes[scopes.length - 1] = null;
+    } else {
+      const invocation = parseGitInvocation(tokens, dir);
+      if (invocation && isFrozenInvocation(invocation)) found.push(invocation);
     }
     for (let n = 0; n < closed && scopes.length > 1; n += 1) scopes.pop();
   }

--- a/src/hooks/shell-quoting.ts
+++ b/src/hooks/shell-quoting.ts
@@ -15,8 +15,15 @@
  * that doesn't generalize.
  *
  * Scope: handles single-quotes (no escapes), double-quotes with `\X` escapes,
- * and unterminated quotes (mask to end of string — safer than the alternative
- * of leaving a runaway region unmasked). Backtick command substitution and
+ * unquoted `\X` escapes (a literal X — notably `\"`, which does *not* open a
+ * quote region), and unterminated quotes (mask to end of string — safer than
+ * the alternative of leaving a runaway region unmasked).
+ *
+ * The unquoted-escape case is load-bearing, not cosmetic: reading `\"` as a
+ * quote opener made `git commit -m \"fix\" && git checkout main` mask from the
+ * first `\"` to end of string — the closing `\"` was swallowed by the
+ * double-quoted `\X` rule — so the guards saw no `&& git checkout main` and
+ * allowed a command bash runs in full. Backtick command substitution and
  * heredocs are intentionally not parsed — they're rare in agent-issued
  * commands and falling back to fully unmasked treatment is fail-closed for
  * the original policy, which matches the hook's overall posture.
@@ -30,8 +37,9 @@ interface MaskStep {
   consumed: number;
 }
 
-/** Unquoted char: pass through, or open a quote region. */
-function stepUnquoted(ch: string): MaskStep {
+/** Unquoted char: pass through, or open a quote region. `\X` is a literal X, not a quote opener. */
+function stepUnquoted(ch: string, next: string | undefined): MaskStep {
+  if (ch === '\\' && next !== undefined) return { out: ch + next, next: 'none', consumed: 2 };
   if (ch === "'") return { out: ' ', next: 'single', consumed: 1 };
   if (ch === '"') return { out: ' ', next: 'double', consumed: 1 };
   return { out: ch, next: 'none', consumed: 1 };
@@ -58,7 +66,7 @@ export function maskQuotedRegions(cmd: string): string {
         ? stepDoubleQuoted(cmd[i], i + 1 < cmd.length)
         : state === 'single'
           ? stepSingleQuoted(cmd[i])
-          : stepUnquoted(cmd[i]);
+          : stepUnquoted(cmd[i], cmd[i + 1]);
     out += step.out;
     state = step.next;
     i += step.consumed;

--- a/src/lib/codex-delivery-evidence.ts
+++ b/src/lib/codex-delivery-evidence.ts
@@ -911,6 +911,13 @@ function platformTripleFor(platformId: DeliveryEvidencePlatformId): string {
 function sourceBranchAllowedForChannel(branch: unknown, channel: DeliveryEvidenceChannel): branch is string {
   if (typeof branch !== 'string') return false;
   if (channel === 'stable') return branch === 'main';
+  // Accepting "main" on the dev channel is LOAD-BEARING, not a loose check: a
+  // stable release cross-publishes dev (reconcile-channel-manifests.sh advances
+  // both latest.json and dev.json; release-publish.yml builds descriptors for
+  // EVIDENCE_CHANNELS=(stable dev) with SOURCE_BRANCH=main), so dev clients on a
+  // stable-promoted version verify a {channel:'dev', sourceBranch:'main'}
+  // descriptor. Narrowing this to "dev" aborts every dev update after a stable
+  // release. Same asymmetry documented in validate-live-dogfood-evidence.ts.
   return branch === 'main' || branch === 'dev';
 }
 

--- a/tests/integration/check-action-pins-matcher.test.ts
+++ b/tests/integration/check-action-pins-matcher.test.ts
@@ -12,7 +12,9 @@
  *   - an unanchored match let a quoted pin inside a trailing comment shadow the
  *     real bare pin on the same line;
  *   - a flow-mapping step (`- { uses: owner/repo@<sha>, name: X }`) was skipped
- *     because the comma stayed glued to the scalar.
+ *     because the comma stayed glued to the scalar;
+ *   - a literal `uses:` inside an earlier quoted value shadowed the real key, so
+ *     the pin on that line was silently never validated (fail-open).
  *
  * No network, no gh auth: `--extract` only runs the regex layer.
  */
@@ -78,6 +80,12 @@ describe('check-action-pins matcher — accepted scalars', () => {
     expect(extract(`      - { uses: owner/repo@${SHA}, name: Build }`)).toEqual([`owner/repo@${SHA}`]);
     expect(extract(`      - { uses: owner/repo@${SHA} }`)).toEqual([`owner/repo@${SHA}`]);
     expect(extract(`      - { uses: "owner/repo@${SHA}", name: Build }`)).toEqual([`owner/repo@${SHA}`]);
+  });
+
+  test('a literal uses: inside an earlier quoted value never shadows the real key', () => {
+    expect(extract(`      - { name: "literal uses: x", uses: owner/repo@${SHA} }`)).toEqual([`owner/repo@${SHA}`]);
+    expect(extract(`      - { name: 'literal uses: x', uses: owner/repo@${SHA} }`)).toEqual([`owner/repo@${SHA}`]);
+    expect(extract(`      - { name: "literal uses: x", uses: "owner/repo@${SHA}" }`)).toEqual([`owner/repo@${SHA}`]);
   });
 });
 


### PR DESCRIPTION
Consolidated fixes for the 8 unresolved bot review threads blocking #2722. Every finding was independently re-verified against the PR head before fixing; one was refuted.

## Fixed (7 threads)
- **shell-quoting fail-open (HIGH, CodeRabbit 3662114937):** unquoted `\"` opened a phantom quote region that blinded gitFreezeGuard and branchGuard for the rest of the command (`git commit -m \"fix\" && git checkout main` was allowed). `stepUnquoted` now consumes `\X` as a literal pair. All 4 reproduced bypasses flip to deny; read-only controls still allow.
- **freeze-guard cwd tracking (Codex 3661572682):** `cd` no longer propagates across `|`/`&` (subshell), and the `||` else-branch is evaluated against the pre-cd directory — so `cd /other | git switch dev` now denies while the legit `cd <lane> || exit 1; git switch <branch>` idiom keeps passing. 9 new regression tests; guard suites 173/173.
- **version.yml permissions (CodeRabbit 3662114920):** workflow default is now `permissions: {}` with both write grants moved verbatim onto `auto-version`. Effective permissions mechanically verified identical before/after.
- **check-action-pins parser (CodeRabbit 3662114921):** `extract_pin` now iterates every `uses:` occurrence and returns the first scalar that parses as a valid pin, so a literal `uses:` inside a quoted value can no longer hide the real ref. Extraction over all 96 real `uses:` lines in `.github/` is byte-identical before/after; new adversarial matcher cases added.
- **release-docs admit assertion (CodeRabbit 3662114925):** now scoped to the sign-attest `admit` job block with negative assertions; mutation-tested.
- **replay-guard behavioral test (CodeRabbit 3662114929):** new `scripts/release-replay-guard.test.ts` executes the actual guard bash against a PATH-stubbed `gh`: published→refuse, draft→admit, 404→admit, ambiguity→fail closed. Catches all 3 mutations that the string assertions missed.
- **homolog ratchet (CodeRabbit 3662114934):** now scans ALL 13 workflows via readdirSync, and fixes a cwd-dependent readFileSync the bot missed.

## Refuted (1 thread)
- **delivery-evidence dev:main (CodeRabbit 3662114940):** the permissive branch is load-bearing — stable releases cross-publish the dev channel with sourceBranch=main (proven with the published v5.260727.5 asset). The suggested fix would abort every dev-channel update after each stable release. Documented the invariant at the call site instead.

## Validation
236 pass / 0 fail across the five affected suites plus 12/12 pins-matcher tests; tsc --noEmit clean; version.yml YAML-parses; effective workflow permissions proven identical; pins extraction byte-identical over the real workflow corpus.