### PR TITLE
fix(release): re-align committed kimi plugin manifest to 5.260805.1

### DIFF
--- a/plugins/genie/.kimi-plugin/plugin.json
+++ b/plugins/genie/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260803.6",
+  "version": "5.260805.1",
   "description": "Human-AI partnership for Kimi Code CLI. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /genie:work, validate with /genie:review, and ship as one team.",
   "author": {
     "name": "Namastex Labs",


### PR DESCRIPTION
## Problem

Every PR against `dev` fails the Build jobs:

```
release-payload-version: FAIL — committed version mismatch in plugins/genie/.kimi-plugin/plugin.json: expected 5.260805.1, got 5.260803.6
```

PR #2736 (kimi plugin) wired `plugins/genie/.kimi-plugin/plugin.json` into `scripts/version.ts` and the `release-payload-version` gate, but the in-PR package.json bump to 5.260805.1 (5d67d00f0) never re-synced the new manifest, which stayed at the version it was created with (5.260803.6).

## Fix

Bump the committed kimi manifest version to match package.json. Future auto-version bumps already cover this file via `version.ts` (added in 857c3d7c6), so this is a one-time alignment.

## Validation

- `bun scripts/release-payload-version.ts --verify-source .` → `release-payload-version: OK (verify-source 5.260805.1)` (this is the exact gate that failed in CI)
- `bun test scripts/release-payload-version.test.ts` → 5 pass, 0 fail

Unblocks Build jobs for #2752 and #2755.