### PR TITLE
fix(review): resolve PR #2743 review threads

### DIFF
--- a/.genie/wishes/lifecycle-lease-busy-grace/WISH.md
+++ b/.genie/wishes/lifecycle-lease-busy-grace/WISH.md
@@ -99,12 +99,12 @@ Group 2 depends on Group 1; one worker running the wave sequentially is acceptab
 7. Update the "ONE protocol, two acquirers" doc comment (`agent-sync.ts:6211-6229`) to record the deliberate one-sided divergence: TS steals fresh same-host dead locks; install.sh's `recover_stale_lifecycle_lock` (`install.sh:245-274`) remains staleness-gated. Note that `acquireRetirementLock` (`:3018`) inherits the early steal via `acquireFileLock` (benign — cross-host retirement refusal unchanged).
 
 **Acceptance Criteria:**
-- [ ] No `throw new Error(\`Another Genie lifecycle command is active…\`)` remains anywhere in `src/genie-commands/`.
-- [ ] Busy messages contain the lock path and no "(the holder converges the same targets)"; no stack trace reaches the terminal.
-- [ ] No `codex-lifecycle-busy` or `INSTALL_ACTION_REQUIRED` trailer is emitted for an agent-sync holder.
-- [ ] Borrow-mismatch (`LIFECYCLE_LEASE_PATH_ENV` set but stale/mismatched) fails without a single retry sleep.
-- [ ] Same-host dead-holder steal detects pid-reuse via start-identity (a reused pid is judged dead and stolen) and never steals cross-host or unknown-host records.
-- [ ] `setup`'s busy message no longer contains the false phrase (inherited from the source fix; `setup.test.ts:1152`'s `toContain('holds the lock')` still passes).
+- [x] No `throw new Error(\`Another Genie lifecycle command is active…\`)` remains anywhere in `src/genie-commands/`.
+- [x] Busy messages contain the lock path and no "(the holder converges the same targets)"; no stack trace reaches the terminal.
+- [x] No `codex-lifecycle-busy` or `INSTALL_ACTION_REQUIRED` trailer is emitted for an agent-sync holder.
+- [x] Borrow-mismatch (`LIFECYCLE_LEASE_PATH_ENV` set but stale/mismatched) fails without a single retry sleep.
+- [x] Same-host dead-holder steal detects pid-reuse via start-identity (a reused pid is judged dead and stolen) and never steals cross-host or unknown-host records.
+- [x] `setup`'s busy message no longer contains the false phrase (inherited from the source fix; `setup.test.ts:1152`'s `toContain('holds the lock')` still passes).
 
 **Validation:**
 ```bash
@@ -126,9 +126,9 @@ bun run typecheck && bun test src/lib/agent-sync.test.ts src/genie-commands/__te
 4. All waits driven by `GENIE_LIFECYCLE_LEASE_WAIT_MS` at millisecond scale — no test slower than ~1s.
 
 **Acceptance Criteria:**
-- [ ] Reverting any Group 1 projection or the steal reorder makes at least one new test fail.
-- [ ] Existing agent-sync report-wording tests pass unmodified.
-- [ ] `tests/integration/install-exit2-propagation.test.ts` passes unmodified.
+- [x] Reverting any Group 1 projection or the steal reorder makes at least one new test fail.
+- [x] Existing agent-sync report-wording tests pass unmodified.
+- [x] `tests/integration/install-exit2-propagation.test.ts` passes unmodified.
 
 **Validation:**
 ```bash
@@ -141,9 +141,9 @@ bun run check
 
 ## QA Criteria
 
-- [ ] Functional: with a second terminal holding the lease (paused `genie install`), `genie update` waits, then either completes (holder finished) or prints one clean line with the lock path and exits 2 — no Bun stack trace.
-- [ ] Functional: kill -9 a lease-holding command, immediately run `genie update` → it steals the dead lock and updates (the 2026-08-02 incident scenario).
-- [ ] Integration: uncontended `genie update` output and behavior unchanged (prompt before lease, delivery after).
+- [x] Functional: live holder → `update --sync-only` (dev-tip binary f7c4314b9, isolated GENIE_HOME sandbox, 2026-08-03) exited 2 with one clean line naming the real lock path, no stack trace, no false phrase.
+- [x] Functional: SIGKILLed holder with fresh-mtime lock → same sandbox run stole the lock in ~100ms (lock file gone) and the command completed exit 0 — the 2026-08-02 incident scenario, fixed.
+- [x] Integration: uncontended sandbox run exited 0 with normal sync output, no busy line.
 - [ ] Regression: `--post-delivery-converge` child still borrows the parent lease correctly (one end-to-end dev-build update).
 
 ---

--- a/plugins/pi-genie/README.md
+++ b/plugins/pi-genie/README.md
@@ -18,13 +18,24 @@ the pi extension **automatically**:
   finishing `genie install` aux-layout normalization), and
 - the agent-sync **`pi` lane** — run by `genie install` and every `genie update`
   — symlinks `~/.pi/agent/extensions/genie` → `$GENIE_HOME/plugins/pi-genie`
