### PR TITLE
spawn-context-contract#umask: parity gate failure names genie doctor --fix

### DIFF
--- a/scripts/hook-bundle-parity.test.ts
+++ b/scripts/hook-bundle-parity.test.ts
@@ -31,7 +31,7 @@ describe('committed hook bundle parity', () => {
 
         writeFileSync(bundle, await renderHookBundle(target.source));
         chmodSync(bundle, 0o744);
-        await expect(assertHookBundleParity(fixture)).rejects.toThrow('must have mode 755');
+        await expect(assertHookBundleParity(fixture)).rejects.toThrow(/must have mode 755.*genie doctor --fix/);
       }
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/scripts/hook-bundle-parity.ts
+++ b/scripts/hook-bundle-parity.ts
@@ -54,7 +54,7 @@ export async function assertHookBundleParity(target: HookBundleTarget): Promise<
   const mode = statSync(target.bundle).mode & 0o777;
   if (mode !== 0o755) {
     throw new Error(
-      `Hook bundle drift: plugins/genie/scripts/${target.name}.cjs must have mode 755 (found ${mode.toString(8)})`,
+      `Hook bundle drift: plugins/genie/scripts/${target.name}.cjs must have mode 755 (found ${mode.toString(8)}); run \`genie doctor --fix\``,
     );
   }
 }


### PR DESCRIPTION
## spawn-context-contract#umask — parity gate failure names the repair path

Message-only change to the pre-push parity gate (`lint:hook-bundles` → `scripts/hook-bundle-parity.ts`), which caught the 2026-08-12 umask-0 push failure.

The mode-drift failure output previously named no repair path:

```
Hook bundle drift: plugins/genie/scripts/<name>.cjs must have mode 755 (found 666)
```

It now names the standing repair:

```
Hook bundle drift: plugins/genie/scripts/<name>.cjs must have mode 755 (found 666); run `genie doctor --fix`
```

No behavioral change: the check still fails closed on both content and mode drift; `bun run lint:hook-bundles` and `scripts/hook-bundle-parity.test.ts` are green.
