### PR TITLE
spawn-context-contract#contract: genie context verb + recorded base state

### DIFF
--- a/plugins/genie/skills/wish/SKILL.md
+++ b/plugins/genie/skills/wish/SKILL.md
@@ -80,6 +80,7 @@ node "<wish-skill-dir>/references/design-review-evidence.mjs" verify ".genie/bra
    Tasks carry the `--wish`/`--group` linkage; the dependency DAG stays in the WISH.md document, not in task rows. If creation fails (no `.genie/genie.db` yet, CLI unavailable), warn and continue — WISH.md in git is the source of truth and must remain usable by `work` without task rows.
 10. **Handoff:** run the wish linter — inside the genie repo, `grep -q '"wishes:lint"' package.json 2>/dev/null && bun run wishes:lint`. If it reports any error, surface it and stop — never hand a structurally broken wish onward. Only after lint passes, auto-invoke `review` (plan review) on the WISH.md. Never suggest `work` directly — the review gate comes first.
 11. **Persist the verdict:** the reviewer only returns evidence. The invoking orchestrator appends that evidence under `## Review Results` and sets the WISH status to `APPROVED` on SHIP, `FIX-FIRST` on FIX-FIRST, or `BLOCKED` on BLOCKED. Do not route to `work` until the `APPROVED` status is on disk.
+12. **Record the wave base (APPROVED only):** once the status on disk is `APPROVED`, run `genie context --wish <slug>` from the repository root. This non-`--plan` resolution pins the integration base SHA as the wish's wave base — every group spawn cuts its worktree from that one SHA. A later run returns the recorded SHA; `genie context --wish <slug> --re-resolve` refreshes it. Never use `--plan` for this step: the preview writes nothing, so it cannot record the base. If the command fails (genie CLI or state DB unavailable — an empty ready-task set is NOT a failure; the base is still recorded and returned), warn and continue — the first non-plan resolution or the first `spawn --wish` records the base instead.
 
 ## Wish Document Sections
 
@@ -103,6 +104,7 @@ node "<wish-skill-dir>/references/design-review-evidence.mjs" verify ".genie/bra
 - Never emit a bracket-link to a non-existent brainstorm — use the `_No brainstorm — direct wish_` stub.
 - Never consume a linked design whose persisted review evidence is missing, non-SHIP, or stale; the wish linter independently enforces this for new wishes.
 - No implementation during `wish` — planning only.
+- On APPROVED, record the wave base with the non-`--plan` `genie context --wish <slug>` (warn and continue on failure; never `--plan`).
 - No speculative optimization: caches, deltas, sharding, background coordination, and configuration surfaces require a current criterion or measurement in the Simplicity Case.
 - Every group testable, bite-sized, and independently shippable; no vague tasks ("improve everything").
 - Every group has non-zero, risk-proportional validation with its scope explained; aggregate integration and release

--- a/skills/wish/SKILL.md
+++ b/skills/wish/SKILL.md
@@ -80,6 +80,7 @@ node "<wish-skill-dir>/references/design-review-evidence.mjs" verify ".genie/bra
    Tasks carry the `--wish`/`--group` linkage; the dependency DAG stays in the WISH.md document, not in task rows. If creation fails (no `.genie/genie.db` yet, CLI unavailable), warn and continue — WISH.md in git is the source of truth and must remain usable by `work` without task rows.
 10. **Handoff:** run the wish linter — inside the genie repo, `grep -q '"wishes:lint"' package.json 2>/dev/null && bun run wishes:lint`. If it reports any error, surface it and stop — never hand a structurally broken wish onward. Only after lint passes, auto-invoke `review` (plan review) on the WISH.md. Never suggest `work` directly — the review gate comes first.
 11. **Persist the verdict:** the reviewer only returns evidence. The invoking orchestrator appends that evidence under `## Review Results` and sets the WISH status to `APPROVED` on SHIP, `FIX-FIRST` on FIX-FIRST, or `BLOCKED` on BLOCKED. Do not route to `work` until the `APPROVED` status is on disk.
+12. **Record the wave base (APPROVED only):** once the status on disk is `APPROVED`, run `genie context --wish <slug>` from the repository root. This non-`--plan` resolution pins the integration base SHA as the wish's wave base — every group spawn cuts its worktree from that one SHA. A later run returns the recorded SHA; `genie context --wish <slug> --re-resolve` refreshes it. Never use `--plan` for this step: the preview writes nothing, so it cannot record the base. If the command fails (genie CLI or state DB unavailable — an empty ready-task set is NOT a failure; the base is still recorded and returned), warn and continue — the first non-plan resolution or the first `spawn --wish` records the base instead.
 
 ## Wish Document Sections
 
@@ -103,6 +104,7 @@ node "<wish-skill-dir>/references/design-review-evidence.mjs" verify ".genie/bra
 - Never emit a bracket-link to a non-existent brainstorm — use the `_No brainstorm — direct wish_` stub.
 - Never consume a linked design whose persisted review evidence is missing, non-SHIP, or stale; the wish linter independently enforces this for new wishes.
 - No implementation during `wish` — planning only.
+- On APPROVED, record the wave base with the non-`--plan` `genie context --wish <slug>` (warn and continue on failure; never `--plan`).
 - No speculative optimization: caches, deltas, sharding, background coordination, and configuration surfaces require a current criterion or measurement in the Simplicity Case.
 - Every group testable, bite-sized, and independently shippable; no vague tasks ("improve everything").
 - Every group has non-zero, risk-proportional validation with its scope explained; aggregate integration and release

--- a/src/genie-commands/doctor-worktrees.ts
+++ b/src/genie-commands/doctor-worktrees.ts
@@ -28,6 +28,7 @@
 import { spawnSync } from 'node:child_process';
 import { realpathSync } from 'node:fs';
 import { basename, sep } from 'node:path';
+import { type IntegrationBranch, resolveIntegration } from '../lib/v5/base-state.js';
 import { resolveWorktreesBase } from '../term-commands/launch.js';
 import type { CheckResult } from './doctor.js';
 import { sizeOfPathTree } from './legacy-v4.js';
@@ -194,40 +195,11 @@ export function parseWorktreePorcelain(text: string): WorktreeRecord[] {
 }
 
 /**
- * The integration branch in its two non-interchangeable shapes. Every git probe
- * takes `ref`; only human output takes `name`. See {@link resolveIntegration}
- * for why the distinction is load-bearing.
- */
-export interface IntegrationBranch {
-  /** Short form, e.g. `dev` or `origin/main`. Display only — never a git argument. */
-  name: string;
-  /** Fully-qualified ref, e.g. `refs/heads/dev`. The only form a probe may use. */
-  ref: string;
-}
-
-/**
  * The branch a launch branch must already be contained in before anything is
- * deleted. Stated here in code with NO config surface, in order:
- *   1. a local `dev` branch — this repo's integration line;
- *   2. else the remote default branch (`refs/remotes/origin/HEAD`);
- *   3. else null — nothing is provably merged, so `--fix` removes NOTHING.
- *
- * Both candidates are carried as fully-qualified refs because a SHORT name is
- * ambiguous: per gitrevisions a bare `dev` resolves `refs/tags/dev` before
- * `refs/heads/dev`, so a tag sitting on a launch branch tip would satisfy the
- * ancestry proof that the real `dev` fails.
+ * deleted. Resolved through the shared policy in `src/lib/v5/base-state.ts`
+ * (local `dev` → remote default → null; config-free) — the single policy
+ * point the `genie context` verb consumes too.
  */
