### PR TITLE
fix(release): operate on release assets by numeric id and retry the admit replay probe

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -81,7 +81,9 @@ jobs:
   admit:
     name: Admit trusted release orchestrator
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    # 5 minutes leaves headroom for the replay guard's bounded retry loop
+    # (three sleeps, 30s worst case) on top of normal step time.
+    timeout-minutes: 5
     permissions:
       # Read-only, and only so the replay guard below can ask whether the tag
       # already carries a published release. contents:write still starts at the
@@ -163,22 +165,49 @@ jobs:
           # and pushes a fresh tag). See automagik-dev/genie#2674.
           # Drafts stay admissible on purpose: an interrupted run must still be
           # able to finish the release it already opened.
+          # The probe retries transient API failures (the admit job has no
+          # checkout, so it cannot source scripts/gh-retry.sh): a definitive
+          # 404 admits, permission failures surface immediately, and anything
+          # unresolved after the bounded loop still fails closed below.
+          # RETRY_SLEEP_SCALE exists so the behavior test runs without sleeps.
           RELEASE_JSON="$(mktemp)"
           RELEASE_ERROR="$(mktemp)"
-          if gh api "repos/${RELEASE_REPOSITORY}/releases/tags/v${INPUT_VERSION}" \
-            >"$RELEASE_JSON" 2>"$RELEASE_ERROR"; then
-            if [[ "$(jq -r '.draft' "$RELEASE_JSON")" != true ]]; then
-              echo "::error ::release-replay.published v${INPUT_VERSION} already has a published GitHub Release — published releases are non-replayable (immutable asset inventory + deterministic released_at); allocate a fresh version instead. See automagik-dev/genie#2674"
-              exit 1
+          release_probe=unknown
+          for attempt in 1 2 3 4; do
+            if gh api "repos/${RELEASE_REPOSITORY}/releases/tags/v${INPUT_VERSION}" \
+              >"$RELEASE_JSON" 2>"$RELEASE_ERROR"; then
+              release_probe=found
+              break
             fi
-            echo "v${INPUT_VERSION} exists only as a draft release; admitting so the interrupted publish can complete"
-          elif grep -q 'HTTP 404' "$RELEASE_ERROR"; then
-            echo "v${INPUT_VERSION} has no GitHub Release yet"
-          else
-            cat "$RELEASE_ERROR" >&2
-            echo "::error ::release-replay.unknown could not determine whether v${INPUT_VERSION} already has a published release; failing closed. See automagik-dev/genie#2674"
-            exit 1
-          fi
+            if grep -q 'HTTP 404' "$RELEASE_ERROR"; then
+              release_probe=absent
+              break
+            fi
+            if grep -qiE 'HTTP 40[13]|forbidden|permission|not authorized|bad credentials' "$RELEASE_ERROR"; then
+              break
+            fi
+            if [[ "$attempt" -lt 4 ]]; then
+              echo "::warning ::release-replay probe attempt ${attempt}/4 failed; retrying"
+              sleep "$(( ${RETRY_SLEEP_SCALE:-5} * attempt ))"
+            fi
+          done
+          case "$release_probe" in
+            found)
+              if [[ "$(jq -r '.draft' "$RELEASE_JSON")" != true ]]; then
+                echo "::error ::release-replay.published v${INPUT_VERSION} already has a published GitHub Release — published releases are non-replayable (immutable asset inventory + deterministic released_at); allocate a fresh version instead. See automagik-dev/genie#2674"
+                exit 1
+              fi
+              echo "v${INPUT_VERSION} exists only as a draft release; admitting so the interrupted publish can complete"
+              ;;
+            absent)
+              echo "v${INPUT_VERSION} has no GitHub Release yet"
+              ;;
+            *)
+              cat "$RELEASE_ERROR" >&2
+              echo "::error ::release-replay.unknown could not determine whether v${INPUT_VERSION} already has a published release; failing closed. See automagik-dev/genie#2674"
+              exit 1
+              ;;
+          esac
 
   prepare-delivery-evidence:
     name: Build canonical delivery descriptors

--- a/scripts/reconcile-release-assets.sh
+++ b/scripts/reconcile-release-assets.sh
@@ -150,18 +150,46 @@ for platform in "${PLATFORMS[@]}"; do
   done
 done
 
+# Sourced after all input validation; the helper probes nothing on load.
+# shellcheck source=scripts/gh-retry.sh
+source "$(dirname "$0")/gh-retry.sh"
+
 WORK_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/genie-release-assets.XXXXXX")"
 trap 'rm -rf "$WORK_ROOT"' EXIT HUP INT TERM
 REMOTE_JSON="$WORK_ROOT/remote.json"
 EXPECTED_JSON="$(printf '%s\n' "${EXPECTED[@]}" | jq -R . | jq -s .)"
 
