### PR TITLE
fix(task-state): serialize assign/wish identity writes inside their immediate transactions

### DIFF
--- a/src/lib/v5/task-state.test.ts
+++ b/src/lib/v5/task-state.test.ts
@@ -1488,6 +1488,98 @@ try {
   }, 30_000);
 });
 
+// ---------------------------------------------------------------------------
+// Multi-PROCESS assignTask/clearTaskAssignment race: concurrent routing writers
+// on one card. Each writer's no-op decision and each clear's `was …` note must
+// come from the row state its OWN immediate transaction serialized against — a
+// stale pre-transaction read would let a clear name a pair that was no longer
+// current (or double-clear an already-cleared card). Replaying the assign/clear
+// timeline must therefore reproduce the final row exactly, and every clear's
+// `was` must equal the pair the replay says was current.
+// ---------------------------------------------------------------------------
+describe('multi-process assignTask/clearTaskAssignment concurrency', () => {
+  test('concurrent routing writers serialize into a replayable assign/clear timeline', async () => {
+    const dbPath = join(dir, 'assign-race.db');
+    const seedDb = openDb({ path: dbPath });
+    const card = createTask(seedDb, { title: 'contested routing card' });
+    seedDb.close(); // checkpoint so child processes see a committed, current schema
+
+    const gdbPath = join(import.meta.dir, 'genie-db.ts');
+    const tsPath = join(import.meta.dir, 'task-state.ts');
+    const workerPath = join(dir, 'assign-worker.ts');
+    writeFileSync(
+      workerPath,
+      `
+import { openDb } from ${JSON.stringify(gdbPath)};
+import { ROSTER, assignTask, clearTaskAssignment } from ${JSON.stringify(tsPath)};
+const [dbPath, taskId, op, idx] = process.argv.slice(2);
+const db = openDb({ path: dbPath });
+try {
+  if (op === 'clear') clearTaskAssignment(db, taskId, { author: 'racer-' + idx, authorKind: 'codex' });
+  else assignTask(db, taskId, ROSTER[Number(idx) % ROSTER.length], 'race-reason-' + idx, { author: 'racer-' + idx, authorKind: 'codex' });
+  process.stdout.write('OK');
+} catch (e) {
+  process.stdout.write('ERR:' + (e && e.message));
+  process.exitCode = 3;
+} finally {
+  db.close();
+}
+`,
+    );
+
+    const N = 9;
+    const runs = Array.from({ length: N }, (_, i) => {
+      const proc = Bun.spawn(['bun', 'run', workerPath, dbPath, card.id, i % 3 === 2 ? 'clear' : 'assign', String(i)], {
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+      return (async () => {
+        const out = await new Response(proc.stdout).text();
+        const err = await new Response(proc.stderr).text();
+        const code = await proc.exited;
+        return { out, err, code };
+      })();
+    });
+
+    const settled = await Promise.allSettled(runs);
+    const outcomes = settled.map((s) =>
+      s.status === 'fulfilled' ? `${s.value.out}(exit ${s.value.code})` : `REJECTED:${s.reason}`,
+    );
+    const ok = outcomes.filter((o) => o.startsWith('OK')).length;
+    if (ok !== N) console.error('assign-race outcomes:', JSON.stringify(outcomes));
+    // Every writer committed cleanly — no SQLITE_BUSY leak, no stale-read failure.
+    expect(ok).toBe(N);
+    expect(outcomes.some((o) => o.includes('SQLITE_BUSY'))).toBe(false);
+
+    const verify = openDb({ path: dbPath });
+    try {
+      // Replay the routing timeline: assigns set the pair, clears must name
+      // exactly the pair that was current when their transaction ran.
+      let replayed: { agent: string; reason: string } | null = null;
+      for (const e of getTaskEvents(verify, card.id)) {
+        if (e.kind === 'assign') {
+          const m = (e.note ?? '').match(/^assigned to (\S+): (.*)$/);
+          expect(m).not.toBeNull();
+          replayed = { agent: m![1], reason: m![2] };
+        } else if (e.kind === 'clear') {
+          const m = (e.note ?? '').match(/^assignment cleared \(was (\S+): (.*)\)$/);
+          expect(m).not.toBeNull();
+          // A serialized clear never fires on an unassigned card, and its
+          // `was` names the pair the replay says was current.
+          expect(replayed).toEqual({ agent: m![1], reason: m![2] });
+          replayed = null;
+        }
+      }
+      const final = getTask(verify, card.id) as TaskRow;
+      expect({ agent: final.assignedAgent, reason: final.assignedReason }).toEqual(
+        replayed ?? { agent: null, reason: null },
+      );
+    } finally {
+      verify.close();
+    }
+  }, 30_000);
+});
+
 describe('importState — replace is a full wipe even without operational rows', () => {
   test('stale meta keys do not survive a --replace into a metadata-only db', () => {
     // Source db: one task, then export. Its meta carries the backfill marker.

--- a/src/lib/v5/task-state.test.ts
+++ b/src/lib/v5/task-state.test.ts
@@ -1406,6 +1406,88 @@ try {
   }, 30_000);
 });
 
+// ---------------------------------------------------------------------------
+// Multi-PROCESS setTaskWish race: concurrent assign/clear/reassign writers on
+// one card. Each writer's `from` (and its timeline note) must come from the row
+// state its OWN immediate transaction serialized against — a stale pre-
+// transaction read would record a `from` that skips another writer's commit and
+// break the timeline chain. Every consecutive pair of wish events must link:
+// event[i].from === event[i-1].to, and the final row must equal the last
+// event's `to`.
+// ---------------------------------------------------------------------------
+describe('multi-process setTaskWish assign/clear/reassign concurrency', () => {
+  test('concurrent identity writers serialize into an unbroken from→to event chain', async () => {
+    const dbPath = join(dir, 'wish-race.db');
+    const seed = openDb({ path: dbPath });
+    const card = createTask(seed, { title: 'contested card' });
+    seed.close(); // checkpoint so child processes see a committed, current schema
+
+    const gdbPath = join(import.meta.dir, 'genie-db.ts');
+    const tsPath = join(import.meta.dir, 'task-state.ts');
+    const workerPath = join(dir, 'wish-worker.ts');
+    writeFileSync(
+      workerPath,
+      `
+import { openDb } from ${JSON.stringify(gdbPath)};
+import { setTaskWish } from ${JSON.stringify(tsPath)};
+const [dbPath, taskId, op, idx] = process.argv.slice(2);
+const db = openDb({ path: dbPath });
+try {
+  const to = op === 'clear' ? { wish: null, group: null } : { wish: 'w' + idx, group: op === 'assign' ? 'g' + idx : null };
+  setTaskWish(db, taskId, to, { author: 'racer-' + idx, authorKind: 'codex' });
+  process.stdout.write('OK');
+} catch (e) {
+  process.stdout.write('ERR:' + (e && e.message));
+  process.exitCode = 3;
+} finally {
+  db.close();
+}
+`,
+    );
+
+    const N = 9;
+    const ops = ['assign', 'reassign', 'clear'];
+    const runs = Array.from({ length: N }, (_, i) => {
+      const proc = Bun.spawn(['bun', 'run', workerPath, dbPath, card.id, ops[i % 3], String(i)], {
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+      return (async () => {
+        const out = await new Response(proc.stdout).text();
+        const err = await new Response(proc.stderr).text();
+        const code = await proc.exited;
+        return { out, err, code };
+      })();
+    });
+
+    const settled = await Promise.allSettled(runs);
+    const outcomes = settled.map((s) =>
+      s.status === 'fulfilled' ? `${s.value.out}(exit ${s.value.code})` : `REJECTED:${s.reason}`,
+    );
+    const ok = outcomes.filter((o) => o.startsWith('OK')).length;
+    if (ok !== N) console.error('wish-race outcomes:', JSON.stringify(outcomes));
+    // Every writer committed cleanly — no SQLITE_BUSY leak, no stale-read failure.
+    expect(ok).toBe(N);
+    expect(outcomes.some((o) => o.includes('SQLITE_BUSY'))).toBe(false);
+
+    const verify = openDb({ path: dbPath });
+    try {
+      const notes = getTaskEvents(verify, card.id)
+        .filter((e) => e.kind === 'wish')
+        .map((e) => (e.note ?? '').split('→'));
+      // Clears may silently no-op against an already-wishless row, but every
+      // distinct assign/reassign writes — the chain is never empty.
+      expect(notes.length).toBeGreaterThan(0);
+      expect(notes[0][0]).toBe('(none)');
+      for (let i = 1; i < notes.length; i++) expect(notes[i][0]).toBe(notes[i - 1][1]);
+      const final = getTask(verify, card.id) as TaskRow;
+      expect(formatWishRef({ wish: final.wish, group: final.group })).toBe(notes[notes.length - 1][1]);
+    } finally {
+      verify.close();
+    }
+  }, 30_000);
+});
+
 describe('importState — replace is a full wipe even without operational rows', () => {
   test('stale meta keys do not survive a --replace into a metadata-only db', () => {
     // Source db: one task, then export. Its meta carries the backfill marker.

--- a/src/lib/v5/task-state.ts
+++ b/src/lib/v5/task-state.ts
@@ -1190,9 +1190,15 @@ export function assignTask(
   requireTask(db, taskId);
   const pair = validateAssignmentPair(agent, reason);
   if (pair.agent == null) throw new AssignmentReasonRequiredError();
-  const current = getTask(db, taskId) as TaskRow;
-  if (current.assignedAgent === pair.agent && current.assignedReason === pair.reason) return current;
-  const apply = db.transaction(() => {
+  // The current-row read and no-op check run INSIDE the immediate transaction,
+  // so concurrent assign/clear/reassign writers each decide against the row
+  // state their own transaction serialized — never a read taken before another
+  // writer's commit (and a card deleted in the window throws UnknownTaskError,
+  // not an FK-constraint error from the event insert).
+  const apply = db.transaction((): TaskRow => {
+    const current = getTask(db, taskId);
+    if (!current) throw new UnknownTaskError(taskId);
+    if (current.assignedAgent === pair.agent && current.assignedReason === pair.reason) return current;
     db.query('UPDATE tasks SET assigned_agent = ?, assigned_reason = ?, updated_at = ? WHERE id = ?').run(
       pair.agent,
       pair.reason,
@@ -1205,9 +1211,9 @@ export function assignTask(
       authorKind: author.authorKind ?? undefined,
       author: author.author ?? undefined,
     });
+    return getTask(db, taskId) as TaskRow;
   });
-  apply.immediate();
-  return getTask(db, taskId) as TaskRow;
+  return apply.immediate() as TaskRow;
 }
 
 /**
@@ -1224,9 +1230,12 @@ export function clearTaskAssignment(
   now: number = Date.now(),
 ): TaskRow {
   requireTask(db, taskId);
-  const current = getTask(db, taskId) as TaskRow;
-  if (current.assignedAgent == null && current.assignedReason == null) return current;
-  const apply = db.transaction(() => {
+  // Read + no-op check inside the immediate transaction — the `was …` note must
+  // name the pair this transaction actually serialized against (see assignTask).
+  const apply = db.transaction((): TaskRow => {
+    const current = getTask(db, taskId);
+    if (!current) throw new UnknownTaskError(taskId);
+    if (current.assignedAgent == null && current.assignedReason == null) return current;
     db.query('UPDATE tasks SET assigned_agent = NULL, assigned_reason = NULL, updated_at = ? WHERE id = ?').run(
       now,
       taskId,
@@ -1237,9 +1246,9 @@ export function clearTaskAssignment(
       authorKind: author.authorKind ?? undefined,
       author: author.author ?? undefined,
     });
+    return getTask(db, taskId) as TaskRow;
   });
-  apply.immediate();
-  return getTask(db, taskId) as TaskRow;
+  return apply.immediate() as TaskRow;
 }
 
 /**

--- a/src/lib/v5/task-state.ts
+++ b/src/lib/v5/task-state.ts
@@ -1424,9 +1424,11 @@ export function formatWishRef(identity: WishIdentity): string {
  * A group name is only meaningful under the wish it was declared in, so the new
  * identity is taken whole: nothing of the previous group survives a wish change,
  * and clearing the wish clears the group with it. Slugs are unvalidated TEXT,
- * exactly as {@link createTask} treats them. The write and the event append are
- * one transaction, so a card can never carry an identity with no matching
- * timeline entry.
+ * exactly as {@link createTask} treats them. The current-row read, no-op check,
+ * write, and event append all run inside one immediate transaction, so
+ * concurrent assign/clear/reassign writers each derive their `from` (and the
+ * timeline note) from the row state their transaction actually serialized
+ * against — never from a read taken before another writer's commit.
  *
  * Re-pointing a card at the identity it already carries is fully silent: no row
  * write (so `updated_at` keeps its earlier value) and no timeline entry.
@@ -1438,13 +1440,13 @@ export function setTaskWish(
   author: EventAuthor,
   now: number = Date.now(),
 ): SetWishResult {
-  const task = getTask(db, taskId);
-  if (!task) throw new UnknownTaskError(taskId);
-  const from: WishIdentity = { wish: task.wish, group: task.group };
   const next: WishIdentity = to.wish === null ? { wish: null, group: null } : to;
-  if (from.wish === next.wish && from.group === next.group) return { task, from, to: next };
-  const note = `${formatWishRef(from)}→${formatWishRef(next)}`;
-  const apply = db.transaction(() => {
+  const apply = db.transaction((): SetWishResult => {
+    const task = getTask(db, taskId);
+    if (!task) throw new UnknownTaskError(taskId);
+    const from: WishIdentity = { wish: task.wish, group: task.group };
+    if (from.wish === next.wish && from.group === next.group) return { task, from, to: next };
+    const note = `${formatWishRef(from)}→${formatWishRef(next)}`;
     db.query('UPDATE tasks SET wish = ?, group_name = ?, updated_at = ? WHERE id = ?').run(
       next.wish,
       next.group,
@@ -1457,9 +1459,9 @@ export function setTaskWish(
       authorKind: author.authorKind ?? undefined,
       author: author.author ?? undefined,
     });
+    return { task: getTask(db, taskId) as TaskRow, from, to: next };
   });
-  apply.immediate();
-  return { task: getTask(db, taskId) as TaskRow, from, to: next };
+  return apply.immediate() as SetWishResult;
 }
 
 /**


### PR DESCRIPTION
Replaces #2768 (same fix, rebuilt on `origin/dev` so no unrelated main-side MCP commits ride the merge).

## Summary
The original review finding targeted `assignTask` — which only exists on `dev` — and it is valid there: `assignTask` and `clearTaskAssignment` read the current row and ran their no-op comparison **before** the `apply.immediate()` transaction. `setTaskWish` had the identical pattern. With worktrees sharing one `genie.db` across processes, a racing writer could commit in that window:

- a clear's `was …` timeline note could name a pair that was no longer current (and a wish event's `from` could skip another writer's commit)
- a stale no-op decision could double-write / double-clear
- a card deleted in the window surfaced a raw FK-constraint error instead of `UnknownTaskError` (`foreign_keys = ON`)

All three functions now run the row read, existence check, no-op comparison, and event append inside one immediate transaction — the existing `checkoutTask`/`deleteTask` pattern. Pair validation and the fail-fast existence check keep their original error precedence; `linkTaskToWish` inherits the fix.

## Regression coverage
Two multi-process `Promise.allSettled` tests (modeled on the roster-race test), 9 concurrent bun processes each against one card:
- **wish identity**: assign/clear/reassign writers must leave an unbroken `from→to` wish-event chain ending at the final row identity
- **routing**: the assign/clear timeline must replay to the exact final row, with every clear naming the pair its transaction serialized against — this one fails ~3/4 runs against the pre-fix code

## Validation
- `bun test src/lib/v5/task-state.test.ts`: 115 pass / 0 fail
- `tsc --noEmit` clean, biome clean on both changed files