-  whenever pi is detected (pi CLI on PATH or the pi extensions dir present).
-  A relocated pi agent dir is honored: the lane targets `$PI_CODING_AGENT_DIR`
-  when set (pi's real override, tilde-expanded), falling back to
-  `~/.pi/agent`. The legacy `$PI_HOME` alias is still accepted.
+  whenever pi is detected (pi CLI on PATH or the pi **agent dir** present — pi
+  only creates `extensions/` when it installs a package, so detection roots one
+  level up; the lane creates `extensions/` when needed and pi discovers the link
+  on its next run). A relocated pi agent dir is honored: the lane targets
+  `$PI_CODING_AGENT_DIR` when set (pi's real override, tilde-expanded), falling
+  back to `~/.pi/agent`. The legacy `$PI_HOME` alias is still accepted.
 
-`genie doctor` reports the link as `agent sync: pi`. No manual step needed on
-fresh installs or updates.
+`genie doctor` reports the link as `agent sync: pi`. Auto-sync needs no manual
+step when `extensions/genie` is absent or already points at
+`$GENIE_HOME/plugins/pi-genie` (a real directory there is backed up and adopted).
+It never repoints a `genie` symlink aimed somewhere else — e.g. a dev checkout
+installed by `install-local.sh`. That case is preserved as-is and reported by
+`genie doctor` as an `agent sync: pi` warning; remediation is manual (remove or
+repoint your own link, then run `genie update`).
+
+`genie uninstall` removes the link the lane created — identity-checked, so a
+`genie` entry pointing at your own checkout (or a real directory) is left in
+place.
 
 For a dev checkout (edits are live) or a detached, release-style copy, the
 local installer remains available (it resolves the same way: `$PI_CODING_AGENT_DIR`

--- a/plugins/pi-genie/references/native-surface.md
+++ b/plugins/pi-genie/references/native-surface.md
@@ -12,7 +12,7 @@ tool is read-only; every payload reports `mutation: "none"`.
 | Session hook | `session_start` hint in Genie workspaces | `pi.on('session_start')` |
 | Context hook | Bounded board snapshot before each turn | `pi.on('before_agent_start')` (system-prompt append) |
 | Skills | pi-native discovery of `~/.agents/skills` / `.agents/skills`; opt-in canonical mirror via `GENIE_PI_CANONICAL_SKILLS=1` | `pi.on('resources_discover')` |
-| Agent sync | Auto-install: symlink `~/.pi/agent/extensions/genie` → `$GENIE_HOME/plugins/pi-genie`; doctor `agent sync: pi` | `runAgentSync` `pi` lane (`genie install` / `genie update` / `--sync-only`) |
+| Agent sync | Auto-install when detected (pi agent dir present OR pi CLI on PATH): symlink `~/.pi/agent/extensions/genie` → `$GENIE_HOME/plugins/pi-genie`; doctor `agent sync: pi`; identity-checked removal on `genie uninstall` | `runAgentSync` `pi` lane (`genie install` / `genie update` / `--sync-only`) |
 | Install | Dev fallback: `scripts/install-local.sh` (symlink default, `--copy` detached) | `~/.pi/agent/extensions/genie` |
 | Version | `plugins/pi-genie/package.json` synced by release machinery | `scripts/version.ts` |
 

--- a/src/genie-commands/__tests__/update.test.ts
+++ b/src/genie-commands/__tests__/update.test.ts
@@ -647,8 +647,10 @@ describe('updateCommand wiring', () => {
     const logSpy = spyOn(console, 'log').mockImplementation((...args: unknown[]) => stdout.push(args.join(' ')));
     const errorSpy = spyOn(console, 'error').mockImplementation((...args: unknown[]) => stderr.push(args.join(' ')));
     process.exitCode = undefined;
-    // Millisecond-scale so the bounded poll is exercised, not endured.
-    process.env.GENIE_LIFECYCLE_LEASE_WAIT_MS = '60';
+    // Millisecond-scale so the bounded poll is exercised, not endured. 500ms
+    // (not 60ms) so a GC/scheduler pause cannot collapse the 25ms poll loop to
+    // a single attempt and flake the `attempts > 1` assertion.
+    process.env.GENIE_LIFECYCLE_LEASE_WAIT_MS = '500';
     let attempts = 0;
     let thrown: unknown;
     try {

--- a/src/genie-commands/doctor.test.ts
+++ b/src/genie-commands/doctor.test.ts
@@ -507,6 +507,71 @@ describe('omni hook-timeout guardrail', () => {
   });
 });
 
+describe('doctorCommand — pi extension link (user-facing CLI surface)', () => {
+  /**
+   * Pin pi's own relocation override at the isolated home so no real `~/.pi` is
+   * read (Bun resolves `homedir()` independently of the `HOME` override).
+   * `await`s inside the window — restoring before the async doctor run would
+   * hand the real pi home back to the check.
+   */
+  async function withIsolatedPiAgentDir<T>(agentDir: string, run: () => Promise<T>): Promise<T> {
+    const prior = process.env.PI_CODING_AGENT_DIR;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    try {
+      return await run();
+    } finally {
+      if (prior === undefined) Reflect.deleteProperty(process.env, 'PI_CODING_AGENT_DIR');
+      else process.env.PI_CODING_AGENT_DIR = prior;
+    }
+  }
+
+  afterEach(() => {
+    process.exitCode = 0;
+  });
+
+  test('a detected pi install with no genie link warns non-fatally with the sync suggestion', async () => {
+    const genieHome = join(isolatedHome, 'genie');
+    mkdirSync(join(genieHome, 'plugins', 'genie', 'skills'), { recursive: true });
+    mkdirSync(join(genieHome, 'plugins', 'pi-genie'), { recursive: true });
+    writeFileSync(join(genieHome, 'VERSION'), '5.0.0\n', 'utf8');
+    const agentDir = join(isolatedHome, '.pi', 'agent');
+    mkdirSync(join(agentDir, 'extensions'), { recursive: true });
+
+    const { output, exitCode } = await withIsolatedPiAgentDir(agentDir, () =>
+      captureDoctor(() => doctorCommand({}, isolatedDoctorDeps())),
+    );
+
+    // Human-readable surface: the warn glyph, the check name, the actionable
+    // detail and the suggestion — and a warning never fails the command.
+    expect(output).toContain('agent sync: pi');
+    expect(output).toContain('extensions/genie link absent');
+    expect(output).toContain('genie update');
+    expect(output).toMatch(/!.*agent sync: pi/);
+    expect(exitCode).toBe(0);
+  });
+
+  test('a correct pi extension link passes and prints no pi warning', async () => {
+    const genieHome = join(isolatedHome, 'genie');
+    const piSource = join(genieHome, 'plugins', 'pi-genie');
+    mkdirSync(join(genieHome, 'plugins', 'genie', 'skills'), { recursive: true });
+    mkdirSync(piSource, { recursive: true });
+    writeFileSync(join(genieHome, 'VERSION'), '5.0.0\n', 'utf8');
+    const agentDir = join(isolatedHome, '.pi', 'agent');
+    mkdirSync(join(agentDir, 'extensions'), { recursive: true });
+    symlinkSync(piSource, join(agentDir, 'extensions', 'genie'));
+
+    const { output, exitCode } = await withIsolatedPiAgentDir(agentDir, () =>
+      captureDoctor(() => doctorCommand({ json: true }, isolatedDoctorDeps())),
+    );
+    const json = JSON.parse(output) as { checks: Array<{ name: string; status: string; detail?: string }> };
+    const pi = json.checks.find((check) => check.name === 'agent sync: pi');
+
+    expect(pi?.status).toBe('pass');
+    expect(pi?.detail).toContain('linked');
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe('doctorCommand — genie.db check branches', () => {
   // The db check resolves its path from the current repo root (git rev-parse),
   // so we drive doctorCommand inside a throwaway git repo to exercise the
@@ -1025,6 +1090,22 @@ describe('checkAgentSync', () => {
     const pi = find(checkAgentSync(paths()), 'agent sync: pi');
     expect(pi?.status).toBe('warn');
     expect(pi?.suggestion).toBeDefined();
+  });
+
+  // The detection gate is the pi AGENT dir (what pi always creates), not the
+  // `extensions` child (which pi only creates when installing a package) — and it
+  // must stay byte-identical to `syncPi`, so every warning here is repairable by
+  // the suggested sync. The pi home alone is still "not detected".
+  test('pi: agent dir without an extensions dir → warn (same gate as the sync lane)', () => {
+    mkdirSync(join(piHome, 'agent'), { recursive: true });
+    const pi = find(checkAgentSync(paths()), 'agent sync: pi');
+    expect(pi?.status).toBe('warn');
+    expect(pi?.suggestion).toBeDefined();
+  });
+
+  test('pi: pi home without an agent dir → not detected', () => {
+    mkdirSync(piHome, { recursive: true });
+    expect(find(checkAgentSync(paths()), 'agent sync: pi')?.detail).toBe('not detected');
   });
 
   // Codex Genie skills are plugin-only (R5): an EMPTY user tier is the healthy

--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -1406,16 +1406,18 @@ interface PiCheckInput {
 
 /**
  * pi health: the `~/.pi/agent/extensions/genie` symlink converging on the
- * shipped `pi-genie` source. Pass when pi is undetected (no extensions dir and
+ * shipped `pi-genie` source. Pass when pi is undetected (no agent dir and
  * no pi CLI) or the source is absent — the link check only runs when both
  * sides exist. The detection gate matches the agent-sync `pi` lane exactly
- * (`syncPi`): extensions dir present OR pi CLI on PATH. Link-only: pi has no
- * enable command or config legs to converge.
+ * (`syncPi`): pi AGENT dir present OR pi CLI on PATH — pi only creates
+ * `<agentDir>/extensions` when it installs a package resource, so gating on
+ * `extensions` here would report "not detected" for real installs the sync lane
+ * converges. Link-only: pi has no enable command or config legs to converge.
  */
 function checkPiSync(input: PiCheckInput): CheckResult[] {
   const { piRoot, piHome } = input;
   const extensionsDir = resolvePiExtensionsDir(process.env, piHome);
-  if (!existsSync(extensionsDir) && input.binary === null) {
+  if (!existsSync(dirname(extensionsDir)) && input.binary === null) {
     return [{ name: 'agent sync: pi', status: 'pass', detail: 'not detected' }];
   }
   if (piRoot === null) {

--- a/src/genie-commands/install.test.ts
+++ b/src/genie-commands/install.test.ts
@@ -1194,8 +1194,10 @@ describe('installCommand — a busy agent-sync lifecycle lease (2026-08-02 incid
 
   beforeEach(() => {
     process.exitCode = 0;
-    // Millisecond-scale: the bounded poll is exercised, not endured.
-    process.env.GENIE_LIFECYCLE_LEASE_WAIT_MS = '60';
+    // Millisecond-scale: the bounded poll is exercised, not endured. 500ms
+    // (not 60ms) so a GC/scheduler pause cannot collapse the 25ms poll loop to
+    // a single attempt and flake the `attempts > 1` assertion.
+    process.env.GENIE_LIFECYCLE_LEASE_WAIT_MS = '500';
     logs = [];
     errors = [];
     logSpy = spyOn(console, 'log').mockImplementation((...a: unknown[]) => {

--- a/src/genie-commands/install.ts
+++ b/src/genie-commands/install.ts
@@ -30,7 +30,11 @@ import {
 } from '../lib/codex-lifecycle-lease.js';
 import { genieConfigExists, getGenieConfigPath } from '../lib/genie-config.js';
 import { retireInstallVersionMarker } from '../lib/install-version-marker.js';
-import { acquireOrderedLifecycleLeases, releaseOrderedLifecycleLeases } from '../lib/ordered-lifecycle-leases.js';
+import {
+  acquireOrderedLifecycleLeases,
+  lifecycleBusyMessage,
+  releaseOrderedLifecycleLeases,
+} from '../lib/ordered-lifecycle-leases.js';
 import {
   type InstallIntegrationsOptions,
   type IntegrationResult,
@@ -411,7 +415,7 @@ export async function installCommand(
       // install.sh parses those machine trailers, and reporting
       // `codex-lifecycle-busy` for an agent-sync holder would be a lie. One
       // human-readable stderr line plus exit 2 is the whole contract here.
-      console.error(`Another Genie lifecycle command is active: ${acquired.detail}`);
+      console.error(lifecycleBusyMessage(acquired.detail));
       process.exitCode = 2;
       return;
     }

--- a/src/genie-commands/uninstall.test.ts
+++ b/src/genie-commands/uninstall.test.ts
@@ -91,12 +91,13 @@ describe('agent-sync managed-asset removal', () => {
   let codexDir: string;
   let agentsSkillsDir: string;
   let hermesHome: string;
+  let piExtensionsDir: string;
   let genieHome: string;
 
   const fixedNow = () => new Date('2026-07-11T12:00:00.000Z');
 
   function targets() {
-    return { claudeDir, codexDir, agentsSkillsDir, hermesHome, genieHome, now: fixedNow };
+    return { claudeDir, codexDir, agentsSkillsDir, hermesHome, piExtensionsDir, genieHome, now: fixedNow };
   }
 
   function withIsolatedHomes<T>(run: () => T): T {
@@ -198,8 +199,10 @@ describe('agent-sync managed-asset removal', () => {
     codexDir = join(tmp, 'codex');
     agentsSkillsDir = join(tmp, 'agents', 'skills');
     hermesHome = join(tmp, 'hermes');
+    piExtensionsDir = join(tmp, 'pi', 'agent', 'extensions');
     genieHome = join(tmp, 'genie');
     mkdirSync(join(genieHome, 'plugins', 'hermes-genie'), { recursive: true });
+    mkdirSync(join(genieHome, 'plugins', 'pi-genie'), { recursive: true });
   });
 
   afterEach(() => {
@@ -622,6 +625,48 @@ describe('agent-sync managed-asset removal', () => {
     symlinkSync(elsewhere, link);
     expect(removeAgentSyncAssets(targets()).removed).not.toContain(link);
     expect(existsSync(link)).toBe(true);
+  });
+
+  // Regression (PR #2743 review): the agent-sync `pi` lane auto-creates
+  // `<pi agent dir>/extensions/genie` → `$GENIE_HOME/plugins/pi-genie`. Uninstall
+  // removes GENIE_HOME, so without this collection every auto-installed pi user
+  // keeps a dangling symlink. Same identity rule as hermes: only ours is removed.
+  test('pi extensions symlink into the genie home is removed; one pointing elsewhere is kept', () => {
+    mkdirSync(piExtensionsDir, { recursive: true });
+    const link = join(piExtensionsDir, 'genie');
+    symlinkSync(join(genieHome, 'plugins', 'pi-genie'), link);
+
+    expect(removeAgentSyncAssets(targets()).removed).toContain(link);
+    expect(existsSync(link)).toBe(false);
+
+    // A user's own link at the same path (dev checkout) is never ours to delete.
+    const elsewhere = join(tmp, 'my-own-pi-extension');
+    mkdirSync(elsewhere, { recursive: true });
+    symlinkSync(elsewhere, link);
+    expect(removeAgentSyncAssets(targets()).removed).not.toContain(link);
+    expect(existsSync(link)).toBe(true);
+  });
+
+  test('a real (non-symlink) dir at the pi extensions/genie path is never removed', () => {
+    mkdirSync(join(piExtensionsDir, 'genie'), { recursive: true });
+    const path = join(piExtensionsDir, 'genie');
+    writeFileSync(join(path, 'package.json'), '{}', 'utf8');
+
+    expect(removeAgentSyncAssets(targets()).removed).not.toContain(path);
+    expect(existsSync(path)).toBe(true);
+  });
+
+  test('identity-bound removal proceeds for a matching pi link', () => {
+    mkdirSync(piExtensionsDir, { recursive: true });
+    const link = join(piExtensionsDir, 'genie');
+    symlinkSync(join(genieHome, 'plugins', 'pi-genie'), link);
+    const asset = collectAgentSyncAssets(targets()).find((a) => a.path === link);
+    if (asset?.identity?.kind !== 'link') throw new Error('expected a link identity for the pi symlink');
+
+    const result = removeAgentSyncAssets(targets(), { plannedAssets: [{ path: link, identity: asset.identity }] });
+
+    expect(result.removed).toContain(link);
+    expect(existsSync(link)).toBe(false);
   });
 
   test('all owned Hermes profile links are removed, not only the main link', () => {
@@ -2602,7 +2647,10 @@ describe('uninstallCommand — warning, lifecycle lease, isolation (Group D)', (
     // operator whose other lifecycle command held the lease got a stack trace
     // instead of an explanation — and no assurance that nothing was removed.
     const priorWait = process.env.GENIE_LIFECYCLE_LEASE_WAIT_MS;
-    process.env.GENIE_LIFECYCLE_LEASE_WAIT_MS = '60'; // millisecond-scale bounded poll
+    // Millisecond-scale bounded poll; 500ms (not 60ms) so a GC/scheduler pause
+    // cannot collapse the 25ms poll loop to a single attempt and flake the
+    // `attempts > 1` assertion.
+    process.env.GENIE_LIFECYCLE_LEASE_WAIT_MS = '500';
     const lockPath = '/fixture/home/.genie-lifecycle-0123456789abcdef.lock';
     let attempts = 0;
     let thrown: unknown;

--- a/src/genie-commands/uninstall.ts
+++ b/src/genie-commands/uninstall.ts
@@ -76,10 +76,17 @@ import {
   acquireLifecycleLease as acquireCodexLifecycleLease,
 } from '../lib/codex-lifecycle-lease.js';
 import { contractPath, getGenieDir } from '../lib/genie-config.js';
-import { resolveClaudeDir, resolveCodexDir, resolveGenieHome, resolveHermesHome } from '../lib/genie-home.js';
+import {
+  resolveClaudeDir,
+  resolveCodexDir,
+  resolveGenieHome,
+  resolveHermesHome,
+  resolvePiExtensionsDir,
+} from '../lib/genie-home.js';
 import {
   type HeldOrderedLifecycleLeases,
   acquireOrderedLifecycleLeases,
+  lifecycleBusyMessage,
   releaseOrderedLifecycleLeases,
 } from '../lib/ordered-lifecycle-leases.js';
 import {
@@ -506,6 +513,7 @@ function assertUninstallBatchLocation(genieHome: string, journalPath: string): v
     codexLegacyCuratedDir(resolveCodexDir()),
     join(resolveCodexDir(), 'agents'),
     join(resolveHermesHome(), 'plugins'),
+    resolvePiExtensionsDir(),
     LOCAL_BIN,
     join(recoveryRoot, 'uninstall-v4'),
   ];
@@ -1089,6 +1097,8 @@ export interface AgentSyncRemovalTargets {
   /** Shared `~/.agents/skills` tier codex skills are synced into (detection root stays `codexDir`). */
   agentsSkillsDir?: string;
   hermesHome?: string;
+  /** pi's extension discovery dir — parent of the auto-synced `extensions/genie` link. */
+  piExtensionsDir?: string;
   genieHome?: string;
   /** Injectable clock for deterministic state-backup and kept-aside paths in tests. */
   now?: () => Date;
@@ -1123,6 +1133,7 @@ function retainedRemovalQuarantines(targets: AgentSyncRemovalTargets = {}): stri
     LOCAL_BIN,
     join(claudeDir, 'rules'),
     join(hermesHome, 'plugins'),
+    targets.piExtensionsDir ?? resolvePiExtensionsDir(),
     dirname(uninstallBatchJournalPath(genieHome)),
     genieCaptureParent,
   ]);
@@ -1266,7 +1277,7 @@ export function recoverUninstallTransactions(targets: AgentSyncRemovalTargets = 
 const LEGACY_KEPT_MARKER = '.genie-kept';
 
 interface AgentSyncAsset {
-  agent: 'claude' | 'codex' | 'hermes';
+  agent: 'claude' | 'codex' | 'hermes' | 'pi';
   kind: 'skill' | 'agent' | 'workflow' | 'link';
   path: string;
   /** True when content diverged or ownership metadata is corrupt; uninstall preserves it. */
@@ -1432,10 +1443,15 @@ function collectManagedCouncil(claudeDir: string, out: AgentSyncAsset[], restric
   });
 }
 
-/** The hermes plugin link is ours only when the symlink resolves into the genie home. */
-function collectHermesLinkPath(
+/**
+ * A synced plugin link (hermes `plugins/genie`, pi `extensions/genie`) is ours
+ * only when the symlink resolves into the genie home. A user's own link pointing
+ * at a dev checkout, and any real dir/file at the same path, are never collected.
+ */
+function collectPluginLinkPath(
   linkPath: string,
   genieHome: string,
+  agent: AgentSyncAsset['agent'],
   out: AgentSyncAsset[],
   restrictToPaths?: ReadonlySet<string>,
 ): void {
@@ -1459,7 +1475,7 @@ function collectHermesLinkPath(
     // pointer before unlinking a symlink the user may have repointed since.
     if (isSameOrContainedPath(home, resolved)) {
       out.push({
-        agent: 'hermes',
+        agent,
         kind: 'link',
         path: linkPath,
         identity: { kind: 'link', target, identity: physicalRootIdentity(after) },
@@ -1476,7 +1492,7 @@ function collectHermesLinks(
   out: AgentSyncAsset[],
   restrictToPaths?: ReadonlySet<string>,
 ): void {
-  collectHermesLinkPath(join(hermesHome, 'plugins', 'genie'), genieHome, out, restrictToPaths);
+  collectPluginLinkPath(join(hermesHome, 'plugins', 'genie'), genieHome, 'hermes', out, restrictToPaths);
   const profilesRoot = join(hermesHome, 'profiles');
   let entries: Dirent[];
   try {
@@ -1489,12 +1505,12 @@ function collectHermesLinks(
     if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(entry.name) || entry.name === '.' || entry.name === '..') continue;
     const profileRoot = resolve(profilesRoot, entry.name);
     if (!isSameOrContainedPath(profilesRoot, profileRoot)) continue;
-    collectHermesLinkPath(join(profileRoot, 'plugins', 'genie'), genieHome, out, restrictToPaths);
+    collectPluginLinkPath(join(profileRoot, 'plugins', 'genie'), genieHome, 'hermes', out, restrictToPaths);
   }
 }
 
 /**
- * Read-only scan for genie-managed agent assets (skills, stamped council.js, hermes link).
+ * Read-only scan for genie-managed agent assets (skills, stamped council.js, hermes/pi links).
  * `restrictToPaths` (resolved paths) bounds the scan to those exact objects, so a
  * batch removing N members re-inspects only each planned path instead of digesting
  * every managed dir once per member. Classification of each returned path is
@@ -1532,11 +1548,23 @@ export function inspectAgentSyncAssets(
   collectManagedSkillDirs(codexLegacyCuratedDir(codexDir), 'codex', out, restrictToPaths);
   collectManagedCouncil(claudeDir, out, restrictToPaths);
   collectHermesLinks(hermesHome, genieHome, out, restrictToPaths);
+  // The agent-sync `pi` lane auto-creates `<pi agent dir>/extensions/genie` →
+  // `$GENIE_HOME/plugins/pi-genie`. Uninstall removes GENIE_HOME, so the link
+  // must be collected here or every auto-installed pi user keeps a dangling
+  // symlink. Identity-checked exactly like the hermes link: only a symlink that
+  // resolves INTO the genie home is ours.
+  collectPluginLinkPath(
+    join(targets.piExtensionsDir ?? resolvePiExtensionsDir(), 'genie'),
+    genieHome,
+    'pi',
+    out,
+    restrictToPaths,
+  );
   return { assets: out, claudeAgentManifest };
 }
 
 export interface AgentSyncRemovalResult {
-  /** Assets deleted outright (digest-clean skills, stamped council.js, hermes link). */
+  /** Assets deleted outright (digest-clean skills, stamped council.js, hermes/pi links). */
   removed: string[];
   /** User-modified/corrupt-metadata/identity-mismatched assets preserved byte-identically at their paths. */
   kept: string[];
@@ -1553,7 +1581,7 @@ export interface AgentSyncRemovalResult {
 export interface AgentSyncRemovalOptions {
   beforeManagedDirRemoval?: (destDir: string, stage: 'before-park' | 'before-delete') => void;
   beforeWorkflowRemoval?: (stage: 'before-park' | 'before-delete') => void;
-  /** Deterministic boundary after a Hermes link is proven and before atomic capture. */
+  /** Deterministic boundary after a plugin link (hermes/pi) is proven and before atomic capture. */
   beforeManagedLinkCapture?: (path: string) => void;
   /**
    * Durable uninstall-batch allowlist with the recorded identity per planned path.
@@ -1664,7 +1692,7 @@ function recordAgentAssetDisposition(
   if (disposition === 'kept-identity-mismatch') result.identityMismatch.push(path);
 }
 
-/** Atomically capture and remove only the exact recorded Hermes link inode. */
+/** Atomically capture and remove only the exact recorded plugin-link (hermes/pi) inode. */
 function removeManagedLink(
   linkPath: string,
   expected: Extract<AgentAssetIdentity, { kind: 'link' }> | undefined,
@@ -1699,13 +1727,13 @@ function removeManagedLink(
   const capture = captureExpectedRemovalPath(
     linkPath,
     expected?.identity ?? liveIdentity,
-    'hermes-link',
+    'plugin-link',
     beforeCapture,
   );
   const capturedStat = lstatSync(capture.capturedPath);
   const capturedTarget = capturedStat.isSymbolicLink() ? readlinkSync(capture.capturedPath) : null;
   if (!capturedStat.isSymbolicLink() || capturedTarget !== (expected?.target ?? liveTarget)) {
-    restoreCapturedNoClobber(capture, `captured Hermes link content changed: ${linkPath}`);
+    restoreCapturedNoClobber(capture, `captured plugin link content changed: ${linkPath}`);
   }
   deleteCapturedRemovalPath(capture);
   result.removed.push(linkPath);
@@ -3493,9 +3521,7 @@ function acquireUninstallLifecycleLeasesOrProject(
     // An agent-sync holder is NOT `codex-lifecycle-busy`: no machine trailer is
     // emitted here, because install.sh parses that code and would be misled
     // about which subsystem is holding the lease. One stderr line, exit 2.
-    console.error(
-      `Another Genie lifecycle command is active: ${acquired.detail}. No files were removed; retry once it completes.`,
-    );
+    console.error(lifecycleBusyMessage(acquired.detail, '. No files were removed; retry once it completes.'));
     process.exitCode = 2;
     return null;
   }
@@ -3557,7 +3583,7 @@ export async function uninstallCommand(
   const removableAssets = agentAssets.length - keptAssets.length;
   if (removableAssets > 0)
     console.log(
-      `  \x1b[31m-\x1b[0m Synced agent assets: ${removableAssets} managed skill dir(s)/agent file(s)/council.js/hermes link across claude/codex/hermes`,
+      `  \x1b[31m-\x1b[0m Synced agent assets: ${removableAssets} managed skill dir(s)/agent file(s)/council.js/plugin link(s) across claude/codex/hermes/pi`,
     );
   if (keptAssets.length > 0) {
     console.log(

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -62,6 +62,7 @@ import { retireInstallVersionMarker } from '../lib/install-version-marker.js';
 import {
   type HeldOrderedLifecycleLeases,
   acquireOrderedLifecycleLeases,
+  lifecycleBusyMessage,
   releaseOrderedLifecycleLeases,
 } from '../lib/ordered-lifecycle-leases.js';
 import {
@@ -1657,17 +1658,6 @@ function resolveUpdatePlatformOrExit(): string {
     error(err instanceof Error ? err.message : String(err));
     process.exit(1);
   }
-}
-
-/**
- * The one busy sentence every update path prints for an agent-sync holder. It
- * carries the acquirer's own (path-naming) detail forward and is deliberately
- * NOT a Codex refusal: no `codex-lifecycle-busy` code and no machine trailer,
- * because install.sh parses those and would be told a falsehood about which
- * subsystem is busy.
- */
-function lifecycleBusyMessage(detail: string): string {
-  return `Another Genie lifecycle command is active: ${detail}`;
 }
 
 /**

--- a/src/lib/agent-sync.test.ts
+++ b/src/lib/agent-sync.test.ts
@@ -310,6 +310,22 @@ describe('fresh create', () => {
     expect(extraAction(report, 'enable')).toBeUndefined();
   });
 
+  // Regression (PR #2743 review): pi only creates `<agentDir>/extensions` when it
+  // installs a package resource, so a real pi install that never installed one has
+  // the agent dir and NO extensions dir. Detection roots at the agent dir, so this
+  // first-run install is still converged with the pi CLI absent from PATH — the
+  // extensions dir is created and pi discovers the link on its next run.
+  test('pi: agent dir present without an extensions dir still creates the link (no pi on PATH)', () => {
+    present(join(fixture.piHome, 'agent'));
+    const report = agentReport(run(), 'pi');
+
+    expect(report.detected).toBe(true);
+    const link = join(fixture.piHome, 'agent', 'extensions', 'genie');
+    expect(lstatSync(link).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(link)).toBe(fixture.piSource);
+    expect(extraAction(report, 'symlink')).toBe('created');
+  });
+
   test('report carries the resolved source metadata', () => {
     present(fixture.claudeDir);
     const report = run();

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -5940,14 +5940,24 @@ function detectHermesBinary(opts: AgentSyncOptions): string | null {
  * discovery dir) onto the shipped `plugins/pi-genie` source. pi has no plugin
  * enable command — the extension auto-loads from the linked dir on next pi
  * start — so the lane is link-only, mirroring the hermes link leg without the
- * enable/config legs. Detection: the pi extensions dir present OR `pi` CLI on
- * PATH; a link is created only when the `pi-genie` source ships next to
- * `plugins/genie`.
+ * enable/config legs. Detection: the pi AGENT dir present OR `pi` CLI on PATH.
+ *
+ * Detection deliberately roots at the agent dir (`dirname` of the extensions
+ * target), not at `extensions` itself: pi only ever creates `<agentDir>/extensions`
+ * when it installs a package resource, so a real pi install that never installed
+ * one has `<agentDir>` (auth.json, sessions, settings.json) and no `extensions`.
+ * Gating on `extensions` would silently skip those installs whenever pi is also
+ * absent from this process's PATH (GUI/hook launches with a truncated PATH).
+ * Creating the dir is safe: pi tolerates a missing extensions dir and discovers
+ * the symlinked extension inside it on its next run. `genie doctor`'s
+ * `checkPiSync` gate must stay identical so every warning is repairable by sync.
+ *
+ * A link is created only when the `pi-genie` source ships next to `plugins/genie`.
  */
 function syncPi(ctx: RunContext, opts: AgentSyncOptions, report: AgentReport): void {
   const extensionsDir = ctx.targets.pi;
   const binary = detectPiBinary(opts);
-  if (!existsSync(extensionsDir) && binary === null) return;
+  if (!existsSync(dirname(extensionsDir)) && binary === null) return;
   report.detected = true;
   if (ctx.piRoot === null) {
     report.advisories.push('pi source (pi-genie) not found next to plugins/genie; skipping link');

--- a/src/lib/ordered-lifecycle-leases.ts
+++ b/src/lib/ordered-lifecycle-leases.ts
@@ -25,6 +25,22 @@ export type OrderedLifecycleLeaseAcquisition =
 export type HeldOrderedLifecycleLeases = Extract<OrderedLifecycleLeaseAcquisition, { ok: true }>;
 
 /**
+ * The one busy sentence every lifecycle path prints for an agent-sync holder.
+ * It carries the acquirer's own (path-naming) detail forward and is deliberately
+ * NOT a Codex refusal: no `codex-lifecycle-busy` code and no machine trailer,
+ * because install.sh parses those and would be told a falsehood about which
+ * subsystem is busy.
+ *
+ * Three consumers: `update.ts` (no suffix), `install.ts` (no suffix), and
+ * `uninstall.ts` (suffix ` No files were removed; retry once it completes.`).
+ * Tests in `__tests__/update.test.ts`, `install.test.ts`, and `uninstall.test.ts`
+ * assert this exact prefix — keep the output byte-identical.
+ */
+export function lifecycleBusyMessage(detail: string, suffix?: string): string {
+  return `Another Genie lifecycle command is active: ${detail}${suffix ?? ''}`;
+}
+
+/**
  * Acquire the process-wide agent-sync lease before the Codex lifecycle lease.
  * A Codex loser releases the already-held outer lease before returning busy.
  */


### PR DESCRIPTION
Round-2 follow-up resolving all 11 unresolved bot review threads on #2743 (dev→main). Every finding was verified against current dev (post-#2746) and, for pi behavior, against the real pi runtime installed on this host before fixing or declining.

## Fixed

**Pi integration**
- **Detection gap (codex-connector P2 + 2× CodeRabbit Major)**: pi creates `<agentDir>/extensions` only during package installs (`package-manager.js:1611,1623`) and tolerates its absence — so a real, package-less pi install has an agent dir but no `extensions/`, and with pi off PATH the old gate silently skipped it. Sync and doctor now detect from the agent dir (or pi on PATH), keeping the #2746 sync/doctor alignment. Regression tests incl. agent-dir-without-extensions and pi-home-without-agent-dir.
- **Uninstall dangling link (codex-connector P2)**: `genie uninstall` now collects `<piExtensionsDir>/genie` with the same identity rule as hermes links (only symlinks resolving into GENIE_HOME); collector generalized `hermes-link` → `plugin-link`. Tests: ours removed, foreign link kept, real dir never removed.
- **README overclaim (CodeRabbit Minor)**: auto-sync claim scoped to absent-or-already-correct targets; conflicts route to `genie doctor`.
- **Doctor CLI coverage (CodeRabbit Major)**: two CLI-level tests through the existing `captureDoctor` harness (warn surface for detected-but-unlinked; linked state via `--json`).

**Lifecycle (follow-ups to #2745)**
- **Busy-message triplication (CodeRabbit Major)**: one exported `lifecycleBusyMessage(detail, suffix?)` in `src/lib/ordered-lifecycle-leases.ts`, consumed by update/install/uninstall; output byte-identical.
- **Flaky 60ms deadlines (CodeRabbit Minor)**: busy-holder tests now use 500ms (25ms poll; a GC pause could collapse the loop to one attempt and break `attempts > 1`).
- **WISH state (CodeRabbit Major)**: checkboxes reconciled with evidence — QA run against the dev-tip binary in an isolated GENIE_HOME sandbox (live holder → clean exit 2 naming the lock path; SIGKILLed holder with fresh lock → stolen in ~100ms, command proceeds; uncontended unchanged).

## Declined (with evidence, in thread replies)
- `ensurePluginLink` symlink-publication window: pre-existing hermes-lane sequence (dbe5a829a); backups are copies, `runAgentSafe` converts the throw to a reported failure, and an atomic-publish refactor needs the no-clobber machinery — separate cross-agent work.
- describe-body `process.exitCode` capture: the file's own pre-existing convention (HEAD:1189).

## Validation
- `bun run check`: all non-test gates pass; full `bun test` 2997 pass / 14 fail — byte-identical to the pre-existing env-conditioned baseline verified at HEAD in a detached worktree.
- Scoped suites for every touched file: 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)