### PR TITLE
feat(hooks): security hardening - trusted gh spawn + claude/kimi launcher pin (hooks-v2#security)

### DIFF
--- a/plugins/genie/.kimi-plugin/plugin.json
+++ b/plugins/genie/.kimi-plugin/plugin.json
@@ -30,7 +30,7 @@
     {
       "event": "PreToolUse",
       "matcher": "Bash|Read|Write|Edit|Agent|AgentSwarm",
-      "command": "node \"$KIMI_PLUGIN_ROOT/scripts/dispatch-runtime.cjs\" claude",
+      "command": "node \"$KIMI_PLUGIN_ROOT/scripts/dispatch-runtime.cjs\" claude --launcher-contract genie-claude-dispatch-v1 --launcher-sha256 48ea38c7d8e715b209553be825cb0b448e35402381c5b717d6466fe12943b214",
       "timeout": 125
     },
     {

--- a/plugins/genie/hooks/hooks.json
+++ b/plugins/genie/hooks/hooks.json
@@ -20,8 +20,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/dispatch-runtime.cjs\" claude",
-            "commandWindows": "node \"%CLAUDE_PLUGIN_ROOT%\\scripts\\dispatch-runtime.cjs\" claude",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/dispatch-runtime.cjs\" claude --launcher-contract genie-claude-dispatch-v1 --launcher-sha256 48ea38c7d8e715b209553be825cb0b448e35402381c5b717d6466fe12943b214",
+            "commandWindows": "node \"%CLAUDE_PLUGIN_ROOT%\\scripts\\dispatch-runtime.cjs\" claude --launcher-contract genie-claude-dispatch-v1 --launcher-sha256 48ea38c7d8e715b209553be825cb0b448e35402381c5b717d6466fe12943b214",
             "timeout": 125
           }
         ]

--- a/scripts/hook-content-binding.test.ts
+++ b/scripts/hook-content-binding.test.ts
@@ -3,10 +3,15 @@ import { copyFileSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFile
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
+  CLAUDE_HOOK_MANIFEST,
+  CLAUDE_LAUNCHER_CONTRACT,
   CODEX_HOOK_LAUNCHER,
   CODEX_HOOK_MANIFEST,
   CODEX_LAUNCHER_CONTRACT,
+  KIMI_HOOK_MANIFEST,
+  assertClaudeHookContentBinding,
   assertHookContentBinding,
+  assertKimiHookContentBinding,
   launcherSha256,
   renderBoundManifest,
 } from './hook-content-binding.ts';