+# Resolve the release identity exactly once. Drafts carry no tag ref, so the
+# status-aware lookup is the only step allowed to touch the flaky by-tag
+# listing; every read, download, and upload below operates on the numeric id.
+resolve_release_id() {
+  local rc=0 release_json
+  release_json="$(gh_release_lookup --expect-exists "$RELEASE_REPOSITORY" "$TAG")" || rc=$?
+  case "$rc" in
+    0) ;;
+    4)
+      echo "release ${TAG} does not exist; run prepare first" >&2
+      exit 3
+      ;;
+    *)
+      echo "cannot determine whether release ${TAG} exists; refusing to proceed" >&2
+      exit 3
+      ;;
+  esac
+  RELEASE_ID="$(jq -r '.id' <<<"$release_json")"
+  [[ "$RELEASE_ID" =~ ^[0-9]+$ ]] || {
+    echo "invalid release id resolved for ${TAG}" >&2
+    exit 3
+  }
+}
+
 fetch_remote_inventory() {
-  gh release view "$TAG" --repo "$RELEASE_REPOSITORY" --json assets,isDraft,isPrerelease >"$REMOTE_JSON"
+  gh_retry gh api "repos/${RELEASE_REPOSITORY}/releases/${RELEASE_ID}" >"$REMOTE_JSON"
   jq -e --argjson expected "$EXPECTED_JSON" '
     (.assets | type == "array") and
-    (.isDraft | type == "boolean") and
-    (.isPrerelease | type == "boolean") and
-    (all(.assets[]; (.name | type == "string"))) and
+    (.draft | type == "boolean") and
+    (.prerelease | type == "boolean") and
+    (all(.assets[]; (.name | type == "string") and ((.id | type == "number") and (.id == (.id | floor))))) and
     (([.assets[].name] | length) == ([.assets[].name] | unique | length)) and
     (all(.assets[]; .name as $name | ($expected | index($name)) != null))
   ' "$REMOTE_JSON" >/dev/null || {
@@ -180,10 +208,17 @@ remote_is_complete() {
 }
 
 download_remote() {
-  local name="$1" destination="$2" path
+  local name="$1" destination="$2" path asset_id
   mkdir "$destination"
-  gh release download "$TAG" --repo "$RELEASE_REPOSITORY" --pattern "$name" --dir "$destination"
+  # Bound to the validated inventory: the asset id comes from REMOTE_JSON, so
+  # exactly the enumerated asset is fetched — no by-tag pattern resolution.
+  asset_id="$(jq -r --arg name "$name" 'first(.assets[] | select(.name == $name)) | .id' "$REMOTE_JSON")"
+  [[ "$asset_id" =~ ^[0-9]+$ ]] || {
+    echo "remote inventory has no asset id for: ${name}" >&2
+    exit 3
+  }
   path="$destination/$name"
+  gh_download_release_asset "$RELEASE_REPOSITORY" "$asset_id" "$path"
   [[ -f "$path" && ! -L "$path" && -s "$path" ]] || {
     echo "downloaded release asset must be a nonempty physical regular file: ${name}" >&2
     exit 3
@@ -210,7 +245,7 @@ verify_inventory() {
       --print-provenance >"$generic_result"
     bash "$(dirname "$0")/release-generic-provenance.sh" verify-reusable "$generic_result"
     result="$WORK_ROOT/native-${platform}.json"
-    gh attestation verify "$tarball" \
+    gh_retry gh attestation verify "$tarball" \
       --repo "$RELEASE_REPOSITORY" \
       --predicate-type "https://github.com/${RELEASE_REPOSITORY}/release-tarballs/v1" \
       --cert-identity "https://github.com/${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml@refs/heads/main" \
@@ -218,7 +253,7 @@ verify_inventory() {
       --format json >"$result"
     remote_control_sha="$(bash "$(dirname "$0")/release-native-predicate.sh" reusable-control-sha "$result")"
     exact_result="$WORK_ROOT/native-exact-${platform}.json"
-    gh attestation verify "$tarball" \
+    gh_retry gh attestation verify "$tarball" \
       --repo "$RELEASE_REPOSITORY" \
       --predicate-type "https://github.com/${RELEASE_REPOSITORY}/release-tarballs/v1" \
       --cert-identity "https://github.com/${RELEASE_REPOSITORY}/.github/workflows/sign-attest.yml@refs/heads/main" \
@@ -239,7 +274,7 @@ verify_inventory() {
         exit 3
       }
       delivery_result="$WORK_ROOT/delivery-${platform}-${evidence_channel}.json"
-      gh attestation verify "$descriptor" \
+      gh_retry gh attestation verify "$descriptor" \
         --bundle "$bundle" \
         --repo "$RELEASE_REPOSITORY" \
         --predicate-type "https://github.com/${RELEASE_REPOSITORY}/delivery-evidence/v1" \
@@ -256,6 +291,7 @@ verify_inventory() {
   done
 }
 
+resolve_release_id
 fetch_remote_inventory
 
 if remote_is_complete; then
@@ -265,18 +301,17 @@ if remote_is_complete; then
   differs=false
   complete="$WORK_ROOT/complete"
   mkdir "$complete"
+  index=0
   for name in "${EXPECTED[@]}"; do
-    gh release download "$TAG" --repo "$RELEASE_REPOSITORY" --pattern "$name" --dir "$complete"
-    [[ -f "$complete/$name" && ! -L "$complete/$name" && -s "$complete/$name" ]] || {
-      echo "downloaded release asset must be a nonempty physical regular file: ${name}" >&2
-      exit 3
-    }
+    download_remote "$name" "$WORK_ROOT/complete-${index}"
+    cp "$WORK_ROOT/complete-${index}/$name" "$complete/$name"
     if ! cmp -- "$DIST_DIR/$name" "$complete/$name"; then
       differs=true
     fi
+    index=$((index + 1))
   done
 
-  if [[ "$(jq -r '.isDraft' "$REMOTE_JSON")" == true ]]; then
+  if [[ "$(jq -r '.draft' "$REMOTE_JSON")" == true ]]; then
     verify_inventory "$complete"
     if [[ "$differs" == true ]]; then
       echo "::notice ::release-assets.draft_reused ${TAG} preserves its complete authenticated draft inventory"
@@ -295,7 +330,7 @@ if remote_is_complete; then
   exit 0
 fi
 
-if [[ "$(jq -r '.isDraft' "$REMOTE_JSON")" == false ]]; then
+if [[ "$(jq -r '.draft' "$REMOTE_JSON")" == false ]]; then
   echo "refusing to mutate an incomplete published immutable release: ${TAG}" >&2
   exit 3
 fi
@@ -320,8 +355,21 @@ for name in "${EXPECTED[@]}"; do
 done
 verify_inventory "$effective"
 
+# Per-asset by-id uploads resume finer than the old batch call. A retried
+# upload whose first attempt actually landed surfaces as already_exists (rc 6):
+# it is skipped — never deleted, never clobbered — and the post-upload
+# re-fetch + byte-compare below stays the authority that catches any mismatch.
 if [[ ${#MISSING[@]} -gt 0 ]]; then
-  gh release upload "$TAG" --repo "$RELEASE_REPOSITORY" "${MISSING[@]}"
+  for path in "${MISSING[@]}"; do
+    name="${path##*/}"
+    upload_rc=0
+    gh_upload_release_asset "$RELEASE_REPOSITORY" "$RELEASE_ID" "$path" || upload_rc=$?
+    if [[ "$upload_rc" -eq 6 ]]; then
+      echo "::notice ::release-assets.upload_skipped ${name} already present on retry; byte verification adjudicates"
+    elif [[ "$upload_rc" -ne 0 ]]; then
+      exit "$upload_rc"
+    fi
+  done
 fi
 
 fetch_remote_inventory

--- a/scripts/reconcile-release-assets.test.ts
+++ b/scripts/reconcile-release-assets.test.ts
@@ -31,9 +31,14 @@ interface FakeState {
   draft: boolean;
   prerelease?: boolean;
   assets: Record<string, string>;
+  assetIds?: Record<string, number>;
   calls?: Array<{ tool: string; args: string[] }>;
   attestationBatchSizes?: number[];
   failOn?: string;
+  failTimes?: Record<string, number>;
+  noRelease?: boolean;
+  uploadLandThenFail?: number;
+  uploadCorruptFirst?: boolean;
   controlSha?: string;
   secondControlSha?: string;
   remoteAssets?: unknown;
@@ -113,32 +118,89 @@ const value = (flag) => { const index = args.indexOf(flag); return index >= 0 ? 
     join(root, 'gh'),
     `#!/usr/bin/env bun
 ${recordPrelude}
-import { basename, join } from 'node:path';
-import { mkdirSync, writeFileSync } from 'node:fs';
 record('gh');
-if (state.failOn && ('gh ' + args.join(' ')).includes(state.failOn)) { save(); process.exit(42); }
-if (args[0] === 'release' && args[1] === 'view') {
-  const assets = state.remoteAssets ?? Object.keys(state.assets).map((name) => ({ name }));
-  console.log(JSON.stringify({ assets, isDraft: state.draft, isPrerelease: state.prerelease ?? !state.draft }));
-  save(); process.exit(0);
-}
-if (args[0] === 'release' && args[1] === 'download') {
-  const name = value('--pattern');
-  const dir = value('--dir');
-  if (!(name in state.assets)) { save(); process.exit(4); }
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(join(dir, name), state.assets[name]);
-  save(); process.exit(0);
-}
-if (args[0] === 'release' && args[1] === 'upload') {
-  if (args.includes('--clobber')) state.usedClobber = true;
-  const paths = [];
-  for (let index = 3; index < args.length; index += 1) {
-    if (args[index] === '--repo') { index += 1; continue; }
-    if (!args[index].startsWith('-')) paths.push(args[index]);
+const joined = 'gh ' + args.join(' ');
+if (state.failTimes) {
+  for (const key of Object.keys(state.failTimes)) {
+    if (state.failTimes[key] > 0 && joined.includes(key)) {
+      state.failTimes[key] -= 1;
+      save();
+      console.error('gh: Internal Server Error (HTTP 502)');
+      process.exit(1);
+    }
   }
-  for (const path of paths) state.assets[basename(path)] = readFileSync(path, 'utf8');
-  save(); process.exit(0);
+}
+if (state.failOn && joined.includes(state.failOn)) { save(); process.exit(42); }
+const ensureIds = () => {
+  state.assetIds ??= {};
+  let next = Object.values(state.assetIds).reduce((left, right) => Math.max(left, right), 0);
+  for (const name of Object.keys(state.assets)) if (!(name in state.assetIds)) state.assetIds[name] = ++next;
+};
+const releaseJson = () => {
+  ensureIds();
+  const assets = state.remoteAssets ?? Object.keys(state.assets).map((name) => ({ name, id: state.assetIds[name] }));
+  return JSON.stringify({
+    id: 500,
+    tag_name: 'v${VERSION}',
+    draft: state.draft,
+    prerelease: state.prerelease ?? !state.draft,
+    assets,
+  });
+};
+if (args[0] === 'api' && /\\/releases\\/tags\\//.test(args[1] ?? '')) {
+  // Published releases resolve via the tag ref; drafts have none.
+  if (!state.noRelease && state.draft !== true) { console.log(releaseJson()); save(); process.exit(0); }
+  save();
+  console.error('gh: Not Found (HTTP 404)');
+  process.exit(1);
+}
+if (args[0] === 'api' && args.includes('--paginate')) {
+  if (!state.noRelease && state.draft === true) console.log('500');
+  save();
+  process.exit(0);
+}
+const assetPath = args.find((arg) => /\\/releases\\/assets\\/[0-9]+$/.test(arg));
+if (args[0] === 'api' && assetPath) {
+  ensureIds();
+  const id = Number(assetPath.split('/').pop());
+  const name = Object.keys(state.assetIds).find((candidate) => state.assetIds[candidate] === id);
+  if (!name || !(name in state.assets)) { save(); console.error('gh: Not Found (HTTP 404)'); process.exit(4); }
+  process.stdout.write(state.assets[name]);
+  save();
+  process.exit(0);
+}
+if (args[0] === 'api' && args.includes('POST') && args.some((arg) => arg.includes('uploads.github.com'))) {
+  if (args.includes('--clobber')) state.usedClobber = true;
+  const url = args.find((arg) => arg.includes('uploads.github.com'));
+  const name = url.split('name=')[1];
+  const bytes = readFileSync(value('--input'), 'utf8');
+  ensureIds();
+  if (name in state.assets) {
+    save();
+    console.error('HTTP 422: Validation Failed (already_exists)');
+    process.exit(1);
+  }
+  if (state.uploadLandThenFail && state.uploadLandThenFail > 0) {
+    // The upload landed server-side but the response was lost: store the
+    // bytes, then report a transient failure so the caller retries into
+    // already_exists.
+    state.uploadLandThenFail -= 1;
+    state.assets[name] = state.uploadCorruptFirst ? 'corrupted-bytes-from-lost-response' : bytes;
+    ensureIds();
+    save();
+    console.error('gh: unexpected EOF');
+    process.exit(1);
+  }
+  state.assets[name] = bytes;
+  ensureIds();
+  save();
+  process.exit(0);
+}
+if (args[0] === 'api' && !args.includes('POST') && /\\/releases\\/500$/.test(args[1] ?? '')) {
+  if (state.noRelease) { save(); console.error('gh: Not Found (HTTP 404)'); process.exit(1); }
+  console.log(releaseJson());
+  save();
+  process.exit(0);
 }
 if (args[0] === 'attestation' && args[1] === 'verify') {
   if (args.includes('--bundle')) {
@@ -246,6 +308,8 @@ save();
       CANDIDATE_MANIFEST_DIR: candidates,
       RELEASE_REPOSITORY: 'automagik-dev/genie',
       DIST_DIR: dist,
+      GH_RETRY_SLEEPS: '0 0 0 0',
+      GH_RETRY_LOOKUP_LAG_SLEEP: '0',
     },
     stdout: 'pipe',
     stderr: 'pipe',
@@ -259,12 +323,19 @@ function calls(state: FakeState, tool: string, command?: string): Array<{ tool: 
   );
 }
 
+function uploadCalls(state: FakeState): Array<{ tool: string; args: string[] }> {
+  return (state.calls ?? []).filter(
+    (call) => call.tool === 'gh' && call.args.some((arg) => arg.includes('uploads.github.com')),
+  );
+}
+
 describe('exact GitHub release asset reconciliation', () => {
   test('uploads and byte-verifies the exact dev fanout inventory into an empty draft without clobber', () => {
     const { result, state } = run({ draft: true, assets: {} });
     expect(result.exitCode).toBe(0);
     expect(Object.keys(state.assets).sort()).toEqual([...NAMES].sort());
-    expect(calls(state, 'gh', 'release upload')).toHaveLength(1);
+    // One by-id POST per asset — finer resumption than the old batch upload.
+    expect(uploadCalls(state)).toHaveLength(NAMES.length);
     expect(state.usedClobber).not.toBe(true);
   });
 
@@ -288,7 +359,7 @@ describe('exact GitHub release asset reconciliation', () => {
     expect(stable.result.exitCode).toBe(3);
     expect(stable.result.stderr.toString()).toContain('published immutable release');
     expect(stable.state.assets).toEqual(devAssets);
-    expect(calls(stable.state, 'gh', 'release upload')).toHaveLength(0);
+    expect(uploadCalls(stable.state)).toHaveLength(0);
   });
 
   test('rejects missing and extra local inventory before any GitHub mutation', () => {
@@ -332,14 +403,14 @@ describe('exact GitHub release asset reconciliation', () => {
 
     const mismatch = run({ draft: true, assets: { [NAMES[0]]: 'different' } });
     expect(mismatch.result.exitCode).toBe(3);
-    expect(calls(mismatch.state, 'gh', 'release upload')).toHaveLength(0);
+    expect(uploadCalls(mismatch.state)).toHaveLength(0);
   });
 
   test('a complete authenticated draft reuses prior nondeterministic bundle bytes', () => {
     const draft = run({ draft: true, assets: localAssets('older-run') });
     expect(draft.result.exitCode).toBe(0);
     expect(draft.result.stdout.toString()).toContain('preserves its complete authenticated draft inventory');
-    expect(calls(draft.state, 'gh', 'release upload')).toHaveLength(0);
+    expect(uploadCalls(draft.state)).toHaveLength(0);
   });
 
   test('a retry rejects authenticated old descriptors bound to different candidate manifest bytes', () => {
@@ -352,7 +423,7 @@ describe('exact GitHub release asset reconciliation', () => {
     }
     const retry = run({ draft: true, assets: stale });
     expect(retry.result.exitCode).toBe(3);
-    expect(calls(retry.state, 'gh', 'release upload')).toHaveLength(0);
+    expect(uploadCalls(retry.state)).toHaveLength(0);
   });
 
   test('an interrupted draft preserves prior bundle bytes while uploading only missing assets', () => {
@@ -369,7 +440,7 @@ describe('exact GitHub release asset reconciliation', () => {
     expect(resumed.result.exitCode).toBe(0);
     expect(resumed.state.assets[priorBundle]).toBe(partial[priorBundle]);
     expect(Object.keys(resumed.state.assets).sort()).toEqual([...NAMES].sort());
-    expect(calls(resumed.state, 'gh', 'release upload')).toHaveLength(1);
+    expect(uploadCalls(resumed.state)).toHaveLength(NAMES.length - Object.keys(partial).length);
   });
 
   test('reuses a complete published inventory only after pinned cryptographic verification', () => {
@@ -377,7 +448,7 @@ describe('exact GitHub release asset reconciliation', () => {
     const { result, state } = run({ draft: false, assets: publishedAssets });
     expect(result.exitCode).toBe(0);
     expect(state.assets).toEqual(publishedAssets);
-    expect(calls(state, 'gh', 'release upload')).toHaveLength(0);
+    expect(uploadCalls(state)).toHaveLength(0);
     expect(calls(state, 'cosign')).toHaveLength(4);
     expect(calls(state, 'slsa-verifier')).toHaveLength(4);
     expect(calls(state, 'gh', 'attestation verify')).toHaveLength(12);
@@ -401,7 +472,7 @@ describe('exact GitHub release asset reconciliation', () => {
     const { result, state } = run({ draft: false, assets: publishedAssets });
     expect(result.exitCode).toBe(0);
     expect(state.assets).toEqual(publishedAssets);
-    expect(calls(state, 'gh', 'release upload')).toHaveLength(0);
+    expect(uploadCalls(state)).toHaveLength(0);
     // 4 platforms x 2 passes (unfiltered, then certificate-filtered), each
     // answered with GitHub's immutable-release attestation ahead of ours.
     expect(state.attestationBatchSizes).toHaveLength(8);
@@ -412,30 +483,71 @@ describe('exact GitHub release asset reconciliation', () => {
     const partial = run({ draft: false, prerelease: false, assets: { [NAMES[0]]: localAssets()[NAMES[0]] } });
     expect(partial.result.exitCode).toBe(3);
     expect(partial.result.stderr.toString()).toContain('incomplete published immutable release');
-    expect(calls(partial.state, 'gh', 'release upload')).toHaveLength(0);
+    expect(uploadCalls(partial.state)).toHaveLength(0);
 
     const extra = run({ draft: true, assets: { unexpected: 'x' } });
     expect(extra.result.exitCode).toBe(3);
     expect(extra.result.stderr.toString()).toContain('unexpected assets');
-    expect(calls(extra.state, 'gh', 'release upload')).toHaveLength(0);
+    expect(uploadCalls(extra.state)).toHaveLength(0);
   });
 
   test('rejects duplicate and malformed remote inventory before upload', () => {
     const duplicate = run({
       draft: true,
       assets: {},
-      remoteAssets: [{ name: NAMES[0] }, { name: NAMES[0] }],
+      remoteAssets: [
+        { name: NAMES[0], id: 1 },
+        { name: NAMES[0], id: 2 },
+      ],
     });
     expect(duplicate.result.exitCode).toBe(3);
-    expect(calls(duplicate.state, 'gh', 'release upload')).toHaveLength(0);
+    expect(uploadCalls(duplicate.state)).toHaveLength(0);
 
     const malformed = run({ draft: true, assets: {}, remoteAssets: [{ name: 7 }] });
     expect(malformed.result.exitCode).toBe(3);
-    expect(calls(malformed.state, 'gh', 'release upload')).toHaveLength(0);
+    expect(uploadCalls(malformed.state)).toHaveLength(0);
+  });
+
+  test('rides out transient upload failures without duplicating or clobbering assets', () => {
+    // One 502 on the first upload POST; the retry succeeds. Every asset lands
+    // exactly once and the post-upload byte verification passes.
+    const { result, state } = run({ draft: true, assets: {}, failTimes: { 'uploads.github.com': 1 } });
+    expect(result.exitCode).toBe(0);
+    expect(Object.keys(state.assets).sort()).toEqual([...NAMES].sort());
+    expect(state.usedClobber).not.toBe(true);
+    expect((state.calls ?? []).every((call) => !call.args.includes('DELETE'))).toBe(true);
+  });
+
+  test('an upload that landed but lost its response is skipped, and byte verification adjudicates', () => {
+    // The first POST stores the bytes server-side but reports a transient
+    // failure; the retry surfaces already_exists and is skipped — never
+    // deleted, never clobbered. Identical bytes → success.
+    const clean = run({ draft: true, assets: {}, uploadLandThenFail: 1 });
+    expect(clean.result.exitCode).toBe(0);
+    expect(clean.result.stdout.toString()).toContain('release-assets.upload_skipped');
+    expect(Object.keys(clean.state.assets).sort()).toEqual([...NAMES].sort());
+
+    // Same scenario but the landed bytes are corrupt: the skip must NOT hide
+    // the mismatch — the post-upload byte compare fails closed.
+    const corrupt = run({ draft: true, assets: {}, uploadLandThenFail: 1, uploadCorruptFirst: true });
+    expect(corrupt.result.exitCode).toBe(3);
+    expect(corrupt.result.stderr.toString()).toContain('remote release asset verification failed after upload');
+  }, 30_000);
+
+  test('fails closed before any mutation when the release cannot be resolved', () => {
+    const unknown = run({ draft: true, assets: {}, failTimes: { 'releases/tags': 99 } });
+    expect(unknown.result.exitCode).toBe(3);
+    expect(unknown.result.stderr.toString()).toContain('cannot determine whether release');
+    expect(uploadCalls(unknown.state)).toHaveLength(0);
+
+    const absent = run({ draft: true, assets: {}, noRelease: true });
+    expect(absent.result.exitCode).toBe(3);
+    expect(absent.result.stderr.toString()).toContain('run prepare first');
+    expect(uploadCalls(absent.state)).toHaveLength(0);
   });
 
   test('propagates upload and verification failures', () => {
-    const upload = run({ draft: true, assets: {}, failOn: 'gh release upload' });
+    const upload = run({ draft: true, assets: {}, failOn: 'uploads.github.com' });
     expect(upload.result.exitCode).toBe(42);
 
     const endorsement = run({ draft: true, assets: {}, failOn: 'gh attestation verify' });
@@ -443,7 +555,7 @@ describe('exact GitHub release asset reconciliation', () => {
 
     const verification = run({ draft: false, assets: localAssets('published'), failOn: 'cosign verify-blob' });
     expect(verification.result.exitCode).toBe(42);
-    expect(calls(verification.state, 'gh', 'release upload')).toHaveLength(0);
+    expect(uploadCalls(verification.state)).toHaveLength(0);
 
     const mismatchedSecondPass = run({
       draft: false,
@@ -455,10 +567,10 @@ describe('exact GitHub release asset reconciliation', () => {
 
     const genericPolicy = run({ draft: false, assets: localAssets('published'), invalidGeneric: true });
     expect(genericPolicy.result.exitCode).not.toBe(0);
-    expect(calls(genericPolicy.state, 'gh', 'release upload')).toHaveLength(0);
+    expect(uploadCalls(genericPolicy.state)).toHaveLength(0);
 
     const nativePolicy = run({ draft: false, assets: localAssets('published'), invalidNative: true });
     expect(nativePolicy.result.exitCode).not.toBe(0);
-    expect(calls(nativePolicy.state, 'gh', 'release upload')).toHaveLength(0);
+    expect(uploadCalls(nativePolicy.state)).toHaveLength(0);
   }, 15_000);
 });

--- a/scripts/release-docs.test.ts
+++ b/scripts/release-docs.test.ts
@@ -137,6 +137,10 @@ describe('Group E release and documentation contracts', () => {
     // ambiguous API failures fail closed rather than silently admitting
     expect(admit).toContain('release-replay.unknown');
     expect(admit).toContain(`grep -q 'HTTP 404'`);
+    // the probe retries transient API failures (bounded), never permission
+    // failures — behavior pinned by release-replay-guard.test.ts
+    expect(admit).toContain('for attempt in 1 2 3 4; do');
+    expect(admit).toContain('release_probe=unknown');
     // the guard runs only after the caller is proven
     expect(admit.indexOf('name: Refuse re-dispatch of an already published release')).toBeGreaterThan(
       admit.indexOf('name: Bind caller workflow and control commit'),
@@ -624,6 +628,16 @@ describe('Group E release and documentation contracts', () => {
     expect(helper).not.toContain('gh release edit');
     expect(helper).toContain('-f body=');
     expect(helper).toContain('source "$(dirname "$0")/gh-retry.sh"');
+    // Asset reconciliation resolves the release id once, then reads, uploads,
+    // and downloads by numeric id — never through by-tag draft resolution.
+    const assets = read('scripts/reconcile-release-assets.sh');
+    expect(assets).toContain('source "$(dirname "$0")/gh-retry.sh"');
+    expect(assets).toContain('gh_release_lookup --expect-exists');
+    expect(assets).toContain('gh_upload_release_asset');
+    expect(assets).toContain('gh_download_release_asset');
+    expect(assets).not.toContain('gh release upload');
+    expect(assets).not.toContain('gh release download');
+    expect(assets).toContain('`--clobber` is deliberately forbidden');
   });
 
   test('channel documentation does not claim unsigned manifests are signed or use GitHub latest as authority', () => {

--- a/scripts/release-replay-guard.test.ts
+++ b/scripts/release-replay-guard.test.ts
@@ -41,31 +41,49 @@ interface GhStub {
   exit: number;
 }
 
-/** Run the extracted guard with `gh` stubbed on PATH. */
-function runGuard(stub: GhStub, version = '5.260728.4') {
+/**
+ * Run the extracted guard with `gh` stubbed on PATH. A single stub answers
+ * every call; an array answers call N with entry N (the last entry repeats),
+ * so transient-then-definitive sequences can be scripted.
+ */
+function runGuard(stub: GhStub | GhStub[], version = '5.260728.4') {
   const root = mkdtempSync(join(tmpdir(), 'genie-replay-guard-'));
   roots.push(root);
   const bin = join(root, 'bin');
   mkdirSync(bin, { recursive: true });
+  const sequence = Array.isArray(stub) ? stub : [stub];
+  const countFile = join(root, 'gh-calls');
+  writeFileSync(countFile, '0');
+  const arms = sequence
+    .map((response, index) => {
+      const arm = index === sequence.length - 1 ? '*' : String(index + 1);
+      const body = `${response.stdout ? `printf '%s' '${response.stdout}'\n` : ''}${
+        response.stderr ? `printf '%s\\n' '${response.stderr}' >&2\n` : ''
+      }exit ${response.exit}`;
+      return `  ${arm}) ${body} ;;`;
+    })
+    .join('\n');
   writeFileSync(
     join(bin, 'gh'),
-    `#!/bin/sh\n${stub.stdout ? `printf '%s' '${stub.stdout}'\n` : ''}${stub.stderr ? `printf '%s\\n' '${stub.stderr}' >&2\n` : ''}exit ${stub.exit}\n`,
+    `#!/bin/sh\nn=$(cat '${countFile}')\nn=$((n + 1))\nprintf '%s' "$n" > '${countFile}'\ncase "$n" in\n${arms}\nesac\n`,
   );
   chmodSync(join(bin, 'gh'), 0o755);
 
   const scriptPath = join(root, 'guard.sh');
   writeFileSync(scriptPath, stepScript(readFileSync(WORKFLOW, 'utf8'), STEP));
 
-  return Bun.spawnSync(['bash', scriptPath], {
+  const result = Bun.spawnSync(['bash', scriptPath], {
     env: {
       PATH: `${bin}:${process.env.PATH ?? ''}`,
       GH_TOKEN: 'stub-token',
       RELEASE_REPOSITORY: 'automagik-dev/genie',
       INPUT_VERSION: version,
+      RETRY_SLEEP_SCALE: '0',
     },
     stdout: 'pipe',
     stderr: 'pipe',
   });
+  return Object.assign(result, { ghCalls: Number(readFileSync(countFile, 'utf8')) });
 }
 
 describe('release-publish replay guard behavior', () => {
@@ -94,9 +112,28 @@ describe('release-publish replay guard behavior', () => {
     expect(run.stdout.toString()).toContain('has no GitHub Release yet');
   });
 
-  test('an ambiguous API failure fails closed', () => {
+  test('an ambiguous API failure fails closed after exhausting the bounded retry loop', () => {
     const run = runGuard({ stderr: 'gh: Server Error (HTTP 500)', exit: 1 });
     expect(run.exitCode).toBe(1);
     expect(run.stdout.toString() + run.stderr.toString()).toContain('release-replay.unknown');
+    expect(run.ghCalls).toBe(4);
+  });
+
+  test('transient failures before a definitive 404 still admit the run', () => {
+    const run = runGuard([
+      { stderr: 'gh: Server Error (HTTP 500)', exit: 1 },
+      { stderr: 'gh: Bad Gateway (HTTP 502)', exit: 1 },
+      { stderr: 'gh: Not Found (HTTP 404)', exit: 1 },
+    ]);
+    expect(run.exitCode).toBe(0);
+    expect(run.stdout.toString()).toContain('has no GitHub Release yet');
+    expect(run.ghCalls).toBe(3);
+  });
+
+  test('permission failures fail closed without retrying', () => {
+    const run = runGuard({ stderr: 'gh: HTTP 403 Forbidden', exit: 1 });
+    expect(run.exitCode).toBe(1);
+    expect(run.stdout.toString() + run.stderr.toString()).toContain('release-replay.unknown');
+    expect(run.ghCalls).toBe(1);
   });
 });


### PR DESCRIPTION
## What (PR 2 of 2 — stacked on #2803)

Completes the 2026-08-17 outage hardening. `reconcile-release-assets.sh` resolves the release identity **exactly once** via `gh_release_lookup --expect-exists` (unknown → exit 3 before any mutation; definitively absent → "run prepare first"), then every inventory read, asset download, and asset upload operates on **numeric ids** — the flaky by-tag draft-listing resolution that produced `release not found` mid-publish is gone from the mutation path entirely (`gh release upload/download` no longer appear in the script).

- **Per-asset POSTs to uploads.github.com** replace the batch `gh release upload`: finer resumption, and a retried upload whose first attempt actually landed surfaces as `already_exists` and is **skipped — never deleted, never clobbered** — with the existing post-upload re-fetch + byte-compare remaining the authority. A corrupt landed byte still fails closed (pinned by test).
- Downloads are bound to the validated inventory's asset ids — stronger binding than the old `--pattern` match.
- `gh attestation verify` calls retry transient failures.
- The **admit replay guard** (no checkout → cannot source the helper) gains a self-contained bounded retry loop with the same classification: definitive 404 admits, 401/403 never retried, exhaustion still fails closed as `release-replay.unknown`. Admit timeout 2m → 5m. Behavior pinned by new `release-replay-guard.test.ts` sequence stubs (500,500,404 → admitted; persistent 500 → unknown; 403 → single call).

## Testing

Full assets suite rewritten against the by-id fake `gh` (17 tests), including: transient upload retry with no duplicates/clobber/DELETE; landed-but-lost-response skip adjudicated by byte verification (clean and corrupt variants); lookup-unknown fails closed before any mutation. `bun run check` green apart from the pre-existing darwin doctor-latency flake.

## Post-merge validation

Dispatch a **draft dev-channel release** — exercises admit, prepare, and the by-id inventory/upload/download path end-to-end against the live API without publishing or advancing manifests (finalize/manifests gated on `!inputs.draft`); the next scheduled dev release exercises finalize + immutability + manifests.
