### PR TITLE
chore(release): promote dev to main — GENIE_HOME umask install hotfix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "5.260816.1",
+      "version": "5.260816.2",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "5.260815.1",
+      "version": "5.260815.2",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "5.260814.4",
+      "version": "5.260815.1",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "genie",
-      "version": "5.260815.2",
+      "version": "5.260816.1",
       "source": "./plugins/genie",
       "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, wish them into plans, make with parallel agents, ship as one team. A coding genie that grows with your project."
     }

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,10 @@ yarn-error.log*
 .genie/genie.db
 .genie/genie.db-wal
 .genie/genie.db-shm
+# Cross-process mutex for the MCP write path's WAL-index recovery. Normally
+# created and removed inside one open; survives only a holder that crashed
+# mid-recovery, and the next open reaps it.
+.genie/genie.db-recovery-lock
 
 # Machine-local roadmap sync baseline (pairs genie.db with roadmap.json)
 .genie/roadmap-sync

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@automagik/genie",
 
-  "version": "5.260815.2",
+  "version": "5.260816.1",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
 
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@automagik/genie",
 
-  "version": "5.260815.1",
+  "version": "5.260815.2",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
 
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@automagik/genie",
 
-  "version": "5.260816.1",
+  "version": "5.260816.2",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
 
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@automagik/genie",
 
