### PR TITLE
fix(pi-sync): honor PI_CODING_AGENT_DIR, align doctor/sync detection, fix suggestion copy

### DIFF
--- a/plugins/pi-genie/README.md
+++ b/plugins/pi-genie/README.md
@@ -18,13 +18,17 @@ the pi extension **automatically**:
   finishing `genie install` aux-layout normalization), and
 - the agent-sync **`pi` lane** — run by `genie install` and every `genie update`
   — symlinks `~/.pi/agent/extensions/genie` → `$GENIE_HOME/plugins/pi-genie`
-  whenever pi is detected (pi CLI on PATH or `~/.pi/agent` present).
+  whenever pi is detected (pi CLI on PATH or the pi extensions dir present).
+  A relocated pi agent dir is honored: the lane targets `$PI_CODING_AGENT_DIR`
+  when set (pi's real override, tilde-expanded), falling back to
+  `~/.pi/agent`. The legacy `$PI_HOME` alias is still accepted.
 
 `genie doctor` reports the link as `agent sync: pi`. No manual step needed on
 fresh installs or updates.
 
 For a dev checkout (edits are live) or a detached, release-style copy, the
-local installer remains available:
+local installer remains available (it resolves the same way: `$PI_CODING_AGENT_DIR`
+when set, else `~/.pi/agent`):
 
 ```bash
 # default: symlink ~/.pi/agent/extensions/genie -> this checkout (edits are live)

--- a/plugins/pi-genie/scripts/install-local.sh
+++ b/plugins/pi-genie/scripts/install-local.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Install the Genie pi plugin as $PI_HOME/agent/extensions/genie.
+# Install the Genie pi plugin as $PI_CODING_AGENT_DIR/extensions/genie
+# (or $PI_HOME/agent/extensions/genie via the legacy genie alias).
 #
 # Default mode symlinks the repo checkout (edits are live — tight dev loop);
 # --copy makes a detached, release-style copy instead. A previous install (a
@@ -11,13 +12,13 @@ usage() {
   cat <<'EOF'
 Usage: install-local.sh [--copy] [--force]
 
-Installs plugins/pi-genie as $PI_HOME/agent/extensions/genie.
+Installs plugins/pi-genie into the pi extensions dir:
+  $PI_CODING_AGENT_DIR/extensions   (pi's real relocation override)
+  $PI_HOME/agent/extensions         (legacy genie alias; PI_HOME defaults to $HOME/.pi)
 
   (default)  symlink the repo checkout — edits are live
   --copy     copy the plugin files — detached, release-style install
   --force    replace a standalone ~/.pi/agent/extensions/genie.ts file
-
-PI_HOME defaults to $HOME/.pi (pi's agent dir is $PI_HOME/agent).
 EOF
 }
 
@@ -43,8 +44,19 @@ done
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 plugin_src="$(cd "$script_dir/.." && pwd)"
 
-pi_home="${PI_HOME:-$HOME/.pi}"
-extensions_dir="$pi_home/agent/extensions"
+# Resolve the pi agent dir the same way pi does: $PI_CODING_AGENT_DIR (real
+# relocation override, tilde-expanded) or $PI_HOME/agent (legacy alias).
+if [ -n "${PI_CODING_AGENT_DIR:-}" ]; then
+  agent_dir="$PI_CODING_AGENT_DIR"
+  case "$agent_dir" in
+    "~") agent_dir="$HOME" ;;
+    "~/"*) agent_dir="$HOME/${agent_dir#\~/}" ;;
+  esac
+else
+  pi_home="${PI_HOME:-$HOME/.pi}"
+  agent_dir="$pi_home/agent"
+fi
+extensions_dir="$agent_dir/extensions"
 target="$extensions_dir/genie"
 stale_file="$extensions_dir/genie.ts"
 

--- a/src/genie-commands/doctor.test.ts
+++ b/src/genie-commands/doctor.test.ts
@@ -1020,8 +1020,8 @@ describe('checkAgentSync', () => {
     expect(pi?.detail).toContain('points elsewhere');
   });
 
-  test('pi: pi home present but no link → warn with sync suggestion', () => {
-    mkdirSync(piHome, { recursive: true });
+  test('pi: extensions dir present but no link → warn with sync suggestion', () => {
+    mkdirSync(join(piHome, 'agent', 'extensions'), { recursive: true });
     const pi = find(checkAgentSync(paths()), 'agent sync: pi');
     expect(pi?.status).toBe('warn');
     expect(pi?.suggestion).toBeDefined();

--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -186,8 +186,17 @@ const GLYPH: Record<CheckStatus, string> = {
 };
 
 function whichBinary(name: string): string | null {
+  if (typeof Bun !== 'undefined') {
+    try {
+      return Bun.which(name);
+    } catch {
+      return null;
+    }
+  }
+  // Node fallback — same policy as detectPiBinary/detectHermesBinary in agent-sync.
   try {
-    return Bun.which(name);
+    const found = execFileSync('which', [name], { encoding: 'utf8' }).trim();
+    return found === '' ? null : found;
   } catch {
     return null;
   }
@@ -892,7 +901,7 @@ async function checkOmniHookTimeout(): Promise<CheckResult[]> {
 const SYNC_MANIFEST_NAME = MANIFEST_NAME;
 const SYNC_MANAGED_BY = MANAGED_BY;
 const COUNCIL_WORKFLOW_FILE = TARGET_NAME;
-const SYNC_SUGGESTION = 'Run `genie update` to converge detected Claude and Hermes integrations.';
+const SYNC_SUGGESTION = 'Run `genie update` to converge detected Claude, Hermes and pi integrations.';
 const HERMES_INLINE_SUGGESTION =
   'Rewrite the inline top-level key as a block mapping so genie can merge without deleting your entries, then run `genie update`.';
 
@@ -1397,14 +1406,16 @@ interface PiCheckInput {
 
 /**
  * pi health: the `~/.pi/agent/extensions/genie` symlink converging on the
- * shipped `pi-genie` source. Pass when pi is undetected (no pi home and no pi
- * CLI) or the source is absent — the link check only runs when both sides
- * exist. Link-only: pi has no enable command or config legs to converge.
+ * shipped `pi-genie` source. Pass when pi is undetected (no extensions dir and
+ * no pi CLI) or the source is absent — the link check only runs when both
+ * sides exist. The detection gate matches the agent-sync `pi` lane exactly
+ * (`syncPi`): extensions dir present OR pi CLI on PATH. Link-only: pi has no
+ * enable command or config legs to converge.
  */
 function checkPiSync(input: PiCheckInput): CheckResult[] {
   const { piRoot, piHome } = input;
-  const extensionsDir = resolvePiExtensionsDir(piHome);
-  if (!existsSync(piHome) && input.binary === null) {
+  const extensionsDir = resolvePiExtensionsDir(process.env, piHome);
+  if (!existsSync(extensionsDir) && input.binary === null) {
     return [{ name: 'agent sync: pi', status: 'pass', detail: 'not detected' }];
   }
   if (piRoot === null) {

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -5932,8 +5932,9 @@ function detectHermesBinary(opts: AgentSyncOptions): string | null {
  * discovery dir) onto the shipped `plugins/pi-genie` source. pi has no plugin
  * enable command — the extension auto-loads from the linked dir on next pi
  * start — so the lane is link-only, mirroring the hermes link leg without the
- * enable/config legs. Detection: pi home present OR `pi` CLI on PATH; a link
- * is created only when the `pi-genie` source ships next to `plugins/genie`.
+ * enable/config legs. Detection: the pi extensions dir present OR `pi` CLI on
+ * PATH; a link is created only when the `pi-genie` source ships next to
+ * `plugins/genie`.
  */
 function syncPi(ctx: RunContext, opts: AgentSyncOptions, report: AgentReport): void {
   const extensionsDir = ctx.targets.pi;

--- a/src/lib/genie-home.test.ts
+++ b/src/lib/genie-home.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { resolveCodexDir } from './genie-home.js';
+import { resolveCodexDir, resolvePiExtensionsDir, resolvePiHome } from './genie-home.js';
 
 describe('resolveCodexDir', () => {
   test('honors a non-empty override', () => {
@@ -13,6 +14,50 @@ describe('resolveCodexDir', () => {
     expect(resolveCodexDir({ CODEX_HOME: '' } as NodeJS.ProcessEnv, '/home/test')).toBe(join('/home/test', '.codex'));
     expect(resolveCodexDir({ CODEX_HOME: '   ' } as NodeJS.ProcessEnv, '/home/test')).toBe(
       join('/home/test', '.codex'),
+    );
+  });
+});
+
+describe('resolvePiHome', () => {
+  test('defaults to ~/.pi', () => {
+    expect(resolvePiHome({}, '/home/test')).toBe(join('/home/test', '.pi'));
+  });
+
+  test('honors the legacy $PI_HOME alias when non-empty', () => {
+    expect(resolvePiHome({ PI_HOME: '/custom/pi' } as NodeJS.ProcessEnv, '/home/test')).toBe('/custom/pi');
+  });
+
+  test('empty and whitespace-only $PI_HOME overrides fall back', () => {
+    expect(resolvePiHome({ PI_HOME: '' } as NodeJS.ProcessEnv, '/home/test')).toBe(join('/home/test', '.pi'));
+    expect(resolvePiHome({ PI_HOME: '   ' } as NodeJS.ProcessEnv, '/home/test')).toBe(join('/home/test', '.pi'));
+  });
+});
+
+describe('resolvePiExtensionsDir', () => {
+  test('defaults to <piHome>/agent/extensions', () => {
+    expect(resolvePiExtensionsDir({}, join('/home/test', '.pi'))).toBe(
+      join('/home/test', '.pi', 'agent', 'extensions'),
+    );
+  });
+
+  test('piHome derives from the legacy $PI_HOME alias when not passed explicitly', () => {
+    expect(resolvePiExtensionsDir({ PI_HOME: '/custom/pi' } as NodeJS.ProcessEnv)).toBe(
+      join('/custom/pi', 'agent', 'extensions'),
+    );
+  });
+
+  test('$PI_CODING_AGENT_DIR (pi real override) wins over any piHome', () => {
+    expect(
+      resolvePiExtensionsDir({ PI_CODING_AGENT_DIR: '/relocated/agent' } as NodeJS.ProcessEnv, join('/ignored', 'pi')),
+    ).toBe(join('/relocated', 'agent', 'extensions'));
+  });
+
+  test('$PI_CODING_AGENT_DIR is tilde-expanded exactly like pi expands it', () => {
+    expect(resolvePiExtensionsDir({ PI_CODING_AGENT_DIR: '~' } as NodeJS.ProcessEnv)).toBe(
+      join(homedir(), 'extensions'),
+    );
+    expect(resolvePiExtensionsDir({ PI_CODING_AGENT_DIR: '~/relocated/agent' } as NodeJS.ProcessEnv)).toBe(
+      join(homedir(), 'relocated', 'agent', 'extensions'),
     );
   });
 });

--- a/src/lib/genie-home.ts
+++ b/src/lib/genie-home.ts
@@ -2,7 +2,7 @@
  * Genie home + agent directory resolution.
  *
  * Every path the agent-sync engine reads or writes is derived from one of these
- * four roots. Each honors its conventional environment override so tests can
+ * roots. Each honors its conventional environment override so tests can
  * redirect ALL state into a tmpdir and never touch the real `$HOME`, and so
  * operators can relocate any one agent's config without moving the others.
  */
@@ -37,12 +37,28 @@ export function resolveHermesHome(): string {
   return process.env.HERMES_HOME || join(homedir(), '.hermes');
 }
 
-/** Pi agent config root — `$PI_HOME` or `~/.pi`. */
-export function resolvePiHome(): string {
-  return process.env.PI_HOME || join(homedir(), '.pi');
+/** Pi agent config root — `$PI_HOME` (legacy genie alias) or `~/.pi`. */
+export function resolvePiHome(env: NodeJS.ProcessEnv = process.env, home = homedir()): string {
+  const override = env.PI_HOME;
+  return typeof override === 'string' && override.trim().length > 0 ? override : join(home, '.pi');
 }
 
-/** Pi extension discovery dir — `<piHome>/agent/extensions`. */
-export function resolvePiExtensionsDir(home: string = resolvePiHome()): string {
-  return join(home, 'agent', 'extensions');
+/**
+ * Pi extension discovery dir — `<agentDir>/extensions`.
+ *
+ * The agent dir honors `$PI_CODING_AGENT_DIR` (pi's real relocation override,
+ * tilde-expanded exactly as pi expands it) before falling back to
+ * `<piHome>/agent`; `piHome` defaults to {@link resolvePiHome}. The legacy
+ * `$PI_HOME` alias stays accepted for genie tooling but never overrides pi's
+ * own variable, so a relocated pi is always converged where pi actually reads.
+ */
+export function resolvePiExtensionsDir(env: NodeJS.ProcessEnv = process.env, home?: string): string {
+  const agentDir = env.PI_CODING_AGENT_DIR ?? join(home ?? resolvePiHome(env), 'agent');
+  return join(expandTilde(agentDir), 'extensions');
+}
+
+function expandTilde(path: string, home = homedir()): string {
+  if (path === '~') return home;
+  if (path.startsWith('~/')) return join(home, path.slice(2));
+  return path;
 }


### PR DESCRIPTION
Review follow-up for PR #2743 (pi extension auto-sync). All findings from the #2743 review, verified against the real pi runtime:

## Fixes

1. **`PI_HOME` → `PI_CODING_AGENT_DIR`** (`src/lib/genie-home.ts`)
   pi's real relocation override is `PI_CODING_AGENT_DIR` (default `~/.pi/agent`) — `PI_HOME` does not exist in pi. Previously a relocated pi would get the link written where pi never reads it, silently dead, and doctor would still report it healthy.
   - `resolvePiExtensionsDir` now prefers `$PI_CODING_AGENT_DIR`, tilde-expanded exactly as pi expands it, falling back to `<piHome>/agent`.
   - `$PI_HOME` stays as a legacy genie alias but never overrides pi's own variable.
   - `resolvePiHome` follows the module's injectable `(env, home)` pattern (like `resolveCodexDir`) with empty-override guard.

2. **Doctor/sync detection gate mismatch** (`src/genie-commands/doctor.ts`)
   `checkPiSync` gated "not detected" on `~/.pi` existing, while `syncPi` gates on `~/.pi/agent/extensions` existing — so doctor could warn with a suggestion that runs and changes nothing. Both now gate on the extensions dir present OR pi CLI on PATH, making every doctor warning actionable.

3. **Stale `SYNC_SUGGESTION` copy** — now mentions pi ("Claude, Hermes and pi integrations").

4. **`whichBinary` Node fallback** in doctor.ts — matches the `execFileSync('which', …)` policy already used by `detectPiBinary`/`detectHermesBinary` in agent-sync.

5. **`install-local.sh` + README** — dev installer resolves the agent dir via `PI_CODING_AGENT_DIR` (tilde-expanded) with the `$PI_HOME` alias fallback, same policy as the auto-sync lane.

## Verification
- New unit tests: `genie-home.test.ts` (PI_HOME / PI_CODING_AGENT_DIR / tilde resolution), doctor gate test pinned to the extensions dir.
- Targeted suites: 571 pass / 4 fail — the 4 are the pre-existing codex-fallback fixture failures present on the base (verified against clean `origin/dev`).
- `bunx tsc --noEmit` clean; biome check clean (only the pre-existing `checkAgentSync` complexity warning); `bash -n` + end-to-end sandbox run of `install-local.sh` under both `PI_CODING_AGENT_DIR` and `PI_HOME`.
- Note: the full-suite failures (hook-bundle parity etc.) are local-environment artifacts (clone umask 002 → mode 775; bun build determinism), identical on the clean base — none touch pi/agent-sync/doctor.