-function resolveIntegration(root: string): IntegrationBranch | null {
-  if (git(root, ['show-ref', '--verify', '--quiet', 'refs/heads/dev']).ok) {
-    return { name: 'dev', ref: 'refs/heads/dev' };
-  }
-  const head = git(root, ['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD']);
-  if (!head.ok) return null;
-  const ref = head.stdout.trim();
-  return ref.startsWith('refs/remotes/') ? { name: ref.slice('refs/remotes/'.length), ref } : null;
-}
-
-/** Display name of the integration branch, or null when none resolves. */
 export function resolveIntegrationBranch(root: string): string | null {
   return resolveIntegration(root)?.name ?? null;
 }

--- a/src/genie.ts
+++ b/src/genie.ts
@@ -25,6 +25,7 @@ import { updateCommand } from './genie-commands/update.js';
 import { registerHookNamespace } from './hooks/dispatch-command.js';
 import { installWorkspaceCheck } from './lib/interactivity.js';
 import { VERSION } from './lib/version.js';
+import { registerContextCommand } from './term-commands/context.js';
 import { registerIdeaCommand } from './term-commands/idea.js';
 import { registerInitCommand } from './term-commands/init.js';
 import { registerLaunchCommand } from './term-commands/launch.js';
@@ -191,6 +192,7 @@ registerMcpCommand(program);
 registerUiBridgeCommand(program);
 registerV5TaskCommands(program);
 registerV5BoardCommands(program);
+registerContextCommand(program);
 registerIdeaCommand(program);
 registerOmniCommands(program);
 

