### PR TITLE
fix(plugins): auto-install pi-genie via install.sh and genie update

### DIFF
--- a/plugins/pi-genie/README.md
+++ b/plugins/pi-genie/README.md
@@ -11,6 +11,21 @@ loader with zero npm installs.
 
 ## Install
 
+From the release that ships `plugins/pi-genie` in the payload, genie installs
+the pi extension **automatically**:
+
+- `install.sh` extracts the payload into `$GENIE_HOME/plugins/pi-genie` (via the
+  finishing `genie install` aux-layout normalization), and
+- the agent-sync **`pi` lane** — run by `genie install` and every `genie update`
+  — symlinks `~/.pi/agent/extensions/genie` → `$GENIE_HOME/plugins/pi-genie`
+  whenever pi is detected (pi CLI on PATH or `~/.pi/agent` present).
+
+`genie doctor` reports the link as `agent sync: pi`. No manual step needed on
+fresh installs or updates.
+
+For a dev checkout (edits are live) or a detached, release-style copy, the
+local installer remains available:
+
 ```bash
 # default: symlink ~/.pi/agent/extensions/genie -> this checkout (edits are live)
 plugins/pi-genie/scripts/install-local.sh

--- a/plugins/pi-genie/references/native-surface.md
+++ b/plugins/pi-genie/references/native-surface.md
@@ -12,7 +12,8 @@ tool is read-only; every payload reports `mutation: "none"`.
 | Session hook | `session_start` hint in Genie workspaces | `pi.on('session_start')` |
 | Context hook | Bounded board snapshot before each turn | `pi.on('before_agent_start')` (system-prompt append) |
 | Skills | pi-native discovery of `~/.agents/skills` / `.agents/skills`; opt-in canonical mirror via `GENIE_PI_CANONICAL_SKILLS=1` | `pi.on('resources_discover')` |
-| Install | `scripts/install-local.sh` (symlink default, `--copy` detached) | `~/.pi/agent/extensions/genie` |
+| Agent sync | Auto-install: symlink `~/.pi/agent/extensions/genie` → `$GENIE_HOME/plugins/pi-genie`; doctor `agent sync: pi` | `runAgentSync` `pi` lane (`genie install` / `genie update` / `--sync-only`) |
+| Install | Dev fallback: `scripts/install-local.sh` (symlink default, `--copy` detached) | `~/.pi/agent/extensions/genie` |
 | Version | `plugins/pi-genie/package.json` synced by release machinery | `scripts/version.ts` |
 
 ## Tool-to-CLI mapping (argv-only, never a shell string)

--- a/src/genie-commands/__tests__/update.test.ts
+++ b/src/genie-commands/__tests__/update.test.ts
@@ -2295,7 +2295,7 @@ describe('runV4CleanupSafe', () => {
 describe('runAgentSyncSafe (agent-sync phase)', () => {
   function makeReport(): AgentSyncReport {
     return {
-      source: { pluginRoot: '/home/.genie/plugins/genie', hermesRoot: null, version: '5.0.0' },
+      source: { pluginRoot: '/home/.genie/plugins/genie', hermesRoot: null, piRoot: null, version: '5.0.0' },
       agents: [
         {
           agent: 'claude',

--- a/src/genie-commands/doctor.test.ts
+++ b/src/genie-commands/doctor.test.ts
@@ -797,6 +797,7 @@ describe('checkAgentSync', () => {
   let codexDir: string;
   let agentsSkillsDir: string;
   let hermesHome: string;
+  let piHome: string;
 
   function writeSourceSkill(name: string, body: string): void {
     mkdirSync(join(pluginRoot, 'skills', name), { recursive: true });
@@ -845,6 +846,9 @@ describe('checkAgentSync', () => {
       // Disable the best-effort `hermes plugins list` enable probe by default so no
       // test ever spawns a real process; probe-specific tests inject a reader.
       hermesBinary: null as string | null,
+      // Same for the pi CLI probe — the link check keys off the pi home alone.
+      piBinary: null as string | null,
+      piHome,
       settingsPath: join(claudeDir, 'settings.json'),
     };
   }
@@ -859,8 +863,10 @@ describe('checkAgentSync', () => {
     codexDir = join(tmp, 'codex');
     agentsSkillsDir = join(tmp, 'agents', 'skills');
     hermesHome = join(tmp, 'hermes');
+    piHome = join(tmp, 'pi');
     mkdirSync(join(pluginRoot, 'skills'), { recursive: true });
     mkdirSync(join(genieHome, 'plugins', 'hermes-genie'), { recursive: true });
+    mkdirSync(join(genieHome, 'plugins', 'pi-genie'), { recursive: true });
     writeFileSync(join(genieHome, 'VERSION'), '5.0.0\n', 'utf8');
     writeSourceSkill('wish', '# wish\n');
     writeSourceSkill('review', '# review\n');
@@ -882,6 +888,7 @@ describe('checkAgentSync', () => {
     expect(find(results, 'agent sync: claude')?.detail).toBe('not detected');
     expect(find(results, 'agent sync: codex')?.detail).toBe('not detected');
     expect(find(results, 'agent sync: hermes')?.detail).toBe('not detected');
+    expect(find(results, 'agent sync: pi')?.detail).toBe('not detected');
     expect(results.every((r) => r.status !== 'fail')).toBe(true);
   });
 
@@ -995,6 +1002,29 @@ describe('checkAgentSync', () => {
     const hermes = find(checkAgentSync(paths()), 'agent sync: hermes');
     expect(hermes?.status).toBe('warn');
     expect(hermes?.detail).toContain('points elsewhere');
+  });
+
+  test('pi: correct extensions link → pass', () => {
+    mkdirSync(join(piHome, 'agent', 'extensions'), { recursive: true });
+    symlinkSync(join(genieHome, 'plugins', 'pi-genie'), join(piHome, 'agent', 'extensions', 'genie'));
+    const pi = find(checkAgentSync(paths()), 'agent sync: pi');
+    expect(pi?.status).toBe('pass');
+    expect(pi?.detail).toContain('linked');
+  });
+
+  test('pi: extensions link pointing elsewhere → warn', () => {
+    mkdirSync(join(piHome, 'agent', 'extensions'), { recursive: true });
+    symlinkSync(join(tmp, 'somewhere-else'), join(piHome, 'agent', 'extensions', 'genie'));
+    const pi = find(checkAgentSync(paths()), 'agent sync: pi');
+    expect(pi?.status).toBe('warn');
+    expect(pi?.detail).toContain('points elsewhere');
+  });
+
+  test('pi: pi home present but no link → warn with sync suggestion', () => {
+    mkdirSync(piHome, { recursive: true });
+    const pi = find(checkAgentSync(paths()), 'agent sync: pi');
+    expect(pi?.status).toBe('warn');
+    expect(pi?.suggestion).toBeDefined();
   });
 
   // Codex Genie skills are plugin-only (R5): an EMPTY user tier is the healthy

--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -71,6 +71,8 @@ import {
   resolveCodexDir,
   resolveGenieHome as resolveGlobalGenieHome,
   resolveHermesHome,
+  resolvePiExtensionsDir,
+  resolvePiHome,
 } from '../lib/genie-home.js';
 import { hasDuplicateMcpGenieKeys } from '../lib/hermes-mcp-config.js';
 import { hasDuplicateSkillsExternalDirsKeys, resolveProductSkillsRoot } from '../lib/hermes-skills-config.js';
@@ -902,6 +904,12 @@ interface AgentSyncPaths {
   agentsSkillsDir?: string;
   hermesHome?: string;
   /**
+   * Pi CLI detection override for the link check. `undefined` probes PATH;
+   * `null` explicitly skips the probe (pi CLI absent → silent).
+   */
+  piBinary?: string | null;
+  piHome?: string;
+  /**
    * Hermes CLI detection override for the best-effort enable probe. `undefined`
    * probes PATH; `null` explicitly skips the probe (hermes CLI absent → silent).
    */
@@ -1380,6 +1388,39 @@ function checkHermesSync(input: HermesCheckInput): CheckResult[] {
   return results;
 }
 
+interface PiCheckInput {
+  piRoot: string | null;
+  piHome: string;
+  /** `undefined` probes PATH; `null` skips the probe. */
+  binary?: string | null;
+}
+
+/**
+ * pi health: the `~/.pi/agent/extensions/genie` symlink converging on the
+ * shipped `pi-genie` source. Pass when pi is undetected (no pi home and no pi
+ * CLI) or the source is absent — the link check only runs when both sides
+ * exist. Link-only: pi has no enable command or config legs to converge.
+ */
+function checkPiSync(input: PiCheckInput): CheckResult[] {
+  const { piRoot, piHome } = input;
+  const extensionsDir = resolvePiExtensionsDir(piHome);
+  if (!existsSync(piHome) && input.binary === null) {
+    return [{ name: 'agent sync: pi', status: 'pass', detail: 'not detected' }];
+  }
+  if (piRoot === null) {
+    return [{ name: 'agent sync: pi', status: 'pass', detail: 'pi-genie source absent — link check skipped' }];
+  }
+  const link = hermesLinkState(join(extensionsDir, 'genie'), piRoot, 'extensions/genie');
+  return [
+    {
+      name: 'agent sync: pi',
+      status: link.ok ? 'pass' : 'warn',
+      detail: link.detail,
+      suggestion: link.ok ? undefined : SYNC_SUGGESTION,
+    },
+  ];
+}
+
 /** `mcp_servers.genie.command` must be an absolute path to an existing, executable file. */
 function checkHermesMcp(configText: string | null, configPath: string): CheckResult {
   const name = 'agent sync: hermes mcp';
@@ -1578,21 +1619,25 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function hermesLinkState(linkPath: string, hermesRoot: string): { ok: boolean; detail: string } {
+function hermesLinkState(
+  linkPath: string,
+  hermesRoot: string,
+  label = 'plugins/genie',
+): { ok: boolean; detail: string } {
   let stat: ReturnType<typeof lstatSync>;
   try {
     stat = lstatSync(linkPath);
   } catch {
-    return { ok: false, detail: 'plugins/genie link absent' };
+    return { ok: false, detail: `${label} link absent` };
   }
-  if (!stat.isSymbolicLink()) return { ok: false, detail: 'plugins/genie present but not a symlink' };
+  if (!stat.isSymbolicLink()) return { ok: false, detail: `${label} present but not a symlink` };
   try {
     const target = readlinkSync(linkPath);
     if (resolve(dirname(linkPath), target) === resolve(hermesRoot))
       return { ok: true, detail: `linked → ${hermesRoot}` };
     return { ok: false, detail: `points elsewhere (${target})` };
   } catch {
-    return { ok: false, detail: 'plugins/genie symlink unreadable' };
+    return { ok: false, detail: `${label} symlink unreadable` };
   }
 }
 
@@ -1647,6 +1692,7 @@ export function checkAgentSync(paths: AgentSyncPaths = {}): CheckResult[] {
   const codexDir = paths.codexDir ?? resolveCodexDir();
   const agentsSkillsDir = paths.agentsSkillsDir ?? resolveAgentsSkillsDir();
   const hermesHome = paths.hermesHome ?? resolveHermesHome();
+  const piHome = paths.piHome ?? resolvePiHome();
   const settingsPath = paths.settingsPath ?? join(claudeDir, 'settings.json');
   const source = resolveGenieSource(genieHome);
   if (source.pluginRoot === null) {
@@ -1671,6 +1717,13 @@ export function checkAgentSync(paths: AgentSyncPaths = {}): CheckResult[] {
         pluginRoot,
         binary: hermesBinary,
         pluginsList: paths.hermesPluginsList,
+      }),
+    ),
+    ...safeAgentChecks('pi', () =>
+      checkPiSync({
+        piRoot: source.piRoot,
+        piHome,
+        binary: paths.piBinary !== undefined ? paths.piBinary : whichBinary('pi'),
       }),
     ),
     ...safeAgentChecks('marketplace', () => checkMarketplacePlugin(settingsPath)),

--- a/src/lib/agent-sync.test.ts
+++ b/src/lib/agent-sync.test.ts
@@ -123,6 +123,8 @@ interface Fixture {
   agentsSkillsDir: string;
   hermesHome: string;
   hermesSource: string;
+  piHome: string;
+  piSource: string;
 }
 
 let fixture: Fixture;
@@ -158,6 +160,7 @@ function setup(opts: SetupOptions = {}): Fixture {
   const pluginsBase = opts.binLayout ? join(genieHome, 'bin', 'plugins') : join(genieHome, 'plugins');
   const pluginRoot = join(pluginsBase, 'genie');
   const hermesSource = join(pluginsBase, 'hermes-genie');
+  const piSource = join(pluginsBase, 'pi-genie');
 
   const skills = opts.skills ?? {
     alpha: { 'SKILL.md': '# alpha\n', 'references/a.md': 'alpha ref\n' },
@@ -170,6 +173,7 @@ function setup(opts: SetupOptions = {}): Fixture {
 
   if (opts.withTemplate ?? true) writeFile(join(pluginRoot, 'workflows', 'council.js'), TEMPLATE_BODY);
   writeFile(join(hermesSource, 'plugin.json'), '{"name":"hermes-genie"}\n');
+  writeFile(join(piSource, 'package.json'), '{"name":"genie-pi-plugin"}\n');
 
   const version = opts.version === undefined ? '9.9.9' : opts.version;
   if (version !== null) writeFile(join(genieHome, 'VERSION'), `${version}\n`);
@@ -183,6 +187,8 @@ function setup(opts: SetupOptions = {}): Fixture {
     agentsSkillsDir: join(root, 'agents', 'skills'),
     hermesHome: join(root, 'hermes'),
     hermesSource,
+    piHome: join(root, 'pi'),
+    piSource,
   };
 }
 
@@ -198,9 +204,11 @@ function run(extra: Partial<AgentSyncOptions> = {}): AgentSyncReport {
       claude: fixture.claudeDir,
       codex: fixture.codexDir,
       hermes: fixture.hermesHome,
+      pi: join(fixture.piHome, 'agent', 'extensions'),
       agentsSkills: fixture.agentsSkillsDir,
     },
     hermesBinary: null,
+    piBinary: null,
     now: FIXED_NOW,
     log: () => undefined,
     ...extra,
@@ -286,11 +294,25 @@ describe('fresh create', () => {
     expect(extraAction(report, 'enable')).toBe('ran');
   });
 
+  test('pi: extensions link created when pi home present, no enable command', () => {
+    present(join(fixture.piHome, 'agent', 'extensions'));
+    const report = agentReport(run(), 'pi');
+
+    expect(report.detected).toBe(true);
+    const link = join(fixture.piHome, 'agent', 'extensions', 'genie');
+    expect(lstatSync(link).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(link)).toBe(fixture.piSource);
+    expect(extraAction(report, 'symlink')).toBe('created');
+    // pi has no plugin enable command — the link alone loads the extension.
+    expect(extraAction(report, 'enable')).toBeUndefined();
+  });
+
   test('report carries the resolved source metadata', () => {
     present(fixture.claudeDir);
     const report = run();
     expect(report.source.pluginRoot).toBe(fixture.pluginRoot);
     expect(report.source.hermesRoot).toBe(fixture.hermesSource);
+    expect(report.source.piRoot).toBe(fixture.piSource);
     expect(report.source.version).toBe('9.9.9');
   });
 });
@@ -1332,6 +1354,7 @@ describe('idempotent re-run', () => {
     present(fixture.claudeDir);
     present(fixture.codexDir);
     present(fixture.hermesHome);
+    present(join(fixture.piHome, 'agent', 'extensions'));
     const enableCalls: string[][] = [];
     const opts: Partial<AgentSyncOptions> = {
       hermesBinary: '/fake/bin/hermes',
@@ -1348,6 +1371,9 @@ describe('idempotent re-run', () => {
 
     const hermes = agentReport(second, 'hermes');
     expect(extraAction(hermes, 'symlink')).toBe('unchanged');
+
+    const pi = agentReport(second, 'pi');
+    expect(extraAction(pi, 'symlink')).toBe('unchanged');
 
     expect(enableCalls).toHaveLength(1); // fired on the first run only
     expect(second.backupsDir).toBeNull();
@@ -1802,7 +1828,7 @@ describe('undetected agents', () => {
   test('a missing agent dir yields detected:false and zero writes', () => {
     // no target dirs created at all
     const report = run();
-    for (const agent of ['claude', 'hermes'] as const) {
+    for (const agent of ['claude', 'hermes', 'pi'] as const) {
       expect(agentReport(report, agent).detected).toBe(false);
     }
     // codex never appears in the report at all — runAgentSync has no codex arm.
@@ -1810,6 +1836,7 @@ describe('undetected agents', () => {
     expect(existsSync(fixture.claudeDir)).toBe(false);
     expect(existsSync(fixture.codexDir)).toBe(false);
     expect(existsSync(join(fixture.hermesHome, 'plugins'))).toBe(false);
+    expect(existsSync(join(fixture.piHome, 'agent'))).toBe(false);
     expect(report.backupsDir).toBeNull();
   });
 
@@ -1828,13 +1855,15 @@ describe('explicit client selection', () => {
     present(fixture.claudeDir);
     present(fixture.codexDir);
     present(fixture.hermesHome);
+    present(join(fixture.piHome, 'agent', 'extensions'));
     writeFile(join(fixture.agentsSkillsDir, 'alpha', 'SKILL.md'), '# seeded, pre-existing\n');
     const report = run({ selection: 'codex' });
     // runAgentSync has no `codex` arm at all: `selection: 'codex'` matches
-    // none of the claude/hermes gates either, so nothing runs.
+    // none of the claude/hermes/pi gates either, so nothing runs.
     expect(report.agents).toEqual([]);
     expect(existsSync(join(fixture.claudeDir, 'skills'))).toBe(false);
     expect(existsSync(join(fixture.hermesHome, 'plugins', 'genie'))).toBe(false);
+    expect(existsSync(join(fixture.piHome, 'agent', 'extensions', 'genie'))).toBe(false);
     expect(readFileSync(join(fixture.agentsSkillsDir, 'alpha', 'SKILL.md'), 'utf8')).toBe('# seeded, pre-existing\n');
   });
 
@@ -1842,11 +1871,13 @@ describe('explicit client selection', () => {
     present(fixture.claudeDir);
     present(fixture.codexDir);
     present(fixture.hermesHome);
+    present(join(fixture.piHome, 'agent', 'extensions'));
     const report = run({ selection: 'none' });
     expect(report.agents).toEqual([]);
     expect(existsSync(join(fixture.claudeDir, 'skills'))).toBe(false);
     expect(existsSync(join(fixture.agentsSkillsDir, 'alpha'))).toBe(false);
     expect(existsSync(join(fixture.hermesHome, 'plugins', 'genie'))).toBe(false);
+    expect(existsSync(join(fixture.piHome, 'agent', 'extensions', 'genie'))).toBe(false);
   });
 
   // Regression (restore-hermes-sync-leg): a prior release narrowed every
@@ -1856,16 +1887,18 @@ describe('explicit client selection', () => {
   // This is the R2/A1 + hermes-restoration contract pinned at the engine
   // level: 'auto' must converge BOTH claude and hermes, and must NEVER touch
   // the shared ~/.agents/skills tier (there is no codex arm to do so).
-  test('auto selection converges claude AND hermes, and never touches a seeded ~/.agents/skills fixture', () => {
+  test('auto selection converges claude, hermes AND pi, and never touches a seeded ~/.agents/skills fixture', () => {
     present(fixture.claudeDir);
     present(fixture.hermesHome);
+    present(join(fixture.piHome, 'agent', 'extensions'));
     writeFile(join(fixture.agentsSkillsDir, 'alpha', 'SKILL.md'), '# seeded, pre-existing\n');
 
     const report = run({ selection: 'auto' });
 
-    expect(report.agents.map((agent) => agent.agent).sort()).toEqual(['claude', 'hermes']);
+    expect(report.agents.map((agent) => agent.agent).sort()).toEqual(['claude', 'hermes', 'pi']);
     expect(skillAction(agentReport(report, 'claude'), 'alpha')).toBe('created');
     expect(extraAction(agentReport(report, 'hermes'), 'symlink')).toBe('created');
+    expect(extraAction(agentReport(report, 'pi'), 'symlink')).toBe('created');
     // R2/A1: the seeded ~/.agents/skills fixture is byte-identical — no codex
     // arm exists to have written or removed anything there.
     expect(readFileSync(join(fixture.agentsSkillsDir, 'alpha', 'SKILL.md'), 'utf8')).toBe('# seeded, pre-existing\n');
@@ -2481,6 +2514,7 @@ describe('resolveGenieSource', () => {
     const report = run();
     expect(report.source.pluginRoot).toBe(fixture.pluginRoot);
     expect(report.source.pluginRoot).toContain(join('bin', 'plugins', 'genie'));
+    expect(report.source.piRoot).toContain(join('bin', 'plugins', 'pi-genie'));
     expect(skillAction(agentReport(report, 'claude'), 'alpha')).toBe('created');
   });
 
@@ -3820,7 +3854,7 @@ describe('shared lifecycle lease', () => {
 describe('runAgentSyncSafe codex role-agent refresh wiring', () => {
   function fakeReport(overrides: Partial<AgentSyncReport> = {}, codexDetected = true): AgentSyncReport {
     return {
-      source: { pluginRoot: '/home/.genie/plugins/genie', hermesRoot: null, version: '5.0.0' },
+      source: { pluginRoot: '/home/.genie/plugins/genie', hermesRoot: null, piRoot: null, version: '5.0.0' },
       agents: [
         { agent: 'claude', detected: true, skills: [], extras: [], advisories: [] },
         { agent: 'codex', detected: codexDetected, skills: [], extras: [], advisories: [] },

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -54,7 +54,13 @@ import {
 import { homedir, hostname } from 'node:os';
 import { basename, dirname, join, relative, resolve, sep } from 'node:path';
 import historicalCodexFallbackAllowlist from '../fixtures/codex-fallback-allowlist.json';
-import { resolveClaudeDir, resolveCodexDir, resolveGenieHome, resolveHermesHome } from './genie-home.js';
+import {
+  resolveClaudeDir,
+  resolveCodexDir,
+  resolveGenieHome,
+  resolveHermesHome,
+  resolvePiExtensionsDir,
+} from './genie-home.js';
 import { HermesConfigError, mergeMcpServersGenie } from './hermes-mcp-config.js';
 import { mergeSkillsExternalDir } from './hermes-skills-config.js';
 
@@ -178,12 +184,17 @@ export interface AgentSyncOptions {
    * is the shared `~/.agents/skills` tier codex skills are synced INTO;
    * `codex` (`~/.codex`) stays the detection root + legacy-lane parent.
    */
-  targets?: { claude?: string; codex?: string; hermes?: string; agentsSkills?: string };
+  targets?: { claude?: string; codex?: string; hermes?: string; pi?: string; agentsSkills?: string };
   /**
    * Hermes binary override for enable-exec detection. A non-null string forces
    * "detected"; `null` explicitly skips exec; `undefined` probes PATH.
    */
   hermesBinary?: string | null;
+  /**
+   * Pi binary override for extension-dir detection. A non-null string forces
+   * "detected"; `null` explicitly skips exec; `undefined` probes PATH.
+   */
+  piBinary?: string | null;
   /** Injectable exec seam for `hermes plugins enable genie` (default execFileSync). */
   execHermesEnable?: (args: string[]) => void;
   /** Structured log sink (no console in src). */
@@ -303,7 +314,7 @@ export type SkillAction =
   | 'kept-modified-orphan';
 
 export interface AgentReport {
-  agent: 'claude' | 'codex' | 'hermes';
+  agent: 'claude' | 'codex' | 'hermes' | 'pi';
   detected: boolean;
   skills: Array<{ name: string; action: SkillAction; detail?: string }>;
   /** Non-skill outcomes: stamp / symlink / enable lines. */
@@ -327,6 +338,7 @@ export interface AgentSyncReport {
 export interface GenieSource {
   pluginRoot: string | null;
   hermesRoot: string | null;
+  piRoot: string | null;
   version: string | null;
 }
 
@@ -378,7 +390,9 @@ interface RunContext {
   hermesRoot: string | null;
   version: string | null;
   now: () => Date;
-  targets: { claude: string; codex: string; hermes: string; agentsSkills: string };
+  targets: { claude: string; codex: string; hermes: string; pi: string; agentsSkills: string };
+  /** Canonical pi plugin source (first existing of `plugins/pi-genie`, `bin/plugins/pi-genie`). */
+  piRoot: string | null;
   /** Copy `existingDir` into the run's backup root and return the backup path. */
   backupInto: (agent: string, name: string, existingDir: string) => string;
   /**
@@ -437,8 +451,9 @@ export function resolveGenieSource(genieHome: string): GenieSource {
     join(genieHome, 'plugins', 'hermes-genie'),
     join(genieHome, 'bin', 'plugins', 'hermes-genie'),
   ]);
+  const piRoot = firstExisting([join(genieHome, 'plugins', 'pi-genie'), join(genieHome, 'bin', 'plugins', 'pi-genie')]);
   const version = readTrimmed(join(genieHome, 'VERSION')) || null;
-  return { pluginRoot, hermesRoot, version };
+  return { pluginRoot, hermesRoot, piRoot, version };
 }
 
 function firstExisting(paths: string[]): string | null {
@@ -3251,7 +3266,7 @@ export function removeManagedSkillTree(
   const ctx = createRunContext(
     genieHome,
     '',
-    { pluginRoot: null, hermesRoot: null, version: null },
+    { pluginRoot: null, hermesRoot: null, piRoot: null, version: null },
     {
       genieHome,
       renameManagedDir: options.renameManagedDir,
@@ -5722,7 +5737,14 @@ function syncHermes(ctx: RunContext, opts: AgentSyncOptions, report: AgentReport
     return;
   }
   const hermesRoot = ctx.hermesRoot;
-  const mainAction = ensureHermesLink(ctx, join(hermesHome, 'plugins', 'genie'), hermesRoot, 'plugins-genie', report);
+  const mainAction = ensurePluginLink(
+    ctx,
+    join(hermesHome, 'plugins', 'genie'),
+    hermesRoot,
+    'hermes',
+    'plugins-genie',
+    report,
+  );
   ensureStickyProfileLink(ctx, hermesHome, hermesRoot, report);
   // A freshly linked main plugin — created OR adopted from a real dir — is newly
   // enabled; fire enable exactly once. Never gated on the sticky-profile link.
@@ -5817,36 +5839,42 @@ function convergeHermesLeg(
  *   other symlink  → leave it (dev checkout) + advise,
  *   real dir/file  → back up, then replace with the symlink.
  */
-function ensureHermesLink(
+function ensurePluginLink(
   ctx: RunContext,
   linkPath: string,
-  hermesRoot: string,
+  sourceRoot: string,
+  agent: 'hermes' | 'pi',
   backupName: string,
   report: AgentReport,
 ): LinkAction {
   mkdirSync(dirname(linkPath), { recursive: true });
   const stat = lstatSafe(linkPath);
   if (stat === null) {
-    symlinkSync(hermesRoot, linkPath);
-    report.extras.push({ kind: 'symlink', action: 'created', detail: `${linkPath} -> ${hermesRoot}` });
+    symlinkSync(sourceRoot, linkPath);
+    report.extras.push({ kind: 'symlink', action: 'created', detail: `${linkPath} -> ${sourceRoot}` });
     return 'created';
   }
-  if (stat.isSymbolicLink()) return reconcileExistingSymlink(linkPath, hermesRoot, report);
-  const backup = ctx.backupInto('hermes', backupName, linkPath);
+  if (stat.isSymbolicLink()) return reconcileExistingSymlink(linkPath, sourceRoot, agent, report);
+  const backup = ctx.backupInto(agent, backupName, linkPath);
   rmSync(linkPath, { recursive: true, force: true });
-  symlinkSync(hermesRoot, linkPath);
+  symlinkSync(sourceRoot, linkPath);
   report.extras.push({ kind: 'symlink', action: 'adopted', detail: `real dir backed up to ${backup}` });
   return 'adopted';
 }
 
-function reconcileExistingSymlink(linkPath: string, hermesRoot: string, report: AgentReport): LinkAction {
+function reconcileExistingSymlink(
+  linkPath: string,
+  sourceRoot: string,
+  agent: string,
+  report: AgentReport,
+): LinkAction {
   const current = readlinkSync(linkPath);
-  if (resolve(dirname(linkPath), current) === resolve(hermesRoot)) {
+  if (resolve(dirname(linkPath), current) === resolve(sourceRoot)) {
     report.extras.push({ kind: 'symlink', action: 'unchanged', detail: linkPath });
     return 'unchanged';
   }
   report.extras.push({ kind: 'symlink', action: 'skipped-unmanaged-kept', detail: current });
-  report.advisories.push(`hermes link ${linkPath} points elsewhere (${current}); left as-is`);
+  report.advisories.push(`${agent} link ${linkPath} points elsewhere (${current}); left as-is`);
   return 'skipped-unmanaged-kept';
 }
 
@@ -5867,7 +5895,7 @@ function ensureStickyProfileLink(ctx: RunContext, hermesHome: string, hermesRoot
     return;
   }
   const linkPath = join(profileRoot, 'plugins', 'genie');
-  ensureHermesLink(ctx, linkPath, hermesRoot, `profiles-${active}-plugins-genie`, report);
+  ensurePluginLink(ctx, linkPath, hermesRoot, 'hermes', `profiles-${active}-plugins-genie`, report);
 }
 
 function runHermesEnable(opts: AgentSyncOptions, binary: string, report: AgentReport): void {
@@ -5893,6 +5921,38 @@ function detectHermesBinary(opts: AgentSyncOptions): string | null {
   if (typeof Bun !== 'undefined') return Bun.which('hermes');
   try {
     const found = execFileSync('which', ['hermes'], { encoding: 'utf8' }).trim();
+    return found === '' ? null : found;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The pi lane: converge `~/.pi/agent/extensions/genie` (pi's global extension
+ * discovery dir) onto the shipped `plugins/pi-genie` source. pi has no plugin
+ * enable command — the extension auto-loads from the linked dir on next pi
+ * start — so the lane is link-only, mirroring the hermes link leg without the
+ * enable/config legs. Detection: pi home present OR `pi` CLI on PATH; a link
+ * is created only when the `pi-genie` source ships next to `plugins/genie`.
+ */
+function syncPi(ctx: RunContext, opts: AgentSyncOptions, report: AgentReport): void {
+  const extensionsDir = ctx.targets.pi;
+  const binary = detectPiBinary(opts);
+  if (!existsSync(extensionsDir) && binary === null) return;
+  report.detected = true;
+  if (ctx.piRoot === null) {
+    report.advisories.push('pi source (pi-genie) not found next to plugins/genie; skipping link');
+    return;
+  }
+  const linkPath = join(extensionsDir, 'genie');
+  ensurePluginLink(ctx, linkPath, ctx.piRoot, 'pi', 'extensions-genie', report);
+}
+
+function detectPiBinary(opts: AgentSyncOptions): string | null {
+  if (opts.piBinary !== undefined) return opts.piBinary;
+  if (typeof Bun !== 'undefined') return Bun.which('pi');
+  try {
+    const found = execFileSync('which', ['pi'], { encoding: 'utf8' }).trim();
     return found === '' ? null : found;
   } catch {
     return null;
@@ -6969,6 +7029,7 @@ export function runAgentSync(opts: AgentSyncOptions = {}): AgentSyncReport {
     }
     if (selection === 'auto' || selection === 'all') {
       agents.push(runAgentSafe('hermes', (report) => syncHermes(ctx, opts, report)));
+      agents.push(runAgentSafe('pi', (report) => syncPi(ctx, opts, report)));
     }
     return { source, agents, backupsDir: ctx.backupsDirIfCreated() };
   } finally {
@@ -6987,6 +7048,7 @@ function createRunContext(
     claude: opts.targets?.claude ?? resolveClaudeDir(),
     codex: opts.targets?.codex ?? resolveCodexDir(),
     hermes: opts.targets?.hermes ?? resolveHermesHome(),
+    pi: opts.targets?.pi ?? resolvePiExtensionsDir(),
     agentsSkills: opts.targets?.agentsSkills ?? resolveAgentsSkillsDir(),
   };
   const stamp = now().toISOString().replace(/[:.]/g, '-');
@@ -7018,6 +7080,7 @@ function createRunContext(
     genieHome,
     pluginRoot,
     hermesRoot: source.hermesRoot,
+    piRoot: source.piRoot,
     version: source.version,
     now,
     targets,

--- a/src/lib/genie-home.ts
+++ b/src/lib/genie-home.ts
@@ -36,3 +36,13 @@ export function resolveCodexDir(env: NodeJS.ProcessEnv = process.env, home = hom
 export function resolveHermesHome(): string {
   return process.env.HERMES_HOME || join(homedir(), '.hermes');
 }
+
+/** Pi agent config root — `$PI_HOME` or `~/.pi`. */
+export function resolvePiHome(): string {
+  return process.env.PI_HOME || join(homedir(), '.pi');
+}
+
+/** Pi extension discovery dir — `<piHome>/agent/extensions`. */
+export function resolvePiExtensionsDir(home: string = resolvePiHome()): string {
+  return join(home, 'agent', 'extensions');
+}


### PR DESCRIPTION
## Problem

The pi plugin (`plugins/pi-genie`) ships in the release payload (the tarball copies the whole `plugins/` tree) but **nothing wires it into the auto-install path**. `install.sh` → `genie install` extracts the payload to `$GENIE_HOME/plugins/`, and `genie install` / `genie update` run agent-sync — yet there is no `pi` lane, so `~/.pi/agent/extensions/genie` is never created and pi never loads the extension. The hermes plugin has a sync lane; pi has none.

## Fix

Add the agent-sync **pi lane**, mirroring the hermes link leg (pi has no enable command or config legs — the extension auto-loads from the linked dir):

- `genie-home.ts`: `resolvePiHome()` (`$PI_HOME` or `~/.pi`) and `resolvePiExtensionsDir()` (`<piHome>/agent/extensions`)
- `agent-sync.ts`:
  - `GenieSource.piRoot` resolved from `plugins/pi-genie` / `bin/plugins/pi-genie`
  - `syncPi`: symlink `~/.pi/agent/extensions/genie` → `$GENIE_HOME/plugins/pi-genie` when pi is detected (pi CLI on PATH or pi home present); runs under `auto`/`all` selections of `genie install`, `genie update`, and `--sync-only`
  - generalized `ensureHermesLink` → `ensurePluginLink` (agent-labeled backup + advisory messages)
- `doctor.ts`: `agent sync: pi` check reusing the link-state helper (now label-parameterized so the pi message reads `extensions/genie`, not `plugins/genie`)
- tests: pi lane create/unchanged/selection-gate coverage, doctor pi checks (pass / points-elsewhere / missing link), bin-layout source resolution, `GenieSource` literals updated
- docs: `plugins/pi-genie/README.md` + `references/native-surface.md` document the auto-install path (dev `install-local.sh` remains for checkout work)

## Result

On the next release that ships `plugins/pi-genie`: `curl …/install.sh | bash` lands the payload at `$GENIE_HOME/plugins/pi-genie` and the finishing `genie install` links it into `~/.pi/agent/extensions/genie` automatically; `genie update` re-converges the link. `genie doctor` reports it as `agent sync: pi`.

## Verification

- `bunx tsc --noEmit` clean
- `bun test` on the affected suites (agent-sync, doctor, install, uninstall, setup, update): 0 new failures vs a clean `dev` checkout in this environment (14 pre-existing environment-dependent failures — boundary tests running against the real `~/.genie`, dogfood tests needing git remotes, and a mid-release codex fixture — are identical with and without this change)
- `bunx biome check` clean on changed files (2 pre-existing complexity warnings in `doctor.ts`, unchanged)
- `bunx knip` clean
- pi plugin's own `bun test extension.test.ts`: 15/15 pass