### PR TITLE
fix(hooks): close round-2 guard gaps found on promotion PR #2722

### DIFF
--- a/src/hooks/__tests__/branch-guard.test.ts
+++ b/src/hooks/__tests__/branch-guard.test.ts
@@ -432,6 +432,20 @@ describe('branch-guard', () => {
       expect(result!.decision).toBe('deny');
     });
 
+    // Regression: PR #2726 review (CodeRabbit 3667949010). An escaped `;` is an
+    // argument, not a separator — bash runs one `git checkout` whose args
+    // include a literal `;`, and never reaches a commit. The chained-mutation
+    // pattern must not read it as `checkout main && commit`.
+    test('an escaped separator is not a command chain', async () => {
+      expect(await branchGuard(makePayload('git checkout main \\; git commit -m x'))).toBeUndefined();
+    });
+
+    test('but a real separator still blocks the same chain', async () => {
+      const result = await branchGuard(makePayload('git checkout main ; git commit -m x'));
+      expect(result).toBeDefined();
+      expect(result!.decision).toBe('deny');
+    });
+
     test('still blocks real gh pr merge targeting main (quoted args do not shield the actual command)', async () => {
       const result = await branchGuard(makePayload('gh pr merge 123 --squash --body "some note"'), mockDeps('main'));
       expect(result).toBeDefined();

--- a/src/hooks/__tests__/git-freeze-guard.test.ts
+++ b/src/hooks/__tests__/git-freeze-guard.test.ts
@@ -379,6 +379,44 @@ describe('git-freeze-guard', () => {
     });
   });
 
+  // Regression: PR #2726 review (CodeRabbit 3667949010). Escaping a character
+  // is how a shell author says "this is not syntax", so an escaped `;`/`|`/`&`
+  // is an argument, not a separator. The walk split on them anyway and denied
+  // single commands: bash runs `echo \; git switch dev` as one `echo` that
+  // prints `; git switch dev` — verified — and no git at all.
+  describe('escaped structural characters are literals, not separators', () => {
+    const allowed = [
+      'echo \\; git switch dev',
+      'echo \\| git switch dev',
+      'echo \\& git switch dev',
+      // One `git commit` whose arguments happen to read like a second command.
+      'git commit -m x \\; git switch dev',
+    ];
+
+    for (const cmd of allowed) {
+      test(`allows: ${cmd}`, async () => {
+        expect(await run(subagent(cmd))).toBeUndefined();
+      });
+    }
+
+    // The other direction: masking an escape must not hide real structure.
+    test('an unescaped separator still denies', async () => {
+      expect((await run(subagent('echo hi ; git switch dev')))?.decision).toBe('deny');
+    });
+
+    // An escaped backtick is not a command substitution, so it must not mask
+    // the rest of the line the way a real one does — bash runs the tail.
+    test('an escaped backtick does not swallow the command after it', async () => {
+      expect((await run(subagent('echo \\` && git switch dev')))?.decision).toBe('deny');
+    });
+
+    // `\` + newline is a line continuation: bash removes both and runs one
+    // command. Splitting on that newline used to hide the subcommand.
+    test('a line continuation joins the statement rather than splitting it', async () => {
+      expect((await run(subagent('git \\\n switch dev')))?.decision).toBe('deny');
+    });
+  });
+
   // =========================================================================
   // Fail-open boundaries
   // =========================================================================