-  "version": "5.260814.4",
+  "version": "5.260815.1",
   "description": "Collaborative terminal toolkit for human + AI workflows. NOTE: npm distribution discontinued 2026-05-09 — install via `curl -fsSL https://raw.githubusercontent.com/automagik-dev/genie/main/install.sh | bash` (cosign + SLSA verified). See https://automagik.dev/genie/release-process",
 
   "license": "MIT",

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260815.2",
+  "version": "5.260816.1",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260814.4",
+  "version": "5.260815.1",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260816.1",
+  "version": "5.260816.2",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/.claude-plugin/plugin.json
+++ b/plugins/genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260815.1",
+  "version": "5.260815.2",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/genie/.codex-plugin/plugin.json
+++ b/plugins/genie/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260814.4",
+  "version": "5.260815.1",
   "description": "Plan, execute, review, and ship software with Genie workflows in Codex.",
   "author": {
     "name": "Namastex Labs",

--- a/plugins/genie/.codex-plugin/plugin.json
+++ b/plugins/genie/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260815.1",
+  "version": "5.260815.2",
   "description": "Plan, execute, review, and ship software with Genie workflows in Codex.",
   "author": {
     "name": "Namastex Labs",

--- a/plugins/genie/.codex-plugin/plugin.json
+++ b/plugins/genie/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260815.2",
+  "version": "5.260816.1",
   "description": "Plan, execute, review, and ship software with Genie workflows in Codex.",
   "author": {
     "name": "Namastex Labs",

--- a/plugins/genie/.codex-plugin/plugin.json
+++ b/plugins/genie/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260816.1",
+  "version": "5.260816.2",
   "description": "Plan, execute, review, and ship software with Genie workflows in Codex.",
   "author": {
     "name": "Namastex Labs",

--- a/plugins/genie/.kimi-plugin/plugin.json
+++ b/plugins/genie/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260815.2",
+  "version": "5.260816.1",
   "description": "Human-AI partnership for Kimi Code CLI. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /genie:work, validate with /genie:review, and ship as one team.",
   "author": {
     "name": "Namastex Labs",

--- a/plugins/genie/.kimi-plugin/plugin.json
+++ b/plugins/genie/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260814.4",
+  "version": "5.260815.1",
   "description": "Human-AI partnership for Kimi Code CLI. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /genie:work, validate with /genie:review, and ship as one team.",
   "author": {
     "name": "Namastex Labs",

--- a/plugins/genie/.kimi-plugin/plugin.json
+++ b/plugins/genie/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260816.1",
+  "version": "5.260816.2",
   "description": "Human-AI partnership for Kimi Code CLI. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /genie:work, validate with /genie:review, and ship as one team.",
   "author": {
     "name": "Namastex Labs",

--- a/plugins/genie/.kimi-plugin/plugin.json
+++ b/plugins/genie/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "genie",
-  "version": "5.260815.1",
+  "version": "5.260815.2",
   "description": "Human-AI partnership for Kimi Code CLI. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /genie:work, validate with /genie:review, and ship as one team.",
   "author": {
     "name": "Namastex Labs",

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "5.260815.1",
+  "version": "5.260815.2",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "license": "MIT",

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "5.260815.2",
+  "version": "5.260816.1",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "license": "MIT",

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "5.260814.4",
+  "version": "5.260815.1",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "license": "MIT",

--- a/plugins/genie/package.json
+++ b/plugins/genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-plugin",
-  "version": "5.260816.1",
+  "version": "5.260816.2",
   "private": true,
   "description": "Runtime dependencies for genie bundled CLIs",
   "license": "MIT",

--- a/plugins/hermes-genie/plugin.yaml
+++ b/plugins/hermes-genie/plugin.yaml
@@ -1,5 +1,5 @@
 name: genie
-version: 5.260815.2
+version: 5.260816.1
 description: "Native Hermes surface for Genie orchestration: read-only status plus work-plan and review-plan gap tools that the MCP board surface does not cover, hooks, commands, and a thin cockpit skill. Board/task truth comes from the genie MCP tools."
 provides_tools:
   # Default surface: exactly the three gap tools the MCP board surface does not cover.

--- a/plugins/hermes-genie/plugin.yaml
+++ b/plugins/hermes-genie/plugin.yaml
@@ -1,5 +1,5 @@
 name: genie
-version: 5.260814.4
+version: 5.260815.1
 description: "Native Hermes surface for Genie orchestration: read-only status plus work-plan and review-plan gap tools that the MCP board surface does not cover, hooks, commands, and a thin cockpit skill. Board/task truth comes from the genie MCP tools."
 provides_tools:
   # Default surface: exactly the three gap tools the MCP board surface does not cover.

--- a/plugins/hermes-genie/plugin.yaml
+++ b/plugins/hermes-genie/plugin.yaml
@@ -1,5 +1,5 @@
 name: genie
-version: 5.260815.1
+version: 5.260815.2
 description: "Native Hermes surface for Genie orchestration: read-only status plus work-plan and review-plan gap tools that the MCP board surface does not cover, hooks, commands, and a thin cockpit skill. Board/task truth comes from the genie MCP tools."
 provides_tools:
   # Default surface: exactly the three gap tools the MCP board surface does not cover.

--- a/plugins/hermes-genie/plugin.yaml
+++ b/plugins/hermes-genie/plugin.yaml
@@ -1,5 +1,5 @@
 name: genie
-version: 5.260816.1
+version: 5.260816.2
 description: "Native Hermes surface for Genie orchestration: read-only status plus work-plan and review-plan gap tools that the MCP board surface does not cover, hooks, commands, and a thin cockpit skill. Board/task truth comes from the genie MCP tools."
 provides_tools:
   # Default surface: exactly the three gap tools the MCP board surface does not cover.

--- a/plugins/pi-genie/package.json
+++ b/plugins/pi-genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-pi-plugin",
-  "version": "5.260815.2",
+  "version": "5.260816.1",
   "private": true,
   "description": "Pi extension manifest for the Genie pi plugin — the plugin payload is plugins/pi-genie/extension.ts",
   "license": "MIT",

--- a/plugins/pi-genie/package.json
+++ b/plugins/pi-genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-pi-plugin",
-  "version": "5.260815.1",
+  "version": "5.260815.2",
   "private": true,
   "description": "Pi extension manifest for the Genie pi plugin — the plugin payload is plugins/pi-genie/extension.ts",
   "license": "MIT",

--- a/plugins/pi-genie/package.json
+++ b/plugins/pi-genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-pi-plugin",
-  "version": "5.260814.4",
+  "version": "5.260815.1",
   "private": true,
   "description": "Pi extension manifest for the Genie pi plugin — the plugin payload is plugins/pi-genie/extension.ts",
   "license": "MIT",

--- a/plugins/pi-genie/package.json
+++ b/plugins/pi-genie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genie-pi-plugin",
-  "version": "5.260816.1",
+  "version": "5.260816.2",
   "private": true,
   "description": "Pi extension manifest for the Genie pi plugin — the plugin payload is plugins/pi-genie/extension.ts",
   "license": "MIT",

--- a/src/genie-commands/auxiliary-trees.ts
+++ b/src/genie-commands/auxiliary-trees.ts
@@ -168,7 +168,10 @@ function inspectTree(context: AuxiliaryTreeTransaction): { digest: string } | { 
 function stageFreshTree(context: AuxiliaryTreeTransaction, sourceDigest: string): AuxiliaryTreeOutcome | null {
   const { options, ops, excluded, staging } = context;
   try {
-    mkdirSync(dirname(options.destination), { recursive: true });
+    // Every production caller destination is `<GENIE_HOME>/<tree>`, so this
+    // parent is GENIE_HOME itself and must never inherit group/other write
+    // bits from a permissive umask. The tree contents below keep source modes.
+    mkdirSync(dirname(options.destination), { recursive: true, mode: 0o700 });
     ops.copyTree(options.source, staging, excluded);
   } catch (error) {
     return failure(options, 'copy-fresh', error, verifiedArtifact(ops, options.source, sourceDigest, excluded));

--- a/src/genie-commands/legacy-v4.ts
+++ b/src/genie-commands/legacy-v4.ts
@@ -380,7 +380,9 @@ function warnFailure(ctx: CleanupContext, path: string, error: unknown): void {
 /** Copy a home-relative file into the run's backup dir, preserving structure. */
 function backupFile(ctx: CleanupContext, filePath: string): string {
   const dest = join(ctx.backupRoot, relative(ctx.home, filePath));
-  mkdirSync(dirname(dest), { recursive: true });
+  // backupRoot is `<GENIE_HOME>/state-backups/…`, so GENIE_HOME can be created
+  // here as an intermediate — 0o700 keeps it safe under a permissive umask.
+  mkdirSync(dirname(dest), { recursive: true, mode: 0o700 });
   copyFileSync(filePath, dest);
   ctx.backupDirUsed = true;
   return dest;
@@ -405,7 +407,7 @@ function listRelativeFiles(root: string): string[] {
  */
 function backupCacheManifest(ctx: CleanupContext, relic: V4CacheRelic): string {
   const dest = join(ctx.backupRoot, 'cache-manifests', `genie-${relic.version}.txt`);
-  mkdirSync(dirname(dest), { recursive: true });
+  mkdirSync(dirname(dest), { recursive: true, mode: 0o700 });
   let orphanedAt = '';
   try {
     orphanedAt = readFileSync(join(relic.path, V4_LEGACY_MANIFEST.orphanMarkerFile), 'utf-8').trim();
@@ -473,7 +475,7 @@ function cleanupHomeResidue(ctx: CleanupContext, relics: V4HomeResidueRelic[]): 
   for (const relic of relics) {
     try {
       const backupPath = join(ctx.backupRoot, 'genie-home', relic.relPath);
-      mkdirSync(dirname(backupPath), { recursive: true });
+      mkdirSync(dirname(backupPath), { recursive: true, mode: 0o700 });
       cpSync(relic.path, backupPath, { recursive: true });
       ctx.backupDirUsed = true;
       rmSync(relic.path, { recursive: true, force: true });
@@ -487,7 +489,8 @@ function cleanupHomeResidue(ctx: CleanupContext, relics: V4HomeResidueRelic[]): 
 
 function writeCleanupLog(genieHome: string, logLines: string[]): string {
   const logsDir = join(genieHome, 'logs');
-  mkdirSync(logsDir, { recursive: true });
+  // `<GENIE_HOME>/logs` — GENIE_HOME is the intermediate created here.
+  mkdirSync(logsDir, { recursive: true, mode: 0o700 });
   const logFile = join(logsDir, 'v4-cleanup.log');
   appendFileSync(logFile, `${logLines.join('\n')}\n`, 'utf-8');
   return logFile;

--- a/src/genie-commands/setup.ts
+++ b/src/genie-commands/setup.ts
@@ -1175,7 +1175,7 @@ function installGenieTmuxConf(): void {
   if (!src) return;
 
   try {
-    mkdirSync(genieHome, { recursive: true });
+    mkdirSync(genieHome, { recursive: true, mode: 0o700 });
     copyFileSync(src, dest);
     console.log(`\x1b[32m\u2713\x1b[0m Installed genie tmux config to ${dest}`);
   } catch {

--- a/src/genie-commands/uninstall.ts
+++ b/src/genie-commands/uninstall.ts
@@ -1756,7 +1756,10 @@ function createAgentFileBackup(targets: AgentSyncRemovalTargets): (name: string,
   return (name, bytes) => {
     if (backupRoot === null) backupRoot = allocateExclusiveBackupRoot(genieHome, `agent-sync-uninstall-${stamp}`);
     const destination = join(backupRoot, 'claude', 'agents', name);
-    mkdirSync(dirname(destination), { recursive: true });
+    // Under `<GENIE_HOME>/state-backups/…`. The allocator above already creates
+    // that parent at 0o700; declaring it here too removes the ordering
+    // dependence so this can never be the unsafe first creator.
+    mkdirSync(dirname(destination), { recursive: true, mode: 0o700 });
     writeFileSync(destination, bytes, { flag: 'wx' });
     return destination;
   };

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -1169,7 +1169,8 @@ async function collectUpdateDiagnostics(
   extras: UpdateDiagnosticsExtras,
 ): Promise<{ path: string; signals: RecentLogSignal[]; newestStaleTimestamp: string | null }> {
   const logsDir = join(GENIE_HOME, 'logs');
-  mkdirSync(logsDir, { recursive: true });
+  // `<GENIE_HOME>/logs` — GENIE_HOME is the intermediate created here.
+  mkdirSync(logsDir, { recursive: true, mode: 0o700 });
   const generatedAt = new Date().toISOString();
   const safeStamp = generatedAt.replace(/[:.]/g, '-');
   const path = join(logsDir, `update-diagnostics-${safeStamp}.json`);

--- a/src/lib/codex-activation-persistence.ts
+++ b/src/lib/codex-activation-persistence.ts
@@ -108,7 +108,12 @@ export interface AtomicWriteOptions {
 export function atomicWriteFileSync(path: string, content: string, options: AtomicWriteOptions = {}): void {
   const mode = options.mode ?? 0o600;
   const dir = dirname(path);
-  mkdirSync(dir, { recursive: true });
+  // Every caller writes under GENIE_HOME — the activation store's paths derive
+  // from `resolveGenieHome()`, delivery evidence sits under
+  // `<GENIE_HOME>/<evidence>`, and the capability sidecar lands beside the
+  // prior binary in `<GENIE_HOME>/bin/.previous`. A direct mode is therefore
+  // correct here; no caller opt-in is needed.
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
   if (options.backup) backupExistingRegularFile(path);
   const staging = join(dir, `.${basenameOf(path)}.staging-${process.pid}-${uniqueSuffix()}`);
   const fd = openSync(staging, fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL, mode);

--- a/src/lib/codex-lifecycle-lease.test.ts
+++ b/src/lib/codex-lifecycle-lease.test.ts
@@ -82,7 +82,7 @@ function hasUnsafeWriteBits(path: string): boolean {
 afterEach(() => {
   for (const lease of heldLeases.splice(0)) lease.release();
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
-  for (const mask of umaskRestores.splice(0)) process.umask(mask);
+  for (const mask of umaskRestores.splice(0).reverse()) process.umask(mask);
 });
 
 function hold(result: ReturnType<typeof acquireLifecycleLease>): HeldLifecycleLease {

--- a/src/lib/codex-lifecycle-lease.test.ts
+++ b/src/lib/codex-lifecycle-lease.test.ts
@@ -63,9 +63,26 @@ function stagingFiles(genieHome: string): string[] {
   return readdirSync(genieHome).filter((name) => /^\.codex-lifecycle\.lock\.staging-[0-9a-f]{2}$/.test(name));
 }
 
+const umaskRestores: number[] = [];
+
+/** Set a process umask for one test; the afterEach below always restores it. */
+function useUmask(mask: number): void {
+  umaskRestores.push(process.umask(mask));
+}
+
+/**
+ * The predicate `assertSafeOwnedDirectory` applies in install-promotion.ts,
+ * which is module-private there. A directory carrying any group or other write
+ * bit is rejected as unsafe permissions and aborts the install.
+ */
+function hasUnsafeWriteBits(path: string): boolean {
+  return (lstatSync(path).mode & 0o022) !== 0;
+}
+
 afterEach(() => {
   for (const lease of heldLeases.splice(0)) lease.release();
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  for (const mask of umaskRestores.splice(0)) process.umask(mask);
 });
 
 function hold(result: ReturnType<typeof acquireLifecycleLease>): HeldLifecycleLease {
@@ -91,6 +108,25 @@ describe('acquireLifecycleLease — acquisition and mutual exclusion', () => {
     const lease = hold(acquireLifecycleLease('update-delivery', { genieHome }));
     expect(lease.kind).toBe('update-delivery');
     expect(existsSync(join(genieHome, LEASE_FILE))).toBe(true);
+  });
+
+  test('a GENIE_HOME first created by the lease is never group- or other-writable under a permissive umask', () => {
+    // Regression: fresh Linux installs create GENIE_HOME here first, and under
+    // Ubuntu's user-private-group default umask 002 an unmoded recursive mkdir
+    // produced 0775. The install promoter then aborted with "GENIE_HOME has
+    // unsafe permissions". Assert the resulting mode, not umask mechanics, so
+    // the invariant holds across platforms and runtimes.
+    const fixtureRoot = freshHome();
+    useUmask(0o002);
+    const intermediate = join(fixtureRoot, 'intermediate');
+    const genieHome = join(intermediate, '.genie');
+    expect(existsSync(intermediate)).toBe(false);
+
+    hold(acquireLifecycleLease('update-delivery', { genieHome }));
+
+    expect(existsSync(join(genieHome, LEASE_FILE))).toBe(true);
+    expect(hasUnsafeWriteBits(genieHome)).toBe(false);
+    expect(hasUnsafeWriteBits(intermediate)).toBe(false);
   });
 
   test('a second acquisition while held returns a typed busy refusal naming the holder kind', () => {

--- a/src/lib/codex-lifecycle-lease.ts
+++ b/src/lib/codex-lifecycle-lease.ts
@@ -257,7 +257,11 @@ function tryCreateLease(
   afterCaptureForTest?: (event: LifecycleLeaseCaptureEvent) => void,
 ): CreateResult {
   try {
-    mkdirSync(dirOf(path), { recursive: true });
+    // 0o700 on every created level: this is often the first creation of
+    // GENIE_HOME on a fresh machine, and a permissive umask (002 on Ubuntu's
+    // user-private-group default) would otherwise leave it group-writable,
+    // which the install promoter rejects as unsafe permissions.
+    mkdirSync(dirOf(path), { recursive: true, mode: 0o700 });
   } catch (error) {
     return {
       ok: false,

--- a/src/lib/genie-config.ts
+++ b/src/lib/genie-config.ts
@@ -33,7 +33,9 @@ export function genieConfigExists(): boolean {
 function ensureGenieDir(): void {
   const dir = getGenieDir();
   if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
+    // GENIE_HOME itself — 0o700 so it is safe even when this runs before any
+    // lease-owning creator, rather than relying on call ordering.
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
 }
 

--- a/src/lib/genie-home-permissions.test.ts
+++ b/src/lib/genie-home-permissions.test.ts
@@ -34,7 +34,7 @@ const umaskRestores: number[] = [];
 const PERMISSIVE_UMASK = 0o002;
 
 afterEach(() => {
-  for (const mask of umaskRestores.splice(0)) process.umask(mask);
+  for (const mask of umaskRestores.splice(0).reverse()) process.umask(mask);
   for (const cleanup of cleanups.splice(0).reverse()) cleanup();
 });
 
@@ -219,8 +219,8 @@ const REPO_ROOT = new URL('../..', import.meta.url).pathname;
  */
 const GENIE_HOME_TOKENS = /genieHome|GENIE_HOME|resolveGenieHome|backupRoot/;
 
-/** A safe mode grants nothing to group or other. */
-const SAFE_MODE = /mode:\s*0o[0-7]{3,4}/;
+/** A safe mode grants nothing to group or other: both low digits lack the write bit. */
+const SAFE_MODE = /mode:\s*0o[0-7]?[0-7][0145][0145]\b/;
 
 /**
  * Verified NOT to create GENIE_HOME, despite matching the token heuristic.

--- a/src/lib/genie-home-permissions.test.ts
+++ b/src/lib/genie-home-permissions.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Cross-module invariant: no code path that FIRST creates GENIE_HOME may leave
+ * group or other write bits on it.
+ *
+ * Regression for fresh Linux installs of v5.260814.5 failing with
+ * `InstallPromotionError: GENIE_HOME has unsafe permissions`. Under Ubuntu's
+ * user-private-group default umask 002, an unmoded `mkdirSync(…, { recursive:
+ * true })` yields 0775, and `assertSafeOwnedDirectory` in install-promotion.ts
+ * rejects any directory whose mode carries `0o022`.
+ *
+ * Several unrelated modules can win the race to be that first creator, so the
+ * invariant is asserted here in one place rather than per module. The lease
+ * path — the site the original incident traced to — additionally keeps its own
+ * colocated regression test in codex-lifecycle-lease.test.ts.
+ *
+ * Assertions are on the RESULTING mode, never on umask mechanics, so they hold
+ * across platforms and runtimes (local darwin/bun vs. the Linux CI where the
+ * bug reproduces).
+ */
+import { afterEach, describe, expect, test } from 'bun:test';
+import { lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { dirname, join, relative } from 'node:path';
+import { convergeAuxiliaryTree } from '../genie-commands/auxiliary-trees.js';
+import { persistIntegrationConsent } from './runtime-integrations.js';
+import { openGlobalDb, resolveGlobalDbPath } from './v5/global-db.js';
+import { openSqlite } from './v5/sqlite-open.js';
+import { findWorkspace } from './workspace.js';
+
+const cleanups: Array<() => void> = [];
+const umaskRestores: number[] = [];
+
+/** Ubuntu's user-private-group default — the umask that produced the incident. */
+const PERMISSIVE_UMASK = 0o002;
+
+afterEach(() => {
+  for (const mask of umaskRestores.splice(0)) process.umask(mask);
+  for (const cleanup of cleanups.splice(0).reverse()) cleanup();
+});
+
+function useUmask(mask: number): void {
+  umaskRestores.push(process.umask(mask));
+}
+
+function tempRoot(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  cleanups.push(() => rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+
+/**
+ * The predicate `assertSafeOwnedDirectory` applies in install-promotion.ts,
+ * which is module-private there. Any group or other write bit aborts the
+ * install with "has unsafe permissions".
+ */
+function hasUnsafeWriteBits(path: string): boolean {
+  return (lstatSync(path).mode & 0o022) !== 0;
+}
+
+describe('GENIE_HOME first-creation permissions', () => {
+  // Each entry receives a GENIE_HOME path that does NOT exist yet, and must
+  // leave it safe for the install promoter after creating it.
+  const creators: Array<{ site: string; create: (genieHome: string) => void }> = [
+    {
+      site: 'runtime-integrations.ts — persistIntegrationConsent',
+      create: (genieHome) => persistIntegrationConsent('auto', genieHome),
+    },
+    {
+      // The global genie.db lives directly in GENIE_HOME, and every `genie
+      // omni` subcommand opens it leaseless — so this is a first-creator.
+      site: 'global-db.ts — openGlobalDb',
+      create: (genieHome) => openGlobalDb({ path: join(genieHome, 'genie.db') }).close(),
+    },
+    {
+      site: 'auxiliary-trees.ts — convergeAuxiliaryTree staging',
+      create: (genieHome) => {
+        // Production callers always pass `<GENIE_HOME>/<tree>`, so the parent
+        // this stages into is GENIE_HOME itself.
+        const source = tempRoot('genie-aux-source-');
+        writeFileSync(join(source, 'payload.txt'), 'payload\n');
+        const outcome = convergeAuxiliaryTree({
+          label: 'plugins',
+          source,
+          destination: join(genieHome, 'plugins'),
+        });
+        if (outcome.status === 'failed') throw new Error(`convergence failed at ${outcome.stage}: ${outcome.error}`);
+      },
+    },
+  ];
+
+  for (const { site, create } of creators) {
+    test(`${site} creates GENIE_HOME without group/other write bits under a permissive umask`, () => {
+      const root = tempRoot('genie-home-perms-');
+      useUmask(PERMISSIVE_UMASK);
+      const intermediate = join(root, 'intermediate');
+      const genieHome = join(intermediate, '.genie');
+
+      create(genieHome);
+
+      expect(hasUnsafeWriteBits(genieHome)).toBe(false);
+      expect(hasUnsafeWriteBits(intermediate)).toBe(false);
+    });
+  }
+
+  test('workspace.ts — saveWorkspaceRoot creates GENIE_HOME without group/other write bits', () => {
+    // `saveWorkspaceRoot` deliberately refuses to persist workspaces under
+    // tmpdir(), so the workspace root must live outside it for the mkdir to be
+    // reached at all. GENIE_HOME itself still points into tmp.
+    const workspaceRoot = mkdtempSync(join(homedir(), '.genie-home-perms-test-'));
+    cleanups.push(() => rmSync(workspaceRoot, { recursive: true, force: true }));
+    mkdirSync(join(workspaceRoot, '.genie'), { recursive: true });
+    writeFileSync(join(workspaceRoot, '.genie', 'workspace.json'), JSON.stringify({ name: 'perms-test' }));
+
+    const root = tempRoot('genie-home-perms-workspace-');
+    const intermediate = join(root, 'intermediate');
+    const genieHome = join(intermediate, '.genie');
+    const previousGenieHome = process.env.GENIE_HOME;
+    process.env.GENIE_HOME = genieHome;
+    cleanups.push(() => {
+      if (previousGenieHome === undefined) {
+        // biome-ignore lint/performance/noDelete: process.env assignment coerces undefined→"undefined"; delete is the only correct unset
+        delete process.env.GENIE_HOME;
+      } else {
+        process.env.GENIE_HOME = previousGenieHome;
+      }
+    });
+    useUmask(PERMISSIVE_UMASK);
+
+    expect(findWorkspace(workspaceRoot)?.root).toBe(workspaceRoot);
+
+    // Guard the guard: if the tmp refusal ever starts swallowing this root the
+    // mode assertions below would vacuously pass on a directory never created.
+    expect(JSON.parse(readFileSync(join(genieHome, 'config.json'), 'utf8')).workspaceRoot).toBe(workspaceRoot);
+    expect(hasUnsafeWriteBits(genieHome)).toBe(false);
+    expect(hasUnsafeWriteBits(intermediate)).toBe(false);
+  });
+
+  test('the global db resolves into GENIE_HOME, while a per-repo .genie keeps the ambient umask', () => {
+    // The two halves of the deliberate split in openSqlite's `dirMode`. The
+    // global db's directory IS GENIE_HOME (so it opts in to 0o700); the
+    // per-repo `.genie/` lives inside the user's own repository, where forcing
+    // owner-only would be surprising, so it stays at the ambient umask.
+    const root = tempRoot('genie-home-perms-split-');
+    const genieHome = join(root, '.genie-home');
+    const previousGenieHome = process.env.GENIE_HOME;
+    process.env.GENIE_HOME = genieHome;
+    cleanups.push(() => {
+      if (previousGenieHome === undefined) {
+        // biome-ignore lint/performance/noDelete: process.env assignment coerces undefined→"undefined"; delete is the only correct unset
+        delete process.env.GENIE_HOME;
+      } else {
+        process.env.GENIE_HOME = previousGenieHome;
+      }
+    });
+    expect(dirname(resolveGlobalDbPath())).toBe(genieHome);
+
+    useUmask(PERMISSIVE_UMASK);
+    openGlobalDb().close();
+    expect(hasUnsafeWriteBits(genieHome)).toBe(false);
+
+    const repoGenieDir = join(root, 'repo', '.genie');
+    openSqlite({
+      path: join(repoGenieDir, 'genie.db'),
+      schemaVersion: 1,
+      ensureSchema: (db) => db.exec('CREATE TABLE IF NOT EXISTS t (id INTEGER PRIMARY KEY)'),
+    }).close();
+    expect(lstatSync(repoGenieDir).mode & 0o777).toBe(0o775);
+  });
+
+  test('no recursive mkdirSync under GENIE_HOME lacks an explicit safe mode', () => {
+    // Negative scan: a NEW unmoded GENIE_HOME creator fails here by default
+    // rather than having to be remembered. For several sites — installGenie-
+    // TmuxConf, the legacy-v4 backups, the update diagnostics log — this is the
+    // only coverage, since they are private, wizard-only, or destructive.
+    const offenders = scanUnsafeGenieHomeMkdirs(REPO_ROOT);
+    expect(offenders).toEqual([]);
+  });
+
+  test('GENIE_HOME creators the scan cannot see keep an explicit safe mode', () => {
+    // The scan reads expressions, so it only sees GENIE_HOME when a token
+    // survives local const expansion. These sites receive the path as a
+    // function parameter or through a cross-module accessor, so no token is
+    // visible at the call and the scan structurally cannot flag them. Pin them
+    // by hand — verified reachable, and each regressed the incident on its own.
+    const pinned: Array<[file: string, marker: string, why: string]> = [
+      ['src/term-commands/hook/trust.ts', 'mkdirSync(dir, {', '<GENIE_HOME>/hooks via `genie hook trust`'],
+      ['src/lib/genie-config.ts', 'mkdirSync(dir, {', 'GENIE_HOME via getGenieDir()'],
+      ['src/genie-commands/auxiliary-trees.ts', 'mkdirSync(dirname(options.destination), {', 'GENIE_HOME parent'],
+      ['src/lib/codex-lifecycle-lease.ts', 'mkdirSync(dirOf(path), {', 'GENIE_HOME via the lease path'],
+      [
+        'src/lib/codex-activation-persistence.ts',
+        'mkdirSync(dir, {',
+        'atomicWriteFileSync — every caller writes under GENIE_HOME',
+      ],
+    ];
+
+    for (const [file, marker, why] of pinned) {
+      const call = readFileSync(join(REPO_ROOT, file), 'utf8')
+        .split('\n')
+        .find((line) => line.includes(marker));
+      expect(call, `${file}: no call matching \`${marker}\``).toBeDefined();
+      expect(call, `${file}: ${why} — must declare a safe mode`).toMatch(SAFE_MODE);
+    }
+
+    // The shared sqlite primitive takes its mode from the caller, so the pin is
+    // on the global DB opting in — the per-repo DB deliberately does not.
+    expect(readFileSync(join(REPO_ROOT, 'src/lib/v5/global-db.ts'), 'utf8')).toContain('dirMode: 0o700');
+  });
+});
+
+const REPO_ROOT = new URL('../..', import.meta.url).pathname;
+
+// ─── Source scan ──────────────────────────────────────────────────────────────
+
+/**
+ * Targets whose text still names a GENIE_HOME source after local `const`
+ * expansion. `backupRoot` is included because it is always
+ * `<GENIE_HOME>/state-backups/…`.
+ */
+const GENIE_HOME_TOKENS = /genieHome|GENIE_HOME|resolveGenieHome|backupRoot/;
+
+/** A safe mode grants nothing to group or other. */
+const SAFE_MODE = /mode:\s*0o[0-7]{3,4}/;
+
+/**
+ * Verified NOT to create GENIE_HOME, despite matching the token heuristic.
+ * Keyed by `<path>:<line>` with the reason it is exempt.
+ */
+const SCAN_EXEMPTIONS = new Map<string, string>([
+  [
+    'src/lib/agent-sync.ts:5171',
+    // Triggered by the identifier `before`: the scan's file-scoped const map
+    // resolves it to the file's FIRST `const before = lstatSync(path)`
+    // (agent-sync.ts:883), whose `path` cascades into a genieHome token. The
+    // real target here is `join(transactionDir, 'before')` inside a council
+    // workflow transaction dir the preceding renameSync already published, so
+    // GENIE_HOME is never created.
+    'council workflow transaction dir, not GENIE_HOME (scan token collision)',
+  ],
+]);
+
+interface UnsafeMkdir {
+  site: string;
+  target: string;
+}
+
+/**
+ * Flag every recursive `mkdirSync` in `src/` whose target resolves to or under
+ * GENIE_HOME but declares no explicit mode. Identifiers are expanded through
+ * same-file `const`/`let` initializers so indirection like
+ * `const logsDir = join(GENIE_HOME, 'logs')` is still caught.
+ *
+ * The expansion is file-scoped rather than block-scoped, which can over-match
+ * when a parameter shares a name with an unrelated const. That direction is
+ * deliberate: over-matching costs one reviewed SCAN_EXEMPTIONS entry, while
+ * under-matching would silently ship the bug this file exists to prevent.
+ */
+function scanUnsafeGenieHomeMkdirs(repoRoot: string): UnsafeMkdir[] {
+  const offenders: UnsafeMkdir[] = [];
+  for (const file of sourceFiles(join(repoRoot, 'src'))) {
+    const lines = readFileSync(file, 'utf8').split('\n');
+    const consts = new Map<string, string>();
+    for (const line of lines) {
+      const declaration = /^\s*(?:const|let)\s+([A-Za-z_$][\w$]*)\s*=\s*(.+?);?\s*$/.exec(line);
+      if (declaration && !consts.has(declaration[1])) consts.set(declaration[1], declaration[2]);
+    }
+    for (const [index, line] of lines.entries()) {
+      const call = /mkdirSync\(\s*(.+?),\s*\{(.*?)\}\s*\)/.exec(line);
+      if (!call || !call[2].includes('recursive: true') || SAFE_MODE.test(call[2])) continue;
+      const [, target] = call;
+      if (!GENIE_HOME_TOKENS.test(expandIdentifiers(target, consts))) continue;
+      const site = `${relative(repoRoot, file)}:${index + 1}`;
+      if (!SCAN_EXEMPTIONS.has(site)) offenders.push({ site, target });
+    }
+  }
+  return offenders;
+}
+
+function expandIdentifiers(expression: string, consts: Map<string, string>, depth = 0): string {
+  if (depth > 8) return expression;
+  let expanded = expression;
+  for (const name of new Set(expression.match(/[A-Za-z_$][\w$]*/g) ?? [])) {
+    const initializer = consts.get(name);
+    if (initializer === undefined || initializer === expression) continue;
+    expanded = expanded.replace(new RegExp(`\\b${name}\\b`, 'g'), `(${initializer})`);
+  }
+  return expanded === expression ? expanded : expandIdentifiers(expanded, consts, depth + 1);
+}
+
+function sourceFiles(dir: string): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name !== '__tests__') found.push(...sourceFiles(path));
+    } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+      found.push(path);
+    }
+  }
+  return found;
+}

--- a/src/lib/genie-home-permissions.test.ts
+++ b/src/lib/genie-home-permissions.test.ts
@@ -21,6 +21,7 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import { lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { convergeAuxiliaryTree } from '../genie-commands/auxiliary-trees.js';
 import { persistIntegrationConsent } from './runtime-integrations.js';
 import { openGlobalDb, resolveGlobalDbPath } from './v5/global-db.js';
@@ -208,7 +209,7 @@ describe('GENIE_HOME first-creation permissions', () => {
   });
 });
 
-const REPO_ROOT = new URL('../..', import.meta.url).pathname;
+const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
 
 // ─── Source scan ──────────────────────────────────────────────────────────────
 
@@ -221,6 +222,15 @@ const GENIE_HOME_TOKENS = /genieHome|GENIE_HOME|resolveGenieHome|backupRoot/;
 
 /** A safe mode grants nothing to group or other: both low digits lack the write bit. */
 const SAFE_MODE = /mode:\s*0o[0-7]?[0-7][0145][0145]\b/;
+
+/**
+ * A `mkdirSync(target, { options })` call, matched against whole-file source so
+ * a formatter-wrapped call spanning several lines is still seen — including the
+ * trailing comma Biome adds when it wraps the argument list. Both groups
+ * exclude `;` so an options-less `mkdirSync(dir);` cannot swallow a later
+ * statement's object literal.
+ */
+const MKDIR_CALL = /mkdirSync\(\s*([^;]+?),\s*\{([^;]*?)\}\s*,?\s*\)/g;
 
 /**
  * Verified NOT to create GENIE_HOME, despite matching the token heuristic.
@@ -258,18 +268,19 @@ interface UnsafeMkdir {
 function scanUnsafeGenieHomeMkdirs(repoRoot: string): UnsafeMkdir[] {
   const offenders: UnsafeMkdir[] = [];
   for (const file of sourceFiles(join(repoRoot, 'src'))) {
-    const lines = readFileSync(file, 'utf8').split('\n');
+    const source = readFileSync(file, 'utf8');
     const consts = new Map<string, string>();
-    for (const line of lines) {
+    for (const line of source.split('\n')) {
       const declaration = /^\s*(?:const|let)\s+([A-Za-z_$][\w$]*)\s*=\s*(.+?);?\s*$/.exec(line);
       if (declaration && !consts.has(declaration[1])) consts.set(declaration[1], declaration[2]);
     }
-    for (const [index, line] of lines.entries()) {
-      const call = /mkdirSync\(\s*(.+?),\s*\{(.*?)\}\s*\)/.exec(line);
-      if (!call || !call[2].includes('recursive: true') || SAFE_MODE.test(call[2])) continue;
-      const [, target] = call;
+    for (const call of source.matchAll(MKDIR_CALL)) {
+      const options = call[2];
+      if (!options.includes('recursive: true') || SAFE_MODE.test(options)) continue;
+      const target = call[1].replace(/\s+/g, ' ');
       if (!GENIE_HOME_TOKENS.test(expandIdentifiers(target, consts))) continue;
-      const site = `${relative(repoRoot, file)}:${index + 1}`;
+      const line = source.slice(0, call.index).split('\n').length;
+      const site = `${relative(repoRoot, file)}:${line}`;
       if (!SCAN_EXEMPTIONS.has(site)) offenders.push({ site, target });
     }
   }

--- a/src/lib/runtime-integrations.ts
+++ b/src/lib/runtime-integrations.ts
@@ -102,7 +102,9 @@ export interface IntegrationConsentTransitionRef {
 
 function writeIntegrationConsentState(state: IntegrationConsentState, genieHome: string): void {
   const path = join(genieHome, INTEGRATION_CONSENT_NAME);
-  mkdirSync(genieHome, { recursive: true });
+  // Another first-creator of GENIE_HOME: 0o700 so a permissive umask cannot
+  // leave it group-writable, which the install promoter rejects outright.
+  mkdirSync(genieHome, { recursive: true, mode: 0o700 });
   const staging = `${path}.staging-${process.pid}`;
   writeFileSync(
     staging,
@@ -2512,7 +2514,8 @@ function readRefreshIntent(path: string, runtime: RuntimeName): RefreshIntent | 
 }
 
 function writeRefreshIntent(path: string, intent: RefreshIntent): void {
-  mkdirSync(dirname(path), { recursive: true });
+  // `stateDir` defaults to `resolveGenieHome()`, so this dirname is GENIE_HOME.
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
   const staging = `${path}.staging-${process.pid}`;
   writeFileSync(staging, `${JSON.stringify(intent, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
   renameSync(staging, path);

--- a/src/lib/v5/global-db.ts
+++ b/src/lib/v5/global-db.ts
@@ -79,6 +79,10 @@ export function openGlobalDb(opts: OpenGlobalOptions = {}): Database {
     schemaVersion: GLOBAL_SCHEMA_VERSION,
     ensureSchema,
     schemaIsCurrent,
+    // This directory is GENIE_HOME, and every `genie omni` subcommand reaches
+    // it leaseless — so this open is a first-creator that must not leave group
+    // or other write bits behind for the install promoter to reject.
+    dirMode: 0o700,
   });
 }
 

--- a/src/lib/v5/mcp-tools.test.ts
+++ b/src/lib/v5/mcp-tools.test.ts
@@ -866,8 +866,19 @@ interface RpcResponse {
   error?: { code: number; message: string };
 }
 
+/** One spawned `genie mcp` run: its responses plus the evidence for missing ones. */
+interface McpServerRun {
+  responses: RpcResponse[];
+  /** stdout lines that were not parseable JSON — what a child killed mid-write leaves. */
+  unparsedStdout: string[];
+  stderr: string;
+  exitCode: number | null;
+  /** Set when the OS killed the child; SIGBUS/SIGSEGV escape every JS handler. */
+  signal: string | null;
+}
+
 /** Spawn a real `genie mcp` server subprocess (as an MCP client would). */
-async function spawnMcpServer(cwd: string, requests: Record<string, unknown>[]): Promise<RpcResponse[]> {
+async function spawnMcpServer(cwd: string, requests: Record<string, unknown>[]): Promise<McpServerRun> {
   const proc = Bun.spawn(['bun', join(import.meta.dir, '..', '..', 'genie.ts'), 'mcp'], {
     cwd,
     stdin: 'pipe',
@@ -877,12 +888,40 @@ async function spawnMcpServer(cwd: string, requests: Record<string, unknown>[]):
   });
   proc.stdin.write(`${requests.map((r) => JSON.stringify(r)).join('\n')}\n`);
   await proc.stdin.end();
-  const stdout = await new Response(proc.stdout).text();
+  // Drain both pipes concurrently: a child that fills stderr while we block on
+  // stdout would wedge, and stderr is the only record a native death leaves.
+  const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
   await proc.exited;
-  return stdout
-    .split('\n')
-    .filter((l) => l.trim().length > 0)
-    .map((l) => JSON.parse(l) as RpcResponse);
+  const responses: RpcResponse[] = [];
+  const unparsedStdout: string[] = [];
+  for (const line of stdout.split('\n')) {
+    if (line.trim().length === 0) continue;
+    try {
+      responses.push(JSON.parse(line) as RpcResponse);
+    } catch {
+      unparsedStdout.push(line);
+    }
+  }
+  return { responses, unparsedStdout, stderr, exitCode: proc.exitCode, signal: proc.signalCode };
+}
+
+/**
+ * The response for `id`, or a failure naming what the child actually did. A
+ * server the kernel killed exits with stdout unflushed, so a bare
+ * `expect(res).toBeDefined()` reports only that the response is missing — never
+ * that the process died, with what signal, or what it printed first.
+ */
+function mcpResponse(run: McpServerRun, id: number): RpcResponse {
+  const found = run.responses.find((r) => r.id === id);
+  if (found) return found;
+  throw new Error(
+    [
+      `no JSON-RPC response id=${id} (exit=${run.exitCode} signal=${run.signal})`,
+      `  ids seen: ${JSON.stringify(run.responses.map((r) => r.id))}`,
+      `  unparsed stdout: ${JSON.stringify(run.unparsedStdout)}`,
+      `  stderr: ${run.stderr.trim() || '(empty)'}`,
+    ].join('\n'),
+  );
 }
 
 const MCP_INIT = {
@@ -1311,13 +1350,13 @@ describe('MCP_WRITE_TOOLS — the 12 operative write tools', () => {
       ]);
 
     const [a, b] = await Promise.all([drive('w1'), drive('w2')]);
-    const aRes = a.find((r) => r.id === 2);
-    const bRes = b.find((r) => r.id === 2);
-    expect(aRes).toBeDefined();
-    expect(bRes).toBeDefined();
-    expect(aRes?.error).toBeUndefined(); // no JSON-RPC error, no -32603
-    expect(bRes?.error).toBeUndefined();
-    const outcomes = [aRes!, bRes!];
+    // Accessors, not `toBeDefined()`: a missing response must report the child's
+    // exit status, signal and stderr, not just its own absence.
+    const aRes = mcpResponse(a, 2);
+    const bRes = mcpResponse(b, 2);
+    expect(aRes.error).toBeUndefined(); // no JSON-RPC error, no -32603
+    expect(bRes.error).toBeUndefined();
+    const outcomes = [aRes, bRes];
     const winners = outcomes.filter((r) => r.result?.isError === false);
     const losers = outcomes.filter((r) => r.result?.isError === true);
     expect(winners).toHaveLength(1);

--- a/src/lib/v5/mcp-tools.test.ts
+++ b/src/lib/v5/mcp-tools.test.ts
@@ -1334,7 +1334,7 @@ describe('MCP_WRITE_TOOLS — the 12 operative write tools', () => {
     } finally {
       check.close();
     }
-  });
+  }, 30_000); // two cold `bun src/genie.ts mcp` boots race here; loaded CI runners exceed the 5s default
 });
 
 function callOn(ctx: ToolContext, name: string, args: Record<string, unknown>): unknown {

--- a/src/lib/v5/sqlite-open.test.ts
+++ b/src/lib/v5/sqlite-open.test.ts
@@ -13,11 +13,12 @@
 
 import { Database } from 'bun:sqlite';
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { existsSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync, statSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   BusyDbError,
+  RECOVERY_LOCK_WAIT_MS,
   WalIndexPoisonError,
   hasStaleReadonlyWalIndex,
   isBusyError,
@@ -343,6 +344,77 @@ describe('openWithWalIndexRecovery', () => {
     expect(attempts).toBe(1);
     db.exec('INSERT INTO t (id) VALUES (2)'); // writable
     db.close();
+  });
+
+  /**
+   * The cross-process mutex that makes the helper's single-owner assumption
+   * true. Two MCP servers on one database used to enter the probe/rebuild
+   * concurrently and race on the wal-index mmap, which the kernel resolves by
+   * killing a process outright on Linux.
+   */
+  describe('recovery lock', () => {
+    const lockOf = (path: string) => `${path}-recovery-lock`;
+
+    test('the lock is taken for the open and released after it, on success and on throw', () => {
+      const path = seeded(join(base, 'db.sqlite'));
+      let heldDuringOpen = false;
+      const db = openWithWalIndexRecovery(path, () => {
+        heldDuringOpen = existsSync(lockOf(path));
+        return new Database(path);
+      });
+      expect(heldDuringOpen).toBe(true); // held before any handle exists
+      expect(existsSync(lockOf(path))).toBe(false);
+      db.close();
+
+      expect(() =>
+        openWithWalIndexRecovery(path, () => {
+          throw new Error('unrelated failure');
+        }),
+      ).toThrow('unrelated failure');
+      expect(existsSync(lockOf(path))).toBe(false); // released in `finally`, not only on success
+    });
+
+    test('a lock whose holder died is reclaimed at once — a crash mid-recovery bricks nothing', async () => {
+      const path = seeded(join(base, 'db.sqlite'));
+      const child = Bun.spawn(['true'], { stdout: 'ignore', stderr: 'ignore' });
+      const holder = child.pid;
+      await child.exited; // reaped: `process.kill(holder, 0)` now raises ESRCH
+      writeFileSync(lockOf(path), String(holder));
+
+      const started = Date.now();
+      const db = openWithWalIndexRecovery(path, () => new Database(path));
+      // Reclaimed on PID evidence, not by waiting out the 30s age fallback.
+      expect(Date.now() - started).toBeLessThan(RECOVERY_LOCK_WAIT_MS);
+      db.exec('INSERT INTO t (id) VALUES (4)'); // and the open really happened
+      db.close();
+      expect(existsSync(lockOf(path))).toBe(false);
+    });
+
+    test('a lock whose PID is unreadable is reclaimed once it ages out', () => {
+      const path = seeded(join(base, 'db.sqlite'));
+      writeFileSync(lockOf(path), 'not-a-pid'); // no liveness evidence to go on
+      const aged = new Date(Date.now() - 10 * RECOVERY_LOCK_WAIT_MS);
+      utimesSync(lockOf(path), aged, aged);
+
+      const db = openWithWalIndexRecovery(path, () => new Database(path));
+      db.close();
+      expect(existsSync(lockOf(path))).toBe(false);
+    });
+
+    test('a lock held by a LIVE holder past the wait budget fails typed-busy, never as corruption', () => {
+      const path = seeded(join(base, 'db.sqlite'));
+      writeFileSync(lockOf(path), String(process.pid)); // this process is alive by definition
+
+      let attempts = 0;
+      expect(() =>
+        openWithWalIndexRecovery(path, () => {
+          attempts += 1;
+          return new Database(path);
+        }),
+      ).toThrow(BusyDbError); // transient contention — the caller retries, never degrades
+      expect(attempts).toBe(0); // no handle was ever created outside the mutex
+      rmSync(lockOf(path), { force: true });
+    }, 15_000); // deliberately waits out the full RECOVERY_LOCK_WAIT_MS budget
   });
 
   test('a non-poison open failure propagates unchanged (no sidecars are touched)', () => {

--- a/src/lib/v5/sqlite-open.ts
+++ b/src/lib/v5/sqlite-open.ts
@@ -21,7 +21,7 @@
  */
 
 import { Database } from 'bun:sqlite';
-import { closeSync, mkdirSync, openSync, readSync, statSync } from 'node:fs';
+import { closeSync, mkdirSync, openSync, readFileSync, readSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 
 /**
@@ -229,6 +229,16 @@ function openInitialized(opts: OpenSqliteOptions): Database {
 // session, whose close writes the header (`openWriteableDb` in mcp-tools.ts,
 // re-opened by `promoteDegradedHandle` in mcp-server.ts). That path is
 // single-owner and low-concurrency — the fleet never runs the probe.
+//
+// "Single-owner" is an assumption about the CALLER, and one MCP server per
+// database does honour it. Two MCP servers on one `.genie/genie.db` do not: both
+// enter the recovery path at startup and race on handle creation, the wal-index
+// mmap and the exclusive-lock proof below. On Linux that race intermittently
+// kills a process natively (SIGBUS/SIGSEGV inside bun's shm handling), which no
+// JS `catch` can observe — the process simply disappears mid-request. The
+// cross-process mutex below therefore makes the assumption true instead of
+// merely documenting it: the whole probe/rebuild/reopen sequence runs under a
+// lock file, so a second entrant waits rather than racing.
 
 /** Bytes of the `-shm` WAL-index header this module inspects (iChange @8, nPage @20). */
 const WAL_INDEX_HEADER_BYTES = 24;
@@ -357,11 +367,111 @@ function rebuildSidecarsExclusively(path: string): boolean {
 }
 
 /**
+ * Suffix of the cross-process recovery mutex, named as a sidecar of the database
+ * so the same `.gitignore` stanza that hides `-wal`/`-shm` hides it too.
+ */
+const RECOVERY_LOCK_SUFFIX = '-recovery-lock';
+
+/**
+ * How long a contender waits for the recovery lock before giving up. Generous
+ * enough to outlast a holder that is mid-rebuild on a loaded CI runner; bounded
+ * so a wedged holder degrades into a retryable {@link BusyDbError} rather than a
+ * hang.
+ */
+export const RECOVERY_LOCK_WAIT_MS = 5_000;
+
+/** Poll interval while waiting for the lock. */
+const RECOVERY_LOCK_POLL_MS = 25;
+
+/**
+ * Age at which a lock whose holder cannot be proven dead is assumed abandoned.
+ * A legitimate hold is bounded by two opens, each at most `busy_timeout` plus
+ * the backoff budget (~11.6s together), so this sits comfortably above it: a
+ * live-but-slow holder is never reaped. The usual crashed-holder case does not
+ * wait this out — the PID liveness check below reclaims it on the next poll.
+ */
+const RECOVERY_LOCK_STALE_MS = 30_000;
+
+/** True when `pid` still names a live process (EPERM means alive, just not ours). */
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+/**
+ * True when the existing lock belongs to a holder that died mid-recovery. The
+ * recorded PID is the primary evidence; the age is the fallback for a lock whose
+ * PID is unreadable, malformed, or reused. An unreadable/vanished lock is NOT
+ * abandoned — plain acquisition retry already covers that.
+ */
+function recoveryLockIsAbandoned(lockPath: string): boolean {
+  let ageMs: number;
+  let recorded: string;
+  try {
+    ageMs = Date.now() - statSync(lockPath).mtimeMs;
+    recorded = readFileSync(lockPath, 'utf8').trim();
+  } catch {
+    return false;
+  }
+  const pid = Number.parseInt(recorded, 10);
+  if (Number.isInteger(pid) && pid > 0 && !processIsAlive(pid)) return true;
+  return ageMs >= RECOVERY_LOCK_STALE_MS;
+}
+
+/**
+ * Take the recovery mutex for `path`, waiting out a live holder up to
+ * {@link RECOVERY_LOCK_WAIT_MS} and reclaiming an abandoned one.
+ *
+ * Returns the lock path to release, or `null` when the lock file itself cannot
+ * be created (a read-only or missing directory). A missing mutex is not a reason
+ * to fail an otherwise-healthy open: the caller proceeds unserialized, exactly
+ * as it did before this lock existed. Only a lock held past the wait budget
+ * fails, and it fails as {@link BusyDbError} because that is what it is —
+ * transient contention on a healthy database, safe to retry.
+ */
+function acquireRecoveryLock(path: string): string | null {
+  const lockPath = `${path}${RECOVERY_LOCK_SUFFIX}`;
+  const deadline = Date.now() + RECOVERY_LOCK_WAIT_MS;
+  for (;;) {
+    try {
+      writeFileSync(lockPath, String(process.pid), { flag: 'wx' });
+      return lockPath;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') return null;
+      if (recoveryLockIsAbandoned(lockPath)) releaseRecoveryLock(lockPath);
+      else if (Date.now() >= deadline) {
+        throw new BusyDbError(path, new Error(`WAL-index recovery lock held past ${RECOVERY_LOCK_WAIT_MS}ms`));
+      } else sleepMs(RECOVERY_LOCK_POLL_MS);
+    }
+  }
+}
+
+/** Drop the recovery mutex. A lock already gone (reaped as stale) is not an error. */
+function releaseRecoveryLock(lockPath: string | null): void {
+  if (lockPath === null) return;
+  try {
+    unlinkSync(lockPath);
+  } catch {
+    // Already reclaimed by a stale-lock reaper — nothing left to release.
+  }
+}
+
+/**
  * Run `open`, healing a poisoned WAL index around it. The poison is detected two
  * ways because platforms differ in where it surfaces: the open may throw, or it
  * may hand back a handle whose every write fails — caught by the post-open
  * probe. Either way the sidecars are rebuilt and the open is retried EXACTLY
  * ONCE.
+ *
+ * The entire sequence is serialized across processes by a lock file taken BEFORE
+ * the first handle exists, so concurrent entrants never race on the wal-index
+ * mmap (see the section header). A waiter that wins the lock re-runs the probe
+ * from scratch rather than assuming anything: by then the previous holder has
+ * usually healed the database, and the ordinary healthy path just proceeds.
  *
  * CALLERS: the MCP write path only (`tryWriteOpen` in mcp-tools.ts). See the
  * section header above for why this must never wrap the fleet-wide
@@ -376,6 +486,16 @@ function rebuildSidecarsExclusively(path: string): boolean {
  * the rebuild is skipped the ORIGINAL error propagates and both sidecars survive.
  */
 export function openWithWalIndexRecovery(path: string, open: () => Database): Database {
+  const lockPath = acquireRecoveryLock(path);
+  try {
+    return openUnderRecoveryLock(path, open);
+  } finally {
+    releaseRecoveryLock(lockPath);
+  }
+}
+
+/** The probe/rebuild/reopen sequence itself. Runs only under the recovery mutex. */
+function openUnderRecoveryLock(path: string, open: () => Database): Database {
   let db: Database;
   try {
     db = open();

--- a/src/lib/v5/sqlite-open.ts
+++ b/src/lib/v5/sqlite-open.ts
@@ -160,6 +160,14 @@ export interface OpenSqliteOptions {
    * without contending on the schema write lock. Omit to always run ensureSchema.
    */
   schemaIsCurrent?: (db: Database) => boolean;
+  /**
+   * Mode for the containing directory when this open creates it. Set ONLY by
+   * the global DB, whose directory IS GENIE_HOME and must never carry group or
+   * other write bits (the install promoter rejects those). Left unset for the
+   * per-repo `.genie/`, which lives inside the user's own repository where
+   * forcing 0o700 would be surprising — that path keeps the ambient umask.
+   */
+  dirMode?: number;
 }
 
 /**
@@ -175,7 +183,7 @@ export interface OpenSqliteOptions {
  */
 export function openSqlite(opts: OpenSqliteOptions): Database {
   const { path } = opts;
-  if (path !== ':memory:') mkdirSync(dirname(path), { recursive: true });
+  if (path !== ':memory:') mkdirSync(dirname(path), { recursive: true, mode: opts.dirMode });
   return openInitialized(opts);
 }
 

--- a/src/lib/workspace.ts
+++ b/src/lib/workspace.ts
@@ -163,7 +163,9 @@ function saveWorkspaceRoot(root: string): void {
     const config = existsSync(configPath) ? JSON.parse(readFileSync(configPath, 'utf-8')) : {};
     if (config.workspaceRoot === root) return;
     config.workspaceRoot = root;
-    mkdirSync(home, { recursive: true });
+    // Another first-creator of GENIE_HOME: 0o700 so a permissive umask cannot
+    // leave it group-writable, which the install promoter rejects outright.
+    mkdirSync(home, { recursive: true, mode: 0o700 });
     writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf-8');
   } catch {
     /* best-effort */

--- a/src/term-commands/hook/trust.ts
+++ b/src/term-commands/hook/trust.ts
@@ -65,7 +65,9 @@ function findRepoRoot(start: string): string | null {
 
 function writeTrustFile(path: string, file: TrustFile): void {
   const dir = dirname(path);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  // `<GENIE_HOME>/hooks/` — GENIE_HOME is created here as an intermediate, so
+  // 0o700 keeps a permissive umask from leaving it group-writable.
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
 
   // Atomic write via temp + rename so a crash mid-write doesn't corrupt the
   // trust file (the security boundary). Stable JSON (sorted keys, 2-space


### PR DESCRIPTION
## Summary

Promotes `dev` to `main` to release the fix for the fresh-install failure affecting all Linux machines with umask `002` (Ubuntu/Debian default):

```
InstallPromotionError: GENIE_HOME has unsafe permissions
```

## Contents

- **#2798 — fix(install): create GENIE_HOME with mode 0o700 everywhere it is first created.** Every code path that can first-create `~/.genie` now declares `mode: 0o700` (which no umask can widen), matching the install promoter's `0o022` safety predicate. Includes a two-layer regression guard: a negative source scan over `src/` plus a pinned-site test for parameter-carried paths the scan cannot see, with behavioral tests driving the real creator functions under umask `002`.
- **Review hardening** from CodeRabbit findings: nested umask restores now unwind in reverse order, and `SAFE_MODE` rejects explicit modes carrying group/other write bits (`0o775`/`0o777`).
- **Review follow-ups (710beab62)** — test-only hardening from the PR review: an explicit 30s timeout on the cross-process MCP claim-contention test, `fileURLToPath` for the test's `REPO_ROOT` (percent-encoded checkout paths), and the negative `mkdirSync` scan now matches multi-line/Biome-wrapped calls.
- **e3c14d92d — fix(v5): serialize cross-process WAL-index recovery behind a stale-safe lock.** Root cause of the intermittent claim-contention CI failure: two MCP servers starting concurrently on the same `genie.db` both entered the single-owner WAL-recovery path and raced on handles/WAL-index mapping, intermittently killing one child natively on Linux. Recovery now takes a PID-aware, self-reaping lock for the whole probe/rebuild/reopen sequence; lock-timeout maps to the existing busy semantics.
- **df1e3d34c — test(v5): surface spawned MCP server stderr and exit status** so any future harness failure names its cause.
- `[auto-version]` bumps riding the fixes; currently `5.260816.2`.

## Remediation for already-affected machines

This fix stops new installs from creating a group-writable `~/.genie`; it does not (by design) change the mode of an existing directory. A machine where an earlier failed install already left `~/.genie` at `0775` will still be rejected by the promoter's safety check. One-time remedy:

```bash
chmod 700 ~/.genie
```

then re-run the installer.

## Validation

All 17 CI checks passed on #2798 against `dev` (Linux glibc/musl/arm64 builds, E2E v5 lifecycle, unit gate, plugin smoke, security scans). The intermittent cross-process claim-contention failure that blocked earlier heads (pre-existing on dev since Aug 13–14, unrelated to the umask diff) was traced to the WAL-recovery race fixed by `e3c14d92d`; on `df1e3d34c` both the push and pull_request CI runs are fully green (3347 pass / 0 fail; the contention test passes in ~93ms). Merging this PR lets the release automation advance the stable manifest and unbreak `install.sh` for new users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Genie home, workspace, backup, log, cache, trust, lease, and database directories now use owner-only permissions (`0700`).
  - Directory creation remains secure even when permissive system umasks are configured.

- **Bug Fixes**
  - Improved protection for newly created application state and diagnostic files.

- **Tests**
  - Added regression coverage for directory permissions across supported creation paths and environments.

- **Chores**
  - Updated Genie package and plugin versions to `5.260815.2`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
