### PR TITLE
fix(install): create GENIE_HOME with mode 0o700 everywhere it is first created

### DIFF
--- a/src/genie-commands/auxiliary-trees.ts
+++ b/src/genie-commands/auxiliary-trees.ts
@@ -168,7 +168,10 @@ function inspectTree(context: AuxiliaryTreeTransaction): { digest: string } | { 
 function stageFreshTree(context: AuxiliaryTreeTransaction, sourceDigest: string): AuxiliaryTreeOutcome | null {
   const { options, ops, excluded, staging } = context;
   try {
-    mkdirSync(dirname(options.destination), { recursive: true });
+    // Every production caller destination is `<GENIE_HOME>/<tree>`, so this
+    // parent is GENIE_HOME itself and must never inherit group/other write
+    // bits from a permissive umask. The tree contents below keep source modes.
+    mkdirSync(dirname(options.destination), { recursive: true, mode: 0o700 });
     ops.copyTree(options.source, staging, excluded);
   } catch (error) {
     return failure(options, 'copy-fresh', error, verifiedArtifact(ops, options.source, sourceDigest, excluded));

--- a/src/genie-commands/legacy-v4.ts
+++ b/src/genie-commands/legacy-v4.ts
@@ -380,7 +380,9 @@ function warnFailure(ctx: CleanupContext, path: string, error: unknown): void {
 /** Copy a home-relative file into the run's backup dir, preserving structure. */
 function backupFile(ctx: CleanupContext, filePath: string): string {
   const dest = join(ctx.backupRoot, relative(ctx.home, filePath));
-  mkdirSync(dirname(dest), { recursive: true });
+  // backupRoot is `<GENIE_HOME>/state-backups/…`, so GENIE_HOME can be created
+  // here as an intermediate — 0o700 keeps it safe under a permissive umask.
+  mkdirSync(dirname(dest), { recursive: true, mode: 0o700 });
   copyFileSync(filePath, dest);
   ctx.backupDirUsed = true;
   return dest;
@@ -405,7 +407,7 @@ function listRelativeFiles(root: string): string[] {
  */
 function backupCacheManifest(ctx: CleanupContext, relic: V4CacheRelic): string {
   const dest = join(ctx.backupRoot, 'cache-manifests', `genie-${relic.version}.txt`);
-  mkdirSync(dirname(dest), { recursive: true });
+  mkdirSync(dirname(dest), { recursive: true, mode: 0o700 });
   let orphanedAt = '';
   try {
     orphanedAt = readFileSync(join(relic.path, V4_LEGACY_MANIFEST.orphanMarkerFile), 'utf-8').trim();
@@ -473,7 +475,7 @@ function cleanupHomeResidue(ctx: CleanupContext, relics: V4HomeResidueRelic[]): 
   for (const relic of relics) {
     try {
       const backupPath = join(ctx.backupRoot, 'genie-home', relic.relPath);
-      mkdirSync(dirname(backupPath), { recursive: true });
+      mkdirSync(dirname(backupPath), { recursive: true, mode: 0o700 });
       cpSync(relic.path, backupPath, { recursive: true });
       ctx.backupDirUsed = true;
       rmSync(relic.path, { recursive: true, force: true });
@@ -487,7 +489,8 @@ function cleanupHomeResidue(ctx: CleanupContext, relics: V4HomeResidueRelic[]): 
 
 function writeCleanupLog(genieHome: string, logLines: string[]): string {
   const logsDir = join(genieHome, 'logs');
-  mkdirSync(logsDir, { recursive: true });
+  // `<GENIE_HOME>/logs` — GENIE_HOME is the intermediate created here.
+  mkdirSync(logsDir, { recursive: true, mode: 0o700 });
   const logFile = join(logsDir, 'v4-cleanup.log');
   appendFileSync(logFile, `${logLines.join('\n')}\n`, 'utf-8');
   return logFile;

--- a/src/genie-commands/setup.ts
+++ b/src/genie-commands/setup.ts
@@ -1175,7 +1175,7 @@ function installGenieTmuxConf(): void {
   if (!src) return;
 
   try {
-    mkdirSync(genieHome, { recursive: true });
+    mkdirSync(genieHome, { recursive: true, mode: 0o700 });
     copyFileSync(src, dest);
     console.log(`\x1b[32m\u2713\x1b[0m Installed genie tmux config to ${dest}`);
   } catch {

--- a/src/genie-commands/uninstall.ts
+++ b/src/genie-commands/uninstall.ts
@@ -1756,7 +1756,10 @@ function createAgentFileBackup(targets: AgentSyncRemovalTargets): (name: string,
   return (name, bytes) => {
     if (backupRoot === null) backupRoot = allocateExclusiveBackupRoot(genieHome, `agent-sync-uninstall-${stamp}`);
     const destination = join(backupRoot, 'claude', 'agents', name);
-    mkdirSync(dirname(destination), { recursive: true });
+    // Under `<GENIE_HOME>/state-backups/…`. The allocator above already creates
+    // that parent at 0o700; declaring it here too removes the ordering
+    // dependence so this can never be the unsafe first creator.
+    mkdirSync(dirname(destination), { recursive: true, mode: 0o700 });
     writeFileSync(destination, bytes, { flag: 'wx' });
     return destination;
   };

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -1169,7 +1169,8 @@ async function collectUpdateDiagnostics(
   extras: UpdateDiagnosticsExtras,
 ): Promise<{ path: string; signals: RecentLogSignal[]; newestStaleTimestamp: string | null }> {
   const logsDir = join(GENIE_HOME, 'logs');
-  mkdirSync(logsDir, { recursive: true });
+  // `<GENIE_HOME>/logs` — GENIE_HOME is the intermediate created here.
+  mkdirSync(logsDir, { recursive: true, mode: 0o700 });
   const generatedAt = new Date().toISOString();
   const safeStamp = generatedAt.replace(/[:.]/g, '-');
   const path = join(logsDir, `update-diagnostics-${safeStamp}.json`);

--- a/src/lib/codex-activation-persistence.ts
+++ b/src/lib/codex-activation-persistence.ts
@@ -108,7 +108,12 @@ export interface AtomicWriteOptions {
 export function atomicWriteFileSync(path: string, content: string, options: AtomicWriteOptions = {}): void {
   const mode = options.mode ?? 0o600;
   const dir = dirname(path);
-  mkdirSync(dir, { recursive: true });
+  // Every caller writes under GENIE_HOME — the activation store's paths derive
+  // from `resolveGenieHome()`, delivery evidence sits under
+  // `<GENIE_HOME>/<evidence>`, and the capability sidecar lands beside the
+  // prior binary in `<GENIE_HOME>/bin/.previous`. A direct mode is therefore
+  // correct here; no caller opt-in is needed.
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
   if (options.backup) backupExistingRegularFile(path);
   const staging = join(dir, `.${basenameOf(path)}.staging-${process.pid}-${uniqueSuffix()}`);
   const fd = openSync(staging, fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL, mode);

--- a/src/lib/codex-lifecycle-lease.test.ts
+++ b/src/lib/codex-lifecycle-lease.test.ts
@@ -82,7 +82,7 @@ function hasUnsafeWriteBits(path: string): boolean {
 afterEach(() => {
   for (const lease of heldLeases.splice(0)) lease.release();
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
-  for (const mask of umaskRestores.splice(0)) process.umask(mask);
+  for (const mask of umaskRestores.splice(0).reverse()) process.umask(mask);
 });
 
 function hold(result: ReturnType<typeof acquireLifecycleLease>): HeldLifecycleLease {

--- a/src/lib/codex-lifecycle-lease.test.ts
+++ b/src/lib/codex-lifecycle-lease.test.ts
@@ -63,9 +63,26 @@ function stagingFiles(genieHome: string): string[] {
   return readdirSync(genieHome).filter((name) => /^\.codex-lifecycle\.lock\.staging-[0-9a-f]{2}$/.test(name));
 }
 
+const umaskRestores: number[] = [];
+
+/** Set a process umask for one test; the afterEach below always restores it. */
+function useUmask(mask: number): void {
+  umaskRestores.push(process.umask(mask));
+}
+
+/**
+ * The predicate `assertSafeOwnedDirectory` applies in install-promotion.ts,
+ * which is module-private there. A directory carrying any group or other write
+ * bit is rejected as unsafe permissions and aborts the install.
+ */
+function hasUnsafeWriteBits(path: string): boolean {
+  return (lstatSync(path).mode & 0o022) !== 0;
+}
+
 afterEach(() => {
   for (const lease of heldLeases.splice(0)) lease.release();
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  for (const mask of umaskRestores.splice(0)) process.umask(mask);
 });
 
 function hold(result: ReturnType<typeof acquireLifecycleLease>): HeldLifecycleLease {
@@ -91,6 +108,25 @@ describe('acquireLifecycleLease — acquisition and mutual exclusion', () => {
     const lease = hold(acquireLifecycleLease('update-delivery', { genieHome }));
     expect(lease.kind).toBe('update-delivery');
     expect(existsSync(join(genieHome, LEASE_FILE))).toBe(true);
+  });
+
+  test('a GENIE_HOME first created by the lease is never group- or other-writable under a permissive umask', () => {
+    // Regression: fresh Linux installs create GENIE_HOME here first, and under
+    // Ubuntu's user-private-group default umask 002 an unmoded recursive mkdir
+    // produced 0775. The install promoter then aborted with "GENIE_HOME has
+    // unsafe permissions". Assert the resulting mode, not umask mechanics, so
+    // the invariant holds across platforms and runtimes.
+    const fixtureRoot = freshHome();
+    useUmask(0o002);
+    const intermediate = join(fixtureRoot, 'intermediate');
+    const genieHome = join(intermediate, '.genie');
+    expect(existsSync(intermediate)).toBe(false);
+
+    hold(acquireLifecycleLease('update-delivery', { genieHome }));
+
+    expect(existsSync(join(genieHome, LEASE_FILE))).toBe(true);
+    expect(hasUnsafeWriteBits(genieHome)).toBe(false);
+    expect(hasUnsafeWriteBits(intermediate)).toBe(false);
   });
 
   test('a second acquisition while held returns a typed busy refusal naming the holder kind', () => {

--- a/src/lib/codex-lifecycle-lease.ts
+++ b/src/lib/codex-lifecycle-lease.ts
@@ -257,7 +257,11 @@ function tryCreateLease(
   afterCaptureForTest?: (event: LifecycleLeaseCaptureEvent) => void,
 ): CreateResult {
   try {
-    mkdirSync(dirOf(path), { recursive: true });
+    // 0o700 on every created level: this is often the first creation of
+    // GENIE_HOME on a fresh machine, and a permissive umask (002 on Ubuntu's
+    // user-private-group default) would otherwise leave it group-writable,
+    // which the install promoter rejects as unsafe permissions.
+    mkdirSync(dirOf(path), { recursive: true, mode: 0o700 });
   } catch (error) {
     return {
       ok: false,

--- a/src/lib/genie-config.ts
+++ b/src/lib/genie-config.ts
@@ -33,7 +33,9 @@ export function genieConfigExists(): boolean {
 function ensureGenieDir(): void {
   const dir = getGenieDir();
   if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
+    // GENIE_HOME itself — 0o700 so it is safe even when this runs before any
+    // lease-owning creator, rather than relying on call ordering.
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
 }
 

--- a/src/lib/genie-home-permissions.test.ts
+++ b/src/lib/genie-home-permissions.test.ts
@@ -34,7 +34,7 @@ const umaskRestores: number[] = [];
 const PERMISSIVE_UMASK = 0o002;
 
 afterEach(() => {
-  for (const mask of umaskRestores.splice(0)) process.umask(mask);
+  for (const mask of umaskRestores.splice(0).reverse()) process.umask(mask);
   for (const cleanup of cleanups.splice(0).reverse()) cleanup();
 });
 
@@ -219,8 +219,8 @@ const REPO_ROOT = new URL('../..', import.meta.url).pathname;
  */
 const GENIE_HOME_TOKENS = /genieHome|GENIE_HOME|resolveGenieHome|backupRoot/;
 
-/** A safe mode grants nothing to group or other. */
-const SAFE_MODE = /mode:\s*0o[0-7]{3,4}/;
+/** A safe mode grants nothing to group or other: both low digits lack the write bit. */
+const SAFE_MODE = /mode:\s*0o[0-7]?[0-7][0145][0145]\b/;
 
 /**
  * Verified NOT to create GENIE_HOME, despite matching the token heuristic.

--- a/src/lib/genie-home-permissions.test.ts
+++ b/src/lib/genie-home-permissions.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Cross-module invariant: no code path that FIRST creates GENIE_HOME may leave
+ * group or other write bits on it.
+ *
+ * Regression for fresh Linux installs of v5.260814.5 failing with
+ * `InstallPromotionError: GENIE_HOME has unsafe permissions`. Under Ubuntu's
+ * user-private-group default umask 002, an unmoded `mkdirSync(…, { recursive:
+ * true })` yields 0775, and `assertSafeOwnedDirectory` in install-promotion.ts
+ * rejects any directory whose mode carries `0o022`.
+ *
+ * Several unrelated modules can win the race to be that first creator, so the
+ * invariant is asserted here in one place rather than per module. The lease
+ * path — the site the original incident traced to — additionally keeps its own
+ * colocated regression test in codex-lifecycle-lease.test.ts.
+ *
+ * Assertions are on the RESULTING mode, never on umask mechanics, so they hold
+ * across platforms and runtimes (local darwin/bun vs. the Linux CI where the
+ * bug reproduces).
+ */
+import { afterEach, describe, expect, test } from 'bun:test';
+import { lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { dirname, join, relative } from 'node:path';
+import { convergeAuxiliaryTree } from '../genie-commands/auxiliary-trees.js';
+import { persistIntegrationConsent } from './runtime-integrations.js';
+import { openGlobalDb, resolveGlobalDbPath } from './v5/global-db.js';
+import { openSqlite } from './v5/sqlite-open.js';
+import { findWorkspace } from './workspace.js';
+
+const cleanups: Array<() => void> = [];
+const umaskRestores: number[] = [];
+
+/** Ubuntu's user-private-group default — the umask that produced the incident. */
+const PERMISSIVE_UMASK = 0o002;
+
+afterEach(() => {
+  for (const mask of umaskRestores.splice(0)) process.umask(mask);
+  for (const cleanup of cleanups.splice(0).reverse()) cleanup();
+});
+
+function useUmask(mask: number): void {
+  umaskRestores.push(process.umask(mask));
+}
+
+function tempRoot(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  cleanups.push(() => rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+
+/**
+ * The predicate `assertSafeOwnedDirectory` applies in install-promotion.ts,
+ * which is module-private there. Any group or other write bit aborts the
+ * install with "has unsafe permissions".
+ */
+function hasUnsafeWriteBits(path: string): boolean {
+  return (lstatSync(path).mode & 0o022) !== 0;
+}
+
+describe('GENIE_HOME first-creation permissions', () => {
+  // Each entry receives a GENIE_HOME path that does NOT exist yet, and must
+  // leave it safe for the install promoter after creating it.
+  const creators: Array<{ site: string; create: (genieHome: string) => void }> = [
+    {
+      site: 'runtime-integrations.ts — persistIntegrationConsent',
+      create: (genieHome) => persistIntegrationConsent('auto', genieHome),
+    },
+    {
+      // The global genie.db lives directly in GENIE_HOME, and every `genie
+      // omni` subcommand opens it leaseless — so this is a first-creator.
+      site: 'global-db.ts — openGlobalDb',
+      create: (genieHome) => openGlobalDb({ path: join(genieHome, 'genie.db') }).close(),
+    },
+    {
+      site: 'auxiliary-trees.ts — convergeAuxiliaryTree staging',
+      create: (genieHome) => {
+        // Production callers always pass `<GENIE_HOME>/<tree>`, so the parent
+        // this stages into is GENIE_HOME itself.
+        const source = tempRoot('genie-aux-source-');
+        writeFileSync(join(source, 'payload.txt'), 'payload\n');
+        const outcome = convergeAuxiliaryTree({
+          label: 'plugins',
+          source,
+          destination: join(genieHome, 'plugins'),
+        });
+        if (outcome.status === 'failed') throw new Error(`convergence failed at ${outcome.stage}: ${outcome.error}`);
+      },
+    },
+  ];
+
+  for (const { site, create } of creators) {
+    test(`${site} creates GENIE_HOME without group/other write bits under a permissive umask`, () => {
+      const root = tempRoot('genie-home-perms-');
+      useUmask(PERMISSIVE_UMASK);
+      const intermediate = join(root, 'intermediate');
+      const genieHome = join(intermediate, '.genie');
+
+      create(genieHome);
+
+      expect(hasUnsafeWriteBits(genieHome)).toBe(false);
+      expect(hasUnsafeWriteBits(intermediate)).toBe(false);
+    });
+  }
+
+  test('workspace.ts — saveWorkspaceRoot creates GENIE_HOME without group/other write bits', () => {
+    // `saveWorkspaceRoot` deliberately refuses to persist workspaces under
+    // tmpdir(), so the workspace root must live outside it for the mkdir to be
+    // reached at all. GENIE_HOME itself still points into tmp.
+    const workspaceRoot = mkdtempSync(join(homedir(), '.genie-home-perms-test-'));
+    cleanups.push(() => rmSync(workspaceRoot, { recursive: true, force: true }));
+    mkdirSync(join(workspaceRoot, '.genie'), { recursive: true });
+    writeFileSync(join(workspaceRoot, '.genie', 'workspace.json'), JSON.stringify({ name: 'perms-test' }));
+
+    const root = tempRoot('genie-home-perms-workspace-');
+    const intermediate = join(root, 'intermediate');
+    const genieHome = join(intermediate, '.genie');
+    const previousGenieHome = process.env.GENIE_HOME;
+    process.env.GENIE_HOME = genieHome;
+    cleanups.push(() => {
+      if (previousGenieHome === undefined) {
+        // biome-ignore lint/performance/noDelete: process.env assignment coerces undefined→"undefined"; delete is the only correct unset
+        delete process.env.GENIE_HOME;
+      } else {
+        process.env.GENIE_HOME = previousGenieHome;
+      }
+    });
+    useUmask(PERMISSIVE_UMASK);
+
+    expect(findWorkspace(workspaceRoot)?.root).toBe(workspaceRoot);
+
+    // Guard the guard: if the tmp refusal ever starts swallowing this root the
+    // mode assertions below would vacuously pass on a directory never created.
+    expect(JSON.parse(readFileSync(join(genieHome, 'config.json'), 'utf8')).workspaceRoot).toBe(workspaceRoot);
+    expect(hasUnsafeWriteBits(genieHome)).toBe(false);
+    expect(hasUnsafeWriteBits(intermediate)).toBe(false);
+  });
+
+  test('the global db resolves into GENIE_HOME, while a per-repo .genie keeps the ambient umask', () => {
+    // The two halves of the deliberate split in openSqlite's `dirMode`. The
+    // global db's directory IS GENIE_HOME (so it opts in to 0o700); the
+    // per-repo `.genie/` lives inside the user's own repository, where forcing
+    // owner-only would be surprising, so it stays at the ambient umask.
+    const root = tempRoot('genie-home-perms-split-');
+    const genieHome = join(root, '.genie-home');
+    const previousGenieHome = process.env.GENIE_HOME;
+    process.env.GENIE_HOME = genieHome;
+    cleanups.push(() => {
+      if (previousGenieHome === undefined) {
+        // biome-ignore lint/performance/noDelete: process.env assignment coerces undefined→"undefined"; delete is the only correct unset
+        delete process.env.GENIE_HOME;
+      } else {
+        process.env.GENIE_HOME = previousGenieHome;
+      }
+    });
+    expect(dirname(resolveGlobalDbPath())).toBe(genieHome);
+
+    useUmask(PERMISSIVE_UMASK);
+    openGlobalDb().close();
+    expect(hasUnsafeWriteBits(genieHome)).toBe(false);
+
+    const repoGenieDir = join(root, 'repo', '.genie');
+    openSqlite({
+      path: join(repoGenieDir, 'genie.db'),
+      schemaVersion: 1,
+      ensureSchema: (db) => db.exec('CREATE TABLE IF NOT EXISTS t (id INTEGER PRIMARY KEY)'),
+    }).close();
+    expect(lstatSync(repoGenieDir).mode & 0o777).toBe(0o775);
+  });
+
+  test('no recursive mkdirSync under GENIE_HOME lacks an explicit safe mode', () => {
+    // Negative scan: a NEW unmoded GENIE_HOME creator fails here by default
+    // rather than having to be remembered. For several sites — installGenie-
+    // TmuxConf, the legacy-v4 backups, the update diagnostics log — this is the
+    // only coverage, since they are private, wizard-only, or destructive.
+    const offenders = scanUnsafeGenieHomeMkdirs(REPO_ROOT);
+    expect(offenders).toEqual([]);
+  });
+
+  test('GENIE_HOME creators the scan cannot see keep an explicit safe mode', () => {
+    // The scan reads expressions, so it only sees GENIE_HOME when a token
+    // survives local const expansion. These sites receive the path as a
+    // function parameter or through a cross-module accessor, so no token is
+    // visible at the call and the scan structurally cannot flag them. Pin them
+    // by hand — verified reachable, and each regressed the incident on its own.
+    const pinned: Array<[file: string, marker: string, why: string]> = [
+      ['src/term-commands/hook/trust.ts', 'mkdirSync(dir, {', '<GENIE_HOME>/hooks via `genie hook trust`'],
+      ['src/lib/genie-config.ts', 'mkdirSync(dir, {', 'GENIE_HOME via getGenieDir()'],
+      ['src/genie-commands/auxiliary-trees.ts', 'mkdirSync(dirname(options.destination), {', 'GENIE_HOME parent'],
+      ['src/lib/codex-lifecycle-lease.ts', 'mkdirSync(dirOf(path), {', 'GENIE_HOME via the lease path'],
+      [
+        'src/lib/codex-activation-persistence.ts',
+        'mkdirSync(dir, {',
+        'atomicWriteFileSync — every caller writes under GENIE_HOME',
+      ],
+    ];
+
+    for (const [file, marker, why] of pinned) {
+      const call = readFileSync(join(REPO_ROOT, file), 'utf8')
+        .split('\n')
+        .find((line) => line.includes(marker));
+      expect(call, `${file}: no call matching \`${marker}\``).toBeDefined();
+      expect(call, `${file}: ${why} — must declare a safe mode`).toMatch(SAFE_MODE);
+    }
+
+    // The shared sqlite primitive takes its mode from the caller, so the pin is
+    // on the global DB opting in — the per-repo DB deliberately does not.
+    expect(readFileSync(join(REPO_ROOT, 'src/lib/v5/global-db.ts'), 'utf8')).toContain('dirMode: 0o700');
+  });
+});
+
+const REPO_ROOT = new URL('../..', import.meta.url).pathname;
+
+// ─── Source scan ──────────────────────────────────────────────────────────────
+
+/**
+ * Targets whose text still names a GENIE_HOME source after local `const`
+ * expansion. `backupRoot` is included because it is always
+ * `<GENIE_HOME>/state-backups/…`.
+ */
+const GENIE_HOME_TOKENS = /genieHome|GENIE_HOME|resolveGenieHome|backupRoot/;
+
+/** A safe mode grants nothing to group or other. */
+const SAFE_MODE = /mode:\s*0o[0-7]{3,4}/;
+
+/**
+ * Verified NOT to create GENIE_HOME, despite matching the token heuristic.
+ * Keyed by `<path>:<line>` with the reason it is exempt.
+ */
+const SCAN_EXEMPTIONS = new Map<string, string>([
+  [
+    'src/lib/agent-sync.ts:5171',
+    // Triggered by the identifier `before`: the scan's file-scoped const map
+    // resolves it to the file's FIRST `const before = lstatSync(path)`
+    // (agent-sync.ts:883), whose `path` cascades into a genieHome token. The
+    // real target here is `join(transactionDir, 'before')` inside a council
+    // workflow transaction dir the preceding renameSync already published, so
+    // GENIE_HOME is never created.
+    'council workflow transaction dir, not GENIE_HOME (scan token collision)',
+  ],
+]);
+
+interface UnsafeMkdir {
+  site: string;
+  target: string;
+}
+
+/**
+ * Flag every recursive `mkdirSync` in `src/` whose target resolves to or under
+ * GENIE_HOME but declares no explicit mode. Identifiers are expanded through
+ * same-file `const`/`let` initializers so indirection like
+ * `const logsDir = join(GENIE_HOME, 'logs')` is still caught.
+ *
+ * The expansion is file-scoped rather than block-scoped, which can over-match
+ * when a parameter shares a name with an unrelated const. That direction is
+ * deliberate: over-matching costs one reviewed SCAN_EXEMPTIONS entry, while
+ * under-matching would silently ship the bug this file exists to prevent.
+ */
+function scanUnsafeGenieHomeMkdirs(repoRoot: string): UnsafeMkdir[] {
+  const offenders: UnsafeMkdir[] = [];
+  for (const file of sourceFiles(join(repoRoot, 'src'))) {
+    const lines = readFileSync(file, 'utf8').split('\n');
+    const consts = new Map<string, string>();
+    for (const line of lines) {
+      const declaration = /^\s*(?:const|let)\s+([A-Za-z_$][\w$]*)\s*=\s*(.+?);?\s*$/.exec(line);
+      if (declaration && !consts.has(declaration[1])) consts.set(declaration[1], declaration[2]);
+    }
+    for (const [index, line] of lines.entries()) {
+      const call = /mkdirSync\(\s*(.+?),\s*\{(.*?)\}\s*\)/.exec(line);
+      if (!call || !call[2].includes('recursive: true') || SAFE_MODE.test(call[2])) continue;
+      const [, target] = call;
+      if (!GENIE_HOME_TOKENS.test(expandIdentifiers(target, consts))) continue;
+      const site = `${relative(repoRoot, file)}:${index + 1}`;
+      if (!SCAN_EXEMPTIONS.has(site)) offenders.push({ site, target });
+    }
+  }
+  return offenders;
+}
+
+function expandIdentifiers(expression: string, consts: Map<string, string>, depth = 0): string {
+  if (depth > 8) return expression;
+  let expanded = expression;
+  for (const name of new Set(expression.match(/[A-Za-z_$][\w$]*/g) ?? [])) {
+    const initializer = consts.get(name);
+    if (initializer === undefined || initializer === expression) continue;
+    expanded = expanded.replace(new RegExp(`\\b${name}\\b`, 'g'), `(${initializer})`);
+  }
+  return expanded === expression ? expanded : expandIdentifiers(expanded, consts, depth + 1);
+}
+
+function sourceFiles(dir: string): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name !== '__tests__') found.push(...sourceFiles(path));
+    } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+      found.push(path);
+    }
+  }
+  return found;
+}

--- a/src/lib/runtime-integrations.ts
+++ b/src/lib/runtime-integrations.ts
@@ -102,7 +102,9 @@ export interface IntegrationConsentTransitionRef {
 
 function writeIntegrationConsentState(state: IntegrationConsentState, genieHome: string): void {
   const path = join(genieHome, INTEGRATION_CONSENT_NAME);
-  mkdirSync(genieHome, { recursive: true });
+  // Another first-creator of GENIE_HOME: 0o700 so a permissive umask cannot
+  // leave it group-writable, which the install promoter rejects outright.
+  mkdirSync(genieHome, { recursive: true, mode: 0o700 });
   const staging = `${path}.staging-${process.pid}`;
   writeFileSync(
     staging,
@@ -2512,7 +2514,8 @@ function readRefreshIntent(path: string, runtime: RuntimeName): RefreshIntent | 
 }
 
 function writeRefreshIntent(path: string, intent: RefreshIntent): void {
-  mkdirSync(dirname(path), { recursive: true });
+  // `stateDir` defaults to `resolveGenieHome()`, so this dirname is GENIE_HOME.
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
   const staging = `${path}.staging-${process.pid}`;
   writeFileSync(staging, `${JSON.stringify(intent, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
   renameSync(staging, path);

--- a/src/lib/v5/global-db.ts
+++ b/src/lib/v5/global-db.ts
@@ -79,6 +79,10 @@ export function openGlobalDb(opts: OpenGlobalOptions = {}): Database {
     schemaVersion: GLOBAL_SCHEMA_VERSION,
     ensureSchema,
     schemaIsCurrent,
+    // This directory is GENIE_HOME, and every `genie omni` subcommand reaches
+    // it leaseless — so this open is a first-creator that must not leave group
+    // or other write bits behind for the install promoter to reject.
+    dirMode: 0o700,
   });
 }
 

--- a/src/lib/v5/sqlite-open.ts
+++ b/src/lib/v5/sqlite-open.ts
@@ -160,6 +160,14 @@ export interface OpenSqliteOptions {
    * without contending on the schema write lock. Omit to always run ensureSchema.
    */
   schemaIsCurrent?: (db: Database) => boolean;
+  /**
+   * Mode for the containing directory when this open creates it. Set ONLY by
+   * the global DB, whose directory IS GENIE_HOME and must never carry group or
+   * other write bits (the install promoter rejects those). Left unset for the
+   * per-repo `.genie/`, which lives inside the user's own repository where
+   * forcing 0o700 would be surprising — that path keeps the ambient umask.
+   */
+  dirMode?: number;
 }
 
 /**
@@ -175,7 +183,7 @@ export interface OpenSqliteOptions {
  */
 export function openSqlite(opts: OpenSqliteOptions): Database {
   const { path } = opts;
-  if (path !== ':memory:') mkdirSync(dirname(path), { recursive: true });
+  if (path !== ':memory:') mkdirSync(dirname(path), { recursive: true, mode: opts.dirMode });
   return openInitialized(opts);
 }
 

--- a/src/lib/workspace.ts
+++ b/src/lib/workspace.ts
@@ -163,7 +163,9 @@ function saveWorkspaceRoot(root: string): void {
     const config = existsSync(configPath) ? JSON.parse(readFileSync(configPath, 'utf-8')) : {};
     if (config.workspaceRoot === root) return;
     config.workspaceRoot = root;
-    mkdirSync(home, { recursive: true });
+    // Another first-creator of GENIE_HOME: 0o700 so a permissive umask cannot
+    // leave it group-writable, which the install promoter rejects outright.
+    mkdirSync(home, { recursive: true, mode: 0o700 });
     writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf-8');
   } catch {
     /* best-effort */

--- a/src/term-commands/hook/trust.ts
+++ b/src/term-commands/hook/trust.ts
@@ -65,7 +65,9 @@ function findRepoRoot(start: string): string | null {
 
 function writeTrustFile(path: string, file: TrustFile): void {
   const dir = dirname(path);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  // `<GENIE_HOME>/hooks/` — GENIE_HOME is created here as an intermediate, so
+  // 0o700 keeps a permissive umask from leaving it group-writable.
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
 
   // Atomic write via temp + rename so a crash mid-write doesn't corrupt the
   // trust file (the security boundary). Stable JSON (sorted keys, 2-space


### PR DESCRIPTION
## Summary

Fresh Linux installs of **v5.260814.5** fail for anyone with umask `002` (Ubuntu/Debian user-private-group default):

```
InstallPromotionError: GENIE_HOME has unsafe permissions
    at assertSafeOwnedDirectory
    at recoverPendingInstallPromotions
    at installPromoteCommand
```

**Root cause:** whichever code path first creates `~/.genie` used `mkdirSync(..., { recursive: true })` with no `mode`, so under umask `002` the directory is created `0775`. The install promoter's `assertSafeOwnedDirectory` correctly rejects any group/other write bit (`permissions & 0o022`), aborting the install.

**Fix:** every first-creator of GENIE_HOME now declares `mode: 0o700`, which no umask can widen (`mkdir` applies `mode & ~umask`; umask only clears bits). Sites: the codex lifecycle lease (the site the reported incident traced to), integration consent, workspace config, tmux setup, auxiliary trees, `hook trust`, genie-config, legacy-v4 backups/logs, update diagnostics, uninstall backups, and `atomicWriteFileSync` (all nine callers verified GENIE_HOME-rooted; `mode` never re-chmods an existing dir, so no reachable behavior change). The shared sqlite open primitive gains an opt-in `dirMode` passed only by the global DB — a per-repo `.genie/` inside a user's repository deliberately keeps the ambient umask, pinned by test.

`0o700` matches existing practice: `agent-sync` already creates GENIE_HOME at `0o700`, and every GENIE_HOME-adjacent dir (install staging, uninstall backups, the omni host-key dir) already uses it. No consumer expects group access.

## Regression guards

`src/lib/genie-home-permissions.test.ts`:
- behavioral tests drive the real creator functions under umask `002` and assert the resulting mode against the promoter's `0o022` predicate (not umask mechanics — holds on darwin and Linux)
- a negative source scan fails on any **new** unmoded recursive `mkdirSync` targeting GENIE_HOME
- a pinned-site test covers parameter-carried paths the scan structurally cannot see (each pin verified to fail on regression)

## Validation

- `bun test src/lib/genie-home-permissions.test.ts src/lib/codex-lifecycle-lease.test.ts` — 49 pass / 0 fail
- `bun run check` — typecheck, lint (3 pre-existing warnings), all lint gates, dead-code clean; 3352 tests pass with 2 environmental darwin failures proven at pristine `origin/main` baseline (doctor 120ms latency budget; one load-sensitive worktree test that passes in isolation)

Found and verified through a trace → fix → adversarial re-review cycle (3 loops, independent reviewer, every fix regression-tested in place).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Improved privacy for application data, backups, logs, configuration, trust files, workspace state, and database directories.
  - Newly created directories now use owner-only access by default, reducing exposure from permissive system settings.

- **Bug Fixes**
  - Prevented group or other users from gaining write access when directories are created under permissive umask configurations.

- **Tests**
  - Added regression coverage validating secure directory permissions across initialization, persistence, database, and backup workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->