--- a/src/hooks/__tests__/git-freeze-guard.test.ts
+++ b/src/hooks/__tests__/git-freeze-guard.test.ts
@@ -19,6 +19,7 @@ const TOPOLOGY: Record<string, string> = {
   [LANE]: LANE,
   [`${LANE}/src`]: LANE,
   '/other': '/other',
+  '/other2': '/other2',
 };
 
 interface CallLog {
@@ -264,6 +265,51 @@ describe('git-freeze-guard', () => {
     test('allows the guarded-cd idiom into an owned worktree', async () => {
       expect(await run(subagent(`cd ${LANE} || exit 1; git switch dev`))).toBeUndefined();
     });
+  });
+
+  // =========================================================================
+  // A cd can fail, so every directory it could leave the shell in is checked
+  // =========================================================================
+
+  // Regression: PR #2726 review (CodeRabbit 3667949005). Tracking only the
+  // `cd` target assumed the `cd` worked. When it doesn't, the shell stays put
+  // and the git call lands in the shared checkout — the exact case the freeze
+  // exists for. Verified against bash: `cd /nonexistent || true && pwd` prints
+  // the *original* directory, because `||` consumes the failure and `&&` then
+  // proceeds. So the walk keeps every reachable directory and denies if any of
+  // them is the shared root.
+  describe('denies when the shared checkout is still reachable after a cd', () => {
+    const blocked = [
+      // The reported bypass: `||` swallows the failure, `&&` carries on.
+      'cd /definitely-missing || true && git reset --hard',
+      // Neither branch of the `||` rules the shared checkout out.
+      'cd /other || cd /other2; git switch dev',
+      // `;` does not depend on the cd at all, so a failed cd reaches the git.
+      'cd /definitely-missing; git switch dev',
+      // `&&` suspends the failure branch; the later `;` resumes it.
+      `cd ${LANE} && echo ok ; git switch dev`,
+    ];
+
+    for (const cmd of blocked) {
+      test(`denies: ${cmd}`, async () => {
+        expect((await run(subagent(cmd)))?.decision).toBe('deny');
+      });
+    }
+
+    // The counterweights. `&&` genuinely rules the shared checkout out — the
+    // git call cannot run unless the cd succeeded — and a terminator ends the
+    // failure branch outright. Both must stay allowed or the guard is unusable.
+    const allowed = [
+      `cd ${LANE} && git switch dev`,
+      `cd ${LANE} || exit 1; git switch dev`,
+      `cd ${LANE} || return 1; git switch dev`,
+    ];
+
+    for (const cmd of allowed) {
+      test(`allows: ${cmd}`, async () => {
+        expect(await run(subagent(cmd))).toBeUndefined();
+      });
+    }
   });
 
   // =========================================================================

--- a/src/hooks/handlers/git-freeze-guard.ts
+++ b/src/hooks/handlers/git-freeze-guard.ts
@@ -18,7 +18,7 @@
  *
  * ## Fail-open, deliberately
  *
- * Every ambiguity resolves to *allow*, not deny:
+ * Ambiguity about *what the command is* resolves to allow:
  *   - no `agent_id` on the payload (main thread, Codex, an older/newer client
  *     that drops the field) → allow;
  *   - a `cd` / `git -C` target that isn't a literal path (variable, glob,
@@ -35,6 +35,15 @@
  *     through the same walk. That is a knowing gap, and a cheap one: the freeze
  *     exists to catch the accidental `git switch dev`, and nobody types the
  *     substituted form by accident.
+ *
+ * Ambiguity about *where a known frozen command runs* is the one exception, and
+ * it resolves to deny. A `cd` can fail, and when it does the git call after it
+ * lands in the shared checkout — which is exactly the case the freeze exists
+ * for. So {@link findFrozenInvocations} keeps every directory the shell could
+ * be in and denies if any of them is the shared root. The cost is that
+ * `cd <dir>; git switch x` is denied where `cd <dir> && git switch x` is
+ * allowed; that is the same distinction bash itself draws, and `&&` is the
+ * correct way to write it.
  *
  * This is the opposite of {@link branchGuard}'s fail-closed posture, and it is
  * the point. The freeze has no server-side backstop the way branch protection
@@ -295,76 +304,135 @@ function isSubshellEdge(separator: string | undefined): boolean {
   return separator !== undefined && SUBSHELL_SEPARATORS.has(separator);
 }
 
-/** How far a `cd`/`pushd` statement reaches, given the operators around it. */
-interface DirectoryChange {
-  /** The scope's directory afterwards — unchanged when the `cd` ran in a subshell. */
-  scope: string | null;
-  /** Pre-`cd` directory the `||` else-branch runs in, when one follows. */
-  elseDir?: string | null;
-}
-
 /**
- * Decide what a `cd <target>` does to the directories the walk tracks.
- *
- * Beside `|` or `&` it does nothing: that `cd` is a separate process, and the
- * parent shell — where the later statements run — never moves. Before `||` it
- * applies, but the else-branch it guards runs only on failure, so that one
- * statement belongs to the directory the shell was in beforehand.
+ * Directories a statement may be running in. More than one means the walk could
+ * not tell the shell's branches apart, and `null` is one it could not resolve.
  */
-function applyDirectoryChange(
-  target: string | undefined,
-  dir: string | null,
-  before: string | undefined,
-  after: string | undefined,
-): DirectoryChange {
-  if (isSubshellEdge(before) || isSubshellEdge(after)) return { scope: dir };
-  return { scope: joinPath(dir, target), elseDir: after === '||' ? dir : undefined };
+type DirSet = Set<string | null>;
+
+function union(a: DirSet, b: DirSet): DirSet {
+  return new Set([...a, ...b]);
+}
+
+/** One shell scope's reachable directories — a `(…)` group pushes a fresh one. */
+interface Scope {
+  /** Where the next statement can run. */
+  live: DirSet;
+  /**
+   * Directories a short-circuit suspended rather than ruled out. `a && b` skips
+   * `b` when `a` fails, but a later `;` resumes with the shell exactly where the
+   * failure left it, so those directories rejoin at the next unconditional
+   * boundary instead of being dropped.
+   */
+  pending: DirSet;
+}
+
+/** Where a statement leaves the shell, split by whether it succeeded. */
+interface Outcome {
+  ok: DirSet;
+  failed: DirSet;
 }
 
 /**
- * Walk the statements of a compound command left to right, tracking `cd` as it
- * goes, and return every frozen git invocation found.
+ * Commands that abandon the path they are on, so nothing downstream inherits
+ * their directories. This is what keeps `cd <worktree> || exit 1` from leaving
+ * the pre-`cd` directory reachable.
+ */
+const PATH_TERMINATORS = new Set(['exit', 'return']);
+
+/**
+ * Where one statement leaves the shell.
  *
- * Directories are a stack rather than a single value because `(` opens a scope
- * the shell discards at the matching `)`: a `cd` inside a subshell applies to
- * the statements within it and to nothing after it.
+ * `movesParent` is false for a statement beside `|` or `&`: it runs in its own
+ * process, so neither its `cd` nor its `exit` reaches the parent shell.
+ */
+function statementOutcome(tokens: string[], live: DirSet, movesParent: boolean): Outcome {
+  const verb = tokens[0];
+  if (!movesParent) return { ok: new Set(live), failed: new Set(live) };
+  if (verb !== undefined && PATH_TERMINATORS.has(verb)) return { ok: new Set(), failed: new Set() };
+  if (verb === 'cd' || verb === 'pushd') {
+    const moved: DirSet = new Set();
+    for (const dir of live) moved.add(joinPath(dir, tokens[1]));
+    // A `cd` that fails leaves the shell where it was, and nothing here can
+    // prove it succeeded — so both directories stay reachable.
+    return { ok: moved, failed: new Set(live) };
+  }
+  if (verb === 'popd') return { ok: new Set([null]), failed: new Set(live) };
+  return { ok: new Set(live), failed: new Set(live) };
+}
+
+/** Fold a statement's outcome into its scope according to the operator that follows. */
+function advance(scope: Scope, outcome: Outcome, after: string | undefined): void {
+  if (after === '&&') {
+    scope.live = outcome.ok;
+    scope.pending = union(scope.pending, outcome.failed);
+    return;
+  }
+  if (after === '||') {
+    scope.live = outcome.failed;
+    scope.pending = union(scope.pending, outcome.ok);
+    return;
+  }
+  // `;`, a newline, `|`, `&`, or end of command: the next statement runs however
+  // this one turned out, so every suspended branch rejoins here.
+  scope.live = union(union(outcome.ok, outcome.failed), scope.pending);
+  scope.pending = new Set();
+}
+
+/** Record every frozen invocation this statement could be, one per reachable directory. */
+function collectFrozen(tokens: string[], live: DirSet, found: GitInvocation[]): void {
+  if (tokens[0] !== 'git') return;
+  for (const dir of live) {
+    const invocation = parseGitInvocation(tokens, dir);
+    if (invocation && isFrozenInvocation(invocation)) found.push(invocation);
+  }
+}
+
+/**
+ * Walk the statements of a compound command left to right, tracking where the
+ * shell can be, and return every frozen git invocation found.
  *
- * A `cd`'s reach also depends on the separators around it, so the walk reads
- * the operators as well as the statements:
- *   - beside `|` or `&` the `cd` is its own process and moves nothing the later
- *     statements can see (`cd /other | git switch dev` runs git in the *shared*
- *     checkout, and treating the `cd` as effective let it through);
- *   - before `||` the `cd` does apply, but the statement guarded by the `||`
- *     runs only when the `cd` *failed*, so that one statement is judged against
- *     the directory the shell was in beforehand. Both halves matter: without
- *     the first, `cd /missing || git rebase origin/dev` slips past; without the
- *     second, the routine `cd <worktree> || exit 1; git switch dev` is denied.
+ * Two things make "where the shell is" a *set* rather than a single directory.
+ *
+ * A `(` opens a scope the shell discards at the matching `)`, so directories
+ * are a stack: a `cd` inside a subshell applies within it and to nothing after.
+ *
+ * And a `cd` can fail. Nothing here can prove one succeeded, so both the target
+ * and the directory the shell came from stay reachable until the branch that
+ * kept the old one provably ends — which is what `exit`/`return` do and what
+ * `&&`/`||` only *look* like they do. The freeze then denies if **any**
+ * reachable directory is the shared checkout, failing closed on the ambiguity:
+ * in `cd /nowhere || true && git reset --hard` the `cd` fails, `true` succeeds,
+ * `&&` proceeds, and bash resets the shared checkout. Tracking only the target
+ * let that through, and `cd /nowhere; git switch dev` with it.
+ *
+ * The operators are read as well as the statements, because they decide which
+ * branch reaches the next statement: `&&` forwards only success (suspending the
+ * failure branch until a later `;` resumes it), `||` forwards only failure, and
+ * `|`/`&` put the statement in its own process so its `cd` moves nothing the
+ * parent shell can see.
  */
 function findFrozenInvocations(command: string, cwd: string | null): GitInvocation[] {
   const masked = maskOpaqueRegions(maskQuotedRegions(command));
   if (!/\bgit\b/.test(masked)) return [];
   // Capturing separators, so even indices are statements and odd are operators.
   const parts = masked.split(SEGMENT_SEPARATORS);
-  const scopes: (string | null)[] = [cwd];
+  const scopes: Scope[] = [{ live: new Set([cwd]), pending: new Set() }];
   const found: GitInvocation[] = [];
-  /** One-shot override: the pre-`cd` directory an `||` else-branch runs in. */
-  let elseDir: string | null | undefined;
   for (let p = 0; p < parts.length; p += 2) {
     const { tokens, opened, closed } = parseStatement(parts[p]);
-    for (let n = 0; n < opened; n += 1) scopes.push(scopes[scopes.length - 1]);
-    const dir = elseDir === undefined ? scopes[scopes.length - 1] : elseDir;
-    elseDir = undefined;
-    if (tokens[0] === 'cd' || tokens[0] === 'pushd') {
-      const change = applyDirectoryChange(tokens[1], dir, parts[p - 1], parts[p + 1]);
-      scopes[scopes.length - 1] = change.scope;
-      elseDir = change.elseDir;
-    } else if (tokens[0] === 'popd') {
-      scopes[scopes.length - 1] = null;
-    } else {
-      const invocation = parseGitInvocation(tokens, dir);
-      if (invocation && isFrozenInvocation(invocation)) found.push(invocation);
+    for (let n = 0; n < opened; n += 1) {
+      scopes.push({ live: new Set(scopes[scopes.length - 1].live), pending: new Set() });
     }
+    const inner = scopes[scopes.length - 1];
+    const movesParent = !isSubshellEdge(parts[p - 1]) && !isSubshellEdge(parts[p + 1]);
+    collectFrozen(tokens, inner.live, found);
+    const outcome = statementOutcome(tokens, inner.live, movesParent);
     for (let n = 0; n < closed && scopes.length > 1; n += 1) scopes.pop();
+    const scope = scopes[scopes.length - 1];
+    // A statement that closed its subshell leaves the enclosing shell untouched.
+    const reaching = scope === inner ? outcome : { ok: new Set(scope.live), failed: new Set(scope.live) };
+    advance(scope, reaching, parts[p + 1]);
   }
   return found;
 }

--- a/src/hooks/shell-quoting.ts
+++ b/src/hooks/shell-quoting.ts
@@ -15,16 +15,21 @@
  * that doesn't generalize.
  *
  * Scope: handles single-quotes (no escapes), double-quotes with `\X` escapes,
- * unquoted `\X` escapes (a literal X — notably `\"`, which does *not* open a
- * quote region), and unterminated quotes (mask to end of string — safer than
- * the alternative of leaving a runaway region unmasked).
+ * unquoted `\X` escapes, and unterminated quotes (mask to end of string —
+ * safer than the alternative of leaving a runaway region unmasked).
  *
- * The unquoted-escape case is load-bearing, not cosmetic: reading `\"` as a
- * quote opener made `git commit -m \"fix\" && git checkout main` mask from the
- * first `\"` to end of string — the closing `\"` was swallowed by the
- * double-quoted `\X` rule — so the guards saw no `&& git checkout main` and
- * allowed a command bash runs in full. Backtick command substitution and
- * heredocs are intentionally not parsed — they're rare in agent-issued
+ * The unquoted-escape case is load-bearing in both directions, and both were
+ * live bugs. Reading `\"` as a quote *opener* made
+ * `git commit -m \"fix\" && git checkout main` mask from the first `\"` to end
+ * of string — the closing `\"` was swallowed by the double-quoted `\X` rule —
+ * so the guards never saw `&& git checkout main` and allowed a line bash runs
+ * in full. Passing `\X` through *unmasked* was the mirror error: callers read
+ * `;`, `|`, `&` and backticks as structure, so `echo \; git switch dev` split
+ * into two statements and denied, though bash runs one `echo` with a literal
+ * `;` argument. Masking it settles both — the character survives as a
+ * placeholder holding its position, but never as syntax.
+ *
+ * Heredocs are intentionally not parsed — they're rare in agent-issued
  * commands and falling back to fully unmasked treatment is fail-closed for
  * the original policy, which matches the hook's overall posture.
  */
@@ -37,9 +42,15 @@ interface MaskStep {
   consumed: number;
 }
 
-/** Unquoted char: pass through, or open a quote region. `\X` is a literal X, not a quote opener. */
+/**
+ * Unquoted char: pass through, or open a quote region.
+ *
+ * `\X` is masked rather than passed through. An escaped character is data, and
+ * escaping it is precisely how a shell author says "this is not syntax" — so it
+ * is masked for the same reason quoted text is.
+ */
 function stepUnquoted(ch: string, next: string | undefined): MaskStep {
-  if (ch === '\\' && next !== undefined) return { out: ch + next, next: 'none', consumed: 2 };
+  if (ch === '\\' && next !== undefined) return { out: '  ', next: 'none', consumed: 2 };
   if (ch === "'") return { out: ' ', next: 'single', consumed: 1 };
   if (ch === '"') return { out: ' ', next: 'double', consumed: 1 };
   return { out: ch, next: 'none', consumed: 1 };


### PR DESCRIPTION
Round-2 follow-ups to #2726, fixing the two CodeRabbit findings on the promotion PR #2722 head plus three same-class bugs found while reproducing them.

- **Reachable-directory tracking (3667949005, confirmed):** `cd /definitely-missing || true && git reset --hard` really did reset the shared checkout while the guard allowed it — and plain `cd /nowhere; git switch dev` had the same hole. The walk now tracks the SET of directories the shell could be in: `cd` yields target-on-success/origin-on-failure, `&&` forwards success only, `||` failure only, `;`/newline rejoin both, `exit`/`return` terminate a branch; deny if any reachable dir is the shared root. `cd <worktree> || exit 1; git switch dev` stays allowed; `cd <dir>; git switch x` now denies (bash itself draws that distinction — write `cd <dir> && git switch x`).
- **Escaped chars are data, not syntax (3667949010, confirmed):** `echo \; git switch dev` no longer false-denies. Same root cause also closed two under-blocks: an escaped backtick opened a phantom command substitution hiding real commands, and `\`+newline line continuation split one command in two.

Validation: 189/189 guard tests (173 existing untouched + 16 new), typecheck/lint/knip clean, complexity budget intact, full suite green except the pre-existing env-sensitive ui-bridge socket test.