### PR TITLE
fix(test): pin selection in the manual post-update convergence test

### DIFF
--- a/src/genie-commands/__tests__/update.test.ts
+++ b/src/genie-commands/__tests__/update.test.ts
@@ -2455,6 +2455,9 @@ describe('manual post-update convergence (2026-07-11 cascade regression)', () =>
     const result = runManualUpdateConvergence({
       expectedVersion: '5.260711.3',
       bundleRoot: '/tmp/verified-bundle',
+      // Explicit selection: the default reads the host's persisted integration
+      // consent, so omitting it makes the test depend on machine state (#2732).
+      selection: 'all',
       runSync: () => calls.push('parent-safe-sync'),
       refreshPlugins: (options) => {
         calls.push(`parent-plugin-refresh:${options.expectedVersion}:${options.selection}`);


### PR DESCRIPTION
## Problem

The test `manual post-update convergence … runs the canonical convergence APIs` called `runManualUpdateConvergence` without a `selection`, so the default (`options.selection ?? readIntegrationConsent(GENIE_HOME)`, update.ts:2796) reads the **host machine's** `~/.genie/.integration-consent.json`. On a codex-consent machine `narrowUpdateAgentSyncSelection('codex')` → null, `runSync` never fires, and `expect(calls[0]).toBe('parent-safe-sync')` fails — while CI (no consent file) and all/auto machines pass. Same commit, same binary, different machine state.

## Fix

One line: `selection: 'all'` in the test's options, matching every other caller in the file (the codex-only, auto, and hermes-leg tests already pin theirs). `'all'` narrows to `'claude'` for both arms, consistent with the existing expectation `parent-plugin-refresh:5.260711.3:claude`.

## Proof matrix (update.test.ts, dev @ 9be108a32)

| Consent state | Before | After |
|---|---|---|
| canary home, `selection: "codex"` | **1 fail** | 192 pass |
| canary home, no consent file (≈CI) | 192 pass | 192 pass |
| real home, `selection: "all"` | 192 pass | 192 pass |

Closes #2732