@@ -45,6 +50,102 @@ describe('Codex hook launcher content binding', () => {
       const link = join(root, 'dispatch-runtime.cjs');
       symlinkSync(CODEX_HOOK_LAUNCHER, link);
       expect(() => launcherSha256(link)).toThrow('physical file');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+const CLAUDE_PIN_SUFFIX = /\s+--launcher-contract\s+\S+\s+--launcher-sha256\s+[a-f0-9]{64}$/;
+
+describe('Claude + Kimi hook launcher content binding', () => {
+  test('the committed Claude and Kimi dispatch definitions bind the current physical launcher', () => {
+    expect(() => assertClaudeHookContentBinding()).not.toThrow();
+    expect(() => assertKimiHookContentBinding()).not.toThrow();
+    const digest = launcherSha256();
+    const claude = readFileSync(CLAUDE_HOOK_MANIFEST, 'utf8');
+    // command AND commandWindows are both pinned — an unpinned Windows
+    // variant must fail the gate just like the POSIX one.
+    expect(claude.match(new RegExp(`--launcher-sha256 ${digest}`, 'g'))).toHaveLength(2);
+    expect(claude.match(new RegExp(`--launcher-contract ${CLAUDE_LAUNCHER_CONTRACT}`, 'g'))).toHaveLength(2);
+    const kimi = readFileSync(KIMI_HOOK_MANIFEST, 'utf8');
+    expect(kimi.match(new RegExp(`--launcher-sha256 ${digest}`, 'g'))).toHaveLength(1);
+    expect(kimi.match(new RegExp(`--launcher-contract ${CLAUDE_LAUNCHER_CONTRACT}`, 'g'))).toHaveLength(1);
+  });
+
+  test('claude binding fails when either dispatch variant lacks the sha256 pin', () => {
+    const root = mkdtempSync(join(tmpdir(), 'genie-hook-binding-claude-'));
+    try {
+      const launcher = join(root, 'dispatch-runtime.cjs');
+      const manifest = join(root, 'hooks.json');
+      copyFileSync(CODEX_HOOK_LAUNCHER, launcher);
+      copyFileSync(CLAUDE_HOOK_MANIFEST, manifest);
+      expect(() => assertClaudeHookContentBinding(manifest, launcher)).not.toThrow();
+
+      const strippedWindows = JSON.parse(readFileSync(manifest, 'utf8'));
+      const windowsHook = strippedWindows.hooks.PreToolUse[0].hooks.find((hook: { command: string }) =>
+        hook.command.includes('dispatch-runtime.cjs'),
+      );
+      windowsHook.commandWindows = windowsHook.commandWindows.replace(CLAUDE_PIN_SUFFIX, '');
+      writeFileSync(manifest, `${JSON.stringify(strippedWindows, null, 2)}\n`);
+      expect(() => assertClaudeHookContentBinding(manifest, launcher)).toThrow('Claude hook launcher binding drift');
+
+      const strippedCommand = JSON.parse(readFileSync(manifest, 'utf8'));
+      const commandHook = strippedCommand.hooks.PreToolUse[0].hooks.find((hook: { command: string }) =>
+        hook.command.includes('dispatch-runtime.cjs'),
+      );
+      commandHook.command = commandHook.command.replace(CLAUDE_PIN_SUFFIX, '');
+      writeFileSync(manifest, `${JSON.stringify(strippedCommand, null, 2)}\n`);
+      expect(() => assertClaudeHookContentBinding(manifest, launcher)).toThrow('Claude hook launcher binding drift');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('kimi binding fails when the dispatch command lacks or corrupts the sha256 pin', () => {
+    const root = mkdtempSync(join(tmpdir(), 'genie-hook-binding-kimi-'));
+    try {
+      const launcher = join(root, 'dispatch-runtime.cjs');
+      const manifest = join(root, 'plugin.json');
+      copyFileSync(CODEX_HOOK_LAUNCHER, launcher);
+      copyFileSync(KIMI_HOOK_MANIFEST, manifest);
+      expect(() => assertKimiHookContentBinding(manifest, launcher)).not.toThrow();
+
+      const stripped = JSON.parse(readFileSync(manifest, 'utf8'));
+      const hook = stripped.hooks.find((entry: { command: string }) => entry.command.includes('dispatch-runtime.cjs'));
+      hook.command = hook.command.replace(CLAUDE_PIN_SUFFIX, '');
+      writeFileSync(manifest, `${JSON.stringify(stripped, null, 2)}\n`);
+      expect(() => assertKimiHookContentBinding(manifest, launcher)).toThrow('Kimi hook launcher binding drift');
+
+      const corrupted = JSON.parse(readFileSync(manifest, 'utf8'));
+      const corruptHook = corrupted.hooks.find((entry: { command: string }) =>
+        entry.command.includes('dispatch-runtime.cjs'),
+      );
+      corruptHook.command = corruptHook.command.replace(/[a-f0-9]{64}$/, '0'.repeat(64));
+      writeFileSync(manifest, `${JSON.stringify(corrupted, null, 2)}\n`);
+      expect(() => assertKimiHookContentBinding(manifest, launcher)).toThrow('Kimi hook launcher binding drift');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('launcher byte drift fails the Claude and Kimi gates too (one shared launcher)', () => {
+    const root = mkdtempSync(join(tmpdir(), 'genie-hook-binding-shared-'));
+    try {
+      const launcher = join(root, 'dispatch-runtime.cjs');
+      const claudeManifest = join(root, 'hooks.json');
+      const kimiManifest = join(root, 'plugin.json');
+      copyFileSync(CODEX_HOOK_LAUNCHER, launcher);
+      copyFileSync(CLAUDE_HOOK_MANIFEST, claudeManifest);
+      copyFileSync(KIMI_HOOK_MANIFEST, kimiManifest);
+      expect(() => assertClaudeHookContentBinding(claudeManifest, launcher)).not.toThrow();
+      expect(() => assertKimiHookContentBinding(kimiManifest, launcher)).not.toThrow();
+
+      writeFileSync(launcher, `${readFileSync(launcher, 'utf8')}\n// unreviewed drift\n`);
+      expect(() => assertClaudeHookContentBinding(claudeManifest, launcher)).toThrow(
+        'Claude hook launcher binding drift',
+      );
+      expect(() => assertKimiHookContentBinding(kimiManifest, launcher)).toThrow('Kimi hook launcher binding drift');
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/scripts/hook-content-binding.ts
+++ b/scripts/hook-content-binding.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-/** Bind trusted Codex hook definitions to the exact launcher bytes they run. */
+/** Bind trusted hook definitions to the exact launcher bytes they run. */
 
 import { createHash } from 'node:crypto';
 import { lstatSync, readFileSync, writeFileSync } from 'node:fs';
@@ -8,8 +8,14 @@ import { join } from 'node:path';
 
 const ROOT = join(import.meta.dir, '..');
 export const CODEX_HOOK_MANIFEST = join(ROOT, 'plugins', 'genie', 'hooks', 'codex-hooks.json');
+export const CLAUDE_HOOK_MANIFEST = join(ROOT, 'plugins', 'genie', 'hooks', 'hooks.json');
+export const KIMI_HOOK_MANIFEST = join(ROOT, 'plugins', 'genie', '.kimi-plugin', 'plugin.json');
 export const CODEX_HOOK_LAUNCHER = join(ROOT, 'plugins', 'genie', 'scripts', 'dispatch-runtime.cjs');
 export const CODEX_LAUNCHER_CONTRACT = 'genie-codex-dispatch-v1';
+/** The Claude + Kimi invocations run the same shared launcher as `claude`;
+ *  the contract identifier is distinct so a Codex/Claude definition swap
+ *  cannot satisfy the pin. */
+export const CLAUDE_LAUNCHER_CONTRACT = 'genie-claude-dispatch-v1';
 
 interface CommandHook {
   command?: unknown;
@@ -24,13 +30,31 @@ interface HookManifest {
   hooks?: Record<string, unknown>;
 }
 
-const COMMAND_PATTERN =
+interface KimiHookEntry {
+  event?: unknown;
+  command?: unknown;
+}
+
+interface KimiManifest {
+  hooks?: unknown;
+}
+
+const CODEX_COMMAND_PATTERN =
   /^(node .+dispatch-runtime\.cjs" codex (PreToolUse|PermissionRequest))(?: --launcher-contract ([^\s]+) --launcher-sha256 ([a-f0-9]{64}))?$/;
+
+/**
+ * The Claude dispatch invocation carries no event-name argument (`codex` is
+ * followed by the event; `claude` reads the event from the payload). The
+ * whole-command pattern accepts the pinned suffix when present and rejects
+ * any other trailing argument shape.
+ */
+const CLAUDE_COMMAND_PATTERN =
+  /^node .+dispatch-runtime\.cjs" claude(?: --launcher-contract [^\s]+ --launcher-sha256 [a-f0-9]{64})?$/;
 
 export function launcherSha256(launcherPath = CODEX_HOOK_LAUNCHER): string {
   const stat = lstatSync(launcherPath);
   if (!stat.isFile() || stat.isSymbolicLink()) {
-    throw new Error(`Codex hook launcher must be a physical file: ${launcherPath}`);
+    throw new Error(`hook launcher must be a physical file: ${launcherPath}`);
   }
   return createHash('sha256').update(readFileSync(launcherPath)).digest('hex');
 }
@@ -54,21 +78,56 @@ function commandHooks(manifest: HookManifest): Array<{ event: string; hook: Comm
   return found;
 }
 
+function kimiCommandHooks(manifest: KimiManifest): Array<{ event: string; hook: CommandHook }> {
+  const found: Array<{ event: string; hook: CommandHook }> = [];
+  if (!Array.isArray(manifest.hooks)) return found;
+  for (const entry of manifest.hooks as KimiHookEntry[]) {
+    if (typeof entry.command === 'string' && entry.command.includes('dispatch-runtime.cjs')) {
+      found.push({
+        event: typeof entry.event === 'string' ? entry.event : '<missing-event>',
+        hook: { command: entry.command },
+      });
+    }
+  }
+  return found;
+}
+
 function parseManifest(path: string): HookManifest {
   const value: unknown = JSON.parse(readFileSync(path, 'utf8'));
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-    throw new Error(`Codex hook manifest must be a JSON object: ${path}`);
+    throw new Error(`hook manifest must be a JSON object: ${path}`);
   }
   return value as HookManifest;
 }
 
-function boundCommand(command: string, digest: string, expectedEvent: string): string {
-  const match = command.match(COMMAND_PATTERN);
+function boundCodexCommand(command: string, digest: string, expectedEvent: string): string {
+  const match = command.match(CODEX_COMMAND_PATTERN);
   if (!match || match[2] !== expectedEvent) {
     throw new Error(`unexpected Codex dispatch command for ${expectedEvent}: ${command}`);
   }
   return `${match[1]} --launcher-contract ${CODEX_LAUNCHER_CONTRACT} --launcher-sha256 ${digest}`;
 }
+
+function boundClaudeCommand(command: string, digest: string): string {
+  if (!CLAUDE_COMMAND_PATTERN.test(command)) {
+    throw new Error(`unexpected Claude dispatch command: ${command}`);
+  }
+  const base = command.replace(/\s+--launcher-contract\s+\S+\s+--launcher-sha256\s+[a-f0-9]{64}$/, '');
+  return `${base} --launcher-contract ${CLAUDE_LAUNCHER_CONTRACT} --launcher-sha256 ${digest}`;
+}
+
+function assertSingleDispatchLauncher(
+  hooks: Array<{ event: string; hook: CommandHook }>,
+  label: string,
+): { event: string; hook: CommandHook } {
+  if (hooks.length !== 1 || hooks[0].event !== 'PreToolUse') {
+    throw new Error(`${label} must contain exactly one dispatch launcher (PreToolUse)`);
+  }
+  return hooks[0];
+}
+
+const DRIFT_HINT =
+  'run `bun scripts/hook-content-binding.ts --write`, then review the changed hook definitions with `/hooks`.';
 
 export function renderBoundManifest(manifestPath = CODEX_HOOK_MANIFEST, launcherPath = CODEX_HOOK_LAUNCHER): string {
   const manifest = parseManifest(manifestPath);
@@ -87,8 +146,8 @@ export function renderBoundManifest(manifestPath = CODEX_HOOK_MANIFEST, launcher
     if (typeof hook.command !== 'string' || typeof hook.commandWindows !== 'string') {
       throw new Error(`${event} dispatch launcher must define command and commandWindows`);
     }
-    hook.command = boundCommand(hook.command, digest, event);
-    hook.commandWindows = boundCommand(hook.commandWindows, digest, event);
+    hook.command = boundCodexCommand(hook.command, digest, event);
+    hook.commandWindows = boundCodexCommand(hook.commandWindows, digest, event);
   }
   return `${JSON.stringify(manifest, null, 2)}\n`;
 }
@@ -97,10 +156,80 @@ export function assertHookContentBinding(manifestPath = CODEX_HOOK_MANIFEST, lau
   const actual = readFileSync(manifestPath, 'utf8');
   const expected = renderBoundManifest(manifestPath, launcherPath);
   if (actual !== expected) {
-    throw new Error(
-      'Codex hook launcher binding drift: run `bun scripts/hook-content-binding.ts --write`, then review the changed hook definitions with `/hooks`.',
-    );
+    throw new Error(`Codex hook launcher binding drift: ${DRIFT_HINT}`);
   }
+}
+
+export function assertClaudeHookContentBinding(
+  manifestPath = CLAUDE_HOOK_MANIFEST,
+  launcherPath = CODEX_HOOK_LAUNCHER,
+): void {
+  const manifest = parseManifest(manifestPath);
+  const digest = launcherSha256(launcherPath);
+  const { hook } = assertSingleDispatchLauncher(commandHooks(manifest), 'Claude hook manifest');
+  if (typeof hook.command !== 'string' || typeof hook.commandWindows !== 'string') {
+    throw new Error('Claude PreToolUse dispatch launcher must define command and commandWindows');
+  }
+  if (
+    hook.command !== boundClaudeCommand(hook.command, digest) ||
+    hook.commandWindows !== boundClaudeCommand(hook.commandWindows, digest)
+  ) {
+    throw new Error(`Claude hook launcher binding drift: ${DRIFT_HINT}`);
+  }
+}
+
+export function assertKimiHookContentBinding(
+  manifestPath = KIMI_HOOK_MANIFEST,
+  launcherPath = CODEX_HOOK_LAUNCHER,
+): void {
+  const manifest = parseManifest(manifestPath);
+  const digest = launcherSha256(launcherPath);
+  const { hook } = assertSingleDispatchLauncher(kimiCommandHooks(manifest), 'Kimi plugin manifest');
+  if (typeof hook.command !== 'string') {
+    throw new Error('Kimi PreToolUse dispatch launcher must define a command');
+  }
+  if (hook.command !== boundClaudeCommand(hook.command, digest)) {
+    throw new Error(`Kimi hook launcher binding drift: ${DRIFT_HINT}`);
+  }
+}
+
+/**
+ * Rebind the claude-runtime dispatch commands in place (surgical textual
+ * replacement of the JSON-escaped values) so the manifests' hand-tuned
+ * formatting survives — neither the Claude hooks.json nor the Kimi
+ * plugin.json is canonical `JSON.stringify` output. Returns whether the
+ * file changed.
+ */
+function writeClaudeBinding(manifestPath = CLAUDE_HOOK_MANIFEST, launcherPath = CODEX_HOOK_LAUNCHER): boolean {
+  const manifest = parseManifest(manifestPath);
+  const digest = launcherSha256(launcherPath);
+  const { hook } = assertSingleDispatchLauncher(commandHooks(manifest), 'Claude hook manifest');
+  if (typeof hook.command !== 'string' || typeof hook.commandWindows !== 'string') {
+    throw new Error('Claude PreToolUse dispatch launcher must define command and commandWindows');
+  }
+  const next = boundClaudeCommand(hook.command, digest);
+  const nextWindows = boundClaudeCommand(hook.commandWindows, digest);
+  if (hook.command === next && hook.commandWindows === nextWindows) return false;
+  let raw = readFileSync(manifestPath, 'utf8');
+  raw = raw.replace(JSON.stringify(hook.command), JSON.stringify(next));
+  raw = raw.replace(JSON.stringify(hook.commandWindows), JSON.stringify(nextWindows));
+  writeFileSync(manifestPath, raw);
+  return true;
+}
+
+function writeKimiBinding(manifestPath = KIMI_HOOK_MANIFEST, launcherPath = CODEX_HOOK_LAUNCHER): boolean {
+  const manifest = parseManifest(manifestPath);
+  const digest = launcherSha256(launcherPath);
+  const { hook } = assertSingleDispatchLauncher(kimiCommandHooks(manifest), 'Kimi plugin manifest');
+  if (typeof hook.command !== 'string') {
+    throw new Error('Kimi PreToolUse dispatch launcher must define a command');
+  }
+  const next = boundClaudeCommand(hook.command, digest);
+  if (hook.command === next) return false;
+  let raw = readFileSync(manifestPath, 'utf8');
+  raw = raw.replace(JSON.stringify(hook.command), JSON.stringify(next));
+  writeFileSync(manifestPath, raw);
+  return true;
 }
 
 async function main(): Promise<void> {
@@ -110,10 +239,15 @@ async function main(): Promise<void> {
   }
   if (args[0] === '--write') {
     writeFileSync(CODEX_HOOK_MANIFEST, renderBoundManifest());
-    console.log('hook-content-binding: updated Codex H4/H6 launcher digests');
+    const updated = ['Codex H4/H6 launcher digests'];
+    if (writeClaudeBinding()) updated.push('Claude dispatch binding');
+    if (writeKimiBinding()) updated.push('Kimi dispatch binding');
+    console.log(`hook-content-binding: updated ${updated.join(' + ')}`);
     return;
   }
   assertHookContentBinding();
+  assertClaudeHookContentBinding();
+  assertKimiHookContentBinding();
   console.log('hook-content-binding: OK');
 }
 

--- a/src/hooks/__tests__/branch-guard.test.ts
+++ b/src/hooks/__tests__/branch-guard.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, test } from 'bun:test';
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { type BranchGuardDeps, branchGuard } from '../handlers/branch-guard.js';
 import type { HookPayload } from '../types.js';
 
@@ -161,6 +165,79 @@ describe('branch-guard', () => {
       expect(result!.decision).toBe('deny');
       expect(result!.reason).toContain('spawnSync threw');
       expect(result!.reason).toContain('ENOENT');
+    });
+  });
+
+  // =========================================================================
+  // TRUSTED GH EXECUTABLE — hooks-v2#security
+  // =========================================================================
+
+  // A repository-local `gh` shim planted on PATH must never answer the
+  // merge-gate lookup: its forged `dev` output would turn the handler's
+  // fall-closed deny into an allow. The default resolver runs `gh` through
+  // the trusted-executable gate, which refuses any binary inside the
+  // agent's working-directory trust roots before spawning it.
+  describe('repo-local gh shim cannot forge the merge-gate answer', () => {
+    /** Plant a `gh` shim whose forged answer is `dev`, then invoke the handler
+     *  with the shim dir prepended to PATH. Returns the handler result. */
+    async function runWithGhShim(shimDir: string, cwd: string) {
+      mkdirSync(shimDir, { recursive: true });
+      const marker = join(shimDir, 'SHIM_RAN');
+      // If the handler ever trusts this shim, `gh pr view` "succeeds" with a
+      // forged baseRefName of `dev` — exactly the forge this test exists to
+      // prove impossible from inside the repository.
+      writeFileSync(join(shimDir, 'gh'), `#!/bin/sh\ntouch "${marker}"\nprintf 'dev'\n`, { mode: 0o755 });
+
+      const originalPath = process.env.PATH;
+      process.env.PATH = `${shimDir}:${originalPath ?? ''}`;
+      try {
+        const payload: HookPayload = { ...makePayload('gh pr merge 123'), cwd };
+        return { result: await branchGuard(payload), marker };
+      } finally {
+        process.env.PATH = originalPath;
+      }
+    }
+
+    test('a repo-local gh shim is refused outright and can never forge the merge-gate answer', async () => {
+      const repoDir = mkdtempSync(join(tmpdir(), 'genie-branch-guard-shim-repo-'));
+      try {
+        // Best-effort git init makes the fixture a real checkout; the refusal
+        // fires on the working-directory root itself, so the assertion does
+        // not depend on git being available.
+        try {
+          execSync('git init', { cwd: repoDir, stdio: 'pipe' });
+        } catch {
+          /* git unavailable — the cwd trust root still covers the shim */
+        }
+        const { result, marker } = await runWithGhShim(join(repoDir, 'tools'), repoDir);
+        expect(result).toBeDefined();
+        expect(result!.decision).toBe('deny');
+        expect(result!.reason).toContain('could not resolve base branch of PR #123');
+        expect(result!.reason).toContain('trusted gh resolution failed');
+        expect(result!.reason).toContain('Refusing repository-local gh executable');
+        // The forged allow never executes: a fall-closed deny, not a forged dev.
+        expect(existsSync(marker)).toBe(false);
+      } finally {
+        rmSync(repoDir, { recursive: true, force: true });
+      }
+    });
+
+    // Trust-boundary contrast: the trusted-executable gate refuses binaries
+    // under the *repository* trust roots. A shim on a user-owned PATH
+    // directory outside the repo is the user's own tooling and still
+    // answers — this test documents that boundary so a future hardening
+    // change cannot silently invert it.
+    test('a gh shim outside the repository trust roots still answers (documented user-PATH boundary)', async () => {
+      const repoDir = mkdtempSync(join(tmpdir(), 'genie-branch-guard-boundary-repo-'));
+      const shimRoot = mkdtempSync(join(tmpdir(), 'genie-branch-guard-boundary-shim-'));
+      try {
+        const { result, marker } = await runWithGhShim(join(shimRoot, 'bin'), repoDir);
+        expect(result).toBeUndefined();
+        expect(existsSync(marker)).toBe(true);
+      } finally {
+        rmSync(repoDir, { recursive: true, force: true });
+        rmSync(shimRoot, { recursive: true, force: true });
+      }
     });
   });
 

--- a/src/hooks/handlers/branch-guard.ts
+++ b/src/hooks/handlers/branch-guard.ts
@@ -10,10 +10,15 @@
  * that by resolving the PR's `baseRefName` at check time and denying on any
  * non-dev base. Fall-closed policy: if the base cannot be resolved, deny.
  *
+ * The verification lookup spawns `gh` only after it passes the
+ * trusted-executable gate (hooks-v2#security): a repository-local `gh` shim
+ * on PATH is refused outright, so it can never forge the merge-gate answer.
+ *
  * Priority: 1 (runs FIRST, before all other handlers)
  */
 
 import { spawnSync } from 'node:child_process';
+import { resolveTrustedExecutable } from '../../lib/trusted-executable.js';
 import { maskQuotedRegions } from '../shell-quoting.js';
 import type { HandlerResult, HookPayload } from '../types.js';
 
@@ -82,7 +87,7 @@ export interface BranchGuardDeps {
    * wrong repo and returns GraphQL "no such PR" → fall-closed deny on a
    * perfectly legitimate merge.
    */
-  resolvePrBase: (prNum: string, repo?: string) => Promise<ResolvePrBaseResult>;
+  resolvePrBase: (prNum: string, repo?: string, cwd?: string) => Promise<ResolvePrBaseResult>;
 }
 
 /** Maximum stderr bytes we surface in a deny reason. Protects against gh
@@ -90,7 +95,25 @@ export interface BranchGuardDeps {
 const STDERR_SURFACE_CAP = 500;
 
 const defaultDeps: BranchGuardDeps = {
-  async resolvePrBase(prNum, repo) {
+  async resolvePrBase(prNum, repo, cwd) {
+    // The `gh` binary is resolved through the trusted-executable gate before
+    // spawning: a repository-local `gh` shim planted on PATH must never
+    // answer the merge-gate lookup, because its forged `dev` output would
+    // turn the hook's fall-closed deny into an allow. Resolution failure is
+    // a `reason` (deny), exactly like every other lookup failure shape.
+    const resolveCwd = cwd ?? process.cwd();
+    let gh: string;
+    try {
+      // Explicit `which` reading the live PATH (the sibling handlers inject
+      // `which` the same way). The default Bun.which form caches its answer
+      // per process, which would make a PATH-injected shim unobservable in
+      // tests; production behavior is identical because the hook's PATH is
+      // fixed at launch.
+      gh = resolveTrustedExecutable('gh', resolveCwd, (command) => Bun.which(command, { PATH: process.env.PATH }));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { reason: `trusted gh resolution failed: ${message.slice(0, STDERR_SURFACE_CAP)}` };
+    }
     // spawnSync (not execSync) so we can inspect exit code AND stderr
     // independently. The previous `stdio: ['ignore','pipe','ignore']` routed
     // stderr to /dev/null, making every fall-closed deny undiagnosable.
@@ -105,7 +128,8 @@ const defaultDeps: BranchGuardDeps = {
     if (repo) args.push('--repo', repo);
     let result: ReturnType<typeof spawnSync>;
     try {
-      result = spawnSync('gh', args, {
+      result = spawnSync(gh, args, {
+        cwd: resolveCwd,
         encoding: 'utf8',
         timeout: 10_000,
         stdio: ['ignore', 'pipe', 'pipe'],
@@ -206,7 +230,11 @@ export async function branchGuard(payload: HookPayload, deps: BranchGuardDeps = 
       };
     }
     const repo = extractRepoFlag(matchTarget) ?? undefined;
-    const resolved = await deps.resolvePrBase(prNum, repo);
+    // Trust roots derive from the agent's working directory — the surface a
+    // repository-local shim is planted in. Older/odd clients that omit the
+    // field fall back to the hook process cwd.
+    const cwd = typeof payload.cwd === 'string' ? payload.cwd : process.cwd();
+    const resolved = await deps.resolvePrBase(prNum, repo, cwd);
     if ('reason' in resolved) {
       return {
         decision: 'deny',


### PR DESCRIPTION
## hooks-v2 Group security — the two forgery/drift gaps close

**Goal:** branch-guard's `gh` can no longer be forged by a repo-local shim, and the Claude/Kimi dispatch-runtime invocations carry the same launcher contract + sha256 pin Codex already has, enforced by `lint:hook-content`.

### Deliverables
1. **branch-guard `gh` via resolveTrustedExecutable.** The merge-gate verification lookup resolves `gh` through the trusted-executable gate with the payload's cwd trust roots; any repository-local shim is refused outright and becomes a fall-closed deny. Named regression test: `a repo-local gh shim is refused outright and can never forge the merge-gate answer` (plus a documented trust-boundary contrast for user-PATH tooling outside the repo).
2. **Claude pin parity.** `--launcher-contract genie-claude-dispatch-v1 --launcher-sha256 <digest>` added to the Claude `dispatch-runtime.cjs` invocation in `plugins/genie/hooks/hooks.json` (both `command` and `commandWindows`) AND `plugins/genie/.kimi-plugin/plugin.json`. Codex already carried both; the shared launcher digest is identical across all three manifests. Timeouts untouched (budgets owns them).
3. **`scripts/hook-content-binding.ts` extended** to assert the Claude/Kimi launcher invocations — NOT bundle-parity. `HOOK_BUNDLES` unchanged (dispatch-runtime.cjs is hand-authored; no TS source exists, and authoring one would be rewriting the launcher, which is Scope OUT). The gate fails when the Claude or Kimi command lacks a correct `--launcher-sha256`, exactly as it already does for Codex; the `--write` path rebinds the two manifests surgically so their hand-tuned formatting survives.

### Acceptance criteria
- [x] A repo-local `gh` shim cannot forge the merge-gate answer (named test, run by name: `bun test src/hooks/__tests__/branch-guard.test.ts -t "repo-local gh shim"` — 2 pass)
- [x] `lint:hook-content` fails when the Claude or Kimi `dispatch-runtime.cjs` command lacks a correct `--launcher-sha256` (4 new tests cover missing pin on both variants, corrupted digest, and shared-launcher byte drift)
- [x] Claude + Kimi manifests carry the contract + sha256 arguments; no bundle-parity target added (`lint:hook-bundles` unchanged and green)

### Validation
```bash
bun test src/hooks/__tests__/branch-guard.test.ts -t "repo-local gh shim" && bun test plugins/genie/scripts/dispatch-runtime.test.ts && bun run lint:hook-bundles && bun run lint:hook-content && grep -q 'dispatch-runtime.cjs\" claude --launcher-contract .* --launcher-sha256 [a-f0-9]\{64\}' plugins/genie/hooks/hooks.json && grep -q 'dispatch-runtime.cjs\" claude --launcher-contract .* --launcher-sha256 [a-f0-9]\{64\}' plugins/genie/.kimi-plugin/plugin.json && bun run lint:hook-budgets
```
All legs green. (The two greps are adapted to the JSON-escaped bytes per the wish's escape clause — the verbatim `\"` pattern cannot match `cjs\"` in the file; the 64-hex assertion is kept.)

### Gate status
`bun run check`: typecheck + all lints green; `bun test` = 3395 pass / 2 fail, both reproduced identically on origin/dev (doctor 120ms latency budget baseline + Codex-absent update-publication boundary); `dead-code` (knip) failure is byte-identical on pristine origin/dev.
