### PR TITLE
fix(pi): treat empty or whitespace pi env overrides as absent

### DIFF
--- a/plugins/pi-genie/scripts/install-local.sh
+++ b/plugins/pi-genie/scripts/install-local.sh
@@ -46,14 +46,22 @@ plugin_src="$(cd "$script_dir/.." && pwd)"
 
 # Resolve the pi agent dir the same way pi does: $PI_CODING_AGENT_DIR (real
 # relocation override, tilde-expanded) or $PI_HOME/agent (legacy alias).
-if [ -n "${PI_CODING_AGENT_DIR:-}" ]; then
+# An empty or whitespace-only override is treated as unset: it would otherwise
+# resolve to a cwd-relative "extensions" path and mutate the wrong directory.
+pi_agent_dir_trimmed="$(printf '%s' "${PI_CODING_AGENT_DIR:-}" | tr -d '[:space:]')"
+pi_home_trimmed="$(printf '%s' "${PI_HOME:-}" | tr -d '[:space:]')"
+if [ -n "$pi_agent_dir_trimmed" ]; then
   agent_dir="$PI_CODING_AGENT_DIR"
   case "$agent_dir" in
     "~") agent_dir="$HOME" ;;
     "~/"*) agent_dir="$HOME/${agent_dir#\~/}" ;;
   esac
 else
-  pi_home="${PI_HOME:-$HOME/.pi}"
+  if [ -n "$pi_home_trimmed" ]; then
+    pi_home="$PI_HOME"
+  else
+    pi_home="$HOME/.pi"
+  fi
   agent_dir="$pi_home/agent"
 fi
 extensions_dir="$agent_dir/extensions"

--- a/src/lib/genie-home.test.ts
+++ b/src/lib/genie-home.test.ts
@@ -60,4 +60,16 @@ describe('resolvePiExtensionsDir', () => {
       join(homedir(), 'relocated', 'agent', 'extensions'),
     );
   });
+
+  test('empty or whitespace-only $PI_CODING_AGENT_DIR falls back to <piHome>/agent', () => {
+    expect(resolvePiExtensionsDir({ PI_CODING_AGENT_DIR: '' } as NodeJS.ProcessEnv, join('/home/test', '.pi'))).toBe(
+      join('/home/test', '.pi', 'agent', 'extensions'),
+    );
+    expect(resolvePiExtensionsDir({ PI_CODING_AGENT_DIR: '   ' } as NodeJS.ProcessEnv, join('/home/test', '.pi'))).toBe(
+      join('/home/test', '.pi', 'agent', 'extensions'),
+    );
+    expect(resolvePiExtensionsDir({ PI_CODING_AGENT_DIR: '  ', PI_HOME: '/custom/pi' } as NodeJS.ProcessEnv)).toBe(
+      join('/custom/pi', 'agent', 'extensions'),
+    );
+  });
 });

--- a/src/lib/genie-home.ts
+++ b/src/lib/genie-home.ts
@@ -53,7 +53,9 @@ export function resolvePiHome(env: NodeJS.ProcessEnv = process.env, home = homed
  * own variable, so a relocated pi is always converged where pi actually reads.
  */
 export function resolvePiExtensionsDir(env: NodeJS.ProcessEnv = process.env, home?: string): string {
-  const agentDir = env.PI_CODING_AGENT_DIR ?? join(home ?? resolvePiHome(env), 'agent');
+  const override = env.PI_CODING_AGENT_DIR;
+  const agentDir =
+    typeof override === 'string' && override.trim().length > 0 ? override : join(home ?? resolvePiHome(env), 'agent');
   return join(expandTilde(agentDir), 'extensions');
 }
 


### PR DESCRIPTION
Round-3 follow-up for the two remaining #2743 threads (both verified valid):

- `resolvePiExtensionsDir`: `PI_CODING_AGENT_DIR=''` passed the `??` and resolved a **cwd-relative** `extensions` dir, so doctor/sync could inspect or mutate the wrong directory. Now uses the same trim guard as `resolvePiHome`. Regression tests: empty / whitespace-only / whitespace+`PI_HOME` fall back to `<piHome>/agent/extensions`.
- `install-local.sh`: whitespace-only `PI_CODING_AGENT_DIR` or `PI_HOME` built relative paths under cwd; both are now trimmed for the presence test (untrimmed value still used when non-blank, preserving interior spaces and tilde expansion).

Validation: typecheck clean; `genie-home.test.ts` 10/10; `bash -n` clean; traced shell resolution for all five env permutations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)