### PR TITLE
spawn-context-contract#doctor-modes: mode-drift check + tighten-only --fix across all worktrees

### DIFF
--- a/scripts/hook-bundle-parity.test.ts
+++ b/scripts/hook-bundle-parity.test.ts
@@ -30,7 +30,13 @@ describe('committed hook bundle parity', () => {
         await expect(assertHookBundleParity(fixture)).rejects.toThrow('Hook bundle drift');
 
         writeFileSync(bundle, await renderHookBundle(target.source));
+        // 744 is STRICTER than 755: the tighten-only doctor cannot restore
+        // the lost executable bits, so the message names regeneration.
         chmodSync(bundle, 0o744);
+        await expect(assertHookBundleParity(fixture)).rejects.toThrow(/must have mode 755.*--write/);
+        // 777 is WIDER than 755: exactly the group/world-writable drift the
+        // doctor's tighten-only repair exists for.
+        chmodSync(bundle, 0o777);
         await expect(assertHookBundleParity(fixture)).rejects.toThrow(/must have mode 755.*genie doctor --fix/);
       }
     } finally {

--- a/scripts/hook-bundle-parity.ts
+++ b/scripts/hook-bundle-parity.ts
@@ -53,8 +53,16 @@ export async function assertHookBundleParity(target: HookBundleTarget): Promise<
   }
   const mode = statSync(target.bundle).mode & 0o777;
   if (mode !== 0o755) {
+    // Tighten-only doctor semantics: `genie doctor --fix` repairs only
+    // group/world-writable (wider-than-755) drift. A bundle that LOST its
+    // executable bits (e.g. 644) is stricter than the index, and the doctor
+    // deliberately never widens it — regeneration is that repair.
+    const widerThan755 = (mode & ~0o755) !== 0;
+    const missingBits = (0o755 & ~mode) !== 0;
+    const advice =
+      widerThan755 && !missingBits ? 'run `genie doctor --fix`' : 'run `bun scripts/hook-bundle-parity.ts --write`';
     throw new Error(
-      `Hook bundle drift: plugins/genie/scripts/${target.name}.cjs must have mode 755 (found ${mode.toString(8)}); run \`genie doctor --fix\``,
+      `Hook bundle drift: plugins/genie/scripts/${target.name}.cjs must have mode 755 (found ${mode.toString(8)}); ${advice}`,
     );
   }
 }

