### PR TITLE
fix(release): retry transient GitHub API failures with fail-closed classification

### DIFF
--- a/scripts/gh-retry.sh
+++ b/scripts/gh-retry.sh
@@ -1,0 +1,183 @@
+# Sourced helper: bounded, fail-closed retry for GitHub CLI calls in the
+# release pipeline. Never executed directly; callers `source` it after their
+# own input validation. It installs no EXIT trap — every caller owns its own —
+# and cleans its temp files explicitly.
+#
+# Classification contract (2026-08-17 outage postmortem, run 31969294922):
+# only failures that are provably transient are retried. Permission and
+# validation failures surface immediately, and anything unclassifiable —
+# including an empty stderr — is passed through untouched so a mutation is
+# never blindly replayed against ambiguous state and existing exit-code
+# passthrough semantics survive.
+
+GH_RETRY_ATTEMPTS="${GH_RETRY_ATTEMPTS:-5}"
+GH_RETRY_SLEEPS="${GH_RETRY_SLEEPS:-5 10 20 40}"
+
+# gh_retry [--not-found-transient] <command> [args...]
+# Runs the command up to GH_RETRY_ATTEMPTS times, buffering stdout and stderr
+# per attempt so a failed attempt's partial output never leaks into a caller's
+# $(...) capture or `> file` redirect. On success the final attempt's stdout
+# and stderr are replayed verbatim; on failure the last exit code and stderr
+# pass through unchanged.
+# --not-found-transient: treat 404/"release not found" as retryable. Only pass
+# this when the caller has separately established that the target exists
+# (e.g. a release published moments earlier), where a 404 is replication lag.
+gh_retry() {
+  local not_found_transient=false
+  if [[ "${1:-}" == "--not-found-transient" ]]; then
+    not_found_transient=true
+    shift
+  fi
+  local out err rc=0 attempt idx
+  local -a sleeps
+  read -r -a sleeps <<<"${GH_RETRY_SLEEPS}"
+  [[ ${#sleeps[@]} -gt 0 ]] || sleeps=(1)
+  out="$(mktemp)" || return 3
+  err="$(mktemp)" || { rm -f "$out"; return 3; }
+  for ((attempt = 1; attempt <= GH_RETRY_ATTEMPTS; attempt++)); do
+    rc=0
+    "$@" >"$out" 2>"$err" || rc=$?
+    if [[ "$rc" -eq 0 ]]; then
+      cat "$out"
+      cat "$err" >&2
+      rm -f "$out" "$err"
+      return 0
+    fi
+    # Permission/validation failures are never retried, and are checked first
+    # so a 403 whose message also suggests retrying is still surfaced at once.
+    if grep -qiE 'HTTP 40[13]|forbidden|permission|not authorized|bad credentials|HTTP 422|validation failed|already_exists' "$err"; then
+      break
+    fi
+    if grep -qiE 'release not found|HTTP 404|not found' "$err"; then
+      # Retryable only under the caller's explicit existence proof.
+      [[ "$not_found_transient" == true ]] || break
+    elif ! grep -qiE 'timed? ?out|connection re(set|fused)|could not resolve|TLS|unexpected EOF|HTTP 5[0-9][0-9]|HTTP 429|rate limit|service unavailable|bad gateway|gateway time-?out|internal server error' "$err"; then
+      # Unclassifiable (including empty stderr): fail closed immediately.
+      break
+    fi
+    if ((attempt < GH_RETRY_ATTEMPTS)); then
+      echo "::warning ::gh-retry.attempt ${attempt}/${GH_RETRY_ATTEMPTS} failed (exit ${rc}); retrying: $1" >&2
+      idx=$((attempt - 1))
+      ((idx < ${#sleeps[@]})) || idx=$((${#sleeps[@]} - 1))
+      sleep "${sleeps[$idx]}"
+    fi
+  done
+  cat "$out"
+  cat "$err" >&2
+  rm -f "$out" "$err"
+  return "$rc"
+}
+
+# gh_release_lookup [--expect-exists] <owner/repo> <tag>
+# Status-aware existence probe. Prints the release's REST JSON on stdout when
+# it exists (published or draft) and returns:
+#   0 — release exists (JSON printed)
+#   4 — definitively absent (tag ref 404 AND the draft listing has no match)
+#   3 — unknown or ambiguous; the CALLER MUST FAIL CLOSED. Unknown never
+#       degrades to "not found": creating a release on a flake is how a
+#       duplicate draft is born.
+#   2 — invalid arguments
+# Drafts carry no tag ref, so a definitive 404 on releases/tags/<tag> falls
+# back to the paginated release listing filtered to drafts, and a single match
+# is re-confirmed by numeric id before being trusted.
+# --expect-exists: the caller knows the release must exist (it was created or
+# published moments earlier), so a definitively-absent result is re-probed to
+# ride out listing read-after-write lag before being returned.
+gh_release_lookup() {
+  local expect_exists=false
+  if [[ "${1:-}" == "--expect-exists" ]]; then
+    expect_exists=true
+    shift
+  fi
+  local repo="${1:-}" tag="${2:-}"
+  [[ "$repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || { echo "gh_release_lookup: invalid repository: ${repo}" >&2; return 2; }
+  [[ "$tag" =~ ^[A-Za-z0-9._-]+$ ]] || { echo "gh_release_lookup: invalid tag: ${tag}" >&2; return 2; }
+  local rounds=1 round rc
+  [[ "$expect_exists" == true ]] && rounds=3
+  for ((round = 1; round <= rounds; round++)); do
+    rc=0
+    gh_release_lookup_once "$repo" "$tag" || rc=$?
+    [[ "$rc" -eq 4 ]] || return "$rc"
+    if ((round < rounds)); then
+      echo "::warning ::gh-retry.lookup ${tag} not visible yet (round ${round}/${rounds}); waiting for listing consistency" >&2
+      sleep "${GH_RETRY_LOOKUP_LAG_SLEEP:-5}"
+    fi
+  done
+  return 4
+}
+
+gh_release_lookup_once() {
+  local repo="$1" tag="$2" out err rc=0
+  out="$(mktemp)" || return 3
+  err="$(mktemp)" || { rm -f "$out"; return 3; }
+  gh_retry gh api "repos/${repo}/releases/tags/${tag}" >"$out" 2>"$err" || rc=$?
+  if [[ "$rc" -eq 0 ]]; then
+    cat "$out"
+    cat "$err" >&2
+    rm -f "$out" "$err"
+    return 0
+  fi
+  if ! grep -qiE 'HTTP 404|not found' "$err"; then
+    cat "$err" >&2
+    rm -f "$out" "$err"
+    echo "could not determine whether release ${tag} exists in ${repo}" >&2
+    return 3
+  fi
+  rm -f "$out" "$err"
+  local ids
+  ids="$(gh_retry gh api --paginate "repos/${repo}/releases?per_page=100" --jq ".[] | select(.draft and .tag_name == \"${tag}\") | .id")" || {
+    echo "could not enumerate draft releases for ${repo} while resolving ${tag}" >&2
+    return 3
+  }
+  [[ -n "$ids" ]] || return 4
+  if [[ "$(wc -l <<<"$ids" | tr -d ' ')" -ne 1 ]]; then
+    echo "multiple draft releases carry tag ${tag} in ${repo}; refusing to pick one" >&2
+    return 3
+  fi
+  local id="$ids" json
+  [[ "$id" =~ ^[0-9]+$ ]] || { echo "draft listing returned a non-numeric release id for ${tag}" >&2; return 3; }
+  json="$(gh_retry gh api "repos/${repo}/releases/${id}")" || {
+    echo "could not confirm draft release ${id} for ${tag}" >&2
+    return 3
+  }
+  [[ "$(jq -r '.tag_name' <<<"$json")" == "$tag" ]] || {
+    echo "draft release ${id} does not carry tag ${tag}; refusing" >&2
+    return 3
+  }
+  printf '%s\n' "$json"
+  return 0
+}
+
+# gh_download_release_asset <owner/repo> <asset_id> <dest_file>
+# Downloads one release asset by numeric id (works for drafts and published
+# releases alike; no by-tag listing resolution involved).
+gh_download_release_asset() {
+  local repo="$1" asset_id="$2" dest="$3"
+  [[ "$asset_id" =~ ^[0-9]+$ ]] || { echo "gh_download_release_asset: invalid asset id: ${asset_id}" >&2; return 2; }
+  gh_retry gh api -H "Accept: application/octet-stream" "repos/${repo}/releases/assets/${asset_id}" >"$dest"
+}
+
+# gh_upload_release_asset <owner/repo> <release_id> <file>
+# Uploads one asset by numeric release id via uploads.github.com. Returns 6
+# when the asset name already exists on the release so the caller can decide
+# (the release pipeline skips and lets its post-upload byte-compare adjudicate
+# — assets are never clobbered or deleted).
+gh_upload_release_asset() {
+  local repo="$1" release_id="$2" file="$3" name err rc=0
+  [[ "$release_id" =~ ^[0-9]+$ ]] || { echo "gh_upload_release_asset: invalid release id: ${release_id}" >&2; return 2; }
+  name="$(basename "$file")"
+  [[ "$name" =~ ^[A-Za-z0-9._-]+$ ]] || { echo "gh_upload_release_asset: refusing unsafe asset name: ${name}" >&2; return 2; }
+  err="$(mktemp)" || return 3
+  gh_retry gh api --method POST \
+    -H "Content-Type: application/octet-stream" \
+    "https://uploads.github.com/repos/${repo}/releases/${release_id}/assets?name=${name}" \
+    --input "$file" >/dev/null 2>"$err" || rc=$?
+  if [[ "$rc" -ne 0 ]] && grep -qi 'already_exists' "$err"; then
+    cat "$err" >&2
+    rm -f "$err"
+    return 6
+  fi
+  cat "$err" >&2
+  rm -f "$err"
+  return "$rc"
+}

--- a/scripts/gh-retry.test.ts
+++ b/scripts/gh-retry.test.ts
@@ -1,0 +1,257 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const HELPER = join(import.meta.dir, 'gh-retry.sh');
+const roots: string[] = [];
+
+interface ScriptedResponse {
+  exit?: number;
+  stdout?: string;
+  stderr?: string;
+}
+
+interface FakeGhState {
+  responses?: ScriptedResponse[];
+  calls?: string[][];
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+// Runs one helper function against a fake `gh` that replays a scripted queue
+// of {exit, stdout, stderr} responses in call order.
+function run(fn: string, fnArgs: string[], responses: ScriptedResponse[], overrides: Record<string, string> = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'genie-gh-retry-'));
+  roots.push(root);
+  const statePath = join(root, 'state.json');
+  const ghPath = join(root, 'gh');
+  writeFileSync(statePath, JSON.stringify({ responses }));
+  writeFileSync(
+    ghPath,
+    `#!/usr/bin/env bun
+import { readFileSync, writeFileSync } from 'node:fs';
+const path = process.env.GH_FAKE_STATE;
+const state = JSON.parse(readFileSync(path, 'utf8'));
+const args = process.argv.slice(2);
+state.calls ??= [];
+state.calls.push(args);
+const response = state.responses?.length ? state.responses.shift() : { exit: 0 };
+writeFileSync(path, JSON.stringify(state));
+if (response.stdout) console.log(response.stdout);
+if (response.stderr) console.error(response.stderr);
+process.exit(response.exit ?? 0);
+`,
+  );
+  chmodSync(ghPath, 0o755);
+  const result = Bun.spawnSync(['bash', '-c', 'source "$0" && "$@"', HELPER, fn, ...fnArgs], {
+    cwd: root,
+    env: {
+      ...process.env,
+      PATH: `${root}:${process.env.PATH ?? ''}`,
+      GH_FAKE_STATE: statePath,
+      GH_RETRY_SLEEPS: '0 0 0 0',
+      GH_RETRY_LOOKUP_LAG_SLEEP: '0',
+      ...overrides,
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  return {
+    result,
+    root,
+    state: JSON.parse(readFileSync(statePath, 'utf8')) as FakeGhState,
+  };
+}
+
+const REPO = 'automagik-dev/genie';
+const releaseJson = (id: number, tag = 'v1.2.3') => JSON.stringify({ id, tag_name: tag, draft: true, body: '' });
+
+describe('gh_retry', () => {
+  test('retries transient failures and emits only the successful stdout', () => {
+    const { result, state } = run(
+      'gh_retry',
+      ['gh', 'api', 'repos/x/y'],
+      [
+        { exit: 1, stderr: 'gh: Internal Server Error (HTTP 502)' },
+        { exit: 1, stderr: 'gh: Service Unavailable' },
+        { exit: 0, stdout: 'payload' },
+      ],
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString()).toBe('payload\n');
+    expect(state.calls).toHaveLength(3);
+  });
+
+  test('never retries permission failures', () => {
+    const { result, state } = run(
+      'gh_retry',
+      ['gh', 'api', 'repos/x/y'],
+      [{ exit: 1, stderr: 'gh: HTTP 403 Forbidden' }],
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain('403');
+    expect(state.calls).toHaveLength(1);
+  });
+
+  test('unknown failures (empty stderr) pass through untouched without retry', () => {
+    // Default-closed: never blind-retry a mutation against ambiguous state,
+    // and preserve caller exit-code passthrough semantics.
+    const { result, state } = run('gh_retry', ['gh', 'api', 'repos/x/y'], [{ exit: 42 }]);
+    expect(result.exitCode).toBe(42);
+    expect(state.calls).toHaveLength(1);
+  });
+
+  test('exhaustion preserves the final exit code and stderr', () => {
+    const responses = Array.from({ length: 5 }, () => ({ exit: 7, stderr: 'gh: HTTP 502 Bad Gateway' }));
+    const { result, state } = run('gh_retry', ['gh', 'api', 'repos/x/y'], responses);
+    expect(result.exitCode).toBe(7);
+    expect(result.stderr.toString()).toContain('502');
+    expect(state.calls).toHaveLength(5);
+  });
+
+  test('not-found is retried only under --not-found-transient', () => {
+    const closed = run('gh_retry', ['gh', 'api', 'repos/x/y'], [{ exit: 1, stderr: 'release not found' }]);
+    expect(closed.result.exitCode).toBe(1);
+    expect(closed.state.calls).toHaveLength(1);
+
+    const lag = run(
+      'gh_retry',
+      ['--not-found-transient', 'gh', 'api', 'repos/x/y'],
+      [
+        { exit: 1, stderr: 'release not found' },
+        { exit: 1, stderr: 'gh: Not Found (HTTP 404)' },
+        { exit: 0, stdout: 'found' },
+      ],
+    );
+    expect(lag.result.exitCode).toBe(0);
+    expect(lag.result.stdout.toString()).toBe('found\n');
+    expect(lag.state.calls).toHaveLength(3);
+  });
+});
+
+describe('gh_release_lookup', () => {
+  test('published release resolves via the tag ref', () => {
+    const { result } = run('gh_release_lookup', [REPO, 'v1.2.3'], [{ exit: 0, stdout: releaseJson(55) }]);
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout.toString()).id).toBe(55);
+  });
+
+  test('draft resolves through the listing and is confirmed by id', () => {
+    const { result, state } = run(
+      'gh_release_lookup',
+      [REPO, 'v1.2.3'],
+      [
+        { exit: 1, stderr: 'gh: Not Found (HTTP 404)' },
+        { exit: 0, stdout: '77' },
+        { exit: 0, stdout: releaseJson(77) },
+      ],
+    );
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout.toString()).id).toBe(77);
+    expect(state.calls?.[2]?.join(' ')).toContain(`repos/${REPO}/releases/77`);
+  });
+
+  test('definitive 404 with an empty listing is definitively absent (rc 4)', () => {
+    const { result } = run(
+      'gh_release_lookup',
+      [REPO, 'v1.2.3'],
+      [
+        { exit: 1, stderr: 'gh: Not Found (HTTP 404)' },
+        { exit: 0, stdout: '' },
+      ],
+    );
+    expect(result.exitCode).toBe(4);
+  });
+
+  test('transient exhaustion is unknown (rc 3), never "not found"', () => {
+    const responses = Array.from({ length: 5 }, () => ({ exit: 1, stderr: 'gh: HTTP 500' }));
+    const { result } = run('gh_release_lookup', [REPO, 'v1.2.3'], responses);
+    expect(result.exitCode).toBe(3);
+    expect(result.stderr.toString()).toContain('could not determine whether release');
+  });
+
+  test('duplicate drafts with the same tag are ambiguous (rc 3)', () => {
+    const { result } = run(
+      'gh_release_lookup',
+      [REPO, 'v1.2.3'],
+      [
+        { exit: 1, stderr: 'gh: Not Found (HTTP 404)' },
+        { exit: 0, stdout: '77\n78' },
+      ],
+    );
+    expect(result.exitCode).toBe(3);
+    expect(result.stderr.toString()).toContain('multiple draft releases');
+  });
+
+  test('--expect-exists rides out listing read-after-write lag', () => {
+    const { result } = run(
+      'gh_release_lookup',
+      ['--expect-exists', REPO, 'v1.2.3'],
+      [
+        { exit: 1, stderr: 'gh: Not Found (HTTP 404)' },
+        { exit: 0, stdout: '' },
+        { exit: 1, stderr: 'gh: Not Found (HTTP 404)' },
+        { exit: 0, stdout: '' },
+        { exit: 1, stderr: 'gh: Not Found (HTTP 404)' },
+        { exit: 0, stdout: '77' },
+        { exit: 0, stdout: releaseJson(77) },
+      ],
+    );
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout.toString()).id).toBe(77);
+  });
+
+  test('rejects invalid repository or tag inputs', () => {
+    expect(run('gh_release_lookup', ['not-a-repo', 'v1.2.3'], []).result.exitCode).toBe(2);
+    expect(run('gh_release_lookup', [REPO, 'v1;rm -rf'], []).result.exitCode).toBe(2);
+  });
+});
+
+describe('gh_upload_release_asset / gh_download_release_asset', () => {
+  test('already_exists surfaces as rc 6 after a single attempt', () => {
+    const root = mkdtempSync(join(tmpdir(), 'genie-gh-retry-asset-'));
+    roots.push(root);
+    const asset = join(root, 'genie-1.2.3-linux-x64.tar.gz');
+    writeFileSync(asset, 'bytes');
+    const { result, state } = run(
+      'gh_upload_release_asset',
+      [REPO, '55', asset],
+      [{ exit: 1, stderr: 'HTTP 422: Validation Failed (already_exists)' }],
+    );
+    expect(result.exitCode).toBe(6);
+    expect(state.calls).toHaveLength(1);
+  });
+
+  test('refuses unsafe asset names and non-numeric ids without calling gh', () => {
+    const root = mkdtempSync(join(tmpdir(), 'genie-gh-retry-asset-'));
+    roots.push(root);
+    const weird = join(root, 'weird name!.tar.gz');
+    writeFileSync(weird, 'bytes');
+    const badName = run('gh_upload_release_asset', [REPO, '55', weird], []);
+    expect(badName.result.exitCode).toBe(2);
+    expect(badName.state.calls ?? []).toHaveLength(0);
+
+    const badId = run('gh_download_release_asset', [REPO, 'abc', join(root, 'out')], []);
+    expect(badId.result.exitCode).toBe(2);
+    expect(badId.state.calls ?? []).toHaveLength(0);
+  });
+
+  test('download writes only the successful attempt bytes to the destination', () => {
+    const root = mkdtempSync(join(tmpdir(), 'genie-gh-retry-asset-'));
+    roots.push(root);
+    const dest = join(root, 'asset.bin');
+    const { result } = run(
+      'gh_download_release_asset',
+      [REPO, '901', dest],
+      [
+        { exit: 1, stdout: 'partial-garbage', stderr: 'gh: HTTP 502' },
+        { exit: 0, stdout: 'real-bytes' },
+      ],
+    );
+    expect(result.exitCode).toBe(0);
+    expect(readFileSync(dest, 'utf8')).toBe('real-bytes\n');
+  });
+});

--- a/scripts/materialize-release-subjects.sh
+++ b/scripts/materialize-release-subjects.sh
@@ -29,17 +29,24 @@ effective="$work_root/effective"
 mkdir "$effective"
 for name in "${BASE_ASSETS[@]}"; do cp "$DIST_DIR/$name" "$effective/$name"; done
 
+# shellcheck source=scripts/gh-retry.sh
+source "$(dirname "$0")/gh-retry.sh"
+
+# Status-aware existence probe: transient API failures are retried and an
+# unresolvable state fails closed instead of being misread as "no release".
+# The lookup also resolves drafts (which carry no tag ref) via the listing.
 remote_json="$work_root/remote.json"
 remote_exists=true
-if ! gh release view "v${VERSION}" --repo "$RELEASE_REPOSITORY" --json assets >"$remote_json" 2>"$work_root/view.err"; then
-  if grep -qiE 'release not found|HTTP[^0-9]*404|status[^0-9]*404' "$work_root/view.err"; then
-    remote_exists=false
-  else
-    cat "$work_root/view.err" >&2
+lookup_rc=0
+gh_release_lookup "$RELEASE_REPOSITORY" "v${VERSION}" >"$remote_json" || lookup_rc=$?
+case "$lookup_rc" in
+  0) ;;
+  4) remote_exists=false ;;
+  *)
     echo "could not determine whether v${VERSION} already has release subjects" >&2
     exit 3
-  fi
-fi
+    ;;
+esac
 
 if [[ "$remote_exists" == true ]]; then
   jq -e '
@@ -54,7 +61,10 @@ if [[ "$remote_exists" == true ]]; then
     if jq -e --arg name "$name" 'any(.assets[]; .name == $name)' "$remote_json" >/dev/null; then
       destination="$work_root/remote-${name//[^A-Za-z0-9]/_}"
       mkdir "$destination"
-      gh release download "v${VERSION}" --repo "$RELEASE_REPOSITORY" --pattern "$name" --dir "$destination"
+      # Download by asset id — bound to the validated inventory, and free of
+      # the by-tag draft-listing resolution.
+      asset_id="$(jq -r --arg name "$name" 'first(.assets[] | select(.name == $name)) | .id' "$remote_json")"
+      gh_download_release_asset "$RELEASE_REPOSITORY" "$asset_id" "$destination/$name"
       [[ -f "$destination/$name" && ! -L "$destination/$name" && -s "$destination/$name" ]] || {
         echo "downloaded release subject must be a nonempty physical file: ${name}" >&2
         exit 3

--- a/scripts/materialize-release-subjects.test.ts
+++ b/scripts/materialize-release-subjects.test.ts
@@ -53,22 +53,25 @@ describe('promotion effective release subject selection', () => {
 
     const assets = PLATFORMS.flatMap((platform) => {
       const name = `genie-${VERSION}-${platform}.tar.gz`;
-      return [name, `${name}.bundle`, `${name}.intoto.jsonl`].map((asset) => ({ name: asset }));
-    });
+      return [name, `${name}.bundle`, `${name}.intoto.jsonl`];
+    }).map((name, index) => ({ name, id: index + 1 }));
     writeFileSync(
       join(bin, 'gh'),
       `#!/usr/bin/env bun
-import { copyFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 const args = process.argv.slice(2);
-if (args[0] === 'release' && args[1] === 'view') {
-  console.log(${JSON.stringify(JSON.stringify({ assets }))});
+const assets = ${JSON.stringify(assets)};
+if (args[0] === 'api' && /\\/releases\\/tags\\//.test(args[1] ?? '')) {
+  console.log(JSON.stringify({ id: 900, tag_name: 'v${VERSION}', draft: false, prerelease: true, assets }));
   process.exit(0);
 }
-if (args[0] === 'release' && args[1] === 'download') {
-  const name = args[args.indexOf('--pattern') + 1];
-  const dir = args[args.indexOf('--dir') + 1];
-  copyFileSync(join(process.env.REMOTE_DIR, name), join(dir, name));
+const assetPath = args.find((arg) => /\\/releases\\/assets\\/[0-9]+$/.test(arg));
+if (args[0] === 'api' && assetPath) {
+  const id = Number(assetPath.split('/').pop());
+  const name = assets.find((asset) => asset.id === id)?.name;
+  if (!name) process.exit(1);
+  process.stdout.write(readFileSync(join(process.env.REMOTE_DIR, name)));
   process.exit(0);
 }
 if (args[0] === 'attestation' && args[1] === 'verify' && args.includes('--help')) process.exit(1);
@@ -138,5 +141,34 @@ process.exit(2);
         scanPhysicalTree(join(remotePayloads.get(platform)!, 'plugins', 'genie')).digest,
       );
     }
+  }, 15_000);
+
+  test('fails closed when the remote release probe cannot be resolved', () => {
+    // A transient API outage must never be misread as "no remote subjects":
+    // that would silently rebind promoted descriptors to same-run bytes.
+    const root = mkdtempSync(join(tmpdir(), 'genie-release-subjects-'));
+    roots.push(root);
+    const dist = join(root, 'dist');
+    const bin = join(root, 'bin');
+    mkdirSync(dist);
+    mkdirSync(bin);
+    for (const platform of PLATFORMS) createTarball(dist, platform, 'current');
+    writeFileSync(join(bin, 'gh'), '#!/usr/bin/env bash\necho "gh: Internal Server Error (HTTP 502)" >&2\nexit 1\n');
+    chmodSync(join(bin, 'gh'), 0o755);
+    const materialized = Bun.spawnSync(['bash', MATERIALIZE], {
+      cwd: root,
+      env: {
+        ...process.env,
+        PATH: `${bin}:${process.env.PATH ?? ''}`,
+        VERSION,
+        RELEASE_REPOSITORY: 'automagik-dev/genie',
+        DIST_DIR: dist,
+        GH_RETRY_SLEEPS: '0 0 0 0',
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    expect(materialized.exitCode).toBe(3);
+    expect(materialized.stderr.toString()).toContain('could not determine whether');
   }, 15_000);
 });

--- a/scripts/reconcile-release-note.sh
+++ b/scripts/reconcile-release-note.sh
@@ -29,21 +29,55 @@ case "$MODE" in
   *) echo "usage: reconcile-release-note.sh prepare|finalize" >&2; exit 64 ;;
 esac
 
+# shellcheck source=scripts/gh-retry.sh
+source "$(dirname "$0")/gh-retry.sh"
+
 MIGRATION_MARKER="<!-- genie-agent-sync-migration-v1 -->"
 MIGRATION_NOTE=$'<!-- genie-agent-sync-migration-v1 -->\n**One-time integration convergence:** when upgrading from a Genie release older than `5.260711.6` to `5.260711.6` or later, let the first command finish and run `genie update` once more explicitly. The newly installed binary preserves user-owned skills/agents and converges the plugin, hooks, and optional role agents. Confirm exactly H3/H4/H6, review changed hashes with `/hooks`, and start a new Codex task; SessionStart never performs this hop.'
 TAG="v${VERSION}"
 
-release_exists=false
-if gh release view "${TAG}" --repo "${RELEASE_REPOSITORY}" >/dev/null 2>&1; then
-  release_exists=true
-fi
+# A draft has no tag ref, so existence is resolved by the status-aware lookup:
+# 0 = exists (JSON), 4 = definitively absent, anything else = unknown, which
+# MUST fail closed — a transient API error read as "missing" is how a
+# duplicate draft gets created (2026-08-17 outage postmortem).
+resolve_release() {
+  local rc=0
+  release_json=""
+  if [[ "$MODE" == "finalize" || "${1:-}" == "--expect-exists" ]]; then
+    release_json="$(gh_release_lookup --expect-exists "${RELEASE_REPOSITORY}" "${TAG}")" || rc=$?
+  else
+    release_json="$(gh_release_lookup "${RELEASE_REPOSITORY}" "${TAG}")" || rc=$?
+  fi
+  case "$rc" in
+    0) release_exists=true ;;
+    4) release_exists=false ;;
+    *)
+      echo "cannot determine whether release ${TAG} exists; refusing to proceed" >&2
+      exit 3
+      ;;
+  esac
+  release_id=""
+  is_draft=""
+  is_prerelease=""
+  body=""
+  if [[ "$release_exists" == true ]]; then
+    release_id="$(jq -r '.id' <<<"$release_json")"
+    is_draft="$(jq -r '.draft' <<<"$release_json")"
+    is_prerelease="$(jq -r '.prerelease' <<<"$release_json")"
+    body="$(jq -r '.body // ""' <<<"$release_json")"
+    [[ "$release_id" =~ ^[0-9]+$ && "$is_draft" =~ ^(true|false)$ && "$is_prerelease" =~ ^(true|false)$ ]] || {
+      echo "invalid release state for ${TAG}" >&2
+      exit 3
+    }
+  fi
+}
+
+resolve_release
 
 # A stable release is monotonic. Replaying the same immutable version through a
 # prerelease channel must never bypass production approval to demote the release
 # or clobber its assets while latest.json still names it.
 if [[ "${release_exists}" == "true" && "${CHANNEL}" != "stable" ]]; then
-  state="$(gh release view "${TAG}" --repo "${RELEASE_REPOSITORY}" --json isPrerelease,isDraft --jq '[.isPrerelease,.isDraft] | @tsv')"
-  IFS=$'\t' read -r is_prerelease is_draft <<<"${state}"
   if [[ "${is_prerelease}" != "true" && "${is_draft}" != "true" ]]; then
     echo "refusing to demote existing stable release ${TAG} through channel ${CHANNEL}" >&2
     exit 3
@@ -57,14 +91,28 @@ if [[ "$MODE" == "prepare" ]]; then
     notes+="${MIGRATION_NOTE}"
     create_args=(release create "${TAG}" --repo "${RELEASE_REPOSITORY}" --title "${TAG}" --notes "${notes}" --draft --latest=false --verify-tag)
     [[ "${CHANNEL}" != "stable" ]] && create_args+=(--prerelease)
-    gh "${create_args[@]}"
+    if ! gh_retry gh "${create_args[@]}"; then
+      # The create may have landed while its response was lost, or a concurrent
+      # run won the race. Re-resolve before failing; only a still-absent
+      # release makes the create failure real.
+      resolve_release --expect-exists
+      [[ "$release_exists" == true ]] || {
+        echo "release create failed for ${TAG}" >&2
+        exit 3
+      }
+    else
+      resolve_release --expect-exists
+      [[ "$release_exists" == true ]] || {
+        echo "created release ${TAG} but cannot resolve it afterwards" >&2
+        exit 3
+      }
+    fi
   fi
 
-  body="$(gh release view "${TAG}" --repo "${RELEASE_REPOSITORY}" --json body --jq '.body // ""')"
   if [[ "${body}" != *"${MIGRATION_MARKER}"* ]]; then
     [[ -z "${body}" ]] || body+=$'\n\n'
     body+="${MIGRATION_NOTE}"
-    gh release edit "${TAG}" --repo "${RELEASE_REPOSITORY}" --notes "${body}"
+    gh_retry gh api -X PATCH "repos/${RELEASE_REPOSITORY}/releases/${release_id}" -f body="${body}" >/dev/null
   fi
   exit 0
 fi
@@ -73,7 +121,6 @@ fi
   echo "cannot finalize missing release ${TAG}; prepare and verify assets first" >&2
   exit 3
 }
-body="$(gh release view "${TAG}" --repo "${RELEASE_REPOSITORY}" --json body --jq '.body // ""')"
 [[ "$body" == *"${MIGRATION_MARKER}"* ]] || {
   echo "cannot finalize ${TAG} without the reconciled migration note" >&2
   exit 3
@@ -89,13 +136,6 @@ body="$(gh release view "${TAG}" --repo "${RELEASE_REPOSITORY}" --json body --jq
 # already in its channel's terminal published state is left immutable so
 # repository-level immutable releases can enforce that boundary.
 if [[ "${DRAFT}" == "false" ]]; then
-  final_state="$(gh release view "${TAG}" --repo "${RELEASE_REPOSITORY}" \
-    --json databaseId,isDraft,isPrerelease --jq '[.databaseId,.isDraft,.isPrerelease] | @tsv')"
-  IFS=$'\t' read -r release_id is_draft is_prerelease <<<"$final_state"
-  [[ "$release_id" =~ ^[0-9]+$ && "$is_draft" =~ ^(true|false)$ && "$is_prerelease" =~ ^(true|false)$ ]] || {
-    echo "invalid release state for ${TAG}" >&2
-    exit 3
-  }
   if [[ "${CHANNEL}" == "stable" ]]; then
     # Stable is the promotion channel. Publish (or promote an already-published
     # dev prerelease) to the sole GitHub Latest: prerelease=false + latest=true.
@@ -106,7 +146,7 @@ if [[ "${DRAFT}" == "false" ]]; then
       echo "${TAG} is already published as the latest stable release; preserving its metadata"
       exit 0
     fi
-    gh api -X PATCH "repos/${RELEASE_REPOSITORY}/releases/${release_id}" \
+    gh_retry gh api -X PATCH "repos/${RELEASE_REPOSITORY}/releases/${release_id}" \
       -F draft=false -F prerelease=false -f make_latest=true >/dev/null
     exit 0
   fi
@@ -116,6 +156,6 @@ if [[ "${DRAFT}" == "false" ]]; then
     echo "${TAG} is already published; preserving its immutable release metadata"
     exit 0
   fi
-  gh api -X PATCH "repos/${RELEASE_REPOSITORY}/releases/${release_id}" \
+  gh_retry gh api -X PATCH "repos/${RELEASE_REPOSITORY}/releases/${release_id}" \
     -F draft=false -F "prerelease=${is_prerelease}" -f make_latest=false >/dev/null
 fi

--- a/scripts/reconcile-release-note.test.ts
+++ b/scripts/reconcile-release-note.test.ts
@@ -16,6 +16,7 @@ interface FakeReleaseState {
   makeLatest?: string;
   verifiedTag?: boolean;
   failOn?: string;
+  failTimes?: Record<string, number>;
 }
 
 afterEach(() => {
@@ -49,17 +50,42 @@ const field = (flag, name) => {
     if (args[index] === flag && args[index + 1].startsWith(name + '=')) return args[index + 1].slice(name.length + 1);
   }
 };
-if (state.failOn && args.join(' ').includes(state.failOn)) { save(); process.exit(42); }
-if (args[0] === 'release' && args[1] === 'view') {
-  if (!state.exists) { save(); process.exit(1); }
-  const json = value('--json');
-  if (json === 'body') console.log(state.body ?? '');
-  if (json === 'isPrerelease,isDraft') {
-    console.log(String(state.prerelease === true) + '\\t' + String(state.draft === true));
+const joined = args.join(' ');
+// Transient simulation: fail matching invocations with a retryable 502 until
+// the per-substring budget is exhausted, then behave normally.
+if (state.failTimes) {
+  for (const key of Object.keys(state.failTimes)) {
+    if (state.failTimes[key] > 0 && joined.includes(key)) {
+      state.failTimes[key] -= 1;
+      save();
+      console.error('gh: Internal Server Error (HTTP 502)');
+      process.exit(1);
+    }
   }
-  if (json === 'databaseId,isDraft,isPrerelease') {
-    console.log(String(state.id ?? 101) + '\\t' + String(state.draft === true) + '\\t' + String(state.prerelease === true));
-  }
+}
+if (state.failOn && joined.includes(state.failOn)) { save(); process.exit(42); }
+const releaseJson = () => JSON.stringify({
+  id: state.id ?? 101,
+  draft: state.draft === true,
+  prerelease: state.prerelease === true,
+  tag_name: 'v5.260711.6',
+  body: state.body ?? '',
+});
+if (args[0] === 'api' && /\\/releases\\/tags\\//.test(args[1] ?? '')) {
+  // The tags endpoint resolves published releases only; drafts carry no tag ref.
+  if (state.exists && state.draft !== true) { console.log(releaseJson()); save(); process.exit(0); }
+  save();
+  console.error('gh: Not Found (HTTP 404)');
+  process.exit(1);
+}
+if (args[0] === 'api' && args.includes('--paginate')) {
+  if (state.exists && state.draft === true) console.log(String(state.id ?? 101));
+  save();
+  process.exit(0);
+}
+if (args[0] === 'api' && !args.includes('PATCH') && /\\/releases\\/[0-9]+$/.test(args[1] ?? '')) {
+  if (!state.exists) { save(); console.error('gh: Not Found (HTTP 404)'); process.exit(1); }
+  console.log(releaseJson());
   save();
   process.exit(0);
 }
@@ -74,15 +100,12 @@ if (args[0] === 'release' && args[1] === 'create') {
   save();
   process.exit(0);
 }
-if (args[0] === 'release' && args[1] === 'edit') {
-  if (value('--notes') !== undefined) state.body = value('--notes');
-  save();
-  process.exit(0);
-}
-if (args[0] === 'api') {
+if (args[0] === 'api' && args.includes('PATCH')) {
+  const body = field('-f', 'body');
   const draft = field('-F', 'draft');
   const prerelease = field('-F', 'prerelease');
   const makeLatest = field('-f', 'make_latest');
+  if (body !== undefined) state.body = body;
   if (draft !== undefined) state.draft = draft === 'true';
   if (prerelease !== undefined) state.prerelease = prerelease === 'true';
   if (makeLatest !== undefined) state.makeLatest = makeLatest;
@@ -104,6 +127,8 @@ process.exit(2);
       CHANNEL: 'stable',
       DRAFT: 'false',
       RELEASE_REPOSITORY: 'automagik-dev/genie',
+      GH_RETRY_SLEEPS: '0 0 0 0',
+      GH_RETRY_LOOKUP_LAG_SLEEP: '0',
       ...overrides,
     },
     stdout: 'pipe',
@@ -114,6 +139,9 @@ process.exit(2);
     state: JSON.parse(readFileSync(statePath, 'utf8')) as FakeReleaseState,
   };
 }
+
+const patchCalls = (state: FakeReleaseState) =>
+  (state.calls ?? []).filter((args) => args[0] === 'api' && args.includes('PATCH'));
 
 describe('release migration-note reconciliation', () => {
   test('prepare creates a verified-tag draft that is explicitly non-latest', () => {
@@ -136,7 +164,33 @@ describe('release migration-note reconciliation', () => {
     const second = run(first.state);
     expect(second.result.exitCode).toBe(0);
     expect(second.state.body.match(/genie-agent-sync-migration-v1/g)).toHaveLength(1);
-    expect(second.state.calls?.filter((args) => args[1] === 'edit')).toHaveLength(1);
+    expect(patchCalls(second.state)).toHaveLength(1);
+  });
+
+  test('prepare fails closed when release existence cannot be determined', () => {
+    // A transient API failure must never be read as "the release is missing":
+    // that is how a duplicate draft gets created mid-outage. Exhausted retries
+    // on the existence probe → exit 3 with ZERO create calls.
+    const { result, state } = run({
+      exists: false,
+      body: '',
+      failTimes: { 'releases/tags': 10 },
+    });
+    expect(result.exitCode).toBe(3);
+    expect(result.stderr.toString()).toContain('cannot determine whether release');
+    expect(state.calls?.filter((args) => args[1] === 'create')).toHaveLength(0);
+  });
+
+  test('prepare rides out transient API failures on the existence probe', () => {
+    const { result, state } = run({
+      exists: false,
+      body: '',
+      failTimes: { 'releases/tags': 2 },
+    });
+    expect(result.exitCode).toBe(0);
+    expect(state.calls?.filter((args) => args[1] === 'create')).toHaveLength(1);
+    const tagProbes = state.calls?.filter((args) => args[0] === 'api' && /\/releases\/tags\//.test(args[1] ?? ''));
+    expect(tagProbes?.length).toBeGreaterThanOrEqual(3);
   });
 
   test('stable finalize promotes to Latest from a fresh draft or a dev-published prerelease', () => {
@@ -160,7 +214,10 @@ describe('release migration-note reconciliation', () => {
     expect(fromDevPublished.state.draft).toBe(false);
     expect(fromDevPublished.state.prerelease).toBe(false);
     expect(fromDevPublished.state.makeLatest).toBe('true');
-    expect(fromDevPublished.state.calls?.filter((args) => args[0] === 'api')).toHaveLength(1);
+    expect(patchCalls(fromDevPublished.state)).toHaveLength(1);
+    // All resolution happens by numeric id — never through the flaky by-tag
+    // `gh release view` draft-listing path.
+    expect(fromDraft.state.calls?.filter((args) => args[0] === 'release' && args[1] === 'view')).toHaveLength(0);
   });
 
   test('dev finalize publishes a prerelease that is never Latest', () => {
@@ -192,7 +249,7 @@ describe('release migration-note reconciliation', () => {
     expect(stable.result.exitCode).toBe(0);
     expect(stable.state.prerelease).toBe(false);
     expect(stable.state.makeLatest).toBe('true');
-    expect(stable.state.calls?.filter((args) => args[0] === 'api')).toHaveLength(0);
+    expect(patchCalls(stable.state)).toHaveLength(0);
 
     // A dev release already published as a prerelease is immutable on the dev
     // channel — flags preserved, never Latest, no PATCH.
@@ -211,7 +268,7 @@ describe('release migration-note reconciliation', () => {
     expect(devPublished.result.exitCode).toBe(0);
     expect(devPublished.state.prerelease).toBe(true);
     expect(devPublished.state.makeLatest).toBe('false');
-    expect(devPublished.state.calls?.filter((args) => args[0] === 'api')).toHaveLength(0);
+    expect(patchCalls(devPublished.state)).toHaveLength(0);
   });
 
   test('DRAFT=true leaves the fully prepared release unpublished', () => {
@@ -220,7 +277,7 @@ describe('release migration-note reconciliation', () => {
     });
     expect(draft.result.exitCode).toBe(0);
     expect(draft.state.draft).toBe(true);
-    expect(draft.state.calls?.filter((args) => args[0] === 'api')).toHaveLength(0);
+    expect(patchCalls(draft.state)).toHaveLength(0);
   });
 
   test('refuses to replay an existing stable release through a prerelease channel', () => {
@@ -244,8 +301,10 @@ describe('release migration-note reconciliation', () => {
   });
 
   test('propagates GitHub API failures instead of reporting success', () => {
-    const edit = run({ exists: true, body: 'needs note', draft: true, failOn: 'release edit' });
-    expect(edit.result.exitCode).toBe(42);
+    // Unknown-class failures (exit 42, empty stderr) are never retried and
+    // pass through verbatim — default-closed classification.
+    const noteAppend = run({ exists: true, body: 'needs note', draft: true, failOn: 'api -X PATCH' });
+    expect(noteAppend.result.exitCode).toBe(42);
 
     const publish = run(
       {

--- a/scripts/release-docs.test.ts
+++ b/scripts/release-docs.test.ts
@@ -619,7 +619,11 @@ describe('Group E release and documentation contracts', () => {
     expect(helper).toContain('genie-agent-sync-migration-v1');
     expect(helper).toContain('older than `5.260711.6`');
     expect(helper).toContain('create_args=(release create');
-    expect(helper).toContain('gh release edit');
+    // Note reconciliation mutates the body by numeric release id (transient-
+    // aware PATCH), never through the flaky by-tag `gh release edit` path.
+    expect(helper).not.toContain('gh release edit');
+    expect(helper).toContain('-f body=');
+    expect(helper).toContain('source "$(dirname "$0")/gh-retry.sh"');
   });
 
   test('channel documentation does not claim unsigned manifests are signed or use GitHub latest as authority', () => {

--- a/scripts/release-guard.sh
+++ b/scripts/release-guard.sh
@@ -29,6 +29,11 @@
 # Exit codes: 0 ok | 3 guard failed (fail closed) | 64 misuse
 set -euo pipefail
 
+# Transient-aware gh call wrapper. Sourcing probes nothing: input validation
+# still runs before any network call in every subcommand.
+# shellcheck source=scripts/gh-retry.sh
+source "$(dirname "$0")/gh-retry.sh"
+
 # Release publication uses Genie's exact numeric 5.YYMMDD.N scheme. Channels
 # carry dev/stable semantics, so suffix-bearing tags are rejected before any
 # asset upload or manifest reconciliation can begin.
@@ -331,11 +336,11 @@ guard_trusted_release() {
   control_tmp="$(mktemp)"
   trap 'rm -f "${source_tmp:-}" "${control_tmp:-}"' EXIT
 
-  if ! gh api "repos/${expected_repo}/actions/runs/${SOURCE_CI_RUN_ID}" >"$source_tmp" 2>/dev/null; then
+  if ! gh_retry gh api "repos/${expected_repo}/actions/runs/${SOURCE_CI_RUN_ID}" >"$source_tmp"; then
     fail "could not fetch source CI run ${SOURCE_CI_RUN_ID} from ${expected_repo}"
   fi
-  if ! gh api -X GET "repos/${expected_repo}/actions/workflows/ci.yml/runs" \
-      -f branch=main -f event=push -f status=success -f per_page=100 >"$control_tmp" 2>/dev/null; then
+  if ! gh_retry gh api -X GET "repos/${expected_repo}/actions/workflows/ci.yml/runs" \
+      -f branch=main -f event=push -f status=success -f per_page=100 >"$control_tmp"; then
     fail "could not fetch successful main CI runs from ${expected_repo}"
   fi
 
@@ -494,7 +499,7 @@ guard_run_provenance() {
   tmp="$(mktemp)"
   # ${tmp:-} because the EXIT trap outlives this function's local under set -u.
   trap 'rm -f "${tmp:-}"' EXIT
-  if ! gh api "repos/${expected_repo}/actions/runs/${run_id}" >"$tmp" 2>/dev/null; then
+  if ! gh_retry gh api "repos/${expected_repo}/actions/runs/${run_id}" >"$tmp"; then
     fail "could not fetch upstream run ${run_id} from ${expected_repo} (bad run_id or insufficient token scope)"
   fi
   check_run_provenance "$tmp"

--- a/scripts/release-guard.test.ts
+++ b/scripts/release-guard.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test';
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -244,6 +244,52 @@ describe('guard-run-provenance (orchestrated vs break-glass)', () => {
       PATH: `${root}:${process.env.PATH ?? ''}`,
     });
     expect(result.exitCode).toBe(0);
+  });
+
+  test('rides out transient gh failures before validating the run record', () => {
+    const root = mkroot('genie-run-gh-flaky-');
+    const ghPath = join(root, 'gh');
+    const counter = join(root, 'calls');
+    writeFileSync(counter, '0');
+    writeFileSync(
+      ghPath,
+      `#!/usr/bin/env bun\nimport { readFileSync, writeFileSync, writeSync } from 'node:fs';\nconst counter = ${JSON.stringify(
+        counter,
+      )};\nconst calls = Number(readFileSync(counter, 'utf8')) + 1;\nwriteFileSync(counter, String(calls));\nif (calls <= 2) { console.error('gh: HTTP 502 Bad Gateway'); process.exit(1); }\nconst rec = ${JSON.stringify(
+        VALID_RUN,
+      )};\nwriteSync(1, JSON.stringify(rec));\nprocess.exit(0);\n`,
+    );
+    chmodSync(ghPath, 0o755);
+    const result = guard('guard-run-provenance', {
+      ...PROVENANCE_ENV,
+      RUN_ID: '123456',
+      PATH: `${root}:${process.env.PATH ?? ''}`,
+      GH_RETRY_SLEEPS: '0 0 0 0',
+    });
+    expect(result.exitCode).toBe(0);
+    expect(readFileSync(counter, 'utf8')).toBe('3');
+  });
+
+  test('permission failures fail closed after a single attempt', () => {
+    const root = mkroot('genie-run-gh-forbidden-');
+    const ghPath = join(root, 'gh');
+    const counter = join(root, 'calls');
+    writeFileSync(counter, '0');
+    writeFileSync(
+      ghPath,
+      `#!/usr/bin/env bun\nimport { readFileSync, writeFileSync } from 'node:fs';\nconst counter = ${JSON.stringify(
+        counter,
+      )};\nwriteFileSync(counter, String(Number(readFileSync(counter, 'utf8')) + 1));\nconsole.error('gh: HTTP 403 Forbidden');\nprocess.exit(1);\n`,
+    );
+    chmodSync(ghPath, 0o755);
+    const result = guard('guard-run-provenance', {
+      ...PROVENANCE_ENV,
+      RUN_ID: '123456',
+      PATH: `${root}:${process.env.PATH ?? ''}`,
+      GH_RETRY_SLEEPS: '0 0 0 0',
+    });
+    expect(result.exitCode).toBe(3);
+    expect(readFileSync(counter, 'utf8')).toBe('1');
   });
 });
 

--- a/scripts/release-immutability.sh
+++ b/scripts/release-immutability.sh
@@ -9,6 +9,9 @@ RELEASE_REPOSITORY="${RELEASE_REPOSITORY:-${GITHUB_REPOSITORY:-}}"
   exit 2
 }
 
+# shellcheck source=scripts/gh-retry.sh
+source "$(dirname "$0")/gh-retry.sh"
+
 case "${1:-}" in
   release)
     : "${VERSION:?VERSION is required for release verification}"
@@ -16,7 +19,11 @@ case "${1:-}" in
       echo "invalid immutable release version: ${VERSION}" >&2
       exit 2
     }
-    response="$(gh api "repos/${RELEASE_REPOSITORY}/releases/tags/v${VERSION}")"
+    # The release was published moments earlier by note-finalize, so a 404 on
+    # the tag ref is replication lag, not absence — retried alongside other
+    # transient failures. A successful response with immutable=false is a
+    # policy failure and is never retried.
+    response="$(gh_retry --not-found-transient gh api "repos/${RELEASE_REPOSITORY}/releases/tags/v${VERSION}")"
     jq -e '.immutable == true' <<<"$response" >/dev/null || {
       echo "published release v${VERSION} is not immutable; refusing to advance channel manifests" >&2
       exit 3

--- a/scripts/release-immutability.test.ts
+++ b/scripts/release-immutability.test.ts
@@ -10,7 +10,7 @@ afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
-function run(mode: string, state: { immutable?: unknown; fail?: boolean }) {
+function run(mode: string, state: { immutable?: unknown; fail?: boolean; failTimes?: number; calls?: number }) {
   const root = mkdtempSync(join(tmpdir(), 'genie-release-immutability-'));
   roots.push(root);
   const statePath = join(root, 'state.json');
@@ -19,8 +19,14 @@ function run(mode: string, state: { immutable?: unknown; fail?: boolean }) {
   writeFileSync(
     gh,
     `#!/usr/bin/env bun
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 const state = JSON.parse(readFileSync(process.env.GH_FAKE_STATE, 'utf8'));
+state.calls = (state.calls ?? 0) + 1;
+writeFileSync(process.env.GH_FAKE_STATE, JSON.stringify(state));
+if (state.failTimes && state.calls <= state.failTimes) {
+  console.error('gh: Internal Server Error (HTTP 502)');
+  process.exit(1);
+}
 if (state.fail) process.exit(42);
 console.log(JSON.stringify({ immutable: state.immutable }));
 `,
@@ -33,28 +39,45 @@ console.log(JSON.stringify({ immutable: state.immutable }));
       GH_FAKE_STATE: statePath,
       RELEASE_REPOSITORY: 'automagik-dev/genie',
       VERSION: '5.260714.3',
+      GH_RETRY_SLEEPS: '0 0 0 0',
     },
     stdout: 'pipe',
     stderr: 'pipe',
   });
-  return result;
+  return {
+    result,
+    state: JSON.parse(readFileSync(statePath, 'utf8')) as { calls?: number },
+  };
 }
 
 describe('immutable release publication gate', () => {
   test('requires the exact published release object to be immutable before manifests', () => {
-    expect(run('release', { immutable: true }).exitCode).toBe(0);
+    expect(run('release', { immutable: true }).result.exitCode).toBe(0);
     const mutable = run('release', { immutable: false });
-    expect(mutable.exitCode).toBe(3);
-    expect(mutable.stderr.toString()).toContain('refusing to advance channel manifests');
+    expect(mutable.result.exitCode).toBe(3);
+    expect(mutable.result.stderr.toString()).toContain('refusing to advance channel manifests');
+    // immutable=false is a policy failure on a successful response — it is
+    // never retried.
+    expect(mutable.state.calls).toBe(1);
   });
 
   test('propagates GitHub API failures', () => {
-    expect(run('release', { fail: true }).exitCode).toBe(42);
+    // Unknown-class failures (empty stderr) are not retried — this pins both
+    // the verbatim exit-code passthrough and the default-closed classification.
+    const failed = run('release', { fail: true });
+    expect(failed.result.exitCode).toBe(42);
+    expect(failed.state.calls).toBe(1);
+  });
+
+  test('rides out transient API failures before the immutability check', () => {
+    const flaky = run('release', { immutable: true, failTimes: 2 });
+    expect(flaky.result.exitCode).toBe(0);
+    expect(flaky.state.calls).toBe(3);
   });
 
   test('does not assume GITHUB_TOKEN can read repository Administration settings', () => {
     expect(readFileSync(SCRIPT, 'utf8')).not.toContain('/immutable-releases');
     const unsupported = run('repository', { immutable: true });
-    expect(unsupported.exitCode).toBe(64);
+    expect(unsupported.result.exitCode).toBe(64);
   });
 });


### PR DESCRIPTION
## Why

During the 2026-08-17 GitHub outage, release run 31969294922 (v5.260816.2) failed **three separate times**, each on a single-shot `gh` call:

1. sign jobs — codeload 429/502/503 (not fixable repo-side)
2. `publish` — `gh release upload` → `release not found` while the draft existed
3. `finalize` — `gh release view` → `release not found`

Root cause: drafts have no tag ref, so by-tag `gh release view/upload/download` resolves them through the releases *listing* — the API surface most sensitive to outage/eventual-consistency — and no release script retried anything. During the outage, by-numeric-id reads kept working while by-tag failed.

A latent hazard was also found: `reconcile-release-note.sh` silenced its existence probe, so a transient API failure was indistinguishable from 404 — `prepare` could create a **duplicate draft** mid-outage.

## What (PR 1 of 2 — retry-only)

New sourced helper `scripts/gh-retry.sh`:
- `gh_retry` — bounded backoff (5/10/20/40s), retrying ONLY provably transient failures (5xx/429/timeouts/connection). 401/403/422 and unclassifiable errors (incl. empty stderr) pass through immediately: never blind-retry a mutation; exit-code passthrough survives.
- `gh_release_lookup` — status-aware existence probe (tag ref, then draft listing confirmed by id). **Unknown never degrades to "not found"** — callers fail closed, so prepare can no longer create a duplicate draft on a flake.
- by-id asset download/upload primitives (used by PR 2).

Converted: `reconcile-release-note.sh` (probe + all reads/mutations by numeric id; `gh release edit` → by-id PATCH), `release-immutability.sh` (`--not-found-transient`: post-publish 404 is replication lag; `immutable=false` still never retried), `materialize-release-subjects.sh` (probe + asset-id downloads), `release-guard.sh` (retried CI-run fetches, stderr no longer discarded).

## Invariants preserved

No `--clobber`; stable monotonicity; finalize idempotence; `immutable=false` never retried; ambiguity always fails closed; validation before network; verify-release attestation stays best-effort; exit-code contracts intact (one documented delta: note.sh exit 3 gains "existence unknown").

## Testing

`bun run check` green apart from the pre-existing darwin doctor-latency flake (fails at pristine origin/main too). New `gh-retry.test.ts` (15 tests) + retry/fail-closed regression tests in every converted script's suite, including the duplicate-draft incident regression (ambiguous probe → exit 3, zero creates).

Stacked PR 2 (by-id asset reconciliation + admit-probe retry) follows.