--- a/src/lib/interactivity.ts
+++ b/src/lib/interactivity.ts
@@ -67,6 +67,10 @@ const WORKSPACE_EXEMPT = new Set([
   // behavior.
   'task',
   'board',
+  // `context` is the read-only spawn-context contract verb. Like `task`/
+  // `board` it self-resolves from the git common-dir and must work in a fresh
+  // repo with no workspace.json.
+  'context',
   // `idea` is the one-verb quick-capture (roadmap board's Idea lane). Same v5
   // sqlite-backed self-resolving DB as `task`/`board`; it must work in a fresh
   // repo with no workspace.json (QA: `genie idea` on a fresh repo).

--- a/src/lib/v5/base-state.ts
+++ b/src/lib/v5/base-state.ts
@@ -1,0 +1,155 @@
+/**
+ * Genie v5 base state — the single shared integration-branch policy plus the
+ * recorded per-wish spawn base.
+ *
+ * The policy was extracted from doctor's worktree classifier
+ * (see genie-commands/doctor-worktrees.ts) so every consumer resolves "the
+ * integration branch" through ONE config-free function. In order:
+ *
+ *   1. a local `dev` branch — this repo's integration line;
+ *   2. else the remote default branch (`refs/remotes/origin/HEAD`);
+ *   3. else null — nothing is resolvable, every consumer fails closed.
+ *
+ * Both candidates are carried as fully-qualified refs because a SHORT name is
+ * ambiguous: per gitrevisions a bare `dev` resolves `refs/tags/dev` before
+ * `refs/heads/dev`, so a tag sitting on a work branch tip would satisfy a
+ * probe the real `dev` fails.
+ *
+ * The recorded state is one `meta` row per wish (`wish_base:<slug>`): the
+ * branch the wish was planned on plus the integration base SHA pinned at plan
+ * time (wish skill on APPROVED) or at first non-`--plan` resolution (legacy
+ * wishes). The full 40-hex SHA is the only value that ever crosses the spawn
+ * boundary — never a raw ref (TOCTOU + argv-injection immunity).
+ */
+
+import type { Database } from 'bun:sqlite';
+import { spawnSync } from 'node:child_process';
+
+/**
+ * The integration branch in its two non-interchangeable shapes. Every git
+ * probe takes `ref`; only human output takes `name`.
+ */
+export interface IntegrationBranch {
+  /** Short form, e.g. `dev` or `origin/main`. Display only — never a git argument. */
+  name: string;
+  /** Fully-qualified ref, e.g. `refs/heads/dev`. The only form a probe may use. */
+  ref: string;
+}
+
+interface GitOutcome {
+  ok: boolean;
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function gitFailure(stderr: string): GitOutcome {
+  return { ok: false, status: null, stdout: '', stderr };
+}
+
+/**
+ * Run git without ever throwing: a failed spawn is reported like any non-zero
+ * exit, and every caller turns an unsuccessful outcome into a refusal.
+ * Bounded: a probe hanging on a lock, credential prompt, or network mount must
+ * not wedge a CLI command; a timeout surfaces as a refusal.
+ */
+function git(root: string, args: string[]): GitOutcome {
+  try {
+    const res = spawnSync('git', args, {
+      cwd: root,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 10_000,
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    if (res.error) return gitFailure(res.error.message);
+    return { ok: res.status === 0, status: res.status, stdout: res.stdout ?? '', stderr: (res.stderr ?? '').trim() };
+  } catch (error) {
+    return gitFailure(error instanceof Error ? error.message : String(error));
+  }
+}
+
+/**
+ * The integration branch a spawn base is resolved from. Stated here in code
+ * with NO config surface (see module docs). Extracted from doctor's
+ * `resolveIntegration` — this function is the single policy point.
+ */
+export function resolveIntegration(root: string): IntegrationBranch | null {
+  if (git(root, ['show-ref', '--verify', '--quiet', 'refs/heads/dev']).ok) {
+    return { name: 'dev', ref: 'refs/heads/dev' };
+  }
+  const head = git(root, ['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD']);
+  if (!head.ok) return null;
+  const ref = head.stdout.trim();
+  return ref.startsWith('refs/remotes/') ? { name: ref.slice('refs/remotes/'.length), ref } : null;
+}
+
+/** A full commit SHA: 40 lowercase hex characters. */
+const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/;
+
+/**
+ * Peel `rev` to its full commit SHA via `git rev-parse --verify <rev>^{commit}`.
+ * Null on ANY failure — an unresolvable base proves nothing and must fail
+ * closed. The `^{commit}` suffix rejects anything that is not a commit object
+ * (tags peel through to their target commit); callers only ever pass
+ * internally-composed refs (`refs/...`) or a recorded 40-hex SHA here, never
+ * user input, so the probe cannot be steered by argv injection.
+ */
+export function peelCommit(root: string, rev: string): string | null {
+  const res = git(root, ['rev-parse', '--verify', `${rev}^{commit}`]);
+  if (!res.ok) return null;
+  const sha = res.stdout.trim();
+  return FULL_SHA_PATTERN.test(sha) ? sha : null;
+}
+
+// ============================================================================
+// Recorded per-wish base (one meta row per wish)
+// ============================================================================
+
+/** `meta` key prefix for a wish's recorded base. */
+const WISH_BASE_KEY_PREFIX = 'wish_base:';
+
+function wishBaseKey(slug: string): string {
+  return `${WISH_BASE_KEY_PREFIX}${slug}`;
+}
+
+/** One recorded wave base: the wish's plan branch plus its pinned base SHA. */
+export interface WishBaseRecord {
+  branch: string;
+  base: string;
+  recordedAt: number;
+}
+
+/**
+ * Read the recorded base for `slug`: `null` when absent, the record when
+ * valid, or the literal `'corrupt'` when a row exists but does not parse to a
+ * valid record (non-empty branch, full-SHA base, numeric timestamp). A corrupt
+ * record is NEVER auto-healed here — callers fail closed so a re-resolve
+ * replaces it deliberately.
+ */
+export function readWishBase(db: Database, slug: string): WishBaseRecord | null | 'corrupt' {
+  const row = db.query('SELECT value FROM meta WHERE key = ?').get(wishBaseKey(slug)) as {
+    value: string;
+  } | null;
+  if (row === null) return null;
+  try {
+    const parsed = JSON.parse(row.value) as WishBaseRecord;
+    if (
+      typeof parsed.branch === 'string' &&
+      parsed.branch !== '' &&
+      typeof parsed.base === 'string' &&
+      FULL_SHA_PATTERN.test(parsed.base) &&
+      typeof parsed.recordedAt === 'number'
+    ) {
+      return parsed;
+    }
+  } catch {
+    // fall through to corrupt
+  }
+  return 'corrupt';
+}
+
+/** Upsert the recorded base for `slug` (INSERT OR REPLACE — idempotent). */
+export function writeWishBase(db: Database, slug: string, record: WishBaseRecord): void {
+  db.query('INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)').run(wishBaseKey(slug), JSON.stringify(record));
+}

--- a/src/term-commands/context.test.ts
+++ b/src/term-commands/context.test.ts
@@ -1,0 +1,543 @@
+/**
+ * genie context — CLI-level tests. Each case invokes the real `genie.ts`
+ * entry as a user would (subprocess), against throwaway REAL git repositories
+ * (the contract's whole job is reading git + genie.db truth, so a mocked git
+ * would test nothing), and asserts exit code AND stderr, not just stdout.
+ */
+
+import { Database } from 'bun:sqlite';
+import { afterEach, describe, expect, test } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveIntegrationBranch } from '../genie-commands/doctor-worktrees.js';
+import { peelCommit, resolveIntegration } from '../lib/v5/base-state.js';
+import { openDb, resolveDbPath } from '../lib/v5/genie-db.js';
+import { claimTask, createTask, listTasks } from '../lib/v5/task-state.js';
+import { contextCommand, openReadonlyHandle } from './context.js';
+
+const GENIE = join(import.meta.dir, '..', 'genie.ts');
+
+const scratchRoots: string[] = [];
+
+afterEach(() => {
+  for (const dir of scratchRoots.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'Test',
+      GIT_AUTHOR_EMAIL: 'test@example.com',
+      GIT_COMMITTER_NAME: 'Test',
+      GIT_COMMITTER_EMAIL: 'test@example.com',
+    },
+  }).trim();
+}
+
+interface CliResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+/** Spawn `bun genie.ts context ...` with a clean color environment (no FORCE_COLOR warning on stderr). */
+async function cli(cwd: string, ...args: string[]): Promise<CliResult> {
+  const env: Record<string, string> = { NO_COLOR: '1' };
+  for (const [key, value] of Object.entries(process.env)) {
+    if (key === 'FORCE_COLOR' || key === 'NO_COLOR') continue;
+    if (value !== undefined) env[key] = value;
+  }
+  const proc = Bun.spawn(['bun', GENIE, 'context', ...args], {
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env,
+  });
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  const code = await proc.exited;
+  return { stdout, stderr, code };
+}
+
+/** The line terminator is the only newline allowed in a payload/failure line. */
+function singleLine(text: string): string {
+  expect(text.trimEnd().includes('\n')).toBe(false);
+  return text.trimEnd();
+}
+
+/** Parse the success payload, failing the test on any shape surprise. */
+function payloadOf(result: CliResult): Record<string, unknown> {
+  expect(result.code).toBe(0);
+  expect(result.stderr).toBe('');
+  return JSON.parse(singleLine(result.stdout)) as Record<string, unknown>;
+}
+
+/** Parse the machine-readable failure line, failing the test on any shape surprise. */
+function failureOf(result: CliResult): { error: string; reason: string } {
+  expect(result.code).toBe(1);
+  expect(result.stdout).toBe('');
+  const parsed = JSON.parse(singleLine(result.stderr)) as { error: string; reason: string };
+  expect(typeof parsed.error).toBe('string');
+  expect(typeof parsed.reason).toBe('string');
+  return parsed;
+}
+
+/** A payload field asserted as a string (payloadOf returns unknown-valued fields). */
+function str(value: unknown): string {
+  expect(typeof value).toBe('string');
+  return value as string;
+}
+
+interface Fixture {
+  dir: string;
+  root: string;
+}
+
+/** Seeded repo. `integration: 'none'` omits the `dev` branch. */
+function makeFixture(options: { integration?: 'dev' | 'none' } = {}): Fixture {
+  const dir = mkdtempSync(join(tmpdir(), 'genie-context-'));
+  scratchRoots.push(dir);
+  const root = join(dir, 'repo');
+  mkdirSync(root);
+  git(dir, 'init', '-q', root);
+  git(root, 'config', 'user.email', 'test@example.com');
+  git(root, 'config', 'user.name', 'Test');
+  git(root, 'config', 'commit.gpgsign', 'false');
+  writeFileSync(join(root, 'README.md'), 'seed\n');
+  git(root, 'add', '-A');
+  git(root, 'commit', '-q', '-m', 'seed');
+  if (options.integration !== 'none') git(root, 'branch', 'dev');
+  return { dir, root };
+}
+
+/** Bare origin remote whose default branch becomes the integration fallback. */
+function addOriginDefault(fx: Fixture, branch: string): void {
+  const origin = join(fx.dir, 'origin.git');
+  mkdirSync(origin);
+  git(fx.dir, 'init', '--bare', '-q', origin);
+  git(fx.root, 'remote', 'add', 'origin', origin);
+  git(fx.root, 'push', '-q', 'origin', `HEAD:refs/heads/${branch}`);
+  git(fx.root, 'remote', 'set-head', 'origin', branch);
+}
+
+function devSha(fx: Fixture): string {
+  return git(fx.root, 'rev-parse', 'refs/heads/dev^{commit}');
+}
+
+function advanceDev(fx: Fixture): string {
+  // Commit on the DEV branch (the checkout sits on the init branch, not dev).
+  git(fx.root, 'checkout', '-q', 'dev');
+  git(fx.root, 'commit', '-q', '--allow-empty', '-m', 'advance');
+  git(fx.root, 'checkout', '-q', '-');
+  return devSha(fx);
+}
+
+/** Seed the repo's genie.db with one ready task per group (groups listed in order). */
+function seedTasks(fx: Fixture, wish: string, groups: string[]): void {
+  const db = openDb({ cwd: fx.root });
+  for (const group of groups) {
+    createTask(db, { title: `task ${group}`, wish, group });
+  }
+  db.close();
+}
+
+function metaRow(fx: Fixture, key: string): string | null {
+  const db = new Database(resolveDbPath(fx.root), { readonly: true });
+  try {
+    const row = db.query('SELECT value FROM meta WHERE key = ?').get(key) as { value: string } | null;
+    return row?.value ?? null;
+  } finally {
+    db.close();
+  }
+}
+
+function dbBytes(fx: Fixture): Buffer {
+  return readFileSync(resolveDbPath(fx.root));
+}
+
+function genieDirEntries(fx: Fixture): string[] {
+  const dir = join(fx.root, '.genie');
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir).sort();
+}
+
+const DEV_SHA_PATTERN = /^[0-9a-f]{40}$/;
+
+// ============================================================================
+// Read-only open semantics
+// ============================================================================
+
+describe('read-only open', () => {
+  test('with a pending non-empty WAL, the readonly open still sees the uncheckpointed rows', () => {
+    const fx = makeFixture();
+    seedTasks(fx, 'probe', []);
+    const dbPath = resolveDbPath(fx.root);
+    const writer = new Database(dbPath, { create: true });
+    writer.query('INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)').run('probe', 'uncheckpointed');
+    // Writer stays OPEN — the frame sits in the -wal, not the main file.
+    const handle = openReadonlyHandle(dbPath);
+    expect(handle).not.toBeNull();
+    try {
+      const row = handle?.query('SELECT value FROM meta WHERE key = ?').get('probe') as { value: string };
+      expect(row.value).toBe('uncheckpointed');
+    } finally {
+      handle?.close();
+      writer.close();
+    }
+  });
+});
+
+// ============================================================================
+// Wishless form — integration branch + SHA, zero state
+// ============================================================================
+
+describe('wishless context', () => {
+  test('resolves a local dev branch to its full commit SHA with zero DB writes', async () => {
+    const fx = makeFixture();
+    const result = await cli(fx.root);
+    const payload = payloadOf(result);
+    expect(payload).toEqual({ version: 1, branch: 'dev', base: devSha(fx), tasks: [] });
+    expect(DEV_SHA_PATTERN.test(str(payload.base))).toBe(true);
+    expect(existsSync(join(fx.root, '.genie', 'genie.db'))).toBe(false);
+    expect(genieDirEntries(fx)).toEqual([]);
+  });
+
+  test('--plan prints the identical payload and still writes nothing', async () => {
+    const fx = makeFixture();
+    const plain = await cli(fx.root);
+    const planned = await cli(fx.root, '--plan');
+    expect(planned.stdout).toBe(plain.stdout);
+    expect(planned.code).toBe(0);
+    expect(genieDirEntries(fx)).toEqual([]);
+  });
+
+  test('falls back to the remote default branch when there is no dev', async () => {
+    const fx = makeFixture({ integration: 'none' });
+    addOriginDefault(fx, 'main');
+    const result = await cli(fx.root);
+    const payload = payloadOf(result);
+    // The payload names the LOGICAL local branch (`main`), never the
+    // remote-tracking name (`origin/main`) a consumer might pass to
+    // `git worktree add -b` and silently create `refs/heads/origin/main`.
+    expect(str(payload.branch)).toBe('main');
+    expect(str(payload.base)).toBe(git(fx.root, 'rev-parse', 'refs/remotes/origin/HEAD^{commit}'));
+    expect(genieDirEntries(fx)).toEqual([]);
+  });
+
+  test('fails closed with a machine-readable reason when no integration branch resolves', async () => {
+    const fx = makeFixture({ integration: 'none' });
+    const result = await cli(fx.root);
+    expect(failureOf(result).error).toBe('no-integration-branch');
+  });
+
+  test('refuses --group and --re-resolve without --wish', async () => {
+    const fx = makeFixture();
+    expect(failureOf(await cli(fx.root, '--group', 'g')).error).toBe('group-requires-wish');
+    expect(failureOf(await cli(fx.root, '--re-resolve')).error).toBe('re-resolve-requires-wish');
+  });
+});
+
+// ============================================================================
+// Wish-scoped form — recorded base state
+// ============================================================================
+
+describe('wish context', () => {
+  test('first non-plan resolution resolves, records, and returns the composed payload', async () => {
+    const fx = makeFixture();
+    seedTasks(fx, 'demo', ['alpha']);
+    const result = await cli(fx.root, '--wish', 'demo', '--group', 'alpha');
+    const payload = payloadOf(result);
+    expect(payload).toEqual({
+      version: 1,
+      wish: 'demo',
+      group: 'alpha',
+      branch: 'wish/demo-alpha',
+      base: devSha(fx),
+      tasks: [{ id: expect.any(String), title: 'task alpha' }],
+    });
+    // The wave pin was recorded: wish branch + pinned SHA + timestamp.
+    const record = JSON.parse(metaRow(fx, 'wish_base:demo') ?? 'null') as {
+      branch: string;
+      base: string;
+      recordedAt: number;
+    };
+    expect(record.branch).toBe('wish/demo');
+    expect(str(record.base)).toBe(devSha(fx));
+    expect(typeof record.recordedAt).toBe('number');
+  });
+
+  test('second call returns the recorded base even after the integration branch moves', async () => {
+    const fx = makeFixture();
+    seedTasks(fx, 'demo', ['alpha']);
+    const first = payloadOf(await cli(fx.root, '--wish', 'demo', '--group', 'alpha'));
+    advanceDev(fx);
+    const second = payloadOf(await cli(fx.root, '--wish', 'demo', '--group', 'alpha'));
+    expect(str(second.base)).toBe(str(first.base));
+    expect(str(second.base)).not.toBe(devSha(fx));
+    const record = JSON.parse(metaRow(fx, 'wish_base:demo') ?? 'null') as { base: string };
+    expect(str(record.base)).toBe(str(first.base));
+  });
+
+  test('--re-resolve refreshes the recorded base from the integration branch', async () => {
+    const fx = makeFixture();
+    seedTasks(fx, 'demo', ['alpha']);
+    const first = payloadOf(await cli(fx.root, '--wish', 'demo', '--group', 'alpha'));
+    const advanced = advanceDev(fx);
+    const refreshed = payloadOf(await cli(fx.root, '--wish', 'demo', '--group', 'alpha', '--re-resolve'));
+    expect(str(refreshed.base)).toBe(advanced);
+    expect(str(refreshed.base)).not.toBe(str(first.base));
+    expect((JSON.parse(metaRow(fx, 'wish_base:demo') ?? 'null') as { base: string }).base).toBe(advanced);
+  });
+
+  test('--plan never writes the wave pin, not even when no base is recorded', async () => {
+    const fx = makeFixture();
+    seedTasks(fx, 'demo', ['alpha']);
+    // Strip SQLite's own sidecars BEFORE the snapshot: bun's darwin writer
+    // leaves a 32KB -shm and a 0-byte -wal behind when it closes, so a
+    // snapshot taken right after seeding would already contain them and the
+    // darwin strict pin below could never discriminate the immutable open
+    // from the plain-readonly fallback. The writer closed cleanly, so the
+    // -wal holds no frames worth keeping — removing it loses nothing.
+    for (const sidecar of ['genie.db-shm', 'genie.db-wal']) {
+      rmSync(join(fx.root, '.genie', sidecar), { force: true });
+    }
+    const bytesBefore = dbBytes(fx);
+    const entriesBefore = genieDirEntries(fx);
+    expect(entriesBefore).toEqual(['genie.db']);
+    const payload = payloadOf(await cli(fx.root, '--wish', 'demo', '--group', 'alpha', '--plan'));
+    // Directory evidence is taken BEFORE any further DB open: a later probe
+    // would itself create (or fail to create) sidecars, masking what --plan
+    // did. Note the row check below uses the production openReadonlyHandle —
+    // a plain readonly open cannot open a stripped WAL db on darwin at all.
+    const added = genieDirEntries(fx).filter((name) => !entriesBefore.includes(name));
+    expect(str(payload.base)).toBe(devSha(fx));
+    const planHandle = openReadonlyHandle(resolveDbPath(fx.root));
+    try {
+      expect(planHandle?.query('SELECT value FROM meta WHERE key = ?').get('wish_base:demo')).toBeNull();
+    } finally {
+      planHandle?.close();
+    }
+    expect(dbBytes(fx).equals(bytesBefore)).toBe(true);
+    // Cross-platform bound: anything --plan added must be exactly the
+    // genie.db-shm/-wal pair (the documented plain-readonly fallback on
+    // SQLite builds that reject the immutable URI form) — never any other
+    // file of any name.
+    expect(added.every((name) => name === 'genie.db-shm' || name === 'genie.db-wal')).toBe(true);
+    // Where the immutable open is honored (observed on darwin builds), pin the
+    // strict contract: NO new file of any name appears — this is what
+    // discriminates immutable from the fallback.
+    if (process.platform === 'darwin') expect(added).toEqual([]);
+  });
+
+  test('--plan returns the recorded base (what spawn would consume) without re-resolving', async () => {
+    const fx = makeFixture();
+    seedTasks(fx, 'demo', ['alpha']);
+    payloadOf(await cli(fx.root, '--wish', 'demo', '--group', 'alpha'));
+    advanceDev(fx);
+    const planned = payloadOf(await cli(fx.root, '--wish', 'demo', '--group', 'alpha', '--plan'));
+    expect(str(planned.base)).not.toBe(devSha(fx));
+  });
+
+  test('--plan --re-resolve previews the refreshed base but writes nothing', async () => {
+    const fx = makeFixture();
+    seedTasks(fx, 'demo', ['alpha']);
+    payloadOf(await cli(fx.root, '--wish', 'demo', '--group', 'alpha'));
+    const advanced = advanceDev(fx);
+    const before = dbBytes(fx);
+    const planned = payloadOf(await cli(fx.root, '--wish', 'demo', '--group', 'alpha', '--plan', '--re-resolve'));
+    expect(str(planned.base)).toBe(advanced);
+    expect(dbBytes(fx).equals(before)).toBe(true);
+    expect((JSON.parse(metaRow(fx, 'wish_base:demo') ?? 'null') as { base: string }).base).not.toBe(advanced);
+  });
+
+  test('--plan on a repo with no genie.db still returns branch+base (empty tasks) and creates nothing', async () => {
+    const fx = makeFixture();
+    const payload = payloadOf(await cli(fx.root, '--wish', 'demo', '--group', 'alpha', '--plan'));
+    expect(payload).toEqual({
+      version: 1,
+      wish: 'demo',
+      branch: 'wish/demo-alpha',
+      base: devSha(fx),
+      tasks: [],
+      group: 'alpha',
+    });
+    expect(genieDirEntries(fx)).toEqual([]);
+    expect(existsSync(join(fx.root, '.genie', 'genie.db'))).toBe(false);
+  });
+
+  test('group-less form returns the recorded wish branch and every ready task', async () => {
+    const fx = makeFixture();
+    seedTasks(fx, 'demo', ['alpha', 'beta']);
+    const payload = payloadOf(await cli(fx.root, '--wish', 'demo'));
+    expect(payload.group).toBeUndefined();
+    expect(str(payload.branch)).toBe('wish/demo');
+    expect(payload.tasks).toEqual([
+      { id: expect.any(String), title: 'task alpha' },
+      { id: expect.any(String), title: 'task beta' },
+    ]);
+  });
+
+  test('--group filters the ready tasks to that group only', async () => {
+    const fx = makeFixture();
+    seedTasks(fx, 'demo', ['alpha', 'beta']);
+    const payload = payloadOf(await cli(fx.root, '--wish', 'demo', '--group', 'beta'));
+    expect(str(payload.branch)).toBe('wish/demo-beta');
+    expect(payload.tasks).toEqual([{ id: expect.any(String), title: 'task beta' }]);
+  });
+
+  test('a wish with no ready tasks still resolves+records the base and exits 0 with empty tasks', async () => {
+    const fx = makeFixture();
+    const payload = payloadOf(await cli(fx.root, '--wish', 'demo', '--group', 'alpha'));
+    expect(payload).toEqual({
+      version: 1,
+      wish: 'demo',
+      branch: 'wish/demo-alpha',
+      base: devSha(fx),
+      tasks: [],
+      group: 'alpha',
+    });
+    expect(metaRow(fx, 'wish_base:demo')).not.toBeNull();
+  });
+
+  test('a claimed (in_progress) group still gets its base: empty tasks, exit 0 — resume works', async () => {
+    const fx = makeFixture();
+    seedTasks(fx, 'demo', ['alpha']);
+    const db = openDb({ cwd: fx.root });
+    const task = listTasks(db, { wish: 'demo', status: 'ready' })[0];
+    claimTask(db, task.id, 'worker');
+    db.close();
+    const payload = payloadOf(await cli(fx.root, '--wish', 'demo', '--group', 'alpha'));
+    expect(payload.tasks).toEqual([]);
+    expect(str(payload.base)).toBe(devSha(fx));
+    expect(str(payload.branch)).toBe('wish/demo-alpha');
+  });
+
+  test('fails closed with machine-readable reasons for every degradation', async () => {
+    const fx = makeFixture({ integration: 'none' });
+    seedTasks(fx, 'demo', ['alpha']);
+    expect(failureOf(await cli(fx.root, '--wish', 'demo', '--group', 'alpha')).error).toBe('no-integration-branch');
+
+    // A recorded base whose object is gone refuses, and --re-resolve heals.
+    const bogus = '1111111111111111111111111111111111111111';
+    const db = openDb({ cwd: fx.root });
+    db.query('INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)').run(
+      'wish_base:demo',
+      JSON.stringify({ branch: 'wish/demo', base: bogus, recordedAt: 1 }),
+    );
+    db.close();
+    const missing = failureOf(await cli(fx.root, '--wish', 'demo', '--group', 'alpha'));
+    expect(missing.error).toBe('recorded-base-missing');
+    expect(missing.reason).toContain('--re-resolve');
+
+    // A malformed record refuses too — never silently re-resolved.
+    const db2 = openDb({ cwd: fx.root });
+    db2.query('INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)').run('wish_base:demo', '{not json');
+    db2.close();
+    expect(failureOf(await cli(fx.root, '--wish', 'demo', '--group', 'alpha')).error).toBe('corrupt-base-record');
+  });
+
+  test('rejects injection payloads with a machine-readable reason', async () => {
+    const fx = makeFixture();
+    seedTasks(fx, 'demo', ['alpha']);
+    for (const slug of ['a;b', 'a"b', 'a b', 'a$(x)', 'a`b`', 'a|b', 'a\nb']) {
+      const result = await cli(fx.root, '--wish', slug, '--group', 'alpha');
+      expect(failureOf(result).error).toBe('invalid-wish-slug');
+    }
+    expect(failureOf(await cli(fx.root, '--wish', 'demo', '--group', 'a;b')).error).toBe('invalid-group-name');
+    // A `-`-prefixed value is consumed by the argument parser as the option's
+    // value, then rejected by the charset gate — never resolved, never recorded.
+    expect(failureOf(await cli(fx.root, '--wish', '--foo', '--group', 'alpha')).error).toBe('invalid-wish-slug');
+  });
+
+  test('rejects everything git check-ref-format rejects in the composed ref', async () => {
+    const fx = makeFixture();
+    seedTasks(fx, 'demo', ['alpha']);
+    for (const slug of ['a..b', '.hidden', 'trailing.', 'padlock.LOCK', 'padlock.lock']) {
+      const result = await cli(fx.root, '--wish', slug, '--group', 'alpha');
+      expect(failureOf(result).error).toBe('invalid-wish-slug');
+    }
+    for (const group of ['a..b', '.hidden', 'trailing.', 'padlock.lock']) {
+      const result = await cli(fx.root, '--wish', 'demo', '--group', group);
+      expect(failureOf(result).error).toBe('invalid-group-name');
+    }
+    // None of the rejected names left a wave-pin record behind.
+    expect(metaRow(fx, 'wish_base:.hidden')).toBeNull();
+    expect(metaRow(fx, 'wish_base:a..b')).toBeNull();
+  });
+
+  test('rejects a `-`-prefixed slug with a machine-readable reason and records nothing', () => {
+    const fx = makeFixture();
+    seedTasks(fx, 'demo', ['alpha']);
+    const errors: string[] = [];
+    const code = contextCommand(
+      { wish: '-x', group: 'alpha' },
+      { cwd: fx.root, write: () => {}, writeErr: (line) => errors.push(line) },
+    );
+    expect(code).toBe(1);
+    expect((JSON.parse(errors[0]) as { error: string }).error).toBe('invalid-wish-slug');
+    expect(metaRow(fx, 'wish_base:-x')).toBeNull();
+  });
+
+  test('payload is shell-consumable: one line, JSON-escaped titles, no raw refs', async () => {
+    const fx = makeFixture();
+    const db = openDb({ cwd: fx.root });
+    createTask(db, { title: 'quote " semi; dollar $(touch pwned) newline\nline', wish: 'demo', group: 'alpha' });
+    db.close();
+    const result = await cli(fx.root, '--wish', 'demo', '--group', 'alpha');
+    const payload = payloadOf(result);
+    const tasks = payload.tasks as Array<{ id: string; title: string }>;
+    expect(tasks[0].title).toBe('quote " semi; dollar $(touch pwned) newline\nline');
+    expect(existsSync(join(fx.root, 'pwned'))).toBe(false);
+    expect(DEV_SHA_PATTERN.test(str(payload.base))).toBe(true);
+    expect(typeof payload.branch).toBe('string');
+  });
+});
+
+// ============================================================================
+// Shared base-resolution policy (extracted from doctor)
+// ============================================================================
+
+describe('shared integration policy', () => {
+  test('base-state is the single policy point doctor and context share', () => {
+    const fx = makeFixture();
+    const shared = resolveIntegration(fx.root);
+    expect(shared).toEqual({ name: 'dev', ref: 'refs/heads/dev' });
+    expect(resolveIntegrationBranch(fx.root)).toBe(shared?.name ?? null);
+  });
+
+  test('a git failure resolves to null specifically — never a throw, never a guess', () => {
+    // An empty directory is not a repository: every probe fails and the
+    // policy must say "nothing resolvable" instead of throwing or inventing
+    // a branch.
+    const bare = mkdtempSync(join(tmpdir(), 'genie-context-nogit-'));
+    scratchRoots.push(bare);
+    expect(resolveIntegration(bare)).toBeNull();
+    expect(peelCommit(bare, 'refs/heads/dev')).toBeNull();
+    expect(resolveIntegrationBranch(bare)).toBeNull();
+  });
+});
+
+// ============================================================================
+// Stat sanity used only to keep the fixture helper honest
+// ============================================================================
+
+test('fixture helper leaves the temp tree as expected', () => {
+  const fx = makeFixture();
+  expect(existsSync(join(fx.root, '.git'))).toBe(true);
+  expect(statSync(join(fx.root, 'README.md')).isFile()).toBe(true);
+});

--- a/src/term-commands/context.ts
+++ b/src/term-commands/context.ts
@@ -1,0 +1,441 @@
+/**
+ * genie context — the single spawn-context contract point.
+ *
+ * Resolves what a spawn must be based on and prints it as ONE line of
+ * versioned JSON on stdout — nothing else. remotty's spawn consumes exactly
+ * this output:
+ *
+ *   genie context --wish <slug> --group <g>   wish-scoped (first non-plan resolution records the base)
+ *   genie context --wish <slug>               wish branch + all its ready tasks
+ *   genie context [--wish ...] --plan         same payload, strictly read-only (writes nothing)
+ *   genie context                             wishless: integration branch + SHA (no state at all)
+ *
+ * Payload (version 1), one line (fields in this exact order):
+ *   wish + group: {"version":1,"wish":"<slug>","branch":"wish/<slug>-<g>","base":"<40-hex>","tasks":[{"id":"...","title":"..."}],"group":"<g>"}
+ *   wish only:    {"version":1,"wish":"<slug>","branch":"wish/<slug>","base":"<40-hex>","tasks":[...]}
+ *   wishless:     {"version":1,"branch":"<integration-name>","base":"<40-hex>","tasks":[]}
+ *
+ * `base` is always a full 40-hex commit SHA (`^{commit}`-verified) — no raw
+ * ref crosses the boundary. `base` is the ONLY thing a consumer may build a
+ * worktree from; `branch` merely NAMES the integration line (wishless form:
+ * the logical local branch name — the remote prefix of the fallback path is
+ * stripped, e.g. `main`, never `origin/main`). The composed
+ * `wish/<slug>-<group>` branch is opaque to consumers — the slug/group
+ * boundary is unrecoverable from it (slugs may contain `-`).
+ *
+ * Every degradation exits non-zero with a machine-readable JSON line on
+ * stderr: {"error":"<code>","reason":"<text>"}. An empty `tasks` array is
+ * NOT a degradation: whenever branch+base resolve, the payload is emitted
+ * with exit 0 — a group with no ready tasks (all claimed/done, or task rows
+ * missing) still gets its base, so a resumed or re-spawned session never
+ * degrades to a missing worktree base.
+ *
+ * Injection hardening: the wish slug and group name are validated by genie
+ * (the sole validator) against the launch charset plus everything `git
+ * check-ref-format` rejects in the composed ref — no leading `-` (git-option
+ * hazard) or `.`, no trailing `.`, no `..`, no `.lock` suffix. Names are only
+ * ever woven into the composed `wish/...` branch NAME and JSON-escaped in the
+ * output — nothing user-supplied is ever passed to git or a shell. The
+ * recorded base is re-verified with the same `^{commit}` peel before it is
+ * returned.
+ *
+ * Recorded base state (one `meta` row `wish_base:<slug>` per wish, see
+ * src/lib/v5/base-state.ts): the wish skill writes it at plan time (on
+ * APPROVED); a legacy wish's first non-`--plan` resolution records it
+ * (no base → resolve+record+return); later calls return the recorded SHA;
+ * `--re-resolve` refreshes it from the integration branch. `--plan` never
+ * writes — not the record, not the DB, not a file. Carve-out: on SQLite
+ * builds that reject the immutable URI filename (observed: bun's Linux
+ * binary), the `--plan` read-only open falls back to a plain readonly
+ * connection and SQLite's own VFS may recreate its `-shm`/`-wal` sidecar
+ * files; genie itself never writes through it (see
+ * {@link openReadonlyHandle}).
+ */
+
+import { Database } from 'bun:sqlite';
+import { existsSync, statSync } from 'node:fs';
+import type { Command } from 'commander';
+import { resolveGitWorktreeRoot } from '../lib/codex-project-mcp.js';
+import {
+  type IntegrationBranch,
+  peelCommit,
+  readWishBase,
+  resolveIntegration,
+  writeWishBase,
+} from '../lib/v5/base-state.js';
+import { isReadableGenieDb, openDb, resolveDbPath } from '../lib/v5/genie-db.js';
+import { BUSY_TIMEOUT_MS } from '../lib/v5/sqlite-open.js';
+import { listTasks } from '../lib/v5/task-state.js';
+
+// ============================================================================
+// Contract surface
+// ============================================================================
+
+/** The payload schema version. Consumers must check this before parsing fields. */
+export const CONTEXT_VERSION = 1;
+
+/**
+ * Allowed charset for the wish slug and group name, which are woven into the
+ * composed `wish/<slug>-<group>` branch name in the payload. Genie is the sole
+ * validator of this charset (the spawn side consumes the names opaque). The
+ * FIRST character may not be `-` (a git-option hazard for any consumer that
+ * ever passes it through) or `.` (hidden-path hazard), matching the wish
+ * skill's own scaffold gate.
+ */
+export const NAME_PATTERN = /^[A-Za-z0-9_][A-Za-z0-9._-]*$/;
+
+/**
+ * True when `value` is a safe wish slug / group name: the {@link NAME_PATTERN}
+ * charset PLUS everything `git check-ref-format` rejects in the composed ref —
+ * no `..` anywhere, no trailing `.`, and no `.lock` suffix (case-insensitive,
+ * matching modern git).
+ */
+export function isSafeName(value: string): boolean {
+  return NAME_PATTERN.test(value) && !value.includes('..') && !value.endsWith('.') && !/\.lock$/i.test(value);
+}
+
+/** One ready task in the payload — id for `genie task checkout`, title for the kickoff prompt. */
+export interface ContextTask {
+  id: string;
+  title: string;
+}
+
+/** The versioned payload printed on success. */
+export interface ContextPayload {
+  version: typeof CONTEXT_VERSION;
+  /** Wish slug — present only in the wish-scoped form. */
+  wish?: string;
+  /** Group name — present only when `--group` was given. */
+  group?: string;
+  /**
+   * Branch the spawn should live on: the composed `wish/<slug>-<group>` /
+   * recorded wish branch (wish form) or the integration branch name (wishless).
+   */
+  branch: string;
+  /** Full 40-hex commit SHA the branch is based on — the only value that crosses the boundary. */
+  base: string;
+  /** Ready tasks of the group (or of the whole wish without `--group`). Always `[]` wishless. */
+  tasks: ContextTask[];
+}
+
+export interface ContextOptions {
+  wish?: string;
+  group?: string;
+  plan?: boolean;
+  reResolve?: boolean;
+}
+
+/** Test seam: cwd, DB path, clock, and the two output sinks. */
+export interface ContextDeps {
+  cwd?: string;
+  dbPath?: string;
+  now?: () => number;
+  write?: (line: string) => void;
+  writeErr?: (line: string) => void;
+}
+
+/** Every degradation carries a stable machine-readable code. */
+export class ContextError extends Error {
+  readonly code: string;
+  constructor(code: string, reason: string) {
+    super(reason);
+    this.name = 'ContextError';
+    this.code = code;
+  }
+}
+
+function failClosed(code: string, reason: string): never {
+  throw new ContextError(code, reason);
+}
+
+// ============================================================================
+// DB open (writes only when NOT --plan; --plan opens read-only or not at all)
+// ============================================================================
+
+/**
+ * Open a read-only handle for an existing DB file, or null when the open
+ * itself fails (absent file, transient lock, malformed header). Never creates
+ * and never writes — the only open `--plan` may perform.
+ *
+ * Preferred: SQLite immutable semantics (`file:…?immutable=1`) when no
+ * uncheckpointed WAL frames exist (no `-wal`, or a 0-byte one — the normal
+ * state right after any writer closed). It creates NO `-shm`/`-wal` sidecars
+ * and works on read-only mounts. Two fallbacks, both documented contract
+ * carve-outs rather than silent behavior:
+ *   - a non-empty `-wal` (a concurrent or crashed writer left frames): a
+ *     plain readonly open so reads see the WAL; the writer already created
+ *     the sidecars, so nothing new appears;
+ *   - a SQLite build that rejects the URI filename form (observed: bun's
+ *     Linux binary) makes the immutable open throw: fall back to the same
+ *     plain readonly open — consistent reads, and SQLite's own VFS may
+ *     recreate its `-shm`/`-wal` sidecars. Genie itself never writes the
+ *     database, never adds a row, and never creates any other file.
+ * The immutable read is as-of the last checkpoint; a writer that starts in
+ * the tiny stat→open window can leave a fresh preview slightly stale, never
+ * wrong about the resolved base policy.
+ */
+export function openReadonlyHandle(dbPath: string): Database | null {
+  try {
+    let walBytes = 0;
+    try {
+      walBytes = statSync(`${dbPath}-wal`).size;
+    } catch {
+      walBytes = 0;
+    }
+    if (walBytes > 0) return openPlainReadonly(dbPath);
+    try {
+      return new Database(`file:${dbPath}?immutable=1`, { readonly: true });
+    } catch {
+      return openPlainReadonly(dbPath);
+    }
+  } catch {
+    return null;
+  }
+}
+
+/** Plain readonly open with the shared busy_timeout. Null on any failure. */
+function openPlainReadonly(dbPath: string): Database | null {
+  try {
+    const db = new Database(dbPath, { readonly: true });
+    db.exec(`PRAGMA busy_timeout = ${BUSY_TIMEOUT_MS}`);
+    return db;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The DB handle for a wish-scoped resolution. Non-plan uses the standard
+ * write-path open (which may create/backfill the DB — the record write is the
+ * point); `--plan` opens the existing file read-only with zero sidecar
+ * creation (validated shape, no heal — healing writes) or returns null when
+ * the file is absent.
+ */
+function openWishDb(options: ContextOptions, deps: ContextDeps, cwd: string): Database | null {
+  const dbPath = deps.dbPath ?? resolveDbPath(cwd);
+  if (options.plan !== true) {
+    try {
+      return openDb({ path: dbPath });
+    } catch (err) {
+      failClosed(
+        'unreadable-db',
+        `Cannot open genie state DB at ${dbPath}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+  if (!existsSync(dbPath)) return null;
+  const db = openReadonlyHandle(dbPath);
+  if (db === null)
+    failClosed('unreadable-db', `Cannot open genie state DB read-only at ${dbPath} (locked or malformed).`);
+  let readable = false;
+  try {
+    readable = isReadableGenieDb(db);
+  } catch {
+    readable = false;
+  }
+  if (!readable) {
+    db.close();
+    failClosed(
+      'unreadable-db',
+      `Genie state DB at ${dbPath} is not readable by this build; run any genie task command once to migrate it.`,
+    );
+  }
+  return db;
+}
+
+// ============================================================================
+// Base resolution (recorded base → integration policy → fail closed)
+// ============================================================================
+
+/** Resolve the root of the git worktree containing `cwd`, failing closed outside one. */
+function requireRepoRoot(deps: ContextDeps): string {
+  const root = resolveGitWorktreeRoot(deps.cwd ?? process.cwd());
+  if (root === null) failClosed('not-a-git-repo', 'genie context must be run inside a git repository.');
+  return root;
+}
+
+interface ResolvedBase {
+  base: string;
+  /** Wish branch the payload uses when no `--group` is given. */
+  branch: string;
+  /** True when the base was freshly resolved from the integration branch (record absent or --re-resolve). */
+  fresh: boolean;
+}
+
+/**
+ * The base a wish-scoped payload is cut from. A valid recorded base is
+ * re-verified (never re-resolved) and returned unless `--re-resolve` asks for
+ * a fresh one; the integration branch via the shared policy otherwise. The
+ * caller persists a freshly resolved base on non-plan resolutions only.
+ */
+function resolveWishBase(
+  root: string,
+  db: Database | null,
+  slug: string,
+  reResolve: boolean | undefined,
+): ResolvedBase {
+  const record = db === null ? null : readWishBase(db, slug);
+  if (record === 'corrupt') {
+    failClosed(
+      'corrupt-base-record',
+      `Recorded base for wish ${JSON.stringify(slug)} is malformed; re-run with --re-resolve to replace it.`,
+    );
+  }
+  if (record !== null && reResolve !== true) {
+    if (peelCommit(root, record.base) === null) {
+      failClosed(
+        'recorded-base-missing',
+        `Recorded base ${record.base} for wish ${JSON.stringify(slug)} no longer resolves in this repository; re-run with --re-resolve.`,
+      );
+    }
+    return { base: record.base, branch: record.branch, fresh: false };
+  }
+  const integration = resolveIntegration(root);
+  if (integration === null) {
+    failClosed(
+      'no-integration-branch',
+      'No integration branch resolvable (create a local `dev` branch or set the remote default: `git remote set-head origin -a`).',
+    );
+  }
+  const sha = peelCommit(root, integration.ref);
+  if (sha === null) {
+    failClosed(
+      'unresolvable-base',
+      `Integration branch ${integration.ref} does not resolve to a commit in this repository.`,
+    );
+  }
+  return { base: sha, branch: `wish/${slug}`, fresh: true };
+}
+
+// ============================================================================
+// Resolvers
+// ============================================================================
+
+/**
+ * The branch name the wishless payload reports for an integration line. The
+ * shared policy names a local `dev` branch `dev` but the remote-HEAD fallback
+ * path as a remote-tracking name (`origin/main`); reporting THAT would let a
+ * consumer pass it to `git worktree add -b` and silently create
+ * `refs/heads/origin/main`. Strip the remote prefix so the payload names the
+ * logical local branch (`main`). Display only — consumers must build
+ * worktrees from `base`, never from this name.
+ */
+function integrationLineBranch(integration: IntegrationBranch): string {
+  const slash = integration.name.indexOf('/');
+  return slash === -1 ? integration.name : integration.name.slice(slash + 1);
+}
+
+/** Wishless form: integration branch name + its SHA. Reads git only — no DB open, no writes, ever. */
+function resolveWishlessContext(deps: ContextDeps): ContextPayload {
+  const root = requireRepoRoot(deps);
+  const integration = resolveIntegration(root);
+  if (integration === null) {
+    failClosed(
+      'no-integration-branch',
+      'No integration branch resolvable (create a local `dev` branch or set the remote default: `git remote set-head origin -a`).',
+    );
+  }
+  const sha = peelCommit(root, integration.ref);
+  if (sha === null) {
+    failClosed(
+      'unresolvable-base',
+      `Integration branch ${integration.ref} does not resolve to a commit in this repository.`,
+    );
+  }
+  return { version: CONTEXT_VERSION, branch: integrationLineBranch(integration), base: sha, tasks: [] };
+}
+
+/** Wish-scoped form: recorded-or-resolved base, composed branch, and the ready tasks of the group/wish. */
+function resolveWishContext(slug: string, options: ContextOptions, deps: ContextDeps): ContextPayload {
+  if (!isSafeName(slug)) {
+    failClosed(
+      'invalid-wish-slug',
+      `Invalid wish slug ${JSON.stringify(slug)}. Slugs must match ${NAME_PATTERN.source} with no '..', no leading '-' or '.', no trailing '.', and no '.lock' suffix.`,
+    );
+  }
+  const group = options.group;
+  if (group !== undefined && !isSafeName(group)) {
+    failClosed(
+      'invalid-group-name',
+      `Invalid group name ${JSON.stringify(group)}. Group names must match ${NAME_PATTERN.source} with no '..', no leading '-' or '.', no trailing '.', and no '.lock' suffix.`,
+    );
+  }
+  const cwd = deps.cwd ?? process.cwd();
+  const root = requireRepoRoot(deps);
+  const db = openWishDb(options, deps, cwd);
+  try {
+    const resolved = resolveWishBase(root, db, slug, options.reResolve);
+    // Persist a freshly resolved base on the first non-plan resolution only:
+    // no base → resolve+record+return; recorded → return it (done above);
+    // --re-resolve refreshes. --plan never writes.
+    if (db !== null && options.plan !== true && resolved.fresh) {
+      writeWishBase(db, slug, { branch: resolved.branch, base: resolved.base, recordedAt: (deps.now ?? Date.now)() });
+    }
+    // Tasks are advisory payload, never a gate: once branch+base resolve the
+    // payload is emitted with exit 0 even when the ready set is empty (all
+    // tasks claimed/done, task rows missing, or no genie.db at all) — a
+    // resumed or re-spawned session must still receive its base.
+    const ready = db === null ? [] : listTasks(db, { wish: slug, status: 'ready' });
+    const tasks = ready
+      .filter((task) => group === undefined || task.group === group)
+      .map((task) => ({ id: task.id, title: task.title }));
+    const payload: ContextPayload = {
+      version: CONTEXT_VERSION,
+      wish: slug,
+      branch: group === undefined ? resolved.branch : `wish/${slug}-${group}`,
+      base: resolved.base,
+      tasks,
+    };
+    if (group !== undefined) payload.group = group;
+    return payload;
+  } finally {
+    db?.close();
+  }
+}
+
+// ============================================================================
+// Command entry
+// ============================================================================
+
+/**
+ * Run the context resolution and print the payload (stdout, one line, exit 0)
+ * or the machine-readable failure (stderr, one JSON line, exit 1). Never
+ * throws.
+ */
+export function contextCommand(options: ContextOptions, deps: ContextDeps = {}): number {
+  const write = deps.write ?? ((line: string) => process.stdout.write(`${line}\n`));
+  const writeErr = deps.writeErr ?? ((line: string) => process.stderr.write(`${line}\n`));
+  try {
+    if (options.group !== undefined && options.wish === undefined) {
+      failClosed('group-requires-wish', '--group requires --wish.');
+    }
+    if (options.reResolve === true && options.wish === undefined) {
+      failClosed('re-resolve-requires-wish', '--re-resolve requires --wish.');
+    }
+    const payload =
+      options.wish === undefined ? resolveWishlessContext(deps) : resolveWishContext(options.wish, options, deps);
+    write(JSON.stringify(payload));
+    return 0;
+  } catch (err) {
+    const failure =
+      err instanceof ContextError
+        ? err
+        : new ContextError('internal', err instanceof Error ? err.message : String(err));
+    writeErr(JSON.stringify({ error: failure.code, reason: failure.message }));
+    return 1;
+  }
+}
+
+/** Register `genie context` on the CLI program. */
+export function registerContextCommand(program: Command): void {
+  program
+    .command('context')
+    .description('Resolve spawn context: wish/group branch + base SHA, or the integration branch (versioned JSON)')
+    .option('--wish <slug>', 'Wish slug (charset-restricted); absent = wishless integration lookup')
+    .option('--group <name>', 'Wish group (requires --wish)')
+    .option('--plan', 'Print the payload strictly read-only — writes nothing, including the recorded base')
+    .option('--re-resolve', 'Refresh the recorded base SHA instead of returning it (requires --wish)')
+    .action((options: ContextOptions) => {
+      process.exit(contextCommand(options));
+    });
+}


### PR DESCRIPTION
## spawn-context-contract — Group contract

The one contract point: `genie context` resolves wish/group/branch/base SHA with `--plan` preview.

### Deliverables
1. `genie context --wish <slug> [--group g] [--plan]` verb: versioned JSON (branch + resolved base SHA + group tasks), SHA-only payload, fail-closed degradation (non-zero + machine-readable JSON reason), injection-hardened (charset-gated slug/group, `^{commit}` verify, single-line JSON output).
2. Recorded base state: one `meta` row per wish (`wish_base:<slug>`); wish skill writes it at plan time on APPROVED (skills/wish flow step 12 + plugin mirror); first non-plan resolution persists (no base → resolve+record+return; recorded → return it; `--re-resolve` refreshes).
3. Base-resolution policy extracted from doctor's `resolveIntegration` into one shared exported function in `src/lib/v5/base-state.ts` (no bash twin; doctor-worktrees imports it — 19/19 doctor tests green).
4. `--plan` prints the same payload spawn will consume, strictly read-only — no writes including the wave pin (readonly DB open, no heal, no file creation; tested byte-for-byte).
5. Wishless form `genie context [--plan]` resolves the repo's integration branch + SHA (same versioned payload minus wish/group fields, no state write — zero DB opens).

### Payload (version 1)
- wish+group: `{"version":1,"wish":"<slug>","group":"<g>","branch":"wish/<slug>-<g>","base":"<40-hex>","tasks":[{"id","title"}]}`
- wish only: `{"version":1,"wish":"<slug>","branch":"wish/<slug>","base":"<40-hex>","tasks":[...]}`
- wishless: `{"version":1,"branch":"<integration-name>","base":"<40-hex>","tasks":[]}`

Failure (exit 1): `{"error":"<code>","reason":"<text>"}` on stderr.

### Validation
```bash
bun test src/term-commands/context.test.ts && bun run typecheck && bun run lint
```
22/22 context tests, typecheck clean, lint clean (only the 3 pre-existing baseline complexity warnings in doctor.ts/mcp.test.ts).