--- a/src/genie-commands/doctor-modes.test.ts
+++ b/src/genie-commands/doctor-modes.test.ts
@@ -1,0 +1,460 @@
+/**
+ * doctor-modes: on-disk mode drift inside every registered worktree.
+ *
+ * Every fixture is a REAL git repo with REAL `git worktree add` worktrees
+ * under the system temp dir — the scanner's whole job is reading git truth and
+ * lstat truth, so a mocked git would test nothing. Nothing outside
+ * `mkdtempSync` roots is ever touched, and every fixture sets its modes
+ * explicitly so no ambient umask can leak into an assertion.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import {
+  chmodSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { checkWorktreeModes, classifyModeDrift, repairWorktreeModes, scanWorktreeModes } from './doctor-modes.js';
+import { cleanupLaunchWorktrees } from './doctor-worktrees.js';
+import { doctorCommand } from './doctor.js';
+
+const scratchRoots: string[] = [];
+
+afterEach(() => {
+  for (const dir of scratchRoots.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+interface Fixture {
+  /** Temp dir holding the repo, the worktrees base, and planted symlink targets. */
+  dir: string;
+  /** Main checkout. */
+  root: string;
+  /** Stand-in for the launch worktrees base. */
+  base: string;
+}
+
+/** Seeded repo with tracked files at a.txt (644), sub/b.txt (644), bin/run.sh (755). */
+function makeFixture(): Fixture {
+  const dir = mkdtempSync(join(tmpdir(), 'genie-doctor-modes-'));
+  scratchRoots.push(dir);
+  const root = join(dir, 'repo');
+  const base = join(dir, 'worktrees');
+  mkdirSync(root);
+  mkdirSync(base);
+  chmodSync(root, 0o755);
+  git(root, 'init', '-q');
+  git(root, 'config', 'user.email', 'test@example.com');
+  git(root, 'config', 'user.name', 'Test');
+  git(root, 'config', 'commit.gpgsign', 'false');
+  writeFileSync(join(root, 'a.txt'), 'alpha\n');
+  chmodSync(join(root, 'a.txt'), 0o644);
+  mkdirSync(join(root, 'sub'));
+  chmodSync(join(root, 'sub'), 0o755);
+  writeFileSync(join(root, 'sub', 'b.txt'), 'beta\n');
+  chmodSync(join(root, 'sub', 'b.txt'), 0o644);
+  mkdirSync(join(root, 'bin'));
+  chmodSync(join(root, 'bin'), 0o755);
+  writeFileSync(join(root, 'bin', 'run.sh'), '#!/bin/sh\necho hi\n');
+  chmodSync(join(root, 'bin', 'run.sh'), 0o755);
+  git(root, 'add', '-A');
+  git(root, 'commit', '-q', '-m', 'seed');
+  git(root, 'branch', 'dev');
+  return { dir, root, base };
+}
+
+/** Materialize a worktree under the base on a fresh branch, with explicit modes. */
+function addWorktree(fixture: Fixture, branch: string): string {
+  const path = join(fixture.base, branch.split('/').pop() ?? branch);
+  git(fixture.root, 'worktree', 'add', '-q', '-b', branch, path);
+  chmodSync(path, 0o755);
+  return path;
+}
+
+function modeOf(path: string): number {
+  return lstatSync(path).mode & 0o7777;
+}
+
+/** git reports canonical paths (macOS temp dirs live behind /private). */
+function canonical(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+}
+
+/** The drift entries for one worktree path (canonicalized), optionally one relPath. */
+function entriesFor(scan: ReturnType<typeof scanWorktreeModes>, worktree: string, relPath: string | null = null) {
+  return scan.entries.filter(
+    (entry) => entry.worktree === canonical(worktree) && (relPath === null || entry.relPath === relPath),
+  );
+}
+
+/** Run the `--fix` half against the fixture, capturing its log lines. */
+function runRepair(fixture: Fixture): string[] {
+  const lines: string[] = [];
+  repairWorktreeModes(fixture.root, { logSink: (line) => lines.push(line) });
+  return lines;
+}
+
+describe('mode drift classification (pure)', () => {
+  test('wider, stricter, and mixed are told apart; dir repair set is exactly 0775/0777', () => {
+    expect(classifyModeDrift(0o666, 0o644, 'file')).toMatchObject({ disposition: 'wider' });
+    expect(classifyModeDrift(0o777, 0o755, 'file')).toMatchObject({ disposition: 'wider' });
+    expect(classifyModeDrift(0o600, 0o644, 'file')).toMatchObject({ disposition: 'stricter' });
+    expect(classifyModeDrift(0o660, 0o644, 'file')).toMatchObject({ disposition: 'mixed' });
+    expect(classifyModeDrift(0o644, 0o644, 'file')).toBeNull();
+
+    expect(classifyModeDrift(0o775, 0o755, 'dir')).toMatchObject({ disposition: 'wider' });
+    expect(classifyModeDrift(0o777, 0o755, 'dir')).toMatchObject({ disposition: 'wider' });
+    expect(classifyModeDrift(0o700, 0o755, 'dir')).toMatchObject({ disposition: 'stricter' });
+    expect(classifyModeDrift(0o770, 0o755, 'dir')).toMatchObject({ disposition: 'mixed' });
+    // Wider than 0755 but outside the named set: setgid is plausibly intentional.
+    expect(classifyModeDrift(0o2775, 0o755, 'dir')).toMatchObject({ disposition: 'refused' });
+  });
+});
+
+describe('wider drift is reported and tightened to the index mode', () => {
+  test('a 0666 file (index 0644) tightens to 0644; repair is idempotent', () => {
+    const fixture = makeFixture();
+    const wt = addWorktree(fixture, 'wish/demo-alpha');
+    chmodSync(join(wt, 'a.txt'), 0o666);
+
+    const entry = entriesFor(scanWorktreeModes(fixture.root), wt, 'a.txt')[0];
+    expect(entry).toMatchObject({ kind: 'file', disposition: 'wider', indexMode: '644', diskMode: '666' });
+    const report = checkWorktreeModes(fixture.root)
+      .map((check) => `${check.name} — ${check.detail} — ${check.suggestion ?? ''}`)
+      .join('\n');
+    expect(report).toContain('1 wider');
+    expect(report).toContain('--fix tightens to 644');
+    expect(report).toContain('genie doctor --fix');
+
+    const lines = runRepair(fixture).join('\n');
+    expect(lines).toContain(`tightened ${canonical(wt)}/a.txt (666 → 644)`);
+    expect(modeOf(join(wt, 'a.txt'))).toBe(0o644);
+
+    // Second run: nothing wider left ⇒ strict no-op, no chatter.
+    expect(runRepair(fixture)).toEqual([]);
+    expect(scanWorktreeModes(fixture.root).entries).toEqual([]);
+    expect(checkWorktreeModes(fixture.root)[0]).toMatchObject({
+      name: 'mode drift',
+      status: 'pass',
+      detail: 'none found',
+    });
+  });
+
+  test('a 0777 executable (index 0755) tightens to 0755', () => {
+    const fixture = makeFixture();
+    const wt = addWorktree(fixture, 'wish/demo-beta');
+    chmodSync(join(wt, 'bin', 'run.sh'), 0o777);
+
+    const entry = entriesFor(scanWorktreeModes(fixture.root), wt, 'bin/run.sh')[0];
+    expect(entry).toMatchObject({ disposition: 'wider', indexMode: '755', diskMode: '777' });
+    runRepair(fixture);
+    expect(modeOf(join(wt, 'bin', 'run.sh'))).toBe(0o755);
+  });
+
+  test('drift in the main checkout is reported and repaired too', () => {
+    const fixture = makeFixture();
+    chmodSync(join(fixture.root, 'a.txt'), 0o666);
+
+    const entry = entriesFor(scanWorktreeModes(fixture.root), fixture.root, 'a.txt')[0];
+    expect(entry).toMatchObject({ disposition: 'wider', indexMode: '644', diskMode: '666' });
+    runRepair(fixture);
+    expect(modeOf(join(fixture.root, 'a.txt'))).toBe(0o644);
+  });
+});
+
+describe('tighten-only: stricter modes survive --fix untouched', () => {
+  test('a 0600 file is reported but never widened', () => {
+    const fixture = makeFixture();
+    const wt = addWorktree(fixture, 'wish/demo-alpha');
+    chmodSync(join(wt, 'a.txt'), 0o600);
+
+    const entry = entriesFor(scanWorktreeModes(fixture.root), wt, 'a.txt')[0];
+    expect(entry).toMatchObject({ disposition: 'stricter', indexMode: '644', diskMode: '600' });
+    const itemLine = checkWorktreeModes(fixture.root).find((check) => check.name.includes('a.txt'));
+    expect(itemLine?.status).toBe('pass'); // informational, never a warning to fix
+    expect(itemLine?.detail).toContain('never widened');
+
+    expect(runRepair(fixture)).toEqual([]); // nothing wider ⇒ strict no-op
+    expect(modeOf(join(wt, 'a.txt'))).toBe(0o600);
+  });
+
+  test('a 0700 dir is reported but never widened', () => {
+    const fixture = makeFixture();
+    const wt = addWorktree(fixture, 'wish/demo-beta');
+    chmodSync(join(wt, 'sub'), 0o700);
+
+    const entry = entriesFor(scanWorktreeModes(fixture.root), wt, 'sub')[0];
+    expect(entry).toMatchObject({ kind: 'dir', disposition: 'stricter', indexMode: '755', diskMode: '700' });
+    runRepair(fixture);
+    expect(modeOf(join(wt, 'sub'))).toBe(0o700);
+  });
+
+  test('a mixed mode (0660 file, 0770 dir) is kept and never edited', () => {
+    const fixture = makeFixture();
+    const wt = addWorktree(fixture, 'wish/demo-gamma');
+    chmodSync(join(wt, 'a.txt'), 0o660);
+    chmodSync(join(wt, 'sub'), 0o770);
+
+    expect(entriesFor(scanWorktreeModes(fixture.root), wt, 'a.txt')[0]).toMatchObject({ disposition: 'mixed' });
+    expect(entriesFor(scanWorktreeModes(fixture.root), wt, 'sub')[0]).toMatchObject({ disposition: 'mixed' });
+    runRepair(fixture);
+    expect(modeOf(join(wt, 'a.txt'))).toBe(0o660);
+    expect(modeOf(join(wt, 'sub'))).toBe(0o770);
+  });
+});
+
+describe('directory repair is included', () => {
+  test('0777 worktree root and 0775 nested dir tighten to 0755', () => {
+    const fixture = makeFixture();
+    const wt = addWorktree(fixture, 'wish/demo-alpha');
+    chmodSync(wt, 0o777);
+    chmodSync(join(wt, 'sub'), 0o775);
+
+    const scan = scanWorktreeModes(fixture.root);
+    expect(entriesFor(scan, wt, '')[0]).toMatchObject({
+      kind: 'dir',
+      disposition: 'wider',
+      indexMode: '755',
+      diskMode: '777',
+    });
+    expect(entriesFor(scan, wt, 'sub')[0]).toMatchObject({ kind: 'dir', disposition: 'wider', diskMode: '775' });
+
+    runRepair(fixture);
+    expect(modeOf(wt)).toBe(0o755);
+    expect(modeOf(join(wt, 'sub'))).toBe(0o755);
+  });
+});
+
+describe('planted symlinks are never followed', () => {
+  test('a tracked file replaced by a symlink is refused; the target is never operated on', () => {
+    const fixture = makeFixture();
+    const wt = addWorktree(fixture, 'wish/demo-alpha');
+    const victim = join(fixture.dir, 'victim.txt');
+    writeFileSync(victim, 'secret\n');
+    chmodSync(victim, 0o644);
+    rmSync(join(wt, 'a.txt'));
+    symlinkSync(victim, join(wt, 'a.txt'));
+
+    const entry = entriesFor(scanWorktreeModes(fixture.root), wt, 'a.txt')[0];
+    expect(entry).toMatchObject({ disposition: 'refused', indexMode: '644' });
+    expect(entry.reason).toContain('symlink');
+    const itemLine = checkWorktreeModes(fixture.root).find((check) => check.name.includes('a.txt'));
+    expect(itemLine?.detail).toContain('--fix will not touch it');
+
+    runRepair(fixture);
+    expect(lstatSync(join(wt, 'a.txt')).isSymbolicLink()).toBe(true);
+    expect(modeOf(victim)).toBe(0o644); // untouched through the link
+  });
+
+  test('a directory replaced by a symlink blocks every file beneath it', () => {
+    const fixture = makeFixture();
+    const wt = addWorktree(fixture, 'wish/demo-beta');
+    const outdir = join(fixture.dir, 'outdir');
+    mkdirSync(outdir);
+    writeFileSync(join(outdir, 'precious.txt'), 'precious\n');
+    chmodSync(join(outdir, 'precious.txt'), 0o600); // even a stricter target must not change
+    chmodSync(outdir, 0o777);
+    rmSync(join(wt, 'sub'), { recursive: true });
+    symlinkSync(outdir, join(wt, 'sub'));
+
+    const scan = scanWorktreeModes(fixture.root);
+    const dirEntry = entriesFor(scan, wt, 'sub')[0];
+    expect(dirEntry).toMatchObject({ kind: 'dir', disposition: 'refused' });
+    expect(dirEntry.reason).toContain('never followed');
+    const fileEntry = entriesFor(scan, wt, 'sub/b.txt')[0];
+    expect(fileEntry).toMatchObject({ disposition: 'refused' });
+    expect(fileEntry.reason).toContain('never followed');
+
+    runRepair(fixture);
+    expect(lstatSync(join(wt, 'sub')).isSymbolicLink()).toBe(true);
+    expect(modeOf(join(outdir, 'precious.txt'))).toBe(0o600);
+    expect(modeOf(outdir)).toBe(0o777);
+  });
+
+  test('tracked symlink (120000) and gitlink (160000) index entries are skipped outright', () => {
+    const fixture = makeFixture();
+    const wt = addWorktree(fixture, 'wish/demo-gamma');
+    symlinkSync('a.txt', join(wt, 'link.txt'));
+    git(wt, 'add', 'link.txt');
+    git(wt, 'commit', '-q', '-m', 'add tracked symlink');
+    git(wt, 'update-index', '--add', '--cacheinfo', '160000', 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef', 'submod');
+
+    const scan = scanWorktreeModes(fixture.root);
+    expect(scan.entries.some((entry) => entry.relPath === 'link.txt')).toBe(false);
+    expect(scan.entries.some((entry) => entry.relPath === 'submod')).toBe(false);
+    expect(runRepair(fixture)).toEqual([]);
+    expect(lstatSync(join(wt, 'link.txt')).isSymbolicLink()).toBe(true);
+  });
+});
+
+describe('probe errors keep the item with a reason', () => {
+  test('a vanished worktree refuses the whole tree instead of assuming it is clean', () => {
+    const fixture = makeFixture();
+    const wt = addWorktree(fixture, 'wish/demo-alpha');
+    // Porcelain prints canonical paths; once the directory is gone realpath
+    // fails, so capture the canonical spelling while it still exists.
+    const canonicalWt = canonical(wt);
+    rmSync(wt, { recursive: true, force: true });
+
+    const entry = scanWorktreeModes(fixture.root).entries.find((e) => e.worktree === canonicalWt);
+    expect(entry).toMatchObject({ relPath: null, kind: 'worktree', disposition: 'refused' });
+    expect(entry?.reason).toBe('worktree directory no longer exists');
+    const report = checkWorktreeModes(fixture.root)
+      .map((check) => `${check.name} — ${check.detail} — ${check.suggestion ?? ''}`)
+      .join('\n');
+    expect(report).toContain('--fix will not touch it');
+    expect(report).toContain('Run `git worktree prune`');
+
+    expect(runRepair(fixture)).toEqual([]);
+  });
+
+  test('outside a git repository: enumeration failure is surfaced; null root emits nothing', () => {
+    const plainDir = mkdtempSync(join(tmpdir(), 'genie-doctor-modes-plain-'));
+    scratchRoots.push(plainDir);
+    const checks = checkWorktreeModes(plainDir);
+    expect(checks).toHaveLength(1);
+    expect(checks[0]).toMatchObject({ name: 'mode drift', status: 'warn' });
+    expect(checks[0].detail).toContain('enumeration failed');
+
+    expect(checkWorktreeModes(null)).toEqual([]);
+    repairWorktreeModes(null, {
+      logSink: () => {
+        throw new Error('repair must not run without a repo root');
+      },
+    });
+  });
+});
+
+describe('dirty worktrees: repair applies, removal stays refused', () => {
+  test('--fix tightens drift inside a dirty worktree but never removes it', () => {
+    const fixture = makeFixture();
+    const wt = addWorktree(fixture, 'wish/demo-alpha');
+    writeFileSync(join(wt, 'scratch.txt'), 'work in progress\n');
+    chmodSync(join(wt, 'a.txt'), 0o666);
+
+    // The worktrees-removal proof still refuses a dirty tree (regression).
+    const cleanupLines: string[] = [];
+    cleanupLaunchWorktrees(fixture.root, { worktreesBase: fixture.base, logSink: (line) => cleanupLines.push(line) });
+    expect(cleanupLines).toEqual([]);
+    expect(lstatSync(join(wt, 'scratch.txt')).isFile()).toBe(true);
+
+    // Mode repair still applies: content hygiene does not depend on cleanliness.
+    runRepair(fixture);
+    expect(modeOf(join(wt, 'a.txt'))).toBe(0o644);
+    expect(lstatSync(join(wt, 'scratch.txt')).isFile()).toBe(true);
+  });
+});
+
+describe('doctor wiring', () => {
+  const ISOLATED_KEYS = ['HOME', 'GENIE_HOME', 'CODEX_HOME', 'CLAUDE_CONFIG_DIR', 'GENIE_WORKTREES_DIR'] as const;
+  let saved: Partial<Record<(typeof ISOLATED_KEYS)[number], string>> = {};
+
+  afterEach(() => {
+    for (const key of ISOLATED_KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+    saved = {};
+  });
+
+  /** Point every home-shaped env at the fixture so doctor never reads the real host. */
+  function isolate(fixture: Fixture): void {
+    for (const key of ISOLATED_KEYS) {
+      if (process.env[key] !== undefined) saved[key] = process.env[key];
+    }
+    const home = join(fixture.dir, 'home');
+    mkdirSync(home, { recursive: true });
+    chmodSync(home, 0o755);
+    process.env.HOME = home;
+    process.env.GENIE_HOME = join(home, 'genie');
+    process.env.CODEX_HOME = join(home, 'codex');
+    process.env.CLAUDE_CONFIG_DIR = join(home, 'claude');
+    process.env.GENIE_WORKTREES_DIR = fixture.base;
+  }
+
+  async function runDoctor(
+    fixture: Fixture,
+    options: { json?: boolean; fix?: boolean },
+  ): Promise<{ output: string; exitCode: number }> {
+    const realWrite = process.stdout.write.bind(process.stdout);
+    const priorExit = process.exitCode;
+    process.exitCode = 0;
+    let buffer = '';
+    process.stdout.write = ((chunk: string) => {
+      buffer += chunk;
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      await doctorCommand(options, {
+        root: fixture.root,
+        databaseRoot: fixture.root,
+        pluginProbe: { cliAvailable: false, status: 'unavailable', installed: false, detail: 'fixture absent' },
+        codexActivation: null,
+        projectContext: null,
+        bunVersion: '1.3.10',
+        bunPath: '/usr/bin/bun',
+      });
+      return { output: buffer, exitCode: typeof process.exitCode === 'number' ? process.exitCode : 0 };
+    } finally {
+      process.stdout.write = realWrite;
+      process.exitCode = priorExit ?? 0;
+    }
+  }
+
+  test('doctor --json reports per-worktree drift with dispositions; detect-only mutates nothing', async () => {
+    const fixture = makeFixture();
+    isolate(fixture);
+    const wt = addWorktree(fixture, 'wish/demo-alpha');
+    chmodSync(join(wt, 'a.txt'), 0o666);
+    chmodSync(join(wt, 'sub'), 0o700);
+
+    const { output, exitCode } = await runDoctor(fixture, { json: true });
+    expect(exitCode).toBe(0);
+    const json = JSON.parse(output) as {
+      checks: Array<{ name: string; status: string; detail?: string }>;
+    };
+    const modeChecks = json.checks.filter((check) => check.name.startsWith('mode drift'));
+    expect(modeChecks[0].detail).toContain('1 wider, 1 stricter');
+    expect(modeChecks.map((check) => check.detail).join('\n')).toContain('--fix tightens to 644');
+    expect(modeChecks.map((check) => check.detail).join('\n')).toContain('never widened');
+    // Detect-only: reporting drift must not repair it — repair stays behind --fix.
+    expect(modeOf(join(wt, 'a.txt'))).toBe(0o666);
+    expect(modeOf(join(wt, 'sub'))).toBe(0o700);
+  });
+
+  test('doctor --fix tightens only the wider items; stricter items survive; report reflects the post-fix state', async () => {
+    const fixture = makeFixture();
+    isolate(fixture);
+    const wt = addWorktree(fixture, 'wish/demo-alpha');
+    // A real content change keeps the worktree alive through the removal sweep
+    // (mode-only drift is invisible to `git status`), so repair can act on it.
+    writeFileSync(join(wt, 'scratch.txt'), 'work in progress\n');
+    chmodSync(join(wt, 'a.txt'), 0o666);
+    chmodSync(join(wt, 'sub'), 0o700);
+
+    const { output, exitCode } = await runDoctor(fixture, { json: true, fix: true });
+    expect(exitCode).toBe(0);
+    expect(lstatSync(join(wt, 'scratch.txt')).isFile()).toBe(true); // never removed
+    expect(modeOf(join(wt, 'a.txt'))).toBe(0o644);
+    expect(modeOf(join(wt, 'sub'))).toBe(0o700); // never widened
+    const json = JSON.parse(output) as { checks: Array<{ name: string; detail?: string }> };
+    const summary = json.checks.find((check) => check.name === 'mode drift');
+    expect(summary?.detail).toContain('1 stricter');
+    expect(summary?.detail).not.toContain('wider');
+  });
+});

--- a/src/genie-commands/doctor-modes.test.ts
+++ b/src/genie-commands/doctor-modes.test.ts
@@ -4,8 +4,9 @@
  * Every fixture is a REAL git repo with REAL `git worktree add` worktrees
  * under the system temp dir — the scanner's whole job is reading git truth and
  * lstat truth, so a mocked git would test nothing. Nothing outside
- * `mkdtempSync` roots is ever touched, and every fixture sets its modes
- * explicitly so no ambient umask can leak into an assertion.
+ * `mkdtempSync` roots is ever touched, and every fixture materializes its git
+ * content under an explicit umask 022 so NO ambient umask (the suite is run
+ * green under both `umask 022` and `umask 000`) can leak into an assertion.
  */
 
 import { afterEach, describe, expect, test } from 'bun:test';
@@ -45,7 +46,23 @@ interface Fixture {
   base: string;
 }
 
-/** Seeded repo with tracked files at a.txt (644), sub/b.txt (644), bin/run.sh (755). */
+/** Run `fn` under an explicit umask, restoring the ambient one afterwards. */
+function withUmask<T>(mask: number, fn: () => T): T {
+  const prior = process.umask(mask);
+  try {
+    return fn();
+  } finally {
+    process.umask(prior);
+  }
+}
+
+/**
+ * Seeded repo with tracked files at a.txt (644), sub/b.txt (644),
+ * bin/run.sh (755), and a nested a/b/c.txt (644) for the non-deepest planted
+ * symlink case. Everything is materialized under umask 022 so the seed — and
+ * every `git worktree add` checkout of it — carries sane modes regardless of
+ * the ambient umask the suite runs under.
+ */
 function makeFixture(): Fixture {
   const dir = mkdtempSync(join(tmpdir(), 'genie-doctor-modes-'));
   scratchRoots.push(dir);
@@ -54,30 +71,42 @@ function makeFixture(): Fixture {
   mkdirSync(root);
   mkdirSync(base);
   chmodSync(root, 0o755);
-  git(root, 'init', '-q');
-  git(root, 'config', 'user.email', 'test@example.com');
-  git(root, 'config', 'user.name', 'Test');
-  git(root, 'config', 'commit.gpgsign', 'false');
-  writeFileSync(join(root, 'a.txt'), 'alpha\n');
-  chmodSync(join(root, 'a.txt'), 0o644);
-  mkdirSync(join(root, 'sub'));
-  chmodSync(join(root, 'sub'), 0o755);
-  writeFileSync(join(root, 'sub', 'b.txt'), 'beta\n');
-  chmodSync(join(root, 'sub', 'b.txt'), 0o644);
-  mkdirSync(join(root, 'bin'));
-  chmodSync(join(root, 'bin'), 0o755);
-  writeFileSync(join(root, 'bin', 'run.sh'), '#!/bin/sh\necho hi\n');
-  chmodSync(join(root, 'bin', 'run.sh'), 0o755);
-  git(root, 'add', '-A');
-  git(root, 'commit', '-q', '-m', 'seed');
-  git(root, 'branch', 'dev');
+  withUmask(0o022, () => {
+    git(root, 'init', '-q');
+    git(root, 'config', 'user.email', 'test@example.com');
+    git(root, 'config', 'user.name', 'Test');
+    git(root, 'config', 'commit.gpgsign', 'false');
+    writeFileSync(join(root, 'a.txt'), 'alpha\n');
+    chmodSync(join(root, 'a.txt'), 0o644);
+    mkdirSync(join(root, 'sub'));
+    chmodSync(join(root, 'sub'), 0o755);
+    writeFileSync(join(root, 'sub', 'b.txt'), 'beta\n');
+    chmodSync(join(root, 'sub', 'b.txt'), 0o644);
+    mkdirSync(join(root, 'bin'));
+    chmodSync(join(root, 'bin'), 0o755);
+    writeFileSync(join(root, 'bin', 'run.sh'), '#!/bin/sh\necho hi\n');
+    chmodSync(join(root, 'bin', 'run.sh'), 0o755);
+    mkdirSync(join(root, 'a', 'b'), { recursive: true });
+    chmodSync(join(root, 'a'), 0o755);
+    chmodSync(join(root, 'a', 'b'), 0o755);
+    writeFileSync(join(root, 'a', 'b', 'c.txt'), 'gamma\n');
+    chmodSync(join(root, 'a', 'b', 'c.txt'), 0o644);
+    git(root, 'add', '-A');
+    git(root, 'commit', '-q', '-m', 'seed');
+    git(root, 'branch', 'dev');
+  });
   return { dir, root, base };
 }
 
 /** Materialize a worktree under the base on a fresh branch, with explicit modes. */
 function addWorktree(fixture: Fixture, branch: string): string {
   const path = join(fixture.base, branch.split('/').pop() ?? branch);
-  git(fixture.root, 'worktree', 'add', '-q', '-b', branch, path);
+  // Materialize under umask 022: `git worktree add` checks out every tracked
+  // file with modes derived from the ambient umask, and a 000 ambient would
+  // turn the whole fresh tree into wider-than-index drift (failing every
+  // "1 wider" assertion). The explicit root chmod stays as a second line of
+  // defense for the worktree root itself.
+  withUmask(0o022, () => git(fixture.root, 'worktree', 'add', '-q', '-b', branch, path));
   chmodSync(path, 0o755);
   return path;
 }
@@ -123,6 +152,10 @@ describe('mode drift classification (pure)', () => {
     expect(classifyModeDrift(0o770, 0o755, 'dir')).toMatchObject({ disposition: 'mixed' });
     // Wider than 0755 but outside the named set: setgid is plausibly intentional.
     expect(classifyModeDrift(0o2775, 0o755, 'dir')).toMatchObject({ disposition: 'refused' });
+    // Setuid/setgid bits on a file: reported, never stripped — even when the
+    // permission bits themselves agree with the index.
+    expect(classifyModeDrift(0o4755, 0o755, 'file')).toMatchObject({ disposition: 'refused' });
+    expect(classifyModeDrift(0o4755, 0o644, 'file')).toMatchObject({ disposition: 'refused' });
   });
 });
 
@@ -202,6 +235,20 @@ describe('tighten-only: stricter modes survive --fix untouched', () => {
     expect(entry).toMatchObject({ kind: 'dir', disposition: 'stricter', indexMode: '755', diskMode: '700' });
     runRepair(fixture);
     expect(modeOf(join(wt, 'sub'))).toBe(0o700);
+  });
+
+  test('a setuid/setgid file is reported and never stripped', () => {
+    const fixture = makeFixture();
+    const wt = addWorktree(fixture, 'wish/demo-alpha');
+    // bun's chmodSync drops the setuid bit on macOS, so plant it via the
+    // system chmod — the on-disk mode is what the scanner must classify.
+    execFileSync('chmod', ['4755', join(wt, 'a.txt')], { stdio: 'ignore' }); // perms wider than index 644 AND setuid
+
+    const entry = entriesFor(scanWorktreeModes(fixture.root), wt, 'a.txt')[0];
+    expect(entry).toMatchObject({ disposition: 'refused' });
+    expect(entry.reason).toContain('setuid');
+    runRepair(fixture);
+    expect(modeOf(join(wt, 'a.txt'))).toBe(0o4755); // never stripped
   });
 
   test('a mixed mode (0660 file, 0770 dir) is kept and never edited', () => {
@@ -286,6 +333,36 @@ describe('planted symlinks are never followed', () => {
     expect(modeOf(outdir)).toBe(0o777);
   });
 
+  test("a tracked dir BENEATH a planted symlink is refused, never probed or chmod'd through", () => {
+    // PoC regression: tracked a/b/c.txt, and repo/a swapped for a symlink to
+    // an OUTSIDE tree that happens to contain a 0777 dir named 'b'. lstatSync
+    // follows intermediate components, so probing a/b stats outside/b — the
+    // dir loop must refuse a/b from its blocking ancestor instead.
+    const fixture = makeFixture();
+    const wt = addWorktree(fixture, 'wish/demo-alpha');
+    const outside = join(fixture.dir, 'outside');
+    mkdirSync(join(outside, 'b'), { recursive: true });
+    writeFileSync(join(outside, 'b', 'c.txt'), 'victim\n');
+    chmodSync(join(outside, 'b', 'c.txt'), 0o600);
+    chmodSync(join(outside, 'b'), 0o777);
+    chmodSync(outside, 0o755);
+    rmSync(join(wt, 'a'), { recursive: true });
+    symlinkSync(outside, join(wt, 'a'));
+
+    const scan = scanWorktreeModes(fixture.root);
+    const aEntry = entriesFor(scan, wt, 'a')[0];
+    expect(aEntry).toMatchObject({ kind: 'dir', disposition: 'refused' });
+    const bEntry = entriesFor(scan, wt, 'a/b')[0];
+    expect(bEntry).toMatchObject({ kind: 'dir', disposition: 'refused' });
+    expect(bEntry.reason).toContain('never followed');
+
+    const lines = runRepair(fixture).join('\n');
+    expect(lines).not.toContain('a/b'); // the outside dir is never repaired
+    expect(modeOf(join(outside, 'b'))).toBe(0o777); // outside tree untouched
+    expect(modeOf(join(outside, 'b', 'c.txt'))).toBe(0o600);
+    expect(lstatSync(join(wt, 'a')).isSymbolicLink()).toBe(true);
+  });
+
   test('tracked symlink (120000) and gitlink (160000) index entries are skipped outright', () => {
     const fixture = makeFixture();
     const wt = addWorktree(fixture, 'wish/demo-gamma');
@@ -299,6 +376,35 @@ describe('planted symlinks are never followed', () => {
     expect(scan.entries.some((entry) => entry.relPath === 'submod')).toBe(false);
     expect(runRepair(fixture)).toEqual([]);
     expect(lstatSync(join(wt, 'link.txt')).isSymbolicLink()).toBe(true);
+  });
+});
+
+describe("scan→repair window: a swapped-in symlink is never chmod'd through", () => {
+  test('a path classified wider then swapped for a symlink is refused at the mutation site', () => {
+    const fixture = makeFixture();
+    const wt = addWorktree(fixture, 'wish/demo-alpha');
+    chmodSync(join(wt, 'a.txt'), 0o666);
+
+    // The scan classifies a.txt as wider (666 → 644) — then, inside the
+    // scan→repair window, the file is swapped for a symlink to a 0600 victim.
+    const scan = scanWorktreeModes(fixture.root);
+    expect(entriesFor(scan, wt, 'a.txt')[0]).toMatchObject({ disposition: 'wider' });
+    const victim = join(fixture.dir, 'victim.txt');
+    writeFileSync(victim, 'secret\n');
+    chmodSync(victim, 0o600);
+    rmSync(join(wt, 'a.txt'));
+    symlinkSync(victim, join(wt, 'a.txt'));
+
+    // Repair must re-prove the path (O_NOFOLLOW open) and refuse it: the
+    // victim's stricter mode is never widened, the link is never followed.
+    const lines: string[] = [];
+    repairWorktreeModes(fixture.root, { logSink: (line) => lines.push(line), scan });
+    const chatter = lines.join('\n');
+    expect(chatter).toContain('kept');
+    expect(chatter).toContain('O_NOFOLLOW');
+    expect(chatter).not.toContain('✔');
+    expect(modeOf(victim)).toBe(0o600);
+    expect(lstatSync(join(wt, 'a.txt')).isSymbolicLink()).toBe(true);
   });
 });
 
@@ -321,6 +427,21 @@ describe('probe errors keep the item with a reason', () => {
     expect(report).toContain('Run `git worktree prune`');
 
     expect(runRepair(fixture)).toEqual([]);
+  });
+
+  test('an unparseable index mode refuses the item instead of chmodding garbage', () => {
+    const fixture = makeFixture();
+    const wt = addWorktree(fixture, 'wish/demo-alpha');
+    chmodSync(join(wt, 'a.txt'), 0o666);
+    const scan = scanWorktreeModes(fixture.root);
+    const entry = entriesFor(scan, wt, 'a.txt')[0];
+    entry.indexMode = 'not-octal'; // corrupt the entry inside the scan→repair seam
+
+    const lines: string[] = [];
+    repairWorktreeModes(fixture.root, { logSink: (line) => lines.push(line), scan });
+    expect(lines.join('\n')).toContain('unparseable index mode');
+    expect(lines.join('\n')).toContain('kept');
+    expect(modeOf(join(wt, 'a.txt'))).toBe(0o666); // untouched
   });
 
   test('outside a git repository: enumeration failure is surfaced; null root emits nothing', () => {

--- a/src/genie-commands/doctor-modes.ts
+++ b/src/genie-commands/doctor-modes.ts
@@ -1,0 +1,544 @@
+/**
+ * doctor: on-disk mode drift inside every registered worktree.
+ *
+ * `genie launch` materializes worktrees from agent shells that historically
+ * ran `umask 000`, so checked-out trees accumulate files and directories that
+ * are group/world-writable (0666/0777) or wider than the index says. This
+ * module makes that drift visible in `genie doctor` and repairable by
+ * `genie doctor --fix` — but only as a tightening, never a widening.
+ *
+ * Three properties govern everything here:
+ *
+ *  1. Enumeration is authoritative, never heuristic. Worktrees come from
+ *     `git worktree list --porcelain`, files and their index modes from
+ *     `git ls-files -s -z` run inside each worktree — the same truth git
+ *     itself acts on. Directories are not tracked, so the directory set is
+ *     the ancestor chain of tracked paths (including the worktree root), and
+ *     the comparison mode for a directory is git's canonical 0755. Ignored
+ *     and untracked content is out of scope by construction.
+ *
+ *  2. Repair is tighten-only. A regular file is restored to its index mode
+ *     ONLY when the on-disk mode is a strict superset of it (removing bits is
+ *     the only mutation ever made). Directories are tightened ONLY from the
+ *     named drift shapes 0775/0777 to 0755. A stricter-than-index mode (0600
+ *     files, 0700 dirs) is reported as informational and never widened; a
+ *     mode with both extra and missing bits is reported and never edited; a
+ *     probe that fails or is refused (symlink planted on disk, vanished
+ *     directory) keeps the item with the reason. Every refusal is surfaced.
+ *
+ *  3. Symlinks are never followed. Every probe uses lstat; index entries of
+ *     kind 120000/160000 are skipped outright, and a symlink occupying the
+ *     path of a tracked file — or of a directory that tracked files live
+ *     under — refuses the item instead of operating through the link.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { type Stats, chmodSync, lstatSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import { parseWorktreePorcelain } from './doctor-worktrees.js';
+import type { CheckResult } from './doctor.js';
+
+/**
+ * How one drifted item may be disposed of. Only `wider` is reachable by
+ * `--fix`; every other disposition is a kept line.
+ */
+export type ModeDriftDisposition =
+  /** On-disk mode is a strict superset of the index mode; --fix tightens it. */
+  | 'wider'
+  /** On-disk mode is a strict subset of the index mode; informational, never widened. */
+  | 'stricter'
+  /** Both extra and missing bits; never edited. */
+  | 'mixed'
+  /** Probe failed or was refused (planted symlink, vanished dir, git error); kept with reason. */
+  | 'refused';
+
+export interface ModeDriftEntry {
+  /** Absolute worktree path exactly as git reported it. */
+  worktree: string;
+  /**
+   * Worktree-relative path of the drifted item; '' is the worktree root dir;
+   * null only for a whole-worktree refusal (nothing inside was probeable).
+   */
+  relPath: string | null;
+  kind: 'file' | 'dir' | 'worktree';
+  /** Octal display of the index mode (files) or git's canonical dir mode 0755. */
+  indexMode: string | null;
+  /** Octal display of the on-disk lstat mode. */
+  diskMode: string | null;
+  disposition: ModeDriftDisposition;
+  /** Why it landed in that class; surfaced verbatim in the doctor line. */
+  reason: string;
+}
+
+export interface ModeDriftScan {
+  entries: ModeDriftEntry[];
+  /** Non-null when enumeration itself failed; `entries` is then empty. */
+  enumerationError: string | null;
+}
+
+export interface ModeRepairDeps {
+  /** Line sink for `--fix` chatter. Defaults to stdout. */
+  logSink?: (line: string) => void;
+}
+
+/** git's canonical directory permission shape: tree dirs are 0755, always. */
+const CANONICAL_DIR_MODE = 0o755;
+/** The only directory modes `--fix` tightens — the two umask-drift shapes. */
+const DIR_TIGHTEN_MODES = new Set<number>([0o775, 0o777]);
+/** Index entry kinds with no permission domain of their own; skipped outright. */
+const SKIP_INDEX_MODES = new Set<number>([0o120000, 0o160000]);
+
+interface GitOutcome {
+  ok: boolean;
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function gitFailure(stderr: string): GitOutcome {
+  return { ok: false, status: null, stdout: '', stderr };
+}
+
+/**
+ * Run git without ever throwing: a failed spawn (e.g. the worktree directory
+ * vanished, so `cwd` no longer exists) is reported like any non-zero exit, and
+ * every caller turns an unsuccessful outcome into a refusal.
+ */
+function git(cwd: string, args: string[]): GitOutcome {
+  try {
+    const res = spawnSync('git', args, {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 10_000,
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    if (res.error) return gitFailure(res.error.message);
+    return { ok: res.status === 0, status: res.status, stdout: res.stdout ?? '', stderr: (res.stderr ?? '').trim() };
+  } catch (error) {
+    return gitFailure(error instanceof Error ? error.message : String(error));
+  }
+}
+
+function firstLine(text: string, fallback: string): string {
+  const line = text.split('\n')[0]?.trim() ?? '';
+  return line === '' ? fallback : line;
+}
+
+/** Octal display: 0o644 → '644', 0o1777 → '1777' (high bits widen it naturally). */
+function octal(mode: number): string {
+  return mode.toString(8).padStart(3, '0');
+}
+
+interface IndexEntry {
+  /** Full index mode (100644/100755/120000/160000). */
+  mode: number;
+  /** Worktree-relative path, raw (unquoted thanks to -z). */
+  path: string;
+}
+
+/** Parse `git ls-files -s -z`: `<mode> <object> <stage>\t<path>\0` records. */
+function parseLsFilesZ(text: string): IndexEntry[] {
+  const entries: IndexEntry[] = [];
+  for (const record of text.split('\0')) {
+    if (record === '') continue;
+    const tab = record.indexOf('\t');
+    if (tab === -1) continue;
+    const mode = Number.parseInt(record.slice(0, tab).split(' ')[0] ?? '', 8);
+    if (!Number.isInteger(mode)) continue;
+    entries.push({ mode, path: record.slice(tab + 1) });
+  }
+  return entries;
+}
+
+/**
+ * Every ancestor directory of the tracked paths, including the worktree root
+ * (''). Only these directories are probed: git never tracks directories, so
+ * the tracked paths are the sole authority on which directories are tree
+ * content — an ignored `node_modules/` is residue, not tree content.
+ */
+function ancestorDirs(paths: string[]): Set<string> {
+  const dirs = new Set<string>(['']);
+  for (const path of paths) {
+    const parts = path.split('/');
+    let acc = '';
+    for (let index = 0; index < parts.length - 1; index += 1) {
+      acc = acc === '' ? parts[index] : `${acc}/${parts[index]}`;
+      dirs.add(acc);
+    }
+  }
+  return dirs;
+}
+
+type DirProbe =
+  /** A real directory: carry its lstat mode for the 0755 comparison. */
+  | { kind: 'dir'; mode: number }
+  /** A symlink on disk where a directory belongs — descendants are never followed. */
+  | { kind: 'symlink' }
+  /** A non-directory non-symlink (file, fifo, socket) occupies the slot. */
+  | { kind: 'not-dir' }
+  /** lstat failed; without a mode nothing is proven. */
+  | { kind: 'error'; reason: string };
+
+interface DirVerdict {
+  /** The drift entry for the directory itself, or null when clean. */
+  entry: ModeDriftEntry | null;
+  /** Non-null when every tracked file beneath must be refused for this reason. */
+  blocksDescendants: string | null;
+}
+
+function probeDir(path: string): DirProbe {
+  let stat: ReturnType<typeof lstatSync>;
+  try {
+    stat = lstatSync(path);
+  } catch (error) {
+    return { kind: 'error', reason: error instanceof Error ? error.message : String(error) };
+  }
+  if (stat.isSymbolicLink()) return { kind: 'symlink' };
+  if (!stat.isDirectory()) return { kind: 'not-dir' };
+  return { kind: 'dir', mode: stat.mode };
+}
+
+/**
+ * Compare one on-disk mode against the mode it must match. Pure + exported so
+ * the tighten-only contract is unit-tested without a worktree on disk.
+ *
+ * Returns null when the modes agree; otherwise a disposition plus the reason
+ * the item keeps or is tightened. `dir` narrows the repairable set to the
+ * named drift shapes: a wider directory outside {0775, 0777} (e.g. setgid
+ * 2775) is refused rather than edited, because its extra bits may be
+ * intentional.
+ */
+export function classifyModeDrift(
+  diskMode: number,
+  indexMode: number,
+  kind: 'file' | 'dir',
+): { disposition: ModeDriftDisposition; reason: string } | null {
+  const disk = diskMode & 0o7777;
+  const index = indexMode & 0o777;
+  if (disk === index) return null;
+  const wider = (disk & ~index) !== 0;
+  const stricter = (index & ~disk) !== 0;
+  if (wider && !stricter) {
+    if (kind === 'dir' && !DIR_TIGHTEN_MODES.has(disk)) {
+      return {
+        disposition: 'refused',
+        reason: `wider than ${octal(index)} but outside the named repair set (only 0775/0777 dirs are tightened)`,
+      };
+    }
+    return { disposition: 'wider', reason: 'on-disk mode is a superset of the index mode' };
+  }
+  if (!wider && stricter) {
+    return {
+      disposition: 'stricter',
+      reason: `on-disk mode is stricter than ${octal(index)} — never widened`,
+    };
+  }
+  return { disposition: 'mixed', reason: 'on-disk mode has both extra and missing bits — never edited' };
+}
+
+/** Verdict for one tracked-path ancestor directory against canonical 0755. */
+function classifyDir(worktree: string, relDir: string, probe: DirProbe): DirVerdict {
+  const base = { worktree, relPath: relDir, kind: 'dir' as const, indexMode: octal(CANONICAL_DIR_MODE) };
+  if (probe.kind === 'symlink') {
+    const reason = 'on-disk is a symlink where a directory belongs — never followed';
+    return {
+      entry: { ...base, diskMode: null, disposition: 'refused', reason },
+      blocksDescendants: `ancestor '${relDir === '' ? '.' : relDir}' is a symlink on disk — never followed`,
+    };
+  }
+  if (probe.kind === 'not-dir') {
+    const reason = 'on-disk is a non-directory where a directory belongs — never edited';
+    return {
+      entry: { ...base, diskMode: null, disposition: 'refused', reason },
+      blocksDescendants: `ancestor '${relDir === '' ? '.' : relDir}' is not a directory — never followed`,
+    };
+  }
+  if (probe.kind === 'error') {
+    return {
+      entry: { ...base, diskMode: null, disposition: 'refused', reason: `lstat failed: ${probe.reason}` },
+      blocksDescendants: null,
+    };
+  }
+  const verdict = classifyModeDrift(probe.mode, CANONICAL_DIR_MODE, 'dir');
+  return {
+    entry: verdict === null ? null : { ...base, diskMode: octal(probe.mode & 0o7777), ...verdict },
+    blocksDescendants: null,
+  };
+}
+
+/** First ancestor dir (from the root down) whose probe blocks file probes, if any. */
+function blockingAncestor(path: string, probes: Map<string, DirVerdict>): string | null {
+  const rootBlock = probes.get('')?.blocksDescendants ?? null;
+  if (rootBlock !== null) return rootBlock;
+  const parts = path.split('/');
+  let acc = '';
+  for (let index = 0; index < parts.length - 1; index += 1) {
+    acc = acc === '' ? parts[index] : `${acc}/${parts[index]}`;
+    const reason = probes.get(acc)?.blocksDescendants ?? null;
+    if (reason !== null) return reason;
+  }
+  return null;
+}
+
+type FileProbe =
+  /** Missing on disk (ENOENT): content dirt, not mode drift — silently skipped. */
+  { kind: 'missing' } | { kind: 'error'; reason: string } | { kind: 'present'; stat: Stats };
+
+/** lstat that never throws; a missing item is reported as such, not as drift. */
+function probeFile(path: string): FileProbe {
+  try {
+    return { kind: 'present', stat: lstatSync(path) };
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return { kind: 'missing' };
+    return { kind: 'error', reason: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+/** Mode drift inside ONE worktree. A git probe failure refuses the whole tree. */
+function scanWorktree(worktree: string): ModeDriftEntry[] {
+  // A registration whose directory is gone can never be probed: refuse it
+  // before spawning git, which would only fail with a cryptic spawn error.
+  try {
+    lstatSync(worktree);
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      return [
+        {
+          worktree,
+          relPath: null,
+          kind: 'worktree',
+          indexMode: null,
+          diskMode: null,
+          disposition: 'refused',
+          reason: 'worktree directory no longer exists',
+        },
+      ];
+    }
+  }
+  const listing = git(worktree, ['ls-files', '-s', '-z']);
+  if (!listing.ok) {
+    return [
+      {
+        worktree,
+        relPath: null,
+        kind: 'worktree',
+        indexMode: null,
+        diskMode: null,
+        disposition: 'refused',
+        reason: firstLine(listing.stderr, 'git ls-files failed'),
+      },
+    ];
+  }
+  const index = parseLsFilesZ(listing.stdout);
+  const dirs = [...ancestorDirs(index.map((entry) => entry.path))].sort();
+  const probes = new Map<string, DirVerdict>();
+  const entries: ModeDriftEntry[] = [];
+  for (const dir of dirs) {
+    const verdict = classifyDir(worktree, dir, probeDir(join(worktree, dir)));
+    probes.set(dir, verdict);
+    if (verdict.entry !== null) entries.push(verdict.entry);
+  }
+  const seen = new Set<string>();
+  for (const file of index) {
+    if (SKIP_INDEX_MODES.has(file.mode) || seen.has(file.path)) continue;
+    seen.add(file.path);
+    const blocked = blockingAncestor(file.path, probes);
+    if (blocked !== null) {
+      entries.push({
+        worktree,
+        relPath: file.path,
+        kind: 'file',
+        indexMode: octal(file.mode & 0o777),
+        diskMode: null,
+        disposition: 'refused',
+        reason: `${blocked}`,
+      });
+      continue;
+    }
+    const probe = probeFile(join(worktree, file.path));
+    if (probe.kind === 'missing') continue; // content dirt, not mode drift
+    if (probe.kind === 'error') {
+      entries.push({
+        worktree,
+        relPath: file.path,
+        kind: 'file',
+        indexMode: octal(file.mode & 0o777),
+        diskMode: null,
+        disposition: 'refused',
+        reason: `lstat failed: ${probe.reason}`,
+      });
+      continue;
+    }
+    const stat = probe.stat;
+    if (stat.isSymbolicLink()) {
+      entries.push({
+        worktree,
+        relPath: file.path,
+        kind: 'file',
+        indexMode: octal(file.mode & 0o777),
+        diskMode: null,
+        disposition: 'refused',
+        reason: 'on-disk is a symlink where the index records a regular file — never followed',
+      });
+      continue;
+    }
+    if (!stat.isFile()) {
+      entries.push({
+        worktree,
+        relPath: file.path,
+        kind: 'file',
+        indexMode: octal(file.mode & 0o777),
+        diskMode: null,
+        disposition: 'refused',
+        reason: 'on-disk is a non-file where the index records a regular file — never edited',
+      });
+      continue;
+    }
+    const verdict = classifyModeDrift(stat.mode, file.mode, 'file');
+    if (verdict !== null) {
+      entries.push({
+        worktree,
+        relPath: file.path,
+        kind: 'file',
+        indexMode: octal(file.mode & 0o777),
+        diskMode: octal(stat.mode & 0o7777),
+        ...verdict,
+      });
+    }
+  }
+  return entries;
+}
+
+/** Worktree path display: '' and null both collapse to the bare basename. */
+function displayName(entry: ModeDriftEntry): string {
+  return entry.relPath === null || entry.relPath === ''
+    ? basename(entry.worktree)
+    : `${basename(entry.worktree)}:${entry.relPath}`;
+}
+
+/**
+ * Enumerate every registered worktree and classify each drifted item inside.
+ * The main checkout and the checkout doctor runs from are included — mode
+ * hygiene is content repair, never removal, so nothing is exempt from it.
+ */
+export function scanWorktreeModes(root: string): ModeDriftScan {
+  const list = git(root, ['worktree', 'list', '--porcelain']);
+  if (!list.ok) {
+    return { entries: [], enumerationError: firstLine(list.stderr, 'git worktree list failed') };
+  }
+  const records = parseWorktreePorcelain(list.stdout);
+  const entries = records.flatMap((record) => scanWorktree(record.path));
+  entries.sort((left, right) => {
+    if (left.worktree !== right.worktree) return left.worktree < right.worktree ? -1 : 1;
+    const a = left.relPath ?? '';
+    const b = right.relPath ?? '';
+    if (a !== b) return a < b ? -1 : 1;
+    return left.kind < right.kind ? -1 : 1;
+  });
+  return { entries, enumerationError: null };
+}
+
+const CHECK_NAME = 'mode drift';
+
+const FIX_ADVICE =
+  'Run `genie doctor --fix` to tighten wider-than-index modes (files to their index modes; 0775/0777 dirs to 0755).';
+/**
+ * The remedy for a refused registration whose directory is gone: every probe
+ * inside it fails, so it would warn forever — only a prune clears it.
+ */
+const PRUNE_ADVICE = 'Run `git worktree prune` to drop registrations whose directory no longer exists.';
+
+/** Headline: how much drift exists and whether anything is provably repairable. */
+function summarizeScan(scan: ModeDriftScan): CheckResult {
+  if (scan.entries.length === 0) return { name: CHECK_NAME, status: 'pass', detail: 'none found' };
+  const count = (disposition: ModeDriftDisposition): number =>
+    scan.entries.filter((entry) => entry.disposition === disposition).length;
+  const wider = count('wider');
+  const stricter = count('stricter');
+  const mixed = count('mixed');
+  const refused = count('refused');
+  const worktrees = new Set(scan.entries.map((entry) => entry.worktree)).size;
+  const parts = [
+    wider > 0 ? `${wider} wider` : '',
+    stricter > 0 ? `${stricter} stricter` : '',
+    mixed > 0 ? `${mixed} mixed` : '',
+    refused > 0 ? `${refused} refused` : '',
+  ].filter((part) => part !== '');
+  const across = `${parts.join(', ')} drift item(s) across ${worktrees} worktree(s)`;
+  const vanished = scan.entries.some((entry) => entry.kind === 'worktree');
+  if (wider === 0) {
+    return vanished
+      ? { name: CHECK_NAME, status: 'warn', detail: `${across} — nothing to fix`, suggestion: PRUNE_ADVICE }
+      : { name: CHECK_NAME, status: 'pass', detail: `${across} — nothing to fix` };
+  }
+  const suggestion = [FIX_ADVICE, vanished ? PRUNE_ADVICE : ''].filter((part) => part !== '').join(' ');
+  return { name: CHECK_NAME, status: 'warn', detail: across, suggestion };
+}
+
+/** One line per drifted item, stating its disposition and the reason. */
+function describeEntry(entry: ModeDriftEntry): CheckResult {
+  const name = `${CHECK_NAME}: ${displayName(entry)}`;
+  const modes = `on-disk ${entry.diskMode ?? 'unknown'}, ${entry.kind === 'dir' ? 'canonical' : 'index'} ${entry.indexMode ?? 'unknown'}`;
+  switch (entry.disposition) {
+    case 'wider':
+      return { name, status: 'warn', detail: `${modes} — --fix tightens to ${entry.indexMode}` };
+    case 'stricter':
+      return { name, status: 'pass', detail: `kept (${entry.reason}; ${modes}) — never widened` };
+    case 'mixed':
+      return { name, status: 'warn', detail: `kept (${entry.reason}; ${modes}) — never edited` };
+    case 'refused':
+      return { name, status: 'warn', detail: `kept (${entry.reason}) — --fix will not touch it` };
+  }
+}
+
+/**
+ * Detect-only view of the mode drift. Pure read: doctor without `--fix`
+ * mutates nothing here. Outside a git repo (`root === null`) there is nothing
+ * to enumerate and no check is emitted.
+ */
+export function checkWorktreeModes(root: string | null): CheckResult[] {
+  if (root === null) return [];
+  const scan = scanWorktreeModes(root);
+  if (scan.enumerationError !== null) {
+    return [
+      {
+        name: CHECK_NAME,
+        status: 'warn',
+        detail: `enumeration failed: ${scan.enumerationError}`,
+        suggestion: 'Run `git worktree list` from the repo root to see why git refused.',
+      },
+    ];
+  }
+  return [summarizeScan(scan), ...scan.entries.map(describeEntry)];
+}
+
+/**
+ * `--fix` half: tighten every item the scan proved wider than its index mode —
+ * files to their exact index permissions, 0775/0777 dirs to 0755. Idempotent:
+ * a repo with no wider item is a strict no-op. A per-item chmod failure is
+ * reported and skipped; it never escalates and never touches a non-wider item.
+ */
+export function repairWorktreeModes(root: string | null, deps: ModeRepairDeps = {}): void {
+  if (root === null) return;
+  const emit = deps.logSink ?? ((line: string) => process.stdout.write(`${line}\n`));
+  const scan = scanWorktreeModes(root);
+  if (scan.enumerationError !== null) {
+    emit(`  \x1b[33m!\x1b[0m mode repair skipped: enumeration failed (${scan.enumerationError})`);
+    return;
+  }
+  const wider = scan.entries.filter((entry) => entry.disposition === 'wider');
+  if (wider.length === 0) return;
+  emit(`\x1b[2mTightening ${wider.length} wider-than-index mode(s)...\x1b[0m`);
+  for (const entry of wider) {
+    const path = entry.relPath === null ? entry.worktree : join(entry.worktree, entry.relPath);
+    try {
+      // A `wider` entry implies the on-disk mode is a strict superset of the
+      // index mode, so setting the index mode exactly only ever removes bits.
+      chmodSync(path, Number.parseInt(entry.indexMode ?? '', 8));
+      emit(`  \x1b[32m✔\x1b[0m tightened ${path} (${entry.diskMode} → ${entry.indexMode})`);
+    } catch (error) {
+      emit(`  \x1b[33m!\x1b[0m kept ${path}: chmod failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+}

--- a/src/genie-commands/doctor-modes.ts
+++ b/src/genie-commands/doctor-modes.ts
@@ -23,17 +23,21 @@
  *     named drift shapes 0775/0777 to 0755. A stricter-than-index mode (0600
  *     files, 0700 dirs) is reported as informational and never widened; a
  *     mode with both extra and missing bits is reported and never edited; a
- *     probe that fails or is refused (symlink planted on disk, vanished
+ *     file carrying setuid/setgid/sticky bits is reported and never stripped;
+ *     a probe that fails or is refused (symlink planted on disk, vanished
  *     directory) keeps the item with the reason. Every refusal is surfaced.
  *
  *  3. Symlinks are never followed. Every probe uses lstat; index entries of
  *     kind 120000/160000 are skipped outright, and a symlink occupying the
- *     path of a tracked file — or of a directory that tracked files live
- *     under — refuses the item instead of operating through the link.
+ *     path of a tracked file — or of a directory that tracked files OR
+ *     directories live under — refuses the item instead of operating through
+ *     the link. The single mutation site re-proves the path with
+ *     open(O_NOFOLLOW) + fchmod on the descriptor, so a swap between scan and
+ *     repair can never be chmod'd through either.
  */
 
 import { spawnSync } from 'node:child_process';
-import { type Stats, chmodSync, lstatSync } from 'node:fs';
+import { constants, type Stats, closeSync, fchmodSync, fstatSync, lstatSync, openSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import { parseWorktreePorcelain } from './doctor-worktrees.js';
 import type { CheckResult } from './doctor.js';
@@ -79,6 +83,12 @@ export interface ModeDriftScan {
 export interface ModeRepairDeps {
   /** Line sink for `--fix` chatter. Defaults to stdout. */
   logSink?: (line: string) => void;
+  /**
+   * Pre-computed scan (test seam for the scan→repair window): when omitted the
+   * repair re-scans on entry, exactly like production. A stale injected scan
+   * must still be fail-closed — the mutation site re-proves the path type.
+   */
+  scan?: ModeDriftScan;
 }
 
 /** git's canonical directory permission shape: tree dirs are 0755, always. */
@@ -207,7 +217,10 @@ function probeDir(path: string): DirProbe {
  * the item keeps or is tightened. `dir` narrows the repairable set to the
  * named drift shapes: a wider directory outside {0775, 0777} (e.g. setgid
  * 2775) is refused rather than edited, because its extra bits may be
- * intentional.
+ * intentional. Files get the same carve-out for the privilege bits: setuid/
+ * setgid/sticky are reported and NEVER stripped — the only mutation a chmod
+ * to the index mode could make on them is a privilege-semantics change, not
+ * drift hygiene.
  */
 export function classifyModeDrift(
   diskMode: number,
@@ -217,6 +230,9 @@ export function classifyModeDrift(
   const disk = diskMode & 0o7777;
   const index = indexMode & 0o777;
   if (disk === index) return null;
+  if (kind === 'file' && (disk & 0o7000) !== 0) {
+    return { disposition: 'refused', reason: 'setuid/setgid/sticky bits present on a file — never stripped' };
+  }
   const wider = (disk & ~index) !== 0;
   const stricter = (index & ~disk) !== 0;
   if (wider && !stricter) {
@@ -295,27 +311,90 @@ function probeFile(path: string): FileProbe {
   }
 }
 
-/** Mode drift inside ONE worktree. A git probe failure refuses the whole tree. */
-function scanWorktree(worktree: string): ModeDriftEntry[] {
-  // A registration whose directory is gone can never be probed: refuse it
-  // before spawning git, which would only fail with a cryptic spawn error.
+/**
+ * Verdict for one tracked path's directory slot. A blocked dir (an ancestor is
+ * a symlink on disk) is refused WITHOUT probing it: lstatSync follows
+ * intermediate components, so probing `a/b` under a symlinked `a` would stat a
+ * path OUTSIDE the worktree — and could classify, then repair, someone else's
+ * directory. The dir list is sorted root-down, so the blocking ancestor is
+ * always already in `probes` when a deeper dir is reached.
+ */
+function probeTreeDir(worktree: string, dir: string, probes: Map<string, DirVerdict>): DirVerdict {
+  const blocked = blockingAncestor(dir, probes);
+  if (blocked !== null) {
+    return {
+      entry: {
+        worktree,
+        relPath: dir,
+        kind: 'dir',
+        indexMode: octal(CANONICAL_DIR_MODE),
+        diskMode: null,
+        disposition: 'refused',
+        reason: `${blocked}`,
+      },
+      blocksDescendants: null,
+    };
+  }
+  return classifyDir(worktree, dir, probeDir(join(worktree, dir)));
+}
+
+/** Verdict for one tracked file, or null when it is clean or missing on disk. */
+function classifyFile(worktree: string, file: IndexEntry, probes: Map<string, DirVerdict>): ModeDriftEntry | null {
+  const base = { worktree, relPath: file.path, kind: 'file' as const, indexMode: octal(file.mode & 0o777) };
+  const blocked = blockingAncestor(file.path, probes);
+  if (blocked !== null) return { ...base, diskMode: null, disposition: 'refused', reason: `${blocked}` };
+  const probe = probeFile(join(worktree, file.path));
+  if (probe.kind === 'missing') return null; // content dirt, not mode drift
+  if (probe.kind === 'error') {
+    return { ...base, diskMode: null, disposition: 'refused', reason: `lstat failed: ${probe.reason}` };
+  }
+  const stat = probe.stat;
+  if (stat.isSymbolicLink()) {
+    return {
+      ...base,
+      diskMode: null,
+      disposition: 'refused',
+      reason: 'on-disk is a symlink where the index records a regular file — never followed',
+    };
+  }
+  if (!stat.isFile()) {
+    return {
+      ...base,
+      diskMode: null,
+      disposition: 'refused',
+      reason: 'on-disk is a non-file where the index records a regular file — never edited',
+    };
+  }
+  const verdict = classifyModeDrift(stat.mode, file.mode, 'file');
+  return verdict === null ? null : { ...base, diskMode: octal(stat.mode & 0o7777), ...verdict };
+}
+
+/** Whole-worktree refusal for a registration whose directory no longer exists. */
+function vanishedWorktreeRefusal(worktree: string): ModeDriftEntry | null {
   try {
     lstatSync(worktree);
   } catch (error) {
     if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
-      return [
-        {
-          worktree,
-          relPath: null,
-          kind: 'worktree',
-          indexMode: null,
-          diskMode: null,
-          disposition: 'refused',
-          reason: 'worktree directory no longer exists',
-        },
-      ];
+      return {
+        worktree,
+        relPath: null,
+        kind: 'worktree',
+        indexMode: null,
+        diskMode: null,
+        disposition: 'refused',
+        reason: 'worktree directory no longer exists',
+      };
     }
   }
+  return null;
+}
+
+/** Mode drift inside ONE worktree. A git probe failure refuses the whole tree. */
+function scanWorktree(worktree: string): ModeDriftEntry[] {
+  // A registration whose directory is gone can never be probed: refuse it
+  // before spawning git, which would only fail with a cryptic spawn error.
+  const vanished = vanishedWorktreeRefusal(worktree);
+  if (vanished !== null) return [vanished];
   const listing = git(worktree, ['ls-files', '-s', '-z']);
   if (!listing.ok) {
     return [
@@ -335,7 +414,7 @@ function scanWorktree(worktree: string): ModeDriftEntry[] {
   const probes = new Map<string, DirVerdict>();
   const entries: ModeDriftEntry[] = [];
   for (const dir of dirs) {
-    const verdict = classifyDir(worktree, dir, probeDir(join(worktree, dir)));
+    const verdict = probeTreeDir(worktree, dir, probes);
     probes.set(dir, verdict);
     if (verdict.entry !== null) entries.push(verdict.entry);
   }
@@ -343,69 +422,8 @@ function scanWorktree(worktree: string): ModeDriftEntry[] {
   for (const file of index) {
     if (SKIP_INDEX_MODES.has(file.mode) || seen.has(file.path)) continue;
     seen.add(file.path);
-    const blocked = blockingAncestor(file.path, probes);
-    if (blocked !== null) {
-      entries.push({
-        worktree,
-        relPath: file.path,
-        kind: 'file',
-        indexMode: octal(file.mode & 0o777),
-        diskMode: null,
-        disposition: 'refused',
-        reason: `${blocked}`,
-      });
-      continue;
-    }
-    const probe = probeFile(join(worktree, file.path));
-    if (probe.kind === 'missing') continue; // content dirt, not mode drift
-    if (probe.kind === 'error') {
-      entries.push({
-        worktree,
-        relPath: file.path,
-        kind: 'file',
-        indexMode: octal(file.mode & 0o777),
-        diskMode: null,
-        disposition: 'refused',
-        reason: `lstat failed: ${probe.reason}`,
-      });
-      continue;
-    }
-    const stat = probe.stat;
-    if (stat.isSymbolicLink()) {
-      entries.push({
-        worktree,
-        relPath: file.path,
-        kind: 'file',
-        indexMode: octal(file.mode & 0o777),
-        diskMode: null,
-        disposition: 'refused',
-        reason: 'on-disk is a symlink where the index records a regular file — never followed',
-      });
-      continue;
-    }
-    if (!stat.isFile()) {
-      entries.push({
-        worktree,
-        relPath: file.path,
-        kind: 'file',
-        indexMode: octal(file.mode & 0o777),
-        diskMode: null,
-        disposition: 'refused',
-        reason: 'on-disk is a non-file where the index records a regular file — never edited',
-      });
-      continue;
-    }
-    const verdict = classifyModeDrift(stat.mode, file.mode, 'file');
-    if (verdict !== null) {
-      entries.push({
-        worktree,
-        relPath: file.path,
-        kind: 'file',
-        indexMode: octal(file.mode & 0o777),
-        diskMode: octal(stat.mode & 0o7777),
-        ...verdict,
-      });
-    }
+    const entry = classifyFile(worktree, file, probes);
+    if (entry !== null) entries.push(entry);
   }
   return entries;
 }
@@ -468,9 +486,19 @@ function summarizeScan(scan: ModeDriftScan): CheckResult {
   const across = `${parts.join(', ')} drift item(s) across ${worktrees} worktree(s)`;
   const vanished = scan.entries.some((entry) => entry.kind === 'worktree');
   if (wider === 0) {
-    return vanished
-      ? { name: CHECK_NAME, status: 'warn', detail: `${across} — nothing to fix`, suggestion: PRUNE_ADVICE }
-      : { name: CHECK_NAME, status: 'pass', detail: `${across} — nothing to fix` };
+    // Fail-closed reads fail-closed: refusals (probe errors, planted symlinks)
+    // and unfixable mixed drift escalate the headline to warn even though
+    // nothing is repairable. Stricter items alone stay an informational pass —
+    // they are deliberate hardening, not damage.
+    if (refused > 0 || mixed > 0 || vanished) {
+      return {
+        name: CHECK_NAME,
+        status: 'warn',
+        detail: `${across} — nothing to fix`,
+        suggestion: vanished ? PRUNE_ADVICE : undefined,
+      };
+    }
+    return { name: CHECK_NAME, status: 'pass', detail: `${across} — nothing to fix` };
   }
   const suggestion = [FIX_ADVICE, vanished ? PRUNE_ADVICE : ''].filter((part) => part !== '').join(' ');
   return { name: CHECK_NAME, status: 'warn', detail: across, suggestion };
@@ -484,6 +512,18 @@ function describeEntry(entry: ModeDriftEntry): CheckResult {
     case 'wider':
       return { name, status: 'warn', detail: `${modes} — --fix tightens to ${entry.indexMode}` };
     case 'stricter':
+      // A stricter FILE on a tracked-100755 path (e.g. a bundle that lost its
+      // executable bit) names the one repair that restores it: a manual chmod.
+      // That is a widening, so it is a user decision — never a --fix action.
+      if (entry.kind === 'file' && entry.indexMode === '755') {
+        return {
+          name,
+          status: 'pass',
+          detail: `kept (${entry.reason}; ${modes}) — never widened`,
+          suggestion:
+            'Restoring the executable bit is a widening: run `chmod 755 <path>` yourself if the index mode is intended — --fix never widens.',
+        };
+      }
       return { name, status: 'pass', detail: `kept (${entry.reason}; ${modes}) — never widened` };
     case 'mixed':
       return { name, status: 'warn', detail: `kept (${entry.reason}; ${modes}) — never edited` };
@@ -514,15 +554,51 @@ export function checkWorktreeModes(root: string | null): CheckResult[] {
 }
 
 /**
+ * The single mutation site. The path was classified from an lstat taken
+ * during a scan that may be arbitrarily stale, so it is re-proven here:
+ * `open(O_NOFOLLOW)` refuses when the final component has been swapped for a
+ * symlink (ELOOP), `O_NONBLOCK` keeps a planted FIFO from wedging the open,
+ * the opened descriptor is type-checked (regular file or directory only), and
+ * the chmod acts on the descriptor — never on the path — so nothing between
+ * open and fchmod can redirect it. A re-lstat alone is not sufficient: the
+ * swap could land between the lstat and the chmod.
+ */
+function tightenNoFollow(path: string, mode: number): string | null {
+  let fd: number;
+  try {
+    fd = openSync(path, constants.O_RDONLY | constants.O_NONBLOCK | constants.O_NOFOLLOW);
+  } catch (error) {
+    return `open(O_NOFOLLOW) refused: ${error instanceof Error ? error.message : String(error)}`;
+  }
+  try {
+    const stat = fstatSync(fd);
+    if (!stat.isFile() && !stat.isDirectory()) {
+      return 'opened descriptor is not a regular file or directory — never edited';
+    }
+    fchmodSync(fd, mode);
+    return null;
+  } catch (error) {
+    return `fchmod refused: ${error instanceof Error ? error.message : String(error)}`;
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+      /* descriptor cleanup is best-effort; the mutation already succeeded or refused */
+    }
+  }
+}
+
+/**
  * `--fix` half: tighten every item the scan proved wider than its index mode —
  * files to their exact index permissions, 0775/0777 dirs to 0755. Idempotent:
- * a repo with no wider item is a strict no-op. A per-item chmod failure is
- * reported and skipped; it never escalates and never touches a non-wider item.
+ * a repo with no wider item is a strict no-op. A per-item open/fchmod failure
+ * is reported and skipped; it never escalates and never touches a non-wider
+ * item.
  */
 export function repairWorktreeModes(root: string | null, deps: ModeRepairDeps = {}): void {
   if (root === null) return;
   const emit = deps.logSink ?? ((line: string) => process.stdout.write(`${line}\n`));
-  const scan = scanWorktreeModes(root);
+  const scan = deps.scan ?? scanWorktreeModes(root);
   if (scan.enumerationError !== null) {
     emit(`  \x1b[33m!\x1b[0m mode repair skipped: enumeration failed (${scan.enumerationError})`);
     return;
@@ -532,13 +608,18 @@ export function repairWorktreeModes(root: string | null, deps: ModeRepairDeps = 
   emit(`\x1b[2mTightening ${wider.length} wider-than-index mode(s)...\x1b[0m`);
   for (const entry of wider) {
     const path = entry.relPath === null ? entry.worktree : join(entry.worktree, entry.relPath);
-    try {
-      // A `wider` entry implies the on-disk mode is a strict superset of the
-      // index mode, so setting the index mode exactly only ever removes bits.
-      chmodSync(path, Number.parseInt(entry.indexMode ?? '', 8));
-      emit(`  \x1b[32m✔\x1b[0m tightened ${path} (${entry.diskMode} → ${entry.indexMode})`);
-    } catch (error) {
-      emit(`  \x1b[33m!\x1b[0m kept ${path}: chmod failed: ${error instanceof Error ? error.message : String(error)}`);
+    // Guarded parse: a wider entry whose index mode fails to parse is kept
+    // with the reason — chmodding garbage would be neither tightening nor
+    // fail-closed.
+    const target = entry.indexMode === null ? Number.NaN : Number.parseInt(entry.indexMode, 8);
+    if (!Number.isInteger(target) || target < 0 || target > 0o7777) {
+      emit(`  \x1b[33m!\x1b[0m kept ${path}: unparseable index mode '${entry.indexMode}' — --fix will not touch it`);
+      continue;
     }
+    // A `wider` entry implies the on-disk mode is a strict superset of the
+    // index mode, so setting the index mode exactly only ever removes bits.
+    const failure = tightenNoFollow(path, target);
+    if (failure === null) emit(`  \x1b[32m✔\x1b[0m tightened ${path} (${entry.diskMode} → ${entry.indexMode})`);
+    else emit(`  \x1b[33m!\x1b[0m kept ${path}: ${failure}`);
   }
 }

--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -91,6 +91,7 @@ import {
   resolveProjectContext,
 } from '../lib/v5/genie-db.js';
 import { VERSION } from '../lib/version.js';
+import { checkWorktreeModes, repairWorktreeModes } from './doctor-modes.js';
 import { checkLaunchWorktrees, cleanupLaunchWorktrees } from './doctor-worktrees.js';
 import {
   cleanupV4,
@@ -2108,6 +2109,11 @@ export async function doctorCommand(options?: { json?: boolean; fix?: boolean },
   if (options?.fix) {
     cleanupV4(cleanupOptions);
     cleanupLaunchWorktrees(root, cleanupOptions);
+    // Mode repair runs AFTER worktree removal: the removal scan decides on the
+    // pre-repair state, so a worktree whose only dirt is mode drift is never
+    // removed in the same run that tightens it (removal stays fail-closed on
+    // the state the user last saw; the next --fix may reclaim it).
+    repairWorktreeModes(root, cleanupOptions);
   }
 
   // Group E: ONE bounded host observation feeds the probe, the advisory, and
@@ -2137,6 +2143,7 @@ export async function doctorCommand(options?: { json?: boolean; fix?: boolean },
     ),
     ...checkV4Residue(),
     ...checkLaunchWorktrees(root),
+    ...checkWorktreeModes(root),
     ...checkAgentSync(),
     ...(await checkOmniHookTimeout()),
     ...checkIndexLaneDrift(root, databaseRoot),


### PR DESCRIPTION
## hooks-v2#retire — Group retire (1 of 3 in the serial manifest train)

Retires the four dead/speculative hook surfaces without breaking stale cached manifests. Train car 1 of 3 (budgets and security follow serially — they own manifest timeouts and the security content; nothing here touches those).

### Deliverables
1. **orchestration-guard removed** — builtin handler deleted, registry entry removed from `src/hooks/index.ts`. It was never a script, so no stub exists for it.
2. **validate-completion removed from the Stop hook** in the Claude and Kimi manifests (Stop telemetry takes over in Wave 2).
3. **Mirror-gate arrays updated in the same commit** — `validate-completion` removed from `HOOK_BUNDLES`; `src/validate-completion.ts` deleted and swapped in `CHECK_JS_TARGETS` for the hand-written stub `validate-completion.cjs` (first-run-check pattern, mode 0755, exits 0 on every invocation). `scripts/build.js` no longer regenerates it.
4. **trust.ts CLI + loader quarantined** — re-entry conditions recorded (sha256 verify before import; no non-TTY auto-trust). Both `registerHookTrustCommand` lines removed from `dispatch-command.ts` (import + invocation) — the one carved exception. `genie hook trust` no longer pretends to protect anything.
5. **omni health probe moved to `genie doctor`** — new `omni bridge health` check (bounded 3s probe, silent when omni is unconfigured). Companion PR automagik-dev/omni#905 removes the plugin's SessionStart 300s hook; the two land together. The installed-marketplace re-sync is a separate morning follow-up AFTER the omni PR merges.
6. **Retirement stub at every removed script path** — `validate-completion.cjs` exits 0 so a stale cached manifest is harmless.
7. **Scrub-vs-keep** — zero references to the retired names in the three manifests + `src/hooks/index.ts`; KEEP-exempt prose (skills, README) rewritten past-tense, not scrubbed.

### Acceptance evidence
- `bun run check` (typecheck, biome, knip, skills/wishes/complexity/council lints, `lint:hook-bundles`, `lint:hook-content`, `lint:plugin-executables`, 3272 tests): **3269 pass / 3 fail — all three reproduce on `origin/dev` in this environment** (release-asset GitHub-draft upload timeout; doctor 120ms latency budget ~1030ms — the known-red baseline; updateCommand publication boundary). Zero new failures from this change.
- Zero entries naming the retired hooks in `plugins/genie/hooks/hooks.json`, `codex-hooks.json`, `.kimi-plugin/plugin.json`, `src/hooks/index.ts` (`git grep` proven).
- `node plugins/genie/scripts/validate-completion.cjs </dev/null` → exit 0. No orchestration-guard script/stub exists.
- `registerHookTrustCommand` gone from `dispatch-command.ts` (only the quarantined file's own definition remains).
- Doctor probe unit-tested (pure evaluator + wired check with injected fetch).

### Known red legs (by spec/policy)
- The validation leg `! grep -q 'validate-completion' scripts/hook-bundle-parity.ts scripts/plugin-executables-check.ts` is red by construction: deliverable 3 mandates the stub be registered in `CHECK_JS_TARGETS` (first-run-check pattern), so the literal `validate-completion.cjs` necessarily appears in `plugin-executables-check.ts`. The leg's intent holds: `hook-bundle-parity.ts` has zero matches, and the retired `src/validate-completion.ts` entry is gone from `CHECK_JS_TARGETS` (the only occurrence is the mandated stub registration).
- The installed-marketplace leg (`"timeout": 300` in `~/.claude/plugins/marketplaces/automagik-dev/plugins/omni/hooks/hooks.json`) stays red by policy until the omni PR merges + the re-sync morning action — not touched here.

### Merge policy
Workers never merge — this is OPEN for the orchestrator's blanket dev authorization. The omni PR (automagik-dev/omni#905) is OPEN-ONLY, never merge.


---

### Fix loop 1 (execution review) — AC3 holes closed

- **Planted symlink at a non-deepest dir**: the dir loop now refuses any dir whose blocking ancestor is a symlink BEFORE probing it (lstat follows intermediate components — the reviewer's PoC was chmod'ing `outside/b` 777→755 through the link). Regression test plants the symlink above a tracked dir; PoC re-run now fails safe: `outside/b` stays 777, victim stays 600, repair is a no-op.
- **TOCTOU at the mutation site**: repair opens `O_NOFOLLOW|O_NONBLOCK`, verifies the descriptor type via `fstat` (regular file/dir only), and `fchmod`s the fd — never the path. A path swapped for a symlink between scan and repair is refused (ELOOP) with the target's mode untouched. Repair accepts an injected scan (test seam) so the scan→repair window has a regression test.
- **Umask determinism**: fixtures materialize all git content under an explicit umask 022; suite proven green under both `umask 022` and `umask 000` (41/41 incl. parity each).
- **Parity advice split** (cross-PR, authorized): a 644 bundle (stricter than 755) now names `bun scripts/hook-bundle-parity.ts --write`; only wider drift names `genie doctor --fix`. Parity test pins both repair paths.
- **Reviewer LOW items**: refused/mixed drift escalates the headline to warn (fail-closed reads fail-closed); setuid/setgid/sticky files are reported and never stripped; stricter files on tracked-100755 paths name the manual `chmod 755` repair; the repair's index-mode parse is guarded.
