### PR TITLE
fix(agent-sync): suppress the bare-name role-agent fan-out when the plugin is enabled

### DIFF
--- a/src/genie-commands/doctor.test.ts
+++ b/src/genie-commands/doctor.test.ts
@@ -1593,6 +1593,48 @@ describe('checkAgentSync — claude role agents', () => {
     expect(find(results, ROLE_CHECK)?.roleAgents?.duplicateSurface).toBe(true);
   });
 
+  test('plugin enabled → a surviving fan-out reads as prunable stale, not current', () => {
+    writeSourceAgent('scout', '# scout\n');
+    writeTargetAgent('scout', '# scout\n');
+    writeAgentManifest({ 'scout.md': { digest: computeFileDigest(join(agentsDir, 'scout.md')) } });
+    writeSettings({ enabledPlugins: { 'genie@automagik': true } });
+
+    const check = find(checkAgentSync(paths()), ROLE_CHECK);
+    // Byte-identical to source, but the expected source set is empty while the
+    // plugin serves genie:* — so it is leftover state, not a current delivery.
+    expect(stateMap(check)['scout.md']).toBe('genie-managed-stale');
+    expect(check?.status).toBe('warn');
+  });
+
+  test('plugin enabled + manifest-only leftover (file gone) → stale warn but no duplicate warning', () => {
+    writeSourceAgent('scout', '# scout\n');
+    // Manifest entry survives but the file was deleted: stale ownership
+    // metadata, yet nothing actually double-lists in the picker.
+    writeAgentManifest({ 'scout.md': { digest: 'f'.repeat(64) } });
+    writeSettings({ enabledPlugins: { 'genie@automagik': true } });
+
+    const results = checkAgentSync(paths());
+    const check = find(results, ROLE_CHECK);
+    expect(stateMap(check)['scout.md']).toBe('missing-from-target');
+    expect(check?.status).toBe('warn');
+    expect(find(results, DUP_CHECK)).toBeUndefined();
+    expect(check?.roleAgents?.duplicateSurface).toBe(false);
+  });
+
+  test('plugin enabled + fan-out already pruned → passes with no duplicate warning', () => {
+    writeSourceAgent('scout', '# scout\n');
+    writeSettings({ enabledPlugins: { 'genie@automagik': true } });
+
+    const results = checkAgentSync(paths());
+    const check = find(results, ROLE_CHECK);
+    // Without this, every suppressed agent reads as missing-from-target and
+    // doctor advises `genie update` forever.
+    expect(check?.status).toBe('pass');
+    expect(check?.detail).toContain('role-agent mirror suppressed');
+    expect(find(results, DUP_CHECK)).toBeUndefined();
+    expect(check?.roleAgents?.duplicateSurface).toBe(false);
+  });
+
   test('plugin disabled or absent → no duplicate warning, duplicateSurface flag false', () => {
     writeSourceAgent('scout', '# scout\n');
     writeTargetAgent('scout', '# scout\n');

--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -1100,8 +1100,17 @@ function classifyRoleAgentFile(
 }
 
 /** Classify every source role agent (and any managed manifest entry) under `<claudeDir>/agents`. */
-function classifyRoleAgents(pluginRoot: string, agentsDir: string): Omit<RoleAgentDelivery, 'duplicateSurface'> {
-  const sourceState = sourceAgentDigests(pluginRoot);
+function classifyRoleAgents(
+  pluginRoot: string,
+  agentsDir: string,
+  suppressed = false,
+): Omit<RoleAgentDelivery, 'duplicateSurface'> {
+  // Plugin enabled → sync suppresses the WHOLE bare-name role-agent fan-out
+  // (agents load as genie:* from the plugin), so the expected source set is
+  // empty and any surviving managed file is prunable leftover state. Without
+  // this, every suppressed agent reads as missing-from-target and doctor
+  // advises `genie update` forever — the same trap the skills check avoids.
+  const sourceState = suppressed ? { digests: new Map<string, string>(), issues: [] } : sourceAgentDigests(pluginRoot);
   const source = sourceState.digests;
   const manifest = readAgentFilesManifestState(agentsDir);
   const entries = manifest.kind === 'managed' ? manifest.files : {};
@@ -1120,7 +1129,10 @@ function classifyRoleAgents(pluginRoot: string, agentsDir: string): Omit<RoleAge
 }
 
 /** Human-facing summary + a stale flag (any non-current state, or an unusable manifest, warns). */
-function roleAgentSummary(delivery: Omit<RoleAgentDelivery, 'duplicateSurface'>): { detail: string; stale: boolean } {
+function roleAgentSummary(
+  delivery: Omit<RoleAgentDelivery, 'duplicateSurface'>,
+  suppressed = false,
+): { detail: string; stale: boolean } {
   const sourceProblem =
     delivery.sourceIssues.length === 0 ? null : `source inventory unavailable (${delivery.sourceIssues.join('; ')})`;
   if (delivery.manifestStatus === 'unsafe') {
@@ -1130,9 +1142,11 @@ function roleAgentSummary(delivery: Omit<RoleAgentDelivery, 'duplicateSurface'>)
     };
   }
   if (delivery.files.length === 0) {
+    const empty = suppressed
+      ? 'role-agent mirror suppressed (genie@automagik plugin enabled)'
+      : 'no genie role agents detected';
     return {
-      detail:
-        sourceProblem === null ? 'no genie role agents detected' : `${sourceProblem}; no genie role agents detected`,
+      detail: sourceProblem === null ? empty : `${sourceProblem}; ${empty}`,
       stale: sourceProblem !== null,
     };
   }
@@ -1152,16 +1166,6 @@ function roleAgentSummary(delivery: Omit<RoleAgentDelivery, 'duplicateSurface'>)
   return { detail, stale };
 }
 
-/** `enabledPlugins["genie@automagik"] === true` in Claude Code's settings.json (unreadable → false). */
-function roleAgentDuplicateSurface(settingsPath: string): boolean {
-  try {
-    const settings = JSON.parse(readFileSync(settingsPath, 'utf8')) as { enabledPlugins?: Record<string, boolean> };
-    return settings.enabledPlugins?.['genie@automagik'] === true;
-  } catch {
-    return false;
-  }
-}
-
 /**
  * Per-file role-agent delivery check + the duplicate-surface warning. The
  * structured {@link RoleAgentDelivery} rides `--json` as `checks[].roleAgents`
@@ -1169,9 +1173,14 @@ function roleAgentDuplicateSurface(settingsPath: string): boolean {
  * duplicate warning is emitted as its own line ONLY when the plugin is enabled.
  */
 function checkRoleAgents(pluginRoot: string, claudeDir: string, settingsPath: string): CheckResult[] {
-  const classification = classifyRoleAgents(pluginRoot, join(claudeDir, 'agents'));
-  const duplicateSurface = roleAgentDuplicateSurface(settingsPath);
-  const { detail, stale } = roleAgentSummary(classification);
+  const pluginEnabled = claudeGeniePluginEnabled(settingsPath);
+  const classification = classifyRoleAgents(pluginRoot, join(claudeDir, 'agents'), pluginEnabled);
+  // Once the fan-out is pruned there is nothing left to double-list, so the
+  // duplicate warning tracks surviving bare-name files, not merely the plugin.
+  // missing-from-target is stale ownership metadata, not a file in the picker —
+  // the main check already warns about it; nothing actually double-lists.
+  const duplicateSurface = pluginEnabled && classification.files.some((f) => f.state !== 'missing-from-target');
+  const { detail, stale } = roleAgentSummary(classification, pluginEnabled);
   const results: CheckResult[] = [
     {
       name: 'agent sync: claude role agents',
@@ -1186,9 +1195,8 @@ function checkRoleAgents(pluginRoot: string, claudeDir: string, settingsPath: st
       name: 'agent sync: duplicate role-agent surface',
       status: 'warn',
       detail:
-        'genie@automagik plugin enabled — plugin `genie:*` agents and fanned bare-named agents both surface (duplicate listings)',
-      suggestion:
-        'Keep the genie plugin disabled (bare-named agents are fanned by `genie update`), or expect duplicates.',
+        'genie@automagik plugin enabled — plugin `genie:*` agents and leftover bare-named agents both surface (duplicate listings)',
+      suggestion: SYNC_SUGGESTION,
     });
   }
   return results;

--- a/src/lib/agent-sync.test.ts
+++ b/src/lib/agent-sync.test.ts
@@ -1646,8 +1646,10 @@ describe('claude skills mirror suppression', () => {
     expect(existsSync(join(fixture.claudeDir, 'skills', 'beta'))).toBe(false);
     expect(readFileSync(join(report.backupsDir as string, 'claude', 'beta', 'SKILL.md'), 'utf8')).toBe('# beta\n');
     expect(extraAction(claude, 'skills-mirror')).toBe('suppressed');
-    // Non-skill deliveries are untouched by the suppression.
-    expect(existsSync(join(fixture.claudeDir, 'agents', 'reviewer.md'))).toBe(true);
+    // The role-agent fan-out is suppressed by the same switch; the council
+    // stamp is not a duplicated surface and stays delivered.
+    expect(extraAction(claude, 'agents-mirror')).toBe('suppressed');
+    expect(existsSync(join(fixture.claudeDir, 'agents', 'reviewer.md'))).toBe(false);
     expect(existsSync(join(fixture.claudeDir, 'workflows', 'council.js'))).toBe(true);
   });
 
@@ -1660,8 +1662,9 @@ describe('claude skills mirror suppression', () => {
     expect(existsSync(join(fixture.claudeDir, 'skills', 'alpha'))).toBe(false);
     expect(existsSync(join(fixture.claudeDir, 'skills', 'beta'))).toBe(false);
     expect(extraAction(claude, 'skills-mirror')).toBe('suppressed');
-    // Agents fan-out and the council stamp are independent of the skills mirror.
-    expect(agentFileAction(claude, 'reviewer')).toBe('created');
+    // The agent fan-out is suppressed too; only the council stamp is written.
+    expect(agentFileAction(claude, 'reviewer')).toBeUndefined();
+    expect(existsSync(join(fixture.claudeDir, 'agents', 'reviewer.md'))).toBe(false);
     expect(extraAction(claude, 'stamp')).toBe('written');
   });
 
@@ -1730,6 +1733,45 @@ describe('claude skills mirror suppression', () => {
     expect(existsSync(join(fixture.claudeDir, 'skills', 'council'))).toBe(false);
   });
 
+  test('enabling the plugin prunes a previously fanned role agent, backing the bytes up first', () => {
+    present(fixture.claudeDir);
+    run(); // seed reviewer.md as a managed fan-out
+    expect(existsSync(join(fixture.claudeDir, 'agents', 'reviewer.md'))).toBe(true);
+    writeClaudeSettings(true);
+
+    const report = run();
+    const claude = agentReport(report, 'claude');
+    expect(agentFileAction(claude, 'reviewer')).toBe('removed');
+    expect(existsSync(join(fixture.claudeDir, 'agents', 'reviewer.md'))).toBe(false);
+    expect(extraAction(claude, 'agents-mirror')).toBe('suppressed');
+    // Retirement is backup-first: the bytes survive under the backups root.
+    expect(existsSync(join(report.backupsDir as string, 'claude', 'agents', 'reviewer.md'))).toBe(true);
+  });
+
+  test('a hand-edited role agent survives suppression instead of being pruned', () => {
+    present(fixture.claudeDir);
+    run();
+    writeFile(join(fixture.claudeDir, 'agents', 'reviewer.md'), '# reviewer hand-edited\n');
+    writeClaudeSettings(true);
+
+    const claude = agentReport(run(), 'claude');
+    expect(readFileSync(join(fixture.claudeDir, 'agents', 'reviewer.md'), 'utf8')).toBe('# reviewer hand-edited\n');
+    expect(agentFileAction(claude, 'reviewer')).not.toBe('removed');
+  });
+
+  test('re-disabling the plugin brings the role-agent fan-out back', () => {
+    present(fixture.claudeDir);
+    run();
+    writeClaudeSettings(true);
+    expect(agentFileAction(agentReport(run(), 'claude'), 'reviewer')).toBe('removed');
+    writeClaudeSettings(false);
+
+    const claude = agentReport(run(), 'claude');
+    expect(agentFileAction(claude, 'reviewer')).toBe('created');
+    expect(existsSync(join(fixture.claudeDir, 'agents', 'reviewer.md'))).toBe(true);
+    expect(extraAction(claude, 'agents-mirror')).toBeUndefined();
+  });
+
   test('GENIE_FORCE_CLAUDE_SKILLS_MIRROR=1 kill-switch forces the mirror despite an enabled plugin', () => {
     present(fixture.claudeDir);
     writeClaudeSettings(true);
@@ -1740,6 +1782,9 @@ describe('claude skills mirror suppression', () => {
       expect(skillAction(claude, 'alpha')).toBe('created');
       expect(skillAction(claude, 'beta')).toBe('created');
       expect(extraAction(claude, 'skills-mirror')).toBeUndefined();
+      // The one switch restores BOTH suppressed surfaces.
+      expect(agentFileAction(claude, 'reviewer')).toBe('created');
+      expect(extraAction(claude, 'agents-mirror')).toBeUndefined();
     } finally {
       if (prior === undefined) {
         // biome-ignore lint/performance/noDelete: process.env assignment coerces undefined→"undefined"; delete is the only correct unset

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -94,6 +94,8 @@ export const CLAUDE_EXCLUDED_SKILLS = new Set(['council']);
  * value, all return false — sync must never abort or change behavior on a
  * broken settings file. GENIE_FORCE_CLAUDE_SKILLS_MIRROR=1 is the ops
  * kill-switch: forces pre-hotfix behavior (mirror + doctor expects mirror).
+ * It governs BOTH suppressed surfaces — the bare-name skills mirror and the
+ * bare-name role-agent fan-out — despite the historical `SKILLS` in its name.
  */
 export function claudeGeniePluginEnabled(settingsPath: string): boolean {
   if (process.env.GENIE_FORCE_CLAUDE_SKILLS_MIRROR === '1') return false;
@@ -4555,8 +4557,13 @@ function unpublishFlatAgent(ctx: FlatAgentTxnCtx, state: FlatAgentOpState, targe
  * every unrelated sibling in `~/.claude/agents` remains invisible. All ops run
  * in ONE transaction with a single ownership commit.
  */
-function syncClaudeAgentFiles(ctx: RunContext, claudeDir: string, report: AgentReport): void {
-  const sourceAgents = enumerateSourceAgentFiles(ctx.pluginRoot);
+function syncClaudeAgentFiles(ctx: RunContext, claudeDir: string, report: AgentReport, pluginEnabled = false): void {
+  // Plugin enabled → Claude Code already serves every role agent as genie:*;
+  // the bare-name fan-out double-lists them. An empty source set sends every
+  // manifest-owned file down planAgentOrphan, which backs the bytes up before
+  // retiring them and preserves user-edited files as kept-modified-orphan —
+  // the same suppression contract the skills mirror uses above.
+  const sourceAgents = pluginEnabled ? [] : enumerateSourceAgentFiles(ctx.pluginRoot);
   const targetDir = join(claudeDir, 'agents');
   const initialState = inspectAgentFilesManifest(targetDir);
   if (initialState.kind === 'unsafe') {
@@ -5664,7 +5671,15 @@ function syncClaude(ctx: RunContext, report: AgentReport): void {
       detail: 'genie@automagik plugin enabled — bare-name skills mirror pruned; skills load as genie:* from the plugin',
     });
   }
-  syncClaudeAgentFiles(ctx, claudeDir, report);
+  syncClaudeAgentFiles(ctx, claudeDir, report, pluginEnabled);
+  if (pluginEnabled) {
+    report.extras.push({
+      kind: 'agents-mirror',
+      action: 'suppressed',
+      detail:
+        'genie@automagik plugin enabled — bare-name role-agent fan-out pruned; agents load as genie:* from the plugin',
+    });
+  }
   stampClaudeWorkflow(ctx, claudeDir, report);
 }
 


### PR DESCRIPTION
## Root cause

`syncClaude` computes `pluginEnabled` and uses it to suppress the bare-name **skills** mirror (the ~4.5k-tokens/msg double-listing hotfix), but never passed it to `syncClaudeAgentFiles`. Role agents were fanned into `~/.claude/agents` unconditionally while the plugin served the same seven files as `genie:*` — so every agent double-listed in the picker (`reviewer` + `genie:reviewer`, ×7).

## Mechanism

Thread `pluginEnabled` through; when true, feed `syncClaudeAgentFiles` an **empty source set**. Every manifest-owned file then flows down the existing `planAgentOrphan` path: backup-first retirement, hand-edited files preserved as `kept-modified-orphan`. No new deletion machinery. Once the claim empties, the manifest itself is removed, so subsequent suppressed runs hit the clean early return.

`GENIE_FORCE_CLAUDE_SKILLS_MIRROR=1` already restores **both** surfaces — it gates inside `claudeGeniePluginEnabled` (doc comment updated; the historical `SKILLS` in the name notwithstanding).

## Doctor semantics (reviewers: one JSON meaning change)

- Plugin enabled + fan-out pruned → **pass** with `role-agent mirror suppressed` (previously: 7× `missing-from-target` warn advising `genie update` forever)
- Plugin enabled + leftover file on disk → `genie-managed-stale` + duplicate-surface warn pointing at `SYNC_SUGGESTION` (previously the warn told users to disable the plugin)
- Manifest-only leftover (file deleted, entry survives) → main check warns, **no** duplicate warning (nothing actually double-lists)
- **`--json` rider `roleAgents.duplicateSurface` changed meaning**: was "plugin enabled", now "plugin enabled AND surviving bare-name files". Repo-wide search found no consumers beyond doctor + its test.
- `checkRoleAgents` now uses `claudeGeniePluginEnabled` (kill-switch-aware); deleted the duplicate `roleAgentDuplicateSurface` reader that ignored the kill-switch.

Two legacy assertions in the skills-suppression test block were **intentionally inverted** (agents were asserted to survive suppression — that was the bug).

## Evidence

- `bun test src/lib/agent-sync.test.ts src/genie-commands/doctor.test.ts` → 369 pass
- Full `bun run check`: 2953 pass / 2 fail — both (`ui-bridge lifetime`, `manual post-update convergence`) reproduce on clean `origin/dev` with the change stashed (pre-existing)
- **Dogfooded on a real machine**: branch build `update --sync-only` retired all 7 fanned agents with byte backups (`agent removed ×7, agents-mirror suppressed`); doctor flipped `warn → pass`
- **Codex-verified** (`codex exec`, gpt-5.6-sol): clean-dev baseline bundle vs branch bundle, `doctor --json` back-to-back from the same cwd — diff confined to exactly the two intended checks, all 24 other checks byte-identical (verdict PASS)
- Adversarial Fable review: SHIP; MINOR-1 (false duplicate warn on manifest-only leftovers) fixed in this PR with a locking test

## Known limitation (out of scope)

On codex-only-consent machines `SYNC_SUGGESTION` is structurally inert (`narrowUpdateAgentSyncSelection` → null for `codex`), so the new stale-leftover warn can't self-resolve there; same for the silent hand-edited-leftover case (Fable MINOR-2). Both tracked in #2730.