### PR TITLE
fix(doctor,v5): orphan duplicate visibility + torn sync baselines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,7 @@ core
 # particular can hold live session tokens (e.g. BW_SESSION).
 .codex/
 .dash/
+.empryo
+.mcp.json
+.rlmx/
+.warp/

--- a/src/genie-commands/doctor.test.ts
+++ b/src/genie-commands/doctor.test.ts
@@ -1606,6 +1606,23 @@ describe('checkAgentSync — claude role agents', () => {
     expect(check?.status).toBe('warn');
   });
 
+  test('plugin enabled + kept orphan whose manifest entry was relinquished still warns as a duplicate', () => {
+    // agent-sync's kept-modified-orphan aftermath: the user edited the bare agent,
+    // so sync left the FILE on disk and only dropped its manifest entry. Claude
+    // Code still lists bare `reviewer` next to plugin `genie:reviewer`, so neither
+    // the classification nor the duplicate warning may go blind to it.
+    writeSourceAgent('reviewer', '# reviewer\n');
+    writeTargetAgent('reviewer', '# reviewer, hand-edited\n');
+    writeSettings({ enabledPlugins: { 'genie@automagik': true } });
+
+    const results = checkAgentSync(paths());
+    const check = find(results, ROLE_CHECK);
+    expect(stateMap(check)['reviewer.md']).toBe('present-unmanaged');
+    expect(check?.status).toBe('warn');
+    expect(check?.roleAgents?.duplicateSurface).toBe(true);
+    expect(find(results, DUP_CHECK)?.status).toBe('warn');
+  });
+
   test('plugin enabled + manifest-only leftover (file gone) → stale warn but no duplicate warning', () => {
     writeSourceAgent('scout', '# scout\n');
     // Manifest entry survives but the file was deleted: stale ownership

--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -1076,26 +1076,35 @@ function safeFileDigest(path: string): string | null {
  * "current" mirrors the skills contract (on-disk == manifest == source). Returns
  * null for a name genie does not speak for (a user-authored agent absent from
  * both source and the manifest is never reported).
+ *
+ * `suppressed` (plugin enabled → the bare-name fan-out is not expected to exist)
+ * changes only what an ABSENT file means: nothing is owed to the target, so a
+ * source name with no file and no manifest entry is not `missing-from-target`,
+ * and a surviving file can never be `genie-managed-current` — it is prunable
+ * leftover state. Files that DO exist are still classified, because Claude Code
+ * still lists them next to the plugin's `genie:*` agents.
  */
 function classifyRoleAgentFile(
   agentsDir: string,
   name: string,
   source: Map<string, string>,
   entries: Record<string, AgentFileManifestEntry>,
+  suppressed = false,
 ): RoleAgentFileState | null {
   const present = isRegularFile(join(agentsDir, name));
   const entry = entries[name];
   const inSource = source.has(name);
   if (entry === undefined) {
     if (present) return inSource ? 'present-unmanaged' : null;
-    return inSource ? 'missing-from-target' : null;
+    return inSource && !suppressed ? 'missing-from-target' : null;
   }
   // A manifest entry is durable ownership evidence even after both the source
   // and live file disappear. Report it as missing so doctor never hides stale
   // ownership metadata behind a healthy empty inventory.
   if (!present) return 'missing-from-target';
   const onDisk = safeFileDigest(join(agentsDir, name));
-  const current = inSource && onDisk !== null && onDisk === entry.digest && entry.digest === source.get(name);
+  const current =
+    !suppressed && inSource && onDisk !== null && onDisk === entry.digest && entry.digest === source.get(name);
   return current ? 'genie-managed-current' : 'genie-managed-stale';
 }
 
@@ -1106,24 +1115,30 @@ function classifyRoleAgents(
   suppressed = false,
 ): Omit<RoleAgentDelivery, 'duplicateSurface'> {
   // Plugin enabled → sync suppresses the WHOLE bare-name role-agent fan-out
-  // (agents load as genie:* from the plugin), so the expected source set is
-  // empty and any surviving managed file is prunable leftover state. Without
-  // this, every suppressed agent reads as missing-from-target and doctor
-  // advises `genie update` forever — the same trap the skills check avoids.
-  const sourceState = suppressed ? { digests: new Map<string, string>(), issues: [] } : sourceAgentDigests(pluginRoot);
+  // (agents load as genie:* from the plugin), so nothing is owed to the target
+  // and any surviving file is prunable leftover state. That suppression flows
+  // into the per-file classifier, NOT into an emptied source inventory: the
+  // source names are what make a surviving bare-name file inspectable at all,
+  // and dropping them would hide a user-edited orphan that agent-sync
+  // deliberately KEPT on disk while relinquishing its manifest entry — exactly
+  // the duplicate listing this check exists to report.
+  const sourceState = sourceAgentDigests(pluginRoot);
   const source = sourceState.digests;
   const manifest = readAgentFilesManifestState(agentsDir);
   const entries = manifest.kind === 'managed' ? manifest.files : {};
   const names = new Set<string>([...source.keys(), ...Object.keys(entries)]);
   const files: RoleAgentDelivery['files'] = [];
   for (const name of [...names].sort()) {
-    const state = classifyRoleAgentFile(agentsDir, name, source, entries);
+    const state = classifyRoleAgentFile(agentsDir, name, source, entries, suppressed);
     if (state !== null) files.push({ name, state });
   }
   return {
     manifestStatus: manifest.kind,
     manifestReason: manifest.kind === 'unsafe' ? manifest.reason : undefined,
-    sourceIssues: sourceState.issues,
+    // Under suppression the mirror is not expected to exist, so source-inventory
+    // problems are not mirror defects — reporting them would advise `genie update`
+    // forever over a fan-out genie is deliberately not delivering.
+    sourceIssues: suppressed ? [] : sourceState.issues,
     files,
   };
 }

--- a/src/lib/v5/roadmap-sync.ts
+++ b/src/lib/v5/roadmap-sync.ts
@@ -81,23 +81,34 @@ function serializeSnapshot(state: unknown): string {
 }
 
 /**
- * Stamp the CURRENT (roadmap.json, genie.db) pair as the sync baseline.
- * Called after an explicit `task import`/`task export --write` succeeds: the
- * operator has just declared this pair intentional, so future syncs measure
- * drift from here.
+ * Baseline the pair an explicit `task export --write` just published, where
+ * `state` is the snapshot whose bytes were written to roadmap.json. Both hashes
+ * come from that ONE snapshot: re-snapshotting the db here (or re-reading the
+ * file) could pick up a concurrent worktree's write and stamp a baseline
+ * describing state the published file never held — the next `task sync` would
+ * then read as in-sync and that mid-window change would never be exported.
+ * Callers must therefore run this inside the same immediate transaction that
+ * produced `state` and wrote the file.
  */
-export function recordSyncBaseline(db: Database, cwd?: string): void {
-  const filePath = resolveRoadmapPath(cwd);
-  const dbHash = canonicalHash(roadmapSnapshot(db));
-  let fileHash = dbHash;
-  if (existsSync(filePath)) {
-    try {
-      fileHash = canonicalHash(JSON.parse(readFileSync(filePath, 'utf-8')));
-    } catch {
-      // Unreadable file: baseline the db side only; next sync will flag it.
-    }
-  }
-  writeMarker(resolveSyncMarkerPath(cwd), { fileHash, dbHash });
+export function recordExportBaseline(state: StateExport, cwd?: string): void {
+  // The file holds exactly `serializeSnapshot(state)`, and sync hashes the
+  // PARSED file — structurally identical to `state`, so one hash covers both.
+  const hash = canonicalHash(state);
+  writeMarker(resolveSyncMarkerPath(cwd), { fileHash: hash, dbHash: hash });
+}
+
+/**
+ * Baseline the pair an explicit `task import` just settled: `snapshot` is the
+ * parsed roadmap.json that was applied, and the db side is re-measured because
+ * a merge import (no `--replace`) leaves a db that is a superset of the file.
+ * Same locking contract as {@link recordExportBaseline} — the re-snapshot must
+ * happen under the caller's immediate transaction, alongside the import itself.
+ */
+export function recordImportBaseline(db: Database, snapshot: unknown, cwd?: string): void {
+  writeMarker(resolveSyncMarkerPath(cwd), {
+    fileHash: canonicalHash(snapshot),
+    dbHash: canonicalHash(roadmapSnapshot(db)),
+  });
 }
 
 /**

--- a/src/term-commands/v5-task.test.ts
+++ b/src/term-commands/v5-task.test.ts
@@ -478,6 +478,31 @@ describe('roadmap.json canonical sync', () => {
     expect(settled.code).toBe(0);
   });
 
+  test('a subdirectory spelling of roadmap.json is roadmap-sliced, and is not the canonical baseline', async () => {
+    const db = openDb({ cwd: repo });
+    createTask(db, { title: 'card' });
+    hireAgent(db, { wish: 'w', agentAdapterId: 'claude', worktree: '/tmp/machine-local-wt' });
+    db.close();
+    await mkdir(join(repo, 'src', '.genie'), { recursive: true });
+
+    // Same relative spelling, different cwd: it resolves to src/.genie/roadmap.json,
+    // NOT the canonical repo-root file. It is still a git-trackable file named
+    // roadmap.json, so the machine-local hire_roster must not travel in it.
+    const w = await cli(join(repo, 'src'), 'export', '--write', '.genie/roadmap.json');
+    expect(w.code).toBe(0);
+    expect(w.stderr).toBe('');
+    const written = readFileSync(join(repo, 'src', '.genie', 'roadmap.json'), 'utf-8');
+    expect(written).not.toContain('/tmp/machine-local-wt');
+    expect((JSON.parse(written) as StateExport).hire_roster).toEqual([]);
+
+    // And it did not stamp the sync baseline: the canonical file is still
+    // unpublished, so sync publishes it instead of reporting an in-sync pair.
+    const synced = await cli(repo, 'sync');
+    expect(synced.code).toBe(0);
+    expect(synced.stdout).toContain('Published board snapshot');
+    expect((JSON.parse(snapshotOf(repo)) as StateExport).tasks).toHaveLength(1);
+  });
+
   test('pulled snapshot imports on sync; local mutation exports; divergence is refused then resolvable', async () => {
     // Machine A (repo): publish F1, then F2 with one more card.
     const db = openDb({ cwd: repo });

--- a/src/term-commands/v5-task.ts
+++ b/src/term-commands/v5-task.ts
@@ -17,15 +17,16 @@
  */
 
 import type { Database } from 'bun:sqlite';
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { existsSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
 import type { Command } from 'commander';
 import { color, formatTimestamp, padRight, truncate } from '../lib/term-format.js';
 import { livenessBadge } from '../lib/v5/card-render.js';
 import { openDb, resolveRoadmapPath } from '../lib/v5/genie-db.js';
-import { recordSyncBaseline, roadmapSnapshot, syncRoadmap } from '../lib/v5/roadmap-sync.js';
+import { recordExportBaseline, recordImportBaseline, roadmapSnapshot, syncRoadmap } from '../lib/v5/roadmap-sync.js';
 import {
   type EventAuthor,
+  type ImportSummary,
   type TaskCardRow,
   type TaskFilter,
   type TaskRow,
@@ -425,26 +426,64 @@ interface ExportOptions {
   write?: string | boolean;
 }
 
+/**
+ * Realpath-normalized form for path IDENTITY comparison. A raw string compare is
+ * wrong twice over: `--write <relative>` resolves against process.cwd() while
+ * `resolveRoadmapPath()` resolves against the git COMMON root, and macOS spells
+ * the same directory two ways (`/var/...` vs `/private/var/...`). The target file
+ * itself may not exist yet, so normalize the existing parent + basename.
+ */
+function normalizedPath(path: string): string {
+  try {
+    return join(realpathSync(dirname(path)), basename(path));
+  } catch {
+    return path;
+  }
+}
+
+function samePath(a: string, b: string): boolean {
+  return normalizedPath(a) === normalizedPath(b);
+}
+
+/**
+ * True for ANY target spelled `<dir>/.genie/roadmap.json`, not just this repo's
+ * canonical file — a subdirectory or linked-worktree spelling resolves elsewhere
+ * yet is still a git-trackable file under the canonical name. Such a file gets
+ * the roadmap slice so full-state `hire_roster` rows (machine-local worktree
+ * paths) can never travel in it. Custom-file writes and the plain stdout dump
+ * stay the complete database, so a backup file round-trips lossless.
+ */
+function isRoadmapSlicePath(path: string): boolean {
+  const normalized = normalizedPath(path);
+  return basename(normalized) === 'roadmap.json' && basename(dirname(normalized)) === '.genie';
+}
+
 function handleExport(opts: ExportOptions): void {
   run(() => {
     const db = openDb();
     try {
-      // Only the canonical roadmap.json gets the roadmap slice (no hire_roster —
-      // machine-local worktree paths). Custom-file writes and the plain stdout
-      // dump stay the complete database, so a backup file round-trips lossless.
       const target = opts.write ? (typeof opts.write === 'string' ? resolve(opts.write) : resolveRoadmapPath()) : null;
-      const canonical = target === resolveRoadmapPath();
-      const state = canonical ? roadmapSnapshot(db) : exportState(db);
-      const json = `${JSON.stringify(state, null, 2)}\n`;
-      if (target) {
-        writeFileSync(target, json);
-        // Writing the canonical snapshot declares "this pair is intentional" —
-        // it is the keep-the-local-board resolution for a diverged sync.
-        if (canonical) recordSyncBaseline(db);
-        out(`Wrote board snapshot to ${target}.`);
+      if (target === null) {
+        process.stdout.write(`${JSON.stringify(exportState(db), null, 2)}\n`);
         return;
       }
-      process.stdout.write(json);
+      const sliced = isRoadmapSlicePath(target);
+      const canonical = sliced && samePath(target, resolveRoadmapPath());
+      // ONE immediate transaction over snapshot → file write → baseline. genie.db
+      // is shared across worktrees, so a writer landing mid-sequence would
+      // otherwise yield a torn snapshot (dependency rows whose tasks were missed)
+      // or a baseline dbHash describing a NEWER db than the published file — the
+      // next `task sync` then reads as in-sync and silently drops that change.
+      const publish = db.transaction(() => {
+        const state = sliced ? roadmapSnapshot(db) : exportState(db);
+        writeFileSync(target, `${JSON.stringify(state, null, 2)}\n`);
+        // Writing the canonical snapshot declares "this pair is intentional" —
+        // it is the keep-the-local-board resolution for a diverged sync. Only the
+        // true canonical path may stamp it; a same-named file elsewhere must not.
+        if (canonical) recordExportBaseline(state);
+      });
+      publish.immediate();
+      out(`Wrote board snapshot to ${target}.`);
     } finally {
       db.close();
     }
@@ -484,10 +523,21 @@ function handleImport(file: string | undefined, opts: ImportOptions): void {
     }
     const db = openDb();
     try {
-      // The canonical snapshot is roadmap-scoped: local hires stay untouched.
-      const canonical = source === resolveRoadmapPath();
-      const summary = importState(db, snapshot, { replace: opts.replace, preserveHireRoster: canonical });
-      if (canonical) recordSyncBaseline(db);
+      // A roadmap-sliced snapshot carries no hires, so local hires stay untouched;
+      // only the true canonical file may stamp the sync baseline.
+      const sliced = isRoadmapSlicePath(source);
+      const canonical = sliced && samePath(source, resolveRoadmapPath());
+      // ONE immediate transaction over import → baseline (importState's own
+      // transaction nests as a savepoint): the baseline's post-import db
+      // re-snapshot must not see another worktree's write, or the marker would
+      // claim a db state the file never described and the next `task sync` would
+      // report in-sync while that change stayed unpublished.
+      const apply = db.transaction(() => {
+        const result = importState(db, snapshot, { replace: opts.replace, preserveHireRoster: sliced });
+        if (canonical) recordImportBaseline(db, snapshot);
+        return result;
+      });
+      const summary = apply.immediate() as ImportSummary;
       out(
         `Imported ${summary.tasks} tasks, ${summary.boards} boards, ${summary.dependencies} dependencies, ${summary.events} events, ${summary.wishGroups} wish groups, ${summary.hires} hires from ${source}.`,
       );


### PR DESCRIPTION
Follow-up to #2740 (pi-genie plugin): three commits, all validated.

## fix(doctor): keep suppressed role-agent orphans visible to the duplicate check

With a plugin enabled, agent-sync suppresses the bare-name role-agent fan-out — but a user-edited orphan that sync **kept on disk** (relinquishing only its manifest entry) still loads next to the plugin's `genie:*` agent. The previous suppression path emptied the source inventory, making that orphan invisible: neither classified nor warned as a duplicate.

Suppression now only changes what an *absent* file means (nothing owed to the target; a surviving file is prunable leftover state). Source names stay in the inventory so a surviving bare-name file is still classified `present-unmanaged` and the duplicate warning still fires. Source-inventory issues stay suppressed to avoid advising `genie update` forever over a fan-out genie deliberately does not deliver.

## fix(v5): stamp sync baselines from the exact published snapshot

`recordSyncBaseline` re-snapshot the db and re-read the file, so a concurrent worktree write between publish and baseline could stamp a marker describing state the published file never held — the next `task sync` would read as in-sync and silently drop that change.

- Split into `recordExportBaseline(state)` (both hashes from the one snapshot written) and `recordImportBaseline(db, snapshot)` (file hash from the parsed file, db re-measured — merge imports leave a superset). Both run inside the caller's immediate transaction alongside the publish/import.
- Export/import gained realpath-normalized path identity (cwd-relative spellings, `/var` vs `/private/var`), so only the true canonical `roadmap.json` may stamp the baseline, while **any** `<dir>/.genie/roadmap.json` spelling is roadmap-sliced — machine-local `hire_roster` paths can never travel in it. Custom-file writes and the stdout dump stay the complete database.

## chore: ignore machine-local tool configs

`.mcp.json`, `.warp/`, `.rlmx/` are personal tooling state (absolute binary paths, model choices, terminal MCP registrations). Extends the existing machine-local block (`.codex/`, `.dash/`, `.empryo`).

## Validation

- Touched test files: 149 pass (doctor + v5-task).
- Full `bun run check`: 2975/2976 — the single failure (`ui-bridge lifetime > holds zero listening TCP sockets`) reproduces on the clean tree (verified via stash), pre-existing and unrelated.
- Two Biome complexity warnings on `doctor.ts` (`codexPluginSurfaceChecks`, `doctorCommand`) are pre-existing in untouched functions.